### PR TITLE
feat: the Cartier divisor of a locally principal Weil divisor

### DIFF
--- a/TauCeti/AlgebraicGeometry/CartierDivisor/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/CartierDivisor/Basic.lean
@@ -29,8 +29,10 @@ unit.
 * `Scheme.toRationalUnitSheaf` is the monomorphism `𝒪_X^× ⟶ 𝒦_X^×`;
 * `Scheme.cartierDivisorSheaf` is its cokernel in sheaves of abelian groups;
 * `Scheme.CartierDivisor` is the additive group of global sections of that cokernel;
+* `Scheme.rationalUnitClass` sends a nonzero rational function to its class in the
+  Cartier-divisor sheaf over a nonempty open subset, its *local equation* there;
 * `Scheme.principalCartierDivisor` sends a nonzero rational function to its principal Cartier
-  divisor.
+  divisor, the case of the whole space.
 
 This advances `TauCetiRoadmap/JacobianChallenge/README.md`, Layer A, item "Cartier divisors; the
 dictionaries `Cartier ≃ line bundles` and (smooth curve) `Weil ≃ Cartier`". The rational-function
@@ -149,68 +151,146 @@ lemma toRationalUnitSheaf_app_comp_toCartierDivisor :
 local instance : Nonempty (⊤ : X.Opens) :=
   ⟨⟨Classical.choice (inferInstanceAs (Nonempty X)), by simp⟩⟩
 
-/-- On the whole space, the units of the rational-function sheaf are the units of the function
-field. -/
-def rationalUnitSectionsEquiv :
-    Additive (((rationalFunctionsRing X).presheaf.obj (op (⊤ : X.Opens)))ˣ) ≃+
+/-- Over a nonempty open subset, the units of the rational-function sheaf are the units of the
+function field. -/
+def rationalUnitSectionsEquiv (U : X.Opens) [Nonempty U] :
+    Additive (((rationalFunctionsRing X).presheaf.obj (op U))ˣ) ≃+
       Additive X.functionFieldˣ := by
-  exact (Units.mapEquiv (rationalFunctionsRingEquiv (⊤ : X.Opens)).toMulEquiv).toAdditive
+  exact (Units.mapEquiv (rationalFunctionsRingEquiv U).toMulEquiv).toAdditive
 
-/-- The global rational-unit equivalence applies the rational-functions equivalence to a
-unit. -/
+/-- The rational-unit equivalence applies the rational-functions equivalence to a unit. -/
 @[simp]
-lemma rationalUnitSectionsEquiv_apply
-    (f : ((rationalFunctionsRing X).presheaf.obj (op (⊤ : X.Opens)))ˣ) :
-    rationalUnitSectionsEquiv X (Additive.ofMul f) =
+lemma rationalUnitSectionsEquiv_apply (U : X.Opens) [Nonempty U]
+    (f : ((rationalFunctionsRing X).presheaf.obj (op U))ˣ) :
+    rationalUnitSectionsEquiv X U (Additive.ofMul f) =
       Additive.ofMul (Units.map
-        (rationalFunctionsRingEquiv (⊤ : X.Opens)).toMonoidHom f) := by
+        (rationalFunctionsRingEquiv U).toMonoidHom f) := by
   rfl
 
-/-- The homomorphism from global regular units to units of the function field induced by the
-germ map. -/
-noncomputable def regularUnitToFunctionField :
-    ((X.presheaf.obj (op (⊤ : X.Opens))) : Type u)ˣ →* X.functionFieldˣ := by
-  exact Units.map (X.germToFunctionField (⊤ : X.Opens)).hom.toMonoidHom
+/-- The homomorphism from regular units on `U` to units of the function field induced by the
+germ map at the generic point. -/
+noncomputable def regularUnitToFunctionField (U : X.Opens) [Nonempty U] :
+    ((X.presheaf.obj (op U)) : Type u)ˣ →* X.functionFieldˣ := by
+  exact Units.map (X.germToFunctionField U).hom.toMonoidHom
 
 /-- The map on regular units applies the germ map to the underlying section. -/
 @[simp]
-lemma regularUnitToFunctionField_apply
-    (f : ((X.presheaf.obj (op (⊤ : X.Opens))) : Type u)ˣ) :
-    regularUnitToFunctionField X f =
-      Units.map (X.germToFunctionField (⊤ : X.Opens)).hom.toMonoidHom f := by
+lemma regularUnitToFunctionField_apply (U : X.Opens) [Nonempty U]
+    (f : ((X.presheaf.obj (op U)) : Type u)ˣ) :
+    regularUnitToFunctionField X U f =
+      Units.map (X.germToFunctionField U).hom.toMonoidHom f := by
   rfl
 
-/-- The equivalence from global rational units to function-field units carries the image of a
-global regular unit to the unit induced by its germ in the function field. -/
-lemma rationalUnitSectionsEquiv_toRationalUnitSheaf_app
-    (f : ((X.presheaf.obj (op (⊤ : X.Opens))) : Type u)ˣ) :
-    rationalUnitSectionsEquiv X
-        (((toRationalUnitSheaf X).hom.app (op (⊤ : X.Opens))).hom (Additive.ofMul f)) =
-      Additive.ofMul (regularUnitToFunctionField X f) := by
+/-- The equivalence from rational units to function-field units carries the image of a regular
+unit to the unit induced by its germ in the function field. -/
+lemma rationalUnitSectionsEquiv_toRationalUnitSheaf_app (U : X.Opens) [Nonempty U]
+    (f : ((X.presheaf.obj (op U)) : Type u)ˣ) :
+    rationalUnitSectionsEquiv X U
+        (((toRationalUnitSheaf X).hom.app (op U)).hom (Additive.ofMul f)) =
+      Additive.ofMul (regularUnitToFunctionField X U f) := by
   have hunit :
-      ((toRationalUnitSheaf X).hom.app (op (⊤ : X.Opens))).hom (Additive.ofMul f) =
+      ((toRationalUnitSheaf X).hom.app (op U)).hom (Additive.ofMul f) =
         Additive.ofMul (Units.map
           ((toRationalFunctionsRing X).hom.app
-            (op (⊤ : X.Opens))).hom.toMonoidHom f) :=
+            (op U)).hom.toMonoidHom f) :=
     CategoryTheory.Sheaf.additiveUnitsFunctor_map_app_apply
       (Opens.grothendieckTopology X) (toRationalFunctionsRing X)
-        (op (⊤ : X.Opens)) (Additive.ofMul f)
+        (op U) (Additive.ofMul f)
   rw [hunit, rationalUnitSectionsEquiv_apply, regularUnitToFunctionField_apply]
   apply congrArg Additive.ofMul
   apply Units.ext
   simp only [Units.coe_map]
   -- The units API exposes underlying values, while the rational-functions comparison
   -- theorems use the definitionally equal module-sheaf section type.
-  change rationalFunctionsRingEquiv (⊤ : X.Opens)
-      ((toRationalFunctionsRing X).hom.app (op (⊤ : X.Opens)) (f : Γ(X, ⊤))) =
-    X.germToFunctionField (⊤ : X.Opens) f
+  change rationalFunctionsRingEquiv U
+      ((toRationalFunctionsRing X).hom.app (op U) (f : Γ(X, U))) =
+    X.germToFunctionField U f
   rw [← toRationalFunctionsRing_app, ← rationalFunctionsEquiv_apply,
     rationalFunctionsEquiv_toRationalFunctions_app]
