### PR TITLE
feat: add multinomial coordinate marginals

### DIFF
--- a/TauCeti/Algebra/Order/Antidiag/Pi.lean
+++ b/TauCeti/Algebra/Order/Antidiag/Pi.lean
@@ -1,0 +1,34 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Order.Antidiag.Pi
+
+/-!
+# Vanishing off the index set of a function antidiagonal
+
+`Finset.piAntidiag s n` is the finset of functions with support contained in `s` whose values sum
+to `n` over `s`.  Such a function therefore vanishes at every point outside `s`.
+
+## Main results
+
+* `Finset.eq_zero_of_notMem_of_mem_piAntidiag`: a member of `Finset.piAntidiag s n` vanishes off
+  `s`.
+-/
+
+public section
+
+namespace Finset
+
+variable {ι μ : Type*} [DecidableEq ι] [AddCommMonoid μ] [HasAntidiagonal μ] [DecidableEq μ]
+  {s : Finset ι} {n : μ} {f : ι → μ} {i : ι}
+
+/-- A function in `Finset.piAntidiag s n` has support contained in `s`, so it takes the value `0`
+at every point outside `s`. -/
+theorem eq_zero_of_notMem_of_mem_piAntidiag (hi : i ∉ s) (hf : f ∈ piAntidiag s n) : f i = 0 :=
+  not_not.1 fun h ↦ hi ((mem_piAntidiag.1 hf).2 i h)
+
+end Finset

--- a/TauCeti/Probability/Distributions/Multinomial/Basic.lean
+++ b/TauCeti/Probability/Distributions/Multinomial/Basic.lean
@@ -72,7 +72,7 @@ def multinomialWeight (w : ι → NNReal) (k : ι → ℕ) : ℝ≥0∞ :=
 
 /-- The extended nonnegative multinomial weight in terms of the multinomial coefficient and cell
 weights. -/
-theorem multinomialWeight_eq (w : ι → NNReal) (k : ι → ℕ) :
+theorem multinomialWeight_def (w : ι → NNReal) (k : ι → ℕ) :
     multinomialWeight w k =
       (Nat.multinomial Finset.univ k : ℝ≥0∞) * ∏ i, (w i : ℝ≥0∞) ^ k i := (rfl)
 
