### PR TITLE
refactor(RootSystem): root the whole `RootPositiveForm` namespace

### DIFF
--- a/TauCeti/LinearAlgebra/RootSystem/RankTwo.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/RankTwo.lean
@@ -347,7 +347,7 @@ the given base.
 
 The bridge is root length. A pair of roots pairing to `-3` has its transposed pairing `-1`, so the
 two differ in squared length by the factor `3`; every root has the length of a simple root
-(`TauCeti.RootPairing.RootPositiveForm.exists_mem_support_rootLength_eq`), so two of the simple
+(`RootPairing.RootPositiveForm.exists_mem_support_rootLength_eq`), so two of the simple
 roots already differ by that factor, and reading the ratio back off the Cartan matrix makes their
 two off-diagonal entries `-3` and `-1`. Since the base has two elements, these entries and the
 diagonal entries `2` identify its Cartan matrix with the standard matrix of `G₂`. -/

--- a/TauCeti/LinearAlgebra/RootSystem/RootLength.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/RootLength.lean
@@ -81,11 +81,11 @@ transposed matrix instead would make that identity false.
   for a valid type.
 * `TauCeti.DynkinType.isLongSimpleRoot_C_iff_not_isLongSimpleRoot_B`: `Bₙ` and `Cₙ` carry the same
   diagram with the lengths exchanged.
-* `TauCeti.RootPairing.RootPositiveForm.rootLength_le_iff_pairingIn_le`: in any root pairing
+* `RootPairing.RootPositiveForm.rootLength_le_iff_pairingIn_le`: in any root pairing
   carrying a root-positive form, two roots meeting at a strictly negative pairing compare in length
   exactly as the transposed pair of pairings compares. This is the statement that makes the
   Cartan-matrix reading above meaningful.
-* `TauCeti.RootPairing.RootPositiveForm.rootLength_le_iff_dynkinRootLength_le`: for a base matched
+* `RootPairing.RootPositiveForm.rootLength_le_iff_dynkinRootLength_le`: for a base matched
   to a Dynkin type, adjacent simple roots compare in length exactly as
   `TauCeti.DynkinType.rootLength` says they do.
 
@@ -461,7 +461,7 @@ private lemma le_iff_le_of_mul_eq_mul {S : Type*} [CommRing S] [LinearOrder S]
   · have h1 : a * y ≤ a * x := h ▸ mul_le_mul_of_nonneg_right hca hx.le
     exact (mul_le_mul_left_of_neg ha).mp h1
 
