### PR TITLE
feat: connect bounded Euler characteristics to finrank

### DIFF
--- a/TauCeti/Algebra/Category/FGModuleCat/Finrank.lean
+++ b/TauCeti/Algebra/Category/FGModuleCat/Finrank.lean
@@ -1,0 +1,63 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Category.FGModuleCat.Abelian
+public import Mathlib.Algebra.Category.ModuleCat.Free
+public import TauCeti.CategoryTheory.GrothendieckGroup.Abelian
+
+/-!
+# Finrank as an additive invariant
+
+This file packages finrank on finite-dimensional vector spaces as an invariant additive on short
+exact sequences. It is the reusable bridge from `FGModuleCat` to abelian Grothendieck groups.
+-/
+
+public section
+
+namespace TauCeti
+
+open CategoryTheory
+
+universe u v
+
+namespace AbelianK0.AdditiveInvariant
+
+variable (k : Type u) [DivisionRing k]
+
+/-- Finrank on `FGModuleCat k`, as a `ℤ`-valued invariant additive on short exact sequences. -/
+@[expose]
+noncomputable def finrank : AbelianK0.AdditiveInvariant (FGModuleCat.{v} k) ℤ where
+  obj X := Module.finrank k X
+  map_iso {_ _} e := congrArg Int.ofNat (FGModuleCat.isoToLinearEquiv e).finrank_eq
+  map_shortExact {S} hS := by
+    let F := forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)
+    have hS' : (S.map F).ShortExact := hS.map_of_exact F
+    let _ : Module.Finite k (S.map F).X₁ := S.X₁.property
+    let _ : Module.Finite k (S.map F).X₃ := S.X₃.property
+    have h := ModuleCat.free_shortExact_finrank_add hS' (n := Module.finrank k S.X₁)
+      (p := Module.finrank k S.X₃) rfl rfl
+    exact_mod_cast h
+
+@[simp]
+lemma finrank_obj (X : FGModuleCat.{v} k) :
+    (finrank k).obj X = (Module.finrank k X : ℤ) := rfl
+
+end AbelianK0.AdditiveInvariant
+
+namespace FGModuleCat
+
+variable (k : Type u) [DivisionRing k]
+
+/-- Forgetting the finite-generation witness does not change finrank. -/
+@[simp]
+theorem finrank_forget₂_obj (X : FGModuleCat.{v} k) :
+    Module.finrank k ((forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)).obj X) =
+      Module.finrank k X := rfl
+
+end FGModuleCat
+
+end TauCeti

--- a/TauCeti/Algebra/Category/FGModuleCat/Finrank.lean
+++ b/TauCeti/Algebra/Category/FGModuleCat/Finrank.lean
@@ -17,9 +17,9 @@ exact sequences. It is the reusable bridge from `FGModuleCat` to abelian Grothen
 
 Additivity has to be read off from `ModuleCat.free_shortExact_finrank_add`, which lives one
 category down, so the file first records how the forgetful functor
-`forget₂ (FGModuleCat k) (ModuleCat k)` interacts with finiteness and with finrank. Those two
-statements are the only place where the definitional identification of an `FGModuleCat` object
-with its underlying module is used; everything else goes through them.
+`forget₂ (FGModuleCat k) (ModuleCat k)` interacts with finrank. This is the only place where the
+definitional identification of an `FGModuleCat` object with its underlying module is used;
+everything else goes through it.
 -/
 
 public section
@@ -31,10 +31,6 @@ universe u v
 namespace FGModuleCat
 
 variable {R : Type u} [Ring R]
-
-/-- The module underlying an object of `FGModuleCat R` is finite. -/
-instance moduleFinite_forget₂_obj (X : FGModuleCat.{v} R) :
-    Module.Finite R ((forget₂ (FGModuleCat.{v} R) (ModuleCat.{v} R)).obj X) := X.property
 
 /-- Forgetting the finite-generation witness does not change finrank. -/
 @[simp]
@@ -59,8 +55,8 @@ noncomputable def finrank : AbelianK0.AdditiveInvariant (FGModuleCat.{v} k) ℤ 
   map_shortExact {S} hS := by
     let F := forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)
     have hS' : (S.map F).ShortExact := hS.map_of_exact F
-    let _ : Module.Finite k (S.map F).X₁ := FGModuleCat.moduleFinite_forget₂_obj S.X₁
-    let _ : Module.Finite k (S.map F).X₃ := FGModuleCat.moduleFinite_forget₂_obj S.X₃
+    let _ : Module.Finite k (S.map F).X₁ := inferInstanceAs (Module.Finite k S.X₁)
+    let _ : Module.Finite k (S.map F).X₃ := inferInstanceAs (Module.Finite k S.X₃)
     have h := ModuleCat.free_shortExact_finrank_add hS' (n := Module.finrank k S.X₁)
       (p := Module.finrank k S.X₃) (FGModuleCat.finrank_forget₂_obj S.X₁)
       (FGModuleCat.finrank_forget₂_obj S.X₃)

--- a/TauCeti/Algebra/Category/FGModuleCat/Finrank.lean
+++ b/TauCeti/Algebra/Category/FGModuleCat/Finrank.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Algebra.Category.FGModuleCat.Abelian
 public import Mathlib.Algebra.Category.ModuleCat.Free
+public import TauCeti.Algebra.Category.ModuleCat.Finrank
 public import TauCeti.CategoryTheory.GrothendieckGroup.Abelian
 
 /-!
@@ -28,8 +29,9 @@ namespace AbelianK0.AdditiveInvariant
 
 variable (k : Type u) [DivisionRing k]
 
-/-- Finrank on `FGModuleCat k`, as a `ℤ`-valued invariant additive on short exact sequences. -/
-@[expose]
+/-- Finrank on `FGModuleCat k`, as a `ℤ`-valued invariant additive on short exact sequences.
+
+The definition is sealed; use `finrank_obj` to evaluate it on an object. -/
 noncomputable def finrank : AbelianK0.AdditiveInvariant (FGModuleCat.{v} k) ℤ where
   obj X := Module.finrank k X
   map_iso {_ _} e := congrArg Int.ofNat (FGModuleCat.isoToLinearEquiv e).finrank_eq
@@ -44,20 +46,8 @@ noncomputable def finrank : AbelianK0.AdditiveInvariant (FGModuleCat.{v} k) ℤ 
 
 @[simp]
 lemma finrank_obj (X : FGModuleCat.{v} k) :
-    (finrank k).obj X = (Module.finrank k X : ℤ) := rfl
+    (finrank k).obj X = (Module.finrank k X : ℤ) := (rfl)
 
 end AbelianK0.AdditiveInvariant
-
-namespace FGModuleCat
-
-variable (k : Type u) [DivisionRing k]
-
-/-- Forgetting the finite-generation witness does not change finrank. -/
-@[simp]
-theorem finrank_forget₂_obj (X : FGModuleCat.{v} k) :
-    Module.finrank k ((forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)).obj X) =
-      Module.finrank k X := rfl
-
-end FGModuleCat
 
 end TauCeti

--- a/TauCeti/Algebra/Category/FGModuleCat/Finrank.lean
+++ b/TauCeti/Algebra/Category/FGModuleCat/Finrank.lean
@@ -66,6 +66,7 @@ noncomputable def finrank : AbelianK0.AdditiveInvariant (FGModuleCat.{v} k) ℤ 
       (FGModuleCat.finrank_forget₂_obj S.X₃)
     exact_mod_cast h
 
+/-- Evaluate the finrank additive invariant as the integer-valued module finrank. -/
 @[simp]
 lemma finrank_obj (X : FGModuleCat.{v} k) :
     (finrank k).obj X = (Module.finrank k X : ℤ) := (rfl)

--- a/TauCeti/Algebra/Category/FGModuleCat/Finrank.lean
+++ b/TauCeti/Algebra/Category/FGModuleCat/Finrank.lean
@@ -33,7 +33,7 @@ namespace FGModuleCat
 variable {R : Type u} [Ring R]
 
 /-- The module underlying an object of `FGModuleCat R` is finite. -/
-theorem moduleFinite_forget₂_obj (X : FGModuleCat.{v} R) :
+instance moduleFinite_forget₂_obj (X : FGModuleCat.{v} R) :
     Module.Finite R ((forget₂ (FGModuleCat.{v} R) (ModuleCat.{v} R)).obj X) := X.property
 
 /-- Forgetting the finite-generation witness does not change finrank. -/

--- a/TauCeti/Algebra/Category/FGModuleCat/Finrank.lean
+++ b/TauCeti/Algebra/Category/FGModuleCat/Finrank.lean
@@ -7,7 +7,6 @@ module
 
 public import Mathlib.Algebra.Category.FGModuleCat.Abelian
 public import Mathlib.Algebra.Category.ModuleCat.Free
-public import TauCeti.Algebra.Category.ModuleCat.Finrank
 public import TauCeti.CategoryTheory.GrothendieckGroup.Abelian
 
 /-!
@@ -15,15 +14,37 @@ public import TauCeti.CategoryTheory.GrothendieckGroup.Abelian
 
 This file packages finrank on finite-dimensional vector spaces as an invariant additive on short
 exact sequences. It is the reusable bridge from `FGModuleCat` to abelian Grothendieck groups.
+
+Additivity has to be read off from `ModuleCat.free_shortExact_finrank_add`, which lives one
+category down, so the file first records how the forgetful functor
+`forget₂ (FGModuleCat k) (ModuleCat k)` interacts with finiteness and with finrank. Those two
+statements are the only place where the definitional identification of an `FGModuleCat` object
+with its underlying module is used; everything else goes through them.
 -/
 
 public section
 
-namespace TauCeti
-
 open CategoryTheory
 
 universe u v
