### PR TITLE
feat(EulerProduct): expand the logarithmic Euler product over prime powers

### DIFF
--- a/TauCeti/Analysis/SpecialFunctions/Complex/LogBounds.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Complex/LogBounds.lean
@@ -1,0 +1,65 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.SpecialFunctions.Complex.LogBounds
+
+/-!
+# Summability of the Taylor series of `-log (1 - ·)` over a family
+
+Mathlib's `Complex.hasSum_taylorSeries_neg_log'` expands `-log (1 - z)` as `∑' e, z ^ (e+1)/(e+1)`
+for a single `z` of modulus less than one.  Summing that over a family `r : ι → ℂ` needs the double
+family indexed by `ι × ℕ` to be summable, which is what licenses regrouping the sum fibrewise.
+
+`∀ i, ‖r i‖ < 1` alone is not enough: the fibre at `i` sums to `‖r i‖ / (1 - ‖r i‖)`, and without
+control on how close `‖r i‖` comes to `1` that is not dominated by the summable `∑ ‖r i‖`.
+Summability of `r` supplies the missing uniformity through `Summable.tendsto_cofinite_zero`, which
+pushes `‖r i‖` below `1 / 2` off a finite set; there the fibre sum is at most `2 ‖r i‖`, and
+`Summable.of_norm_bounded_eventually` takes exactly that eventual bound, so the finitely many
+exceptional indices need no separate treatment.
+
+## Main results
+
+* `Complex.summable_taylorSeries_neg_log`: for a summable `r : ι → ℂ` with every `‖r i‖ < 1`, the
+  family `(i, e) ↦ r i ^ (e + 1) / (e + 1)` is summable over `ι × ℕ`.
+-/
+
+public section
+
+namespace Complex
+
+/-- **The Taylor family of `-log (1 - rᵢ)` is summable over index and exponent together.**  For a
+summable family `r` of complex numbers, all of modulus less than one, the double family
+`(i, e) ↦ rᵢ ^ (e + 1) / (e + 1)` is absolutely summable, so its sum may be taken fibrewise.
+
+Both hypotheses are needed, and neither is arithmetic: see the module docstring for why
+`∀ i, ‖r i‖ < 1` alone does not suffice. -/
+theorem summable_taylorSeries_neg_log {ι : Type*} {r : ι → ℂ} (hr : Summable r)
+    (h1 : ∀ i, ‖r i‖ < 1) :
+    Summable fun ie : ι × ℕ ↦ r ie.1 ^ (ie.2 + 1) / ((ie.2 : ℂ) + 1) := by
+  have hhalf : ∀ᶠ i in Filter.cofinite, ‖r i‖ ≤ 1 / 2 :=
+    hr.tendsto_cofinite_zero.norm.eventually_le_const (by norm_num)
+  have hmaj : Summable fun ie : ι × ℕ ↦ ‖r ie.1‖ ^ (ie.2 + 1) := by
+    have hfib : ∀ i, Summable fun e : ℕ ↦ ‖r i‖ ^ (e + 1) := fun i ↦
+      ((summable_geometric_of_lt_one (norm_nonneg _) (h1 i)).mul_left ‖r i‖).congr fun e ↦ by ring
+    have hval : ∀ i, ∑' e : ℕ, ‖r i‖ ^ (e + 1) = ‖r i‖ / (1 - ‖r i‖) := fun i ↦ by
+      rw [tsum_congr fun e ↦ pow_succ' ‖r i‖ e, tsum_mul_left,
+        tsum_geometric_of_lt_one (norm_nonneg _) (h1 i), div_eq_mul_inv]
+    have houter : Summable fun i ↦ ∑' e : ℕ, ‖r i‖ ^ (e + 1) := by
+      refine Summable.of_norm_bounded_eventually (g := fun i ↦ 2 * ‖r i‖) (hr.norm.mul_left 2) ?_
+      filter_upwards [hhalf] with i hi
+      rw [Real.norm_of_nonneg (by positivity), hval i, div_le_iff₀ (by linarith [h1 i])]
+      nlinarith [norm_nonneg (r i)]
+    exact (summable_prod_of_nonneg fun ie ↦ pow_nonneg (norm_nonneg _) _).mpr ⟨hfib, houter⟩
+  refine hmaj.of_norm_bounded ?_
+  rintro ⟨i, e⟩
+  rw [norm_div, norm_pow]
+  refine div_le_self (by positivity) ?_
+  have hcast : ((e : ℂ) + 1) = ((e + 1 : ℕ) : ℂ) := by push_cast; ring
+  rw [hcast, Complex.norm_natCast]
+  exact_mod_cast Nat.succ_le_succ (Nat.zero_le e)
+
+end Complex

--- a/TauCeti/Analysis/SpecialFunctions/Complex/LogBounds.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Complex/LogBounds.lean
@@ -8,23 +8,22 @@ module
 public import Mathlib.Analysis.SpecialFunctions.Complex.LogBounds
 
 /-!
