### PR TITLE
feat(Frobenius): the tower formula over the fixed field of one automorphism (empty after the reuse fix — please close)

### DIFF
--- a/TauCeti/NumberTheory/NumberField/Frobenius/FixedField.lean
+++ b/TauCeti/NumberTheory/NumberField/Frobenius/FixedField.lean
@@ -1,0 +1,83 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.FieldTheory.Galois.FixedField
+public import TauCeti.NumberTheory.NumberField.Frobenius.Tower
+
+/-!
+# The Frobenius over the fixed field of a single automorphism
+
+`TauCeti.NumberField.exists_isArithFrobAt_pow_inertiaDeg` relates an arithmetic Frobenius over `K`
+to one over an intermediate field `M`, at the cost of a power: the exponent is the residue degree
+`f(𝔓 / 𝔭)` of the intermediate prime. This file records that statement for the one intermediate
+field a fibre count actually uses, `L ^ ⟨σ⟩`, and the case in which the exponent disappears.
+
+The base is spelled `IntermediateField.fixedField (Subgroup.zpowers σ)` rather than abbreviated,
+following `TauCeti.FieldTheory.Galois.FixedField`.
+
+## Main results
+
+* `AlgEquiv.exists_isArithFrobAt_fixedField_pow_inertiaDeg`: over `L ^ ⟨σ⟩` there is an arithmetic
+  Frobenius at `Q` restricting to `τ ^ f(𝔓 / 𝔭)`.
+* `AlgEquiv.exists_isArithFrobAt_fixedField_of_inertiaDeg_eq_one`: when `f(𝔓 / 𝔭) = 1` it
+  restricts to `τ` itself.
+-/
+
+public section
+
+open NumberField IntermediateField
+
+open scoped NumberField
+
+namespace AlgEquiv
+
+variable {K L : Type*} [Field K] [NumberField K] [Field L] [NumberField L] [Algebra K L]
+  [IsGalois K L]
+
+-- Source. Both statements are specified by the Chebotarev roadmap:
+-- `TauCetiRoadmap/Chebotarev/README.md` §8.2 puts `E = L^⟨σ⟩` and needs, for `𝔭` unramified in `L`
+-- and `𝔓 = Q ∩ 𝓞 E`, that "8.1 gives `Frob_{L/E}(𝔓) = Frob_{L/K}(Q)` on the nose" exactly when
+-- `f(𝔓/𝔭) = 1`; it pins them at `TauCetiRoadmap/Chebotarev/Suggested.lean` as
+-- `artinClass_restrict_fixedField` and `isArithFrobAt_fixedField_of_inertiaDeg_one`.
+
+/-- **The tower formula over the fixed field of `⟨σ⟩`.** For a prime `Q` of `𝓞 L` unramified over
+`K`, with `𝔓 = Q ∩ 𝓞 (L ^ ⟨σ⟩)` and `𝔭 = Q ∩ 𝓞 K`, an arithmetic Frobenius `τ` at `Q` over `K`
+becomes, after raising to the residue degree `f(𝔓 / 𝔭)`, the restriction of an arithmetic Frobenius
+at `Q` over `L ^ ⟨σ⟩`.
+
+This is `TauCeti.NumberField.exists_isArithFrobAt_pow_inertiaDeg` at the intermediate field a fibre
+count uses. It is stated separately because that base carries the instances only through the fixed
+field's own construction, and a caller should not have to rediscover them. -/
+theorem exists_isArithFrobAt_fixedField_pow_inertiaDeg (σ : L ≃ₐ[K] L)
+    (Q : Ideal (𝓞 L)) [Q.IsPrime]
+    (𝔓 : Ideal (𝓞 (fixedField (Subgroup.zpowers σ)))) (𝔭 : Ideal (𝓞 K))
+    (hQE : Q.under (𝓞 (fixedField (Subgroup.zpowers σ))) = 𝔓) (hQK : Q.under (𝓞 K) = 𝔭)
+    (hur : ∀ (Q' : Ideal (𝓞 L)) [Q'.IsPrime] [Q'.LiesOver 𝔭], Algebra.IsUnramifiedAt (𝓞 K) Q')
+    (τ : L ≃ₐ[K] L) (hτ : IsArithFrobAt (𝓞 K) τ Q) :
+    ∃ τE : L ≃ₐ[fixedField (Subgroup.zpowers σ)] L,
+      IsArithFrobAt (𝓞 (fixedField (Subgroup.zpowers σ))) τE Q ∧
+        AlgEquiv.restrictScalars K τE = τ ^ 𝔓.inertiaDeg (𝓞 K) :=
+  exists_isArithFrobAt_pow_inertiaDeg _ Q 𝔓 𝔭 hQE hQK hur τ hτ
+
+/-- **At residue degree one the exponent disappears.** The relative Frobenius over `L ^ ⟨σ⟩` then
+restricts to the absolute one unpowered, which is the only situation in which a fibre count may
+compare the two without an exponent. -/
+theorem exists_isArithFrobAt_fixedField_of_inertiaDeg_eq_one (σ : L ≃ₐ[K] L)
+    (Q : Ideal (𝓞 L)) [Q.IsPrime]
+    (𝔓 : Ideal (𝓞 (fixedField (Subgroup.zpowers σ)))) (𝔭 : Ideal (𝓞 K))
+    (hQE : Q.under (𝓞 (fixedField (Subgroup.zpowers σ))) = 𝔓) (hQK : Q.under (𝓞 K) = 𝔭)
+    (hf : 𝔓.inertiaDeg (𝓞 K) = 1)
+    (hur : ∀ (Q' : Ideal (𝓞 L)) [Q'.IsPrime] [Q'.LiesOver 𝔭], Algebra.IsUnramifiedAt (𝓞 K) Q')
+    (τ : L ≃ₐ[K] L) (hτ : IsArithFrobAt (𝓞 K) τ Q) :
+    ∃ τE : L ≃ₐ[fixedField (Subgroup.zpowers σ)] L,
+      IsArithFrobAt (𝓞 (fixedField (Subgroup.zpowers σ))) τE Q ∧
+        AlgEquiv.restrictScalars K τE = τ := by
+  obtain ⟨τE, hfrob, hres⟩ :=
+    exists_isArithFrobAt_fixedField_pow_inertiaDeg σ Q 𝔓 𝔭 hQE hQK hur τ hτ
+  exact ⟨τE, hfrob, by rw [hres, hf, pow_one]⟩
+
+end AlgEquiv


### PR DESCRIPTION
> **Status note (2026-09-09) — this PR wants closing, not work.**
>
> The `reuse` block asks to *"delete both declarations and call
> `NumberField.exists_isArithFrobAt_pow_inertiaDeg (fixedField (Subgroup.zpowers σ)) ...` at the
> consumer"*. I have checked what that leaves:
>
> * the PR adds **exactly one file** (`Frobenius/FixedField.lean`, +83/−0) containing **exactly the
>   two theorems** the block names;
> * **neither name has a single consumer** anywhere on `main`.
>
> So there is no consumer to inline them at, and deleting both — which is the instructed fix —
> empties the file and leaves an empty PR. The finding is right and the correct response to it is to
> close this, not to push a commit.
>
> Recorded rather than acted on: closing is a human/CI action, not one this worker takes.

---

> **Blocked and withdrawn.** The `reuse` rubric blocked this at round 1, correctly: both
> declarations are wrappers with no new content, the instances they claimed to supply resolve by
> typeclass search on their own, and neither has a consumer anywhere. Deleting them leaves an empty
> file, so there is nothing to fix. Marked draft; it should be closed rather than revised. The
> reasoning below is left as written, including the justification that turned out to be wrong.

Layer 8.2 of the Chebotarev roadmap works over one particular intermediate field, `E = L^⟨σ⟩`, and
needs the tower law there — plus the case in which its exponent vanishes.

```lean
theorem AlgEquiv.exists_isArithFrobAt_fixedField_pow_inertiaDeg (σ : L ≃ₐ[K] L) … :
    ∃ τE : L ≃ₐ[fixedField (Subgroup.zpowers σ)] L,
      IsArithFrobAt (𝓞 (fixedField (Subgroup.zpowers σ))) τE Q ∧
        AlgEquiv.restrictScalars K τE = τ ^ 𝔓.inertiaDeg (𝓞 K)

theorem AlgEquiv.exists_isArithFrobAt_fixedField_of_inertiaDeg_eq_one (σ : L ≃ₐ[K] L) …
    (hf : 𝔓.inertiaDeg (𝓞 K) = 1) … :
    ∃ τE : L ≃ₐ[fixedField (Subgroup.zpowers σ)] L,
      IsArithFrobAt (𝓞 (fixedField (Subgroup.zpowers σ))) τE Q ∧
        AlgEquiv.restrictScalars K τE = τ
```

### What these add, given the general theorem already exists

`NumberField.exists_isArithFrobAt_pow_inertiaDeg` is on main and is stated for an arbitrary
intermediate `M`, so the first proof is one application and the second is three lines. The content
is not the argument but the *base*: `L^⟨σ⟩` carries `Algebra`, `IsScalarTower`, `IsGalois` and
`NumberField` only through the fixed field's own construction, and a fibre count should be able to
name the relative Frobenius without rediscovering them. §8.2 uses exactly the `f(𝔓/𝔭) = 1` case —
"8.1 gives `Frob_{L/E}(𝔓) = Frob_{L/K}(Q)` on the nose" — which is the second theorem.

### The roadmap's name is not used

`Suggested.lean` pins these as `artinClass_restrict_fixedField` and
`isArithFrobAt_fixedField_of_inertiaDeg_one`, over a base it calls `cyclicFixedField`. That
abbreviation was **declined on main**: `TauCeti/FieldTheory/Galois/FixedField.lean` says in terms
that "the field is spelled `IntermediateField.fixedField (Subgroup.zpowers σ)` throughout rather
than abbreviated". This follows that decision, and the names say what the statements conclude
rather than reproducing the roadmap's internal labels.

### Absence

`exists_isArithFrobAt_pow_inertiaDeg` exists (`NumberField/Frobenius/Tower.lean:167`) but is never
specialised: the only occurrence of `fixedField (Subgroup.zpowers` anywhere under
`TauCeti/NumberTheory/` is an unrelated line in `Chebotarev/TaggedFixedField.lean`. Neither pinned
name appears in the repository. Open PRs matching "fixedField Frobenius" are #5968 and #5910, both
in the Lie-theory lane, and #5977, which is the cyclic-group index lemma.

Roadmap: Chebotarev
<!--tauceti-target:v1 {"focus":"Chebotarev","id":"TauCetiRoadmap/Chebotarev/Suggested.lean:artinClass_restrict_fixedField"}-->

Provenance: none external — the statements are specified by
`TauCetiRoadmap/Chebotarev/README.md` §8.2 and pinned in
`TauCetiRoadmap/Chebotarev/Suggested.lean`; the proofs are applications of TauCeti's own
`NumberField.exists_isArithFrobAt_pow_inertiaDeg`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011dmwkBnj4rJc75STgbwsLF


