### PR TITLE
feat: nonvanishing local components of Weil differentials

### DIFF
--- a/TauCeti/FieldTheory/FunctionField/Differential/LocalComponent.lean
+++ b/TauCeti/FieldTheory/FunctionField/Differential/LocalComponent.lean
@@ -28,9 +28,9 @@ theorem**: it is Stichtenoth's `(1.45)` for `x = 1`, and it holds over an arbitr
 with no analysis and before any residue map has been constructed.
 
 This is Stichtenoth, *Algebraic Function Fields and Codes*, 2nd ed., Definitions 1.7.1,
-Proposition 1.7.2 and the divisor-free half of Proposition 1.7.3(a).  The nonvanishing of every
-local component of a nonzero differential, and hence the fact that one local component determines
-the differential, are proved in
+Proposition 1.7.2 and the divisor-free half of Proposition 1.7.3(a).  For a function field with
+exact constants, the nonvanishing of every local component of a nonzero differential, and hence
+the fact that one local component determines the differential, are proved in
 `TauCeti.FieldTheory.FunctionField.Differential.LocalNonvanishing`.  The remaining statements of
 Section I.7 — that `v_P (ω)` is the largest bound its local component respects and the explicit
 generator of `Ω_{k(x)}` — need the divisor of a Weil differential.

--- a/TauCeti/FieldTheory/FunctionField/Differential/LocalComponent.lean
+++ b/TauCeti/FieldTheory/FunctionField/Differential/LocalComponent.lean
@@ -28,10 +28,12 @@ theorem**: it is Stichtenoth's `(1.45)` for `x = 1`, and it holds over an arbitr
 with no analysis and before any residue map has been constructed.
 
 This is Stichtenoth, *Algebraic Function Fields and Codes*, 2nd ed., Definitions 1.7.1,
-Proposition 1.7.2 and the divisor-free half of Proposition 1.7.3(a).  The remaining statements of
-Section I.7 — that no local component of a nonzero Weil differential vanishes, that `v_P (ω)` is
-the largest bound its local component respects, and the explicit generator of `Ω_{k(x)}` — need
-the divisor of a Weil differential, and are not proved here.
+Proposition 1.7.2 and the divisor-free half of Proposition 1.7.3(a).  The nonvanishing of every
+local component of a nonzero differential, and hence the fact that one local component determines
+the differential, are proved in
+`TauCeti.FieldTheory.FunctionField.Differential.LocalNonvanishing`.  The remaining statements of
+Section I.7 — that `v_P (ω)` is the largest bound its local component respects and the explicit
+generator of `Ω_{k(x)}` — need the divisor of a Weil differential.
 
 The repartitions `ι_P x` themselves are built in
 `TauCeti.FieldTheory.FunctionField.Repartition.Basic`, next to the repartition space and its

--- a/TauCeti/FieldTheory/FunctionField/Differential/LocalNonvanishing.lean
+++ b/TauCeti/FieldTheory/FunctionField/Differential/LocalNonvanishing.lean
@@ -11,9 +11,9 @@ public import TauCeti.FieldTheory.FunctionField.Differential.LocalComponent
 /-!
 # Nonvanishing of local components of Weil differentials
 
-Every local component of a nonzero Weil differential on an algebraic function field is nonzero.
-Consequently, fixing any one place `P`, the map `ω ↦ ω_P` is injective on the space of Weil
-differentials: one local component determines the global differential.
+Every local component of a nonzero Weil differential on an algebraic function field with exact
+constants is nonzero.  Consequently, fixing any one place `P`, the map `ω ↦ ω_P` is injective on
+the space of Weil differentials: one local component determines the global differential.
 
 The key point is that allowing a double pole at `P` strictly enlarges the space of regular Weil
 differentials.  Indeed,
@@ -32,12 +32,12 @@ differential and for comparing Weil differentials with Kähler differentials thr
 
 ## Main results
 
