### PR TITLE
refactor(Analysis): root the `Differentiable` and `DifferentiableOn` theorems

### DIFF
--- a/TauCeti/Analysis/Calculus/Sard/EqualDimension.lean
+++ b/TauCeti/Analysis/Calculus/Sard/EqualDimension.lean
@@ -32,9 +32,9 @@ higher-regularity argument when the dimensions differ.
 
 * `TauCeti.addHaar_image_eq_zero_of_not_surjective_fderivWithin`: a map between equal-dimensional
   spaces sends a set of nonsurjective derivative points to a null set.
-* `TauCeti.Differentiable.addHaar_image_criticalPoints_eq_zero`: the critical values of a globally
+* `Differentiable.addHaar_image_criticalPoints_eq_zero`: the critical values of a globally
   differentiable map between equal-dimensional spaces form a null set.
-* `TauCeti.Differentiable.dense_compl_image_criticalPoints`: the regular values of such a map are
+* `Differentiable.dense_compl_image_criticalPoints`: the regular values of such a map are
   dense.
 
 The measure-theoretic input follows Sébastien Gouëzel's Mathlib formalization of the change of
@@ -93,7 +93,7 @@ theorem addHaar_image_eq_zero_of_not_surjective_fderivWithin
 /-- The critical values of a differentiable map between equal-dimensional finite-dimensional real
 normed spaces have additive Haar measure zero. A point is critical here exactly when the Fréchet
 derivative is not surjective. -/
-theorem Differentiable.addHaar_image_criticalPoints_eq_zero
+theorem _root_.Differentiable.addHaar_image_criticalPoints_eq_zero
     (hf : Differentiable ℝ f) (hdim : finrank ℝ E = finrank ℝ F) :
     ν (f '' {x | ¬ Surjective (fderiv ℝ f x)}) = 0 := by
   apply addHaar_image_eq_zero_of_not_surjective_fderivWithin ν hdim
@@ -104,7 +104,7 @@ theorem Differentiable.addHaar_image_criticalPoints_eq_zero
 /-- The regular values of a differentiable map between equal-dimensional finite-dimensional real
 normed spaces are dense. Here the regular values are expressed as the complement of the image of
 the points where the Fréchet derivative is not surjective. -/
-theorem Differentiable.dense_compl_image_criticalPoints
+theorem _root_.Differentiable.dense_compl_image_criticalPoints
     (hf : Differentiable ℝ f) (hdim : finrank ℝ E = finrank ℝ F) :
     Dense (f '' {x | ¬ Surjective (fderiv ℝ f x)})ᶜ := by
   let t : Set F := f '' {x | ¬ Surjective (fderiv ℝ f x)}

--- a/TauCeti/Analysis/Calculus/Sard/FlatStratum.lean
+++ b/TauCeti/Analysis/Calculus/Sard/FlatStratum.lean
@@ -19,7 +19,7 @@ if `f` is `C^{k+1}` and every iterated derivative of order `1 ≤ i ≤ k` vanis
 Morse--Sard theorem this is the estimate for the innermost stratum `Σ_k` of the critical set, the
 one place where regularity beyond `C¹` is genuinely needed; the two slices already available,
 `TauCeti.addHaar_image_eq_zero_of_not_surjective_fderivWithin` (equal dimensions, `C¹`) and
