### PR TITLE
refactor(Affine): extract the vanishing criterion for the Weierstrass `W_Y` partial

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Derivative.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Derivative.lean
@@ -28,12 +28,15 @@ derivative it is named after.
 * `WeierstrassCurve.Affine.derivative_eval_polynomial`: the chain rule along a substitution
   `Y := p`, which expresses `derivative (W(X, p))` through *both* partials. For a constant
   `p = C y` the `Y`-term drops out and this reads `W_X(X, y)`.
+* `WeierstrassCurve.Affine.polynomialY_eq_zero_iff`: `W_Y` vanishes exactly in characteristic two
+  with `a₁ = a₃ = 0`, the criterion behind the next item.
 * `WeierstrassCurve.Affine.polynomialY_ne_zero`: `W_Y` is a nonzero polynomial once `Δ ≠ 0`. This
   is what makes the Weierstrass equation separable in `Y`, and so the function field a separable
   extension of the rational functions in `x`; in characteristic two the leading term of `W_Y`
   vanishes and the discriminant is what rules out `a₁ = a₃ = 0`.
 
-The first three hold over an arbitrary commutative ring; the fourth adds `Δ ≠ 0`.
+The three derivative identities and the vanishing criterion hold over an arbitrary commutative
+ring; only `polynomialY_ne_zero` adds `Δ ≠ 0`.
 
 ## Implementation notes
 
@@ -111,29 +114,34 @@ one-variable polynomial `W(X, p)` splits into the two partials of `W`, the `Y`-o
   rw [hbridge, equivPolynomial_mapCoeffs_polynomial, derivative_polynomial] at h
   simpa using h
 
-/-- The partial derivative `W_Y = 2Y + a₁X + a₃` of the Weierstrass polynomial is a nonzero
-polynomial whenever the discriminant is nonzero. In characteristic two the first term vanishes,
-and it is `Δ ≠ 0` that rules out `a₁ = a₃ = 0`. -/
-theorem polynomialY_ne_zero (hΔ : W.Δ ≠ 0) : W.polynomialY ≠ 0 := by
-  intro h
-  rw [WeierstrassCurve.Affine.polynomialY] at h
+/-- **`W_Y = 2Y + a₁X + a₃` vanishes exactly when `2 = 0` and `a₁ = a₃ = 0`.** Read as a
+polynomial in `Y` over `R[X]`, its coefficients are `2` and `a₁X + a₃`, and the coefficients of the
+latter are `a₁` and `a₃`; so the three vanish together. In particular `W_Y` can only vanish in
+characteristic two. -/
+theorem polynomialY_eq_zero_iff : W.polynomialY = 0 ↔ (2 : R) = 0 ∧ W.a₁ = 0 ∧ W.a₃ = 0 := by
+  rw [WeierstrassCurve.Affine.polynomialY]
+  refine ⟨fun h ↦ ?_, fun ⟨h2, ha₁, ha₃⟩ ↦ by simp [h2, ha₁, ha₃]⟩
   have h1 := congr_arg (fun p => p.coeff 1) h
   have h0 := congr_arg (fun p => p.coeff 0) h
   simp only [map_add, map_mul, coeff_add, coeff_mul_X, coeff_C, ↓reduceIte, coeff_mul_C,
     zero_mul, add_zero, coeff_zero, Polynomial.C_eq_zero, mul_coeff_zero, coeff_X, one_ne_zero,
     mul_zero, zero_add] at h1 h0
-  have ha1 : W.a₁ = 0 := by
-    have := congr_arg (fun p => p.coeff 1) h0
+  refine ⟨h1, ?_, ?_⟩
+  · have := congr_arg (fun p => p.coeff 1) h0
     simp only [coeff_add, coeff_mul_X, coeff_C_zero, coeff_C_succ, add_zero, coeff_zero] at this
     exact this
-  have ha3 : W.a₃ = 0 := by
-    have := congr_arg (fun p => p.coeff 0) h0
+  · have := congr_arg (fun p => p.coeff 0) h0
     simp only [coeff_add, mul_coeff_zero, coeff_C_zero, coeff_X_zero, mul_zero, zero_add,
       coeff_zero] at this
     exact this