+
+namespace FGModuleCat
+
+variable {R : Type u} [Ring R]
+
+/-- The module underlying an object of `FGModuleCat R` is finite. -/
+theorem moduleFinite_forget₂_obj (X : FGModuleCat.{v} R) :
+    Module.Finite R ((forget₂ (FGModuleCat.{v} R) (ModuleCat.{v} R)).obj X) := X.property
+
+/-- Forgetting the finite-generation witness does not change finrank. -/
+@[simp]
+theorem finrank_forget₂_obj (X : FGModuleCat.{v} R) :
+    Module.finrank R ((forget₂ (FGModuleCat.{v} R) (ModuleCat.{v} R)).obj X) =
+      Module.finrank R X := (rfl)
+
+end FGModuleCat
+
+namespace TauCeti
 
 namespace AbelianK0.AdditiveInvariant
 
@@ -38,10 +59,11 @@ noncomputable def finrank : AbelianK0.AdditiveInvariant (FGModuleCat.{v} k) ℤ 
   map_shortExact {S} hS := by
     let F := forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)
     have hS' : (S.map F).ShortExact := hS.map_of_exact F
-    let _ : Module.Finite k (S.map F).X₁ := S.X₁.property
-    let _ : Module.Finite k (S.map F).X₃ := S.X₃.property
+    let _ : Module.Finite k (S.map F).X₁ := FGModuleCat.moduleFinite_forget₂_obj S.X₁
+    let _ : Module.Finite k (S.map F).X₃ := FGModuleCat.moduleFinite_forget₂_obj S.X₃
     have h := ModuleCat.free_shortExact_finrank_add hS' (n := Module.finrank k S.X₁)
-      (p := Module.finrank k S.X₃) rfl rfl
+      (p := Module.finrank k S.X₃) (FGModuleCat.finrank_forget₂_obj S.X₁)
+      (FGModuleCat.finrank_forget₂_obj S.X₃)
     exact_mod_cast h
 
 @[simp]

--- a/TauCeti/Algebra/Category/FGModuleCat/Homology.lean
+++ b/TauCeti/Algebra/Category/FGModuleCat/Homology.lean
@@ -22,7 +22,7 @@ open CategoryTheory
 
 universe u v
 
-namespace TauCeti.HomologicalComplex
+namespace HomologicalComplex
 
 variable {k : Type u} [DivisionRing k]
 
@@ -45,4 +45,4 @@ noncomputable def homologyForgetIso (K : CochainComplex (FGModuleCat.{v} k) ℤ)
       (K.homologyIsoSc' i j l
         ((ComplexShape.up ℤ).prev_eq' hij) ((ComplexShape.up ℤ).next_eq' hjl)).symm
 
-end TauCeti.HomologicalComplex
+end HomologicalComplex

--- a/TauCeti/Algebra/Category/FGModuleCat/Homology.lean
+++ b/TauCeti/Algebra/Category/FGModuleCat/Homology.lean
@@ -12,7 +12,8 @@ public import Mathlib.Algebra.Homology.ShortComplex.HomologicalComplex
 # Homology and the forgetful functor from `FGModuleCat`
 
 This file records the comparison between taking homology in `FGModuleCat` and taking homology
-after forgetting to `ModuleCat`.
+after forgetting to `ModuleCat`.  It lets invariants of homology objects, such as finrank, be
+transported between the two categories for Euler-characteristic computations.
 -/
 
 public section

--- a/TauCeti/Algebra/Category/FGModuleCat/Homology.lean
+++ b/TauCeti/Algebra/Category/FGModuleCat/Homology.lean
@@ -1,0 +1,47 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Category.FGModuleCat.Abelian
+public import Mathlib.Algebra.Homology.ShortComplex.HomologicalComplex
+
+/-!
+# Homology and the forgetful functor from `FGModuleCat`
+
+This file records the comparison between taking homology in `FGModuleCat` and taking homology
+after forgetting to `ModuleCat`.
+-/
+
+public section
+
+open CategoryTheory
+
+universe u v
+
+namespace TauCeti.HomologicalComplex
+
+variable {k : Type u} [DivisionRing k]
+
+/-- The comparison between homology after forgetting an `FGModuleCat` cochain complex and the
+underlying module of its homology. -/
+noncomputable def homologyForgetIso (K : CochainComplex (FGModuleCat.{v} k) ℤ) (n : ℤ) :
+    (((forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)).mapHomologicalComplex _).obj K).homology n ≅
+      (forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)).obj (K.homology n) := by
+  let i := n - 1
+  let j := n
+  let l := n + 1
+  have hij : i + 1 = j := by dsimp [i, j]; omega
+  have hjl : j + 1 = l := by dsimp [j, l]
+  exact HomologicalComplex.homologyIsoSc'
+      (((forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)).mapHomologicalComplex _).obj K) i j l
+      ((ComplexShape.up ℤ).prev_eq' hij) ((ComplexShape.up ℤ).next_eq' hjl) ≪≫
+    (K.sc' i j l).mapHomologyIso
+      (forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)) ≪≫
+    (forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)).mapIso
+      (K.homologyIsoSc' i j l
+        ((ComplexShape.up ℤ).prev_eq' hij) ((ComplexShape.up ℤ).next_eq' hjl)).symm
+
+end TauCeti.HomologicalComplex

--- a/TauCeti/Algebra/Category/ModuleCat/Finrank.lean
+++ b/TauCeti/Algebra/Category/ModuleCat/Finrank.lean
@@ -11,7 +11,7 @@ public import Mathlib.LinearAlgebra.Dimension.Finite
 /-!
 # Finrank of a zero object of `ModuleCat`
 
-Vanishing of an object of `ModuleCat k` is naturally expressed categorically, as
+Vanishing of an object of `ModuleCat R` is naturally expressed categorically, as
 `CategoryTheory.Limits.IsZero`, while the dimension counts that consume it speak of
 `Module.finrank`. This file supplies the one translation between the two: a zero object has
 finrank zero.
@@ -29,11 +29,11 @@ universe v u
 
 namespace ModuleCat
 
-variable {k : Type u} [DivisionRing k]
+variable {R : Type u} [Ring R] [Nontrivial R]
 
-/-- A zero object in `ModuleCat k` has finrank zero. -/
-theorem finrank_eq_zero_of_isZero {X : ModuleCat.{v} k} (hX : IsZero X) :
-    Module.finrank k X = 0 := by
+/-- A zero object in `ModuleCat R` has finrank zero. -/
+theorem finrank_eq_zero_of_isZero {X : ModuleCat.{v} R} (hX : IsZero X) :
+    Module.finrank R X = 0 := by
   let _ : Subsingleton X := ModuleCat.subsingleton_of_isZero hX
   exact Module.finrank_zero_of_subsingleton
 

--- a/TauCeti/Algebra/Category/ModuleCat/Finrank.lean
+++ b/TauCeti/Algebra/Category/ModuleCat/Finrank.lean
@@ -9,18 +9,23 @@ public import Mathlib.Algebra.Category.ModuleCat.Basic
 public import Mathlib.LinearAlgebra.Dimension.Finite
 
 /-!
-# Finrank in `ModuleCat`
+# Finrank of a zero object of `ModuleCat`
 
-This file records basic categorical properties of finrank for vector spaces.
+Vanishing of an object of `ModuleCat k` is naturally expressed categorically, as
+`CategoryTheory.Limits.IsZero`, while the dimension counts that consume it speak of
+`Module.finrank`. This file supplies the one translation between the two: a zero object has
+finrank zero.
+
+That translation is what bounds the `Module.finrank` support of a bounded complex of vector
+spaces by its bounding interval, which is in turn what makes Mathlib's `finsum`-based Euler
+characteristic of such a complex an honest finite sum.
 -/
 
 public section
 
-namespace TauCeti
-
 open CategoryTheory CategoryTheory.Limits
 
-universe u v
+universe v u
 
 namespace ModuleCat
 
@@ -33,5 +38,3 @@ theorem finrank_eq_zero_of_isZero {X : ModuleCat.{v} k} (hX : IsZero X) :
   exact Module.finrank_zero_of_subsingleton
 
 end ModuleCat
-
-end TauCeti

--- a/TauCeti/Algebra/Category/ModuleCat/Finrank.lean
+++ b/TauCeti/Algebra/Category/ModuleCat/Finrank.lean
@@ -1,0 +1,37 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Category.ModuleCat.Basic
+public import Mathlib.LinearAlgebra.Dimension.Finite
+
+/-!
+# Finrank in `ModuleCat`
+
+This file records basic categorical properties of finrank for vector spaces.
+-/
+
+public section
+
+namespace TauCeti
+
+open CategoryTheory CategoryTheory.Limits
+
+universe u v
+
+namespace ModuleCat
+
+variable {k : Type u} [DivisionRing k]
+
+/-- A zero object in `ModuleCat k` has finrank zero. -/
+theorem finrank_eq_zero_of_isZero {X : ModuleCat.{v} k} (hX : IsZero X) :
+    Module.finrank k X = 0 := by
+  let _ : Subsingleton X := ModuleCat.subsingleton_of_isZero hX
+  exact Module.finrank_zero_of_subsingleton
+
+end ModuleCat
+
+end TauCeti

--- a/TauCeti/Algebra/Homology/Embedding/CochainComplex.lean
+++ b/TauCeti/Algebra/Homology/Embedding/CochainComplex.lean
@@ -17,9 +17,10 @@ statements one strict inequality at a time. An argument that runs over the degre
 complex instead wants the two bounds packaged as a single finite interval `Finset.Icc a b`, so
 that membership in the summation range is the only case distinction left.
 
-This file records the resulting two statements: outside `Finset.Icc a b` both the terms and the
-cohomology of a complex strictly supported in `[a, b]` vanish. They are the finiteness input to
-alternating-sum (Euler characteristic) computations over a bounded complex.
+This file records the resulting two statements: outside `Finset.Icc a b`, the terms of a strictly
+bounded complex vanish, while its cohomology vanishes under the corresponding cohomological
+bounds. They are the finiteness input to alternating-sum (Euler characteristic) computations over
+a bounded complex.
 
 ## Main results
 