-`TauCeti.Differentiable.addHaar_image_eq_zero_of_finrank_lt_finrank` (smaller source,
+`Differentiable.addHaar_image_eq_zero_of_finrank_lt_finrank` (smaller source,
 differentiable), neither says anything when the source dimension exceeds the target dimension.
 
 The argument is the classical one, but the covering estimate is replaced by Hausdorff dimension.

--- a/TauCeti/Analysis/Calculus/Sard/LowDimension.lean
+++ b/TauCeti/Analysis/Calculus/Sard/LowDimension.lean
@@ -28,17 +28,17 @@ higher-regularity Morse--Sard argument to the remaining case where the source di
 
 ## Main declarations
 
-* `TauCeti.DifferentiableOn.addHaar_image_eq_zero_of_dimH_lt_finrank`: a differentiable map on a
+* `DifferentiableOn.addHaar_image_eq_zero_of_dimH_lt_finrank`: a differentiable map on a
   set of sufficiently small Hausdorff dimension sends it to an additive-Haar-null set.
-* `TauCeti.Differentiable.addHaar_image_eq_zero_of_finrank_lt_finrank`: a differentiable map into a
+* `Differentiable.addHaar_image_eq_zero_of_finrank_lt_finrank`: a differentiable map into a
   strictly higher-dimensional space sends every subset to an additive-Haar-null set.
-* `TauCeti.Differentiable.addHaar_range_eq_zero_of_finrank_lt_finrank`: the whole range of such a
+* `Differentiable.addHaar_range_eq_zero_of_finrank_lt_finrank`: the whole range of such a
   map is additive-Haar-null.
 * `TauCeti.not_surjective_fderiv_of_finrank_lt_finrank`: every derivative in this dimension range
   is nonsurjective.
 * `TauCeti.setOf_not_surjective_fderiv_eq_univ_of_finrank_lt_finrank`: every point belongs to the
   critical locus in this dimension range.
-* `TauCeti.Differentiable.addHaar_image_not_surjective_fderiv_eq_zero_of_finrank_lt_finrank`: the
+* `Differentiable.addHaar_image_not_surjective_fderiv_eq_zero_of_finrank_lt_finrank`: the
   critical values are additive-Haar-null, in the form used by Sard's theorem.
 
 The Hausdorff-dimension argument follows the one used for the lower-dimensional Sard corollary in
@@ -64,7 +64,7 @@ the codomain sends that set to an additive-Haar-null set.
 
 The source may be any real normed space, the codomain may carry an arbitrary finite-dimensional
 norm, and `ν` may be any normalization of additive Haar measure. -/
-theorem DifferentiableOn.addHaar_image_eq_zero_of_dimH_lt_finrank
+theorem _root_.DifferentiableOn.addHaar_image_eq_zero_of_dimH_lt_finrank
     (hf : DifferentiableOn ℝ f s) (hsF : dimH s < finrank ℝ F) : ν (f '' s) = 0 := by
   have hν : ν ≪ (μH[(finrank ℝ F : ℝ)] : Measure F) :=
     absolutelyContinuous_isAddHaarMeasure ν _
@@ -74,7 +74,7 @@ theorem DifferentiableOn.addHaar_image_eq_zero_of_dimH_lt_finrank
 
 /-- A differentiable map from a finite-dimensional real normed space to a strictly
 higher-dimensional one sends every subset of its domain to an additive-Haar-null set. -/
-theorem Differentiable.addHaar_image_eq_zero_of_finrank_lt_finrank
+theorem _root_.Differentiable.addHaar_image_eq_zero_of_finrank_lt_finrank
     (hf : Differentiable ℝ f) (hEF : finrank ℝ E < finrank ℝ F) (t : Set E) :
     ν (f '' t) = 0 := by
   apply DifferentiableOn.addHaar_image_eq_zero_of_dimH_lt_finrank
@@ -85,7 +85,7 @@ theorem Differentiable.addHaar_image_eq_zero_of_finrank_lt_finrank
 /-- A differentiable map from a finite-dimensional real normed space to a strictly
 higher-dimensional one has additive-Haar-null range. This is the lower-dimensional-source case of
 Sard's theorem: every point of the source is critical because no derivative can be surjective. -/
-theorem Differentiable.addHaar_range_eq_zero_of_finrank_lt_finrank
+theorem _root_.Differentiable.addHaar_range_eq_zero_of_finrank_lt_finrank
     (hf : Differentiable ℝ f) (hEF : finrank ℝ E < finrank ℝ F) :
     ν (range f) = 0 := by
   rw [← image_univ]
@@ -114,7 +114,7 @@ theorem setOf_not_surjective_fderiv_eq_univ_of_finrank_lt_finrank (f : E → F)
 strictly higher-dimensional one have additive Haar measure zero. In this dimension range every
 point is critical, but stating the result for the critical locus gives the Sard form consumed by
 later regular-value arguments. -/
-theorem Differentiable.addHaar_image_not_surjective_fderiv_eq_zero_of_finrank_lt_finrank
+theorem _root_.Differentiable.addHaar_image_not_surjective_fderiv_eq_zero_of_finrank_lt_finrank
     (hf : Differentiable ℝ f) (hEF : finrank ℝ E < finrank ℝ F) :
     ν (f '' {x | ¬ Surjective (fderiv ℝ f x)}) = 0 := by
   rw [setOf_not_surjective_fderiv_eq_univ_of_finrank_lt_finrank f hEF, image_univ]

--- a/TauCeti/Analysis/Calculus/Sard/OutermostStratum.lean
+++ b/TauCeti/Analysis/Calculus/Sard/OutermostStratum.lean
@@ -25,8 +25,8 @@ target carries no measurable structure of its own.
 The strata of the critical set are handled in the neighbouring files, and this one supplies the
 outermost stratum, where the derivative is nonzero but not surjective, together with the assembly
 of all the strata into the theorem itself. The two earlier slices,
-`TauCeti.Differentiable.addHaar_image_criticalPoints_eq_zero` (equal dimensions),
-`TauCeti.Differentiable.addHaar_image_not_surjective_fderiv_eq_zero_of_finrank_lt_finrank`
+`Differentiable.addHaar_image_criticalPoints_eq_zero` (equal dimensions),
+`Differentiable.addHaar_image_not_surjective_fderiv_eq_zero_of_finrank_lt_finrank`
 (smaller source), are both subsumed by the statement proved here, which needs no relation between
 the two dimensions.
 

--- a/TauCeti/Analysis/Complex/Conformal/Biholomorph.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Biholomorph.lean
@@ -19,7 +19,7 @@ their source, target, inverse, and topological equivalence in one existing Mathl
 
 The forward map of `DifferentiableOn.toOpenPartialHomeomorph` is the original function, its source
 is the given open set, its target is the image, and its inverse is `Function.invFunOn`. The inverse
-is holomorphic by `TauCeti.DifferentiableOn.invFunOn`. Both directions are conformal: injectivity
+is holomorphic by `DifferentiableOn.invFunOn`. Both directions are conformal: injectivity
 on an open neighbourhood forces the complex derivative to be nonzero, so Mathlib's
 `DifferentiableAt.conformalAt` applies.
 
@@ -29,11 +29,11 @@ equivalence and `ConformalAt` API from a holomorphic bijection.
 
 ## Main declarations
 
-* `TauCeti.DifferentiableOn.toOpenPartialHomeomorph` packages an injective holomorphic map.
-* `TauCeti.DifferentiableOn.toHomeomorphOfBijOn` packages a holomorphic bijection between open
+* `DifferentiableOn.toOpenPartialHomeomorph` packages an injective holomorphic map.
+* `DifferentiableOn.toHomeomorphOfBijOn` packages a holomorphic bijection between open
   sets as a homeomorphism of their subtypes.
-* `TauCeti.DifferentiableOn.conformalAt_of_isOpen_of_injOn` proves its pointwise conformality.
-* `TauCeti.DifferentiableOn.conformalAt_toOpenPartialHomeomorph_symm` proves conformality of the
+* `DifferentiableOn.conformalAt_of_isOpen_of_injOn` proves its pointwise conformality.
+* `DifferentiableOn.conformalAt_toOpenPartialHomeomorph_symm` proves conformality of the
   inverse.
 
 ## Coordination with upstream Mathlib
@@ -57,7 +57,7 @@ image.
 
 On the image, `Function.invFunOn f U` selects the unique preimage in `U`; no injectivity of `f`
 outside `U` is required. -/
-noncomputable def DifferentiableOn.toOpenPartialHomeomorph
+noncomputable def _root_.DifferentiableOn.toOpenPartialHomeomorph
     (hf : DifferentiableOn ℂ f U) (hU : IsOpen U) (hinj : InjOn f U) :
     OpenPartialHomeomorph ℂ ℂ :=
   OpenPartialHomeomorph.ofContinuousOpenRestrict (hinj.toPartialEquiv f U) hf.continuousOn
@@ -66,96 +66,96 @@ noncomputable def DifferentiableOn.toOpenPartialHomeomorph
 /-- The source of the partial homeomorphism associated to an injective holomorphic map is its
 given domain. -/
 @[simp]
-theorem DifferentiableOn.toOpenPartialHomeomorph_source
+theorem _root_.DifferentiableOn.toOpenPartialHomeomorph_source
     (hf : DifferentiableOn ℂ f U) (hU : IsOpen U) (hinj : InjOn f U) :
-    (TauCeti.DifferentiableOn.toOpenPartialHomeomorph hf hU hinj).source = U :=
+    (DifferentiableOn.toOpenPartialHomeomorph hf hU hinj).source = U :=
   (rfl)
 
 /-- The target of the partial homeomorphism associated to an injective holomorphic map is its
 image. -/
 @[simp]
-theorem DifferentiableOn.toOpenPartialHomeomorph_target
+theorem _root_.DifferentiableOn.toOpenPartialHomeomorph_target
     (hf : DifferentiableOn ℂ f U) (hU : IsOpen U) (hinj : InjOn f U) :
-    (TauCeti.DifferentiableOn.toOpenPartialHomeomorph hf hU hinj).target = f '' U :=
+    (DifferentiableOn.toOpenPartialHomeomorph hf hU hinj).target = f '' U :=
   (rfl)
 
 /-- The partial homeomorphism associated to an injective holomorphic map applies as the original
 map. -/
 @[simp]
-theorem DifferentiableOn.toOpenPartialHomeomorph_apply
+theorem _root_.DifferentiableOn.toOpenPartialHomeomorph_apply
     (hf : DifferentiableOn ℂ f U) (hU : IsOpen U) (hinj : InjOn f U) (z : ℂ) :
-    TauCeti.DifferentiableOn.toOpenPartialHomeomorph hf hU hinj z = f z :=
+    DifferentiableOn.toOpenPartialHomeomorph hf hU hinj z = f z :=
   (rfl)
 
 /-- The underlying function of the partial homeomorphism associated to an injective holomorphic
 map is the original map. -/
 @[simp]
-theorem DifferentiableOn.toOpenPartialHomeomorph_coe
+theorem _root_.DifferentiableOn.toOpenPartialHomeomorph_coe
     (hf : DifferentiableOn ℂ f U) (hU : IsOpen U) (hinj : InjOn f U) :
-    (TauCeti.DifferentiableOn.toOpenPartialHomeomorph hf hU hinj : ℂ → ℂ) = f :=
-  funext (TauCeti.DifferentiableOn.toOpenPartialHomeomorph_apply hf hU hinj)
+    (DifferentiableOn.toOpenPartialHomeomorph hf hU hinj : ℂ → ℂ) = f :=
+  funext (DifferentiableOn.toOpenPartialHomeomorph_apply hf hU hinj)
 
 /-- The inverse of the partial homeomorphism associated to an injective holomorphic map is
 `Function.invFunOn` for the specified domain. -/
 @[simp]
-theorem DifferentiableOn.toOpenPartialHomeomorph_symm_apply
+theorem _root_.DifferentiableOn.toOpenPartialHomeomorph_symm_apply
     (hf : DifferentiableOn ℂ f U) (hU : IsOpen U) (hinj : InjOn f U) (w : ℂ) :
-    (TauCeti.DifferentiableOn.toOpenPartialHomeomorph hf hU hinj).symm w =
+    (DifferentiableOn.toOpenPartialHomeomorph hf hU hinj).symm w =
       Function.invFunOn f U w :=
   (rfl)
 
 /-- The underlying inverse function of the partial homeomorphism associated to an injective
 holomorphic map is `Function.invFunOn` for the specified domain. -/
 @[simp]
-theorem DifferentiableOn.toOpenPartialHomeomorph_coe_symm
+theorem _root_.DifferentiableOn.toOpenPartialHomeomorph_coe_symm
     (hf : DifferentiableOn ℂ f U) (hU : IsOpen U) (hinj : InjOn f U) :
-    ((TauCeti.DifferentiableOn.toOpenPartialHomeomorph hf hU hinj).symm : ℂ → ℂ) =
+    ((DifferentiableOn.toOpenPartialHomeomorph hf hU hinj).symm : ℂ → ℂ) =
       Function.invFunOn f U :=
-  funext (TauCeti.DifferentiableOn.toOpenPartialHomeomorph_symm_apply hf hU hinj)
+  funext (DifferentiableOn.toOpenPartialHomeomorph_symm_apply hf hU hinj)
 
 /-- Package a holomorphic bijection from an open set `U` onto a set `V` as a homeomorphism between
 the corresponding subtypes.
 
 This is the subtype equivalence carried by
-`TauCeti.DifferentiableOn.toOpenPartialHomeomorph`, with its target identified using the supplied
+`DifferentiableOn.toOpenPartialHomeomorph`, with its target identified using the supplied
 `BijOn` hypothesis. -/
-noncomputable def DifferentiableOn.toHomeomorphOfBijOn {V : Set ℂ}
+noncomputable def _root_.DifferentiableOn.toHomeomorphOfBijOn {V : Set ℂ}
     (hf : DifferentiableOn ℂ f U) (hU : IsOpen U) (hbij : BijOn f U V) : U ≃ₜ V :=
-  (TauCeti.DifferentiableOn.toOpenPartialHomeomorph hf hU hbij.injOn)
+  (DifferentiableOn.toOpenPartialHomeomorph hf hU hbij.injOn)
     |>.homeomorphOfImageSubsetSource
       (by
-        rw [TauCeti.DifferentiableOn.toOpenPartialHomeomorph_source hf hU hbij.injOn])
+        rw [DifferentiableOn.toOpenPartialHomeomorph_source hf hU hbij.injOn])
       (by
-        simpa only [TauCeti.DifferentiableOn.toOpenPartialHomeomorph_apply hf hU hbij.injOn]
+        simpa only [DifferentiableOn.toOpenPartialHomeomorph_apply hf hU hbij.injOn]
           using hbij.image_eq)
 
 /-- The homeomorphism induced by a holomorphic bijection applies as the original map. -/
 @[simp]