-* `TauCeti.repartitionDualComponent_ne_zero`: every local component of a nonzero Weil differential
-  is nonzero.
-* `TauCeti.repartitionDualComponent_eq_zero_iff`: a Weil differential is zero exactly when its
-  local component at one fixed place is zero.
-* `TauCeti.repartitionDualComponent_eq_iff`: two Weil differentials are equal exactly when their
-  local components at one fixed place are equal.
+* `TauCeti.repartitionDualComponent_ne_zero`: over an exact constant field, every local component
+  of a nonzero Weil differential is nonzero.
+* `TauCeti.repartitionDualComponent_eq_zero_iff`: over an exact constant field, a Weil differential
+  is zero exactly when its local component at one fixed place is zero.
+* `TauCeti.repartitionDualComponent_inj`: over an exact constant field, two Weil differentials are
+  equal exactly when their local components at one fixed place are equal.
 
 ## References
 
@@ -100,8 +100,8 @@ private theorem exists_repartitionDualComponent_ne_zero (hF : IsFunctionField k 
   · exact repartitionDualComponent_apply_eq_zero_of_le hωD Q (by
       simpa [D, WeilDivisor.coeff_zsmul, WeilDivisor.coeff_ofPoint_of_ne hQP] using hx)
 
-/-- **Every local component of a nonzero Weil differential is nonzero**
-(Stichtenoth, Proposition 1.7.3(a)). -/
+/-- Over an exact constant field, **every local component of a nonzero Weil differential is
+nonzero** (Stichtenoth, Proposition 1.7.3(a)). -/
 theorem repartitionDualComponent_ne_zero (hF : IsFunctionField k F)
     (hex : IsIntegrallyClosedIn k F) {ω : Module.Dual k ↥(repartitionSpace k F)}
     (hω : ω ∈ weilDifferentialSpace k F) (hω0 : ω ≠ 0) (P : Place k F) :
@@ -114,7 +114,8 @@ theorem repartitionDualComponent_ne_zero (hF : IsFunctionField k F)
   rw [← hc, repartitionDualComponent_repartitionDualMul, hωP, LinearMap.zero_apply,
     LinearMap.zero_apply]
 
-/-- A Weil differential is zero exactly when its local component at one fixed place is zero. -/
+/-- Over an exact constant field, a Weil differential is zero exactly when its local component at
+one fixed place is zero. -/
 @[simp]
 theorem repartitionDualComponent_eq_zero_iff (hF : IsFunctionField k F)
     (hex : IsIntegrallyClosedIn k F) {ω : Module.Dual k ↥(repartitionSpace k F)}
@@ -126,10 +127,10 @@ theorem repartitionDualComponent_eq_zero_iff (hF : IsFunctionField k F)
   ext x
   simp
 
-/-- **One local component determines a Weil differential**: two Weil differentials are equal if
-and only if their local components at any one fixed place are equal. -/
+/-- Over an exact constant field, **one local component determines a Weil differential**: two Weil
+differentials are equal if and only if their local components at any one fixed place are equal. -/
 @[simp]
-theorem repartitionDualComponent_eq_iff (hF : IsFunctionField k F)
+theorem repartitionDualComponent_inj (hF : IsFunctionField k F)
     (hex : IsIntegrallyClosedIn k F) {ω η : Module.Dual k ↥(repartitionSpace k F)}
     (hω : ω ∈ weilDifferentialSpace k F) (hη : η ∈ weilDifferentialSpace k F)
     (P : Place k F) :

--- a/TauCeti/FieldTheory/FunctionField/Differential/LocalNonvanishing.lean
+++ b/TauCeti/FieldTheory/FunctionField/Differential/LocalNonvanishing.lean
@@ -1,0 +1,147 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.FieldTheory.FunctionField.Differential.Dimension
+public import TauCeti.FieldTheory.FunctionField.Differential.LocalComponent
+
+/-!
+# Nonvanishing of local components of Weil differentials
+
+Every local component of a nonzero Weil differential on an algebraic function field is nonzero.
+Consequently, fixing any one place `P`, the map `ω ↦ ω_P` is injective on the space of Weil
+differentials: one local component determines the global differential.
+
+The key point is that allowing a double pole at `P` strictly enlarges the space of regular Weil
+differentials.  Indeed,
+
+`dim_k Ω_F(-2P) = 2 deg P - 1 + g > g = dim_k Ω_F(0)`.
+
+Thus some differential in `Ω_F(-2P)` is not regular.  Its local component at `P` cannot vanish,
+because the local-component characterization of the filtration would then make it regular after
+all.  Since the full space of Weil differentials is one-dimensional over `F`, multiplication by a
+function carries this witness to any prescribed nonzero differential, and multiplication cannot
+create a zero local component.
+
+This is the nonvanishing assertion and the final clause of Stichtenoth, *Algebraic Function Fields
+and Codes*, 2nd ed., Proposition 1.7.3(a).  It is the local input for defining the order of a Weil
+differential and for comparing Weil differentials with Kähler differentials through residues.
+
+## Main results
+
+* `TauCeti.repartitionDualComponent_ne_zero`: every local component of a nonzero Weil differential
+  is nonzero.
+* `TauCeti.repartitionDualComponent_eq_zero_iff`: a Weil differential is zero exactly when its
+  local component at one fixed place is zero.
+* `TauCeti.repartitionDualComponent_eq_iff`: two Weil differentials are equal exactly when their
+  local components at one fixed place are equal.
+
+## References
+
+* H. Stichtenoth, *Algebraic Function Fields and Codes*, 2nd ed., GTM 254, Springer, 2009,
+  Proposition 1.7.3(a).
+-/
+
+public section
+
+namespace TauCeti
+
+open AlgebraicGeometry
+
+variable {k F : Type*} [Field k] [Field F] [Algebra k F]
+
+/-- At every place of an algebraic function field with exact constants, some Weil differential
+has a nonzero local component.
+
+The witness can be taken from `Ω_F(-2P)`: this space has dimension
+`2 * deg P - 1 + g`, strictly larger than the `g`-dimensional space `Ω_F(0)` of regular
+differentials. -/
+private theorem exists_repartitionDualComponent_ne_zero (hF : IsFunctionField k F)
+    (hex : IsIntegrallyClosedIn k F) (P : Place k F) :
+    ∃ ω : Module.Dual k ↥(repartitionSpace k F),
+      ω ∈ weilDifferentialSpace k F ∧ repartitionDualComponent ω P ≠ 0 := by
+  let D : Divisor k F := (-2 : ℤ) • WeilDivisor.ofPoint P
+  have hDneg : D < 0 := WeilDivisor.zsmul_ofPoint_lt_zero P (by omega)
+  have hle : weilDifferentialFiltration (0 : Divisor k F) ≤
+      weilDifferentialFiltration D :=
+    weilDifferentialFiltration_antitone hDneg.le
+  have hfdD := finiteDimensional_weilDifferentialFiltration hF hex D
+  have hdimD := finrank_weilDifferentialFiltration hF hex D
+  have hdim0 := finrank_weilDifferentialFiltration_zero hF hex
+  have hP : (1 : ℤ) ≤ P.degree := by
+    exact_mod_cast P.one_le_degree_of_isFunctionField hF
+  have hdimlt : Module.finrank k ↥(weilDifferentialFiltration (0 : Divisor k F)) <
+      Module.finrank k ↥(weilDifferentialFiltration D) := by
+    rw [hdim0]
+    rw [Divisor.indexOfSpecialty_def,
+      Divisor.dim_eq_zero_of_lt_zero hF hDneg, Divisor.degree_zsmul,
+      Divisor.degree_ofPoint] at hdimD
+    dsimp [D] at hdimD
+    have hdimD' : (genus k F : ℤ) <
+        Module.finrank k ↥(weilDifferentialFiltration D) := by
+      rw [hdimD]
+      omega
+    exact_mod_cast hdimD'
+  have hlt : weilDifferentialFiltration (0 : Divisor k F) <
+      weilDifferentialFiltration D :=
+    Submodule.lt_of_le_of_finrank_lt_finrank hle hdimlt
+  obtain ⟨ω, hωD, hω0⟩ := SetLike.exists_of_lt hlt
+  have hωspace : ω ∈ weilDifferentialSpace k F :=
+    weilDifferentialFiltration_le_weilDifferentialSpace D hωD
+  refine ⟨ω, hωspace, fun hcomponent ↦ hω0 ?_⟩
+  rw [mem_weilDifferentialFiltration_iff_repartitionDualComponent_eq_zero hωspace]
+  intro Q x hx
+  rcases eq_or_ne Q P with rfl | hQP
+  · rw [hcomponent]
+    exact LinearMap.zero_apply _
+  · exact repartitionDualComponent_apply_eq_zero_of_le hωD Q (by
+      simpa [D, WeilDivisor.coeff_zsmul, WeilDivisor.coeff_ofPoint_of_ne hQP] using hx)
+
+/-- **Every local component of a nonzero Weil differential is nonzero**
+(Stichtenoth, Proposition 1.7.3(a)). -/
+theorem repartitionDualComponent_ne_zero (hF : IsFunctionField k F)
+    (hex : IsIntegrallyClosedIn k F) {ω : Module.Dual k ↥(repartitionSpace k F)}
+    (hω : ω ∈ weilDifferentialSpace k F) (hω0 : ω ≠ 0) (P : Place k F) :
+    repartitionDualComponent ω P ≠ 0 := by
+  obtain ⟨η, hη, hηP⟩ := exists_repartitionDualComponent_ne_zero hF hex P
+  obtain ⟨c, hc⟩ := exists_repartitionDualMul_eq hF hex hω hω0 hη
+  intro hωP
+  apply hηP
+  ext x
+  rw [← hc, repartitionDualComponent_repartitionDualMul, hωP, LinearMap.zero_apply,
+    LinearMap.zero_apply]
+
+/-- A Weil differential is zero exactly when its local component at one fixed place is zero. -/
+theorem repartitionDualComponent_eq_zero_iff (hF : IsFunctionField k F)
+    (hex : IsIntegrallyClosedIn k F) {ω : Module.Dual k ↥(repartitionSpace k F)}
+    (hω : ω ∈ weilDifferentialSpace k F) (P : Place k F) :
+    repartitionDualComponent ω P = 0 ↔ ω = 0 := by
+  refine ⟨fun h ↦ not_ne_iff.mp fun hω0 ↦
+    repartitionDualComponent_ne_zero hF hex hω hω0 P h, ?_⟩
+  rintro rfl
+  ext x
+  simp
+
+/-- **One local component determines a Weil differential**: two Weil differentials are equal if
+and only if their local components at any one fixed place are equal. -/
+theorem repartitionDualComponent_eq_iff (hF : IsFunctionField k F)
+    (hex : IsIntegrallyClosedIn k F) {ω η : Module.Dual k ↥(repartitionSpace k F)}
+    (hω : ω ∈ weilDifferentialSpace k F) (hη : η ∈ weilDifferentialSpace k F)
+    (P : Place k F) :
+    repartitionDualComponent ω P = repartitionDualComponent η P ↔ ω = η := by
+  constructor
+  · intro hcomponent
+    have hsub : repartitionDualComponent (ω - η) P = 0 := by
+      ext x
+      have hx := LinearMap.congr_fun hcomponent x
+      rw [repartitionDualComponent_apply, LinearMap.sub_apply, LinearMap.zero_apply]
+      exact sub_eq_zero.mpr (by simpa only [repartitionDualComponent_apply] using hx)
+    exact sub_eq_zero.mp <|
+      (repartitionDualComponent_eq_zero_iff hF hex (Submodule.sub_mem _ hω hη) P).mp hsub
+  · rintro rfl
+    rfl
+
+end TauCeti

--- a/TauCeti/FieldTheory/FunctionField/Differential/LocalNonvanishing.lean
+++ b/TauCeti/FieldTheory/FunctionField/Differential/LocalNonvanishing.lean
@@ -115,6 +115,7 @@ theorem repartitionDualComponent_ne_zero (hF : IsFunctionField k F)
     LinearMap.zero_apply]
 
 /-- A Weil differential is zero exactly when its local component at one fixed place is zero. -/
