### PR TITLE
feat(Newforms): the coprime filter of a form vanishing off p·L is p-supported

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/Newforms/CoprimeFilter.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/CoprimeFilter.lean
@@ -8,6 +8,7 @@ module
 import Mathlib.Data.Nat.Squarefree
 public import TauCeti.NumberTheory.ModularForms.Degeneracy
 public import TauCeti.NumberTheory.ModularForms.HeckeSlash.LevelSupported
+public import TauCeti.NumberTheory.ModularForms.Newforms.QSupport
 
 /-!
 # Coprime-index filters on `S_k(Γ₁(N), χ)`
@@ -37,6 +38,9 @@ The construction never lowers a level.
 * `TauCeti.exists_mem_cuspFormCharSpace_qExpansion_coeff_eq_ite_coprime_of_squarefree`:
   Miyake's Lemma 4.6.5 as stated, for a squarefree `L` whose primes divide `N`, at level
   `L * N`.
+* `TauCeti.exists_mem_cuspFormCharSpace_qExpansionSupportedOnDvd_of_squarefree`: the filter at a
+  squarefree `L`, for an `f` vanishing at every index coprime to `p * L`, is additionally
+  **supported on the multiples of `p`** — the hypothesis the Atkin–Lehner descent consumes.
 * `TauCeti.exists_mem_cuspFormCharSpace_qExpansion_coeff_eq_ite_coprime_zero`: the complementary
   filter, under the filter's own hypothesis and at its own level — a nonzero `L` whose primes
   divide `N`, at level `∏ L.primeFactors * N`.
@@ -353,5 +357,40 @@ theorem exists_mem_cuspFormCharSpace_qExpansion_coeff_eq_ite_coprime_zero_mul_sq
     rwa [MonoidHom.comp_assoc, ZMod.unitsMap_comp] at this
   · rw [CuspForm.coe_ofLe]
     exact hhq n
+
+/-- **The filter of a form vanishing off `p · L` is supported on the multiples of `p`.** If
+`f ∈ S_k(Γ₁(N), χ)` has `aₙ(f) = 0` at every `n` coprime to `p · L`, then its coprime-to-`L`
+filter `g` — the same cusp form of level `L * N` that
+`TauCeti.exists_mem_cuspFormCharSpace_qExpansion_coeff_eq_ite_coprime_of_squarefree` produces —
+satisfies `QExpansionSupportedOnDvd p g`.
+
+The two hypotheses meet on a single index. At an `n` not divisible by `p`, primality of `p` makes
+`n` coprime to `p`; if `n` is also coprime to `L` then it is coprime to `p · L`, so the vanishing
+hypothesis kills `aₙ(f)`, which is what the filter put at `aₙ(g)`. At every other `n` the filter
+already put `0` there. So `g` is left with nothing off the multiples of `p`.
+
+This is the form the Atkin–Lehner descent consumes: `QExpansionSupportedOnDvd p g` is exactly the
+hypothesis of `TauCeti.mem_cuspFormsOld_of_qExpansionSupportedOnDvd`. Squarefreeness of `L` and
+`L.primeFactors ⊆ N.primeFactors` are inherited unchanged from the filter; `p` is not required to
+divide `N`, and no relation between `p` and `L` is assumed. -/
+theorem exists_mem_cuspFormCharSpace_qExpansionSupportedOnDvd_of_squarefree
+    (χ : (ZMod N)ˣ →* ℂˣ) {f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k}
+    (hf : f ∈ cuspFormCharSpace k χ) {p L : ℕ} (hp : p.Prime) (hL : Squarefree L)
+    (hLN : L.primeFactors ⊆ N.primeFactors)
+    (hvan : ∀ n, Nat.Coprime n (p * L) → (qExpansion 1 f).coeff n = 0) :
+    ∃ g : CuspForm ((Gamma1 (L * N)).map (mapGL ℝ)) k,
+      g ∈ cuspFormCharSpace k (χ.comp (ZMod.unitsMap (Nat.dvd_mul_left N L))) ∧
+        QExpansionSupportedOnDvd p g ∧
+        ∀ n, (qExpansion 1 g).coeff n =
+          if Nat.Coprime n L then (qExpansion 1 f).coeff n else 0 := by
+  obtain ⟨g, hgχ, hgq⟩ :=
+    exists_mem_cuspFormCharSpace_qExpansion_coeff_eq_ite_coprime_of_squarefree χ hf hL hLN
+  refine ⟨g, hgχ, ?_, hgq⟩
+  rw [qExpansionSupportedOnDvd_iff, PowerSeries.isSupportedOnDvd_iff]
+  intro n hn
+  rw [hgq n]
+  split_ifs with hcop
+  · exact hvan n (Nat.Coprime.mul_right (hp.coprime_iff_not_dvd.mpr hn).symm hcop)
+  · rfl
 
 end TauCeti