-theorem DifferentiableOn.toHomeomorphOfBijOn_apply {V : Set ℂ}
+theorem _root_.DifferentiableOn.toHomeomorphOfBijOn_apply {V : Set ℂ}
     (hf : DifferentiableOn ℂ f U) (hU : IsOpen U) (hbij : BijOn f U V) (z : U) :
-    ((TauCeti.DifferentiableOn.toHomeomorphOfBijOn hf hU hbij z : V) : ℂ) = f z :=
+    ((DifferentiableOn.toHomeomorphOfBijOn hf hU hbij z : V) : ℂ) = f z :=
   (rfl)
 
 /-- The inverse homeomorphism induced by a holomorphic bijection applies as
 `Function.invFunOn`. -/
 @[simp]
-theorem DifferentiableOn.toHomeomorphOfBijOn_symm_apply {V : Set ℂ}
+theorem _root_.DifferentiableOn.toHomeomorphOfBijOn_symm_apply {V : Set ℂ}
     (hf : DifferentiableOn ℂ f U) (hU : IsOpen U) (hbij : BijOn f U V) (w : V) :
-    (((TauCeti.DifferentiableOn.toHomeomorphOfBijOn hf hU hbij).symm w : U) : ℂ) =
+    (((DifferentiableOn.toHomeomorphOfBijOn hf hU hbij).symm w : U) : ℂ) =
       Function.invFunOn f U w :=
   (rfl)
 
 /-- The inverse of the open partial homeomorphism associated to an injective holomorphic map is
 holomorphic on its target. -/
