### PR TITLE
refactor(MeasureTheory): root the two flagged `Integrable` theorems

### DIFF
--- a/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Envelope.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Envelope.lean
@@ -60,8 +60,8 @@ open MeasureTheory Polynomial Polynomial.Chebyshev
 /-- **Finite exponential moments of the Chebyshev weight.** For every rate `a` the function
 `e^{a|x|}` is integrable against the weighted measure `w·(volume|_{(-1,1]})`. The measure lives on a
 bounded interval, so this is the bounded-support principle
-`TauCeti.Integrable.exp_abs_smul_of_ae_abs_le` applied to integrability of the weight itself, which
-is Mathlib's `Polynomial.Chebyshev.intervalIntegrable_sqrt_one_sub_sq_inv`.
+`MeasureTheory.Integrable.exp_abs_smul_of_ae_abs_le` applied to integrability of the weight
+itself, which is Mathlib's `Polynomial.Chebyshev.intervalIntegrable_sqrt_one_sub_sq_inv`.
 
 This is the single analytic hypothesis behind both the `L²` membership of the polynomials and the
 completeness of the family. -/

--- a/TauCeti/MeasureTheory/Function/BoundedSupportExponential.lean
+++ b/TauCeti/MeasureTheory/Function/BoundedSupportExponential.lean
@@ -34,7 +34,8 @@ variable [NormedSpace 𝕜 β] {μ : Measure α} {g : α → β}
 
 /-- Multiplication by `exp (a * ‖x‖)` preserves integrability on a measure whose support is
 essentially contained in a closed ball. -/
-protected theorem Integrable.exp_norm_smul_of_ae_norm_le (hg : Integrable g μ) (a R : ℝ)
+protected theorem _root_.MeasureTheory.Integrable.exp_norm_smul_of_ae_norm_le
+    (hg : Integrable g μ) (a R : ℝ)
     (hR : ∀ᵐ x ∂μ, ‖x‖ ≤ R) :
     Integrable (fun x : α => (Real.exp (a * ‖x‖) : 𝕜) • g x) μ := by
   have h_exp : AEStronglyMeasurable (fun x : α => (Real.exp (a * ‖x‖) : 𝕜)) μ := by
@@ -52,7 +53,8 @@ protected theorem Integrable.exp_norm_smul_of_ae_norm_le (hg : Integrable g μ) 
     Real.exp_le_exp.mpr (hmul_left.trans hmul_right)
 
 /-- Real-line version of `Integrable.exp_norm_smul_of_ae_norm_le`, stated with `|x|`. -/
-protected theorem Integrable.exp_abs_smul_of_ae_abs_le {μ : Measure ℝ} {g : ℝ → β}
+protected theorem _root_.MeasureTheory.Integrable.exp_abs_smul_of_ae_abs_le {μ : Measure ℝ}
+    {g : ℝ → β}
     (hg : Integrable g μ) (a R : ℝ) (hR : ∀ᵐ x ∂μ, |x| ≤ R) :
     Integrable (fun x : ℝ => (Real.exp (a * |x|) : 𝕜) • g x) μ := by
   simpa [Real.norm_eq_abs] using


### PR DESCRIPTION
`exp_norm_smul_of_ae_norm_le` and `exp_abs_smul_of_ae_abs_le` are the two declarations `lint-dot-notation` flags in `TauCeti/MeasureTheory/Function/BoundedSupportExponential.lean`, and together they are the whole of `TauCeti.Integrable`.

## Why `MeasureTheory.Integrable` and not root `Integrable`

The obvious reading of the linter — move to the root namespace of the same name — would be wrong here. Mathlib's namespaces hold:

| namespace | declarations |
|---|---:|
| `MeasureTheory.Integrable` | **174** |
| root `Integrable` | **1** (`norm_condExp_rpow_le`) |

The lone root declaration is the anomaly, not the home. The predicate in both statements is `MeasureTheory.Integrable` — this file already says `open MeasureTheory` — so that is where dot notation on an `Integrable g μ` hypothesis resolves, and where these two belong.

Both stay `protected`, as they were.

The one external reference, a docstring in `Analysis/SpecialFunctions/Trigonometric/Chebyshev/Envelope.lean`, named the `TauCeti.Integrable.…` path this move destroys; it now names the rooted one, and the surrounding paragraph is rewrapped for the longer name.

`lint-dot-notation`: 978 → 976, 0 new.

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYwXN9WBAPasmBQXr6iQcp