### PR TITLE
feat: the density of a multivariate Gaussian measure

### DIFF
--- a/TauCeti/Analysis/Matrix/EuclideanLin.lean
+++ b/TauCeti/Analysis/Matrix/EuclideanLin.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Analysis.CStarAlgebra.Matrix
-public import Mathlib.Analysis.InnerProductSpace.Adjoint
 
 /-!
 # The map of a matrix on Euclidean space
@@ -50,38 +49,37 @@ theorem inner_toEuclideanLin_toEuclideanLin (A : Matrix κ ι 𝕜) (B : Matrix 
 
 section Invertible
 
-/-- **The continuous linear equivalence of an invertible matrix** on Euclidean space. Its inverse
-is the map of the inverse matrix, so a change of variables along it substitutes `A⁻¹` with no
-further work. -/
+/-- **The continuous linear equivalence of an invertible matrix** on Euclidean space.
+
+This specialises `ContinuousLinearMap.toContinuousLinearEquivOfDetNeZero` to a matrix: the
+hypothesis becomes invertibility of `A.det`, and `Matrix.toEuclideanCLE_symm_apply` identifies the
+inverse with the map of `A⁻¹` rather than with the abstract `LinearMap.inverse`, so a change of
+variables along it substitutes `A⁻¹` with no further work. -/
 noncomputable def toEuclideanCLE (A : Matrix ι ι 𝕜) (hA : IsUnit A.det) :
     EuclideanSpace 𝕜 ι ≃L[𝕜] EuclideanSpace 𝕜 ι :=
-  ContinuousLinearEquiv.equivOfInverse (toEuclideanCLM (𝕜 := 𝕜) A) (toEuclideanCLM (𝕜 := 𝕜) A⁻¹)
-    (fun x => by
-      rw [← mul_apply_eq_comp, ← map_mul, nonsing_inv_mul _ hA, map_one, one_apply_eq_self])
-    (fun x => by
-      rw [← mul_apply_eq_comp, ← map_mul, mul_nonsing_inv _ hA, map_one, one_apply_eq_self])
+  (toEuclideanCLM (𝕜 := 𝕜) A).toContinuousLinearEquivOfDetNeZero <| by
+    rw [ContinuousLinearMap.det, coe_toEuclideanCLM_eq_toEuclideanLin, LinearMap.det_toLpLin]
+    exact hA.ne_zero
 
 @[simp]
 theorem toEuclideanCLE_apply (A : Matrix ι ι 𝕜) (hA : IsUnit A.det) (x : EuclideanSpace 𝕜 ι) :
     A.toEuclideanCLE hA x = A.toEuclideanLin x := by
-  rw [toEuclideanCLE, ContinuousLinearEquiv.equivOfInverse_apply,
+  rw [toEuclideanCLE, ContinuousLinearMap.toContinuousLinearEquivOfDetNeZero_apply,
     ← coe_toEuclideanCLM_eq_toEuclideanLin, ContinuousLinearMap.coe_coe]
 
 @[simp]
 theorem toEuclideanCLE_symm_apply (A : Matrix ι ι 𝕜) (hA : IsUnit A.det)
     (y : EuclideanSpace 𝕜 ι) : (A.toEuclideanCLE hA).symm y = A⁻¹.toEuclideanLin y := by
-  rw [toEuclideanCLE, ContinuousLinearEquiv.symm_equivOfInverse,
-    ContinuousLinearEquiv.equivOfInverse_apply, ← coe_toEuclideanCLM_eq_toEuclideanLin,
-    ContinuousLinearMap.coe_coe]
-
-theorem coe_toEuclideanCLE (A : Matrix ι ι 𝕜) (hA : IsUnit A.det) :
-    (A.toEuclideanCLE hA : EuclideanSpace 𝕜 ι →ₗ[𝕜] EuclideanSpace 𝕜 ι) = A.toEuclideanLin :=
-  LinearMap.ext fun x => A.toEuclideanCLE_apply hA x
+  rw [ContinuousLinearEquiv.symm_apply_eq, toEuclideanCLE_apply]
+  simp only [← coe_toEuclideanCLM_eq_toEuclideanLin, ContinuousLinearMap.coe_coe]
+  rw [← mul_apply_eq_comp, ← map_mul, mul_nonsing_inv _ hA, map_one, one_apply_eq_self]
 
 @[simp]
 theorem det_toEuclideanCLE (A : Matrix ι ι 𝕜) (hA : IsUnit A.det) :
     LinearMap.det (A.toEuclideanCLE hA : EuclideanSpace 𝕜 ι →ₗ[𝕜] EuclideanSpace 𝕜 ι) = A.det := by
-  rw [coe_toEuclideanCLE, LinearMap.det_toLpLin]
+  have hcoe : (A.toEuclideanCLE hA : EuclideanSpace 𝕜 ι →ₗ[𝕜] EuclideanSpace 𝕜 ι)
+      = A.toEuclideanLin := LinearMap.ext fun x => A.toEuclideanCLE_apply hA x
+  rw [hcoe, LinearMap.det_toLpLin]
 
 end Invertible
 

--- a/TauCeti/Analysis/Matrix/EuclideanLin.lean
+++ b/TauCeti/Analysis/Matrix/EuclideanLin.lean
@@ -52,30 +52,31 @@ section Invertible
 /-- **The continuous linear equivalence of an invertible matrix** on Euclidean space, defined
 when `A.det` is a unit. It acts as `A` does, and its inverse is the map of `A⁻¹`, so a change of
 variables along it substitutes `A⁻¹`. -/
-noncomputable def toEuclideanCLE (A : Matrix ι ι 𝕜) (hA : IsUnit A.det) :
+noncomputable def toEuclideanCLE (A : Matrix ι ι 𝕜) (hA : A.det ≠ 0) :
     EuclideanSpace 𝕜 ι ≃L[𝕜] EuclideanSpace 𝕜 ι :=
   (toEuclideanCLM (𝕜 := 𝕜) A).toContinuousLinearEquivOfDetNeZero <| by
     rw [ContinuousLinearMap.det, coe_toEuclideanCLM_eq_toEuclideanLin, LinearMap.det_toLpLin]
-    exact hA.ne_zero
+    exact hA
 
 /-- The equivalence acts as the matrix does. -/
 @[simp]
-theorem toEuclideanCLE_apply (A : Matrix ι ι 𝕜) (hA : IsUnit A.det) (x : EuclideanSpace 𝕜 ι) :
+theorem toEuclideanCLE_apply (A : Matrix ι ι 𝕜) (hA : A.det ≠ 0) (x : EuclideanSpace 𝕜 ι) :
     A.toEuclideanCLE hA x = A.toEuclideanLin x := by
   rw [toEuclideanCLE, ContinuousLinearMap.toContinuousLinearEquivOfDetNeZero_apply,
     ← coe_toEuclideanCLM_eq_toEuclideanLin, ContinuousLinearMap.coe_coe]
 
 /-- The inverse of the equivalence is the map of the inverse matrix. -/
 @[simp]
-theorem toEuclideanCLE_symm_apply (A : Matrix ι ι 𝕜) (hA : IsUnit A.det)
+theorem toEuclideanCLE_symm_apply (A : Matrix ι ι 𝕜) (hA : A.det ≠ 0)
     (y : EuclideanSpace 𝕜 ι) : (A.toEuclideanCLE hA).symm y = A⁻¹.toEuclideanLin y := by
   rw [ContinuousLinearEquiv.symm_apply_eq, toEuclideanCLE_apply]
   simp only [← coe_toEuclideanCLM_eq_toEuclideanLin, ContinuousLinearMap.coe_coe]
-  rw [← mul_apply_eq_comp, ← map_mul, mul_nonsing_inv _ hA, map_one, one_apply_eq_self]
+  rw [← mul_apply_eq_comp, ← map_mul, mul_nonsing_inv _ (isUnit_iff_ne_zero.mpr hA), map_one,
+    one_apply_eq_self]
 
 /-- The determinant of the equivalence is the determinant of the matrix. -/
 @[simp]
-theorem det_toEuclideanCLE (A : Matrix ι ι 𝕜) (hA : IsUnit A.det) :
+theorem det_toEuclideanCLE (A : Matrix ι ι 𝕜) (hA : A.det ≠ 0) :
     LinearMap.det (A.toEuclideanCLE hA : EuclideanSpace 𝕜 ι →ₗ[𝕜] EuclideanSpace 𝕜 ι) = A.det := by
   have hcoe : (A.toEuclideanCLE hA : EuclideanSpace 𝕜 ι →ₗ[𝕜] EuclideanSpace 𝕜 ι)
       = A.toEuclideanLin := LinearMap.ext fun x => A.toEuclideanCLE_apply hA x

--- a/TauCeti/Analysis/Matrix/EuclideanLin.lean
+++ b/TauCeti/Analysis/Matrix/EuclideanLin.lean
@@ -49,12 +49,9 @@ theorem inner_toEuclideanLin_toEuclideanLin (A : Matrix κ ι 𝕜) (B : Matrix 
 
 section Invertible
 
-/-- **The continuous linear equivalence of an invertible matrix** on Euclidean space.
-
-This specialises `ContinuousLinearMap.toContinuousLinearEquivOfDetNeZero` to a matrix: the
-hypothesis becomes invertibility of `A.det`, and `Matrix.toEuclideanCLE_symm_apply` identifies the
-inverse with the map of `A⁻¹` rather than with the abstract `LinearMap.inverse`, so a change of
-variables along it substitutes `A⁻¹` with no further work. -/
+/-- **The continuous linear equivalence of an invertible matrix** on Euclidean space, defined
+when `A.det` is a unit. It acts as `A` does, and its inverse is the map of `A⁻¹`, so a change of
+variables along it substitutes `A⁻¹`. -/
 noncomputable def toEuclideanCLE (A : Matrix ι ι 𝕜) (hA : IsUnit A.det) :
     EuclideanSpace 𝕜 ι ≃L[𝕜] EuclideanSpace 𝕜 ι :=
   (toEuclideanCLM (𝕜 := 𝕜) A).toContinuousLinearEquivOfDetNeZero <| by

--- a/TauCeti/Analysis/Matrix/EuclideanLin.lean
+++ b/TauCeti/Analysis/Matrix/EuclideanLin.lean
@@ -5,20 +5,29 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import Mathlib.Analysis.CStarAlgebra.Matrix
 public import Mathlib.Analysis.InnerProductSpace.Adjoint
 
 /-!
-# Quadratic forms of matrices on Euclidean space
+# The map of a matrix on Euclidean space
+
+Two ingredients of a linear change of variables on `EuclideanSpace 𝕜 ι`.
 
 Pulling the quadratic form `x ↦ ⟪x, B x⟫` of a square matrix `B` back along the linear map of a
 rectangular matrix `A` gives the quadratic form of the congruent matrix `Aᴴ * B * A`. This is
 the change-of-variables identity behind every computation of a quadratic statistic after a linear
 transformation of the underlying vector.
 
+An invertible square matrix induces not just a map but a continuous linear equivalence, whose
+inverse is the map of the inverse matrix. That is the form a substitution needs: it supplies the
+inverse substitution and, through `LinearMap.det_toLpLin`, the Jacobian.
+
 ## Main results
 
 * `Matrix.inner_toEuclideanLin_toEuclideanLin` — the quadratic form of `B` at `A x` is the
-  quadratic form of `Aᴴ * B * A` at `x`.
+  quadratic form of `Aᴴ * B * A` at `x`;
+* `Matrix.toEuclideanCLE` — the continuous linear equivalence of an invertible matrix, with its
+  `apply`, `symm_apply`, coercion and determinant lemmas.
 -/
 
 public section
@@ -38,5 +47,42 @@ theorem inner_toEuclideanLin_toEuclideanLin (A : Matrix κ ι 𝕜) (B : Matrix 
       ⟪x, (Aᴴ * B * A).toEuclideanLin x⟫_𝕜 := by
   rw [← LinearMap.adjoint_inner_right, ← toEuclideanLin_conjTranspose_eq_adjoint]
   simp only [toEuclideanLin, toLpLin_mul_same, LinearMap.comp_apply]
+
+section Invertible
+
+/-- **The continuous linear equivalence of an invertible matrix** on Euclidean space. Its inverse
+is the map of the inverse matrix, so a change of variables along it substitutes `A⁻¹` with no
+further work. -/
+noncomputable def toEuclideanCLE (A : Matrix ι ι 𝕜) (hA : IsUnit A.det) :
+    EuclideanSpace 𝕜 ι ≃L[𝕜] EuclideanSpace 𝕜 ι :=
+  ContinuousLinearEquiv.equivOfInverse (toEuclideanCLM (𝕜 := 𝕜) A) (toEuclideanCLM (𝕜 := 𝕜) A⁻¹)
+    (fun x => by
+      rw [← mul_apply_eq_comp, ← map_mul, nonsing_inv_mul _ hA, map_one, one_apply_eq_self])
+    (fun x => by
+      rw [← mul_apply_eq_comp, ← map_mul, mul_nonsing_inv _ hA, map_one, one_apply_eq_self])
+
+@[simp]
+theorem toEuclideanCLE_apply (A : Matrix ι ι 𝕜) (hA : IsUnit A.det) (x : EuclideanSpace 𝕜 ι) :
+    A.toEuclideanCLE hA x = A.toEuclideanLin x := by
+  rw [toEuclideanCLE, ContinuousLinearEquiv.equivOfInverse_apply,
+    ← coe_toEuclideanCLM_eq_toEuclideanLin, ContinuousLinearMap.coe_coe]
+
+@[simp]
+theorem toEuclideanCLE_symm_apply (A : Matrix ι ι 𝕜) (hA : IsUnit A.det)
+    (y : EuclideanSpace 𝕜 ι) : (A.toEuclideanCLE hA).symm y = A⁻¹.toEuclideanLin y := by
+  rw [toEuclideanCLE, ContinuousLinearEquiv.symm_equivOfInverse,
+    ContinuousLinearEquiv.equivOfInverse_apply, ← coe_toEuclideanCLM_eq_toEuclideanLin,
+    ContinuousLinearMap.coe_coe]
+
+theorem coe_toEuclideanCLE (A : Matrix ι ι 𝕜) (hA : IsUnit A.det) :
+    (A.toEuclideanCLE hA : EuclideanSpace 𝕜 ι →ₗ[𝕜] EuclideanSpace 𝕜 ι) = A.toEuclideanLin :=
+  LinearMap.ext fun x => A.toEuclideanCLE_apply hA x
+
+@[simp]
+theorem det_toEuclideanCLE (A : Matrix ι ι 𝕜) (hA : IsUnit A.det) :
+    LinearMap.det (A.toEuclideanCLE hA : EuclideanSpace 𝕜 ι →ₗ[𝕜] EuclideanSpace 𝕜 ι) = A.det := by
+  rw [coe_toEuclideanCLE, LinearMap.det_toLpLin]
+
+end Invertible
 
 end Matrix

--- a/TauCeti/Analysis/Matrix/EuclideanLin.lean
+++ b/TauCeti/Analysis/Matrix/EuclideanLin.lean
@@ -61,12 +61,14 @@ noncomputable def toEuclideanCLE (A : Matrix ι ι 𝕜) (hA : IsUnit A.det) :
     rw [ContinuousLinearMap.det, coe_toEuclideanCLM_eq_toEuclideanLin, LinearMap.det_toLpLin]
     exact hA.ne_zero
 
+/-- The equivalence acts as the matrix does. -/
 @[simp]
 theorem toEuclideanCLE_apply (A : Matrix ι ι 𝕜) (hA : IsUnit A.det) (x : EuclideanSpace 𝕜 ι) :
     A.toEuclideanCLE hA x = A.toEuclideanLin x := by
   rw [toEuclideanCLE, ContinuousLinearMap.toContinuousLinearEquivOfDetNeZero_apply,
     ← coe_toEuclideanCLM_eq_toEuclideanLin, ContinuousLinearMap.coe_coe]
 
+/-- The inverse of the equivalence is the map of the inverse matrix. -/
 @[simp]
 theorem toEuclideanCLE_symm_apply (A : Matrix ι ι 𝕜) (hA : IsUnit A.det)
     (y : EuclideanSpace 𝕜 ι) : (A.toEuclideanCLE hA).symm y = A⁻¹.toEuclideanLin y := by
@@ -74,6 +76,7 @@ theorem toEuclideanCLE_symm_apply (A : Matrix ι ι 𝕜) (hA : IsUnit A.det)
   simp only [← coe_toEuclideanCLM_eq_toEuclideanLin, ContinuousLinearMap.coe_coe]
   rw [← mul_apply_eq_comp, ← map_mul, mul_nonsing_inv _ hA, map_one, one_apply_eq_self]
 
+/-- The determinant of the equivalence is the determinant of the matrix. -/
 @[simp]
 theorem det_toEuclideanCLE (A : Matrix ι ι 𝕜) (hA : IsUnit A.det) :
     LinearMap.det (A.toEuclideanCLE hA : EuclideanSpace 𝕜 ι →ₗ[𝕜] EuclideanSpace 𝕜 ι) = A.det := by

--- a/TauCeti/MeasureTheory/Measure/WithDensity.lean
+++ b/TauCeti/MeasureTheory/Measure/WithDensity.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.MeasureTheory.Integral.Lebesgue.Map
+public import Mathlib.MeasureTheory.Measure.Lebesgue.EqHaar
 public import Mathlib.MeasureTheory.Measure.WithDensity
 
 /-!
@@ -18,8 +19,17 @@ special case of a Radon–Nikodym derivative, in
 
 Combined with a rescaling law for the measure itself, such as
 `MeasureTheory.Measure.map_linearMap_addHaar_eq_smul_addHaar` on a finite-dimensional real normed
-space, this is what turns a density for one member of a family of measures into a density for its
-images.
+space, this gives the change-of-variables formula for a density under an invertible affine map.
+That is the shape a location–scale family needs: it turns a density for the standard member of the
+family into a density for every other member.
+
+## Main statements
+
+* `MeasurableEquiv.map_withDensity`: the image of a weighted measure along a measurable
+  equivalence is the image measure weighted by the transported weight.
+* `MeasureTheory.Measure.map_affine_withDensity`: the image of a weighted Haar measure under an
+  invertible affine map is that Haar measure weighted by the substituted density, rescaled by the
+  constant Jacobian factor.
 -/
 public section
 
@@ -45,3 +55,40 @@ theorem map_withDensity (e : α ≃ᵐ β) (μ : Measure α) (f : α → ℝ≥0
   simp only [MeasurableEquiv.symm_apply_apply]
 
 end MeasurableEquiv
+
+namespace MeasureTheory.Measure
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [MeasurableSpace E] [BorelSpace E]
+  [FiniteDimensional ℝ E]
+
+/-- **Change of variables for a density under an invertible affine map.** The image of
+`μ.withDensity g` under `x ↦ c + A x` is `μ` weighted by the substituted density
+`y ↦ g (A⁻¹ (y - c))`, scaled by the constant Jacobian factor `|det A|⁻¹`. -/
+theorem map_affine_withDensity (μ : Measure E) [μ.IsAddHaarMeasure] (A : E ≃L[ℝ] E) (c : E)
+    (g : E → ℝ≥0∞) :
+    (μ.withDensity g).map (fun x => c + A x) =
+      μ.withDensity fun y =>
+        ENNReal.ofReal |(LinearMap.det (A : E →ₗ[ℝ] E))⁻¹| * g (A.symm (y - c)) := by
+  set r : ℝ≥0∞ := ENNReal.ofReal |(LinearMap.det (A : E →ₗ[ℝ] E))⁻¹| with hr
+  have hdet : LinearMap.det (A : E →ₗ[ℝ] E) ≠ 0 := ((A : E ≃ₗ[ℝ] E).isUnit_det').ne_zero
+  have hmapA : μ.map A = r • μ := by
+    rw [hr]
+    simpa using Measure.map_linearMap_addHaar_eq_smul_addHaar μ hdet
+  -- the linear part rescales the measure by the Jacobian, and substitutes `A⁻¹` in the density
+  have hlin : (μ.withDensity g).map A = μ.withDensity fun y => r * g (A.symm y) := by
+    rw [← A.coe_toHomeomorph, ← Homeomorph.toMeasurableEquiv_coe, MeasurableEquiv.map_withDensity]
+    simp only [Homeomorph.toMeasurableEquiv_coe, Homeomorph.toMeasurableEquiv_symm_coe,
+      ContinuousLinearEquiv.coe_toHomeomorph, ContinuousLinearEquiv.coe_symm_toHomeomorph]
+    rw [hmapA, withDensity_smul_measure, ← withDensity_smul' _ _ ENNReal.ofReal_ne_top]
+    exact congrArg μ.withDensity (funext fun y => by simp only [Pi.smul_apply, smul_eq_mul, hr])
+  -- the translation leaves the Haar measure alone, and substitutes `· - c` in the density
+  calc (μ.withDensity g).map (fun x => c + A x)
+      = ((μ.withDensity g).map A).map (fun y : E => c + y) :=
+        (Measure.map_map (by fun_prop) (by fun_prop)).symm
+    _ = (μ.withDensity fun y => r * g (A.symm y)).map (fun y : E => c + y) := by rw [hlin]
+    _ = μ.withDensity fun y => r * g (A.symm (y - c)) := by
+        rw [← MeasurableEquiv.coe_addLeft c, MeasurableEquiv.map_withDensity]
+        simp only [MeasurableEquiv.coe_addLeft, MeasurableEquiv.symm_addLeft,
+          map_add_left_eq_self, neg_add_eq_sub]
+
+end MeasureTheory.Measure

--- a/TauCeti/MeasureTheory/Measure/WithDensity.lean
+++ b/TauCeti/MeasureTheory/Measure/WithDensity.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.MeasureTheory.Integral.Lebesgue.Map
-public import Mathlib.MeasureTheory.Measure.Lebesgue.EqHaar
 public import Mathlib.MeasureTheory.Measure.WithDensity
 
 /-!
@@ -17,22 +16,11 @@ A weight travels with the measure it weights: along a measurable equivalence `e`
 special case of a Radon–Nikodym derivative, in
 `MeasurableEmbedding.map_withDensity_rnDeriv`.
 
-On a finite-dimensional real normed space carrying an additive Haar measure, an invertible affine
-map rescales the measure itself by the constant `|det A|⁻¹`
-(`MeasureTheory.Measure.map_linearMap_addHaar_eq_smul_addHaar`), so the two facts combine into the
-classical change-of-variables formula for a density under an affine substitution. That is the
-shape a location–scale family needs: it turns a density for the standard member of the family
-into a density for every other member.
-
-## Main statements
-
-* `MeasurableEquiv.map_withDensity`: the image of a weighted measure along a measurable
-  equivalence is the image measure weighted by the transported weight.
-* `MeasureTheory.Measure.map_affine_withDensity`: the image of a weighted Haar measure under an
-  invertible affine map is that Haar measure weighted by the substituted density, rescaled by the
-  constant Jacobian factor.
+Combined with a rescaling law for the measure itself, such as
+`MeasureTheory.Measure.map_linearMap_addHaar_eq_smul_addHaar` on a finite-dimensional real normed
+space, this is what turns a density for one member of a family of measures into a density for its
+images.
 -/
-
 public section
 
 noncomputable section
@@ -60,40 +48,3 @@ theorem map_withDensity (e : α ≃ᵐ β) (μ : Measure α) (f : α → ℝ≥0
   simp only [MeasurableEquiv.symm_apply_apply]
 
 end MeasurableEquiv
-
-namespace MeasureTheory.Measure
-
-variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [MeasurableSpace E] [BorelSpace E]
-  [FiniteDimensional ℝ E]
-
-/-- **Change of variables for a density under an invertible affine map.** The image of
-`μ.withDensity g` under `x ↦ c + A x` is `μ` weighted by the substituted density
-`y ↦ g (A⁻¹ (y - c))`, scaled by the constant Jacobian factor `|det A|⁻¹`. -/
-theorem map_affine_withDensity (μ : Measure E) [μ.IsAddHaarMeasure] (A : E ≃L[ℝ] E) (c : E)
-    (g : E → ℝ≥0∞) :
-    (μ.withDensity g).map (fun x => c + A x) =
-      μ.withDensity fun y =>
-        ENNReal.ofReal |(LinearMap.det (A : E →ₗ[ℝ] E))⁻¹| * g (A.symm (y - c)) := by
-  set r : ℝ≥0∞ := ENNReal.ofReal |(LinearMap.det (A : E →ₗ[ℝ] E))⁻¹| with hr
-  have hdet : LinearMap.det (A : E →ₗ[ℝ] E) ≠ 0 := ((A : E ≃ₗ[ℝ] E).isUnit_det').ne_zero
-  have hmapA : μ.map A = r • μ := by
-    rw [hr]
-    simpa using Measure.map_linearMap_addHaar_eq_smul_addHaar μ hdet
-  -- the linear part rescales the measure by the Jacobian, and substitutes `A⁻¹` in the density
-  have hlin : (μ.withDensity g).map A = μ.withDensity fun y => r * g (A.symm y) := by
-    rw [← A.coe_toHomeomorph, ← Homeomorph.toMeasurableEquiv_coe, MeasurableEquiv.map_withDensity]
-    simp only [Homeomorph.toMeasurableEquiv_coe, Homeomorph.toMeasurableEquiv_symm_coe,
-      ContinuousLinearEquiv.coe_toHomeomorph, ContinuousLinearEquiv.coe_symm_toHomeomorph]
-    rw [hmapA, withDensity_smul_measure, ← withDensity_smul' _ _ ENNReal.ofReal_ne_top]
-    exact congrArg μ.withDensity (funext fun y => by simp only [Pi.smul_apply, smul_eq_mul, hr])
-  -- the translation leaves the Haar measure alone, and substitutes `· - c` in the density
-  calc (μ.withDensity g).map (fun x => c + A x)
-      = ((μ.withDensity g).map A).map (fun y : E => c + y) :=
-        (Measure.map_map (by fun_prop) (by fun_prop)).symm
-    _ = (μ.withDensity fun y => r * g (A.symm y)).map (fun y : E => c + y) := by rw [hlin]
-    _ = μ.withDensity fun y => r * g (A.symm (y - c)) := by
-        rw [← MeasurableEquiv.coe_addLeft c, MeasurableEquiv.map_withDensity]
-        simp only [MeasurableEquiv.coe_addLeft, MeasurableEquiv.symm_addLeft,
-          map_add_left_eq_self, neg_add_eq_sub]
-
-end MeasureTheory.Measure

--- a/TauCeti/MeasureTheory/Measure/WithDensity.lean
+++ b/TauCeti/MeasureTheory/Measure/WithDensity.lean
@@ -34,11 +34,8 @@ namespace MeasurableEquiv
 variable {α β : Type*} [MeasurableSpace α] [MeasurableSpace β]
 
 /-- **A weight travels with the measure it weights.** Pushing `μ.withDensity f` forward along a
-measurable equivalence `e` gives the pushforward of `μ` weighted by `f ∘ e.symm`.
-
-No measurability of `f` is needed: on a measurable set both sides unfold to the lower integral of
-`f` over the preimage, and `MeasureTheory.lintegral_map_equiv` transports that integral along `e`
-with no hypothesis on the integrand. -/
+measurable equivalence `e` gives the pushforward of `μ` weighted by `f ∘ e.symm`. The weight `f`
+is arbitrary; no measurability of it is required. -/
 theorem map_withDensity (e : α ≃ᵐ β) (μ : Measure α) (f : α → ℝ≥0∞) :
     (μ.withDensity f).map e = (μ.map e).withDensity fun y => f (e.symm y) := by
   ext s hs

--- a/TauCeti/MeasureTheory/Measure/WithDensity.lean
+++ b/TauCeti/MeasureTheory/Measure/WithDensity.lean
@@ -26,11 +26,11 @@ into a density for every other member.
 
 ## Main statements
 
-* `TauCeti.map_withDensity_equiv`: the image of a weighted measure along a measurable
+* `MeasurableEquiv.map_withDensity`: the image of a weighted measure along a measurable
   equivalence is the image measure weighted by the transported weight.
-* `TauCeti.map_affine_withDensity`: the image of a weighted Haar measure under an invertible
-  affine map is that Haar measure weighted by the substituted density, rescaled by the constant
-  Jacobian factor.
+* `MeasureTheory.Measure.map_affine_withDensity`: the image of a weighted Haar measure under an
+  invertible affine map is that Haar measure weighted by the substituted density, rescaled by the
+  constant Jacobian factor.
 -/
 
 public section
@@ -41,7 +41,7 @@ open MeasureTheory
 
 open scoped ENNReal
 
-namespace TauCeti
+namespace MeasurableEquiv
 
 variable {α β : Type*} [MeasurableSpace α] [MeasurableSpace β]
 
@@ -51,13 +51,17 @@ measurable equivalence `e` gives the pushforward of `μ` weighted by `f ∘ e.sy
 No measurability of `f` is needed: on a measurable set both sides unfold to the lower integral of
 `f` over the preimage, and `MeasureTheory.lintegral_map_equiv` transports that integral along `e`
 with no hypothesis on the integrand. -/
-theorem map_withDensity_equiv (e : α ≃ᵐ β) (μ : Measure α) (f : α → ℝ≥0∞) :
+theorem map_withDensity (e : α ≃ᵐ β) (μ : Measure α) (f : α → ℝ≥0∞) :
     (μ.withDensity f).map e = (μ.map e).withDensity fun y => f (e.symm y) := by
   ext s hs
   rw [withDensity_apply _ hs, Measure.map_apply e.measurable hs,
     withDensity_apply _ (e.measurable hs), Measure.restrict_map e.measurable hs,
     lintegral_map_equiv]
   simp only [MeasurableEquiv.symm_apply_apply]
+
+end MeasurableEquiv
+
+namespace MeasureTheory.Measure
 
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [MeasurableSpace E] [BorelSpace E]
   [FiniteDimensional ℝ E]
@@ -77,7 +81,7 @@ theorem map_affine_withDensity (μ : Measure E) [μ.IsAddHaarMeasure] (A : E ≃
     simpa using Measure.map_linearMap_addHaar_eq_smul_addHaar μ hdet
   -- the linear part rescales the measure by the Jacobian, and substitutes `A⁻¹` in the density
   have hlin : (μ.withDensity g).map A = μ.withDensity fun y => r * g (A.symm y) := by
-    rw [← A.coe_toHomeomorph, ← Homeomorph.toMeasurableEquiv_coe, map_withDensity_equiv]
+    rw [← A.coe_toHomeomorph, ← Homeomorph.toMeasurableEquiv_coe, MeasurableEquiv.map_withDensity]
     simp only [Homeomorph.toMeasurableEquiv_coe, Homeomorph.toMeasurableEquiv_symm_coe,
       ContinuousLinearEquiv.coe_toHomeomorph, ContinuousLinearEquiv.coe_symm_toHomeomorph]
     rw [hmapA, withDensity_smul_measure, ← withDensity_smul' _ _ ENNReal.ofReal_ne_top]
@@ -88,8 +92,8 @@ theorem map_affine_withDensity (μ : Measure E) [μ.IsAddHaarMeasure] (A : E ≃
         (Measure.map_map (by fun_prop) (by fun_prop)).symm
     _ = (μ.withDensity fun y => r * g (A.symm y)).map (fun y : E => c + y) := by rw [hlin]
     _ = μ.withDensity fun y => r * g (A.symm (y - c)) := by
-        rw [← MeasurableEquiv.coe_addLeft c, map_withDensity_equiv]
+        rw [← MeasurableEquiv.coe_addLeft c, MeasurableEquiv.map_withDensity]
         simp only [MeasurableEquiv.coe_addLeft, MeasurableEquiv.symm_addLeft,
           map_add_left_eq_self, neg_add_eq_sub]
 
-end TauCeti
+end MeasureTheory.Measure

--- a/TauCeti/MeasureTheory/Measure/WithDensity.lean
+++ b/TauCeti/MeasureTheory/Measure/WithDensity.lean
@@ -1,0 +1,95 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.MeasureTheory.Integral.Lebesgue.Map
+public import Mathlib.MeasureTheory.Measure.Lebesgue.EqHaar
+public import Mathlib.MeasureTheory.Measure.WithDensity
+
+/-!
+# Pushing a weighted measure forward
+
+A weight travels with the measure it weights: along a measurable equivalence `e`, the image of
+`μ.withDensity f` is the image of `μ` weighted by `f ∘ e.symm`. Mathlib has this only for the
+special case of a Radon–Nikodym derivative, in
+`MeasurableEmbedding.map_withDensity_rnDeriv`.
+
+On a finite-dimensional real normed space carrying an additive Haar measure, an invertible affine
+map rescales the measure itself by the constant `|det A|⁻¹`
+(`MeasureTheory.Measure.map_linearMap_addHaar_eq_smul_addHaar`), so the two facts combine into the
+classical change-of-variables formula for a density under an affine substitution. That is the
+shape a location–scale family needs: it turns a density for the standard member of the family
+into a density for every other member.
+
+## Main statements
+
+* `TauCeti.map_withDensity_equiv`: the image of a weighted measure along a measurable
+  equivalence is the image measure weighted by the transported weight.
+* `TauCeti.map_affine_withDensity`: the image of a weighted Haar measure under an invertible
+  affine map is that Haar measure weighted by the substituted density, rescaled by the constant
+  Jacobian factor.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory
+
+open scoped ENNReal
+
+namespace TauCeti
+
+variable {α β : Type*} [MeasurableSpace α] [MeasurableSpace β]
+
+/-- **A weight travels with the measure it weights.** Pushing `μ.withDensity f` forward along a
+measurable equivalence `e` gives the pushforward of `μ` weighted by `f ∘ e.symm`.
+
+No measurability of `f` is needed: on a measurable set both sides unfold to the lower integral of
+`f` over the preimage, and `MeasureTheory.lintegral_map_equiv` transports that integral along `e`
+with no hypothesis on the integrand. -/
+theorem map_withDensity_equiv (e : α ≃ᵐ β) (μ : Measure α) (f : α → ℝ≥0∞) :
+    (μ.withDensity f).map e = (μ.map e).withDensity fun y => f (e.symm y) := by
+  ext s hs
+  rw [withDensity_apply _ hs, Measure.map_apply e.measurable hs,
+    withDensity_apply _ (e.measurable hs), Measure.restrict_map e.measurable hs,
+    lintegral_map_equiv]
+  simp only [MeasurableEquiv.symm_apply_apply]
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [MeasurableSpace E] [BorelSpace E]
+  [FiniteDimensional ℝ E]
+
+/-- **Change of variables for a density under an invertible affine map.** The image of
+`μ.withDensity g` under `x ↦ c + A x` is `μ` weighted by the substituted density
+`y ↦ g (A⁻¹ (y - c))`, scaled by the constant Jacobian factor `|det A|⁻¹`. -/
+theorem map_affine_withDensity (μ : Measure E) [μ.IsAddHaarMeasure] (A : E ≃L[ℝ] E) (c : E)
+    (g : E → ℝ≥0∞) :
+    (μ.withDensity g).map (fun x => c + A x) =
+      μ.withDensity fun y =>
+        ENNReal.ofReal |(LinearMap.det (A : E →ₗ[ℝ] E))⁻¹| * g (A.symm (y - c)) := by
+  set r : ℝ≥0∞ := ENNReal.ofReal |(LinearMap.det (A : E →ₗ[ℝ] E))⁻¹| with hr
+  have hdet : LinearMap.det (A : E →ₗ[ℝ] E) ≠ 0 := ((A : E ≃ₗ[ℝ] E).isUnit_det').ne_zero
+  have hmapA : μ.map A = r • μ := by
+    rw [hr]
+    simpa using Measure.map_linearMap_addHaar_eq_smul_addHaar μ hdet
+  -- the linear part rescales the measure by the Jacobian, and substitutes `A⁻¹` in the density
+  have hlin : (μ.withDensity g).map A = μ.withDensity fun y => r * g (A.symm y) := by
+    rw [← A.coe_toHomeomorph, ← Homeomorph.toMeasurableEquiv_coe, map_withDensity_equiv]
+    simp only [Homeomorph.toMeasurableEquiv_coe, Homeomorph.toMeasurableEquiv_symm_coe,
+      ContinuousLinearEquiv.coe_toHomeomorph, ContinuousLinearEquiv.coe_symm_toHomeomorph]
+    rw [hmapA, withDensity_smul_measure, ← withDensity_smul' _ _ ENNReal.ofReal_ne_top]
+    exact congrArg μ.withDensity (funext fun y => by simp only [Pi.smul_apply, smul_eq_mul, hr])
+  -- the translation leaves the Haar measure alone, and substitutes `· - c` in the density
+  calc (μ.withDensity g).map (fun x => c + A x)
+      = ((μ.withDensity g).map A).map (fun y : E => c + y) :=
+        (Measure.map_map (by fun_prop) (by fun_prop)).symm
+    _ = (μ.withDensity fun y => r * g (A.symm y)).map (fun y : E => c + y) := by rw [hlin]
+    _ = μ.withDensity fun y => r * g (A.symm (y - c)) := by
+        rw [← MeasurableEquiv.coe_addLeft c, map_withDensity_equiv]
+        simp only [MeasurableEquiv.coe_addLeft, MeasurableEquiv.symm_addLeft,
+          map_add_left_eq_self, neg_add_eq_sub]
+
+end TauCeti

--- a/TauCeti/Probability/Distributions/Gaussian/Density.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/Density.lean
@@ -118,7 +118,7 @@ theorem stdGaussian_eq_withDensity :
   have hvol : (volume : Measure (ι → ℝ)).map ⇑(MeasurableEquiv.toLp 2 (ι → ℝ)) = volume :=
     (PiLp.volume_preserving_toLp ι).map_eq
   rw [← map_pi_eq_stdGaussian, pi_gaussianReal_eq_withDensity,
-    ← MeasurableEquiv.coe_toLp 2 (ι → ℝ), map_withDensity_equiv, ← volume_pi, hvol]
+    ← MeasurableEquiv.coe_toLp 2 (ι → ℝ), MeasurableEquiv.map_withDensity, ← volume_pi, hvol]
   refine withDensity_congr_ae (.of_forall fun y => congrArg ENNReal.ofReal ?_)
   rw [prod_gaussianPDFReal_zero_one, MeasurableEquiv.coe_toLp_symm,
     ← EuclideanSpace.real_norm_sq_eq]
@@ -152,7 +152,7 @@ theorem multivariateGaussian_eq_withDensity (hS : S.PosDef) (m : EuclideanSpace 
     rw [Real.sqrt_eq_rpow, ← Real.rpow_neg hdetS.le]
     congr 1
     ring
-  rw [multivariateGaussian, stdGaussian_eq_withDensity, hAfun, map_affine_withDensity,
+  rw [multivariateGaussian, stdGaussian_eq_withDensity, hAfun, Measure.map_affine_withDensity,
     Matrix.det_toEuclideanCLE]
   refine withDensity_congr_ae (.of_forall fun y => ?_)
   simp only [multivariateGaussianPDF, multivariateGaussianPDFReal,

--- a/TauCeti/Probability/Distributions/Gaussian/Density.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/Density.lean
@@ -14,6 +14,10 @@ public import TauCeti.Probability.Distributions.Gaussian.Pi
 import Mathlib.MeasureTheory.Measure.Haar.InnerProductSpace
 import Mathlib.MeasureTheory.Measure.Lebesgue.EqHaar
 
+-- Source of the derivation used here: `TauCetiRoadmap/StandardDistributions/README.md` prescribes
+-- obtaining the nondegenerate case from `TauCeti.pi_gaussianReal_eq_withDensity` by an affine
+-- change of variables rather than rebuilding the product-density calculation.
+
 /-!
 # The density of a multivariate Gaussian measure
 
@@ -51,9 +55,6 @@ form into the one of `S⁻¹`.
 ## References
 
 * M. L. Eaton, *Multivariate Statistics: A Vector Space Approach*.
-* `TauCetiRoadmap/StandardDistributions/README.md`, which prescribes deriving the nondegenerate
-  case from `TauCeti.pi_gaussianReal_eq_withDensity` by an affine change of variables rather than
-  rebuilding the product-density calculation.
 -/
 
 public section

--- a/TauCeti/Probability/Distributions/Gaussian/Density.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/Density.lean
@@ -96,6 +96,26 @@ theorem multivariateGaussianPDFReal_pos (hdet : 0 < S.det) (m : EuclideanSpace �
   rw [multivariateGaussianPDFReal]
   positivity
 
+/-- The real-valued density is nonnegative at every covariance parameter. At a negative
+determinant the real power `S.det ^ (-1/2)` vanishes, so the density is `0` there. -/
+theorem multivariateGaussianPDFReal_nonneg (m : EuclideanSpace ℝ ι) (S : Matrix ι ι ℝ)
+    (x : EuclideanSpace ℝ ι) : 0 ≤ multivariateGaussianPDFReal m S x := by
+  have hdet : 0 ≤ S.det ^ (-(1 : ℝ) / 2) := by
+    rcases le_or_gt 0 S.det with h | h
+    · exact Real.rpow_nonneg h _
+    · rw [Real.rpow_def_of_neg h, show -(1 : ℝ) / 2 * π = -(π / 2) by ring, Real.cos_neg,
+        Real.cos_pi_div_two, mul_zero]
+  have hπ : (0 : ℝ) ≤ (2 * π) ^ (-(Fintype.card ι : ℝ) / 2) := Real.rpow_nonneg (by positivity) _
+  rw [multivariateGaussianPDFReal]
+  exact mul_nonneg (mul_nonneg hπ hdet) (Real.exp_nonneg _)
+
+/-- The `ℝ≥0∞`-valued density carries the real-valued one back through `ENNReal.toReal`. -/
+@[simp]
+theorem toReal_multivariateGaussianPDF (m : EuclideanSpace ℝ ι) (S : Matrix ι ι ℝ)
+    (x : EuclideanSpace ℝ ι) :
+    (multivariateGaussianPDF m S x).toReal = multivariateGaussianPDFReal m S x := by
+  rw [multivariateGaussianPDF, ENNReal.toReal_ofReal (multivariateGaussianPDFReal_nonneg m S x)]
+
 /-- The real-valued density is measurable. -/
 @[fun_prop]
 theorem measurable_multivariateGaussianPDFReal (m : EuclideanSpace ℝ ι) (S : Matrix ι ι ℝ) :
@@ -204,19 +224,22 @@ theorem mutuallySingular_multivariateGaussian_volume (hS : ¬ S.PosDef)
       LinearMap.range (Matrix.toEuclideanLin (CFC.sqrt S)) with hp
     have hptop : p ≠ ⊤ :=
       (LinearMap.range_lt_top_of_det_eq_zero (by rw [LinearMap.det_toLpLin]; exact hdet0)).ne
-    set t : Set (EuclideanSpace ℝ ι) :=
-      (fun y => -m + y) ⁻¹' (p : Set (EuclideanSpace ℝ ι)) with ht
-    have htc : MeasurableSet tᶜ :=
-      ((p.closed_of_finiteDimensional.preimage (by fun_prop)).measurableSet).compl
-    refine ⟨tᶜ, htc, ?_, ?_⟩
-    · rw [multivariateGaussian, Measure.map_apply (by fun_prop) htc]
+    -- the law is carried by the proper affine subspace through `m` with direction `p`
+    set A : AffineSubspace ℝ (EuclideanSpace ℝ ι) := AffineSubspace.mk' m p with hA
+    have hAtop : A ≠ ⊤ := fun h => hptop <| by
+      rw [← AffineSubspace.direction_mk' m p, ← hA, h, AffineSubspace.direction_top]
+    have hAc : MeasurableSet (A : Set (EuclideanSpace ℝ ι))ᶜ :=
+      A.closed_of_finiteDimensional.measurableSet.compl
+    refine ⟨(A : Set (EuclideanSpace ℝ ι))ᶜ, hAc, ?_, ?_⟩
+    · rw [multivariateGaussian, Measure.map_apply (by fun_prop) hAc]
       convert measure_empty (μ := stdGaussian (EuclideanSpace ℝ ι))
       ext x
       simp only [Set.mem_preimage, Set.mem_compl_iff, Set.mem_empty_iff_false, iff_false, not_not,
-        ht, neg_add_cancel_left, SetLike.mem_coe, hp]
+        hA, SetLike.mem_coe, AffineSubspace.mem_mk', vsub_eq_sub,
+        add_sub_cancel_left, hp]
       exact LinearMap.mem_range_self _ x
-    · rw [compl_compl, ht, measure_preimage_add]
-      exact Measure.addHaar_submodule volume p hptop
+    · rw [compl_compl]
+      exact Measure.addHaar_affineSubspace volume A hAtop
   · rw [multivariateGaussian_of_not_posSemidef m hSS]
     exact mutuallySingular_dirac m volume
 

--- a/TauCeti/Probability/Distributions/Gaussian/Density.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/Density.lean
@@ -22,7 +22,8 @@ A multivariate Gaussian law with positive-definite covariance `S` is Lebesgue me
 `(2π)^(-d/2) * (det S)^(-1/2) * exp (-⟪x - m, S⁻¹ (x - m)⟫ / 2)`,
 
 where `d` is the dimension. Every other covariance parameter gives a law carried by a proper
-affine subspace, hence singular with respect to Lebesgue measure and with no density at all.
+affine subspace, so it is singular with respect to Lebesgue measure and has no density against
+it.
 
 The nondegenerate case comes from the isotropic product density
 (`TauCeti.pi_gaussianReal_eq_withDensity`) by an affine change of variables along the square root
@@ -64,8 +65,8 @@ variable {ι : Type*} [Fintype ι] [DecidableEq ι]
 
 /-- The **density of the multivariate Gaussian law** with mean `m` and covariance `S`, as a real
 number. It is the density of `multivariateGaussian m S` when `S` is positive definite
-(`TauCeti.multivariateGaussian_eq_withDensity`); at every other `S` that law has no density
-(`TauCeti.mutuallySingular_multivariateGaussian_volume`). -/
+(`TauCeti.multivariateGaussian_eq_withDensity`); at every other `S` that law has no density with
+respect to Lebesgue measure (`TauCeti.mutuallySingular_multivariateGaussian_volume`). -/
 def multivariateGaussianPDFReal (m : EuclideanSpace ℝ ι) (S : Matrix ι ι ℝ)
     (x : EuclideanSpace ℝ ι) : ℝ :=
   (2 * π) ^ (-(Fintype.card ι : ℝ) / 2) * S.det ^ (-(1 : ℝ) / 2) *
@@ -103,8 +104,10 @@ theorem multivariateGaussianPDFReal_nonneg (m : EuclideanSpace ℝ ι) (S : Matr
   have hdet : 0 ≤ S.det ^ (-(1 : ℝ) / 2) := by
     rcases le_or_gt 0 S.det with h | h
     · exact Real.rpow_nonneg h _
-    · rw [Real.rpow_def_of_neg h, show -(1 : ℝ) / 2 * π = -(π / 2) by ring, Real.cos_neg,
-        Real.cos_pi_div_two, mul_zero]
+    -- at a negative base the real power is `exp (log · * y) * cos (y * π)`, which vanishes at
+    -- the exponent `y = -1/2`
+    · have harg : -(1 : ℝ) / 2 * π = -(π / 2) := by ring
+      rw [Real.rpow_def_of_neg h, harg, Real.cos_neg, Real.cos_pi_div_two, mul_zero]
   have hπ : (0 : ℝ) ≤ (2 * π) ^ (-(Fintype.card ι : ℝ) / 2) := Real.rpow_nonneg (by positivity) _
   rw [multivariateGaussianPDFReal]
   exact mul_nonneg (mul_nonneg hπ hdet) (Real.exp_nonneg _)

--- a/TauCeti/Probability/Distributions/Gaussian/Density.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/Density.lean
@@ -12,11 +12,6 @@ public import TauCeti.Probability.Distributions.Gaussian.Multivariate
 public import TauCeti.Probability.Distributions.Gaussian.Pi
 
 import Mathlib.MeasureTheory.Measure.Haar.InnerProductSpace
-import Mathlib.MeasureTheory.Measure.Lebesgue.EqHaar
-
--- Source of the derivation used here: `TauCetiRoadmap/StandardDistributions/README.md` prescribes
--- obtaining the nondegenerate case from `TauCeti.pi_gaussianReal_eq_withDensity` by an affine
--- change of variables rather than rebuilding the product-density calculation.
 
 /-!
 # The density of a multivariate Gaussian measure
@@ -170,20 +165,15 @@ theorem stdGaussian_eq_withDensity :
 /-- **A nondegenerate multivariate Gaussian law is Lebesgue measure with the Gaussian density.** -/
 theorem multivariateGaussian_eq_withDensity (hS : S.PosDef) (m : EuclideanSpace ℝ ι) :
     multivariateGaussian m S = volume.withDensity (multivariateGaussianPDF m S) := by
-  -- The proof has four stages. First, facts about the square root `√S`: it is positive
-  -- semidefinite, squares to `S`, and has determinant `√(det S)`, hence is invertible and induces
-  -- a continuous linear equivalence `R` of `EuclideanSpace ℝ ι` (`hR` to `hAfun`). Second, the
-  -- inverse square root pulls the isotropic quadratic form back to the one of `S⁻¹` (`hconj`,
-  -- `hnorm`), and the two ways of writing the normalising constant agree (`hrpow`). Third, the
-  -- affine substitution `x ↦ m + R x` transports any density along the map (`hmapR`, `hmap`).
-  -- Finally, rewriting `multivariateGaussian` by the standard density and that transport reduces
-  -- the goal to a pointwise identity between the two closed forms.
+  -- The square root of `S` gives the affine substitution `x ↦ m + √S x` carrying the standard
+  -- Gaussian to this one; `Measure.map_affine_withDensity` transports the density along it, and
+  -- the inverse square root turns the isotropic quadratic form into the one of `S⁻¹`.
   have hR : (CFC.sqrt S).PosSemidef := Matrix.LE.le.posSemidef (CFC.sqrt_nonneg S)
   have hRR : CFC.sqrt S * CFC.sqrt S = S := CFC.sqrt_mul_sqrt_self S hS.posSemidef.nonneg
   have hdetS : 0 < S.det := hS.det_pos
   have hdetR : (CFC.sqrt S).det = √S.det := by simpa using hS.posSemidef.det_sqrt
   have hdetRpos : 0 < (CFC.sqrt S).det := by rw [hdetR]; positivity
-  have hRunit : IsUnit (CFC.sqrt S).det := hdetRpos.ne'.isUnit
+  have hRunit : (CFC.sqrt S).det ≠ 0 := hdetRpos.ne'
   have hCLM : ∀ (X : Matrix ι ι ℝ) (z : EuclideanSpace ℝ ι),
       Matrix.toEuclideanCLM (𝕜 := ℝ) X z = X.toEuclideanLin z := fun X z => by
     rw [← Matrix.coe_toEuclideanCLM_eq_toEuclideanLin X, ContinuousLinearMap.coe_coe]
@@ -204,41 +194,7 @@ theorem multivariateGaussian_eq_withDensity (hS : S.PosDef) (m : EuclideanSpace 
     rw [Real.sqrt_eq_rpow, ← Real.rpow_neg hdetS.le]
     congr 1
     ring
-  -- Stage three. The linear part rescales `volume` by the constant Jacobian `|det R|⁻¹` and
-  -- substitutes `R⁻¹` in the weight; the translation leaves `volume` alone and substitutes
-  -- `· - m`. The statement is left general in the weight `g` because the two stages compose
-  -- along `MeasurableEquiv.map_withDensity`, which is itself general in the weight.
-  set R : EuclideanSpace ℝ ι ≃L[ℝ] EuclideanSpace ℝ ι := Matrix.toEuclideanCLE (CFC.sqrt S) hRunit
-    with hRdef
-  set r : ℝ≥0∞ := ENNReal.ofReal
-    |(LinearMap.det (R : EuclideanSpace ℝ ι →ₗ[ℝ] EuclideanSpace ℝ ι))⁻¹| with hr
-  have hdetne : LinearMap.det (R : EuclideanSpace ℝ ι →ₗ[ℝ] EuclideanSpace ℝ ι) ≠ 0 :=
-    ((R : EuclideanSpace ℝ ι ≃ₗ[ℝ] EuclideanSpace ℝ ι).isUnit_det').ne_zero
-  have hmapR : (volume : Measure (EuclideanSpace ℝ ι)).map R = r • volume := by
-    rw [hr]
-    simpa using Measure.map_linearMap_addHaar_eq_smul_addHaar volume hdetne
-  have hmap : ∀ g : EuclideanSpace ℝ ι → ℝ≥0∞,
-      ((volume : Measure (EuclideanSpace ℝ ι)).withDensity g).map (fun x => m + R x)
-        = volume.withDensity fun y => r * g (R.symm (y - m)) := fun g => by
-    have hlin : ((volume : Measure (EuclideanSpace ℝ ι)).withDensity g).map R
-        = volume.withDensity fun y => r * g (R.symm y) := by
-      rw [← R.coe_toHomeomorph, ← Homeomorph.toMeasurableEquiv_coe, MeasurableEquiv.map_withDensity]
-      simp only [Homeomorph.toMeasurableEquiv_coe, Homeomorph.toMeasurableEquiv_symm_coe,
-        ContinuousLinearEquiv.coe_toHomeomorph, ContinuousLinearEquiv.coe_symm_toHomeomorph]
-      rw [hmapR, withDensity_smul_measure, ← withDensity_smul' _ _ ENNReal.ofReal_ne_top]
-      exact congrArg volume.withDensity
-        (funext fun y => by simp only [Pi.smul_apply, smul_eq_mul, hr])
-    calc ((volume : Measure (EuclideanSpace ℝ ι)).withDensity g).map (fun x => m + R x)
-        = (((volume : Measure (EuclideanSpace ℝ ι)).withDensity g).map R).map
-            (fun y : EuclideanSpace ℝ ι => m + y) :=
-          (Measure.map_map (by fun_prop) (by fun_prop)).symm
-      _ = (volume.withDensity fun y => r * g (R.symm y)).map
-            (fun y : EuclideanSpace ℝ ι => m + y) := by rw [hlin]
-      _ = volume.withDensity fun y => r * g (R.symm (y - m)) := by
-          rw [← MeasurableEquiv.coe_addLeft m, MeasurableEquiv.map_withDensity]
-          simp only [MeasurableEquiv.coe_addLeft, MeasurableEquiv.symm_addLeft,
-            map_add_left_eq_self, neg_add_eq_sub]
-  rw [multivariateGaussian, stdGaussian_eq_withDensity, hAfun, hmap, hr, hRdef,
+  rw [multivariateGaussian, stdGaussian_eq_withDensity, hAfun, Measure.map_affine_withDensity,
     Matrix.det_toEuclideanCLE]
   refine withDensity_congr_ae (.of_forall fun y => ?_)
   simp only [multivariateGaussianPDF, multivariateGaussianPDFReal,

--- a/TauCeti/Probability/Distributions/Gaussian/Density.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/Density.lean
@@ -112,6 +112,22 @@ theorem multivariateGaussianPDFReal_nonneg (m : EuclideanSpace ℝ ι) (S : Matr
   rw [multivariateGaussianPDFReal]
   exact mul_nonneg (mul_nonneg hπ hdet) (Real.exp_nonneg _)
 
+/-- The `ℝ≥0∞`-valued density is positive wherever the determinant is. -/
+theorem multivariateGaussianPDF_pos (hdet : 0 < S.det) (m : EuclideanSpace ℝ ι)
+    (x : EuclideanSpace ℝ ι) : 0 < multivariateGaussianPDF m S x :=
+  ENNReal.ofReal_pos.mpr (multivariateGaussianPDFReal_pos hdet m x)
+
+/-- The `ℝ≥0∞`-valued density is finite at every covariance parameter. -/
+@[simp]
+theorem multivariateGaussianPDF_ne_top (m : EuclideanSpace ℝ ι) (S : Matrix ι ι ℝ)
+    (x : EuclideanSpace ℝ ι) : multivariateGaussianPDF m S x ≠ ⊤ :=
+  ENNReal.ofReal_ne_top
+
+/-- The `ℝ≥0∞`-valued density is finite at every covariance parameter. -/
+theorem multivariateGaussianPDF_lt_top (m : EuclideanSpace ℝ ι) (S : Matrix ι ι ℝ)
+    (x : EuclideanSpace ℝ ι) : multivariateGaussianPDF m S x < ⊤ :=
+  ENNReal.ofReal_lt_top
+
 /-- The `ℝ≥0∞`-valued density carries the real-valued one back through `ENNReal.toReal`. -/
 @[simp]
 theorem toReal_multivariateGaussianPDF (m : EuclideanSpace ℝ ι) (S : Matrix ι ι ℝ)

--- a/TauCeti/Probability/Distributions/Gaussian/Density.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/Density.lean
@@ -169,6 +169,14 @@ theorem stdGaussian_eq_withDensity :
 /-- **A nondegenerate multivariate Gaussian law is Lebesgue measure with the Gaussian density.** -/
 theorem multivariateGaussian_eq_withDensity (hS : S.PosDef) (m : EuclideanSpace ℝ ι) :
     multivariateGaussian m S = volume.withDensity (multivariateGaussianPDF m S) := by
+  -- The proof has four stages. First, facts about the square root `√S`: it is positive
+  -- semidefinite, squares to `S`, and has determinant `√(det S)`, hence is invertible and induces
+  -- a continuous linear equivalence `R` of `EuclideanSpace ℝ ι` (`hR` to `hAfun`). Second, the
+  -- inverse square root pulls the isotropic quadratic form back to the one of `S⁻¹` (`hconj`,
+  -- `hnorm`), and the two ways of writing the normalising constant agree (`hrpow`). Third, the
+  -- affine substitution `x ↦ m + R x` transports any density along the map (`hmapR`, `hmap`).
+  -- Finally, rewriting `multivariateGaussian` by the standard density and that transport reduces
+  -- the goal to a pointwise identity between the two closed forms.
   have hR : (CFC.sqrt S).PosSemidef := Matrix.LE.le.posSemidef (CFC.sqrt_nonneg S)
   have hRR : CFC.sqrt S * CFC.sqrt S = S := CFC.sqrt_mul_sqrt_self S hS.posSemidef.nonneg
   have hdetS : 0 < S.det := hS.det_pos
@@ -195,9 +203,10 @@ theorem multivariateGaussian_eq_withDensity (hS : S.PosDef) (m : EuclideanSpace 
     rw [Real.sqrt_eq_rpow, ← Real.rpow_neg hdetS.le]
     congr 1
     ring
-  -- the affine substitution `x ↦ m + √S x` transports the standard density: the linear part
-  -- rescales `volume` by the Jacobian and substitutes `(√S)⁻¹`, and the translation leaves
-  -- `volume` alone
+  -- Stage three. The linear part rescales `volume` by the constant Jacobian `|det R|⁻¹` and
+  -- substitutes `R⁻¹` in the weight; the translation leaves `volume` alone and substitutes
+  -- `· - m`. The statement is left general in the weight `g` because the two stages compose
+  -- along `MeasurableEquiv.map_withDensity`, which is itself general in the weight.
   set R : EuclideanSpace ℝ ι ≃L[ℝ] EuclideanSpace ℝ ι := Matrix.toEuclideanCLE (CFC.sqrt S) hRunit
     with hRdef
   set r : ℝ≥0∞ := ENNReal.ofReal

--- a/TauCeti/Probability/Distributions/Gaussian/Density.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/Density.lean
@@ -1,0 +1,230 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.Matrix.EuclideanLin
+public import TauCeti.MeasureTheory.Measure.WithDensity
+public import TauCeti.Probability.Density
+public import TauCeti.Probability.Distributions.Gaussian.Multivariate
+public import TauCeti.Probability.Distributions.Gaussian.Pi
+
+import Mathlib.MeasureTheory.Measure.Haar.InnerProductSpace
+
+/-!
+# The density of a multivariate Gaussian measure
+
+A multivariate Gaussian law with positive-definite covariance `S` is Lebesgue measure on
+`EuclideanSpace ℝ ι` weighted by the classical density
+
+`(2π)^(-d/2) * (det S)^(-1/2) * exp (-⟪x - m, S⁻¹ (x - m)⟫ / 2)`,
+
+where `d` is the dimension. Every other covariance parameter gives a law carried by a proper
+affine subspace, hence singular with respect to Lebesgue measure and with no density at all.
+
+The nondegenerate case comes from the isotropic product density
+(`TauCeti.pi_gaussianReal_eq_withDensity`) by an affine change of variables along the square root
+of the covariance, which contributes the Jacobian `√(det S)` and turns the isotropic quadratic
+form into the one of `S⁻¹`.
+
+## Main definitions
+
+* `TauCeti.multivariateGaussianPDFReal` — the real-valued density;
+* `TauCeti.multivariateGaussianPDF` — its `ℝ≥0∞`-valued companion.
+
+## Main results
+
+* `TauCeti.stdGaussian_eq_withDensity` — the standard Gaussian on `EuclideanSpace ℝ ι` is Lebesgue
+  measure weighted by `(2π)^(-d/2) * exp (-‖x‖² / 2)`;
+* `TauCeti.multivariateGaussian_eq_withDensity` — the density presentation of the law;
+* `TauCeti.hasPDF_of_hasLaw_multivariateGaussian` and
+  `TauCeti.pdf_eq_multivariateGaussianPDF_of_hasLaw_multivariateGaussian` — the `HasPDF` bridge
+  and the identification of `MeasureTheory.pdf`;
+* `TauCeti.rnDeriv_multivariateGaussian` — the Radon–Nikodym derivative;
+* `TauCeti.mutuallySingular_multivariateGaussian_volume` — singularity at every covariance
+  parameter that is not positive definite.
+
+## References
+
+* M. L. Eaton, *Multivariate Statistics: A Vector Space Approach*.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory ProbabilityTheory Real
+open scoped ENNReal RealInnerProductSpace MatrixOrder Matrix.Norms.L2Operator
+
+namespace TauCeti
+
+variable {ι : Type*} [Fintype ι] [DecidableEq ι]
+
+/-- The **density of the multivariate Gaussian law** with mean `m` and covariance `S`, as a real
+number. It is the density of `multivariateGaussian m S` when `S` is positive definite
+(`TauCeti.multivariateGaussian_eq_withDensity`); at every other `S` that law has no density
+(`TauCeti.mutuallySingular_multivariateGaussian_volume`). -/
+def multivariateGaussianPDFReal (m : EuclideanSpace ℝ ι) (S : Matrix ι ι ℝ)
+    (x : EuclideanSpace ℝ ι) : ℝ :=
+  (2 * π) ^ (-(Fintype.card ι : ℝ) / 2) * S.det ^ (-(1 : ℝ) / 2) *
+    exp (-⟪x - m, S⁻¹.toEuclideanLin (x - m)⟫ / 2)
+
+/-- The `ℝ≥0∞`-valued companion to `TauCeti.multivariateGaussianPDFReal`. -/
+def multivariateGaussianPDF (m : EuclideanSpace ℝ ι) (S : Matrix ι ι ℝ)
+    (x : EuclideanSpace ℝ ι) : ℝ≥0∞ :=
+  ENNReal.ofReal (multivariateGaussianPDFReal m S x)
+
+variable {m : EuclideanSpace ℝ ι} {S : Matrix ι ι ℝ}
+
+/-- The defining formula of the real-valued density. -/
+theorem multivariateGaussianPDFReal_def (m : EuclideanSpace ℝ ι) (S : Matrix ι ι ℝ) :
+    multivariateGaussianPDFReal m S = fun x => (2 * π) ^ (-(Fintype.card ι : ℝ) / 2) *
+      S.det ^ (-(1 : ℝ) / 2) * exp (-⟪x - m, S⁻¹.toEuclideanLin (x - m)⟫ / 2) := (rfl)
+
+/-- The `ℝ≥0∞`-valued density is the `ENNReal.ofReal` lift of the real-valued one. -/
+theorem multivariateGaussianPDF_def (m : EuclideanSpace ℝ ι) (S : Matrix ι ι ℝ) :
+    multivariateGaussianPDF m S =
+      fun x => ENNReal.ofReal (multivariateGaussianPDFReal m S x) := (rfl)
+
+/-- The density is positive wherever the determinant is, in particular at a positive-definite
+covariance, where `Matrix.PosDef.det_pos` supplies the hypothesis. -/
+theorem multivariateGaussianPDFReal_pos (hdet : 0 < S.det) (m : EuclideanSpace ℝ ι)
+    (x : EuclideanSpace ℝ ι) : 0 < multivariateGaussianPDFReal m S x := by
+  have hπ : 0 < 2 * π := by positivity
+  rw [multivariateGaussianPDFReal]
+  positivity
+
+/-- The real-valued density is measurable. -/
+@[fun_prop]
+theorem measurable_multivariateGaussianPDFReal (m : EuclideanSpace ℝ ι) (S : Matrix ι ι ℝ) :
+    Measurable (multivariateGaussianPDFReal m S) := by
+  unfold multivariateGaussianPDFReal
+  fun_prop
+
+/-- The `ℝ≥0∞`-valued density is measurable. -/
+@[fun_prop]
+theorem measurable_multivariateGaussianPDF (m : EuclideanSpace ℝ ι) (S : Matrix ι ι ℝ) :
+    Measurable (multivariateGaussianPDF m S) :=
+  (measurable_multivariateGaussianPDFReal m S).ennreal_ofReal
+
+omit [DecidableEq ι] in
+/-- **The standard Gaussian on `EuclideanSpace ℝ ι` has the isotropic Gaussian density.** -/
+theorem stdGaussian_eq_withDensity :
+    stdGaussian (EuclideanSpace ℝ ι) =
+      volume.withDensity fun x =>
+        ENNReal.ofReal ((2 * π) ^ (-(Fintype.card ι : ℝ) / 2) * exp (-‖x‖ ^ 2 / 2)) := by
+  have hvol : (volume : Measure (ι → ℝ)).map ⇑(MeasurableEquiv.toLp 2 (ι → ℝ)) = volume :=
+    (PiLp.volume_preserving_toLp ι).map_eq
+  rw [← map_pi_eq_stdGaussian, pi_gaussianReal_eq_withDensity,
+    ← MeasurableEquiv.coe_toLp 2 (ι → ℝ), map_withDensity_equiv, ← volume_pi, hvol]
+  refine withDensity_congr_ae (.of_forall fun y => congrArg ENNReal.ofReal ?_)
+  rw [prod_gaussianPDFReal_zero_one, MeasurableEquiv.coe_toLp_symm,
+    ← EuclideanSpace.real_norm_sq_eq]
+
+/-- **A nondegenerate multivariate Gaussian law is Lebesgue measure with the Gaussian density.** -/
+theorem multivariateGaussian_eq_withDensity (hS : S.PosDef) (m : EuclideanSpace ℝ ι) :
+    multivariateGaussian m S = volume.withDensity (multivariateGaussianPDF m S) := by
+  have hR : (CFC.sqrt S).PosSemidef := Matrix.LE.le.posSemidef (CFC.sqrt_nonneg S)
+  have hRR : CFC.sqrt S * CFC.sqrt S = S := CFC.sqrt_mul_sqrt_self S hS.posSemidef.nonneg
+  have hdetS : 0 < S.det := hS.det_pos
+  have hdetR : (CFC.sqrt S).det = √S.det := by simpa using hS.posSemidef.det_sqrt
+  have hdetRpos : 0 < (CFC.sqrt S).det := by rw [hdetR]; positivity
+  have hRunit : IsUnit (CFC.sqrt S).det := hdetRpos.ne'.isUnit
+  have hCLM : ∀ (X : Matrix ι ι ℝ) (z : EuclideanSpace ℝ ι),
+      Matrix.toEuclideanCLM (𝕜 := ℝ) X z = X.toEuclideanLin z := fun X z => by
+    rw [← Matrix.coe_toEuclideanCLM_eq_toEuclideanLin X, ContinuousLinearMap.coe_coe]
+  -- the square root is invertible, so it induces a continuous linear equivalence
+  have hAfun : (fun x : EuclideanSpace ℝ ι => m + Matrix.toEuclideanCLM (𝕜 := ℝ) (CFC.sqrt S) x)
+      = fun x => m + Matrix.toEuclideanCLE (CFC.sqrt S) hRunit x :=
+    funext fun x => by rw [hCLM, Matrix.toEuclideanCLE_apply]
+  -- the inverse square root pulls the isotropic quadratic form back to the one of `S⁻¹`
+  have hconj : ((CFC.sqrt S)⁻¹).conjTranspose * 1 * (CFC.sqrt S)⁻¹ = S⁻¹ := by
+    rw [mul_one, hR.isHermitian.inv.eq, ← Matrix.mul_inv_rev, hRR]
+  have hnorm : ∀ z : EuclideanSpace ℝ ι,
+      ‖(CFC.sqrt S)⁻¹.toEuclideanLin z‖ ^ 2 = ⟪z, S⁻¹.toEuclideanLin z⟫ :=
+    fun z => by
+      rw [← real_inner_self_eq_norm_sq, ← hconj,
+        ← Matrix.inner_toEuclideanLin_toEuclideanLin (CFC.sqrt S)⁻¹ 1 z]
+      simp
+  have hrpow : S.det ^ (-(1 : ℝ) / 2) = (√S.det)⁻¹ := by
+    rw [Real.sqrt_eq_rpow, ← Real.rpow_neg hdetS.le]
+    congr 1
+    ring
+  rw [multivariateGaussian, stdGaussian_eq_withDensity, hAfun, map_affine_withDensity,
+    Matrix.det_toEuclideanCLE]
+  refine withDensity_congr_ae (.of_forall fun y => ?_)
+  simp only [multivariateGaussianPDF, multivariateGaussianPDFReal,
+    Matrix.toEuclideanCLE_symm_apply]
+  rw [← ENNReal.ofReal_mul (by positivity), hnorm, abs_of_pos (by positivity), hdetR, hrpow]
+  congr 1
+  ring
+
+variable {Ω : Type*} [MeasurableSpace Ω] {P : Measure Ω} {X : Ω → EuclideanSpace ℝ ι}
+
+/-- A random vector with a nondegenerate multivariate Gaussian law has a density. -/
+theorem hasPDF_of_hasLaw_multivariateGaussian (hS : S.PosDef)
+    (hX : HasLaw X (multivariateGaussian m S) P) : HasPDF X P :=
+  Probability.hasPDF_of_hasLaw_withDensity (measurable_multivariateGaussianPDF m S).aemeasurable
+    (by rwa [← multivariateGaussian_eq_withDensity hS])
+
+/-- The density of a nondegenerate multivariate Gaussian law is `multivariateGaussianPDF`. -/
+theorem pdf_eq_multivariateGaussianPDF_of_hasLaw_multivariateGaussian (hS : S.PosDef)
+    (hX : HasLaw X (multivariateGaussian m S) P) :
+    pdf X P =ᵐ[volume] multivariateGaussianPDF m S :=
+  Probability.pdf_eq_of_hasLaw_withDensity (measurable_multivariateGaussianPDF m S).aemeasurable
+    (by rwa [← multivariateGaussian_eq_withDensity hS])
+
+/-- **The Radon–Nikodym derivative of a nondegenerate multivariate Gaussian law.** -/
+theorem rnDeriv_multivariateGaussian (hS : S.PosDef) (m : EuclideanSpace ℝ ι) :
+    (multivariateGaussian m S).rnDeriv volume =ᵐ[volume] multivariateGaussianPDF m S := by
+  rw [multivariateGaussian_eq_withDensity hS]
+  exact Measure.rnDeriv_withDensity _ (measurable_multivariateGaussianPDF m S)
+
+/-- **Every degenerate multivariate Gaussian law is singular.** A positive-semidefinite but
+singular covariance carries the law on the proper affine subspace `m + range (CFC.sqrt S)`; any
+other covariance makes the law a point mass. -/
+theorem mutuallySingular_multivariateGaussian_volume (hS : ¬ S.PosDef)
+    (m : EuclideanSpace ℝ ι) :
+    multivariateGaussian m S ⟂ₘ (volume : Measure (EuclideanSpace ℝ ι)) := by
+  -- over an empty index type every matrix is positive definite, so the index type is nonempty
+  have hne : Nonempty ι := by
+    by_contra h
+    rw [not_nonempty_iff] at h
+    exact hS ⟨by ext i; exact isEmptyElim i,
+      fun x hx => absurd (Finsupp.ext fun i => isEmptyElim i) hx⟩
+  by_cases hSS : S.PosSemidef
+  · have hdet0 : (CFC.sqrt S).det = 0 := by
+      have hS0 : S.det = 0 := by
+        by_contra hd
+        exact hS (hSS.posDef_iff_det_ne_zero.mpr hd)
+      simp [hSS.det_sqrt, hS0]
+    set p : Submodule ℝ (EuclideanSpace ℝ ι) :=
+      LinearMap.range (Matrix.toEuclideanLin (CFC.sqrt S)) with hp
+    have hptop : p ≠ ⊤ :=
+      (LinearMap.range_lt_top_of_det_eq_zero (by rw [LinearMap.det_toLpLin]; exact hdet0)).ne
+    set t : Set (EuclideanSpace ℝ ι) :=
+      (fun y => -m + y) ⁻¹' (p : Set (EuclideanSpace ℝ ι)) with ht
+    have htc : MeasurableSet tᶜ :=
+      ((p.closed_of_finiteDimensional.preimage (by fun_prop)).measurableSet).compl
+    refine ⟨tᶜ, htc, ?_, ?_⟩
+    · rw [multivariateGaussian, Measure.map_apply (by fun_prop) htc]
+      convert measure_empty (μ := stdGaussian (EuclideanSpace ℝ ι))
+      ext x
+      simp only [Set.mem_preimage, Set.mem_compl_iff, Set.mem_empty_iff_false, iff_false, not_not,
+        ht, neg_add_cancel_left, SetLike.mem_coe, hp]
+      exact LinearMap.mem_range_self _ x
+    · rw [compl_compl, ht, measure_preimage_add]
+      exact Measure.addHaar_submodule volume p hptop
+  · rw [multivariateGaussian_of_not_posSemidef m hSS]
+    exact mutuallySingular_dirac m volume
+
+/-- A degenerate multivariate Gaussian law has vanishing Radon–Nikodym derivative. -/
+theorem rnDeriv_multivariateGaussian_of_not_posDef (hS : ¬ S.PosDef)
+    (m : EuclideanSpace ℝ ι) :
+    (multivariateGaussian m S).rnDeriv volume =ᵐ[volume] 0 :=
+  Measure.MutuallySingular.rnDeriv_ae_eq_zero
+    (mutuallySingular_multivariateGaussian_volume hS m)
+
+end TauCeti

--- a/TauCeti/Probability/Distributions/Gaussian/Density.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/Density.lean
@@ -50,6 +50,9 @@ form into the one of `S⁻¹`.
 ## References
 
 * M. L. Eaton, *Multivariate Statistics: A Vector Space Approach*.
+* `TauCetiRoadmap/StandardDistributions/README.md`, which prescribes deriving the nondegenerate
+  case from `TauCeti.pi_gaussianReal_eq_withDensity` by an affine change of variables rather than
+  rebuilding the product-density calculation.
 -/
 
 public section

--- a/TauCeti/Probability/Distributions/Gaussian/Density.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/Density.lean
@@ -12,6 +12,7 @@ public import TauCeti.Probability.Distributions.Gaussian.Multivariate
 public import TauCeti.Probability.Distributions.Gaussian.Pi
 
 import Mathlib.MeasureTheory.Measure.Haar.InnerProductSpace
+import Mathlib.MeasureTheory.Measure.Lebesgue.EqHaar
 
 /-!
 # The density of a multivariate Gaussian measure
@@ -194,7 +195,40 @@ theorem multivariateGaussian_eq_withDensity (hS : S.PosDef) (m : EuclideanSpace 
     rw [Real.sqrt_eq_rpow, ← Real.rpow_neg hdetS.le]
     congr 1
     ring
-  rw [multivariateGaussian, stdGaussian_eq_withDensity, hAfun, Measure.map_affine_withDensity,
+  -- the affine substitution `x ↦ m + √S x` transports the standard density: the linear part
+  -- rescales `volume` by the Jacobian and substitutes `(√S)⁻¹`, and the translation leaves
+  -- `volume` alone
+  set R : EuclideanSpace ℝ ι ≃L[ℝ] EuclideanSpace ℝ ι := Matrix.toEuclideanCLE (CFC.sqrt S) hRunit
+    with hRdef
+  set r : ℝ≥0∞ := ENNReal.ofReal
+    |(LinearMap.det (R : EuclideanSpace ℝ ι →ₗ[ℝ] EuclideanSpace ℝ ι))⁻¹| with hr
+  have hdetne : LinearMap.det (R : EuclideanSpace ℝ ι →ₗ[ℝ] EuclideanSpace ℝ ι) ≠ 0 :=
+    ((R : EuclideanSpace ℝ ι ≃ₗ[ℝ] EuclideanSpace ℝ ι).isUnit_det').ne_zero
+  have hmapR : (volume : Measure (EuclideanSpace ℝ ι)).map R = r • volume := by
+    rw [hr]
+    simpa using Measure.map_linearMap_addHaar_eq_smul_addHaar volume hdetne
+  have hmap : ∀ g : EuclideanSpace ℝ ι → ℝ≥0∞,
+      ((volume : Measure (EuclideanSpace ℝ ι)).withDensity g).map (fun x => m + R x)
+        = volume.withDensity fun y => r * g (R.symm (y - m)) := fun g => by
+    have hlin : ((volume : Measure (EuclideanSpace ℝ ι)).withDensity g).map R
+        = volume.withDensity fun y => r * g (R.symm y) := by
+      rw [← R.coe_toHomeomorph, ← Homeomorph.toMeasurableEquiv_coe, MeasurableEquiv.map_withDensity]
+      simp only [Homeomorph.toMeasurableEquiv_coe, Homeomorph.toMeasurableEquiv_symm_coe,
+        ContinuousLinearEquiv.coe_toHomeomorph, ContinuousLinearEquiv.coe_symm_toHomeomorph]
+      rw [hmapR, withDensity_smul_measure, ← withDensity_smul' _ _ ENNReal.ofReal_ne_top]
+      exact congrArg volume.withDensity
+        (funext fun y => by simp only [Pi.smul_apply, smul_eq_mul, hr])
+    calc ((volume : Measure (EuclideanSpace ℝ ι)).withDensity g).map (fun x => m + R x)
+        = (((volume : Measure (EuclideanSpace ℝ ι)).withDensity g).map R).map
+            (fun y : EuclideanSpace ℝ ι => m + y) :=
+          (Measure.map_map (by fun_prop) (by fun_prop)).symm
+      _ = (volume.withDensity fun y => r * g (R.symm y)).map
+            (fun y : EuclideanSpace ℝ ι => m + y) := by rw [hlin]
+      _ = volume.withDensity fun y => r * g (R.symm (y - m)) := by
+          rw [← MeasurableEquiv.coe_addLeft m, MeasurableEquiv.map_withDensity]
+          simp only [MeasurableEquiv.coe_addLeft, MeasurableEquiv.symm_addLeft,
+            map_add_left_eq_self, neg_add_eq_sub]
+  rw [multivariateGaussian, stdGaussian_eq_withDensity, hAfun, hmap, hr, hRdef,
     Matrix.det_toEuclideanCLE]
   refine withDensity_congr_ae (.of_forall fun y => ?_)
   simp only [multivariateGaussianPDF, multivariateGaussianPDFReal,

--- a/TauCeti/Probability/Distributions/Gaussian/Pi.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/Pi.lean
@@ -44,8 +44,8 @@ variable (ι : Type*) [Fintype ι]
 theorem prod_gaussianPDFReal_pos (x : ι → ℝ) : 0 < ∏ i, gaussianPDFReal 0 1 (x i) :=
   Finset.prod_pos fun i _ => gaussianPDFReal_pos 0 1 (x i) one_ne_zero
 
-/-- **The joint standard Gaussian density on `ℝ^ι` in closed form.** Each factor contributes one
-power of `(2π)^(-1/2)`, and the exponents add up to minus half the sum of the squared
+/-- **The joint standard Gaussian density on `ℝ^ι` in closed form**: the normalisation
+`(2π)^(-d/2)` in the dimension `d`, times the exponential of minus half the sum of the squared
 coordinates. -/
 theorem prod_gaussianPDFReal_zero_one (x : ι → ℝ) :
     ∏ i, gaussianPDFReal 0 1 (x i)

--- a/TauCeti/Probability/Distributions/Gaussian/Pi.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/Pi.lean
@@ -6,7 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.MeasureTheory.Measure.PiWithDensity
-public import Mathlib.Probability.Distributions.Gaussian.Real
+public import TauCeti.Probability.Distributions.Gaussian.Basic
 
 /-!
 # The standard Gaussian measure on a finite product
@@ -22,6 +22,8 @@ basis that consumes them.
 
 ## Main statements
 
+* `TauCeti.prod_gaussianPDFReal_zero_one`: the joint density in closed form,
+  `(2π)^(-d/2) · e^{-∑ᵢ xᵢ²/2}`, where `d` is the number of coordinates.
 * `TauCeti.pi_gaussianReal_eq_withDensity`: `γ^ι = volume^ι` weighted by the joint density.
 * `TauCeti.pi_volume_absolutelyContinuous_pi_gaussianReal`: the joint density never vanishes, so
   `volume^ι`-null sets are exactly `γ^ι`-null sets in the direction one needs to move an
@@ -30,7 +32,7 @@ basis that consumes them.
 
 public section
 
-open MeasureTheory ProbabilityTheory
+open MeasureTheory ProbabilityTheory Real
 
 open scoped ENNReal
 
@@ -41,6 +43,24 @@ variable (ι : Type*) [Fintype ι]
 /-- The joint standard Gaussian density on `ℝ^ι` is everywhere positive. -/
 theorem prod_gaussianPDFReal_pos (x : ι → ℝ) : 0 < ∏ i, gaussianPDFReal 0 1 (x i) :=
   Finset.prod_pos fun i _ => gaussianPDFReal_pos 0 1 (x i) one_ne_zero
+
+/-- **The joint standard Gaussian density on `ℝ^ι` in closed form.** Each factor contributes one
+power of `(2π)^(-1/2)`, and the exponents add up to minus half the sum of the squared
+coordinates. -/
+theorem prod_gaussianPDFReal_zero_one (x : ι → ℝ) :
+    ∏ i, gaussianPDFReal 0 1 (x i)
+      = (2 * π) ^ (-(Fintype.card ι : ℝ) / 2) * exp (-(∑ i, x i ^ 2) / 2) := by
+  have hπ : (0 : ℝ) < 2 * π := by positivity
+  have hconst : (√(2 * π))⁻¹ ^ Fintype.card ι = (2 * π) ^ (-(Fintype.card ι : ℝ) / 2) := by
+    rw [Real.sqrt_eq_rpow, ← Real.rpow_neg hπ.le, ← Real.rpow_natCast _ (Fintype.card ι),
+      ← Real.rpow_mul hπ.le]
+    congr 1
+    ring
+  have hexp : ∑ i, -(x i ^ 2 / 2) = -(∑ i, x i ^ 2) / 2 := by
+    rw [Finset.sum_neg_distrib, ← Finset.sum_div]
+    ring
+  rw [Finset.prod_congr rfl fun i (_ : i ∈ Finset.univ) => gaussianPDFReal_zero_one (x i),
+    Finset.prod_mul_distrib, Finset.prod_const, Finset.card_univ, ← Real.exp_sum, hconst, hexp]
 
 /-- The joint standard Gaussian density on `ℝ^ι` is measurable. -/
 theorem measurable_prod_gaussianPDFReal :


### PR DESCRIPTION
A multivariate Gaussian law with positive-definite covariance `S` is Lebesgue measure on `EuclideanSpace ℝ ι` weighted by the classical density, and every other covariance parameter gives a law that is singular with respect to Lebesgue measure. This is Layer 5, item 2 (**Multivariate Gaussian density**) of `TauCetiRoadmap/StandardDistributions/README.md`, together with the density requirements that item inherits from *What every distribution must provide*: a `fooPDFReal`/`fooPDF` pair, a `withDensity` presentation, a `MeasureTheory.HasPDF` theorem, and an `rnDeriv` theorem. Layer 5 item 1 (`covMatrix`, and `multivariateGaussian_zero_eq_map_stdGaussian_sqrt`) is already on `main` and is what this builds on.

`TauCeti/Probability/Distributions/Gaussian/Density.lean` (new) defines `multivariateGaussianPDFReal` and its `ℝ≥0∞`-valued companion `multivariateGaussianPDF`, and proves:

- `stdGaussian_eq_withDensity`: the standard Gaussian on `EuclideanSpace ℝ ι` is `volume` weighted by `(2π)^(-d/2) * exp (-‖x‖² / 2)`;
- `multivariateGaussian_eq_withDensity`, `hasPDF_of_hasLaw_multivariateGaussian`, `pdf_eq_multivariateGaussianPDF_of_hasLaw_multivariateGaussian`, and the roadmap's `rnDeriv_multivariateGaussian`, at positive-definite `S`;
- `mutuallySingular_multivariateGaussian_volume` and `rnDeriv_multivariateGaussian_of_not_posDef` at every other `S`, positive-semidefinite or not.

The proof follows the route the roadmap prescribes rather than rebuilding the product-density calculation. `TauCeti.pi_gaussianReal_eq_withDensity` gives the isotropic product density; transporting it along the volume-preserving `WithLp.toLp 2` gives the standard Gaussian on Euclidean space; and an affine change of variables by `CFC.sqrt S` gives the general case, with the Jacobian `√(det S)` from `Matrix.PosSemidef.det_sqrt` and the quadratic form from the existing `Matrix.inner_toEuclideanLin_toEuclideanLin`. In the degenerate case `CFC.sqrt S` is singular, so the law is carried by a proper affine subspace, which is Lebesgue-null; when `S` is not even positive semidefinite the law is `Measure.dirac m` by Mathlib's `multivariateGaussian_of_not_posSemidef`.

Three supporting pieces are what that change of variables needs, and each is added in the file whose topic it belongs to rather than hidden inside the density proof:

- `TauCeti/MeasureTheory/Measure/WithDensity.lean` (new) — `map_withDensity_equiv`, that a weight travels with the measure it weights along a measurable equivalence (Mathlib has this only for Radon–Nikodym derivatives, in `MeasurableEmbedding.map_withDensity_rnDeriv`), and `map_affine_withDensity`, which combines it with `Measure.map_linearMap_addHaar_eq_smul_addHaar` into the change-of-variables formula for a density under an invertible affine substitution — the shape any location–scale family needs.
- `TauCeti/Analysis/Matrix/EuclideanLin.lean` — `Matrix.toEuclideanCLE`, the continuous linear equivalence of an invertible matrix, with its `apply`, `symm_apply`, coercion and determinant lemmas, next to the quadratic-form pullback already there.
- `TauCeti/Probability/Distributions/Gaussian/Pi.lean` — `prod_gaussianPDFReal_zero_one`, the closed form of the joint standard Gaussian density, alongside the positivity and measurability lemmas about the same product.

Roadmap: StandardDistributions