-# Summability of the Taylor series of `-log (1 - ·)` over a family
+# The Taylor series of `-log (1 - ·)` summed over a family
 
 Mathlib's `Complex.hasSum_taylorSeries_neg_log'` expands `-log (1 - z)` as `∑' e, z ^ (e+1)/(e+1)`
-for a single `z` of modulus less than one.  Summing that over a family `r : ι → ℂ` needs the double
-family indexed by `ι × ℕ` to be summable, which is what licenses regrouping the sum fibrewise.
+for a single `z` of modulus less than one.  This file sums that over a family `r : ι → ℂ`: the
+double family indexed by `ι × ℕ` is summable, so the sum may be regrouped fibrewise and the
+prime-power-style sum over pairs equals the sum of local logarithms.
 
-`∀ i, ‖r i‖ < 1` alone is not enough: the fibre at `i` sums to `‖r i‖ / (1 - ‖r i‖)`, and without
-control on how close `‖r i‖` comes to `1` that is not dominated by the summable `∑ ‖r i‖`.
-Summability of `r` supplies the missing uniformity through `Summable.tendsto_cofinite_zero`, which
-pushes `‖r i‖` below `1 / 2` off a finite set; there the fibre sum is at most `2 ‖r i‖`, and
-`Summable.of_norm_bounded_eventually` takes exactly that eventual bound, so the finitely many
-exceptional indices need no separate treatment.
+Both hypotheses are needed.  `∀ i, ‖r i‖ < 1` alone does not suffice: the fibre at `i` sums to
+`‖r i‖ / (1 - ‖r i‖)`, which is dominated by `‖r i‖` only when `‖r i‖` is bounded away from `1`,
+and summability of `r` is what supplies that uniformity.
 
 ## Main results
 
 * `Complex.summable_taylorSeries_neg_log`: for a summable `r : ι → ℂ` with every `‖r i‖ < 1`, the
   family `(i, e) ↦ r i ^ (e + 1) / (e + 1)` is summable over `ι × ℕ`.
+* `Complex.tsum_taylorSeries_neg_log`: its sum over `ι × ℕ` is `∑' i, -log (1 - r i)`.
 -/
 
 public section
@@ -61,5 +60,16 @@ theorem summable_taylorSeries_neg_log {ι : Type*} {r : ι → ℂ} (hr : Summab
   have hcast : ((e : ℂ) + 1) = ((e + 1 : ℕ) : ℂ) := by push_cast; ring
   rw [hcast, Complex.norm_natCast]
   exact_mod_cast Nat.succ_le_succ (Nat.zero_le e)
+
+
+/-- **The double sum is the sum of the local logarithms.**  For a summable `r : ι → ℂ` with every
+`‖r i‖ < 1`, summing the Taylor series of `-log (1 - r i)` over `ι × ℕ` gives `∑' i, -log (1 - r i)`
+— the fibrewise regrouping that `summable_taylorSeries_neg_log` licenses. -/
+theorem tsum_taylorSeries_neg_log {ι : Type*} {r : ι → ℂ} (hr : Summable r)
+    (h1 : ∀ i, ‖r i‖ < 1) :
+    ∑' ie : ι × ℕ, r ie.1 ^ (ie.2 + 1) / ((ie.2 : ℂ) + 1) = ∑' i, -Complex.log (1 - r i) := by
+  have hfib : ∀ i, HasSum (fun e : ℕ ↦ r i ^ (e + 1) / ((e : ℂ) + 1))
+      (-Complex.log (1 - r i)) := fun i ↦ hasSum_taylorSeries_neg_log' (h1 i)
+  exact ((summable_taylorSeries_neg_log hr h1).hasSum.prod_fiberwise hfib).tsum_eq.symm
 
 end Complex

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Logarithm.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Logarithm.lean
@@ -8,7 +8,6 @@ module
 public import TauCeti.Analysis.SpecialFunctions.Complex.LogBounds
 public import TauCeti.NumberTheory.ArithmeticDirichletSeries.EulerProduct.Analytic
 
-import Mathlib.Analysis.SpecialFunctions.Complex.LogBounds
 import Mathlib.NumberTheory.EulerProduct.ExpLog
 
 /-!

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Logarithm.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Logarithm.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.NumberTheory.ArithmeticDirichletSeries.EulerProduct.Analytic
 
+import Mathlib.Analysis.SpecialFunctions.Complex.LogBounds
 import Mathlib.NumberTheory.EulerProduct.ExpLog
 
 /-!
@@ -31,6 +32,8 @@ series to be nonvanishing there first, which
 
 * `TauCeti.MultiplicativeIdealWeight.exp_tsum_neg_log_one_sub_eq_LSeries`: the `L`-series as the
   exponential of a sum of principal logarithms over the primes.
+* `TauCeti.MultiplicativeIdealWeight.exp_tsum_primePow_eq_LSeries`: the same sum re-indexed by a
+  prime and an exponent.
 -/
 
 public section
@@ -69,6 +72,56 @@ theorem exp_tsum_neg_log_one_sub_eq_LSeries
     (χ.summable_div_of_summable_idealTerm hs)).neg.hasSum.cexp.tprod_eq
   simp only [Function.comp_apply, exp_neg, exp_log (hne _)] at H
   exact H.symm.trans (χ.hasProd_eulerFactor hs).tprod_eq
