### PR TITLE
feat: identify the finite-action fundamental group

### DIFF
--- a/TauCeti/CategoryTheory/Action/ProfiniteCompletion.lean
+++ b/TauCeti/CategoryTheory/Action/ProfiniteCompletion.lean
@@ -7,7 +7,6 @@ module
 
 public import Mathlib.CategoryTheory.Galois.Examples
 public import Mathlib.CategoryTheory.Galois.IsFundamentalgroup
-public import Mathlib.Topology.Algebra.Category.ProfiniteGrp.Completion
 public import TauCeti.Topology.Algebra.Group.Profinite.Completion
 
 /-!
@@ -71,9 +70,9 @@ theorem continuousActionHom_eta (A : Action FintypeCat.{u} G) :
       GrpCat.ofHom (MulAction.toPermHom G A.V) :=
   ProfiniteGrp.ProfiniteCompletion.lift_eta _
 
-/-- The canonical action of the profinite completion of `G` on a finite `G`-set. -/
+/-- The profinite completion acts on every finite `G`-set. -/
 @[instance_reducible]
-def mulAction (A : Action FintypeCat.{u} G) : MulAction
+instance instMulAction (A : Action FintypeCat.{u} G) : MulAction
     (ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G)) A.V where
   smul g x := actionHom G A g x
   one_smul x := by
@@ -87,16 +86,12 @@ def mulAction (A : Action FintypeCat.{u} G) : MulAction
     rw [map_mul (actionHom G A) g h]
     rfl
 
-/-- The profinite completion acts on every finite `G`-set. -/
-instance instMulAction (A : Action FintypeCat.{u} G) : MulAction
-    (ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G)) A.V :=
-  mulAction G A
-
-/-- The profinite-completion action, in the exact form expected by the forgetful functor. -/
+/-- Specialize `instMulAction` to assist typeclass inference: `Action.forget` is not reducible,
+so instance synthesis does not see `(Action.forget FintypeCat G).obj A` as `A.V`. -/
 instance instMulActionForgetObj (A : Action FintypeCat.{u} G) : MulAction
     (ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G))
     ((Action.forget FintypeCat G).obj A) :=
-  mulAction G A
+  instMulAction G A
 
 /-- The extended permutation representation restricts along `G → Ĝ` to the original one. -/
 @[simp]
@@ -116,18 +111,6 @@ theorem etaFn_smul (A : Action FintypeCat.{u} G) (g : G) (x : A.V) :
     ProfiniteGrp.ProfiniteCompletion.etaFn (GrpCat.of G) g • x = g • x := by
   -- Unfold only the registered action, leaving the completion construction opaque.
   change actionHom G A (ProfiniteGrp.ProfiniteCompletion.etaFn (GrpCat.of G) g) x = g • x
-  rw [actionHom_etaFn]
-  rfl
-
-/-- The restriction formula for the action carried by the forgetful functor. -/
-@[simp]
-theorem etaFn_smul_forget (A : Action FintypeCat.{u} G) (g : G)
-    (x : (Action.forget FintypeCat G).obj A) :
-    ProfiniteGrp.ProfiniteCompletion.etaFn (GrpCat.of G) g • x =
-      ConcreteCategory.hom (A.ρ g) x := by
-  -- `Action.forget` hides the underlying finite type and hence the registered action.
-  change actionHom G A (ProfiniteGrp.ProfiniteCompletion.etaFn (GrpCat.of G) g) x =
-    ConcreteCategory.hom (A.ρ g) x
   rw [actionHom_etaFn]
   rfl
 

--- a/TauCeti/CategoryTheory/Action/ProfiniteCompletion.lean
+++ b/TauCeti/CategoryTheory/Action/ProfiniteCompletion.lean
@@ -24,9 +24,9 @@ finite `G`-sets.
 * `TauCeti.ProfiniteCompletion.etaFn_smul`: the extended action restricts to the original action
   along the canonical map from `G`.
 * `TauCeti.ProfiniteCompletion.instIsFundamentalGroup`: the profinite completion is a fundamental
-  group of the forgetful functor on finite `G`-sets.
-* `TauCeti.ProfiniteCompletion.autForgetFiniteActionMulEquiv`: the resulting canonical
-  isomorphism with the automorphism group of the forgetful functor.
+  group of the forgetful functor on finite `G`-sets. Consequently
+  `CategoryTheory.PreGaloisCategory.toAutMulEquiv` identifies the profinite completion with the
+  automorphism group of that functor.
 
 The construction uses Mathlib's profinite completion and its universal property.
 -/
@@ -247,33 +247,5 @@ instance instIsFundamentalGroup : CategoryTheory.PreGaloisCategory.IsFundamental
   transitive_of_isGalois A := isPretransitive_of_isConnected G A
   continuous_smul A := continuousSMul G A
   non_trivial' g h := eq_one_of_forall_smul_eq G g h
-
-/-- The profinite completion of `G` is canonically isomorphic to the automorphism group of the
-forgetful fibre functor on finite `G`-sets. -/
-noncomputable def autForgetFiniteActionMulEquiv :
-    ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G) ≃*
-      Aut (Action.forget FintypeCat.{u} G) :=
-  CategoryTheory.PreGaloisCategory.toAutMulEquiv
-    (Action.forget FintypeCat.{u} G)
-    (ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G))
-
-/-- Under `autForgetFiniteActionMulEquiv`, an element of the profinite completion acts on every
-finite `G`-set by its extended action. -/
-@[simp]
-theorem autForgetFiniteActionMulEquiv_hom_app_apply
-    (g : ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G))
-    (A : Action FintypeCat.{u} G) (x : (Action.forget FintypeCat G).obj A) :
-    (autForgetFiniteActionMulEquiv G g).hom.app A x = g • x := by
-  -- Reveal the `toAut` homomorphism packaged by `toAutMulEquiv`.
-  change (CategoryTheory.PreGaloisCategory.toAut
-    (Action.forget FintypeCat.{u} G)
-    (ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G)) g).hom.app A x = _
-  rw [CategoryTheory.PreGaloisCategory.toAut_hom_app_apply]
-
-/-- The canonical isomorphism with the automorphism group of the forgetful functor is a
-homeomorphism. -/
-theorem autForgetFiniteActionMulEquiv_isHomeomorph :
-    IsHomeomorph (autForgetFiniteActionMulEquiv G) :=
-  CategoryTheory.PreGaloisCategory.toAutMulEquiv_isHomeomorph _ _
 
 end TauCeti.ProfiniteCompletion

--- a/TauCeti/CategoryTheory/Action/ProfiniteCompletion.lean
+++ b/TauCeti/CategoryTheory/Action/ProfiniteCompletion.lean
@@ -62,7 +62,7 @@ def actionHom (A : Action FintypeCat.{u} G) :
   change ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G) →* Equiv.Perm A.V at f
   exact f
 
-/-- The extended continuous representation restricts along the canonical morphism `G → Ĝ` to the
+/-- The extended continuous representation restricts along the canonical morphism `G → Ĝ` to the
 original permutation representation. -/
 @[simp]
 theorem continuousActionHom_eta (A : Action FintypeCat.{u} G) :

