### PR TITLE
feat(FormalGroup): the parametrisation respects negation

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Eval.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Eval.lean
@@ -49,10 +49,10 @@ docstring says where its conclusion comes from.
 ## Main results
 
 * `WeierstrassCurve.formalWEval_eq_pow_mul_formalUEval` : the factorisation `w(t) = t ^ 3 * u(t)`.
-* `WeierstrassCurve.algebraMap_formalInverseEval_div_formalWEval` and
+* `WeierstrassCurve.algebraMap_formalInverseEval_div_algebraMap_formalWEval_formalInverseEval` and
   `WeierstrassCurve.neg_one_div_algebraMap_formalWEval_formalInverseEval` : the inverse law on
   coordinates — over a field, `ι` fixes `t / w(t)` and sends `-1 / w(t)` to the curve's `negY` of
-  it, `y ↦ -y - a₁x - a₃`.
+  it, `y ↦ -y - a₁x - a₃`. Neither needs `w(t)` to be nonzero.
 * `WeierstrassCurve.formalWEval_zero` : `w(0) = 0`, an immediate consequence of that
   factorisation and the reason the zero parameter carries no affine coordinates.
 * `WeierstrassCurve.formalWEval_mem`, `WeierstrassCurve.formalInverseEval_mem` : a parameter in
