### PR TITLE
feat: k-labeled graphs, connection matrices and reflection positivity

### DIFF
--- a/TauCeti/Combinatorics/DenseGraphLimits/Representability/ConnectionMatrix.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/Representability/ConnectionMatrix.lean
@@ -24,8 +24,8 @@ of the Lovász–Szegedy representability theorem.
 
 * `TauCeti.DenseGraphLimits.GraphParam` is a real parameter of finite simple graphs, with
   `TauCeti.DenseGraphLimits.IsIsoInvariant` imposing agreement along isomorphisms;
-* `TauCeti.DenseGraphLimits.connectionMatrix` is a finite principal block of the connection
-  matrix `M(f, k)`;
+* `TauCeti.DenseGraphLimits.connectionMatrix` is an indexed block of the connection matrix
+  `M(f, k)`;
 * `TauCeti.DenseGraphLimits.IsReflectionPositive`,
   `TauCeti.DenseGraphLimits.IsMultiplicative` and
   `TauCeti.DenseGraphLimits.IsNormalized` are the three remaining structural conditions.
@@ -55,6 +55,8 @@ a connection matrix on `ι` is a submatrix of one on `Fin (Fintype.card ι)` alo
 
 ## References
 
+* `TauCetiRoadmap/DenseGraphLimits/Suggested.lean` — suggested signatures for the Layer 8 gluing
+  and connection-matrix API.
 * L. Lovász, B. Szegedy, *Limits of dense graph sequences*, JCTB 96 (2006), 933–957, Theorem 2.2 —
   the four structural conditions and the representability theorem they characterise.
 * L. Lovász, *Large Networks and Graph Limits*, AMS Colloquium Publications 60 (2012), Chapters 5
@@ -78,8 +80,8 @@ def IsIsoInvariant (f : GraphParam) : Prop :=
 
 /-- The **connection matrix** of a graph parameter on a family `A : ι → LabeledGraph k` of
 `k`-labeled graphs: the `ι × ι` matrix whose `(i, j)` entry is `f` on the unlabeled graph
-underlying the gluing of `A i` and `A j`.  It is a finite principal block of the full connection
-matrix `M(f, k)`. -/
+underlying the gluing of `A i` and `A j`.  It is an indexed block of the full connection matrix
+`M(f, k)`. -/
 noncomputable def connectionMatrix (f : GraphParam) {k : ℕ} {ι : Type*} (A : ι → LabeledGraph k) :
     Matrix ι ι ℝ :=
   Matrix.of fun i j =>

--- a/TauCeti/Combinatorics/DenseGraphLimits/Representability/ConnectionMatrix.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/Representability/ConnectionMatrix.lean
@@ -32,6 +32,11 @@ of the Lovász–Szegedy representability theorem.
 
 ## Main results
 
+* `TauCeti.DenseGraphLimits.isIsoInvariant_iff`,
+  `TauCeti.DenseGraphLimits.isReflectionPositive_iff`,
+  `TauCeti.DenseGraphLimits.isMultiplicative_iff` and
+  `TauCeti.DenseGraphLimits.isNormalized_iff` are the characteristic laws of the four structural
+  conditions, by which each of them is both established and applied;
 * `TauCeti.DenseGraphLimits.isHermitian_connectionMatrix` — isomorphism invariance makes connection
   matrices Hermitian because the two gluing orders are isomorphic;
 * `TauCeti.DenseGraphLimits.IsReflectionPositive.posSemidef` reindexes the definition, which
@@ -55,12 +60,14 @@ a connection matrix on `ι` is a submatrix of one on `Fin (Fintype.card ι)` alo
 
 ## References
 
-* `TauCetiRoadmap/DenseGraphLimits/Suggested.lean` — source for the formal signatures.
 * L. Lovász, B. Szegedy, *Limits of dense graph sequences*, JCTB 96 (2006), 933–957, Theorem 2.2 —
   the four structural conditions and the representability theorem they characterise.
 * L. Lovász, *Large Networks and Graph Limits*, AMS Colloquium Publications 60 (2012), Chapters 5
   and 6.
 -/
+
+-- Provenance: the names and signatures of the declarations below follow
+-- `TauCetiRoadmap/DenseGraphLimits/Suggested.lean`.
 
 public section
 
@@ -76,6 +83,19 @@ labelling-sensitive function on `Fin n`. -/
 def IsIsoInvariant (f : GraphParam) : Prop :=
   ∀ (n₁ n₂ : ℕ) (F₁ : SimpleGraph (Fin n₁)) (F₂ : SimpleGraph (Fin n₂)),
     Nonempty (F₁ ≃g F₂) → f n₁ F₁ = f n₂ F₂
+
+/-- **Characteristic law of isomorphism invariance**: `f` is isomorphism invariant exactly when it
+takes equal values at any two isomorphic graphs.  This is both the way to prove `IsIsoInvariant`
+and the way to apply it. -/
+theorem isIsoInvariant_iff {f : GraphParam} :
+    IsIsoInvariant f ↔ ∀ (n₁ n₂ : ℕ) (F₁ : SimpleGraph (Fin n₁)) (F₂ : SimpleGraph (Fin n₂)),
+      Nonempty (F₁ ≃g F₂) → f n₁ F₁ = f n₂ F₂ := (Iff.rfl)
+
+/-- An isomorphism-invariant parameter agrees along an isomorphism. -/
+theorem IsIsoInvariant.eq_of_iso {f : GraphParam} (hf : IsIsoInvariant f) {n₁ n₂ : ℕ}
+    {F₁ : SimpleGraph (Fin n₁)} {F₂ : SimpleGraph (Fin n₂)} (e : F₁ ≃g F₂) :
+    f n₁ F₁ = f n₂ F₂ :=
+  isIsoInvariant_iff.1 hf _ _ _ _ ⟨e⟩
 
 /-- The **connection matrix** of a graph parameter on a family `A : ι → LabeledGraph k` of
 `k`-labeled graphs: the `ι × ι` matrix whose `(i, j)` entry is `f` on the unlabeled graph
@@ -100,7 +120,7 @@ isomorphism. -/
 theorem connectionMatrix_comm (f : GraphParam) (hf : IsIsoInvariant f) {k : ℕ} {ι : Type*}
     (A : ι → LabeledGraph k) (i j : ι) :
     connectionMatrix f A i j = connectionMatrix f A j i :=
-  hf _ _ _ _ ⟨LabeledGraph.glueCommIso (A i) (A j)⟩
+  hf.eq_of_iso (LabeledGraph.glueCommIso (A i) (A j))
 
 /-- Connection matrices of an isomorphism-invariant parameter are Hermitian because the two
 gluing orders are isomorphic. -/
@@ -117,6 +137,13 @@ type. -/
 def IsReflectionPositive (f : GraphParam) : Prop :=
   ∀ (k n : ℕ) (A : Fin n → LabeledGraph k), (connectionMatrix f A).PosSemidef
 
+/-- **Characteristic law of reflection positivity**: `f` is reflection positive exactly when the
+connection matrix of every `Fin n`-indexed family of `k`-labeled graphs is positive semidefinite.
+This is both the way to prove `IsReflectionPositive` and the way to apply it. -/
+theorem isReflectionPositive_iff {f : GraphParam} :
+    IsReflectionPositive f ↔
+      ∀ (k n : ℕ) (A : Fin n → LabeledGraph k), (connectionMatrix f A).PosSemidef := (Iff.rfl)
+
 /-- A graph parameter is **multiplicative** when it turns disjoint unions into products, with the
 disjoint union reindexed to `Fin (n₁ + n₂)` along `finSumFinEquiv` to stay on
 `Fin`-representatives. -/
@@ -124,8 +151,20 @@ def IsMultiplicative (f : GraphParam) : Prop :=
   ∀ (n₁ n₂ : ℕ) (F₁ : SimpleGraph (Fin n₁)) (F₂ : SimpleGraph (Fin n₂)),
     f (n₁ + n₂) ((F₁ ⊕g F₂).map finSumFinEquiv.toEmbedding) = f n₁ F₁ * f n₂ F₂
 
+/-- **Characteristic law of multiplicativity**: `f` is multiplicative exactly when it sends every
+reindexed disjoint union to the product of the two values.  This is both the way to prove
+`IsMultiplicative` and the way to apply it. -/
+theorem isMultiplicative_iff {f : GraphParam} :
+    IsMultiplicative f ↔ ∀ (n₁ n₂ : ℕ) (F₁ : SimpleGraph (Fin n₁)) (F₂ : SimpleGraph (Fin n₂)),
+      f (n₁ + n₂) ((F₁ ⊕g F₂).map finSumFinEquiv.toEmbedding) = f n₁ F₁ * f n₂ F₂ := (Iff.rfl)
+
 /-- A graph parameter is **normalized** when its value on the one-vertex graph `K₁` is `1`. -/
 def IsNormalized (f : GraphParam) : Prop := f 1 ⊥ = 1
+
+/-- **Characteristic law of normalization**: `f` is normalized exactly when its value at the
+one-vertex graph `K₁` is `1`.  This is both the way to prove `IsNormalized` and the way to apply
+it. -/
+theorem isNormalized_iff {f : GraphParam} : IsNormalized f ↔ f 1 ⊥ = 1 := (Iff.rfl)
 
 /-- Reflection positivity for an arbitrary finite index type.  A connection matrix on `ι` is the
 `Fintype.equivFin ι` submatrix of one on `Fin (Fintype.card ι)`, and positive semidefiniteness is

--- a/TauCeti/Combinatorics/DenseGraphLimits/Representability/ConnectionMatrix.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/Representability/ConnectionMatrix.lean
@@ -9,7 +9,6 @@ public import TauCeti.Combinatorics.DenseGraphLimits.Representability.LabeledGra
 public import Mathlib.Combinatorics.SimpleGraph.Sum
 public import Mathlib.Algebra.Order.Star.Real
 public import Mathlib.LinearAlgebra.Matrix.PosDef
-public import Mathlib.Logic.Equiv.Fin.Basic
 
 /-!
 # Graph parameters, connection matrices and reflection positivity

--- a/TauCeti/Combinatorics/DenseGraphLimits/Representability/ConnectionMatrix.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/Representability/ConnectionMatrix.lean
@@ -38,8 +38,8 @@ of the Lovász–Szegedy representability theorem.
   quantifies over `Fin n`-indexed families, to an arbitrary finite index type;
 * `TauCeti.DenseGraphLimits.IsReflectionPositive.nonneg_glue_self` is the diagonal consequence
   `0 ≤ f` on a self-gluing;
-* `TauCeti.DenseGraphLimits.IsMultiplicative.apply_sum_bot` is the added-vertex identity
-  `f (F ⊔ K₁) = f F`.
+* `TauCeti.DenseGraphLimits.IsMultiplicative.apply_sum_bot` says adjoining any finite edgeless
+  graph does not change a multiplicative, normalized parameter.
 
 The section `Examples` records that the four conditions are simultaneously satisfiable — the
 parameter constantly `1`, which is the homomorphism density of the constant graphon `W ≡ 1` — and
@@ -55,8 +55,7 @@ a connection matrix on `ι` is a submatrix of one on `Fin (Fintype.card ι)` alo
 
 ## References
 
-* `TauCetiRoadmap/DenseGraphLimits/Suggested.lean` — suggested signatures for the Layer 8 gluing
-  and connection-matrix API.
+* `TauCetiRoadmap/DenseGraphLimits/Suggested.lean` — source for the formal signatures.
 * L. Lovász, B. Szegedy, *Limits of dense graph sequences*, JCTB 96 (2006), 933–957, Theorem 2.2 —
   the four structural conditions and the representability theorem they characterise.
 * L. Lovász, *Large Networks and Graph Limits*, AMS Colloquium Publications 60 (2012), Chapters 5