+
+/-- **The prime-power family is summable.** Bounding `‖rᵉ⁺¹ / (e + 1)‖` by `‖r‖ᵉ⁺¹` reduces this
+to a geometric sum in each fibre; summability of the ratios sends them to zero along the cofinite
+filter, so all but finitely many are at most `1 / 2` and the fibre sums are then at most `2‖r‖`. -/
+theorem summable_div_pow_div_of_summable_idealTerm
+    (hs : Summable (idealTerm K χ.toIdealArithmeticFunction s)) :
+    Summable fun pe : HeightOneSpectrum (𝓞 K) × ℕ ↦
+      (χ pe.1.asIdeal / (Ideal.absNorm pe.1.asIdeal : ℂ) ^ s) ^ (pe.2 + 1) / ((pe.2 : ℂ) + 1) := by
+  set r : HeightOneSpectrum (𝓞 K) → ℂ :=
+    fun P ↦ χ P.asIdeal / (Ideal.absNorm P.asIdeal : ℂ) ^ s with hr_def
+  have hr : Summable r := χ.summable_div_of_summable_idealTerm hs
+  have h1 : ∀ P, ‖r P‖ < 1 := χ.norm_div_lt_one_of_summable_idealTerm hs
+  have hhalf : ∀ᶠ P in Filter.cofinite, ‖r P‖ ≤ 1 / 2 :=
+    hr.tendsto_cofinite_zero.norm.eventually_le_const (by norm_num)
+  have hmaj : Summable fun pe : HeightOneSpectrum (𝓞 K) × ℕ ↦ ‖r pe.1‖ ^ (pe.2 + 1) := by
+    have hfib : ∀ P, Summable fun e : ℕ ↦ ‖r P‖ ^ (e + 1) := fun P ↦
+      ((summable_geometric_of_lt_one (norm_nonneg _) (h1 P)).mul_left ‖r P‖).congr fun e ↦ by ring
+    have hval : ∀ P, ∑' e : ℕ, ‖r P‖ ^ (e + 1) = ‖r P‖ / (1 - ‖r P‖) := fun P ↦ by
+      rw [tsum_congr fun e ↦ pow_succ' ‖r P‖ e, tsum_mul_left,
+        tsum_geometric_of_lt_one (norm_nonneg _) (h1 P), div_eq_mul_inv]
+    have houter : Summable fun P ↦ ∑' e : ℕ, ‖r P‖ ^ (e + 1) := by
+      refine Summable.of_norm_bounded_eventually (g := fun P ↦ 2 * ‖r P‖) (hr.norm.mul_left 2) ?_
+      filter_upwards [hhalf] with P hP
+      rw [Real.norm_of_nonneg (by positivity), hval P, div_le_iff₀ (by linarith [h1 P])]
+      nlinarith [norm_nonneg (r P)]
+    exact (summable_prod_of_nonneg fun pe ↦ pow_nonneg (norm_nonneg _) _).mpr ⟨hfib, houter⟩
+  refine hmaj.of_norm_bounded ?_
+  rintro ⟨P, e⟩
+  rw [norm_div, norm_pow]
+  refine div_le_self (by positivity) ?_
+  have hcast : ((e : ℂ) + 1) = ((e + 1 : ℕ) : ℂ) := by push_cast; ring
+  rw [hcast, Complex.norm_natCast]
+  exact_mod_cast Nat.succ_le_succ (Nat.zero_le e)
+
+/-- **The Euler product expanded over prime powers.** Substituting the Taylor series of
+`-log (1 - ·)` at each prime turns the logarithmic form into a sum indexed by a prime and an
+exponent. The caveat above applies unchanged: this identifies the double sum only modulo
+`2πi ℤ`, so it is a re-indexing of the exponential form and not the logarithm Layer 3.4 asks for. -/
+theorem exp_tsum_primePow_eq_LSeries
+    (hs : Summable (idealTerm K χ.toIdealArithmeticFunction s)) :
+    exp (∑' pe : HeightOneSpectrum (𝓞 K) × ℕ,
+        (χ pe.1.asIdeal / (Ideal.absNorm pe.1.asIdeal : ℂ) ^ s) ^ (pe.2 + 1) / ((pe.2 : ℂ) + 1)) =
+      LSeries (normCoeff K χ.toIdealArithmeticFunction) s := by
+  have hfib : ∀ P : HeightOneSpectrum (𝓞 K),
+      HasSum (fun e : ℕ ↦
+          (χ P.asIdeal / (Ideal.absNorm P.asIdeal : ℂ) ^ s) ^ (e + 1) / ((e : ℂ) + 1))
+        (-log (1 - χ P.asIdeal / (Ideal.absNorm P.asIdeal : ℂ) ^ s)) :=
+    fun P ↦ hasSum_taylorSeries_neg_log' (χ.norm_div_lt_one_of_summable_idealTerm hs P)
+  have hdouble := (χ.summable_div_pow_div_of_summable_idealTerm hs).hasSum.prod_fiberwise hfib
+  rw [← χ.exp_tsum_neg_log_one_sub_eq_LSeries hs, ← hdouble.tsum_eq]
 
 end MultiplicativeIdealWeight
 

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Logarithm.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Logarithm.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.Analysis.SpecialFunctions.Complex.LogBounds
 public import TauCeti.NumberTheory.ArithmeticDirichletSeries.EulerProduct.Analytic
 
 import Mathlib.Analysis.SpecialFunctions.Complex.LogBounds
