### PR TITLE
feat(Localization): the fractions t/s generate a localisation away from s

### DIFF
--- a/TauCeti/RingTheory/Localization/Away.lean
+++ b/TauCeti/RingTheory/Localization/Away.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import Mathlib.Algebra.Algebra.Subalgebra.Lattice
 public import Mathlib.RingTheory.Localization.Away.Basic
 
 /-!
@@ -35,6 +36,9 @@ Huber namespace, alongside `TauCeti/RingTheory/Localization/DenIdeal.lean`.
 * `TauCeti.Localization.divBy_mul_cancel_left` and
   `TauCeti.Localization.divBy_mul_cancel_right`: `(s · t)/s = t` and `(t · s)/s = t`.
 * `TauCeti.Localization.divBy_self`: `s/s = 1`.
+* `TauCeti.Localization.adjoin_invSelf_eq_top`: `S` is generated over `A` by `1/s`.
+* `TauCeti.Localization.adjoin_divBy_eq_top`: as soon as the numerators `T` generate the unit
+  ideal, the fractions `t/s` alone already generate `S` over `A`.
 * `TauCeti.Localization.divBy_mul_divBy_of_eq_mul`: for `s = u * r`, the fraction `(a · b)/s`
   splits as `(a · r)/s · (b · u)/s`, each half carrying one factor of the denominator.
 * `TauCeti.Localization.awayLift_divBy`: the comparison map to a localisation at a multiple