-theorem DifferentiableOn.differentiableOn_toOpenPartialHomeomorph_symm
+theorem _root_.DifferentiableOn.differentiableOn_toOpenPartialHomeomorph_symm
     (hf : DifferentiableOn ℂ f U) (hU : IsOpen U) (hinj : InjOn f U) :
     DifferentiableOn ℂ
-      (TauCeti.DifferentiableOn.toOpenPartialHomeomorph hf hU hinj).symm (f '' U) := by
-  rw [TauCeti.DifferentiableOn.toOpenPartialHomeomorph_coe_symm hf hU hinj]
-  exact TauCeti.DifferentiableOn.invFunOn hf hU hinj
+      (DifferentiableOn.toOpenPartialHomeomorph hf hU hinj).symm (f '' U) := by
+  rw [DifferentiableOn.toOpenPartialHomeomorph_coe_symm hf hU hinj]
+  exact DifferentiableOn.invFunOn hf hU hinj
 
 /-- An injective holomorphic map on an open set is conformal at every point of that set. -/
-theorem DifferentiableOn.conformalAt_of_isOpen_of_injOn
+theorem _root_.DifferentiableOn.conformalAt_of_isOpen_of_injOn
     (hf : DifferentiableOn ℂ f U) (hU : IsOpen U) (hinj : InjOn f U)
     {z : ℂ} (hz : z ∈ U) : ConformalAt f z := by
   exact (hf.analyticAt (hU.mem_nhds hz)).differentiableAt.conformalAt
@@ -163,26 +163,26 @@ theorem DifferentiableOn.conformalAt_of_isOpen_of_injOn
 
 /-- The open partial homeomorphism associated to an injective holomorphic map is conformal on its
 source. -/
-theorem DifferentiableOn.conformalAt_toOpenPartialHomeomorph
+theorem _root_.DifferentiableOn.conformalAt_toOpenPartialHomeomorph
     (hf : DifferentiableOn ℂ f U) (hU : IsOpen U) (hinj : InjOn f U)
     {z : ℂ} (hz : z ∈ U) :
-    ConformalAt (TauCeti.DifferentiableOn.toOpenPartialHomeomorph hf hU hinj) z := by
-  rw [TauCeti.DifferentiableOn.toOpenPartialHomeomorph_coe hf hU hinj]
-  exact TauCeti.DifferentiableOn.conformalAt_of_isOpen_of_injOn hf hU hinj hz
+    ConformalAt (DifferentiableOn.toOpenPartialHomeomorph hf hU hinj) z := by
+  rw [DifferentiableOn.toOpenPartialHomeomorph_coe hf hU hinj]
+  exact DifferentiableOn.conformalAt_of_isOpen_of_injOn hf hU hinj hz
 
 /-- The inverse of the open partial homeomorphism associated to an injective holomorphic map is
 conformal on its target. -/
