### PR TITLE
feat(EulerProduct): the Euler product in logarithmic form over a number field

### DIFF
--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Analytic.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Analytic.lean
@@ -146,6 +146,14 @@ theorem coe_normCoeff_supportedPart_empty (hf : f 1 = 1) :
   funext n
   simp [ArithmeticFunction.one_apply, LSeries.delta]
 
+/-- **The prime terms are a subseries of the ideal terms.** Each height-one prime contributes its
+own ideal as the `e = 1` member of its power series, and distinct primes give distinct ideals, so
+absolute convergence over ideals restricts to the primes. Multiplicativity plays no part. -/
+theorem summable_idealTerm_comp_primeIdealPow (hs : Summable (idealTerm K f s)) :
+    Summable fun P : HeightOneSpectrum (𝓞 K) ↦ idealTerm K f s (P.primeIdealPow 1) :=
+  hs.comp_injective fun P Q h ↦ HeightOneSpectrum.asIdeal_injective
+    (by simpa only [HeightOneSpectrum.coe_primeIdealPow, pow_one] using congrArg Subtype.val h)
+
 end IdealArithmeticFunction
 
 namespace EulerProductData
@@ -286,6 +294,15 @@ theorem norm_div_lt_one_of_summable_idealTerm
   rw [← summable_geometric_iff_norm_lt_one]
   exact (hs.comp_injective P.primeIdealPow_injective).congr fun e ↦
     idealTerm_toIdealArithmeticFunction_primeIdealPow χ P e s
+
+/-- **The local ratios are summable over the primes.** The multiplicative specialisation of
+`IdealArithmeticFunction.summable_idealTerm_comp_primeIdealPow`: at a prime the ideal term *is* the
+ratio `χ(P) N(P)⁻ˢ`. -/
+theorem summable_localRatio (hs : Summable (idealTerm K χ.toIdealArithmeticFunction s)) :
+    Summable fun P : HeightOneSpectrum (𝓞 K) ↦
+      χ P.asIdeal / (Ideal.absNorm P.asIdeal : ℂ) ^ s :=
+  (IdealArithmeticFunction.summable_idealTerm_comp_primeIdealPow hs).congr fun P ↦ by
+    simp [idealTerm_toIdealArithmeticFunction_primeIdealPow χ P 1 s]
 
 /-- The local Euler factor of a completely multiplicative weight is the geometric closed form
 `(1 - χ(P) N(P)⁻ˢ)⁻¹`. -/

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Analytic.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Analytic.lean
@@ -149,7 +149,7 @@ theorem coe_normCoeff_supportedPart_empty (hf : f 1 = 1) :
 /-- **The prime terms are a subseries of the ideal terms.** Each height-one prime contributes its
 own ideal as the `e = 1` member of its power series, and distinct primes give distinct ideals, so
 absolute convergence over ideals restricts to the primes. Multiplicativity plays no part. -/
-theorem summable_idealTerm_comp_primeIdealPow (hs : Summable (idealTerm K f s)) :
+theorem summable_idealTerm_primeIdealPow_one (hs : Summable (idealTerm K f s)) :
     Summable fun P : HeightOneSpectrum (𝓞 K) ↦ idealTerm K f s (P.primeIdealPow 1) :=
   hs.comp_injective fun P Q h ↦ HeightOneSpectrum.asIdeal_injective
     (by simpa only [HeightOneSpectrum.coe_primeIdealPow, pow_one] using congrArg Subtype.val h)
@@ -296,12 +296,13 @@ theorem norm_div_lt_one_of_summable_idealTerm
     idealTerm_toIdealArithmeticFunction_primeIdealPow χ P e s
 
 /-- **The local ratios are summable over the primes.** The multiplicative specialisation of
-`IdealArithmeticFunction.summable_idealTerm_comp_primeIdealPow`: at a prime the ideal term *is* the
+`IdealArithmeticFunction.summable_idealTerm_primeIdealPow_one`: at a prime the ideal term *is* the
 ratio `χ(P) N(P)⁻ˢ`. -/