--- a/TauCeti/CategoryTheory/Action/ProfiniteCompletion.lean
+++ b/TauCeti/CategoryTheory/Action/ProfiniteCompletion.lean
@@ -1,0 +1,338 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.CategoryTheory.Galois.Examples
+public import Mathlib.CategoryTheory.Galois.IsFundamentalgroup
+public import TauCeti.Topology.Algebra.Group.Profinite.Completion
+
+/-!
+# Profinite completion and finite group actions
+
+The action of an abstract group `G` on a finite set extends uniquely and continuously to the
+profinite completion of `G`. These extensions are natural in the finite `G`-set, and together
+exhibit the profinite completion as the fundamental group of the forgetful fibre functor from
+finite `G`-sets.
+
+## Main declarations
+
+* `TauCeti.ProfiniteCompletion.continuousActionHom`: the continuous permutation representation
+  extending a finite `G`-action.
+* `TauCeti.ProfiniteCompletion.etaFn_smul`: the extended action restricts to the original action
+  along the canonical map from `G`.
+* `TauCeti.ProfiniteCompletion.instIsFundamentalGroup`: the profinite completion is a fundamental
+  group of the forgetful functor on finite `G`-sets.
+* `TauCeti.ProfiniteCompletion.autForgetFiniteActionMulEquiv`: the resulting canonical
+  isomorphism with the automorphism group of the forgetful functor.
+
+The construction uses Mathlib's profinite completion and its universal property. No external
+formalization is copied.
+-/
+
+public section
+noncomputable section
+
+open CategoryTheory
+open scoped CategoryTheory.PreGaloisCategory
+open CategoryTheory.Limits
+
+universe u
+
+namespace TauCeti.ProfiniteCompletion
+
+variable (G : Type u) [Group G]
+
+/-- The permutation representation of the profinite completion extending a finite `G`-action. -/
+def actionHom (A : Action FintypeCat.{u} G) :
+    ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G) →* Equiv.Perm A.V := by
+  let _ : TopologicalSpace (Equiv.Perm A.V) := ⊥
+  let _ : DiscreteTopology (Equiv.Perm A.V) := ⟨rfl⟩
+  exact ((continuousMonoidHomEquiv G (Equiv.Perm A.V)).symm
+    (MulAction.toPermHom G A.V)).toMonoidHom
+
+/-- The continuous permutation representation of the profinite completion extending a finite
+`G`-action. -/
+def continuousActionHom (A : Action FintypeCat.{u} G) :
+    ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G) ⟶
+      ProfiniteGrp.ofFiniteGrp (FiniteGrp.of (Equiv.Perm A.V)) := by
+  apply ConcreteCategory.ofHom
+  let _ : TopologicalSpace (Equiv.Perm A.V) := ⊥
+  let _ : DiscreteTopology (Equiv.Perm A.V) := ⟨rfl⟩
+  let f := (continuousMonoidHomEquiv G (Equiv.Perm A.V)).symm
+    (MulAction.toPermHom G A.V)
+  -- `ofFiniteGrp` hides its discrete underlying permutation group.
+  change ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G) →ₜ* Equiv.Perm A.V
+  exact f
+
+/-- A continuous permutation representation extending the action of `G` is the canonical
+extension `continuousActionHom`. -/
+theorem continuousActionHom_unique (A : Action FintypeCat.{u} G)
+    (f : ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G) ⟶
+      ProfiniteGrp.ofFiniteGrp (FiniteGrp.of (Equiv.Perm A.V)))
+    (h : ProfiniteGrp.ProfiniteCompletion.eta (GrpCat.of G) ≫
+        (forget₂ ProfiniteGrp GrpCat).map f =
+      GrpCat.ofHom (MulAction.toPermHom G A.V)) :
+    f = continuousActionHom G A := by
+  apply ProfiniteGrp.hom_ext
+  apply continuousMonoidHom_ext G
+  intro g
+  have hg := ConcreteCategory.congr_hom h g
+  change f.hom (ProfiniteGrp.ProfiniteCompletion.etaFn (GrpCat.of G) g) =
+    MulAction.toPermHom G A.V g at hg
+  have hc : actionHom G A (ProfiniteGrp.ProfiniteCompletion.etaFn (GrpCat.of G) g) =
+      MulAction.toPermHom G A.V g := by
+    let _ : TopologicalSpace (Equiv.Perm A.V) := ⊥
+    let _ : DiscreteTopology (Equiv.Perm A.V) := ⟨rfl⟩
+    exact continuousMonoidHomEquiv_symm_apply_etaFn G (Equiv.Perm A.V)
+      (MulAction.toPermHom G A.V) g
+  exact hg.trans hc.symm
+
+/-- The canonical action of the profinite completion of `G` on a finite `G`-set. -/
+@[instance_reducible]
+def mulAction (A : Action FintypeCat.{u} G) : MulAction
+    (ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G)) A.V where
+  smul g x := actionHom G A g x
+  one_smul x := by
+    -- Expose the action's defining permutation so that the homomorphism law applies.
+    change actionHom G A 1 x = x
+    rw [map_one (actionHom G A)]
+    rfl
+  mul_smul g h x := by
+    -- Expose the action's defining permutation so that the homomorphism law applies.
+    change actionHom G A (g * h) x = actionHom G A g (actionHom G A h x)
+    rw [map_mul (actionHom G A) g h]
+    rfl
+
+/-- The profinite completion acts on every finite `G`-set. -/
+instance instMulAction (A : Action FintypeCat.{u} G) : MulAction
+    (ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G)) A.V :=
+  mulAction G A
+
+/-- The profinite-completion action, in the exact form expected by the forgetful functor. -/
+instance instMulActionForgetObj (A : Action FintypeCat.{u} G) : MulAction
+    (ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G))
+    ((Action.forget FintypeCat G).obj A) :=
+  mulAction G A
+
+/-- The extended permutation representation restricts along `G → Ĝ` to the original one. -/
+@[simp]
+theorem actionHom_etaFn (A : Action FintypeCat.{u} G) (g : G) :
+    actionHom G A (ProfiniteGrp.ProfiniteCompletion.etaFn (GrpCat.of G) g) =
+      MulAction.toPermHom G A.V g := by
+  let _ : TopologicalSpace (Equiv.Perm A.V) := ⊥
+  let _ : DiscreteTopology (Equiv.Perm A.V) := ⟨rfl⟩
+  exact continuousMonoidHomEquiv_symm_apply_etaFn G (Equiv.Perm A.V)
+    (MulAction.toPermHom G A.V) g
+
+/-- The extended action restricts along the canonical map `G → Ĝ` to the original action. -/
+@[simp]
+theorem etaFn_smul (A : Action FintypeCat.{u} G) (g : G) (x : A.V) :
+    ProfiniteGrp.ProfiniteCompletion.etaFn (GrpCat.of G) g • x = g • x := by
+  -- Unfold only the registered action, leaving the completion construction opaque.
+  change actionHom G A (ProfiniteGrp.ProfiniteCompletion.etaFn (GrpCat.of G) g) x = g • x
+  rw [actionHom_etaFn]
+  rfl
+
+/-- The restriction formula for the action carried by the forgetful functor. -/
+@[simp]
+theorem etaFn_smul_forget (A : Action FintypeCat.{u} G) (g : G)
+    (x : (Action.forget FintypeCat G).obj A) :
+    ProfiniteGrp.ProfiniteCompletion.etaFn (GrpCat.of G) g • x =
+      ConcreteCategory.hom (A.ρ g) x := by
+  -- `Action.forget` hides the underlying finite type and hence the registered action.
+  change actionHom G A (ProfiniteGrp.ProfiniteCompletion.etaFn (GrpCat.of G) g) x =
+    ConcreteCategory.hom (A.ρ g) x
+  rw [actionHom_etaFn]
+  rfl
+
+/-- The extended action on a finite `G`-set is continuous when the set has the discrete
+topology. -/
+theorem continuousSMul (A : Action FintypeCat.{u} G) :
+    @ContinuousSMul
+      (ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G)) A.V
+      inferInstance inferInstance ⊥ := by
+  let _ : TopologicalSpace A.V := ⊥
+  let _ : DiscreteTopology A.V := ⟨rfl⟩
+  let _ : TopologicalSpace (Equiv.Perm A.V) := ⊥
+  let _ : DiscreteTopology (Equiv.Perm A.V) := ⟨rfl⟩
+  refine ⟨?_⟩
+  -- The class projection does not unfold the deliberately reducible action instance.
+  change Continuous fun p :
+    ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G) × A.V =>
+      actionHom G A p.1 p.2
+  have hf : Continuous (actionHom G A) := by
+    have h := (continuousActionHom G A).hom.continuous_toFun
+    -- `ofFiniteGrp` hides its discrete underlying permutation group.
+    change Continuous (actionHom G A) at h
+    exact h
+  have heval : Continuous (fun p : Equiv.Perm A.V × A.V => p.1 p.2) :=
+    continuous_of_discreteTopology
+  exact heval.comp (hf.prodMap (continuous_id : Continuous (id : A.V → A.V)))
+
+/-- The profinite-completion actions on finite `G`-sets are natural in equivariant maps. -/
+instance instIsNaturalSMul : CategoryTheory.PreGaloisCategory.IsNaturalSMul
+    (Action.forget FintypeCat.{u} G)
+    (ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G)) where
+  naturality g {A B} f x := by
+    let _ : TopologicalSpace A.V := ⊥
+    let _ : DiscreteTopology A.V := ⟨rfl⟩
+    let _ : TopologicalSpace B.V := ⊥
+    let _ : DiscreteTopology B.V := ⟨rfl⟩
+    let hA := continuousSMul G A
+    let hB := continuousSMul G B
+    have hAx : Continuous (fun a :
+        ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G) => a • x) :=
+      hA.continuous_smul.comp (continuous_id.prodMk continuous_const)
+    have hBx : Continuous (fun a :
+        ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G) => a • f.hom x) :=
+      hB.continuous_smul.comp (continuous_id.prodMk continuous_const)
+    have hfun :
+        (fun a : ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G) => f.hom (a • x)) =
+          (fun a => a • f.hom x) :=
+      (ProfiniteGrp.ProfiniteCompletion.denseRange (G := GrpCat.of G)).equalizer
+        (continuous_of_discreteTopology.comp hAx) hBx (funext fun a => by
+          -- Reveal both extended actions beneath `Action.forget` before using equivariance.
+          change f.hom (actionHom G A
+            (ProfiniteGrp.ProfiniteCompletion.etaFn (GrpCat.of G) a) x) =
+            actionHom G B (ProfiniteGrp.ProfiniteCompletion.etaFn (GrpCat.of G) a) (f.hom x)
+          rw [actionHom_etaFn, actionHom_etaFn]
+          exact ConcreteCategory.congr_hom (f.comm a) x)
+    exact congrFun hfun g
+
+/-- On a connected finite `G`-set, the profinite-completion action is transitive. -/
+theorem isPretransitive_of_isConnected (A : Action FintypeCat.{u} G)
+    [CategoryTheory.PreGaloisCategory.IsConnected A] :
+    MulAction.IsPretransitive
+      (ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G)) A.V where
+  exists_smul_eq x y := by
+    let _ := CategoryTheory.FintypeCat.Action.pretransitive_of_isConnected G A
+    obtain ⟨g, hg⟩ := MulAction.exists_smul_eq G x y
+    exact ⟨ProfiniteGrp.ProfiniteCompletion.etaFn (GrpCat.of G) g, by
+      rw [etaFn_smul]
+      exact hg⟩
+
+/-- The projection from the profinite completion onto its finite quotient indexed by `H`. -/
+def coordinateHom (H : FiniteIndexNormalSubgroup G) :
+    ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G) →* G ⧸ H.toSubgroup := by
+  let f := ((ProfiniteGrp.limitCone
+    (ProfiniteGrp.ProfiniteCompletion.diagram (GrpCat.of G))).π.app H).hom
+    |>.toMonoidHom
+  -- The finite-quotient object hides its underlying quotient group.
+  change ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G) →* G ⧸ H.toSubgroup at f
+  exact f
+
+/-- The `H`-coordinate of the canonical image of `g` is its coset modulo `H`. -/
+@[simp]
+theorem coordinateHom_etaFn (H : FiniteIndexNormalSubgroup G) (g : G) :
+    coordinateHom G H (ProfiniteGrp.ProfiniteCompletion.etaFn (GrpCat.of G) g) =
+      QuotientGroup.mk g := by
+  rfl
+
+/-- On the finite quotient by `H`, acting on the identity coset reads the `H`-coordinate of
+an element of the profinite completion. -/
+theorem actionHom_one_quotient (H : FiniteIndexNormalSubgroup G)
+    (g : ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G)) :
+    let A : Action FintypeCat.{u} G := G ⧸ₐ H.toSubgroup
+    actionHom G A g (1 : G ⧸ H.toSubgroup) = coordinateHom G H g := by
+  let A : Action FintypeCat.{u} G := G ⧸ₐ H.toSubgroup
+  let _ : TopologicalSpace (G ⧸ H.toSubgroup) := ⊥
+  let _ : DiscreteTopology (G ⧸ H.toSubgroup) := ⟨rfl⟩
+  let _ : TopologicalSpace A.V := ⊥
+  let _ : DiscreteTopology A.V := ⟨rfl⟩
+  let _ : TopologicalSpace (Equiv.Perm A.V) := ⊥
+  let _ : DiscreteTopology (Equiv.Perm A.V) := ⟨rfl⟩
+  have hl : Continuous (fun z :
+      ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G) =>
+        actionHom G A z (1 : G ⧸ H.toSubgroup)) := by
+    have hf : Continuous (actionHom G A) := by
+      have h := (continuousActionHom G A).hom.continuous_toFun
+      -- `ofFiniteGrp` hides its discrete underlying permutation group.
+      change Continuous (actionHom G A) at h
+      exact h
+    have heval : Continuous (fun e : Equiv.Perm A.V =>
+        e (1 : G ⧸ H.toSubgroup)) := continuous_of_discreteTopology
+    exact heval.comp hf
+  have hr : Continuous (fun z :
+      ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G) => coordinateHom G H z) := by
+    have h := ((ProfiniteGrp.limitCone
+      (ProfiniteGrp.ProfiniteCompletion.diagram (GrpCat.of G))).π.app H).hom.continuous_toFun
+    -- The limit projection is definitionally the unbundled coordinate homomorphism.
+    change Continuous (coordinateHom G H) at h
+    exact h
+  have hfun := (ProfiniteGrp.ProfiniteCompletion.denseRange (G := GrpCat.of G)).equalizer
+    hl hr (funext fun a => by
+      simp only [Function.comp_apply]
+      -- Reveal the two extensions on the dense canonical image.
+      change actionHom G A (ProfiniteGrp.ProfiniteCompletion.etaFn (GrpCat.of G) a)
+          (1 : G ⧸ H.toSubgroup) = (QuotientGroup.mk a : G ⧸ H.toSubgroup)
+      rw [actionHom_etaFn]
+      exact mul_one (QuotientGroup.mk a : G ⧸ H.toSubgroup))
+  exact congrFun hfun g
+
+/-- An element of the profinite completion acting trivially on every finite `G`-set is the
+identity. The regular actions on the finite quotients detect all coordinates of the limit. -/
+theorem eq_one_of_forall_smul_eq
+    (g : ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G))
+    (h : ∀ (A : Action FintypeCat.{u} G)
+      (x : (Action.forget FintypeCat G).obj A), g • x = x) :
+    g = 1 := by
+  apply ProfiniteGrp.limit_ext
+  intro H
+  -- `limit_ext` presents the coordinate as a bundled cone projection.
+  change coordinateHom G H g = 1
+  let A : Action FintypeCat.{u} G := G ⧸ₐ H.toSubgroup
+  have hg := h A (1 : G ⧸ H.toSubgroup)
+  -- Reveal the finite-quotient action beneath the forgetful functor.
+  change actionHom G A g (1 : G ⧸ H.toSubgroup) =
+    (1 : G ⧸ H.toSubgroup) at hg
+  rw [actionHom_one_quotient] at hg
+  exact hg
+
+/-- The profinite completion of `G` is a fundamental group of the forgetful fibre functor on
+finite `G`-sets. -/
+instance instIsFundamentalGroup : CategoryTheory.PreGaloisCategory.IsFundamentalGroup
+    (Action.forget FintypeCat.{u} G)
+    (ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G)) where
+  naturality := CategoryTheory.PreGaloisCategory.IsNaturalSMul.naturality
+  transitive_of_isGalois A := by
+    intro
+    constructor
+    intro x y
+    let _ := CategoryTheory.FintypeCat.Action.pretransitive_of_isConnected G A
+    -- The forgetful functor's object is definitionally the action's underlying finite type.
+    obtain ⟨g, hg⟩ := MulAction.exists_smul_eq G (show A.V from x) (show A.V from y)
+    refine ⟨ProfiniteGrp.ProfiniteCompletion.etaFn (GrpCat.of G) g, ?_⟩
+    rw [etaFn_smul_forget]
+    exact hg
+  continuous_smul A := continuousSMul G A
+  non_trivial' g h := eq_one_of_forall_smul_eq G g h
+
+/-- The profinite completion of `G` is canonically isomorphic to the automorphism group of the
+forgetful fibre functor on finite `G`-sets. -/
+noncomputable def autForgetFiniteActionMulEquiv :
+    ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G) ≃*
+      Aut (Action.forget FintypeCat.{u} G) :=
+  CategoryTheory.PreGaloisCategory.toAutMulEquiv
+    (Action.forget FintypeCat.{u} G)
+    (ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G))
+
+/-- Under `autForgetFiniteActionMulEquiv`, the image of `g : G` acts on every finite `G`-set by
+the original action of `g`. -/
+@[simp]
+theorem autForgetFiniteActionMulEquiv_etaFn_hom_app_apply
+    (g : G) (A : Action FintypeCat.{u} G)
+    (x : (Action.forget FintypeCat G).obj A) :
+    (autForgetFiniteActionMulEquiv G
+      (ProfiniteGrp.ProfiniteCompletion.etaFn (GrpCat.of G) g)).hom.app A x =
+        ConcreteCategory.hom (A.ρ g) x := by
+  -- Reveal the `toAut` homomorphism packaged by `toAutMulEquiv`.
+  change (CategoryTheory.PreGaloisCategory.toAut
+    (Action.forget FintypeCat.{u} G)
+    (ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G))
+    (ProfiniteGrp.ProfiniteCompletion.etaFn (GrpCat.of G) g)).hom.app A x = _
+  rw [CategoryTheory.PreGaloisCategory.toAut_hom_app_apply, etaFn_smul_forget]
+
+end TauCeti.ProfiniteCompletion