-theorem DifferentiableOn.conformalAt_toOpenPartialHomeomorph_symm
+theorem _root_.DifferentiableOn.conformalAt_toOpenPartialHomeomorph_symm
     (hf : DifferentiableOn ℂ f U) (hU : IsOpen U) (hinj : InjOn f U)
     {w : ℂ} (hw : w ∈ f '' U) :
     ConformalAt
-      (TauCeti.DifferentiableOn.toOpenPartialHomeomorph hf hU hinj).symm w := by
-  let e := TauCeti.DifferentiableOn.toOpenPartialHomeomorph hf hU hinj
+      (DifferentiableOn.toOpenPartialHomeomorph hf hU hinj).symm w := by
+  let e := DifferentiableOn.toOpenPartialHomeomorph hf hU hinj
   have hinv : InjOn e.symm (f '' U) := by
     simpa only [e, OpenPartialHomeomorph.symm_source,
-      TauCeti.DifferentiableOn.toOpenPartialHomeomorph_target] using e.symm.injOn
-  exact TauCeti.DifferentiableOn.conformalAt_of_isOpen_of_injOn
-    (TauCeti.DifferentiableOn.differentiableOn_toOpenPartialHomeomorph_symm hf hU hinj)
+      DifferentiableOn.toOpenPartialHomeomorph_target] using e.symm.injOn
+  exact DifferentiableOn.conformalAt_of_isOpen_of_injOn
+    (DifferentiableOn.differentiableOn_toOpenPartialHomeomorph_symm hf hU hinj)
     (isOpen_image_of_differentiableOn_of_injOn hU hf hinj) hinv hw
 
 end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/BoundaryCorrespondence.lean
+++ b/TauCeti/Analysis/Complex/Conformal/BoundaryCorrespondence.lean
@@ -34,7 +34,7 @@ available, into the boundary homeomorphism the milestone asks for.
 
 Properness is the inverse function theorem in disguise. An injective holomorphic map on an open set
 is an open partial homeomorphism onto its image
-(`TauCeti.DifferentiableOn.toOpenPartialHomeomorph`), and `U ∩ f ⁻¹' K` is exactly the image of `K`
+(`DifferentiableOn.toOpenPartialHomeomorph`), and `U ∩ f ⁻¹' K` is exactly the image of `K`
 under its inverse `Function.invFunOn f U`, so it is compact as the continuous image of a compact
 set. Everything else follows from that one fact. If `z i → w` with `z i ∈ U` and `w ∉ U`, then
 `f (z i)` cannot lie in a compact `K ⊆ f '' U` frequently: otherwise `z i` would frequently lie in
