### PR TITLE
refactor(TotallyReal): root the flagged `IsCompl` helper

### DIFF
--- a/TauCeti/LinearAlgebra/Submodule/Compl.lean
+++ b/TauCeti/LinearAlgebra/Submodule/Compl.lean
@@ -5,7 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.LinearAlgebra.Span.Basic
+public import Mathlib.LinearAlgebra.Prod
 
 /-!
 # Complementary submodules induced on a subspace
@@ -20,6 +20,7 @@ not a consequence of spanning the ambient module.
 
 * `TauCeti.Submodule.isCompl_comap_subtype`: a disjoint pair of submodules whose intersections with
   `U` span `U` restricts to a complementary pair of submodules of `U`.
+* `IsCompl.prod`: a product of complementary pairs is complementary.
 -/
 
 public section
@@ -47,5 +48,19 @@ theorem isCompl_comap_subtype {U A B : Submodule R M} (hAB : Disjoint A B)
     exact le_antisymm (sup_le inf_le_left inf_le_left) hU
 
 end Submodule
+
+section Prod
+
+variable {R E F : Type*} [Semiring R] [AddCommMonoid E] [Module R E] [AddCommMonoid F] [Module R F]
+variable {L₁ L₂ : Submodule R E} {M₁ M₂ : Submodule R F}
+
+/-- Products of complementary submodules are complementary. -/
+theorem _root_.IsCompl.prod (hL : IsCompl L₁ L₂) (hM : IsCompl M₁ M₂) :
+    IsCompl (L₁.prod M₁) (L₂.prod M₂) := by
+  refine IsCompl.of_eq ?_ ?_
+  · rw [Submodule.prod_inf_prod, hL.inf_eq_bot, hM.inf_eq_bot, Submodule.prod_bot]
+  · rw [Submodule.prod_sup_prod, hL.sup_eq_top, hM.sup_eq_top, Submodule.prod_top]
+
+end Prod
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/Submodule/Compl.lean
+++ b/TauCeti/LinearAlgebra/Submodule/Compl.lean
@@ -8,13 +8,20 @@ module
 public import Mathlib.LinearAlgebra.Prod
 
 /-!
-# Complementary submodules induced on a subspace
+# Complementary submodules under restriction and products
 
-Mathlib's `Submodule.isCompl_comap_subtype_of_isCompl_of_le` restricts a complementary pair to a
-subspace that contains one of the two. This file records the variant that applies when neither
-member of the pair lies in the subspace: a disjoint pair cuts a subspace `U` into a complementary
-pair as soon as the two intersections with `U` span `U` — for a general `U` a genuine hypothesis,
-not a consequence of spanning the ambient module.
+Two ways complementarity of a pair of submodules survives a construction.
+
+**Restriction to a subspace.** Mathlib's `Submodule.isCompl_comap_subtype_of_isCompl_of_le`
+restricts a complementary pair to a subspace that contains one of the two. This file records the
+variant that applies when neither member of the pair lies in the subspace: a disjoint pair cuts a
+subspace `U` into a complementary pair as soon as the two intersections with `U` span `U` — for a
+general `U` a genuine hypothesis, not a consequence of spanning the ambient module.
+
+**Products.** Complementarity is also preserved by products: a complementary pair in `E` and one in
+`F` give a complementary pair in `E × F`. This is what lets a direct-sum decomposition be built
+factor by factor, and it is used that way for the doubled totally real modules in
+`TauCeti/LinearAlgebra/TotallyReal/Basic.lean`.
 
 ## Main results
 

--- a/TauCeti/LinearAlgebra/TotallyReal/Basic.lean
+++ b/TauCeti/LinearAlgebra/TotallyReal/Basic.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.LinearAlgebra.Submodule.Compl
-public import Mathlib.LinearAlgebra.Prod
 public import Mathlib.LinearAlgebra.Projection
 
 /-!

--- a/TauCeti/LinearAlgebra/TotallyReal/Basic.lean
+++ b/TauCeti/LinearAlgebra/TotallyReal/Basic.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.LinearAlgebra.Submodule.Compl
 public import Mathlib.LinearAlgebra.Prod
 public import Mathlib.LinearAlgebra.Projection
 
@@ -84,22 +85,6 @@ theorem prod {K : F →ₗ[R] F} {M : Submodule R F} (hL : IsTotallyReal J L) (h
     hL.inf_eq_bot, hM.inf_eq_bot, Submodule.prod_bot]
 
 end IsTotallyReal
-
-section
-
-variable {L₁ L₂ : Submodule R E} {M₁ M₂ : Submodule R F}
-
-/-- Products of complementary submodules are complementary.
-
-This is a local helper for the maximal totally real product and doubled-module lemmas below; it
-is `private` because it is not part of the totally real subspace API surface. -/
-private theorem _root_.IsCompl.prod (hL : IsCompl L₁ L₂) (hM : IsCompl M₁ M₂) :
-    IsCompl (L₁.prod M₁) (L₂.prod M₂) := by
-  refine IsCompl.of_eq ?_ ?_
-  · rw [Submodule.prod_inf_prod, hL.inf_eq_bot, hM.inf_eq_bot, Submodule.prod_bot]
-  · rw [Submodule.prod_sup_prod, hL.sup_eq_top, hM.sup_eq_top, Submodule.prod_top]
-
-end
 
 namespace IsMaximalTotallyReal
 