+
+/-- The class in the Cartier-divisor sheaf over a nonempty open subset `U` of a nonzero rational
+function, regarded as a local equation there. The multiplicative group of the function field is
+written additively in the domain. -/
+def rationalUnitClass (U : X.Opens) [Nonempty U] :
+    Additive X.functionFieldˣ →+ ((cartierDivisorSheaf X).obj.obj (op U) : Type u) :=
+  (((toCartierDivisorSheaf X).hom.app (op U)).hom).comp
+    (rationalUnitSectionsEquiv X U).symm.toAddMonoidHom
+
+/-- Restricting a rational unit to a smaller nonempty open subset does not change the underlying
+nonzero rational function. -/
+@[simp]
+lemma rationalUnitSectionsEquiv_symm_restrict {U V : X.Opens} [Nonempty U] [Nonempty V]
+    (h : V ≤ U) (g : Additive X.functionFieldˣ) :
+    TopCat.Presheaf.restrictOpen (F := (rationalUnitSheaf X).obj)
+        ((rationalUnitSectionsEquiv X U).symm g) V h =
+      (rationalUnitSectionsEquiv X V).symm g := by
+  apply (rationalUnitSectionsEquiv X V).injective
+  rw [AddEquiv.apply_symm_apply]
+  set t := (rationalUnitSectionsEquiv X U).symm g with ht
+  have hgt : rationalUnitSectionsEquiv X U t = g := by
+    rw [ht, AddEquiv.apply_symm_apply]
+  have hgt' : g = Additive.ofMul (Units.map
+      (rationalFunctionsRingEquiv U).toMonoidHom (Additive.toMul t)) := by
+    rw [← hgt]
+    exact rationalUnitSectionsEquiv_apply X U (Additive.toMul t)
+  -- Restricting a unit of the rational-function sheaf restricts its underlying section.
+  have hrestrict :
+      TopCat.Presheaf.restrictOpen (F := (rationalUnitSheaf X).obj) t V h =
+        Additive.ofMul (Units.map
+          ((rationalFunctionsRing X).presheaf.map (homOfLE h).op).hom.toMonoidHom
+            (Additive.toMul t)) :=
+    CategoryTheory.Sheaf.additiveUnitsFunctor_obj_map_apply
+      (Opens.grothendieckTopology X) (rationalFunctionsRing X) (homOfLE h).op t
+  rw [hrestrict, hgt', rationalUnitSectionsEquiv_apply]
+  refine congrArg Additive.ofMul (Units.ext ?_)
+  simp
+
+/-- The class of a nonzero rational function commutes with restriction to a smaller nonempty
+open subset: a local equation stays a local equation. -/
+@[simp]
+lemma rationalUnitClass_restrict {U V : X.Opens} [Nonempty U] [Nonempty V] (h : V ≤ U)
+    (g : Additive X.functionFieldˣ) :
+    (rationalUnitClass X U g) |_ V = rationalUnitClass X V g := by
+  have hmap :
+      ((toCartierDivisorSheaf X).hom.app (op V)).hom
+          (TopCat.Presheaf.restrictOpen (F := (rationalUnitSheaf X).obj)
+            ((rationalUnitSectionsEquiv X U).symm g) V h) =
+        (rationalUnitClass X U g) |_ V :=
+    TopCat.Presheaf.map_restrict (toCartierDivisorSheaf X).hom h _
+  rw [← hmap, rationalUnitSectionsEquiv_symm_restrict]
+  rfl
+
+/-- A regular unit on `U` has zero Cartier-divisor class over `U`. -/
+@[simp]
+lemma rationalUnitClass_germToFunctionField (U : X.Opens) [Nonempty U]
+    (f : ((X.presheaf.obj (op U)) : Type u)ˣ) :
+    rationalUnitClass X U
+      (Additive.ofMul (Units.map (X.germToFunctionField U).hom f)) = 0 := by
+  have hsymm :
+      (rationalUnitSectionsEquiv X U).symm
+          (Additive.ofMul (regularUnitToFunctionField X U f)) =
+        ((toRationalUnitSheaf X).hom.app (op U)).hom (Additive.ofMul f) := by
+    apply (rationalUnitSectionsEquiv X U).injective
+    rw [AddEquiv.apply_symm_apply]
+    exact (rationalUnitSectionsEquiv_toRationalUnitSheaf_app X U f).symm
+  have hzero :
+      ((toCartierDivisorSheaf X).hom.app (op U)).hom
+        (((toRationalUnitSheaf X).hom.app (op U)).hom (Additive.ofMul f)) = 0 := by
+    have hcomp := toRationalUnitSheaf_comp_toCartierDivisorSheaf X
+    have happ := congrArg (fun k ↦ k.hom.app (op U)) hcomp
+    exact ConcreteCategory.congr_hom happ (Additive.ofMul f)
+  refine (congrArg (rationalUnitClass X U)
+    (congrArg Additive.ofMul (regularUnitToFunctionField_apply X U f).symm)).trans ?_
+  change ((toCartierDivisorSheaf X).hom.app (op U)).hom
+    ((rationalUnitSectionsEquiv X U).symm
+      (Additive.ofMul (regularUnitToFunctionField X U f))) = 0
+  rw [hsymm]
+  exact hzero
 
 /-- A nonzero rational function determines its principal Cartier divisor. The multiplicative
 group of the function field is written additively in the domain. -/
 def principalCartierDivisorAddHom : Additive X.functionFieldˣ →+ CartierDivisor X :=
-  (toCartierDivisor X).comp (rationalUnitSectionsEquiv X).symm.toAddMonoidHom
+  rationalUnitClass X ⊤
 
 /-- The principal Cartier divisor of a nonzero rational function. -/
 def principalCartierDivisor (f : X.functionFieldˣ) : CartierDivisor X :=
@@ -240,33 +320,23 @@ lemma principalCartierDivisor_inv (f : X.functionFieldˣ) :
 lemma principalCartierDivisor_regularUnitToFunctionField
     (f : ((X.presheaf.obj (op (⊤ : X.Opens))) : Type u)ˣ) :
     principalCartierDivisor X
-      (Units.map (X.germToFunctionField (⊤ : X.Opens)).hom f) = 0 := by
-  refine (congrArg (principalCartierDivisor X)
-    (regularUnitToFunctionField_apply X f).symm).trans ?_
-  have hsymm :
-      (rationalUnitSectionsEquiv X).symm
-          (Additive.ofMul (regularUnitToFunctionField X f)) =
-        ((toRationalUnitSheaf X).hom.app
-          (op (⊤ : X.Opens))).hom (Additive.ofMul f) := by
-    apply (rationalUnitSectionsEquiv X).injective
-    rw [AddEquiv.apply_symm_apply]
-    exact (rationalUnitSectionsEquiv_toRationalUnitSheaf_app X f).symm
-  calc
-    principalCartierDivisor X (regularUnitToFunctionField X f) =
-        (toCartierDivisor X) ((rationalUnitSectionsEquiv X).symm
-          (Additive.ofMul (regularUnitToFunctionField X f))) := rfl
-    _ = (toCartierDivisor X)
-        (((toRationalUnitSheaf X).hom.app
-          (op (⊤ : X.Opens))).hom (Additive.ofMul f)) := congrArg _ hsymm
-    _ = 0 := by
-      have hzero := DFunLike.congr_fun
-        (toRationalUnitSheaf_app_comp_toCartierDivisor X) (Additive.ofMul f)
-      -- Evaluating the categorical composite gives the definitionally equal composite of
-      -- the underlying additive homomorphisms.
-      change (toCartierDivisor X)
-        (((toRationalUnitSheaf X).hom.app
-          (op (⊤ : X.Opens))).hom (Additive.ofMul f)) = 0 at hzero
-      exact hzero
+      (Units.map (X.germToFunctionField (⊤ : X.Opens)).hom f) = 0 :=
+  rationalUnitClass_germToFunctionField X ⊤ f
+
+/-- Restricting a principal Cartier divisor to a nonempty open subset gives the class of the same
+rational function there: a principal divisor has a global equation. -/
+@[simp]
+lemma principalCartierDivisorAddHom_restrict (g : Additive X.functionFieldˣ) (U : X.Opens)
+    [Nonempty U] :
+    (principalCartierDivisorAddHom X g) |_ U = rationalUnitClass X U g :=
+  rationalUnitClass_restrict X le_top g
+
+/-- Restricting a principal Cartier divisor to a nonempty open subset gives the class of the same
+rational function there. -/
+@[simp]
+lemma principalCartierDivisor_restrict (f : X.functionFieldˣ) (U : X.Opens) [Nonempty U] :
+    (principalCartierDivisor X f) |_ U = rationalUnitClass X U (Additive.ofMul f) :=
+  principalCartierDivisorAddHom_restrict X (Additive.ofMul f) U
 
 end Scheme
 

--- a/TauCeti/AlgebraicGeometry/CartierDivisor/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/CartierDivisor/Basic.lean
@@ -258,22 +258,24 @@ open subset: a local equation stays a local equation. -/
 @[simp]
 lemma rationalUnitClass_restrict {U V : X.Opens} [Nonempty U] [Nonempty V] (h : V ≤ U)
     (g : Additive X.functionFieldˣ) :
-    (rationalUnitClass X U g) |_ V = rationalUnitClass X V g := by
-  have hmap :
-      ((toCartierDivisorSheaf X).hom.app (op V)).hom
+    ((toCartierDivisorSheaf X).hom.app (op U)).hom
+        ((rationalUnitSectionsEquiv X U).symm g) |_ V = rationalUnitClass X V g := by
+  calc
+    _ = ((toCartierDivisorSheaf X).hom.app (op V)).hom
           (TopCat.Presheaf.restrictOpen (F := (rationalUnitSheaf X).obj)
-            ((rationalUnitSectionsEquiv X U).symm g) V h) =
-        (rationalUnitClass X U g) |_ V :=
-    TopCat.Presheaf.map_restrict (toCartierDivisorSheaf X).hom h _
-  rw [← hmap, rationalUnitSectionsEquiv_symm_restrict]
-  rfl
+            ((rationalUnitSectionsEquiv X U).symm g) V h) :=
+      (TopCat.Presheaf.map_restrict (toCartierDivisorSheaf X).hom h _).symm
+    _ = _ := by rw [rationalUnitSectionsEquiv_symm_restrict, ← rationalUnitClass_apply]
 
 /-- A regular unit on `U` has zero Cartier-divisor class over `U`. -/
 @[simp]
 lemma rationalUnitClass_germToFunctionField_eq_zero (U : X.Opens) [Nonempty U]
     (f : ((X.presheaf.obj (op U)) : Type u)ˣ) :
-    rationalUnitClass X U
-      (Additive.ofMul (Units.map (X.germToFunctionField U).hom f)) = 0 := by
+    ((toCartierDivisorSheaf X).hom.app (op U)).hom
+      ((rationalUnitSectionsEquiv X U).symm
+        (Additive.ofMul (Units.map (X.germToFunctionField U).hom f))) = 0 := by
+  change rationalUnitClass X U
+    (Additive.ofMul (Units.map (X.germToFunctionField U).hom f)) = 0
   have hsymm :
       (rationalUnitSectionsEquiv X U).symm
           (Additive.ofMul (regularUnitToFunctionField X U f)) =

--- a/TauCeti/AlgebraicGeometry/CartierDivisor/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/CartierDivisor/Basic.lean
@@ -218,7 +218,6 @@ def rationalUnitClass (U : X.Opens) [Nonempty U] :
 
 /-- Evaluating the rational-unit class applies the quotient map to the corresponding rational
 unit section. -/
-@[simp]
 lemma rationalUnitClass_apply (U : X.Opens) [Nonempty U] (g : Additive X.functionFieldˣ) :
     rationalUnitClass X U g = ((toCartierDivisorSheaf X).hom.app (op U)).hom
       ((rationalUnitSectionsEquiv X U).symm g) :=
@@ -258,8 +257,8 @@ open subset: a local equation stays a local equation. -/
 @[simp]
 lemma rationalUnitClass_restrict {U V : X.Opens} [Nonempty U] [Nonempty V] (h : V ≤ U)
     (g : Additive X.functionFieldˣ) :
