### PR TITLE
feat: prove the special orthogonal standard comodule irreducible

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/SpecialOrthogonal/Irreducible.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialOrthogonal/Irreducible.lean
@@ -123,8 +123,9 @@ private theorem single_one_mem_of_ne_bot
   have hmultiple : ((4 : k) * v i) • Pi.single i 1 ∈ N := by
     simpa only [i] using four_smul_single_mem k n N hv hn
   have htwo : (2 : k) ≠ 0 := two_ne_zero
+  have h4 : (4 : k) = 2 * 2 := by norm_num
   have hfour : (4 : k) ≠ 0 := by
-    rw [show (4 : k) = 2 * 2 by norm_num]
+    rw [h4]
     exact mul_ne_zero htwo htwo
   have hc : (4 : k) * v i ≠ 0 := mul_ne_zero hfour hvi
   have hi : Pi.single i 1 ∈ N := by
@@ -135,8 +136,8 @@ private theorem single_one_mem_of_ne_bot
   · simpa [hai] using hi
   · let g := coordinateRotation (R := k) i a hai
     have hrotated := mulVec_mem k n N g hi
-    rw [coordinateRotation_mulVec_single_left] at hrotated
-    exact hrotated
+    simpa only [g, Matrix.mulVec_single, MulOpposite.op_one, one_smul,
+      coordinateRotation_col_left] using hrotated
 
 /-- **The standard comodule of `SOₙ` is simple in dimension at least three** over a field in
 characteristic different from two. -/
@@ -153,11 +154,12 @@ theorem isSimpleOrder_subcomodule_of_three_le (hn : 3 ≤ n) :
     by_cases hN : N = ⊥
     · exact Or.inl hN
     · right
