### PR TITLE
feat(Huber): a continuous surjection out of A⟨X⟩ is already a strict presentation

### DIFF
--- a/TauCeti/RingTheory/Huber/TopologicallyFiniteType.lean
+++ b/TauCeti/RingTheory/Huber/TopologicallyFiniteType.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.Topology.Algebra.Ring.Ideal
 public import TauCeti.RingTheory.Huber.StronglyNoetherian
 public import TauCeti.RingTheory.Huber.WeightedRestrictedSeries.Completion
+public import TauCeti.RingTheory.Huber.OpenMapping
 
 import TauCeti.RingTheory.Huber.WeightedRestrictedSeries.FirstCountable
 import TauCeti.Topology.Algebra.GroupCompletion
@@ -86,6 +87,11 @@ it.
 * `TauCeti.Huber.IsStrictlyTopologicallyFiniteType.isStronglyNoetherian`: over a strongly
   noetherian Huber ring, an algebra strictly topologically of finite type is again strongly
   noetherian.
+* `TauCeti.Huber.isStrictlyTopologicallyFiniteType_of_surjective`: **over a Tate ring, a
+  continuous surjection out of `A⟨X₁, …, Xₖ⟩` is already a strict presentation** — openness is
+  supplied by the open mapping theorem rather than assumed.
+* `TauCeti.Huber.isStronglyNoetherian_of_surjective`: consequently such a surjection transfers
+  strong noetherianness from the base, with no openness obligation.
 
 ## References
 
@@ -249,5 +255,66 @@ theorem IsStrictlyTopologicallyFiniteType.isStronglyNoetherian {φ : A →+* B}
   exact hπ.isStronglyNoetherian
 
 end StronglyNoetherian
+
+/-! ### Presentations supplied by the open mapping theorem
+
+Over a Tate ring a strict presentation need not be exhibited as an *open* map: **openness is
+automatic**. A continuous surjection out of `A⟨X₁, …, Xₖ⟩` onto a complete Hausdorff first
+countable algebra is open by `TauCeti.Huber.IsTateRing.isOpenMap`, so surjectivity and continuity
+alone already make it a strict presentation.
+-/
+
+section OpenMappingPresentation
+
+open Filter
+open scoped Uniformity
+
+variable {A : Type*} [CommRing A] [UniformSpace A] [NonarchimedeanRing A] [IsTateRing A]
+  {B : Type*} [CommRing B] [UniformSpace B] [IsUniformAddGroup B] [CompleteSpace B]
+  [(𝓤 B).IsCountablyGenerated] [T0Space B] [Algebra A B] [ContinuousConstSMul A B]
+
+/-- **Over a Tate ring, a continuous surjection out of `A⟨X₁, …, Xₖ⟩` is a strict
+presentation.** No openness has to be checked: `TauCeti.Huber.IsTateRing.isOpenMap` supplies it
+from surjectivity and continuity alone, so the analytic half of Wedhorn Definition 6.28 is free
+and only the algebraic half — that `π` is onto — has to be established.
+
+The hypotheses on the target are the ones that open mapping theorem asks for, and they are
+exactly the standing hypotheses of Wedhorn's §8.2: complete, Hausdorff, and first countable in
+the form of a countably generated uniformity. The source needs nothing extra — completeness,
+nonarchimedean-ness, a countably generated uniformity and `ContinuousSMul` all hold for
+`A⟨X₁, …, Xₖ⟩` and are found by instance resolution.
+
+This is not covered by `TauCeti.Huber.isStrictlyTopologicallyFiniteType_quotientMk_algebraMap`,
+which presents the *literal* quotient type `A⟨X₁, …, Xₖ⟩ ⧸ I`. The target here is an arbitrary
+ring receiving a surjection, which is what a consumer actually holds: a completed rational
+localisation is not a quotient type, and identifying it with one is precisely the work this
+avoids.
+
+**This constructs no surjection.** Exhibiting a continuous surjection onto a given `B` is the
+work; what this theorem does is guarantee that having done it, nothing analytic remains. -/
+theorem isStrictlyTopologicallyFiniteType_of_surjective {k : ℕ}
+    (π : restrictedMvPowerSeriesCompletion k A →ₐ[A] B)
+    (hπ : Continuous π) (hs : Function.Surjective π) :
+    IsStrictlyTopologicallyFiniteType (algebraMap A B) := by
+  let _ : (𝓤 (restrictedMvPowerSeriesCompletion k A)).IsCountablyGenerated :=
+    IsUniformAddGroup.uniformity_countably_generated
+  exact isStrictlyTopologicallyFiniteType_iff.mpr
+    ⟨k, π.toRingHom, ⟨hs, hπ, IsTateRing.isOpenMap π.toLinearMap hs hπ.continuousAt⟩,
+      π.comp_algebraMap⟩
+
+/-- **Strong noetherianity transfers along a continuous surjection out of `A⟨X₁, …, Xₖ⟩`.**
+
+Composing the previous theorem with
+`TauCeti.Huber.IsStrictlyTopologicallyFiniteType.isStronglyNoetherian`. It is the form Wedhorn's
+§8.2 consumes: presenting a rational localisation as a *continuous surjective* image of
+`A⟨X₁, …, Xₖ⟩` is enough to inherit strong noetherianness from the base, with no openness
+obligation of its own. -/
+theorem isStronglyNoetherian_of_surjective [IsStronglyNoetherian A] [NonarchimedeanRing B] {k : ℕ}
+    (π : restrictedMvPowerSeriesCompletion k A →ₐ[A] B)
+    (hπ : Continuous π) (hs : Function.Surjective π) :
+    IsStronglyNoetherian B :=
+  (isStrictlyTopologicallyFiniteType_of_surjective π hπ hs).isStronglyNoetherian
+
+end OpenMappingPresentation
 
 end TauCeti.Huber