--- a/TauCeti/CategoryTheory/Action/ProfiniteCompletion.lean
+++ b/TauCeti/CategoryTheory/Action/ProfiniteCompletion.lean
@@ -7,7 +7,7 @@ module
 
 public import Mathlib.CategoryTheory.Galois.Examples
 public import Mathlib.CategoryTheory.Galois.IsFundamentalgroup
-public import TauCeti.Topology.Algebra.Group.Profinite.Completion
+public import Mathlib.Topology.Algebra.Category.ProfiniteGrp.Completion
 
 /-!
 # Profinite completion and finite group actions
@@ -45,26 +45,21 @@ namespace TauCeti.ProfiniteCompletion
 
 variable (G : Type u) [Group G]
 
-/-- The permutation representation of the profinite completion extending a finite `G`-action. -/
-def actionHom (A : Action FintypeCat.{u} G) :
-    ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G) →* Equiv.Perm A.V := by
-  let _ : TopologicalSpace (Equiv.Perm A.V) := ⊥
-  let _ : DiscreteTopology (Equiv.Perm A.V) := ⟨rfl⟩
-  exact ((continuousMonoidHomEquiv G (Equiv.Perm A.V)).symm
-    (MulAction.toPermHom G A.V)).toMonoidHom
-
 /-- The continuous permutation representation of the profinite completion extending a finite
 `G`-action. -/
 def continuousActionHom (A : Action FintypeCat.{u} G) :
     ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G) ⟶