-      apply top_unique
-      intro v _
-      rw [pi_eq_sum_univ' v]
-      exact N.toSubmodule.sum_mem fun a _ ↦
-        N.toSubmodule.smul_mem (v a) (single_one_mem_of_ne_bot k n N hN hn a)
+      have htop : N.toSubmodule = ⊤ :=
+        (Submodule.eq_top_iff_forall_basis_mem (Pi.basisFun k (Fin n))).2 fun a ↦ by
+          simpa using single_one_mem_of_ne_bot k n N hN hn a
+      exact Subcomodule.ext fun v ↦ by
+        rw [← Subcomodule.mem_toSubmodule, htop]
+        simp
 
 /-- **The standard comodule of `SOₙ` is completely reducible in dimension at least three** over
 a field of characteristic different from two. -/

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialOrthogonal/Irreducible.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialOrthogonal/Irreducible.lean
@@ -12,10 +12,10 @@ public import TauCeti.LinearAlgebra.Matrix.SpecialOrthogonalGroup.CoordinateRota
 /-!
 # Irreducibility of the special orthogonal standard comodule
 
-Over a field in which `2` is invertible, the standard representation of `SOₙ` is irreducible in
-dimension at least three. Coordinate half-turns isolate a chosen coordinate of a vector in an
-invariant subspace, and coordinate rotations then carry that standard basis vector to every other
-one. Thus every nonzero subcomodule is the whole standard representation.
+Over a field of characteristic different from two, the standard representation of `SOₙ` is
+irreducible in dimension at least three. Coordinate half-turns isolate a chosen coordinate of a
+vector in an invariant subspace, and coordinate rotations then carry that standard basis vector to
+every other one. Thus every nonzero subcomodule is the whole standard representation.
 
 The dimension bound is sharp for this argument and for the statement: over an algebraically
 closed field, the standard representation of `SO₂` is the sum of two one-dimensional characters.
@@ -40,7 +40,7 @@ The proof uses the point-action interface of
 public section
 
 open Module
-open Matrix.SpecialOrthogonalGroup
+open TauCeti.Matrix.SpecialOrthogonalGroup
 open scoped Matrix
 
 namespace TauCeti.SpecialOrthogonal
@@ -49,7 +49,7 @@ universe u
 
 noncomputable section
 
-variable (k : Type u) [Field k] (n : ℕ) [Invertible (2 : k)]
+variable (k : Type u) [Field k] (n : ℕ) [NeZero (2 : k)]
 
 attribute [local instance] standardComodule
 
@@ -61,7 +61,7 @@ private theorem firstThree_ne (hn : 3 ≤ n) {a b : Fin 3} (hab : a ≠ b) :
     firstThree n hn a ≠ firstThree n hn b :=
   (firstThree n hn).injective.ne hab
 
-omit [Invertible (2 : k)] in
+omit [NeZero (2 : k)] in
 /-- In an invariant subspace, three coordinate half-turns isolate four times one coordinate of
 a vector. -/
 private theorem four_smul_single_mem
@@ -71,7 +71,7 @@ private theorem four_smul_single_mem
   let i := firstThree n hn 0
   let j := firstThree n hn 1
   let l := firstThree n hn 2
-  change (4 * w i) • Pi.single i 1 ∈ N
+  suffices (4 * w i) • Pi.single i 1 ∈ N by simpa only [i]
   have hij : i ≠ j := firstThree_ne n hn (by decide)
   have hil : i ≠ l := firstThree_ne n hn (by decide)
   have hjl : j ≠ l := firstThree_ne n hn (by decide)
@@ -120,9 +120,9 @@ private theorem single_one_mem_of_ne_bot
       refine ⟨(g : Matrix (Fin n) (Fin n) k) *ᵥ w, mulVec_mem k n N g hw, ?_⟩
       rw [coordinateRotation_mulVec]
       simpa [Ne.symm hpi] using hp
-  have hmultiple := four_smul_single_mem k n N hv hn
-  change ((4 : k) * v i) • Pi.single i 1 ∈ N at hmultiple
-  have htwo : (2 : k) ≠ 0 := IsUnit.ne_zero (isUnit_of_invertible (2 : k))
+  have hmultiple : ((4 : k) * v i) • Pi.single i 1 ∈ N := by
+    simpa only [i] using four_smul_single_mem k n N hv hn
+  have htwo : (2 : k) ≠ 0 := two_ne_zero
   have hfour : (4 : k) ≠ 0 := by
     rw [show (4 : k) = 2 * 2 by norm_num]
     exact mul_ne_zero htwo htwo
@@ -139,7 +139,7 @@ private theorem single_one_mem_of_ne_bot
     exact hrotated
 
 /-- **The standard comodule of `SOₙ` is simple in dimension at least three** over a field in
-which `2` is invertible. -/
+characteristic different from two. -/
 theorem isSimpleOrder_subcomodule_of_three_le (hn : 3 ≤ n) :
     IsSimpleOrder (Subcomodule k (coordinateHopfAlgebra k n) (Fin n → k)) := by
   refine { exists_pair_ne := ⟨⊥, ⊤, ?_⟩, eq_bot_or_eq_top := ?_ }
@@ -160,7 +160,7 @@ theorem isSimpleOrder_subcomodule_of_three_le (hn : 3 ≤ n) :
         N.toSubmodule.smul_mem (v a) (single_one_mem_of_ne_bot k n N hN hn a)
 
 /-- **The standard comodule of `SOₙ` is completely reducible in dimension at least three** over
-a field in which `2` is invertible. -/
+a field of characteristic different from two. -/
 theorem isCompletelyReducible_standardComodule_of_three_le (hn : 3 ≤ n) :
     Comodule.IsCompletelyReducible k (coordinateHopfAlgebra k n) (Fin n → k) := by
   let _ : IsSimpleOrder (Subcomodule k (coordinateHopfAlgebra k n) (Fin n → k)) :=

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialOrthogonal/Irreducible.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialOrthogonal/Irreducible.lean
@@ -1,0 +1,172 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.SpecialOrthogonal.StandardComodule
+public import TauCeti.Algebra.Coalgebra.Comodule.LinearlyReductive
+public import TauCeti.LinearAlgebra.Matrix.SpecialOrthogonalGroup.CoordinateRotation
+
+/-!
+# Irreducibility of the special orthogonal standard comodule
+
+Over a field in which `2` is invertible, the standard representation of `SOₙ` is irreducible in
+dimension at least three. Coordinate half-turns isolate a chosen coordinate of a vector in an
+invariant subspace, and coordinate rotations then carry that standard basis vector to every other
+one. Thus every nonzero subcomodule is the whole standard representation.
+
+The dimension bound is sharp for this argument and for the statement: over an algebraically
+closed field, the standard representation of `SO₂` is the sum of two one-dimensional characters.
+That representation is completely reducible but not irreducible.
+
+## Main declarations
+
+* `TauCeti.SpecialOrthogonal.isSimpleOrder_subcomodule_of_three_le`: the subcomodules of the
+  standard representation form a simple order in dimension at least three.
+* `TauCeti.SpecialOrthogonal.isCompletelyReducible_standardComodule_of_three_le`: the standard
+  representation is completely reducible in those dimensions.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), §§2.3 and 4.a.
+* J. C. Jantzen, *Representations of Algebraic Groups*, I.2.
+
+The proof uses the point-action interface of
+`TauCeti.Algebra.AlgebraicGroup.SpecialOrthogonal.StandardComodule`.
+-/
+
+public section
+
+open Module
+open Matrix.SpecialOrthogonalGroup
+open scoped Matrix
+
+namespace TauCeti.SpecialOrthogonal
+
+universe u
+
+noncomputable section
+
+variable (k : Type u) [Field k] (n : ℕ) [Invertible (2 : k)]
+
+attribute [local instance] standardComodule
+
+/-- Three distinguished coordinates in `Fin n`, available when `3 ≤ n`. -/
+private def firstThree (hn : 3 ≤ n) : Fin 3 ↪ Fin n := Fin.castLEEmb hn
+
+/-- The first three distinguished coordinates are pairwise distinct. -/
+private theorem firstThree_ne (hn : 3 ≤ n) {a b : Fin 3} (hab : a ≠ b) :
+    firstThree n hn a ≠ firstThree n hn b :=
+  (firstThree n hn).injective.ne hab
+
+omit [Invertible (2 : k)] in
+/-- In an invariant subspace, three coordinate half-turns isolate four times one coordinate of
+a vector. -/
+private theorem four_smul_single_mem
+    (N : Subcomodule k (coordinateHopfAlgebra k n) (Fin n → k))
+    {w : Fin n → k} (hw : w ∈ N) (hn : 3 ≤ n) :
+    (4 * w (firstThree n hn 0)) • Pi.single (firstThree n hn 0) 1 ∈ N := by
+  let i := firstThree n hn 0
+  let j := firstThree n hn 1
+  let l := firstThree n hn 2
+  change (4 * w i) • Pi.single i 1 ∈ N
+  have hij : i ≠ j := firstThree_ne n hn (by decide)
+  have hil : i ≠ l := firstThree_ne n hn (by decide)
+  have hjl : j ≠ l := firstThree_ne n hn (by decide)
+  let gij := coordinateHalfTurn (R := k) i j hij
+  let gil := coordinateHalfTurn (R := k) i l hil
+  let gjl := coordinateHalfTurn (R := k) j l hjl
+  have hijw : (gij : Matrix (Fin n) (Fin n) k) *ᵥ w ∈ N := mulVec_mem k n N gij hw
+  have hilw : (gil : Matrix (Fin n) (Fin n) k) *ᵥ w ∈ N := mulVec_mem k n N gil hw
+  have hjlw : (gjl : Matrix (Fin n) (Fin n) k) *ᵥ w ∈ N := mulVec_mem k n N gjl hw
+  have hcomb :
+      (w - (gij : Matrix (Fin n) (Fin n) k) *ᵥ w) +
+          (w - (gil : Matrix (Fin n) (Fin n) k) *ᵥ w) -
+        (w - (gjl : Matrix (Fin n) (Fin n) k) *ᵥ w) ∈ N :=
+    N.toSubmodule.sub_mem
+      (N.toSubmodule.add_mem (N.toSubmodule.sub_mem hw hijw) (N.toSubmodule.sub_mem hw hilw))
+      (N.toSubmodule.sub_mem hw hjlw)
+  convert hcomb using 1
+  ext a
+  simp only [gij, gil, gjl, Pi.sub_apply, Pi.add_apply, coordinateHalfTurn_mulVec,
+    Pi.smul_apply, smul_eq_mul, Pi.single_apply]
+  by_cases hai : a = i
+  · subst a
+    simp_all
+    ring
+  · by_cases haj : a = j
+    · subst a
+      simp_all
+    · by_cases hal : a = l
+      · subst a
+        simp_all
+      · simp_all
+
+/-- Every standard basis vector belongs to a nonzero invariant subspace of the standard
+special orthogonal representation in dimension at least three. -/
+private theorem single_one_mem_of_ne_bot
+    (N : Subcomodule k (coordinateHopfAlgebra k n) (Fin n → k)) (hN : N ≠ ⊥)
+    (hn : 3 ≤ n) (a : Fin n) : Pi.single a 1 ∈ N := by
+  let i := firstThree n hn 0
+  obtain ⟨w, hw, hw0⟩ := N.ne_bot_iff.mp hN
+  obtain ⟨p, hp⟩ := Function.ne_iff.mp hw0
+  simp only [Pi.zero_apply] at hp
+  obtain ⟨v, hv, hvi⟩ : ∃ v : Fin n → k, v ∈ N ∧ v i ≠ 0 := by
+    by_cases hpi : p = i
+    · exact ⟨w, hw, by simpa [hpi] using hp⟩
+    · let g := coordinateRotation (R := k) p i hpi
+      refine ⟨(g : Matrix (Fin n) (Fin n) k) *ᵥ w, mulVec_mem k n N g hw, ?_⟩
+      rw [coordinateRotation_mulVec]
+      simpa [Ne.symm hpi] using hp
+  have hmultiple := four_smul_single_mem k n N hv hn
+  change ((4 : k) * v i) • Pi.single i 1 ∈ N at hmultiple
+  have htwo : (2 : k) ≠ 0 := IsUnit.ne_zero (isUnit_of_invertible (2 : k))
+  have hfour : (4 : k) ≠ 0 := by
+    rw [show (4 : k) = 2 * 2 by norm_num]
+    exact mul_ne_zero htwo htwo
+  have hc : (4 : k) * v i ≠ 0 := mul_ne_zero hfour hvi
+  have hi : Pi.single i 1 ∈ N := by
+    have hscaled := N.toSubmodule.smul_mem ((4 : k) * v i)⁻¹ hmultiple
+    rw [smul_smul, inv_mul_cancel₀ hc, one_smul] at hscaled
+    exact hscaled
+  by_cases hai : i = a
+  · simpa [hai] using hi
+  · let g := coordinateRotation (R := k) i a hai
+    have hrotated := mulVec_mem k n N g hi
+    rw [coordinateRotation_mulVec_single_left] at hrotated
+    exact hrotated
+
+/-- **The standard comodule of `SOₙ` is simple in dimension at least three** over a field in
+which `2` is invertible. -/
+theorem isSimpleOrder_subcomodule_of_three_le (hn : 3 ≤ n) :
+    IsSimpleOrder (Subcomodule k (coordinateHopfAlgebra k n) (Fin n → k)) := by
+  refine { exists_pair_ne := ⟨⊥, ⊤, ?_⟩, eq_bot_or_eq_top := ?_ }
+  · intro h
+    have hone : (Pi.single (firstThree n hn 0) (1 : k) : Fin n → k) ∈
+        (⊥ : Subcomodule k (coordinateHopfAlgebra k n) (Fin n → k)) :=
+      h ▸ Subcomodule.mem_top _
+    rw [Subcomodule.mem_bot] at hone
+    simpa using congrFun hone (firstThree n hn 0)
+  · intro N
+    by_cases hN : N = ⊥
+    · exact Or.inl hN
+    · right
+      apply top_unique
+      intro v _
+      rw [pi_eq_sum_univ' v]
+      exact N.toSubmodule.sum_mem fun a _ ↦
+        N.toSubmodule.smul_mem (v a) (single_one_mem_of_ne_bot k n N hN hn a)
+
+/-- **The standard comodule of `SOₙ` is completely reducible in dimension at least three** over
+a field in which `2` is invertible. -/
+theorem isCompletelyReducible_standardComodule_of_three_le (hn : 3 ≤ n) :
+    Comodule.IsCompletelyReducible k (coordinateHopfAlgebra k n) (Fin n → k) := by
+  let _ : IsSimpleOrder (Subcomodule k (coordinateHopfAlgebra k n) (Fin n → k)) :=
+    isSimpleOrder_subcomodule_of_three_le k n hn
+  exact Comodule.isCompletelyReducible_of_isSimpleOrder
+
+end
+
+end TauCeti.SpecialOrthogonal

--- a/TauCeti/LinearAlgebra/Matrix/SpecialOrthogonalGroup/CoordinateRotation.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SpecialOrthogonalGroup/CoordinateRotation.lean
@@ -1,0 +1,135 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import Mathlib.LinearAlgebra.Matrix.Permutation
+public import Mathlib.LinearAlgebra.UnitaryGroup
+
+/-!
+# Coordinate rotations in the special orthogonal group
+
+For two distinct coordinates, the signed transposition which sends the first basis vector to the
+second and the second to the negative of the first is special orthogonal. Its square changes the
+sign of exactly those two coordinates. These elementary matrices give a convenient, ring-valued
+interface for arguments with the standard representation of a special orthogonal group.
+
+## Main declarations
+
+* `Matrix.SpecialOrthogonalGroup.coordinateRotation`: the signed coordinate transposition.
+* `Matrix.SpecialOrthogonalGroup.coordinateHalfTurn`: its square, negating two coordinates.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), §2.3.
+-/
+
+public section
+
+open Matrix
+
+namespace Matrix.SpecialOrthogonalGroup
+
+universe u
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+variable {R : Type u} [CommRing R]
+
+attribute [local instance] starRingOfComm
+
+/-- The special orthogonal matrix which sends the `i`-th basis vector to the `j`-th basis
+vector, sends the `j`-th basis vector to the negative of the `i`-th basis vector, and fixes the
+remaining basis vectors. -/
+def coordinateRotation (i j : n) (hij : i ≠ j) : Matrix.specialOrthogonalGroup n R :=
+  ⟨(Equiv.swap i j).permMatrix R * Matrix.diagonal (Function.update 1 j (-1)), by
+    rw [Matrix.mem_specialOrthogonalGroup_iff]
+    constructor
+    · rw [Matrix.mem_orthogonalGroup_iff]
+      have hdiag : Matrix.diagonal (Function.update 1 j (-1 : R)) *
+          Matrix.diagonal (Function.update 1 j (-1 : R)) = 1 := by
+        ext a b
+        by_cases hab : a = b
+        · subst b
+          by_cases haj : a = j <;> simp [haj]
+        · simp [hab]
+      rw [Matrix.transpose_mul, Matrix.diagonal_transpose, Matrix.transpose_permMatrix]
+      simp only [Matrix.mul_assoc]
+      rw [← Matrix.mul_assoc (Matrix.diagonal _) (Matrix.diagonal _), hdiag,
+        Matrix.one_mul]
+      simp [← Matrix.permMatrix_mul]
+    · rw [Matrix.det_mul, Matrix.det_permutation, Matrix.det_diagonal]
+      rw [Finset.prod_update_of_mem (Finset.mem_univ j)]
+      simp [hij]⟩
+
+/-- The underlying matrix of a coordinate rotation is the signed permutation matrix used in its
+definition. -/
+theorem coe_coordinateRotation (i j : n) (hij : i ≠ j) :
+    (coordinateRotation (R := R) i j hij : Matrix n n R) =
+      (Equiv.swap i j).permMatrix R * Matrix.diagonal (Function.update 1 j (-1)) := (rfl)
+
+/-- A coordinate rotation exchanges the selected coordinates with the sign on the first output
+coordinate. -/
+@[simp]
+theorem coordinateRotation_mulVec (i j : n) (hij : i ≠ j) (w : n → R) (a : n) :
+    ((coordinateRotation (R := R) i j hij : Matrix n n R) *ᵥ w) a =
+      if a = i then -w j else if a = j then w i else w a := by
+  rw [coe_coordinateRotation, ← Matrix.mulVec_mulVec, Matrix.permMatrix_mulVec]
+  simp only [Function.comp_apply, Matrix.mulVec_diagonal, Function.update_apply]
+  by_cases hai : a = i
+  · subst a
+    simp
+  · by_cases haj : a = j
+    · subst a
+      simp [hij, hij.symm]
+    · simp [hai, haj, Equiv.swap_apply_of_ne_of_ne]
+
+/-- A coordinate rotation sends the `i`-th basis vector to the `j`-th basis vector. -/
+theorem coordinateRotation_mulVec_single_left (i j : n) (hij : i ≠ j) :
+    (coordinateRotation (R := R) i j hij : Matrix n n R) *ᵥ Pi.single i 1 =
+      Pi.single j 1 := by
+  ext a
+  rw [coordinateRotation_mulVec]
+  by_cases hai : a = i
+  · subst a
+    simp [hij]
+  · by_cases haj : a = j <;> simp [hai, haj, hij.symm]
+
+/-- A coordinate rotation sends the `j`-th basis vector to the negative of the `i`-th basis
+vector. -/
+theorem coordinateRotation_mulVec_single_right (i j : n) (hij : i ≠ j) :
+    (coordinateRotation (R := R) i j hij : Matrix n n R) *ᵥ Pi.single j 1 =
+      -Pi.single i 1 := by
+  ext a
+  rw [coordinateRotation_mulVec]
+  by_cases hai : a = i
+  · subst a
+    simp
+  · by_cases haj : a = j <;> simp [hai, haj, hij.symm]
+
+/-- Squaring a coordinate rotation gives the half-turn which negates the two selected
+coordinates. -/
+def coordinateHalfTurn (i j : n) (hij : i ≠ j) : Matrix.specialOrthogonalGroup n R :=
+  coordinateRotation (R := R) i j hij ^ 2
+
+/-- A coordinate half-turn is the square of the corresponding coordinate rotation. -/
+theorem coordinateHalfTurn_def (i j : n) (hij : i ≠ j) :
+    coordinateHalfTurn (R := R) i j hij = coordinateRotation (R := R) i j hij ^ 2 := (rfl)
+
+/-- A coordinate half-turn negates exactly the two selected coordinates. -/
+@[simp]
+theorem coordinateHalfTurn_mulVec (i j : n) (hij : i ≠ j) (w : n → R) (a : n) :
+    ((coordinateHalfTurn (R := R) i j hij : Matrix n n R) *ᵥ w) a =
+      if a = i ∨ a = j then -w a else w a := by
+  rw [coordinateHalfTurn, pow_two, Submonoid.coe_mul, ← Matrix.mulVec_mulVec]
+  simp only [coordinateRotation_mulVec]
+  by_cases hai : a = i
+  · subst a
+    simp [hij, hij.symm]
+  · by_cases haj : a = j
+    · subst a
+      simp [hij.symm]
+    · simp [hai, haj]
+
+end Matrix.SpecialOrthogonalGroup

