### PR TITLE
feat: the fundamental group is the automorphism group of the fibre functor

### DIFF
--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/FiberFunctor.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/FiberFunctor.lean
@@ -56,10 +56,6 @@ restriction.
 * Lenstra, *Galois theory for schemes*, Section 3, for the automorphism group of a fibre functor.
 -/
 
--- Provenance: the Tau Ceti `UniversalCovers` roadmap, `README.md`, section "Stage 2: lifting
--- criterion and Galois correspondence", which asks for the classification of covers to be phrased
--- through `Mathlib/CategoryTheory/Galois` and its fibre-functor interface.
-
 public section
 noncomputable section
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/FiberFunctor.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/FiberFunctor.lean
@@ -1,0 +1,162 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicTopology.UniversalCover.Classification.FundamentalGroupAction
+public import TauCeti.CategoryTheory.Action.Tannaka
+
+/-!
+# The fundamental group is the automorphism group of the fibre functor
+
+Let `X` be path connected, locally path connected and semilocally simply connected, and fix a
+basepoint `x₀`. Sending a covering space of `X` to its fibre over `x₀` is a functor
+
+  `TauCeti.CoveringSpace.fiberFunctor x₀ : CoveringSpace X ⥤ Type u`,
+
+and this file identifies its automorphism group:
+
+  `TauCeti.CoveringSpace.autFiberFunctorMulEquiv x₀ :`
+  `  FundamentalGroup X x₀ ≃* Aut (fiberFunctor x₀)`.
+
+A loop class acts on each fibre by monodromy, and `autFiberFunctorMulEquiv_hom_app_apply` records
+that the automorphism attached to it is exactly that action.
+
+This is the fibre-functor reading of the classification. The classification itself is already
+available as an equivalence of categories with `π₁(X, x₀)`-sets, and the fibre functor is that
+equivalence followed by the forgetful functor to types, so the identification is Tannaka duality
+for `G`-sets, `TauCeti.autCompForgetActionMulEquiv`.
+
+The statement is about *all* covering spaces of `X`, not just the finite ones, and this is what
+makes it clean. On the finite covers `TauCeti.FiniteCoveringSpace.fiberFunctor` is a fibre functor
+for a Galois category, and Mathlib's recognition interface there,
+`CategoryTheory.PreGaloisCategory.IsFundamentalGroup`, asks for a *compact* topological group,
+which a discrete `π₁(X, x₀)` is only when it is finite. Keeping all covers removes that
+restriction.
+
+## Main declarations
+
+* `TauCeti.CoveringSpace.fiberFunctor`: the fibre over `x₀`, as a functor to types, with
+  `fiberFunctor_obj` and `fiberFunctor_map` computing it.
+* `TauCeti.CoveringSpace.autFiberFunctorMulEquiv`: **the fundamental group of `X` at `x₀` is the
+  automorphism group of the fibre functor over `x₀`**, with
+  `autFiberFunctorMulEquiv_hom_app_apply` computing the automorphism attached to a loop class.
+* `TauCeti.CoveringSpace.endFiberFunctorMulEquiv`: the same for natural *endo*morphisms of the
+  fibre functor, which are therefore all invertible.
+* `TauCeti.CoveringSpace.existsUnique_monodromy_eq`: every natural automorphism of the fibre
+  functor is monodromy along a unique loop class.
+* `TauCeti.CoveringSpace.monodromy_eq_self_iff`: a loop class acting trivially on every fibre is
+  trivial.
+
+## References
+
+* Hatcher, *Algebraic Topology*, Section 1.3, for the monodromy description of covers.
+* Lenstra, *Galois theory for schemes*, Section 3, for the automorphism group of a fibre functor.
+-/
+
+-- Provenance: the Tau Ceti `UniversalCovers` roadmap, `README.md`, section "Stage 2: lifting
+-- criterion and Galois correspondence", which asks for the classification of covers to be phrased
+-- through `Mathlib/CategoryTheory/Galois` and its fibre-functor interface.
+
+public section
+noncomputable section
+
+open CategoryTheory Topology
+
+universe u
+
+namespace TauCeti.CoveringSpace
+
+variable {X : TopCat.{u}} (x₀ : X)
+
+/-- The functor taking a covering space of `X` to its fibre over `x₀`.
+
+It is the fibre-action functor followed by the forgetful functor from `π₁(X, x₀)`-sets to types,
+and is `@[expose]`d so that its values hold by `rfl` in downstream modules. -/
+@[expose] def fiberFunctor : CoveringSpace X ⥤ Type u :=
+  fiberActionFunctor x₀ ⋙ Action.forget (Type u) (FundamentalGroup X x₀)
+
+@[simp]
+theorem fiberFunctor_obj (p : CoveringSpace X) :
+    (fiberFunctor x₀).obj p = ↥(⇑p.proj ⁻¹' {x₀}) :=
+  (rfl)
+
+/-- A map of covering spaces acts on the fibre over the basepoint by restriction. -/
+@[simp]
+theorem fiberFunctor_map {p q : CoveringSpace X} (f : p ⟶ q) :
+    (fiberFunctor x₀).map f =
+      ↾(IsCoveringMap.fiberMap f.hom.left.hom (proj_hom_comp_hom_left_hom f) x₀) :=
+  fiberActionFunctor_map_hom x₀ f
+
+section Classification
+
+variable [PathConnectedSpace X] [LocallyPathConnectedSpace X]
+  [SemilocallySimplyConnectedSpace X]
+
+/-- The fundamental group of `X` at `x₀` is the monoid of natural endomorphisms of the fibre
+functor over `x₀`. Since the fundamental group is a group, so is this endomorphism monoid: every
+natural endomorphism of the fibre functor is invertible. -/
+def endFiberFunctorMulEquiv : FundamentalGroup X x₀ ≃* End (fiberFunctor x₀) :=
+  endCompForgetActionMulEquiv _ (fiberActionFunctor x₀)
+
+variable {x₀}
+
+/-- The natural endomorphism of the fibre functor attached to a loop class acts on each fibre by
+monodromy along that loop. -/
+@[simp]
+theorem endFiberFunctorMulEquiv_app_apply (g : FundamentalGroup X x₀) (p : CoveringSpace X)
+    (e : ⇑p.proj ⁻¹' {x₀}) :
+    (endFiberFunctorMulEquiv x₀ g).app p e = p.isCoveringMap_proj.monodromy g e :=
+  endCompForgetActionMulEquiv_app_apply (fiberActionFunctor x₀) g p e
+
+variable (x₀)
+
+/-- **The fundamental group of `X` at `x₀` is the automorphism group of the fibre functor over
+`x₀`.**
+
+A loop class is sent to the natural automorphism acting on every fibre by monodromy; that this is
+a bijection onto all natural automorphisms is Tannaka duality for `π₁(X, x₀)`-sets, transported
+along the classification of covering spaces by `π₁(X, x₀)`-sets. -/
+def autFiberFunctorMulEquiv : FundamentalGroup X x₀ ≃* Aut (fiberFunctor x₀) :=
+  autCompForgetActionMulEquiv _ (fiberActionFunctor x₀)
+
+variable {x₀}
+
+/-- The automorphism of the fibre functor attached to a loop class acts on each fibre by
+monodromy along that loop. -/
+@[simp]
+theorem autFiberFunctorMulEquiv_hom_app_apply (g : FundamentalGroup X x₀) (p : CoveringSpace X)
+    (e : ⇑p.proj ⁻¹' {x₀}) :
+    (autFiberFunctorMulEquiv x₀ g).hom.app p e = p.isCoveringMap_proj.monodromy g e :=
+  autCompForgetActionMulEquiv_hom_app_apply (fiberActionFunctor x₀) g p e
+
+/-- Every natural automorphism of the fibre functor is monodromy along a unique loop class. -/
+theorem existsUnique_monodromy_eq (η : Aut (fiberFunctor x₀)) :
+    ∃! g : FundamentalGroup X x₀, ∀ (p : CoveringSpace X) (e : ⇑p.proj ⁻¹' {x₀}),
+      p.isCoveringMap_proj.monodromy g e = η.hom.app p e := by
+  refine ⟨(autFiberFunctorMulEquiv x₀).symm η, fun p e => ?_, fun g hg => ?_⟩
+  · rw [← autFiberFunctorMulEquiv_hom_app_apply, MulEquiv.apply_symm_apply]
+  · refine (autFiberFunctorMulEquiv x₀).injective (Aut.ext (NatTrans.ext (funext fun p => ?_)))
+    ext e
+    rw [MulEquiv.apply_symm_apply]
+    exact (autFiberFunctorMulEquiv_hom_app_apply g p e).trans (hg p e)
+
+/-- A loop class acting trivially by monodromy on the fibre of *every* covering space of `X` is
+trivial. This is the faithfulness condition that
+`CategoryTheory.PreGaloisCategory.IsFundamentalGroup` calls `non_trivial'`. -/
+theorem monodromy_eq_self_iff (g : FundamentalGroup X x₀) :
+    (∀ (p : CoveringSpace X) (e : ⇑p.proj ⁻¹' {x₀}), p.isCoveringMap_proj.monodromy g e = e) ↔
+      g = 1 := by
+  refine ⟨fun hg => ?_, fun hg p e => ?_⟩
+  · rw [← (autFiberFunctorMulEquiv x₀).map_eq_one_iff]
+    refine Aut.ext (NatTrans.ext (funext fun p => ?_))
+    ext e
+    exact (autFiberFunctorMulEquiv_hom_app_apply g p e).trans (hg p e)
+  · subst hg
+    exact one_smul (FundamentalGroup X x₀) (show ToType ((fiberActionFunctor x₀).obj p) from e)
+
+end Classification
+
+end TauCeti.CoveringSpace

--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/FiberFunctor.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/FiberFunctor.lean
@@ -47,8 +47,8 @@ restriction.
   fibre functor, which are therefore all invertible.
 * `TauCeti.CoveringSpace.existsUnique_monodromy_eq`: every natural automorphism of the fibre
   functor is monodromy along a unique loop class.
-* `TauCeti.CoveringSpace.monodromy_eq_self_iff`: a loop class acting trivially on every fibre is
-  trivial.
+* `TauCeti.CoveringSpace.forall_monodromy_eq_self_iff_eq_one`: a loop class acting trivially on
+  every fibre is trivial.
 
 ## References
 
@@ -74,7 +74,8 @@ variable {X : TopCat.{u}} (x₀ : X)
 /-- The functor taking a covering space of `X` to its fibre over `x₀`.
 
 It is the fibre-action functor followed by the forgetful functor from `π₁(X, x₀)`-sets to types,
-and is `@[expose]`d so that its values hold by `rfl` in downstream modules. -/
+and is `@[expose]`d so that the concrete fibre types in its public value lemmas are definitionally
+equal to the functor's values. -/
 @[expose] def fiberFunctor : CoveringSpace X ⥤ Type u :=
   fiberActionFunctor x₀ ⋙ Action.forget (Type u) (FundamentalGroup X x₀)
 
@@ -132,6 +133,15 @@ theorem autFiberFunctorMulEquiv_hom_app_apply (g : FundamentalGroup X x₀) (p :
     (autFiberFunctorMulEquiv x₀ g).hom.app p e = p.isCoveringMap_proj.monodromy g e :=
   autCompForgetActionMulEquiv_hom_app_apply (fiberActionFunctor x₀) g p e
 
+/-- The inverse of the automorphism attached to a loop class is monodromy along the inverse loop
+class. -/
+@[simp]
+theorem autFiberFunctorMulEquiv_inv_app_apply (g : FundamentalGroup X x₀)
+    (p : CoveringSpace X) (e : ⇑p.proj ⁻¹' {x₀}) :
+    (autFiberFunctorMulEquiv x₀ g).inv.app p e =
+      p.isCoveringMap_proj.monodromy (g⁻¹ : FundamentalGroup X x₀) e :=
+  autCompForgetActionMulEquiv_inv_app_apply (fiberActionFunctor x₀) g p e
+
 /-- Every natural automorphism of the fibre functor is monodromy along a unique loop class. -/
 theorem existsUnique_monodromy_eq (η : Aut (fiberFunctor x₀)) :
     ∃! g : FundamentalGroup X x₀, ∀ (p : CoveringSpace X) (e : ⇑p.proj ⁻¹' {x₀}),
@@ -146,7 +156,7 @@ theorem existsUnique_monodromy_eq (η : Aut (fiberFunctor x₀)) :
 /-- A loop class acting trivially by monodromy on the fibre of *every* covering space of `X` is
 trivial. This is the faithfulness condition that
 `CategoryTheory.PreGaloisCategory.IsFundamentalGroup` calls `non_trivial'`. -/
-theorem monodromy_eq_self_iff (g : FundamentalGroup X x₀) :
+theorem forall_monodromy_eq_self_iff_eq_one (g : FundamentalGroup X x₀) :
     (∀ (p : CoveringSpace X) (e : ⇑p.proj ⁻¹' {x₀}), p.isCoveringMap_proj.monodromy g e = e) ↔
       g = 1 := by
   refine ⟨fun hg => ?_, fun hg p e => ?_⟩
@@ -155,7 +165,11 @@ theorem monodromy_eq_self_iff (g : FundamentalGroup X x₀) :
     ext e
     exact (autFiberFunctorMulEquiv_hom_app_apply g p e).trans (hg p e)
   · subst hg
-    exact one_smul (FundamentalGroup X x₀) (show ToType ((fiberActionFunctor x₀).obj p) from e)
+    rw [← fiberActionFunctor_obj_ρ_apply]
+    have hV : ToType ((fiberActionFunctor x₀).obj p) = ⇑p.proj ⁻¹' {x₀} :=
+      fiberActionFunctor_obj_V x₀ p
+    cases hV
+    exact (Action.instMulAction ((fiberActionFunctor x₀).obj p)).one_smul e
 
 end Classification
 

--- a/TauCeti/CategoryTheory/Action/Tannaka.lean
+++ b/TauCeti/CategoryTheory/Action/Tannaka.lean
@@ -13,17 +13,18 @@ public import Mathlib.CategoryTheory.Whiskering
 
 A monoid `G` can be read off from the category `Action (Type u) G` of `G`-sets together with the
 forgetful functor `Action.forget (Type u) G` to types: the monoid of natural endomorphisms of that
-functor is `G` itself, and for a group `G` its automorphism group is `G`.
+functor is `G` itself, so its automorphism group is the unit group `Gˣ`, which for a group `G` is
+`G` again.
 
 The proof is the usual one. A natural endomorphism `η` is determined by its value `s` at the
 identity of the left regular `G`-set `Action.leftRegular G`, because for every `G`-set `A` and
 every point `x` of `A` the orbit map `a ↦ a • x` is a map of `G`-sets out of the left regular one,
 and naturality against it forces `η` to act as `x ↦ s • x`.
 
-The last statement below transports the group form along an equivalence: a functor `C ⥤ Type u`
-that factors as an equivalence onto `G`-sets followed by the forgetful functor has automorphism
-group `G`. This is the form the classification of covering spaces consumes, with `C` the covering
-spaces of a based space and `G` its fundamental group.
+The last statements below transport this along an equivalence: a functor `C ⥤ Type u` that factors
+as an equivalence onto `G`-sets followed by the forgetful functor has endomorphism monoid `G` and
+automorphism group `Gˣ`. This is the form the classification of covering spaces consumes, with `C`
+the covering spaces of a based space and `G` its fundamental group.
 
 No finiteness enters, so this is not Mathlib's `CategoryTheory.PreGaloisCategory` picture: there a
 fibre functor takes values in `FintypeCat` and `CategoryTheory.PreGaloisCategory.IsFundamentalGroup`
@@ -39,10 +40,13 @@ asks for a *compact* topological group, which for a discrete `G` means a finite 
   every `G`-set by the element of `G` it produces at the identity of the left regular `G`-set.
 * `TauCeti.endForgetActionMulEquiv`: **Tannaka duality for `G`-sets**: `G` is the monoid of
   natural endomorphisms of the forgetful functor.
-* `TauCeti.toAutForgetAction` and `TauCeti.autForgetActionMulEquiv`: the group form, for `G` a
-  group.
-* `TauCeti.endCompForgetActionMulEquiv` and `TauCeti.autCompForgetActionMulEquiv`: both forms
-  transported along an equivalence `C ⥤ Action (Type u) G`.
+* `TauCeti.unitsAutForgetActionMulEquiv`: the automorphism form, over a monoid: the automorphism
+  group of the forgetful functor is `Gˣ`.
+* `TauCeti.autForgetActionMulEquiv`: its specialisation to a group `G`, where the automorphism
+  group is `G` itself.
+* `TauCeti.endCompForgetActionMulEquiv`, `TauCeti.unitsAutCompForgetActionMulEquiv` and
+  `TauCeti.autCompForgetActionMulEquiv`: all three forms transported along an equivalence
+  `C ⥤ Action (Type u) G`.
 
 ## References
 
@@ -115,6 +119,9 @@ theorem end_forgetAction_app_apply (η : End (Action.forget (Type u) G)) {s : G}
 
 variable (G)
 
+/-- Acting by the elements of `G` exhausts the natural endomorphisms of the forgetful functor, and
+does so without repetition: evaluation at the identity of the left regular `G`-set inverts
+`TauCeti.toEndForgetAction`, by `TauCeti.end_forgetAction_app_apply`. -/
 theorem toEndForgetAction_bijective : Function.Bijective (toEndForgetAction G) := by
   refine ⟨fun g h hgh => ?_, fun η => ⟨η.app (Action.leftRegular G) (1 : G), ?_⟩⟩
   · rw [← toEndForgetAction_app_leftRegular_one g, ← toEndForgetAction_app_leftRegular_one h, hgh]
@@ -153,6 +160,53 @@ theorem endForgetActionMulEquiv_symm_apply_eq (η : End (Action.forget (Type u) 
 
 variable (G)
 
+/-- **Tannaka duality for `G`-sets**, automorphism form: the automorphism group of the forgetful
+functor from `G`-sets to types is the group of units of the monoid `G`.
+
+An automorphism is an invertible endomorphism, so this is the endomorphism form
+`TauCeti.endForgetActionMulEquiv` on units. -/
+def unitsAutForgetActionMulEquiv : Gˣ ≃* Aut (Action.forget (Type u) G) :=
+  (Units.mapEquiv (endForgetActionMulEquiv G)).trans (Aut.unitsEndEquivAut _)
+
+variable {G}
+
+@[simp]
+theorem unitsAutForgetActionMulEquiv_hom_app_apply (g : Gˣ) (A : Action (Type u) G)
+    (x : ToType A) :
+    (unitsAutForgetActionMulEquiv G g).hom.app A x = (g : G) • x := by
+  -- `Aut.unitsEndEquivAut` keeps the underlying endomorphism as the `hom` projection.
+  change (endForgetActionMulEquiv G (g : G)).app A x = _
+  rw [endForgetActionMulEquiv_apply, toEndForgetAction_app_apply]
+
+@[simp]
+theorem unitsAutForgetActionMulEquiv_inv_app_apply (g : Gˣ) (A : Action (Type u) G)
+    (x : ToType A) :
+    (unitsAutForgetActionMulEquiv G g).inv.app A x = ((g⁻¹ : Gˣ) : G) • x := by
+  -- `Aut.unitsEndEquivAut` keeps the endomorphism of the inverse unit as the `inv` projection.
+  change (endForgetActionMulEquiv G ((g⁻¹ : Gˣ) : G)).app A x = _
+  rw [endForgetActionMulEquiv_apply, toEndForgetAction_app_apply]
+
+/-- The inverse of the automorphism form of Tannaka duality is characterized by evaluating the
+forward natural transformation at the identity of the left regular `G`-set. -/
+@[simp]
+theorem unitsAutForgetActionMulEquiv_symm_apply_eq (η : Aut (Action.forget (Type u) G)) (g : Gˣ) :
+    (unitsAutForgetActionMulEquiv G).symm η = g ↔
+      η.hom.app (Action.leftRegular G) (1 : G) = (g : G) := by
+  rw [MulEquiv.symm_apply_eq]
+  constructor
+  · intro h
+    rw [h]
+    -- The left regular scalar action is definitionally multiplication.
+    change (g : G) * 1 = (g : G)
+    exact mul_one (g : G)
+  · intro h
+    refine Aut.ext (NatTrans.ext (funext fun A => ?_))
+    ext x
+    exact (end_forgetAction_app_apply η.hom h A x).trans
+      (unitsAutForgetActionMulEquiv_hom_app_apply g A x).symm
+
+variable (G)
+
 /-- Tannaka duality transported along an equivalence: if a functor `e` from a category `C` to
 `G`-sets is an equivalence, then `G` is the monoid of natural endomorphisms of the composite
 functor `C ⥤ Type u`. -/
@@ -177,51 +231,69 @@ theorem endCompForgetActionMulEquiv_app_apply {C : Type*} [Category C]
     change (endForgetActionMulEquiv G g).app (e.obj p) x = g • x
     rw [endForgetActionMulEquiv_apply, toEndForgetAction_app_apply]
 
+variable (G)
+
+/-- The automorphism form of Tannaka duality, transported along an equivalence: if a functor `e`
+from a category `C` to `G`-sets is an equivalence, then `Gˣ` is the automorphism group of the
+composite `C ⥤ Type u`. -/
+def unitsAutCompForgetActionMulEquiv {C : Type*} [Category C] (e : C ⥤ Action (Type u) G)
+    [e.IsEquivalence] : Gˣ ≃* Aut (e ⋙ Action.forget (Type u) G) :=
+  (Units.mapEquiv (endCompForgetActionMulEquiv G e)).trans (Aut.unitsEndEquivAut _)
+
+variable {G}
+
+/-- The value of a transported natural automorphism on a point of a fibre; not a `simp` lemma, for
+the reason given at `TauCeti.endCompForgetActionMulEquiv_app_apply`. -/
+theorem unitsAutCompForgetActionMulEquiv_hom_app_apply {C : Type*} [Category C]
+    (e : C ⥤ Action (Type u) G) [e.IsEquivalence] (g : Gˣ) (p : C) (x : ToType (e.obj p)) :
+    (unitsAutCompForgetActionMulEquiv G e g).hom.app p x = (g : G) • x :=
+  by
+    -- `Aut.unitsEndEquivAut` keeps the underlying endomorphism as the `hom` projection.
+    change (endCompForgetActionMulEquiv G e (g : G)).app p x = _
+    exact endCompForgetActionMulEquiv_app_apply e (g : G) p x
+
+/-- The inverse of a transported natural automorphism acts by the inverse unit on every fibre; not
+a `simp` lemma, for the reason given at `TauCeti.endCompForgetActionMulEquiv_app_apply`. -/
+theorem unitsAutCompForgetActionMulEquiv_inv_app_apply {C : Type*} [Category C]
+    (e : C ⥤ Action (Type u) G) [e.IsEquivalence] (g : Gˣ) (p : C) (x : ToType (e.obj p)) :
+    (unitsAutCompForgetActionMulEquiv G e g).inv.app p x = ((g⁻¹ : Gˣ) : G) • x :=
+  by
+    -- `Aut.unitsEndEquivAut` keeps the endomorphism of the inverse unit as the `inv` projection.
+    change (endCompForgetActionMulEquiv G e ((g⁻¹ : Gˣ) : G)).app p x = _
+    exact endCompForgetActionMulEquiv_app_apply e ((g⁻¹ : Gˣ) : G) p x
+
 end Monoid
 
 section Group
 
 variable (G : Type u) [Group G]
 
-/-- Acting by `g : G` on every `G`-set is a natural *automorphism* of the forgetful functor from
-`G`-sets to types, with inverse the action of `g⁻¹`. -/
-def toAutForgetAction : G →* Aut (Action.forget (Type u) G) where
-  toFun g :=
-    { hom := toEndForgetAction G g
-      inv := toEndForgetAction G g⁻¹
-      hom_inv_id := by
-        rw [← End.mul_def, ← map_mul, inv_mul_cancel, map_one, End.one_def]
-      inv_hom_id := by
-        rw [← End.mul_def, ← map_mul, mul_inv_cancel, map_one, End.one_def] }
-  map_one' := Aut.ext (map_one (toEndForgetAction G))
-  map_mul' g h := Aut.ext (map_mul (toEndForgetAction G) g h)
-
-variable {G}
-
-@[simp]
-theorem toAutForgetAction_hom (g : G) :
-    (toAutForgetAction G g).hom = toEndForgetAction G g :=
-  by
-    -- Unfold the unexposed constructor once to establish its public projection rule.
-    change toEndForgetAction G g = toEndForgetAction G g
-    rfl
-
-variable (G)
-
 /-- **Tannaka duality for `G`-sets**, group form: a group `G` is the automorphism group of the
-forgetful functor from `G`-sets to types. -/
+forgetful functor from `G`-sets to types. This is the monoid form
+`TauCeti.unitsAutForgetActionMulEquiv` read through the identification `toUnits` of a group with
+its group of units. -/
 def autForgetActionMulEquiv : G ≃* Aut (Action.forget (Type u) G) :=
-  MulEquiv.ofBijective (toAutForgetAction G) <| by
-    refine ⟨fun g h hgh => (toEndForgetAction_bijective G).1 ?_,
-      fun η => ((toEndForgetAction_bijective G).2 η.hom).imp fun g hg => Aut.ext hg⟩
-    rw [← toAutForgetAction_hom g, ← toAutForgetAction_hom h, hgh]
+  toUnits.trans (unitsAutForgetActionMulEquiv G)
 
 variable {G}
+
+/-- The group form of Tannaka duality is the monoid form at the unit attached to `g`. -/
+theorem autForgetActionMulEquiv_apply (g : G) :
+    autForgetActionMulEquiv G g = unitsAutForgetActionMulEquiv G (toUnits g) :=
+  (rfl)
 
 @[simp]
 theorem autForgetActionMulEquiv_hom_app_apply (g : G) (A : Action (Type u) G) (x : ToType A) :
-    (autForgetActionMulEquiv G g).hom.app A x = g • x :=
-  toEndForgetAction_app_apply g A x
+    (autForgetActionMulEquiv G g).hom.app A x = g • x := by
+  rw [autForgetActionMulEquiv_apply, unitsAutForgetActionMulEquiv_hom_app_apply,
+    val_toUnits_apply]
+
+/-- The inverse of the automorphism associated to `g` acts by `g⁻¹`. -/
+@[simp]
+theorem autForgetActionMulEquiv_inv_app_apply (g : G) (A : Action (Type u) G) (x : ToType A) :
+    (autForgetActionMulEquiv G g).inv.app A x = g⁻¹ • x := by
+  rw [autForgetActionMulEquiv_apply, unitsAutForgetActionMulEquiv_inv_app_apply, ← map_inv,
+    val_toUnits_apply]
 
 /-- The inverse Tannaka equivalence is characterized by evaluating the forward natural
 transformation at the identity of the left regular `G`-set. -/
@@ -242,46 +314,39 @@ theorem autForgetActionMulEquiv_symm_apply_eq (η : Aut (Action.forget (Type u) 
     exact (end_forgetAction_app_apply η.hom h A x).trans
       (autForgetActionMulEquiv_hom_app_apply g A x).symm
 
-/-- The inverse of the automorphism associated to `g` acts by `g⁻¹`. -/
-@[simp]
-theorem autForgetActionMulEquiv_inv_app_apply (g : G) (A : Action (Type u) G) (x : ToType A) :
-    (autForgetActionMulEquiv G g).inv.app A x = g⁻¹ • x := by
-  -- `Aut` stores the group inverse's forward map in the `inv` projection.
-  change ((autForgetActionMulEquiv G g)⁻¹).hom.app A x = _
-  rw [← map_inv]
-  exact autForgetActionMulEquiv_hom_app_apply g⁻¹ A x
-
 variable (G)
 
 /-- Tannaka duality transported along an equivalence: if a functor `e` from a category `C` to
-`G`-sets is an equivalence, then `G` is the automorphism group of the composite `C ⥤ Type u`. -/
+`G`-sets is an equivalence, then the group `G` is the automorphism group of the composite
+`C ⥤ Type u`. -/
 def autCompForgetActionMulEquiv {C : Type*} [Category C] (e : C ⥤ Action (Type u) G)
     [e.IsEquivalence] : G ≃* Aut (e ⋙ Action.forget (Type u) G) :=
-  (autForgetActionMulEquiv G).trans
-    ((Functor.FullyFaithful.ofFullyFaithful
-      ((Functor.whiskeringLeft C (Action (Type u) G) (Type u)).obj e)).autMulEquivOfFullyFaithful _)
+  toUnits.trans (unitsAutCompForgetActionMulEquiv G e)
 
 variable {G}
+
+/-- The transported group form of Tannaka duality is the transported monoid form at the unit
+attached to `g`. -/
+theorem autCompForgetActionMulEquiv_apply {C : Type*} [Category C] (e : C ⥤ Action (Type u) G)
+    [e.IsEquivalence] (g : G) :
+    autCompForgetActionMulEquiv G e g = unitsAutCompForgetActionMulEquiv G e (toUnits g) :=
+  (rfl)
 
 /-- The value of a transported natural automorphism on a point of a fibre; not a `simp` lemma, for
 the reason given at `TauCeti.endCompForgetActionMulEquiv_app_apply`. -/
 theorem autCompForgetActionMulEquiv_hom_app_apply {C : Type*} [Category C]
     (e : C ⥤ Action (Type u) G) [e.IsEquivalence] (g : G) (p : C) (x : ToType (e.obj p)) :
-    (autCompForgetActionMulEquiv G e g).hom.app p x = g • x :=
-  by
-    -- Unfold the unexposed transport once; its value is then governed by the public base rule.
-    change (autForgetActionMulEquiv G g).hom.app (e.obj p) x = g • x
-    exact autForgetActionMulEquiv_hom_app_apply g (e.obj p) x
+    (autCompForgetActionMulEquiv G e g).hom.app p x = g • x := by
+  rw [autCompForgetActionMulEquiv_apply, unitsAutCompForgetActionMulEquiv_hom_app_apply,
+    val_toUnits_apply]
 
 /-- The inverse of a transported natural automorphism acts by `g⁻¹` on every fibre; not a `simp`
 lemma, for the reason given at `TauCeti.endCompForgetActionMulEquiv_app_apply`. -/
 theorem autCompForgetActionMulEquiv_inv_app_apply {C : Type*} [Category C]
     (e : C ⥤ Action (Type u) G) [e.IsEquivalence] (g : G) (p : C) (x : ToType (e.obj p)) :
     (autCompForgetActionMulEquiv G e g).inv.app p x = g⁻¹ • x := by
-  -- `Aut` stores the group inverse's forward map in the `inv` projection.
-  change ((autCompForgetActionMulEquiv G e g)⁻¹).hom.app p x = _
-  rw [← map_inv]
-  exact autCompForgetActionMulEquiv_hom_app_apply e g⁻¹ p x
+  rw [autCompForgetActionMulEquiv_apply, unitsAutCompForgetActionMulEquiv_inv_app_apply,
+    ← map_inv, val_toUnits_apply]
 
 end Group
 

--- a/TauCeti/CategoryTheory/Action/Tannaka.lean
+++ b/TauCeti/CategoryTheory/Action/Tannaka.lean
@@ -1,0 +1,225 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.CategoryTheory.Action.Concrete
+public import Mathlib.CategoryTheory.Whiskering
+public import TauCeti.CategoryTheory.Action.Transitive
+
+/-!
+# Tannaka duality for `G`-sets
+
+A monoid `G` can be read off from the category `Action (Type u) G` of `G`-sets together with the
+forgetful functor `Action.forget (Type u) G` to types: the monoid of natural endomorphisms of that
+functor is `G` itself, and for a group `G` its automorphism group is `G`.
+
+The proof is the usual one. A natural endomorphism `η` is determined by its value `s` at the
+identity of the left regular `G`-set `Action.leftRegular G`, because for every `G`-set `A` and
+every point `x` of `A` the orbit map `a ↦ a • x` is a map of `G`-sets out of the left regular one,
+and naturality against it forces `η` to act as `x ↦ s • x`.
+
+The last statement below transports the group form along an equivalence: a functor `C ⥤ Type u`
+that factors as an equivalence onto `G`-sets followed by the forgetful functor has automorphism
+group `G`. This is the form the classification of covering spaces consumes, with `C` the covering
+spaces of a based space and `G` its fundamental group.
+
+No finiteness enters, so this is not Mathlib's `CategoryTheory.PreGaloisCategory` picture: there a
+fibre functor takes values in `FintypeCat` and `CategoryTheory.PreGaloisCategory.IsFundamentalGroup`
+asks for a *compact* topological group, which for a discrete `G` means a finite one.
+
+## Main declarations
+
+* `TauCeti.toEndForgetAction`: the monoid map sending `g : G` to the natural endomorphism of the
+  forgetful functor acting by `g`, with `TauCeti.toEndForgetAction_app_apply` computing it.
+* `TauCeti.leftRegularHom`: the orbit map of a point of a `G`-set, as a map of `G`-sets out of the
+  left regular `G`-set.
+* `TauCeti.end_forgetAction_app_apply`: a natural endomorphism of the forgetful functor acts on
+  every `G`-set by the element of `G` it produces at the identity of the left regular `G`-set.
+* `TauCeti.endForgetActionMulEquiv`: **Tannaka duality for `G`-sets**: `G` is the monoid of
+  natural endomorphisms of the forgetful functor.
+* `TauCeti.toAutForgetAction` and `TauCeti.autForgetActionMulEquiv`: the group form, for `G` a
+  group.
+* `TauCeti.endCompForgetActionMulEquiv` and `TauCeti.autCompForgetActionMulEquiv`: both forms
+  transported along an equivalence `C ⥤ Action (Type u) G`.
+
+## References
+
+The argument is the standard Tannaka reconstruction of a group from its permutation
+representations; see for instance Lenstra, *Galois theory for schemes*, Section 3, where the same
+naturality-against-orbit-maps computation identifies the automorphism group of a fibre functor.
+Mathlib's `Mathlib/RepresentationTheory/Tannaka.lean` proves the *linear* analogue for finite
+groups, a different statement sharing no proof with this one.
+-/
+
+public section
+noncomputable section
+
+open CategoryTheory
+
+universe u
+
+namespace TauCeti
+
+section Monoid
+
+variable (G : Type u) [Monoid G]
+
+/-- Acting by `g : G` on every `G`-set is a natural endomorphism of the forgetful functor from
+`G`-sets to types; this is the resulting monoid map `G →* End (Action.forget (Type u) G)`.
+
+It is `@[expose]`d so that its values hold by `rfl`. -/
+@[expose] def toEndForgetAction : G →* End (Action.forget (Type u) G) where
+  toFun g := { app A := A.ρ g, naturality _ _ f := (f.comm g).symm }
+  map_one' := NatTrans.ext (funext fun A => map_one A.ρ)
+  map_mul' g h := NatTrans.ext (funext fun A => map_mul A.ρ g h)
+
+variable {G}
+
+@[simp]
+theorem toEndForgetAction_app_apply (g : G) (A : Action (Type u) G) (x : ToType A) :
+    (toEndForgetAction G g).app A x = g • x :=
+  rfl
+
+@[simp]
+theorem toEndForgetAction_app_leftRegular_one (g : G) :
+    (toEndForgetAction G g).app (Action.leftRegular G) (1 : G) = g :=
+  mul_one g
+
+/-- The orbit map `a ↦ a • x` of a point `x` of a `G`-set `A`, as a map of `G`-sets from the left
+regular `G`-set to `A`.
+
+It is `@[expose]`d so that its values hold by `rfl`. -/
+@[expose] def leftRegularHom {A : Action (Type u) G} (x : ToType A) :
+    Action.leftRegular G ⟶ A where
+  hom := ↾(fun a : G => a • x)
+  comm g := by ext a; exact mul_smul g a x
+
+@[simp]
+theorem leftRegularHom_hom_apply {A : Action (Type u) G} (x : ToType A) (a : G) :
+    (leftRegularHom x).hom a = a • x :=
+  rfl
+
+/-- A natural endomorphism of the forgetful functor from `G`-sets to types acts on every `G`-set
+as the element of `G` it produces at the identity of the left regular `G`-set: naturality against
+the orbit map `TauCeti.leftRegularHom` leaves it no other choice. -/
+theorem end_forgetAction_app_apply (η : End (Action.forget (Type u) G)) {s : G}
+    (hs : η.app (Action.leftRegular G) (1 : G) = s) (A : Action (Type u) G) (x : ToType A) :
+    η.app A x = s • x := by
+  subst hs
+  calc η.app A x = η.app A ((1 : G) • x) := by rw [one_smul]
+    _ = _ := NatTrans.naturality_apply η (leftRegularHom x) (1 : G)
+
+variable (G)
+
+theorem toEndForgetAction_bijective : Function.Bijective (toEndForgetAction G) := by
+  refine ⟨fun g h hgh => ?_, fun η => ⟨η.app (Action.leftRegular G) (1 : G), ?_⟩⟩
+  · rw [← toEndForgetAction_app_leftRegular_one g, ← toEndForgetAction_app_leftRegular_one h, hgh]
+  · refine NatTrans.ext (funext fun A => ?_)
+    ext x
+    exact (end_forgetAction_app_apply η rfl A x).symm
+
+/-- **Tannaka duality for `G`-sets.** A monoid `G` is the monoid of natural endomorphisms of the
+forgetful functor from `G`-sets to types. -/
+def endForgetActionMulEquiv : G ≃* End (Action.forget (Type u) G) :=
+  MulEquiv.ofBijective (toEndForgetAction G) (toEndForgetAction_bijective G)
+
+variable {G}
+
+@[simp]
+theorem endForgetActionMulEquiv_apply (g : G) :
+    endForgetActionMulEquiv G g = toEndForgetAction G g :=
+  (rfl)
+
+variable (G)
+
+/-- Tannaka duality transported along an equivalence: if a functor `e` from a category `C` to
+`G`-sets is an equivalence, then `G` is the monoid of natural endomorphisms of the composite
+functor `C ⥤ Type u`. -/
+@[expose] def endCompForgetActionMulEquiv {C : Type*} [Category C] (e : C ⥤ Action (Type u) G)
+    [e.IsEquivalence] : G ≃* End (e ⋙ Action.forget (Type u) G) :=
+  (endForgetActionMulEquiv G).trans
+    ((Functor.FullyFaithful.ofFullyFaithful
+      ((Functor.whiskeringLeft C (Action (Type u) G) (Type u)).obj e)).mulEquivEnd _)
+
+variable {G}
+
+/-- The value of a transported natural endomorphism on a point of a fibre.
+
+This is not a `simp` lemma: `simp` rewrites the composite `(e ⋙ Action.forget (Type u) G).obj p`
+appearing in the type of `x` to `(Action.forget (Type u) G).obj (e.obj p)`, so the left-hand side
+here is not in `simp`-normal form. -/
+theorem endCompForgetActionMulEquiv_app_apply {C : Type*} [Category C]
+    (e : C ⥤ Action (Type u) G) [e.IsEquivalence] (g : G) (p : C) (x : ToType (e.obj p)) :
+    (endCompForgetActionMulEquiv G e g).app p x = g • x :=
+  (rfl)
+
+end Monoid
+
+section Group
+
+variable (G : Type u) [Group G]
+
+/-- Acting by `g : G` on every `G`-set is a natural *automorphism* of the forgetful functor from
+`G`-sets to types, with inverse the action of `g⁻¹`.
+
+It is `@[expose]`d so that its values hold by `rfl`. -/
+@[expose] def toAutForgetAction : G →* Aut (Action.forget (Type u) G) where
+  toFun g :=
+    { hom := toEndForgetAction G g
+      inv := toEndForgetAction G g⁻¹
+      hom_inv_id := by
+        rw [← End.mul_def, ← map_mul, inv_mul_cancel, map_one, End.one_def]
+      inv_hom_id := by
+        rw [← End.mul_def, ← map_mul, mul_inv_cancel, map_one, End.one_def] }
+  map_one' := Aut.ext (map_one (toEndForgetAction G))
+  map_mul' g h := Aut.ext (map_mul (toEndForgetAction G) g h)
+
+variable {G}
+
+@[simp]
+theorem toAutForgetAction_hom (g : G) :
+    (toAutForgetAction G g).hom = toEndForgetAction G g :=
+  rfl
+
+variable (G)
+
+/-- **Tannaka duality for `G`-sets**, group form: a group `G` is the automorphism group of the
+forgetful functor from `G`-sets to types. -/
+def autForgetActionMulEquiv : G ≃* Aut (Action.forget (Type u) G) :=
+  MulEquiv.ofBijective (toAutForgetAction G) <| by
+    refine ⟨fun g h hgh => (toEndForgetAction_bijective G).1 ?_,
+      fun η => ((toEndForgetAction_bijective G).2 η.hom).imp fun g hg => Aut.ext hg⟩
+    rw [← toAutForgetAction_hom g, ← toAutForgetAction_hom h, hgh]
+
+variable {G}
+
+@[simp]
+theorem autForgetActionMulEquiv_hom_app_apply (g : G) (A : Action (Type u) G) (x : ToType A) :
+    (autForgetActionMulEquiv G g).hom.app A x = g • x :=
+  (rfl)
+
+variable (G)
+
+/-- Tannaka duality transported along an equivalence: if a functor `e` from a category `C` to
+`G`-sets is an equivalence, then `G` is the automorphism group of the composite `C ⥤ Type u`. -/
+@[expose] def autCompForgetActionMulEquiv {C : Type*} [Category C] (e : C ⥤ Action (Type u) G)
+    [e.IsEquivalence] : G ≃* Aut (e ⋙ Action.forget (Type u) G) :=
+  (autForgetActionMulEquiv G).trans
+    ((Functor.FullyFaithful.ofFullyFaithful
+      ((Functor.whiskeringLeft C (Action (Type u) G) (Type u)).obj e)).autMulEquivOfFullyFaithful _)
+
+variable {G}
+
+/-- The value of a transported natural automorphism on a point of a fibre; not a `simp` lemma, for
+the reason given at `TauCeti.endCompForgetActionMulEquiv_app_apply`. -/
+theorem autCompForgetActionMulEquiv_hom_app_apply {C : Type*} [Category C]
+    (e : C ⥤ Action (Type u) G) [e.IsEquivalence] (g : G) (p : C) (x : ToType (e.obj p)) :
+    (autCompForgetActionMulEquiv G e g).hom.app p x = g • x :=
+  (rfl)
+
+end Group
+
+end TauCeti

--- a/TauCeti/CategoryTheory/Action/Tannaka.lean
+++ b/TauCeti/CategoryTheory/Action/Tannaka.lean
@@ -34,8 +34,8 @@ asks for a *compact* topological group, which for a discrete `G` means a finite 
 
 * `TauCeti.toEndForgetAction`: the monoid map sending `g : G` to the natural endomorphism of the
   forgetful functor acting by `g`, with `TauCeti.toEndForgetAction_app_apply` computing it.
-* `TauCeti.leftRegularHom`: the orbit map of a point of a `G`-set, as a map of `G`-sets out of the
-  left regular `G`-set.
+* `CategoryTheory.Action.leftRegularHom`: the orbit map of a point of a `G`-set, as a map of
+  `G`-sets out of the left regular `G`-set.
 * `TauCeti.end_forgetAction_app_apply`: a natural endomorphism of the forgetful functor acts on
   every `G`-set by the element of `G` it produces at the identity of the left regular `G`-set.
 * `TauCeti.endForgetActionMulEquiv`: **Tannaka duality for `G`-sets**: `G` is the monoid of
@@ -94,14 +94,15 @@ theorem toEndForgetAction_app_leftRegular_one (g : G) :
 
 /-- The orbit map `a ↦ a • x` of a point `x` of a `G`-set `A`, as a map of `G`-sets from the left
 regular `G`-set to `A`. -/
-def leftRegularHom {A : Action (Type u) G} (x : ToType A) :
+def _root_.CategoryTheory.Action.leftRegularHom {A : Action (Type u) G} (x : ToType A) :
     Action.leftRegular G ⟶ A where
   hom := ↾(fun a : G => a • x)
   comm g := by ext a; exact mul_smul g a x
 
 @[simp]
-theorem leftRegularHom_hom_apply {A : Action (Type u) G} (x : ToType A) (a : G) :
-    (leftRegularHom x).hom a = a • x :=
+theorem _root_.CategoryTheory.Action.leftRegularHom_hom_apply {A : Action (Type u) G}
+    (x : ToType A) (a : G) :
+    (Action.leftRegularHom x).hom a = a • x :=
   by
     -- Unfold the unexposed constructor once to establish its public computation rule.
     change a • x = a • x
@@ -109,13 +110,13 @@ theorem leftRegularHom_hom_apply {A : Action (Type u) G} (x : ToType A) (a : G) 
 
 /-- A natural endomorphism of the forgetful functor from `G`-sets to types acts on every `G`-set
 as the element of `G` it produces at the identity of the left regular `G`-set: naturality against
-the orbit map `TauCeti.leftRegularHom` leaves it no other choice. -/
+the orbit map `CategoryTheory.Action.leftRegularHom` leaves it no other choice. -/
 theorem end_forgetAction_app_apply (η : End (Action.forget (Type u) G)) {s : G}
     (hs : η.app (Action.leftRegular G) (1 : G) = s) (A : Action (Type u) G) (x : ToType A) :
     η.app A x = s • x := by
   subst hs
   calc η.app A x = η.app A ((1 : G) • x) := by rw [one_smul]
-    _ = _ := NatTrans.naturality_apply η (leftRegularHom x) (1 : G)
+    _ = _ := NatTrans.naturality_apply η (Action.leftRegularHom x) (1 : G)
 
 variable (G)
 

--- a/TauCeti/CategoryTheory/Action/Tannaka.lean
+++ b/TauCeti/CategoryTheory/Action/Tannaka.lean
@@ -79,6 +79,7 @@ variable {G}
 theorem toEndForgetAction_app_apply (g : G) (A : Action (Type u) G) (x : ToType A) :
     (toEndForgetAction G g).app A x = g • x :=
   by
+    -- Unfold the unexposed constructor once to establish its public computation rule.
     change A.ρ g x = g • x
     rfl
 
@@ -98,6 +99,7 @@ def leftRegularHom {A : Action (Type u) G} (x : ToType A) :
 theorem leftRegularHom_hom_apply {A : Action (Type u) G} (x : ToType A) (a : G) :
     (leftRegularHom x).hom a = a • x :=
   by
+    -- Unfold the unexposed constructor once to establish its public computation rule.
     change a • x = a • x
     rfl
 
@@ -146,8 +148,8 @@ theorem endForgetActionMulEquiv_symm_apply_eq (η : End (Action.forget (Type u) 
     rw [endForgetActionMulEquiv_apply]
     refine NatTrans.ext (funext fun A => ?_)
     ext x
-    change η.app A x = A.ρ g x
-    exact end_forgetAction_app_apply η h A x
+    exact (end_forgetAction_app_apply η h A x).trans
+      (toEndForgetAction_app_apply g A x).symm
 
 variable (G)
 
@@ -171,6 +173,7 @@ theorem endCompForgetActionMulEquiv_app_apply {C : Type*} [Category C]
     (e : C ⥤ Action (Type u) G) [e.IsEquivalence] (g : G) (p : C) (x : ToType (e.obj p)) :
     (endCompForgetActionMulEquiv G e g).app p x = g • x :=
   by
+    -- Unfold the unexposed transport once; its value is then governed by the public base rule.
     change (endForgetActionMulEquiv G g).app (e.obj p) x = g • x
     rw [endForgetActionMulEquiv_apply, toEndForgetAction_app_apply]
 
@@ -199,6 +202,7 @@ variable {G}
 theorem toAutForgetAction_hom (g : G) :
     (toAutForgetAction G g).hom = toEndForgetAction G g :=
   by
+    -- Unfold the unexposed constructor once to establish its public projection rule.
     change toEndForgetAction G g = toEndForgetAction G g
     rfl
 
@@ -217,9 +221,7 @@ variable {G}
 @[simp]
 theorem autForgetActionMulEquiv_hom_app_apply (g : G) (A : Action (Type u) G) (x : ToType A) :
     (autForgetActionMulEquiv G g).hom.app A x = g • x :=
-  by
-    change (toEndForgetAction G g).app A x = g • x
-    exact toEndForgetAction_app_apply g A x
+  toEndForgetAction_app_apply g A x
 
 /-- The inverse Tannaka equivalence is characterized by evaluating the forward natural
 transformation at the identity of the left regular `G`-set. -/
@@ -231,18 +233,20 @@ theorem autForgetActionMulEquiv_symm_apply_eq (η : Aut (Action.forget (Type u) 
   constructor
   · intro h
     rw [h]
-    change g • (1 : G) = g
+    -- The left regular scalar action is definitionally multiplication.
+    change g * 1 = g
     exact mul_one g
   · intro h
     refine Aut.ext (NatTrans.ext (funext fun A => ?_))
     ext x
-    change η.hom.app A x = A.ρ g x
-    exact end_forgetAction_app_apply η.hom h A x
+    exact (end_forgetAction_app_apply η.hom h A x).trans
+      (autForgetActionMulEquiv_hom_app_apply g A x).symm
 
 /-- The inverse of the automorphism associated to `g` acts by `g⁻¹`. -/
 @[simp]
 theorem autForgetActionMulEquiv_inv_app_apply (g : G) (A : Action (Type u) G) (x : ToType A) :
     (autForgetActionMulEquiv G g).inv.app A x = g⁻¹ • x := by
+  -- `Aut` stores the group inverse's forward map in the `inv` projection.
   change ((autForgetActionMulEquiv G g)⁻¹).hom.app A x = _
   rw [← map_inv]
   exact autForgetActionMulEquiv_hom_app_apply g⁻¹ A x
@@ -265,6 +269,7 @@ theorem autCompForgetActionMulEquiv_hom_app_apply {C : Type*} [Category C]
     (e : C ⥤ Action (Type u) G) [e.IsEquivalence] (g : G) (p : C) (x : ToType (e.obj p)) :
     (autCompForgetActionMulEquiv G e g).hom.app p x = g • x :=
   by
+    -- Unfold the unexposed transport once; its value is then governed by the public base rule.
     change (autForgetActionMulEquiv G g).hom.app (e.obj p) x = g • x
     exact autForgetActionMulEquiv_hom_app_apply g (e.obj p) x
 
@@ -273,6 +278,7 @@ lemma, for the reason given at `TauCeti.endCompForgetActionMulEquiv_app_apply`. 
 theorem autCompForgetActionMulEquiv_inv_app_apply {C : Type*} [Category C]
     (e : C ⥤ Action (Type u) G) [e.IsEquivalence] (g : G) (p : C) (x : ToType (e.obj p)) :
     (autCompForgetActionMulEquiv G e g).inv.app p x = g⁻¹ • x := by
+  -- `Aut` stores the group inverse's forward map in the `inv` projection.
   change ((autCompForgetActionMulEquiv G e g)⁻¹).hom.app p x = _
   rw [← map_inv]
   exact autCompForgetActionMulEquiv_hom_app_apply e g⁻¹ p x

--- a/TauCeti/CategoryTheory/Action/Tannaka.lean
+++ b/TauCeti/CategoryTheory/Action/Tannaka.lean
@@ -268,8 +268,8 @@ theorem autCompForgetActionMulEquiv_hom_app_apply {C : Type*} [Category C]
     change (autForgetActionMulEquiv G g).hom.app (e.obj p) x = g • x
     exact autForgetActionMulEquiv_hom_app_apply g (e.obj p) x
 
-/-- The inverse of a transported natural automorphism acts by `g⁻¹` on every fibre. -/
-@[simp]
+/-- The inverse of a transported natural automorphism acts by `g⁻¹` on every fibre; not a `simp`
+lemma, for the reason given at `TauCeti.endCompForgetActionMulEquiv_app_apply`. -/
 theorem autCompForgetActionMulEquiv_inv_app_apply {C : Type*} [Category C]
     (e : C ⥤ Action (Type u) G) [e.IsEquivalence] (g : G) (p : C) (x : ToType (e.obj p)) :
     (autCompForgetActionMulEquiv G e g).inv.app p x = g⁻¹ • x := by

--- a/TauCeti/CategoryTheory/Action/Tannaka.lean
+++ b/TauCeti/CategoryTheory/Action/Tannaka.lean
@@ -7,7 +7,6 @@ module
 
 public import Mathlib.CategoryTheory.Action.Concrete
 public import Mathlib.CategoryTheory.Whiskering
-public import TauCeti.CategoryTheory.Action.Transitive
 
 /-!
 # Tannaka duality for `G`-sets
@@ -68,10 +67,8 @@ section Monoid
 variable (G : Type u) [Monoid G]
 
 /-- Acting by `g : G` on every `G`-set is a natural endomorphism of the forgetful functor from
-`G`-sets to types; this is the resulting monoid map `G →* End (Action.forget (Type u) G)`.
-
-It is `@[expose]`d so that its values hold by `rfl`. -/
-@[expose] def toEndForgetAction : G →* End (Action.forget (Type u) G) where
+`G`-sets to types; this is the resulting monoid map `G →* End (Action.forget (Type u) G)`. -/
+def toEndForgetAction : G →* End (Action.forget (Type u) G) where
   toFun g := { app A := A.ρ g, naturality _ _ f := (f.comm g).symm }
   map_one' := NatTrans.ext (funext fun A => map_one A.ρ)
   map_mul' g h := NatTrans.ext (funext fun A => map_mul A.ρ g h)
@@ -81,7 +78,9 @@ variable {G}
 @[simp]
 theorem toEndForgetAction_app_apply (g : G) (A : Action (Type u) G) (x : ToType A) :
     (toEndForgetAction G g).app A x = g • x :=
-  rfl
+  by
+    change A.ρ g x = g • x
+    rfl
 
 @[simp]
 theorem toEndForgetAction_app_leftRegular_one (g : G) :
@@ -89,10 +88,8 @@ theorem toEndForgetAction_app_leftRegular_one (g : G) :
   mul_one g
 
 /-- The orbit map `a ↦ a • x` of a point `x` of a `G`-set `A`, as a map of `G`-sets from the left
-regular `G`-set to `A`.
-
-It is `@[expose]`d so that its values hold by `rfl`. -/
-@[expose] def leftRegularHom {A : Action (Type u) G} (x : ToType A) :
+regular `G`-set to `A`. -/
+def leftRegularHom {A : Action (Type u) G} (x : ToType A) :
     Action.leftRegular G ⟶ A where
   hom := ↾(fun a : G => a • x)
   comm g := by ext a; exact mul_smul g a x
@@ -100,7 +97,9 @@ It is `@[expose]`d so that its values hold by `rfl`. -/
 @[simp]
 theorem leftRegularHom_hom_apply {A : Action (Type u) G} (x : ToType A) (a : G) :
     (leftRegularHom x).hom a = a • x :=
-  rfl
+  by
+    change a • x = a • x
+    rfl
 
 /-- A natural endomorphism of the forgetful functor from `G`-sets to types acts on every `G`-set
 as the element of `G` it produces at the identity of the left regular `G`-set: naturality against
@@ -133,12 +132,29 @@ theorem endForgetActionMulEquiv_apply (g : G) :
     endForgetActionMulEquiv G g = toEndForgetAction G g :=
   (rfl)
 
+/-- The inverse Tannaka equivalence is characterized by evaluation at the identity of the left
+regular `G`-set. -/
+@[simp]
+theorem endForgetActionMulEquiv_symm_apply_eq (η : End (Action.forget (Type u) G)) (g : G) :
+    (endForgetActionMulEquiv G).symm η = g ↔
+      η.app (Action.leftRegular G) (1 : G) = g := by
+  rw [MulEquiv.symm_apply_eq]
+  constructor
+  · intro h
+    rw [h, endForgetActionMulEquiv_apply, toEndForgetAction_app_leftRegular_one]
+  · intro h
+    rw [endForgetActionMulEquiv_apply]
+    refine NatTrans.ext (funext fun A => ?_)
+    ext x
+    change η.app A x = A.ρ g x
+    exact end_forgetAction_app_apply η h A x
+
 variable (G)
 
 /-- Tannaka duality transported along an equivalence: if a functor `e` from a category `C` to
 `G`-sets is an equivalence, then `G` is the monoid of natural endomorphisms of the composite
 functor `C ⥤ Type u`. -/
-@[expose] def endCompForgetActionMulEquiv {C : Type*} [Category C] (e : C ⥤ Action (Type u) G)
+def endCompForgetActionMulEquiv {C : Type*} [Category C] (e : C ⥤ Action (Type u) G)
     [e.IsEquivalence] : G ≃* End (e ⋙ Action.forget (Type u) G) :=
   (endForgetActionMulEquiv G).trans
     ((Functor.FullyFaithful.ofFullyFaithful
@@ -154,7 +170,9 @@ here is not in `simp`-normal form. -/
 theorem endCompForgetActionMulEquiv_app_apply {C : Type*} [Category C]
     (e : C ⥤ Action (Type u) G) [e.IsEquivalence] (g : G) (p : C) (x : ToType (e.obj p)) :
     (endCompForgetActionMulEquiv G e g).app p x = g • x :=
-  (rfl)
+  by
+    change (endForgetActionMulEquiv G g).app (e.obj p) x = g • x
+    rw [endForgetActionMulEquiv_apply, toEndForgetAction_app_apply]
 
 end Monoid
 
@@ -163,10 +181,8 @@ section Group
 variable (G : Type u) [Group G]
 
 /-- Acting by `g : G` on every `G`-set is a natural *automorphism* of the forgetful functor from
-`G`-sets to types, with inverse the action of `g⁻¹`.
-
-It is `@[expose]`d so that its values hold by `rfl`. -/
-@[expose] def toAutForgetAction : G →* Aut (Action.forget (Type u) G) where
+`G`-sets to types, with inverse the action of `g⁻¹`. -/
+def toAutForgetAction : G →* Aut (Action.forget (Type u) G) where
   toFun g :=
     { hom := toEndForgetAction G g
       inv := toEndForgetAction G g⁻¹
@@ -182,7 +198,9 @@ variable {G}
 @[simp]
 theorem toAutForgetAction_hom (g : G) :
     (toAutForgetAction G g).hom = toEndForgetAction G g :=
-  rfl
+  by
+    change toEndForgetAction G g = toEndForgetAction G g
+    rfl
 
 variable (G)
 
@@ -199,13 +217,41 @@ variable {G}
 @[simp]
 theorem autForgetActionMulEquiv_hom_app_apply (g : G) (A : Action (Type u) G) (x : ToType A) :
     (autForgetActionMulEquiv G g).hom.app A x = g • x :=
-  (rfl)
+  by
+    change (toEndForgetAction G g).app A x = g • x
+    exact toEndForgetAction_app_apply g A x
+
+/-- The inverse Tannaka equivalence is characterized by evaluating the forward natural
+transformation at the identity of the left regular `G`-set. -/
+@[simp]
+theorem autForgetActionMulEquiv_symm_apply_eq (η : Aut (Action.forget (Type u) G)) (g : G) :
+    (autForgetActionMulEquiv G).symm η = g ↔
+      η.hom.app (Action.leftRegular G) (1 : G) = g := by
+  rw [MulEquiv.symm_apply_eq]
+  constructor
+  · intro h
+    rw [h]
+    change g • (1 : G) = g
+    exact mul_one g
+  · intro h
+    refine Aut.ext (NatTrans.ext (funext fun A => ?_))
+    ext x
+    change η.hom.app A x = A.ρ g x
+    exact end_forgetAction_app_apply η.hom h A x
+
+/-- The inverse of the automorphism associated to `g` acts by `g⁻¹`. -/
+@[simp]
+theorem autForgetActionMulEquiv_inv_app_apply (g : G) (A : Action (Type u) G) (x : ToType A) :
+    (autForgetActionMulEquiv G g).inv.app A x = g⁻¹ • x := by
+  change ((autForgetActionMulEquiv G g)⁻¹).hom.app A x = _
+  rw [← map_inv]
+  exact autForgetActionMulEquiv_hom_app_apply g⁻¹ A x
 
 variable (G)
 
 /-- Tannaka duality transported along an equivalence: if a functor `e` from a category `C` to
 `G`-sets is an equivalence, then `G` is the automorphism group of the composite `C ⥤ Type u`. -/
-@[expose] def autCompForgetActionMulEquiv {C : Type*} [Category C] (e : C ⥤ Action (Type u) G)
+def autCompForgetActionMulEquiv {C : Type*} [Category C] (e : C ⥤ Action (Type u) G)
     [e.IsEquivalence] : G ≃* Aut (e ⋙ Action.forget (Type u) G) :=
   (autForgetActionMulEquiv G).trans
     ((Functor.FullyFaithful.ofFullyFaithful
@@ -218,7 +264,18 @@ the reason given at `TauCeti.endCompForgetActionMulEquiv_app_apply`. -/
 theorem autCompForgetActionMulEquiv_hom_app_apply {C : Type*} [Category C]
     (e : C ⥤ Action (Type u) G) [e.IsEquivalence] (g : G) (p : C) (x : ToType (e.obj p)) :
     (autCompForgetActionMulEquiv G e g).hom.app p x = g • x :=
-  (rfl)
+  by
+    change (autForgetActionMulEquiv G g).hom.app (e.obj p) x = g • x
+    exact autForgetActionMulEquiv_hom_app_apply g (e.obj p) x
+
+/-- The inverse of a transported natural automorphism acts by `g⁻¹` on every fibre. -/
+@[simp]
+theorem autCompForgetActionMulEquiv_inv_app_apply {C : Type*} [Category C]
+    (e : C ⥤ Action (Type u) G) [e.IsEquivalence] (g : G) (p : C) (x : ToType (e.obj p)) :
+    (autCompForgetActionMulEquiv G e g).inv.app p x = g⁻¹ • x := by
+  change ((autCompForgetActionMulEquiv G e g)⁻¹).hom.app p x = _
+  rw [← map_inv]
+  exact autCompForgetActionMulEquiv_hom_app_apply e g⁻¹ p x
 
 end Group
 

--- a/TauCeti/CategoryTheory/Action/Tannaka.lean
+++ b/TauCeti/CategoryTheory/Action/Tannaka.lean
@@ -195,10 +195,10 @@ theorem unitsAutForgetActionMulEquiv_symm_apply_eq (η : Aut (Action.forget (Typ
   rw [MulEquiv.symm_apply_eq]
   constructor
   · intro h
-    rw [h]
-    -- The left regular scalar action is definitionally multiplication.
-    change (g : G) * 1 = (g : G)
-    exact mul_one (g : G)
+    subst h
+    exact (unitsAutForgetActionMulEquiv_hom_app_apply g (Action.leftRegular G) (1 : G)).trans
+      ((toEndForgetAction_app_apply (g : G) (Action.leftRegular G) (1 : G)).symm.trans
+        (toEndForgetAction_app_leftRegular_one (g : G)))
   · intro h
     refine Aut.ext (NatTrans.ext (funext fun A => ?_))
     ext x
@@ -238,7 +238,9 @@ from a category `C` to `G`-sets is an equivalence, then `Gˣ` is the automorphis
 composite `C ⥤ Type u`. -/
 def unitsAutCompForgetActionMulEquiv {C : Type*} [Category C] (e : C ⥤ Action (Type u) G)
     [e.IsEquivalence] : Gˣ ≃* Aut (e ⋙ Action.forget (Type u) G) :=
-  (Units.mapEquiv (endCompForgetActionMulEquiv G e)).trans (Aut.unitsEndEquivAut _)
+  (unitsAutForgetActionMulEquiv G).trans
+    ((Functor.FullyFaithful.ofFullyFaithful
+      ((Functor.whiskeringLeft C (Action (Type u) G) (Type u)).obj e)).autMulEquivOfFullyFaithful _)
 
 variable {G}
 
@@ -246,21 +248,19 @@ variable {G}
 the reason given at `TauCeti.endCompForgetActionMulEquiv_app_apply`. -/
 theorem unitsAutCompForgetActionMulEquiv_hom_app_apply {C : Type*} [Category C]
     (e : C ⥤ Action (Type u) G) [e.IsEquivalence] (g : Gˣ) (p : C) (x : ToType (e.obj p)) :
-    (unitsAutCompForgetActionMulEquiv G e g).hom.app p x = (g : G) • x :=
-  by
-    -- `Aut.unitsEndEquivAut` keeps the underlying endomorphism as the `hom` projection.
-    change (endCompForgetActionMulEquiv G e (g : G)).app p x = _
-    exact endCompForgetActionMulEquiv_app_apply e (g : G) p x
+    (unitsAutCompForgetActionMulEquiv G e g).hom.app p x = (g : G) • x := by
+  -- The transport whiskers with `e`, so the value is the untransported one at `e.obj p`.
+  change (unitsAutForgetActionMulEquiv G g).hom.app (e.obj p) x = _
+  exact unitsAutForgetActionMulEquiv_hom_app_apply g (e.obj p) x
 
 /-- The inverse of a transported natural automorphism acts by the inverse unit on every fibre; not
 a `simp` lemma, for the reason given at `TauCeti.endCompForgetActionMulEquiv_app_apply`. -/
 theorem unitsAutCompForgetActionMulEquiv_inv_app_apply {C : Type*} [Category C]
     (e : C ⥤ Action (Type u) G) [e.IsEquivalence] (g : Gˣ) (p : C) (x : ToType (e.obj p)) :
-    (unitsAutCompForgetActionMulEquiv G e g).inv.app p x = ((g⁻¹ : Gˣ) : G) • x :=
-  by
-    -- `Aut.unitsEndEquivAut` keeps the endomorphism of the inverse unit as the `inv` projection.
-    change (endCompForgetActionMulEquiv G e ((g⁻¹ : Gˣ) : G)).app p x = _
-    exact endCompForgetActionMulEquiv_app_apply e ((g⁻¹ : Gˣ) : G) p x
+    (unitsAutCompForgetActionMulEquiv G e g).inv.app p x = ((g⁻¹ : Gˣ) : G) • x := by
+  -- The transport whiskers with `e`, so the value is the untransported one at `e.obj p`.
+  change (unitsAutForgetActionMulEquiv G g).inv.app (e.obj p) x = _
+  exact unitsAutForgetActionMulEquiv_inv_app_apply g (e.obj p) x
 
 end Monoid
 
@@ -304,10 +304,10 @@ theorem autForgetActionMulEquiv_symm_apply_eq (η : Aut (Action.forget (Type u) 
   rw [MulEquiv.symm_apply_eq]
   constructor
   · intro h
-    rw [h]
-    -- The left regular scalar action is definitionally multiplication.
-    change g * 1 = g
-    exact mul_one g
+    subst h
+    exact (autForgetActionMulEquiv_hom_app_apply g (Action.leftRegular G) (1 : G)).trans
+      ((toEndForgetAction_app_apply g (Action.leftRegular G) (1 : G)).symm.trans
+        (toEndForgetAction_app_leftRegular_one g))
   · intro h
     refine Aut.ext (NatTrans.ext (funext fun A => ?_))
     ext x


### PR DESCRIPTION
This PR identifies the automorphism group of the fibre functor on covering spaces: over a path-connected, locally path-connected, semilocally simply connected base `X` with basepoint `x₀`, `TauCeti.CoveringSpace.autFiberFunctorMulEquiv x₀ : FundamentalGroup X x₀ ≃* Aut (fiberFunctor x₀)`, with the automorphism attached to a loop class acting on each fibre by monodromy. It serves Stage 2, item 8 of `TauCetiRoadmap/UniversalCovers/README.md`, whose "alternative lens" asks for the classification of covers to be phrased via the monodromy functor and `Mathlib/CategoryTheory/Galois`, whose recognition interface `CategoryTheory.PreGaloisCategory.IsFundamentalGroup`/`toAutMulEquiv` is exactly about recognising a group as the automorphism group of a fibre functor. That lens was built here in `Classification/GaloisCategory.lean` up to the point of exhibiting the fibre over `x₀` as a fibre functor for the Galois category of finite covers, but the automorphism group of that functor was never identified; this PR closes that gap, and over *all* covers rather than the finite ones, where the answer would be a profinite completion rather than `π₁(X, x₀)` itself.

The mathematics is Tannaka duality for permutation representations, which is new here, so it is proved in its own general file `TauCeti/CategoryTheory/Action/Tannaka.lean` (200 lines) rather than inline: for a monoid `G`, `TauCeti.endForgetActionMulEquiv : G ≃* End (Action.forget (Type u) G)`, hence `TauCeti.unitsAutForgetActionMulEquiv : Gˣ ≃* Aut (Action.forget (Type u) G)` (an automorphism is an invertible endomorphism), which for a group `G` specialises along `toUnits` to `TauCeti.autForgetActionMulEquiv : G ≃* Aut (Action.forget (Type u) G)`. The proof is the standard one: a natural endomorphism `η` is pinned down by `s = η.app (Action.leftRegular G) 1`, because for every `G`-set `A` and point `x` the orbit map `a ↦ a • x` is a map of `G`-sets out of the left regular one (`TauCeti.leftRegularHom`, the `Action`-level analogue of Mathlib's `Rep.leftRegularHom`), and naturality against it forces `η.app A x = s • x`. All three forms are then transported along an arbitrary equivalence onto `G`-sets by `TauCeti.endCompForgetActionMulEquiv`, `TauCeti.unitsAutCompForgetActionMulEquiv` and `TauCeti.autCompForgetActionMulEquiv`, so that any functor factoring as an equivalence onto `G`-sets followed by the forgetful functor has `G` as its endomorphism monoid and automorphism group.

`TauCeti/AlgebraicTopology/UniversalCover/Classification/FiberFunctor.lean` (162 lines) applies this. It names the fibre functor `TauCeti.CoveringSpace.fiberFunctor x₀ : CoveringSpace X ⥤ Type u` as the existing `fiberActionFunctor x₀` followed by the forgetful functor, records its values, and feeds the existing equivalence `TauCeti.CoveringSpace.fiberActionEquivalence` into the transported statements. Alongside the headline `MulEquiv` it gives `endFiberFunctorMulEquiv` (so every natural *endo*morphism of the fibre functor is already invertible), `existsUnique_monodromy_eq` (every natural automorphism is monodromy along a unique loop class) and `monodromy_eq_self_iff` (a loop class acting trivially on every fibre is trivial — the faithfulness condition Mathlib calls `non_trivial'`).

No Mathlib proof is vendored. Mathlib supplies `Action.leftRegular`, `Action.forget`, `Aut`/`End` and `Functor.FullyFaithful.mulEquivEnd`/`autMulEquivOfFullyFaithful`; the vendored universal-cover construction this rests on, adapted from Kim Morrison's mathlib4#38292, is already credited where it lives. Mathlib's `Mathlib/RepresentationTheory/Tannaka.lean` proves the *linear* Tannaka duality for finite groups, a different statement sharing no proof with this one, so nothing there is reused.

What remains on the roadmap after this PR: identifying the automorphism group of `TauCeti.FiniteCoveringSpace.fiberFunctor` on the Galois category of *finite* covers, which is the profinite completion of `π₁(X, x₀)` and needs a profinite-completion construction that this library does not yet have.

Roadmap: UniversalCovers

<!--tauceti-target:v1 {"focus":"UniversalCovers","id":"aut-fiber-functor-fundamental-group"}-->

🤖 Prepared with Claude Code