@@ -74,36 +75,6 @@ theorem exp_tsum_neg_log_one_sub_eq_LSeries
     (χ.summable_div_of_summable_idealTerm hs)).neg.hasSum.cexp.tprod_eq
   simp only [Function.comp_apply, exp_neg, exp_log (hne _)] at H
   exact H.symm.trans (χ.hasProd_eulerFactor hs).tprod_eq
-
-/-- **The Taylor family of `-log (1 - rᵢ)` is summable over index and exponent together.**  For a
-summable family `r` of complex numbers all of modulus less than one, the double family
-`(i, e) ↦ rᵢ ^ (e + 1) / (e + 1)` is absolutely summable, so its sum may be taken fibrewise.
-
-Only `Summable r` and `∀ i, ‖r i‖ < 1` are used; nothing here is arithmetic. -/
-private theorem summable_taylorSeries_neg_log {ι : Type*} {r : ι → ℂ} (hr : Summable r)
-    (h1 : ∀ i, ‖r i‖ < 1) :
-    Summable fun ie : ι × ℕ ↦ r ie.1 ^ (ie.2 + 1) / ((ie.2 : ℂ) + 1) := by
-  have hhalf : ∀ᶠ i in Filter.cofinite, ‖r i‖ ≤ 1 / 2 :=
-    hr.tendsto_cofinite_zero.norm.eventually_le_const (by norm_num)
-  have hmaj : Summable fun ie : ι × ℕ ↦ ‖r ie.1‖ ^ (ie.2 + 1) := by
-    have hfib : ∀ i, Summable fun e : ℕ ↦ ‖r i‖ ^ (e + 1) := fun i ↦
-      ((summable_geometric_of_lt_one (norm_nonneg _) (h1 i)).mul_left ‖r i‖).congr fun e ↦ by ring
-    have hval : ∀ i, ∑' e : ℕ, ‖r i‖ ^ (e + 1) = ‖r i‖ / (1 - ‖r i‖) := fun i ↦ by
-      rw [tsum_congr fun e ↦ pow_succ' ‖r i‖ e, tsum_mul_left,
-        tsum_geometric_of_lt_one (norm_nonneg _) (h1 i), div_eq_mul_inv]
-    have houter : Summable fun i ↦ ∑' e : ℕ, ‖r i‖ ^ (e + 1) := by
-      refine Summable.of_norm_bounded_eventually (g := fun i ↦ 2 * ‖r i‖) (hr.norm.mul_left 2) ?_
-      filter_upwards [hhalf] with i hi
-      rw [Real.norm_of_nonneg (by positivity), hval i, div_le_iff₀ (by linarith [h1 i])]
-      nlinarith [norm_nonneg (r i)]
-    exact (summable_prod_of_nonneg fun ie ↦ pow_nonneg (norm_nonneg _) _).mpr ⟨hfib, houter⟩
-  refine hmaj.of_norm_bounded ?_
-  rintro ⟨i, e⟩
-  rw [norm_div, norm_pow]
-  refine div_le_self (by positivity) ?_
-  have hcast : ((e : ℂ) + 1) = ((e + 1 : ℕ) : ℂ) := by push_cast; ring
-  rw [hcast, Complex.norm_natCast]
-  exact_mod_cast Nat.succ_le_succ (Nat.zero_le e)
 
 /-- **The prime-power family is absolutely summable.**  Under absolute convergence of the
 ideal-indexed series, the double family indexed by a prime `P` and an exponent `e` is summable, so

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Logarithm.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Logarithm.lean
@@ -96,13 +96,10 @@ theorem tsum_prime_pow_eq_tsum_neg_log_one_sub
     ∑' pe : HeightOneSpectrum (𝓞 K) × ℕ,
         (χ pe.1.asIdeal / (Ideal.absNorm pe.1.asIdeal : ℂ) ^ s) ^ (pe.2 + 1) / ((pe.2 : ℂ) + 1) =
       ∑' P : HeightOneSpectrum (𝓞 K),
