### PR TITLE
chore: AI-gate the bibliography, matching the scope check

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,3 +25,11 @@
 # bypasses code-owner review for a direct merge, but not at enqueue time), so they are AI-gated.
 /lake-manifest.json
 /lean-toolchain
+
+# The bibliography doc-gen4 resolves docstring citations against. pr-build.yml already permits it
+# for the same reason it permits the pins, and states that reasoning at length: filling in an entry
+# is the same work as writing the docstring that cites it, and it is BibTeX read only by the pages
+# build, never by Lake or the harness. Leaving it human-owned here left the two definitions of
+# "in scope" disagreeing, and #4029 sat fully green for six days as a result. The rest of docbuild/
+# stays human-owned; its lakefile, pin and generator scripts feed the docs build itself.
+/docbuild/docs/references.bib


### PR DESCRIPTION
This PR adds `docbuild/docs/references.bib` to the AI-gated section of CODEOWNERS, so it stops requiring a human code owner.

`pr-build.yml` already treats that path as in scope and argues the case at length: filling in an entry is the same work as writing the docstring that cites it, and the file is BibTeX read only by the pages build, never by Lake or the review harness. CODEOWNERS never followed, so the two definitions of "in scope" disagreed and every bibliography change still fell to `*`.

#4029 is what that costs. One file of BibTeX entries, with `build`, `bump-guard` and `scope` all green and all ten rubrics green at its head, sitting since 2 September because CODEOWNERS matched it against `*`.

The rest of `docbuild/` stays human-owned: its lakefile, its pin, and the two generator scripts feed the docs build itself.

This is only half of what #4029 needs. The merge runner keeps its own allowed-extras list in TauCetiReview, which already contains this path as of `d1e9e43` on 2 September, but the merge workflows here pin `b613bf8`, which predates it. Bumping that pin is a separate change, opened separately, because it also moves merge-queue reconciliation semantics and should be judged on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)