### PR TITLE
feat: the Alexander polynomial of a braid closure from the Burau representation

### DIFF
--- a/TauCeti/KnotTheory/Burau/Alexander.lean
+++ b/TauCeti/KnotTheory/Burau/Alexander.lean
@@ -1,0 +1,530 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.KnotTheory.Alexander
+public import TauCeti.KnotTheory.Burau.Basic
+public import TauCeti.KnotTheory.Markov
+public import TauCeti.LinearAlgebra.Matrix.CornerMinor
+
+/-!
+# The Alexander polynomial of a braid closure, from the Burau representation
+
+Closing a braid on `n` strands, by joining the `i`-th endpoint at the top to the `i`-th endpoint
+at the bottom, presents an oriented link. This file attaches a Laurent-polynomial-valued invariant
+to that presentation, read off the unreduced Burau representation:
+`TauCeti.MarkovBraid.burauAlexander` is the determinant of `burau b - 1` with its last row and its
+last column deleted.
+
+That *corner minor* is the right quantity because of the two invariant vectors of the Burau
+representation. The all-ones column vector is fixed and the geometric row vector
+`(1, t, …, t ^ (n - 1))` is fixed, so `burau b - 1` is annihilated by the first on the right and
+by the second on the left; a matrix with two such annihilators has a corner minor unchanged by
+conjugation by anything fixing them (`Matrix.det_submatrix_castSucc_conj`), and that is precisely
+Markov's conjugation move. The other Markov move, adding a strand and crossing it once with the
+previous one, multiplies the corner minor by `-t` when the new crossing is positive and by `-1`
+when it is negative. Both factors are units, so the corner minor is constant along Markov
+equivalence up to a unit of the coefficient ring: `TauCeti.MarkovEquiv.associated_burauAlexander`.
+By Markov's theorem (not formalized here) that makes it an invariant of the closure as an oriented
+link, defined up to a unit; over `ℤ[T;T⁻¹]` at `t = T` the units are `± T ^ k`, which is the
+classical indeterminacy of the Alexander polynomial.
+
+The unreduced representation is used rather than the reduced one exactly because of that
+transformation law: the two stabilizations must change the invariant by a unit, and here they do.
+
+Two computations keep the invariant honest. The braid `σ₀ ^ 3` on two strands, whose closure is
+the right-handed trefoil, has invariant `-t (t ^ 2 - t + 1)`; over `ℤ[T;T⁻¹]` this is associated
+to `T - 1 + T⁻¹`, the value that the Seifert-matrix route of `TauCeti/KnotTheory/Alexander.lean`
+produces from `TauCeti.KnotTheory.trefoilSeifertMatrix`, so the two routes to the Alexander
+polynomial agree on the trefoil. Over `ℤ` at `t = -1` the same braid has invariant `3` while the
+trivial one-strand braid has invariant `1`, and `3` and `1` are not associated in `ℤ`; hence the
+two are not Markov equivalent. Their closures both have one component, so this is a separation
+that `TauCeti.MarkovBraid.componentCount` cannot make.
+
+Everything is stated over an arbitrary commutative ring `R` and an arbitrary unit `t : Rˣ`, as in
+`TauCeti/KnotTheory/Burau/Basic.lean`; the knot-theoretic case is `R = ℤ[T;T⁻¹]` and `t = T`.
+
+## Main definitions
+
+* `TauCeti.MarkovBraid.burauAlexander`: the corner minor of `burau b - 1`.
+
+## Main results
+
+* `TauCeti.KnotTheory.submatrix_burau_strandIncl` and
+  `TauCeti.KnotTheory.burau_strandIncl_mulVec_single`: the Burau matrix of a braid with an extra
+  uncrossed strand is the old matrix in the old strands, and fixes the new strand.
+* `TauCeti.KnotTheory.burau_sub_one_mulVec_one` and
+  `TauCeti.KnotTheory.geom_vecMul_burau_sub_one`: the two vectors annihilating `burau b - 1`,
+  and `TauCeti.KnotTheory.det_burau_sub_one`, its vanishing determinant.
+* `TauCeti.MarkovBraid.burauAlexander_conj`,
+  `TauCeti.MarkovBraid.burauAlexander_stabilize` and
+  `TauCeti.MarkovBraid.burauAlexander_stabilizeInv`: the effect of each Markov move.
+* `TauCeti.MarkovEquiv.associated_burauAlexander`: Markov-equivalent braids have associated
+  invariants.
+* `TauCeti.MarkovBraid.burauAlexander_sigma_pow_three`: the trefoil value `-t (t ^ 2 - t + 1)`.
+* `TauCeti.KnotTheory.associated_alexander_trefoilSeifertMatrix`: on the trefoil this agrees, up
+  to a unit of `ℤ[T;T⁻¹]`, with the Alexander polynomial of a Seifert matrix.
+* `TauCeti.not_markovEquiv_sigma_pow_three_one`: the trefoil braid is not Markov equivalent to
+  the trivial one-strand braid.
+
+## References
+
+* W. Burau, *Über Zopfgruppen und gleichsinnig verdrillte Verkettungen*, Abh. Math. Semin. Univ.
+  Hambg. 11 (1935), 179-186.
+* J. Birman, *Braids, Links, and Mapping Class Groups*, Annals of Mathematics Studies 82 (1974),
+  Theorem 3.11 (the Alexander polynomial of a braid closure from the Burau matrix).
+* C. Kassel, V. Turaev, *Braid Groups*, Springer GTM 247 (2008), Section 3.3.
+* W. B. R. Lickorish, *An Introduction to Knot Theory*, Springer GTM 175 (1997), Chapters 1, 6
+  and 16.
+-/
+
+public section
+
+open Matrix
+
+namespace TauCeti
+
+open KnotTheory
+
+variable {R : Type*} [CommRing R] {n : ℕ}
+
+namespace KnotTheory
+
+/-! ### The Burau matrix of a braid with an extra uncrossed strand -/
+
+private theorem burauCol_castSucc (t : R) (i : Fin n) (u : Fin (n + 1)) :
+    burauCol (n := n + 2) t i.castSucc u.castSucc = burauCol (n := n + 1) t i u := by
+  rw [burauCol_apply, burauCol_apply]
+  simp only [Fin.ext_iff, BraidGroup.val_strand, BraidGroup.val_strandSucc, Fin.val_castSucc]
+
+private theorem burauRow_castSucc (i : Fin n) (u : Fin (n + 1)) :
+    burauRow R (n := n + 2) i.castSucc u.castSucc = burauRow R (n := n + 1) i u := by
+  rw [burauRow_apply, burauRow_apply]
+  simp only [Fin.ext_iff, BraidGroup.val_strand, BraidGroup.val_strandSucc, Fin.val_castSucc]
+
+/-- Deleting the last row and column of a product is the product of the deletions, provided the
+left factor has the last standard basis vector as its last column. -/
+private theorem submatrix_mul_of_mulVec_single
+    (X Y : Matrix (Fin (n + 2)) (Fin (n + 2)) R)
+    (hX : X *ᵥ Pi.single (Fin.last (n + 1)) 1 = Pi.single (Fin.last (n + 1)) 1) :
+    (X * Y).submatrix Fin.castSucc Fin.castSucc =
+      X.submatrix Fin.castSucc Fin.castSucc * Y.submatrix Fin.castSucc Fin.castSucc := by
+  have hcol : X.col (Fin.last (n + 1)) = Pi.single (Fin.last (n + 1)) 1 := by
+    rw [← Matrix.mulVec_single_one]
+    exact hX
+  have hentry : ∀ i : Fin (n + 2),
+      X i (Fin.last (n + 1)) = (Pi.single (Fin.last (n + 1)) 1 : Fin (n + 2) → R) i :=
+    fun i => congrFun hcol i
+  ext u v
+  rw [Matrix.submatrix_apply, Matrix.mul_apply, Matrix.mul_apply, Fin.sum_univ_castSucc, hentry,
+    Pi.single_eq_of_ne (Fin.castSucc_lt_last u).ne, zero_mul, add_zero]
+  rfl
+
+private theorem burau_strandIncl_aux (t : Rˣ) (b : BraidGroup (n + 1)) :
+    ((burau (n + 2) t (BraidGroup.strandIncl b) : Matrix (Fin (n + 2)) (Fin (n + 2)) R) *ᵥ
+        Pi.single (Fin.last (n + 1)) 1 = Pi.single (Fin.last (n + 1)) 1) ∧
+      (burau (n + 2) t (BraidGroup.strandIncl b) :
+          Matrix (Fin (n + 2)) (Fin (n + 2)) R).submatrix Fin.castSucc Fin.castSucc =
+        (burau (n + 1) t b : Matrix (Fin (n + 1)) (Fin (n + 1)) R) := by
+  induction b using BraidGroup.sigma_induction_on with
+  | sigma i =>
+    rw [BraidGroup.strandIncl_sigma, burau_sigma, burau_sigma, coe_burauGL, coe_burauGL]
+    refine ⟨?_, ?_⟩
+    · rw [burauMatrix_mulVec, burauRow_dotProduct]
+      have h₁ : (Pi.single (Fin.last (n + 1)) 1 : Fin (n + 2) → R)
+          (BraidGroup.strand (n := n + 2) i.castSucc) = 0 := by
+        refine Pi.single_eq_of_ne ?_ 1
+        simp only [Ne, Fin.ext_iff, BraidGroup.val_strand, Fin.val_last, Fin.val_castSucc]
+        omega
+      have h₂ : (Pi.single (Fin.last (n + 1)) 1 : Fin (n + 2) → R)
+          (BraidGroup.strandSucc (n := n + 2) i.castSucc) = 0 := by
+        refine Pi.single_eq_of_ne ?_ 1
+        simp only [Ne, Fin.ext_iff, BraidGroup.val_strandSucc, Fin.val_last, Fin.val_castSucc]
+        omega
+      rw [h₁, h₂, sub_self, zero_smul, sub_zero]
+    · ext u v
+      rw [Matrix.submatrix_apply, burauMatrix_apply, burauMatrix_apply, burauCol_castSucc,
+        burauRow_castSucc]
+      simp [Fin.castSucc_inj]
+  | one =>
+    rw [map_one, map_one, map_one, Units.val_one, Units.val_one]
+    refine ⟨Matrix.one_mulVec _, ?_⟩
+    ext u v
+    rw [Matrix.submatrix_apply, Matrix.one_apply, Matrix.one_apply]
+    simp [Fin.castSucc_inj]
+  | mul b b' hb hb' =>
+    rw [map_mul, map_mul, map_mul, Units.val_mul, Units.val_mul]
+    refine ⟨?_, ?_⟩
+    · rw [← Matrix.mulVec_mulVec, hb'.1, hb.1]
+    · rw [submatrix_mul_of_mulVec_single _ _ hb.1, hb.2, hb'.2, ← Units.val_mul, ← map_mul]
+  | inv b hb =>
+    have hunit : ((burau (n + 2) t (BraidGroup.strandIncl b))⁻¹ : GL (Fin (n + 2)) R) *
+        (burau (n + 2) t (BraidGroup.strandIncl b)) = 1 := inv_mul_cancel _
+    have hmat : ((burau (n + 2) t (BraidGroup.strandIncl b⁻¹) : GL (Fin (n + 2)) R) :
+          Matrix (Fin (n + 2)) (Fin (n + 2)) R) *
+        (burau (n + 2) t (BraidGroup.strandIncl b) : Matrix (Fin (n + 2)) (Fin (n + 2)) R) = 1 := by
+      rw [map_inv, map_inv, ← Units.val_mul, hunit, Units.val_one]
+    have hcol : (burau (n + 2) t (BraidGroup.strandIncl b⁻¹) :
+        Matrix (Fin (n + 2)) (Fin (n + 2)) R) *ᵥ Pi.single (Fin.last (n + 1)) 1 =
+        Pi.single (Fin.last (n + 1)) 1 := by
+      conv_lhs => rw [← hb.1]
+      rw [Matrix.mulVec_mulVec, hmat, Matrix.one_mulVec]
+    refine ⟨hcol, ?_⟩
+    have hprod := congrArg (fun X : Matrix (Fin (n + 2)) (Fin (n + 2)) R =>
+      X.submatrix Fin.castSucc Fin.castSucc) hmat
+    simp only [submatrix_mul_of_mulVec_single _ _ hcol, hb.2] at hprod
+    have hone : ((1 : Matrix (Fin (n + 2)) (Fin (n + 2)) R)).submatrix
+        Fin.castSucc Fin.castSucc = 1 := by
+      ext u v
+      rw [Matrix.submatrix_apply, Matrix.one_apply, Matrix.one_apply]
+      simp [Fin.castSucc_inj]
+    rw [hone] at hprod
+    calc (burau (n + 2) t (BraidGroup.strandIncl b⁻¹) :
+          Matrix (Fin (n + 2)) (Fin (n + 2)) R).submatrix Fin.castSucc Fin.castSucc
+        = _ * ((burau (n + 1) t b : Matrix (Fin (n + 1)) (Fin (n + 1)) R) *
+            (burau (n + 1) t b⁻¹ : Matrix (Fin (n + 1)) (Fin (n + 1)) R)) := by
+          rw [show (burau (n + 1) t b : Matrix (Fin (n + 1)) (Fin (n + 1)) R) *
+            (burau (n + 1) t b⁻¹ : Matrix (Fin (n + 1)) (Fin (n + 1)) R) = 1 by
+              rw [map_inv, ← Units.val_mul, mul_inv_cancel, Units.val_one], Matrix.mul_one]
+      _ = (burau (n + 1) t b⁻¹ : Matrix (Fin (n + 1)) (Fin (n + 1)) R) := by
+          rw [← Matrix.mul_assoc, hprod, Matrix.one_mul]
+
+/-- **The Burau matrix of a braid with an uncrossed strand added.** Deleting the new strand's row
+and column recovers the Burau matrix of the original braid. -/
+theorem submatrix_burau_strandIncl (t : Rˣ) (b : BraidGroup (n + 1)) :
+    (burau (n + 2) t (BraidGroup.strandIncl b) :
+        Matrix (Fin (n + 2)) (Fin (n + 2)) R).submatrix Fin.castSucc Fin.castSucc =
+      (burau (n + 1) t b : Matrix (Fin (n + 1)) (Fin (n + 1)) R) :=
+  (burau_strandIncl_aux t b).2
+
+/-- The new strand of `TauCeti.BraidGroup.strandIncl b` is fixed by the Burau matrix: the last
+column is the last standard basis vector. -/
+theorem burau_strandIncl_mulVec_single (t : Rˣ) (b : BraidGroup (n + 1)) :
+    (burau (n + 2) t (BraidGroup.strandIncl b) : Matrix (Fin (n + 2)) (Fin (n + 2)) R) *ᵥ
+        Pi.single (Fin.last (n + 1)) 1 = Pi.single (Fin.last (n + 1)) 1 :=
+  (burau_strandIncl_aux t b).1
+
+/-! ### The elementary Burau matrix of the last crossing -/
+
+private theorem burauCol_last_castSucc (t : R) (c : Fin (n + 1)) :
+    burauCol (n := n + 2) t (Fin.last n) c.castSucc = if c = Fin.last n then t else 0 := by
+  have hc := c.isLt
+  have h1 : (c.castSucc = BraidGroup.strand (n := n + 2) (Fin.last n)) ↔ c = Fin.last n := by
+    simp only [Fin.ext_iff, BraidGroup.val_strand, Fin.val_castSucc, Fin.val_last]
+  have h2 : ¬ c.castSucc = BraidGroup.strandSucc (n := n + 2) (Fin.last n) := by
+    simp only [Fin.ext_iff, BraidGroup.val_strandSucc, Fin.val_castSucc, Fin.val_last]
+    omega
+  simp only [burauCol_apply, h1, h2, ite_false, sub_zero]
+
+private theorem burauRow_last_castSucc (c : Fin (n + 1)) :
+    burauRow R (n := n + 2) (Fin.last n) c.castSucc = if c = Fin.last n then 1 else 0 := by
+  have hc := c.isLt
+  have h1 : (c.castSucc = BraidGroup.strand (n := n + 2) (Fin.last n)) ↔ c = Fin.last n := by
+    simp only [Fin.ext_iff, BraidGroup.val_strand, Fin.val_castSucc, Fin.val_last]
+  have h2 : ¬ c.castSucc = BraidGroup.strandSucc (n := n + 2) (Fin.last n) := by
+    simp only [Fin.ext_iff, BraidGroup.val_strandSucc, Fin.val_castSucc, Fin.val_last]
+    omega
+  simp only [burauRow_apply, h1, h2, ite_false, sub_zero]
+
+/-! ### The two vectors annihilating `burau b - 1` -/
+
+/-- The all-ones column vector is annihilated by `burau b - 1`. -/
+theorem burau_sub_one_mulVec_one (t : Rˣ) (b : BraidGroup n) :
+    ((burau n t b : Matrix (Fin n) (Fin n) R) - 1) *ᵥ (1 : Fin n → R) = 0 := by
+  rw [Matrix.sub_mulVec, burau_mulVec_one, Matrix.one_mulVec, sub_self]
+
+/-- The geometric row vector `(1, t, …, t ^ (n - 1))` annihilates `burau b - 1`. -/
+theorem geom_vecMul_burau_sub_one (t : Rˣ) (b : BraidGroup n) :
+    (fun k : Fin n => (t : R) ^ (k : ℕ)) ᵥ* ((burau n t b : Matrix (Fin n) (Fin n) R) - 1) = 0 := by
+  rw [Matrix.vecMul_sub, vecMul_burau_geom, Matrix.vecMul_one, sub_self]
+
+/-- **The matrix `burau b - 1` is singular.** Its determinant vanishes because the all-ones vector
+is in its kernel. -/
+theorem det_burau_sub_one (t : Rˣ) (b : BraidGroup (n + 1)) :
+    ((burau (n + 1) t b : Matrix (Fin (n + 1)) (Fin (n + 1)) R) - 1).det = 0 :=
+  Matrix.det_eq_zero_of_mulVec_eq_zero_of_mem_nonZeroDivisors (burau_sub_one_mulVec_one t b)
+    (i := 0) (by simp)
+
+/-! ### Adding a strand and crossing it once -/
+
+/-- The Burau matrix of a stabilised braid, with its last row and column deleted. The elementary
+matrix of the new crossing enters only through the scalar `k`, which is `t` for the positive
+crossing and `1` for the negative one. -/
+private theorem submatrix_burau_strandIncl_mul (t : Rˣ) (b : BraidGroup (n + 1)) (k : R)
+    (S : Matrix (Fin (n + 2)) (Fin (n + 2)) R)
+    (hS : ∀ c v : Fin (n + 1), S c.castSucc v.castSucc =
+      (if c = v then 1 else 0) -
+        k * (if c = Fin.last n then 1 else 0) * (if v = Fin.last n then 1 else 0)) :
+    (((burau (n + 2) t (BraidGroup.strandIncl b) :
+          Matrix (Fin (n + 2)) (Fin (n + 2)) R) * S) - 1).submatrix Fin.castSucc Fin.castSucc =
+      ((burau (n + 1) t b : Matrix (Fin (n + 1)) (Fin (n + 1)) R) - 1).updateCol (Fin.last n)
+        (fun u => (1 - k) * (burau (n + 1) t b : Matrix (Fin (n + 1)) (Fin (n + 1)) R)
+          u (Fin.last n) - (Pi.single (Fin.last n) 1 : Fin (n + 1) → R) u) := by
+  have hPb : ∀ x y : Fin (n + 1),
+      (burau (n + 2) t (BraidGroup.strandIncl b) : Matrix (Fin (n + 2)) (Fin (n + 2)) R)
+          x.castSucc y.castSucc =
+        (burau (n + 1) t b : Matrix (Fin (n + 1)) (Fin (n + 1)) R) x y := fun x y =>
+    congrFun (congrFun (submatrix_burau_strandIncl t b) x) y
+  have hcol : (burau (n + 2) t (BraidGroup.strandIncl b) :
+      Matrix (Fin (n + 2)) (Fin (n + 2)) R).col (Fin.last (n + 1)) =
+      Pi.single (Fin.last (n + 1)) 1 := by
+    rw [← Matrix.mulVec_single_one]
+    exact burau_strandIncl_mulVec_single t b
+  have hentry : ∀ i : Fin (n + 2),
+      (burau (n + 2) t (BraidGroup.strandIncl b) : Matrix (Fin (n + 2)) (Fin (n + 2)) R) i
+          (Fin.last (n + 1)) = (Pi.single (Fin.last (n + 1)) 1 : Fin (n + 2) → R) i :=
+    fun i => congrFun hcol i
+  have hlast : ∀ x : Fin (n + 1),
+      (burau (n + 2) t (BraidGroup.strandIncl b) : Matrix (Fin (n + 2)) (Fin (n + 2)) R)
+        x.castSucc (Fin.last (n + 1)) = 0 := fun x => by
+    rw [hentry, Pi.single_eq_of_ne (Fin.castSucc_lt_last x).ne]
+  ext u v
+  have hsum : ∑ c : Fin (n + 1),
+      (burau (n + 1) t b : Matrix (Fin (n + 1)) (Fin (n + 1)) R) u c *
+        ((if c = v then (1 : R) else 0) - k * (if c = Fin.last n then 1 else 0) *
+          (if v = Fin.last n then 1 else 0)) =
+      (burau (n + 1) t b : Matrix (Fin (n + 1)) (Fin (n + 1)) R) u v -
+        k * (if v = Fin.last n then 1 else 0) *
+          (burau (n + 1) t b : Matrix (Fin (n + 1)) (Fin (n + 1)) R) u (Fin.last n) := by
+    have hexp : ∀ c : Fin (n + 1),
+        (burau (n + 1) t b : Matrix (Fin (n + 1)) (Fin (n + 1)) R) u c *
+          ((if c = v then (1 : R) else 0) - k * (if c = Fin.last n then 1 else 0) *
+            (if v = Fin.last n then 1 else 0)) =
+        (if c = v then (burau (n + 1) t b : Matrix (Fin (n + 1)) (Fin (n + 1)) R) u c else 0) -
+          (if c = Fin.last n then k * (if v = Fin.last n then 1 else 0) *
+            (burau (n + 1) t b : Matrix (Fin (n + 1)) (Fin (n + 1)) R) u c else 0) := by
+      intro c
+      split_ifs <;> ring
+    rw [Finset.sum_congr rfl fun c _ => hexp c, Finset.sum_sub_distrib,
+      Finset.sum_ite_eq' Finset.univ v, Finset.sum_ite_eq' Finset.univ (Fin.last n)]
+    simp
+  rw [Matrix.submatrix_apply, Matrix.sub_apply, Matrix.mul_apply, Fin.sum_univ_castSucc, hlast,
+    zero_mul, add_zero]
+  simp only [hPb, hS, Matrix.one_apply, Fin.castSucc_inj]
+  rw [hsum]
+  rcases eq_or_ne v (Fin.last n) with rfl | hv
+  · rw [Matrix.updateCol_self]
+    simp only [Pi.single_apply, ite_true]
+    ring
+  · rw [Matrix.updateCol_ne hv, Matrix.sub_apply, Matrix.one_apply]
+    simp only [hv, ite_false, mul_zero, zero_mul, sub_zero]
+
+/-- The determinant of a matrix `M - 1` whose last column has been replaced by
+`c • M.col (last) - e (last)`, in terms of the corner minor of `M - 1`. -/
+private theorem det_updateCol_last_aux (M : Matrix (Fin (n + 1)) (Fin (n + 1)) R)
+    (hdet : (M - 1).det = 0) (c : R) :
+    ((M - 1).updateCol (Fin.last n)
+        (fun u => c * M u (Fin.last n) - (Pi.single (Fin.last n) 1 : Fin (n + 1) → R) u)).det =
+      (c - 1) * ((M - 1).submatrix Fin.castSucc Fin.castSucc).det := by
+  have hfun : (fun u => c * M u (Fin.last n) - (Pi.single (Fin.last n) 1 : Fin (n + 1) → R) u) =
+      c • (fun u => (M - 1) u (Fin.last n)) +
+        (c - 1) • (Pi.single (Fin.last n) 1 : Fin (n + 1) → R) := by
+    funext u
+    simp only [Pi.add_apply, Pi.smul_apply, smul_eq_mul, Matrix.sub_apply, Matrix.one_apply,
+      Pi.single_apply]
+    split_ifs <;> ring
+  rw [hfun, Matrix.det_updateCol_add, Matrix.det_updateCol_smul, Matrix.det_updateCol_smul,
+    Matrix.updateCol_eq_self, hdet, Matrix.det_updateCol_last_single, mul_zero, zero_add]
+
+/-! ### The two-strand braids -/
+
+private theorem burauMatrix_two (t : R) : burauMatrix (n := 2) t 0 = !![1 - t, t; 1, 0] := by
+  have h0 : BraidGroup.strand (n := 2) 0 = 0 := by
+    simp [Fin.ext_iff]
+  have h1 : BraidGroup.strandSucc (n := 2) 0 = 1 := by
+    simp [Fin.ext_iff]
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [burauMatrix_apply, burauCol_apply, burauRow_apply, h0, h1]
+
+private theorem burauMatrix_two_pow_three_apply (t : R) :
+    (burauMatrix (n := 2) t 0 ^ 3) 0 0 = (1 - t) * (1 + t ^ 2) := by
+  rw [pow_succ, pow_succ, pow_one, burauMatrix_two]
+  simp only [Matrix.mul_fin_two, Matrix.cons_val', Matrix.cons_val_zero, Matrix.empty_val',
+    Matrix.cons_val_fin_one, Matrix.of_apply]
+  ring
+
+end KnotTheory
+
+namespace MarkovBraid
+
+/-- **The Alexander polynomial of the closure of a braid**, computed from the unreduced Burau
+representation: the determinant of `burau b - 1` with its last row and last column deleted.
+
+The value depends on the braid, not only on its closure, but only up to a unit of `R`;
+`TauCeti.MarkovEquiv.associated_burauAlexander` is the precise statement. Over `R = ℤ[T;T⁻¹]` at
+`t = T` the units are `± T ^ k`, which is the classical indeterminacy of the Alexander polynomial,
+and `TauCeti.KnotTheory.associated_alexander_trefoilSeifertMatrix` checks the normalisation
+against the Seifert-matrix route on the trefoil. -/
+def burauAlexander (β : MarkovBraid) (t : Rˣ) : R :=
+  (((burau (β.predStrands + 1) t β.braid :
+      Matrix (Fin (β.predStrands + 1)) (Fin (β.predStrands + 1)) R) - 1).submatrix
+    Fin.castSucc Fin.castSucc).det
+
+/-- On one strand there is nothing to delete: the corner minor of a `1 × 1` matrix is the empty
+determinant. Informally, the closure of the trivial one-strand braid is the unknot. -/
+@[simp]
+theorem burauAlexander_one_strand (t : Rˣ) (b : BraidGroup 1) :
+    burauAlexander (R := R) ⟨0, b⟩ t = 1 :=
+  Matrix.det_fin_zero
+
+/-- **Markov move I leaves the invariant unchanged.** Passing from `b` to `c * b * c⁻¹` conjugates
+`burau b - 1` by `burau c`, which fixes both of the vectors annihilating it, so
+`Matrix.det_submatrix_castSucc_conj` applies. -/
+theorem burauAlexander_conj (t : Rˣ) (b c : BraidGroup (n + 1)) :
+    burauAlexander (R := R) ⟨n, c * b * c⁻¹⟩ t = burauAlexander (R := R) ⟨n, b⟩ t := by
+  have hinv : (burau (n + 1) t c : Matrix (Fin (n + 1)) (Fin (n + 1)) R) *
+      (burau (n + 1) t c⁻¹ : Matrix (Fin (n + 1)) (Fin (n + 1)) R) = 1 := by
+    rw [map_inv, ← Units.val_mul, mul_inv_cancel, Units.val_one]
+  have hnonsing : (burau (n + 1) t c : Matrix (Fin (n + 1)) (Fin (n + 1)) R)⁻¹ =
+      (burau (n + 1) t c⁻¹ : Matrix (Fin (n + 1)) (Fin (n + 1)) R) :=
+    Matrix.inv_eq_right_inv hinv
+  have hconj : (burau (n + 1) t (c * b * c⁻¹) :
+        Matrix (Fin (n + 1)) (Fin (n + 1)) R) - 1 =
+      (burau (n + 1) t c : Matrix (Fin (n + 1)) (Fin (n + 1)) R) *
+        ((burau (n + 1) t b : Matrix (Fin (n + 1)) (Fin (n + 1)) R) - 1) *
+        (burau (n + 1) t c : Matrix (Fin (n + 1)) (Fin (n + 1)) R)⁻¹ := by
+    rw [Matrix.mul_sub, Matrix.mul_one, Matrix.sub_mul, hnonsing, hinv, map_mul, map_mul,
+      Units.val_mul, Units.val_mul]
+  rw [burauAlexander, burauAlexander, hconj]
+  exact Matrix.det_submatrix_castSucc_conj _ _ (burau_sub_one_mulVec_one t b)
+    (geom_vecMul_burau_sub_one t b) (burau_mulVec_one t c) (vecMul_burau_geom t c)
+    (Matrix.isUnit_iff_isUnit_det _ |>.mp (burau (n + 1) t c).isUnit) (by simp)
+    (by simpa using t.isUnit.pow n)
+
+/-- **Markov move II, positive stabilization, multiplies the invariant by `-t`.** -/
+theorem burauAlexander_stabilize (t : Rˣ) (b : BraidGroup (n + 1)) :
+    burauAlexander (R := R) ⟨n + 1, BraidGroup.strandIncl b * BraidGroup.sigma (Fin.last n)⟩ t =
+      -(t : R) * burauAlexander (R := R) ⟨n, b⟩ t := by
+  have hS : ∀ c v : Fin (n + 1),
+      burauMatrix (n := n + 2) (t : R) (Fin.last n) c.castSucc v.castSucc =
+        (if c = v then 1 else 0) - (t : R) * (if c = Fin.last n then 1 else 0) *
+          (if v = Fin.last n then 1 else 0) := by
+    intro c v
+    rw [burauMatrix_apply, burauCol_last_castSucc, burauRow_last_castSucc]
+    simp only [Fin.castSucc_inj]
+    split_ifs <;> ring
+  have hmul : (burau (n + 2) t (BraidGroup.strandIncl b * BraidGroup.sigma (Fin.last n)) :
+      Matrix (Fin (n + 2)) (Fin (n + 2)) R) =
+      (burau (n + 2) t (BraidGroup.strandIncl b) : Matrix (Fin (n + 2)) (Fin (n + 2)) R) *
+        burauMatrix (t : R) (Fin.last n) := by
+    rw [map_mul, Units.val_mul, burau_sigma, coe_burauGL]
+  rw [burauAlexander, burauAlexander, hmul, submatrix_burau_strandIncl_mul t b (t : R) _ hS,
+    det_updateCol_last_aux _ (det_burau_sub_one t b) (1 - (t : R))]
+  ring
+
+/-- **Markov move II, negative stabilization, multiplies the invariant by `-1`.** -/
+theorem burauAlexander_stabilizeInv (t : Rˣ) (b : BraidGroup (n + 1)) :
+    burauAlexander (R := R)
+        ⟨n + 1, BraidGroup.strandIncl b * (BraidGroup.sigma (Fin.last n))⁻¹⟩ t =
+      -burauAlexander (R := R) ⟨n, b⟩ t := by
+  have hS : ∀ c v : Fin (n + 1),
+      (burauMatrix (n := n + 2) (t : R) (Fin.last n))⁻¹ c.castSucc v.castSucc =
+        (if c = v then 1 else 0) - (1 : R) * (if c = Fin.last n then 1 else 0) *
+          (if v = Fin.last n then 1 else 0) := by
+    intro c v
+    rw [inv_burauMatrix, Matrix.sub_apply, Matrix.smul_apply, Matrix.vecMulVec_apply,
+      burauCol_last_castSucc, burauRow_last_castSucc, Matrix.one_apply]
+    simp only [Fin.castSucc_inj, smul_eq_mul]
+    split_ifs <;> simp [Units.inv_mul]
+  have hmul : (burau (n + 2) t (BraidGroup.strandIncl b * (BraidGroup.sigma (Fin.last n))⁻¹) :
+      Matrix (Fin (n + 2)) (Fin (n + 2)) R) =
+      (burau (n + 2) t (BraidGroup.strandIncl b) : Matrix (Fin (n + 2)) (Fin (n + 2)) R) *
+        (burauMatrix (t : R) (Fin.last n))⁻¹ := by
+    rw [map_mul, Units.val_mul, map_inv, Matrix.coe_units_inv, burau_sigma, coe_burauGL]
+  rw [burauAlexander, burauAlexander, hmul, submatrix_burau_strandIncl_mul t b (1 : R) _ hS,
+    det_updateCol_last_aux _ (det_burau_sub_one t b) (1 - (1 : R))]
+  ring
+
+/-- **The Burau-Alexander polynomial of the closure of the three-fold crossing on two strands**,
+whose closure is the right-handed trefoil. Over `ℤ[T;T⁻¹]` at `t = T` this is `-T ^ 2` times the
+Conway-normalised Alexander polynomial `T - 1 + T⁻¹` of the trefoil. -/
+theorem burauAlexander_sigma_pow_three (t : Rˣ) :
+    burauAlexander (R := R) ⟨1, BraidGroup.sigma 0 ^ 3⟩ t =
+      -(t : R) * ((t : R) ^ 2 - (t : R) + 1) := by
+  have hm : (burau 2 t (BraidGroup.sigma 0 ^ 3) : Matrix (Fin 2) (Fin 2) R) =
+      burauMatrix (t : R) 0 ^ 3 := by
+    rw [map_pow, burau_sigma, Units.val_pow_eq_pow_val, coe_burauGL]
+  rw [burauAlexander, hm, Matrix.det_fin_one, Matrix.submatrix_apply, Matrix.sub_apply,
+    Matrix.one_apply]
+  rw [show (Fin.castSucc (0 : Fin 1) : Fin 2) = 0 from rfl, burauMatrix_two_pow_three_apply]
+  simp only [ite_true]
+  ring
+
+/-- On the integers at `t = -1` the invariant of the trefoil braid is `3`, matching the
+determinant `3` of the trefoil. -/
+theorem burauAlexander_sigma_pow_three_neg_one :
+    burauAlexander (R := ℤ) ⟨1, BraidGroup.sigma 0 ^ 3⟩ (-1) = 3 := by
+  rw [burauAlexander_sigma_pow_three]
+  norm_num
+
+end MarkovBraid
+
+/-- A single Markov move changes the Burau-Alexander invariant only by a unit. -/
+theorem IsMarkovMove.associated_burauAlexander {β γ : MarkovBraid} (h : IsMarkovMove β γ)
+    (t : Rˣ) : Associated (β.burauAlexander t) (γ.burauAlexander t) := by
+  induction h with
+  | conj b c => rw [MarkovBraid.burauAlexander_conj]
+  | stabilize b =>
+    refine Associated.symm ⟨-t, ?_⟩
+    rw [MarkovBraid.burauAlexander_stabilize, Units.val_neg]
+    ring
+  | stabilizeInv b =>
+    refine Associated.symm ⟨-1, ?_⟩
+    rw [MarkovBraid.burauAlexander_stabilizeInv, Units.val_neg, Units.val_one]
+    ring
+
+/-- **The Burau-Alexander polynomial is a Markov invariant, up to a unit.** By Markov's theorem
+this says that it is an invariant of the oriented link obtained by closing the braid; over
+`ℤ[T;T⁻¹]` the units are `± T ^ k`, which is exactly the classical indeterminacy of the Alexander
+polynomial. -/
+theorem MarkovEquiv.associated_burauAlexander {β γ : MarkovBraid} (h : MarkovEquiv β γ) (t : Rˣ) :
+    Associated (β.burauAlexander t) (γ.burauAlexander t) :=
+  h.induction (fun hmove => hmove.associated_burauAlexander t) (fun _ => Associated.refl _)
+    (fun _ ih => ih.symm) (fun _ _ ih ih' => ih.trans ih')
+
+/-- **The trefoil braid is not Markov equivalent to the trivial one-strand braid.** Both closures
+have one component, so `TauCeti.MarkovEquiv.componentCount_eq` cannot separate them; the
+Burau-Alexander invariant can, taking the values `3` and `1` over `ℤ` at `t = -1`, which are not
+associated. Informally, the trefoil is not the unknot. -/
+theorem not_markovEquiv_sigma_pow_three_one :
+    ¬ MarkovEquiv ⟨1, BraidGroup.sigma 0 ^ 3⟩ ⟨0, 1⟩ := fun h => by
+  have hassoc := h.associated_burauAlexander (R := ℤ) (-1)
+  rw [MarkovBraid.burauAlexander_sigma_pow_three_neg_one,
+    MarkovBraid.burauAlexander_one_strand] at hassoc
+  have h3 : (3 : ℤ) = 1 ∨ (3 : ℤ) = -1 := Int.isUnit_iff.mp (associated_one_iff_isUnit.mp hassoc)
+  omega
+
+namespace KnotTheory
+
+open LaurentPolynomial
+
+/-- **The Burau route and the Seifert-matrix route to the Alexander polynomial agree on the
+trefoil.** The braid `σ₀ ^ 3` closes to the right-handed trefoil, and
+`TauCeti.KnotTheory.trefoilSeifertMatrix` is a Seifert matrix of that knot; the two invariants
+agree up to the unit `-T ^ (-2)` of `ℤ[T;T⁻¹]`, which is the exact indeterminacy that
+`TauCeti.MarkovEquiv.associated_burauAlexander` allows. -/
+theorem associated_alexander_trefoilSeifertMatrix :
+    Associated (MarkovBraid.burauAlexander (R := ℤ[T;T⁻¹]) ⟨1, BraidGroup.sigma 0 ^ 3⟩
+      (isUnit_T 1).unit) (alexander trefoilSeifertMatrix) := by
+  have hTT : (T (-1) : ℤ[T;T⁻¹]) * T 1 = 1 := by
+    rw [← T_add, show (-1 : ℤ) + 1 = 0 from by norm_num, T_zero]
+  have hsq : (T (-1) : ℤ[T;T⁻¹]) * (T 1) ^ 2 = T 1 := by
+    rw [sq, ← mul_assoc, hTT, one_mul]
+  have hmul : (T 1 : ℤ[T;T⁻¹]) * T (-2) = T (-1) := by
+    rw [← T_add, show (1 : ℤ) + -2 = -1 from by norm_num]
+  refine ⟨-(isUnit_T (R := ℤ) (-2)).unit, ?_⟩
+  rw [MarkovBraid.burauAlexander_sigma_pow_three, IsUnit.unit_spec, Units.val_neg,
+    IsUnit.unit_spec, alexander_trefoilSeifertMatrix]
+  calc -(T 1 : ℤ[T;T⁻¹]) * ((T 1) ^ 2 - T 1 + 1) * -T (-2)
+      = (T 1 * T (-2)) * ((T 1) ^ 2 - T 1 + 1) := by ring
+    _ = T (-1) * ((T 1) ^ 2 - T 1 + 1) := by rw [hmul]
+    _ = T 1 - 1 + T (-1) := by
+        rw [mul_add, mul_sub, hsq, hTT, mul_one]
+
+end KnotTheory
+
+end TauCeti

--- a/TauCeti/KnotTheory/Burau/Alexander.lean
+++ b/TauCeti/KnotTheory/Burau/Alexander.lean
@@ -326,7 +326,7 @@ The value depends on the braid, not only on its closure, but only up to a unit o
 `t = T` the units are `± T ^ k`, which is the classical indeterminacy of the Alexander polynomial,
 and `TauCeti.KnotTheory.associated_burauAlexander_alexander_trefoilSeifertMatrix` checks the
 normalisation against the Seifert-matrix route on the trefoil. -/
-@[expose] def burauAlexander (β : MarkovBraid) (t : Rˣ) : R :=
+def burauAlexander (β : MarkovBraid) (t : Rˣ) : R :=
   (((burau (β.predStrands + 1) t β.braid :
       Matrix (Fin (β.predStrands + 1)) (Fin (β.predStrands + 1)) R) - 1).submatrix
     Fin.castSucc Fin.castSucc).det
@@ -337,7 +337,7 @@ theorem burauAlexander_def (β : MarkovBraid) (t : Rˣ) :
       (((burau (β.predStrands + 1) t β.braid :
           Matrix (Fin (β.predStrands + 1)) (Fin (β.predStrands + 1)) R) - 1).submatrix
         Fin.castSucc Fin.castSucc).det :=
-  rfl
+  (rfl)
 
 /-- On one strand there is nothing to delete: the corner minor of a `1 × 1` matrix is the empty
 determinant. Informally, the closure of the trivial one-strand braid is the unknot. -/

--- a/TauCeti/KnotTheory/Burau/Alexander.lean
+++ b/TauCeti/KnotTheory/Burau/Alexander.lean
@@ -65,8 +65,8 @@ Everything is stated over an arbitrary commutative ring `R` and an arbitrary uni
 * `TauCeti.MarkovEquiv.associated_burauAlexander`: Markov-equivalent braids have associated
   invariants.
 * `TauCeti.MarkovBraid.burauAlexander_sigma_pow_three`: the trefoil value `-t (t ^ 2 - t + 1)`.
-* `TauCeti.KnotTheory.associated_alexander_trefoilSeifertMatrix`: on the trefoil this agrees, up
-  to a unit of `ℤ[T;T⁻¹]`, with the Alexander polynomial of a Seifert matrix.
+* `TauCeti.KnotTheory.associated_burauAlexander_alexander_trefoilSeifertMatrix`: on the trefoil
+  this agrees, up to a unit of `ℤ[T;T⁻¹]`, with the Alexander polynomial of a Seifert matrix.
 * `TauCeti.not_markovEquiv_sigma_pow_three_one`: the trefoil braid is not Markov equivalent to
   the trivial one-strand braid.
 
@@ -105,24 +105,6 @@ private theorem burauRow_castSucc (i : Fin n) (u : Fin (n + 1)) :
   rw [burauRow_apply, burauRow_apply]
   simp only [Fin.ext_iff, BraidGroup.val_strand, BraidGroup.val_strandSucc, Fin.val_castSucc]
 
-/-- Deleting the last row and column of a product is the product of the deletions, provided the
-left factor has the last standard basis vector as its last column. -/
-private theorem submatrix_mul_of_mulVec_single
-    (X Y : Matrix (Fin (n + 2)) (Fin (n + 2)) R)
-    (hX : X *ᵥ Pi.single (Fin.last (n + 1)) 1 = Pi.single (Fin.last (n + 1)) 1) :
-    (X * Y).submatrix Fin.castSucc Fin.castSucc =
-      X.submatrix Fin.castSucc Fin.castSucc * Y.submatrix Fin.castSucc Fin.castSucc := by
-  have hcol : X.col (Fin.last (n + 1)) = Pi.single (Fin.last (n + 1)) 1 := by
-    rw [← Matrix.mulVec_single_one]
-    exact hX
-  have hentry : ∀ i : Fin (n + 2),
-      X i (Fin.last (n + 1)) = (Pi.single (Fin.last (n + 1)) 1 : Fin (n + 2) → R) i :=
-    fun i => congrFun hcol i
-  ext u v
-  rw [Matrix.submatrix_apply, Matrix.mul_apply, Matrix.mul_apply, Fin.sum_univ_castSucc, hentry,
-    Pi.single_eq_of_ne (Fin.castSucc_lt_last u).ne, zero_mul, add_zero]
-  rfl
-
 private theorem burau_strandIncl_aux (t : Rˣ) (b : BraidGroup (n + 1)) :
     ((burau (n + 2) t (BraidGroup.strandIncl b) : Matrix (Fin (n + 2)) (Fin (n + 2)) R) *ᵥ
         Pi.single (Fin.last (n + 1)) 1 = Pi.single (Fin.last (n + 1)) 1) ∧
@@ -159,7 +141,8 @@ private theorem burau_strandIncl_aux (t : Rˣ) (b : BraidGroup (n + 1)) :
     rw [map_mul, map_mul, map_mul, Units.val_mul, Units.val_mul]
     refine ⟨?_, ?_⟩
     · rw [← Matrix.mulVec_mulVec, hb'.1, hb.1]
-    · rw [submatrix_mul_of_mulVec_single _ _ hb.1, hb.2, hb'.2, ← Units.val_mul, ← map_mul]
+    · rw [Matrix.submatrix_mul_of_mulVec_single _ _ hb.1, hb.2, hb'.2, ← Units.val_mul,
+        ← map_mul]
   | inv b hb =>
     have hunit : ((burau (n + 2) t (BraidGroup.strandIncl b))⁻¹ : GL (Fin (n + 2)) R) *
         (burau (n + 2) t (BraidGroup.strandIncl b)) = 1 := inv_mul_cancel _
@@ -175,20 +158,21 @@ private theorem burau_strandIncl_aux (t : Rˣ) (b : BraidGroup (n + 1)) :
     refine ⟨hcol, ?_⟩
     have hprod := congrArg (fun X : Matrix (Fin (n + 2)) (Fin (n + 2)) R =>
       X.submatrix Fin.castSucc Fin.castSucc) hmat
-    simp only [submatrix_mul_of_mulVec_single _ _ hcol, hb.2] at hprod
+    simp only [Matrix.submatrix_mul_of_mulVec_single _ _ hcol, hb.2] at hprod
     have hone : ((1 : Matrix (Fin (n + 2)) (Fin (n + 2)) R)).submatrix
         Fin.castSucc Fin.castSucc = 1 := by
       ext u v
       rw [Matrix.submatrix_apply, Matrix.one_apply, Matrix.one_apply]
       simp [Fin.castSucc_inj]
     rw [hone] at hprod
+    have hbinv : (burau (n + 1) t b : Matrix (Fin (n + 1)) (Fin (n + 1)) R) *
+        (burau (n + 1) t b⁻¹ : Matrix (Fin (n + 1)) (Fin (n + 1)) R) = 1 := by
+      rw [map_inv, ← Units.val_mul, mul_inv_cancel, Units.val_one]
     calc (burau (n + 2) t (BraidGroup.strandIncl b⁻¹) :
           Matrix (Fin (n + 2)) (Fin (n + 2)) R).submatrix Fin.castSucc Fin.castSucc
         = _ * ((burau (n + 1) t b : Matrix (Fin (n + 1)) (Fin (n + 1)) R) *
             (burau (n + 1) t b⁻¹ : Matrix (Fin (n + 1)) (Fin (n + 1)) R)) := by
-          rw [show (burau (n + 1) t b : Matrix (Fin (n + 1)) (Fin (n + 1)) R) *
-            (burau (n + 1) t b⁻¹ : Matrix (Fin (n + 1)) (Fin (n + 1)) R) = 1 by
-              rw [map_inv, ← Units.val_mul, mul_inv_cancel, Units.val_one], Matrix.mul_one]
+          rw [hbinv, Matrix.mul_one]
       _ = (burau (n + 1) t b⁻¹ : Matrix (Fin (n + 1)) (Fin (n + 1)) R) := by
           rw [← Matrix.mul_assoc, hprod, Matrix.one_mul]
 
@@ -312,23 +296,6 @@ private theorem submatrix_burau_strandIncl_mul (t : Rˣ) (b : BraidGroup (n + 1)
   · rw [Matrix.updateCol_ne hv, Matrix.sub_apply, Matrix.one_apply]
     simp only [hv, ite_false, mul_zero, zero_mul, sub_zero]
 
-/-- The determinant of a matrix `M - 1` whose last column has been replaced by
-`c • M.col (last) - e (last)`, in terms of the corner minor of `M - 1`. -/
-private theorem det_updateCol_last_aux (M : Matrix (Fin (n + 1)) (Fin (n + 1)) R)
-    (hdet : (M - 1).det = 0) (c : R) :
-    ((M - 1).updateCol (Fin.last n)
-        (fun u => c * M u (Fin.last n) - (Pi.single (Fin.last n) 1 : Fin (n + 1) → R) u)).det =
-      (c - 1) * ((M - 1).submatrix Fin.castSucc Fin.castSucc).det := by
-  have hfun : (fun u => c * M u (Fin.last n) - (Pi.single (Fin.last n) 1 : Fin (n + 1) → R) u) =
-      c • (fun u => (M - 1) u (Fin.last n)) +
-        (c - 1) • (Pi.single (Fin.last n) 1 : Fin (n + 1) → R) := by
-    funext u
-    simp only [Pi.add_apply, Pi.smul_apply, smul_eq_mul, Matrix.sub_apply, Matrix.one_apply,
-      Pi.single_apply]
-    split_ifs <;> ring
-  rw [hfun, Matrix.det_updateCol_add, Matrix.det_updateCol_smul, Matrix.det_updateCol_smul,
-    Matrix.updateCol_eq_self, hdet, Matrix.det_updateCol_last_single, mul_zero, zero_add]
-
 /-! ### The two-strand braids -/
 
 private theorem burauMatrix_two (t : R) : burauMatrix (n := 2) t 0 = !![1 - t, t; 1, 0] := by
@@ -357,19 +324,27 @@ representation: the determinant of `burau b - 1` with its last row and last colu
 The value depends on the braid, not only on its closure, but only up to a unit of `R`;
 `TauCeti.MarkovEquiv.associated_burauAlexander` is the precise statement. Over `R = ℤ[T;T⁻¹]` at
 `t = T` the units are `± T ^ k`, which is the classical indeterminacy of the Alexander polynomial,
-and `TauCeti.KnotTheory.associated_alexander_trefoilSeifertMatrix` checks the normalisation
-against the Seifert-matrix route on the trefoil. -/
-def burauAlexander (β : MarkovBraid) (t : Rˣ) : R :=
+and `TauCeti.KnotTheory.associated_burauAlexander_alexander_trefoilSeifertMatrix` checks the
+normalisation against the Seifert-matrix route on the trefoil. -/
+@[expose] def burauAlexander (β : MarkovBraid) (t : Rˣ) : R :=
   (((burau (β.predStrands + 1) t β.braid :
       Matrix (Fin (β.predStrands + 1)) (Fin (β.predStrands + 1)) R) - 1).submatrix
     Fin.castSucc Fin.castSucc).det
+
+/-- The Burau–Alexander invariant is the corner minor of `burau β.braid - 1`. -/
+theorem burauAlexander_def (β : MarkovBraid) (t : Rˣ) :
+    burauAlexander (R := R) β t =
+      (((burau (β.predStrands + 1) t β.braid :
+          Matrix (Fin (β.predStrands + 1)) (Fin (β.predStrands + 1)) R) - 1).submatrix
+        Fin.castSucc Fin.castSucc).det :=
+  rfl
 
 /-- On one strand there is nothing to delete: the corner minor of a `1 × 1` matrix is the empty
 determinant. Informally, the closure of the trivial one-strand braid is the unknot. -/
 @[simp]
 theorem burauAlexander_one_strand (t : Rˣ) (b : BraidGroup 1) :
     burauAlexander (R := R) ⟨0, b⟩ t = 1 :=
-  Matrix.det_fin_zero
+  by rw [burauAlexander_def, Matrix.det_fin_zero]
 
 /-- **Markov move I leaves the invariant unchanged.** Passing from `b` to `c * b * c⁻¹` conjugates
 `burau b - 1` by `burau c`, which fixes both of the vectors annihilating it, so
@@ -389,7 +364,7 @@ theorem burauAlexander_conj (t : Rˣ) (b c : BraidGroup (n + 1)) :
         (burau (n + 1) t c : Matrix (Fin (n + 1)) (Fin (n + 1)) R)⁻¹ := by
     rw [Matrix.mul_sub, Matrix.mul_one, Matrix.sub_mul, hnonsing, hinv, map_mul, map_mul,
       Units.val_mul, Units.val_mul]
-  rw [burauAlexander, burauAlexander, hconj]
+  rw [burauAlexander_def, burauAlexander_def, hconj]
   exact Matrix.det_submatrix_castSucc_conj _ _ (burau_sub_one_mulVec_one t b)
     (geom_vecMul_burau_sub_one t b) (burau_mulVec_one t c) (vecMul_burau_geom t c)
     (Matrix.isUnit_iff_isUnit_det _ |>.mp (burau (n + 1) t c).isUnit) (by simp)
@@ -412,8 +387,10 @@ theorem burauAlexander_stabilize (t : Rˣ) (b : BraidGroup (n + 1)) :
       (burau (n + 2) t (BraidGroup.strandIncl b) : Matrix (Fin (n + 2)) (Fin (n + 2)) R) *
         burauMatrix (t : R) (Fin.last n) := by
     rw [map_mul, Units.val_mul, burau_sigma, coe_burauGL]
-  rw [burauAlexander, burauAlexander, hmul, submatrix_burau_strandIncl_mul t b (t : R) _ hS,
-    det_updateCol_last_aux _ (det_burau_sub_one t b) (1 - (t : R))]
+  rw [burauAlexander_def, burauAlexander_def, hmul,
+    submatrix_burau_strandIncl_mul t b (t : R) _ hS,
+    Matrix.det_updateCol_last_smul_col_sub_single_of_det_sub_one_eq_zero _
+      (det_burau_sub_one t b) (1 - (t : R))]
   ring
 
 /-- **Markov move II, negative stabilization, multiplies the invariant by `-1`.** -/
@@ -435,8 +412,10 @@ theorem burauAlexander_stabilizeInv (t : Rˣ) (b : BraidGroup (n + 1)) :
       (burau (n + 2) t (BraidGroup.strandIncl b) : Matrix (Fin (n + 2)) (Fin (n + 2)) R) *
         (burauMatrix (t : R) (Fin.last n))⁻¹ := by
     rw [map_mul, Units.val_mul, map_inv, Matrix.coe_units_inv, burau_sigma, coe_burauGL]
-  rw [burauAlexander, burauAlexander, hmul, submatrix_burau_strandIncl_mul t b (1 : R) _ hS,
-    det_updateCol_last_aux _ (det_burau_sub_one t b) (1 - (1 : R))]
+  rw [burauAlexander_def, burauAlexander_def, hmul,
+    submatrix_burau_strandIncl_mul t b (1 : R) _ hS,
+    Matrix.det_updateCol_last_smul_col_sub_single_of_det_sub_one_eq_zero _
+      (det_burau_sub_one t b) (1 - (1 : R))]
   ring
 
 /-- **The Burau-Alexander polynomial of the closure of the three-fold crossing on two strands**,
@@ -448,9 +427,10 @@ theorem burauAlexander_sigma_pow_three (t : Rˣ) :
   have hm : (burau 2 t (BraidGroup.sigma 0 ^ 3) : Matrix (Fin 2) (Fin 2) R) =
       burauMatrix (t : R) 0 ^ 3 := by
     rw [map_pow, burau_sigma, Units.val_pow_eq_pow_val, coe_burauGL]
-  rw [burauAlexander, hm, Matrix.det_fin_one, Matrix.submatrix_apply, Matrix.sub_apply,
+  rw [burauAlexander_def, hm, Matrix.det_fin_one, Matrix.submatrix_apply, Matrix.sub_apply,
     Matrix.one_apply]
-  rw [show (Fin.castSucc (0 : Fin 1) : Fin 2) = 0 from rfl, burauMatrix_two_pow_three_apply]
+  have hcast : (Fin.castSucc (0 : Fin 1) : Fin 2) = 0 := rfl
+  rw [hcast, burauMatrix_two_pow_three_apply]
   simp only [ite_true]
   ring
 
@@ -507,15 +487,17 @@ trefoil.** The braid `σ₀ ^ 3` closes to the right-handed trefoil, and
 `TauCeti.KnotTheory.trefoilSeifertMatrix` is a Seifert matrix of that knot; the two invariants
 agree up to the unit `-T ^ (-2)` of `ℤ[T;T⁻¹]`, which is the exact indeterminacy that
 `TauCeti.MarkovEquiv.associated_burauAlexander` allows. -/
-theorem associated_alexander_trefoilSeifertMatrix :
+theorem associated_burauAlexander_alexander_trefoilSeifertMatrix :
     Associated (MarkovBraid.burauAlexander (R := ℤ[T;T⁻¹]) ⟨1, BraidGroup.sigma 0 ^ 3⟩
       (isUnit_T 1).unit) (alexander trefoilSeifertMatrix) := by
   have hTT : (T (-1) : ℤ[T;T⁻¹]) * T 1 = 1 := by
-    rw [← T_add, show (-1 : ℤ) + 1 = 0 from by norm_num, T_zero]
+    have hnegadd : (-1 : ℤ) + 1 = 0 := by norm_num
+    rw [← T_add, hnegadd, T_zero]
   have hsq : (T (-1) : ℤ[T;T⁻¹]) * (T 1) ^ 2 = T 1 := by
     rw [sq, ← mul_assoc, hTT, one_mul]
   have hmul : (T 1 : ℤ[T;T⁻¹]) * T (-2) = T (-1) := by
-    rw [← T_add, show (1 : ℤ) + -2 = -1 from by norm_num]
+    have hadd : (1 : ℤ) + -2 = -1 := by norm_num
+    rw [← T_add, hadd]
   refine ⟨-(isUnit_T (R := ℤ) (-2)).unit, ?_⟩
   rw [MarkovBraid.burauAlexander_sigma_pow_three, IsUnit.unit_spec, Units.val_neg,
     IsUnit.unit_spec, alexander_trefoilSeifertMatrix]

--- a/TauCeti/LinearAlgebra/Matrix/CornerMinor.lean
+++ b/TauCeti/LinearAlgebra/Matrix/CornerMinor.lean
@@ -1,0 +1,336 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.LinearAlgebra.Matrix.NonsingularInverse
+import Mathlib.Tactic.LinearCombination
+
+/-!
+# The corner minor of a doubly singular matrix
+
+The *corner minor* of a square matrix `A` indexed by `Fin (n + 1)` is the determinant of the
+submatrix obtained by deleting its last row and its last column, that is, the determinant of
+`A.submatrix Fin.castSucc Fin.castSucc`. Unlike the determinant it is not a conjugation
+invariant in general. It becomes one on a matrix that is annihilated on the right by a column
+vector `u` and on the left by a row vector `w`, as soon as the conjugating matrix fixes `u` and
+`w` as well and the last coordinates of `u` and `w` are units: this is
+`Matrix.det_submatrix_castSucc_conj`.
+
+The mechanism is that `u` and `w` give `A` a factorisation through the corner minor's own index
+type `Fin n`: the identity with its last row replaced by `w` carries `A` into the image of the
+inclusion `Fin n ↪ Fin (n + 1)`, and the identity with its last column replaced by `u` does the
+same on the other side. A conjugation `A ↦ N * A * N⁻¹` by a matrix fixing `u` and `w` therefore
+multiplies the corner minor by `N.det` on one side and by `N.det⁻¹` on the other.
+
+The two Laplace expansions along the last row and the last column, in the sparse case used
+throughout, are recorded first, together with the description of the corner minor as an ordinary
+determinant after the last column is replaced by the last standard basis vector.
+
+The intended source of such a matrix is `burau b - 1` for a braid `b`, where `u` is the all-ones
+vector and `w` is the geometric vector `(1, t, …, t ^ n)`.
+
+## Main results
+
+* `Matrix.det_eq_mul_det_submatrix_castSucc_of_row` and
+  `Matrix.det_eq_mul_det_submatrix_castSucc_of_col`: the determinant of a matrix whose last row,
+  or whose last column, vanishes off the diagonal is the corner entry times the corner minor.
+* `Matrix.det_updateCol_last_single`: replacing the last column by the last standard basis vector
+  turns the determinant into the corner minor.
+* `Matrix.det_submatrix_castSucc_conj`: the corner minor of `N * A * N⁻¹` equals that of `A`,
+  when `A` is annihilated by `u` on the right and by `w` on the left and `N` fixes both.
+-/
+
+public section
+
+namespace Matrix
+
+variable {n : ℕ} {R : Type*} [CommRing R]
+
+/-- Laplace expansion along the last row of a matrix whose last row vanishes off the diagonal. -/
+theorem det_eq_mul_det_submatrix_castSucc_of_row (A : Matrix (Fin (n + 1)) (Fin (n + 1)) R)
+    (h : ∀ j, j ≠ Fin.last n → A (Fin.last n) j = 0) :
+    A.det = A (Fin.last n) (Fin.last n) * (A.submatrix Fin.castSucc Fin.castSucc).det := by
+  rw [Matrix.det_succ_row A (Fin.last n),
+    Finset.sum_eq_single (Fin.last n) (fun j _ hj => by rw [h j hj]; ring) (by simp)]
+  rw [Fin.succAbove_last, Fin.val_last, Even.neg_one_pow ⟨n, rfl⟩, one_mul]
+
+/-- Laplace expansion along the last column of a matrix whose last column vanishes off the
+diagonal. -/
+theorem det_eq_mul_det_submatrix_castSucc_of_col (A : Matrix (Fin (n + 1)) (Fin (n + 1)) R)
+    (h : ∀ i, i ≠ Fin.last n → A i (Fin.last n) = 0) :
+    A.det = A (Fin.last n) (Fin.last n) * (A.submatrix Fin.castSucc Fin.castSucc).det := by
+  rw [← Matrix.det_transpose A, det_eq_mul_det_submatrix_castSucc_of_row Aᵀ h,
+    Matrix.transpose_apply, ← Matrix.transpose_submatrix, Matrix.det_transpose]
+
+/-- Replacing the last column of a matrix by the last standard basis vector turns its determinant
+into its corner minor. -/
+theorem det_updateCol_last_single (A : Matrix (Fin (n + 1)) (Fin (n + 1)) R) :
+    (A.updateCol (Fin.last n) (Pi.single (Fin.last n) 1)).det =
+      (A.submatrix Fin.castSucc Fin.castSucc).det := by
+  rw [det_eq_mul_det_submatrix_castSucc_of_col _ fun i hi => by
+      rw [Matrix.updateCol_self, Pi.single_eq_of_ne hi],
+    Matrix.updateCol_self, Pi.single_eq_same, one_mul]
+  congr 1
+  ext a b
+  rw [Matrix.submatrix_apply, Matrix.submatrix_apply,
+    Matrix.updateCol_ne (Fin.castSucc_lt_last b).ne]
+
+/-! ### The two rectangular matrices that delete and restore the last coordinate -/
+
+/-- The `n × (n + 1)` matrix that deletes the last coordinate. -/
+private def projCastSucc (n : ℕ) (R : Type*) [CommRing R] : Matrix (Fin n) (Fin (n + 1)) R :=
+  (1 : Matrix (Fin (n + 1)) (Fin (n + 1)) R).submatrix Fin.castSucc id
+
+/-- The `(n + 1) × n` matrix that includes the first `n` coordinates. -/
+private def inclCastSucc (n : ℕ) (R : Type*) [CommRing R] : Matrix (Fin (n + 1)) (Fin n) R :=
+  (1 : Matrix (Fin (n + 1)) (Fin (n + 1)) R).submatrix id Fin.castSucc
+
+private theorem projCastSucc_apply (a : Fin n) (b : Fin (n + 1)) :
+    projCastSucc n R a b = if a.castSucc = b then 1 else 0 := by
+  rw [projCastSucc, Matrix.submatrix_apply, Matrix.one_apply]
+  rfl
+
+private theorem inclCastSucc_apply (a : Fin (n + 1)) (b : Fin n) :
+    inclCastSucc n R a b = if a = b.castSucc then 1 else 0 := by
+  rw [inclCastSucc, Matrix.submatrix_apply, Matrix.one_apply]
+  rfl
+
+private theorem projCastSucc_mul {m : Type*} (A : Matrix (Fin (n + 1)) m R) :
+    projCastSucc n R * A = A.submatrix Fin.castSucc id := by
+  ext i k
+  simp [Matrix.mul_apply, projCastSucc_apply, ite_mul]
+
+private theorem mul_inclCastSucc {m : Type*} (A : Matrix m (Fin (n + 1)) R) :
+    A * inclCastSucc n R = A.submatrix id Fin.castSucc := by
+  ext i k
+  simp [Matrix.mul_apply, inclCastSucc_apply, mul_ite]
+
+private theorem projCastSucc_mul_mul_inclCastSucc (A : Matrix (Fin (n + 1)) (Fin (n + 1)) R) :
+    projCastSucc n R * A * inclCastSucc n R = A.submatrix Fin.castSucc Fin.castSucc := by
+  rw [Matrix.mul_assoc, mul_inclCastSucc, projCastSucc_mul, Matrix.submatrix_submatrix]
+  rfl
+
+/-! ### The two square matrices built from the annihilating vectors -/
+
+/-- The identity with its last row replaced by `w`. -/
+private def rowFrame (w : Fin (n + 1) → R) : Matrix (Fin (n + 1)) (Fin (n + 1)) R :=
+  (1 : Matrix (Fin (n + 1)) (Fin (n + 1)) R).updateRow (Fin.last n) w
+
+/-- The identity with its last column replaced by `u`. -/
+private def colFrame (u : Fin (n + 1) → R) : Matrix (Fin (n + 1)) (Fin (n + 1)) R :=
+  (1 : Matrix (Fin (n + 1)) (Fin (n + 1)) R).updateCol (Fin.last n) u
+
+private theorem rowFrame_castSucc (w : Fin (n + 1) → R) (a : Fin n) (b : Fin (n + 1)) :
+    rowFrame w a.castSucc b = (1 : Matrix (Fin (n + 1)) (Fin (n + 1)) R) a.castSucc b := by
+  rw [rowFrame, Matrix.updateRow_ne (Fin.castSucc_lt_last a).ne]
+
+private theorem colFrame_castSucc (u : Fin (n + 1) → R) (a : Fin (n + 1)) (b : Fin n) :
+    colFrame u a b.castSucc = (1 : Matrix (Fin (n + 1)) (Fin (n + 1)) R) a b.castSucc := by
+  rw [colFrame, Matrix.updateCol_ne (Fin.castSucc_lt_last b).ne]
+
+private theorem submatrix_rowFrame (w : Fin (n + 1) → R) :
+    (rowFrame w).submatrix Fin.castSucc Fin.castSucc = 1 := by
+  ext a b
+  rw [Matrix.submatrix_apply, rowFrame_castSucc]
+  simp [Matrix.one_apply]
+
+private theorem submatrix_colFrame (u : Fin (n + 1) → R) :
+    (colFrame u).submatrix Fin.castSucc Fin.castSucc = 1 := by
+  ext a b
+  rw [Matrix.submatrix_apply, colFrame_castSucc]
+  simp [Matrix.one_apply]
+
+private theorem det_rowFrame (w : Fin (n + 1) → R) : (rowFrame w).det = w (Fin.last n) := by
+  rw [det_eq_mul_det_submatrix_castSucc_of_col _ ?_, submatrix_rowFrame, Matrix.det_one, mul_one,
+    rowFrame, Matrix.updateRow_self]
+  intro i hi
+  rw [rowFrame, Matrix.updateRow_ne hi, Matrix.one_apply_ne hi]
+
+private theorem det_colFrame (u : Fin (n + 1) → R) : (colFrame u).det = u (Fin.last n) := by
+  rw [det_eq_mul_det_submatrix_castSucc_of_row _ ?_, submatrix_colFrame, Matrix.det_one, mul_one,
+    colFrame, Matrix.updateCol_self]
+  intro j hj
+  rw [colFrame, Matrix.updateCol_ne hj, Matrix.one_apply_ne' hj]
+
+private theorem projCastSucc_mul_rowFrame (w : Fin (n + 1) → R) :
+    projCastSucc n R * rowFrame w = projCastSucc n R := by
+  rw [projCastSucc_mul]
+  ext a b
+  rw [Matrix.submatrix_apply, rowFrame_castSucc]
+  rfl
+
+private theorem colFrame_mul_inclCastSucc (u : Fin (n + 1) → R) :
+    colFrame u * inclCastSucc n R = inclCastSucc n R := by
+  rw [mul_inclCastSucc]
+  ext a b
+  rw [Matrix.submatrix_apply, colFrame_castSucc]
+  rfl
+
+private theorem rowFrame_mul (A : Matrix (Fin (n + 1)) (Fin (n + 1)) R) {w : Fin (n + 1) → R}
+    (hw : w ᵥ* A = 0) :
+    rowFrame w * A = inclCastSucc n R * (projCastSucc n R * A) := by
+  rw [projCastSucc_mul]
+  ext i k
+  rcases eq_or_ne i (Fin.last n) with rfl | hi
+  · have h1 : (rowFrame w * A) (Fin.last n) k = (w ᵥ* A) k := by
+      simp [Matrix.mul_apply, Matrix.vecMul, dotProduct, rowFrame, Matrix.updateRow_self]
+    have h2 : ∀ j : Fin n, inclCastSucc n R (Fin.last n) j = 0 := fun j => by
+      rw [inclCastSucc_apply]
+      simp [(Fin.castSucc_lt_last j).ne']
+    rw [h1, hw, Pi.zero_apply, Matrix.mul_apply]
+    simp [h2]
+  · obtain ⟨i, rfl⟩ := Fin.eq_castSucc_of_ne_last hi
+    have h2 : ∀ j : Fin n, inclCastSucc n R i.castSucc j = if i = j then 1 else 0 := fun j => by
+      rw [inclCastSucc_apply]
+      simp [Fin.castSucc_inj]
+    rw [Matrix.mul_apply, Matrix.mul_apply]
+    simp only [rowFrame_castSucc, h2, Matrix.one_apply, ite_mul, zero_mul, one_mul,
+      Finset.sum_ite_eq, Finset.mem_univ, ite_true, Matrix.submatrix_apply, id]
+
+private theorem mul_colFrame (A : Matrix (Fin (n + 1)) (Fin (n + 1)) R) {u : Fin (n + 1) → R}
+    (hu : A *ᵥ u = 0) :
+    A * colFrame u = A * inclCastSucc n R * projCastSucc n R := by
+  rw [mul_inclCastSucc]
+  ext i k
+  rcases eq_or_ne k (Fin.last n) with rfl | hk
+  · have h1 : (A * colFrame u) i (Fin.last n) = (A *ᵥ u) i := by
+      simp [Matrix.mul_apply, Matrix.mulVec, dotProduct, colFrame, Matrix.updateCol_self]
+    have h2 : ∀ j : Fin n, projCastSucc n R j (Fin.last n) = 0 := fun j => by
+      rw [projCastSucc_apply]
+      simp [(Fin.castSucc_lt_last j).ne]
+    rw [h1, hu, Pi.zero_apply, Matrix.mul_apply]
+    simp [h2]
+  · obtain ⟨k, rfl⟩ := Fin.eq_castSucc_of_ne_last hk
+    have h2 : ∀ j : Fin n, projCastSucc n R j k.castSucc = if j = k then 1 else 0 := fun j => by
+      rw [projCastSucc_apply]
+      simp [Fin.castSucc_inj]
+    rw [Matrix.mul_apply, Matrix.mul_apply]
+    simp only [colFrame_castSucc, h2, Matrix.one_apply, mul_ite, mul_zero, mul_one,
+      Finset.sum_ite_eq', Finset.mem_univ, ite_true, Matrix.submatrix_apply, id]
+
+/-! ### Conjugation invariance of the corner minor -/
+
+private theorem det_projCastSucc_mul_mul (N : Matrix (Fin (n + 1)) (Fin (n + 1)) R)
+    {w : Fin (n + 1) → R} (hwN : w ᵥ* N = w) (hw : IsUnit (w (Fin.last n))) :
+    (projCastSucc n R * N * ((rowFrame w)⁻¹ * inclCastSucc n R)).det = N.det := by
+  have hdet : IsUnit (rowFrame w).det := by rw [det_rowFrame]; exact hw
+  have hmul : rowFrame w * (rowFrame w)⁻¹ = 1 := Matrix.mul_nonsing_inv _ hdet
+  have hlast : rowFrame w (Fin.last n) = w := Matrix.updateRow_self
+  have hrow : (rowFrame w * N * (rowFrame w)⁻¹) (Fin.last n) =
+      (1 : Matrix (Fin (n + 1)) (Fin (n + 1)) R) (Fin.last n) := by
+    have h1 : (rowFrame w * N) (Fin.last n) = rowFrame w (Fin.last n) := by
+      rw [Matrix.mul_apply_eq_vecMul, hlast, hwN]
+    rw [Matrix.mul_apply_eq_vecMul, h1, ← Matrix.mul_apply_eq_vecMul, hmul]
+  have hsub : (rowFrame w * N * (rowFrame w)⁻¹).submatrix Fin.castSucc Fin.castSucc =
+      projCastSucc n R * N * ((rowFrame w)⁻¹ * inclCastSucc n R) := by
+    rw [← projCastSucc_mul_mul_inclCastSucc]
+    calc projCastSucc n R * (rowFrame w * N * (rowFrame w)⁻¹) * inclCastSucc n R
+        = projCastSucc n R * rowFrame w * (N * ((rowFrame w)⁻¹ * inclCastSucc n R)) := by
+          simp only [Matrix.mul_assoc]
+      _ = projCastSucc n R * N * ((rowFrame w)⁻¹ * inclCastSucc n R) := by
+          rw [projCastSucc_mul_rowFrame, Matrix.mul_assoc]
+  have hone : (rowFrame w).det * ((rowFrame w)⁻¹).det = 1 := by
+    rw [← Matrix.det_mul, hmul, Matrix.det_one]
+  have hexp : (rowFrame w * N * (rowFrame w)⁻¹).det =
+      (projCastSucc n R * N * ((rowFrame w)⁻¹ * inclCastSucc n R)).det := by
+    rw [det_eq_mul_det_submatrix_castSucc_of_row _ fun j hj => by
+      rw [congrFun hrow j, Matrix.one_apply_ne' hj], hsub, congrFun hrow (Fin.last n),
+      Matrix.one_apply_eq, one_mul]
+  rw [← hexp, Matrix.det_mul, Matrix.det_mul]
+  linear_combination N.det * hone
+
+private theorem det_mul_mul_inclCastSucc (M : Matrix (Fin (n + 1)) (Fin (n + 1)) R)
+    {u : Fin (n + 1) → R} (hMu : M *ᵥ u = u) (hu : IsUnit (u (Fin.last n))) :
+    (projCastSucc n R * (colFrame u)⁻¹ * M * inclCastSucc n R).det = M.det := by
+  have hdet : IsUnit (colFrame u).det := by rw [det_colFrame]; exact hu
+  have hmul : (colFrame u)⁻¹ * colFrame u = 1 := Matrix.nonsing_inv_mul _ hdet
+  have hUe : colFrame u *ᵥ Pi.single (Fin.last n) 1 = u := by
+    rw [Matrix.mulVec_single_one]
+    funext i
+    rw [Matrix.col_apply, colFrame, Matrix.updateCol_self]
+  have hUinv : (colFrame u)⁻¹ *ᵥ u = Pi.single (Fin.last n) 1 := by
+    have h : (colFrame u)⁻¹ *ᵥ (colFrame u *ᵥ Pi.single (Fin.last n) 1) =
+        Pi.single (Fin.last n) 1 := by
+      rw [Matrix.mulVec_mulVec, hmul, Matrix.one_mulVec]
+    rwa [hUe] at h
+  have key : ∀ i, ((colFrame u)⁻¹ * M * colFrame u) i (Fin.last n) =
+      (Pi.single (Fin.last n) 1 : Fin (n + 1) → R) i := by
+    have hkey : ((colFrame u)⁻¹ * M * colFrame u) *ᵥ Pi.single (Fin.last n) 1 =
+        Pi.single (Fin.last n) 1 := by
+      rw [← Matrix.mulVec_mulVec, ← Matrix.mulVec_mulVec, hUe, hMu, hUinv]
+    intro i
+    have h := congrFun hkey i
+    rwa [Matrix.mulVec_single_one, Matrix.col_apply] at h
+  have hsub : ((colFrame u)⁻¹ * M * colFrame u).submatrix Fin.castSucc Fin.castSucc =
+      projCastSucc n R * (colFrame u)⁻¹ * M * inclCastSucc n R := by
+    rw [← projCastSucc_mul_mul_inclCastSucc]
+    calc projCastSucc n R * ((colFrame u)⁻¹ * M * colFrame u) * inclCastSucc n R
+        = projCastSucc n R * (colFrame u)⁻¹ * M * (colFrame u * inclCastSucc n R) := by
+          simp only [Matrix.mul_assoc]
+      _ = projCastSucc n R * (colFrame u)⁻¹ * M * inclCastSucc n R := by
+          rw [colFrame_mul_inclCastSucc]
+  have hone : ((colFrame u)⁻¹).det * (colFrame u).det = 1 := by
+    rw [← Matrix.det_mul, hmul, Matrix.det_one]
+  have hexp : ((colFrame u)⁻¹ * M * colFrame u).det =
+      (projCastSucc n R * (colFrame u)⁻¹ * M * inclCastSucc n R).det := by
+    rw [det_eq_mul_det_submatrix_castSucc_of_col _ fun i hi => by
+      rw [key i, Pi.single_eq_of_ne hi], hsub, key (Fin.last n), Pi.single_eq_same, one_mul]
+  rw [← hexp, Matrix.det_mul, Matrix.det_mul]
+  linear_combination M.det * hone
+
+/-- **The corner minor is a conjugation invariant on doubly singular matrices.** If a square
+matrix `A` is annihilated on the right by a column vector `u` and on the left by a row vector `w`,
+both of which have a unit in their last coordinate, then conjugating `A` by any invertible matrix
+that fixes `u` and `w` leaves the determinant of `A.submatrix Fin.castSucc Fin.castSucc`
+unchanged. -/
+theorem det_submatrix_castSucc_conj (A N : Matrix (Fin (n + 1)) (Fin (n + 1)) R)
+    {u w : Fin (n + 1) → R} (hAu : A *ᵥ u = 0) (hwA : w ᵥ* A = 0) (hNu : N *ᵥ u = u)
+    (hwN : w ᵥ* N = w) (hN : IsUnit N.det) (hu : IsUnit (u (Fin.last n)))
+    (hw : IsUnit (w (Fin.last n))) :
+    ((N * A * N⁻¹).submatrix Fin.castSucc Fin.castSucc).det =
+      (A.submatrix Fin.castSucc Fin.castSucc).det := by
+  have hNinv : N * N⁻¹ = 1 := Matrix.mul_nonsing_inv _ hN
+  have hNinv' : N⁻¹ * N = 1 := Matrix.nonsing_inv_mul _ hN
+  have hNinvu : N⁻¹ *ᵥ u = u := by
+    conv_lhs => rw [← hNu]
+    rw [Matrix.mulVec_mulVec, hNinv', Matrix.one_mulVec]
+  have hrowdet : IsUnit (rowFrame w).det := by rw [det_rowFrame]; exact hw
+  have hcoldet : IsUnit (colFrame u).det := by rw [det_colFrame]; exact hu
+  have hGinv : (rowFrame w)⁻¹ * rowFrame w = 1 := Matrix.nonsing_inv_mul _ hrowdet
+  have hUinv : colFrame u * (colFrame u)⁻¹ = 1 := Matrix.mul_nonsing_inv _ hcoldet
+  -- the canonical factorisation of `A` through the corner index type
+  have hA1 : (rowFrame w)⁻¹ * inclCastSucc n R * (projCastSucc n R * A) = A := by
+    calc (rowFrame w)⁻¹ * inclCastSucc n R * (projCastSucc n R * A)
+        = (rowFrame w)⁻¹ * (inclCastSucc n R * (projCastSucc n R * A)) := by
+          rw [Matrix.mul_assoc]
+      _ = A := by rw [← rowFrame_mul A hwA, ← Matrix.mul_assoc, hGinv, Matrix.one_mul]
+  have hA2 : A * inclCastSucc n R * (projCastSucc n R * (colFrame u)⁻¹) = A := by
+    calc A * inclCastSucc n R * (projCastSucc n R * (colFrame u)⁻¹)
+        = A * inclCastSucc n R * projCastSucc n R * (colFrame u)⁻¹ :=
+          (Matrix.mul_assoc _ _ _).symm
+      _ = A := by rw [← mul_colFrame A hAu, Matrix.mul_assoc, hUinv, Matrix.mul_one]
+  have hPA : projCastSucc n R * A =
+      A.submatrix Fin.castSucc Fin.castSucc * (projCastSucc n R * (colFrame u)⁻¹) := by
+    calc projCastSucc n R * A
+        = projCastSucc n R * (A * inclCastSucc n R * (projCastSucc n R * (colFrame u)⁻¹)) := by
+          rw [hA2]
+      _ = projCastSucc n R * A * inclCastSucc n R * (projCastSucc n R * (colFrame u)⁻¹) := by
+          simp only [Matrix.mul_assoc]
+      _ = _ := by rw [projCastSucc_mul_mul_inclCastSucc]
+  have main : (N * A * N⁻¹).submatrix Fin.castSucc Fin.castSucc =
+      projCastSucc n R * N * ((rowFrame w)⁻¹ * inclCastSucc n R) *
+        (A.submatrix Fin.castSucc Fin.castSucc) *
+        (projCastSucc n R * (colFrame u)⁻¹ * N⁻¹ * inclCastSucc n R) := by
+    rw [← projCastSucc_mul_mul_inclCastSucc]
+    conv_lhs => rw [← hA1]
+    rw [hPA]
+    simp only [Matrix.mul_assoc]
+  rw [main, Matrix.det_mul, Matrix.det_mul,
+    det_projCastSucc_mul_mul N hwN hw, det_mul_mul_inclCastSucc N⁻¹ hNinvu hu]
+  have hone : N.det * (N⁻¹).det = 1 := by rw [← Matrix.det_mul, hNinv, Matrix.det_one]
+  linear_combination (A.submatrix Fin.castSucc Fin.castSucc).det * hone
+
+end Matrix

--- a/TauCeti/LinearAlgebra/Matrix/CornerMinor.lean
+++ b/TauCeti/LinearAlgebra/Matrix/CornerMinor.lean
@@ -52,7 +52,32 @@ public section
 
 namespace Matrix
 
-variable {n : ℕ} {R : Type*} [CommRing R]
+variable {n : ℕ} {R : Type*}
+
+section NonAssocSemiring
+
+variable [NonAssocSemiring R]
+
+/-- Deleting the last row and column of a product is the product of the deletions, provided the
+left factor has the last standard basis vector as its last column. -/
+theorem submatrix_mul_of_mulVec_single (X Y : Matrix (Fin (n + 1)) (Fin (n + 1)) R)
+    (hX : X *ᵥ Pi.single (Fin.last n) 1 = Pi.single (Fin.last n) 1) :
+    (X * Y).submatrix Fin.castSucc Fin.castSucc =
+      X.submatrix Fin.castSucc Fin.castSucc * Y.submatrix Fin.castSucc Fin.castSucc := by
+  have hcol : X.col (Fin.last n) = Pi.single (Fin.last n) 1 := by
+    rw [← Matrix.mulVec_single_one]
+    exact hX
+  have hentry : ∀ i : Fin (n + 1),
+      X i (Fin.last n) = (Pi.single (Fin.last n) 1 : Fin (n + 1) → R) i :=
+    fun i => congrFun hcol i
+  ext u v
+  rw [Matrix.submatrix_apply, Matrix.mul_apply, Matrix.mul_apply, Fin.sum_univ_castSucc, hentry,
+    Pi.single_eq_of_ne (Fin.castSucc_lt_last u).ne, zero_mul, add_zero]
+  rfl
+
+end NonAssocSemiring
+
+variable [CommRing R]
 
 /-- Laplace expansion along the last row of a matrix whose last row vanishes off the diagonal. -/
 theorem det_eq_mul_det_submatrix_castSucc_of_row (A : Matrix (Fin (n + 1)) (Fin (n + 1)) R)
@@ -82,23 +107,6 @@ theorem det_updateCol_last_single (A : Matrix (Fin (n + 1)) (Fin (n + 1)) R) :
   ext a b
   rw [Matrix.submatrix_apply, Matrix.submatrix_apply,
     Matrix.updateCol_ne (Fin.castSucc_lt_last b).ne]
-
-/-- Deleting the last row and column of a product is the product of the deletions, provided the
-left factor has the last standard basis vector as its last column. -/
-theorem submatrix_mul_of_mulVec_single (X Y : Matrix (Fin (n + 1)) (Fin (n + 1)) R)
-    (hX : X *ᵥ Pi.single (Fin.last n) 1 = Pi.single (Fin.last n) 1) :
-    (X * Y).submatrix Fin.castSucc Fin.castSucc =
-      X.submatrix Fin.castSucc Fin.castSucc * Y.submatrix Fin.castSucc Fin.castSucc := by
-  have hcol : X.col (Fin.last n) = Pi.single (Fin.last n) 1 := by
-    rw [← Matrix.mulVec_single_one]
-    exact hX
-  have hentry : ∀ i : Fin (n + 1),
-      X i (Fin.last n) = (Pi.single (Fin.last n) 1 : Fin (n + 1) → R) i :=
-    fun i => congrFun hcol i
-  ext u v
-  rw [Matrix.submatrix_apply, Matrix.mul_apply, Matrix.mul_apply, Fin.sum_univ_castSucc, hentry,
-    Pi.single_eq_of_ne (Fin.castSucc_lt_last u).ne, zero_mul, add_zero]
-  rfl
 
 /-- The determinant of a matrix `M - 1` whose last column has been replaced by
 `c • M.col (last) - e (last)`, in terms of the corner minor of `M - 1`. -/

--- a/TauCeti/LinearAlgebra/Matrix/CornerMinor.lean
+++ b/TauCeti/LinearAlgebra/Matrix/CornerMinor.lean
@@ -39,6 +39,11 @@ vector and `w` is the geometric vector `(1, t, …, t ^ n)`.
   or whose last column, vanishes off the diagonal is the corner entry times the corner minor.
 * `Matrix.det_updateCol_last_single`: replacing the last column by the last standard basis vector
   turns the determinant into the corner minor.
+* `Matrix.submatrix_mul_of_mulVec_single`: deleting the last row and column commutes with a
+  product when the left factor fixes the last standard basis vector.
+* `Matrix.det_updateCol_last_smul_col_sub_single_of_det_sub_one_eq_zero`: a determinant formula
+  for replacing the last column of `M - 1` by a linear combination of the last columns of `M`
+  and `1`.
 * `Matrix.det_submatrix_castSucc_conj`: the corner minor of `N * A * N⁻¹` equals that of `A`,
   when `A` is annihilated by `u` on the right and by `w` on the left and `N` fixes both.
 -/
@@ -77,6 +82,40 @@ theorem det_updateCol_last_single (A : Matrix (Fin (n + 1)) (Fin (n + 1)) R) :
   ext a b
   rw [Matrix.submatrix_apply, Matrix.submatrix_apply,
     Matrix.updateCol_ne (Fin.castSucc_lt_last b).ne]
+
+/-- Deleting the last row and column of a product is the product of the deletions, provided the
+left factor has the last standard basis vector as its last column. -/
+theorem submatrix_mul_of_mulVec_single (X Y : Matrix (Fin (n + 1)) (Fin (n + 1)) R)
+    (hX : X *ᵥ Pi.single (Fin.last n) 1 = Pi.single (Fin.last n) 1) :
+    (X * Y).submatrix Fin.castSucc Fin.castSucc =
+      X.submatrix Fin.castSucc Fin.castSucc * Y.submatrix Fin.castSucc Fin.castSucc := by
+  have hcol : X.col (Fin.last n) = Pi.single (Fin.last n) 1 := by
+    rw [← Matrix.mulVec_single_one]
+    exact hX
+  have hentry : ∀ i : Fin (n + 1),
+      X i (Fin.last n) = (Pi.single (Fin.last n) 1 : Fin (n + 1) → R) i :=
+    fun i => congrFun hcol i
+  ext u v
+  rw [Matrix.submatrix_apply, Matrix.mul_apply, Matrix.mul_apply, Fin.sum_univ_castSucc, hentry,
+    Pi.single_eq_of_ne (Fin.castSucc_lt_last u).ne, zero_mul, add_zero]
+  rfl
+
+/-- The determinant of a matrix `M - 1` whose last column has been replaced by
+`c • M.col (last) - e (last)`, in terms of the corner minor of `M - 1`. -/
+theorem det_updateCol_last_smul_col_sub_single_of_det_sub_one_eq_zero
+    (M : Matrix (Fin (n + 1)) (Fin (n + 1)) R) (hdet : (M - 1).det = 0) (c : R) :
+    ((M - 1).updateCol (Fin.last n)
+        (fun u => c * M u (Fin.last n) - (Pi.single (Fin.last n) 1 : Fin (n + 1) → R) u)).det =
+      (c - 1) * ((M - 1).submatrix Fin.castSucc Fin.castSucc).det := by
+  have hfun : (fun u => c * M u (Fin.last n) - (Pi.single (Fin.last n) 1 : Fin (n + 1) → R) u) =
+      c • (fun u => (M - 1) u (Fin.last n)) +
+        (c - 1) • (Pi.single (Fin.last n) 1 : Fin (n + 1) → R) := by
+    funext u
+    simp only [Pi.add_apply, Pi.smul_apply, smul_eq_mul, Matrix.sub_apply, Matrix.one_apply,
+      Pi.single_apply]
+    split_ifs <;> ring
+  rw [hfun, Matrix.det_updateCol_add, Matrix.det_updateCol_smul, Matrix.det_updateCol_smul,
+    Matrix.updateCol_eq_self, hdet, Matrix.det_updateCol_last_single, mul_zero, zero_add]
 
 /-! ### The two rectangular matrices that delete and restore the last coordinate -/
 


### PR DESCRIPTION
This PR reads an Alexander polynomial of a braid closure off the unreduced Burau representation and proves that it is a Markov invariant up to a unit. `TauCeti.MarkovBraid.burauAlexander` is the determinant of `burau b - 1` with its last row and its last column deleted; conjugation leaves it unchanged, positive stabilization multiplies it by `-t` and negative stabilization by `-1`, so Markov-equivalent braids have associated values (`TauCeti.MarkovEquiv.associated_burauAlexander`). Two computations pin it down and keep it from being vacuous: the braid `σ₀ ^ 3` on two strands, whose closure is the right-handed trefoil, has value `-t (t ^ 2 - t + 1)`, which over `ℤ[T;T⁻¹]` at `t = T` is associated to the value `T - 1 + T⁻¹` that the Seifert-matrix route of `TauCeti/KnotTheory/Alexander.lean` produces from `trefoilSeifertMatrix`; and over `ℤ` at `t = -1` the same braid has value `3` while the trivial one-strand braid has value `1`, so the two are not Markov equivalent — a separation the existing component-count invariant of `TauCeti/KnotTheory/Markov.lean` cannot make, both closures being knots.

The milestone is Layer 4 of `TauCetiRoadmap/GeometricTopology/README.md`, "knot theory, done properly", and specifically its knot-polynomial bullet, which asks for "multiple algorithms for the same invariant, starting from different presentations, with theorems that they agree: Alexander from a Seifert matrix, from the Conway skein relation on a diagram, and from the Burau representation of a braid", and whose code sketch names `alexander_eq_burau (β : BraidWord n)`. This is the braid half of that agreement. The two inputs already exist on `main`: `TauCeti/KnotTheory/Alexander.lean` supplies the Seifert-matrix route and states in its own module docstring that "the agreement of this route ... with the Burau representation of a braid" is separate work, while `TauCeti/KnotTheory/Burau/{Basic,Reduced}.lean` supply the representation and `TauCeti/KnotTheory/Markov.lean` supplies the moves and the equivalence relation. What remains on that bullet after this PR is the third route, Alexander from the Conway skein relation on a diagram, which waits on the knot-diagram presentation that the layer names as its hub (in flight as the PD-code and Gauss-code PRs #5945 and #5849) and on Markov's theorem itself.

Two files are added, both new. `TauCeti/LinearAlgebra/Matrix/CornerMinor.lean` (336 lines) is prerequisite matrix infrastructure: the two sparse Laplace expansions along the last row and the last column, the description of the corner minor `det (A.submatrix Fin.castSucc Fin.castSucc)` as an ordinary determinant after the last column is replaced by the last standard basis vector, and the theorem `Matrix.det_submatrix_castSucc_conj` that the corner minor of a matrix annihilated on the right by a column vector `u` and on the left by a row vector `w` is unchanged by conjugation by any invertible matrix fixing `u` and `w`. It lives in the `Matrix` namespace beside `TauCeti/LinearAlgebra/Matrix/Minor.lean`, since its statements mention only Mathlib types. `TauCeti/KnotTheory/Burau/Alexander.lean` (530 lines) is the knot theory: the Burau matrix of a braid with an extra uncrossed strand, the two annihilating vectors of `burau b - 1` and its vanishing determinant, the definition and the three Markov-move computations, and the two evaluations above.

The mathematics follows the classical account of the Burau matrix of a braid closure in J. Birman, *Braids, Links, and Mapping Class Groups*, Annals of Mathematics Studies 82 (1974), Theorem 3.11, with Kassel–Turaev, *Braid Groups*, GTM 247, Section 3.3 and Lickorish, *An Introduction to Knot Theory*, GTM 175 for the conventions; the references are recorded in the module docstring. No Mathlib or external implementation is vendored, and the only Mathlib machinery used beyond the ambient matrix API is `Matrix.det_succ_row`, `Matrix.det_updateCol_add`/`_smul`, and `Matrix.det_eq_zero_of_mulVec_eq_zero_of_mem_nonZeroDivisors`.

Roadmap: GeometricTopology

<!--tauceti-target:v1 {"focus":"GeometricTopology","id":"braid-alexander-polynomial"}-->

🤖 Prepared with Claude Code
