### PR TITLE
refactor(RootSystem): root the whole `TauCeti.RootPairing` subtree

### DIFF
--- a/TauCeti/LinearAlgebra/RootSystem/BraidRelation.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/BraidRelation.lean
@@ -24,8 +24,8 @@ The iterates of the product are supplied by Mathlib's
 `Module.reflection_mul_reflection_pow_apply` and `Module.reflection_mul_reflection_pow_apply_self`,
 which express `(r₁r₂)ⁿ` over an arbitrary commutative ring through the Chebyshev `S`-polynomials
 (`Polynomial.Chebyshev.S`) evaluated at `t = c - 2`;
-`TauCeti.RootPairing.weylGroup.pow_ofIdx_mul_ofIdx_smul` and
-`TauCeti.RootPairing.weylGroup.pow_ofIdx_mul_ofIdx_smul_root` are those formulas for a product of
+`RootPairing.weylGroup.pow_ofIdx_mul_ofIdx_smul` and
+`RootPairing.weylGroup.pow_ofIdx_mul_ofIdx_smul_root` are those formulas for a product of
 two reflections of a root pairing, read as elements of the Weyl group. Substituting `c = 1, 2, 3`,
 that is `t = -1, 0, 1`, makes the two Chebyshev coefficients of the general formula vanish at the
 exponents `3`, `4`, `6`, which gives `g³ = 1`, `g⁴ = 1`, `g⁶ = 1`; the remaining value `c = 0` is
@@ -46,21 +46,21 @@ product to `{0, 1, 2, 3}` and the case analysis closes.
 
 ## Main results
 
-* `TauCeti.RootPairing.weylGroup.pow_ofIdx_mul_ofIdx_smul` and
-  `TauCeti.RootPairing.weylGroup.pow_ofIdx_mul_ofIdx_smul_root`: the iterates of a product of two
+* `RootPairing.weylGroup.pow_ofIdx_mul_ofIdx_smul` and
+  `RootPairing.weylGroup.pow_ofIdx_mul_ofIdx_smul_root`: the iterates of a product of two
   reflections, acting on a weight and on the first of the two roots.
-* `TauCeti.RootPairing.weylGroup.pow_three_ofIdx_mul_ofIdx_eq_one`,
-  `TauCeti.RootPairing.weylGroup.pow_four_ofIdx_mul_ofIdx_eq_one`,
-  `TauCeti.RootPairing.weylGroup.pow_six_ofIdx_mul_ofIdx_eq_one`: the braid relations at Cartan
+* `RootPairing.weylGroup.pow_three_ofIdx_mul_ofIdx_eq_one`,
+  `RootPairing.weylGroup.pow_four_ofIdx_mul_ofIdx_eq_one`,
+  `RootPairing.weylGroup.pow_six_ofIdx_mul_ofIdx_eq_one`: the braid relations at Cartan
   product `1`, `2`, `3`, and
-  `TauCeti.RootPairing.weylGroup.orderOf_ofIdx_mul_ofIdx_eq_three`,
-  `TauCeti.RootPairing.weylGroup.orderOf_ofIdx_mul_ofIdx_eq_four`,
-  `TauCeti.RootPairing.weylGroup.orderOf_ofIdx_mul_ofIdx_eq_six`: the matching exact orders under
+  `RootPairing.weylGroup.orderOf_ofIdx_mul_ofIdx_eq_three`,
+  `RootPairing.weylGroup.orderOf_ofIdx_mul_ofIdx_eq_four`,
+  `RootPairing.weylGroup.orderOf_ofIdx_mul_ofIdx_eq_six`: the matching exact orders under
   characteristic zero.
-* `TauCeti.RootPairing.weylGroup.orderOf_ofIdx_mul_ofIdx_eq_coxeterMatrixOfBase`: **the entries of
+* `RootPairing.weylGroup.orderOf_ofIdx_mul_ofIdx_eq_coxeterMatrixOfBase`: **the entries of
   the Coxeter matrix of a base are the orders of the products of the corresponding simple
   reflections.**
-* `TauCeti.RootPairing.weylGroup.pow_coxeterMatrixOfBase_ofIdx_mul_ofIdx_eq_one`: the braid
+* `RootPairing.weylGroup.pow_coxeterMatrixOfBase_ofIdx_mul_ofIdx_eq_one`: the braid
   relations of that Coxeter matrix hold in the Weyl group.
 
 ## References
@@ -80,7 +80,7 @@ open Set Polynomial.Chebyshev
 
 universe u v w x
 