-        -log (1 - χ P.asIdeal / (Ideal.absNorm P.asIdeal : ℂ) ^ s) := by
-  have hfib : ∀ P : HeightOneSpectrum (𝓞 K),
-      HasSum (fun e : ℕ ↦
-          (χ P.asIdeal / (Ideal.absNorm P.asIdeal : ℂ) ^ s) ^ (e + 1) / ((e : ℂ) + 1))
-        (-log (1 - χ P.asIdeal / (Ideal.absNorm P.asIdeal : ℂ) ^ s)) :=
-    fun P ↦ hasSum_taylorSeries_neg_log' (χ.norm_div_lt_one_of_summable_idealTerm hs P)
-  exact ((χ.summable_div_pow_div_of_summable_idealTerm hs).hasSum.prod_fiberwise hfib).tsum_eq.symm
+        -log (1 - χ P.asIdeal / (Ideal.absNorm P.asIdeal : ℂ) ^ s) :=
+  tsum_taylorSeries_neg_log
+    (r := fun P : HeightOneSpectrum (𝓞 K) ↦ χ P.asIdeal / (Ideal.absNorm P.asIdeal : ℂ) ^ s)
+    (χ.summable_div_of_summable_idealTerm hs) (χ.norm_div_lt_one_of_summable_idealTerm hs)
 
 /-- **The Euler product expanded over prime powers.**  The `L`-series is the exponential of the
 sum over pairs `(P, e)` of a prime and an exponent.  The caveat above applies unchanged: `exp` is

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Logarithm.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Logarithm.lean
@@ -75,18 +75,6 @@ theorem exp_tsum_neg_log_one_sub_eq_LSeries
   simp only [Function.comp_apply, exp_neg, exp_log (hne _)] at H
   exact H.symm.trans (χ.hasProd_eulerFactor hs).tprod_eq
 
-/-- **The prime-power family is absolutely summable.**  Under absolute convergence of the
-ideal-indexed series, the double family indexed by a prime `P` and an exponent `e` is summable, so
-the sum over `(P, e)` may be regrouped fibrewise over `P`.  This is what licenses the re-indexing
-in `tsum_prime_pow_eq_tsum_neg_log_one_sub`. -/
-theorem summable_div_pow_div_of_summable_idealTerm
-    (hs : Summable (idealTerm K χ.toIdealArithmeticFunction s)) :
-    Summable fun pe : HeightOneSpectrum (𝓞 K) × ℕ ↦
-      (χ pe.1.asIdeal / (Ideal.absNorm pe.1.asIdeal : ℂ) ^ s) ^ (pe.2 + 1) / ((pe.2 : ℂ) + 1) :=
-  summable_taylorSeries_neg_log
-    (r := fun P : HeightOneSpectrum (𝓞 K) ↦ χ P.asIdeal / (Ideal.absNorm P.asIdeal : ℂ) ^ s)
-    (χ.summable_div_of_summable_idealTerm hs) (χ.norm_div_lt_one_of_summable_idealTerm hs)
-
 /-- **The prime-power sum is the prime-indexed logarithm sum.**  Substituting the Taylor series of
 `-log (1 - ·)` at each prime and regrouping over the primes identifies the two sums *as complex
 numbers*, before any exponential is taken.  This is the statement a consumer needs in order to

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Logarithm.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Logarithm.lean
@@ -32,8 +32,10 @@ series to be nonvanishing there first, which
 
 * `TauCeti.MultiplicativeIdealWeight.exp_tsum_neg_log_one_sub_eq_LSeries`: the `L`-series as the
   exponential of a sum of principal logarithms over the primes.
-* `TauCeti.MultiplicativeIdealWeight.exp_tsum_primePow_eq_LSeries`: the same sum re-indexed by a
-  prime and an exponent.
+* `TauCeti.MultiplicativeIdealWeight.tsum_prime_pow_eq_tsum_neg_log_one_sub`: that sum re-indexed
+  by a prime and an exponent, as an identity of complex numbers.
+* `TauCeti.MultiplicativeIdealWeight.exp_tsum_prime_pow_eq_LSeries`: the exponential form of the
+  re-indexed sum.
 -/
 
 public section
@@ -73,55 +75,75 @@ theorem exp_tsum_neg_log_one_sub_eq_LSeries
   simp only [Function.comp_apply, exp_neg, exp_log (hne _)] at H
   exact H.symm.trans (χ.hasProd_eulerFactor hs).tprod_eq
 