--- a/TauCeti/LinearAlgebra/TotallyReal/Basic.lean
+++ b/TauCeti/LinearAlgebra/TotallyReal/Basic.lean
@@ -85,7 +85,7 @@ theorem prod {K : F →ₗ[R] F} {M : Submodule R F} (hL : IsTotallyReal J L) (h
 
 end IsTotallyReal
 
-namespace IsCompl
+section
 
 variable {L₁ L₂ : Submodule R E} {M₁ M₂ : Submodule R F}
 
@@ -93,13 +93,13 @@ variable {L₁ L₂ : Submodule R E} {M₁ M₂ : Submodule R F}
 
 This is a local helper for the maximal totally real product and doubled-module lemmas below; it
 is `private` because it is not part of the totally real subspace API surface. -/
-private theorem prod (hL : IsCompl L₁ L₂) (hM : IsCompl M₁ M₂) :
+private theorem _root_.IsCompl.prod (hL : IsCompl L₁ L₂) (hM : IsCompl M₁ M₂) :
     IsCompl (L₁.prod M₁) (L₂.prod M₂) := by
   refine IsCompl.of_eq ?_ ?_
   · rw [Submodule.prod_inf_prod, hL.inf_eq_bot, hM.inf_eq_bot, Submodule.prod_bot]
   · rw [Submodule.prod_sup_prod, hL.sup_eq_top, hM.sup_eq_top, Submodule.prod_top]
 
-end IsCompl
+end
 
 namespace IsMaximalTotallyReal
 
@@ -134,7 +134,7 @@ theorem prod (hL : IsMaximalTotallyReal J L) (hM : IsMaximalTotallyReal K M) :
     IsMaximalTotallyReal (LinearMap.prodMap J K) (L.prod M) := by
   rw [isMaximalTotallyReal_iff]
   rw [LinearMap.prodMap_map_prod]
-  exact TauCeti.IsCompl.prod hL.isCompl hM.isCompl
+  exact IsCompl.prod hL.isCompl hM.isCompl
 
 end IsMaximalTotallyReal
 
@@ -186,7 +186,7 @@ theorem isMaximalTotallyReal_prod_top_bot_skewSwap :
       ((⊤ : Submodule R E).prod (⊥ : Submodule R E)) := by
   rw [isMaximalTotallyReal_iff]
   rw [map_prod_top_bot_skewSwap]
-  exact TauCeti.IsCompl.prod isCompl_top_bot isCompl_bot_top
+  exact IsCompl.prod isCompl_top_bot isCompl_bot_top
 
 /-- The second factor in `E × E` is maximal totally real for the standard doubled-module complex
 structure. -/
@@ -195,7 +195,7 @@ theorem isMaximalTotallyReal_prod_bot_top_skewSwap :
       ((⊥ : Submodule R E).prod (⊤ : Submodule R E)) := by
   rw [isMaximalTotallyReal_iff]
   rw [map_prod_bot_top_skewSwap]
-  exact TauCeti.IsCompl.prod isCompl_bot_top isCompl_top_bot
+  exact IsCompl.prod isCompl_bot_top isCompl_top_bot
 
 end Submodule
 


### PR DESCRIPTION
`IsCompl.prod` was the only declaration `lint-dot-notation` flagged in `TauCeti/LinearAlgebra/TotallyReal/Basic.lean` and the only member of `TauCeti.IsCompl` in the tree. Mathlib's root `IsCompl` holds 32 declarations and none is called `prod`.

## What review changed

`api-design` and `placement` agreed the rooting alone was not enough: the statement is a generic fact about complementary submodules, with no totally-real hypotheses, so `private` did not justify keeping it in `TotallyReal/Basic`. It now lives in **`TauCeti/LinearAlgebra/Submodule/Compl.lean`** — the destination `placement` named — as a public `IsCompl.prod`, and the totally-real file imports that module.

`Mathlib.LinearAlgebra.Prod` travels with it, since `Submodule.prod` appears in the statement. That makes the destination's previous `Span.Basic` import redundant, so it is dropped. The three uses in the totally-real file already read `IsCompl.prod` and resolve unchanged.

## The remaining nested namespace

`Compl.lean` now holds a rooted `IsCompl.prod` beside its own `namespace Submodule` (1 declaration). `Submodule` **is** a Mathlib namespace, so this is a fair question — but `TauCeti.Submodule` holds **24 declarations across 7 files**, so rooting it here would slice a namespace across files rather than move it. That is a separate and larger change.

`lint-dot-notation`: 978 → 977, 0 new.

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYwXN9WBAPasmBQXr6iQcp