--- a/TauCeti/LinearAlgebra/Matrix/SpecialOrthogonalGroup/CoordinateRotation.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SpecialOrthogonalGroup/CoordinateRotation.lean
@@ -86,9 +86,10 @@ theorem coordinateRotation_mulVec (i j : n) (hij : i ≠ j) (w : n → R) (a : n
     · simp [hai, haj, Equiv.swap_apply_of_ne_of_ne]
 
 /-- A coordinate rotation sends the `i`-th basis vector to the `j`-th basis vector. -/
-theorem coordinateRotation_mulVec_single_left (i j : n) (hij : i ≠ j) :
-    (coordinateRotation (R := R) i j hij : Matrix n n R) *ᵥ Pi.single i 1 =
-      Pi.single j 1 := by
+@[simp]
+theorem coordinateRotation_col_left (i j : n) (hij : i ≠ j) :
+    (coordinateRotation (R := R) i j hij : Matrix n n R).col i = Pi.single j 1 := by
+  rw [← Matrix.mulVec_single_one]
   ext a
   rw [coordinateRotation_mulVec]
   by_cases hai : a = i
@@ -98,9 +99,10 @@ theorem coordinateRotation_mulVec_single_left (i j : n) (hij : i ≠ j) :
 
 /-- A coordinate rotation sends the `j`-th basis vector to the negative of the `i`-th basis
 vector. -/
-theorem coordinateRotation_mulVec_single_right (i j : n) (hij : i ≠ j) :
-    (coordinateRotation (R := R) i j hij : Matrix n n R) *ᵥ Pi.single j 1 =
-      -Pi.single i 1 := by
+@[simp]
+theorem coordinateRotation_col_right (i j : n) (hij : i ≠ j) :
+    (coordinateRotation (R := R) i j hij : Matrix n n R).col j = -Pi.single i 1 := by
+  rw [← Matrix.mulVec_single_one]
   ext a
   rw [coordinateRotation_mulVec]
   by_cases hai : a = i

--- a/TauCeti/LinearAlgebra/Matrix/SpecialOrthogonalGroup/CoordinateRotation.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SpecialOrthogonalGroup/CoordinateRotation.lean
@@ -5,7 +5,7 @@ Authors: Codex
 -/
 module
 
-public import Mathlib.LinearAlgebra.Matrix.Permutation
+public import Mathlib.LinearAlgebra.Matrix.Swap
 public import Mathlib.LinearAlgebra.UnitaryGroup
 
 /-!
@@ -43,7 +43,7 @@ attribute [local instance] starRingOfComm
 vector, sends the `j`-th basis vector to the negative of the `i`-th basis vector, and fixes the
 remaining basis vectors. -/
 def coordinateRotation (i j : n) (hij : i ≠ j) : Matrix.specialOrthogonalGroup n R :=
-  ⟨(Equiv.swap i j).permMatrix R * Matrix.diagonal (Function.update 1 j (-1)), by
+  ⟨Matrix.swap R i j * Matrix.diagonal (Function.update 1 j (-1)), by
     rw [Matrix.mem_specialOrthogonalGroup_iff]
     constructor
     · rw [Matrix.mem_orthogonalGroup_iff]
@@ -54,20 +54,19 @@ def coordinateRotation (i j : n) (hij : i ≠ j) : Matrix.specialOrthogonalGroup
         · subst b
           by_cases haj : a = j <;> simp [haj]
         · simp [hab]
-      rw [Matrix.transpose_mul, Matrix.diagonal_transpose, Matrix.transpose_permMatrix]
+      rw [Matrix.transpose_mul, Matrix.diagonal_transpose, Matrix.transpose_swap]
       simp only [Matrix.mul_assoc]
       rw [← Matrix.mul_assoc (Matrix.diagonal _) (Matrix.diagonal _), hdiag,
-        Matrix.one_mul]
-      simp [← Matrix.permMatrix_mul]
-    · rw [Matrix.det_mul, Matrix.det_permutation, Matrix.det_diagonal]
+        Matrix.one_mul, Matrix.swap_mul_self]
+    · rw [Matrix.det_mul, Matrix.swap, Matrix.det_permutation, Matrix.det_diagonal]
       rw [Finset.prod_update_of_mem (Finset.mem_univ j)]
       simp [hij]⟩
 