-/-- **The prime-power family is summable.** Bounding `‖rᵉ⁺¹ / (e + 1)‖` by `‖r‖ᵉ⁺¹` reduces this
-to a geometric sum in each fibre; summability of the ratios sends them to zero along the cofinite
-filter, so all but finitely many are at most `1 / 2` and the fibre sums are then at most `2‖r‖`. -/
-theorem summable_div_pow_div_of_summable_idealTerm
-    (hs : Summable (idealTerm K χ.toIdealArithmeticFunction s)) :
-    Summable fun pe : HeightOneSpectrum (𝓞 K) × ℕ ↦
-      (χ pe.1.asIdeal / (Ideal.absNorm pe.1.asIdeal : ℂ) ^ s) ^ (pe.2 + 1) / ((pe.2 : ℂ) + 1) := by
-  set r : HeightOneSpectrum (𝓞 K) → ℂ :=
-    fun P ↦ χ P.asIdeal / (Ideal.absNorm P.asIdeal : ℂ) ^ s with hr_def
-  have hr : Summable r := χ.summable_div_of_summable_idealTerm hs
-  have h1 : ∀ P, ‖r P‖ < 1 := χ.norm_div_lt_one_of_summable_idealTerm hs
-  have hhalf : ∀ᶠ P in Filter.cofinite, ‖r P‖ ≤ 1 / 2 :=
+/-- **The Taylor family of `-log (1 - rᵢ)` is summable over index and exponent together.**  For a
+summable family `r` of complex numbers all of modulus less than one, the double family
+`(i, e) ↦ rᵢ ^ (e + 1) / (e + 1)` is absolutely summable, so its sum may be taken fibrewise.
+
+Only `Summable r` and `∀ i, ‖r i‖ < 1` are used; nothing here is arithmetic. -/
+private theorem summable_taylorSeries_neg_log {ι : Type*} {r : ι → ℂ} (hr : Summable r)
+    (h1 : ∀ i, ‖r i‖ < 1) :
+    Summable fun ie : ι × ℕ ↦ r ie.1 ^ (ie.2 + 1) / ((ie.2 : ℂ) + 1) := by
+  have hhalf : ∀ᶠ i in Filter.cofinite, ‖r i‖ ≤ 1 / 2 :=
     hr.tendsto_cofinite_zero.norm.eventually_le_const (by norm_num)
-  have hmaj : Summable fun pe : HeightOneSpectrum (𝓞 K) × ℕ ↦ ‖r pe.1‖ ^ (pe.2 + 1) := by
-    have hfib : ∀ P, Summable fun e : ℕ ↦ ‖r P‖ ^ (e + 1) := fun P ↦
-      ((summable_geometric_of_lt_one (norm_nonneg _) (h1 P)).mul_left ‖r P‖).congr fun e ↦ by ring
-    have hval : ∀ P, ∑' e : ℕ, ‖r P‖ ^ (e + 1) = ‖r P‖ / (1 - ‖r P‖) := fun P ↦ by
-      rw [tsum_congr fun e ↦ pow_succ' ‖r P‖ e, tsum_mul_left,
-        tsum_geometric_of_lt_one (norm_nonneg _) (h1 P), div_eq_mul_inv]
-    have houter : Summable fun P ↦ ∑' e : ℕ, ‖r P‖ ^ (e + 1) := by
-      refine Summable.of_norm_bounded_eventually (g := fun P ↦ 2 * ‖r P‖) (hr.norm.mul_left 2) ?_
-      filter_upwards [hhalf] with P hP
-      rw [Real.norm_of_nonneg (by positivity), hval P, div_le_iff₀ (by linarith [h1 P])]
-      nlinarith [norm_nonneg (r P)]
-    exact (summable_prod_of_nonneg fun pe ↦ pow_nonneg (norm_nonneg _) _).mpr ⟨hfib, houter⟩
+  have hmaj : Summable fun ie : ι × ℕ ↦ ‖r ie.1‖ ^ (ie.2 + 1) := by
+    have hfib : ∀ i, Summable fun e : ℕ ↦ ‖r i‖ ^ (e + 1) := fun i ↦
+      ((summable_geometric_of_lt_one (norm_nonneg _) (h1 i)).mul_left ‖r i‖).congr fun e ↦ by ring
+    have hval : ∀ i, ∑' e : ℕ, ‖r i‖ ^ (e + 1) = ‖r i‖ / (1 - ‖r i‖) := fun i ↦ by
+      rw [tsum_congr fun e ↦ pow_succ' ‖r i‖ e, tsum_mul_left,
+        tsum_geometric_of_lt_one (norm_nonneg _) (h1 i), div_eq_mul_inv]
+    have houter : Summable fun i ↦ ∑' e : ℕ, ‖r i‖ ^ (e + 1) := by
+      refine Summable.of_norm_bounded_eventually (g := fun i ↦ 2 * ‖r i‖) (hr.norm.mul_left 2) ?_
+      filter_upwards [hhalf] with i hi
+      rw [Real.norm_of_nonneg (by positivity), hval i, div_le_iff₀ (by linarith [h1 i])]
+      nlinarith [norm_nonneg (r i)]
+    exact (summable_prod_of_nonneg fun ie ↦ pow_nonneg (norm_nonneg _) _).mpr ⟨hfib, houter⟩
   refine hmaj.of_norm_bounded ?_
-  rintro ⟨P, e⟩
+  rintro ⟨i, e⟩
   rw [norm_div, norm_pow]
   refine div_le_self (by positivity) ?_
   have hcast : ((e : ℂ) + 1) = ((e + 1 : ℕ) : ℂ) := by push_cast; ring
   rw [hcast, Complex.norm_natCast]
   exact_mod_cast Nat.succ_le_succ (Nat.zero_le e)
 