--- a/TauCeti/RingTheory/Huber/TopologicallyFiniteType.lean
+++ b/TauCeti/RingTheory/Huber/TopologicallyFiniteType.lean
@@ -8,8 +8,8 @@ module
 public import Mathlib.Topology.Algebra.Ring.Ideal
 public import TauCeti.RingTheory.Huber.StronglyNoetherian
 public import TauCeti.RingTheory.Huber.WeightedRestrictedSeries.Completion
-public import TauCeti.RingTheory.Huber.OpenMapping
 
+import TauCeti.RingTheory.Huber.OpenMapping
 import TauCeti.RingTheory.Huber.WeightedRestrictedSeries.FirstCountable
 import TauCeti.Topology.Algebra.GroupCompletion
 
@@ -88,10 +88,8 @@ it.
   noetherian Huber ring, an algebra strictly topologically of finite type is again strongly
   noetherian.
 * `TauCeti.Huber.isStrictlyTopologicallyFiniteType_of_surjective`: **over a Tate ring, a
-  continuous surjection out of `A⟨X₁, …, Xₖ⟩` is already a strict presentation** — openness is
-  supplied by the open mapping theorem rather than assumed.
-* `TauCeti.Huber.isStronglyNoetherian_of_surjective`: consequently such a surjection transfers
-  strong noetherianness from the base, with no openness obligation.
+  surjection out of `A⟨X₁, …, Xₖ⟩` that is continuous at zero is already a strict
+  presentation** — openness is supplied by the open mapping theorem rather than assumed.
 
 ## References
 
@@ -259,9 +257,9 @@ end StronglyNoetherian
 /-! ### Presentations supplied by the open mapping theorem
 
 Over a Tate ring a strict presentation need not be exhibited as an *open* map: **openness is
-automatic**. A continuous surjection out of `A⟨X₁, …, Xₖ⟩` onto a complete Hausdorff first
-countable algebra is open by `TauCeti.Huber.IsTateRing.isOpenMap`, so surjectivity and continuity
-alone already make it a strict presentation.
+automatic**. A surjection out of `A⟨X₁, …, Xₖ⟩` onto a complete Hausdorff first countable algebra
+that is continuous at zero is open by `TauCeti.Huber.IsTateRing.isOpenMap`, so continuity and
+surjectivity together already make it a strict presentation.
 -/
 
 section OpenMappingPresentation