@@ -91,7 +91,7 @@ def multinomialMeasure (n : ℕ) (p : StdSimplex NNReal ι) : Measure (ι → �
 
 open Classical in
 /-- The multinomial measure as its defining finite weighted sum of Dirac measures. -/
-theorem multinomialMeasure_eq_sum_dirac (n : ℕ) (p : StdSimplex NNReal ι) :
+theorem multinomialMeasure_def (n : ℕ) (p : StdSimplex NNReal ι) :
     multinomialMeasure n p =
       ∑ k ∈ Finset.piAntidiag Finset.univ n,
         multinomialWeight p.weights k • Measure.dirac k := (rfl)

--- a/TauCeti/Probability/Distributions/Multinomial/Basic.lean
+++ b/TauCeti/Probability/Distributions/Multinomial/Basic.lean
@@ -70,6 +70,12 @@ theorem multinomialWeightReal_nonneg (w : ι → NNReal) (k : ι → ℕ) :
 def multinomialWeight (w : ι → NNReal) (k : ι → ℕ) : ℝ≥0∞ :=
   (Nat.multinomial Finset.univ k : ℝ≥0∞) * ∏ i, (w i : ℝ≥0∞) ^ k i
 
+/-- The extended nonnegative multinomial weight in terms of the multinomial coefficient and cell
+weights. -/
+theorem multinomialWeight_eq (w : ι → NNReal) (k : ι → ℕ) :
+    multinomialWeight w k =
+      (Nat.multinomial Finset.univ k : ℝ≥0∞) * ∏ i, (w i : ℝ≥0∞) ^ k i := (rfl)
+
 /-- The extended nonnegative multinomial weight has the expected real value. -/
 @[simp]
 theorem multinomialWeight_toReal (w : ι → NNReal) (k : ι → ℕ) :
@@ -82,6 +88,13 @@ open Classical in
 The finite antidiagonal consists precisely of the count vectors whose coordinates sum to `n`. -/
 def multinomialMeasure (n : ℕ) (p : StdSimplex NNReal ι) : Measure (ι → ℕ) :=
   ∑ k ∈ Finset.piAntidiag Finset.univ n, multinomialWeight p.weights k • Measure.dirac k
+
+open Classical in
+/-- The multinomial measure as its defining finite weighted sum of Dirac measures. -/
+theorem multinomialMeasure_eq_sum_dirac (n : ℕ) (p : StdSimplex NNReal ι) :
+    multinomialMeasure n p =
+      ∑ k ∈ Finset.piAntidiag Finset.univ n,
+        multinomialWeight p.weights k • Measure.dirac k := (rfl)
 
 open Classical in
 /-- The real multinomial weights on a fixed antidiagonal satisfy the multinomial theorem. -/

--- a/TauCeti/Probability/Distributions/Multinomial/Marginal.lean
+++ b/TauCeti/Probability/Distributions/Multinomial/Marginal.lean
@@ -15,14 +15,11 @@ Each coordinate of a multinomial count vector has the binomial distribution with
 probability equal to the corresponding cell probability.  This file proves that statement at the
 level of measures.
 
-The proof separates the chosen coordinate from the remaining count antidiagonal.  Mathlib's
-`Nat.multinomial_cons` factors each coefficient, and `Finset.sum_pow_eq_sum_piAntidiag` sums the
-remaining cell weights.
-
 ## Main definitions and results
 
-* `TauCeti.Probability.multinomialCellProbability`: a cell weight as a unit-interval parameter.
-* `TauCeti.Probability.map_apply_multinomialMeasure`: a coordinate marginal is binomial.
+* `TauCeti.Convexity.StdSimplex.multinomialCellProbability`: a cell weight as a unit-interval
+  parameter.
+* `TauCeti.Probability.map_eval_multinomialMeasure`: a coordinate marginal is binomial.
 
 ## References
 
@@ -37,9 +34,7 @@ noncomputable section
 open Convexity MeasureTheory ProbabilityTheory
 open scoped ENNReal ProbabilityTheory
 
-namespace TauCeti
-
-namespace Probability
+namespace TauCeti.Convexity.StdSimplex
 
 variable {ι : Type*} [Fintype ι]
 
@@ -52,6 +47,12 @@ omit [Fintype ι] in
 @[simp]
 theorem coe_multinomialCellProbability (p : StdSimplex NNReal ι) (i : ι) :
     (multinomialCellProbability p i : ℝ) = p.weights i := (rfl)
+
+end TauCeti.Convexity.StdSimplex
+
+namespace TauCeti.Probability
+
+variable {ι : Type*} [Fintype ι]
 
 open Classical in
 private lemma multinomialWeight_add_apply (w : ι → NNReal) (i : ι) (m q : ℕ)
@@ -170,9 +171,9 @@ private lemma sum_multinomialWeight_eq_apply (w : ι → NNReal) (n m : ℕ) (i 
 
 /-- The count in a fixed cell of a multinomial random vector is binomial, with success probability
 equal to that cell's weight. -/
-theorem map_apply_multinomialMeasure (n : ℕ) (p : StdSimplex NNReal ι) (i : ι) :
+theorem map_eval_multinomialMeasure (n : ℕ) (p : StdSimplex NNReal ι) (i : ι) :
     (multinomialMeasure n p).map (fun k ↦ k i) =
-      Bin(n, multinomialCellProbability p i) := by
+      Bin(n, TauCeti.Convexity.StdSimplex.multinomialCellProbability p i) := by
   classical
   apply Measure.ext_of_singleton
   intro m
@@ -205,9 +206,7 @@ theorem map_apply_multinomialMeasure (n : ℕ) (p : StdSimplex NNReal ι) (i : �
     sub_nonneg.mpr (by exact_mod_cast p.weights_apply_le_one i)
   rw [ENNReal.toReal_ofReal]
   · simp
-  · rw [coe_multinomialCellProbability]
+  · rw [TauCeti.Convexity.StdSimplex.coe_multinomialCellProbability]
     exact mul_nonneg (mul_nonneg (by positivity) (by positivity)) (pow_nonneg hcomp _)
 
-end Probability
-
-end TauCeti
+end TauCeti.Probability

--- a/TauCeti/Probability/Distributions/Multinomial/Marginal.lean
+++ b/TauCeti/Probability/Distributions/Multinomial/Marginal.lean
@@ -17,8 +17,7 @@ level of measures.
 
 ## Main definitions and results
 
-* `TauCeti.Convexity.StdSimplex.multinomialCellProbability`: a cell weight as a unit-interval
-  parameter.
+* `TauCeti.Probability.multinomialCellProbability`: a cell weight as a unit-interval parameter.
 * `TauCeti.Probability.map_eval_multinomialMeasure`: a coordinate marginal is binomial.
 
 ## References
@@ -34,25 +33,20 @@ noncomputable section
 open Convexity MeasureTheory ProbabilityTheory
 open scoped ENNReal ProbabilityTheory
 
-namespace TauCeti.Convexity.StdSimplex
+namespace TauCeti.Probability
 
-variable {ι : Type*} [Fintype ι]
+variable {ι : Type*}
 
 /-- The probability of one cell of a multinomial parameter, regarded as a binomial parameter. -/
 def multinomialCellProbability (p : StdSimplex NNReal ι) (i : ι) : unitInterval :=
   ⟨(p.weights i : ℝ), by positivity, by exact_mod_cast p.weights_apply_le_one i⟩
 
-omit [Fintype ι] in
 /-- A multinomial cell probability has the value of the corresponding simplex weight. -/
 @[simp]
 theorem coe_multinomialCellProbability (p : StdSimplex NNReal ι) (i : ι) :
     (multinomialCellProbability p i : ℝ) = p.weights i := (rfl)
 
-end TauCeti.Convexity.StdSimplex
-
-namespace TauCeti.Probability
-
-variable {ι : Type*} [Fintype ι]
+variable [Fintype ι]
 
 open Classical in
 private lemma multinomialWeight_add_apply (w : ι → NNReal) (i : ι) (m q : ℕ)
@@ -173,7 +167,7 @@ private lemma sum_multinomialWeight_eq_apply (w : ι → NNReal) (n m : ℕ) (i 
 equal to that cell's weight. -/
 theorem map_eval_multinomialMeasure (n : ℕ) (p : StdSimplex NNReal ι) (i : ι) :
     (multinomialMeasure n p).map (fun k ↦ k i) =
-      Bin(n, TauCeti.Convexity.StdSimplex.multinomialCellProbability p i) := by
+      Bin(n, multinomialCellProbability p i) := by
   classical
   apply Measure.ext_of_singleton
   intro m
@@ -206,7 +200,7 @@ theorem map_eval_multinomialMeasure (n : ℕ) (p : StdSimplex NNReal ι) (i : ι
     sub_nonneg.mpr (by exact_mod_cast p.weights_apply_le_one i)
   rw [ENNReal.toReal_ofReal]
   · simp
-  · rw [TauCeti.Convexity.StdSimplex.coe_multinomialCellProbability]
+  · rw [coe_multinomialCellProbability]
     exact mul_nonneg (mul_nonneg (by positivity) (by positivity)) (pow_nonneg hcomp _)
 
 end TauCeti.Probability

--- a/TauCeti/Probability/Distributions/Multinomial/Marginal.lean
+++ b/TauCeti/Probability/Distributions/Multinomial/Marginal.lean
@@ -1,0 +1,213 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Probability.Distributions.Binomial
+public import TauCeti.Probability.Distributions.Multinomial.Basic
+
+/-!
+# Coordinate marginals of the multinomial distribution
+
+Each coordinate of a multinomial count vector has the binomial distribution with success
+probability equal to the corresponding cell probability.  This file proves that statement at the
+level of measures.
+
+The proof separates the chosen coordinate from the remaining count antidiagonal.  Mathlib's
+`Nat.multinomial_cons` factors each coefficient, and `Finset.sum_pow_eq_sum_piAntidiag` sums the
+remaining cell weights.
+
+## Main definitions and results
+
+* `TauCeti.Probability.multinomialCellProbability`: a cell weight as a unit-interval parameter.
+* `TauCeti.Probability.map_apply_multinomialMeasure`: a coordinate marginal is binomial.
+
+## References
+
+* N. L. Johnson, S. Kotz, N. Balakrishnan, *Discrete Multivariate Distributions*, Wiley,
+  1997, Chapter 35.
+-/
+
+public section
+
+noncomputable section
+
+open Convexity MeasureTheory ProbabilityTheory
+open scoped ENNReal ProbabilityTheory
+
+namespace TauCeti
+
+namespace Probability
+
+variable {ι : Type*} [Fintype ι]
+
+/-- The probability of one cell of a multinomial parameter, regarded as a binomial parameter. -/
+def multinomialCellProbability (p : StdSimplex NNReal ι) (i : ι) : unitInterval :=
+  ⟨(p.weights i : ℝ), by positivity, by exact_mod_cast p.weights_apply_le_one i⟩
+
+omit [Fintype ι] in
+/-- A multinomial cell probability has the value of the corresponding simplex weight. -/
+@[simp]
+theorem coe_multinomialCellProbability (p : StdSimplex NNReal ι) (i : ι) :
+    (multinomialCellProbability p i : ℝ) = p.weights i := (rfl)
+
+open Classical in
+private lemma multinomialWeight_add_apply (w : ι → NNReal) (i : ι) (m q : ℕ)
+    (g : ι → ℕ) (hg : g ∈ Finset.piAntidiag (Finset.univ.erase i) q) :
+    multinomialWeight w ((addRightEmbedding fun j ↦ if j = i then m else 0) g) =
+      ((m + q).choose m : ℝ≥0∞) * (w i : ℝ≥0∞) ^ m *
+        ((Nat.multinomial (Finset.univ.erase i) g : ℝ≥0∞) *
+          ∏ j ∈ Finset.univ.erase i, (w j : ℝ≥0∞) ^ g j) := by
+  have hi : i ∉ Finset.univ.erase i := Finset.notMem_erase i Finset.univ
+  have hgi : g i = 0 := by
+    by_contra h
+    exact hi ((Finset.mem_piAntidiag.mp hg).2 i h)
+  have hsum : ∑ j ∈ Finset.univ.erase i, g j = q :=
+    (Finset.mem_piAntidiag.mp hg).1
+  have huniv : (Finset.univ.erase i).cons i hi = Finset.univ := by ext; simp
+  rw [multinomialWeight_eq, ← huniv, Nat.multinomial_cons, Finset.prod_cons]
+  simp only [addRightEmbedding_apply, Pi.add_apply, hgi, zero_add]
+  have hsum_add : ∑ j ∈ Finset.univ.erase i, (g j + if j = i then m else 0) = q := by
+    calc
+      _ = ∑ j ∈ Finset.univ.erase i, g j := by
+        apply Finset.sum_congr rfl
+        intro j hj
+        simp [(Finset.mem_erase.mp hj).1]
+      _ = q := hsum
+  have hmultinomial :
+      Nat.multinomial (Finset.univ.erase i) (g + fun j ↦ if j = i then m else 0) =
+        Nat.multinomial (Finset.univ.erase i) g := by
+    apply Nat.multinomial_congr
+    intro j hj
+    simp [(Finset.mem_erase.mp hj).1]
+  have hprod :
+      (∏ j ∈ Finset.univ.erase i, (w j : ℝ≥0∞) ^ (g j + if j = i then m else 0)) =
+        ∏ j ∈ Finset.univ.erase i, (w j : ℝ≥0∞) ^ g j := by
+    apply Finset.prod_congr rfl
+    intro j hj
+    simp [(Finset.mem_erase.mp hj).1]
+  have herase : ((Finset.univ.erase i).cons i hi).erase i = Finset.univ.erase i := by
+    ext
+    simp
+  rw [hsum_add, hmultinomial, hprod, herase]
+  push_cast
+  ring
+
+open Classical in
+private lemma sum_multinomialWeight_eq_apply (w : ι → NNReal) (n m : ℕ) (i : ι) :
+    (∑ k ∈ Finset.piAntidiag Finset.univ n,
+        if k i = m then multinomialWeight w k else 0) =
+      (n.choose m : ℝ≥0∞) * (w i : ℝ≥0∞) ^ m *
+        (∑ j ∈ Finset.univ.erase i, (w j : ℝ≥0∞)) ^ (n - m) := by
+  have huniv : (Finset.univ.erase i).cons i (Finset.notMem_erase i Finset.univ) =
+      Finset.univ := by ext; simp
+  conv_lhs =>
+    rw [← huniv, Finset.piAntidiag_cons, Finset.sum_disjiUnion]
+  simp only [Finset.sum_map]
+  by_cases hmn : m ≤ n
+  · rw [Finset.sum_eq_single (m, n - m)]
+    · calc
+        (∑ g ∈ Finset.piAntidiag (Finset.univ.erase i) (n - m),
+            if (addRightEmbedding fun j ↦ if j = i then m else 0) g i = m then
+              multinomialWeight w ((addRightEmbedding fun j ↦ if j = i then m else 0) g)
+            else 0) =
+            ∑ g ∈ Finset.piAntidiag (Finset.univ.erase i) (n - m),
+              multinomialWeight w
+                ((addRightEmbedding fun j ↦ if j = i then m else 0) g) := by
+          apply Finset.sum_congr rfl
+          intro g hg
+          have hgi : g i = 0 := by
+            by_contra h
+            exact Finset.notMem_erase i Finset.univ
+              ((Finset.mem_piAntidiag.mp hg).2 i h)
+          simp [addRightEmbedding_apply, hgi]
+        _ = (n.choose m : ℝ≥0∞) * (w i : ℝ≥0∞) ^ m *
+            ∑ g ∈ Finset.piAntidiag (Finset.univ.erase i) (n - m),
+              (Nat.multinomial (Finset.univ.erase i) g : ℝ≥0∞) *
+                ∏ j ∈ Finset.univ.erase i, (w j : ℝ≥0∞) ^ g j := by
+          rw [Finset.mul_sum]
+          apply Finset.sum_congr rfl
+          intro g hg
+          rw [multinomialWeight_add_apply w i m (n - m) g hg,
+            Nat.add_sub_of_le hmn]
+        _ = _ := by
+          rw [← Finset.sum_pow_eq_sum_piAntidiag]
+    · rintro ⟨a, b⟩ hab hpne
+      have ha : a ≠ m := by
+        intro ham
+        apply hpne
+        ext
+        · exact ham
+        · have hab' := Finset.mem_antidiagonal.mp hab
+          omega
+      apply Finset.sum_eq_zero
+      intro g hg
+      have hgi : g i = 0 := by
+        by_contra h
+        exact Finset.notMem_erase i Finset.univ
+          ((Finset.mem_piAntidiag.mp hg).2 i h)
+      simp [addRightEmbedding_apply, hgi, ha]
+    · intro hnot
+      exact (hnot (by simp [Finset.mem_antidiagonal, Nat.add_sub_of_le hmn])).elim
+  · have hnm : n < m := Nat.lt_of_not_ge hmn
+    rw [Finset.sum_eq_zero]
+    · simp [Nat.choose_eq_zero_of_lt hnm]
+    · rintro ⟨a, b⟩ hab
+      apply Finset.sum_eq_zero
+      intro g hg
+      have ha : a ≠ m := by
+        have han : a ≤ n := by
+          have := Finset.mem_antidiagonal.mp hab
+          omega
+        omega
+      have hgi : g i = 0 := by
+        by_contra h
+        exact Finset.notMem_erase i Finset.univ
+          ((Finset.mem_piAntidiag.mp hg).2 i h)
+      simp [addRightEmbedding_apply, hgi, ha]
+
+/-- The count in a fixed cell of a multinomial random vector is binomial, with success probability
+equal to that cell's weight. -/
+theorem map_apply_multinomialMeasure (n : ℕ) (p : StdSimplex NNReal ι) (i : ι) :
+    (multinomialMeasure n p).map (fun k ↦ k i) =
+      Bin(n, multinomialCellProbability p i) := by
+  classical
+  apply Measure.ext_of_singleton
+  intro m
+  rw [Measure.map_apply (by fun_prop) (MeasurableSet.singleton m),
+    multinomialMeasure_eq_sum_dirac, Measure.finsetSum_apply, binomial_singleton]
+  simp only [Measure.smul_apply, Measure.dirac_apply, Set.indicator, Pi.one_apply,
+    Set.mem_preimage, Set.mem_singleton_iff, smul_eq_mul, mul_ite, mul_one, mul_zero]
+  rw [sum_multinomialWeight_eq_apply]
+  have hsum : p.weights i + ∑ j ∈ Finset.univ.erase i, p.weights j = 1 := by
+    rw [← Finset.sum_insert (Finset.notMem_erase i Finset.univ),
+      Finset.insert_erase (Finset.mem_univ i)]
+    exact p.total_of_fintype
+  have hrestNNReal : ∑ j ∈ Finset.univ.erase i, p.weights j = 1 - p.weights i := by
+    apply eq_tsub_of_add_eq
+    simpa [add_comm] using hsum
+  have hrest : ∑ j ∈ Finset.univ.erase i, (p.weights j : ℝ≥0∞) =
+      ENNReal.ofReal (1 - (p.weights i : ℝ)) := by
+    rw [← ENNReal.toReal_eq_toReal_iff'
+        (ENNReal.sum_ne_top.2 fun _ _ ↦ ENNReal.coe_ne_top) (by finiteness),
+      ENNReal.toReal_sum (by simp), ENNReal.toReal_ofReal]
+    · calc
+        (∑ j ∈ Finset.univ.erase i, ((p.weights j : ℝ≥0∞).toReal)) =
+            ((∑ j ∈ Finset.univ.erase i, p.weights j : NNReal) : ℝ) := by simp
+        _ = ((1 - p.weights i : NNReal) : ℝ) := by rw [hrestNNReal]
+        _ = 1 - (p.weights i : ℝ) :=
+          NNReal.coe_sub (p.weights_apply_le_one i)
+    · exact sub_nonneg.mpr (by exact_mod_cast p.weights_apply_le_one i)
+  rw [hrest, ← ENNReal.toReal_eq_toReal_iff' (by finiteness) (by finiteness)]
+  have hcomp : 0 ≤ 1 - (p.weights i : ℝ) :=
+    sub_nonneg.mpr (by exact_mod_cast p.weights_apply_le_one i)
+  rw [ENNReal.toReal_ofReal]
+  · simp
+  · rw [coe_multinomialCellProbability]
+    exact mul_nonneg (mul_nonneg (by positivity) (by positivity)) (pow_nonneg hcomp _)
+
+end Probability
+
+end TauCeti

--- a/TauCeti/Probability/Distributions/Multinomial/Marginal.lean
+++ b/TauCeti/Probability/Distributions/Multinomial/Marginal.lean
@@ -49,6 +49,12 @@ theorem coe_multinomialCellProbability (p : StdSimplex NNReal ι) (i : ι) :
 variable [Fintype ι]
 
 open Classical in
+private lemma eq_zero_of_mem_piAntidiag_erase (i : ι) {q : ℕ} {g : ι → ℕ}
+    (hg : g ∈ Finset.piAntidiag (Finset.univ.erase i) q) : g i = 0 := by
+  by_contra h
+  exact Finset.notMem_erase i Finset.univ ((Finset.mem_piAntidiag.mp hg).2 i h)
+
+open Classical in
 private lemma multinomialWeight_add_apply (w : ι → NNReal) (i : ι) (m q : ℕ)
     (g : ι → ℕ) (hg : g ∈ Finset.piAntidiag (Finset.univ.erase i) q) :
     multinomialWeight w ((addRightEmbedding fun j ↦ if j = i then m else 0) g) =
@@ -56,13 +62,11 @@ private lemma multinomialWeight_add_apply (w : ι → NNReal) (i : ι) (m q : �
         ((Nat.multinomial (Finset.univ.erase i) g : ℝ≥0∞) *
           ∏ j ∈ Finset.univ.erase i, (w j : ℝ≥0∞) ^ g j) := by
   have hi : i ∉ Finset.univ.erase i := Finset.notMem_erase i Finset.univ
-  have hgi : g i = 0 := by
-    by_contra h
-    exact hi ((Finset.mem_piAntidiag.mp hg).2 i h)
+  have hgi := eq_zero_of_mem_piAntidiag_erase i hg
   have hsum : ∑ j ∈ Finset.univ.erase i, g j = q :=
     (Finset.mem_piAntidiag.mp hg).1
   have huniv : (Finset.univ.erase i).cons i hi = Finset.univ := by ext; simp
-  rw [multinomialWeight_eq, ← huniv, Nat.multinomial_cons, Finset.prod_cons]
+  rw [multinomialWeight_def, ← huniv, Nat.multinomial_cons, Finset.prod_cons]
   simp only [addRightEmbedding_apply, Pi.add_apply, hgi, zero_add]
   have hsum_add : ∑ j ∈ Finset.univ.erase i, (g j + if j = i then m else 0) = q := by
     calc
@@ -113,10 +117,7 @@ private lemma sum_multinomialWeight_eq_apply (w : ι → NNReal) (n m : ℕ) (i 
                 ((addRightEmbedding fun j ↦ if j = i then m else 0) g) := by
           apply Finset.sum_congr rfl
           intro g hg
-          have hgi : g i = 0 := by
-            by_contra h
-            exact Finset.notMem_erase i Finset.univ
-              ((Finset.mem_piAntidiag.mp hg).2 i h)
+          have hgi := eq_zero_of_mem_piAntidiag_erase i hg
           simp [addRightEmbedding_apply, hgi]
         _ = (n.choose m : ℝ≥0∞) * (w i : ℝ≥0∞) ^ m *
             ∑ g ∈ Finset.piAntidiag (Finset.univ.erase i) (n - m),
@@ -139,10 +140,7 @@ private lemma sum_multinomialWeight_eq_apply (w : ι → NNReal) (n m : ℕ) (i 
           omega
       apply Finset.sum_eq_zero
       intro g hg
-      have hgi : g i = 0 := by
-        by_contra h
-        exact Finset.notMem_erase i Finset.univ
-          ((Finset.mem_piAntidiag.mp hg).2 i h)
+      have hgi := eq_zero_of_mem_piAntidiag_erase i hg
       simp [addRightEmbedding_apply, hgi, ha]
     · intro hnot
       exact (hnot (by simp [Finset.mem_antidiagonal, Nat.add_sub_of_le hmn])).elim
@@ -157,10 +155,7 @@ private lemma sum_multinomialWeight_eq_apply (w : ι → NNReal) (n m : ℕ) (i 
           have := Finset.mem_antidiagonal.mp hab
           omega
         omega
-      have hgi : g i = 0 := by
-        by_contra h
-        exact Finset.notMem_erase i Finset.univ
-          ((Finset.mem_piAntidiag.mp hg).2 i h)
+      have hgi := eq_zero_of_mem_piAntidiag_erase i hg
       simp [addRightEmbedding_apply, hgi, ha]
 
 /-- The count in a fixed cell of a multinomial random vector is binomial, with success probability
@@ -172,7 +167,7 @@ theorem map_eval_multinomialMeasure (n : ℕ) (p : StdSimplex NNReal ι) (i : ι
   apply Measure.ext_of_singleton
   intro m
   rw [Measure.map_apply (by fun_prop) (MeasurableSet.singleton m),
-    multinomialMeasure_eq_sum_dirac, Measure.finsetSum_apply, binomial_singleton]
+    multinomialMeasure_def, Measure.finsetSum_apply, binomial_singleton]
   simp only [Measure.smul_apply, Measure.dirac_apply, Set.indicator, Pi.one_apply,
     Set.mem_preimage, Set.mem_singleton_iff, smul_eq_mul, mul_ite, mul_one, mul_zero]
   rw [sum_multinomialWeight_eq_apply]

--- a/TauCeti/Probability/Distributions/Multinomial/Marginal.lean
+++ b/TauCeti/Probability/Distributions/Multinomial/Marginal.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Probability.Distributions.Binomial
 public import TauCeti.Probability.Distributions.Multinomial.Basic
+import TauCeti.Algebra.Order.Antidiag.Pi
 
 /-!
 # Coordinate marginals of the multinomial distribution
@@ -53,12 +54,6 @@ namespace TauCeti.Probability
 variable {ι : Type*} [Fintype ι]
 
 open Classical in
-private lemma eq_zero_of_mem_piAntidiag_erase (i : ι) {q : ℕ} {g : ι → ℕ}
-    (hg : g ∈ Finset.piAntidiag (Finset.univ.erase i) q) : g i = 0 := by
-  by_contra h
-  exact Finset.notMem_erase i Finset.univ ((Finset.mem_piAntidiag.mp hg).2 i h)
-
-open Classical in
 private lemma multinomialWeight_add_apply (w : ι → NNReal) (i : ι) (m q : ℕ)
     (g : ι → ℕ) (hg : g ∈ Finset.piAntidiag (Finset.univ.erase i) q) :
     multinomialWeight w ((addRightEmbedding fun j ↦ if j = i then m else 0) g) =
@@ -66,7 +61,7 @@ private lemma multinomialWeight_add_apply (w : ι → NNReal) (i : ι) (m q : �
         ((Nat.multinomial (Finset.univ.erase i) g : ℝ≥0∞) *
           ∏ j ∈ Finset.univ.erase i, (w j : ℝ≥0∞) ^ g j) := by
   have hi : i ∉ Finset.univ.erase i := Finset.notMem_erase i Finset.univ
-  have hgi := eq_zero_of_mem_piAntidiag_erase i hg
+  have hgi := Finset.eq_zero_of_notMem_of_mem_piAntidiag hi hg
   have hsum : ∑ j ∈ Finset.univ.erase i, g j = q :=
     (Finset.mem_piAntidiag.mp hg).1
   have huniv : (Finset.univ.erase i).cons i hi = Finset.univ := by ext; simp
@@ -104,8 +99,8 @@ private lemma sum_multinomialWeight_eq_apply (w : ι → NNReal) (n m : ℕ) (i 
         if k i = m then multinomialWeight w k else 0) =
       (n.choose m : ℝ≥0∞) * (w i : ℝ≥0∞) ^ m *
         (∑ j ∈ Finset.univ.erase i, (w j : ℝ≥0∞)) ^ (n - m) := by
-  have huniv : (Finset.univ.erase i).cons i (Finset.notMem_erase i Finset.univ) =
-      Finset.univ := by ext; simp
+  have hi : i ∉ Finset.univ.erase i := Finset.notMem_erase i Finset.univ
+  have huniv : (Finset.univ.erase i).cons i hi = Finset.univ := by ext; simp
   conv_lhs =>
     rw [← huniv, Finset.piAntidiag_cons, Finset.sum_disjiUnion]
   simp only [Finset.sum_map]
@@ -121,7 +116,7 @@ private lemma sum_multinomialWeight_eq_apply (w : ι → NNReal) (n m : ℕ) (i 
                 ((addRightEmbedding fun j ↦ if j = i then m else 0) g) := by
           apply Finset.sum_congr rfl
           intro g hg
-          have hgi := eq_zero_of_mem_piAntidiag_erase i hg
+          have hgi := Finset.eq_zero_of_notMem_of_mem_piAntidiag hi hg
           simp [addRightEmbedding_apply, hgi]
         _ = (n.choose m : ℝ≥0∞) * (w i : ℝ≥0∞) ^ m *
             ∑ g ∈ Finset.piAntidiag (Finset.univ.erase i) (n - m),
@@ -144,7 +139,7 @@ private lemma sum_multinomialWeight_eq_apply (w : ι → NNReal) (n m : ℕ) (i 
           omega
       apply Finset.sum_eq_zero
       intro g hg
-      have hgi := eq_zero_of_mem_piAntidiag_erase i hg
+      have hgi := Finset.eq_zero_of_notMem_of_mem_piAntidiag hi hg
       simp [addRightEmbedding_apply, hgi, ha]
     · intro hnot
       exact (hnot (by simp [Finset.mem_antidiagonal, Nat.add_sub_of_le hmn])).elim
@@ -159,7 +154,7 @@ private lemma sum_multinomialWeight_eq_apply (w : ι → NNReal) (n m : ℕ) (i 
           have := Finset.mem_antidiagonal.mp hab
           omega
         omega
-      have hgi := eq_zero_of_mem_piAntidiag_erase i hg
+      have hgi := Finset.eq_zero_of_notMem_of_mem_piAntidiag hi hg
       simp [addRightEmbedding_apply, hgi, ha]
 
 /-- The count in a fixed cell of a multinomial random vector is binomial, with success probability

--- a/TauCeti/Probability/Distributions/Multinomial/Marginal.lean
+++ b/TauCeti/Probability/Distributions/Multinomial/Marginal.lean
@@ -17,7 +17,7 @@ level of measures.
 
 ## Main definitions and results
 
-* `TauCeti.Probability.multinomialCellProbability`: a cell weight as a unit-interval parameter.
+* `Convexity.StdSimplex.multinomialCellProbability`: a cell weight as a unit-interval parameter.
 * `TauCeti.Probability.map_eval_multinomialMeasure`: a coordinate marginal is binomial.
 
 ## References
@@ -33,7 +33,7 @@ noncomputable section
 open Convexity MeasureTheory ProbabilityTheory
 open scoped ENNReal ProbabilityTheory
 
-namespace TauCeti.Probability
+namespace Convexity.StdSimplex
 
 variable {ι : Type*}
 
@@ -44,9 +44,13 @@ def multinomialCellProbability (p : StdSimplex NNReal ι) (i : ι) : unitInterva
 /-- A multinomial cell probability has the value of the corresponding simplex weight. -/
 @[simp]
 theorem coe_multinomialCellProbability (p : StdSimplex NNReal ι) (i : ι) :
-    (multinomialCellProbability p i : ℝ) = p.weights i := (rfl)
+    (p.multinomialCellProbability i : ℝ) = p.weights i := (rfl)
 
-variable [Fintype ι]
+end Convexity.StdSimplex
+
+namespace TauCeti.Probability
+
+variable {ι : Type*} [Fintype ι]
 
 open Classical in
 private lemma eq_zero_of_mem_piAntidiag_erase (i : ι) {q : ℕ} {g : ι → ℕ}
@@ -162,7 +166,7 @@ private lemma sum_multinomialWeight_eq_apply (w : ι → NNReal) (n m : ℕ) (i 
 equal to that cell's weight. -/
 theorem map_eval_multinomialMeasure (n : ℕ) (p : StdSimplex NNReal ι) (i : ι) :
     (multinomialMeasure n p).map (fun k ↦ k i) =
-      Bin(n, multinomialCellProbability p i) := by
+      Bin(n, p.multinomialCellProbability i) := by
   classical
   apply Measure.ext_of_singleton
   intro m
@@ -195,7 +199,7 @@ theorem map_eval_multinomialMeasure (n : ℕ) (p : StdSimplex NNReal ι) (i : ι
     sub_nonneg.mpr (by exact_mod_cast p.weights_apply_le_one i)
   rw [ENNReal.toReal_ofReal]
   · simp
-  · rw [coe_multinomialCellProbability]
+  · rw [StdSimplex.coe_multinomialCellProbability]
     exact mul_nonneg (mul_nonneg (by positivity) (by positivity)) (pow_nonneg hcomp _)
 
 end TauCeti.Probability


### PR DESCRIPTION
This PR proves that every coordinate of `multinomialMeasure n p` has the native binomial law with parameter equal to the corresponding simplex weight. It advances `StandardDistributions/README.md`, Layer 5, item 5, “Multinomial distribution,” specifically the target to prove native binomial coordinate marginals. After this PR, the multinomial milestone still requires aggregation along finite maps, the Euclidean mean and covariance formulas, characteristic and directional exponential transforms, and parameter measurability.

The proof splits the count antidiagonal at the chosen coordinate, factors each coefficient with Mathlib's `Nat.multinomial_cons`, and sums the remaining weights using `Finset.sum_pow_eq_sum_piAntidiag`. It handles counts above the sample size directly, so the result covers every singleton and hence identifies the measures without a support side condition.

The new `TauCeti/Probability/Distributions/Multinomial/Marginal.lean` module has 200 lines and introduces `Convexity.StdSimplex.multinomialCellProbability` together with `TauCeti.Probability.map_eval_multinomialMeasure`. The general fact that a member of `Finset.piAntidiag s n` vanishes off `s` mentions only Mathlib objects, so it is a public `Finset` lemma in the new 34-line `TauCeti/Algebra/Order/Antidiag/Pi.lean`, which mirrors the Mathlib module defining `Finset.piAntidiag`. `TauCeti/Probability/Distributions/Multinomial/Basic.lean` gains explicit equations for the two opaque definitions consumed downstream. No Mathlib code is vendored; the implementation reuses Mathlib's multinomial-coefficient, antidiagonal, multinomial-theorem, binomial-mass, and countable-measure extensionality APIs. The mathematical statement follows Johnson, Kotz, and Balakrishnan, *Discrete Multivariate Distributions*, Chapter 35, cited in the module documentation.

Roadmap: StandardDistributions

<!--tauceti-target:v1 {"focus":"StandardDistributions","id":"multinomial-coordinate-marginals"}-->

🤖 Prepared with Codex