-      ProfiniteGrp.ofFiniteGrp (FiniteGrp.of (Equiv.Perm A.V)) := by
-  apply ConcreteCategory.ofHom
-  let _ : TopologicalSpace (Equiv.Perm A.V) := ⊥
-  let _ : DiscreteTopology (Equiv.Perm A.V) := ⟨rfl⟩
-  let f := (continuousMonoidHomEquiv G (Equiv.Perm A.V)).symm
-    (MulAction.toPermHom G A.V)
+      ProfiniteGrp.ofFiniteGrp (FiniteGrp.of (Equiv.Perm A.V)) :=
+  ProfiniteGrp.ProfiniteCompletion.lift
+    (P := ProfiniteGrp.ofFiniteGrp (FiniteGrp.of (Equiv.Perm A.V)))
+    (GrpCat.ofHom (MulAction.toPermHom G A.V))
+
+/-- The permutation representation of the profinite completion extending a finite `G`-action. -/
+def actionHom (A : Action FintypeCat.{u} G) :
+    ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G) →* Equiv.Perm A.V := by
+  let f := (continuousActionHom G A).hom.toMonoidHom
   -- `ofFiniteGrp` hides its discrete underlying permutation group.
-  change ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G) →ₜ* Equiv.Perm A.V
+  change ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G) →* Equiv.Perm A.V at f
   exact f
 
 /-- A continuous permutation representation extending the action of `G` is the canonical
@@ -75,20 +70,11 @@ theorem continuousActionHom_unique (A : Action FintypeCat.{u} G)
     (h : ProfiniteGrp.ProfiniteCompletion.eta (GrpCat.of G) ≫
         (forget₂ ProfiniteGrp GrpCat).map f =
       GrpCat.ofHom (MulAction.toPermHom G A.V)) :