--- a/TauCeti/NumberTheory/ModularForms/Newforms/CoprimeFilter.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/CoprimeFilter.lean
@@ -38,9 +38,11 @@ The construction never lowers a level.
 * `TauCeti.exists_mem_cuspFormCharSpace_qExpansion_coeff_eq_ite_coprime_of_squarefree`:
   Miyake's Lemma 4.6.5 as stated, for a squarefree `L` whose primes divide `N`, at level
   `L * N`.
-* `TauCeti.exists_mem_cuspFormCharSpace_qExpansionSupportedOnDvd_of_squarefree`: the filter at a
-  squarefree `L`, for an `f` vanishing at every index coprime to `p * L`, is additionally
-  **supported on the multiples of `p`** — the hypothesis the Atkin–Lehner descent consumes.
+* `TauCeti.exists_mem_cuspFormCharSpace_qExpansionSupportedOnDvd`: for an `f` vanishing at every
+  index coprime to `p * L`, the filter is additionally **supported on the multiples of `p`** — the
+  hypothesis the Atkin–Lehner descent consumes — with
+  `TauCeti.exists_mem_cuspFormCharSpace_qExpansionSupportedOnDvd_of_squarefree` its squarefree
+  specialization at level `L * N`.
 * `TauCeti.exists_mem_cuspFormCharSpace_qExpansion_coeff_eq_ite_coprime_zero`: the complementary
   filter, under the filter's own hypothesis and at its own level — a nonzero `L` whose primes
   divide `N`, at level `∏ L.primeFactors * N`.
@@ -95,6 +97,14 @@ divide `N`, and the `h`-form for an arbitrary nonzero `L`, the source stating on
 forms at this stage (its `_general` variant generalizes the target level, not `L`). The `h`-form
 in particular is not built by a second recursion: in its general form it is one subtraction at
 the filter's own level, and each wider-`L` form adds a single `CuspForm.ofLe` on top of it.
+
+`exists_mem_cuspFormCharSpace_qExpansionSupportedOnDvd` and its squarefree specialization state
+AINTLIB's `miyake_g_p_supported`, which lives in
+`StrongMultiplicityOne/DescentCosets.lean` at the same pinned commit and license. The source
+states it for a squarefree `l'` and concludes membership in its `qSupportedOnDvdSubmodule`; here
+the general nonzero-`L` form is the primary statement, the conclusion is the
+`QExpansionSupportedOnDvd` predicate this repository already uses, and the squarefree form is
+derived from it rather than proved separately.
 
 `coprime_prod_primeFactors_iff` is AINTLIB's `coprime_prod_primeFactors_iff_coprime`, which
 lives one file up in `StrongMultiplicityOne.lean`. It is restated here for an arbitrary nonzero
@@ -360,19 +370,43 @@ theorem exists_mem_cuspFormCharSpace_qExpansion_coeff_eq_ite_coprime_zero_mul_sq
 
 /-- **The filter of a form vanishing off `p · L` is supported on the multiples of `p`.** If
 `f ∈ S_k(Γ₁(N), χ)` has `aₙ(f) = 0` at every `n` coprime to `p · L`, then its coprime-to-`L`
-filter `g` — the same cusp form of level `L * N` that
-`TauCeti.exists_mem_cuspFormCharSpace_qExpansion_coeff_eq_ite_coprime_of_squarefree` produces —
-satisfies `QExpansionSupportedOnDvd p g`.
+filter — the cusp form of level `∏ L.primeFactors * N` that
+`TauCeti.exists_mem_cuspFormCharSpace_qExpansion_coeff_eq_ite_coprime` produces — satisfies
+`QExpansionSupportedOnDvd p`.
 