-  -- `2 = 0` and `a₁ = a₃ = 0` together contradict `Δ ≠ 0`.
-  exact (WeierstrassCurve.a₁_ne_zero_or_a₃_ne_zero_of_Δ_ne_zero_of_two_eq_zero W hΔ h1).elim
-    (fun h => h ha1) fun h => h ha3
+
+/-- The partial derivative `W_Y = 2Y + a₁X + a₃` of the Weierstrass polynomial is a nonzero
+polynomial whenever the discriminant is nonzero. In characteristic two the first term vanishes,
+and it is `Δ ≠ 0` that rules out `a₁ = a₃ = 0`. -/
+theorem polynomialY_ne_zero (hΔ : W.Δ ≠ 0) : W.polynomialY ≠ 0 := fun h ↦
+  have ⟨two, ha₁, ha₃⟩ := W.polynomialY_eq_zero_iff.mp h
+  (WeierstrassCurve.a₁_ne_zero_or_a₃_ne_zero_of_Δ_ne_zero_of_two_eq_zero W hΔ two).elim
+    (fun h ↦ h ha₁) fun h ↦ h ha₃
 
 end WeierstrassCurve.Affine
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Derivative.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Derivative.lean
@@ -117,6 +117,7 @@ one-variable polynomial `W(X, p)` splits into the two partials of `W`, the `Y`-o
 /-- **`W_Y = 2Y + a₁X + a₃` vanishes exactly when `2 = 0` and `a₁ = a₃ = 0`.** So `W_Y` is a
 nonzero polynomial wherever `2 ≠ 0`, and where `2 = 0` it is nonzero exactly when `a₁ ≠ 0` or
 `a₃ ≠ 0`; `polynomialY_ne_zero` draws the latter from `Δ ≠ 0`. -/
+@[simp]
 theorem polynomialY_eq_zero_iff : W.polynomialY = 0 ↔ (2 : R) = 0 ∧ W.a₁ = 0 ∧ W.a₃ = 0 := by
   refine ⟨fun h ↦ ?_, fun ⟨h2, ha₁, ha₃⟩ ↦ by simp [polynomialY, h2, ha₁, ha₃]⟩
   -- Read `W_Y` as a polynomial in `Y` over `R[X]`: its coefficients are `2` and `a₁X + a₃`, whose

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Derivative.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Derivative.lean
@@ -28,15 +28,15 @@ derivative it is named after.
 * `WeierstrassCurve.Affine.derivative_eval_polynomial`: the chain rule along a substitution
   `Y := p`, which expresses `derivative (W(X, p))` through *both* partials. For a constant
   `p = C y` the `Y`-term drops out and this reads `W_X(X, y)`.
-* `WeierstrassCurve.Affine.polynomialY_eq_zero_iff`: `W_Y` vanishes exactly in characteristic two
-  with `a₁ = a₃ = 0`, the criterion behind the next item.
+* `WeierstrassCurve.Affine.polynomialY_eq_zero_iff`: `W_Y` vanishes exactly when `2 = 0` and
+  `a₁ = a₃ = 0`, the criterion behind `polynomialY_ne_zero`.
 * `WeierstrassCurve.Affine.polynomialY_ne_zero`: `W_Y` is a nonzero polynomial once `Δ ≠ 0`. This
   is what makes the Weierstrass equation separable in `Y`, and so the function field a separable
   extension of the rational functions in `x`; in characteristic two the leading term of `W_Y`
   vanishes and the discriminant is what rules out `a₁ = a₃ = 0`.
 
-The three derivative identities and the vanishing criterion hold over an arbitrary commutative
-ring; only `polynomialY_ne_zero` adds `Δ ≠ 0`.
+Every statement here holds over an arbitrary commutative ring; only `polynomialY_ne_zero` carries
+a further hypothesis, `Δ ≠ 0`.
 
 ## Implementation notes
 
@@ -114,34 +114,24 @@ one-variable polynomial `W(X, p)` splits into the two partials of `W`, the `Y`-o
   rw [hbridge, equivPolynomial_mapCoeffs_polynomial, derivative_polynomial] at h
   simpa using h
 
-/-- **`W_Y = 2Y + a₁X + a₃` vanishes exactly when `2 = 0` and `a₁ = a₃ = 0`.** Read as a
-polynomial in `Y` over `R[X]`, its coefficients are `2` and `a₁X + a₃`, and the coefficients of the
-latter are `a₁` and `a₃`; so the three vanish together. In particular `W_Y` can only vanish in
-characteristic two. -/
+/-- **`W_Y = 2Y + a₁X + a₃` vanishes exactly when `2 = 0` and `a₁ = a₃ = 0`.** So `W_Y` is a
+nonzero polynomial wherever `2 ≠ 0`, and where `2 = 0` it is nonzero exactly when `a₁ ≠ 0` or
+`a₃ ≠ 0`; `polynomialY_ne_zero` draws the latter from `Δ ≠ 0`. -/
 theorem polynomialY_eq_zero_iff : W.polynomialY = 0 ↔ (2 : R) = 0 ∧ W.a₁ = 0 ∧ W.a₃ = 0 := by