-    f = continuousActionHom G A := by
-  apply ProfiniteGrp.hom_ext
-  apply continuousMonoidHom_ext G
-  intro g
-  have hg := ConcreteCategory.congr_hom h g
-  change f.hom (ProfiniteGrp.ProfiniteCompletion.etaFn (GrpCat.of G) g) =
-    MulAction.toPermHom G A.V g at hg
-  have hc : actionHom G A (ProfiniteGrp.ProfiniteCompletion.etaFn (GrpCat.of G) g) =
-      MulAction.toPermHom G A.V g := by
-    let _ : TopologicalSpace (Equiv.Perm A.V) := ⊥
-    let _ : DiscreteTopology (Equiv.Perm A.V) := ⟨rfl⟩
-    exact continuousMonoidHomEquiv_symm_apply_etaFn G (Equiv.Perm A.V)
-      (MulAction.toPermHom G A.V) g
-  exact hg.trans hc.symm
+    f = continuousActionHom G A :=
+  ProfiniteGrp.ProfiniteCompletion.lift_unique _ _
+    (h.trans (ProfiniteGrp.ProfiniteCompletion.lift_eta
+      (P := ProfiniteGrp.ofFiniteGrp (FiniteGrp.of (Equiv.Perm A.V)))
+      (GrpCat.ofHom (MulAction.toPermHom G A.V))).symm)
 
 /-- The canonical action of the profinite completion of `G` on a finite `G`-set. -/
 @[instance_reducible]
@@ -122,10 +108,14 @@ instance instMulActionForgetObj (A : Action FintypeCat.{u} G) : MulAction
 theorem actionHom_etaFn (A : Action FintypeCat.{u} G) (g : G) :
     actionHom G A (ProfiniteGrp.ProfiniteCompletion.etaFn (GrpCat.of G) g) =
       MulAction.toPermHom G A.V g := by
-  let _ : TopologicalSpace (Equiv.Perm A.V) := ⊥
-  let _ : DiscreteTopology (Equiv.Perm A.V) := ⟨rfl⟩
-  exact continuousMonoidHomEquiv_symm_apply_etaFn G (Equiv.Perm A.V)
-    (MulAction.toPermHom G A.V) g
+  have h := ConcreteCategory.congr_hom
+    (ProfiniteGrp.ProfiniteCompletion.lift_eta
+      (P := ProfiniteGrp.ofFiniteGrp (FiniteGrp.of (Equiv.Perm A.V)))
+      (GrpCat.ofHom (MulAction.toPermHom G A.V))) g
+  -- `lift_eta` presents the restriction as a composite of bundled group homomorphisms.
+  change actionHom G A (ProfiniteGrp.ProfiniteCompletion.etaFn (GrpCat.of G) g) =
+    MulAction.toPermHom G A.V g at h
+  exact h
 
 /-- The extended action restricts along the canonical map `G → Ĝ` to the original action. -/
 @[simp]
@@ -297,16 +287,7 @@ instance instIsFundamentalGroup : CategoryTheory.PreGaloisCategory.IsFundamental
     (Action.forget FintypeCat.{u} G)
     (ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G)) where
   naturality := CategoryTheory.PreGaloisCategory.IsNaturalSMul.naturality
-  transitive_of_isGalois A := by
-    intro
-    constructor
-    intro x y
-    let _ := CategoryTheory.FintypeCat.Action.pretransitive_of_isConnected G A
-    -- The forgetful functor's object is definitionally the action's underlying finite type.
-    obtain ⟨g, hg⟩ := MulAction.exists_smul_eq G (show A.V from x) (show A.V from y)
-    refine ⟨ProfiniteGrp.ProfiniteCompletion.etaFn (GrpCat.of G) g, ?_⟩
-    rw [etaFn_smul_forget]
-    exact hg
+  transitive_of_isGalois A := isPretransitive_of_isConnected G A
   continuous_smul A := continuousSMul G A
   non_trivial' g h := eq_one_of_forall_smul_eq G g h
 

--- a/TauCeti/CategoryTheory/Action/ProfiniteCompletion.lean
+++ b/TauCeti/CategoryTheory/Action/ProfiniteCompletion.lean
@@ -244,15 +244,16 @@ theorem eq_one_of_forall_smul_eq
     g = 1 := by
   apply ProfiniteGrp.limit_ext
   intro H
-  -- `limit_ext` presents the coordinate as a bundled cone projection.
-  change coordinateHom G H g = 1
   let A : Action FintypeCat.{u} G := G ⧸ₐ H.toSubgroup
   have hg := h A (1 : G ⧸ H.toSubgroup)
   -- Reveal the finite-quotient action beneath the forgetful functor.
   change actionHom G A g (1 : G ⧸ H.toSubgroup) =
     (1 : G ⧸ H.toSubgroup) at hg
-  rw [actionHom_one_quotient] at hg
-  exact hg
+  have hg' : coordinateHom G H g = (1 : G ⧸ H.toSubgroup) := by
+    rw [← actionHom_one_quotient G H g]
+    exact hg
+  rw [← coordinateHom_apply G H g, ← coordinateHom_apply G H 1, map_one]
+  exact hg'
 
 /-- The profinite completion of `G` is a fundamental group of the forgetful fibre functor on
 finite `G`-sets. -/

--- a/TauCeti/CategoryTheory/Action/ProfiniteCompletion.lean
+++ b/TauCeti/CategoryTheory/Action/ProfiniteCompletion.lean
@@ -61,15 +61,6 @@ def actionHom (A : Action FintypeCat.{u} G) :
   change ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G) →* Equiv.Perm A.V at f
   exact f
 
-/-- The extended continuous representation restricts along the canonical morphism `G → Ĝ` to the
-original permutation representation. -/
-@[simp]
-theorem continuousActionHom_eta (A : Action FintypeCat.{u} G) :
-    ProfiniteGrp.ProfiniteCompletion.eta (GrpCat.of G) ≫
-        (forget₂ ProfiniteGrp GrpCat).map (continuousActionHom G A) =
-      GrpCat.ofHom (MulAction.toPermHom G A.V) :=
-  ProfiniteGrp.ProfiniteCompletion.lift_eta _
-
 /-- The profinite completion acts on every finite `G`-set. -/
 @[instance_reducible]
 instance instMulAction (A : Action FintypeCat.{u} G) : MulAction
@@ -98,9 +89,10 @@ instance instMulActionForgetObj (A : Action FintypeCat.{u} G) : MulAction
 theorem actionHom_etaFn (A : Action FintypeCat.{u} G) (g : G) :
     actionHom G A (ProfiniteGrp.ProfiniteCompletion.etaFn (GrpCat.of G) g) =
       MulAction.toPermHom G A.V g := by
-  have h := ConcreteCategory.congr_hom (continuousActionHom_eta G A) g
-  -- `continuousActionHom_eta` presents the restriction as a composite of bundled group
-  -- homomorphisms.
+  have h := ConcreteCategory.congr_hom (ProfiniteGrp.ProfiniteCompletion.lift_eta
+    (P := ProfiniteGrp.ofFiniteGrp (FiniteGrp.of (Equiv.Perm A.V)))
+    (GrpCat.ofHom (MulAction.toPermHom G A.V))) g
+  -- `lift_eta` presents the restriction as a composite of bundled group homomorphisms.
   change actionHom G A (ProfiniteGrp.ProfiniteCompletion.etaFn (GrpCat.of G) g) =
     MulAction.toPermHom G A.V g at h
   exact h