@@ -46,10 +47,10 @@ theorem isZero_X_of_notMem_Icc (K : CochainComplex A ℤ) (a b : ℤ) [K.IsStric
   · exact K.isZero_of_isStrictlyGE a n h
   · exact K.isZero_of_isStrictlyLE b n (by omega)
 
-/-- The homology of a strictly bounded cochain complex is zero outside any interval supplied by
-its bounds. -/
-theorem isZero_homology_of_notMem_Icc (K : CochainComplex A ℤ) (a b : ℤ) [K.IsStrictlyGE a]
-    [K.IsStrictlyLE b] {n : ℤ} [K.HasHomology n] (hn : n ∉ Finset.Icc a b) :
+/-- The homology of a cochain complex is zero outside any interval supplied by its cohomological
+bounds. -/
+theorem isZero_homology_of_notMem_Icc (K : CochainComplex A ℤ) (a b : ℤ) [K.IsGE a]
+    [K.IsLE b] {n : ℤ} [K.HasHomology n] (hn : n ∉ Finset.Icc a b) :
     IsZero (K.homology n) := by
   rw [Finset.mem_Icc] at hn
   rcases lt_or_ge n a with h | h

--- a/TauCeti/Algebra/Homology/Embedding/CochainComplex.lean
+++ b/TauCeti/Algebra/Homology/Embedding/CochainComplex.lean
@@ -1,0 +1,59 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Homology.Embedding.CochainComplex
+public import Mathlib.Data.Int.Interval
+
+/-!
+# Vanishing outside the bounds of a bounded cochain complex
+
+Mathlib records the boundedness of a cochain complex indexed by `ℤ` in the classes
+`CochainComplex.IsStrictlyGE` and `CochainComplex.IsStrictlyLE`, and converts them into vanishing
+statements one strict inequality at a time. An argument that runs over the degrees of a bounded
+complex instead wants the two bounds packaged as a single finite interval `Finset.Icc a b`, so
+that membership in the summation range is the only case distinction left.
+
+This file records the resulting two statements: outside `Finset.Icc a b` both the terms and the
+cohomology of a complex strictly supported in `[a, b]` vanish. They are the finiteness input to
+alternating-sum (Euler characteristic) computations over a bounded complex.
+
+## Main results
+
+* `HomologicalComplex.isZero_X_of_notMem_Icc`: the terms vanish outside the bounding interval.
+* `HomologicalComplex.isZero_homology_of_notMem_Icc`: the cohomology vanishes outside the
+  bounding interval.
+-/
+
+public section
+
+open CategoryTheory CategoryTheory.Limits
+
+universe v u
+
+namespace HomologicalComplex
+
+variable {A : Type u} [Category.{v} A] [HasZeroMorphisms A]
+
+/-- A strictly bounded cochain complex is zero outside any interval supplied by its bounds. -/
+theorem isZero_X_of_notMem_Icc (K : CochainComplex A ℤ) (a b : ℤ) [K.IsStrictlyGE a]
+    [K.IsStrictlyLE b] {n : ℤ} (hn : n ∉ Finset.Icc a b) : IsZero (K.X n) := by
+  rw [Finset.mem_Icc] at hn
+  rcases lt_or_ge n a with h | h
+  · exact K.isZero_of_isStrictlyGE a n h
+  · exact K.isZero_of_isStrictlyLE b n (by omega)
+
+/-- The homology of a strictly bounded cochain complex is zero outside any interval supplied by
+its bounds. -/
+theorem isZero_homology_of_notMem_Icc (K : CochainComplex A ℤ) (a b : ℤ) [K.IsStrictlyGE a]
+    [K.IsStrictlyLE b] {n : ℤ} [K.HasHomology n] (hn : n ∉ Finset.Icc a b) :
+    IsZero (K.homology n) := by
+  rw [Finset.mem_Icc] at hn
+  rcases lt_or_ge n a with h | h
+  · exact K.isZero_of_isGE a n h
+  · exact K.isZero_of_isLE b n (by omega)
+
+end HomologicalComplex

--- a/TauCeti/Algebra/Homology/EulerCharacteristic/FiniteDimensional.lean
+++ b/TauCeti/Algebra/Homology/EulerCharacteristic/FiniteDimensional.lean
@@ -62,11 +62,11 @@ theorem finrankSupport_X_subset_Icc (K : CochainComplex (ModuleCat.{v} k) ℤ)
   exact ModuleCat.finrank_eq_zero_of_isZero
     (K.isZero_X_of_notMem_Icc a b (fun h => hn (Finset.mem_coe.2 h)))
 
-/-- The finrank support of the homology of a strictly bounded complex of vector spaces lies in any
-interval supplied by its bounds. -/
+/-- The finrank support of the homology of a cohomologically bounded complex of vector spaces lies
+in any interval supplied by its bounds. -/
 theorem finrankSupport_homology_subset_Icc
     (K : CochainComplex (ModuleCat.{v} k) ℤ) (a b : ℤ)
-    [K.IsStrictlyGE a] [K.IsStrictlyLE b] :
+    [K.IsGE a] [K.IsLE b] :
     GradedObject.finrankSupport (fun n => K.homology n) ⊆ Finset.Icc a b := by
   rw [GradedObject.finrankSupport_subset_iff]
   intro n hn
@@ -105,11 +105,20 @@ theorem finrank_homology_forget (n : ℤ) :
 vector spaces is the honest finite sum of the dimensions of its homology objects.  The homology on
 the right is computed in `FGModuleCat k`; exactness of the forgetful functor identifies it with the
 homology used on the left. -/
-theorem homologyEulerChar_forgetFG_eq_sum_finrank (a b : ℤ) [K.IsStrictlyGE a]
-    [K.IsStrictlyLE b] {s : Finset ℤ} (hs : Finset.Icc a b ⊆ s) :
+theorem homologyEulerChar_forgetFG_eq_sum_finrank (a b : ℤ) [K.IsGE a]
+    [K.IsLE b] {s : Finset ℤ} (hs : Finset.Icc a b ⊆ s) :
     homologyEulerChar
       (((forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)).mapHomologicalComplex _).obj K) =
       ∑ n ∈ s, (n.negOnePow : ℤ) * Module.finrank k (K.homology n) := by
+  let F := forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)
+  let _ : CochainComplex.IsGE ((F.mapHomologicalComplex _).obj K) a := by
+    rw [CochainComplex.isGE_iff]
+    intro i hi
+    exact (K.exactAt_of_isGE a i hi).map F
+  let _ : CochainComplex.IsLE ((F.mapHomologicalComplex _).obj K) b := by
+    rw [CochainComplex.isLE_iff]
+    intro i hi
+    exact (K.exactAt_of_isLE b i hi).map F
   rw [homologyEulerChar_eq_sum_finSet_of_finrankSupport_subset
     (((forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)).mapHomologicalComplex _).obj K) s]
   · apply Finset.sum_congr rfl

--- a/TauCeti/Algebra/Homology/EulerCharacteristic/FiniteDimensional.lean
+++ b/TauCeti/Algebra/Homology/EulerCharacteristic/FiniteDimensional.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Algebra.Homology.EulerCharacteristic
 public import TauCeti.Algebra.Category.FGModuleCat.Finrank
+public import TauCeti.Algebra.Category.FGModuleCat.Homology
 public import TauCeti.Algebra.Category.ModuleCat.Finrank
 public import TauCeti.Algebra.Homology.Embedding.CochainComplex
 public import TauCeti.CategoryTheory.GrothendieckGroup.EulerCharacteristic
@@ -90,25 +91,6 @@ theorem eulerChar_forgetFG_eq_sum_finrank (a b : ℤ) [K.IsStrictlyGE a]
       (((forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)).mapHomologicalComplex _).obj K)
       a b).trans hs
 
-/-- The comparison between homology after forgetting an `FGModuleCat` complex and the underlying
-module of its homology, obtained from exactness of the forgetful functor. -/
-private noncomputable def homologyForgetIso (n : ℤ) :
-    (((forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)).mapHomologicalComplex _).obj K).homology n ≅
-      (forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)).obj (K.homology n) := by
-  let i := n - 1
-  let j := n
-  let l := n + 1
-  have hij : i + 1 = j := by dsimp [i, j]; omega
-  have hjl : j + 1 = l := by dsimp [j, l]
-  exact homologyIsoSc'
-      (((forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)).mapHomologicalComplex _).obj K) i j l
-      ((ComplexShape.up ℤ).prev_eq' hij) ((ComplexShape.up ℤ).next_eq' hjl) ≪≫
-    (K.sc' i j l).mapHomologyIso
-      (forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)) ≪≫
-    (forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)).mapIso
-      (K.homologyIsoSc' i j l
-        ((ComplexShape.up ℤ).prev_eq' hij) ((ComplexShape.up ℤ).next_eq' hjl)).symm
-
 /-- Forgetting an `FGModuleCat` complex before taking homology does not change homology finrank. -/
 @[simp]
 theorem finrank_homology_forget (n : ℤ) :
@@ -116,7 +98,7 @@ theorem finrank_homology_forget (n : ℤ) :
       ((((forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)).mapHomologicalComplex _).obj
         K).homology n) =
       Module.finrank k (K.homology n) :=
-  (homologyForgetIso K n).toLinearEquiv.finrank_eq.trans
+  (TauCeti.HomologicalComplex.homologyForgetIso K n).toLinearEquiv.finrank_eq.trans
     (FGModuleCat.finrank_forget₂_obj (K.homology n))
 
 /-- Mathlib's `finsum` homology Euler characteristic of a bounded complex of finite-dimensional

--- a/TauCeti/Algebra/Homology/EulerCharacteristic/FiniteDimensional.lean
+++ b/TauCeti/Algebra/Homology/EulerCharacteristic/FiniteDimensional.lean
@@ -49,29 +49,30 @@ universe u v
 
 variable {k : Type u} [DivisionRing k]
 
-private theorem finrank_eq_zero_of_isZero {X : ModuleCat.{v} k} (hX : IsZero X) :
-    Module.finrank k X = 0 := by
-  let _ : Subsingleton X := ModuleCat.subsingleton_of_isZero hX
-  exact Module.finrank_zero_of_subsingleton
+namespace HomologicalComplex
 