-    ((toCartierDivisorSheaf X).hom.app (op U)).hom
-        ((rationalUnitSectionsEquiv X U).symm g) |_ V = rationalUnitClass X V g := by
+    rationalUnitClass X U g |_ V = rationalUnitClass X V g := by
+  rw [rationalUnitClass_apply]
   calc
     _ = ((toCartierDivisorSheaf X).hom.app (op V)).hom
           (TopCat.Presheaf.restrictOpen (F := (rationalUnitSheaf X).obj)
@@ -271,10 +270,8 @@ lemma rationalUnitClass_restrict {U V : X.Opens} [Nonempty U] [Nonempty V] (h : 
 @[simp]
 lemma rationalUnitClass_germToFunctionField_eq_zero (U : X.Opens) [Nonempty U]
     (f : ((X.presheaf.obj (op U)) : Type u)ˣ) :
-    ((toCartierDivisorSheaf X).hom.app (op U)).hom
-      ((rationalUnitSectionsEquiv X U).symm
-        (Additive.ofMul (Units.map (X.germToFunctionField U).hom f))) = 0 := by
-  rw [← rationalUnitClass_apply]
+    rationalUnitClass X U
+      (Additive.ofMul (Units.map (X.germToFunctionField U).hom f)) = 0 := by
   have hsymm :
       (rationalUnitSectionsEquiv X U).symm
           (Additive.ofMul (regularUnitToFunctionField X U f)) =

--- a/TauCeti/AlgebraicGeometry/CartierDivisor/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/CartierDivisor/Basic.lean
@@ -216,6 +216,14 @@ def rationalUnitClass (U : X.Opens) [Nonempty U] :
   (((toCartierDivisorSheaf X).hom.app (op U)).hom).comp
     (rationalUnitSectionsEquiv X U).symm.toAddMonoidHom
 
+/-- Evaluating the rational-unit class applies the quotient map to the corresponding rational
+unit section. -/
+@[simp]
+lemma rationalUnitClass_apply (U : X.Opens) [Nonempty U] (g : Additive X.functionFieldˣ) :
+    rationalUnitClass X U g = ((toCartierDivisorSheaf X).hom.app (op U)).hom
+      ((rationalUnitSectionsEquiv X U).symm g) :=
+  AddMonoidHom.comp_apply _ _ _
+
 /-- Restricting a rational unit to a smaller nonempty open subset does not change the underlying
 nonzero rational function. -/
 @[simp]
@@ -262,7 +270,7 @@ lemma rationalUnitClass_restrict {U V : X.Opens} [Nonempty U] [Nonempty V] (h : 
 
 /-- A regular unit on `U` has zero Cartier-divisor class over `U`. -/
 @[simp]
-lemma rationalUnitClass_germToFunctionField (U : X.Opens) [Nonempty U]
+lemma rationalUnitClass_germToFunctionField_eq_zero (U : X.Opens) [Nonempty U]
     (f : ((X.presheaf.obj (op U)) : Type u)ˣ) :
     rationalUnitClass X U
       (Additive.ofMul (Units.map (X.germToFunctionField U).hom f)) = 0 := by
@@ -281,9 +289,7 @@ lemma rationalUnitClass_germToFunctionField (U : X.Opens) [Nonempty U]
     exact ConcreteCategory.congr_hom happ (Additive.ofMul f)
   refine (congrArg (rationalUnitClass X U)
     (congrArg Additive.ofMul (regularUnitToFunctionField_apply X U f).symm)).trans ?_
-  change ((toCartierDivisorSheaf X).hom.app (op U)).hom
-    ((rationalUnitSectionsEquiv X U).symm
-      (Additive.ofMul (regularUnitToFunctionField X U f))) = 0
+  rw [rationalUnitClass_apply]
   rw [hsymm]
   exact hzero
 
@@ -321,7 +327,7 @@ lemma principalCartierDivisor_regularUnitToFunctionField
     (f : ((X.presheaf.obj (op (⊤ : X.Opens))) : Type u)ˣ) :
     principalCartierDivisor X
       (Units.map (X.germToFunctionField (⊤ : X.Opens)).hom f) = 0 :=
-  rationalUnitClass_germToFunctionField X ⊤ f
+  rationalUnitClass_germToFunctionField_eq_zero X ⊤ f
 
 /-- Restricting a principal Cartier divisor to a nonempty open subset gives the class of the same
 rational function there: a principal divisor has a global equation. -/

--- a/TauCeti/AlgebraicGeometry/CartierDivisor/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/CartierDivisor/Basic.lean
@@ -274,8 +274,7 @@ lemma rationalUnitClass_germToFunctionField_eq_zero (U : X.Opens) [Nonempty U]
     ((toCartierDivisorSheaf X).hom.app (op U)).hom
       ((rationalUnitSectionsEquiv X U).symm
         (Additive.ofMul (Units.map (X.germToFunctionField U).hom f))) = 0 := by
-  change rationalUnitClass X U
-    (Additive.ofMul (Units.map (X.germToFunctionField U).hom f)) = 0
+  rw [← rationalUnitClass_apply]
   have hsymm :
       (rationalUnitSectionsEquiv X U).symm
           (Additive.ofMul (regularUnitToFunctionField X U f)) =
@@ -291,8 +290,7 @@ lemma rationalUnitClass_germToFunctionField_eq_zero (U : X.Opens) [Nonempty U]
     exact ConcreteCategory.congr_hom happ (Additive.ofMul f)
   refine (congrArg (rationalUnitClass X U)
     (congrArg Additive.ofMul (regularUnitToFunctionField_apply X U f).symm)).trans ?_
-  rw [rationalUnitClass_apply]
-  rw [hsymm]
+  rw [rationalUnitClass_apply, hsymm]
   exact hzero
 
 /-- A nonzero rational function determines its principal Cartier divisor. The multiplicative

--- a/TauCeti/AlgebraicGeometry/Modules/RationalFunctions.lean
+++ b/TauCeti/AlgebraicGeometry/Modules/RationalFunctions.lean
@@ -26,10 +26,8 @@ condition and the `𝒪_X`-module structure automatic.
 
 ## Main declarations
 
-* `TauCeti.AlgebraicGeometry.Scheme.genericPoint_mem` and
-  `TauCeti.AlgebraicGeometry.Scheme.nonempty_inf`, the two elementary facts about nonempty open
-  subsets of an irreducible scheme used throughout: they contain the generic point, and hence
-  meet pairwise;
+* `TauCeti.AlgebraicGeometry.Scheme.genericPoint_mem`, the elementary fact that every nonempty open
+  subset of an irreducible scheme contains the generic point;
 * `TauCeti.AlgebraicGeometry.Scheme.fromSpecFunctionField`, the canonical morphism
   `Spec K(X) ⟶ X` from the spectrum of the function field, and
   `TauCeti.AlgebraicGeometry.Scheme.fromSpecFunctionField_preimage`: it pulls a nonempty open
@@ -109,13 +107,6 @@ variable {X}
 /-- The generic point of an irreducible scheme lies in every nonempty open subset. -/
 theorem genericPoint_mem (U : X.Opens) [Nonempty U] : genericPoint X ∈ U :=
   ((genericPoint_spec X).mem_open_set_iff U.isOpen).mpr (by simpa using ‹Nonempty U›)
-
-/-- Two nonempty open subsets of an irreducible scheme meet: both contain the generic point.
-
-This is not an instance, because it would apply to its own hypotheses. -/
-theorem nonempty_inf (U V : X.Opens) [Nonempty U] [Nonempty V] :
-    Nonempty (U ⊓ V : X.Opens) :=
-  ⟨⟨genericPoint X, genericPoint_mem U, genericPoint_mem V⟩⟩
 
 instance instUniqueSpecFunctionField (X : Scheme.{u}) [IrreducibleSpace X] :
     Unique (Spec X.functionField) where

--- a/TauCeti/AlgebraicGeometry/Modules/RationalFunctions.lean
+++ b/TauCeti/AlgebraicGeometry/Modules/RationalFunctions.lean
@@ -26,6 +26,10 @@ condition and the `𝒪_X`-module structure automatic.
 
 ## Main declarations
 
+* `TauCeti.AlgebraicGeometry.Scheme.genericPoint_mem` and
+  `TauCeti.AlgebraicGeometry.Scheme.nonempty_inf`, the two elementary facts about nonempty open
+  subsets of an irreducible scheme used throughout: they contain the generic point, and hence
+  meet pairwise;
 * `TauCeti.AlgebraicGeometry.Scheme.fromSpecFunctionField`, the canonical morphism
   `Spec K(X) ⟶ X` from the spectrum of the function field, and
   `TauCeti.AlgebraicGeometry.Scheme.fromSpecFunctionField_preimage`: it pulls a nonempty open
@@ -105,6 +109,13 @@ variable {X}
 /-- The generic point of an irreducible scheme lies in every nonempty open subset. -/
 theorem genericPoint_mem (U : X.Opens) [Nonempty U] : genericPoint X ∈ U :=
   ((genericPoint_spec X).mem_open_set_iff U.isOpen).mpr (by simpa using ‹Nonempty U›)
+
+/-- Two nonempty open subsets of an irreducible scheme meet: both contain the generic point.
+
+This is not an instance, because it would apply to its own hypotheses. -/
+theorem nonempty_inf (U V : X.Opens) [Nonempty U] [Nonempty V] :
+    Nonempty (U ⊓ V : X.Opens) :=
+  ⟨⟨genericPoint X, genericPoint_mem U, genericPoint_mem V⟩⟩
 
 instance instUniqueSpecFunctionField (X : Scheme.{u}) [IrreducibleSpace X] :
     Unique (Spec X.functionField) where

--- a/TauCeti/AlgebraicGeometry/Scheme/Regular.lean
+++ b/TauCeti/AlgebraicGeometry/Scheme/Regular.lean
@@ -5,8 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.AlgebraicGeometry.WeilDivisor.Scheme.Basic
-public import Mathlib.AlgebraicGeometry.OrderOfVanishing
+public import TauCeti.AlgebraicGeometry.WeilDivisor.Scheme.Order
 public import Mathlib.RingTheory.Valuation.Discrete.IsDiscreteValuationRing
 
 /-!
@@ -27,10 +26,15 @@ of a regular function on `U`.
   with no proper generization the local ring is already the whole function field;
 * `TauCeti.AlgebraicGeometry.Scheme.exists_germToFunctionField_eq_of_ord_nonneg`: a rational
   function with nonnegative order at every codimension-one point of `U` is the germ at the generic
-  point of a section of `𝒪_X` over `U`.
+  point of a section of `𝒪_X` over `U`;
+* `TauCeti.AlgebraicGeometry.Scheme.exists_units_germToFunctionField_eq_of_ord_eq_zero`: a nonzero
+  rational function with *zero* order at every codimension-one point of `U` is the germ of a unit
+  of `Γ(X, U)`.
 
-The last statement is the one-dimensional case of algebraic Hartogs' principle, and it is the
-input that identifies the sheaf `𝒪_X(0)` of the zero divisor with the structure sheaf.
+The third statement is the one-dimensional case of algebraic Hartogs' principle, and it is the
+input that identifies the sheaf `𝒪_X(0)` of the zero divisor with the structure sheaf. The last
+one applies it to a function and to its inverse; it is the local comparison used to glue the
+local equations of a locally principal Weil divisor into a Cartier divisor.
 
 The argument follows Hartshorne, *Algebraic Geometry*, II.6.3A and Proposition II.6.11, in the
 dimension-one case where the intersection of the local rings can be taken over the points of `U`
@@ -144,6 +148,30 @@ theorem exists_germToFunctionField_eq_of_ord_nonneg
   have hres : X.presheaf.map (homOfLE (hVU y)).op a = s y := ha y
   rw [← hs y, ← hres,
     X.presheaf.germ_res_apply (homOfLE (hVU y)) (genericPoint X) (hgen _ (hne y)) a]
+
+/-- **A rational function without zeros or poles is a regular unit.** On a locally Noetherian
+integral scheme, let `U` be a nonempty open subset of dimension at most one whose codimension-one
+local rings are discrete valuation rings. A nonzero rational function whose order vanishes at
+every codimension-one point of `U` is the germ of a unit of `Γ(X, U)`.
+
+The proof applies algebraic Hartogs' principle to the function and to its inverse; the two
+resulting regular functions multiply to a section with germ `1`, hence to `1`. -/
+theorem exists_units_germToFunctionField_eq_of_ord_eq_zero
+    {U : X.Opens} [Nonempty U]
+    (hDVR : ∀ y : CodimensionOnePoint X, (y : X) ∈ U →
+      IsDiscreteValuationRing (X.presheaf.stalk (y : X)))
+    (hU : ∀ y ∈ U, coheight y ≤ 1) {f : X.functionFieldˣ}
+    (hf : ∀ (y : CodimensionOnePoint X), (y : X) ∈ U → X.ord (f : X.functionField) y = 0) :
+    ∃ a : Γ(X, U)ˣ, X.germToFunctionField U (a : Γ(X, U)) = (f : X.functionField) := by
+  obtain ⟨a, ha⟩ := exists_germToFunctionField_eq_of_ord_nonneg hDVR hU
+    (f := (f : X.functionField)) fun y hy ↦ (hf y hy).ge
+  obtain ⟨b, hb⟩ := exists_germToFunctionField_eq_of_ord_nonneg hDVR hU
+    (f := ((f⁻¹ : X.functionFieldˣ) : X.functionField)) fun y hy ↦ by
+      rw [Units.val_inv_eq_inv_val, ord_inv, hf y hy, neg_zero]
+  have hab : a * b = 1 := by
+    refine X.germToFunctionField_injective U ?_
+    rw [map_mul, ha, hb, map_one, Units.mul_inv]
+  exact ⟨⟨a, b, hab, (mul_comm b a).trans hab⟩, ha⟩
 
 end Scheme
 

--- a/TauCeti/AlgebraicGeometry/Scheme/Regular.lean
+++ b/TauCeti/AlgebraicGeometry/Scheme/Regular.lean
@@ -27,7 +27,7 @@ of a regular function on `U`.
 * `TauCeti.AlgebraicGeometry.Scheme.exists_germToFunctionField_eq_of_ord_nonneg`: a rational
   function with nonnegative order at every codimension-one point of `U` is the germ at the generic
   point of a section of `𝒪_X` over `U`;
-* `TauCeti.AlgebraicGeometry.Scheme.exists_units_germToFunctionField_eq_of_ord_eq_zero`: a nonzero
+* `TauCeti.AlgebraicGeometry.Scheme.exists_unit_germToFunctionField_eq_of_ord_eq_zero`: a nonzero
   rational function with *zero* order at every codimension-one point of `U` is the germ of a unit
   of `Γ(X, U)`.
 
@@ -154,9 +154,8 @@ integral scheme, let `U` be a nonempty open subset of dimension at most one whos
 local rings are discrete valuation rings. A nonzero rational function whose order vanishes at
 every codimension-one point of `U` is the germ of a unit of `Γ(X, U)`.
 
-The proof applies algebraic Hartogs' principle to the function and to its inverse; the two
-resulting regular functions multiply to a section with germ `1`, hence to `1`. -/
-theorem exists_units_germToFunctionField_eq_of_ord_eq_zero
+Simultaneous regularity of the function and its inverse makes the resulting section a unit. -/
+theorem exists_unit_germToFunctionField_eq_of_ord_eq_zero
     {U : X.Opens} [Nonempty U]
     (hDVR : ∀ y : CodimensionOnePoint X, (y : X) ∈ U →
       IsDiscreteValuationRing (X.presheaf.stalk (y : X)))

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Scheme/Cartier.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Scheme/Cartier.lean
@@ -1,0 +1,312 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.CartierDivisor.Basic
+public import TauCeti.AlgebraicGeometry.Scheme.Regular
+public import TauCeti.AlgebraicGeometry.WeilDivisor.Scheme.LocallyPrincipal
+
+/-!
+# The Cartier divisor of a locally principal Weil divisor
+
+Let `X` be a Noetherian integral scheme of dimension at most one whose codimension-one local
+rings are discrete valuation rings. A Weil divisor `D` on `X` which is locally principal is
+described near every point by one nonzero rational function, its *local equation* there. This
+file glues those local equations into a single Cartier divisor, that is, into a global section
+of `𝒦_X^× / 𝒪_X^×`.
+
+The gluing is possible because two local equations for the same divisor on the same open subset
+differ by a rational function of order zero at every codimension-one point, and such a function is
+a regular unit by the one-dimensional algebraic Hartogs' principle of
+`TauCeti/AlgebraicGeometry/Scheme/Regular.lean`. The resulting Cartier divisor is characterized —
+and hence uniquely determined — by the requirement that it restrict to the class of `g` over every
+open subset carrying a local equation `g`.
+
+## Main declarations
+
+* `SchemeWeilDivisor.rationalUnitClass_eq_of_forall_coeff_eq`: two local equations of the same
+  divisor have the same Cartier class;
+* `SchemeWeilDivisor.IsLocallyPrincipal.existsUnique_cartierDivisor`: the characterizing
+  existence-and-uniqueness statement;
+* `SchemeWeilDivisor.IsLocallyPrincipal.cartierDivisor`, the Cartier divisor of `D`, with its
+  defining property `SchemeWeilDivisor.IsLocallyPrincipal.cartierDivisor_restrict`;
+* `SchemeWeilDivisor.IsLocallyPrincipal.cartierDivisor_add` and
+  `SchemeWeilDivisor.cartierDivisor_principalDivisor`: the construction is additive and sends the
+  divisor of `g` to the principal Cartier divisor of `g`;
+* `SchemeWeilDivisor.toCartierDivisorHom`, the resulting homomorphism from the group of locally
+  principal Weil divisors to the group of Cartier divisors.
+
+This advances `TauCetiRoadmap/JacobianChallenge/README.md`, Layer A, target "Divisors on a curve:
+Weil divisors `⊕_x ℤ` and Cartier divisors; the dictionaries `Cartier ≃ line bundles` and (smooth
+curve) `Weil ≃ Cartier`". It supplies the forward map of the `Weil ≃ Cartier` dictionary; the
+inverse map, and the induced isomorphism `Cl(X) ≅ Pic X`, are left to later work.
+
+The construction follows Hartshorne, *Algebraic Geometry*, II.6.11, and the Stacks Project,
+*Divisors*, Tag 0BE9. No formalization is vendored: the gluing is Mathlib's unique gluing for
+sheaves on a topological space, applied to the Cartier-divisor sheaf.
+-/
+
+public section
+
+open AlgebraicGeometry CategoryTheory Opposite Order TopologicalSpace
+
+namespace TauCeti
+
+namespace AlgebraicGeometry
+
+universe u
+
+namespace SchemeWeilDivisor
+
+variable {X : Scheme.{u}} [IsIntegral X]
+
+noncomputable section
+
+section Curve
+
+variable [IsLocallyNoetherian X]
+  [∀ y : CodimensionOnePoint X, IsDiscreteValuationRing (X.presheaf.stalk (y : X))]
+
+/-- **Two local equations agree as Cartier divisors.** If two nonzero rational functions both have
+the coefficients of `D` as their orders at every codimension-one point of a nonempty open subset
+`U` of a curve, then they have the same class in `𝒦_X^× / 𝒪_X^×` over `U`.
+
+Their ratio has order zero at every codimension-one point of `U`, hence is a regular unit on `U`
+by the one-dimensional algebraic Hartogs' principle, and regular units have zero class. -/
+theorem rationalUnitClass_eq_of_forall_coeff_eq (hX : ∀ y : X, coheight y ≤ 1)
+    {D : SchemeWeilDivisor X} {U : X.Opens} [Nonempty U] {g h : Additive X.functionFieldˣ}
+    (hg : ∀ y : CodimensionOnePoint X, (y : X) ∈ U → WeilDivisor.coeff D y = orderAt y g)
+    (hh : ∀ y : CodimensionOnePoint X, (y : X) ∈ U → WeilDivisor.coeff D y = orderAt y h) :
+    Scheme.rationalUnitClass X U g = Scheme.rationalUnitClass X U h := by
+  have hord : ∀ y : CodimensionOnePoint X, (y : X) ∈ U →
+      X.ord ((Additive.toMul (g - h) : X.functionFieldˣ) : X.functionField) (y : X) = 0 := by
+    intro y hy
+    rw [← orderAt_apply y (g - h), map_sub, ← hg y hy, ← hh y hy, sub_self]
+  obtain ⟨u, hu⟩ := Scheme.exists_units_germToFunctionField_eq_of_ord_eq_zero
+    (U := U) (fun _ _ ↦ inferInstance) (fun y _ ↦ hX y) hord
+  have hunit : Units.map (X.germToFunctionField U).hom u = Additive.toMul (g - h) :=
+    Units.ext hu
+  have hzero := Scheme.rationalUnitClass_germToFunctionField X U u
+  rw [hunit] at hzero
+  refine sub_eq_zero.mp ?_
+  rw [← map_sub]
+  exact hzero
+
+/-- **The local criterion for the Cartier divisor of `D`.** If a Cartier divisor `E` restricts,
+near every point, to the class of a local equation of `D`, then it does so over *every* nonempty
+open subset carrying a local equation of `D`.
+
+This is the sheaf-separatedness step: the two sections agree on a cover of the given open
+subset. -/
+theorem restrict_eq_rationalUnitClass (hX : ∀ y : X, coheight y ≤ 1)
+    {D : SchemeWeilDivisor X} {E : Scheme.CartierDivisor X}
+    (hE : ∀ x : X, ∃ (W : X.Opens) (_ : Nonempty W) (k : Additive X.functionFieldˣ), x ∈ W ∧
+      (∀ y : CodimensionOnePoint X, (y : X) ∈ W → WeilDivisor.coeff D y = orderAt y k) ∧
+      E |_ W = Scheme.rationalUnitClass X W k)
+    {U : X.Opens} [Nonempty U] {g : Additive X.functionFieldˣ}
+    (hg : ∀ y : CodimensionOnePoint X, (y : X) ∈ U → WeilDivisor.coeff D y = orderAt y g) :
+    E |_ U = Scheme.rationalUnitClass X U g := by
+  choose W hWne k hxW hk hEW using hE
+  have hne : ∀ x : X, Nonempty (W x ⊓ U : X.Opens) := fun x ↦
+    have := hWne x
+    Scheme.nonempty_inf (W x) U
+  refine (Scheme.cartierDivisorSheaf X).eq_of_locally_eq'
+    (fun x : X ↦ (W x ⊓ U : X.Opens)) U (fun x ↦ homOfLE inf_le_right)
+    (fun x hx ↦ Opens.mem_iSup.mpr ⟨x, ⟨hxW x, hx⟩⟩) _ _ fun x ↦ ?_
+  -- Needed as an instance for the classes over `W x ⊓ U` below.
+  have := hWne x
+  have hleft : E |_ (W x ⊓ U : X.Opens) =
+      Scheme.rationalUnitClass X (W x ⊓ U : X.Opens) (k x) := by
+    rw [← TopCat.Presheaf.restrict_restrict (inf_le_left : W x ⊓ U ≤ W x) (le_top : W x ≤ ⊤) E,
+      hEW x, Scheme.rationalUnitClass_restrict X inf_le_left]
+  have hright : (Scheme.rationalUnitClass X U g) |_ (W x ⊓ U : X.Opens) =
+      Scheme.rationalUnitClass X (W x ⊓ U : X.Opens) g :=
+    Scheme.rationalUnitClass_restrict X inf_le_right g
+  refine (TopCat.Presheaf.restrict_restrict (inf_le_right : W x ⊓ U ≤ U)
+    (le_top : U ≤ ⊤) E).trans
+      (hleft.trans ((rationalUnitClass_eq_of_forall_coeff_eq (D := D) hX
+        (fun y hy ↦ hk x y (Opens.mem_inf.mp hy).1)
+        fun y hy ↦ hg y (Opens.mem_inf.mp hy).2).trans hright.symm))
+
+namespace IsLocallyPrincipal
+
+variable {D E : SchemeWeilDivisor X}
+
+/-- **The Cartier divisor of a locally principal Weil divisor exists and is unique.** On a curve,
+a locally principal Weil divisor `D` determines a unique Cartier divisor whose restriction to
+every nonempty open subset carrying a local equation `g` of `D` is the class of `g`. -/
+theorem existsUnique_cartierDivisor (hX : ∀ y : X, coheight y ≤ 1)
+    (hD : IsLocallyPrincipal D) :
+    ∃! E : Scheme.CartierDivisor X, ∀ (U : X.Opens) (_ : Nonempty U)
+      (g : Additive X.functionFieldˣ),
+      (∀ y : CodimensionOnePoint X, (y : X) ∈ U → WeilDivisor.coeff D y = orderAt y g) →
+        E |_ U = Scheme.rationalUnitClass X U g := by
+  choose U hxU g hg using isLocallyPrincipal_iff.mp hD
+  have hne : ∀ x : X, Nonempty (U x) := fun x ↦ ⟨⟨x, hxU x⟩⟩
+  have hne₂ : ∀ x z : X, Nonempty (U x ⊓ U z : X.Opens) := fun x z ↦
+    Scheme.nonempty_inf (U x) (U z)
+  have hcompat : TopCat.Presheaf.IsCompatible (Scheme.cartierDivisorSheaf X).obj U
+      fun x ↦ Scheme.rationalUnitClass X (U x) (g x) := by
+    intro x z
+    have hx : (Scheme.rationalUnitClass X (U x) (g x)) |_ (U x ⊓ U z : X.Opens) =
+        Scheme.rationalUnitClass X (U x ⊓ U z : X.Opens) (g x) :=
+      Scheme.rationalUnitClass_restrict X inf_le_left (g x)
+    have hz : (Scheme.rationalUnitClass X (U z) (g z)) |_ (U x ⊓ U z : X.Opens) =
+        Scheme.rationalUnitClass X (U x ⊓ U z : X.Opens) (g z) :=
+      Scheme.rationalUnitClass_restrict X inf_le_right (g z)
+    exact hx.trans ((rationalUnitClass_eq_of_forall_coeff_eq (D := D) hX
+      (fun y hy ↦ hg x y (Opens.mem_inf.mp hy).1)
+      fun y hy ↦ hg z y (Opens.mem_inf.mp hy).2).trans hz.symm)
+  obtain ⟨E, hE, -⟩ := (Scheme.cartierDivisorSheaf X).existsUnique_gluing' U ⊤
+    (fun _ ↦ homOfLE le_top) (fun x _ ↦ Opens.mem_iSup.mpr ⟨x, hxU x⟩) _ hcompat
+  have hlocal : ∀ x : X, ∃ (W : X.Opens) (_ : Nonempty W) (k : Additive X.functionFieldˣ),
+      x ∈ W ∧
+      (∀ y : CodimensionOnePoint X, (y : X) ∈ W → WeilDivisor.coeff D y = orderAt y k) ∧
+      E |_ W = Scheme.rationalUnitClass X W k :=
+    fun x ↦ ⟨U x, hne x, g x, hxU x, hg x, hE x⟩
+  refine ⟨E, fun V hV k hk ↦ ?_, fun E' hE' ↦ ?_⟩
+  · -- The nonemptiness of `V` is carried by the statement, not by instance search.
+    have := hV
+    exact restrict_eq_rationalUnitClass hX hlocal hk
+  · refine (Scheme.cartierDivisorSheaf X).eq_of_locally_eq' U ⊤ (fun _ ↦ homOfLE le_top)
+      (fun x _ ↦ Opens.mem_iSup.mpr ⟨x, hxU x⟩) _ _ fun x ↦ ?_
+    exact (hE' (U x) (hne x) (g x) (hg x)).trans (hE x).symm
+
+/-- The Cartier divisor associated with a locally principal Weil divisor on a curve. -/
+def cartierDivisor (hX : ∀ y : X, coheight y ≤ 1) (hD : IsLocallyPrincipal D) :
+    Scheme.CartierDivisor X :=
+  (existsUnique_cartierDivisor hX hD).choose
+
+/-- **The defining property of the associated Cartier divisor.** Over a nonempty open subset
+carrying a local equation `g` of `D`, the Cartier divisor of `D` restricts to the class of `g`. -/
+theorem cartierDivisor_restrict (hX : ∀ y : X, coheight y ≤ 1) (hD : IsLocallyPrincipal D)
+    (U : X.Opens) [Nonempty U] (g : Additive X.functionFieldˣ)
+    (hg : ∀ y : CodimensionOnePoint X, (y : X) ∈ U → WeilDivisor.coeff D y = orderAt y g) :
+    (cartierDivisor hX hD) |_ U = Scheme.rationalUnitClass X U g :=
+  (existsUnique_cartierDivisor hX hD).choose_spec.1 U ‹_› g hg
+
+/-- A Cartier divisor which restricts, near every point, to the class of a local equation of `D`
+is the Cartier divisor of `D`. -/
+theorem eq_cartierDivisor (hX : ∀ y : X, coheight y ≤ 1) (hD : IsLocallyPrincipal D)
+    {E : Scheme.CartierDivisor X}
+    (hE : ∀ x : X, ∃ (W : X.Opens) (_ : Nonempty W) (k : Additive X.functionFieldˣ), x ∈ W ∧
+      (∀ y : CodimensionOnePoint X, (y : X) ∈ W → WeilDivisor.coeff D y = orderAt y k) ∧
+      E |_ W = Scheme.rationalUnitClass X W k) :
+    E = cartierDivisor hX hD := by
+  refine (existsUnique_cartierDivisor hX hD).choose_spec.2 E fun V hV k hk ↦ ?_
+  -- The nonemptiness of `V` is carried by the statement, not by instance search.
+  have := hV
+  exact restrict_eq_rationalUnitClass hX hE hk
+
+/-- The zero Weil divisor has the zero Cartier divisor. -/
+@[simp]
+theorem cartierDivisor_zero (hX : ∀ y : X, coheight y ≤ 1) :
+    cartierDivisor hX (isLocallyPrincipal_zero (X := X)) = 0 := by
+  refine (eq_cartierDivisor hX _ fun x ↦ ?_).symm
+  have hne : Nonempty (⊤ : X.Opens) := ⟨⟨x, trivial⟩⟩
+  refine ⟨⊤, hne, 0, trivial, ?_, ?_⟩
+  · intro y _
+    rw [WeilDivisor.coeff_zero, map_zero]
+  · rw [map_zero]
+    exact map_zero ((Scheme.cartierDivisorSheaf X).obj.map
+      (homOfLE (le_refl (⊤ : X.Opens))).op).hom
+
+/-- **The construction is additive.** The Cartier divisor of a sum of locally principal Weil
+divisors is the sum of their Cartier divisors: local equations multiply. -/
+theorem cartierDivisor_add (hX : ∀ y : X, coheight y ≤ 1) (hD : IsLocallyPrincipal D)
+    (hE : IsLocallyPrincipal E) :
+    cartierDivisor hX (hD.add hE) = cartierDivisor hX hD + cartierDivisor hX hE := by
+  refine (eq_cartierDivisor hX (hD.add hE) fun x ↦ ?_).symm
+  obtain ⟨V, hxV, g, hg⟩ := isLocallyPrincipal_iff.mp hD x
+  obtain ⟨W, hxW, h, hh⟩ := isLocallyPrincipal_iff.mp hE x
+  have hne : Nonempty (V ⊓ W : X.Opens) := ⟨⟨x, hxV, hxW⟩⟩
+  refine ⟨V ⊓ W, hne, g + h, ⟨hxV, hxW⟩, ?_, ?_⟩
+  · intro y hy
+    rw [WeilDivisor.coeff_add, hg y (Opens.mem_inf.mp hy).1, hh y (Opens.mem_inf.mp hy).2, map_add]
+  · have hV : (cartierDivisor hX hD) |_ (V ⊓ W : X.Opens) =
+        Scheme.rationalUnitClass X (V ⊓ W : X.Opens) g :=
+      cartierDivisor_restrict hX hD _ g fun y hy ↦ hg y (Opens.mem_inf.mp hy).1
+    have hW : (cartierDivisor hX hE) |_ (V ⊓ W : X.Opens) =
+        Scheme.rationalUnitClass X (V ⊓ W : X.Opens) h :=
+      cartierDivisor_restrict hX hE _ h fun y hy ↦ hh y (Opens.mem_inf.mp hy).2
+    rw [map_add, ← hV, ← hW]
+    exact map_add ((Scheme.cartierDivisorSheaf X).obj.map
+      (homOfLE (le_top : (V ⊓ W : X.Opens) ≤ ⊤)).op).hom _ _
+
+/-- **The construction respects negation.** -/
+theorem cartierDivisor_neg (hX : ∀ y : X, coheight y ≤ 1) (hD : IsLocallyPrincipal D) :
+    cartierDivisor hX hD.neg = -cartierDivisor hX hD := by
+  refine (eq_cartierDivisor hX hD.neg fun x ↦ ?_).symm
+  obtain ⟨V, hxV, g, hg⟩ := isLocallyPrincipal_iff.mp hD x
+  have hne : Nonempty V := ⟨⟨x, hxV⟩⟩
+  refine ⟨V, hne, -g, hxV, ?_, ?_⟩
+  · intro y hy
+    rw [WeilDivisor.coeff_neg, hg y hy, map_neg]
+  · have hV : (cartierDivisor hX hD) |_ V = Scheme.rationalUnitClass X V g :=
+      cartierDivisor_restrict hX hD _ g hg
+    rw [map_neg, ← hV]
+    exact map_neg ((Scheme.cartierDivisorSheaf X).obj.map
+      (homOfLE (le_top : V ≤ ⊤)).op).hom _
+
+end IsLocallyPrincipal
+
+end Curve
+
+section Noetherian
+
+variable [IsNoetherian X]
+  [∀ y : CodimensionOnePoint X, IsDiscreteValuationRing (X.presheaf.stalk (y : X))]
+
+/-- **A principal Weil divisor has the principal Cartier divisor of the same rational function.**
+The rational function is a global equation, so the two constructions agree over the whole
+scheme. -/
+theorem cartierDivisor_principalDivisor (hX : ∀ y : X, coheight y ≤ 1)
+    (g : Additive X.functionFieldˣ) :
+    IsLocallyPrincipal.cartierDivisor hX (isLocallyPrincipal_principalDivisor g) =
+      Scheme.principalCartierDivisorAddHom X g := by
+  refine (IsLocallyPrincipal.eq_cartierDivisor hX _ fun x ↦ ?_).symm
+  have hne : Nonempty (⊤ : X.Opens) := ⟨⟨x, trivial⟩⟩
+  refine ⟨⊤, hne, g, trivial, ?_, ?_⟩
+  · intro y _
+    rw [WeilDivisor.OrderSystem.coeff_principalDivisor, WeilDivisor.OrderSystem.ofScheme_ord]
+  · exact Scheme.principalCartierDivisorAddHom_restrict X g ⊤
+
+/-- **The Weil-to-Cartier homomorphism.** On a curve, the group of locally principal Weil divisors
+maps to the group of Cartier divisors, compatibly with local equations. -/
+def toCartierDivisorHom (hX : ∀ y : X, coheight y ≤ 1) :
+    locallyPrincipalSubgroup X →+ Scheme.CartierDivisor X where
+  toFun D := IsLocallyPrincipal.cartierDivisor hX (mem_locallyPrincipalSubgroup.mp D.2)
+  map_zero' := IsLocallyPrincipal.cartierDivisor_zero hX
+  map_add' D E := IsLocallyPrincipal.cartierDivisor_add hX
+    (mem_locallyPrincipalSubgroup.mp D.2) (mem_locallyPrincipalSubgroup.mp E.2)
+
+/-- The Weil-to-Cartier homomorphism computes the Cartier divisor of the underlying divisor. -/
+@[simp]
+lemma toCartierDivisorHom_apply (hX : ∀ y : X, coheight y ≤ 1)
+    (D : locallyPrincipalSubgroup X) :
+    toCartierDivisorHom hX D =
+      IsLocallyPrincipal.cartierDivisor hX (mem_locallyPrincipalSubgroup.mp D.2) :=
+  (rfl)
+
+/-- The Weil-to-Cartier homomorphism carries principal Weil divisors to principal Cartier
+divisors. -/
+theorem toCartierDivisorHom_principalDivisor (hX : ∀ y : X, coheight y ≤ 1)
+    (g : Additive X.functionFieldˣ) :
+    toCartierDivisorHom hX ⟨(WeilDivisor.OrderSystem.ofScheme X).principalDivisor g,
+        principalSubgroup_le_locallyPrincipalSubgroup
+          ((WeilDivisor.OrderSystem.ofScheme X).principalDivisor_mem_principalSubgroup g)⟩ =
+      Scheme.principalCartierDivisorAddHom X g :=
+  cartierDivisor_principalDivisor hX g
+
+end Noetherian
+
+end
+
+end SchemeWeilDivisor
+
+end AlgebraicGeometry
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Scheme/Cartier.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Scheme/Cartier.lean
@@ -89,7 +89,7 @@ theorem rationalUnitClass_eq_of_forall_coeff_eq {D : SchemeWeilDivisor X}
   rw [hunit] at hzero
   refine sub_eq_zero.mp ?_
   rw [← map_sub]
-  exact hzero
+  simpa only [Scheme.rationalUnitClass_apply, ofMul_toMul] using hzero
 
 /-- **The local criterion for the Cartier divisor of `D`.** If a Cartier divisor `E` restricts,
 near every point, to the class of a local equation of `D`, then it does so over *every* nonempty
@@ -116,13 +116,21 @@ theorem restrict_eq_rationalUnitClass {D : SchemeWeilDivisor X} {E : Scheme.Cart
     (fun x hx ↦ Opens.mem_iSup.mpr ⟨x, ⟨hxW x, hx⟩⟩) _ _ fun x ↦ ?_
   -- Needed as an instance for the classes over `W x ⊓ U` below.
   have := hWne x
+  have hrestrictLeft :
+      (Scheme.rationalUnitClass X (W x) (k x)) |_ (W x ⊓ U : X.Opens) =
+        Scheme.rationalUnitClass X (W x ⊓ U : X.Opens) (k x) := by
+    simpa only [Scheme.rationalUnitClass_apply] using
+      Scheme.rationalUnitClass_restrict (X := X) (U := W x) (V := W x ⊓ U)
+        inf_le_left (k x)
   have hleft : E |_ (W x ⊓ U : X.Opens) =
       Scheme.rationalUnitClass X (W x ⊓ U : X.Opens) (k x) := by
     rw [← TopCat.Presheaf.restrict_restrict (inf_le_left : W x ⊓ U ≤ W x) (le_top : W x ≤ ⊤) E,
-      hEW x, Scheme.rationalUnitClass_restrict X inf_le_left]
+      hEW x, hrestrictLeft]
   have hright : (Scheme.rationalUnitClass X U g) |_ (W x ⊓ U : X.Opens) =
-      Scheme.rationalUnitClass X (W x ⊓ U : X.Opens) g :=
-    Scheme.rationalUnitClass_restrict X inf_le_right g
+      Scheme.rationalUnitClass X (W x ⊓ U : X.Opens) g := by
+    simpa only [Scheme.rationalUnitClass_apply] using
+      Scheme.rationalUnitClass_restrict (X := X) (U := U) (V := W x ⊓ U)
+        inf_le_right g
   refine (TopCat.Presheaf.restrict_restrict (inf_le_right : W x ⊓ U ≤ U)
     (le_top : U ≤ ⊤) E).trans
       (hleft.trans ((rationalUnitClass_eq_of_forall_coeff_eq (D := D)
@@ -154,11 +162,15 @@ theorem existsUnique_cartierDivisor (hX : ∀ y : X, coheight y ≤ 1)
       fun x ↦ Scheme.rationalUnitClass X (U x) (g x) := by
     intro x z
     have hx : (Scheme.rationalUnitClass X (U x) (g x)) |_ (U x ⊓ U z : X.Opens) =
-        Scheme.rationalUnitClass X (U x ⊓ U z : X.Opens) (g x) :=
-      Scheme.rationalUnitClass_restrict X inf_le_left (g x)
+        Scheme.rationalUnitClass X (U x ⊓ U z : X.Opens) (g x) := by
+      simpa only [Scheme.rationalUnitClass_apply] using
+        Scheme.rationalUnitClass_restrict (X := X) (U := U x) (V := U x ⊓ U z)
+          inf_le_left (g x)
     have hz : (Scheme.rationalUnitClass X (U z) (g z)) |_ (U x ⊓ U z : X.Opens) =
-        Scheme.rationalUnitClass X (U x ⊓ U z : X.Opens) (g z) :=
-      Scheme.rationalUnitClass_restrict X inf_le_right (g z)
+        Scheme.rationalUnitClass X (U x ⊓ U z : X.Opens) (g z) := by
+      simpa only [Scheme.rationalUnitClass_apply] using
+        Scheme.rationalUnitClass_restrict (X := X) (U := U z) (V := U x ⊓ U z)
+          inf_le_right (g z)
     exact hx.trans ((rationalUnitClass_eq_of_forall_coeff_eq (D := D)
       (fun _ _ ↦ inferInstance) (fun y _ ↦ hX y)
       (fun y hy ↦ hg x y (Opens.mem_inf.mp hy).1)

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Scheme/Cartier.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Scheme/Cartier.lean
@@ -110,9 +110,9 @@ theorem restrict_eq_rationalUnitClass (hX : ∀ y : X, coheight y ≤ 1)
     (hg : ∀ y : CodimensionOnePoint X, (y : X) ∈ U → WeilDivisor.coeff D y = orderAt y g) :
     E |_ U = Scheme.rationalUnitClass X U g := by
   choose W hWne k hxW hk hEW using hE
-  have hne : ∀ x : X, Nonempty (W x ⊓ U : X.Opens) := fun x ↦
-    have := hWne x
-    Scheme.nonempty_inf (W x) U
+  have hne : ∀ x : X, Nonempty (W x ⊓ U : X.Opens) := fun x ↦ by
+    simpa using nonempty_preirreducible_inter (W x).isOpen U.isOpen
+      (by simpa using hWne x) (by simpa using (inferInstance : Nonempty U))
   refine (Scheme.cartierDivisorSheaf X).eq_of_locally_eq'
     (fun x : X ↦ (W x ⊓ U : X.Opens)) U (fun x ↦ homOfLE inf_le_right)
     (fun x hx ↦ Opens.mem_iSup.mpr ⟨x, ⟨hxW x, hx⟩⟩) _ _ fun x ↦ ?_
@@ -146,8 +146,9 @@ theorem existsUnique_cartierDivisor (hX : ∀ y : X, coheight y ≤ 1)
         E |_ U = Scheme.rationalUnitClass X U g := by
   choose U hxU g hg using isLocallyPrincipal_iff.mp hD
   have hne : ∀ x : X, Nonempty (U x) := fun x ↦ ⟨⟨x, hxU x⟩⟩
-  have hne₂ : ∀ x z : X, Nonempty (U x ⊓ U z : X.Opens) := fun x z ↦
-    Scheme.nonempty_inf (U x) (U z)
+  have hne₂ : ∀ x z : X, Nonempty (U x ⊓ U z : X.Opens) := fun x z ↦ by
+    simpa using nonempty_preirreducible_inter (U x).isOpen (U z).isOpen
+      (by simpa using hne x) (by simpa using hne z)
   have hcompat : TopCat.Presheaf.IsCompatible (Scheme.cartierDivisorSheaf X).obj U
       fun x ↦ Scheme.rationalUnitClass X (U x) (g x) := by
     intro x z

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Scheme/Cartier.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Scheme/Cartier.lean
@@ -39,14 +39,9 @@ open subset carrying a local equation `g`.
 * `SchemeWeilDivisor.toCartierDivisorHom`, the resulting homomorphism from the group of locally
   principal Weil divisors to the group of Cartier divisors.
 
-This advances `TauCetiRoadmap/JacobianChallenge/README.md`, Layer A, target "Divisors on a curve:
-Weil divisors `⊕_x ℤ` and Cartier divisors; the dictionaries `Cartier ≃ line bundles` and (smooth
-curve) `Weil ≃ Cartier`". It supplies the forward map of the `Weil ≃ Cartier` dictionary; the
-inverse map, and the induced isomorphism `Cl(X) ≅ Pic X`, are left to later work.
-
 The construction follows Hartshorne, *Algebraic Geometry*, II.6.11, and the Stacks Project,
-*Divisors*, Tag 0BE9. No formalization is vendored: the gluing is Mathlib's unique gluing for
-sheaves on a topological space, applied to the Cartier-divisor sheaf.
+*Divisors*, Tag 0BE9. The gluing uses Mathlib's unique gluing for sheaves on a topological space,
+applied to the Cartier-divisor sheaf.
 -/
 
 public section
@@ -68,7 +63,6 @@ noncomputable section
 section Curve
 
 variable [IsLocallyNoetherian X]
-  [∀ y : CodimensionOnePoint X, IsDiscreteValuationRing (X.presheaf.stalk (y : X))]
 
 /-- **Two local equations agree as Cartier divisors.** If two nonzero rational functions both have
 the coefficients of `D` as their orders at every codimension-one point of a nonempty open subset
@@ -76,8 +70,10 @@ the coefficients of `D` as their orders at every codimension-one point of a none
 
 Their ratio has order zero at every codimension-one point of `U`, hence is a regular unit on `U`
 by the one-dimensional algebraic Hartogs' principle, and regular units have zero class. -/
-theorem rationalUnitClass_eq_of_forall_coeff_eq (hX : ∀ y : X, coheight y ≤ 1)
-    {D : SchemeWeilDivisor X} {U : X.Opens} [Nonempty U] {g h : Additive X.functionFieldˣ}
+theorem rationalUnitClass_eq_of_forall_coeff_eq {D : SchemeWeilDivisor X}
+    {U : X.Opens} [Nonempty U] (hDVR : ∀ y : CodimensionOnePoint X, (y : X) ∈ U →
+      IsDiscreteValuationRing (X.presheaf.stalk (y : X)))
+    (hU : ∀ y ∈ U, coheight y ≤ 1) {g h : Additive X.functionFieldˣ}
     (hg : ∀ y : CodimensionOnePoint X, (y : X) ∈ U → WeilDivisor.coeff D y = orderAt y g)
     (hh : ∀ y : CodimensionOnePoint X, (y : X) ∈ U → WeilDivisor.coeff D y = orderAt y h) :
     Scheme.rationalUnitClass X U g = Scheme.rationalUnitClass X U h := by
@@ -85,11 +81,11 @@ theorem rationalUnitClass_eq_of_forall_coeff_eq (hX : ∀ y : X, coheight y ≤ 
       X.ord ((Additive.toMul (g - h) : X.functionFieldˣ) : X.functionField) (y : X) = 0 := by
     intro y hy
     rw [← orderAt_apply y (g - h), map_sub, ← hg y hy, ← hh y hy, sub_self]
-  obtain ⟨u, hu⟩ := Scheme.exists_units_germToFunctionField_eq_of_ord_eq_zero
-    (U := U) (fun _ _ ↦ inferInstance) (fun y _ ↦ hX y) hord
+  obtain ⟨u, hu⟩ := Scheme.exists_unit_germToFunctionField_eq_of_ord_eq_zero
+    (U := U) hDVR hU hord
   have hunit : Units.map (X.germToFunctionField U).hom u = Additive.toMul (g - h) :=
     Units.ext hu
-  have hzero := Scheme.rationalUnitClass_germToFunctionField X U u
+  have hzero := Scheme.rationalUnitClass_germToFunctionField_eq_zero X U u
   rw [hunit] at hzero
   refine sub_eq_zero.mp ?_
   rw [← map_sub]
@@ -101,12 +97,14 @@ open subset carrying a local equation of `D`.
 
 This is the sheaf-separatedness step: the two sections agree on a cover of the given open
 subset. -/
-theorem restrict_eq_rationalUnitClass (hX : ∀ y : X, coheight y ≤ 1)
-    {D : SchemeWeilDivisor X} {E : Scheme.CartierDivisor X}
+theorem restrict_eq_rationalUnitClass {D : SchemeWeilDivisor X} {E : Scheme.CartierDivisor X}
+    {U : X.Opens} [Nonempty U] (hDVR : ∀ y : CodimensionOnePoint X, (y : X) ∈ U →
+      IsDiscreteValuationRing (X.presheaf.stalk (y : X)))
+    (hU : ∀ y ∈ U, coheight y ≤ 1)
     (hE : ∀ x : X, ∃ (W : X.Opens) (_ : Nonempty W) (k : Additive X.functionFieldˣ), x ∈ W ∧
       (∀ y : CodimensionOnePoint X, (y : X) ∈ W → WeilDivisor.coeff D y = orderAt y k) ∧
       E |_ W = Scheme.rationalUnitClass X W k)
-    {U : X.Opens} [Nonempty U] {g : Additive X.functionFieldˣ}
+    {g : Additive X.functionFieldˣ}
     (hg : ∀ y : CodimensionOnePoint X, (y : X) ∈ U → WeilDivisor.coeff D y = orderAt y g) :
     E |_ U = Scheme.rationalUnitClass X U g := by
   choose W hWne k hxW hk hEW using hE
@@ -127,13 +125,16 @@ theorem restrict_eq_rationalUnitClass (hX : ∀ y : X, coheight y ≤ 1)
     Scheme.rationalUnitClass_restrict X inf_le_right g
   refine (TopCat.Presheaf.restrict_restrict (inf_le_right : W x ⊓ U ≤ U)
     (le_top : U ≤ ⊤) E).trans
-      (hleft.trans ((rationalUnitClass_eq_of_forall_coeff_eq (D := D) hX
+      (hleft.trans ((rationalUnitClass_eq_of_forall_coeff_eq (D := D)
+        (fun y hy ↦ hDVR y (Opens.mem_inf.mp hy).2)
+        (fun y hy ↦ hU y (Opens.mem_inf.mp hy).2)
         (fun y hy ↦ hk x y (Opens.mem_inf.mp hy).1)
         fun y hy ↦ hg y (Opens.mem_inf.mp hy).2).trans hright.symm))
 
 namespace IsLocallyPrincipal
 
 variable {D E : SchemeWeilDivisor X}
+  [∀ y : CodimensionOnePoint X, IsDiscreteValuationRing (X.presheaf.stalk (y : X))]
 
 /-- **The Cartier divisor of a locally principal Weil divisor exists and is unique.** On a curve,
 a locally principal Weil divisor `D` determines a unique Cartier divisor whose restriction to
@@ -158,7 +159,8 @@ theorem existsUnique_cartierDivisor (hX : ∀ y : X, coheight y ≤ 1)
     have hz : (Scheme.rationalUnitClass X (U z) (g z)) |_ (U x ⊓ U z : X.Opens) =
         Scheme.rationalUnitClass X (U x ⊓ U z : X.Opens) (g z) :=
       Scheme.rationalUnitClass_restrict X inf_le_right (g z)
-    exact hx.trans ((rationalUnitClass_eq_of_forall_coeff_eq (D := D) hX
+    exact hx.trans ((rationalUnitClass_eq_of_forall_coeff_eq (D := D)
+      (fun _ _ ↦ inferInstance) (fun y _ ↦ hX y)
       (fun y hy ↦ hg x y (Opens.mem_inf.mp hy).1)
       fun y hy ↦ hg z y (Opens.mem_inf.mp hy).2).trans hz.symm)
   obtain ⟨E, hE, -⟩ := (Scheme.cartierDivisorSheaf X).existsUnique_gluing' U ⊤
@@ -171,7 +173,7 @@ theorem existsUnique_cartierDivisor (hX : ∀ y : X, coheight y ≤ 1)
   refine ⟨E, fun V hV k hk ↦ ?_, fun E' hE' ↦ ?_⟩
   · -- The nonemptiness of `V` is carried by the statement, not by instance search.
     have := hV
-    exact restrict_eq_rationalUnitClass hX hlocal hk
+    exact restrict_eq_rationalUnitClass (fun _ _ ↦ inferInstance) (fun y _ ↦ hX y) hlocal hk
   · refine (Scheme.cartierDivisorSheaf X).eq_of_locally_eq' U ⊤ (fun _ ↦ homOfLE le_top)
       (fun x _ ↦ Opens.mem_iSup.mpr ⟨x, hxU x⟩) _ _ fun x ↦ ?_
     exact (hE' (U x) (hne x) (g x) (hg x)).trans (hE x).symm
@@ -200,7 +202,7 @@ theorem eq_cartierDivisor (hX : ∀ y : X, coheight y ≤ 1) (hD : IsLocallyPrin
   refine (existsUnique_cartierDivisor hX hD).choose_spec.2 E fun V hV k hk ↦ ?_
   -- The nonemptiness of `V` is carried by the statement, not by instance search.
   have := hV
-  exact restrict_eq_rationalUnitClass hX hE hk
+  exact restrict_eq_rationalUnitClass (fun _ _ ↦ inferInstance) (fun y _ ↦ hX y) hE hk
 
 /-- The zero Weil divisor has the zero Cartier divisor. -/
 @[simp]
@@ -217,6 +219,7 @@ theorem cartierDivisor_zero (hX : ∀ y : X, coheight y ≤ 1) :
 
 /-- **The construction is additive.** The Cartier divisor of a sum of locally principal Weil
 divisors is the sum of their Cartier divisors: local equations multiply. -/
+@[simp]
 theorem cartierDivisor_add (hX : ∀ y : X, coheight y ≤ 1) (hD : IsLocallyPrincipal D)
     (hE : IsLocallyPrincipal E) :
     cartierDivisor hX (hD.add hE) = cartierDivisor hX hD + cartierDivisor hX hE := by
@@ -238,6 +241,7 @@ theorem cartierDivisor_add (hX : ∀ y : X, coheight y ≤ 1) (hD : IsLocallyPri
       (homOfLE (le_top : (V ⊓ W : X.Opens) ≤ ⊤)).op).hom _ _
 
 /-- **The construction respects negation.** -/
+@[simp]
 theorem cartierDivisor_neg (hX : ∀ y : X, coheight y ≤ 1) (hD : IsLocallyPrincipal D) :
     cartierDivisor hX hD.neg = -cartierDivisor hX hD := by
   refine (eq_cartierDivisor hX hD.neg fun x ↦ ?_).symm
@@ -253,6 +257,25 @@ theorem cartierDivisor_neg (hX : ∀ y : X, coheight y ≤ 1) (hD : IsLocallyPri
       (homOfLE (le_top : V ≤ ⊤)).op).hom _
 
 end IsLocallyPrincipal
+
+variable [∀ y : CodimensionOnePoint X, IsDiscreteValuationRing (X.presheaf.stalk (y : X))]
+
+/-- **The Weil-to-Cartier homomorphism.** On a curve, the group of locally principal Weil divisors
+maps to the group of Cartier divisors, compatibly with local equations. -/
+def toCartierDivisorHom (hX : ∀ y : X, coheight y ≤ 1) :
+    locallyPrincipalSubgroup X →+ Scheme.CartierDivisor X where
+  toFun D := IsLocallyPrincipal.cartierDivisor hX (mem_locallyPrincipalSubgroup.mp D.2)
+  map_zero' := IsLocallyPrincipal.cartierDivisor_zero hX
+  map_add' D E := IsLocallyPrincipal.cartierDivisor_add hX
+    (mem_locallyPrincipalSubgroup.mp D.2) (mem_locallyPrincipalSubgroup.mp E.2)
+
+/-- The Weil-to-Cartier homomorphism computes the Cartier divisor of the underlying divisor. -/
+@[simp]
+lemma toCartierDivisorHom_apply (hX : ∀ y : X, coheight y ≤ 1)
+    (D : locallyPrincipalSubgroup X) :
+    toCartierDivisorHom hX D =
+      IsLocallyPrincipal.cartierDivisor hX (mem_locallyPrincipalSubgroup.mp D.2) :=
+  (rfl)
 
 end Curve
 
@@ -274,23 +297,6 @@ theorem cartierDivisor_principalDivisor (hX : ∀ y : X, coheight y ≤ 1)
   · intro y _
     rw [WeilDivisor.OrderSystem.coeff_principalDivisor, WeilDivisor.OrderSystem.ofScheme_ord]
   · exact Scheme.principalCartierDivisorAddHom_restrict X g ⊤
-
-/-- **The Weil-to-Cartier homomorphism.** On a curve, the group of locally principal Weil divisors
-maps to the group of Cartier divisors, compatibly with local equations. -/
-def toCartierDivisorHom (hX : ∀ y : X, coheight y ≤ 1) :
-    locallyPrincipalSubgroup X →+ Scheme.CartierDivisor X where
-  toFun D := IsLocallyPrincipal.cartierDivisor hX (mem_locallyPrincipalSubgroup.mp D.2)
-  map_zero' := IsLocallyPrincipal.cartierDivisor_zero hX
-  map_add' D E := IsLocallyPrincipal.cartierDivisor_add hX
-    (mem_locallyPrincipalSubgroup.mp D.2) (mem_locallyPrincipalSubgroup.mp E.2)
-
-/-- The Weil-to-Cartier homomorphism computes the Cartier divisor of the underlying divisor. -/
-@[simp]
-lemma toCartierDivisorHom_apply (hX : ∀ y : X, coheight y ≤ 1)
-    (D : locallyPrincipalSubgroup X) :
-    toCartierDivisorHom hX D =
-      IsLocallyPrincipal.cartierDivisor hX (mem_locallyPrincipalSubgroup.mp D.2) :=
-  (rfl)
 
 /-- The Weil-to-Cartier homomorphism carries principal Weil divisors to principal Cartier
 divisors. -/

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Scheme/Cartier.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Scheme/Cartier.lean
@@ -252,21 +252,21 @@ theorem cartierDivisor_add (hX : ∀ y : X, coheight y ≤ 1) (hD : IsLocallyPri
     exact map_add ((Scheme.cartierDivisorSheaf X).obj.map
       (homOfLE (le_top : (V ⊓ W : X.Opens) ≤ ⊤)).op).hom _ _
 
+/-- The Cartier divisor of a locally principal Weil divisor depends only on the divisor. -/
+theorem cartierDivisor_congr (hX : ∀ y : X, coheight y ≤ 1) (hD : IsLocallyPrincipal D)
+    (hE : IsLocallyPrincipal E) (h : D = E) : cartierDivisor hX hD = cartierDivisor hX hE := by
+  subst h
+  rfl
+
 /-- **The construction respects negation.** -/
 @[simp]
 theorem cartierDivisor_neg (hX : ∀ y : X, coheight y ≤ 1) (hD : IsLocallyPrincipal D) :
-    cartierDivisor hX hD.neg = -cartierDivisor hX hD := by
-  refine (eq_cartierDivisor hX hD.neg fun x ↦ ?_).symm
-  obtain ⟨V, hxV, g, hg⟩ := isLocallyPrincipal_iff.mp hD x
-  have hne : Nonempty V := ⟨⟨x, hxV⟩⟩
-  refine ⟨V, hne, -g, hxV, ?_, ?_⟩
-  · intro y hy
-    rw [WeilDivisor.coeff_neg, hg y hy, map_neg]
-  · have hV : (cartierDivisor hX hD) |_ V = Scheme.rationalUnitClass X V g :=
-      cartierDivisor_restrict hX hD _ g hg
-    rw [map_neg, ← hV]
-    exact map_neg ((Scheme.cartierDivisorSheaf X).obj.map
-      (homOfLE (le_top : V ≤ ⊤)).op).hom _
+    cartierDivisor hX hD.neg = -cartierDivisor hX hD :=
+  eq_neg_of_add_eq_zero_left <| by
+    rw [← cartierDivisor_add hX hD.neg hD,
+      cartierDivisor_congr hX (hD.neg.add hD) (isLocallyPrincipal_zero (X := X))
+        (neg_add_cancel D),
+      cartierDivisor_zero]
 
 end IsLocallyPrincipal
 
@@ -299,6 +299,7 @@ variable [IsNoetherian X]
 /-- **A principal Weil divisor has the principal Cartier divisor of the same rational function.**
 The rational function is a global equation, so the two constructions agree over the whole
 scheme. -/
+@[simp]
 theorem cartierDivisor_principalDivisor (hX : ∀ y : X, coheight y ≤ 1)
     (g : Additive X.functionFieldˣ) :
     IsLocallyPrincipal.cartierDivisor hX (isLocallyPrincipal_principalDivisor g) =

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Scheme/Cartier.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Scheme/Cartier.lean
@@ -12,11 +12,11 @@ public import TauCeti.AlgebraicGeometry.WeilDivisor.Scheme.LocallyPrincipal
 /-!
 # The Cartier divisor of a locally principal Weil divisor
 
-Let `X` be a Noetherian integral scheme of dimension at most one whose codimension-one local
-rings are discrete valuation rings. A Weil divisor `D` on `X` which is locally principal is
-described near every point by one nonzero rational function, its *local equation* there. This
-file glues those local equations into a single Cartier divisor, that is, into a global section
-of `𝒦_X^× / 𝒪_X^×`.
+Let `X` be a locally Noetherian integral scheme of dimension at most one whose codimension-one
+local rings are discrete valuation rings. A Weil divisor `D` on `X` which is locally principal
+is described near every point by one nonzero rational function, its *local equation* there.
+This file glues those local equations into a single Cartier divisor, that is, into a global
+section of `𝒦_X^× / 𝒪_X^×`.
 
 The gluing is possible because two local equations for the same divisor on the same open subset
 differ by a rational function of order zero at every codimension-one point, and such a function is
@@ -64,25 +64,24 @@ section Curve
 
 variable [IsLocallyNoetherian X]
 
-/-- **Two local equations agree as Cartier divisors.** If two nonzero rational functions both have
-the coefficients of `D` as their orders at every codimension-one point of a nonempty open subset
-`U` of a curve, then they have the same class in `𝒦_X^× / 𝒪_X^×` over `U`.
+/-- **Rational functions with the same orders agree as Cartier divisors.** If two nonzero rational
+functions have the same order at every codimension-one point of a nonempty open subset `U` of a
+curve, then they have the same class in `𝒦_X^× / 𝒪_X^×` over `U`.
 
 Their ratio has order zero at every codimension-one point of `U`, hence is a regular unit on `U`
 by the one-dimensional algebraic Hartogs' principle, and regular units have zero class. -/
-theorem rationalUnitClass_eq_of_forall_coeff_eq {D : SchemeWeilDivisor X}
-    {U : X.Opens} [Nonempty U] (hDVR : ∀ y : CodimensionOnePoint X, (y : X) ∈ U →
+theorem rationalUnitClass_eq_of_forall_orderAt_eq {U : X.Opens} [Nonempty U]
+    (hDVR : ∀ y : CodimensionOnePoint X, (y : X) ∈ U →
       IsDiscreteValuationRing (X.presheaf.stalk (y : X)))
     (hU : ∀ y ∈ U, coheight y ≤ 1) {g h : Additive X.functionFieldˣ}
-    (hg : ∀ y : CodimensionOnePoint X, (y : X) ∈ U → WeilDivisor.coeff D y = orderAt y g)
-    (hh : ∀ y : CodimensionOnePoint X, (y : X) ∈ U → WeilDivisor.coeff D y = orderAt y h) :
+    (hord : ∀ y : CodimensionOnePoint X, (y : X) ∈ U → orderAt y g = orderAt y h) :
     Scheme.rationalUnitClass X U g = Scheme.rationalUnitClass X U h := by
-  have hord : ∀ y : CodimensionOnePoint X, (y : X) ∈ U →
+  have hquotient : ∀ y : CodimensionOnePoint X, (y : X) ∈ U →
       X.ord ((Additive.toMul (g - h) : X.functionFieldˣ) : X.functionField) (y : X) = 0 := by
     intro y hy
-    rw [← orderAt_apply y (g - h), map_sub, ← hg y hy, ← hh y hy, sub_self]
+    rw [← orderAt_apply y (g - h), map_sub, hord y hy, sub_self]
   obtain ⟨u, hu⟩ := Scheme.exists_unit_germToFunctionField_eq_of_ord_eq_zero
-    (U := U) hDVR hU hord
+    (U := U) hDVR hU hquotient
   have hunit : Units.map (X.germToFunctionField U).hom u = Additive.toMul (g - h) :=
     Units.ext hu
   have hzero := Scheme.rationalUnitClass_germToFunctionField_eq_zero X U u
@@ -90,6 +89,18 @@ theorem rationalUnitClass_eq_of_forall_coeff_eq {D : SchemeWeilDivisor X}
   refine sub_eq_zero.mp ?_
   rw [← map_sub]
   simpa only [Scheme.rationalUnitClass_apply, ofMul_toMul] using hzero
+
+/-- **Two local equations agree as Cartier divisors.** If two nonzero rational functions both have
+the coefficients of `D` as their orders at every codimension-one point of a nonempty open subset
+`U` of a curve, then they have the same class in `𝒦_X^× / 𝒪_X^×` over `U`. -/
+theorem rationalUnitClass_eq_of_forall_coeff_eq {D : SchemeWeilDivisor X}
+    {U : X.Opens} [Nonempty U] (hDVR : ∀ y : CodimensionOnePoint X, (y : X) ∈ U →
+      IsDiscreteValuationRing (X.presheaf.stalk (y : X)))
+    (hU : ∀ y ∈ U, coheight y ≤ 1) {g h : Additive X.functionFieldˣ}
+    (hg : ∀ y : CodimensionOnePoint X, (y : X) ∈ U → WeilDivisor.coeff D y = orderAt y g)
+    (hh : ∀ y : CodimensionOnePoint X, (y : X) ∈ U → WeilDivisor.coeff D y = orderAt y h) :
+    Scheme.rationalUnitClass X U g = Scheme.rationalUnitClass X U h :=
+  rationalUnitClass_eq_of_forall_orderAt_eq hDVR hU fun y hy ↦ (hg y hy).symm.trans (hh y hy)
 
 /-- **The local criterion for the Cartier divisor of `D`.** If a Cartier divisor `E` restricts,
 near every point, to the class of a local equation of `D`, then it does so over *every* nonempty

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Scheme/Order.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Scheme/Order.lean
@@ -21,9 +21,10 @@ This is the local algebraic input for the scheme-theoretic principal-divisor map
 that map also requires the separate global theorem that a nonzero rational function has nonzero
 order at only finitely many codimension-one points; no finiteness assumption is hidden here.
 
-An elementary fact about `Scheme.ord` itself is recorded first: a function regular on `U` has
-nonnegative order at every point of `U` (`Scheme.ord_germToFunctionField_nonneg`), that is, it has
-no poles where it is defined.
+Elementary facts about `Scheme.ord` itself are recorded first: the order of one vanishes
+(`Scheme.ord_one`), the order of an inverse is the negative of the order (`Scheme.ord_inv`), and a
+function regular on `U` has nonnegative order at every point of `U`
+(`Scheme.ord_germToFunctionField_nonneg`), that is, it has no poles where it is defined.
 
 The construction advances `TauCetiRoadmap/JacobianChallenge/README.md`, Layer A, the
 "principal divisors" part of "Divisors on a curve". It reuses Mathlib's
@@ -47,6 +48,24 @@ noncomputable section
 
 namespace Scheme
 
+/-- The constant function one has order zero at every point: it is a global regular unit. -/
+@[simp]
+lemma ord_one {x : X} : X.ord (1 : X.functionField) x = 0 := by
+  let _ : Nonempty (⊤ : X.Opens) := ⟨⟨x, trivial⟩⟩
+  -- Naming this proof fixes the open set before elaborating `ord_of_isUnit`.
+  have hx_top : x ∈ (⊤ : X.Opens) := by simp
+  simpa using X.ord_of_isUnit (U := ⊤) isUnit_one hx_top
+
+/-- The order of an inverse is the negative of the order. Both sides vanish at the zero function,
+whose inverse is again zero. -/
+@[simp]
+lemma ord_inv (f : X.functionField) {x : X} : X.ord f⁻¹ x = -X.ord f x := by
+  rcases eq_or_ne f 0 with rfl | hf
+  · simp
+  · have h := X.ord_mul (x := x) hf (inv_ne_zero hf)
+    rw [mul_inv_cancel₀ hf, ord_one] at h
+    omega
+
 /-- A regular function on `U` has nonnegative order at every point of `U`: it has no poles where
 it is defined. -/
 lemma ord_germToFunctionField_nonneg {U : X.Opens} [Nonempty U] (a : Γ(X, U)) {x : X}
@@ -54,12 +73,7 @@ lemma ord_germToFunctionField_nonneg {U : X.Opens} [Nonempty U] (a : Γ(X, U)) {
   rcases eq_or_ne a 0 with rfl | ha
   · simp
   · have h := Scheme.ord_le_smul hx ha (1 : X.functionField)
-    let _ : Nonempty (⊤ : X.Opens) := ⟨⟨x, trivial⟩⟩
-    -- Naming this proof fixes the open set before elaborating `ord_of_isUnit`.
-    have hx_top : x ∈ (⊤ : X.Opens) := by simp
-    have h_one : X.ord (1 : X.functionField) x = 0 := by
-      simpa using X.ord_of_isUnit (U := ⊤) isUnit_one hx_top
-    rwa [Algebra.smul_def, mul_one, RingHom.algebraMap_toAlgebra, h_one] at h
+    rwa [Algebra.smul_def, mul_one, RingHom.algebraMap_toAlgebra, ord_one] at h
 
 end Scheme
 

--- a/TauCeti/CategoryTheory/Sites/Units.lean
+++ b/TauCeti/CategoryTheory/Sites/Units.lean
@@ -21,6 +21,9 @@ The construction is pointwise: the units functor is a right adjoint and therefor
 limits in the sheaf condition. Thus a sheaf of commutative rings `F` gives a sheaf whose sections
 over `U` are `Additive (F(U)ˣ)`.
 
+The sections and the restriction maps of the resulting sheaf are computed by
+`additiveUnitsFunctor_obj_obj` and `additiveUnitsFunctor_obj_map_apply`.
+
 This is the categorical input for the Cartier-divisor sheaf
 `𝒦_X^× / 𝒪_X^×` in `TauCeti/AlgebraicGeometry/CartierDivisor/Basic.lean`. No formalization is
 vendored; the construction composes Mathlib's `CommMonCat.units`, the multiplicative-to-additive
@@ -66,6 +69,18 @@ lemma additiveUnitsFunctor_map_app_apply {F G : Sheaf J CommRingCat.{u}} (f : F 
       (AddCommGrpCat.of (Additive ((G.obj.obj U : CommRingCat.{u})ˣ)))
       (((additiveUnitsFunctor J).map f).hom.app U)) x =
       Additive.ofMul (Units.map (f.hom.app U).hom.toMonoidHom (Additive.toMul x)) :=
+  rfl
+
+/-- Restricting a section of the additive units sheaf applies the restriction map of the
+underlying sheaf of rings to the underlying unit. -/
+@[simp]
+lemma additiveUnitsFunctor_obj_map_apply (F : Sheaf J CommRingCat.{u}) {U V : Cᵒᵖ} (i : U ⟶ V)
+    (x : Additive ((F.obj.obj U : CommRingCat.{u})ˣ)) :
+    (@AddCommGrpCat.Hom.hom
+      (AddCommGrpCat.of (Additive ((F.obj.obj U : CommRingCat.{u})ˣ)))
+      (AddCommGrpCat.of (Additive ((F.obj.obj V : CommRingCat.{u})ˣ)))
+      (((additiveUnitsFunctor J).obj F).obj.map i)) x =
+      Additive.ofMul (Units.map (F.obj.map i).hom.toMonoidHom (Additive.toMul x)) :=
   rfl
 
 end CategoryTheory.Sheaf


### PR DESCRIPTION
This PR constructs the Cartier divisor of a locally principal Weil divisor on a curve, that is, the forward map of the `Weil ≃ Cartier` dictionary. Given a Noetherian integral scheme `X` of dimension at most one whose codimension-one local rings are discrete valuation rings, and a Weil divisor `D` with `SchemeWeilDivisor.IsLocallyPrincipal D`, the local equations of `D` are glued into a single global section of `𝒦_X^× / 𝒪_X^×`.

The key input is that two local equations of the same divisor over the same nonempty open subset have the same Cartier class: their ratio has order zero at every codimension-one point, hence is a regular unit. That last step is the new `TauCeti.AlgebraicGeometry.Scheme.exists_units_germToFunctionField_eq_of_ord_eq_zero`, which applies the one-dimensional algebraic Hartogs' principle already in `TauCeti/AlgebraicGeometry/Scheme/Regular.lean` to a function and to its inverse. From there `SchemeWeilDivisor.IsLocallyPrincipal.existsUnique_cartierDivisor` glues along a cover of local equations and pins the result down by the requirement that it restrict to the class of `g` over every open subset carrying a local equation `g`; that characterization then yields additivity, compatibility with negation, agreement with `Scheme.principalCartierDivisorAddHom` on principal divisors, and the homomorphism `SchemeWeilDivisor.toCartierDivisorHom : locallyPrincipalSubgroup X →+ Scheme.CartierDivisor X`.

This serves the Layer A milestone "Divisors on a curve: Weil divisors `⊕_x ℤ` and Cartier divisors; the dictionaries `Cartier ≃ line bundles` and (smooth curve) `Weil ≃ Cartier`; principal divisors; `Cl(X) ≅ Pic X`" of `TauCetiRoadmap/JacobianChallenge/README.md`. What remains for that milestone after this PR is the inverse map (a Cartier divisor's associated Weil divisor, via `Scheme.ord` of its local equations) and the resulting isomorphism `Cl(X) ≅ Pic X`.

Supporting changes, all in service of the above:

* `TauCeti/AlgebraicGeometry/WeilDivisor/Scheme/Order.lean` gains `Scheme.ord_one` and `Scheme.ord_inv`, two elementary `Scheme.ord` computations; the `ord 1 = 0` step was previously inlined in `ord_germToFunctionField_nonneg`, whose proof now reuses the named lemma.
* `TauCeti/AlgebraicGeometry/Modules/RationalFunctions.lean` gains `Scheme.nonempty_inf`, next to the existing `Scheme.genericPoint_mem` it is proved from.
* `TauCeti/CategoryTheory/Sites/Units.lean` gains `additiveUnitsFunctor_obj_map_apply`, the restriction-map counterpart of the existing `additiveUnitsFunctor_map_app_apply`.
* `TauCeti/AlgebraicGeometry/CartierDivisor/Basic.lean` generalises `rationalUnitSectionsEquiv`, `regularUnitToFunctionField` and `rationalUnitSectionsEquiv_toRationalUnitSheaf_app` from the whole space to an arbitrary nonempty open subset, and adds `Scheme.rationalUnitClass`, the class of a nonzero rational function in the Cartier-divisor sheaf over such a subset, together with its restriction and regular-unit lemmas. `Scheme.principalCartierDivisorAddHom` is now the case of the whole space; every existing statement about it is retained and reproved from the general one.

No formalization is vendored. The construction follows Hartshorne, *Algebraic Geometry*, II.6.11 and the Stacks Project, *Divisors*, Tag 0BE9; the gluing and separatedness steps are Mathlib's `TopCat.Sheaf.existsUnique_gluing'` and `TopCat.Sheaf.eq_of_locally_eq'`.

Roadmap: JacobianChallenge

<!--tauceti-target:v1 {"focus":"JacobianChallenge","id":"cartier-divisor-of-locally-principal-weil-divisor"}-->

🤖 Prepared with Claude Code