--- a/TauCeti/CategoryTheory/Action/ProfiniteCompletion.lean
+++ b/TauCeti/CategoryTheory/Action/ProfiniteCompletion.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.CategoryTheory.Galois.Examples
 public import Mathlib.CategoryTheory.Galois.IsFundamentalgroup
 public import Mathlib.Topology.Algebra.Category.ProfiniteGrp.Completion
+public import TauCeti.Topology.Algebra.Group.Profinite.Completion
 
 /-!
 # Profinite completion and finite group actions
@@ -28,8 +29,7 @@ finite `G`-sets.
 * `TauCeti.ProfiniteCompletion.autForgetFiniteActionMulEquiv`: the resulting canonical
   isomorphism with the automorphism group of the forgetful functor.
 
-The construction uses Mathlib's profinite completion and its universal property. No external
-formalization is copied.
+The construction uses Mathlib's profinite completion and its universal property.
 -/
 
 public section
@@ -62,19 +62,14 @@ def actionHom (A : Action FintypeCat.{u} G) :
   change ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G) →* Equiv.Perm A.V at f
   exact f
 
-/-- A continuous permutation representation extending the action of `G` is the canonical
-extension `continuousActionHom`. -/
-theorem continuousActionHom_unique (A : Action FintypeCat.{u} G)
-    (f : ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G) ⟶
-      ProfiniteGrp.ofFiniteGrp (FiniteGrp.of (Equiv.Perm A.V)))
-    (h : ProfiniteGrp.ProfiniteCompletion.eta (GrpCat.of G) ≫
-        (forget₂ ProfiniteGrp GrpCat).map f =
-      GrpCat.ofHom (MulAction.toPermHom G A.V)) :
-    f = continuousActionHom G A :=
-  ProfiniteGrp.ProfiniteCompletion.lift_unique _ _
-    (h.trans (ProfiniteGrp.ProfiniteCompletion.lift_eta
-      (P := ProfiniteGrp.ofFiniteGrp (FiniteGrp.of (Equiv.Perm A.V)))
-      (GrpCat.ofHom (MulAction.toPermHom G A.V))).symm)
+/-- The extended continuous representation restricts along the canonical morphism `G → Ĝ` to the
+original permutation representation. -/
+@[simp]
+theorem continuousActionHom_eta (A : Action FintypeCat.{u} G) :
+    ProfiniteGrp.ProfiniteCompletion.eta (GrpCat.of G) ≫
+        (forget₂ ProfiniteGrp GrpCat).map (continuousActionHom G A) =
+      GrpCat.ofHom (MulAction.toPermHom G A.V) :=
+  ProfiniteGrp.ProfiniteCompletion.lift_eta _
 
 /-- The canonical action of the profinite completion of `G` on a finite `G`-set. -/
 @[instance_reducible]
@@ -108,11 +103,9 @@ instance instMulActionForgetObj (A : Action FintypeCat.{u} G) : MulAction
 theorem actionHom_etaFn (A : Action FintypeCat.{u} G) (g : G) :
     actionHom G A (ProfiniteGrp.ProfiniteCompletion.etaFn (GrpCat.of G) g) =
       MulAction.toPermHom G A.V g := by
-  have h := ConcreteCategory.congr_hom
-    (ProfiniteGrp.ProfiniteCompletion.lift_eta
-      (P := ProfiniteGrp.ofFiniteGrp (FiniteGrp.of (Equiv.Perm A.V)))
-      (GrpCat.ofHom (MulAction.toPermHom G A.V))) g
-  -- `lift_eta` presents the restriction as a composite of bundled group homomorphisms.
+  have h := ConcreteCategory.congr_hom (continuousActionHom_eta G A) g
+  -- `continuousActionHom_eta` presents the restriction as a composite of bundled group
+  -- homomorphisms.
   change actionHom G A (ProfiniteGrp.ProfiniteCompletion.etaFn (GrpCat.of G) g) =
     MulAction.toPermHom G A.V g at h
   exact h
@@ -138,6 +131,14 @@ theorem etaFn_smul_forget (A : Action FintypeCat.{u} G) (g : G)
   rw [actionHom_etaFn]
   rfl
 
+/-- The extended permutation representation is continuous, the finite permutation group carrying
+the discrete topology. -/
+theorem continuous_actionHom (A : Action FintypeCat.{u} G) :
+    @Continuous (ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G))
+      (Equiv.Perm A.V) inferInstance ⊥ (actionHom G A) :=
+  -- `ofFiniteGrp` hides its discrete underlying permutation group.
+  (continuousActionHom G A).hom.continuous_toFun
+
 /-- The extended action on a finite `G`-set is continuous when the set has the discrete
 topology. -/
 theorem continuousSMul (A : Action FintypeCat.{u} G) :
@@ -153,11 +154,7 @@ theorem continuousSMul (A : Action FintypeCat.{u} G) :
   change Continuous fun p :
     ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G) × A.V =>
       actionHom G A p.1 p.2
-  have hf : Continuous (actionHom G A) := by
-    have h := (continuousActionHom G A).hom.continuous_toFun
-    -- `ofFiniteGrp` hides its discrete underlying permutation group.
-    change Continuous (actionHom G A) at h
-    exact h
+  have hf : Continuous (actionHom G A) := continuous_actionHom G A
   have heval : Continuous (fun p : Equiv.Perm A.V × A.V => p.1 p.2) :=
     continuous_of_discreteTopology
   exact heval.comp (hf.prodMap (continuous_id : Continuous (id : A.V → A.V)))
@@ -204,23 +201,6 @@ theorem isPretransitive_of_isConnected (A : Action FintypeCat.{u} G)
       rw [etaFn_smul]
       exact hg⟩
 
-/-- The projection from the profinite completion onto its finite quotient indexed by `H`. -/
-def coordinateHom (H : FiniteIndexNormalSubgroup G) :
-    ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G) →* G ⧸ H.toSubgroup := by
-  let f := ((ProfiniteGrp.limitCone
-    (ProfiniteGrp.ProfiniteCompletion.diagram (GrpCat.of G))).π.app H).hom
-    |>.toMonoidHom
-  -- The finite-quotient object hides its underlying quotient group.
-  change ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G) →* G ⧸ H.toSubgroup at f
-  exact f
-
-/-- The `H`-coordinate of the canonical image of `g` is its coset modulo `H`. -/
-@[simp]
-theorem coordinateHom_etaFn (H : FiniteIndexNormalSubgroup G) (g : G) :
-    coordinateHom G H (ProfiniteGrp.ProfiniteCompletion.etaFn (GrpCat.of G) g) =
-      QuotientGroup.mk g := by
-  rfl
-
 /-- On the finite quotient by `H`, acting on the identity coset reads the `H`-coordinate of
 an element of the profinite completion. -/
 theorem actionHom_one_quotient (H : FiniteIndexNormalSubgroup G)
@@ -237,28 +217,21 @@ theorem actionHom_one_quotient (H : FiniteIndexNormalSubgroup G)
   have hl : Continuous (fun z :
       ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G) =>
         actionHom G A z (1 : G ⧸ H.toSubgroup)) := by