-/-- The underlying matrix of a coordinate rotation is the signed permutation matrix used in its
+/-- The underlying matrix of a coordinate rotation is the signed swap matrix used in its
 definition. -/
 theorem coe_coordinateRotation (i j : n) (hij : i ≠ j) :
     (coordinateRotation (R := R) i j hij : Matrix n n R) =
-      (Equiv.swap i j).permMatrix R * Matrix.diagonal (Function.update 1 j (-1)) := (rfl)
+      Matrix.swap R i j * Matrix.diagonal (Function.update 1 j (-1)) := (rfl)
 
 /-- A coordinate rotation exchanges the selected coordinates with the sign on the first output
 coordinate. -/
@@ -75,7 +74,7 @@ coordinate. -/
 theorem coordinateRotation_mulVec (i j : n) (hij : i ≠ j) (w : n → R) (a : n) :
     ((coordinateRotation (R := R) i j hij : Matrix n n R) *ᵥ w) a =
       if a = i then -w j else if a = j then w i else w a := by
-  rw [coe_coordinateRotation, ← Matrix.mulVec_mulVec, Matrix.permMatrix_mulVec]
+  rw [coe_coordinateRotation, ← Matrix.mulVec_mulVec, Matrix.swap_mulVec]
   simp only [Function.comp_apply, Matrix.mulVec_diagonal, Function.update_apply]
   by_cases hai : a = i
   · subst a