-The two hypotheses meet on a single index. At an `n` not divisible by `p`, primality of `p` makes
-`n` coprime to `p`; if `n` is also coprime to `L` then it is coprime to `p · L`, so the vanishing
-hypothesis kills `aₙ(f)`, which is what the filter put at `aₙ(g)`. At every other `n` the filter
-already put `0` there. So `g` is left with nothing off the multiples of `p`.
+`QExpansionSupportedOnDvd p g` is the hypothesis of
+`TauCeti.mem_cuspFormsOld_of_qExpansionSupportedOnDvd`, so this is what carries the coprime filter
+into the level-lowering dichotomy. The hypotheses on `L` are the filter's own, unchanged; `p` need
+not divide `N`, and no relation between `p` and `L` is assumed. -/
+theorem exists_mem_cuspFormCharSpace_qExpansionSupportedOnDvd
+    (χ : (ZMod N)ˣ →* ℂˣ) {f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k}
+    (hf : f ∈ cuspFormCharSpace k χ) {p L : ℕ} [NeZero L] (hp : p.Prime)
+    (hLN : L.primeFactors ⊆ N.primeFactors)
+    (hvan : ∀ n, Nat.Coprime n (p * L) → (qExpansion 1 f).coeff n = 0) :
+    ∃ g : CuspForm ((Gamma1 (L.primeFactors.prod id * N)).map (mapGL ℝ)) k,
+      g ∈ cuspFormCharSpace k
+          (χ.comp (ZMod.unitsMap (Nat.dvd_mul_left N (L.primeFactors.prod id)))) ∧
+        QExpansionSupportedOnDvd p g ∧
+        ∀ n, (qExpansion 1 g).coeff n =
+          if Nat.Coprime n L then (qExpansion 1 f).coeff n else 0 := by
+  obtain ⟨g, hgχ, hgq⟩ := exists_mem_cuspFormCharSpace_qExpansion_coeff_eq_ite_coprime χ hf hLN
+  refine ⟨g, hgχ, ?_, hgq⟩
+  rw [qExpansionSupportedOnDvd_iff, PowerSeries.isSupportedOnDvd_iff]
+  intro n hn
+  -- at an `n` off the multiples of `p`, primality gives `(n, p) = 1`, so the filter's two cases
+  -- are `hvan` and the filter's own zero
+  rw [hgq n]
+  split_ifs with hcop
+  · exact hvan n (Nat.Coprime.mul_right (hp.coprime_iff_not_dvd.mpr hn).symm hcop)
+  · rfl
 
-This is the form the Atkin–Lehner descent consumes: `QExpansionSupportedOnDvd p g` is exactly the
-hypothesis of `TauCeti.mem_cuspFormsOld_of_qExpansionSupportedOnDvd`. Squarefreeness of `L` and
-`L.primeFactors ⊆ N.primeFactors` are inherited unchanged from the filter; `p` is not required to
-divide `N`, and no relation between `p` and `L` is assumed. -/
+/-- **The `p`-supported filter at a squarefree `L`**, where `∏ L.primeFactors` is `L` itself and
+the level is `L * N`.
+
+This is `TauCeti.exists_mem_cuspFormCharSpace_qExpansionSupportedOnDvd` at a squarefree `L`, in
+the same relation as
+`TauCeti.exists_mem_cuspFormCharSpace_qExpansion_coeff_eq_ite_coprime_of_squarefree` stands to the
+filter it specializes. -/
 theorem exists_mem_cuspFormCharSpace_qExpansionSupportedOnDvd_of_squarefree
     (χ : (ZMod N)ˣ →* ℂˣ) {f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k}
     (hf : f ∈ cuspFormCharSpace k χ) {p L : ℕ} (hp : p.Prime) (hL : Squarefree L)
@@ -383,14 +417,10 @@ theorem exists_mem_cuspFormCharSpace_qExpansionSupportedOnDvd_of_squarefree
         QExpansionSupportedOnDvd p g ∧
         ∀ n, (qExpansion 1 g).coeff n =
           if Nat.Coprime n L then (qExpansion 1 f).coeff n else 0 := by
-  obtain ⟨g, hgχ, hgq⟩ :=
-    exists_mem_cuspFormCharSpace_qExpansion_coeff_eq_ite_coprime_of_squarefree χ hf hL hLN
-  refine ⟨g, hgχ, ?_, hgq⟩
-  rw [qExpansionSupportedOnDvd_iff, PowerSeries.isSupportedOnDvd_iff]
-  intro n hn
-  rw [hgq n]
-  split_ifs with hcop
-  · exact hvan n (Nat.Coprime.mul_right (hp.coprime_iff_not_dvd.mpr hn).symm hcop)
-  · rfl
+  have : NeZero L := ⟨hL.ne_zero⟩
+  have hprod : L.primeFactors.prod id = L := by
+    simpa using Nat.prod_primeFactors_of_squarefree hL
+  have key := exists_mem_cuspFormCharSpace_qExpansionSupportedOnDvd χ hf hp hLN hvan
+  rwa [hprod] at key
 
 end TauCeti