-    have hf : Continuous (actionHom G A) := by
-      have h := (continuousActionHom G A).hom.continuous_toFun
-      -- `ofFiniteGrp` hides its discrete underlying permutation group.
-      change Continuous (actionHom G A) at h
-      exact h
+    have hf : Continuous (actionHom G A) := continuous_actionHom G A
     have heval : Continuous (fun e : Equiv.Perm A.V =>
         e (1 : G ⧸ H.toSubgroup)) := continuous_of_discreteTopology
     exact heval.comp hf
   have hr : Continuous (fun z :
-      ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G) => coordinateHom G H z) := by
-    have h := ((ProfiniteGrp.limitCone
-      (ProfiniteGrp.ProfiniteCompletion.diagram (GrpCat.of G))).π.app H).hom.continuous_toFun
-    -- The limit projection is definitionally the unbundled coordinate homomorphism.
-    change Continuous (coordinateHom G H) at h
-    exact h
+      ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G) => coordinateHom G H z) :=
+    continuous_coordinateHom G H
   have hfun := (ProfiniteGrp.ProfiniteCompletion.denseRange (G := GrpCat.of G)).equalizer
     hl hr (funext fun a => by
       simp only [Function.comp_apply]
-      -- Reveal the two extensions on the dense canonical image.
+      -- Reveal the extended action on the dense canonical image.
       change actionHom G A (ProfiniteGrp.ProfiniteCompletion.etaFn (GrpCat.of G) a)
-          (1 : G ⧸ H.toSubgroup) = (QuotientGroup.mk a : G ⧸ H.toSubgroup)
-      rw [actionHom_etaFn]
+          (1 : G ⧸ H.toSubgroup) =
+        coordinateHom G H (ProfiniteGrp.ProfiniteCompletion.etaFn (GrpCat.of G) a)
+      rw [actionHom_etaFn, coordinateHom_etaFn]
       exact mul_one (QuotientGroup.mk a : G ⧸ H.toSubgroup))
   exact congrFun hfun g
 
@@ -300,20 +273,23 @@ noncomputable def autForgetFiniteActionMulEquiv :
     (Action.forget FintypeCat.{u} G)
     (ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G))
 
-/-- Under `autForgetFiniteActionMulEquiv`, the image of `g : G` acts on every finite `G`-set by
-the original action of `g`. -/
+/-- Under `autForgetFiniteActionMulEquiv`, an element of the profinite completion acts on every
+finite `G`-set by its extended action. -/
 @[simp]
-theorem autForgetFiniteActionMulEquiv_etaFn_hom_app_apply
-    (g : G) (A : Action FintypeCat.{u} G)
-    (x : (Action.forget FintypeCat G).obj A) :
-    (autForgetFiniteActionMulEquiv G
-      (ProfiniteGrp.ProfiniteCompletion.etaFn (GrpCat.of G) g)).hom.app A x =
-        ConcreteCategory.hom (A.ρ g) x := by
+theorem autForgetFiniteActionMulEquiv_hom_app_apply
+    (g : ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G))
+    (A : Action FintypeCat.{u} G) (x : (Action.forget FintypeCat G).obj A) :
+    (autForgetFiniteActionMulEquiv G g).hom.app A x = g • x := by
   -- Reveal the `toAut` homomorphism packaged by `toAutMulEquiv`.
   change (CategoryTheory.PreGaloisCategory.toAut
     (Action.forget FintypeCat.{u} G)
-    (ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G))
-    (ProfiniteGrp.ProfiniteCompletion.etaFn (GrpCat.of G) g)).hom.app A x = _
-  rw [CategoryTheory.PreGaloisCategory.toAut_hom_app_apply, etaFn_smul_forget]
+    (ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G)) g).hom.app A x = _
+  rw [CategoryTheory.PreGaloisCategory.toAut_hom_app_apply]
+
+/-- The canonical isomorphism with the automorphism group of the forgetful functor is a
+homeomorphism. -/
+theorem autForgetFiniteActionMulEquiv_isHomeomorph :
+    IsHomeomorph (autForgetFiniteActionMulEquiv G) :=
+  CategoryTheory.PreGaloisCategory.toAutMulEquiv_isHomeomorph _ _
 
 end TauCeti.ProfiniteCompletion

--- a/TauCeti/CategoryTheory/Action/ProfiniteCompletion.lean
+++ b/TauCeti/CategoryTheory/Action/ProfiniteCompletion.lean
@@ -19,7 +19,7 @@ finite `G`-sets.
 
 ## Main declarations
 
-* `TauCeti.ProfiniteCompletion.continuousActionHom`: the continuous permutation representation
+* `TauCeti.ProfiniteCompletion.actionHom`: the continuous permutation representation
   extending a finite `G`-action.
 * `TauCeti.ProfiniteCompletion.etaFn_smul`: the extended action restricts to the original action
   along the canonical map from `G`.
@@ -46,7 +46,7 @@ variable (G : Type u) [Group G]
 
 /-- The continuous permutation representation of the profinite completion extending a finite
 `G`-action. -/
-def continuousActionHom (A : Action FintypeCat.{u} G) :
+private def continuousActionHom (A : Action FintypeCat.{u} G) :
     ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G) ⟶
       ProfiniteGrp.ofFiniteGrp (FiniteGrp.of (Equiv.Perm A.V)) :=
   ProfiniteGrp.ProfiniteCompletion.lift

--- a/TauCeti/Topology/Algebra/Group/Profinite/Completion.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Completion.lean
@@ -104,13 +104,16 @@ private theorem coordinateHom_apply_def (H : FiniteIndexNormalSubgroup G)
 
 /-- The projection onto the finite quotient by `H` evaluates the underlying compatible family of
 cosets at `H`. -/
+@[simp]
 theorem coordinateHom_apply (H : FiniteIndexNormalSubgroup G)
     (x : ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G)) :
     coordinateHom G H x = x.val H :=
   coordinateHom_apply_def G H x
 
 /-- The `H`-coordinate of the canonical image of `g` is its coset modulo `H`. -/
-@[simp]
+-- The priority keeps this specialization ahead of `coordinateHom_apply`, which would otherwise
+-- rewrite its left-hand side to the raw coordinate of the canonical image.
+@[simp high]
 theorem coordinateHom_etaFn (H : FiniteIndexNormalSubgroup G) (g : G) :
     coordinateHom G H (ProfiniteGrp.ProfiniteCompletion.etaFn (GrpCat.of G) g) =
       QuotientGroup.mk g := by

--- a/TauCeti/Topology/Algebra/Group/Profinite/Completion.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Completion.lean
@@ -97,18 +97,15 @@ def coordinateHom (H : FiniteIndexNormalSubgroup G) :
   change ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G) →* G ⧸ H.toSubgroup at f
   exact f
 
-private theorem coordinateHom_apply_def (H : FiniteIndexNormalSubgroup G)
-    (x : ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G)) :
-    coordinateHom G H x = x.val H :=
-  rfl
-
 /-- The projection onto the finite quotient by `H` evaluates the underlying compatible family of
 cosets at `H`. -/
 @[simp]
 theorem coordinateHom_apply (H : FiniteIndexNormalSubgroup G)
     (x : ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G)) :
     coordinateHom G H x = x.val H :=
-  coordinateHom_apply_def G H x
+  -- The limit-cone projection computes on coordinates by definition; isolate that reduction in
+  -- this opaque theorem so that `coordinateHom` itself stays unexposed.
+  (rfl)
 
 /-- The `H`-coordinate of the canonical image of `g` is its coset modulo `H`. -/
 -- The priority keeps this specialization ahead of `coordinateHom_apply`, which would otherwise

--- a/TauCeti/Topology/Algebra/Group/Profinite/Completion.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Completion.lean
@@ -12,10 +12,12 @@ public import Mathlib.Topology.Algebra.Category.ProfiniteGrp.Completion
 
 This file restates the categorical universal property of Mathlib's profinite completion for
 unbundled groups and continuous monoid homomorphisms. It also proves that the canonical map from
