### PR TITLE
feat: make adic formal-group parameters a group

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/AdicPoint.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/AdicPoint.lean
@@ -6,10 +6,12 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.PairEval
+-- Public: `AddGroup.ofLeftAxioms` is an `abbrev`, so the group instance's exposed body names it
+-- and a private import would not make it available.
 public import Mathlib.Algebra.Group.MinimalAxioms
 
 /-!
-# Points of an elliptic formal group in an adic ideal
+# Points of a Weierstrass formal group in an adic ideal
 
 Let `I` be an adic ideal of a complete linearly topologised ring `O`. The elements of `I` form an
 additive commutative group under evaluation of the Weierstrass formal group law: addition is
@@ -59,7 +61,7 @@ namespace WeierstrassCurve
 variable {O : Type*} [CommRing O] [UniformSpace O] [IsUniformAddGroup O] [CompleteSpace O]
   [T2Space O] [IsTopologicalRing O] [IsLinearTopology O O]
 
-/-- A point of the elliptic formal group with parameter in the adic ideal `I`.
+/-- A point of the formal group of a Weierstrass curve, with parameter in the adic ideal `I`.
 
 This is a newtype rather than the ideal subtype itself: `I` already uses the ordinary addition of
 `O`, while `FormalGroupPoint W I` uses evaluation of `W.formalAdd`. -/

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/AdicPoint.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/AdicPoint.lean
@@ -1,0 +1,151 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.PairEval
+public import Mathlib.Algebra.Group.MinimalAxioms
+
+/-!
+# Points of an elliptic formal group in an adic ideal
+
+Let `I` be an adic ideal of a complete linearly topologised ring `O`. The elements of `I` form an
+additive commutative group under evaluation of the Weierstrass formal group law: addition is
+`F(t₁, t₂)` and negation is the formal inverse `ι(t)`. This file packages that group as
+`WeierstrassCurve.FormalGroupPoint W I`.
+
+The wrapper is necessary because the subtype `I` already carries the ordinary addition inherited
+from `O`, whereas the addition here is the generally different formal-group operation. The
+assumption that `I` is adic is carried as `Fact (IsAdic I)`: it makes every parameter evaluable and
+keeps addition and negation inside `I`.
+
+This is only the parameter group. Mapping it into the points of the Weierstrass curve uses
+`WeierstrassCurve.formalPoint`; proving that map additive requires comparing the formal law with
+the geometric chord-and-tangent law.
+
+## Main definitions
+
+* `WeierstrassCurve.FormalGroupPoint`: a parameter in an adic ideal, equipped with the Weierstrass
+  formal group law.
+
+## Main results
+
+* `WeierstrassCurve.FormalGroupPoint.instAddCommGroup`: the evaluated formal law makes these
+  parameters an additive commutative group.
+
+## References
+
+* [J. Silverman, *The Arithmetic of Elliptic Curves*][silverman2009], IV.1.
+
+## Provenance
+
+The packaging follows Michael Stoll's elliptic-curve development
+(`github.com/MichaelStollBayreuth/EllipticCurves` @ `66889eada51a`, Apache-2.0), file
+`EllipticCurves/Mathlib/Chabauty/FormalGroupLaw/Points.lean`, definition
+`ChabautyColeman.FormalGroupLaw.Points` and its `AddCommMonoid` instance. That source treats a
+multivariable formal group law on the maximal ideal of a local ring and does not construct
+inverses. Here the one-dimensional Weierstrass law is evaluated on an arbitrary adic ideal, and its
+already-constructed formal inverse upgrades the result to an additive commutative group.
+-/
+
+public section
+
+open PowerSeries
+
+namespace WeierstrassCurve
+
+variable {O : Type*} [CommRing O] [UniformSpace O] [IsUniformAddGroup O] [CompleteSpace O]
+  [T2Space O] [IsTopologicalRing O] [IsLinearTopology O O]
+
+/-- A point of the elliptic formal group with parameter in the adic ideal `I`.
+
+This is a newtype rather than the ideal subtype itself: `I` already uses the ordinary addition of
+`O`, while `FormalGroupPoint W I` uses evaluation of `W.formalAdd`. -/
+@[ext]
+structure FormalGroupPoint (W : WeierstrassCurve O) (I : Ideal O) where
+  /-- The parameter of a formal-group point. -/
+  val : O
+  /-- The parameter belongs to the ideal on which the formal law is evaluated. -/
+  property : val ∈ I
+
+namespace FormalGroupPoint
+
+variable {W : WeierstrassCurve O} {I : Ideal O}
+
+/-- A formal-group point coerces to its parameter in the coefficient ring. -/
+instance : CoeOut (FormalGroupPoint W I) O := ⟨val⟩
+
+omit [UniformSpace O] [IsUniformAddGroup O] [CompleteSpace O] [T2Space O]
+  [IsTopologicalRing O] [IsLinearTopology O O] in
+/-- The parameter of a formal-group point constructed from `t` is `t`. -/
+@[simp]
+theorem coe_mk (t : O) (ht : t ∈ I) : ((⟨t, ht⟩ : FormalGroupPoint W I) : O) = t := rfl
+
+omit [UniformSpace O] [IsUniformAddGroup O] [CompleteSpace O] [T2Space O]
+  [IsTopologicalRing O] [IsLinearTopology O O] in
+/-- Two formal-group points are equal exactly when their parameters are equal. -/
+@[simp]
+theorem coe_inj {P Q : FormalGroupPoint W I} : (P : O) = Q ↔ P = Q := by
+  constructor
+  · exact fun h ↦ FormalGroupPoint.ext h
+  · exact fun h ↦ congrArg val h
+
+omit [IsUniformAddGroup O] [CompleteSpace O] [T2Space O] [IsTopologicalRing O]
+  [IsLinearTopology O O] in
+/-- A parameter in an adic ideal is an admissible evaluation point for a power series. -/
+theorem hasEval [Fact (IsAdic I)] (P : FormalGroupPoint W I) : PowerSeries.HasEval (P : O) :=
+  (Fact.out : IsAdic I).isTopologicallyNilpotent_of_mem P.property
+
+/-- The zero parameter is the identity formal-group point. -/
+instance : Zero (FormalGroupPoint W I) := ⟨⟨0, I.zero_mem⟩⟩
+
+omit [UniformSpace O] [IsUniformAddGroup O] [CompleteSpace O] [T2Space O]
+  [IsTopologicalRing O] [IsLinearTopology O O] in
+@[simp]
+theorem coe_zero : (((0 : FormalGroupPoint W I) : O)) = 0 := rfl
+
+/-- Addition of formal-group points is evaluation of the Weierstrass formal group law. -/
+noncomputable instance [Fact (IsAdic I)] : Add (FormalGroupPoint W I) :=
+  ⟨fun P Q ↦ ⟨W.formalAddEval P Q, by
+    simpa using W.formalAddEval_mem (I := I) (Fact.out : IsAdic I) (k := 1)
+      (by simpa using P.property) (by simpa using Q.property)⟩⟩
+
+@[simp]
+theorem coe_add [Fact (IsAdic I)] (P Q : FormalGroupPoint W I) :
+    ((P + Q : FormalGroupPoint W I) : O) = W.formalAddEval P Q := (rfl)
+
+/-- Negation of a formal-group point is evaluation of the formal inverse. -/
+noncomputable instance [Fact (IsAdic I)] : Neg (FormalGroupPoint W I) :=
+  ⟨fun P ↦ ⟨W.formalInverseEval P, by
+    simpa using W.formalInverseEval_mem (I := I) (k := 1) P.hasEval
+      (by simpa using P.property)⟩⟩
+
+@[simp]
+theorem coe_neg [Fact (IsAdic I)] (P : FormalGroupPoint W I) :
+    ((-P : FormalGroupPoint W I) : O) = W.formalInverseEval P := (rfl)
+
+/-- The elements of an adic ideal form an additive commutative group under the evaluated Weierstrass
+formal group law. -/
+noncomputable instance instAddCommGroup [Fact (IsAdic I)] :
+    AddCommGroup (FormalGroupPoint W I) :=
+  { AddGroup.ofLeftAxioms (fun P Q S ↦ by
+        ext
+        simpa only [coe_add] using W.formalAddEval_assoc P.hasEval Q.hasEval S.hasEval)
+      (fun P ↦ by
+        ext
+        simpa only [coe_add, coe_zero] using W.formalAddEval_zero_left P.hasEval)
+      (fun P ↦ by
+        ext
+        simp only [coe_add, coe_neg, coe_zero]
+        exact (W.formalAddEval_comm (-P).hasEval P.hasEval).trans
+          (W.formalAddEval_formalInverseEval P.hasEval
+            (W.hasEval_formalInverseEval (Fact.out : IsAdic I) P.property))) with
+    add_comm := fun P Q ↦ by
+      ext
+      simpa only [coe_add] using W.formalAddEval_comm P.hasEval Q.hasEval }
+
+end FormalGroupPoint
+
+end WeierstrassCurve

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/PairEval.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/PairEval.lean
@@ -8,6 +8,9 @@ module
 public import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.Add.Unit
 public import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.Eval
 public import TauCeti.RingTheory.MvPowerSeries.Substitution