-private theorem finrankSupport_X_subset_Icc (K : CochainComplex (ModuleCat.{v} k) ℤ)
+/-- The finrank support of a strictly bounded complex of vector spaces lies in any interval
+supplied by its bounds. -/
+theorem finrankSupport_X_subset_Icc (K : CochainComplex (ModuleCat.{v} k) ℤ)
     (a b : ℤ) [K.IsStrictlyGE a] [K.IsStrictlyLE b] :
     GradedObject.finrankSupport K.X ⊆ Finset.Icc a b := by
   rw [GradedObject.finrankSupport_subset_iff]
   intro n hn
-  exact finrank_eq_zero_of_isZero (TauCeti.HomologicalComplex.isZero_X_of_notMem_Icc K a b
-    (fun h => hn (Finset.mem_coe.2 h)))
+  exact ModuleCat.finrank_eq_zero_of_isZero
+    (TauCeti.HomologicalComplex.isZero_X_of_notMem_Icc K a b
+      (fun h => hn (Finset.mem_coe.2 h)))
 
-private theorem finrankSupport_homology_subset_Icc
+/-- The finrank support of the homology of a strictly bounded complex of vector spaces lies in any
+interval supplied by its bounds. -/
+theorem finrankSupport_homology_subset_Icc
     (K : CochainComplex (ModuleCat.{v} k) ℤ) (a b : ℤ)
     [K.IsStrictlyGE a] [K.IsStrictlyLE b] :
     GradedObject.finrankSupport (fun n => K.homology n) ⊆ Finset.Icc a b := by
   rw [GradedObject.finrankSupport_subset_iff]
   intro n hn
-  exact finrank_eq_zero_of_isZero (TauCeti.HomologicalComplex.isZero_homology_of_notMem_Icc K a b
-    (fun h => hn (Finset.mem_coe.2 h)))
-
-namespace HomologicalComplex
+  exact ModuleCat.finrank_eq_zero_of_isZero
+    (TauCeti.HomologicalComplex.isZero_homology_of_notMem_Icc K a b
+      (fun h => hn (Finset.mem_coe.2 h)))
 
 variable (K : CochainComplex (FGModuleCat.{v} k) ℤ)
 
@@ -87,12 +88,15 @@ theorem eulerChar_forgetFG_eq_sum_finrank (a b : ℤ) [K.IsStrictlyGE a]
   rw [HomologicalComplex.eulerChar_eq_sum_finSet_of_finrankSupport_subset
     (((forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)).mapHomologicalComplex _).obj K) s]
   · simp only [Functor.mapHomologicalComplex_obj_X,
-      ComplexShape.eulerCharSignsUpInt_χ, FGModuleCat.finrank_forget₂_obj]
+      ComplexShape.eulerCharSignsUpInt_χ]
+    rfl
   · exact (finrankSupport_X_subset_Icc
       (((forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)).mapHomologicalComplex _).obj K)
       a b).trans hs
 
-private noncomputable def homologyForgetIso (n : ℤ) :
+/-- The canonical comparison between homology after forgetting an `FGModuleCat` complex and the
+underlying module of its homology. -/
+noncomputable def homologyForgetIso (n : ℤ) :
     (((forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)).mapHomologicalComplex _).obj K).homology n ≅
       (forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)).obj (K.homology n) := by
   let i := n - 1
@@ -109,7 +113,9 @@ private noncomputable def homologyForgetIso (n : ℤ) :
       (K.homologyIsoSc' i j l
         ((ComplexShape.up ℤ).prev_eq' hij) ((ComplexShape.up ℤ).next_eq' hjl)).symm
 
-private theorem finrank_homology_forget (n : ℤ) :
+/-- Forgetting an `FGModuleCat` complex before taking homology does not change homology finrank. -/
+@[simp]
+theorem finrank_homology_forget (n : ℤ) :
     Module.finrank k
       ((((forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)).mapHomologicalComplex _).obj
         K).homology n) =

--- a/TauCeti/Algebra/Homology/EulerCharacteristic/FiniteDimensional.lean
+++ b/TauCeti/Algebra/Homology/EulerCharacteristic/FiniteDimensional.lean
@@ -7,6 +7,8 @@ module
 
 public import Mathlib.Algebra.Homology.EulerCharacteristic
 public import TauCeti.Algebra.Category.FGModuleCat.Finrank
+public import TauCeti.Algebra.Category.ModuleCat.Finrank
+public import TauCeti.Algebra.Homology.Embedding.CochainComplex
 public import TauCeti.CategoryTheory.GrothendieckGroup.EulerCharacteristic
 
 /-!
@@ -25,11 +27,11 @@ possible junk value is used in the Euler--Poincaré identity.
 
 ## Main results
 
-* `TauCeti.HomologicalComplex.eulerChar_forgetFG_eq_sum_finrank`: Mathlib's term Euler
-  characteristic is the finite sum over any finite set containing the bounding interval.
-* `TauCeti.HomologicalComplex.homologyEulerChar_forgetFG_eq_sum_finrank`: Mathlib's homology Euler
+* `HomologicalComplex.eulerChar_forgetFG_eq_sum_finrank`: Mathlib's term Euler characteristic is
+  the finite sum over any finite set containing the bounding interval.
+* `HomologicalComplex.homologyEulerChar_forgetFG_eq_sum_finrank`: Mathlib's homology Euler
   characteristic is the corresponding finite sum of the homology dimensions in `FGModuleCat k`.
-* `TauCeti.HomologicalComplex.eulerChar_forgetFG_eq_homologyEulerChar`: the finite-dimensional
+* `HomologicalComplex.eulerChar_forgetFG_eq_homologyEulerChar`: the finite-dimensional
   Euler--Poincaré identity in Mathlib's Euler-characteristic API.
 
 ## References
@@ -41,15 +43,13 @@ possible junk value is used in the Euler--Poincaré identity.
 
 public section
 
-namespace TauCeti
-
 open CategoryTheory CategoryTheory.Limits
 
 universe u v
 
-variable {k : Type u} [DivisionRing k]
-
 namespace HomologicalComplex
+
+variable {k : Type u} [DivisionRing k]
 
 /-- The finrank support of a strictly bounded complex of vector spaces lies in any interval
 supplied by its bounds. -/
@@ -59,8 +59,7 @@ theorem finrankSupport_X_subset_Icc (K : CochainComplex (ModuleCat.{v} k) ℤ)
   rw [GradedObject.finrankSupport_subset_iff]
   intro n hn
   exact ModuleCat.finrank_eq_zero_of_isZero
-    (TauCeti.HomologicalComplex.isZero_X_of_notMem_Icc K a b
-      (fun h => hn (Finset.mem_coe.2 h)))
+    (K.isZero_X_of_notMem_Icc a b (fun h => hn (Finset.mem_coe.2 h)))
 
 /-- The finrank support of the homology of a strictly bounded complex of vector spaces lies in any
 interval supplied by its bounds. -/
@@ -71,8 +70,7 @@ theorem finrankSupport_homology_subset_Icc
   rw [GradedObject.finrankSupport_subset_iff]
   intro n hn
   exact ModuleCat.finrank_eq_zero_of_isZero
-    (TauCeti.HomologicalComplex.isZero_homology_of_notMem_Icc K a b
-      (fun h => hn (Finset.mem_coe.2 h)))
+    (K.isZero_homology_of_notMem_Icc a b (fun h => hn (Finset.mem_coe.2 h)))
 
 variable (K : CochainComplex (FGModuleCat.{v} k) ℤ)
 
@@ -82,21 +80,19 @@ interval `Finset.Icc a b`.
 -/
 theorem eulerChar_forgetFG_eq_sum_finrank (a b : ℤ) [K.IsStrictlyGE a]
     [K.IsStrictlyLE b] {s : Finset ℤ} (hs : Finset.Icc a b ⊆ s) :
-    HomologicalComplex.eulerChar
-      (((forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)).mapHomologicalComplex _).obj K) =
+    eulerChar (((forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)).mapHomologicalComplex _).obj K) =
       ∑ n ∈ s, (n.negOnePow : ℤ) * Module.finrank k (K.X n) := by
-  rw [HomologicalComplex.eulerChar_eq_sum_finSet_of_finrankSupport_subset
+  rw [eulerChar_eq_sum_finSet_of_finrankSupport_subset
     (((forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)).mapHomologicalComplex _).obj K) s]
-  · simp only [Functor.mapHomologicalComplex_obj_X,
-      ComplexShape.eulerCharSignsUpInt_χ]
-    rfl
+  · simp only [Functor.mapHomologicalComplex_obj_X, ComplexShape.eulerCharSignsUpInt_χ,
+      FGModuleCat.finrank_forget₂_obj]
   · exact (finrankSupport_X_subset_Icc
       (((forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)).mapHomologicalComplex _).obj K)
       a b).trans hs
 
-/-- The canonical comparison between homology after forgetting an `FGModuleCat` complex and the
-underlying module of its homology. -/
-noncomputable def homologyForgetIso (n : ℤ) :
+/-- The comparison between homology after forgetting an `FGModuleCat` complex and the underlying
+module of its homology, obtained from exactness of the forgetful functor. -/
+private noncomputable def homologyForgetIso (n : ℤ) :
     (((forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)).mapHomologicalComplex _).obj K).homology n ≅
       (forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)).obj (K.homology n) := by
   let i := n - 1
@@ -104,7 +100,7 @@ noncomputable def homologyForgetIso (n : ℤ) :
   let l := n + 1
   have hij : i + 1 = j := by dsimp [i, j]; omega
   have hjl : j + 1 = l := by dsimp [j, l]
-  exact HomologicalComplex.homologyIsoSc'
+  exact homologyIsoSc'
       (((forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)).mapHomologicalComplex _).obj K) i j l
       ((ComplexShape.up ℤ).prev_eq' hij) ((ComplexShape.up ℤ).next_eq' hjl) ≪≫
     (K.sc' i j l).mapHomologyIso
@@ -120,7 +116,8 @@ theorem finrank_homology_forget (n : ℤ) :
       ((((forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)).mapHomologicalComplex _).obj
         K).homology n) =
       Module.finrank k (K.homology n) :=
-  (homologyForgetIso K n).toLinearEquiv.finrank_eq
+  (homologyForgetIso K n).toLinearEquiv.finrank_eq.trans
+    (FGModuleCat.finrank_forget₂_obj (K.homology n))
 
 /-- Mathlib's `finsum` homology Euler characteristic of a bounded complex of finite-dimensional
 vector spaces is the honest finite sum of the dimensions of its homology objects.  The homology on