+@[simp]
 theorem repartitionDualComponent_eq_zero_iff (hF : IsFunctionField k F)
     (hex : IsIntegrallyClosedIn k F) {ω : Module.Dual k ↥(repartitionSpace k F)}
     (hω : ω ∈ weilDifferentialSpace k F) (P : Place k F) :
@@ -127,6 +128,7 @@ theorem repartitionDualComponent_eq_zero_iff (hF : IsFunctionField k F)
 
 /-- **One local component determines a Weil differential**: two Weil differentials are equal if
 and only if their local components at any one fixed place are equal. -/
+@[simp]
 theorem repartitionDualComponent_eq_iff (hF : IsFunctionField k F)
     (hex : IsIntegrallyClosedIn k F) {ω η : Module.Dual k ↥(repartitionSpace k F)}
     (hω : ω ∈ weilDifferentialSpace k F) (hη : η ∈ weilDifferentialSpace k F)


### PR DESCRIPTION
This PR proves that every local component of a nonzero Weil differential on an algebraic function field with exact constants is nonzero, and that any one fixed local component determines the global differential. It advances `AlgebraicCurves/README.md`, Layer 5, the **Local components (§1.7)** milestone, specifically Proposition 1.7.3(a)'s targets “`ω_P ≠ 0` always” and “one local component determines `ω`.” After this PR, that milestone still needs the local characterization of the order `v_P(ω)`, the explicit generator `η` of `Ω_{k(x)}` with its local components, and the completion comparison.