@@ -273,10 +271,14 @@ variable {A : Type*} [CommRing A] [UniformSpace A] [NonarchimedeanRing A] [IsTat
   {B : Type*} [CommRing B] [UniformSpace B] [IsUniformAddGroup B] [CompleteSpace B]
   [(𝓤 B).IsCountablyGenerated] [T0Space B] [Algebra A B] [ContinuousConstSMul A B]
 
-/-- **Over a Tate ring, a continuous surjection out of `A⟨X₁, …, Xₖ⟩` is a strict
-presentation.** No openness has to be checked: `TauCeti.Huber.IsTateRing.isOpenMap` supplies it
-from surjectivity and continuity alone, so the analytic half of Wedhorn Definition 6.28 is free
-and only the algebraic half — that `π` is onto — has to be established.
+/-- **Over a Tate ring, a surjection out of `A⟨X₁, …, Xₖ⟩` that is continuous at zero is a strict
+presentation.** Openness is not a third obligation: once continuity at zero and surjectivity are
+in hand, `TauCeti.Huber.IsTateRing.isOpenMap` supplies it, so Wedhorn Definition 6.28 asks for
+nothing beyond the two hypotheses here.
+
+Continuity is asked at zero only, which is what the open mapping theorem consumes; a caller
+holding `Continuous π` passes its `.continuousAt`. The global continuity that `IsOpenQuotientMap`
+records is recovered from it by `continuous_of_continuousAt_zero`.
 
 The hypotheses on the target are the ones that open mapping theorem asks for, and they are
 exactly the standing hypotheses of Wedhorn's §8.2: complete, Hausdorff, and first countable in
@@ -290,30 +292,18 @@ ring receiving a surjection, which is what a consumer actually holds: a complete
 localisation is not a quotient type, and identifying it with one is precisely the work this
 avoids.
 
-**This constructs no surjection.** Exhibiting a continuous surjection onto a given `B` is the
-work; what this theorem does is guarantee that having done it, nothing analytic remains. -/
+**This constructs no surjection.** Exhibiting one onto a given `B` is the work; what this theorem
+does is remove openness from the list of things that then have to be checked. -/
 theorem isStrictlyTopologicallyFiniteType_of_surjective {k : ℕ}
     (π : restrictedMvPowerSeriesCompletion k A →ₐ[A] B)
-    (hπ : Continuous π) (hs : Function.Surjective π) :
+    (hπ : ContinuousAt (π : restrictedMvPowerSeriesCompletion k A → B) 0)
+    (hs : Function.Surjective π) :
     IsStrictlyTopologicallyFiniteType (algebraMap A B) := by
   let _ : (𝓤 (restrictedMvPowerSeriesCompletion k A)).IsCountablyGenerated :=
     IsUniformAddGroup.uniformity_countably_generated
   exact isStrictlyTopologicallyFiniteType_iff.mpr
-    ⟨k, π.toRingHom, ⟨hs, hπ, IsTateRing.isOpenMap π.toLinearMap hs hπ.continuousAt⟩,
-      π.comp_algebraMap⟩
-
-/-- **Strong noetherianity transfers along a continuous surjection out of `A⟨X₁, …, Xₖ⟩`.**
-
-Composing the previous theorem with
-`TauCeti.Huber.IsStrictlyTopologicallyFiniteType.isStronglyNoetherian`. It is the form Wedhorn's
-§8.2 consumes: presenting a rational localisation as a *continuous surjective* image of
-`A⟨X₁, …, Xₖ⟩` is enough to inherit strong noetherianness from the base, with no openness
-obligation of its own. -/
-theorem isStronglyNoetherian_of_surjective [IsStronglyNoetherian A] [NonarchimedeanRing B] {k : ℕ}
-    (π : restrictedMvPowerSeriesCompletion k A →ₐ[A] B)
-    (hπ : Continuous π) (hs : Function.Surjective π) :
-    IsStronglyNoetherian B :=
-  (isStrictlyTopologicallyFiniteType_of_surjective π hπ hs).isStronglyNoetherian
+    ⟨k, π.toRingHom, ⟨hs, continuous_of_continuousAt_zero π.toLinearMap hπ,
+      IsTateRing.isOpenMap π.toLinearMap hs hπ⟩, π.comp_algebraMap⟩
 
 end OpenMappingPresentation
 

--- a/TauCeti/RingTheory/Huber/TopologicallyFiniteType.lean
+++ b/TauCeti/RingTheory/Huber/TopologicallyFiniteType.lean
@@ -258,8 +258,8 @@ end StronglyNoetherian
 
 Over a Tate ring a strict presentation need not be exhibited as an *open* map: **openness is
 automatic**. A surjection out of `A⟨X₁, …, Xₖ⟩` onto a complete Hausdorff first countable algebra
-that is continuous at zero is open by `TauCeti.Huber.IsTateRing.isOpenMap`, so continuity and
-surjectivity together already make it a strict presentation.
+that is continuous at zero is open, so continuity and surjectivity together already make it a
+strict presentation.
 -/
 
 section OpenMappingPresentation
@@ -267,33 +267,26 @@ section OpenMappingPresentation
 open Filter
 open scoped Uniformity
 
-variable {A : Type*} [CommRing A] [UniformSpace A] [NonarchimedeanRing A] [IsTateRing A]
+variable {A : Type*} [CommRing A] [TopologicalSpace A] [NonarchimedeanRing A]
+  [IsTateRing A]
   {B : Type*} [CommRing B] [UniformSpace B] [IsUniformAddGroup B] [CompleteSpace B]
   [(𝓤 B).IsCountablyGenerated] [T0Space B] [Algebra A B] [ContinuousConstSMul A B]
 
 /-- **Over a Tate ring, a surjection out of `A⟨X₁, …, Xₖ⟩` that is continuous at zero is a strict
-presentation.** Openness is not a third obligation: once continuity at zero and surjectivity are
-in hand, `TauCeti.Huber.IsTateRing.isOpenMap` supplies it, so Wedhorn Definition 6.28 asks for
-nothing beyond the two hypotheses here.
+presentation.** Openness is not a third obligation: with continuity at zero and surjectivity in
+hand, Wedhorn Definition 6.28 asks for nothing more.
 
-Continuity is asked at zero only, which is what the open mapping theorem consumes; a caller
-holding `Continuous π` passes its `.continuousAt`. The global continuity that `IsOpenQuotientMap`
-records is recovered from it by `continuous_of_continuousAt_zero`.
+The hypotheses on the target are the standing hypotheses of Wedhorn's §8.2: complete, Hausdorff,
+and first countable in the form of a countably generated uniformity. The source needs nothing
+beyond what `A⟨X₁, …, Xₖ⟩` already carries.
 
-The hypotheses on the target are the ones that open mapping theorem asks for, and they are
-exactly the standing hypotheses of Wedhorn's §8.2: complete, Hausdorff, and first countable in
-the form of a countably generated uniformity. The source needs nothing extra — completeness,
-nonarchimedean-ness, a countably generated uniformity and `ContinuousSMul` all hold for
-`A⟨X₁, …, Xₖ⟩` and are found by instance resolution.
+The target is an arbitrary ring receiving a surjection, not the literal quotient type
+`A⟨X₁, …, Xₖ⟩ ⧸ I` that
+`TauCeti.Huber.isStrictlyTopologicallyFiniteType_quotientMk_algebraMap` covers. That is what a
+consumer holds: a completed rational localisation is not a quotient type.
 
-This is not covered by `TauCeti.Huber.isStrictlyTopologicallyFiniteType_quotientMk_algebraMap`,
-which presents the *literal* quotient type `A⟨X₁, …, Xₖ⟩ ⧸ I`. The target here is an arbitrary
-ring receiving a surjection, which is what a consumer actually holds: a completed rational
-localisation is not a quotient type, and identifying it with one is precisely the work this
-avoids.
-
-**This constructs no surjection.** Exhibiting one onto a given `B` is the work; what this theorem
-does is remove openness from the list of things that then have to be checked. -/
+**This constructs no surjection.** Exhibiting one onto a given `B` is the work; this theorem
+removes openness from the list of things that then have to be checked. -/
 theorem isStrictlyTopologicallyFiniteType_of_surjective {k : ℕ}
     (π : restrictedMvPowerSeriesCompletion k A →ₐ[A] B)
     (hπ : ContinuousAt (π : restrictedMvPowerSeriesCompletion k A → B) 0)

--- a/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Completion.lean
+++ b/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Completion.lean
@@ -57,6 +57,9 @@ Hausdorff — over a complete Hausdorff base, and over a discrete one — is
   `A → A⟨X⟩_T` into the completion is continuous, for an arbitrary weight family;
   `TauCeti.Huber.continuous_algebraMap_restrictedMvPowerSeriesCompletion` is the trivial-weight
   case, the structure map `A → A⟨X₁,…,Xₖ⟩`.
+* `TauCeti.Huber.continuousSMul_completion_weightedRestrictedSubring`: the completion is a
+  topological `A`-algebra. An instance, because it is a hypothesis of the Tate-ring open mapping
+  theorem and so is asked for by typeclass resolution.
 * `TauCeti.Huber.weightedMapCompletion_coe` and
   `TauCeti.Huber.continuous_weightedMapCompletion`: the induced map on the image of `A⟨X⟩_T`,
   and its continuity.
@@ -124,6 +127,18 @@ theorem algebraMap_completion_weightedRestrictedSubring_apply {T : Fin k → Set
         UniformSpace.Completion (weightedRestrictedSubring T hT)) := by
   rw [UniformSpace.Completion.algebraMap_def]
   exact congrArg _ (Subtype.ext (by rw [coe_algebraMap_weightedRestrictedSubring, coe_weightedC]))
+
+/-- **The completion of a weighted restricted power-series ring is a topological `A`-algebra.**
+Scalar multiplication is multiplication by the image of the structure map, which is continuous, so
+this follows from `continuous_algebraMap_completion_weightedRestrictedSubring`.
+
+Registered as an instance because it is a hypothesis of the Tate-ring open mapping theorem, which
+is applied to `A⟨X₁,…,Xₖ⟩` as the source of a presentation. -/
+instance continuousSMul_completion_weightedRestrictedSubring {T : Fin k → Set A}
+    {hT : IsWeightFamily T} :
+    ContinuousSMul A (UniformSpace.Completion (weightedRestrictedSubring T hT)) :=
+  continuousSMul_of_algebraMap _ _
+    (continuous_algebraMap_completion_weightedRestrictedSubring k A hT)
 
 /-- The structure map `A → A⟨X₁,…,Xₖ⟩` is continuous. -/
 theorem continuous_algebraMap_restrictedMvPowerSeriesCompletion :

--- a/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Completion.lean
+++ b/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Completion.lean
@@ -57,9 +57,8 @@ Hausdorff — over a complete Hausdorff base, and over a discrete one — is
   `A → A⟨X⟩_T` into the completion is continuous, for an arbitrary weight family;
   `TauCeti.Huber.continuous_algebraMap_restrictedMvPowerSeriesCompletion` is the trivial-weight
   case, the structure map `A → A⟨X₁,…,Xₖ⟩`.
-* `TauCeti.Huber.continuousSMul_completion_weightedRestrictedSubring`: the completion is a
-  topological `A`-algebra. An instance, because it is a hypothesis of the Tate-ring open mapping
-  theorem and so is asked for by typeclass resolution.
+* `TauCeti.Huber.continuousSMul_completion_weightedRestrictedSubring`: scalar multiplication on
+  the completion is jointly continuous, so it is a topological `A`-algebra.
 * `TauCeti.Huber.weightedMapCompletion_coe` and
   `TauCeti.Huber.continuous_weightedMapCompletion`: the induced map on the image of `A⟨X⟩_T`,
   and its continuity.
@@ -128,12 +127,9 @@ theorem algebraMap_completion_weightedRestrictedSubring_apply {T : Fin k → Set
   rw [UniformSpace.Completion.algebraMap_def]
   exact congrArg _ (Subtype.ext (by rw [coe_algebraMap_weightedRestrictedSubring, coe_weightedC]))
 
-/-- **The completion of a weighted restricted power-series ring is a topological `A`-algebra.**
-Scalar multiplication is multiplication by the image of the structure map, which is continuous, so
-this follows from `continuous_algebraMap_completion_weightedRestrictedSubring`.
-
-Registered as an instance because it is a hypothesis of the Tate-ring open mapping theorem, which
-is applied to `A⟨X₁,…,Xₖ⟩` as the source of a presentation. -/
+/-- **Scalar multiplication on the completion of a weighted restricted power-series ring is
+jointly continuous**: `A⟨X⟩_T` is a topological `A`-algebra. Results about topological modules
+over `A` therefore apply to it. -/
 instance continuousSMul_completion_weightedRestrictedSubring {T : Fin k → Set A}
     {hT : IsWeightFamily T} :
     ContinuousSMul A (UniformSpace.Completion (weightedRestrictedSubring T hT)) :=

--- a/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Completion.lean
+++ b/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Completion.lean
@@ -27,8 +27,10 @@ be complete, Hausdorff and nonarchimedean. That instance is Mathlib's, and is av
 because this module imports it.
 
 This module fixes the notation and records what instance search does not supply: continuity of the
-structure map, and — at `k = 0`, where the construction degenerates to the separated completion of
-`A` — the identification of `A⟨⟩` with `Â` together with its topological API.
+structure map, joint continuity of the `A`-scalar action — so that `A⟨X₁,…,Xₖ⟩` is a topological
+`A`-algebra and results about topological `A`-modules apply to it — and, at `k = 0`, where the
+construction degenerates to the separated completion of `A`, the identification of `A⟨⟩` with `Â`
+together with its topological API.
 
 The predicate that every `A⟨X₁,…,Xₖ⟩` is noetherian is
 `TauCeti.Huber.IsStronglyNoetherian`, in `TauCeti.RingTheory.Huber.StronglyNoetherian`; the


### PR DESCRIPTION
Over a Tate ring, **openness is not an extra obligation on a strict finite-type presentation**.
`TauCeti.Huber.IsTateRing.isOpenMap` — the Tate-ring form of Henkel's open mapping theorem,
already on `main` — supplies it once continuity and surjectivity are in hand. So:

* `TauCeti.Huber.isStrictlyTopologicallyFiniteType_of_surjective` — a surjection
  `A⟨X₁, …, Xₖ⟩ ↠ B` that is **continuous at zero** already makes `algebraMap A B` strictly
  topologically of finite type (Wedhorn Definition 6.28). Openness is not a third obligation.

A strong-noetherian corollary was in the first version and has been **removed** at the reuse
rubric's request: it was a one-line wrapper with no in-repository consumer, and a caller writes
`(isStrictlyTopologicallyFiniteType_of_surjective π hπ hs).isStronglyNoetherian` directly. This
paragraph replaces the bullet that advertised it, which is what the round-2 api-design finding
was reading.

Plus one supporting instance in `WeightedRestrictedSeries/Completion.lean`,
`continuousSMul_completion_weightedRestrictedSubring`: the completion of a weighted restricted
power-series ring is a topological `A`-algebra. It is one of the hypotheses the open mapping
theorem asks of the source, and it follows in a line from the existing
`continuous_algebraMap_completion_weightedRestrictedSubring` via Mathlib's
`continuousSMul_of_algebraMap`.

## Which roadmap item uses this

`TauCetiRoadmap/AdicSpaces/README.md`, **Layer 4.1 step 3 — Wedhorn Proposition 8.30**. That
layer prescribes this step in as many words:

> Prove the additional topological statements separately. The rings and modules in the argument
> are complete, Hausdorff, and metrisable; **use Layer 0's open mapping theorem** to show that the
> relevant images are closed and that the algebraic quotient topology agrees with the topology on
> the target.

The concrete gap is the one `Laurent/Flat.lean` states about itself on `main`:

> it still asks strong noetherianity of `A⟨T/s⟩` rather than of `A`, and **nothing here derives
> the one from the other**.

Wedhorn derives it by presenting `A⟨T/s⟩` as an open quotient of `A⟨X₁, …, Xₙ⟩`. **This PR
discharges the openness half of that presentation once and for all**, leaving surjectivity — the
Examples 6.38/6.39 content — as the only remaining obligation. It claims no part of Proposition
8.30 itself, and it constructs no surjection; the docstring says so explicitly.

## Why not the existing quotient theorem

`isStrictlyTopologicallyFiniteType_quotientMk_algebraMap` already covers presentations, but only
of the **literal quotient type** `A⟨X₁, …, Xₖ⟩ ⧸ I`. The target here is an arbitrary ring
receiving a surjection, which is what a consumer actually holds: a completed rational localisation
is `UniformSpace.Completion (A[1/s])`, not a quotient type, and identifying it with one is exactly
the work this avoids.

## Notes

* One new import: `TauCeti.RingTheory.Huber.OpenMapping` into `TopologicallyFiniteType.lean`.
  Nothing currently imports `TopologicallyFiniteType.lean`, so the fan-out cost is zero today.
* The hypotheses on the target are the open mapping theorem's, and they are the standing
  hypotheses of Wedhorn's §8.2: complete, Hausdorff, first countable. The **source** needs
  nothing extra — every instance it requires is found by resolution once the new `ContinuousSMul`
  one is registered.
* Adding an instance can create diamonds, so all four direct importers plus the far-downstream
  consumers (`Laurent.StronglyNoetherian`, `WeightedEval.Completion`, `Spa.Localization.Surjective`,
  `WeightedRestrictedSeries.Iterate`) were rebuilt — 2492 jobs, all green.
* No `tauceti-target` marker: this authors a **prerequisite**, not the Layer 4.1 step 3 target.

Roadmap: AdicSpaces

Provenance: none — both theorems and the instance are new. Checked against AINTLIB
(`github.com/CBirkbeck/AINTLIB`, Apache-2.0) at commit
`37bbdaeb9ad9e3bc9f0d660feadc2779e455a91c`, which has no finite-type notion at all. Its
open-mapping material (`projects/AdicSpaces/Adic spaces/NoetherianTateModules.lean`) is a
different theorem reached a different way — Wedhorn Proposition 6.18(2) via
`IsModuleTopology.isOpenQuotientMap_of_surjective` for module topologies, not the
complete-first-countable theorem consumed here. Nothing was copied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kb8uv44XKmG5Mw9BvLjsb1