-a finite group to its profinite completion is bijective.
+a finite group to its profinite completion is bijective, and exposes the projections of the
+profinite completion onto the finite quotients it is the limit of.
 
 The correspondence is obtained from `ProfiniteGrp.ProfiniteCompletion.homEquiv`; the finite-group
-result uses its canonical map's dense range and Mathlib's residual-finiteness criterion.
+result uses its canonical map's dense range and Mathlib's residual-finiteness criterion. The
+projections are the components of Mathlib's explicit limit cone.
 -/
 
 public section
@@ -83,6 +85,44 @@ theorem etaFn_bijective_of_finite [Finite G] :
     exact Set.mem_univ x
   rw [(Set.finite_range _).isClosed.closure_eq] at hx
   exact hx
+
+/-- The projection from the profinite completion of `G` onto its finite quotient indexed by the
+finite-index normal subgroup `H`. -/
+@[expose]
+def coordinateHom (H : FiniteIndexNormalSubgroup G) :
+    ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G) →* G ⧸ H.toSubgroup := by
+  let f := ((ProfiniteGrp.limitCone
+    (ProfiniteGrp.ProfiniteCompletion.diagram (GrpCat.of G))).π.app H).hom
+    |>.toMonoidHom
+  -- The finite-quotient object hides its underlying quotient group.
+  change ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G) →* G ⧸ H.toSubgroup at f
+  exact f
+
+/-- The projection onto the finite quotient by `H` evaluates the underlying compatible family of
+cosets at `H`. -/
+theorem coordinateHom_apply (H : FiniteIndexNormalSubgroup G)
+    (x : ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G)) :
+    coordinateHom G H x = x.val H :=
+  -- `limitCone` projects a compatible family of cosets to its `H`-th component by definition.
+  rfl
+
+/-- The `H`-coordinate of the canonical image of `g` is its coset modulo `H`. -/
+@[simp]
+theorem coordinateHom_etaFn (H : FiniteIndexNormalSubgroup G) (g : G) :
+    coordinateHom G H (ProfiniteGrp.ProfiniteCompletion.etaFn (GrpCat.of G) g) =
+      QuotientGroup.mk g := by
+  rw [coordinateHom_apply]
+  -- `etaFn g` is the constant family of cosets of `g`.
+  rfl
+
+/-- The projection onto a finite quotient is continuous, that quotient carrying the discrete
+topology. -/
+theorem continuous_coordinateHom (H : FiniteIndexNormalSubgroup G) :
+    @Continuous (ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G))
+      (G ⧸ H.toSubgroup) inferInstance ⊥ (coordinateHom G H) :=
+  -- The finite-quotient object hides its discrete underlying quotient group.
+  ((ProfiniteGrp.limitCone
+    (ProfiniteGrp.ProfiniteCompletion.diagram (GrpCat.of G))).π.app H).hom.continuous_toFun
 
 end ProfiniteCompletion
 

--- a/TauCeti/Topology/Algebra/Group/Profinite/Completion.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Completion.lean
@@ -88,7 +88,6 @@ theorem etaFn_bijective_of_finite [Finite G] :
 
 /-- The projection from the profinite completion of `G` onto its finite quotient indexed by the
 finite-index normal subgroup `H`. -/
-@[expose]
 def coordinateHom (H : FiniteIndexNormalSubgroup G) :
     ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G) →* G ⧸ H.toSubgroup := by
   let f := ((ProfiniteGrp.limitCone
@@ -98,13 +97,17 @@ def coordinateHom (H : FiniteIndexNormalSubgroup G) :
   change ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G) →* G ⧸ H.toSubgroup at f
   exact f
 
+private theorem coordinateHom_apply_def (H : FiniteIndexNormalSubgroup G)
+    (x : ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G)) :
+    coordinateHom G H x = x.val H :=
+  rfl
+
 /-- The projection onto the finite quotient by `H` evaluates the underlying compatible family of
 cosets at `H`. -/
 theorem coordinateHom_apply (H : FiniteIndexNormalSubgroup G)
     (x : ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G)) :
     coordinateHom G H x = x.val H :=
-  -- `limitCone` projects a compatible family of cosets to its `H`-th component by definition.
-  rfl
+  coordinateHom_apply_def G H x
 
 /-- The `H`-coordinate of the canonical image of `g` is its coset modulo `H`. -/
 @[simp]


### PR DESCRIPTION
This PR extends every finite action of a group `G` uniquely and continuously to its profinite completion and packages those extensions as Mathlib's `PreGaloisCategory.IsFundamentalGroup` for the forgetful fibre functor `Action FintypeCat G ⥤ FintypeCat`; apply `toAutMulEquiv` to identify the profinite completion canonically with the automorphism group of that functor. It advances `TauCetiRoadmap/UniversalCovers/README.md`, Stage 2, item 8, specifically the alternative Galois-category lens through `Mathlib/CategoryTheory/Galois/IsFundamentalgroup.lean`, within the milestone "lifting criterion and Galois correspondence."

This is the next effective step because `TauCeti.FiniteCoveringSpace.fiberFunctor` and its equivalence with finite fundamental-group actions already exist on `main`, while the open all-cover fibre-functor work explicitly leaves the finite-cover automorphism group as a profinite-completion problem. The explicit dependency edge is UniversalCovers Stage 2 item 8 `FiniteCoveringSpace.fiberFunctor` fundamental-group identification ← `ProfiniteCompletion.instIsFundamentalGroup` for finite actions: transporting this instance through `FiniteCoveringSpace.finiteFiberActionEquivalence` will identify `Aut (FiniteCoveringSpace.fiberFunctor x₀)` with the profinite completion of `π₁(X, x₀)`.

The construction extends each finite permutation representation with Mathlib's `ProfiniteGrp.ProfiniteCompletion.lift`, whose `lift_eta` supplies the computation on the canonical image. Naturality follows by equality on the dense canonical image of `G`; connected finite actions remain transitive because that image already acts transitively; and faithfulness is proved honestly by testing an element on the identity coset in every regular finite quotient, which recovers every coordinate of Mathlib's inverse-limit model. The resulting API includes the continuous extension and its restriction along the canonical map, the computation on the canonical image, the induced actions and continuity, and the `IsFundamentalGroup` instance. The canonical isomorphism with `Aut (Action.forget FintypeCat G)`, its action formula and its homeomorphism property are then Mathlib's `toAutMulEquiv`, `toAut_hom_app_apply` and `toAutMulEquiv_isHomeomorph` applied to that instance; this PR adds no wrapper for them.

After this PR, the Stage 2 alternative lens still needs the finite-action result transported through `FiniteCoveringSpace.finiteFiberActionEquivalence` to the concrete finite-cover fibre functor; the topology and the `IsFundamentalGroup` instance that makes Mathlib's automorphism-group identification applicable are supplied here.

No formalization is copied or vendored. The implementation reuses Mathlib's `ProfiniteGrp.ProfiniteCompletion` universal property, the finite-action Galois-category API, and `PreGaloisCategory.toAutMulEquiv`.

Roadmap: UniversalCovers

<!--tauceti-target:v1 {"focus":"UniversalCovers","id":"profinite-completion-fundamental-group-finite-actions"}-->

🤖 Prepared with Codex