@@ -128,10 +125,10 @@ the right is computed in `FGModuleCat k`; exactness of the forgetful functor ide
 homology used on the left. -/
 theorem homologyEulerChar_forgetFG_eq_sum_finrank (a b : ℤ) [K.IsStrictlyGE a]
     [K.IsStrictlyLE b] {s : Finset ℤ} (hs : Finset.Icc a b ⊆ s) :
-    HomologicalComplex.homologyEulerChar
+    homologyEulerChar
       (((forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)).mapHomologicalComplex _).obj K) =
       ∑ n ∈ s, (n.negOnePow : ℤ) * Module.finrank k (K.homology n) := by
-  rw [HomologicalComplex.homologyEulerChar_eq_sum_finSet_of_finrankSupport_subset
+  rw [homologyEulerChar_eq_sum_finSet_of_finrankSupport_subset
     (((forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)).mapHomologicalComplex _).obj K) s]
   · apply Finset.sum_congr rfl
     intro n _
@@ -150,18 +147,14 @@ The source category makes every term finite-dimensional, while the explicit boun
 -/
 theorem eulerChar_forgetFG_eq_homologyEulerChar (a b : ℤ) [K.IsStrictlyGE a]
     [K.IsStrictlyLE b] :
-    HomologicalComplex.eulerChar
+    eulerChar
         (((forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)).mapHomologicalComplex _).obj K) =
-      HomologicalComplex.homologyEulerChar
+      homologyEulerChar
         (((forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)).mapHomologicalComplex _).obj K) := by
-  rw [TauCeti.HomologicalComplex.eulerChar_forgetFG_eq_sum_finrank K a b
-      (s := Finset.Icc a b) subset_rfl,
-    TauCeti.HomologicalComplex.homologyEulerChar_forgetFG_eq_sum_finrank K a b
-      (s := Finset.Icc a b) subset_rfl]
-  have h := AbelianK0.AdditiveInvariant.sum_negOnePow_obj_X_eq_sum_negOnePow_obj_homology
-    (AbelianK0.AdditiveInvariant.finrank k) K a b (s := Finset.Icc a b) subset_rfl
-  simpa only [AbelianK0.AdditiveInvariant.finrank_obj, smul_eq_mul] using h
+  rw [eulerChar_forgetFG_eq_sum_finrank K a b (s := Finset.Icc a b) subset_rfl,
+    homologyEulerChar_forgetFG_eq_sum_finrank K a b (s := Finset.Icc a b) subset_rfl]
+  have h := TauCeti.AbelianK0.AdditiveInvariant.sum_negOnePow_obj_X_eq_sum_negOnePow_obj_homology
+    (TauCeti.AbelianK0.AdditiveInvariant.finrank k) K a b (s := Finset.Icc a b) subset_rfl
+  simpa only [TauCeti.AbelianK0.AdditiveInvariant.finrank_obj, smul_eq_mul] using h
 
 end HomologicalComplex
-
-end TauCeti

--- a/TauCeti/Algebra/Homology/EulerCharacteristic/FiniteDimensional.lean
+++ b/TauCeti/Algebra/Homology/EulerCharacteristic/FiniteDimensional.lean
@@ -1,0 +1,177 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Category.FGModuleCat.Abelian
+public import Mathlib.Algebra.Category.ModuleCat.Free
+public import Mathlib.Algebra.Homology.EulerCharacteristic
+public import TauCeti.CategoryTheory.GrothendieckGroup.EulerCharacteristic
+
+/-!
+# Euler--Poincaré for finite-dimensional cochain complexes
+
+Mathlib defines the Euler characteristic of a homological complex using `finsum`.  That definition
+is intentionally total: it returns zero when the summand has infinite support, and `finrank` itself
+returns zero for modules that are not finite free.  This file identifies those totalized
+definitions with honest finite sums for bounded cochain complexes of finite-dimensional vector
+spaces, and proves that the term and homology Euler characteristics agree.
+
+Finite-dimensionality is encoded by taking the original complex in `FGModuleCat k`.  The
+characteristics are evaluated after applying the forgetful functor to `ModuleCat k`, as required by
+Mathlib's definitions.  Boundedness is retained as explicit lower and upper bounds.  Thus neither
+possible junk value is used in the Euler--Poincaré identity.
+
+## Main results
+
+* `TauCeti.eulerChar_forgetFG_eq_sum_finrank`: Mathlib's term Euler characteristic is the finite
+  sum over any interval containing the support.
+* `TauCeti.homologyEulerChar_forgetFG_eq_sum_finrank`: Mathlib's homology Euler characteristic is
+  the corresponding finite sum of the homology dimensions in `FGModuleCat k`.
+* `TauCeti.eulerChar_forgetFG_eq_homologyEulerChar`: the finite-dimensional Euler--Poincaré
+  identity in Mathlib's Euler-characteristic API.
+
+## References
+
+* Charles A. Weibel, *An Introduction to Homological Algebra*, Sections 1.3 and 1.6.
+* Charles A. Weibel, *The K-book: An Introduction to Algebraic K-theory*, Chapter II,
+  Proposition 6.6.
+-/
+
+public section
+
+namespace TauCeti
+
+open CategoryTheory CategoryTheory.Limits
+
+universe u v
+
+variable (k : Type u) [DivisionRing k]
+
+private noncomputable def finrankAdditiveInvariant :
+    AbelianK0.AdditiveInvariant (FGModuleCat.{v} k) ℤ where
+  obj X := Module.finrank k X
+  map_iso {_ _} e := congrArg Int.ofNat (FGModuleCat.isoToLinearEquiv e).finrank_eq
+  map_shortExact {S} hS := by
+    let F := forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)
+    have hS' : (S.map F).ShortExact := hS.map_of_exact F
+    let _ : Module.Finite k (S.map F).X₁ := S.X₁.property
+    let _ : Module.Finite k (S.map F).X₃ := S.X₃.property
+    have h := ModuleCat.free_shortExact_finrank_add hS' (n := Module.finrank k S.X₁)
+      (p := Module.finrank k S.X₃) rfl rfl
+    exact_mod_cast h
+
+private theorem finrank_eq_zero_of_isZero {X : ModuleCat.{v} k} (hX : IsZero X) :
+    Module.finrank k X = 0 := by
+  let _ : Subsingleton X := ModuleCat.subsingleton_of_isZero hX
+  exact Module.finrank_zero_of_subsingleton
+
+private theorem finrankSupport_X_subset_Icc (K : CochainComplex (ModuleCat.{v} k) ℤ)
+    (a b : ℤ) [K.IsStrictlyGE a] [K.IsStrictlyLE b] :
+    GradedObject.finrankSupport K.X ⊆ Finset.Icc a b := by
+  rw [GradedObject.finrankSupport_subset_iff]
+  intro n hn
+  have hn' : n ∉ Finset.Icc a b := fun h => hn (Finset.mem_coe.2 h)
+  rw [Finset.mem_Icc] at hn'
+  rcases lt_or_ge n a with hna | hna
+  · exact finrank_eq_zero_of_isZero k (K.isZero_of_isStrictlyGE a n hna)
+  · exact finrank_eq_zero_of_isZero k (K.isZero_of_isStrictlyLE b n (by omega))
+
+private theorem finrankSupport_homology_subset_Icc
+    (K : CochainComplex (ModuleCat.{v} k) ℤ) (a b : ℤ)
+    [K.IsStrictlyGE a] [K.IsStrictlyLE b] :
+    GradedObject.finrankSupport (fun n => K.homology n) ⊆ Finset.Icc a b := by
+  rw [GradedObject.finrankSupport_subset_iff]
+  intro n hn
+  have hn' : n ∉ Finset.Icc a b := fun h => hn (Finset.mem_coe.2 h)
+  rw [Finset.mem_Icc] at hn'
+  rcases lt_or_ge n a with hna | hna
+  · exact finrank_eq_zero_of_isZero k (K.isZero_of_isGE a n hna)
+  · exact finrank_eq_zero_of_isZero k (K.isZero_of_isLE b n (by omega))
+
+section
+
+variable (K : CochainComplex (FGModuleCat.{v} k) ℤ)
+
+/-- Mathlib's `finsum` Euler characteristic of a bounded complex of finite-dimensional vector
+spaces is the honest finite sum of its term dimensions over any interval containing its support.
+-/
+theorem eulerChar_forgetFG_eq_sum_finrank (a b : ℤ) [K.IsStrictlyGE a]
+    [K.IsStrictlyLE b] {s : Finset ℤ} (hs : Finset.Icc a b ⊆ s) :
+    HomologicalComplex.eulerChar
+      (((forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)).mapHomologicalComplex _).obj K) =
+      ∑ n ∈ s, (n.negOnePow : ℤ) * Module.finrank k (K.X n) := by
+  rw [HomologicalComplex.eulerChar_eq_sum_finSet_of_finrankSupport_subset
+    (((forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)).mapHomologicalComplex _).obj K) s]
+  · rfl
+  · exact (finrankSupport_X_subset_Icc k
+      (((forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)).mapHomologicalComplex _).obj K)
+      a b).trans hs
+
+private noncomputable def homologyForgetIso (n : ℤ) :
+    (((forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)).mapHomologicalComplex _).obj K).homology n ≅
+      (forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)).obj (K.homology n) := by
+  let i := n - 1
+  let j := n
+  let l := n + 1
+  have hij : i + 1 = j := by dsimp [i, j]; omega
+  have hjl : j + 1 = l := by dsimp [j, l]
+  exact HomologicalComplex.homologyIsoSc'
+      (((forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)).mapHomologicalComplex _).obj K) i j l
+      ((ComplexShape.up ℤ).prev_eq' hij) ((ComplexShape.up ℤ).next_eq' hjl) ≪≫
+    (K.sc' i j l).mapHomologyIso
+      (forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)) ≪≫
+    (forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)).mapIso
+      (K.homologyIsoSc' i j l
+        ((ComplexShape.up ℤ).prev_eq' hij) ((ComplexShape.up ℤ).next_eq' hjl)).symm
+
+private theorem finrank_homology_forget (n : ℤ) :
+    Module.finrank k
+      ((((forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)).mapHomologicalComplex _).obj
+        K).homology n) =
+      Module.finrank k (K.homology n) :=
+  (homologyForgetIso k K n).toLinearEquiv.finrank_eq
+
+/-- Mathlib's `finsum` homology Euler characteristic of a bounded complex of finite-dimensional
+vector spaces is the honest finite sum of the dimensions of its homology objects.  The homology on
+the right is computed in `FGModuleCat k`; exactness of the forgetful functor identifies it with the
+homology used on the left. -/
+theorem homologyEulerChar_forgetFG_eq_sum_finrank (a b : ℤ) [K.IsStrictlyGE a]
+    [K.IsStrictlyLE b] {s : Finset ℤ} (hs : Finset.Icc a b ⊆ s) :
+    HomologicalComplex.homologyEulerChar
+      (((forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)).mapHomologicalComplex _).obj K) =
+      ∑ n ∈ s, (n.negOnePow : ℤ) * Module.finrank k (K.homology n) := by
+  rw [HomologicalComplex.homologyEulerChar_eq_sum_finSet_of_finrankSupport_subset
+    (((forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)).mapHomologicalComplex _).obj K) s]
+  · apply Finset.sum_congr rfl
+    intro n _
+    rw [finrank_homology_forget k K n]
+    rfl
+  · exact (finrankSupport_homology_subset_Icc k
+      (((forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)).mapHomologicalComplex _).obj K)
+      a b).trans hs
+
+/-- **Euler--Poincaré for a bounded finite-dimensional cochain complex.**  Mathlib's Euler
+characteristic of the terms agrees with its homology Euler characteristic after forgetting a
+bounded complex from `FGModuleCat k` to `ModuleCat k`.
+
+The source category makes every term finite-dimensional, while the explicit bounds make both
+`finsum`s finite.  Consequently this equality does not rely on either totalized junk value.
+-/
+theorem eulerChar_forgetFG_eq_homologyEulerChar (a b : ℤ) [K.IsStrictlyGE a]
+    [K.IsStrictlyLE b] :
+    HomologicalComplex.eulerChar
+        (((forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)).mapHomologicalComplex _).obj K) =
+      HomologicalComplex.homologyEulerChar
+        (((forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)).mapHomologicalComplex _).obj K) := by
+  rw [eulerChar_forgetFG_eq_sum_finrank k K a b (s := Finset.Icc a b) subset_rfl,
+    homologyEulerChar_forgetFG_eq_sum_finrank k K a b (s := Finset.Icc a b) subset_rfl]
+  have h := AbelianK0.AdditiveInvariant.sum_negOnePow_obj_X_eq_sum_negOnePow_obj_homology
+    (finrankAdditiveInvariant k) K a b (s := Finset.Icc a b) subset_rfl
+  simpa [finrankAdditiveInvariant, smul_eq_mul] using h
+
+end
+
+end TauCeti