-namespace RootPairing.RootPositiveForm
+section
 
 variable {ι R M N : Type*} [CommRing R] [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
 
@@ -479,7 +479,8 @@ belongs to the longer root.
 The negativity hypothesis is what pins the direction. It is automatic for two distinct simple roots
 of a base, whose pairings are nonpositive, once they are not orthogonal; for a pair with positive
 pairings the comparison is reversed. -/
-theorem rootLength_le_iff_pairingIn_le (B : P.RootPositiveForm S) {i j : ι}
+theorem _root_.RootPairing.RootPositiveForm.rootLength_le_iff_pairingIn_le
+    (B : P.RootPositiveForm S) {i j : ι}
     (h : P.pairingIn S i j < 0) :
     B.rootLength i ≤ B.rootLength j ↔ P.pairingIn S j i ≤ P.pairingIn S i j :=
   le_iff_le_of_mul_eq_mul (B.rootLength_pos i) h
@@ -500,14 +501,15 @@ comparison read off the type is the same for every witness.
 The hypothesis that the two nodes are joined is necessary: two simple roots that are orthogonal are
 constrained by nothing, and in `Cₙ` for instance the first node is short although no neighbour of
 it is longer. -/
-theorem rootLength_le_iff_dynkinRootLength_le {b : P.Base} {t : DynkinType}
+theorem _root_.RootPairing.RootPositiveForm.rootLength_le_iff_dynkinRootLength_le
+    {b : P.Base} {t : DynkinType}
     {e : b.support ≃ Fin t.rank} (he : ∀ i j, b.cartanMatrix i j = t.cartanMatrix (e i) (e j))
     (B : P.RootPositiveForm ℤ) {i j : b.support} (h : b.cartanMatrix i j < 0) :
     B.rootLength i ≤ B.rootLength j ↔ t.rootLength (e i) ≤ t.rootLength (e j) := by
   -- The comparison of `rootLength_le_iff_pairingIn_le` is one of pairings, and the Cartan
   -- entries of a base are those pairings definitionally (`RootPairing.Base.cartanMatrixIn_def`).
   have key : B.rootLength i ≤ B.rootLength j ↔ b.cartanMatrix j i ≤ b.cartanMatrix i j :=
-    rootLength_le_iff_pairingIn_le B h
+    RootPairing.RootPositiveForm.rootLength_le_iff_pairingIn_le B h
   rw [key, he i j, he j i]
   refine (le_iff_le_of_mul_eq_mul (t.rootLength_pos (e i)) ?_
     (t.cartanMatrix_mul_rootLength (e i) (e j))).symm
@@ -515,6 +517,6 @@ theorem rootLength_le_iff_dynkinRootLength_le {b : P.Base} {t : DynkinType}
 
 end IsCrystallographic
 
-end RootPairing.RootPositiveForm
+end
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/RootSystem/Weyl/Orbit.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Weyl/Orbit.lean
@@ -26,10 +26,10 @@ height reaches a simple root from anywhere.
 
 * `TauCeti.exists_mem_support_weylGroupToPerm_eq`: **every root index is the image of a simple root
   index under the Weyl group.**
-* `TauCeti.RootPairing.RootPositiveForm.rootLength_weylGroupToPerm`: root length is a Weyl-group
-  invariant, with `TauCeti.RootPairing.RootPositiveForm.rootLength_reflectionPerm` the special case
+* `RootPairing.RootPositiveForm.rootLength_weylGroupToPerm`: root length is a Weyl-group
+  invariant, with `RootPairing.RootPositiveForm.rootLength_reflectionPerm` the special case
   of a single reflection.
-* `TauCeti.RootPairing.RootPositiveForm.exists_mem_support_rootLength_eq`: **every root has the
+* `RootPairing.RootPositiveForm.exists_mem_support_rootLength_eq`: **every root has the
   length of some simple root.** This is what turns a statement about the two entries of a rank-two
   Cartan matrix into a statement about all the roots.
 
@@ -68,7 +68,7 @@ theorem exists_mem_support_weylGroupToPerm_eq [CharZero R] [Finite ι] [IsDomain
   exact b.induction_reflect j (fun k hk ↦ step k k hk) (fun i hi ↦ ⟨i, hi, 1, by simp⟩)
     fun x k hx _ ↦ step k x hx
 
-namespace RootPairing.RootPositiveForm
+section
 
 variable {S : Type*} [CommRing S] [LinearOrder S] [Algebra S R]
   [FaithfulSMul S R] [Module S M] [IsScalarTower S R M] [P.IsValuedIn S]
@@ -79,7 +79,8 @@ group by construction, and the Weyl group carries the root indexed by `i` to the
 -- Not a `simp` lemma: `simp` unfolds `P.weylGroupToPerm w i` to `(↑↑w).indexEquiv i` through
 -- `MonoidHom.domRestrict_apply` and `RootPairing.Equiv.indexHom_apply`, so this left-hand side is
 -- never in normal form. The `reflectionPerm` form below is the usable `simp` lemma.
-theorem rootLength_weylGroupToPerm (B : P.RootPositiveForm S) (w : P.weylGroup) (i : ι) :
+theorem _root_.RootPairing.RootPositiveForm.rootLength_weylGroupToPerm
+    (B : P.RootPositiveForm S) (w : P.weylGroup) (i : ι) :
     B.rootLength (P.weylGroupToPerm w i) = B.rootLength i := by
   apply FaithfulSMul.algebraMap_injective S R
   rw [B.algebraMap_rootLength, B.algebraMap_rootLength, ← P.weylGroup_apply_root w i]
@@ -88,20 +89,22 @@ theorem rootLength_weylGroupToPerm (B : P.RootPositiveForm S) (w : P.weylGroup) 
 /-- Reflection in any root preserves root lengths. Mathlib's
 `RootPairing.RootPositiveForm.rootLength_reflectionPerm_self` is the case `i = j`. -/
 @[simp]
-theorem rootLength_reflectionPerm (B : P.RootPositiveForm S) (i j : ι) :
+theorem _root_.RootPairing.RootPositiveForm.rootLength_reflectionPerm
+    (B : P.RootPositiveForm S) (i j : ι) :
     B.rootLength (P.reflectionPerm i j) = B.rootLength j := by
   rw [← TauCeti.RootPairing.weylGroupToPerm_ofIdx_apply P i j]
-  exact rootLength_weylGroupToPerm B _ j
+  exact RootPairing.RootPositiveForm.rootLength_weylGroupToPerm B _ j
 
 /-- **Every root has the length of one of the simple roots.** Consequently the set of root lengths
 of a root pairing is read off its base, which is what lets a rank-two Cartan matrix control the
 lengths of all the roots and not only of the two simple ones. -/
-theorem exists_mem_support_rootLength_eq [CharZero R] [Finite ι] [IsDomain R]
+theorem _root_.RootPairing.RootPositiveForm.exists_mem_support_rootLength_eq
+    [CharZero R] [Finite ι] [IsDomain R]
     [P.IsCrystallographic] [P.IsReduced] (B : P.RootPositiveForm S) (b : P.Base) (j : ι) :
     ∃ i ∈ b.support, B.rootLength j = B.rootLength i := by
   obtain ⟨i, hi, w, rfl⟩ := exists_mem_support_weylGroupToPerm_eq b j
-  exact ⟨i, hi, rootLength_weylGroupToPerm B w i⟩
+  exact ⟨i, hi, RootPairing.RootPositiveForm.rootLength_weylGroupToPerm B w i⟩
 
-end RootPairing.RootPositiveForm
+end
 
 end TauCeti


### PR DESCRIPTION
All five `TauCeti.RootPairing.RootPositiveForm` declarations are flagged by `lint-dot-notation`, and together they are the whole namespace. `RootPairing.RootPositiveForm` is a root Mathlib namespace with 18 declarations and no colliding names.

## Why both files in one PR

The five live in two files — `RootLength.lean` (2) and `Weyl/Orbit.lean` (3). Rooting either file alone would leave the namespace half-rooted across the other: a `TauCeti.RootPairing.RootPositiveForm` surviving as a shadow of the Mathlib namespace, with the declarations split between the two. That is the cross-file form of the split `api-design` blocked on in #5950, so both move together.

Both wrappers become `section` rather than disappearing; each carries `variable` lines that would otherwise widen.

## References that followed

- **three in-block sibling uses** — `rootLength_le_iff_pairingIn_le` in `RootLength.lean`, and `rootLength_weylGroupToPerm` twice in `Orbit.lean` — which reached their siblings through the wrapper and are now written in full;
- **six module-docstring references**, one of them in a third file, `RankTwo.lean`.

None of the nine would have failed a build in a way pointing at these files.

`lint-dot-notation`: 977 → 972, 0 new.

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYwXN9WBAPasmBQXr6iQcp