@@ -405,11 +405,13 @@ theorem formalWEval_formalInverseEval {t : O} (hE : PowerSeries.HasEval t)
     congrFun (PowerSeries.coe_aeval hV') W.formalW, hsub] at h
   simpa [hcoe, formalWEval, formalInverseEval, formalInverseDenomInvEval] using h.symm
 
-/-- **The formal inverse fixes the `x`-coordinate.** `ι(t) = -(t · u(t))` and
-`w(ι t) = -(w(t) · u(t))` share the unit `u(t)`, so the sign and the unit cancel in the ratio.
-No nonvanishing is needed: if `w(t) = 0` then `w(ι t) = 0` too and both sides are zero. -/
-theorem algebraMap_formalInverseEval_div_formalWEval {K : Type*} [Field K] [Algebra O K] {t : O}
-    (hE : PowerSeries.HasEval t) (hEV : PowerSeries.HasEval (W.formalInverseEval t)) :
+/-- **The formal inverse fixes the `x`-coordinate.** `ι(t) = -(t · d(t)⁻¹)` and
+`w(ι t) = -(w(t) · d(t)⁻¹)` share the unit `d(t)⁻¹ = formalInverseDenomInvEval t`, so the sign and
+that unit cancel in the ratio. No nonvanishing is needed: if `w(t) = 0` then `w(ι t) = 0` too and
+both sides are zero. -/
+theorem algebraMap_formalInverseEval_div_algebraMap_formalWEval_formalInverseEval
+    {K : Type*} [Field K] [Algebra O K] {t : O} (hE : PowerSeries.HasEval t)
+    (hEV : PowerSeries.HasEval (W.formalInverseEval t)) :
     algebraMap O K (W.formalInverseEval t) /
         algebraMap O K (W.formalWEval (W.formalInverseEval t)) =
       algebraMap O K t / algebraMap O K (W.formalWEval t) := by
@@ -424,8 +426,8 @@ theorem algebraMap_formalInverseEval_div_formalWEval {K : Type*} [Field K] [Alge
   field_simp
 
 /-- **The formal inverse applies the curve's `negY` to the `y`-coordinate**, `y ↦ -y - a₁x - a₃`
-rather than plain negation: `u(t)` inverts `1 - a₁t - a₃w(t)`, which turns `-1 / w(ι t)` into
-`negY` at the coordinates `t / w(t)` and `-1 / w(t)`. As above, no nonvanishing is needed. -/
+rather than plain negation: `d(t)⁻¹` inverts `d(t) = 1 - a₁t - a₃w(t)`, which turns `-1 / w(ι t)`
+into `negY` at the coordinates `t / w(t)` and `-1 / w(t)`. As above, no nonvanishing is needed. -/
 theorem neg_one_div_algebraMap_formalWEval_formalInverseEval {K : Type*} [Field K] [Algebra O K]
     {t : O} (hE : PowerSeries.HasEval t)
     (hEV : PowerSeries.HasEval (W.formalInverseEval t)) :
@@ -442,7 +444,7 @@ theorem neg_one_div_algebraMap_formalWEval_formalInverseEval {K : Type*} [Field 
   have hDU := congrArg (algebraMap O K) (W.formalInverseDenomEval_mul_inv hE)
   have hD := congrArg (algebraMap O K) (W.formalInverseDenomEval_eq hE)
   simp only [map_mul, map_sub, map_one] at hDU hD
-  -- the unit inverts the closed form of the inverse denominator; cross-multiplying leaves that
+  -- `d(t)⁻¹` inverts the closed form of `d(t)`; cross-multiplying leaves exactly that
   have hUD : algebraMap O K (W.formalInverseDenomInvEval t) *
       (1 - algebraMap O K W.a₁ * algebraMap O K t -
         algebraMap O K W.a₃ * algebraMap O K (W.formalWEval t)) = 1 := by

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Eval.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Eval.lean
@@ -50,9 +50,10 @@ docstring says where its conclusion comes from.
 
 * `WeierstrassCurve.formalWEval_eq_pow_mul_formalUEval` : the factorisation `w(t) = t ^ 3 * u(t)`.
 * `WeierstrassCurve.algebraMap_formalInverseEval_div_algebraMap_formalWEval_formalInverseEval` and
-  `WeierstrassCurve.neg_one_div_algebraMap_formalWEval_formalInverseEval` : the inverse law on
-  coordinates — over a field, `ι` fixes `t / w(t)` and sends `-1 / w(t)` to the curve's `negY` of
-  it, `y ↦ -y - a₁x - a₃`. Neither needs `w(t)` to be nonzero.
+  `WeierstrassCurve.neg_one_div_algebraMap_formalWEval_formalInverseEval` : the two division
+  identities the inverse law rests on, over a field and with no nonvanishing hypothesis. Where
+  `w(t) ≠ 0` they say `ι` fixes the `x`-coordinate `t / w(t)` and sends `-1 / w(t)` to the curve's
+  `negY` of it, `y ↦ -y - a₁x - a₃`.
 * `WeierstrassCurve.formalWEval_zero` : `w(0) = 0`, an immediate consequence of that
   factorisation and the reason the zero parameter carries no affine coordinates.
 * `WeierstrassCurve.formalWEval_mem`, `WeierstrassCurve.formalInverseEval_mem` : a parameter in
@@ -425,9 +426,14 @@ theorem algebraMap_formalInverseEval_div_algebraMap_formalWEval_formalInverseEva
   rw [hiota, hwiota]
   field_simp
 
-/-- **The formal inverse applies the curve's `negY` to the `y`-coordinate**, `y ↦ -y - a₁x - a₃`
-rather than plain negation: `d(t)⁻¹` inverts `d(t) = 1 - a₁t - a₃w(t)`, which turns `-1 / w(ι t)`
-into `negY` at the coordinates `t / w(t)` and `-1 / w(t)`. As above, no nonvanishing is needed. -/
+/-- **The formal inverse's `y`-value in closed form**: `d(t)⁻¹` inverts `d(t) = 1 - a₁t - a₃w(t)`,
+which is what turns `-1 / w(ι t)` into the displayed ratio. The identity holds with no nonvanishing
+hypothesis, both sides being zero when `w(t) = 0`.
+
+**When `w(t) ≠ 0` the right-hand side is the curve's `negY`** at the coordinates `t / w(t)` and
+`-1 / w(t)`, so the formal inverse applies `y ↦ -y - a₁x - a₃` rather than plain negation. That
+reading needs the hypothesis: at `w(t) = 0` both ratios are zero by field division, while
+`negY 0 0 = -a₃`. -/
 theorem neg_one_div_algebraMap_formalWEval_formalInverseEval {K : Type*} [Field K] [Algebra O K]
     {t : O} (hE : PowerSeries.HasEval t)
     (hEV : PowerSeries.HasEval (W.formalInverseEval t)) :

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Eval.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Eval.lean
@@ -49,6 +49,10 @@ docstring says where its conclusion comes from.
 ## Main results
 
 * `WeierstrassCurve.formalWEval_eq_pow_mul_formalUEval` : the factorisation `w(t) = t ^ 3 * u(t)`.
+* `WeierstrassCurve.algebraMap_formalInverseEval_div_formalWEval` and
+  `WeierstrassCurve.neg_one_div_algebraMap_formalWEval_formalInverseEval` : the inverse law on
+  coordinates — over a field, `ι` fixes `t / w(t)` and sends `-1 / w(t)` to the curve's `negY` of
+  it, `y ↦ -y - a₁x - a₃`.
 * `WeierstrassCurve.formalWEval_zero` : `w(0) = 0`, an immediate consequence of that
   factorisation and the reason the zero parameter carries no affine coordinates.
 * `WeierstrassCurve.formalWEval_mem`, `WeierstrassCurve.formalInverseEval_mem` : a parameter in
@@ -400,6 +404,52 @@ theorem formalWEval_formalInverseEval {t : O} (hE : PowerSeries.HasEval t)
   rw [W.subst_formalInverse_formalW, map_neg, map_mul,
     congrFun (PowerSeries.coe_aeval hV') W.formalW, hsub] at h
   simpa [hcoe, formalWEval, formalInverseEval, formalInverseDenomInvEval] using h.symm
+
+/-- **The formal inverse fixes the `x`-coordinate.** `ι(t) = -(t · u(t))` and
+`w(ι t) = -(w(t) · u(t))` share the unit `u(t)`, so the sign and the unit cancel in the ratio.
+No nonvanishing is needed: if `w(t) = 0` then `w(ι t) = 0` too and both sides are zero. -/
+theorem algebraMap_formalInverseEval_div_formalWEval {K : Type*} [Field K] [Algebra O K] {t : O}
+    (hE : PowerSeries.HasEval t) (hEV : PowerSeries.HasEval (W.formalInverseEval t)) :
+    algebraMap O K (W.formalInverseEval t) /
+        algebraMap O K (W.formalWEval (W.formalInverseEval t)) =
+      algebraMap O K t / algebraMap O K (W.formalWEval t) := by
+  have hiota := congrArg (algebraMap O K) (W.formalInverseEval_eq hE)
+  have hwiota := congrArg (algebraMap O K) (W.formalWEval_formalInverseEval hE hEV)
+  simp only [map_neg, map_mul] at hiota hwiota
+  by_cases hWt : algebraMap O K (W.formalWEval t) = 0
+  · simp [hwiota, hWt]
+  have hU0 : algebraMap O K (W.formalInverseDenomInvEval t) ≠ 0 :=
+    ((W.isUnit_formalInverseDenomInvEval hE).map (algebraMap O K)).ne_zero
+  rw [hiota, hwiota]
+  field_simp
+
+/-- **The formal inverse applies the curve's `negY` to the `y`-coordinate**, `y ↦ -y - a₁x - a₃`
+rather than plain negation: `u(t)` inverts `1 - a₁t - a₃w(t)`, which turns `-1 / w(ι t)` into
+`negY` at the coordinates `t / w(t)` and `-1 / w(t)`. As above, no nonvanishing is needed. -/
+theorem neg_one_div_algebraMap_formalWEval_formalInverseEval {K : Type*} [Field K] [Algebra O K]
+    {t : O} (hE : PowerSeries.HasEval t)
+    (hEV : PowerSeries.HasEval (W.formalInverseEval t)) :
+    -1 / algebraMap O K (W.formalWEval (W.formalInverseEval t)) =
+      (1 - (W.baseChange K).a₁ * algebraMap O K t -
+          (W.baseChange K).a₃ * algebraMap O K (W.formalWEval t)) /
+        algebraMap O K (W.formalWEval t) := by
+  have hwiota := congrArg (algebraMap O K) (W.formalWEval_formalInverseEval hE hEV)
+  simp only [map_neg, map_mul] at hwiota
+  by_cases hWt : algebraMap O K (W.formalWEval t) = 0
+  · simp [hwiota, hWt]
+  have hU0 : algebraMap O K (W.formalInverseDenomInvEval t) ≠ 0 :=
+    ((W.isUnit_formalInverseDenomInvEval hE).map (algebraMap O K)).ne_zero
+  have hDU := congrArg (algebraMap O K) (W.formalInverseDenomEval_mul_inv hE)
+  have hD := congrArg (algebraMap O K) (W.formalInverseDenomEval_eq hE)
+  simp only [map_mul, map_sub, map_one] at hDU hD
+  -- the unit inverts the closed form of the inverse denominator; cross-multiplying leaves that
+  have hUD : algebraMap O K (W.formalInverseDenomInvEval t) *
+      (1 - algebraMap O K W.a₁ * algebraMap O K t -
+        algebraMap O K W.a₃ * algebraMap O K (W.formalWEval t)) = 1 := by
+    rw [← hD, mul_comm]; exact hDU
+  simp only [baseChange, map_a₁, map_a₃]
+  rw [hwiota, div_neg, neg_div, neg_neg, div_eq_div_iff (mul_ne_zero hWt hU0) hWt]
+  linear_combination -algebraMap O K (W.formalWEval t) * hUD
 
 /-- **The formal inverse is an involution at a parameter**: `ι(ι(t)) = t`. This is `-(-P) = P` for
 the group law near the origin, evaluated at `t`. -/

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Point/Add.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Point/Add.lean
@@ -86,7 +86,6 @@ step read off on coordinates. Both nonsingularity proofs are taken rather than b
 statement says exactly which witnesses the dependent equality is between. -/
 private theorem some_formalThirdRootEval_eq_some_formalAddEval {I : Ideal O} (hI : IsAdic I)
     {t₁ t₂ : O} (h₁ : t₁ ∈ I) (h₂ : t₂ ∈ I)
-    (hwT : algebraMap O K (W.formalWEval (W.formalThirdRootEval t₁ t₂)) ≠ 0)
     (h₃ : (W.baseChange K).toAffine.Nonsingular
       (algebraMap O K (W.formalThirdRootEval t₁ t₂) /
         algebraMap O K (W.formalWEval (W.formalThirdRootEval t₁ t₂)))
@@ -108,9 +107,9 @@ private theorem some_formalThirdRootEval_eq_some_formalAddEval {I : Ideal O} (hI
   -- of the inverse law are exactly what distinguishes the two points
   rw [Affine.Point.some.injEq, W.formalAddEval_eq hE₁ hE₂]
   exact ⟨(W.algebraMap_formalInverseEval_div_formalWEval hET
-      (W.hasEval_formalInverseEval hI hTmem) hwT).symm,
+      (W.hasEval_formalInverseEval hI hTmem)).symm,
     (W.neg_one_div_algebraMap_formalWEval_formalInverseEval hET
-      (W.hasEval_formalInverseEval hI hTmem) hwT).symm⟩
+      (W.hasEval_formalInverseEval hI hTmem)).symm⟩
 
 omit [(W.baseChange K).IsElliptic] in
 open scoped Classical in
@@ -166,7 +165,7 @@ private theorem some_add_some_formalAddEval_of_X_ne {I : Ideal O} (hI : IsAdic I
   obtain ⟨h₃, hadd⟩ := chord_point_add (W.baseChange K) hq₁ hq₂ hslope hint hrel hwT hA
     (W.algebraMap_formalWEval_ne_zero hI h₁ (hne h₁0))
     (W.algebraMap_formalWEval_ne_zero hI h₂ (hne h₂0)) hwT0 hxK hn₁ hn₂
-  exact hadd.trans (W.some_formalThirdRootEval_eq_some_formalAddEval hI h₁ h₂ hwT0 h₃ hnF)
+  exact hadd.trans (W.some_formalThirdRootEval_eq_some_formalAddEval hI h₁ h₂ h₃ hnF)
 
 open scoped Classical in
 /-- **The parametrisation carries the group law**, for two nonzero parameters whose points have

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Point/Add.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Point/Add.lean
@@ -86,6 +86,7 @@ step read off on coordinates. Both nonsingularity proofs are taken rather than b
 statement says exactly which witnesses the dependent equality is between. -/
 private theorem some_formalThirdRootEval_eq_some_formalAddEval {I : Ideal O} (hI : IsAdic I)
     {t₁ t₂ : O} (h₁ : t₁ ∈ I) (h₂ : t₂ ∈ I)
+    (hwT : algebraMap O K (W.formalWEval (W.formalThirdRootEval t₁ t₂)) ≠ 0)
     (h₃ : (W.baseChange K).toAffine.Nonsingular
       (algebraMap O K (W.formalThirdRootEval t₁ t₂) /
         algebraMap O K (W.formalWEval (W.formalThirdRootEval t₁ t₂)))
@@ -103,30 +104,13 @@ private theorem some_formalThirdRootEval_eq_some_formalAddEval {I : Ideal O} (hI
     W.hasEval_formalThirdRootEval hE₁ hE₂
   have hTmem : W.formalThirdRootEval t₁ t₂ ∈ I := by
     simpa using W.formalThirdRootEval_mem hI (k := 1) (by simpa using h₁) (by simpa using h₂)
-  -- the three the coordinate comparison consumes, stated so that `grind` can match on them
-  have hF : algebraMap O K (W.formalAddEval t₁ t₂) =
-      -(algebraMap O K (W.formalThirdRootEval t₁ t₂) *
-        algebraMap O K (W.formalInverseDenomInvEval (W.formalThirdRootEval t₁ t₂))) := by
-    rw [W.formalAddEval_eq hE₁ hE₂, W.formalInverseEval_eq hET]
-    simp [map_neg, map_mul]
-  have hu : algebraMap O K (W.formalInverseDenomEval (W.formalThirdRootEval t₁ t₂)) *
-      algebraMap O K (W.formalInverseDenomInvEval (W.formalThirdRootEval t₁ t₂)) = 1 := by
-    rw [← map_mul, ← map_one (algebraMap O K)]
-    exact congrArg (algebraMap O K) (W.formalInverseDenomEval_mul_inv hET)
-  have hden : algebraMap O K (W.formalInverseDenomEval (W.formalThirdRootEval t₁ t₂)) =
-      1 - (W.baseChange K).a₁ * algebraMap O K (W.formalThirdRootEval t₁ t₂) -
-        (W.baseChange K).a₃ *
-          algebraMap O K (W.formalWEval (W.formalThirdRootEval t₁ t₂)) := by
-    simpa [baseChange, map_sub, map_mul, map_one, map_a₁, map_a₃] using
-      congrArg (algebraMap O K) (W.formalInverseDenomEval_eq hET)
-  have hwF : algebraMap O K (W.formalWEval (W.formalAddEval t₁ t₂)) =
-      -(algebraMap O K (W.formalWEval (W.formalThirdRootEval t₁ t₂)) *
-        algebraMap O K (W.formalInverseDenomInvEval (W.formalThirdRootEval t₁ t₂))) := by
-    rw [W.formalAddEval_eq hE₁ hE₂,
-      W.formalWEval_formalInverseEval hET (W.hasEval_formalInverseEval hI hTmem)]
-    simp [map_neg, map_mul]
-  -- the coordinates of the two points agree, so the points do
-  grind
+  -- the addition series is the formal inverse of the third root, so the two coordinate identities
+  -- of the inverse law are exactly what distinguishes the two points
+  rw [Affine.Point.some.injEq, W.formalAddEval_eq hE₁ hE₂]
+  exact ⟨(W.algebraMap_formalInverseEval_div_formalWEval hET
+      (W.hasEval_formalInverseEval hI hTmem) hwT).symm,
+    (W.neg_one_div_algebraMap_formalWEval_formalInverseEval hET
+      (W.hasEval_formalInverseEval hI hTmem) hwT).symm⟩
 
 omit [(W.baseChange K).IsElliptic] in
 open scoped Classical in
@@ -182,7 +166,7 @@ private theorem some_add_some_formalAddEval_of_X_ne {I : Ideal O} (hI : IsAdic I
   obtain ⟨h₃, hadd⟩ := chord_point_add (W.baseChange K) hq₁ hq₂ hslope hint hrel hwT hA
     (W.algebraMap_formalWEval_ne_zero hI h₁ (hne h₁0))
     (W.algebraMap_formalWEval_ne_zero hI h₂ (hne h₂0)) hwT0 hxK hn₁ hn₂
-  exact hadd.trans (W.some_formalThirdRootEval_eq_some_formalAddEval hI h₁ h₂ h₃ hnF)
+  exact hadd.trans (W.some_formalThirdRootEval_eq_some_formalAddEval hI h₁ h₂ hwT0 h₃ hnF)
 
 open scoped Classical in
 /-- **The parametrisation carries the group law**, for two nonzero parameters whose points have

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Point/Add.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Point/Add.lean
@@ -106,7 +106,7 @@ private theorem some_formalThirdRootEval_eq_some_formalAddEval {I : Ideal O} (hI
   -- the addition series is the formal inverse of the third root, so the two coordinate identities
   -- of the inverse law are exactly what distinguishes the two points
   rw [Affine.Point.some.injEq, W.formalAddEval_eq hE₁ hE₂]
-  exact ⟨(W.algebraMap_formalInverseEval_div_formalWEval hET
+  exact ⟨(W.algebraMap_formalInverseEval_div_algebraMap_formalWEval_formalInverseEval hET
       (W.hasEval_formalInverseEval hI hTmem)).symm,
     (W.neg_one_div_algebraMap_formalWEval_formalInverseEval hET
       (W.hasEval_formalInverseEval hI hTmem)).symm⟩

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Point/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Point/Basic.lean
@@ -41,13 +41,9 @@ into pole orders, but no order or valuation hypothesis is assumed here.
   `WeierstrassCurve.formalPoint_injective`.
 * `WeierstrassCurve.formalPoint_of_param_eq_zero` and
   `WeierstrassCurve.formalPoint_of_param_ne_zero`: the two branches of the definition.
-* `WeierstrassCurve.algebraMap_formalInverseEval_div_formalWEval` and
-  `WeierstrassCurve.neg_one_div_algebraMap_formalWEval_formalInverseEval`: the inverse law on
-  coordinates — the formal inverse fixes `x` and negates `y`. Stated at evaluability, so they are
-  available without an adic ideal, an injective structure map or an elliptic base change, which is
-  what lets the chord case in `Point/Add.lean` use them too.
 * `WeierstrassCurve.formalPoint_formalInverseEval`: **the parametrisation respects negation** —
-  the formal inverse on parameters becomes the group inverse on points.
+  the formal inverse on parameters becomes the group inverse on points, which on a generalised
+  Weierstrass curve sends `y` to `-y - a₁x - a₃` rather than to `-y`.
 * `WeierstrassCurve.xCoord_formalPoint` and `WeierstrassCurve.yCoord_formalPoint`: the point's
   coordinates, through which the closed forms
   `WeierstrassCurve.xCoord_formalPoint_mul_eq_one` and
@@ -236,53 +232,10 @@ theorem formalPoint_injective {I : Ideal O} (hI : IsAdic I) :
     ← W.neg_xCoord_div_yCoord_formalPoint (K := K) hI t₂.property]
   exact congrArg (fun P ↦ -P.xCoord / P.yCoord) h
 
-omit [FaithfulSMul O K] [(W.baseChange K).IsElliptic] in
-/-- **The formal inverse does not move the `x`-coordinate.** `ι(t) = -(t · u(t))` and
-`w(ι t) = -(w(t) · u(t))` share the unit `u(t)`, so the sign and the unit cancel in the ratio. -/
-theorem algebraMap_formalInverseEval_div_formalWEval {t : O} (hE : PowerSeries.HasEval t)
-    (hEV : PowerSeries.HasEval (W.formalInverseEval t))
-    (hWt : algebraMap O K (W.formalWEval t) ≠ 0) :
-    algebraMap O K (W.formalInverseEval t) /
-        algebraMap O K (W.formalWEval (W.formalInverseEval t)) =
-      algebraMap O K t / algebraMap O K (W.formalWEval t) := by
-  have hU0 : algebraMap O K (W.formalInverseDenomInvEval t) ≠ 0 :=
-    ((W.isUnit_formalInverseDenomInvEval hE).map (algebraMap O K)).ne_zero
-  have hiota := congrArg (algebraMap O K) (W.formalInverseEval_eq hE)
-  have hwiota := congrArg (algebraMap O K) (W.formalWEval_formalInverseEval hE hEV)
-  simp only [map_neg, map_mul] at hiota hwiota
-  rw [hiota, hwiota]
-  field_simp
-
-omit [FaithfulSMul O K] [(W.baseChange K).IsElliptic] in
-/-- **The formal inverse negates the `y`-coordinate.** `u(t)` inverts `1 - a₁t - a₃w(t)`, which is
-what turns `-1 / w(ι t)` into the negated `y`-coordinate as the chord construction writes it. -/
-theorem neg_one_div_algebraMap_formalWEval_formalInverseEval {t : O}
-    (hE : PowerSeries.HasEval t) (hEV : PowerSeries.HasEval (W.formalInverseEval t))
-    (hWt : algebraMap O K (W.formalWEval t) ≠ 0) :
-    -1 / algebraMap O K (W.formalWEval (W.formalInverseEval t)) =
-      (1 - (W.baseChange K).a₁ * algebraMap O K t -
-          (W.baseChange K).a₃ * algebraMap O K (W.formalWEval t)) /
-        algebraMap O K (W.formalWEval t) := by
-  have hU0 : algebraMap O K (W.formalInverseDenomInvEval t) ≠ 0 :=
-    ((W.isUnit_formalInverseDenomInvEval hE).map (algebraMap O K)).ne_zero
-  have hwiota := congrArg (algebraMap O K) (W.formalWEval_formalInverseEval hE hEV)
-  have hDU := congrArg (algebraMap O K) (W.formalInverseDenomEval_mul_inv hE)
-  have hD := congrArg (algebraMap O K) (W.formalInverseDenomEval_eq hE)
-  simp only [map_neg, map_mul, map_sub, map_one] at hwiota hDU hD
-  -- the unit inverts the closed form of the inverse denominator; that single identity is what
-  -- the `y`-coordinate needs
-  have hUD : algebraMap O K (W.formalInverseDenomInvEval t) *
-      (1 - algebraMap O K W.a₁ * algebraMap O K t -
-        algebraMap O K W.a₃ * algebraMap O K (W.formalWEval t)) = 1 := by
-    rw [← hD, mul_comm]; exact hDU
-  simp only [baseChange, map_a₁, map_a₃]
-  -- `-1 / -(w(t) · u(t))` is `1 / (w(t) · u(t))`, and cross-multiplying leaves exactly `hUD`
-  rw [hwiota, div_neg, neg_div, neg_neg, div_eq_div_iff (mul_ne_zero hWt hU0) hWt]
-  linear_combination -algebraMap O K (W.formalWEval t) * hUD
-
 open scoped Classical in
 /-- **The parametrisation respects negation.** The formal inverse `ι` on parameters becomes the
-group inverse on points, so `formalPoint` carries the inverse law across. -/
+group inverse on points — on a generalised Weierstrass curve the `negY` transformation
+`y ↦ -y - a₁x - a₃`, not plain negation — so `formalPoint` carries the inverse law across. -/
 theorem formalPoint_formalInverseEval {I : Ideal O} (hI : IsAdic I) {t : O} (ht : t ∈ I) :
     W.formalPoint (K := K) hI (pow_one I ▸ W.formalInverseEval_mem
         (hI.isTopologicallyNilpotent_of_mem ht) (k := 1) ((pow_one I).symm ▸ ht)) =
@@ -303,9 +256,9 @@ theorem formalPoint_formalInverseEval {I : Ideal O} (hI : IsAdic I) {t : O} (ht 
   -- `y`-coordinate the second lemma computes
   simp only [Affine.Point.mk, Affine.Point.neg_some, Affine.Point.some.injEq, Affine.negY]
   refine ⟨W.algebraMap_formalInverseEval_div_formalWEval hE
-      (W.hasEval_formalInverseEval hI ht) hWt, ?_⟩
+      (W.hasEval_formalInverseEval hI ht), ?_⟩
   have hy := W.neg_one_div_algebraMap_formalWEval_formalInverseEval (K := K) hE
-    (W.hasEval_formalInverseEval hI ht) hWt
+    (W.hasEval_formalInverseEval hI ht)
   rw [neg_div, one_div] at hy
   rw [hy]
   field_simp

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Point/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Point/Basic.lean
@@ -61,10 +61,9 @@ The same parametrization is formalised in Michael Stoll's elliptic-curve develop
 `formalPoint_negPoint`. The first three keep their source names; the fourth is not restated,
 `Affine.Point.mk` carrying the equation-to-nonsingularity step itself.
 
-`formalPoint_formalInverseEval` is that source's `formalPoint_negPoint`, whose argument it
-follows: the same split on whether the parameter vanishes, the same reduction through
-`Affine.Point.neg_some` and `Affine.Point.some.injEq`, and on the `y`-coordinate the same
-certificate — the unit relation `d(t) · u(t) = 1` against the closed form of `d(t)`. Its name
+`formalPoint_formalInverseEval` is that source's `formalPoint_negPoint`. It is what makes the
+parameters of an adic ideal closed under inverses as *points*, so that the chord case of
+additivity in `Point/Add.lean` can read the addition series as a negated third root. Its name
 takes this repository's vocabulary, `formalInverseEval` rather than the source's `negPoint`,
 since the object being applied is the evaluated formal inverse.
 
@@ -263,9 +262,10 @@ theorem formalPoint_formalInverseEval {I : Ideal O} (hI : IsAdic I) {t : O} (ht 
   rw [Affine.Point.some.injEq, hiota, hwiota, Affine.negY]
   refine ⟨by field_simp, ?_⟩
   field_simp
-  have ha₁ : (W.baseChange K).toAffine.a₁ = algebraMap O K W.a₁ := rfl
-  have ha₃ : (W.baseChange K).toAffine.a₃ = algebraMap O K W.a₃ := rfl
-  rw [ha₁, ha₃]
+  rw [show (W.baseChange K).toAffine.a₁ = algebraMap O K W.a₁ by
+        rw [baseChange, map_a₁],
+    show (W.baseChange K).toAffine.a₃ = algebraMap O K W.a₃ by
+        rw [baseChange, map_a₃]]
   linear_combination algebraMap O K (W.formalInverseDenomInvEval t) * hD - hDU
 
 end WeierstrassCurve

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Point/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Point/Basic.lean
@@ -234,15 +234,16 @@ theorem formalPoint_injective {I : Ideal O} (hI : IsAdic I) :
     ← W.neg_xCoord_div_yCoord_formalPoint (K := K) hI t₂.property]
   exact congrArg (fun P ↦ -P.xCoord / P.yCoord) h
 
-omit [(W.baseChange K).IsElliptic] in
+omit [FaithfulSMul O K] [(W.baseChange K).IsElliptic] in
 open scoped Classical in
 /-- **The point at the formal inverse's parameter is the negation of the point at the parameter**,
-with both nonsingularity proofs taken rather than built, so the statement says which witnesses the
-equality is between. This is the coordinate content of the inverse law, shared with the chord case
-in `Point/Add.lean`, which cannot use `formalPoint` because it does not assume the base-changed
-curve elliptic. -/
-theorem some_formalInverseEval_eq_neg_some {I : Ideal O} (hI : IsAdic I) {t : O} (ht : t ∈ I)
-    (h0 : t ≠ 0)
+with the nonvanishing of `w(t)` and both nonsingularity proofs taken rather than built. Stated at
+evaluability rather than at membership in an adic ideal, and asking neither that the base-changed
+curve be elliptic nor that the structure map be injective, so that the chord case in
+`Point/Add.lean` — which assumes none of those — can use it. -/
+theorem some_formalInverseEval_eq_neg_some {t : O} (hE : PowerSeries.HasEval t)
+    (hEV : PowerSeries.HasEval (W.formalInverseEval t))
+    (hWt : algebraMap O K (W.formalWEval t) ≠ 0)
     (hV : (W.baseChange K).toAffine.Nonsingular
       (algebraMap O K (W.formalInverseEval t) /
         algebraMap O K (W.formalWEval (W.formalInverseEval t)))
@@ -251,24 +252,19 @@ theorem some_formalInverseEval_eq_neg_some {I : Ideal O} (hI : IsAdic I) {t : O}
       (algebraMap O K t / algebraMap O K (W.formalWEval t))
       (-1 / algebraMap O K (W.formalWEval t))) :
     Affine.Point.some _ _ hV = -Affine.Point.some _ _ hT := by
-  have hE : PowerSeries.HasEval t := hI.isTopologicallyNilpotent_of_mem ht
   -- `ι(t) = -(t · u)` and `w(ι t) = -(w(t) · u)` share the unit `u`, so the `x`-coordinates agree,
   -- and `u` inverts `1 - a₁t - a₃w(t)`, which is what turns the `y`-coordinate into `negY`
-  have hWt : algebraMap O K (W.formalWEval t) ≠ 0 := W.algebraMap_formalWEval_ne_zero hI ht
-    ((map_ne_zero_iff _ (FaithfulSMul.algebraMap_injective O K)).mpr h0)
   have hU0 : algebraMap O K (W.formalInverseDenomInvEval t) ≠ 0 :=
     ((W.isUnit_formalInverseDenomInvEval hE).map (algebraMap O K)).ne_zero
   have hiota := congrArg (algebraMap O K) (W.formalInverseEval_eq hE)
-  have hwiota := congrArg (algebraMap O K) (W.formalWEval_formalInverseEval hE
-    (W.hasEval_formalInverseEval hI ht))
+  have hwiota := congrArg (algebraMap O K) (W.formalWEval_formalInverseEval hE hEV)
   have hDU := congrArg (algebraMap O K) (W.formalInverseDenomEval_mul_inv hE)
   have hD := congrArg (algebraMap O K) (W.formalInverseDenomEval_eq hE)
   simp only [map_neg, map_mul, map_sub, map_one] at hiota hwiota hDU hD
   rw [Affine.Point.neg_some, Affine.Point.some.injEq, hiota, hwiota, Affine.negY]
   refine ⟨by field_simp, ?_⟩
   field_simp
-  rw [show (W.baseChange K).toAffine.a₁ = algebraMap O K W.a₁ by rw [baseChange, map_a₁],
-    show (W.baseChange K).toAffine.a₃ = algebraMap O K W.a₃ by rw [baseChange, map_a₃]]
+  simp only [baseChange, map_a₁, map_a₃]
   linear_combination algebraMap O K (W.formalInverseDenomInvEval t) * hD - hDU
 
 open scoped Classical in
@@ -298,6 +294,9 @@ theorem formalPoint_formalInverseEval {I : Ideal O} (hI : IsAdic I) {t : O} (ht 
   rw [W.formalPoint_of_param_ne_zero hI hVmem hV0,
     W.formalPoint_of_param_ne_zero hI ht h0]
   simpa only [Affine.Point.mk, neg_div, one_div] using
-    W.some_formalInverseEval_eq_neg_some (K := K) hI ht h0 (hn hVmem hV0) (hn ht h0)
+    W.some_formalInverseEval_eq_neg_some (K := K) hE (W.hasEval_formalInverseEval hI ht)
+      (W.algebraMap_formalWEval_ne_zero hI ht
+        ((map_ne_zero_iff _ (FaithfulSMul.algebraMap_injective O K)).mpr h0))
+      (hn hVmem hV0) (hn ht h0)
 
 end WeierstrassCurve

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Point/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Point/Basic.lean
@@ -41,6 +41,8 @@ into pole orders, but no order or valuation hypothesis is assumed here.
   `WeierstrassCurve.formalPoint_injective`.
 * `WeierstrassCurve.formalPoint_of_param_eq_zero` and
   `WeierstrassCurve.formalPoint_of_param_ne_zero`: the two branches of the definition.
+* `WeierstrassCurve.formalPoint_formalInverseEval`: **the parametrisation respects negation** —
+  the formal inverse on parameters becomes the group inverse on points.
 * `WeierstrassCurve.xCoord_formalPoint` and `WeierstrassCurve.yCoord_formalPoint`: the point's
   coordinates, through which the closed forms
   `WeierstrassCurve.xCoord_formalPoint_mul_eq_one` and
@@ -222,5 +224,41 @@ theorem formalPoint_injective {I : Ideal O} (hI : IsAdic I) :
   rw [← W.neg_xCoord_div_yCoord_formalPoint (K := K) hI t₁.property,
     ← W.neg_xCoord_div_yCoord_formalPoint (K := K) hI t₂.property]
   exact congrArg (fun P ↦ -P.xCoord / P.yCoord) h
+
+open scoped Classical in
+/-- **The parametrisation respects negation.** The formal inverse `ι` on parameters becomes the
+group inverse on points, so `formalPoint` carries the inverse law across. -/
+theorem formalPoint_formalInverseEval {I : Ideal O} (hI : IsAdic I) {t : O} (ht : t ∈ I) :
+    W.formalPoint (K := K) hI (pow_one I ▸ W.formalInverseEval_mem
+        (hI.isTopologicallyNilpotent_of_mem ht) (k := 1) ((pow_one I).symm ▸ ht)) =
+      -W.formalPoint (K := K) hI ht := by
+  have hE : PowerSeries.HasEval t := hI.isTopologicallyNilpotent_of_mem ht
+  by_cases h0 : t = 0
+  · subst h0
+    rw [W.formalPoint_of_param_eq_zero hI ht rfl, neg_zero,
+      W.formalPoint_of_param_eq_zero hI _ (by simp [W.formalInverseEval_eq hE])]
+  rw [W.formalPoint_of_param_ne_zero hI _ (W.formalInverseEval_ne_zero hE h0),
+    W.formalPoint_of_param_ne_zero hI ht h0]
+  simp only [Affine.Point.mk, Affine.Point.neg_some]
+  -- the two coordinate identities, read in `K`: `ι(t) = -(t · u)` and `w(ι t) = -(w(t) · u)` share
+  -- the unit `u`, so the `x`-coordinates agree, and `u` inverts `1 - a₁t - a₃w(t)`, which is what
+  -- turns the `y`-coordinate into `negY`
+  have hWt : algebraMap O K (W.formalWEval t) ≠ 0 := W.algebraMap_formalWEval_ne_zero hI ht
+    ((map_ne_zero_iff _ (FaithfulSMul.algebraMap_injective O K)).mpr h0)
+  have hU0 : algebraMap O K (W.formalInverseDenomInvEval t) ≠ 0 :=
+    ((W.isUnit_formalInverseDenomInvEval hE).map (algebraMap O K)).ne_zero
+  have hiota := congrArg (algebraMap O K) (W.formalInverseEval_eq hE)
+  have hwiota := congrArg (algebraMap O K) (W.formalWEval_formalInverseEval hE
+    (W.hasEval_formalInverseEval hI ht))
+  have hDU := congrArg (algebraMap O K) (W.formalInverseDenomEval_mul_inv hE)
+  have hD := congrArg (algebraMap O K) (W.formalInverseDenomEval_eq hE)
+  simp only [map_neg, map_mul, map_sub, map_one] at hiota hwiota hDU hD
+  rw [Affine.Point.some.injEq, hiota, hwiota, Affine.negY]
+  refine ⟨by field_simp, ?_⟩
+  field_simp
+  have ha₁ : (W.baseChange K).toAffine.a₁ = algebraMap O K W.a₁ := rfl
+  have ha₃ : (W.baseChange K).toAffine.a₃ = algebraMap O K W.a₃ := rfl
+  rw [ha₁, ha₃]
+  linear_combination algebraMap O K (W.formalInverseDenomInvEval t) * hD - hDU
 
 end WeierstrassCurve

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Point/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Point/Basic.lean
@@ -235,7 +235,12 @@ theorem formalPoint_injective {I : Ideal O} (hI : IsAdic I) :
 open scoped Classical in
 /-- **The parametrisation respects negation.** The formal inverse `ι` on parameters becomes the
 group inverse on points — on a generalised Weierstrass curve the `negY` transformation
-`y ↦ -y - a₁x - a₃`, not plain negation — so `formalPoint` carries the inverse law across. -/
+`y ↦ -y - a₁x - a₃`, not plain negation — so `formalPoint` carries the inverse law across.
+
+Tagged `@[simp]` in the reducing orientation, towards point negation. Note that `simp` reaches it
+only where the parameter is syntactically `formalInverseEval t`: the parameter sits in the
+membership proof's type, so matching it otherwise would need higher-order unification. -/
+@[simp]
 theorem formalPoint_formalInverseEval {I : Ideal O} (hI : IsAdic I) {t : O} (ht : t ∈ I) :
     W.formalPoint (K := K) hI (pow_one I ▸ W.formalInverseEval_mem
         (hI.isTopologicallyNilpotent_of_mem ht) (k := 1) ((pow_one I).symm ▸ ht)) =

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Point/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Point/Basic.lean
@@ -41,6 +41,9 @@ into pole orders, but no order or valuation hypothesis is assumed here.
   `WeierstrassCurve.formalPoint_injective`.
 * `WeierstrassCurve.formalPoint_of_param_eq_zero` and
   `WeierstrassCurve.formalPoint_of_param_ne_zero`: the two branches of the definition.
+* `WeierstrassCurve.some_formalInverseEval_eq_neg_some`: the coordinate content of the inverse
+  law, at taken nonsingularity witnesses, so that it is available without assuming the
+  base-changed curve elliptic.
 * `WeierstrassCurve.formalPoint_formalInverseEval`: **the parametrisation respects negation** —
   the formal inverse on parameters becomes the group inverse on points.
 * `WeierstrassCurve.xCoord_formalPoint` and `WeierstrassCurve.yCoord_formalPoint`: the point's
@@ -231,6 +234,43 @@ theorem formalPoint_injective {I : Ideal O} (hI : IsAdic I) :
     ← W.neg_xCoord_div_yCoord_formalPoint (K := K) hI t₂.property]
   exact congrArg (fun P ↦ -P.xCoord / P.yCoord) h
 
+omit [(W.baseChange K).IsElliptic] in
+open scoped Classical in
+/-- **The point at the formal inverse's parameter is the negation of the point at the parameter**,
+with both nonsingularity proofs taken rather than built, so the statement says which witnesses the
+equality is between. This is the coordinate content of the inverse law, shared with the chord case
+in `Point/Add.lean`, which cannot use `formalPoint` because it does not assume the base-changed
+curve elliptic. -/
+theorem some_formalInverseEval_eq_neg_some {I : Ideal O} (hI : IsAdic I) {t : O} (ht : t ∈ I)
+    (h0 : t ≠ 0)
+    (hV : (W.baseChange K).toAffine.Nonsingular
+      (algebraMap O K (W.formalInverseEval t) /
+        algebraMap O K (W.formalWEval (W.formalInverseEval t)))
+      (-1 / algebraMap O K (W.formalWEval (W.formalInverseEval t))))
+    (hT : (W.baseChange K).toAffine.Nonsingular
+      (algebraMap O K t / algebraMap O K (W.formalWEval t))
+      (-1 / algebraMap O K (W.formalWEval t))) :
+    Affine.Point.some _ _ hV = -Affine.Point.some _ _ hT := by
+  have hE : PowerSeries.HasEval t := hI.isTopologicallyNilpotent_of_mem ht
+  -- `ι(t) = -(t · u)` and `w(ι t) = -(w(t) · u)` share the unit `u`, so the `x`-coordinates agree,
+  -- and `u` inverts `1 - a₁t - a₃w(t)`, which is what turns the `y`-coordinate into `negY`
+  have hWt : algebraMap O K (W.formalWEval t) ≠ 0 := W.algebraMap_formalWEval_ne_zero hI ht
+    ((map_ne_zero_iff _ (FaithfulSMul.algebraMap_injective O K)).mpr h0)
+  have hU0 : algebraMap O K (W.formalInverseDenomInvEval t) ≠ 0 :=
+    ((W.isUnit_formalInverseDenomInvEval hE).map (algebraMap O K)).ne_zero
+  have hiota := congrArg (algebraMap O K) (W.formalInverseEval_eq hE)
+  have hwiota := congrArg (algebraMap O K) (W.formalWEval_formalInverseEval hE
+    (W.hasEval_formalInverseEval hI ht))
+  have hDU := congrArg (algebraMap O K) (W.formalInverseDenomEval_mul_inv hE)
+  have hD := congrArg (algebraMap O K) (W.formalInverseDenomEval_eq hE)
+  simp only [map_neg, map_mul, map_sub, map_one] at hiota hwiota hDU hD
+  rw [Affine.Point.neg_some, Affine.Point.some.injEq, hiota, hwiota, Affine.negY]
+  refine ⟨by field_simp, ?_⟩
+  field_simp
+  rw [show (W.baseChange K).toAffine.a₁ = algebraMap O K W.a₁ by rw [baseChange, map_a₁],
+    show (W.baseChange K).toAffine.a₃ = algebraMap O K W.a₃ by rw [baseChange, map_a₃]]
+  linear_combination algebraMap O K (W.formalInverseDenomInvEval t) * hD - hDU
+
 open scoped Classical in
 /-- **The parametrisation respects negation.** The formal inverse `ι` on parameters becomes the
 group inverse on points, so `formalPoint` carries the inverse law across. -/
@@ -243,29 +283,21 @@ theorem formalPoint_formalInverseEval {I : Ideal O} (hI : IsAdic I) {t : O} (ht 
   · subst h0
     rw [W.formalPoint_of_param_eq_zero hI ht rfl, neg_zero,
       W.formalPoint_of_param_eq_zero hI _ (by simp [W.formalInverseEval_eq hE])]
-  rw [W.formalPoint_of_param_ne_zero hI _ (W.formalInverseEval_ne_zero hE h0),
+  have hV0 : W.formalInverseEval t ≠ 0 := W.formalInverseEval_ne_zero hE h0
+  have hVmem : W.formalInverseEval t ∈ I := by
+    simpa using W.formalInverseEval_mem (I := I) (k := 1) hE (by simpa using ht)
+  -- `equation_iff_nonsingular` states the `y`-coordinate as `-(w(s))⁻¹`, the shared lemma as
+  -- `-1 / w(s)`; `neg_div` and `one_div` bridge the two
+  have hn : ∀ {s : O} (hs : s ∈ I), s ≠ 0 → (W.baseChange K).toAffine.Nonsingular
+      (algebraMap O K s / algebraMap O K (W.formalWEval s))
+      (-1 / algebraMap O K (W.formalWEval s)) := fun hs hs0 ↦ by
+    simpa only [neg_div, one_div] using Affine.equation_iff_nonsingular.mp
+      (W.equation_formalPoint (hI.isTopologicallyNilpotent_of_mem hs)
+        (W.algebraMap_formalWEval_ne_zero hI hs
+          ((map_ne_zero_iff _ (FaithfulSMul.algebraMap_injective O K)).mpr hs0)))
+  rw [W.formalPoint_of_param_ne_zero hI hVmem hV0,
     W.formalPoint_of_param_ne_zero hI ht h0]
-  simp only [Affine.Point.mk, Affine.Point.neg_some]
-  -- the two coordinate identities, read in `K`: `ι(t) = -(t · u)` and `w(ι t) = -(w(t) · u)` share
-  -- the unit `u`, so the `x`-coordinates agree, and `u` inverts `1 - a₁t - a₃w(t)`, which is what
-  -- turns the `y`-coordinate into `negY`
-  have hWt : algebraMap O K (W.formalWEval t) ≠ 0 := W.algebraMap_formalWEval_ne_zero hI ht
-    ((map_ne_zero_iff _ (FaithfulSMul.algebraMap_injective O K)).mpr h0)
-  have hU0 : algebraMap O K (W.formalInverseDenomInvEval t) ≠ 0 :=
-    ((W.isUnit_formalInverseDenomInvEval hE).map (algebraMap O K)).ne_zero
-  have hiota := congrArg (algebraMap O K) (W.formalInverseEval_eq hE)
-  have hwiota := congrArg (algebraMap O K) (W.formalWEval_formalInverseEval hE
-    (W.hasEval_formalInverseEval hI ht))
-  have hDU := congrArg (algebraMap O K) (W.formalInverseDenomEval_mul_inv hE)
-  have hD := congrArg (algebraMap O K) (W.formalInverseDenomEval_eq hE)
-  simp only [map_neg, map_mul, map_sub, map_one] at hiota hwiota hDU hD
-  rw [Affine.Point.some.injEq, hiota, hwiota, Affine.negY]
-  refine ⟨by field_simp, ?_⟩
-  field_simp
-  rw [show (W.baseChange K).toAffine.a₁ = algebraMap O K W.a₁ by
-        rw [baseChange, map_a₁],
-    show (W.baseChange K).toAffine.a₃ = algebraMap O K W.a₃ by
-        rw [baseChange, map_a₃]]
-  linear_combination algebraMap O K (W.formalInverseDenomInvEval t) * hD - hDU
+  simpa only [Affine.Point.mk, neg_div, one_div] using
+    W.some_formalInverseEval_eq_neg_some (K := K) hI ht h0 (hn hVmem hV0) (hn ht h0)
 
 end WeierstrassCurve

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Point/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Point/Basic.lean
@@ -255,7 +255,7 @@ theorem formalPoint_formalInverseEval {I : Ideal O} (hI : IsAdic I) {t : O} (ht 
   -- `Point.mk` is the `some` constructor, and `negY` at the original point is the negated
   -- `y`-coordinate the second lemma computes
   simp only [Affine.Point.mk, Affine.Point.neg_some, Affine.Point.some.injEq, Affine.negY]
-  refine ⟨W.algebraMap_formalInverseEval_div_formalWEval hE
+  refine ⟨W.algebraMap_formalInverseEval_div_algebraMap_formalWEval_formalInverseEval hE
       (W.hasEval_formalInverseEval hI ht), ?_⟩
   have hy := W.neg_one_div_algebraMap_formalWEval_formalInverseEval (K := K) hE
     (W.hasEval_formalInverseEval hI ht)

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Point/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Point/Basic.lean
@@ -41,9 +41,11 @@ into pole orders, but no order or valuation hypothesis is assumed here.
   `WeierstrassCurve.formalPoint_injective`.
 * `WeierstrassCurve.formalPoint_of_param_eq_zero` and
   `WeierstrassCurve.formalPoint_of_param_ne_zero`: the two branches of the definition.
-* `WeierstrassCurve.some_formalInverseEval_eq_neg_some`: the coordinate content of the inverse
-  law, at taken nonsingularity witnesses, so that it is available without assuming the
-  base-changed curve elliptic.
+* `WeierstrassCurve.algebraMap_formalInverseEval_div_formalWEval` and
+  `WeierstrassCurve.neg_one_div_algebraMap_formalWEval_formalInverseEval`: the inverse law on
+  coordinates — the formal inverse fixes `x` and negates `y`. Stated at evaluability, so they are
+  available without an adic ideal, an injective structure map or an elliptic base change, which is
+  what lets the chord case in `Point/Add.lean` use them too.
 * `WeierstrassCurve.formalPoint_formalInverseEval`: **the parametrisation respects negation** —
   the formal inverse on parameters becomes the group inverse on points.
 * `WeierstrassCurve.xCoord_formalPoint` and `WeierstrassCurve.yCoord_formalPoint`: the point's
@@ -235,37 +237,48 @@ theorem formalPoint_injective {I : Ideal O} (hI : IsAdic I) :
   exact congrArg (fun P ↦ -P.xCoord / P.yCoord) h
 
 omit [FaithfulSMul O K] [(W.baseChange K).IsElliptic] in
-open scoped Classical in
-/-- **The point at the formal inverse's parameter is the negation of the point at the parameter**,
-with the nonvanishing of `w(t)` and both nonsingularity proofs taken rather than built. Stated at
-evaluability rather than at membership in an adic ideal, and asking neither that the base-changed
-curve be elliptic nor that the structure map be injective, so that the chord case in
-`Point/Add.lean` — which assumes none of those — can use it. -/
-theorem some_formalInverseEval_eq_neg_some {t : O} (hE : PowerSeries.HasEval t)
+/-- **The formal inverse does not move the `x`-coordinate.** `ι(t) = -(t · u(t))` and
+`w(ι t) = -(w(t) · u(t))` share the unit `u(t)`, so the sign and the unit cancel in the ratio. -/
+theorem algebraMap_formalInverseEval_div_formalWEval {t : O} (hE : PowerSeries.HasEval t)
     (hEV : PowerSeries.HasEval (W.formalInverseEval t))
-    (hWt : algebraMap O K (W.formalWEval t) ≠ 0)
-    (hV : (W.baseChange K).toAffine.Nonsingular
-      (algebraMap O K (W.formalInverseEval t) /
-        algebraMap O K (W.formalWEval (W.formalInverseEval t)))
-      (-1 / algebraMap O K (W.formalWEval (W.formalInverseEval t))))
-    (hT : (W.baseChange K).toAffine.Nonsingular
-      (algebraMap O K t / algebraMap O K (W.formalWEval t))
-      (-1 / algebraMap O K (W.formalWEval t))) :
-    Affine.Point.some _ _ hV = -Affine.Point.some _ _ hT := by
-  -- `ι(t) = -(t · u)` and `w(ι t) = -(w(t) · u)` share the unit `u`, so the `x`-coordinates agree,
-  -- and `u` inverts `1 - a₁t - a₃w(t)`, which is what turns the `y`-coordinate into `negY`
+    (hWt : algebraMap O K (W.formalWEval t) ≠ 0) :
+    algebraMap O K (W.formalInverseEval t) /
+        algebraMap O K (W.formalWEval (W.formalInverseEval t)) =
+      algebraMap O K t / algebraMap O K (W.formalWEval t) := by
   have hU0 : algebraMap O K (W.formalInverseDenomInvEval t) ≠ 0 :=
     ((W.isUnit_formalInverseDenomInvEval hE).map (algebraMap O K)).ne_zero
   have hiota := congrArg (algebraMap O K) (W.formalInverseEval_eq hE)
   have hwiota := congrArg (algebraMap O K) (W.formalWEval_formalInverseEval hE hEV)
+  simp only [map_neg, map_mul] at hiota hwiota
+  rw [hiota, hwiota]
+  field_simp
+
+omit [FaithfulSMul O K] [(W.baseChange K).IsElliptic] in
+/-- **The formal inverse negates the `y`-coordinate.** `u(t)` inverts `1 - a₁t - a₃w(t)`, which is
+what turns `-1 / w(ι t)` into the negated `y`-coordinate as the chord construction writes it. -/
+theorem neg_one_div_algebraMap_formalWEval_formalInverseEval {t : O}
+    (hE : PowerSeries.HasEval t) (hEV : PowerSeries.HasEval (W.formalInverseEval t))
+    (hWt : algebraMap O K (W.formalWEval t) ≠ 0) :
+    -1 / algebraMap O K (W.formalWEval (W.formalInverseEval t)) =
+      (1 - (W.baseChange K).a₁ * algebraMap O K t -
+          (W.baseChange K).a₃ * algebraMap O K (W.formalWEval t)) /
+        algebraMap O K (W.formalWEval t) := by
+  have hU0 : algebraMap O K (W.formalInverseDenomInvEval t) ≠ 0 :=
+    ((W.isUnit_formalInverseDenomInvEval hE).map (algebraMap O K)).ne_zero
+  have hwiota := congrArg (algebraMap O K) (W.formalWEval_formalInverseEval hE hEV)
   have hDU := congrArg (algebraMap O K) (W.formalInverseDenomEval_mul_inv hE)
   have hD := congrArg (algebraMap O K) (W.formalInverseDenomEval_eq hE)
-  simp only [map_neg, map_mul, map_sub, map_one] at hiota hwiota hDU hD
-  rw [Affine.Point.neg_some, Affine.Point.some.injEq, hiota, hwiota, Affine.negY]
-  refine ⟨by field_simp, ?_⟩
-  field_simp
+  simp only [map_neg, map_mul, map_sub, map_one] at hwiota hDU hD
+  -- the unit inverts the closed form of the inverse denominator; that single identity is what
+  -- the `y`-coordinate needs
+  have hUD : algebraMap O K (W.formalInverseDenomInvEval t) *
+      (1 - algebraMap O K W.a₁ * algebraMap O K t -
+        algebraMap O K W.a₃ * algebraMap O K (W.formalWEval t)) = 1 := by
+    rw [← hD, mul_comm]; exact hDU
   simp only [baseChange, map_a₁, map_a₃]
-  linear_combination algebraMap O K (W.formalInverseDenomInvEval t) * hD - hDU
+  -- `-1 / -(w(t) · u(t))` is `1 / (w(t) · u(t))`, and cross-multiplying leaves exactly `hUD`
+  rw [hwiota, div_neg, neg_div, neg_neg, div_eq_div_iff (mul_ne_zero hWt hU0) hWt]
+  linear_combination -algebraMap O K (W.formalWEval t) * hUD
 
 open scoped Classical in
 /-- **The parametrisation respects negation.** The formal inverse `ι` on parameters becomes the
@@ -282,21 +295,19 @@ theorem formalPoint_formalInverseEval {I : Ideal O} (hI : IsAdic I) {t : O} (ht 
   have hV0 : W.formalInverseEval t ≠ 0 := W.formalInverseEval_ne_zero hE h0
   have hVmem : W.formalInverseEval t ∈ I := by
     simpa using W.formalInverseEval_mem (I := I) (k := 1) hE (by simpa using ht)
-  -- `equation_iff_nonsingular` states the `y`-coordinate as `-(w(s))⁻¹`, the shared lemma as
-  -- `-1 / w(s)`; `neg_div` and `one_div` bridge the two
-  have hn : ∀ {s : O} (hs : s ∈ I), s ≠ 0 → (W.baseChange K).toAffine.Nonsingular
-      (algebraMap O K s / algebraMap O K (W.formalWEval s))
-      (-1 / algebraMap O K (W.formalWEval s)) := fun hs hs0 ↦ by
-    simpa only [neg_div, one_div] using Affine.equation_iff_nonsingular.mp
-      (W.equation_formalPoint (hI.isTopologicallyNilpotent_of_mem hs)
-        (W.algebraMap_formalWEval_ne_zero hI hs
-          ((map_ne_zero_iff _ (FaithfulSMul.algebraMap_injective O K)).mpr hs0)))
+  have hWt : algebraMap O K (W.formalWEval t) ≠ 0 := W.algebraMap_formalWEval_ne_zero hI ht
+    ((map_ne_zero_iff _ (FaithfulSMul.algebraMap_injective O K)).mpr h0)
   rw [W.formalPoint_of_param_ne_zero hI hVmem hV0,
     W.formalPoint_of_param_ne_zero hI ht h0]
-  simpa only [Affine.Point.mk, neg_div, one_div] using
-    W.some_formalInverseEval_eq_neg_some (K := K) hE (W.hasEval_formalInverseEval hI ht)
-      (W.algebraMap_formalWEval_ne_zero hI ht
-        ((map_ne_zero_iff _ (FaithfulSMul.algebraMap_injective O K)).mpr h0))
-      (hn hVmem hV0) (hn ht h0)
+  -- `Point.mk` is the `some` constructor, and `negY` at the original point is the negated
+  -- `y`-coordinate the second lemma computes
+  simp only [Affine.Point.mk, Affine.Point.neg_some, Affine.Point.some.injEq, Affine.negY]
+  refine ⟨W.algebraMap_formalInverseEval_div_formalWEval hE
+      (W.hasEval_formalInverseEval hI ht) hWt, ?_⟩
+  have hy := W.neg_one_div_algebraMap_formalWEval_formalInverseEval (K := K) hE
+    (W.hasEval_formalInverseEval hI ht) hWt
+  rw [neg_div, one_div] at hy
+  rw [hy]
+  field_simp
 
 end WeierstrassCurve

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Point/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Point/Basic.lean
@@ -57,9 +57,16 @@ into pole orders, but no order or valuation hypothesis is assumed here.
 The same parametrization is formalised in Michael Stoll's elliptic-curve development
 (`github.com/MichaelStollBayreuth/EllipticCurves` @ `66889eada51a`, Apache-2.0), file
 `EllipticCurves/WeierstrassFormalGroup/Filtration.lean`, declarations `formalPoint`,
-`formalPoint_of_param_eq_zero`, `formalPoint_of_param_ne_zero` and `formalPoint_nonsingular`. The
-first three keep their source names; the fourth is not restated, `Affine.Point.mk` carrying the
-equation-to-nonsingularity step itself.
+`formalPoint_of_param_eq_zero`, `formalPoint_of_param_ne_zero`, `formalPoint_nonsingular` and
+`formalPoint_negPoint`. The first three keep their source names; the fourth is not restated,
+`Affine.Point.mk` carrying the equation-to-nonsingularity step itself.
+
+`formalPoint_formalInverseEval` is that source's `formalPoint_negPoint`, whose argument it
+follows: the same split on whether the parameter vanishes, the same reduction through
+`Affine.Point.neg_some` and `Affine.Point.some.injEq`, and on the `y`-coordinate the same
+certificate — the unit relation `d(t) · u(t) = 1` against the closed form of `d(t)`. Its name
+takes this repository's vocabulary, `formalInverseEval` rather than the source's `negPoint`,
+since the object being applied is the evaluated formal inverse.
 
 That development states them over `v.adicCompletion K` for a height-one prime of a Dedekind domain
 and builds nonsingularity from a chord lemma of its own. The declarations below are stated over an


### PR DESCRIPTION
`FormalGroup/Point/Basic.lean` sends a parameter `t` of an adic ideal to a point of `W⁄K`, and
`FormalGroup/Eval.lean` evaluates the formal inverse series `ι` at a parameter. This connects the
two: `formalPoint` carries `ι` to negation of points.

```lean
theorem formalPoint_formalInverseEval {I : Ideal O} (hI : IsAdic I) {t : O} (ht : t ∈ I) :
    W.formalPoint (K := K) hI (pow_one I ▸ W.formalInverseEval_mem
        (hI.isTopologicallyNilpotent_of_mem ht) (k := 1) ((pow_one I).symm ▸ ht)) =
      -W.formalPoint (K := K) hI ht
```

The conclusion names the membership term `formalInverseEval_mem` supplies rather than taking it as
a hypothesis, matching the sibling `add_eq_formalPoint_formalAddEval_of_X_ne` in `Point/Add.lean`.

The inverse law's content is two coordinate identities, and they are stated as such:

```lean
theorem algebraMap_formalInverseEval_div_algebraMap_formalWEval_formalInverseEval … :
    algebraMap O K (W.formalInverseEval t) /
        algebraMap O K (W.formalWEval (W.formalInverseEval t)) =
      algebraMap O K t / algebraMap O K (W.formalWEval t)

theorem neg_one_div_algebraMap_formalWEval_formalInverseEval … :   -- `negY`, not plain `-y`
    -1 / algebraMap O K (W.formalWEval (W.formalInverseEval t)) =
      (1 - (W⁄K).a₁ * algebraMap O K t - (W⁄K).a₃ * algebraMap O K (W.formalWEval t)) /
        algebraMap O K (W.formalWEval t)
```

Both live in `FormalGroup/Eval.lean` beside `formalWEval_formalInverseEval`, since they mention no
point type — only evaluations and the algebra map. Both are stated at evaluability of `t` and of
`ι(t)` and ask for **no** nonvanishing: when `w(t) = 0` then `w(ι t) = 0` too and each asserted
division equality has zero on both sides. They ask for no adic ideal, no injective structure map
and no elliptic base change either. **That is what lets the chord case share them**: `Point/Add.lean`'s helpers are stated without those hypotheses (which is why they take
nonsingularity witnesses), so anything usable from both must sit below `formalPoint`, which needs
them. `some_formalThirdRootEval_eq_some_formalAddEval` there now reduces by
`Affine.Point.some.injEq` and applies these two, its body dropping from thirty lines to ten; the
same reduction is what `formalPoint_formalInverseEval` does on its side, after `Affine.Point.mk`
and `Affine.Point.neg_some`.

## Why both coordinates fall out of one unit

`formalInverseEval_eq` gives `ι(t) = -(t · u(t))` and `formalWEval_formalInverseEval` gives
`w(ι t) = -(w(t) · u(t))` — the *same* `u(t)`, the series inverse of the inverse denominator. So

* the `x`-coordinates agree outright: `ι(t) / w(ι t) = (-(t·u)) / (-(w(t)·u)) = t / w(t)`, the two
  signs and the unit cancelling;
* the `y`-coordinate is where the curve enters. `-1 / w(ι t) = 1 / (w(t) · u(t))`, and `u(t)`
  inverts `d(t) = 1 - a₁t - a₃w(t)` (`formalInverseDenomEval_mul_inv`,
  `formalInverseDenomEval_eq`), so that value is `d(t) / w(t) = 1/w(t) - a₁t/w(t) - a₃` — which is
  exactly `negY` at the original point's coordinates.

That is the whole proof: `Affine.Point.neg_some` and `Affine.Point.some.injEq` reduce to those two
identities, `field_simp` closes the first, and the second is one `linear_combination` in the unit
relation against the closed form of `d(t)`. The zero parameter is a separate branch, both sides
being the point at infinity.

Roadmap: EllipticCurves

New mathematics, so a target is cited: `TauCetiRoadmap/EllipticCurves/README.md`, **Layer 1**,
the formal group's milestone **(iii)** — "Convergence: over a complete valued field, `Ê(𝔪)` as an
honest group of points". Preservation of inverses is one of the clauses that makes `Ê(𝔪)` a group
of points rather than an indexed family, alongside the chord case of additivity that
`Point/Add.lean` landed in #6020. (Layer 6 is Mordell–Weil, which consumes this rather than asking
for it.) The same roadmap paragraph names the Stoll development as the port source.

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"formalPoint_formalInverseEval"}-->

Provenance: adapted from Michael Stoll's `EllipticCurves` project
(`github.com/MichaelStollBayreuth/EllipticCurves` @ `66889eada51a`, Apache-2.0),
`EllipticCurves/WeierstrassFormalGroup/Filtration.lean`, declaration `formalPoint_negPoint`. The
argument is that source's: the same split on whether the parameter vanishes, the same reduction
through `Affine.Point.neg_some` and `Affine.Point.some.injEq`, and on the `y`-coordinate the same
certificate — the unit relation against the closed form of the inverse denominator. Stated here
over an arbitrary complete adic ring mapping injectively to a field rather than that source's
`v.adicCompletion K` for a height-one prime of a Dedekind domain, matching the rest of this file.
The name takes this repository's vocabulary, `formalInverseEval` for the source's `iotaEval` /
`negPoint`.

Absent from Mathlib: `Mathlib/AlgebraicGeometry/EllipticCurve/` has no formal-group
parametrisation of points at all, so neither this statement nor its ingredients appear there.

## One note on the `@[simp]` tag

`formalPoint_formalInverseEval` carries `@[simp]` in the reducing orientation, towards point
negation, and `simpNF` accepts it. It is worth recording that `simp` will reach it only where the
parameter is syntactically `formalInverseEval t`. I probed both shapes — the conclusion naming the
membership term, and a variant taking the membership as a hypothesis — and `simp` reported *made no
progress* on each: `formalPoint`'s parameter lives in the membership proof's type, so matching it
otherwise needs higher-order unification, and in the hypothesis form the right-hand side wants a
proof of `t ∈ I` that `simp` cannot produce. The orientation that *would* match unconditionally is
`-formalPoint t = formalPoint (ι t)`, which is the wrong normal form. The docstring says as much,
so the tag is not mistaken for a stronger guarantee than it gives.