-/-- **The Euler product expanded over prime powers.** Substituting the Taylor series of
-`-log (1 - ·)` at each prime turns the logarithmic form into a sum indexed by a prime and an
-exponent. The caveat above applies unchanged: this identifies the double sum only modulo
-`2πi ℤ`, so it is a re-indexing of the exponential form and not the logarithm Layer 3.4 asks for. -/
-theorem exp_tsum_primePow_eq_LSeries
+/-- **The prime-power family is absolutely summable.**  Under absolute convergence of the
+ideal-indexed series, the double family indexed by a prime `P` and an exponent `e` is summable, so
+the sum over `(P, e)` may be regrouped fibrewise over `P`.  This is what licenses the re-indexing
+in `tsum_prime_pow_eq_tsum_neg_log_one_sub`. -/
+theorem summable_div_pow_div_of_summable_idealTerm
     (hs : Summable (idealTerm K χ.toIdealArithmeticFunction s)) :
-    exp (∑' pe : HeightOneSpectrum (𝓞 K) × ℕ,
-        (χ pe.1.asIdeal / (Ideal.absNorm pe.1.asIdeal : ℂ) ^ s) ^ (pe.2 + 1) / ((pe.2 : ℂ) + 1)) =
-      LSeries (normCoeff K χ.toIdealArithmeticFunction) s := by
+    Summable fun pe : HeightOneSpectrum (𝓞 K) × ℕ ↦
+      (χ pe.1.asIdeal / (Ideal.absNorm pe.1.asIdeal : ℂ) ^ s) ^ (pe.2 + 1) / ((pe.2 : ℂ) + 1) :=
+  summable_taylorSeries_neg_log
+    (r := fun P : HeightOneSpectrum (𝓞 K) ↦ χ P.asIdeal / (Ideal.absNorm P.asIdeal : ℂ) ^ s)
+    (χ.summable_div_of_summable_idealTerm hs) (χ.norm_div_lt_one_of_summable_idealTerm hs)
+
+/-- **The prime-power sum is the prime-indexed logarithm sum.**  Substituting the Taylor series of
+`-log (1 - ·)` at each prime and regrouping over the primes identifies the two sums *as complex
+numbers*, before any exponential is taken.  This is the statement a consumer needs in order to
+rewrite one into the other; the exponential form below follows from it. -/
+theorem tsum_prime_pow_eq_tsum_neg_log_one_sub
+    (hs : Summable (idealTerm K χ.toIdealArithmeticFunction s)) :
+    ∑' pe : HeightOneSpectrum (𝓞 K) × ℕ,
+        (χ pe.1.asIdeal / (Ideal.absNorm pe.1.asIdeal : ℂ) ^ s) ^ (pe.2 + 1) / ((pe.2 : ℂ) + 1) =
+      ∑' P : HeightOneSpectrum (𝓞 K),
+        -log (1 - χ P.asIdeal / (Ideal.absNorm P.asIdeal : ℂ) ^ s) := by
   have hfib : ∀ P : HeightOneSpectrum (𝓞 K),
       HasSum (fun e : ℕ ↦
           (χ P.asIdeal / (Ideal.absNorm P.asIdeal : ℂ) ^ s) ^ (e + 1) / ((e : ℂ) + 1))
         (-log (1 - χ P.asIdeal / (Ideal.absNorm P.asIdeal : ℂ) ^ s)) :=
     fun P ↦ hasSum_taylorSeries_neg_log' (χ.norm_div_lt_one_of_summable_idealTerm hs P)
-  have hdouble := (χ.summable_div_pow_div_of_summable_idealTerm hs).hasSum.prod_fiberwise hfib
-  rw [← χ.exp_tsum_neg_log_one_sub_eq_LSeries hs, ← hdouble.tsum_eq]
+  exact ((χ.summable_div_pow_div_of_summable_idealTerm hs).hasSum.prod_fiberwise hfib).tsum_eq.symm
+
+/-- **The Euler product expanded over prime powers.**  The `L`-series is the exponential of the
+sum over pairs `(P, e)` of a prime and an exponent.  The caveat above applies unchanged: `exp` is
+not injective, so this identifies the double sum only modulo `2πi ℤ` and does not exhibit a
+logarithm of the `L`-series. -/
+theorem exp_tsum_prime_pow_eq_LSeries
+    (hs : Summable (idealTerm K χ.toIdealArithmeticFunction s)) :
+    exp (∑' pe : HeightOneSpectrum (𝓞 K) × ℕ,
+        (χ pe.1.asIdeal / (Ideal.absNorm pe.1.asIdeal : ℂ) ^ s) ^ (pe.2 + 1) / ((pe.2 : ℂ) + 1)) =
+      LSeries (normCoeff K χ.toIdealArithmeticFunction) s := by
+  rw [χ.tsum_prime_pow_eq_tsum_neg_log_one_sub hs, χ.exp_tsum_neg_log_one_sub_eq_LSeries hs]
 
 end MultiplicativeIdealWeight
 


### PR DESCRIPTION
> **Correction (round 1 `correctness` block).** This PR does **not** fulfil Layer 3.4, and the
> description below originally said it did. The rubric is right: `exp (∑ …) = L` does not identify
> `∑ …` as *the* logarithm of `L`, because exponentiating loses additive multiples of `2πi`, and
> Layer 3.4 asks for a logarithm chosen on a simply connected zero-free region. What is here is a
> correct exponential Euler-product identity and a **prerequisite** toward that layer, not the layer
> itself. The `tauceti-target` marker has been removed accordingly — it also collided with the
> identical marker on the sibling PR, which would have exposed one of them to the duplicate sweeper.