--- a/TauCeti/Algebra/Homology/EulerCharacteristic/FiniteDimensional.lean
+++ b/TauCeti/Algebra/Homology/EulerCharacteristic/FiniteDimensional.lean
@@ -50,11 +50,13 @@ universe u v
 
 namespace HomologicalComplex
 
-variable {k : Type u} [DivisionRing k]
+section Ring
 
-/-- The finrank support of a strictly bounded complex of vector spaces lies in any interval
+variable {R : Type u} [Ring R] [Nontrivial R]
+
+/-- The finrank support of a strictly bounded complex of modules lies in any interval
 supplied by its bounds. -/
-theorem finrankSupport_X_subset_Icc (K : CochainComplex (ModuleCat.{v} k) ℤ)
+theorem finrankSupport_X_subset_Icc (K : CochainComplex (ModuleCat.{v} R) ℤ)
     (a b : ℤ) [K.IsStrictlyGE a] [K.IsStrictlyLE b] :
     GradedObject.finrankSupport K.X ⊆ Finset.Icc a b := by
   rw [GradedObject.finrankSupport_subset_iff]
@@ -62,10 +64,10 @@ theorem finrankSupport_X_subset_Icc (K : CochainComplex (ModuleCat.{v} k) ℤ)
   exact ModuleCat.finrank_eq_zero_of_isZero
     (K.isZero_X_of_notMem_Icc a b (fun h => hn (Finset.mem_coe.2 h)))
 
-/-- The finrank support of the homology of a cohomologically bounded complex of vector spaces lies
+/-- The finrank support of the homology of a cohomologically bounded complex of modules lies
 in any interval supplied by its bounds. -/
 theorem finrankSupport_homology_subset_Icc
-    (K : CochainComplex (ModuleCat.{v} k) ℤ) (a b : ℤ)
+    (K : CochainComplex (ModuleCat.{v} R) ℤ) (a b : ℤ)
     [K.IsGE a] [K.IsLE b] :
     GradedObject.finrankSupport (fun n => K.homology n) ⊆ Finset.Icc a b := by
   rw [GradedObject.finrankSupport_subset_iff]
@@ -73,7 +75,9 @@ theorem finrankSupport_homology_subset_Icc
   exact ModuleCat.finrank_eq_zero_of_isZero
     (K.isZero_homology_of_notMem_Icc a b (fun h => hn (Finset.mem_coe.2 h)))
 
-variable (K : CochainComplex (FGModuleCat.{v} k) ℤ)
+end Ring
+
+variable {k : Type u} [DivisionRing k] (K : CochainComplex (FGModuleCat.{v} k) ℤ)
 
 /-- Mathlib's `finsum` Euler characteristic of a bounded complex of finite-dimensional vector
 spaces is the honest finite sum of its term dimensions over any finite set containing the bounding

--- a/TauCeti/Algebra/Homology/EulerCharacteristic/FiniteDimensional.lean
+++ b/TauCeti/Algebra/Homology/EulerCharacteristic/FiniteDimensional.lean
@@ -98,7 +98,7 @@ theorem finrank_homology_forget (n : ℤ) :
       ((((forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)).mapHomologicalComplex _).obj
         K).homology n) =
       Module.finrank k (K.homology n) :=
-  (TauCeti.HomologicalComplex.homologyForgetIso K n).toLinearEquiv.finrank_eq.trans
+  (K.homologyForgetIso n).toLinearEquiv.finrank_eq.trans
     (FGModuleCat.finrank_forget₂_obj (K.homology n))
 
 /-- Mathlib's `finsum` homology Euler characteristic of a bounded complex of finite-dimensional

--- a/TauCeti/Algebra/Homology/EulerCharacteristic/FiniteDimensional.lean
+++ b/TauCeti/Algebra/Homology/EulerCharacteristic/FiniteDimensional.lean
@@ -5,9 +5,8 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Algebra.Category.FGModuleCat.Abelian
-public import Mathlib.Algebra.Category.ModuleCat.Free
 public import Mathlib.Algebra.Homology.EulerCharacteristic
+public import TauCeti.Algebra.Category.FGModuleCat.Finrank
 public import TauCeti.CategoryTheory.GrothendieckGroup.EulerCharacteristic
 
 /-!
@@ -26,12 +25,12 @@ possible junk value is used in the Euler--Poincaré identity.
 
 ## Main results
 
-* `TauCeti.eulerChar_forgetFG_eq_sum_finrank`: Mathlib's term Euler characteristic is the finite
-  sum over any interval containing the support.
-* `TauCeti.homologyEulerChar_forgetFG_eq_sum_finrank`: Mathlib's homology Euler characteristic is
-  the corresponding finite sum of the homology dimensions in `FGModuleCat k`.
-* `TauCeti.eulerChar_forgetFG_eq_homologyEulerChar`: the finite-dimensional Euler--Poincaré
-  identity in Mathlib's Euler-characteristic API.
+* `TauCeti.HomologicalComplex.eulerChar_forgetFG_eq_sum_finrank`: Mathlib's term Euler
+  characteristic is the finite sum over any finite set containing the bounding interval.
+* `TauCeti.HomologicalComplex.homologyEulerChar_forgetFG_eq_sum_finrank`: Mathlib's homology Euler
+  characteristic is the corresponding finite sum of the homology dimensions in `FGModuleCat k`.
+* `TauCeti.HomologicalComplex.eulerChar_forgetFG_eq_homologyEulerChar`: the finite-dimensional
+  Euler--Poincaré identity in Mathlib's Euler-characteristic API.
 
 ## References
 
@@ -48,20 +47,7 @@ open CategoryTheory CategoryTheory.Limits
 
 universe u v
 
-variable (k : Type u) [DivisionRing k]
-
-private noncomputable def finrankAdditiveInvariant :
-    AbelianK0.AdditiveInvariant (FGModuleCat.{v} k) ℤ where
-  obj X := Module.finrank k X
-  map_iso {_ _} e := congrArg Int.ofNat (FGModuleCat.isoToLinearEquiv e).finrank_eq
-  map_shortExact {S} hS := by
-    let F := forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)
-    have hS' : (S.map F).ShortExact := hS.map_of_exact F
-    let _ : Module.Finite k (S.map F).X₁ := S.X₁.property
-    let _ : Module.Finite k (S.map F).X₃ := S.X₃.property
-    have h := ModuleCat.free_shortExact_finrank_add hS' (n := Module.finrank k S.X₁)
-      (p := Module.finrank k S.X₃) rfl rfl
-    exact_mod_cast h
+variable {k : Type u} [DivisionRing k]
 
 private theorem finrank_eq_zero_of_isZero {X : ModuleCat.{v} k} (hX : IsZero X) :
     Module.finrank k X = 0 := by