--- a/TauCeti/LinearAlgebra/Matrix/SpecialOrthogonalGroup/CoordinateRotation.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SpecialOrthogonalGroup/CoordinateRotation.lean
@@ -18,8 +18,8 @@ interface for arguments with the standard representation of a special orthogonal
 
 ## Main declarations
 
-* `Matrix.SpecialOrthogonalGroup.coordinateRotation`: the signed coordinate transposition.
-* `Matrix.SpecialOrthogonalGroup.coordinateHalfTurn`: its square, negating two coordinates.
+* `TauCeti.Matrix.SpecialOrthogonalGroup.coordinateRotation`: the signed coordinate transposition.
+* `TauCeti.Matrix.SpecialOrthogonalGroup.coordinateHalfTurn`: its square, negating two coordinates.
 
 ## References
 
@@ -30,7 +30,7 @@ public section
 
 open Matrix
 
-namespace Matrix.SpecialOrthogonalGroup
+namespace TauCeti.Matrix.SpecialOrthogonalGroup
 
 universe u
 
@@ -113,10 +113,6 @@ coordinates. -/
 def coordinateHalfTurn (i j : n) (hij : i ≠ j) : Matrix.specialOrthogonalGroup n R :=
   coordinateRotation (R := R) i j hij ^ 2
 