Layer 3.4 of the ArithmeticDirichletSeries roadmap asks for "the prime-power logarithmic expansion
and its derivative". #6046 gave the logarithmic form of the Euler product; this expands it over
prime powers, which is the shape the layer names.

```lean
theorem TauCeti.MultiplicativeIdealWeight.tsum_prime_pow_eq_tsum_neg_log_one_sub
    (hs : Summable (idealTerm K χ.toIdealArithmeticFunction s)) :
    ∑' pe : HeightOneSpectrum (𝓞 K) × ℕ,
        (χ pe.1.asIdeal / (Ideal.absNorm pe.1.asIdeal : ℂ) ^ s) ^ (pe.2 + 1) / ((pe.2 : ℂ) + 1) =
      ∑' P : HeightOneSpectrum (𝓞 K),
        -log (1 - χ P.asIdeal / (Ideal.absNorm P.asIdeal : ℂ) ^ s)

theorem TauCeti.MultiplicativeIdealWeight.exp_tsum_prime_pow_eq_LSeries
    (hs : Summable (idealTerm K χ.toIdealArithmeticFunction s)) :
    exp (∑' pe : HeightOneSpectrum (𝓞 K) × ℕ,
        (χ pe.1.asIdeal / (Ideal.absNorm pe.1.asIdeal : ℂ) ^ s) ^ (pe.2 + 1) / ((pe.2 : ℂ) + 1)) =
      LSeries (normCoeff K χ.toIdealArithmeticFunction) s
```

The first is the one to rewrite with: it identifies the two sums **as complex numbers**, before any
exponential. `api-design` asked for it in round 1 and was right — equality after `exp` loses
multiples of `2πi`, so the exponential form alone cannot be used to rewrite a prime-power sum into
a prime-indexed one. The second is now two rewrites on top of the first.

### The content is the summability, and it is not pointwise

Given the fibrewise Taylor series, `HasSum.prod_fiberwise` assembles the double sum — but only once
the double family is known summable, and that is where the work is.

None of that argument is arithmetic, and `generality` asked for it to stop pretending otherwise.
It is now `Complex.summable_taylorSeries_neg_log`, generic over `r : ι → ℂ` and needing only
`Summable r` and `∀ i, ‖r i‖ < 1`; the ideal-weight statement specialises it in one line. Round 1's
`api-design` finding then moved it out of this file altogether, into
`TauCeti/Analysis/SpecialFunctions/Complex/LogBounds.lean` — the path mirroring where Mathlib keeps
`Complex.hasSum_taylorSeries_neg_log'`, the single-point expansion this sums over a family.
Round 2's `api-design` and `generality` findings then made the same point about the *identity*
rather than only its prerequisite: `Complex.tsum_taylorSeries_neg_log` now states the fibrewise
regrouping generically too, and the ideal-weight version specialises it in one line.

Norms reduce it to `∑ ‖r_P‖ᵉ⁺¹`, geometric in each fibre with sum `‖r_P‖ / (1 - ‖r_P‖)`. To compare
that against the summable `∑ ‖r_P‖` one needs `‖r_P‖` bounded **away from** `1`, and the pointwise
fact available on `main` — `norm_div_lt_one_of_summable_idealTerm` — gives only `‖r_P‖ < 1`, with no
uniformity. What supplies the gap is summability itself: `Summable.tendsto_cofinite_zero` sends the
ratios to zero along the cofinite filter, so `‖r_P‖ ≤ 1/2` off a finite set and the fibre sums are
then at most `2‖r_P‖` there. `Summable.of_norm_bounded_eventually` takes exactly that eventual
bound, so the finitely many exceptional primes need no separate treatment.

### No longer stacked

**#6046 has merged**, so this now stands on `main` alone. It supplied
`summable_div_of_summable_idealTerm` and `exp_tsum_neg_log_one_sub_eq_LSeries`, both of which this
PR consumes and neither of which it restates. What is left is a single file and 53 added lines —
the two declarations below and nothing else.

### What consumes it

The derivative half of Layer 3.4, which turns this into the von Mangoldt form —
`ArithmeticDirichletSeries/VonMangoldt.lean` on `main` already defines the ideal analogue with its
API, so only the identity is missing. Behind that, #5572, which the `scope` rubric parked with "the
required logarithm and prime-power logarithmic expansion of Layer 3.4 are absent".

Roadmap: ArithmeticDirichletSeries

Provenance: none external — reuses Mathlib's `Complex.hasSum_taylorSeries_neg_log'`,
`HasSum.prod_fiberwise`, `summable_prod_of_nonneg` and `Summable.of_norm_bounded_eventually`
(Apache 2.0), over TauCeti's own `summable_div_of_summable_idealTerm`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011dmwkBnj4rJc75STgbwsLF