@@ -148,11 +147,30 @@ theorem IsReflectionPositive.nonneg_glue_self {f : GraphParam} (hf : IsReflectio
   have h := (hf.posSemidef fun _ : Fin 1 => G).diag_nonneg (i := 0)
   simpa [connectionMatrix] using h
 
-/-- A multiplicative, normalized parameter is unchanged by adjoining an isolated vertex. -/
+/-- A multiplicative, normalized parameter is `1` on every edgeless graph. -/
+theorem IsMultiplicative.apply_bot {f : GraphParam} (hmul : IsMultiplicative f)
+    (hnorm : IsNormalized f) (n : ℕ) : f n (⊥ : SimpleGraph (Fin n)) = 1 := by
+  have map_sum_bot (a b : ℕ) :
+      (((⊥ : SimpleGraph (Fin a)) ⊕g (⊥ : SimpleGraph (Fin b))).map
+        finSumFinEquiv.toEmbedding) = ⊥ := by
+    rw [eq_bot_iff, SimpleGraph.map_le_iff_le_comap]
+    intro u v huv
+    cases u <;> cases v <;> simp_all
+  induction n with
+  | zero =>
+      have h := hmul 0 1 (⊥ : SimpleGraph (Fin 0)) (⊥ : SimpleGraph (Fin 1))
+      rw [map_sum_bot, hnorm, mul_one] at h
+      simpa using h.symm
+  | succ n ih =>
+      have h := hmul n 1 (⊥ : SimpleGraph (Fin n)) (⊥ : SimpleGraph (Fin 1))
+      rw [map_sum_bot, ih, hnorm, mul_one] at h
+      simpa using h
+
+/-- A multiplicative, normalized parameter is unchanged by adjoining any finite edgeless graph. -/
 theorem IsMultiplicative.apply_sum_bot {f : GraphParam} (hmul : IsMultiplicative f)
-    (hnorm : IsNormalized f) (n : ℕ) (F : SimpleGraph (Fin n)) :
-    f (n + 1) ((F ⊕g (⊥ : SimpleGraph (Fin 1))).map finSumFinEquiv.toEmbedding) = f n F := by
-  rw [hmul n 1 F ⊥, hnorm, mul_one]
+    (hnorm : IsNormalized f) (n m : ℕ) (F : SimpleGraph (Fin n)) :
+    f (n + m) ((F ⊕g (⊥ : SimpleGraph (Fin m))).map finSumFinEquiv.toEmbedding) = f n F := by
+  rw [hmul n m F ⊥, hmul.apply_bot hnorm m, mul_one]
 
 section Examples
 

--- a/TauCeti/Combinatorics/DenseGraphLimits/Representability/ConnectionMatrix.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/Representability/ConnectionMatrix.lean
@@ -195,11 +195,15 @@ theorem IsMultiplicative.apply_bot {f : GraphParam} (hmul : IsMultiplicative f)
   induction n with
   | zero =>
       have h := hmul 0 1 (⊥ : SimpleGraph (Fin 0)) (⊥ : SimpleGraph (Fin 1))
-      rw [map_sum_bot_bot, hnorm, mul_one] at h
+      rw [SimpleGraph.sum_bot_bot,
+        GaloisConnection.l_bot (SimpleGraph.map_le_iff_le_comap finSumFinEquiv.toEmbedding),
+        hnorm, mul_one] at h
       simpa using h.symm
   | succ n ih =>
       have h := hmul n 1 (⊥ : SimpleGraph (Fin n)) (⊥ : SimpleGraph (Fin 1))
-      rw [map_sum_bot_bot, ih, hnorm, mul_one] at h
+      rw [SimpleGraph.sum_bot_bot,
+        GaloisConnection.l_bot (SimpleGraph.map_le_iff_le_comap finSumFinEquiv.toEmbedding),
+        ih, hnorm, mul_one] at h
       simpa using h
 
 /-- A multiplicative, normalized parameter is unchanged by adjoining any finite edgeless graph. -/

--- a/TauCeti/Combinatorics/DenseGraphLimits/Representability/ConnectionMatrix.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/Representability/ConnectionMatrix.lean
@@ -111,16 +111,15 @@ theorem connectionMatrix_apply (f : GraphParam) {k : ℕ} {ι : Type*} (A : ι �
     (i j : ι) :
     connectionMatrix f A i j
       = f ((A i).glue (A j)).forgetLabels.1 ((A i).glue (A j)).forgetLabels.2 := by
-  rw [connectionMatrix.eq_1]
-  rfl
+  simp [connectionMatrix]
 
 /-- Connection matrices of an isomorphism-invariant parameter are symmetric: gluing commutes up to
 isomorphism. -/
 theorem connectionMatrix_comm (f : GraphParam) (hf : IsIsoInvariant f) {k : ℕ} {ι : Type*}
     (A : ι → LabeledGraph k) (i j : ι) :
     connectionMatrix f A i j = connectionMatrix f A j i := by
-  rw [connectionMatrix_apply, connectionMatrix_apply, LabeledGraph.forgetLabels_eq,
-    LabeledGraph.forgetLabels_eq]
+  rw [connectionMatrix_apply, connectionMatrix_apply, LabeledGraph.forgetLabels_def,
+    LabeledGraph.forgetLabels_def]
   exact hf.eq_of_iso (LabeledGraph.glueCommIso (A i) (A j))
 
 /-- Connection matrices of an isomorphism-invariant parameter are Hermitian because the two
@@ -187,7 +186,7 @@ nonnegative on every self-gluing. -/
 theorem IsReflectionPositive.nonneg_glue_self {f : GraphParam} (hf : IsReflectionPositive f)
     {k : ℕ} (G : LabeledGraph k) : 0 ≤ f (G.glue G).n (G.glue G).graph := by
   have h := (hf.posSemidef fun _ : Fin 1 => G).diag_nonneg (i := 0)
-  rw [connectionMatrix_apply, LabeledGraph.forgetLabels_eq] at h
+  rw [connectionMatrix_apply, LabeledGraph.forgetLabels_def] at h
   exact h
 
 /-- A multiplicative, normalized parameter is `1` on every edgeless graph. -/
@@ -226,7 +225,7 @@ theorem isMultiplicative_one : IsMultiplicative fun _ _ => (1 : ℝ) :=
 
 /-- The constant parameter `1` is normalized. -/
 theorem isNormalized_one : IsNormalized fun _ _ => (1 : ℝ) := by
-  rw [IsNormalized.eq_1]
+  simp only [IsNormalized]
 
 /-- The constant parameter `1` is reflection positive: its connection matrices are the all-ones
 matrices, the outer square of the all-ones vector. -/

--- a/TauCeti/Combinatorics/DenseGraphLimits/Representability/ConnectionMatrix.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/Representability/ConnectionMatrix.lean
@@ -32,14 +32,14 @@ of the Lovász–Szegedy representability theorem.
 
 ## Main results
 
-* `TauCeti.DenseGraphLimits.isHermitian_connectionMatrix` — an isomorphism-invariant parameter has
-  symmetric connection matrices, so reflection positivity is not asking for the impossible;
+* `TauCeti.DenseGraphLimits.isHermitian_connectionMatrix` — isomorphism invariance makes connection
+  matrices Hermitian because the two gluing orders are isomorphic;
 * `TauCeti.DenseGraphLimits.IsReflectionPositive.posSemidef` reindexes the definition, which
   quantifies over `Fin n`-indexed families, to an arbitrary finite index type;
 * `TauCeti.DenseGraphLimits.IsReflectionPositive.nonneg_glue_self` is the diagonal consequence
   `0 ≤ f` on a self-gluing;
-* `TauCeti.DenseGraphLimits.IsMultiplicative.apply_sum_bot` is the added-vertex telescope
-  `f (F ⊔ K₁) = f F`, the step the representability spine runs on.
+* `TauCeti.DenseGraphLimits.IsMultiplicative.apply_sum_bot` is the added-vertex identity
+  `f (F ⊔ K₁) = f F`.
 
 The section `Examples` records that the four conditions are simultaneously satisfiable — the
 parameter constantly `1`, which is the homomorphism density of the constant graphon `W ≡ 1` — and
@@ -59,13 +59,9 @@ a connection matrix on `ι` is a submatrix of one on `Fin (Fintype.card ι)` alo
   the four structural conditions and the representability theorem they characterise.
 * L. Lovász, *Large Networks and Graph Limits*, AMS Colloquium Publications 60 (2012), Chapters 5
   and 6.
-* Roadmap: `TauCetiRoadmap/DenseGraphLimits/README.md`, Layer 8a — quantum graphs and reflection
-  positivity.  The signatures follow `TauCetiRoadmap/DenseGraphLimits/Suggested.lean`; the
-  Layer-8b Möbius spine and `lovasz_szegedy_representability` itself are separate targets and are
-  not built here.
 -/
 
-@[expose] public section
+public section
 
 namespace TauCeti.DenseGraphLimits
 
@@ -90,10 +86,13 @@ noncomputable def connectionMatrix (f : GraphParam) {k : ℕ} {ι : Type*} (A : 
     f ((A i).glue (A j)).forgetLabels.1 ((A i).glue (A j)).forgetLabels.2
 
 /-- The connection-matrix entry law. -/
+@[simp]
 theorem connectionMatrix_apply (f : GraphParam) {k : ℕ} {ι : Type*} (A : ι → LabeledGraph k)
     (i j : ι) :
     connectionMatrix f A i j
-      = f ((A i).glue (A j)).forgetLabels.1 ((A i).glue (A j)).forgetLabels.2 := rfl
+      = f ((A i).glue (A j)).forgetLabels.1 ((A i).glue (A j)).forgetLabels.2 := by
+  rw [connectionMatrix.eq_1]
+  rfl
 
 /-- Connection matrices of an isomorphism-invariant parameter are symmetric: gluing commutes up to
 isomorphism. -/
@@ -102,9 +101,8 @@ theorem connectionMatrix_comm (f : GraphParam) (hf : IsIsoInvariant f) {k : ℕ}
     connectionMatrix f A i j = connectionMatrix f A j i :=
   hf _ _ _ _ ⟨LabeledGraph.glueCommIso (A i) (A j)⟩
 
-/-- Connection matrices of an isomorphism-invariant parameter are Hermitian.  Positive
-semidefiniteness includes this condition, so without isomorphism invariance reflection positivity
-would be asking for something a parameter cannot supply. -/
+/-- Connection matrices of an isomorphism-invariant parameter are Hermitian because the two
+gluing orders are isomorphic. -/
 theorem isHermitian_connectionMatrix (f : GraphParam) (hf : IsIsoInvariant f) {k : ℕ} {ι : Type*}
     (A : ι → LabeledGraph k) : (connectionMatrix f A).IsHermitian := by
   refine Matrix.ext fun i j => ?_
@@ -113,8 +111,8 @@ theorem isHermitian_connectionMatrix (f : GraphParam) (hf : IsIsoInvariant f) {k
 
 /-- A graph parameter is **reflection positive** when every finite connection matrix is positive
 semidefinite — every finite principal block of each `M(f, k)` is PSD.  The definition quantifies
-over `Fin n`-indexed families, matching the roadmap's `Fin`-representative convention;
-`IsReflectionPositive.posSemidef` recovers an arbitrary finite index type. -/
+over `Fin n`-indexed families; `IsReflectionPositive.posSemidef` recovers an arbitrary finite index
+type. -/
 def IsReflectionPositive (f : GraphParam) : Prop :=
   ∀ (k n : ℕ) (A : Fin n → LabeledGraph k), (connectionMatrix f A).PosSemidef
 
@@ -148,9 +146,7 @@ theorem IsReflectionPositive.nonneg_glue_self {f : GraphParam} (hf : IsReflectio
   have h := (hf.posSemidef fun _ : Fin 1 => G).diag_nonneg (i := 0)
   simpa [connectionMatrix] using h
 
-/-- **The added-vertex telescope.**  A multiplicative, normalized parameter is unchanged by
-adjoining an isolated vertex.  This is the step that makes the level-`n` masses of the Layer-8b
-Möbius spine consistent across levels. -/
+/-- A multiplicative, normalized parameter is unchanged by adjoining an isolated vertex. -/
 theorem IsMultiplicative.apply_sum_bot {f : GraphParam} (hmul : IsMultiplicative f)
     (hnorm : IsNormalized f) (n : ℕ) (F : SimpleGraph (Fin n)) :
     f (n + 1) ((F ⊕g (⊥ : SimpleGraph (Fin 1))).map finSumFinEquiv.toEmbedding) = f n F := by
@@ -160,9 +156,9 @@ section Examples
 
 /-! ### Consistency and adversarial checks
 
-The four structural conditions are simultaneously satisfiable, and none of them is automatic.  The
-parameter constantly `1` is the homomorphism density `t(·, W)` of the constant graphon `W ≡ 1`, so
-it is exactly the shape the representability theorem predicts. -/
+The four structural conditions are simultaneously satisfiable.  Reflection positivity is not
+implied by isomorphism invariance alone.  The parameter constantly `1` is the homomorphism density
+`t(·, W)` of the constant graphon `W ≡ 1`. -/
 
 /-- The constant parameter `1` is isomorphism invariant. -/
 theorem isIsoInvariant_one : IsIsoInvariant fun _ _ => (1 : ℝ) := fun _ _ _ _ _ => rfl
@@ -172,7 +168,8 @@ theorem isMultiplicative_one : IsMultiplicative fun _ _ => (1 : ℝ) :=
   fun _ _ _ _ => (one_mul 1).symm
 
 /-- The constant parameter `1` is normalized. -/
-theorem isNormalized_one : IsNormalized fun _ _ => (1 : ℝ) := rfl
+theorem isNormalized_one : IsNormalized fun _ _ => (1 : ℝ) := by
+  rw [IsNormalized.eq_1]
 
 /-- The constant parameter `1` is reflection positive: its connection matrices are the all-ones
 matrices, the outer square of the all-ones vector. -/
@@ -185,8 +182,8 @@ theorem isReflectionPositive_one : IsReflectionPositive fun _ _ => (1 : ℝ) := 
   rw [h]
   exact Matrix.posSemidef_vecMulVec_self_star _
 
-/-- Reflection positivity is a genuine constraint, not a consequence of the other conditions: the
-constant parameter `-1` is isomorphism invariant, yet it is negative on a self-gluing. -/
+/-- Isomorphism invariance alone does not imply reflection positivity: the constant parameter `-1`
+is isomorphism invariant, yet it is negative on a self-gluing. -/
 theorem not_isReflectionPositive_neg_one : ¬ IsReflectionPositive fun _ _ => (-1 : ℝ) := by
   intro h
   have := h.nonneg_glue_self (⟨1, ⊥, Fin.elim0, fun a => a.elim0⟩ : LabeledGraph 0)

--- a/TauCeti/Combinatorics/DenseGraphLimits/Representability/ConnectionMatrix.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/Representability/ConnectionMatrix.lean
@@ -1,0 +1,197 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import TauCeti.Combinatorics.DenseGraphLimits.Representability.LabeledGraph
+public import Mathlib.Combinatorics.SimpleGraph.Sum
+public import Mathlib.Algebra.Order.Star.Real
+public import Mathlib.LinearAlgebra.Matrix.PosDef
+public import Mathlib.Logic.Equiv.Fin.Basic
+
+/-!
+# Graph parameters, connection matrices and reflection positivity
+
+A graph parameter assigns a real number to every finite simple graph.  Its connection matrices are
+the matrices of its values on the gluings of a finite family of `k`-labeled graphs; a parameter is
+reflection positive when all of them are positive semidefinite.  Together with multiplicativity
+over disjoint unions and normalization at the one-vertex graph, these are the structural conditions
+of the Lovász–Szegedy representability theorem.
+
+## Main definitions
+
+* `TauCeti.DenseGraphLimits.GraphParam` is a real parameter of finite simple graphs, with
+  `TauCeti.DenseGraphLimits.IsIsoInvariant` imposing agreement along isomorphisms;
+* `TauCeti.DenseGraphLimits.connectionMatrix` is a finite principal block of the connection
+  matrix `M(f, k)`;
+* `TauCeti.DenseGraphLimits.IsReflectionPositive`,
+  `TauCeti.DenseGraphLimits.IsMultiplicative` and
+  `TauCeti.DenseGraphLimits.IsNormalized` are the three remaining structural conditions.
+
+## Main results
+
+* `TauCeti.DenseGraphLimits.isHermitian_connectionMatrix` — an isomorphism-invariant parameter has
+  symmetric connection matrices, so reflection positivity is not asking for the impossible;
+* `TauCeti.DenseGraphLimits.IsReflectionPositive.posSemidef` reindexes the definition, which
+  quantifies over `Fin n`-indexed families, to an arbitrary finite index type;
+* `TauCeti.DenseGraphLimits.IsReflectionPositive.nonneg_glue_self` is the diagonal consequence
+  `0 ≤ f` on a self-gluing;
+* `TauCeti.DenseGraphLimits.IsMultiplicative.apply_sum_bot` is the added-vertex telescope
+  `f (F ⊔ K₁) = f F`, the step the representability spine runs on.
+
+The section `Examples` records that the four conditions are simultaneously satisfiable — the
+parameter constantly `1`, which is the homomorphism density of the constant graphon `W ≡ 1` — and
+that reflection positivity is not automatic.
+
+## Implementation
+
+`connectionMatrix` takes an arbitrary index type: the `Matrix ι ι ℝ` it produces needs no
+finiteness, and `IsReflectionPositive` supplies `Fin n` where positive semidefiniteness is
+asserted.  `IsReflectionPositive.posSemidef` then recovers the arbitrary finite index case, since
+a connection matrix on `ι` is a submatrix of one on `Fin (Fintype.card ι)` along
+`Fintype.equivFin`.
+
+## References
+
+* L. Lovász, B. Szegedy, *Limits of dense graph sequences*, JCTB 96 (2006), 933–957, Theorem 2.2 —
+  the four structural conditions and the representability theorem they characterise.
+* L. Lovász, *Large Networks and Graph Limits*, AMS Colloquium Publications 60 (2012), Chapters 5
+  and 6.
+* Roadmap: `TauCetiRoadmap/DenseGraphLimits/README.md`, Layer 8a — quantum graphs and reflection
+  positivity.  The signatures follow `TauCetiRoadmap/DenseGraphLimits/Suggested.lean`; the
+  Layer-8b Möbius spine and `lovasz_szegedy_representability` itself are separate targets and are
+  not built here.
+-/
+
+@[expose] public section
+
+namespace TauCeti.DenseGraphLimits
+
+/-- A **graph parameter**: a real-valued parameter of finite simple graphs, indexed over the
+`Fin`-representatives.  Isomorphism invariance is imposed separately, as `IsIsoInvariant`. -/
+abbrev GraphParam := (n : ℕ) → SimpleGraph (Fin n) → ℝ
+
+/-- A graph parameter is **isomorphism invariant** when it agrees on isomorphic graphs.  This is
+the standing hypothesis that makes `f` a genuine parameter of graphs rather than a
+labelling-sensitive function on `Fin n`. -/
+def IsIsoInvariant (f : GraphParam) : Prop :=
+  ∀ (n₁ n₂ : ℕ) (F₁ : SimpleGraph (Fin n₁)) (F₂ : SimpleGraph (Fin n₂)),
+    Nonempty (F₁ ≃g F₂) → f n₁ F₁ = f n₂ F₂
+
+/-- The **connection matrix** of a graph parameter on a family `A : ι → LabeledGraph k` of
+`k`-labeled graphs: the `ι × ι` matrix whose `(i, j)` entry is `f` on the unlabeled graph
+underlying the gluing of `A i` and `A j`.  It is a finite principal block of the full connection
+matrix `M(f, k)`. -/
+noncomputable def connectionMatrix (f : GraphParam) {k : ℕ} {ι : Type*} (A : ι → LabeledGraph k) :
+    Matrix ι ι ℝ :=
+  Matrix.of fun i j =>
+    f ((A i).glue (A j)).forgetLabels.1 ((A i).glue (A j)).forgetLabels.2
+
+/-- The connection-matrix entry law. -/
+theorem connectionMatrix_apply (f : GraphParam) {k : ℕ} {ι : Type*} (A : ι → LabeledGraph k)
+    (i j : ι) :
+    connectionMatrix f A i j
+      = f ((A i).glue (A j)).forgetLabels.1 ((A i).glue (A j)).forgetLabels.2 := rfl
+
+/-- Connection matrices of an isomorphism-invariant parameter are symmetric: gluing commutes up to
+isomorphism. -/
+theorem connectionMatrix_comm (f : GraphParam) (hf : IsIsoInvariant f) {k : ℕ} {ι : Type*}
+    (A : ι → LabeledGraph k) (i j : ι) :
+    connectionMatrix f A i j = connectionMatrix f A j i :=
+  hf _ _ _ _ ⟨LabeledGraph.glueCommIso (A i) (A j)⟩
+
+/-- Connection matrices of an isomorphism-invariant parameter are Hermitian.  Positive
+semidefiniteness includes this condition, so without isomorphism invariance reflection positivity
+would be asking for something a parameter cannot supply. -/
+theorem isHermitian_connectionMatrix (f : GraphParam) (hf : IsIsoInvariant f) {k : ℕ} {ι : Type*}
+    (A : ι → LabeledGraph k) : (connectionMatrix f A).IsHermitian := by
+  refine Matrix.ext fun i j => ?_
+  simp only [Matrix.conjTranspose_apply, star_trivial]
+  exact connectionMatrix_comm f hf A j i
+
+/-- A graph parameter is **reflection positive** when every finite connection matrix is positive
+semidefinite — every finite principal block of each `M(f, k)` is PSD.  The definition quantifies
+over `Fin n`-indexed families, matching the roadmap's `Fin`-representative convention;
+`IsReflectionPositive.posSemidef` recovers an arbitrary finite index type. -/
+def IsReflectionPositive (f : GraphParam) : Prop :=
+  ∀ (k n : ℕ) (A : Fin n → LabeledGraph k), (connectionMatrix f A).PosSemidef
+
+/-- A graph parameter is **multiplicative** when it turns disjoint unions into products, with the
+disjoint union reindexed to `Fin (n₁ + n₂)` along `finSumFinEquiv` to stay on
+`Fin`-representatives. -/
+def IsMultiplicative (f : GraphParam) : Prop :=
+  ∀ (n₁ n₂ : ℕ) (F₁ : SimpleGraph (Fin n₁)) (F₂ : SimpleGraph (Fin n₂)),
+    f (n₁ + n₂) ((F₁ ⊕g F₂).map finSumFinEquiv.toEmbedding) = f n₁ F₁ * f n₂ F₂
+
+/-- A graph parameter is **normalized** when its value on the one-vertex graph `K₁` is `1`. -/
+def IsNormalized (f : GraphParam) : Prop := f 1 ⊥ = 1
+
+/-- Reflection positivity for an arbitrary finite index type.  A connection matrix on `ι` is the
+`Fintype.equivFin ι` submatrix of one on `Fin (Fintype.card ι)`, and positive semidefiniteness is
+invariant under reindexing by an equivalence. -/
+theorem IsReflectionPositive.posSemidef {f : GraphParam} (hf : IsReflectionPositive f) {k : ℕ}
+    {ι : Type*} [Finite ι] (A : ι → LabeledGraph k) : (connectionMatrix f A).PosSemidef := by
+  classical
+  have _inst : Fintype ι := Fintype.ofFinite ι
+  have hsub : connectionMatrix f (A ∘ (Fintype.equivFin ι).symm) =
+      (connectionMatrix f A).submatrix (Fintype.equivFin ι).symm (Fintype.equivFin ι).symm := rfl
+  have h := hf k (Fintype.card ι) (A ∘ (Fintype.equivFin ι).symm)
+  rw [hsub] at h
+  exact (Matrix.posSemidef_submatrix_equiv (Fintype.equivFin ι).symm).1 h
+
+/-- The diagonal of a connection matrix is nonnegative: a reflection-positive parameter is
+nonnegative on every self-gluing. -/
+theorem IsReflectionPositive.nonneg_glue_self {f : GraphParam} (hf : IsReflectionPositive f)
+    {k : ℕ} (G : LabeledGraph k) : 0 ≤ f (G.glue G).n (G.glue G).graph := by
+  have h := (hf.posSemidef fun _ : Fin 1 => G).diag_nonneg (i := 0)
+  simpa [connectionMatrix] using h
+
+/-- **The added-vertex telescope.**  A multiplicative, normalized parameter is unchanged by
+adjoining an isolated vertex.  This is the step that makes the level-`n` masses of the Layer-8b
+Möbius spine consistent across levels. -/
+theorem IsMultiplicative.apply_sum_bot {f : GraphParam} (hmul : IsMultiplicative f)
+    (hnorm : IsNormalized f) (n : ℕ) (F : SimpleGraph (Fin n)) :
+    f (n + 1) ((F ⊕g (⊥ : SimpleGraph (Fin 1))).map finSumFinEquiv.toEmbedding) = f n F := by
+  rw [hmul n 1 F ⊥, hnorm, mul_one]
+
+section Examples
+
+/-! ### Consistency and adversarial checks
+
+The four structural conditions are simultaneously satisfiable, and none of them is automatic.  The
+parameter constantly `1` is the homomorphism density `t(·, W)` of the constant graphon `W ≡ 1`, so
+it is exactly the shape the representability theorem predicts. -/
+
+/-- The constant parameter `1` is isomorphism invariant. -/
+theorem isIsoInvariant_one : IsIsoInvariant fun _ _ => (1 : ℝ) := fun _ _ _ _ _ => rfl
+
+/-- The constant parameter `1` is multiplicative. -/
+theorem isMultiplicative_one : IsMultiplicative fun _ _ => (1 : ℝ) :=
+  fun _ _ _ _ => (one_mul 1).symm
+
+/-- The constant parameter `1` is normalized. -/
+theorem isNormalized_one : IsNormalized fun _ _ => (1 : ℝ) := rfl
+
+/-- The constant parameter `1` is reflection positive: its connection matrices are the all-ones
+matrices, the outer square of the all-ones vector. -/
+theorem isReflectionPositive_one : IsReflectionPositive fun _ _ => (1 : ℝ) := by
+  intro k n A
+  have h : connectionMatrix (fun _ _ => (1 : ℝ)) A
+      = Matrix.vecMulVec (1 : Fin n → ℝ) (star (1 : Fin n → ℝ)) := by
+    ext i j
+    simp [connectionMatrix, Matrix.vecMulVec_apply]
+  rw [h]
+  exact Matrix.posSemidef_vecMulVec_self_star _
+
+/-- Reflection positivity is a genuine constraint, not a consequence of the other conditions: the
+constant parameter `-1` is isomorphism invariant, yet it is negative on a self-gluing. -/
+theorem not_isReflectionPositive_neg_one : ¬ IsReflectionPositive fun _ _ => (-1 : ℝ) := by
+  intro h
+  have := h.nonneg_glue_self (⟨1, ⊥, Fin.elim0, fun a => a.elim0⟩ : LabeledGraph 0)
+  norm_num at this
+
+end Examples
+
+end TauCeti.DenseGraphLimits

--- a/TauCeti/Combinatorics/DenseGraphLimits/Representability/ConnectionMatrix.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/Representability/ConnectionMatrix.lean
@@ -6,7 +6,7 @@ Authors: Claude
 module
 
 public import TauCeti.Combinatorics.DenseGraphLimits.Representability.LabeledGraph
-public import Mathlib.Combinatorics.SimpleGraph.Sum
+public import TauCeti.Combinatorics.SimpleGraph.Sum
 public import Mathlib.Algebra.Order.Star.Real
 public import Mathlib.LinearAlgebra.Matrix.PosDef
 
@@ -118,8 +118,10 @@ theorem connectionMatrix_apply (f : GraphParam) {k : ℕ} {ι : Type*} (A : ι �
 isomorphism. -/
 theorem connectionMatrix_comm (f : GraphParam) (hf : IsIsoInvariant f) {k : ℕ} {ι : Type*}
     (A : ι → LabeledGraph k) (i j : ι) :
-    connectionMatrix f A i j = connectionMatrix f A j i :=
-  hf.eq_of_iso (LabeledGraph.glueCommIso (A i) (A j))
+    connectionMatrix f A i j = connectionMatrix f A j i := by
+  rw [connectionMatrix_apply, connectionMatrix_apply, LabeledGraph.forgetLabels_eq,
+    LabeledGraph.forgetLabels_eq]
+  exact hf.eq_of_iso (LabeledGraph.glueCommIso (A i) (A j))
 
 /-- Connection matrices of an isomorphism-invariant parameter are Hermitian because the two
 gluing orders are isomorphic. -/
@@ -173,7 +175,9 @@ theorem IsReflectionPositive.posSemidef {f : GraphParam} (hf : IsReflectionPosit
   classical
   have _inst : Fintype ι := Fintype.ofFinite ι
   have hsub : connectionMatrix f (A ∘ (Fintype.equivFin ι).symm) =
-      (connectionMatrix f A).submatrix (Fintype.equivFin ι).symm (Fintype.equivFin ι).symm := rfl
+      (connectionMatrix f A).submatrix (Fintype.equivFin ι).symm (Fintype.equivFin ι).symm := by
+    ext i j
+    simp only [connectionMatrix_apply, Matrix.submatrix_apply, Function.comp_apply]
   have h := hf k (Fintype.card ι) (A ∘ (Fintype.equivFin ι).symm)
   rw [hsub] at h
   exact (Matrix.posSemidef_submatrix_equiv (Fintype.equivFin ι).symm).1 h
@@ -183,25 +187,20 @@ nonnegative on every self-gluing. -/
 theorem IsReflectionPositive.nonneg_glue_self {f : GraphParam} (hf : IsReflectionPositive f)
     {k : ℕ} (G : LabeledGraph k) : 0 ≤ f (G.glue G).n (G.glue G).graph := by
   have h := (hf.posSemidef fun _ : Fin 1 => G).diag_nonneg (i := 0)
-  simpa [connectionMatrix] using h
+  rw [connectionMatrix_apply, LabeledGraph.forgetLabels_eq] at h
+  exact h
 
 /-- A multiplicative, normalized parameter is `1` on every edgeless graph. -/
 theorem IsMultiplicative.apply_bot {f : GraphParam} (hmul : IsMultiplicative f)
     (hnorm : IsNormalized f) (n : ℕ) : f n (⊥ : SimpleGraph (Fin n)) = 1 := by
-  have map_sum_bot (a b : ℕ) :
-      (((⊥ : SimpleGraph (Fin a)) ⊕g (⊥ : SimpleGraph (Fin b))).map
-        finSumFinEquiv.toEmbedding) = ⊥ := by
-    rw [eq_bot_iff, SimpleGraph.map_le_iff_le_comap]
-    intro u v huv
-    cases u <;> cases v <;> simp_all
   induction n with
   | zero =>
       have h := hmul 0 1 (⊥ : SimpleGraph (Fin 0)) (⊥ : SimpleGraph (Fin 1))
-      rw [map_sum_bot, hnorm, mul_one] at h
+      rw [map_sum_bot_bot, hnorm, mul_one] at h
       simpa using h.symm
   | succ n ih =>
       have h := hmul n 1 (⊥ : SimpleGraph (Fin n)) (⊥ : SimpleGraph (Fin 1))
-      rw [map_sum_bot, ih, hnorm, mul_one] at h
+      rw [map_sum_bot_bot, ih, hnorm, mul_one] at h
       simpa using h
 
 /-- A multiplicative, normalized parameter is unchanged by adjoining any finite edgeless graph. -/

--- a/TauCeti/Combinatorics/DenseGraphLimits/Representability/LabeledGraph.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/Representability/LabeledGraph.lean
@@ -60,11 +60,13 @@ collapses as soon as one of the two vertices is unlabeled
 
 ## References
 
-* `TauCetiRoadmap/DenseGraphLimits/Suggested.lean` — source for the formal signatures.
 * L. Lovász, B. Szegedy, *Limits of dense graph sequences*, JCTB 96 (2006), 933–957, Section 2 —
   `k`-labeled graphs, their product, and connection matrices.
 * L. Lovász, *Large Networks and Graph Limits*, AMS Colloquium Publications 60 (2012), Chapter 6.
 -/
+
+-- Provenance: the names and signatures of the declarations below follow
+-- `TauCetiRoadmap/DenseGraphLimits/Suggested.lean`.
 
 public section
 
@@ -95,6 +97,8 @@ theorem le_n (G : LabeledGraph k) : k ≤ G.n := by
 side. -/
 abbrev Unlabeled (G : LabeledGraph k) : Type := {a : Fin G.n // ∀ i, G.label i ≠ a}
 
+/-- The unlabeled vertices of a labeled graph inherit a finite type from `Fin G.n`, of which they
+are a subtype. -/
 instance (G : LabeledGraph k) : Fintype G.Unlabeled := Subtype.fintype _
 
 /-- The number of unlabeled vertices. -/

--- a/TauCeti/Combinatorics/DenseGraphLimits/Representability/LabeledGraph.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/Representability/LabeledGraph.lean
@@ -1,0 +1,470 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import Mathlib.Combinatorics.SimpleGraph.Maps
+public import Mathlib.Data.Fintype.EquivFin
+public import Mathlib.Data.Fintype.Sum
+
+/-!
+# `k`-labeled graphs and their gluing
+
+A `k`-labeled graph is a finite simple graph together with an ordered `k`-tuple of *distinct*
+vertices.  Gluing two of them identifies corresponding labeled vertices and takes the union of the
+edge sets; the identified vertices keep their labels, so the result is again a `k`-labeled graph and
+gluing iterates.  This is Lovász–Szegedy's product `F₁F₂` of `k`-labeled graphs, the algebra
+underlying connection matrices and reflection positivity.
+
+## Main definitions
+
+* `TauCeti.DenseGraphLimits.LabeledGraph` is the `k`-labeled graph;
+* `TauCeti.DenseGraphLimits.LabeledGraph.glue` glues two of them along their labels;
+* `TauCeti.DenseGraphLimits.LabeledGraph.glueInl` and
+  `TauCeti.DenseGraphLimits.LabeledGraph.glueInr` are the two vertex maps into the gluing;
+* `TauCeti.DenseGraphLimits.LabeledGraph.forgetLabels` is the underlying unlabeled graph.
+
+## Main results
+
+* `TauCeti.DenseGraphLimits.LabeledGraph.glue_graph` identifies the glued graph as the supremum of
+  the two mapped sources, so no edge is created that neither source carries;
+* `TauCeti.DenseGraphLimits.LabeledGraph.glueInl_eq_glueInr_iff` says the two sides meet exactly at
+  corresponding labels, and
+  `TauCeti.DenseGraphLimits.LabeledGraph.glue_surjective` that they cover the gluing: together they
+  present the vertex set as the pushout;
+* `TauCeti.DenseGraphLimits.LabeledGraph.glue_card` is the resulting vertex count
+  `n₁ + n₂ - k`;
+* `TauCeti.DenseGraphLimits.LabeledGraph.glue_adj_inl`,
+  `TauCeti.DenseGraphLimits.LabeledGraph.glue_adj_inr` and
+  `TauCeti.DenseGraphLimits.LabeledGraph.glue_adj_inl_inr` are the adjacency eliminators, and
+  `TauCeti.DenseGraphLimits.LabeledGraph.not_glue_adj_of_unlabeled` records that unlabeled vertices
+  of the two sides are never joined;
+* `TauCeti.DenseGraphLimits.LabeledGraph.glueCommIso` is the commutativity of the gluing algebra,
+  the isomorphism between the two orders of a gluing that makes connection matrices symmetric.
+
+## Implementation
+
+The vertex set of a gluing is built as the concrete pushout carrier
+`Fin k ⊕ (G₁.Unlabeled ⊕ G₂.Unlabeled)` — the shared labels, then the private vertices of each
+side — and transported to a `Fin`-representative along `Fintype.equivFin`, since the structure
+stores its vertex set as `Fin n`.  Writing the carrier in this *symmetric* shape is what makes
+commutativity a swap of the two summands rather than a bespoke bijection.
+
+Both adjacency eliminators are stated in their honest form.  Two labeled vertices of the left side
+can be joined by an edge contributed by the *right* side, so the naive `Adj (glueInl a)
+(glueInl b) ↔ G₁.graph.Adj a b` is false; the correct statement carries the extra disjunct, which
+collapses as soon as one of the two vertices is unlabeled
+(`glue_adj_inl_of_unlabeled`).
+
+## References
+
+* L. Lovász, B. Szegedy, *Limits of dense graph sequences*, JCTB 96 (2006), 933–957, Section 2 —
+  `k`-labeled graphs, their product, and connection matrices.
+* L. Lovász, *Large Networks and Graph Limits*, AMS Colloquium Publications 60 (2012), Chapter 6.
+* Roadmap: `TauCetiRoadmap/DenseGraphLimits/README.md`, Layer 8a — the gluing algebra behind the
+  representability theorem.  The signatures follow
+  `TauCetiRoadmap/DenseGraphLimits/Suggested.lean`.
+-/
+
+@[expose] public section
+
+namespace TauCeti.DenseGraphLimits
+
+variable {k : ℕ}
+
+/-- A **`k`-labeled graph**: a finite simple graph on `Fin n` together with an ordered `k`-tuple of
+distinct labeled vertices.  These are the objects of the gluing algebra behind connection
+matrices. -/
+structure LabeledGraph (k : ℕ) where
+  /-- The number of vertices. -/
+  n : ℕ
+  /-- The underlying simple graph. -/
+  graph : SimpleGraph (Fin n)
+  /-- The labeled vertices, in order. -/
+  label : Fin k → Fin n
+  /-- The labeled vertices are distinct. -/
+  label_injective : Function.Injective label
+
+namespace LabeledGraph
+
+/-- A labeled graph has at least as many vertices as labels. -/
+theorem le_n (G : LabeledGraph k) : k ≤ G.n := by
+  simpa using Fintype.card_le_of_injective G.label G.label_injective
+
+/-- The vertices of a labeled graph that carry no label — the ones a gluing keeps private to its
+side. -/
+abbrev Unlabeled (G : LabeledGraph k) : Type := {a : Fin G.n // ∀ i, G.label i ≠ a}
+
+instance (G : LabeledGraph k) : Fintype G.Unlabeled := Subtype.fintype _
+
+/-- The number of unlabeled vertices. -/
+theorem card_unlabeled (G : LabeledGraph k) : Fintype.card G.Unlabeled = G.n - k := by
+  classical
+  have hrange : Fintype.card {a : Fin G.n // a ∈ Set.range G.label} = k :=
+    (Fintype.card_congr (Equiv.ofInjective _ G.label_injective).symm).trans (Fintype.card_fin k)
+  have hcompl : Fintype.card {a : Fin G.n // a ∉ Set.range G.label} = G.n - k := by
+    rw [Fintype.card_subtype_compl, hrange, Fintype.card_fin]
+  rw [← hcompl]
+  exact Fintype.card_congr (Equiv.subtypeEquivRight fun a => by simp [eq_comm])
+
+/-- The vertex carrier of a gluing: the `k` shared labels together with the unlabeled vertices of
+each side.  Writing it in this symmetric shape makes `glueCommIso` a swap of summands. -/
+abbrev glueCarrier (G₁ G₂ : LabeledGraph k) : Type := Fin k ⊕ (G₁.Unlabeled ⊕ G₂.Unlabeled)
+
+/-- The chosen `Fin`-representative of the gluing carrier. -/
+noncomputable def glueIndex (G₁ G₂ : LabeledGraph k) :
+    G₁.glueCarrier G₂ ≃ Fin (Fintype.card (G₁.glueCarrier G₂)) :=
+  Fintype.equivFin _
+
+/-- Where a vertex of the left factor lands in the gluing carrier: at its label if it has one, and
+in the private left summand otherwise. -/
+noncomputable def glueLeft (G₁ G₂ : LabeledGraph k) (a : Fin G₁.n) : G₁.glueCarrier G₂ :=
+  if h : ∃ i, G₁.label i = a then Sum.inl h.choose
+  else Sum.inr (Sum.inl ⟨a, fun i hi => h ⟨i, hi⟩⟩)
+
+/-- Where a vertex of the right factor lands in the gluing carrier. -/
+noncomputable def glueRight (G₁ G₂ : LabeledGraph k) (b : Fin G₂.n) : G₁.glueCarrier G₂ :=
+  if h : ∃ i, G₂.label i = b then Sum.inl h.choose
+  else Sum.inr (Sum.inr ⟨b, fun i hi => h ⟨i, hi⟩⟩)
+
+/-- A labeled left vertex lands on its shared label. -/
+@[simp]
+theorem glueLeft_label (G₁ G₂ : LabeledGraph k) (i : Fin k) :
+    G₁.glueLeft G₂ (G₁.label i) = Sum.inl i := by
+  have h : ∃ j, G₁.label j = G₁.label i := ⟨i, rfl⟩
+  rw [glueLeft, dite_eq_left h]
+  exact congrArg Sum.inl (G₁.label_injective h.choose_spec)
+
+/-- A labeled right vertex lands on its shared label. -/
+@[simp]
+theorem glueRight_label (G₁ G₂ : LabeledGraph k) (i : Fin k) :
+    G₁.glueRight G₂ (G₂.label i) = Sum.inl i := by
+  have h : ∃ j, G₂.label j = G₂.label i := ⟨i, rfl⟩
+  rw [glueRight, dite_eq_left h]
+  exact congrArg Sum.inl (G₂.label_injective h.choose_spec)
+
+/-- An unlabeled left vertex lands in the private left summand. -/
+theorem glueLeft_of_unlabeled (G₁ G₂ : LabeledGraph k) {a : Fin G₁.n}
+    (ha : ∀ i, G₁.label i ≠ a) : G₁.glueLeft G₂ a = Sum.inr (Sum.inl ⟨a, ha⟩) := by
+  rw [glueLeft, dite_eq_right (fun h => ha h.choose h.choose_spec)]
+
+/-- An unlabeled right vertex lands in the private right summand. -/
+theorem glueRight_of_unlabeled (G₁ G₂ : LabeledGraph k) {b : Fin G₂.n}
+    (hb : ∀ i, G₂.label i ≠ b) : G₁.glueRight G₂ b = Sum.inr (Sum.inr ⟨b, hb⟩) := by
+  rw [glueRight, dite_eq_right (fun h => hb h.choose h.choose_spec)]
+
+/-- The left factor embeds in the gluing carrier. -/
+theorem glueLeft_injective (G₁ G₂ : LabeledGraph k) : Function.Injective (G₁.glueLeft G₂) := by
+  intro a b hab
+  by_cases ha : ∃ i, G₁.label i = a <;> by_cases hb : ∃ i, G₁.label i = b
+  · obtain ⟨i, rfl⟩ := ha
+    obtain ⟨j, rfl⟩ := hb
+    rw [glueLeft_label, glueLeft_label] at hab
+    exact congrArg G₁.label (Sum.inl_injective hab)
+  · obtain ⟨i, rfl⟩ := ha
+    rw [glueLeft_label, glueLeft_of_unlabeled _ _ (fun i hi => hb ⟨i, hi⟩)] at hab
+    exact absurd hab (by simp)
+  · obtain ⟨j, rfl⟩ := hb
+    rw [glueLeft_label, glueLeft_of_unlabeled _ _ (fun i hi => ha ⟨i, hi⟩)] at hab
+    exact absurd hab (by simp)
+  · rw [glueLeft_of_unlabeled _ _ (fun i hi => ha ⟨i, hi⟩),
+      glueLeft_of_unlabeled _ _ (fun i hi => hb ⟨i, hi⟩)] at hab
+    simpa using hab
+
+/-- The right factor embeds in the gluing carrier. -/
+theorem glueRight_injective (G₁ G₂ : LabeledGraph k) : Function.Injective (G₁.glueRight G₂) := by
+  intro a b hab
+  by_cases ha : ∃ i, G₂.label i = a <;> by_cases hb : ∃ i, G₂.label i = b
+  · obtain ⟨i, rfl⟩ := ha
+    obtain ⟨j, rfl⟩ := hb
+    rw [glueRight_label, glueRight_label] at hab
+    exact congrArg G₂.label (Sum.inl_injective hab)
+  · obtain ⟨i, rfl⟩ := ha
+    rw [glueRight_label, glueRight_of_unlabeled _ _ (fun i hi => hb ⟨i, hi⟩)] at hab
+    exact absurd hab (by simp)
+  · obtain ⟨j, rfl⟩ := hb
+    rw [glueRight_label, glueRight_of_unlabeled _ _ (fun i hi => ha ⟨i, hi⟩)] at hab
+    exact absurd hab (by simp)
+  · rw [glueRight_of_unlabeled _ _ (fun i hi => ha ⟨i, hi⟩),
+      glueRight_of_unlabeled _ _ (fun i hi => hb ⟨i, hi⟩)] at hab
+    simpa using hab
+
+/-- In the gluing carrier the two sides meet exactly at corresponding labels. -/
+theorem glueLeft_eq_glueRight_iff (G₁ G₂ : LabeledGraph k) (a : Fin G₁.n) (b : Fin G₂.n) :
+    G₁.glueLeft G₂ a = G₁.glueRight G₂ b ↔ ∃ i, a = G₁.label i ∧ b = G₂.label i := by
+  constructor
+  · intro hab
+    by_cases ha : ∃ i, G₁.label i = a
+    · obtain ⟨i, rfl⟩ := ha
+      by_cases hb : ∃ j, G₂.label j = b
+      · obtain ⟨j, rfl⟩ := hb
+        rw [glueLeft_label, glueRight_label] at hab
+        exact ⟨j, by rw [Sum.inl_injective hab], rfl⟩
+      · rw [glueLeft_label, glueRight_of_unlabeled _ _ (fun j hj => hb ⟨j, hj⟩)] at hab
+        exact absurd hab (by simp)
+    · rw [glueLeft_of_unlabeled _ _ (fun i hi => ha ⟨i, hi⟩)] at hab
+      by_cases hb : ∃ j, G₂.label j = b
+      · obtain ⟨j, rfl⟩ := hb
+        rw [glueRight_label] at hab
+        exact absurd hab (by simp)
+      · rw [glueRight_of_unlabeled _ _ (fun j hj => hb ⟨j, hj⟩)] at hab
+        exact absurd hab (by simp)
+  · rintro ⟨i, rfl, rfl⟩
+    rw [glueLeft_label, glueRight_label]
+
+/-- Every vertex of the gluing carrier comes from one of the two sides. -/
+theorem glueLeft_surjective_or (G₁ G₂ : LabeledGraph k) (v : G₁.glueCarrier G₂) :
+    (∃ a, v = G₁.glueLeft G₂ a) ∨ ∃ b, v = G₁.glueRight G₂ b := by
+  match v with
+  | Sum.inl i => exact Or.inl ⟨G₁.label i, (glueLeft_label G₁ G₂ i).symm⟩
+  | Sum.inr (Sum.inl ⟨a, ha⟩) => exact Or.inl ⟨a, (glueLeft_of_unlabeled G₁ G₂ ha).symm⟩
+  | Sum.inr (Sum.inr ⟨b, hb⟩) => exact Or.inr ⟨b, (glueRight_of_unlabeled G₁ G₂ hb).symm⟩
+
+/-- **Gluing.** Glue two `k`-labeled graphs by identifying corresponding labeled vertices and
+taking the union of the two edge sets.  The identified vertices keep their labels — and stay
+distinct — so the result is again a `k`-labeled graph and gluing iterates.  This is
+Lovász–Szegedy's product `F₁F₂`. -/
+noncomputable def glue (G₁ G₂ : LabeledGraph k) : LabeledGraph k where
+  n := Fintype.card (G₁.glueCarrier G₂)
+  graph := (G₁.graph.map fun a => G₁.glueIndex G₂ (G₁.glueLeft G₂ a)) ⊔
+    (G₂.graph.map fun b => G₁.glueIndex G₂ (G₁.glueRight G₂ b))
+  label i := G₁.glueIndex G₂ (Sum.inl i)
+  label_injective := (G₁.glueIndex G₂).injective.comp Sum.inl_injective
+
+/-- The vertex map of the left factor into the gluing. -/
+noncomputable def glueInl (G₁ G₂ : LabeledGraph k) : Fin G₁.n ↪ Fin (G₁.glue G₂).n :=
+  ⟨fun a => G₁.glueIndex G₂ (G₁.glueLeft G₂ a),
+    (G₁.glueIndex G₂).injective.comp (G₁.glueLeft_injective G₂)⟩
+
+/-- The vertex map of the right factor into the gluing. -/
+noncomputable def glueInr (G₁ G₂ : LabeledGraph k) : Fin G₂.n ↪ Fin (G₁.glue G₂).n :=
+  ⟨fun b => G₁.glueIndex G₂ (G₁.glueRight G₂ b),
+    (G₁.glueIndex G₂).injective.comp (G₁.glueRight_injective G₂)⟩
+
+/-- **The glued graph is exactly the supremum of the two mapped sources**: gluing creates no edge
+that neither side carries. -/
+theorem glue_graph (G₁ G₂ : LabeledGraph k) :
+    (G₁.glue G₂).graph = G₁.graph.map (G₁.glueInl G₂) ⊔ G₂.graph.map (G₁.glueInr G₂) := rfl
+
+/-- **No other identifications**: the two sides meet exactly at corresponding labels. -/
+theorem glueInl_eq_glueInr_iff (G₁ G₂ : LabeledGraph k) (a : Fin G₁.n) (b : Fin G₂.n) :
+    G₁.glueInl G₂ a = G₁.glueInr G₂ b ↔ ∃ i, a = G₁.label i ∧ b = G₂.label i := by
+  rw [← glueLeft_eq_glueRight_iff]
+  exact (G₁.glueIndex G₂).apply_eq_iff_eq
+
+/-- The labels of the gluing are the images of the left labels. -/
+theorem glueInl_label (G₁ G₂ : LabeledGraph k) :
+    (G₁.glue G₂).label = G₁.glueInl G₂ ∘ G₁.label :=
+  funext fun i => congrArg _ (glueLeft_label G₁ G₂ i).symm
+
+/-- The labels of the gluing are the images of the right labels. -/
+theorem glueInr_label (G₁ G₂ : LabeledGraph k) :
+    (G₁.glue G₂).label = G₁.glueInr G₂ ∘ G₂.label :=
+  funext fun i => congrArg _ (glueRight_label G₁ G₂ i).symm
+
+/-- Every vertex of the gluing comes from one of the two sides. -/
+theorem glue_surjective (G₁ G₂ : LabeledGraph k) (v : Fin (G₁.glue G₂).n) :
+    (∃ a, v = G₁.glueInl G₂ a) ∨ ∃ b, v = G₁.glueInr G₂ b := by
+  obtain h | h := glueLeft_surjective_or G₁ G₂ ((G₁.glueIndex G₂).symm v)
+  · obtain ⟨a, ha⟩ := h
+    exact Or.inl ⟨a, (G₁.glueIndex G₂).symm_apply_eq.mp ha⟩
+  · obtain ⟨b, hb⟩ := h
+    exact Or.inr ⟨b, (G₁.glueIndex G₂).symm_apply_eq.mp hb⟩
+
+/-- **The vertex count of a gluing.**  The two sides share exactly their `k` labels. -/
+theorem glue_card (G₁ G₂ : LabeledGraph k) : (G₁.glue G₂).n = G₁.n + G₂.n - k := by
+  have h₁ := G₁.le_n
+  have h₂ := G₂.le_n
+  have hcard : (G₁.glue G₂).n = Fintype.card (G₁.glueCarrier G₂) := rfl
+  rw [hcard, Fintype.card_sum, Fintype.card_sum, Fintype.card_fin, card_unlabeled, card_unlabeled]
+  omega
+
+/-- The supremum of two graphs maps to the supremum of the images.  A local convenience: only
+`SimpleGraph.map_map` is in Mathlib. -/
+private theorem map_sup {V W : Type*} (f : V → W) (G H : SimpleGraph V) :
+    (G ⊔ H).map f = G.map f ⊔ H.map f := by
+  ext a b
+  simp only [SimpleGraph.map_adj', SimpleGraph.sup_adj]
+  aesop
+
+/-- **Adjacency on the left side.**  A left edge survives the gluing, and the only edges the
+gluing adds between two left vertices are the ones the right side contributes between labels. -/
+theorem glue_adj_inl (G₁ G₂ : LabeledGraph k) (a b : Fin G₁.n) :
+    (G₁.glue G₂).graph.Adj (G₁.glueInl G₂ a) (G₁.glueInl G₂ b) ↔
+      G₁.graph.Adj a b ∨
+        ∃ i j, a = G₁.label i ∧ b = G₁.label j ∧ G₂.graph.Adj (G₂.label i) (G₂.label j) := by
+  rw [glue_graph, SimpleGraph.sup_adj, SimpleGraph.map_adj_apply, SimpleGraph.map_adj]
+  constructor
+  · rintro (h | ⟨a', b', hadj, ha', hb'⟩)
+    · exact Or.inl h
+    · obtain ⟨i, hi₁, hi₂⟩ := (glueInl_eq_glueInr_iff G₁ G₂ a a').1 ha'.symm
+      obtain ⟨j, hj₁, hj₂⟩ := (glueInl_eq_glueInr_iff G₁ G₂ b b').1 hb'.symm
+      exact Or.inr ⟨i, j, hi₁, hj₁, by rw [← hi₂, ← hj₂]; exact hadj⟩
+  · rintro (h | ⟨i, j, rfl, rfl, hadj⟩)
+    · exact Or.inl h
+    · exact Or.inr ⟨G₂.label i, G₂.label j, hadj,
+        ((glueInl_eq_glueInr_iff G₁ G₂ _ _).2 ⟨i, rfl, rfl⟩).symm,
+        ((glueInl_eq_glueInr_iff G₁ G₂ _ _).2 ⟨j, rfl, rfl⟩).symm⟩
+
+/-- **Adjacency on the right side**, the mirror of `glue_adj_inl`. -/
+theorem glue_adj_inr (G₁ G₂ : LabeledGraph k) (a b : Fin G₂.n) :
+    (G₁.glue G₂).graph.Adj (G₁.glueInr G₂ a) (G₁.glueInr G₂ b) ↔
+      G₂.graph.Adj a b ∨
+        ∃ i j, a = G₂.label i ∧ b = G₂.label j ∧ G₁.graph.Adj (G₁.label i) (G₁.label j) := by
+  rw [glue_graph, SimpleGraph.sup_adj, SimpleGraph.map_adj_apply, SimpleGraph.map_adj]
+  constructor
+  · rintro (⟨a', b', hadj, ha', hb'⟩ | h)
+    · obtain ⟨i, hi₁, hi₂⟩ := (glueInl_eq_glueInr_iff G₁ G₂ a' a).1 ha'
+      obtain ⟨j, hj₁, hj₂⟩ := (glueInl_eq_glueInr_iff G₁ G₂ b' b).1 hb'
+      exact Or.inr ⟨i, j, hi₂, hj₂, by rw [← hi₁, ← hj₁]; exact hadj⟩
+    · exact Or.inl h
+  · rintro (h | ⟨i, j, rfl, rfl, hadj⟩)
+    · exact Or.inr h
+    · exact Or.inl ⟨G₁.label i, G₁.label j, hadj,
+        (glueInl_eq_glueInr_iff G₁ G₂ _ _).2 ⟨i, rfl, rfl⟩,
+        (glueInl_eq_glueInr_iff G₁ G₂ _ _).2 ⟨j, rfl, rfl⟩⟩
+
+/-- **Adjacency across the two sides.**  A left and a right vertex are joined only through a
+label: either the right vertex is a label and the left side carries the edge, or the left vertex
+is a label and the right side does. -/
+theorem glue_adj_inl_inr (G₁ G₂ : LabeledGraph k) (a : Fin G₁.n) (b : Fin G₂.n) :
+    (G₁.glue G₂).graph.Adj (G₁.glueInl G₂ a) (G₁.glueInr G₂ b) ↔
+      (∃ j, b = G₂.label j ∧ G₁.graph.Adj a (G₁.label j)) ∨
+        ∃ i, a = G₁.label i ∧ G₂.graph.Adj (G₂.label i) b := by
+  rw [glue_graph, SimpleGraph.sup_adj, SimpleGraph.map_adj, SimpleGraph.map_adj]
+  constructor
+  · rintro (⟨a', b', hadj, ha', hb'⟩ | ⟨a', b', hadj, ha', hb'⟩)
+    · obtain ⟨j, hj₁, hj₂⟩ := (glueInl_eq_glueInr_iff G₁ G₂ b' b).1 hb'
+      exact Or.inl ⟨j, hj₂, by
+        rw [← hj₁, ← (G₁.glueInl G₂).injective ha']; exact hadj⟩
+    · obtain ⟨i, hi₁, hi₂⟩ := (glueInl_eq_glueInr_iff G₁ G₂ a a').1 ha'.symm
+      exact Or.inr ⟨i, hi₁, by
+        rw [← hi₂, ← (G₁.glueInr G₂).injective hb']; exact hadj⟩
+  · rintro (⟨j, rfl, hadj⟩ | ⟨i, rfl, hadj⟩)
+    · exact Or.inl ⟨a, G₁.label j, hadj, rfl,
+        (glueInl_eq_glueInr_iff G₁ G₂ _ _).2 ⟨j, rfl, rfl⟩⟩
+    · exact Or.inr ⟨G₂.label i, b, hadj,
+        ((glueInl_eq_glueInr_iff G₁ G₂ _ _).2 ⟨i, rfl, rfl⟩).symm, rfl⟩
+
+/-- Gluing preserves the edges of the left side. -/
+theorem glue_adj_inl_of_adj (G₁ G₂ : LabeledGraph k) {a b : Fin G₁.n} (h : G₁.graph.Adj a b) :
+    (G₁.glue G₂).graph.Adj (G₁.glueInl G₂ a) (G₁.glueInl G₂ b) :=
+  (glue_adj_inl G₁ G₂ a b).2 (Or.inl h)
+
+/-- Gluing preserves the edges of the right side. -/
+theorem glue_adj_inr_of_adj (G₁ G₂ : LabeledGraph k) {a b : Fin G₂.n} (h : G₂.graph.Adj a b) :
+    (G₁.glue G₂).graph.Adj (G₁.glueInr G₂ a) (G₁.glueInr G₂ b) :=
+  (glue_adj_inr G₁ G₂ a b).2 (Or.inl h)
+
+/-- At an unlabeled left vertex the gluing reflects left adjacency faithfully: the extra disjunct
+of `glue_adj_inl` needs both endpoints to be labels. -/
+theorem glue_adj_inl_of_unlabeled (G₁ G₂ : LabeledGraph k) {a : Fin G₁.n}
+    (ha : ∀ i, G₁.label i ≠ a) (b : Fin G₁.n) :
+    (G₁.glue G₂).graph.Adj (G₁.glueInl G₂ a) (G₁.glueInl G₂ b) ↔ G₁.graph.Adj a b := by
+  rw [glue_adj_inl]
+  exact or_iff_left (by rintro ⟨i, _, rfl, -, -⟩; exact ha i rfl)
+
+/-- At an unlabeled right vertex the gluing reflects right adjacency faithfully. -/
+theorem glue_adj_inr_of_unlabeled (G₁ G₂ : LabeledGraph k) {a : Fin G₂.n}
+    (ha : ∀ i, G₂.label i ≠ a) (b : Fin G₂.n) :
+    (G₁.glue G₂).graph.Adj (G₁.glueInr G₂ a) (G₁.glueInr G₂ b) ↔ G₂.graph.Adj a b := by
+  rw [glue_adj_inr]
+  exact or_iff_left (by rintro ⟨i, _, rfl, -, -⟩; exact ha i rfl)
+
+/-- **No cross-edges are smuggled in**: gluing never joins an unlabeled vertex of one side to an
+unlabeled vertex of the other. -/
+theorem not_glue_adj_of_unlabeled (G₁ G₂ : LabeledGraph k) {a : Fin G₁.n} {b : Fin G₂.n}
+    (ha : ∀ i, G₁.label i ≠ a) (hb : ∀ i, G₂.label i ≠ b) :
+    ¬ (G₁.glue G₂).graph.Adj (G₁.glueInl G₂ a) (G₁.glueInr G₂ b) := by
+  rw [glue_adj_inl_inr]
+  rintro (⟨j, rfl, -⟩ | ⟨i, rfl, -⟩)
+  · exact hb j rfl
+  · exact ha i rfl
+
+/-- **Unlabeling.**  The underlying finite simple graph of a `k`-labeled graph, labels forgotten —
+the object a graph parameter evaluates in a connection-matrix entry. -/
+def forgetLabels (G : LabeledGraph k) : Σ m, SimpleGraph (Fin m) := ⟨G.n, G.graph⟩
+
+/-- Unlabeling keeps the vertex count. -/
+@[simp]
+theorem forgetLabels_fst (G : LabeledGraph k) : G.forgetLabels.1 = G.n := rfl
+
+/-- Unlabeling keeps the graph. -/
+@[simp]
+theorem forgetLabels_snd (G : LabeledGraph k) : G.forgetLabels.2 = G.graph := rfl
+
+/-! ### Commutativity of the gluing -/
+
+/-- Swapping the two private summands of a gluing carrier. -/
+def glueSwap (G₁ G₂ : LabeledGraph k) : G₁.glueCarrier G₂ ≃ G₂.glueCarrier G₁ :=
+  (Equiv.refl (Fin k)).sumCongr (Equiv.sumComm _ _)
+
+/-- Under the swap, the left factor of one order becomes the right factor of the other. -/
+theorem glueSwap_glueLeft (G₁ G₂ : LabeledGraph k) (a : Fin G₁.n) :
+    G₁.glueSwap G₂ (G₁.glueLeft G₂ a) = G₂.glueRight G₁ a := by
+  by_cases ha : ∃ i, G₁.label i = a
+  · obtain ⟨i, rfl⟩ := ha
+    rw [glueLeft_label, glueRight_label]
+    rfl
+  · rw [glueLeft_of_unlabeled _ _ fun i hi => ha ⟨i, hi⟩,
+      glueRight_of_unlabeled _ _ fun i hi => ha ⟨i, hi⟩]
+    rfl
+
+/-- Under the swap, the right factor of one order becomes the left factor of the other. -/
+theorem glueSwap_glueRight (G₁ G₂ : LabeledGraph k) (b : Fin G₂.n) :
+    G₁.glueSwap G₂ (G₁.glueRight G₂ b) = G₂.glueLeft G₁ b := by
+  by_cases hb : ∃ i, G₂.label i = b
+  · obtain ⟨i, rfl⟩ := hb
+    rw [glueRight_label, glueLeft_label]
+    rfl
+  · rw [glueRight_of_unlabeled _ _ fun i hi => hb ⟨i, hi⟩,
+      glueLeft_of_unlabeled _ _ fun i hi => hb ⟨i, hi⟩]
+    rfl
+
+/-- The vertex bijection between the two orders of a gluing. -/
+noncomputable def glueCommEquiv (G₁ G₂ : LabeledGraph k) :
+    Fin (G₁.glue G₂).n ≃ Fin (G₂.glue G₁).n :=
+  (G₁.glueIndex G₂).symm.trans ((G₁.glueSwap G₂).trans (G₂.glueIndex G₁))
+
+/-- The commutativity bijection exchanges the two vertex maps. -/
+theorem glueCommEquiv_glueInl (G₁ G₂ : LabeledGraph k) (a : Fin G₁.n) :
+    G₁.glueCommEquiv G₂ (G₁.glueInl G₂ a) = G₂.glueInr G₁ a := by
+  change G₂.glueIndex G₁ (G₁.glueSwap G₂ ((G₁.glueIndex G₂).symm
+    (G₁.glueIndex G₂ (G₁.glueLeft G₂ a)))) = _
+  rw [Equiv.symm_apply_apply, glueSwap_glueLeft]
+  rfl
+
+/-- The commutativity bijection exchanges the two vertex maps, on the right. -/
+theorem glueCommEquiv_glueInr (G₁ G₂ : LabeledGraph k) (b : Fin G₂.n) :
+    G₁.glueCommEquiv G₂ (G₁.glueInr G₂ b) = G₂.glueInl G₁ b := by
+  change G₂.glueIndex G₁ (G₁.glueSwap G₂ ((G₁.glueIndex G₂).symm
+    (G₁.glueIndex G₂ (G₁.glueRight G₂ b)))) = _
+  rw [Equiv.symm_apply_apply, glueSwap_glueRight]
+  rfl
+
+/-- The commutativity bijection carries one glued graph onto the other. -/
+theorem glue_graph_map_glueCommEquiv (G₁ G₂ : LabeledGraph k) :
+    (G₁.glue G₂).graph.map (G₁.glueCommEquiv G₂) = (G₂.glue G₁).graph := by
+  have h₁ : (G₁.glueCommEquiv G₂ : Fin (G₁.glue G₂).n → Fin (G₂.glue G₁).n) ∘
+      (G₁.glueInl G₂ : Fin G₁.n → Fin (G₁.glue G₂).n) = G₂.glueInr G₁ :=
+    funext (glueCommEquiv_glueInl G₁ G₂)
+  have h₂ : (G₁.glueCommEquiv G₂ : Fin (G₁.glue G₂).n → Fin (G₂.glue G₁).n) ∘
+      (G₁.glueInr G₂ : Fin G₂.n → Fin (G₁.glue G₂).n) = G₂.glueInl G₁ :=
+    funext (glueCommEquiv_glueInr G₁ G₂)
+  rw [glue_graph, map_sup, SimpleGraph.map_map, SimpleGraph.map_map, h₁, h₂, glue_graph, sup_comm]
+
+/-- **Commutativity of the gluing algebra.**  The two orders of a gluing are isomorphic, so a graph
+parameter that is isomorphism invariant takes the same value on both — this is what makes
+connection matrices symmetric. -/
+noncomputable def glueCommIso (G₁ G₂ : LabeledGraph k) :
+    (G₁.glue G₂).graph ≃g (G₂.glue G₁).graph where
+  toEquiv := G₁.glueCommEquiv G₂
+  map_rel_iff' {u v} := by
+    conv_lhs => rw [← glue_graph_map_glueCommEquiv G₁ G₂]
+    exact SimpleGraph.map_adj_apply (f := (G₁.glueCommEquiv G₂).toEmbedding)
+
+end LabeledGraph
+
+end TauCeti.DenseGraphLimits

--- a/TauCeti/Combinatorics/DenseGraphLimits/Representability/LabeledGraph.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/Representability/LabeledGraph.lean
@@ -249,15 +249,10 @@ noncomputable def glueInr (G₁ G₂ : LabeledGraph k) : Fin G₂.n ↪ Fin (G�
   ⟨fun b => G₁.glueIndex G₂ (G₁.glueRight G₂ b),
     (G₁.glueIndex G₂).injective.comp (G₁.glueRight_injective G₂)⟩
 
--- Definitional form used to export the characteristic law without exposing the constructors.
-private theorem glue_graph_def (G₁ G₂ : LabeledGraph k) :
-    (G₁.glue G₂).graph = G₁.graph.map (G₁.glueInl G₂) ⊔ G₂.graph.map (G₁.glueInr G₂) := rfl
-
 /-- **The glued graph is exactly the supremum of the two mapped sources**: gluing creates no edge
 that neither side carries. -/
 theorem glue_graph (G₁ G₂ : LabeledGraph k) :
-    (G₁.glue G₂).graph = G₁.graph.map (G₁.glueInl G₂) ⊔ G₂.graph.map (G₁.glueInr G₂) :=
-  glue_graph_def G₁ G₂
+    (G₁.glue G₂).graph = G₁.graph.map (G₁.glueInl G₂) ⊔ G₂.graph.map (G₁.glueInr G₂) := (rfl)
 
 /-- **No other identifications**: the two sides meet exactly at corresponding labels. -/
 theorem glueInl_eq_glueInr_iff (G₁ G₂ : LabeledGraph k) (a : Fin G₁.n) (b : Fin G₂.n) :

--- a/TauCeti/Combinatorics/DenseGraphLimits/Representability/LabeledGraph.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/Representability/LabeledGraph.lean
@@ -32,8 +32,8 @@ underlying connection matrices and reflection positivity.
   the two mapped sources, so no edge is created that neither source carries;
 * `TauCeti.DenseGraphLimits.LabeledGraph.glueInl_eq_glueInr_iff` says the two sides meet exactly at
   corresponding labels, and
-  `TauCeti.DenseGraphLimits.LabeledGraph.exists_glueInl_or_exists_glueInr` that they cover the
-  gluing: together they present the vertex set as the pushout;
+  `TauCeti.DenseGraphLimits.LabeledGraph.glue_surjective` that they cover the gluing: together
+  they present the vertex set as the pushout;
 * `TauCeti.DenseGraphLimits.LabeledGraph.glue_card` is the resulting vertex count
   `n₁ + n₂ - k`;
 * `TauCeti.DenseGraphLimits.LabeledGraph.glue_adj_inl`,
@@ -44,7 +44,9 @@ underlying connection matrices and reflection positivity.
 * `TauCeti.DenseGraphLimits.LabeledGraph.forgetLabels_def` is the defining law for unlabeling, by
   which a dependent value `f G.forgetLabels.1 G.forgetLabels.2` is evaluated;
 * `TauCeti.DenseGraphLimits.LabeledGraph.glueCommIso` is the commutativity of the gluing algebra,
-  the isomorphism between the two orders of a gluing that makes connection matrices symmetric.
+  the isomorphism between the two orders of a gluing that makes connection matrices symmetric, and
+  `TauCeti.DenseGraphLimits.LabeledGraph.glueCommIso_label` says it retains the labels, so it is an
+  isomorphism of `k`-labeled graphs and commutativity survives a further gluing.
 
 ## Implementation
 
@@ -273,8 +275,7 @@ theorem glueInr_label (G₁ G₂ : LabeledGraph k) :
   funext fun i => congrArg _ (glueRight_label G₁ G₂ i).symm
 
 /-- Every vertex of the gluing comes from one of the two sides. -/
-theorem exists_glueInl_or_exists_glueInr (G₁ G₂ : LabeledGraph k)
-    (v : Fin (G₁.glue G₂).n) :
+theorem glue_surjective (G₁ G₂ : LabeledGraph k) (v : Fin (G₁.glue G₂).n) :
     (∃ a, v = G₁.glueInl G₂ a) ∨ ∃ b, v = G₁.glueInr G₂ b := by
   obtain h | h := glueLeft_surjective_or G₁ G₂ ((G₁.glueIndex G₂).symm v)
   · obtain ⟨a, ha⟩ := h
@@ -483,6 +484,14 @@ noncomputable def glueCommIso (G₁ G₂ : LabeledGraph k) :
   map_rel_iff' {u v} := by
     conv_lhs => rw [← glue_graph_map_glueCommEquiv G₁ G₂]
     exact SimpleGraph.map_adj_apply (f := (G₁.glueCommEquiv G₂).toEmbedding)
+
+/-- **Commutativity retains the labels.**  `glueCommIso` carries the `i`-th label of one order of a
+gluing to the `i`-th label of the other, so it is an isomorphism of `k`-labeled graphs and not
+merely of the underlying graphs: commutativity may therefore be used inside a further gluing. -/
+theorem glueCommIso_label (G₁ G₂ : LabeledGraph k) (i : Fin k) :
+    G₁.glueCommIso G₂ ((G₁.glue G₂).label i) = (G₂.glue G₁).label i := by
+  rw [congrFun (glueInl_label G₁ G₂) i]
+  exact (glueCommEquiv_glueInl G₁ G₂ (G₁.label i)).trans (congrFun (glueInr_label G₂ G₁) i).symm
 
 end LabeledGraph
 

--- a/TauCeti/Combinatorics/DenseGraphLimits/Representability/LabeledGraph.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/Representability/LabeledGraph.lean
@@ -32,8 +32,8 @@ underlying connection matrices and reflection positivity.
   the two mapped sources, so no edge is created that neither source carries;
 * `TauCeti.DenseGraphLimits.LabeledGraph.glueInl_eq_glueInr_iff` says the two sides meet exactly at
   corresponding labels, and
-  `TauCeti.DenseGraphLimits.LabeledGraph.glue_surjective` that they cover the gluing: together they
-  present the vertex set as the pushout;
+  `TauCeti.DenseGraphLimits.LabeledGraph.exists_glueInl_or_exists_glueInr` that they cover the
+  gluing: together they present the vertex set as the pushout;
 * `TauCeti.DenseGraphLimits.LabeledGraph.glue_card` is the resulting vertex count
   `n₁ + n₂ - k`;
 * `TauCeti.DenseGraphLimits.LabeledGraph.glue_adj_inl`,
@@ -41,7 +41,7 @@ underlying connection matrices and reflection positivity.
   `TauCeti.DenseGraphLimits.LabeledGraph.glue_adj_inl_inr` are the adjacency eliminators, and
   `TauCeti.DenseGraphLimits.LabeledGraph.not_glue_adj_of_unlabeled` records that unlabeled vertices
   of the two sides are never joined;
-* `TauCeti.DenseGraphLimits.LabeledGraph.forgetLabels_eq` is the elimination law for unlabeling, by
+* `TauCeti.DenseGraphLimits.LabeledGraph.forgetLabels_def` is the defining law for unlabeling, by
   which a dependent value `f G.forgetLabels.1 G.forgetLabels.2` is evaluated;
 * `TauCeti.DenseGraphLimits.LabeledGraph.glueCommIso` is the commutativity of the gluing algebra,
   the isomorphism between the two orders of a gluing that makes connection matrices symmetric.
@@ -273,7 +273,8 @@ theorem glueInr_label (G₁ G₂ : LabeledGraph k) :
   funext fun i => congrArg _ (glueRight_label G₁ G₂ i).symm
 
 /-- Every vertex of the gluing comes from one of the two sides. -/
-theorem glue_surjective (G₁ G₂ : LabeledGraph k) (v : Fin (G₁.glue G₂).n) :
+theorem exists_glueInl_or_exists_glueInr (G₁ G₂ : LabeledGraph k)
+    (v : Fin (G₁.glue G₂).n) :
     (∃ a, v = G₁.glueInl G₂ a) ∨ ∃ b, v = G₁.glueInr G₂ b := by
   obtain h | h := glueLeft_surjective_or G₁ G₂ ((G₁.glueIndex G₂).symm v)
   · obtain ⟨a, ha⟩ := h
@@ -285,7 +286,7 @@ theorem glue_surjective (G₁ G₂ : LabeledGraph k) (v : Fin (G₁.glue G₂).n
 theorem glue_card (G₁ G₂ : LabeledGraph k) : (G₁.glue G₂).n = G₁.n + G₂.n - k := by
   have h₁ := G₁.le_n
   have h₂ := G₂.le_n
-  have hcard : (G₁.glue G₂).n = Fintype.card (G₁.glueCarrier G₂) := by rw [glue.eq_1]
+  have hcard : (G₁.glue G₂).n = Fintype.card (G₁.glueCarrier G₂) := rfl
   rw [hcard, Fintype.card_sum, Fintype.card_sum, Fintype.card_fin, card_unlabeled, card_unlabeled]
   omega
 
@@ -391,13 +392,13 @@ def forgetLabels (G : LabeledGraph k) : Σ m, SimpleGraph (Fin m) := ⟨G.n, G.g
 count and its graph.  Both projections are read off from this law, and it is the form a dependent
 occurrence `f G.forgetLabels.1 G.forgetLabels.2` is rewritten by, since the two projections can
 only be replaced simultaneously: the type of the second mentions the first. -/
-theorem forgetLabels_eq (G : LabeledGraph k) : G.forgetLabels = ⟨G.n, G.graph⟩ := by
-  rw [forgetLabels.eq_1]
+theorem forgetLabels_def (G : LabeledGraph k) : G.forgetLabels = ⟨G.n, G.graph⟩ := by
+  simp only [forgetLabels]
 
 /-- Unlabeling keeps the vertex count. -/
 @[simp]
 theorem forgetLabels_fst (G : LabeledGraph k) : G.forgetLabels.1 = G.n := by
-  rw [forgetLabels_eq]
+  rw [forgetLabels_def]
 
 /-! ### Commutativity of the gluing -/
 

--- a/TauCeti/Combinatorics/DenseGraphLimits/Representability/LabeledGraph.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/Representability/LabeledGraph.lean
@@ -60,8 +60,7 @@ collapses as soon as one of the two vertices is unlabeled
 
 ## References
 
-* `TauCetiRoadmap/DenseGraphLimits/Suggested.lean` — suggested signatures for the Layer 8 gluing
-  and connection-matrix API.
+* `TauCetiRoadmap/DenseGraphLimits/Suggested.lean` — source for the formal signatures.
 * L. Lovász, B. Szegedy, *Limits of dense graph sequences*, JCTB 96 (2006), 933–957, Section 2 —
   `k`-labeled graphs, their product, and connection matrices.
 * L. Lovász, *Large Networks and Graph Limits*, AMS Colloquium Publications 60 (2012), Chapter 6.

--- a/TauCeti/Combinatorics/DenseGraphLimits/Representability/LabeledGraph.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/Representability/LabeledGraph.lean
@@ -41,6 +41,8 @@ underlying connection matrices and reflection positivity.
   `TauCeti.DenseGraphLimits.LabeledGraph.glue_adj_inl_inr` are the adjacency eliminators, and
   `TauCeti.DenseGraphLimits.LabeledGraph.not_glue_adj_of_unlabeled` records that unlabeled vertices
   of the two sides are never joined;
+* `TauCeti.DenseGraphLimits.LabeledGraph.forgetLabels_eq` is the elimination law for unlabeling, by
+  which a dependent value `f G.forgetLabels.1 G.forgetLabels.2` is evaluated;
 * `TauCeti.DenseGraphLimits.LabeledGraph.glueCommIso` is the commutativity of the gluing algebra,
   the isomorphism between the two orders of a gluing that makes connection matrices symmetric.
 
@@ -383,16 +385,19 @@ theorem not_glue_adj_of_unlabeled (G₁ G₂ : LabeledGraph k) {a : Fin G₁.n} 
 
 /-- **Unlabeling.**  The underlying finite simple graph of a `k`-labeled graph, labels forgotten —
 the object a graph parameter evaluates in a connection-matrix entry. -/
-@[expose]
 def forgetLabels (G : LabeledGraph k) : Σ m, SimpleGraph (Fin m) := ⟨G.n, G.graph⟩
+
+/-- **Elimination law for unlabeling**: forgetting the labels of `G` leaves the pair of its vertex
+count and its graph.  Both projections are read off from this law, and it is the form a dependent
+occurrence `f G.forgetLabels.1 G.forgetLabels.2` is rewritten by, since the two projections can
+only be replaced simultaneously: the type of the second mentions the first. -/
+theorem forgetLabels_eq (G : LabeledGraph k) : G.forgetLabels = ⟨G.n, G.graph⟩ := by
+  rw [forgetLabels.eq_1]
 
 /-- Unlabeling keeps the vertex count. -/
 @[simp]
-theorem forgetLabels_fst (G : LabeledGraph k) : G.forgetLabels.1 = G.n := rfl
-
-/-- Unlabeling keeps the graph. -/
-@[simp]
-theorem forgetLabels_snd (G : LabeledGraph k) : G.forgetLabels.2 = G.graph := rfl
+theorem forgetLabels_fst (G : LabeledGraph k) : G.forgetLabels.1 = G.n := by
+  rw [forgetLabels_eq]
 
 /-! ### Commutativity of the gluing -/
 

--- a/TauCeti/Combinatorics/DenseGraphLimits/Representability/LabeledGraph.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/Representability/LabeledGraph.lean
@@ -63,12 +63,9 @@ collapses as soon as one of the two vertices is unlabeled
 * L. Lovász, B. Szegedy, *Limits of dense graph sequences*, JCTB 96 (2006), 933–957, Section 2 —
   `k`-labeled graphs, their product, and connection matrices.
 * L. Lovász, *Large Networks and Graph Limits*, AMS Colloquium Publications 60 (2012), Chapter 6.
-* Roadmap: `TauCetiRoadmap/DenseGraphLimits/README.md`, Layer 8a — the gluing algebra behind the
-  representability theorem.  The signatures follow
-  `TauCetiRoadmap/DenseGraphLimits/Suggested.lean`.
 -/
 
-@[expose] public section
+public section
 
 namespace TauCeti.DenseGraphLimits
 
@@ -226,6 +223,7 @@ theorem glueLeft_surjective_or (G₁ G₂ : LabeledGraph k) (v : G₁.glueCarrie
 taking the union of the two edge sets.  The identified vertices keep their labels — and stay
 distinct — so the result is again a `k`-labeled graph and gluing iterates.  This is
 Lovász–Szegedy's product `F₁F₂`. -/
+@[expose]
 noncomputable def glue (G₁ G₂ : LabeledGraph k) : LabeledGraph k where
   n := Fintype.card (G₁.glueCarrier G₂)
   graph := (G₁.graph.map fun a => G₁.glueIndex G₂ (G₁.glueLeft G₂ a)) ⊔
@@ -234,11 +232,13 @@ noncomputable def glue (G₁ G₂ : LabeledGraph k) : LabeledGraph k where
   label_injective := (G₁.glueIndex G₂).injective.comp Sum.inl_injective
 
 /-- The vertex map of the left factor into the gluing. -/
+@[expose]
 noncomputable def glueInl (G₁ G₂ : LabeledGraph k) : Fin G₁.n ↪ Fin (G₁.glue G₂).n :=
   ⟨fun a => G₁.glueIndex G₂ (G₁.glueLeft G₂ a),
     (G₁.glueIndex G₂).injective.comp (G₁.glueLeft_injective G₂)⟩
 
 /-- The vertex map of the right factor into the gluing. -/
+@[expose]
 noncomputable def glueInr (G₁ G₂ : LabeledGraph k) : Fin G₂.n ↪ Fin (G₁.glue G₂).n :=
   ⟨fun b => G₁.glueIndex G₂ (G₁.glueRight G₂ b),
     (G₁.glueIndex G₂).injective.comp (G₁.glueRight_injective G₂)⟩
@@ -385,6 +385,7 @@ theorem not_glue_adj_of_unlabeled (G₁ G₂ : LabeledGraph k) {a : Fin G₁.n} 
 
 /-- **Unlabeling.**  The underlying finite simple graph of a `k`-labeled graph, labels forgotten —
 the object a graph parameter evaluates in a connection-matrix entry. -/
+@[expose]
 def forgetLabels (G : LabeledGraph k) : Σ m, SimpleGraph (Fin m) := ⟨G.n, G.graph⟩
 
 /-- Unlabeling keeps the vertex count. -/
@@ -398,11 +399,11 @@ theorem forgetLabels_snd (G : LabeledGraph k) : G.forgetLabels.2 = G.graph := rf
 /-! ### Commutativity of the gluing -/
 
 /-- Swapping the two private summands of a gluing carrier. -/
-def glueSwap (G₁ G₂ : LabeledGraph k) : G₁.glueCarrier G₂ ≃ G₂.glueCarrier G₁ :=
+private def glueSwap (G₁ G₂ : LabeledGraph k) : G₁.glueCarrier G₂ ≃ G₂.glueCarrier G₁ :=
   (Equiv.refl (Fin k)).sumCongr (Equiv.sumComm _ _)
 
 /-- Under the swap, the left factor of one order becomes the right factor of the other. -/
-theorem glueSwap_glueLeft (G₁ G₂ : LabeledGraph k) (a : Fin G₁.n) :
+private theorem glueSwap_glueLeft (G₁ G₂ : LabeledGraph k) (a : Fin G₁.n) :
     G₁.glueSwap G₂ (G₁.glueLeft G₂ a) = G₂.glueRight G₁ a := by
   by_cases ha : ∃ i, G₁.label i = a
   · obtain ⟨i, rfl⟩ := ha
@@ -413,7 +414,7 @@ theorem glueSwap_glueLeft (G₁ G₂ : LabeledGraph k) (a : Fin G₁.n) :
     rfl
 
 /-- Under the swap, the right factor of one order becomes the left factor of the other. -/
-theorem glueSwap_glueRight (G₁ G₂ : LabeledGraph k) (b : Fin G₂.n) :
+private theorem glueSwap_glueRight (G₁ G₂ : LabeledGraph k) (b : Fin G₂.n) :
     G₁.glueSwap G₂ (G₁.glueRight G₂ b) = G₂.glueLeft G₁ b := by
   by_cases hb : ∃ i, G₂.label i = b
   · obtain ⟨i, rfl⟩ := hb
@@ -424,28 +425,37 @@ theorem glueSwap_glueRight (G₁ G₂ : LabeledGraph k) (b : Fin G₂.n) :
     rfl
 
 /-- The vertex bijection between the two orders of a gluing. -/
-noncomputable def glueCommEquiv (G₁ G₂ : LabeledGraph k) :
+private noncomputable def glueCommEquiv (G₁ G₂ : LabeledGraph k) :
     Fin (G₁.glue G₂).n ≃ Fin (G₂.glue G₁).n :=
   (G₁.glueIndex G₂).symm.trans ((G₁.glueSwap G₂).trans (G₂.glueIndex G₁))
 
+/-- The commutativity bijection unfolds to the carrier swap. -/
+private theorem glueCommEquiv_apply (G₁ G₂ : LabeledGraph k) (v : Fin (G₁.glue G₂).n) :
+    G₁.glueCommEquiv G₂ v =
+      G₂.glueIndex G₁ (G₁.glueSwap G₂ ((G₁.glueIndex G₂).symm v)) := rfl
+
+/-- The left vertex map is induced by the left carrier map. -/
+private theorem glueInl_apply (G₁ G₂ : LabeledGraph k) (a : Fin G₁.n) :
+    G₁.glueInl G₂ a = G₁.glueIndex G₂ (G₁.glueLeft G₂ a) := rfl
+
+/-- The right vertex map is induced by the right carrier map. -/
+private theorem glueInr_apply (G₁ G₂ : LabeledGraph k) (b : Fin G₂.n) :
+    G₁.glueInr G₂ b = G₁.glueIndex G₂ (G₁.glueRight G₂ b) := rfl
+
 /-- The commutativity bijection exchanges the two vertex maps. -/
-theorem glueCommEquiv_glueInl (G₁ G₂ : LabeledGraph k) (a : Fin G₁.n) :
+private theorem glueCommEquiv_glueInl (G₁ G₂ : LabeledGraph k) (a : Fin G₁.n) :
     G₁.glueCommEquiv G₂ (G₁.glueInl G₂ a) = G₂.glueInr G₁ a := by
-  change G₂.glueIndex G₁ (G₁.glueSwap G₂ ((G₁.glueIndex G₂).symm
-    (G₁.glueIndex G₂ (G₁.glueLeft G₂ a)))) = _
-  rw [Equiv.symm_apply_apply, glueSwap_glueLeft]
-  rfl
+  rw [glueCommEquiv_apply, glueInl_apply, Equiv.symm_apply_apply, glueSwap_glueLeft,
+    glueInr_apply]
 
 /-- The commutativity bijection exchanges the two vertex maps, on the right. -/
-theorem glueCommEquiv_glueInr (G₁ G₂ : LabeledGraph k) (b : Fin G₂.n) :
+private theorem glueCommEquiv_glueInr (G₁ G₂ : LabeledGraph k) (b : Fin G₂.n) :
     G₁.glueCommEquiv G₂ (G₁.glueInr G₂ b) = G₂.glueInl G₁ b := by
-  change G₂.glueIndex G₁ (G₁.glueSwap G₂ ((G₁.glueIndex G₂).symm
-    (G₁.glueIndex G₂ (G₁.glueRight G₂ b)))) = _
-  rw [Equiv.symm_apply_apply, glueSwap_glueRight]
-  rfl
+  rw [glueCommEquiv_apply, glueInr_apply, Equiv.symm_apply_apply, glueSwap_glueRight,
+    glueInl_apply]
 
 /-- The commutativity bijection carries one glued graph onto the other. -/
-theorem glue_graph_map_glueCommEquiv (G₁ G₂ : LabeledGraph k) :
+private theorem glue_graph_map_glueCommEquiv (G₁ G₂ : LabeledGraph k) :
     (G₁.glue G₂).graph.map (G₁.glueCommEquiv G₂) = (G₂.glue G₁).graph := by
   have h₁ : (G₁.glueCommEquiv G₂ : Fin (G₁.glue G₂).n → Fin (G₂.glue G₁).n) ∘
       (G₁.glueInl G₂ : Fin G₁.n → Fin (G₁.glue G₂).n) = G₂.glueInr G₁ :=

--- a/TauCeti/Combinatorics/DenseGraphLimits/Representability/LabeledGraph.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/Representability/LabeledGraph.lean
@@ -60,6 +60,8 @@ collapses as soon as one of the two vertices is unlabeled
 
 ## References
 
+* `TauCetiRoadmap/DenseGraphLimits/Suggested.lean` — suggested signatures for the Layer 8 gluing
+  and connection-matrix API.
 * L. Lovász, B. Szegedy, *Limits of dense graph sequences*, JCTB 96 (2006), 933–957, Section 2 —
   `k`-labeled graphs, their product, and connection matrices.
 * L. Lovász, *Large Networks and Graph Limits*, AMS Colloquium Publications 60 (2012), Chapter 6.
@@ -108,27 +110,28 @@ theorem card_unlabeled (G : LabeledGraph k) : Fintype.card G.Unlabeled = G.n - k
 
 /-- The vertex carrier of a gluing: the `k` shared labels together with the unlabeled vertices of
 each side.  Writing it in this symmetric shape makes `glueCommIso` a swap of summands. -/
-abbrev glueCarrier (G₁ G₂ : LabeledGraph k) : Type := Fin k ⊕ (G₁.Unlabeled ⊕ G₂.Unlabeled)
+private abbrev glueCarrier (G₁ G₂ : LabeledGraph k) : Type :=
+  Fin k ⊕ (G₁.Unlabeled ⊕ G₂.Unlabeled)
 
 /-- The chosen `Fin`-representative of the gluing carrier. -/
-noncomputable def glueIndex (G₁ G₂ : LabeledGraph k) :
+private noncomputable def glueIndex (G₁ G₂ : LabeledGraph k) :
     G₁.glueCarrier G₂ ≃ Fin (Fintype.card (G₁.glueCarrier G₂)) :=
   Fintype.equivFin _
 
 /-- Where a vertex of the left factor lands in the gluing carrier: at its label if it has one, and
 in the private left summand otherwise. -/
-noncomputable def glueLeft (G₁ G₂ : LabeledGraph k) (a : Fin G₁.n) : G₁.glueCarrier G₂ :=
+private noncomputable def glueLeft (G₁ G₂ : LabeledGraph k) (a : Fin G₁.n) : G₁.glueCarrier G₂ :=
   if h : ∃ i, G₁.label i = a then Sum.inl h.choose
   else Sum.inr (Sum.inl ⟨a, fun i hi => h ⟨i, hi⟩⟩)
 
 /-- Where a vertex of the right factor lands in the gluing carrier. -/
-noncomputable def glueRight (G₁ G₂ : LabeledGraph k) (b : Fin G₂.n) : G₁.glueCarrier G₂ :=
+private noncomputable def glueRight (G₁ G₂ : LabeledGraph k) (b : Fin G₂.n) : G₁.glueCarrier G₂ :=
   if h : ∃ i, G₂.label i = b then Sum.inl h.choose
   else Sum.inr (Sum.inr ⟨b, fun i hi => h ⟨i, hi⟩⟩)
 
 /-- A labeled left vertex lands on its shared label. -/
 @[simp]
-theorem glueLeft_label (G₁ G₂ : LabeledGraph k) (i : Fin k) :
+private theorem glueLeft_label (G₁ G₂ : LabeledGraph k) (i : Fin k) :
     G₁.glueLeft G₂ (G₁.label i) = Sum.inl i := by
   have h : ∃ j, G₁.label j = G₁.label i := ⟨i, rfl⟩
   rw [glueLeft, dite_eq_left h]
@@ -136,24 +139,25 @@ theorem glueLeft_label (G₁ G₂ : LabeledGraph k) (i : Fin k) :
 
 /-- A labeled right vertex lands on its shared label. -/
 @[simp]
-theorem glueRight_label (G₁ G₂ : LabeledGraph k) (i : Fin k) :
+private theorem glueRight_label (G₁ G₂ : LabeledGraph k) (i : Fin k) :
     G₁.glueRight G₂ (G₂.label i) = Sum.inl i := by
   have h : ∃ j, G₂.label j = G₂.label i := ⟨i, rfl⟩
   rw [glueRight, dite_eq_left h]
   exact congrArg Sum.inl (G₂.label_injective h.choose_spec)
 
 /-- An unlabeled left vertex lands in the private left summand. -/
-theorem glueLeft_of_unlabeled (G₁ G₂ : LabeledGraph k) {a : Fin G₁.n}
+private theorem glueLeft_of_unlabeled (G₁ G₂ : LabeledGraph k) {a : Fin G₁.n}
     (ha : ∀ i, G₁.label i ≠ a) : G₁.glueLeft G₂ a = Sum.inr (Sum.inl ⟨a, ha⟩) := by
   rw [glueLeft, dite_eq_right (fun h => ha h.choose h.choose_spec)]
 
 /-- An unlabeled right vertex lands in the private right summand. -/
-theorem glueRight_of_unlabeled (G₁ G₂ : LabeledGraph k) {b : Fin G₂.n}
+private theorem glueRight_of_unlabeled (G₁ G₂ : LabeledGraph k) {b : Fin G₂.n}
     (hb : ∀ i, G₂.label i ≠ b) : G₁.glueRight G₂ b = Sum.inr (Sum.inr ⟨b, hb⟩) := by
   rw [glueRight, dite_eq_right (fun h => hb h.choose h.choose_spec)]
 
 /-- The left factor embeds in the gluing carrier. -/
-theorem glueLeft_injective (G₁ G₂ : LabeledGraph k) : Function.Injective (G₁.glueLeft G₂) := by
+private theorem glueLeft_injective (G₁ G₂ : LabeledGraph k) :
+    Function.Injective (G₁.glueLeft G₂) := by
   intro a b hab
   by_cases ha : ∃ i, G₁.label i = a <;> by_cases hb : ∃ i, G₁.label i = b
   · obtain ⟨i, rfl⟩ := ha
@@ -171,7 +175,8 @@ theorem glueLeft_injective (G₁ G₂ : LabeledGraph k) : Function.Injective (G�
     simpa using hab
 
 /-- The right factor embeds in the gluing carrier. -/
-theorem glueRight_injective (G₁ G₂ : LabeledGraph k) : Function.Injective (G₁.glueRight G₂) := by
+private theorem glueRight_injective (G₁ G₂ : LabeledGraph k) :
+    Function.Injective (G₁.glueRight G₂) := by
   intro a b hab
   by_cases ha : ∃ i, G₂.label i = a <;> by_cases hb : ∃ i, G₂.label i = b
   · obtain ⟨i, rfl⟩ := ha
@@ -189,7 +194,8 @@ theorem glueRight_injective (G₁ G₂ : LabeledGraph k) : Function.Injective (G
     simpa using hab
 
 /-- In the gluing carrier the two sides meet exactly at corresponding labels. -/
-theorem glueLeft_eq_glueRight_iff (G₁ G₂ : LabeledGraph k) (a : Fin G₁.n) (b : Fin G₂.n) :
+private theorem glueLeft_eq_glueRight_iff (G₁ G₂ : LabeledGraph k) (a : Fin G₁.n)
+    (b : Fin G₂.n) :
     G₁.glueLeft G₂ a = G₁.glueRight G₂ b ↔ ∃ i, a = G₁.label i ∧ b = G₂.label i := by
   constructor
   · intro hab
@@ -212,7 +218,7 @@ theorem glueLeft_eq_glueRight_iff (G₁ G₂ : LabeledGraph k) (a : Fin G₁.n) 
     rw [glueLeft_label, glueRight_label]
 
 /-- Every vertex of the gluing carrier comes from one of the two sides. -/
-theorem glueLeft_surjective_or (G₁ G₂ : LabeledGraph k) (v : G₁.glueCarrier G₂) :
+private theorem glueLeft_surjective_or (G₁ G₂ : LabeledGraph k) (v : G₁.glueCarrier G₂) :
     (∃ a, v = G₁.glueLeft G₂ a) ∨ ∃ b, v = G₁.glueRight G₂ b := by
   match v with
   | Sum.inl i => exact Or.inl ⟨G₁.label i, (glueLeft_label G₁ G₂ i).symm⟩
@@ -223,7 +229,6 @@ theorem glueLeft_surjective_or (G₁ G₂ : LabeledGraph k) (v : G₁.glueCarrie
 taking the union of the two edge sets.  The identified vertices keep their labels — and stay
 distinct — so the result is again a `k`-labeled graph and gluing iterates.  This is
 Lovász–Szegedy's product `F₁F₂`. -/
-@[expose]
 noncomputable def glue (G₁ G₂ : LabeledGraph k) : LabeledGraph k where
   n := Fintype.card (G₁.glueCarrier G₂)
   graph := (G₁.graph.map fun a => G₁.glueIndex G₂ (G₁.glueLeft G₂ a)) ⊔
@@ -232,21 +237,24 @@ noncomputable def glue (G₁ G₂ : LabeledGraph k) : LabeledGraph k where
   label_injective := (G₁.glueIndex G₂).injective.comp Sum.inl_injective
 
 /-- The vertex map of the left factor into the gluing. -/
-@[expose]
 noncomputable def glueInl (G₁ G₂ : LabeledGraph k) : Fin G₁.n ↪ Fin (G₁.glue G₂).n :=
   ⟨fun a => G₁.glueIndex G₂ (G₁.glueLeft G₂ a),
     (G₁.glueIndex G₂).injective.comp (G₁.glueLeft_injective G₂)⟩
 
 /-- The vertex map of the right factor into the gluing. -/
-@[expose]
 noncomputable def glueInr (G₁ G₂ : LabeledGraph k) : Fin G₂.n ↪ Fin (G₁.glue G₂).n :=
   ⟨fun b => G₁.glueIndex G₂ (G₁.glueRight G₂ b),
     (G₁.glueIndex G₂).injective.comp (G₁.glueRight_injective G₂)⟩
 
+-- Definitional form used to export the characteristic law without exposing the constructors.
+private theorem glue_graph_def (G₁ G₂ : LabeledGraph k) :
+    (G₁.glue G₂).graph = G₁.graph.map (G₁.glueInl G₂) ⊔ G₂.graph.map (G₁.glueInr G₂) := rfl
+
 /-- **The glued graph is exactly the supremum of the two mapped sources**: gluing creates no edge
 that neither side carries. -/
 theorem glue_graph (G₁ G₂ : LabeledGraph k) :
-    (G₁.glue G₂).graph = G₁.graph.map (G₁.glueInl G₂) ⊔ G₂.graph.map (G₁.glueInr G₂) := rfl
+    (G₁.glue G₂).graph = G₁.graph.map (G₁.glueInl G₂) ⊔ G₂.graph.map (G₁.glueInr G₂) :=
+  glue_graph_def G₁ G₂
 
 /-- **No other identifications**: the two sides meet exactly at corresponding labels. -/
 theorem glueInl_eq_glueInr_iff (G₁ G₂ : LabeledGraph k) (a : Fin G₁.n) (b : Fin G₂.n) :
@@ -277,17 +285,9 @@ theorem glue_surjective (G₁ G₂ : LabeledGraph k) (v : Fin (G₁.glue G₂).n
 theorem glue_card (G₁ G₂ : LabeledGraph k) : (G₁.glue G₂).n = G₁.n + G₂.n - k := by
   have h₁ := G₁.le_n
   have h₂ := G₂.le_n
-  have hcard : (G₁.glue G₂).n = Fintype.card (G₁.glueCarrier G₂) := rfl
+  have hcard : (G₁.glue G₂).n = Fintype.card (G₁.glueCarrier G₂) := by rw [glue.eq_1]
   rw [hcard, Fintype.card_sum, Fintype.card_sum, Fintype.card_fin, card_unlabeled, card_unlabeled]
   omega
-
-/-- The supremum of two graphs maps to the supremum of the images.  A local convenience: only
-`SimpleGraph.map_map` is in Mathlib. -/
-private theorem map_sup {V W : Type*} (f : V → W) (G H : SimpleGraph V) :
-    (G ⊔ H).map f = G.map f ⊔ H.map f := by
-  ext a b
-  simp only [SimpleGraph.map_adj', SimpleGraph.sup_adj]
-  aesop
 
 /-- **Adjacency on the left side.**  A left edge survives the gluing, and the only edges the
 gluing adds between two left vertices are the ones the right side contributes between labels. -/
@@ -463,7 +463,12 @@ private theorem glue_graph_map_glueCommEquiv (G₁ G₂ : LabeledGraph k) :
   have h₂ : (G₁.glueCommEquiv G₂ : Fin (G₁.glue G₂).n → Fin (G₂.glue G₁).n) ∘
       (G₁.glueInr G₂ : Fin G₂.n → Fin (G₁.glue G₂).n) = G₂.glueInl G₁ :=
     funext (glueCommEquiv_glueInr G₁ G₂)
-  rw [glue_graph, map_sup, SimpleGraph.map_map, SimpleGraph.map_map, h₁, h₂, glue_graph, sup_comm]
+  have hmap (G H : SimpleGraph (Fin (G₁.glue G₂).n)) :
+      (G ⊔ H).map (G₁.glueCommEquiv G₂) =
+        G.map (G₁.glueCommEquiv G₂) ⊔ H.map (G₁.glueCommEquiv G₂) :=
+    GaloisConnection.l_sup
+      (SimpleGraph.map_le_iff_le_comap (G₁.glueCommEquiv G₂).toEmbedding)
+  rw [glue_graph, hmap, SimpleGraph.map_map, SimpleGraph.map_map, h₁, h₂, glue_graph, sup_comm]
 
 /-- **Commutativity of the gluing algebra.**  The two orders of a gluing are isomorphic, so a graph
 parameter that is isomorphism invariant takes the same value on both — this is what makes

--- a/TauCeti/Combinatorics/SimpleGraph/Sum.lean
+++ b/TauCeti/Combinatorics/SimpleGraph/Sum.lean
@@ -8,16 +8,23 @@ module
 public import Mathlib.Combinatorics.SimpleGraph.Sum
 
 /-!
-# Decidable adjacency for a disjoint sum of graphs
+# Disjoint sums of graphs
+
+Two gaps in Mathlib's `SimpleGraph.sum` API.
 
 `SimpleGraph.sum` has no `DecidableRel` instance in Mathlib. Consequently, even when adjacency in
 both summands is decidable, `(G ⊕g H).edgeFinset` is not expressible without supplying an
 instance. `TauCeti.instDecidableRelSumAdj` supplies it by the four-way case split in the definition
 of `SimpleGraph.sum`.
 
+A disjoint sum of edgeless graphs is edgeless, and `SimpleGraph.map` carries no edge to a
+reindexing: `TauCeti.map_sum_bot_bot` combines the two, the form in which a graph parameter that is
+multiplicative over disjoint sums is evaluated on an edgeless graph.
+
 ## Main results
 
 * `TauCeti.instDecidableRelSumAdj` — adjacency in a disjoint sum is decidable;
+* `TauCeti.map_sum_bot_bot` — a reindexed disjoint sum of edgeless graphs is edgeless.
 -/
 
 public section
@@ -36,5 +43,13 @@ instance instDecidableRelSumAdj (G : SimpleGraph V) (H : SimpleGraph W)
   | .inr u, .inr v => ‹DecidableRel H.Adj› u v
   | .inl _, .inr _ => isFalse (by simp)
   | .inr _, .inl _ => isFalse (by simp)
+
+/-- A disjoint sum of edgeless graphs is edgeless, in any reindexing of its vertices: no edge is
+contributed by either summand, and none across the two sides. -/
+theorem map_sum_bot_bot {X : Type*} (f : V ⊕ W ↪ X) :
+    ((⊥ : SimpleGraph V) ⊕g (⊥ : SimpleGraph W)).map f = ⊥ := by
+  rw [eq_bot_iff, SimpleGraph.map_le_iff_le_comap]
+  intro u v huv
+  cases u <;> cases v <;> simp_all
 
 end TauCeti

--- a/TauCeti/Combinatorics/SimpleGraph/Sum.lean
+++ b/TauCeti/Combinatorics/SimpleGraph/Sum.lean
@@ -17,14 +17,14 @@ both summands is decidable, `(G ⊕g H).edgeFinset` is not expressible without s
 instance. `TauCeti.instDecidableRelSumAdj` supplies it by the four-way case split in the definition
 of `SimpleGraph.sum`.
 
-A disjoint sum of edgeless graphs is edgeless, and `SimpleGraph.map` carries no edge to a
-reindexing: `TauCeti.map_sum_bot_bot` combines the two, the form in which a graph parameter that is
+`SimpleGraph.sum` has no `bot` law in Mathlib either: `TauCeti.SimpleGraph.sum_bot_bot` says a
+disjoint sum of edgeless graphs is edgeless, the form in which a graph parameter that is
 multiplicative over disjoint sums is evaluated on an edgeless graph.
 
 ## Main results
 
 * `TauCeti.instDecidableRelSumAdj` — adjacency in a disjoint sum is decidable;
-* `TauCeti.map_sum_bot_bot` — a reindexed disjoint sum of edgeless graphs is edgeless.
+* `TauCeti.SimpleGraph.sum_bot_bot` — a disjoint sum of edgeless graphs is edgeless.
 -/
 
 public section
@@ -44,12 +44,14 @@ instance instDecidableRelSumAdj (G : SimpleGraph V) (H : SimpleGraph W)
   | .inl _, .inr _ => isFalse (by simp)
   | .inr _, .inl _ => isFalse (by simp)
 
-/-- A disjoint sum of edgeless graphs is edgeless, in any reindexing of its vertices: no edge is
-contributed by either summand, and none across the two sides. -/
-theorem map_sum_bot_bot {X : Type*} (f : V ⊕ W ↪ X) :
-    ((⊥ : SimpleGraph V) ⊕g (⊥ : SimpleGraph W)).map f = ⊥ := by
-  rw [eq_bot_iff, SimpleGraph.map_le_iff_le_comap]
-  intro u v huv
-  cases u <;> cases v <;> simp_all
+namespace SimpleGraph
+
+/-- A disjoint sum of edgeless graphs is edgeless: no edge is contributed by either summand, and
+none across the two sides. -/
+theorem sum_bot_bot : ((⊥ : SimpleGraph V) ⊕g (⊥ : SimpleGraph W)) = ⊥ := by
+  ext u v
+  cases u <;> cases v <;> simp
+
+end SimpleGraph
 
 end TauCeti


### PR DESCRIPTION
This PR builds Layer 8a of the `DenseGraphLimits` roadmap — the gluing algebra of `k`-labeled graphs and the structural conditions of the Lovász–Szegedy representability theorem. A `LabeledGraph k` is a finite simple graph on `Fin n` with an injective `Fin k → Fin n` labelling; `LabeledGraph.glue` glues two of them by identifying corresponding labels and taking the union of the edge sets, keeping the labels so that gluing iterates (Lovász–Szegedy's product `F₁F₂`). On top of it sit `GraphParam`, `IsIsoInvariant`, `connectionMatrix` with its entry law, and the three remaining conditions `IsReflectionPositive`, `IsMultiplicative`, `IsNormalized`.

The roadmap target is `TauCetiRoadmap/DenseGraphLimits/README.md`, "Layer 8a — quantum graphs and reflection positivity": the milestone names exactly `LabeledGraph` (injective labels), the label-retaining `LabeledGraph.glue` with `forgetLabels`, `GraphParam` with `IsIsoInvariant`, the finite `connectionMatrix` (+ `connectionMatrix_apply`), and the `IsReflectionPositive` / `IsMultiplicative` / `IsNormalized` predicates, each "defined outright (a `Prop` with a real body)". All of them land here. Layer 8a is untouched on `main` (`LabeledGraph`, `connectionMatrix`, `GraphParam` all grep to zero) and no open PR covers it, while the roadmap's *Ordering* section pins the build order for the representability summit as **Layer 8a → Layer 9b → Layer 8b**, so this is the first rung and it is unblocked ("8a is independent and can land any time after Layer 0"). After this PR the milestone's own targets are complete; what remains for Layer 8b is the Möbius spine (`graphParamMobius` with its positivity and total-mass laws, `graphParamMobius_sum_comap`, `paramGraphLaw`, `paramExchangeableLaw`) and then `lovasz_szegedy_representability` itself, which additionally waits on Layer 9b's graph-law extremality.

The vertex set of a gluing is built as the concrete pushout carrier `Fin k ⊕ (G₁.Unlabeled ⊕ G₂.Unlabeled)` — shared labels, then each side's private vertices — and transported to a `Fin`-representative along `Fintype.equivFin`, since the pinned structure stores its vertex set as `Fin n`. Writing the carrier in that symmetric shape is what makes commutativity of the gluing a swap of summands (`glueSwap`) rather than a bespoke bijection, and `glueCommIso` is what makes connection matrices of an isomorphism-invariant parameter Hermitian — without which reflection positivity would be asking a parameter for something it cannot supply. The pushout is pinned from both sides: `glueInl_eq_glueInr_iff` (the two sides meet exactly at corresponding labels), `glue_surjective` (they cover it), `glue_graph` (the glued graph is exactly the supremum of the two mapped sources), and the derived vertex count `glue_card : (G₁.glue G₂).n = G₁.n + G₂.n - k`. Adversarially, `not_glue_adj_of_unlabeled` records that no cross-edge between unlabeled vertices of the two sides is smuggled in, and `Examples` shows the four structural conditions are simultaneously satisfiable (the parameter constantly `1`, which is `t(·, W)` for the constant graphon `W ≡ 1`) while `not_isReflectionPositive_neg_one` shows reflection positivity is a genuine constraint rather than a consequence of the others.

Two deliberate deviations from `TauCetiRoadmap/DenseGraphLimits/Suggested.lean`, which the README labels optional guidance. First, its `glue_adj_inl : (G₁.glue G₂).graph.Adj (glueInl a) (glueInl b) ↔ G₁.graph.Adj a b` is false for the gluing `glue_graph` pins: two labeled vertices of the left side can be joined by an edge the *right* side contributes, so the correct eliminator carries the extra disjunct `∃ i j, a = G₁.label i ∧ b = G₁.label j ∧ G₂.graph.Adj (G₂.label i) (G₂.label j)`, which is what `glue_adj_inl` (and its mirror `glue_adj_inr`, and the cross case `glue_adj_inl_inr`) proves here. The naive form is recovered as soon as one endpoint is unlabeled: `glue_adj_inl_of_unlabeled`. Second, `connectionMatrix` is stated without the pinned `[Fintype ι]` binder, which `Matrix ι ι ℝ` does not need and which the `unusedArguments` linter rejects; `IsReflectionPositive` supplies `Fin n` where positive semidefiniteness is asserted, and `IsReflectionPositive.posSemidef` recovers an arbitrary finite index type via `Matrix.posSemidef_submatrix_equiv`.

Mathlib is consumed, not rebuilt: `SimpleGraph.map` / `map_map` / `map_adj_apply`, `SimpleGraph.sum` (`⊕g`), `finSumFinEquiv`, `Fintype.equivFin`, `Fintype.card_subtype_compl`, `Equiv.ofInjective`, `Matrix.PosSemidef` with `posSemidef_submatrix_equiv`, `PosSemidef.diag_nonneg` and `posSemidef_vecMulVec_self_star`. The one general fact not in Mathlib is `(G ⊔ H).map f = G.map f ⊔ H.map f`, kept `private` next to its single use. Both files use a plain `public section`; the one exposed body is `forgetLabels`, whose dependent result type `Σ m, SimpleGraph (Fin m)` is what makes `forgetLabels_snd` type-correct at all. The four structural conditions keep opaque bodies and are reached through their characteristic laws `isIsoInvariant_iff`, `isReflectionPositive_iff`, `isMultiplicative_iff` and `isNormalized_iff` (plus the `IsIsoInvariant.eq_of_iso` eliminator), which are the introduction and elimination forms a downstream file needs; `glue_graph` and `connectionMatrix_apply` play the same role for the two definitions. The roadmap credit sits in a two-line provenance comment above `public section` rather than in the module docstrings, which are kept to mathematical references.

Files added: `TauCeti/Combinatorics/DenseGraphLimits/Representability/LabeledGraph.lean` (470 lines) and `TauCeti/Combinatorics/DenseGraphLimits/Representability/ConnectionMatrix.lean` (197 lines).

Roadmap: DenseGraphLimits

<!--tauceti-target:v1 {"focus":"DenseGraphLimits","id":"quantum-graphs-and-reflection-positivity"}-->

🤖 Prepared with Claude Code