-theorem summable_localRatio (hs : Summable (idealTerm K χ.toIdealArithmeticFunction s)) :
+theorem summable_div_of_summable_idealTerm
+    (hs : Summable (idealTerm K χ.toIdealArithmeticFunction s)) :
     Summable fun P : HeightOneSpectrum (𝓞 K) ↦
       χ P.asIdeal / (Ideal.absNorm P.asIdeal : ℂ) ^ s :=
-  (IdealArithmeticFunction.summable_idealTerm_comp_primeIdealPow hs).congr fun P ↦ by
+  (IdealArithmeticFunction.summable_idealTerm_primeIdealPow_one hs).congr fun P ↦ by
     simp [idealTerm_toIdealArithmeticFunction_primeIdealPow χ P 1 s]
 
 /-- The local Euler factor of a completely multiplicative weight is the geometric closed form

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Logarithm.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Logarithm.lean
@@ -10,23 +10,29 @@ public import TauCeti.NumberTheory.ArithmeticDirichletSeries.EulerProduct.Analyt
 import Mathlib.NumberTheory.EulerProduct.ExpLog
 
 /-!
-# The logarithm of an Euler product over the primes of a number field
+# The Euler product over the primes of a number field, in exponential form
 
 Mathlib's `EulerProduct.exp_tsum_primes_log_eq_tsum` writes the Euler product of a completely
 multiplicative `f : ℕ →*₀ ℂ` as `exp (∑' p, -log (1 - f p))`. This file is the ideal-indexed
 analogue, over the height-one primes of the ring of integers of a number field, mirroring the way
 `TauCeti.MultiplicativeIdealWeight.hasProd_eulerFactor` mirrors Mathlib's product form.
 
-The logarithm here is taken factor by factor, so no branch on a region is chosen and no zero-free
-hypothesis is needed: absolute convergence of the ideal-indexed series already forces each local
-ratio into the open unit disc, where `Complex.log (1 - ·)` is the principal value.
+The logarithm is taken factor by factor, using the principal value: absolute convergence of the
+ideal-indexed series forces each local ratio into the open unit disc, where `Complex.log (1 - ·)`
+is defined without choosing anything.
+
+**What this does not give.** `exp` is not injective, so an identity of the form `exp t = L`
+determines `t` only modulo `2πi ℤ`; these theorems therefore do not exhibit a logarithm *of* the
+`L`-series, and in particular are not a holomorphic branch on a region. Obtaining one needs the
+series to be nonvanishing there first, which
+`TauCeti.NumberTheory.ArithmeticDirichletSeries.EulerProduct.Analytic` states it does not supply.
 
 ## Main results
 
 * `TauCeti.MultiplicativeIdealWeight.summable_localRatio`: the local ratios `χ(P) N(P)⁻ˢ` are
   summable over the height-one primes.
-* `TauCeti.MultiplicativeIdealWeight.exp_tsum_neg_log_one_sub_eq_LSeries`: the logarithmic form of
-  the Euler product.
+* `TauCeti.MultiplicativeIdealWeight.exp_tsum_neg_log_one_sub_eq_LSeries`: the `L`-series as the
+  exponential of a sum of principal logarithms over the primes.
 -/
 
 public section