The proof uses a sharp dimension jump already available on `main`. For a place `P`, the filtration step `Ω_F(-2P)` has dimension `2 deg P - 1 + g`, strictly larger than the `g`-dimensional regular step `Ω_F(0)` because `deg P ≥ 1`. A differential in the difference has nonzero component at `P`: if that component vanished, the existing local filtration characterization would put it back in `Ω_F(0)`. Since the full Weil differential space is one-dimensional over `F`, every nonzero differential then has a nonzero component at every place. The coefficient `-2` is essential at degree-one places, where `-P` need not produce a strict jump.

The new module `TauCeti/FieldTheory/FunctionField/Differential/LocalNonvanishing.lean` exposes `repartitionDualComponent_ne_zero`, its zero characterization, and the equality characterization expressing that one component determines a differential. Its internal existence witness remains private. The header of `Differential/LocalComponent.lean` is updated so it no longer says that nonvanishing remains unproved.

This is the most effective currently available critical-path step because the Layer 4 Riemann–Roch summit is already covered by open PRs #5903 and #5940, while this independent Layer 5 local statement is not in flight and is an input to the remaining local-order, explicit-generator, residue-comparison, and cotrace development. Searches across pinned Mathlib and `TauCeti/` found no existing nonvanishing or one-component-determines theorem; the proof reuses Tau Ceti's `finrank_weilDifferentialFiltration`, `finrank_weilDifferentialFiltration_zero`, `mem_weilDifferentialFiltration_iff_repartitionDualComponent_eq_zero`, and `exists_repartitionDualMul_eq`, together with Mathlib's `Submodule.lt_of_le_of_finrank_lt_finrank`. No formalization or Mathlib infrastructure is vendored. The mathematical source is H. Stichtenoth, *Algebraic Function Fields and Codes*, 2nd ed., Proposition 1.7.3(a), cited in the module documentation.

Roadmap: AlgebraicCurves

<!--tauceti-target:v1 {"focus":"AlgebraicCurves","id":"nonzero-weil-differential-local-component"}-->

🤖 Prepared with Codex