-  rw [WeierstrassCurve.Affine.polynomialY]
-  refine ⟨fun h ↦ ?_, fun ⟨h2, ha₁, ha₃⟩ ↦ by simp [h2, ha₁, ha₃]⟩
-  have h1 := congr_arg (fun p => p.coeff 1) h
-  have h0 := congr_arg (fun p => p.coeff 0) h
-  simp only [map_add, map_mul, coeff_add, coeff_mul_X, coeff_C, ↓reduceIte, coeff_mul_C,
-    zero_mul, add_zero, coeff_zero, Polynomial.C_eq_zero, mul_coeff_zero, coeff_X, one_ne_zero,
-    mul_zero, zero_add] at h1 h0
-  refine ⟨h1, ?_, ?_⟩
-  · have := congr_arg (fun p => p.coeff 1) h0
-    simp only [coeff_add, coeff_mul_X, coeff_C_zero, coeff_C_succ, add_zero, coeff_zero] at this
-    exact this
-  · have := congr_arg (fun p => p.coeff 0) h0
-    simp only [coeff_add, mul_coeff_zero, coeff_C_zero, coeff_X_zero, mul_zero, zero_add,
-      coeff_zero] at this
-    exact this
+  refine ⟨fun h ↦ ?_, fun ⟨h2, ha₁, ha₃⟩ ↦ by simp [polynomialY, h2, ha₁, ha₃]⟩
+  -- Read `W_Y` as a polynomial in `Y` over `R[X]`: its coefficients are `2` and `a₁X + a₃`, whose
+  -- own coefficients are `a₁` and `a₃`.
+  have h0 : C W.a₁ * X + C W.a₃ = 0 := by simpa [polynomialY] using congrArg (·.coeff 0) h
+  exact ⟨by simpa [polynomialY] using congrArg (·.coeff 1) h,
+    by simpa using congrArg (·.coeff 1) h0, by simpa using congrArg (·.coeff 0) h0⟩
 
 /-- The partial derivative `W_Y = 2Y + a₁X + a₃` of the Weierstrass polynomial is a nonzero
 polynomial whenever the discriminant is nonzero. In characteristic two the first term vanishes,
-and it is `Δ ≠ 0` that rules out `a₁ = a₃ = 0`. -/
+and it is `Δ ≠ 0` that rules out `a₁ = a₃ = 0`; the criterion carrying no hypothesis on `Δ` is
+`polynomialY_eq_zero_iff`. -/
 theorem polynomialY_ne_zero (hΔ : W.Δ ≠ 0) : W.polynomialY ≠ 0 := fun h ↦
-  have ⟨two, ha₁, ha₃⟩ := W.polynomialY_eq_zero_iff.mp h
-  (WeierstrassCurve.a₁_ne_zero_or_a₃_ne_zero_of_Δ_ne_zero_of_two_eq_zero W hΔ two).elim
-    (fun h ↦ h ha₁) fun h ↦ h ha₃
+  have ⟨h2, ha₁, ha₃⟩ := polynomialY_eq_zero_iff.mp h
+  (a₁_ne_zero_or_a₃_ne_zero_of_Δ_ne_zero_of_two_eq_zero W hΔ h2).elim (· ha₁) (· ha₃)
 
 end WeierstrassCurve.Affine
 


### PR DESCRIPTION
`polynomialY_ne_zero`'s proof already derived `2 = 0`, `a₁ = 0` and `a₃ = 0` from
`polynomialY = 0`, and only then contradicted them against the discriminant. That criterion is the
reusable half of the argument, so this states it on its own:

```lean
@[simp]
theorem polynomialY_eq_zero_iff : W.polynomialY = 0 ↔ (2 : R) = 0 ∧ W.a₁ = 0 ∧ W.a₃ = 0
```

It is marked `@[simp]`: the orientation replaces a polynomial equality with scalar ones and cannot
loop. Every in-repository module mentioning `polynomialY` still builds with it registered.

`polynomialY_ne_zero` becomes a three-line corollary with its statement unchanged, so its two
in-repository consumers — `Affine/FunctionField/GenericPoint.lean` and
`Affine/FunctionField/Separable.lean` — are untouched and still build.

## Why the criterion is worth stating

Mathlib's `W_Y = 2Y + a₁X + a₃` can only vanish in characteristic two, and then only when
`a₁ = a₃ = 0`. That is the case in which the Weierstrass equation is inseparable in `Y`, so the
function field is not a separable extension of the rational functions in `x`;
`isSeparable_functionField_iff` already records the equivalence with `W_Y ≠ 0`. What the criterion
adds is the concrete shape of the curve in the failing case — `y² = x³ + a₂x² + a₄x + a₆` over a
field of characteristic two — which is what any argument treating that branch has to work with.

## Docstring

The module docstring said "The first three hold over an arbitrary commutative ring; the fourth adds
`Δ ≠ 0`". Adding a statement to the file falsifies that sentence, so it is replaced by one naming
the declarations instead of counting them.

Roadmap: EllipticCurves

This is a refactor of existing code and makes no fresh roadmap claim: the criterion was already
proved inside `polynomialY_ne_zero`, and is only being restated. `EllipticCurves` is the roadmap
chiefly motivating the file — its Layer 1 isogeny and formal-group milestones are what consume
`W_Y`'s non-vanishing.

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"refactor:Affine/Derivative.lean:polynomialY_eq_zero_iff"}-->

Provenance: original work — an extraction from this repository's own
`TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Derivative.lean`, declaration
`polynomialY_ne_zero`, whose proof already contained the criterion. No external source.