-namespace RootPairing.weylGroup
+section
 
 variable {ι : Type u} {R : Type v} {M : Type w} {N : Type x}
   [CommRing R] [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
@@ -90,7 +90,7 @@ variable {ι : Type u} {R : Type v} {M : Type w} {N : Type x}
 
 /-- The action of an iterate of the product of the two reflections is the action of the
 corresponding iterate of the product of the two linear reflections. -/
-private lemma pow_ofIdx_mul_ofIdx_smul_eq (n : ℕ) (x : M) :
+private lemma _root_.RootPairing.weylGroup.pow_ofIdx_mul_ofIdx_smul_eq (n : ℕ) (x : M) :
     ((_root_.RootPairing.weylGroup.ofIdx P i *
         _root_.RootPairing.weylGroup.ofIdx P j) ^ n) • x =
       ((P.reflection i * P.reflection j) ^ n) x := by
@@ -104,7 +104,7 @@ private lemma pow_ofIdx_mul_ofIdx_smul_eq (n : ℕ) (x : M) :
 `Module.reflection_mul_reflection_pow_apply` for the reflections in two roots `αᵢ`, `αⱼ` of a root
 pairing, read in the Weyl group; its Chebyshev polynomials are evaluated at the Cartan product
 shifted by `2`, that is at `t = ⟨αᵢ, αⱼ^∨⟩⟨αⱼ, αᵢ^∨⟩ - 2`. -/
-theorem pow_ofIdx_mul_ofIdx_smul (n : ℕ) (x : M)
+theorem _root_.RootPairing.weylGroup.pow_ofIdx_mul_ofIdx_smul (n : ℕ) (x : M)
     (t : R := P.pairing i j * P.pairing j i - 2)
     (ht : t = P.pairing i j * P.pairing j i - 2 := by rfl) :
     ((_root_.RootPairing.weylGroup.ofIdx P i *
@@ -115,23 +115,23 @@ theorem pow_ofIdx_mul_ofIdx_smul (n : ℕ) (x : M)
         ((S R ((n - 1) / 2)).eval t * ((S R (n / 2)).eval t + (S R ((n - 2) / 2)).eval t)) •
           ((P.pairing j i * P.coroot' j x - P.coroot' i x) • P.root i -
             P.coroot' j x • P.root j) := by
-  rw [pow_ofIdx_mul_ofIdx_smul_eq]
+  rw [RootPairing.weylGroup.pow_ofIdx_mul_ofIdx_smul_eq]
   exact Module.reflection_mul_reflection_pow_apply (P.coroot_root_two i) (P.coroot_root_two j) n x t
     (by rw [ht, _root_.RootPairing.root_coroot'_eq_pairing,
       _root_.RootPairing.root_coroot'_eq_pairing]; ring)
 
 /-- **The iterates of a product of two reflections on the first of the two roots.** This is
 Mathlib's `Module.reflection_mul_reflection_pow_apply_self` read in the Weyl group; it is the case
-`x = αᵢ` of `TauCeti.RootPairing.weylGroup.pow_ofIdx_mul_ofIdx_smul`, in a form where the two
+`x = αᵢ` of `RootPairing.weylGroup.pow_ofIdx_mul_ofIdx_smul`, in a form where the two
 coefficients are single Chebyshev values. -/
-theorem pow_ofIdx_mul_ofIdx_smul_root (n : ℕ)
+theorem _root_.RootPairing.weylGroup.pow_ofIdx_mul_ofIdx_smul_root (n : ℕ)
     (t : R := P.pairing i j * P.pairing j i - 2)
     (ht : t = P.pairing i j * P.pairing j i - 2 := by rfl) :
     ((_root_.RootPairing.weylGroup.ofIdx P i *
         _root_.RootPairing.weylGroup.ofIdx P j) ^ n) • P.root i =
       ((S R n).eval t + (S R (n - 1)).eval t) • P.root i +
         ((S R (n - 1)).eval t * -P.pairing i j) • P.root j := by
-  rw [pow_ofIdx_mul_ofIdx_smul_eq]
+  rw [RootPairing.weylGroup.pow_ofIdx_mul_ofIdx_smul_eq]
   exact Module.reflection_mul_reflection_pow_apply_self (P.coroot_root_two i)
     (P.coroot_root_two j) n t
     (by rw [ht, _root_.RootPairing.root_coroot'_eq_pairing,
@@ -142,35 +142,38 @@ theorem pow_ofIdx_mul_ofIdx_smul_root (n : ℕ)
 /-- **The braid relation at Cartan product `1`**: the product of the two reflections has order
 dividing `3`, the `A₂` configuration. -/
 @[simp, grind =]
-theorem pow_three_ofIdx_mul_ofIdx_eq_one (h : P.pairing i j * P.pairing j i = 1) :
+theorem _root_.RootPairing.weylGroup.pow_three_ofIdx_mul_ofIdx_eq_one
+    (h : P.pairing i j * P.pairing j i = 1) :
     (_root_.RootPairing.weylGroup.ofIdx P i *
       _root_.RootPairing.weylGroup.ofIdx P j) ^ 3 = 1 := by
   refine eq_one_of_smul_eq_self fun x ↦ ?_
   -- At `t = -1` the coefficients of the two displacement terms are `S₀(t)(S₁(t) + S₀(t)) = 0`
   -- and `S₁(t)(S₁(t) + S₀(t)) = 0`.
-  rw [pow_ofIdx_mul_ofIdx_smul P i j 3 x (-1) (by rw [h]; ring)]
+  rw [RootPairing.weylGroup.pow_ofIdx_mul_ofIdx_smul P i j 3 x (-1) (by rw [h]; ring)]
   norm_num [S_zero, S_one]
 
 /-- **The braid relation at Cartan product `2`**: the product of the two reflections has order
 dividing `4`, the `B₂` configuration. -/
 @[simp, grind =]
-theorem pow_four_ofIdx_mul_ofIdx_eq_one (h : P.pairing i j * P.pairing j i = 2) :
+theorem _root_.RootPairing.weylGroup.pow_four_ofIdx_mul_ofIdx_eq_one
+    (h : P.pairing i j * P.pairing j i = 2) :
     (_root_.RootPairing.weylGroup.ofIdx P i *
       _root_.RootPairing.weylGroup.ofIdx P j) ^ 4 = 1 := by
   refine eq_one_of_smul_eq_self fun x ↦ ?_
   -- At `t = 0` both coefficients carry the factor `S₁(t) = t = 0`.
-  rw [pow_ofIdx_mul_ofIdx_smul P i j 4 x 0 (by rw [h]; ring)]
+  rw [RootPairing.weylGroup.pow_ofIdx_mul_ofIdx_smul P i j 4 x 0 (by rw [h]; ring)]
   norm_num [S_zero, S_one]
 
 /-- **The braid relation at Cartan product `3`**: the product of the two reflections has order
 dividing `6`, the `G₂` configuration. -/
 @[simp, grind =]
-theorem pow_six_ofIdx_mul_ofIdx_eq_one (h : P.pairing i j * P.pairing j i = 3) :
+theorem _root_.RootPairing.weylGroup.pow_six_ofIdx_mul_ofIdx_eq_one
+    (h : P.pairing i j * P.pairing j i = 3) :
     (_root_.RootPairing.weylGroup.ofIdx P i *
       _root_.RootPairing.weylGroup.ofIdx P j) ^ 6 = 1 := by
   refine eq_one_of_smul_eq_self fun x ↦ ?_
   -- At `t = 1` both coefficients carry the factor `S₂(t) = t² - 1 = 0`.
-  rw [pow_ofIdx_mul_ofIdx_smul P i j 6 x 1 (by rw [h]; ring)]
+  rw [RootPairing.weylGroup.pow_ofIdx_mul_ofIdx_smul P i j 6 x 1 (by rw [h]; ring)]
   norm_num [S_two]
 
 /-! ## The order is no smaller
@@ -180,7 +183,7 @@ expression in the Cartan product `c`, and comparing it with `⟨αᵢ, αᵢ^∨
 
 section LowerBound
 
-private lemma pow_ne_one_of_coroot'_left_ne (n : ℕ)
+private lemma _root_.RootPairing.weylGroup.pow_ne_one_of_coroot'_left_ne (n : ℕ)
     (h : P.coroot' i (((_root_.RootPairing.weylGroup.ofIdx P i *
       _root_.RootPairing.weylGroup.ofIdx P j) ^ n) • P.root i) ≠ 2) :
     (_root_.RootPairing.weylGroup.ofIdx P i *
@@ -190,13 +193,13 @@ private lemma pow_ne_one_of_coroot'_left_ne (n : ℕ)
     _root_.RootPairing.pairing_same] at h
   exact h rfl
 
-private lemma coroot'_left_pow_smul_root (n : ℕ) (t : R)
+private lemma _root_.RootPairing.weylGroup.coroot'_left_pow_smul_root (n : ℕ) (t : R)
     (ht : t = P.pairing i j * P.pairing j i - 2) :
     P.coroot' i (((_root_.RootPairing.weylGroup.ofIdx P i *
         _root_.RootPairing.weylGroup.ofIdx P j) ^ n) • P.root i) =
       2 * ((S R n).eval t + (S R (n - 1)).eval t) -
         (S R (n - 1)).eval t * (P.pairing i j * P.pairing j i) := by
-  rw [pow_ofIdx_mul_ofIdx_smul_root P i j n t ht]
+  rw [RootPairing.weylGroup.pow_ofIdx_mul_ofIdx_smul_root P i j n t ht]
   simp only [map_add, map_smul, smul_eq_mul, _root_.RootPairing.root_coroot'_eq_pairing,
     _root_.RootPairing.pairing_same]
   ring
@@ -205,32 +208,34 @@ variable [CharZero R]
 
 /-- **At Cartan product `1` the product of the two reflections has order exactly `3`.** -/
 @[simp, grind =]
-theorem orderOf_ofIdx_mul_ofIdx_eq_three (h : P.pairing i j * P.pairing j i = 1) :
+theorem _root_.RootPairing.weylGroup.orderOf_ofIdx_mul_ofIdx_eq_three
+    (h : P.pairing i j * P.pairing j i = 1) :
     orderOf (_root_.RootPairing.weylGroup.ofIdx P i *
       _root_.RootPairing.weylGroup.ofIdx P j) = 3 := by
   have hne : (_root_.RootPairing.weylGroup.ofIdx P i *
       _root_.RootPairing.weylGroup.ofIdx P j) ^ 1 ≠ 1 := by
-    refine pow_ne_one_of_coroot'_left_ne P i j 1 ?_
-    rw [coroot'_left_pow_smul_root P i j 1 (-1) (by rw [h]; ring), h]
+    refine RootPairing.weylGroup.pow_ne_one_of_coroot'_left_ne P i j 1 ?_
+    rw [RootPairing.weylGroup.coroot'_left_pow_smul_root P i j 1 (-1) (by rw [h]; ring), h]
     norm_num [S_zero, S_one]
   refine orderOf_eq_of_pow_and_pow_div_prime (by norm_num)
-    (pow_three_ofIdx_mul_ofIdx_eq_one P i j h) fun p hp hpd ↦ ?_
+    (RootPairing.weylGroup.pow_three_ofIdx_mul_ofIdx_eq_one P i j h) fun p hp hpd ↦ ?_
   have hp' : p = 3 := (Nat.prime_dvd_prime_iff_eq hp Nat.prime_three).mp hpd
   subst hp'
   exact hne
 
 /-- **At Cartan product `2` the product of the two reflections has order exactly `4`.** -/
 @[simp, grind =]
-theorem orderOf_ofIdx_mul_ofIdx_eq_four (h : P.pairing i j * P.pairing j i = 2) :
+theorem _root_.RootPairing.weylGroup.orderOf_ofIdx_mul_ofIdx_eq_four
+    (h : P.pairing i j * P.pairing j i = 2) :
     orderOf (_root_.RootPairing.weylGroup.ofIdx P i *
       _root_.RootPairing.weylGroup.ofIdx P j) = 4 := by
   have hne : (_root_.RootPairing.weylGroup.ofIdx P i *
       _root_.RootPairing.weylGroup.ofIdx P j) ^ 2 ≠ 1 := by
-    refine pow_ne_one_of_coroot'_left_ne P i j 2 ?_
-    rw [coroot'_left_pow_smul_root P i j 2 0 (by rw [h]; ring), h]
+    refine RootPairing.weylGroup.pow_ne_one_of_coroot'_left_ne P i j 2 ?_
+    rw [RootPairing.weylGroup.coroot'_left_pow_smul_root P i j 2 0 (by rw [h]; ring), h]
     norm_num [S_one, S_two]
   refine orderOf_eq_of_pow_and_pow_div_prime (by norm_num)
-    (pow_four_ofIdx_mul_ofIdx_eq_one P i j h) fun p hp hpd ↦ ?_
+    (RootPairing.weylGroup.pow_four_ofIdx_mul_ofIdx_eq_one P i j h) fun p hp hpd ↦ ?_
   have hp' : p = 2 := by
     have hpd' : p ∣ 2 ^ 2 := by simpa using hpd
     exact (Nat.prime_dvd_prime_iff_eq hp Nat.prime_two).mp (hp.dvd_of_dvd_pow hpd')
@@ -239,24 +244,25 @@ theorem orderOf_ofIdx_mul_ofIdx_eq_four (h : P.pairing i j * P.pairing j i = 2) 
 
 /-- **At Cartan product `3` the product of the two reflections has order exactly `6`.** -/
 @[simp, grind =]
-theorem orderOf_ofIdx_mul_ofIdx_eq_six (h : P.pairing i j * P.pairing j i = 3) :
+theorem _root_.RootPairing.weylGroup.orderOf_ofIdx_mul_ofIdx_eq_six
+    (h : P.pairing i j * P.pairing j i = 3) :
     orderOf (_root_.RootPairing.weylGroup.ofIdx P i *
       _root_.RootPairing.weylGroup.ofIdx P j) = 6 := by
   have hne₂ : (_root_.RootPairing.weylGroup.ofIdx P i *
       _root_.RootPairing.weylGroup.ofIdx P j) ^ 2 ≠ 1 := by
-    refine pow_ne_one_of_coroot'_left_ne P i j 2 ?_
-    rw [coroot'_left_pow_smul_root P i j 2 1 (by rw [h]; ring), h]
+    refine RootPairing.weylGroup.pow_ne_one_of_coroot'_left_ne P i j 2 ?_
+    rw [RootPairing.weylGroup.coroot'_left_pow_smul_root P i j 2 1 (by rw [h]; ring), h]
     norm_num [S_one, S_two]
   have hne₃ : (_root_.RootPairing.weylGroup.ofIdx P i *
       _root_.RootPairing.weylGroup.ofIdx P j) ^ 3 ≠ 1 := by
-    refine pow_ne_one_of_coroot'_left_ne P i j 3 ?_
-    rw [coroot'_left_pow_smul_root P i j 3 1 (by rw [h]; ring), h]
+    refine RootPairing.weylGroup.pow_ne_one_of_coroot'_left_ne P i j 3 ?_
+    rw [RootPairing.weylGroup.coroot'_left_pow_smul_root P i j 3 1 (by rw [h]; ring), h]
     have h₃ : (S R 3).eval (1 : R) = -1 := by
       have h₃' : S R (3 : ℤ) = Polynomial.X * S R 2 - S R 1 := by simpa using S_add_two R (1 : ℤ)
       simp [h₃', S_one, S_two]
     norm_num [h₃, S_two]
   refine orderOf_eq_of_pow_and_pow_div_prime (by norm_num)
-    (pow_six_ofIdx_mul_ofIdx_eq_one P i j h) fun p hp hpd ↦ ?_
+    (RootPairing.weylGroup.pow_six_ofIdx_mul_ofIdx_eq_one P i j h) fun p hp hpd ↦ ?_
   have hp' : p = 2 ∨ p = 3 := by
     have hpd' : p ∣ 2 * 3 := by simpa using hpd
     rcases (Nat.Prime.dvd_mul hp).mp hpd' with h' | h'
@@ -266,7 +272,7 @@ theorem orderOf_ofIdx_mul_ofIdx_eq_six (h : P.pairing i j * P.pairing j i = 3) :
   · exact hne₃
   · exact hne₂
 
-end LowerBound
+end
 
 /-! ## The entries of the Coxeter matrix of a base -/
 
@@ -275,7 +281,7 @@ section Base
 variable [Finite ι] [CharZero R] [IsDomain R] [P.IsCrystallographic] (b : P.Base)
 
 omit [Finite ι] [CharZero R] [IsDomain R] in
-private lemma pairing_mul_pairing_eq_cast (k l : b.support) :
+private lemma _root_.RootPairing.weylGroup.pairing_mul_pairing_eq_cast (k l : b.support) :
     P.pairing k l * P.pairing l k =
       ((b.cartanMatrix k l * b.cartanMatrix l k : ℤ) : R) := by
   have hk : ∀ m n : b.support, ((b.cartanMatrix m n : ℤ) : R) = P.pairing m n := fun m n ↦ by
@@ -288,14 +294,15 @@ corresponding simple reflections.** On the diagonal both sides are `1`, a simple
 an involution; off the diagonal the four Cartan products `0`, `1`, `2`, `3` give the four dihedral
 orders `2`, `3`, `4`, `6`. -/
 @[simp, grind =]
-theorem orderOf_ofIdx_mul_ofIdx_eq_coxeterMatrixOfBase (k l : b.support) :
+theorem _root_.RootPairing.weylGroup.orderOf_ofIdx_mul_ofIdx_eq_coxeterMatrixOfBase
+    (k l : b.support) :
     orderOf (_root_.RootPairing.weylGroup.ofIdx P (k : ι) *
       _root_.RootPairing.weylGroup.ofIdx P (l : ι)) = coxeterMatrixOfBase P b k l := by
   rcases eq_or_ne k l with rfl | hkl
   · rw [ofIdx_mul_self, orderOf_one]
     simp
   have hmem := cartanMatrix_mul_cartanMatrix_mem_of_ne P b hkl
-  have hcast := pairing_mul_pairing_eq_cast P b k l
+  have hcast := RootPairing.weylGroup.pairing_mul_pairing_eq_cast P b k l
   simp only [mem_insert_iff, mem_singleton_iff] at hmem
   rcases hmem with hc | hc | hc | hc <;> rw [hc] at hcast <;> push_cast at hcast
   · have h₂ : coxeterMatrixOfBase P b k l = 2 := by
@@ -303,21 +310,23 @@ theorem orderOf_ofIdx_mul_ofIdx_eq_coxeterMatrixOfBase (k l : b.support) :
     rw [h₂]
     exact orderOf_ofIdx_mul_ofIdx_eq_two_of_coxeterMatrixOfBase_eq_two P b h₂
   · rw [coxeterMatrixOfBase_apply, hc, coxeterOrder_one]
-    exact orderOf_ofIdx_mul_ofIdx_eq_three P _ _ hcast
+    exact RootPairing.weylGroup.orderOf_ofIdx_mul_ofIdx_eq_three P _ _ hcast
   · rw [coxeterMatrixOfBase_apply, hc, coxeterOrder_two]
-    exact orderOf_ofIdx_mul_ofIdx_eq_four P _ _ hcast
+    exact RootPairing.weylGroup.orderOf_ofIdx_mul_ofIdx_eq_four P _ _ hcast
   · rw [coxeterMatrixOfBase_apply, hc, coxeterOrder_three]
-    exact orderOf_ofIdx_mul_ofIdx_eq_six P _ _ hcast
+    exact RootPairing.weylGroup.orderOf_ofIdx_mul_ofIdx_eq_six P _ _ hcast
 
 /-- **The braid relations of the Coxeter matrix of a base hold in the Weyl group.** This is the
 relation half of the Coxeter presentation of the Weyl group. It is not a `simp` lemma: its
 left-hand side is not in simp normal form, because the exponent `coxeterMatrixOfBase P b k l` is
 itself rewritten by `TauCeti.coxeterMatrixOfBase_apply`. -/
 @[grind =]
-theorem pow_coxeterMatrixOfBase_ofIdx_mul_ofIdx_eq_one (k l : b.support) :
+theorem _root_.RootPairing.weylGroup.pow_coxeterMatrixOfBase_ofIdx_mul_ofIdx_eq_one
+    (k l : b.support) :
     (_root_.RootPairing.weylGroup.ofIdx P (k : ι) *
       _root_.RootPairing.weylGroup.ofIdx P (l : ι)) ^ coxeterMatrixOfBase P b k l = 1 := by
-  rw [← orderOf_ofIdx_mul_ofIdx_eq_coxeterMatrixOfBase P b k l, pow_orderOf_eq_one]
+  rw [← RootPairing.weylGroup.orderOf_ofIdx_mul_ofIdx_eq_coxeterMatrixOfBase P b k l,
+    pow_orderOf_eq_one]
 
 end Base
 

--- a/TauCeti/LinearAlgebra/RootSystem/BraidRelation.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/BraidRelation.lean
@@ -272,7 +272,7 @@ theorem _root_.RootPairing.weylGroup.orderOf_ofIdx_mul_ofIdx_eq_six
   · exact hne₃
   · exact hne₂
 
-end
+end LowerBound
 
 /-! ## The entries of the Coxeter matrix of a base -/
 
@@ -330,6 +330,6 @@ theorem _root_.RootPairing.weylGroup.pow_coxeterMatrixOfBase_ofIdx_mul_ofIdx_eq_
 
 end Base
 
-end RootPairing.weylGroup
+end
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/RootSystem/BraidRelation.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/BraidRelation.lean
@@ -146,7 +146,7 @@ theorem _root_.RootPairing.weylGroup.pow_three_ofIdx_mul_ofIdx_eq_one
     (h : P.pairing i j * P.pairing j i = 1) :
     (_root_.RootPairing.weylGroup.ofIdx P i *
       _root_.RootPairing.weylGroup.ofIdx P j) ^ 3 = 1 := by
-  refine eq_one_of_smul_eq_self fun x ↦ ?_
+  refine RootPairing.weylGroup.eq_one_of_smul_eq_self fun x ↦ ?_
   -- At `t = -1` the coefficients of the two displacement terms are `S₀(t)(S₁(t) + S₀(t)) = 0`
   -- and `S₁(t)(S₁(t) + S₀(t)) = 0`.
   rw [RootPairing.weylGroup.pow_ofIdx_mul_ofIdx_smul P i j 3 x (-1) (by rw [h]; ring)]
@@ -159,7 +159,7 @@ theorem _root_.RootPairing.weylGroup.pow_four_ofIdx_mul_ofIdx_eq_one
     (h : P.pairing i j * P.pairing j i = 2) :
     (_root_.RootPairing.weylGroup.ofIdx P i *
       _root_.RootPairing.weylGroup.ofIdx P j) ^ 4 = 1 := by
-  refine eq_one_of_smul_eq_self fun x ↦ ?_
+  refine RootPairing.weylGroup.eq_one_of_smul_eq_self fun x ↦ ?_
   -- At `t = 0` both coefficients carry the factor `S₁(t) = t = 0`.
   rw [RootPairing.weylGroup.pow_ofIdx_mul_ofIdx_smul P i j 4 x 0 (by rw [h]; ring)]
   norm_num [S_zero, S_one]
@@ -171,7 +171,7 @@ theorem _root_.RootPairing.weylGroup.pow_six_ofIdx_mul_ofIdx_eq_one
     (h : P.pairing i j * P.pairing j i = 3) :
     (_root_.RootPairing.weylGroup.ofIdx P i *
       _root_.RootPairing.weylGroup.ofIdx P j) ^ 6 = 1 := by
-  refine eq_one_of_smul_eq_self fun x ↦ ?_
+  refine RootPairing.weylGroup.eq_one_of_smul_eq_self fun x ↦ ?_
   -- At `t = 1` both coefficients carry the factor `S₂(t) = t² - 1 = 0`.
   rw [RootPairing.weylGroup.pow_ofIdx_mul_ofIdx_smul P i j 6 x 1 (by rw [h]; ring)]
   norm_num [S_two]
@@ -299,7 +299,7 @@ theorem _root_.RootPairing.weylGroup.orderOf_ofIdx_mul_ofIdx_eq_coxeterMatrixOfB
     orderOf (_root_.RootPairing.weylGroup.ofIdx P (k : ι) *
       _root_.RootPairing.weylGroup.ofIdx P (l : ι)) = coxeterMatrixOfBase P b k l := by
   rcases eq_or_ne k l with rfl | hkl
-  · rw [ofIdx_mul_self, orderOf_one]
+  · rw [RootPairing.weylGroup.ofIdx_mul_self, orderOf_one]
     simp
   have hmem := cartanMatrix_mul_cartanMatrix_mem_of_ne P b hkl
   have hcast := RootPairing.weylGroup.pairing_mul_pairing_eq_cast P b k l
@@ -308,7 +308,7 @@ theorem _root_.RootPairing.weylGroup.orderOf_ofIdx_mul_ofIdx_eq_coxeterMatrixOfB
   · have h₂ : coxeterMatrixOfBase P b k l = 2 := by
       rw [coxeterMatrixOfBase_apply, hc, coxeterOrder_zero]
     rw [h₂]
-    exact orderOf_ofIdx_mul_ofIdx_eq_two_of_coxeterMatrixOfBase_eq_two P b h₂
+    exact RootPairing.weylGroup.orderOf_ofIdx_mul_ofIdx_eq_two_of_coxeterMatrixOfBase_eq_two P b h₂
   · rw [coxeterMatrixOfBase_apply, hc, coxeterOrder_one]
     exact RootPairing.weylGroup.orderOf_ofIdx_mul_ofIdx_eq_three P _ _ hcast
   · rw [coxeterMatrixOfBase_apply, hc, coxeterOrder_two]

--- a/TauCeti/LinearAlgebra/RootSystem/Chamber.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Chamber.lean
@@ -67,7 +67,7 @@ The maximization argument is proved as `exists_mem_dominantChamber_of_finite_wey
 asks for no root-system assumption: on top of the standing `Finite ι`, `P.IsCrystallographic` and
 `P.IsReduced` hypotheses that the positive-root permutation step needs, it assumes only
 `Finite P.weylGroup`. The roadmap-signature `exists_mem_dominantChamber` is the root-system case,
-where that finiteness comes from `TauCeti.RootPairing.finite_weylGroup`.
+where that finiteness comes from `RootPairing.finite_weylGroup`.
 
 Regularity quantifies over *all* root indices, not just the positive ones. The two are equivalent,
 since the coroot functional of a negated root is the negative of the original, and quantifying

--- a/TauCeti/LinearAlgebra/RootSystem/Coxeter/Matrix.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Coxeter/Matrix.lean
@@ -396,11 +396,14 @@ theorem _root_.RootPairing.weylGroup.orderOf_ofIdx_mul_ofIdx_eq_two_of_coxeterMa
       _root_.RootPairing.weylGroup.ofIdx P (j : ι)) = 2 := by
   have hij : i ≠ j := by rintro rfl; simp at h
   have hij' : (i : ι) ≠ (j : ι) := fun h ↦ hij (Subtype.ext h)
-  have hcomm := commute_ofIdx_of_isOrthogonal P ((coxeterMatrixOfBase_eq_two_iff P b i j).mp h)
+  have hcomm := RootPairing.weylGroup.commute_ofIdx_of_isOrthogonal P
+    ((coxeterMatrixOfBase_eq_two_iff P b i j).mp h)
   refine orderOf_eq_prime ?_ ?_
-  · rw [hcomm.mul_pow, sq, sq, ofIdx_mul_self, ofIdx_mul_self, mul_one]
-  · rw [Ne, mul_eq_one_iff_eq_inv, inv_eq_of_mul_eq_one_right (ofIdx_mul_self P (j : ι))]
-    exact ofIdx_ne_ofIdx_of_ne P b i.property j.property hij'
+  · rw [hcomm.mul_pow, sq, sq, RootPairing.weylGroup.ofIdx_mul_self,
+      RootPairing.weylGroup.ofIdx_mul_self, mul_one]
+  · rw [Ne, mul_eq_one_iff_eq_inv,
+      inv_eq_of_mul_eq_one_right (RootPairing.weylGroup.ofIdx_mul_self P (j : ι))]
+    exact RootPairing.weylGroup.ofIdx_ne_ofIdx_of_ne P b i.property j.property hij'
 
 end
 

--- a/TauCeti/LinearAlgebra/RootSystem/Coxeter/Matrix.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Coxeter/Matrix.lean
@@ -37,7 +37,7 @@ here and are sent to `0`, Mathlib's encoding of an infinite Coxeter order.
 The final section checks the smallest of the intended braid relations, the one available before the
 Coxeter presentation of the Weyl group is built: an entry is `2` exactly for orthogonal simple
 roots, and there the two simple reflections commute
-(`TauCeti.RootPairing.weylGroup.commute_ofIdx_of_isOrthogonal`) and their product has order exactly
+(`RootPairing.weylGroup.commute_ofIdx_of_isOrthogonal`) and their product has order exactly
 `2`, as the entry asserts.
 
 ## Main definitions
@@ -58,7 +58,7 @@ roots, and there the two simple reflections commute
   exactly when all entries are at most `3`.
 * `TauCeti.coxeterMatrixOfBase_eq_three_of_hasCartanType_A_two` and its `B₂` and `G₂`
   companions evaluate the Coxeter entries of the three rank-two Cartan types.
-* `TauCeti.RootPairing.weylGroup.orderOf_ofIdx_mul_ofIdx_eq_two_of_coxeterMatrixOfBase_eq_two`:
+* `RootPairing.weylGroup.orderOf_ofIdx_mul_ofIdx_eq_two_of_coxeterMatrixOfBase_eq_two`:
   where the matrix entry is `2`, the product of the two simple reflections does have order `2`.
 
 ## References
@@ -272,7 +272,7 @@ product `4` with itself.
 That the entries really are those orders is the classical rank-two computation, and follows in
 general from the Coxeter presentation of the Weyl group, which is not built here; the entry `2` is
 checked directly in
-`TauCeti.RootPairing.weylGroup.orderOf_ofIdx_mul_ofIdx_eq_two_of_coxeterMatrixOfBase_eq_two`.
+`RootPairing.weylGroup.orderOf_ofIdx_mul_ofIdx_eq_two_of_coxeterMatrixOfBase_eq_two`.
 
 The body is not exposed: `TauCeti.coxeterMatrixOfBase_apply` is the entry API. -/
 noncomputable def coxeterMatrixOfBase : CoxeterMatrix b.support :=
@@ -383,14 +383,14 @@ end CartanType
 
 /-! ## The orthogonal case: commuting simple reflections -/
 
-namespace RootPairing.weylGroup
+section
 
 variable [Finite ι] [CharZero R] [IsDomain R] [P.IsCrystallographic]
 
 /-- **Where the Coxeter matrix of a base has the entry `2`, the product of the two simple
 reflections does have order `2`.** This is the one entry of `coxeterMatrixOfBase` that can be
 checked before the Coxeter presentation of the Weyl group is available. -/
-theorem orderOf_ofIdx_mul_ofIdx_eq_two_of_coxeterMatrixOfBase_eq_two
+theorem _root_.RootPairing.weylGroup.orderOf_ofIdx_mul_ofIdx_eq_two_of_coxeterMatrixOfBase_eq_two
     (b : P.Base) {i j : b.support} (h : coxeterMatrixOfBase P b i j = 2) :
     orderOf (_root_.RootPairing.weylGroup.ofIdx P (i : ι) *
       _root_.RootPairing.weylGroup.ofIdx P (j : ι)) = 2 := by
@@ -402,6 +402,6 @@ theorem orderOf_ofIdx_mul_ofIdx_eq_two_of_coxeterMatrixOfBase_eq_two
   · rw [Ne, mul_eq_one_iff_eq_inv, inv_eq_of_mul_eq_one_right (ofIdx_mul_self P (j : ι))]
     exact ofIdx_ne_ofIdx_of_ne P b i.property j.property hij'
 
-end RootPairing.weylGroup
+end
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/RootSystem/Duality.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Duality.lean
@@ -13,7 +13,7 @@ public import TauCeti.LinearAlgebra.RootSystem.Flip
 
 Interchanging the roots and the coroots of a root pairing (`RootPairing.flip`) transposes every
 pairing `⟨αᵢ, αⱼ^∨⟩`, hence transposes the Cartan matrix of a base
-(`TauCeti.RootPairing.Base.cartanMatrix_flip`, proved in `TauCeti.LinearAlgebra.RootSystem.Flip`).
+(`RootPairing.Base.cartanMatrix_flip`, proved in `TauCeti.LinearAlgebra.RootSystem.Flip`).
 On the classification side that operation permutes the Dynkin types, and this file pins the
 permutation: `TauCeti.DynkinType.dual` exchanges `Bₙ` with `Cₙ` and fixes every other type.
 Duality is what makes the orientation carried by `TauCeti.HasCartanType` meaningful, since `Bₙ` and
@@ -241,7 +241,7 @@ variable {ι R M N : Type*} [CommRing R] [CharZero R] [AddCommGroup M] [Module R
   [AddCommGroup N] [Module R N] {P : RootPairing ι R M N} [P.IsCrystallographic]
 
 /-- **The Cartan type of a flipped base is the dual type.** Flipping transposes the Cartan matrix
-(`TauCeti.RootPairing.Base.cartanMatrix_flip`), and transposing a standard Cartan matrix is passing
+(`RootPairing.Base.cartanMatrix_flip`), and transposing a standard Cartan matrix is passing
 to the dual type up to the node relabelling `TauCeti.DynkinType.dualNodeEquiv`. -/
 theorem HasCartanType.flip {b : P.Base} {t : DynkinType} (h : HasCartanType P b t) :
     HasCartanType P.flip b.flip t.dual := by

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/Irreducible.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/Irreducible.lean
@@ -266,7 +266,7 @@ theorem _root_.RootPairing.isIrreducible_of_connected_diagramGraph_cartanMatrix
   -- adjacency in the diagram is exactly nonvanishing of the Cartan entry, hence of the pairing
   have propagate {u v : b.support} (hadj : (diagramGraph b.cartanMatrix).Adj u v)
       (hu : P.root u ∈ q) : P.root v ∈ q :=
-    root_mem_of_pairing_ne_zero (hinv v)
+    RootPairing.root_mem_of_pairing_ne_zero (hinv v)
       (fun hp ↦ (diagramGraph_adj.mp hadj).2.1
         (b.cartanMatrix_apply_eq_zero_iff_pairing.mpr hp)) hu
   have hall : ∀ j : b.support, P.root j ∈ q := by

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/Irreducible.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/Irreducible.lean
@@ -27,9 +27,9 @@ every edge of the Dynkin diagram, so the simple roots span the whole space insid
 
 ## Main results
 
-* `TauCeti.RootPairing.isIrreducible_of_connected_diagramGraph_cartanMatrix`: a connected base
+* `RootPairing.isIrreducible_of_connected_diagramGraph_cartanMatrix`: a connected base
   diagram makes a root system irreducible.
-* `TauCeti.RootPairing.eq_bot_of_forall_root_not_mem`: a submodule invariant under the simple
+* `RootPairing.eq_bot_of_forall_root_not_mem`: a submodule invariant under the simple
   reflections and containing no simple root is trivial.
 * `TauCeti.DynkinType.connected_diagramGraph_cartanMatrix`: every valid standard Dynkin diagram is
   connected.
@@ -214,7 +214,7 @@ theorem connected_diagramGraph_cartanMatrix {t : DynkinType} (ht : t.Valid) :
 
 end DynkinType
 
-namespace RootPairing
+section
 
 variable {K M N ι : Type*} [Field K] [CharZero K] [AddCommGroup M] [Module K M]
   [AddCommGroup N] [Module K N] {P : RootPairing ι K M N} [P.IsCrystallographic]
@@ -225,7 +225,8 @@ trivial.** If `q` is invariant under the reflection at each element of the base'
 misses the root there, then `q = ⊥`.
 
 Invariance is asked at the support only, not under every reflection of `P`. -/
-theorem eq_bot_of_forall_root_not_mem [P.IsRootSystem] {b : P.Base} {q : Submodule K M}
+theorem _root_.RootPairing.eq_bot_of_forall_root_not_mem
+    [P.IsRootSystem] {b : P.Base} {q : Submodule K M}
     (hinv : ∀ i : b.support, q ∈ Module.End.invtSubmodule (P.reflection i))
     (h : ∀ i : b.support, P.root i ∉ q) : q = ⊥ := by
   -- Missing every simple root puts `q` inside all the simple coroot kernels; the coweight basis
@@ -251,7 +252,8 @@ theorem eq_bot_of_forall_root_not_mem [P.IsRootSystem] {b : P.Base} {q : Submodu
 Characteristic zero ensures that a nonzero integral Cartan entry stays nonzero in the field when
 membership propagates across an edge. It also supplies the standard `2 ≠ 0` hypothesis in
 Mathlib's invariant-submodule criterion for a reflection. -/
-theorem isIrreducible_of_connected_diagramGraph_cartanMatrix [P.IsRootSystem] (b : P.Base)
+theorem _root_.RootPairing.isIrreducible_of_connected_diagramGraph_cartanMatrix
+    [P.IsRootSystem] (b : P.Base)
     (hconn : (diagramGraph b.cartanMatrix).Connected) : P.IsIrreducible := by
   let _ : Nontrivial M :=
     ⟨⟨P.root hconn.nonempty.some, 0, P.ne_zero hconn.nonempty.some⟩⟩
@@ -259,7 +261,7 @@ theorem isIrreducible_of_connected_diagramGraph_cartanMatrix [P.IsRootSystem] (b
   intro q hinv hq
   have hsimple : ∃ i : b.support, P.root i ∈ q := by
     by_contra! h
-    exact hq (eq_bot_of_forall_root_not_mem (b := b) (fun i ↦ hinv i) h)
+    exact hq (RootPairing.eq_bot_of_forall_root_not_mem (b := b) (fun i ↦ hinv i) h)
   obtain ⟨i, hi⟩ := hsimple
   -- adjacency in the diagram is exactly nonvanishing of the Cartan entry, hence of the pairing
   have propagate {u v : b.support} (hadj : (diagramGraph b.cartanMatrix).Adj u v)
@@ -282,7 +284,7 @@ theorem isIrreducible_of_connected_diagramGraph_cartanMatrix [P.IsRootSystem] (b
   rw [b.toWeightBasis_apply]
   exact hall j
 
-end RootPairing
+end
 
 namespace HasCartanType
 
@@ -303,7 +305,7 @@ theorem isIrreducible [P.IsRootSystem] {b : P.Base} {t : DynkinType}
       exact ⟨fun h ↦ hij (congrArg e h), h₁, h₂⟩
     · rintro ⟨hij, h₁, h₂⟩
       exact ⟨fun h ↦ hij (e.injective h), h₁, h₂⟩
-  exact TauCeti.RootPairing.isIrreducible_of_connected_diagramGraph_cartanMatrix (P := P) b
+  exact RootPairing.isIrreducible_of_connected_diagramGraph_cartanMatrix (P := P) b
     (graphIso.connected_iff.mpr (DynkinType.connected_diagramGraph_cartanMatrix ht))
 
 end HasCartanType

--- a/TauCeti/LinearAlgebra/RootSystem/Flip.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Flip.lean
@@ -18,14 +18,14 @@ and the Cartan matrix of a base, which is where flipping is used.
 
 ## Main definitions
 
-* `TauCeti.RootPairing.Base.flipSupportEquiv`: the identification of the support of a base with the
+* `RootPairing.Base.flipSupportEquiv`: the identification of the support of a base with the
   support of its flip, which the two Cartan matrices are indexed by.
 
 ## Main results
 
-* `TauCeti.RootPairing.pairingIn_flip`: flipping transposes the *chosen* preimage of a pairing in
+* `RootPairing.pairingIn_flip`: flipping transposes the *chosen* preimage of a pairing in
   the coefficient ring `S`, not only the pairing itself.
-* `TauCeti.RootPairing.Base.cartanMatrix_flip`: the Cartan matrix of the flipped base is the
+* `RootPairing.Base.cartanMatrix_flip`: the Cartan matrix of the flipped base is the
   transpose of the Cartan matrix of the base.
 
 ## References
@@ -43,43 +43,50 @@ namespace TauCeti
 
 variable {ι R M N : Type*} [CommRing R] [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
 
-namespace RootPairing
+section
 
 /-- **Flipping a root pairing transposes its integral pairing.** The pairing of the flipped pairing
 is transposed by definition (`RootPairing.pairing_flip`); the content here is that the *chosen*
 preimage in `S` is transposed too, which needs `algebraMap S R` to be injective. -/
-@[simp] lemma pairingIn_flip (S : Type*) [CommRing S] [Algebra S R] [FaithfulSMul S R]
+@[simp] lemma _root_.RootPairing.pairingIn_flip
+    (S : Type*) [CommRing S] [Algebra S R] [FaithfulSMul S R]
     (P : RootPairing ι R M N) [P.IsValuedIn S] (i j : ι) :
     P.flip.pairingIn S i j = P.pairingIn S j i :=
   FaithfulSMul.algebraMap_injective S R <| by simp
 
-namespace Base
+section
 
 /-- A base of `P` is a base of `P.flip` supported on the same simple indices
 (`RootPairing.Base.flip`); this is the resulting identification of the two index types, which the
 Cartan matrices of the base and of its flip are indexed by. -/
-def flipSupportEquiv {P : RootPairing ι R M N} (b : P.Base) : b.flip.support ≃ b.support :=
+def _root_.RootPairing.Base.flipSupportEquiv
+    {P : RootPairing ι R M N} (b : P.Base) : b.flip.support ≃ b.support :=
   Equiv.subtypeEquivRight fun _ ↦ by rw [RootPairing.Base.flip_support]
 
-@[simp] lemma coe_flipSupportEquiv_apply {P : RootPairing ι R M N} (b : P.Base)
+@[simp] lemma _root_.RootPairing.Base.coe_flipSupportEquiv_apply
+    {P : RootPairing ι R M N} (b : P.Base)
     (i : b.flip.support) :
-    (flipSupportEquiv b i : ι) = i := (rfl)
+    (RootPairing.Base.flipSupportEquiv b i : ι) = i := (rfl)
 
 /-- **The Cartan matrix of the flipped base is the transpose of the Cartan matrix of the base.** -/
-@[simp] lemma cartanMatrix_flip [CharZero R] {P : RootPairing ι R M N} [P.IsCrystallographic]
+@[simp] lemma _root_.RootPairing.Base.cartanMatrix_flip
+    [CharZero R] {P : RootPairing ι R M N} [P.IsCrystallographic]
     (b : P.Base) (i j : b.flip.support) :
-    b.flip.cartanMatrix i j = b.cartanMatrix (flipSupportEquiv b j) (flipSupportEquiv b i) := by
+    b.flip.cartanMatrix i j = b.cartanMatrix (RootPairing.Base.flipSupportEquiv b j)
+      (RootPairing.Base.flipSupportEquiv b i) := by
   have h₁ : b.flip.cartanMatrix i j = P.flip.pairingIn ℤ (i : ι) (j : ι) :=
     RootPairing.Base.cartanMatrixIn_def _ _ _ _
-  have h₂ : b.cartanMatrix (flipSupportEquiv b j) (flipSupportEquiv b i)
+  have h₂ : b.cartanMatrix (RootPairing.Base.flipSupportEquiv b j)
+      (RootPairing.Base.flipSupportEquiv b i)
       = P.pairingIn ℤ (j : ι) (i : ι) := RootPairing.Base.cartanMatrixIn_def _ _ _ _
-  rw [h₁, h₂, pairingIn_flip]
+  rw [h₁, h₂, RootPairing.pairingIn_flip]
 
 /-- Flipping a base twice returns the original base. -/
-@[simp] lemma flip_flip {P : RootPairing ι R M N} (b : P.Base) : b.flip.flip = b := rfl
+@[simp] lemma _root_.RootPairing.Base.flip_flip
+    {P : RootPairing ι R M N} (b : P.Base) : b.flip.flip = b := rfl
 
-end Base
+end
 
-end RootPairing
+end
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/RootSystem/GeckConstruction/DividedPower.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/GeckConstruction/DividedPower.lean
@@ -30,9 +30,9 @@ come from Geck's construction in [Geck](Geck2017).
 
 ## Main declarations
 
-* `TauCeti.RootPairing.GeckConstruction.exists_intCast_dividedPower_e_apply`: divided powers of
+* `RootPairing.GeckConstruction.exists_intCast_dividedPower_e_apply`: divided powers of
   raising matrices have integer entries.
-* `TauCeti.RootPairing.GeckConstruction.exists_intCast_dividedPower_f_apply`: divided powers of
+* `RootPairing.GeckConstruction.exists_intCast_dividedPower_f_apply`: divided powers of
   lowering matrices have integer entries.
 -/
 
@@ -320,11 +320,12 @@ private theorem exists_intCast_dividedPower_f_mulVec_single (s : b.support) (n :
   · exact exists_intCast_dividedPower_e_mulVec_single s n (.inr (-j)) (.inl q)
   · exact exists_intCast_dividedPower_e_mulVec_single s n (.inr (-j)) (.inr (-q))
 
-namespace RootPairing.GeckConstruction
+section
 
 /-- The distinguished upper-right coordinate of a divided power of a Geck raising generator.
 It is `1` in degree one and vanishes in every other degree. -/
-theorem dividedPower_e_apply_inl_inr_neg (s : b.support) (n : ℕ) :
+theorem _root_.RootPairing.GeckConstruction.dividedPower_e_apply_inl_inr_neg
+    (s : b.support) (n : ℕ) :
     let _i := P.indexNeg
     TauCeti.Associative.dividedPower n (e s) (Sum.inl s) (Sum.inr (-s : ι)) =
       if n = 1 then 1 else 0 := by
@@ -345,7 +346,7 @@ theorem dividedPower_e_apply_inl_inr_neg (s : b.support) (n : ℕ) :
 /-- The distinguished upper-right coordinate of a divided power of a Geck lowering generator.
 It is `1` in degree one and vanishes in every other degree. -/
 @[simp]
-theorem dividedPower_f_apply_inl_inr (s : b.support) (n : ℕ) :
+theorem _root_.RootPairing.GeckConstruction.dividedPower_f_apply_inl_inr (s : b.support) (n : ℕ) :
     TauCeti.Associative.dividedPower n (f s) (Sum.inl s) (Sum.inr (s : ι)) =
       if n = 1 then 1 else 0 := by
   let _i := P.indexNeg
@@ -357,11 +358,12 @@ theorem dividedPower_f_apply_inl_inr (s : b.support) (n : ℕ) :
     ← Matrix.mulVec_mulVec, ← Matrix.mulVec_mulVec, omega_mulVec_single, omega_mulVec_apply,
     Matrix.mulVec_single_one]
   simp only [Matrix.col_apply]
-  exact dividedPower_e_apply_inl_inr_neg s n
+  exact RootPairing.GeckConstruction.dividedPower_e_apply_inl_inr_neg s n
 
 /-- Every entry of a divided power of a numbered raising operator in Geck's representation is
 an integer. -/
-theorem exists_intCast_dividedPower_e_apply (s : b.support) (n : ℕ)
+theorem _root_.RootPairing.GeckConstruction.exists_intCast_dividedPower_e_apply
+    (s : b.support) (n : ℕ)
     (i j : b.support ⊕ ι) :
     ∃ z : ℤ, (z : ℚ) = TauCeti.Associative.dividedPower n (e s) i j := by
   obtain ⟨z, hz⟩ := exists_intCast_dividedPower_e_mulVec_single s n j i
@@ -370,14 +372,15 @@ theorem exists_intCast_dividedPower_e_apply (s : b.support) (n : ℕ)
 
 /-- Every entry of a divided power of a numbered lowering operator in Geck's representation is
 an integer. -/
-theorem exists_intCast_dividedPower_f_apply (s : b.support) (n : ℕ)
+theorem _root_.RootPairing.GeckConstruction.exists_intCast_dividedPower_f_apply
+    (s : b.support) (n : ℕ)
     (i j : b.support ⊕ ι) :
     ∃ z : ℤ, (z : ℚ) = TauCeti.Associative.dividedPower n (f s) i j := by
   obtain ⟨z, hz⟩ := exists_intCast_dividedPower_f_mulVec_single s n j i
   rw [Matrix.mulVec_single_one] at hz
   exact ⟨z, hz⟩
 
-end RootPairing.GeckConstruction
+end
 
 end
 end

--- a/TauCeti/LinearAlgebra/RootSystem/InvariantSubmodule.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/InvariantSubmodule.lean
@@ -22,7 +22,7 @@ the nonvanishing of the pairing from adjacency at the call site.
 
 ## Main results
 
-* `TauCeti.RootPairing.root_mem_of_pairing_ne_zero`: membership of a root in a reflection-invariant
+* `RootPairing.root_mem_of_pairing_ne_zero`: membership of a root in a reflection-invariant
   submodule propagates along a nonzero pairing.
 -/
 
@@ -30,7 +30,7 @@ public section
 
 namespace TauCeti
 
-namespace RootPairing
+section
 
 variable {K M N ι : Type*} [Field K] [AddCommGroup M] [Module K M]
   [AddCommGroup N] [Module K N] {P : RootPairing ι K M N}
@@ -38,7 +38,7 @@ variable {K M N ι : Type*} [Field K] [AddCommGroup M] [Module K M]
 /-- **Membership of a root in a reflection-invariant submodule propagates along a nonzero
 pairing.** If `q` is invariant under the reflection at `v`, the pairing of `u` with `v` is nonzero,
 and the root at `u` lies in `q`, then so does the root at `v`. -/
-theorem root_mem_of_pairing_ne_zero {q : Submodule K M} {u v : ι}
+theorem _root_.RootPairing.root_mem_of_pairing_ne_zero {q : Submodule K M} {u v : ι}
     (hinvv : q ∈ Module.End.invtSubmodule (P.reflection v))
     (hpair : P.pairing u v ≠ 0) (hu : P.root u ∈ q) : P.root v ∈ q := by
   -- Reflecting `u` in `v` keeps us inside `q`; subtracting leaves a multiple of `root v`, and the
@@ -49,6 +49,6 @@ theorem root_mem_of_pairing_ne_zero {q : Submodule K M} {u v : ι}
     simpa only [P.reflection_apply_root, sub_sub_cancel] using q.sub_mem hu hrefl
   exact (q.smul_mem_iff hpair).mp hsmul
 
-end RootPairing
+end
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/RootSystem/LongestElement.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/LongestElement.lean
@@ -53,7 +53,7 @@ available here, so length is spelled throughout as `(inversions P b w).ncard`.
 ## Implementation notes
 
 `TauCeti.longestElement` is defined for a root system, where
-`TauCeti.RootPairing.finite_weylGroup` supplies the finiteness of the Weyl group. The existence
+`RootPairing.finite_weylGroup` supplies the finiteness of the Weyl group. The existence
 theorem behind it is proved one level more generally, for a crystallographic reduced pairing with
 finitely many roots whose Weyl group happens to be finite; that is the shape used in
 `TauCeti/LinearAlgebra/RootSystem/Chamber.lean` as well.

--- a/TauCeti/LinearAlgebra/RootSystem/Opposition.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Opposition.lean
@@ -112,8 +112,8 @@ theorem root_opposition (i : ι) :
 /-- **The opposition involution negates the coroot functional along the longest element.** This is
 the coroot-side companion of `TauCeti.root_opposition`: dominance is a condition on the values of
 the simple coroot functionals, so this is the form in which the involution is applied to weights.
-Like its siblings `TauCeti.RootPairing.coroot'_smul` and
-`TauCeti.RootPairing.coroot'_weylGroupToPerm_smul` it is stated pointwise and tagged `@[grind =]`
+Like its siblings `RootPairing.coroot'_smul` and
+`RootPairing.coroot'_weylGroupToPerm_smul` it is stated pointwise and tagged `@[grind =]`
 rather than `@[simp]`, since `P.coroot' j x` is not in simp-normal form: `simp` rewrites it to
 `P.toLinearMap x (P.coroot j)` by `LinearMap.flip_apply`. -/
 @[grind =]

--- a/TauCeti/LinearAlgebra/RootSystem/Positive.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Positive.lean
@@ -48,7 +48,7 @@ positive root is a nonnegative integer combination of the simple coroots.
   over those roots.
 * `TauCeti.mem_support_iff_isPos_and_forall_ne_add` says the simple roots are exactly the
   indecomposable positive roots: those that are not the sum of two positive roots.
-* `TauCeti.RootPairing.Base.isPos_flip_iff` says a root is positive for a base exactly when its
+* `RootPairing.Base.isPos_flip_iff` says a root is positive for a base exactly when its
   coroot is positive for that base, and `TauCeti.posRoots_flip` restates it for the sets.
 * `TauCeti.root_mem_posRootCone_of_mem_posRoots` says the positive roots lie in `Q⁺`,
   `TauCeti.isPointed_posRootCone` says `Q⁺` is pointed,
@@ -609,11 +609,11 @@ lemma sum_posRootsFinset_erase_comp_reflectionPerm [DecidableEq ι] {A : Type*} 
   Finset.sum_equiv (P.reflectionPerm i)
     (fun j ↦ (reflectionPerm_mem_posRootsFinset_erase_iff P b hi j).symm) fun _ _ ↦ rfl
 
-namespace RootPairing.Base
+section
 
 /-- A simple reflection preserves and reflects positivity of every root other than its own simple
 root and the negative of that simple root. -/
-lemma isPos_reflectionPerm_iff {i j : ι} (hj : j ∈ b.support) (hij : i ≠ j)
+lemma _root_.RootPairing.Base.isPos_reflectionPerm_iff {i j : ι} (hj : j ∈ b.support) (hij : i ≠ j)
     (hij' : i ≠ P.reflectionPerm j j) :
     b.IsPos (P.reflectionPerm j i) ↔ b.IsPos i := by
   refine ⟨fun h ↦ ?_, fun h ↦ h.reflectionPerm hj hij⟩
@@ -622,7 +622,8 @@ lemma isPos_reflectionPerm_iff {i j : ι} (hj : j ∈ b.support) (hij : i ≠ j)
 
 /-- **A root is positive for a base exactly when its coroot is positive for that base.** -/
 @[simp]
-theorem isPos_flip_iff [P.flip.IsReduced] (i : ι) : b.flip.IsPos i ↔ b.IsPos i := by
+theorem _root_.RootPairing.Base.isPos_flip_iff
+    [P.flip.IsReduced] (i : ι) : b.flip.IsPos i ↔ b.IsPos i := by
   -- Both sides hold for a simple root, both are exchanged by root negation, and away from a
   -- simple root and its negative both are preserved by the corresponding simple reflection, so
   -- the positive-root induction propagates the equivalence over the whole index type.
@@ -643,11 +644,12 @@ theorem isPos_flip_iff [P.flip.IsReduced] (i : ι) : b.flip.IsPos i ↔ b.IsPos 
   rcases eq_or_ne j (P.reflectionPerm k k) with rfl | hjk'
   · rw [P.reflectionPerm_self k k]
     exact hsimple k hk
-  · rw [isPos_reflectionPerm_iff P b hk hjk hjk', ← hflip k j,
-      isPos_reflectionPerm_iff P.flip b.flip (by simpa using hk) hjk (by rwa [hflip k k])]
+  · rw [RootPairing.Base.isPos_reflectionPerm_iff P b hk hjk hjk', ← hflip k j,
+      RootPairing.Base.isPos_reflectionPerm_iff P.flip b.flip (by simpa using hk) hjk
+        (by rwa [hflip k k])]
     exact hj
 
-end RootPairing.Base
+end
 
 variable [P.flip.IsReduced]
 

--- a/TauCeti/LinearAlgebra/RootSystem/SimpleReflections.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimpleReflections.lean
@@ -170,7 +170,8 @@ theorem _root_.RootPairing.weylGroup.ofIdx_ne_ofIdx_of_ne
   have hindep : LinearIndependent R ![P.root i, P.root j] :=
     b.linearIndependent_pair_of_ne (i := ⟨i, hi⟩) (j := ⟨j, hj⟩) (by simpa using hij)
   have happ : P.root (P.reflectionPerm i j) = P.root (P.reflectionPerm j j) := by
-    rw [← weylGroupToPerm_ofIdx_apply P i j, ← weylGroupToPerm_ofIdx_apply P j j, hEq]
+    rw [← RootPairing.weylGroupToPerm_ofIdx_apply P i j,
+      ← RootPairing.weylGroupToPerm_ofIdx_apply P j j, hEq]
   rw [P.root_reflectionPerm, P.root_reflectionPerm, P.reflection_apply_root,
     P.reflection_apply_self] at happ
   -- `happ` now reads `αⱼ - ⟨αⱼ, αᵢ^∨⟩ • αᵢ = -αⱼ`, so `2 • αⱼ` is a multiple of `αᵢ`.

--- a/TauCeti/LinearAlgebra/RootSystem/SimpleReflections.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimpleReflections.lean
@@ -29,7 +29,7 @@ while root negation does not change the reflection.
 * `TauCeti.wordProd` multiplies out a word in the simple reflections of a base.
 * `TauCeti.wordProd_reverse` says that reversing a word inverts the element it spells.
 * `TauCeti.exists_wordProd_eq` writes every Weyl-group element as a product of simple reflections.
-* `TauCeti.RootPairing.weylGroup.ofIdx_ne_ofIdx_of_ne` says distinct simple roots give distinct
+* `RootPairing.weylGroup.ofIdx_ne_ofIdx_of_ne` says distinct simple roots give distinct
   simple reflections.
 
 ## References
@@ -157,12 +157,13 @@ theorem exists_wordProd_eq (w : P.weylGroup) :
   rw [wordProd, ← FreeMonoid.lift_apply]
   exact hl
 
-namespace RootPairing.weylGroup
+section
 
 omit [Finite ι] [CharZero R] [IsDomain R] [P.IsCrystallographic] [P.IsReduced] in
 /-- Distinct simple roots give distinct simple reflections: the two reflections already disagree on
 the second simple root, since the two simple roots are linearly independent. -/
-theorem ofIdx_ne_ofIdx_of_ne [NeZero (2 : R)] {i j : ι} (hi : i ∈ b.support) (hj : j ∈ b.support)
+theorem _root_.RootPairing.weylGroup.ofIdx_ne_ofIdx_of_ne
+    [NeZero (2 : R)] {i j : ι} (hi : i ∈ b.support) (hj : j ∈ b.support)
     (hij : i ≠ j) :
     _root_.RootPairing.weylGroup.ofIdx P i ≠ _root_.RootPairing.weylGroup.ofIdx P j := by
   intro hEq
@@ -178,6 +179,6 @@ theorem ofIdx_ne_ofIdx_of_ne [NeZero (2 : R)] {i j : ι} (hi : i ∈ b.support) 
       (by linear_combination (norm := module) happ)).2
   exact two_ne_zero h2
 
-end RootPairing.weylGroup
+end
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/RootSystem/Weyl/Chamber.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Weyl/Chamber.lean
@@ -72,7 +72,7 @@ the type `TauCeti.openWeylChambers P b`.
 
 The covering statements are proved as `..._of_finite_weylGroup`, which asks only that the Weyl
 group be finite, and the root-system forms are read off from those using
-`TauCeti.RootPairing.finite_weylGroup`; this follows the shape of
+`RootPairing.finite_weylGroup`; this follows the shape of
 `TauCeti.exists_mem_dominantChamber_of_finite_weylGroup`, which is what they consume.
 
 ## References

--- a/TauCeti/LinearAlgebra/RootSystem/Weyl/Dihedral.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Weyl/Dihedral.lean
@@ -14,7 +14,7 @@ public import TauCeti.LinearAlgebra.RootSystem.BraidRelation
 A base with two simple roots presents its Weyl group by two generators: the two simple reflections
 generate it (`TauCeti.weylGroup_eq_closure_simple`), they are involutions, and the order of their
 product is the corresponding entry of the Coxeter matrix of the base
-(`TauCeti.RootPairing.weylGroup.orderOf_ofIdx_mul_ofIdx_eq_coxeterMatrixOfBase`). That is exactly
+(`RootPairing.weylGroup.orderOf_ofIdx_mul_ofIdx_eq_coxeterMatrixOfBase`). That is exactly
 the input of `TauCeti.nonempty_dihedralGroup_mulEquiv`, so the Weyl group *is* the dihedral group
 of order twice that entry — and, unlike the presentation of the Weyl group in general, this needs
 no completeness statement for the braid relations, since in rank two there is only one of them.

--- a/TauCeti/LinearAlgebra/RootSystem/Weyl/DotAction.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Weyl/DotAction.lean
@@ -178,7 +178,7 @@ theorem dotAction_injective (w : P.weylGroup) : Function.Injective (dotAction P 
 fixes every weight for the linear action, hence is the identity. -/
 theorem dotActionPerm_injective : Function.Injective (dotActionPerm P b) := by
   refine (injective_iff_map_eq_one _).mpr fun w hw ↦ ?_
-  refine _root_.TauCeti.RootPairing.weylGroup.eq_one_of_smul_eq_self fun y ↦ ?_
+  refine _root_.RootPairing.weylGroup.eq_one_of_smul_eq_self fun y ↦ ?_
   have h := congrArg (fun e : Equiv.Perm M ↦ e (y - weylVector P b)) hw
   simp only [dotActionPerm_apply, Equiv.Perm.coe_one, id_eq] at h
   rw [dotAction_eq_iff, sub_add_cancel] at h
@@ -202,7 +202,7 @@ theorem dotAction_eq_self_iff {w : P.weylGroup} {x : M} :
 /-- A simple reflection is an involution for the dot action, as it is for the linear one. -/
 theorem dotAction_ofIdx_involutive (i : ι) :
     Function.Involutive (dotAction P b (_root_.RootPairing.weylGroup.ofIdx P i)) := fun x ↦ by
-  rw [← dotAction_mul, _root_.TauCeti.RootPairing.weylGroup.ofIdx_mul_self, dotAction_one]
+  rw [← dotAction_mul, _root_.RootPairing.weylGroup.ofIdx_mul_self, dotAction_one]
 
 section Reduced
 

--- a/TauCeti/LinearAlgebra/RootSystem/Weyl/Group.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Weyl/Group.lean
@@ -23,29 +23,29 @@ with that of its image.
 
 ## Main results
 
-* `TauCeti.RootPairing.Equiv.indexHom_injective` says that an automorphism of a root system is
+* `RootPairing.Equiv.indexHom_injective` says that an automorphism of a root system is
   determined by its permutation of the roots.
-* `TauCeti.RootPairing.coroot'_reflection_self` says a reflection reverses the sign of its own
+* `RootPairing.coroot'_reflection_self` says a reflection reverses the sign of its own
   coroot functional.
-* `TauCeti.RootPairing.coroot'_smul` and `TauCeti.RootPairing.coroot'_weylGroupToPerm_smul` say an
+* `RootPairing.coroot'_smul` and `RootPairing.coroot'_weylGroupToPerm_smul` say an
   automorphism, and in particular a Weyl-group element, carries the coroot functional of a root to
   the coroot functional of its image.
-* `TauCeti.RootPairing.weylGroupToPerm_ofIdx_apply` evaluates the action of a simple reflection.
-* `TauCeti.RootPairing.weylGroupToPerm_neg` says the action commutes with root negation.
-* `TauCeti.RootPairing.weylGroup.ofIdx_mul_self` says a simple reflection is an involution.
-* `TauCeti.RootPairing.weylGroup.ofIdx_ne_one` says a simple reflection is not the identity over a
+* `RootPairing.weylGroupToPerm_ofIdx_apply` evaluates the action of a simple reflection.
+* `RootPairing.weylGroupToPerm_neg` says the action commutes with root negation.
+* `RootPairing.weylGroup.ofIdx_mul_self` says a simple reflection is an involution.
+* `RootPairing.weylGroup.ofIdx_ne_one` says a simple reflection is not the identity over a
   ring of characteristic zero.
-* `TauCeti.RootPairing.weylGroup.eq_one_of_smul_eq_self` says a Weyl-group element acting trivially
+* `RootPairing.weylGroup.eq_one_of_smul_eq_self` says a Weyl-group element acting trivially
   on the weight space is the identity.
-* `TauCeti.RootPairing.weylGroup.ext` says two Weyl-group elements agreeing on the weight space are
+* `RootPairing.weylGroup.ext` says two Weyl-group elements agreeing on the weight space are
   equal.
-* `TauCeti.RootPairing.weylGroup.ofIdx_weylGroupToPerm_eq_conj` says that conjugating a simple
+* `RootPairing.weylGroup.ofIdx_weylGroupToPerm_eq_conj` says that conjugating a simple
   reflection by a Weyl-group element gives the reflection in the image root index.
-* `TauCeti.RootPairing.weylGroup.commute_ofIdx_of_isOrthogonal` says orthogonal roots have
+* `RootPairing.weylGroup.commute_ofIdx_of_isOrthogonal` says orthogonal roots have
   commuting reflections.
-* `TauCeti.RootPairing.finite_aut` proves that the automorphism group of a finite root system is
-  finite, and `TauCeti.RootPairing.finite_subgroup_aut` deduces the same for every subgroup of it.
-* `TauCeti.RootPairing.finite_weylGroup` is the resulting finiteness theorem for the Weyl group.
+* `RootPairing.finite_aut` proves that the automorphism group of a finite root system is
+  finite, and `RootPairing.finite_subgroup_aut` deduces the same for every subgroup of it.
+* `RootPairing.finite_weylGroup` is the resulting finiteness theorem for the Weyl group.
 
 ## References
 
@@ -65,11 +65,12 @@ section RootSystem
 variable [CommRing R] [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
   (P : _root_.RootPairing ι R M N)
 
-namespace RootPairing.Equiv
+section
 
 /-- If the roots span, an automorphism of a root pairing is determined by its permutation of the
 root indices. -/
-theorem indexHom_injective_of_span_eq_top (hspan : Submodule.span R (range P.root) = ⊤) :
+theorem _root_.RootPairing.Equiv.indexHom_injective_of_span_eq_top
+    (hspan : Submodule.span R (range P.root) = ⊤) :
     Function.Injective (_root_.RootPairing.Equiv.indexHom P) := by
   intro f g hfg
   apply _root_.RootPairing.Equiv.weightHom_injective P
@@ -82,31 +83,32 @@ theorem indexHom_injective_of_span_eq_top (hspan : Submodule.span R (range P.roo
     _root_.RootPairing.Hom.root_weightMap_apply, hfg']
 
 /-- An automorphism of a root system is determined by its permutation of the root indices. -/
-theorem indexHom_injective [P.IsRootSystem] :
+theorem _root_.RootPairing.Equiv.indexHom_injective [P.IsRootSystem] :
     Function.Injective (_root_.RootPairing.Equiv.indexHom P) :=
-  indexHom_injective_of_span_eq_top P
+  RootPairing.Equiv.indexHom_injective_of_span_eq_top P
     (_root_.RootPairing.IsRootSystem.span_root_eq_top (P := P))
 
-end RootPairing.Equiv
+end
 
-namespace RootPairing
+section
 
 /-- Reflecting a root in itself negates its coroot functional. -/
 @[simp]
-lemma coroot'_reflectionPerm_self (i : ι) : P.coroot' (P.reflectionPerm i i) = -P.coroot' i := by
+lemma _root_.RootPairing.coroot'_reflectionPerm_self
+    (i : ι) : P.coroot' (P.reflectionPerm i i) = -P.coroot' i := by
   rw [_root_.RootPairing.coroot', P.coroot_reflectionPerm, P.coreflection_apply_self]
   simp
 
 /-- A reflection reverses the sign of its own coroot functional. -/
 @[grind =]
-lemma coroot'_reflection_self (i : ι) (x : M) :
+lemma _root_.RootPairing.coroot'_reflection_self (i : ι) (x : M) :
     P.coroot' i (P.reflection i x) = -P.coroot' i x := by
-  rw [P.coroot'_reflection, coroot'_reflectionPerm_self]
+  rw [P.coroot'_reflection, RootPairing.coroot'_reflectionPerm_self]
   simp
 
 /-- An automorphism of a root pairing transports coroot functionals along its action on weights. -/
 @[grind =]
-lemma coroot'_smul (g : P.Aut) (i : ι) (x : M) :
+lemma _root_.RootPairing.coroot'_smul (g : P.Aut) (i : ι) (x : M) :
     P.coroot' i (g • x) = P.coroot' (g.indexEquiv.symm i) x := by
   -- This is the transpose condition packaged in `RootPairing.Hom.weight_coweight_transpose`.
   have h := congrFun (congrArg DFunLike.coe
@@ -117,25 +119,26 @@ lemma coroot'_smul (g : P.Aut) (i : ι) (x : M) :
 /-- **A Weyl-group element matches the coroot functional of a root with the coroot functional of
 its image.** -/
 @[grind =]
-lemma coroot'_weylGroupToPerm_smul (w : P.weylGroup) (i : ι) (x : M) :
+lemma _root_.RootPairing.coroot'_weylGroupToPerm_smul (w : P.weylGroup) (i : ι) (x : M) :
     P.coroot' (P.weylGroupToPerm w i) (w • x) = P.coroot' i x := by
-  have h := coroot'_smul P (w : P.Aut) ((w : P.Aut).indexEquiv i) x
+  have h := RootPairing.coroot'_smul P (w : P.Aut) ((w : P.Aut).indexEquiv i) x
   rw [_root_.Equiv.symm_apply_apply] at h
   exact h
 
 /-- If the roots span, the action of the Weyl group on root indices is faithful. -/
-theorem weylGroupToPerm_injective_of_span_eq_top
+theorem _root_.RootPairing.weylGroupToPerm_injective_of_span_eq_top
     (hspan : Submodule.span R (range P.root) = ⊤) :
     Function.Injective P.weylGroupToPerm :=
   (Equiv.indexHom_injective_of_span_eq_top P hspan).comp Subtype.val_injective
 
 /-- The action of the Weyl group on root indices is faithful. -/
-theorem weylGroupToPerm_injective [P.IsRootSystem] : Function.Injective P.weylGroupToPerm :=
+theorem _root_.RootPairing.weylGroupToPerm_injective
+    [P.IsRootSystem] : Function.Injective P.weylGroupToPerm :=
   (Equiv.indexHom_injective P).comp Subtype.val_injective
 
 /-- The Weyl-group permutation of a simple reflection is the corresponding root-index
 reflection. -/
-lemma weylGroupToPerm_ofIdx_apply (i j : ι) :
+lemma _root_.RootPairing.weylGroupToPerm_ofIdx_apply (i j : ι) :
     P.weylGroupToPerm (_root_.RootPairing.weylGroup.ofIdx P i) j =
       P.reflectionPerm i j := by
   -- Mathlib exposes the underlying reflection equivalence, but not its restriction to the
@@ -145,48 +148,48 @@ lemma weylGroupToPerm_ofIdx_apply (i j : ι) :
     (_root_.RootPairing.Equiv.reflection_indexEquiv P i)
 
 /-- Right multiplication by a simple reflection acts by first reflecting the root index. -/
-lemma weylGroupToPerm_mul_ofIdx_apply (w : P.weylGroup) (i j : ι) :
+lemma _root_.RootPairing.weylGroupToPerm_mul_ofIdx_apply (w : P.weylGroup) (i j : ι) :
     P.weylGroupToPerm (w * _root_.RootPairing.weylGroup.ofIdx P i) j =
       P.weylGroupToPerm w (P.reflectionPerm i j) := by
   rw [map_mul]
-  exact congrArg (P.weylGroupToPerm w) (weylGroupToPerm_ofIdx_apply P i j)
+  exact congrArg (P.weylGroupToPerm w) (RootPairing.weylGroupToPerm_ofIdx_apply P i j)
 
 /-- Left multiplication by a simple reflection acts by reflecting the resulting root index. -/
-lemma weylGroupToPerm_ofIdx_mul_apply (w : P.weylGroup) (i j : ι) :
+lemma _root_.RootPairing.weylGroupToPerm_ofIdx_mul_apply (w : P.weylGroup) (i j : ι) :
     P.weylGroupToPerm (_root_.RootPairing.weylGroup.ofIdx P i * w) j =
       P.reflectionPerm i (P.weylGroupToPerm w j) := by
   rw [map_mul]
-  exact weylGroupToPerm_ofIdx_apply P i (P.weylGroupToPerm w j)
+  exact RootPairing.weylGroupToPerm_ofIdx_apply P i (P.weylGroupToPerm w j)
 
 /-- The Weyl-group action on root indices commutes with root negation. -/
-lemma weylGroupToPerm_neg (w : P.weylGroup) (j : ι) :
+lemma _root_.RootPairing.weylGroupToPerm_neg (w : P.weylGroup) (j : ι) :
     letI := P.indexNeg
     P.weylGroupToPerm w (-j) = -(P.weylGroupToPerm w j) :=
   by simp [RootPairing.indexNeg_neg]
 
-namespace weylGroup
+section
 
 /-- A simple reflection of the Weyl group is the corresponding reflection of the root pairing. -/
 @[simp]
-lemma coe_ofIdx (i : ι) :
+lemma _root_.RootPairing.weylGroup.coe_ofIdx (i : ι) :
     ((_root_.RootPairing.weylGroup.ofIdx P i : P.weylGroup) : P.Aut) =
       _root_.RootPairing.Equiv.reflection P i :=
   rfl
 
 /-- A simple reflection of the Weyl group is its own inverse. -/
 @[simp]
-lemma ofIdx_inv_eq (i : ι) :
+lemma _root_.RootPairing.weylGroup.ofIdx_inv_eq (i : ι) :
     (_root_.RootPairing.weylGroup.ofIdx P i)⁻¹ = _root_.RootPairing.weylGroup.ofIdx P i :=
   Subtype.ext (_root_.RootPairing.Equiv.reflection_inv P i)
 
 /-- A simple reflection of the Weyl group is an involution. -/
 @[simp]
-lemma ofIdx_mul_self (i : ι) :
+lemma _root_.RootPairing.weylGroup.ofIdx_mul_self (i : ι) :
     _root_.RootPairing.weylGroup.ofIdx P i * _root_.RootPairing.weylGroup.ofIdx P i = 1 := by
-  rw [mul_eq_one_iff_eq_inv, ofIdx_inv_eq]
+  rw [mul_eq_one_iff_eq_inv, RootPairing.weylGroup.ofIdx_inv_eq]
 
 /-- **A simple reflection is not the identity** over a ring of characteristic zero. -/
-theorem ofIdx_ne_one [CharZero R] (i : ι) :
+theorem _root_.RootPairing.weylGroup.ofIdx_ne_one [CharZero R] (i : ι) :
     _root_.RootPairing.weylGroup.ofIdx P i ≠ 1 := by
   intro h
   have hi := congrArg (fun w : P.weylGroup => P.coroot' i (w • P.root i)) h
@@ -197,7 +200,8 @@ theorem ofIdx_ne_one [CharZero R] (i : ι) :
 variable {P} in
 /-- A Weyl-group element acting trivially on the weight space is the identity: the weight-space
 representation of the automorphism group of a root pairing is faithful. -/
-theorem eq_one_of_smul_eq_self {w : P.weylGroup} (h : ∀ x : M, w • x = x) : w = 1 := by
+theorem _root_.RootPairing.weylGroup.eq_one_of_smul_eq_self
+    {w : P.weylGroup} (h : ∀ x : M, w • x = x) : w = 1 := by
   have hw : (w : P.Aut) = 1 := by
     refine _root_.RootPairing.Equiv.weightHom_injective P ?_
     rw [map_one]
@@ -206,22 +210,23 @@ theorem eq_one_of_smul_eq_self {w : P.weylGroup} (h : ∀ x : M, w • x = x) : 
 
 variable {P} in
 /-- Two Weyl-group elements agreeing on the weight space are equal. -/
-@[ext]
-theorem ext {v w : P.weylGroup} (h : ∀ x : M, v • x = w • x) : v = w := by
+@[RootPairing.weylGroup.ext]
+theorem _root_.RootPairing.weylGroup.ext
+    {v w : P.weylGroup} (h : ∀ x : M, v • x = w • x) : v = w := by
   rw [← mul_inv_eq_one]
-  refine eq_one_of_smul_eq_self fun x ↦ ?_
+  refine RootPairing.weylGroup.eq_one_of_smul_eq_self fun x ↦ ?_
   rw [mul_smul, h, smul_inv_smul]
 
 /-- **Conjugating a simple reflection transports it along the permutation action**: the reflection
 in the image of a root index is the conjugate of the reflection in that root index. -/
-theorem ofIdx_weylGroupToPerm_eq_conj (w : P.weylGroup) (i : ι) :
+theorem _root_.RootPairing.weylGroup.ofIdx_weylGroupToPerm_eq_conj (w : P.weylGroup) (i : ι) :
     _root_.RootPairing.weylGroup.ofIdx P (P.weylGroupToPerm w i) =
       w * _root_.RootPairing.weylGroup.ofIdx P i * w⁻¹ := by
-  refine ext fun x ↦ ?_
+  refine RootPairing.weylGroup.ext fun x ↦ ?_
   -- Both sides send `x` to `x - ⟨x, αᵢ^∨⟩ • w αᵢ`, the right-hand side after undoing `w`.
   have hcoroot : P.coroot' i (w⁻¹ • x) = P.coroot' (P.weylGroupToPerm w i) x := by
     conv_rhs => rw [← smul_inv_smul w x]
-    exact (coroot'_weylGroupToPerm_smul P w i (w⁻¹ • x)).symm
+    exact (RootPairing.coroot'_weylGroupToPerm_smul P w i (w⁻¹ • x)).symm
   have hroot : w • P.root i = P.root (P.weylGroupToPerm w i) := P.weylGroup_apply_root w i
   calc
     _root_.RootPairing.weylGroup.ofIdx P (P.weylGroupToPerm w i) • x
@@ -233,45 +238,47 @@ theorem ofIdx_weylGroupToPerm_eq_conj (w : P.weylGroup) (i : ι) :
       simp [mul_smul, _root_.RootPairing.reflection_apply]
 
 /-- **Orthogonal roots have commuting reflections** in the Weyl group. -/
-theorem commute_ofIdx_of_isOrthogonal {i j : ι} (h : P.IsOrthogonal i j) :
+theorem _root_.RootPairing.weylGroup.commute_ofIdx_of_isOrthogonal
+    {i j : ι} (h : P.IsOrthogonal i j) :
     Commute (_root_.RootPairing.weylGroup.ofIdx P i) (_root_.RootPairing.weylGroup.ofIdx P j) := by
   refine Subtype.ext ?_
   simp only [Subgroup.coe_mul]
   apply _root_.RootPairing.Equiv.weightHom_injective P
-  simpa only [coe_ofIdx, map_mul, _root_.RootPairing.Equiv.weightHom_apply,
+  simpa only [RootPairing.weylGroup.coe_ofIdx, map_mul, _root_.RootPairing.Equiv.weightHom_apply,
     _root_.RootPairing.Equiv.reflection_weightEquiv] using
     (_root_.RootPairing.isOrthogonal_comm P i j h).eq
 
-end weylGroup
+end
 
 variable [Finite ι]
 
 /-- If the roots span, the automorphism group is finite when the root index type is finite. -/
-theorem finite_aut_of_span_eq_top
+theorem _root_.RootPairing.finite_aut_of_span_eq_top
     (hspan : Submodule.span R (range P.root) = ⊤) : Finite P.Aut :=
   Finite.of_injective (_root_.RootPairing.Equiv.indexHom P)
     (Equiv.indexHom_injective_of_span_eq_top P hspan)
 
 /-- The automorphism group of a finite root system is finite. -/
-theorem finite_aut [P.IsRootSystem] : Finite P.Aut :=
-  finite_aut_of_span_eq_top P
+theorem _root_.RootPairing.finite_aut [P.IsRootSystem] : Finite P.Aut :=
+  RootPairing.finite_aut_of_span_eq_top P
     (_root_.RootPairing.IsRootSystem.span_root_eq_top (P := P))
 
 /-- If the roots span, every subgroup of the automorphism group is finite when the root index type
 is finite. -/
-theorem finite_subgroup_aut_of_span_eq_top (hspan : Submodule.span R (range P.root) = ⊤)
+theorem _root_.RootPairing.finite_subgroup_aut_of_span_eq_top
+    (hspan : Submodule.span R (range P.root) = ⊤)
     (G : Subgroup P.Aut) : Finite G :=
-  have := finite_aut_of_span_eq_top P hspan
+  have := RootPairing.finite_aut_of_span_eq_top P hspan
   Subtype.finite
 
 /-- Every subgroup of the automorphism group of a finite root system is finite. -/
-theorem finite_subgroup_aut [P.IsRootSystem] (G : Subgroup P.Aut) : Finite G :=
-  finite_subgroup_aut_of_span_eq_top P
+theorem _root_.RootPairing.finite_subgroup_aut [P.IsRootSystem] (G : Subgroup P.Aut) : Finite G :=
+  RootPairing.finite_subgroup_aut_of_span_eq_top P
     (_root_.RootPairing.IsRootSystem.span_root_eq_top (P := P)) G
 
 /-- If the roots span, the automorphism group has order at most the factorial of the number of
 roots. -/
-theorem card_aut_le_factorial_of_span_eq_top
+theorem _root_.RootPairing.card_aut_le_factorial_of_span_eq_top
     (hspan : Submodule.span R (range P.root) = ⊤) :
     Nat.card P.Aut ≤ Nat.factorial (Nat.card ι) :=
   calc
@@ -282,49 +289,50 @@ theorem card_aut_le_factorial_of_span_eq_top
 
 /-- The automorphism group of a finite root system has order at most the factorial of the number
 of roots. -/
-theorem card_aut_le_factorial [P.IsRootSystem] :
+theorem _root_.RootPairing.card_aut_le_factorial [P.IsRootSystem] :
     Nat.card P.Aut ≤ Nat.factorial (Nat.card ι) :=
-  card_aut_le_factorial_of_span_eq_top P
+  RootPairing.card_aut_le_factorial_of_span_eq_top P
     (_root_.RootPairing.IsRootSystem.span_root_eq_top (P := P))
 
 /-- If the roots span, every subgroup of the automorphism group has order at most the factorial of
 the number of roots. -/
-theorem card_subgroup_aut_le_factorial_of_span_eq_top
+theorem _root_.RootPairing.card_subgroup_aut_le_factorial_of_span_eq_top
     (hspan : Submodule.span R (range P.root) = ⊤)
     (G : Subgroup P.Aut) : Nat.card G ≤ Nat.factorial (Nat.card ι) :=
-  have := finite_aut_of_span_eq_top P hspan
-  G.card_le_card_group.trans (card_aut_le_factorial_of_span_eq_top P hspan)
+  have := RootPairing.finite_aut_of_span_eq_top P hspan
+  G.card_le_card_group.trans (RootPairing.card_aut_le_factorial_of_span_eq_top P hspan)
 
 /-- Every subgroup of the automorphism group of a finite root system has order at most the
 factorial of the number of roots. -/
-theorem card_subgroup_aut_le_factorial [P.IsRootSystem] (G : Subgroup P.Aut) :
+theorem _root_.RootPairing.card_subgroup_aut_le_factorial [P.IsRootSystem] (G : Subgroup P.Aut) :
     Nat.card G ≤ Nat.factorial (Nat.card ι) :=
-  card_subgroup_aut_le_factorial_of_span_eq_top P
+  RootPairing.card_subgroup_aut_le_factorial_of_span_eq_top P
     (_root_.RootPairing.IsRootSystem.span_root_eq_top (P := P)) G
 
 /-- If the roots span, the Weyl group is finite when the root index type is finite. -/
-theorem finite_weylGroup_of_span_eq_top (hspan : Submodule.span R (range P.root) = ⊤) :
+theorem _root_.RootPairing.finite_weylGroup_of_span_eq_top
+    (hspan : Submodule.span R (range P.root) = ⊤) :
     Finite P.weylGroup :=
-  finite_subgroup_aut_of_span_eq_top P hspan P.weylGroup
+  RootPairing.finite_subgroup_aut_of_span_eq_top P hspan P.weylGroup
 
 /-- The Weyl group of a finite root system is finite. -/
-theorem finite_weylGroup [P.IsRootSystem] : Finite P.weylGroup :=
-  finite_subgroup_aut P P.weylGroup
+theorem _root_.RootPairing.finite_weylGroup [P.IsRootSystem] : Finite P.weylGroup :=
+  RootPairing.finite_subgroup_aut P P.weylGroup
 
 /-- If the roots span, the order of the Weyl group is at most the factorial of the number of
 roots. -/
-theorem card_weylGroup_le_factorial_of_span_eq_top
+theorem _root_.RootPairing.card_weylGroup_le_factorial_of_span_eq_top
     (hspan : Submodule.span R (range P.root) = ⊤) :
     Nat.card P.weylGroup ≤ Nat.factorial (Nat.card ι) :=
-  card_subgroup_aut_le_factorial_of_span_eq_top P hspan P.weylGroup
+  RootPairing.card_subgroup_aut_le_factorial_of_span_eq_top P hspan P.weylGroup
 
 /-- The order of the Weyl group of a finite root system is at most the factorial of the number of
 roots. -/
-theorem card_weylGroup_le_factorial [P.IsRootSystem] :
+theorem _root_.RootPairing.card_weylGroup_le_factorial [P.IsRootSystem] :
     Nat.card P.weylGroup ≤ Nat.factorial (Nat.card ι) :=
-  card_subgroup_aut_le_factorial P P.weylGroup
+  RootPairing.card_subgroup_aut_le_factorial P P.weylGroup
 
-end RootPairing
+end
 
 end RootSystem
 

--- a/TauCeti/LinearAlgebra/RootSystem/Weyl/Group.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Weyl/Group.lean
@@ -129,12 +129,12 @@ lemma _root_.RootPairing.coroot'_weylGroupToPerm_smul (w : P.weylGroup) (i : ι)
 theorem _root_.RootPairing.weylGroupToPerm_injective_of_span_eq_top
     (hspan : Submodule.span R (range P.root) = ⊤) :
     Function.Injective P.weylGroupToPerm :=
-  (Equiv.indexHom_injective_of_span_eq_top P hspan).comp Subtype.val_injective
+  (RootPairing.Equiv.indexHom_injective_of_span_eq_top P hspan).comp Subtype.val_injective
 
 /-- The action of the Weyl group on root indices is faithful. -/
 theorem _root_.RootPairing.weylGroupToPerm_injective
     [P.IsRootSystem] : Function.Injective P.weylGroupToPerm :=
-  (Equiv.indexHom_injective P).comp Subtype.val_injective
+  (RootPairing.Equiv.indexHom_injective P).comp Subtype.val_injective
 
 /-- The Weyl-group permutation of a simple reflection is the corresponding root-index
 reflection. -/
@@ -210,7 +210,7 @@ theorem _root_.RootPairing.weylGroup.eq_one_of_smul_eq_self
 
 variable {P} in
 /-- Two Weyl-group elements agreeing on the weight space are equal. -/
-@[RootPairing.weylGroup.ext]
+@[ext]
 theorem _root_.RootPairing.weylGroup.ext
     {v w : P.weylGroup} (h : ∀ x : M, v • x = w • x) : v = w := by
   rw [← mul_inv_eq_one]
@@ -256,7 +256,7 @@ variable [Finite ι]
 theorem _root_.RootPairing.finite_aut_of_span_eq_top
     (hspan : Submodule.span R (range P.root) = ⊤) : Finite P.Aut :=
   Finite.of_injective (_root_.RootPairing.Equiv.indexHom P)
-    (Equiv.indexHom_injective_of_span_eq_top P hspan)
+    (RootPairing.Equiv.indexHom_injective_of_span_eq_top P hspan)
 
 /-- The automorphism group of a finite root system is finite. -/
 theorem _root_.RootPairing.finite_aut [P.IsRootSystem] : Finite P.Aut :=
@@ -284,7 +284,7 @@ theorem _root_.RootPairing.card_aut_le_factorial_of_span_eq_top
   calc
     Nat.card P.Aut ≤ Nat.card (ι ≃ ι) := Nat.card_le_card_of_injective
       (_root_.RootPairing.Equiv.indexHom P)
-        (Equiv.indexHom_injective_of_span_eq_top P hspan)
+        (RootPairing.Equiv.indexHom_injective_of_span_eq_top P hspan)
     _ = Nat.factorial (Nat.card ι) := Nat.card_perm
 
 /-- The automorphism group of a finite root system has order at most the factorial of the number

--- a/TauCeti/LinearAlgebra/RootSystem/Weyl/Numerator.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Weyl/Numerator.lean
@@ -61,7 +61,7 @@ are what makes the numerator *alternating*, which is the content of
 
 `TauCeti.weylNumerator` sums over `Finset.univ` and so carries `[Fintype P.weylGroup]` rather than
 `[Finite P.weylGroup]`. The Weyl group of a finite root system is finite
-(`TauCeti.RootPairing.finite_weylGroup`), and a consumer holding only that instance
+(`RootPairing.finite_weylGroup`), and a consumer holding only that instance
 supplies the `Fintype` with `Fintype.ofFinite`; the value of the sum does not depend on which one,
 since `Fintype` is a subsingleton.
 

--- a/TauCeti/LinearAlgebra/RootSystem/Weyl/Orbit.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Weyl/Orbit.lean
@@ -64,7 +64,7 @@ theorem exists_mem_support_weylGroupToPerm_eq [CharZero R] [Finite ι] [IsDomain
       ∃ i ∈ b.support, ∃ w : P.weylGroup, P.weylGroupToPerm w i = P.reflectionPerm k x := by
     rintro k x ⟨i, hi, w, rfl⟩
     exact ⟨i, hi, _root_.RootPairing.weylGroup.ofIdx P k * w,
-      TauCeti.RootPairing.weylGroupToPerm_ofIdx_mul_apply P w k i⟩
+      RootPairing.weylGroupToPerm_ofIdx_mul_apply P w k i⟩
   exact b.induction_reflect j (fun k hk ↦ step k k hk) (fun i hi ↦ ⟨i, hi, 1, by simp⟩)
     fun x k hx _ ↦ step k x hx
 
@@ -92,7 +92,7 @@ theorem _root_.RootPairing.RootPositiveForm.rootLength_weylGroupToPerm
 theorem _root_.RootPairing.RootPositiveForm.rootLength_reflectionPerm
     (B : P.RootPositiveForm S) (i j : ι) :
     B.rootLength (P.reflectionPerm i j) = B.rootLength j := by
-  rw [← TauCeti.RootPairing.weylGroupToPerm_ofIdx_apply P i j]
+  rw [← RootPairing.weylGroupToPerm_ofIdx_apply P i j]
   exact RootPairing.RootPositiveForm.rootLength_weylGroupToPerm B _ j
 
 /-- **Every root has the length of one of the simple roots.** Consequently the set of root lengths


### PR DESCRIPTION
Sixty-two declarations across five namespaces — `RootPairing` itself and its `weylGroup`, `Base`, `Equiv` and `GeckConstruction` children — move to their root Mathlib namespaces, which hold 400, 4, 87, 56 and 65 declarations respectively and carry no colliding names.

## Why the subtree, and not one namespace at a time

`Weyl/Group.lean` declares into `RootPairing`, `weylGroup` **and** `Equiv` at once, and `Flip.lean` into `RootPairing` and `Base`. Rooting any single namespace therefore leaves the others half-rooted in the same files — the split `api-design` blocked on in #5950, and the reason `RootPairing.Base` alone was not a viable change.

## What moved with the declarations

| | |
|---|---|
| declarations rooted | **62** across 9 files |
| `namespace` wrappers turned into `section` | 12 |
| bare sibling references written in full | 54 |
| fully-qualified `TauCeti.RootPairing.…` references retargeted | 57 |

The sibling references are the load-bearing half: inside `namespace RootPairing`, a declaration written `_root_.RootPairing.foo` is reachable from a later sibling as plain `foo`, so removing the wrapper without qualifying them would be a build failure rather than a review comment.

Keeping the wrappers would have avoided that work — and would have reintroduced exactly the vacuous `namespace` block that #5820 and #5838 were merged to remove.

`lint-dot-notation`: 970 → 915, 0 new.

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYwXN9WBAPasmBQXr6iQcp