### PR DESCRIPTION
TauCeti has Miyake's Lemma 4.6.5 (the coprime-index filter, `Newforms/CoprimeFilter.lean`) and his
Theorem 4.6.4 (the level-lowering dichotomy, reached through
`mem_cuspFormsOld_of_qExpansionSupportedOnDvd`). This adds the step that carries the first into
the second — Miyake's Eq. 4.6.11.

```lean
theorem exists_mem_cuspFormCharSpace_qExpansionSupportedOnDvd
    (χ : (ZMod N)ˣ →* ℂˣ) (hf : f ∈ cuspFormCharSpace k χ)
    {p L : ℕ} [NeZero L] (hp : p.Prime)
    (hLN : L.primeFactors ⊆ N.primeFactors)
    (hvan : ∀ n, Nat.Coprime n (p * L) → (qExpansion 1 f).coeff n = 0) :
    ∃ g : CuspForm ((Gamma1 (L.primeFactors.prod id * N)).map (mapGL ℝ)) k,
      g ∈ cuspFormCharSpace k
          (χ.comp (ZMod.unitsMap (Nat.dvd_mul_left N (L.primeFactors.prod id)))) ∧
        QExpansionSupportedOnDvd p g ∧
        ∀ n, (qExpansion 1 g).coeff n =
          if Nat.Coprime n L then (qExpansion 1 f).coeff n else 0
```

If `f` vanishes at every index coprime to `p · L`, its coprime-to-`L` filter is supported on the
multiples of `p`. `..._of_squarefree` is the squarefree specialization at level `L * N`, derived
by rewriting `∏ L.primeFactors = L` — the same relation the plain filter's squarefree form already
has to the general one.

### The whole content is one index

At an `n` **not** divisible by `p`, primality makes `n` coprime to `p`. If `n` is *also* coprime to
`L`, then it is coprime to `p · L`, so `hvan` kills `aₙ(f)` — which is exactly what the filter
placed at `aₙ(g)`. At every other `n` the filter already placed `0`. Nothing survives off the
multiples of `p`, and squarefreeness of `L` is never consulted.

### Why it is worth naming

`QExpansionSupportedOnDvd p g` is precisely the hypothesis of
`TauCeti.mem_cuspFormsOld_of_qExpansionSupportedOnDvd`, so this is the junction between the two
Miyake results the repository already has. It is stated as a strengthening of the existing filter
rather than as a free-standing lemma about `q`-expansions because the filter is where both the
level bookkeeping and the nebentypus transport are already settled; restating those to expose an
intermediate would duplicate them.

The hypotheses on `L` are inherited from the filter unchanged. Nothing extra is asked of `p`: it
need not divide `N`, and no relation between `p` and `L` is assumed. Only `p.Prime` is new, used
at the single step above.

### Roadmap target

`TauCetiRoadmap/ModularForms/README.md`, **Layer 4** ("eigenforms, newforms, primitive forms; the
conductor"), the bullet **"The Atkin–Lehner Main Lemma"** (Diamond–Shurman Thm 5.7.1, README line
558). That bullet records the Main Lemma as reached through "the per-character route
`mainLemma_charSpace_routeB` … Miyake's sieve/conductor descent"; TauCeti has no
`Newforms/MainLemmaProof.lean`, so the target is still open here. This theorem supplies the
**coprime-filter-to-single-divisor sieve step** of that descent: it converts the filter's
coprimality conclusion into the single-divisor support condition the dichotomy consumes.

### Placement

Added to `Newforms/CoprimeFilter.lean`, beside the filter it strengthens, which costs one new
`public import` of `Newforms/QSupport.lean` for `QExpansionSupportedOnDvd` (it appears in the
statement, hence `public`). Checked for a cycle: `QSupport` imports `Degeneracy`, which
`CoprimeFilter` already imports, and reaches `CoprimeFilter` nowhere.

Roadmap: ModularForms

Provenance: github.com/CBirkbeck/AINTLIB @ `2baa76f74`, Apache-2.0 —
`projects/LeanModularForms/LeanModularForms/StrongMultiplicityOne/DescentCosets.lean`,
`miyake_g_p_supported` (line 40), now also credited in the module's Provenance block. Restated on
TauCeti's own filter and its `QExpansionSupportedOnDvd` predicate rather than the source's
`qSupportedOnDvdSubmodule` membership, and with the general nonzero-`L` form primary where the
source states only the squarefree case.

Verification: `lake build` green (3297 jobs); 13-linter `#lint` over 957 declarations reports 0
errors; no line exceeds 100 characters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQieFQn95rzgvYRvNdX3hR