@@ -73,11 +59,8 @@ private theorem finrankSupport_X_subset_Icc (K : CochainComplex (ModuleCat.{v} k
     GradedObject.finrankSupport K.X ⊆ Finset.Icc a b := by
   rw [GradedObject.finrankSupport_subset_iff]
   intro n hn
-  have hn' : n ∉ Finset.Icc a b := fun h => hn (Finset.mem_coe.2 h)
-  rw [Finset.mem_Icc] at hn'
-  rcases lt_or_ge n a with hna | hna
-  · exact finrank_eq_zero_of_isZero k (K.isZero_of_isStrictlyGE a n hna)
-  · exact finrank_eq_zero_of_isZero k (K.isZero_of_isStrictlyLE b n (by omega))
+  exact finrank_eq_zero_of_isZero (TauCeti.HomologicalComplex.isZero_X_of_notMem_Icc K a b
+    (fun h => hn (Finset.mem_coe.2 h)))
 
 private theorem finrankSupport_homology_subset_Icc
     (K : CochainComplex (ModuleCat.{v} k) ℤ) (a b : ℤ)
@@ -85,18 +68,16 @@ private theorem finrankSupport_homology_subset_Icc
     GradedObject.finrankSupport (fun n => K.homology n) ⊆ Finset.Icc a b := by
   rw [GradedObject.finrankSupport_subset_iff]
   intro n hn
-  have hn' : n ∉ Finset.Icc a b := fun h => hn (Finset.mem_coe.2 h)
-  rw [Finset.mem_Icc] at hn'
-  rcases lt_or_ge n a with hna | hna
-  · exact finrank_eq_zero_of_isZero k (K.isZero_of_isGE a n hna)
-  · exact finrank_eq_zero_of_isZero k (K.isZero_of_isLE b n (by omega))
+  exact finrank_eq_zero_of_isZero (TauCeti.HomologicalComplex.isZero_homology_of_notMem_Icc K a b
+    (fun h => hn (Finset.mem_coe.2 h)))
 
-section
+namespace HomologicalComplex
 
 variable (K : CochainComplex (FGModuleCat.{v} k) ℤ)
 
 /-- Mathlib's `finsum` Euler characteristic of a bounded complex of finite-dimensional vector
-spaces is the honest finite sum of its term dimensions over any interval containing its support.
+spaces is the honest finite sum of its term dimensions over any finite set containing the bounding
+interval `Finset.Icc a b`.
 -/
 theorem eulerChar_forgetFG_eq_sum_finrank (a b : ℤ) [K.IsStrictlyGE a]
     [K.IsStrictlyLE b] {s : Finset ℤ} (hs : Finset.Icc a b ⊆ s) :
@@ -105,8 +86,9 @@ theorem eulerChar_forgetFG_eq_sum_finrank (a b : ℤ) [K.IsStrictlyGE a]
       ∑ n ∈ s, (n.negOnePow : ℤ) * Module.finrank k (K.X n) := by
   rw [HomologicalComplex.eulerChar_eq_sum_finSet_of_finrankSupport_subset
     (((forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)).mapHomologicalComplex _).obj K) s]
-  · rfl
-  · exact (finrankSupport_X_subset_Icc k
+  · simp only [Functor.mapHomologicalComplex_obj_X,
+      ComplexShape.eulerCharSignsUpInt_χ, FGModuleCat.finrank_forget₂_obj]
+  · exact (finrankSupport_X_subset_Icc
       (((forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)).mapHomologicalComplex _).obj K)
       a b).trans hs
 
@@ -132,7 +114,7 @@ private theorem finrank_homology_forget (n : ℤ) :
       ((((forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)).mapHomologicalComplex _).obj
         K).homology n) =
       Module.finrank k (K.homology n) :=
-  (homologyForgetIso k K n).toLinearEquiv.finrank_eq
+  (homologyForgetIso K n).toLinearEquiv.finrank_eq
 
 /-- Mathlib's `finsum` homology Euler characteristic of a bounded complex of finite-dimensional
 vector spaces is the honest finite sum of the dimensions of its homology objects.  The homology on
@@ -147,9 +129,9 @@ theorem homologyEulerChar_forgetFG_eq_sum_finrank (a b : ℤ) [K.IsStrictlyGE a]
     (((forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)).mapHomologicalComplex _).obj K) s]
   · apply Finset.sum_congr rfl
     intro n _
-    rw [finrank_homology_forget k K n]
-    rfl
-  · exact (finrankSupport_homology_subset_Icc k
+    rw [finrank_homology_forget K n]
+    simp only [ComplexShape.eulerCharSignsUpInt_χ]
+  · exact (finrankSupport_homology_subset_Icc
       (((forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)).mapHomologicalComplex _).obj K)
       a b).trans hs
 
@@ -166,12 +148,14 @@ theorem eulerChar_forgetFG_eq_homologyEulerChar (a b : ℤ) [K.IsStrictlyGE a]
         (((forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)).mapHomologicalComplex _).obj K) =
       HomologicalComplex.homologyEulerChar
         (((forget₂ (FGModuleCat.{v} k) (ModuleCat.{v} k)).mapHomologicalComplex _).obj K) := by
-  rw [eulerChar_forgetFG_eq_sum_finrank k K a b (s := Finset.Icc a b) subset_rfl,
-    homologyEulerChar_forgetFG_eq_sum_finrank k K a b (s := Finset.Icc a b) subset_rfl]
+  rw [TauCeti.HomologicalComplex.eulerChar_forgetFG_eq_sum_finrank K a b
+      (s := Finset.Icc a b) subset_rfl,
+    TauCeti.HomologicalComplex.homologyEulerChar_forgetFG_eq_sum_finrank K a b
+      (s := Finset.Icc a b) subset_rfl]
   have h := AbelianK0.AdditiveInvariant.sum_negOnePow_obj_X_eq_sum_negOnePow_obj_homology
-    (finrankAdditiveInvariant k) K a b (s := Finset.Icc a b) subset_rfl
-  simpa [finrankAdditiveInvariant, smul_eq_mul] using h
+    (AbelianK0.AdditiveInvariant.finrank k) K a b (s := Finset.Icc a b) subset_rfl
+  simpa only [AbelianK0.AdditiveInvariant.finrank_obj, smul_eq_mul] using h
 
-end
+end HomologicalComplex
 
 end TauCeti

--- a/TauCeti/CategoryTheory/GrothendieckGroup/EulerCharacteristic.lean
+++ b/TauCeti/CategoryTheory/GrothendieckGroup/EulerCharacteristic.lean
@@ -5,9 +5,8 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Algebra.Homology.Embedding.CochainComplex
 public import Mathlib.Algebra.Homology.QuasiIso
-public import Mathlib.Data.Int.Interval
+public import TauCeti.Algebra.Homology.Embedding.CochainComplex
 public import TauCeti.CategoryTheory.GrothendieckGroup.Abelian
 
 /-!
@@ -70,30 +69,6 @@ namespace TauCeti
 open CategoryTheory CategoryTheory.Limits ZeroObject
 
 universe w v u
-
-namespace HomologicalComplex
-
-variable {A : Type u} [Category.{v} A] [HasZeroMorphisms A]
-
-/-- A strictly bounded cochain complex is zero outside any interval supplied by its bounds. -/
-theorem isZero_X_of_notMem_Icc (K : CochainComplex A ℤ) (a b : ℤ) [K.IsStrictlyGE a]
-    [K.IsStrictlyLE b] {n : ℤ} (hn : n ∉ Finset.Icc a b) : IsZero (K.X n) := by
-  rw [Finset.mem_Icc] at hn
-  rcases lt_or_ge n a with h | h
-  · exact K.isZero_of_isStrictlyGE a n h
-  · exact K.isZero_of_isStrictlyLE b n (by omega)
-
-/-- The homology of a strictly bounded cochain complex is zero outside any interval supplied by
-its bounds. -/
-theorem isZero_homology_of_notMem_Icc (K : CochainComplex A ℤ) (a b : ℤ) [K.IsStrictlyGE a]
-    [K.IsStrictlyLE b] [∀ n, K.HasHomology n] {n : ℤ} (hn : n ∉ Finset.Icc a b) :
-    IsZero (K.homology n) := by
-  rw [Finset.mem_Icc] at hn
-  rcases lt_or_ge n a with h | h
-  · exact K.isZero_of_isGE a n h
-  · exact K.isZero_of_isLE b n (by omega)
-
-end HomologicalComplex
 
 variable {A : Type u} [Category.{v} A] [Abelian A]
 
@@ -221,12 +196,12 @@ theorem sum_negOnePow_obj_X_eq_sum_negOnePow_obj_homology (a b : ℤ) [K.IsStric
       = ∑ n ∈ Finset.Icc a b, ((n.negOnePow : ℤ)) • v.obj (K.X n) :=
     (Finset.sum_subset hs fun x _ hx => by
       rw [obj_eq_zero_of_isZero v
-        (TauCeti.HomologicalComplex.isZero_X_of_notMem_Icc K a b hx), smul_zero]).symm
+        (K.isZero_X_of_notMem_Icc a b hx), smul_zero]).symm
   have hH : ∑ n ∈ s, ((n.negOnePow : ℤ)) • v.obj (K.homology n)
       = ∑ n ∈ Finset.Icc a b, ((n.negOnePow : ℤ)) • v.obj (K.homology n) :=
     (Finset.sum_subset hs fun x _ hx => by
       rw [obj_eq_zero_of_isZero v
-        (TauCeti.HomologicalComplex.isZero_homology_of_notMem_Icc K a b hx), smul_zero]).symm
+        (K.isZero_homology_of_notMem_Icc a b hx), smul_zero]).symm
   rw [hX, hH]
   rcases le_or_gt a b with hab | hab
   · rw [sum_negOnePow_obj_Icc_aux v K a b hab,
@@ -295,7 +270,7 @@ theorem eulerChar_eq_eulerChar_Icc {s : Finset ℤ} (hs : Finset.Icc a b ⊆ s) 
     eulerChar K s = eulerChar K (Finset.Icc a b) :=
   (Finset.sum_subset hs fun x _ hx => by
     rw [of_eq_zero_of_isZero
-      (TauCeti.HomologicalComplex.isZero_X_of_notMem_Icc K a b hx), smul_zero]).symm
+      (K.isZero_X_of_notMem_Icc a b hx), smul_zero]).symm
 
 /-- Enlarging the range of degrees beyond the support of a bounded complex does not change the
 alternating class of its cohomology. -/