-/-- A coordinate half-turn is the square of the corresponding coordinate rotation. -/
-theorem coordinateHalfTurn_def (i j : n) (hij : i ≠ j) :
-    coordinateHalfTurn (R := R) i j hij = coordinateRotation (R := R) i j hij ^ 2 := (rfl)
-
 /-- A coordinate half-turn negates exactly the two selected coordinates. -/
 @[simp]
 theorem coordinateHalfTurn_mulVec (i j : n) (hij : i ≠ j) (w : n → R) (a : n) :
@@ -132,4 +128,4 @@ theorem coordinateHalfTurn_mulVec (i j : n) (hij : i ≠ j) (w : n → R) (a : n
       simp [hij.symm]
     · simp [hai, haj]
 
-end Matrix.SpecialOrthogonalGroup
+end TauCeti.Matrix.SpecialOrthogonalGroup


### PR DESCRIPTION
This PR proves that the standard comodule of the determinant-one special orthogonal group is irreducible over any field in which `2` is invertible, in every dimension `n ≥ 3`, and records the resulting complete reducibility. The exact roadmap target is `ReductiveGroups/README.md`, Worked examples, “`SOₙ` … prove [it is] reductive where applicable,” on the Layer 6 reductivity path: `TauCeti.SpecialOrthogonal.isCompletelyReducible_standardComodule_of_three_le` supplies the representation-theoretic input used by the existing normal-unipotent elimination theorem.

This is the most effective current step because the special-orthogonal coordinate algebra, smoothness away from characteristic two, base-change isomorphism, faithful standard comodule, and point-action formula are already on `main`; complete reducibility of that faithful comodule is the next missing input for trivializing a normal smooth unipotent subgroup. Coordinate half-turns isolate four times one coordinate of a vector in an invariant subspace, and signed coordinate rotations carry the resulting basis vector to every coordinate. The dimension bound is honest: over an algebraically closed field the standard representation of `SO₂` splits into two characters and is not irreducible.

The PR adds `TauCeti/LinearAlgebra/Matrix/SpecialOrthogonalGroup/CoordinateRotation.lean` (135 lines), which constructs the signed coordinate rotation and its two-coordinate half-turn over an arbitrary commutative ring with their matrix and action API, and `TauCeti/Algebra/AlgebraicGroup/SpecialOrthogonal/Irreducible.lean` (172 lines), which proves simplicity and complete reducibility. No Mathlib infrastructure is vendored; the construction reuses Mathlib’s permutation matrices, determinant computation, and `Matrix.specialOrthogonalGroup`, and the comodule argument reuses Tau Ceti’s established special-orthogonal point-action interface. The mathematical interpretation follows Milne, *Algebraic Groups*, §§2.3 and 4.a, and Jantzen, *Representations of Algebraic Groups*, I.2, as cited in the module documentation.

After this PR, the worked-example milestone still needs geometric connectedness of this `SOₙ` model and the low-dimensional cases before the normal-unipotent elimination result can be assembled into reductivity.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"special-orthogonal-standard-comodule-simple"}-->

🤖 Prepared with Codex