+-- Proof-only: supplies `MvPowerSeries.aeval_rename`, the transport of an evaluation along a
+-- renaming, named in no statement here.
+import TauCeti.RingTheory.MvPowerSeries.Rename
 -- Proof-only: supplies the shared `constantCoeff_subst_pair_formalAdd`. Not redundant with the
 -- `Add.Inverse` and `Add.Assoc` imports below: both import `Add.PairSubst` non-`public`, so
 -- nothing it declares is re-exported through them.
@@ -451,29 +454,10 @@ theorem formalAddEval_mem {I : Ideal O} (hI : IsAdic I) {k : ℕ} {t₁ t₂ : O
 /-- **Commutativity of the group law at parameters**: `F(t₁, t₂) = F(t₂, t₁)`. -/
 theorem formalAddEval_comm {t₁ t₂ : O} (h₁ : PowerSeries.HasEval t₁)
     (h₂ : PowerSeries.HasEval t₂) : W.formalAddEval t₁ t₂ = W.formalAddEval t₂ t₁ := by
-  have hpair := hasEval_pair h₁ h₂
-  have hfam : (fun s : Unit ⊕ Unit ↦ MvPowerSeries.aeval hpair
-        ((MvPowerSeries.X ∘ Sum.swap : Unit ⊕ Unit →
-          MvPowerSeries (Unit ⊕ Unit) O) s)) =
-      Sum.elim (fun _ ↦ t₂) fun _ ↦ t₁ := by
-    funext s
-    rcases s with _ | _ <;> simp [MvPowerSeries.coe_aeval]
-  have hev : MvPowerSeries.HasEval fun s : Unit ⊕ Unit ↦ MvPowerSeries.aeval hpair
-      ((MvPowerSeries.X ∘ Sum.swap : Unit ⊕ Unit →
-        MvPowerSeries (Unit ⊕ Unit) O) s) := by
-    rw [hfam]
-    exact hasEval_pair h₂ h₁
-  have hrename := MvPowerSeries.aeval_subst (MvPowerSeries.HasSubst.X_comp Sum.swap)
-    (MvPowerSeries.continuous_aeval hpair) hev W.formalAdd
-  have hcomm := congrArg (MvPowerSeries.aeval hpair) (rename_swap_formalAdd W)
-  rw [MvPowerSeries.rename_eq_subst] at hcomm
-  rw [hrename] at hcomm
-  have hswap : (fun s : Unit ⊕ Unit ↦
-      (Sum.elim (fun _ ↦ t₁) fun _ ↦ t₂) s.swap) = Sum.elim (fun _ ↦ t₂) fun _ ↦ t₁ := by
-    funext s
-    rcases s with _ | _ <;> rfl
-  simpa [formalAddEval, MvPowerSeries.coe_aeval, Algebra.algebraMap_self, hfam, hswap]
-    using hcomm.symm
+  have h := congrArg (MvPowerSeries.aeval (hasEval_pair h₁ h₂)) (rename_swap_formalAdd W)
+  rw [MvPowerSeries.aeval_rename Sum.swap (hasEval_pair h₁ h₂) (hasEval_pair h₂ h₁)
+    (by rintro (_ | _) <;> rfl)] at h
+  simpa [formalAddEval, MvPowerSeries.coe_aeval, Algebra.algebraMap_self] using h.symm
 
 /-- **Associativity of the group law at parameters**: `F(F(t₁, t₂), t₃) = F(t₁, F(t₂, t₃))`. -/
 theorem formalAddEval_assoc {t₁ t₂ t₃ : O} (h₁ : PowerSeries.HasEval t₁)

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/PairEval.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/PairEval.lean
@@ -455,7 +455,8 @@ theorem formalAddEval_mem {I : Ideal O} (hI : IsAdic I) {k : ℕ} {t₁ t₂ : O
 theorem formalAddEval_comm {t₁ t₂ : O} (h₁ : PowerSeries.HasEval t₁)
     (h₂ : PowerSeries.HasEval t₂) : W.formalAddEval t₁ t₂ = W.formalAddEval t₂ t₁ := by
   have h := congrArg (MvPowerSeries.aeval (hasEval_pair h₁ h₂)) (rename_swap_formalAdd W)
-  rw [MvPowerSeries.aeval_rename Sum.swap (hasEval_pair h₁ h₂) (hasEval_pair h₂ h₁)
+  rw [MvPowerSeries.aeval_rename Sum.swap
+    (b := Sum.elim (fun _ ↦ t₂) (fun _ ↦ t₁)) (hasEval_pair h₁ h₂)
     (by rintro (_ | _) <;> rfl)] at h
   simpa [formalAddEval, MvPowerSeries.coe_aeval, Algebra.algebraMap_self] using h.symm
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/PairEval.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/PairEval.lean
@@ -58,6 +58,7 @@ variables, so `MvPowerSeries.hasEval_of_finite_of_isTopologicallyNilpotent` appl
 * `WeierstrassCurve.formalAddEval_formalInverseEval` : `F(t, ι(t)) = 0`, the inverse law.
 * `WeierstrassCurve.formalAddEval_zero_right` and
   `WeierstrassCurve.formalAddEval_zero_left` : the unit laws `F(t, 0) = t` and `F(0, t) = t`.
+* `WeierstrassCurve.formalAddEval_comm` : commutativity `F(t₁, t₂) = F(t₂, t₁)`.
 * `WeierstrassCurve.formalAddEval_assoc` : `F(F(t₁, t₂), t₃) = F(t₁, F(t₂, t₃))`, the group
   law's associativity read at parameters.
 * `WeierstrassCurve.hasEval_formalAddEval` : `F(t₁, t₂)` admits evaluation as soon as `t₁` and
@@ -446,6 +447,34 @@ theorem formalAddEval_mem {I : Ideal O} (hI : IsAdic I) {k : ℕ} {t₁ t₂ : O
   have := Ideal.add_mem _ (hle (W.formalAddEval_sub_add_mem hI hk₁ hk₂))
     (Ideal.add_mem _ hk₁ hk₂)
   simpa using this
+
+/-- **Commutativity of the group law at parameters**: `F(t₁, t₂) = F(t₂, t₁)`. -/
+theorem formalAddEval_comm {t₁ t₂ : O} (h₁ : PowerSeries.HasEval t₁)
+    (h₂ : PowerSeries.HasEval t₂) : W.formalAddEval t₁ t₂ = W.formalAddEval t₂ t₁ := by
+  have hpair := hasEval_pair h₁ h₂
+  have hfam : (fun s : Unit ⊕ Unit ↦ MvPowerSeries.aeval hpair
+        ((MvPowerSeries.X ∘ Sum.swap : Unit ⊕ Unit →
+          MvPowerSeries (Unit ⊕ Unit) O) s)) =
+      Sum.elim (fun _ ↦ t₂) fun _ ↦ t₁ := by
+    funext s
+    rcases s with _ | _ <;> simp [MvPowerSeries.coe_aeval]
+  have hev : MvPowerSeries.HasEval fun s : Unit ⊕ Unit ↦ MvPowerSeries.aeval hpair
+      ((MvPowerSeries.X ∘ Sum.swap : Unit ⊕ Unit →
+        MvPowerSeries (Unit ⊕ Unit) O) s) := by
+    rw [hfam]
+    exact hasEval_pair h₂ h₁
+  have hrename := MvPowerSeries.aeval_subst (MvPowerSeries.HasSubst.X_comp Sum.swap)
+    (MvPowerSeries.continuous_aeval hpair) hev W.formalAdd
+  have hcomm := congrArg (MvPowerSeries.aeval hpair) (rename_swap_formalAdd W)
+  rw [MvPowerSeries.rename_eq_subst] at hcomm
+  rw [hrename] at hcomm
+  have hswap : (fun s : Unit ⊕ Unit ↦
+      (Sum.elim (fun _ ↦ t₁) fun _ ↦ t₂) s.swap) = Sum.elim (fun _ ↦ t₂) fun _ ↦ t₁ := by
+    funext s
+    rcases s with _ | _ <;> rfl
+  simpa [formalAddEval, MvPowerSeries.coe_aeval, Algebra.algebraMap_self, hfam, hswap]
+    using hcomm.symm
+
 /-- **Associativity of the group law at parameters**: `F(F(t₁, t₂), t₃) = F(t₁, F(t₂, t₃))`. -/
 theorem formalAddEval_assoc {t₁ t₂ t₃ : O} (h₁ : PowerSeries.HasEval t₁)
     (h₂ : PowerSeries.HasEval t₂) (h₃ : PowerSeries.HasEval t₃) :

--- a/TauCeti/RingTheory/MvPowerSeries/Rename.lean
+++ b/TauCeti/RingTheory/MvPowerSeries/Rename.lean
@@ -13,14 +13,15 @@ import TauCeti.RingTheory.MvPowerSeries.Substitution
 /-!
 # Renaming the variables of a multivariate power series
 
-Two gaps in Mathlib's `rename` API, each about comparing a renaming with another operation on the
-same series, and one consequence of them: that reindexing a two-variable series along
+Three gaps in Mathlib's `rename` API, each about comparing a renaming with another operation on
+the same series, and one consequence of them: that reindexing a two-variable series along
 `unitSumUnitEquivFinTwo` carries an associativity identity with it.
 
-Substituting after renaming is the substitution along the renamed index: Mathlib has both
-operations and the law that lets them be compared — `rename_eq_subst`, which says a renaming *is*
-the substitution sending each variable to a variable — but not the comparison itself, which is
-what a caller reindexing a series needs.
+Substituting after renaming is the substitution along the renamed index, and evaluating after
+renaming is the evaluation at the reindexed family: Mathlib has all these operations and the law
+that lets them be compared — `rename_eq_subst`, which says a renaming *is* the substitution
+sending each variable to a variable — but not the comparisons themselves, which is what a caller
+reindexing a series needs.
 
 Reading the coefficient of a single-variable monomial through a renaming along an embedding is
 likewise available only through `coeff_embDomain_rename`, which speaks about `Finsupp.embDomain`;
@@ -37,14 +38,16 @@ three-variable ambient ring as well, along `unitSumUnitSumUnitEquivFinThree`.
   substituting `g ∘ e` into `p`.
 * `MvPowerSeries.coeff_single_rename`: the coefficient of `rename e p` at the single-variable
   monomial `single (e i) n` is the coefficient of `p` at `single i n`, for any exponent `n`.
+* `MvPowerSeries.aeval_rename`: evaluating `rename e p` at a family reindexes the family, i.e. it
+  is evaluating `p` at that family precomposed with `e`.
 * `MvPowerSeries.rename_unitSumUnitEquivFinTwo_assoc`: reindexing a two-variable associative
   series from `Unit ⊕ Unit` to `Fin 2` preserves its associativity identity.
 
 ## Provenance
 
-No external source. The first two statements are gaps in Mathlib's `MvPowerSeries` API and each
-proof is a few steps of that same API; the third is the reindexing they were extracted for, and
-its proof rewrites both sides of the identity through the three-variable renaming. All three are
+No external source. The first three statements are gaps in Mathlib's `MvPowerSeries` API and each
+proof is a few steps of that same API; the fourth is the reindexing they were extracted for, and
+its proof rewrites both sides of the identity through the three-variable renaming. All four are
 recorded here rather than inside their callers because they carry no elliptic content.
 -/
 
@@ -207,5 +210,39 @@ theorem rename_unitSumUnitEquivFinTwo_assoc (p : MvPowerSeries (Unit ⊕ Unit) R
   exact h
 
 end CommRing
+
+section Eval
+
+open WithPiTopology
+
+variable [CommRing R] [UniformSpace R] [IsUniformAddGroup R] [IsTopologicalSemiring R]
+variable {S : Type*} [CommRing S] [UniformSpace S] [IsUniformAddGroup S] [IsTopologicalRing S]
+  [IsLinearTopology S S] [T2Space S] [CompleteSpace S] [Algebra R S] [ContinuousSMul R S]
+
+/-- **Evaluating a renamed series reindexes the family**: evaluating `rename e p` at `a` is
+evaluating `p` at `a` precomposed with `e`. This is the evaluation counterpart of `subst_rename`,
+and Mathlib has neither.
+
+The reindexed family is a separate argument `b` together with the pointwise equation
+`b s = a (e s)`, rather than the composite `a ∘ e` itself, because `aeval` carries its family in
+the type of its `HasEval` argument: a caller who knows the reindexed family in a simplified form
+cannot rewrite it under `aeval` afterwards, and supplying it here is the only way to state the
+evaluation it actually wants. -/
+theorem aeval_rename (e : σ → τ) [TendstoCofinite e] {a : τ → S} {b : σ → S} (ha : HasEval a)
+    (hb : HasEval b) (hab : ∀ s, b s = a (e s)) (p : MvPowerSeries σ R) :
+    aeval ha (rename e p) = aeval hb p := by
+  have hfam : (fun s ↦ (aeval ha) ((X ∘ e) s : MvPowerSeries τ R)) = b := by
+    funext s
+    rw [coe_aeval, Function.comp_apply, eval₂_X, hab]
+  have hb' : HasEval fun s ↦ (aeval ha) ((X ∘ e) s : MvPowerSeries τ R) := by
+    rw [hfam]; exact hb
+  rw [rename_eq_subst, aeval_subst (HasSubst.X_comp e) (continuous_aeval ha) hb' p]
+  calc (aeval hb') p
+      = eval₂ (algebraMap R S) (fun s ↦ (aeval ha) ((X ∘ e) s : MvPowerSeries τ R)) p :=
+        congrFun (coe_aeval hb') p
+    _ = eval₂ (algebraMap R S) b p := by rw [hfam]
+    _ = aeval hb p := (congrFun (coe_aeval hb) p).symm
+
+end Eval
 
 end MvPowerSeries

--- a/TauCeti/RingTheory/MvPowerSeries/Rename.lean
+++ b/TauCeti/RingTheory/MvPowerSeries/Rename.lean
@@ -229,8 +229,11 @@ the type of its `HasEval` argument: a caller who knows the reindexed family in a
 cannot rewrite it under `aeval` afterwards, and supplying it here is the only way to state the
 evaluation it actually wants. -/
 theorem aeval_rename (e : σ → τ) [TendstoCofinite e] {a : τ → S} {b : σ → S} (ha : HasEval a)
-    (hb : HasEval b) (hab : ∀ s, b s = a (e s)) (p : MvPowerSeries σ R) :
-    aeval ha (rename e p) = aeval hb p := by
+    (hab : ∀ s, b s = a (e s)) (p : MvPowerSeries σ R) :
+    aeval ha (rename e p) = eval₂ (algebraMap R S) b p := by
+  have hb : HasEval b := by
+    rw [show b = a ∘ e from funext hab]
+    exact ⟨fun s ↦ ha.hpow (e s), ha.tendsto_zero.comp (TendstoCofinite.tendsto_cofinite e)⟩
   have hfam : (fun s ↦ (aeval ha) ((X ∘ e) s : MvPowerSeries τ R)) = b := by
     funext s
     rw [coe_aeval, Function.comp_apply, eval₂_X, hab]
@@ -241,7 +244,6 @@ theorem aeval_rename (e : σ → τ) [TendstoCofinite e] {a : τ → S} {b : σ 
       = eval₂ (algebraMap R S) (fun s ↦ (aeval ha) ((X ∘ e) s : MvPowerSeries τ R)) p :=
         congrFun (coe_aeval hb') p
     _ = eval₂ (algebraMap R S) b p := by rw [hfam]
-    _ = aeval hb p := (congrFun (coe_aeval hb) p).symm
 
 end Eval
 


### PR DESCRIPTION
This PR packages the parameters in an adic ideal as `WeierstrassCurve.FormalGroupPoint W I` and equips them with the evaluated Weierstrass formal group law: addition is `W.formalAddEval`, negation is `W.formalInverseEval`, and the resulting type is an additive commutative group. It also proves the missing parameter-level commutativity theorem `formalAddEval_comm` by evaluating the existing symmetry `rename_swap_formalAdd`.

The exact roadmap target is `TauCetiRoadmap/EllipticCurves/README.md`, Layer 1, formal-group milestone (iii): “Convergence: over a complete valued field, `Ê(𝔪)` as an honest group of points.” The existing evaluation, closure, associativity, unit, and inverse laws supply every other group axiom; this PR turns those separate results into the group object that the milestone asks for. After this PR, milestone (iii) still needs the full additivity of `WeierstrassCurve.formalPoint` in the doubling and inverse cases, after which the parameter group maps homomorphically into the curve; milestone (iv) then identifies its maximal-ideal instance with `E₁(K)`.

The wrapper is deliberately distinct from the ideal subtype, whose inherited addition is ordinary ring addition rather than the formal law. `Fact (IsAdic I)` supplies exactly the convergence and closure hypothesis, and no ellipticity or field hypothesis is imposed because the Weierstrass formal group law exists over every commutative coefficient ring in this setting.

The packaging follows Michael Stoll's Apache-2.0 elliptic-curve development, `github.com/MichaelStollBayreuth/EllipticCurves` at `66889eada51a`, file `EllipticCurves/Mathlib/Chabauty/FormalGroupLaw/Points.lean`, definition `ChabautyColeman.FormalGroupLaw.Points` and its `AddCommMonoid` instance. That source treats a multivariable law on a local ring's maximal ideal and does not construct inverses; this version uses Tau Ceti's one-dimensional evaluated Weierstrass law on an arbitrary adic ideal and its existing formal inverse to obtain an `AddCommGroup`.

No Mathlib code is vendored. The proof reuses Mathlib's `MvPowerSeries.aeval`, Tau Ceti's `MvPowerSeries.aeval_subst`, and Mathlib's `AddGroup.ofLeftAxioms`; the new module is 151 lines and the commutativity transport adds 29 lines to `FormalGroup/PairEval.lean`.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"adic-formal-group-points"}-->

🤖 Prepared with Codex