@@ -54,6 +58,14 @@ is `TauCeti/RingTheory/Huber/LocalizationTopology/Basic.lean`, which records the
 checked against `dev/adic-spaces` at commit `37bbdaeb9`, which has neither the splitting identity
 for a factored denominator nor any statement about `IsLocalization.Away.lift` on distinguished
 fractions. Both are proved here directly from Mathlib's `mk'` API.
+
+`adjoin_invSelf_eq_top` and `adjoin_divBy_eq_top` are **also later additions with no AINTLIB
+analogue**, checked against the same commit. What that source has is
+`locSubring_isNoetherianRing`, which presents the *ring of definition* `A₀[t₁/s, …, tₙ/s]` as an
+image of `MvPolynomial T A₀`; that surjectivity is true by construction, since `locSubring` is
+defined as the adjoin, and it says nothing about the localisation `S` itself. Generating the whole
+of `S` over `A` is a strictly stronger statement and needs the hypothesis on `T` below, which the
+source never states.
 
 ## References
 
@@ -199,6 +211,60 @@ theorem awayLift_divBy {V W : Type*} [CommSemiring V] [CommSemiring W] [Algebra 
     IsLocalization.Away.lift u hu (divBy a u : V) = (divBy (a * r) w : W) := by
   rw [divBy_def, IsLocalization.Away.lift, IsLocalization.lift_mk'_spec, ← divBy_mul,
     show u * (a * r) = a * w by rw [hw]; ring, divBy_mul_cancel_right]
+
+/-! ### The fractions generate
+
+A localisation away from `s` is generated over `A` by `1/s` alone; and as soon as the numerators
+generate the unit ideal, already by the fractions `t/s` themselves. Nothing topological enters —
+this is the algebraic half of the statement that a rational localisation is a quotient of a
+polynomial ring, one variable per numerator.
+
+Neither statement is phrased as a surjectivity of `MvPolynomial.aeval`, although that is what
+each of them says: Mathlib's `Algebra.adjoin_range_eq_range_aeval` rewrites one into the other,
+and stating it here would cost the file an `MvPolynomial` import to say what a consumer can
+already say in a line. -/
+
+/-- **A localisation away from `s` is generated over `A` by `1/s`.** Every element is `a/sⁿ`,
+which is `a · (1/s)ⁿ`. -/
+theorem adjoin_invSelf_eq_top :
+    Algebra.adjoin A {(IsLocalization.Away.invSelf s : S)} = ⊤ := by
+  rw [eq_top_iff]
+  rintro x -
+  obtain ⟨⟨a, m⟩, hx⟩ := IsLocalization.surj (Submonoid.powers s) x
+  obtain ⟨n, hn⟩ := m.2
+  have hx' : x = algebraMap A S a * (IsLocalization.Away.invSelf s : S) ^ n := by
+    rw [← hx, ← hn, map_pow, mul_assoc, ← mul_pow, IsLocalization.Away.mul_invSelf, one_pow,
+      mul_one]
+  rw [hx']
+  refine mul_mem (Subalgebra.algebraMap_mem _ a) (pow_mem ?_ n)
+  exact Algebra.subset_adjoin rfl
+
+/-- **Numerators generating the unit ideal make their fractions generate the localisation.** If
+`T` spans `A` as an ideal then `S` is already `A[t/s : t ∈ T]` — no separate `1/s` is needed.
+
+Writing `1 = ∑ cₜ · t` and dividing by `s` exhibits `1/s` as `∑ cₜ · (t/s)`, after which
+`adjoin_invSelf_eq_top` finishes. The hypothesis cannot be dropped: over `A = ℤ` with `s = p` and
+`T = {p}` the fractions generate only `ℤ`, not `ℤ[1/p]`.
+
+The hypothesis is exactly what Wedhorn's rational subsets supply: there `T · A` is required to be
+*open*, and an open ideal of a Tate ring is `⊤` by
+`TauCeti.Huber.IsTateRing.eq_top_of_isOpen`. -/
+theorem adjoin_divBy_eq_top {T : Set A} (hT : Ideal.span T = ⊤) :
+    Algebra.adjoin A (Set.range fun t : T ↦ (divBy (t : A) s : S)) = ⊤ := by
+  set E := Algebra.adjoin A (Set.range fun t : T ↦ (divBy (t : A) s : S))
+  have key : ∀ a ∈ Ideal.span T, algebraMap A S a * (IsLocalization.Away.invSelf s : S) ∈ E := by
+    intro a ha
+    induction ha using Submodule.span_induction with
+    | mem y hy =>
+        exact algebraMap_mul_invSelf (S := S) y s ▸ Algebra.subset_adjoin ⟨⟨y, hy⟩, rfl⟩
+    | zero => simp
+    | add y z _ _ hy hz => rw [map_add, add_mul]; exact add_mem hy hz
+    | smul c y _ hy =>
+        rw [smul_eq_mul, map_mul, mul_assoc]
+        exact mul_mem (Subalgebra.algebraMap_mem _ _) hy
+  rw [eq_top_iff, ← adjoin_invSelf_eq_top s (S := S), Algebra.adjoin_le_iff,
+    Set.singleton_subset_iff]
+  simpa using key 1 ((Ideal.eq_top_iff_one _).mp hT)
 
 /-! ### The trivial denominator
 


### PR DESCRIPTION
`TauCeti/RingTheory/Localization/Away.lean` names the fraction `t/s` in a localisation away
from `s` and gives the identities for manipulating it. This adds the two statements saying those
fractions **generate**:

* `TauCeti.Localization.adjoin_invSelf_eq_top` — `S` is generated over `A` by `1/s` alone. Every
  element is `a/sⁿ`, which is `a · (1/s)ⁿ`.
* `TauCeti.Localization.adjoin_divBy_eq_top` — as soon as the numerators `T` generate the **unit
  ideal**, the fractions `t/s` alone already generate `S` over `A`; no separate `1/s` is needed.

Both are pure `IsLocalization.Away` algebra over a commutative semiring: no topology, no Huber
structure, no completion. Neither is phrased as surjectivity of an `MvPolynomial.aeval`, although
that is what each says — Mathlib's `Algebra.adjoin_range_eq_range_aeval` rewrites one into the
other, and stating it here would cost the file an `MvPolynomial` import to say what a consumer
already says in a line. The module docstring records that.

## Which roadmap item uses this

`TauCetiRoadmap/AdicSpaces/README.md`, **Layer 4.1 step 3 — Wedhorn Proposition 8.30**: *"prove
that restriction maps between rational localisations are flat."*

`Laurent/Flat.lean` on `main` already has the chain, but its *What this is not* section states the
remaining gap exactly:

> it still asks strong noetherianity of `A⟨T/s⟩` rather than of `A`, and **nothing here derives the
> one from the other**.

The derivation Wedhorn's §8.2 supplies runs through the presentation

```text
A⟨X₁,…,Xₙ⟩ ↠ A⟨T/s⟩,      Xᵢ ↦ tᵢ/s
```

as an open quotient map, which makes `A⟨T/s⟩` strictly topologically of finite type over `A`, at
which point `IsStrictlyTopologicallyFiniteType.isStronglyNoetherian` (#5906) closes the gap and the
chain in #5957 gives Proposition 8.30 from Wedhorn's own hypothesis.

**This PR is the algebraic first step of that presentation, and nothing more.** It says the
evaluation map is surjective *before* completion — that `A[T/s]` is already all of `A[1/s]`.
Openness, and surjectivity after completion, are separate and are where the mathematical content
of Wedhorn's Examples 6.38/6.39 sits. Nothing here claims Proposition 8.30, or any part of it.

## The hypothesis is the one rational subsets carry

`Ideal.span T = ⊤` looks strong, but it is exactly what Wedhorn's rational subsets supply: there
`T · A` is required to be **open**, and an open ideal of a Tate ring is `⊤`
(`TauCeti.Huber.IsTateRing.eq_top_of_isOpen`, already on `main`). The roadmap states the same fact
in the Layer 4.1 text — *"a nonzero Tate ring has no proper open ideal"*. So a caller in the
intended setting discharges it in one line.

It cannot be dropped: over `A = ℤ` with `s = p` and `T = {p}` the fractions generate only `ℤ`, not
`ℤ[1/p]`. The docstring records that counterexample.

## Notes

* One new import, `Mathlib.Algebra.Algebra.Subalgebra.Lattice`, for `Algebra.adjoin` itself.
* `adjoin_invSelf_eq_top` needed `pow_mem`'s subalgebra pinned by `refine`; left as a metavariable
  it sent `isDefEq` unfolding `Algebra.adjoin` through `Subsemiring.closure`/`sInf` and blew the
  heartbeat budget (66 s in one application). It is well inside budget now.
* No `tauceti-target` marker: this authors a **prerequisite**, not the Layer 4.1 step 3 target, so
  it must not claim that target's id.

Roadmap: AdicSpaces

Provenance: none — both statements are new. Checked against AINTLIB
(`github.com/CBirkbeck/AINTLIB`, Apache-2.0) at commit `37bbdaeb9ad9e3bc9f0d660feadc2779e455a91c`:
its nearest material is `locSubring_isNoetherianRing` in
`projects/AdicSpaces/Adic spaces/LocalizationTopology.lean`, which presents the *ring of definition*
`A₀[t₁/s, …, tₙ/s]` as a surjective image of `MvPolynomial T A₀`. That surjectivity holds by
construction, since `locSubring` is defined as the adjoin, and it says nothing about the
localisation `S`; generating `S` over `A` is strictly stronger and needs the hypothesis on `T`,
which the source never states. Nothing was copied. The module docstring records the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kb8uv44XKmG5Mw9BvLjsb1