@@ -57,11 +63,13 @@ theorem summable_localRatio (hs : Summable (idealTerm K χ.toIdealArithmeticFunc
   refine (hs.comp_injective hinj).congr fun P ↦ ?_
   simp [idealTerm_toIdealArithmeticFunction_primeIdealPow χ P 1 s]
 
-/-- **The Euler product in logarithmic form.** For a completely multiplicative ideal weight whose
+/-- **The Euler product in exponential form.** For a completely multiplicative ideal weight whose
 ideal-indexed series converges absolutely at `s`, the `L`-series is the exponential of the sum of
-`-log (1 - χ(P) N(P)⁻ˢ)` over the height-one primes.
+principal logarithms `-log (1 - χ(P) N(P)⁻ˢ)` over the height-one primes.
 
-This is the number-field analogue of Mathlib's `EulerProduct.exp_tsum_primes_log_eq_tsum`. -/
+The sum is not thereby a logarithm of the `L`-series: `exp` identifies it only modulo `2πi ℤ`.
+This is the number-field analogue of Mathlib's `EulerProduct.exp_tsum_primes_log_eq_tsum`, and
+carries the same limitation. -/
 theorem exp_tsum_neg_log_one_sub_eq_LSeries
     (hs : Summable (idealTerm K χ.toIdealArithmeticFunction s)) :
     exp (∑' P : HeightOneSpectrum (𝓞 K),

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Logarithm.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Logarithm.lean
@@ -65,7 +65,8 @@ theorem exp_tsum_neg_log_one_sub_eq_LSeries
     rw [sub_eq_zero] at h
     rw [← h] at hlt
     simp at hlt
-  have H := (Summable.clog_one_sub (χ.summable_localRatio hs)).neg.hasSum.cexp.tprod_eq
+  have H := (Summable.clog_one_sub
+    (χ.summable_div_of_summable_idealTerm hs)).neg.hasSum.cexp.tprod_eq
   simp only [Function.comp_apply, exp_neg, exp_log (hne _)] at H
   exact H.symm.trans (χ.hasProd_eulerFactor hs).tprod_eq
 

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Logarithm.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Logarithm.lean
@@ -29,8 +29,6 @@ series to be nonvanishing there first, which
 
 ## Main results
 
-* `TauCeti.MultiplicativeIdealWeight.summable_localRatio`: the local ratios `χ(P) N(P)⁻ˢ` are
-  summable over the height-one primes.
 * `TauCeti.MultiplicativeIdealWeight.exp_tsum_neg_log_one_sub_eq_LSeries`: the `L`-series as the
   exponential of a sum of principal logarithms over the primes.
 -/
@@ -48,20 +46,6 @@ namespace MultiplicativeIdealWeight
 open IdealArithmeticFunction
 
 variable {K : Type*} [Field K] [NumberField K] (χ : MultiplicativeIdealWeight K) {s : ℂ}
-
-/-- **The local ratios are summable over the primes.** Each prime contributes its ratio as the
-`e = 1` term of the geometric subseries along its own powers, and distinct primes give distinct
-ideals, so this is a subseries of the ideal-indexed one. -/
-theorem summable_localRatio (hs : Summable (idealTerm K χ.toIdealArithmeticFunction s)) :
-    Summable fun P : HeightOneSpectrum (𝓞 K) ↦
-      χ P.asIdeal / (Ideal.absNorm P.asIdeal : ℂ) ^ s := by
-  have hinj : Function.Injective fun P : HeightOneSpectrum (𝓞 K) ↦ P.primeIdealPow 1 := by
-    intro P Q h
-    have hpow : P.asIdeal ^ 1 = Q.asIdeal ^ 1 := by
-      simpa only [HeightOneSpectrum.coe_primeIdealPow] using congrArg Subtype.val h
-    exact HeightOneSpectrum.ext (by simpa using hpow)
-  refine (hs.comp_injective hinj).congr fun P ↦ ?_
-  simp [idealTerm_toIdealArithmeticFunction_primeIdealPow χ P 1 s]
 
 /-- **The Euler product in exponential form.** For a completely multiplicative ideal weight whose
 ideal-indexed series converges absolutely at `s`, the `L`-series is the exponential of the sum of

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Logarithm.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Logarithm.lean
@@ -1,0 +1,82 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.NumberTheory.ArithmeticDirichletSeries.EulerProduct.Analytic
+
+import Mathlib.NumberTheory.EulerProduct.ExpLog
+
+/-!
+# The logarithm of an Euler product over the primes of a number field
+
+Mathlib's `EulerProduct.exp_tsum_primes_log_eq_tsum` writes the Euler product of a completely
+multiplicative `f : ℕ →*₀ ℂ` as `exp (∑' p, -log (1 - f p))`. This file is the ideal-indexed
+analogue, over the height-one primes of the ring of integers of a number field, mirroring the way
+`TauCeti.MultiplicativeIdealWeight.hasProd_eulerFactor` mirrors Mathlib's product form.
+
+The logarithm here is taken factor by factor, so no branch on a region is chosen and no zero-free
+hypothesis is needed: absolute convergence of the ideal-indexed series already forces each local
+ratio into the open unit disc, where `Complex.log (1 - ·)` is the principal value.
+
+## Main results
+
+* `TauCeti.MultiplicativeIdealWeight.summable_localRatio`: the local ratios `χ(P) N(P)⁻ˢ` are
+  summable over the height-one primes.
+* `TauCeti.MultiplicativeIdealWeight.exp_tsum_neg_log_one_sub_eq_LSeries`: the logarithmic form of
+  the Euler product.
+-/
+
+public section
+
+namespace TauCeti
+
+open Complex IsDedekindDomain
+
+open scoped NumberField
+
+namespace MultiplicativeIdealWeight
+
+open IdealArithmeticFunction
+
+variable {K : Type*} [Field K] [NumberField K] (χ : MultiplicativeIdealWeight K) {s : ℂ}
+
+/-- **The local ratios are summable over the primes.** Each prime contributes its ratio as the
+`e = 1` term of the geometric subseries along its own powers, and distinct primes give distinct
+ideals, so this is a subseries of the ideal-indexed one. -/
+theorem summable_localRatio (hs : Summable (idealTerm K χ.toIdealArithmeticFunction s)) :
+    Summable fun P : HeightOneSpectrum (𝓞 K) ↦
+      χ P.asIdeal / (Ideal.absNorm P.asIdeal : ℂ) ^ s := by
+  have hinj : Function.Injective fun P : HeightOneSpectrum (𝓞 K) ↦ P.primeIdealPow 1 := by
+    intro P Q h
+    have hpow : P.asIdeal ^ 1 = Q.asIdeal ^ 1 := by
+      simpa only [HeightOneSpectrum.coe_primeIdealPow] using congrArg Subtype.val h
+    exact HeightOneSpectrum.ext (by simpa using hpow)
+  refine (hs.comp_injective hinj).congr fun P ↦ ?_
+  simp [idealTerm_toIdealArithmeticFunction_primeIdealPow χ P 1 s]
+
+/-- **The Euler product in logarithmic form.** For a completely multiplicative ideal weight whose
+ideal-indexed series converges absolutely at `s`, the `L`-series is the exponential of the sum of
+`-log (1 - χ(P) N(P)⁻ˢ)` over the height-one primes.
+
+This is the number-field analogue of Mathlib's `EulerProduct.exp_tsum_primes_log_eq_tsum`. -/
+theorem exp_tsum_neg_log_one_sub_eq_LSeries
+    (hs : Summable (idealTerm K χ.toIdealArithmeticFunction s)) :
+    exp (∑' P : HeightOneSpectrum (𝓞 K),
+        -log (1 - χ P.asIdeal / (Ideal.absNorm P.asIdeal : ℂ) ^ s)) =
+      LSeries (normCoeff K χ.toIdealArithmeticFunction) s := by
+  have hne (P : HeightOneSpectrum (𝓞 K)) :
+      1 - χ P.asIdeal / (Ideal.absNorm P.asIdeal : ℂ) ^ s ≠ 0 := fun h ↦ by
+    have hlt := χ.norm_div_lt_one_of_summable_idealTerm hs P
+    rw [sub_eq_zero] at h
+    rw [← h] at hlt
+    simp at hlt
+  have H := (Summable.clog_one_sub (χ.summable_localRatio hs)).neg.hasSum.cexp.tprod_eq
+  simp only [Function.comp_apply, exp_neg, exp_log (hne _)] at H
+  exact H.symm.trans (χ.hasProd_eulerFactor hs).tprod_eq
+
+end MultiplicativeIdealWeight
+
+end TauCeti


### PR DESCRIPTION
> **Correction (round 1 `correctness` block).** This PR does **not** fulfil Layer 3.4, and the
> description below originally said it did. The rubric is right: `exp (∑ …) = L` does not identify
> `∑ …` as *the* logarithm of `L`, because exponentiating loses additive multiples of `2πi`, and
> Layer 3.4 asks for a logarithm chosen on a simply connected zero-free region. What is here is a
> correct exponential Euler-product identity and a **prerequisite** toward that layer, not the layer
> itself. The `tauceti-target` marker has been removed accordingly — it also collided with the
> identical marker on the sibling PR, which would have exposed one of them to the duplicate sweeper.

Layer 3.4 of the ArithmeticDirichletSeries roadmap asks to "prove both the prime-power logarithmic
expansion and its derivative". This is the expansion.

```lean
theorem TauCeti.MultiplicativeIdealWeight.exp_tsum_neg_log_one_sub_eq_LSeries
    (hs : Summable (idealTerm K χ.toIdealArithmeticFunction s)) :
    exp (∑' P : HeightOneSpectrum (𝓞 K),
        -log (1 - χ P.asIdeal / (Ideal.absNorm P.asIdeal : ℂ) ^ s)) =
      LSeries (normCoeff K χ.toIdealArithmeticFunction) s
```

It is the ideal-indexed analogue of Mathlib's `EulerProduct.exp_tsum_primes_log_eq_tsum`, and
stands to it exactly as `MultiplicativeIdealWeight.hasProd_eulerFactor` stands to Mathlib's product
form — which is the stated purpose of the `EulerProduct/` directory here.

### No zero-free region is needed, and that is worth saying

The roadmap frames 3.4 as "on a simply connected zero-free region, choose a logarithm". That
framing is required for the **derivative**, which needs a single holomorphic branch. The expansion
does not. Taking the logarithm factor by factor, absolute convergence of the ideal-indexed series
already forces `‖χ(P) N(P)⁻ˢ‖ < 1` at every prime — that is
`norm_div_lt_one_of_summable_idealTerm`, already on main — so each `1 - χ(P) N(P)⁻ˢ` lies in the
open disc about `1` where `Complex.log` is the principal value, and nothing has to be chosen.

I mention it because I spent a round concluding the opposite, that the expansion was blocked behind
nonvanishing and a holomorphic branch. Mathlib's proof shows the cheaper route.

### The supporting step

`summable_div_of_summable_idealTerm` says the ratios `χ(P) N(P)⁻ˢ` are summable over the
height-one primes. Each
is the `e = 1` term of the geometric subseries along that prime's own powers, and `P ↦ P.asIdeal` is
injective, so the family is a subseries of the ideal-indexed one. It is consumed by the expansion in
this PR and will be consumed again by the derivative.

### Absence

Mathlib has `exp_tsum_primes_log_eq_tsum` only for `f : ℕ →*₀ ℂ`; there is no ideal-indexed form,
and `Summable.clog_one_sub` is the general-index lemma this reuses rather than reproves. On `main`,
`EulerProduct/Analytic.lean` provides the product form and states in its own docstring that "no
nonvanishing statement is made here"; the queries `eulerFactor.*ne_zero`, `tprod_ne_zero`,
`exp_tsum`, `clog_one_sub` and `Summable (fun P : HeightOneSpectrum` return nothing.

### What consumes it

The derivative half of 3.4, next; and beyond it #5572, which the `scope` rubric parked with "the
required logarithm and prime-power logarithmic expansion of Layer 3.4 are absent".

Roadmap: ArithmeticDirichletSeries

Provenance: none external — the argument follows Mathlib's `EulerProduct.exp_tsum_primes_log_eq_tsum`
(`Mathlib/NumberTheory/EulerProduct/ExpLog.lean`, Apache 2.0), re-indexed over height-one primes and
built on TauCeti's own `hasProd_eulerFactor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011dmwkBnj4rJc75STgbwsLF


