### PR TITLE
chore: bump the merge runner pin so the bibliography allowance takes effect

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -76,10 +76,10 @@ jobs:
     if: ${{ needs.resolve.outputs.pr != '' }}
     # Pinned to a TauCetiReview commit; bump deliberately. The reusable workflow receives the App
     # secrets, so a floating @main would be a supply-chain risk.
-    uses: TauCetiProject/TauCetiReview/.github/workflows/merge-only.yml@b613bf827a7acfecf858e6c44e20c28df602239b
+    uses: TauCetiProject/TauCetiReview/.github/workflows/merge-only.yml@afb424eda89e8ac96d9eb69f6a88972055a4cd1b
     with:
       pr: ${{ needs.resolve.outputs.pr }}
-      review_ref: b613bf827a7acfecf858e6c44e20c28df602239b
+      review_ref: afb424eda89e8ac96d9eb69f6a88972055a4cd1b
     # Pass only the App credentials merge-only needs, not all of TauCeti's secrets.
     secrets:
       APP_ID: ${{ secrets.APP_ID }}

--- a/.github/workflows/merge-sweep.yml
+++ b/.github/workflows/merge-sweep.yml
@@ -32,10 +32,10 @@ jobs:
   sweep:
     # Pinned to a TauCetiReview commit; bump deliberately. The reusable workflow receives the App
     # secrets, so a floating @main would be a supply-chain risk.
-    uses: TauCetiProject/TauCetiReview/.github/workflows/merge-sweep.yml@b613bf827a7acfecf858e6c44e20c28df602239b
+    uses: TauCetiProject/TauCetiReview/.github/workflows/merge-sweep.yml@afb424eda89e8ac96d9eb69f6a88972055a4cd1b
     with:
       dry_run: ${{ inputs.dry-run || false }}
-      review_ref: b613bf827a7acfecf858e6c44e20c28df602239b
+      review_ref: afb424eda89e8ac96d9eb69f6a88972055a4cd1b
     secrets:
       APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
This PR moves the TauCetiReview pin in `auto-merge.yml` and `merge-sweep.yml` from `b613bf8` to `afb424e`, so that the bibliography entry already present in the runner's allowed extras actually applies.

The runner gained `docbuild/docs/references.bib` in its allowed extras on 2 September, in `d1e9e43`. The workflows here pin `b613bf8`, a branch commit from 30 August whose squashed equivalent is on main, so the running merge gate has never had that entry. That is why #4029 is green on every check and every rubric and still cannot be enqueued.

The pin exists because the reusable workflow receives the App secrets, and its own comment says to bump it deliberately. So, read rather than assumed, this is what the bump pulls in:

- `d1e9e43` the bibliography in the allowed extras, the reason for the bump
- `f2efe54` verify scoreboard ownership before mutation, a security fix
- `74f120a` tolerate non-message events in Claude tool traces
- `afb424e` rubric wording changes
- `22bac7a` the merge-queue churn fix the old pin already carried, in squashed form

The change worth judging on its own is in `merge-only.yml`. Queue reconciliation moves from "every current-head scoreboard must be green" to "the newest completed current-head scoreboard", with a live review delaying enqueue rather than revoking a completed verdict, and dequeue now checks queue membership before mutating. That is a real change to how merges are decided. It is upstream's work, not mine, but it lands with this bump and is the reason this is a separate pull request from the CODEOWNERS change in #6018.

Nothing here changes secret handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)