@@ -303,7 +278,7 @@ theorem homologyEulerChar_eq_homologyEulerChar_Icc {s : Finset ℤ} (hs : Finset
     homologyEulerChar K s = homologyEulerChar K (Finset.Icc a b) :=
   (Finset.sum_subset hs fun x _ hx => by
     rw [of_eq_zero_of_isZero
-      (TauCeti.HomologicalComplex.isZero_homology_of_notMem_Icc K a b hx), smul_zero]).symm
+      (K.isZero_homology_of_notMem_Icc a b hx), smul_zero]).symm
 
 /-- The Euler characteristic of a bounded complex does not depend on the finite range of degrees
 over which it is summed, as long as that range contains the support. -/

--- a/TauCeti/CategoryTheory/GrothendieckGroup/EulerCharacteristic.lean
+++ b/TauCeti/CategoryTheory/GrothendieckGroup/EulerCharacteristic.lean
@@ -71,13 +71,9 @@ open CategoryTheory CategoryTheory.Limits ZeroObject
 
 universe w v u
 
-variable {A : Type u} [Category.{v} A] [Abelian A]
-
-private theorem isZero_kernel_of_isZero {X Y : A} (f : X ⟶ Y) (hX : IsZero X) :
-    IsZero (kernel f) :=
-  IsZero.of_iso hX (kernelIsoOfEq (hX.eq_of_src f 0) ≪≫ kernelZeroIsoSource)
-
 namespace HomologicalComplex
+
+variable {A : Type u} [Category.{v} A] [HasZeroMorphisms A]
 
 /-- A strictly bounded cochain complex is zero outside any interval supplied by its bounds. -/
 theorem isZero_X_of_notMem_Icc (K : CochainComplex A ℤ) (a b : ℤ) [K.IsStrictlyGE a]
@@ -90,13 +86,20 @@ theorem isZero_X_of_notMem_Icc (K : CochainComplex A ℤ) (a b : ℤ) [K.IsStric
 /-- The homology of a strictly bounded cochain complex is zero outside any interval supplied by
 its bounds. -/
 theorem isZero_homology_of_notMem_Icc (K : CochainComplex A ℤ) (a b : ℤ) [K.IsStrictlyGE a]
-    [K.IsStrictlyLE b] {n : ℤ} (hn : n ∉ Finset.Icc a b) : IsZero (K.homology n) := by
+    [K.IsStrictlyLE b] [∀ n, K.HasHomology n] {n : ℤ} (hn : n ∉ Finset.Icc a b) :
+    IsZero (K.homology n) := by
   rw [Finset.mem_Icc] at hn
   rcases lt_or_ge n a with h | h
   · exact K.isZero_of_isGE a n h
   · exact K.isZero_of_isLE b n (by omega)
 
 end HomologicalComplex
+
+variable {A : Type u} [Category.{v} A] [Abelian A]
+
+private theorem isZero_kernel_of_isZero {X Y : A} (f : X ⟶ Y) (hX : IsZero X) :
+    IsZero (kernel f) :=
+  IsZero.of_iso hX (kernelIsoOfEq (hX.eq_of_src f 0) ≪≫ kernelZeroIsoSource)
 
 namespace AbelianK0
 

--- a/TauCeti/CategoryTheory/GrothendieckGroup/EulerCharacteristic.lean
+++ b/TauCeti/CategoryTheory/GrothendieckGroup/EulerCharacteristic.lean
@@ -77,19 +77,26 @@ private theorem isZero_kernel_of_isZero {X Y : A} (f : X ⟶ Y) (hX : IsZero X) 
     IsZero (kernel f) :=
   IsZero.of_iso hX (kernelIsoOfEq (hX.eq_of_src f 0) ≪≫ kernelZeroIsoSource)
 
-private theorem isZero_X_of_notMem_Icc (K : CochainComplex A ℤ) (a b : ℤ) [K.IsStrictlyGE a]
+namespace HomologicalComplex
+
+/-- A strictly bounded cochain complex is zero outside any interval supplied by its bounds. -/
+theorem isZero_X_of_notMem_Icc (K : CochainComplex A ℤ) (a b : ℤ) [K.IsStrictlyGE a]
     [K.IsStrictlyLE b] {n : ℤ} (hn : n ∉ Finset.Icc a b) : IsZero (K.X n) := by
   rw [Finset.mem_Icc] at hn
   rcases lt_or_ge n a with h | h
   · exact K.isZero_of_isStrictlyGE a n h
   · exact K.isZero_of_isStrictlyLE b n (by omega)
 
-private theorem isZero_homology_of_notMem_Icc (K : CochainComplex A ℤ) (a b : ℤ) [K.IsStrictlyGE a]
+/-- The homology of a strictly bounded cochain complex is zero outside any interval supplied by
+its bounds. -/
+theorem isZero_homology_of_notMem_Icc (K : CochainComplex A ℤ) (a b : ℤ) [K.IsStrictlyGE a]
     [K.IsStrictlyLE b] {n : ℤ} (hn : n ∉ Finset.Icc a b) : IsZero (K.homology n) := by
   rw [Finset.mem_Icc] at hn
   rcases lt_or_ge n a with h | h
   · exact K.isZero_of_isGE a n h
   · exact K.isZero_of_isLE b n (by omega)
+
+end HomologicalComplex
 
 namespace AbelianK0
 
@@ -210,11 +217,13 @@ theorem sum_negOnePow_obj_X_eq_sum_negOnePow_obj_homology (a b : ℤ) [K.IsStric
   have hX : ∑ n ∈ s, ((n.negOnePow : ℤ)) • v.obj (K.X n)
       = ∑ n ∈ Finset.Icc a b, ((n.negOnePow : ℤ)) • v.obj (K.X n) :=
     (Finset.sum_subset hs fun x _ hx => by
-      rw [obj_eq_zero_of_isZero v (isZero_X_of_notMem_Icc K a b hx), smul_zero]).symm
+      rw [obj_eq_zero_of_isZero v
+        (TauCeti.HomologicalComplex.isZero_X_of_notMem_Icc K a b hx), smul_zero]).symm
   have hH : ∑ n ∈ s, ((n.negOnePow : ℤ)) • v.obj (K.homology n)
       = ∑ n ∈ Finset.Icc a b, ((n.negOnePow : ℤ)) • v.obj (K.homology n) :=
     (Finset.sum_subset hs fun x _ hx => by
-      rw [obj_eq_zero_of_isZero v (isZero_homology_of_notMem_Icc K a b hx), smul_zero]).symm
+      rw [obj_eq_zero_of_isZero v
+        (TauCeti.HomologicalComplex.isZero_homology_of_notMem_Icc K a b hx), smul_zero]).symm
   rw [hX, hH]
   rcases le_or_gt a b with hab | hab
   · rw [sum_negOnePow_obj_Icc_aux v K a b hab,
@@ -282,14 +291,16 @@ Euler characteristic. -/
 theorem eulerChar_eq_eulerChar_Icc {s : Finset ℤ} (hs : Finset.Icc a b ⊆ s) :
     eulerChar K s = eulerChar K (Finset.Icc a b) :=
   (Finset.sum_subset hs fun x _ hx => by
-    rw [of_eq_zero_of_isZero (isZero_X_of_notMem_Icc K a b hx), smul_zero]).symm
+    rw [of_eq_zero_of_isZero
+      (TauCeti.HomologicalComplex.isZero_X_of_notMem_Icc K a b hx), smul_zero]).symm
 
 /-- Enlarging the range of degrees beyond the support of a bounded complex does not change the
 alternating class of its cohomology. -/
 theorem homologyEulerChar_eq_homologyEulerChar_Icc {s : Finset ℤ} (hs : Finset.Icc a b ⊆ s) :
     homologyEulerChar K s = homologyEulerChar K (Finset.Icc a b) :=
   (Finset.sum_subset hs fun x _ hx => by
-    rw [of_eq_zero_of_isZero (isZero_homology_of_notMem_Icc K a b hx), smul_zero]).symm
+    rw [of_eq_zero_of_isZero
+      (TauCeti.HomologicalComplex.isZero_homology_of_notMem_Icc K a b hx), smul_zero]).symm
 
 /-- The Euler characteristic of a bounded complex does not depend on the finite range of degrees
 over which it is summed, as long as that range contains the support. -/


### PR DESCRIPTION
This PR connects the bounded-complex Euler--Poincaré theorem already proved for arbitrary additive invariants to Mathlib's `HomologicalComplex.eulerChar` and `homologyEulerChar` API. It represents finite-dimensional vector spaces by `FGModuleCat k`, keeps lower and upper bounds as explicit hypotheses, proves that both `finsum` definitions are honest finite alternating finrank sums, and then derives their equality without using either totalized junk value.

It advances the GrothendieckEulerForms Layer 5 milestone **Bounded complexes and Euler--Poincaré**, specifically its target to record finite-dimensionality and boundedness explicitly for vector spaces and connect the resulting theorem to Mathlib's landed Euler-characteristic API. This is the most effective next step because the general additive-invariant Euler--Poincaré theorem is already present, while the roadmap's documented finite-dimensional Mathlib bridge was still missing.

The proof reuses `HomologicalComplex.eulerChar_eq_sum_finSet_of_finrankSupport_subset`, its homology analogue, `ModuleCat.free_shortExact_finrank_add`, and Tau Ceti's existing `AbelianK0.AdditiveInvariant.sum_negOnePow_obj_X_eq_sum_negOnePow_obj_homology`; it also constructs the exact-forgetful-functor comparison between homology in `FGModuleCat k` and `ModuleCat k`. The mathematical references are Weibel, *An Introduction to Homological Algebra*, Sections 1.3 and 1.6, and Weibel, *The K-book*, Chapter II, Proposition 6.6.

After this PR, Layer 5 still needs the Ext-finite-pair interface, long-exact-sequence additivity, descent to the relevant Grothendieck groups, and the graded counterparts required by the roadmap.

Roadmap: GrothendieckEulerForms

<!--tauceti-target:v1 {"focus":"GrothendieckEulerForms","id":"bounded-complex-finrank-euler-poincare"}-->

🤖 Prepared with Codex