@@ -78,7 +78,7 @@ L5 is absent from [mathlib4#33505](https://github.com/leanprover-community/mathl
 in-progress human-curated Riemann-mapping-theorem effort, which stops at the mapping theorem itself.
 So this file is new Lean formalization rather than a temporary shim. It does consume the L0–L3 shims
 `TauCeti.isOpen_image_of_differentiableOn_of_injOn` and
-`TauCeti.DifferentiableOn.toOpenPartialHomeomorph`, which are to be refactored onto Mathlib once the
+`DifferentiableOn.toOpenPartialHomeomorph`, which are to be refactored onto Mathlib once the
 upstream work lands.
 
 ## References
@@ -109,12 +109,12 @@ theorem isCompact_inter_preimage_of_differentiableOn_of_injOn (hUo : IsOpen U)
     IsCompact (U ∩ f ⁻¹' K) := by
   -- In the packaging of `f` as an open partial homeomorphism onto its image, `U ∩ f ⁻¹' K` is the
   -- image of `K` under the inverse, hence compact.
-  set e := TauCeti.DifferentiableOn.toOpenPartialHomeomorph hfd hUo hfi with he
+  set e := DifferentiableOn.toOpenPartialHomeomorph hfd hUo hfi with he
   have hKt : K ⊆ e.target := by
-    simpa only [he, TauCeti.DifferentiableOn.toOpenPartialHomeomorph_target] using hKf
+    simpa only [he, DifferentiableOn.toOpenPartialHomeomorph_target] using hKf
   have hset : e.symm '' K = U ∩ f ⁻¹' K := by
-    simpa only [he, TauCeti.DifferentiableOn.toOpenPartialHomeomorph_source,
-      TauCeti.DifferentiableOn.toOpenPartialHomeomorph_coe] using
+    simpa only [he, DifferentiableOn.toOpenPartialHomeomorph_source,
+      DifferentiableOn.toOpenPartialHomeomorph_coe] using
       e.symm_image_eq_source_inter_preimage hKt
   exact hset ▸ hK.image_of_continuousOn (e.continuousOn_symm.mono hKt)
 

--- a/TauCeti/Analysis/Complex/Conformal/Inverse/Function.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Inverse/Function.lean
@@ -18,7 +18,7 @@ functions that are injective on an open set and for holomorphic open partial hom
 
 ## Main results
 
-* `TauCeti.DifferentiableOn.invFunOn` — the inverse of a holomorphic injection on an open set is
+* `DifferentiableOn.invFunOn` — the inverse of a holomorphic injection on an open set is
   holomorphic on its image.
 * `TauCeti.hasDerivAt_invFunOn` — the derivative of the inverse at `f z₀` is
   `(deriv f z₀)⁻¹`, via `HasDerivAt.of_local_left_inverse`.
@@ -41,7 +41,7 @@ The inverse of a holomorphic injection on an open set is holomorphic on its imag
 The inverse is `Function.invFunOn f U`, which chooses the unique preimage lying in `U`. No global
 injectivity of `f` outside `U` is required.
 -/
-theorem DifferentiableOn.invFunOn {f : ℂ → ℂ} {U : Set ℂ} (hf : DifferentiableOn ℂ f U)
+theorem _root_.DifferentiableOn.invFunOn {f : ℂ → ℂ} {U : Set ℂ} (hf : DifferentiableOn ℂ f U)
     (hU : IsOpen U) (hinj : InjOn f U) :
     DifferentiableOn ℂ (Function.invFunOn f U) (f '' U) := by
   rintro _ ⟨z, hz, rfl⟩
@@ -59,7 +59,7 @@ theorem DifferentiableOn.invFunOn {f : ℂ → ℂ} {U : Set ℂ} (hf : Differen
 theorem OpenPartialHomeomorph.differentiableOn_symm {e : OpenPartialHomeomorph ℂ ℂ}
     (he : DifferentiableOn ℂ e e.source) :
     DifferentiableOn ℂ e.symm e.target := by
-  have hinv := TauCeti.DifferentiableOn.invFunOn he e.open_source e.injOn
+  have hinv := DifferentiableOn.invFunOn he e.open_source e.injOn
   rw [e.image_source_eq_target] at hinv
   exact hinv.congr fun z hz => by
     calc
@@ -80,7 +80,7 @@ theorem hasDerivAt_invFunOn {f : ℂ → ℂ} {U : Set ℂ}
   have hΩ : IsOpen (f '' U) := isOpen_image_of_differentiableOn_of_injOn hU hf hinj
   have hp : f z₀ ∈ f '' U := mem_image_of_mem f hz₀
   have hgcont : ContinuousAt (Function.invFunOn f U) (f z₀) :=
-    ((TauCeti.DifferentiableOn.invFunOn hf hU hinj).differentiableAt
+    ((DifferentiableOn.invFunOn hf hU hinj).differentiableAt
       (hΩ.mem_nhds hp)).continuousAt
   have hgz : Function.invFunOn f U (f z₀) = z₀ := hinj.leftInvOn_invFunOn hz₀
   have hfz : HasDerivAt f (deriv f z₀) (Function.invFunOn f U (f z₀)) := by

--- a/TauCeti/Analysis/Complex/Conformal/Jordan/Domain.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Jordan/Domain.lean
@@ -228,7 +228,7 @@ already carried across by `f`: the image of an open set under an injective holom
 and the image is bounded because `F` is continuous on the compact `closure U`. A caller holding
 `h : TauCeti.IsJordanDomain (f '' U)` supplies `h.isConnected` and `h.isJordanCurve_frontier`.
 Connectedness of `U` itself is likewise not assumed: `f` is an open partial homeomorphism of `U`
-onto `f '' U` (`TauCeti.DifferentiableOn.toOpenPartialHomeomorph`), so `U` is the image of the
+onto `f '' U` (`DifferentiableOn.toOpenPartialHomeomorph`), so `U` is the image of the
 connected `f '' U` under the continuous inverse. -/
 theorem isJordanDomain_of_isJordanCurve_frontier_image (hUo : IsOpen U)
     (hUb : Bornology.IsBounded U) (hfd : DifferentiableOn ℂ f U)

--- a/TauCeti/Analysis/Complex/Conformal/Reflection/Injective.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Reflection/Injective.lean
@@ -48,8 +48,8 @@ the real axis, where the two branches meet.
 The reflection hypotheses here are exactly those of the reflection principle, plus the two extra
 ones (`hupper` and `hinj`); the holomorphy of the extension is quoted from
 `differentiableOn_schwarzReflection_of_symmetric`, its pointwise conformality from
-`TauCeti.DifferentiableOn.conformalAt_of_isOpen_of_injOn`, and the holomorphy of the inverse from
-`TauCeti.DifferentiableOn.invFunOn`.
+`DifferentiableOn.conformalAt_of_isOpen_of_injOn`, and the holomorphy of the inverse from
+`DifferentiableOn.invFunOn`.
 
 ## Main results
 
@@ -218,7 +218,7 @@ theorem conformalAt_schwarzReflection_of_symmetric
     (hupper : Set.MapsTo f (Ω ∩ {z : ℂ | 0 < z.im}) {z : ℂ | 0 < z.im})
     (hinj : Set.InjOn f (Ω ∩ {z : ℂ | 0 ≤ z.im}))
     {z : ℂ} (hz : z ∈ Ω) : ConformalAt (schwarzReflection f) z :=
-  TauCeti.DifferentiableOn.conformalAt_of_isOpen_of_injOn
+  DifferentiableOn.conformalAt_of_isOpen_of_injOn
     (differentiableOn_schwarzReflection_of_symmetric hΩopen hΩ hcont hholo hreal) hΩopen
     (injOn_schwarzReflection_of_symmetric hΩ hupper (fun w hw h => (hreal w hw h).ge) hinj) hz
 
@@ -233,7 +233,7 @@ theorem differentiableOn_invFunOn_schwarzReflection_of_symmetric
     (hupper : Set.MapsTo f (Ω ∩ {z : ℂ | 0 < z.im}) {z : ℂ | 0 < z.im})
     (hinj : Set.InjOn f (Ω ∩ {z : ℂ | 0 ≤ z.im})) :
     DifferentiableOn ℂ (Function.invFunOn (schwarzReflection f) Ω) (schwarzReflection f '' Ω) :=
-  TauCeti.DifferentiableOn.invFunOn
+  DifferentiableOn.invFunOn
     (differentiableOn_schwarzReflection_of_symmetric hΩopen hΩ hcont hholo hreal) hΩopen
     (injOn_schwarzReflection_of_symmetric hΩ hupper (fun w hw h => (hreal w hw h).ge) hinj)
 

--- a/TauCeti/Analysis/Complex/Conformal/Removability/Arc.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Removability/Arc.lean
@@ -65,7 +65,7 @@ theorem
     rintro _ ⟨z, hz, rfl⟩
     simpa only [e.left_inv (hΩe hz)] using hz
   have he_invFunOn :=
-    TauCeti.DifferentiableOn.invFunOn he hΩ (e.injOn.mono hΩe)
+    DifferentiableOn.invFunOn he hΩ (e.injOn.mono hΩe)
   have he_inv : DifferentiableOn ℂ e.symm (e '' Ω) :=
     he_invFunOn.congr fun _ hw => by
       rcases hw with ⟨z, hz, rfl⟩

--- a/TauCeti/Analysis/Complex/Conformal/RiemannMapping/Conformal.lean
+++ b/TauCeti/Analysis/Complex/Conformal/RiemannMapping/Conformal.lean
@@ -57,7 +57,7 @@ theorem riemannMapping_homeomorph {Ω : Set ℂ}
     (hΩo : IsOpen Ω) (hΩc : IsSimplyConnected Ω) (hΩ : Ω ≠ univ) :
     Nonempty (Ω ≃ₜ Complex.UnitDisc) := by
   obtain ⟨f, hbij, hfd, -⟩ := riemannMapping hΩo hΩc hΩ
-  exact ⟨TauCeti.DifferentiableOn.toHomeomorphOfBijOn hfd hΩo hbij⟩
+  exact ⟨DifferentiableOn.toHomeomorphOfBijOn hfd hΩo hbij⟩
 
 /-- **The Riemann mapping theorem as a conformal open partial homeomorphism.** A simply connected
 open proper subset `Ω` of `ℂ` is the source of an open partial homeomorphism whose target is the
@@ -73,21 +73,21 @@ theorem riemannMapping_openPartialHomeomorph {Ω : Set ℂ}
       (∀ z ∈ Ω, ConformalAt e z) ∧
       ∀ w ∈ ball (0 : ℂ) 1, ConformalAt e.symm w := by
   obtain ⟨f, hbij, hfd, -⟩ := riemannMapping hΩo hΩc hΩ
-  refine ⟨TauCeti.DifferentiableOn.toOpenPartialHomeomorph hfd hΩo hbij.injOn,
+  refine ⟨DifferentiableOn.toOpenPartialHomeomorph hfd hΩo hbij.injOn,
     ?_, ?_, ?_, ?_, ?_, ?_⟩
-  · exact TauCeti.DifferentiableOn.toOpenPartialHomeomorph_source hfd hΩo hbij.injOn
+  · exact DifferentiableOn.toOpenPartialHomeomorph_source hfd hΩo hbij.injOn
   · exact
-      (TauCeti.DifferentiableOn.toOpenPartialHomeomorph_target hfd hΩo hbij.injOn).trans
+      (DifferentiableOn.toOpenPartialHomeomorph_target hfd hΩo hbij.injOn).trans
         hbij.image_eq
-  · rw [TauCeti.DifferentiableOn.toOpenPartialHomeomorph_coe hfd hΩo hbij.injOn]
+  · rw [DifferentiableOn.toOpenPartialHomeomorph_coe hfd hΩo hbij.injOn]
     exact hfd
   · have hinv :=
-      TauCeti.DifferentiableOn.differentiableOn_toOpenPartialHomeomorph_symm hfd hΩo hbij.injOn
+      DifferentiableOn.differentiableOn_toOpenPartialHomeomorph_symm hfd hΩo hbij.injOn
     simpa only [hbij.image_eq] using hinv
   · exact fun z hz =>
-      TauCeti.DifferentiableOn.conformalAt_toOpenPartialHomeomorph hfd hΩo hbij.injOn hz
+      DifferentiableOn.conformalAt_toOpenPartialHomeomorph hfd hΩo hbij.injOn hz
   · intro w hw
-    exact TauCeti.DifferentiableOn.conformalAt_toOpenPartialHomeomorph_symm hfd hΩo hbij.injOn
+    exact DifferentiableOn.conformalAt_toOpenPartialHomeomorph_symm hfd hΩo hbij.injOn
       (hbij.image_eq ▸ hw)
 
 end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/RiemannMapping/Equivalence.lean
+++ b/TauCeti/Analysis/Complex/Conformal/RiemannMapping/Equivalence.lean
@@ -32,7 +32,7 @@ other. This file proves those two statements, and the sharpness of the propernes
   homeomorphic to the disc.
 * `TauCeti.exists_bijOn_self_apply_eq_of_isSimplyConnected` — homogeneity: the biholomorphic
   self-maps of a simply connected open `Ω ⊆ ℂ` act transitively on `Ω`.
-* `TauCeti.Differentiable.exists_const_forall_eq_of_isSimplyConnected`,
+* `Differentiable.exists_const_forall_eq_of_isSimplyConnected`,
   `TauCeti.not_injOn_univ_of_isSimplyConnected` and
   `TauCeti.not_bijOn_univ_of_isSimplyConnected` — an entire function with values in a simply
   connected open proper set is constant, hence not injective, so `ℂ` itself is biholomorphic to no
@@ -44,7 +44,7 @@ other. This file proves those two statements, and the sharpness of the propernes
 
 Everything runs through the Riemann map. Transporting a domain `Ω` to the disc and a second domain
 `Ω'` back off it composes to a biholomorphism `Ω ≃ Ω'`; the inverse of a holomorphic injection on
-an open set is holomorphic by `TauCeti.DifferentiableOn.invFunOn`, so the composite inverse needs
+an open set is holomorphic by `DifferentiableOn.invFunOn`, so the composite inverse needs
 no separate argument. Homogeneity inserts, between the two transports of one and the same domain,
 a disc automorphism carrying one image point to the other; that automorphism is supplied by the
 transitivity of `TauCeti.unitDiscAut` and read back as a scalar map. The whole plane, which has no
@@ -89,12 +89,12 @@ private lemma bijOn_invFunOn_of_bijOn_ball {g : ℂ → ℂ} (hbij : BijOn g Ω 
 
 /-- A holomorphic bijection of an open set onto its image has a holomorphic inverse there.
 
-This repackages `TauCeti.DifferentiableOn.invFunOn` with the image identified by a `Set.BijOn`
+This repackages `DifferentiableOn.invFunOn` with the image identified by a `Set.BijOn`
 hypothesis, which is the form the constructions in this file produce. -/
 private lemma differentiableOn_invFunOn_of_bijOn {f : ℂ → ℂ} (hΩo : IsOpen Ω)
     (hfd : DifferentiableOn ℂ f Ω) (hbij : BijOn f Ω Ω') :
     DifferentiableOn ℂ (Function.invFunOn f Ω) Ω' := by
-  have hinv := TauCeti.DifferentiableOn.invFunOn hfd hΩo hbij.injOn
+  have hinv := DifferentiableOn.invFunOn hfd hΩo hbij.injOn
   rwa [hbij.image_eq] at hinv
 
 /-- **Any two simply connected proper domains of `ℂ` are conformally equivalent.** If `Ω` and `Ω'`
@@ -244,7 +244,7 @@ too.
 
 For bounded `Ω` this is Liouville's theorem itself, but the statement covers unbounded `Ω` such as
 the slit plane, where the Riemann map is doing genuine work. -/
-theorem Differentiable.exists_const_forall_eq_of_isSimplyConnected {f : ℂ → ℂ}
+theorem _root_.Differentiable.exists_const_forall_eq_of_isSimplyConnected {f : ℂ → ℂ}
     (hf : Differentiable ℂ f) (hΩo : IsOpen Ω) (hΩc : IsSimplyConnected Ω) (hΩ : Ω ≠ univ)
     (hmaps : ∀ z, f z ∈ Ω) :
     ∃ c, ∀ z, f z = c := by
@@ -259,7 +259,7 @@ theorem Differentiable.exists_const_forall_eq_of_isSimplyConnected {f : ℂ → 
   exact ⟨f 0, fun z => hrbij.injOn (hmaps z) (hmaps 0) ((hc z).trans (hc 0).symm)⟩
 
 /-- **No injective entire function takes its values in a simply connected proper domain.** Such a
-function is constant by `TauCeti.Differentiable.exists_const_forall_eq_of_isSimplyConnected`, and a
+function is constant by `Differentiable.exists_const_forall_eq_of_isSimplyConnected`, and a
 constant map on `ℂ` is not injective.
 
 Only the values of `f` are constrained, not the image: `f` is not required to cover `Ω`. -/

--- a/TauCeti/Analysis/Complex/Conformal/RiemannMapping/Existence.lean
+++ b/TauCeti/Analysis/Complex/Conformal/RiemannMapping/Existence.lean
@@ -89,7 +89,7 @@ theorem exists_bijOn_ball_differentiableOn_invFunOn {Ω : Set ℂ} (hΩo : IsOpe
   obtain ⟨f, hbij, hfd, -⟩ := riemannMapping hΩo hΩc hΩ
   refine ⟨f, hbij, hfd, ?_, hbij.injOn.leftInvOn_invFunOn, hbij.surjOn.rightInvOn_invFunOn⟩
   -- Dot notation would resolve to `Function.invFunOn`; name the lemma explicitly.
-  have hinv := TauCeti.DifferentiableOn.invFunOn hfd hΩo hbij.injOn
+  have hinv := DifferentiableOn.invFunOn hfd hΩo hbij.injOn
   rwa [hbij.image_eq] at hinv
 
 end TauCeti


### PR DESCRIPTION
All 22 declarations `lint-dot-notation` flags in `TauCeti.Differentiable` and `TauCeti.DifferentiableOn` move to their root Mathlib namespaces — 89 and 85 declarations there respectively, with no colliding names.

## Why the two namespaces go together

They are entangled only with each other. `Analysis/Calculus/Sard/LowDimension.lean` holds members of both, so rooting either namespace alone would leave that file half-rooted — the split `api-design` blocked on in #5950, in its cross-file form.

Taken jointly the change is self-contained: the five declaring files carry **no other flagged declarations**, and none of them has a nested namespace at all. The headers are dotted declarations sitting directly in `namespace TauCeti`, so there is no wrapper to unwrap and nothing is left behind.

| | |
|---|---|
| declarations rooted | **22** across 5 files |
| references retargeted | **84** across 13 files |
| files that only *consume* these names | **8** |

None of the 84 would have failed a build in a way pointing at the declarations: they name the `TauCeti.…` path in full, which simply ceases to exist.

`lint-dot-notation`: 975 → 953, 0 new.

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYwXN9WBAPasmBQXr6iQcp