### PR TITLE
feat: the character table of Sₙ satisfies the character-table specification

### DIFF
--- a/TauCeti/Combinatorics/Enumerative/Partition/Basic.lean
+++ b/TauCeti/Combinatorics/Enumerative/Partition/Basic.lean
@@ -17,11 +17,20 @@ are the single part `n` when `n ≠ 0`, and none when `n = 0`.  The third is
 `Nat.Partition.singletonSecondRow n = (n+1, 1)`, the partition of `n+2` with two parts whose
 second part is a single box; it is written at `n+2` so that both parts are positive with no
 hypothesis on `n`.
+
+It also records `TauCeti.parts_equivCast`, the transport of a partition along an equality of the
+number being partitioned: such a transport leaves the parts alone.
 -/
 
 public section
 
 namespace TauCeti
+
+/-- **Transporting a partition along an equality of the number being partitioned does not change
+its parts.** -/
+theorem parts_equivCast {m l : ℕ} (h : m = l) (p : m.Partition) :
+    (Equiv.cast (congrArg Nat.Partition h) p).parts = p.parts := by
+  subst h; rfl
 
 namespace Nat.Partition
 

--- a/TauCeti/RepresentationTheory/Symmetric/ClassSize.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/ClassSize.lean
@@ -279,15 +279,11 @@ theorem zPart_partitionEquivConjClasses_symm_mk (n : ℕ) (σ : Equiv.Perm (Fin 
     zPart ((partitionEquivConjClasses n).symm (ConjClasses.mk σ)) = zPart σ.partition :=
   zPart_congr (parts_partitionEquivConjClasses_symm_mk n σ)
 
-/-- **The weight of the partition of the identity is the order of the group**: the identity
-commutes with everything, so its centralizer is the whole of `Equiv.Perm α`. -/
+/-- **The weight of the partition of the identity is the order of the group**: the cycle type of
+the identity is empty, so all `Fintype.card α` of its parts equal `1`. -/
 theorem zPart_partition_one (α : Type*) [Fintype α] [DecidableEq α] :
     zPart ((1 : Equiv.Perm α).partition) = (Fintype.card α)! := by
-  have hcentralizer : Subgroup.centralizer {(1 : Equiv.Perm α)} = ⊤ := by
-    ext x
-    simp [Subgroup.mem_centralizer_iff]
-  rw [← nat_card_centralizer_eq_zPart, hcentralizer]
-  simp [Nat.card_eq_fintype_card, Fintype.card_perm]
+  simpa using zPart_partition (1 : Equiv.Perm α)
 
 /-- **The class-size formula on the conjugacy class attached to a partition**: the class
 `TauCeti.partitionEquivConjClasses n ν` has `n ! / zPart ν` elements.  This is

--- a/TauCeti/RepresentationTheory/Symmetric/ClassSize.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/ClassSize.lean
@@ -291,8 +291,9 @@ theorem zPart_partition_one (α : Type*) [Fintype α] [DecidableEq α] :
     zPart ((1 : Equiv.Perm α).partition) = (Fintype.card α)! := by
   simpa using zPart_partition (1 : Equiv.Perm α)
 
-/-- **The class-size formula on a conjugacy class**: a conjugacy class `C` of permutations of `α`
-has `(Fintype.card α)! / zPart (permConjClassPartition C)` elements.  This is
+/-- **The multiplicative class-size formula on a conjugacy class**: the cardinality of a
+conjugacy class `C` of permutations of `α`, multiplied by
+`zPart (permConjClassPartition C)`, is `(Fintype.card α)!`. This is
 `TauCeti.card_isConj_mul_zPart` read on the class itself rather than on the permutations conjugate
 to a representative. -/
 theorem card_carrier_mul_zPart (C : ConjClasses (Equiv.Perm α)) :
@@ -305,8 +306,9 @@ theorem card_carrier_mul_zPart (C : ConjClasses (Equiv.Perm α)) :
   rw [hcarrier, permConjClassPartition_mk]
   simpa using card_isConj_mul_zPart σ
 
-/-- The class-size formula on the class attached to a partition: the class
-`TauCeti.partitionEquivPermConjClasses α p` has `(Fintype.card α)! / zPart p` elements. -/
+/-- The multiplicative class-size formula on the class attached to a partition: the cardinality
+of `TauCeti.partitionEquivPermConjClasses α p`, multiplied by `zPart p`, is
+`(Fintype.card α)!`. -/
 theorem card_carrier_partitionEquivPermConjClasses_mul_zPart (p : (Fintype.card α).Partition) :
     Nat.card (partitionEquivPermConjClasses α p).carrier * zPart p = (Fintype.card α)! := by
   simpa using card_carrier_mul_zPart (partitionEquivPermConjClasses α p)
@@ -317,8 +319,9 @@ theorem card_carrier_partitionEquivPermConjClasses (p : (Fintype.card α).Partit
   (Nat.div_eq_of_eq_mul_left (zPart_pos p)
     (card_carrier_partitionEquivPermConjClasses_mul_zPart p).symm).symm
 
-/-- The class-size formula on the class attached to a partition, for `Equiv.Perm (Fin n)`: the
-class `TauCeti.partitionEquivConjClasses n ν` has `n ! / zPart ν` elements.  This is
+/-- The multiplicative class-size formula on the class attached to a partition, for
+`Equiv.Perm (Fin n)`: the cardinality of `TauCeti.partitionEquivConjClasses n ν`, multiplied by
+`zPart ν`, is `n !`. This is
 `TauCeti.card_carrier_mul_zPart` with the transport along `Fintype.card (Fin n) = n` carried out;
 it is the form the orthogonality relations consume. -/
 theorem card_carrier_partitionEquivConjClasses_mul_zPart {n : ℕ} (ν : n.Partition) :

--- a/TauCeti/RepresentationTheory/Symmetric/ClassSize.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/ClassSize.lean
@@ -283,9 +283,10 @@ theorem zPart_partitionEquivConjClasses_symm_mk (n : ℕ) (σ : Equiv.Perm (Fin 
 commutes with everything, so its centralizer is the whole of `Equiv.Perm α`. -/
 theorem zPart_partition_one (α : Type*) [Fintype α] [DecidableEq α] :
     zPart ((1 : Equiv.Perm α).partition) = (Fintype.card α)! := by
-  rw [← nat_card_centralizer_eq_zPart,
-    show Subgroup.centralizer {(1 : Equiv.Perm α)} = ⊤ from by
-      ext x; simp [Subgroup.mem_centralizer_iff]]
+  have hcentralizer : Subgroup.centralizer {(1 : Equiv.Perm α)} = ⊤ := by
+    ext x
+    simp [Subgroup.mem_centralizer_iff]
+  rw [← nat_card_centralizer_eq_zPart, hcentralizer]
   simp [Nat.card_eq_fintype_card, Fintype.card_perm]
 
 /-- **The class-size formula on the conjugacy class attached to a partition**: the class

--- a/TauCeti/RepresentationTheory/Symmetric/ClassSize.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/ClassSize.lean
@@ -26,9 +26,9 @@ The main results are `nat_card_centralizer_eq_zPart`, the multiplicative class-s
 normalisation `sum_factorial_div_zPart`, which says the class sizes add up to `n !`.  These are the
 weights in the orthogonality relations for the characters of the symmetric group, where the class
 with partition `μ` is weighted by `1 / zPart μ`.  The last section reads the formula on a
-conjugacy class itself rather than on a fibre of the partition map, as `card_carrier_mul_zPart`,
-and specializes it to the class attached to a partition, `card_carrier_partitionEquivConjClasses`
-being the form those orthogonality relations consume.
+conjugacy class itself rather than on a fibre of the partition map, as
+`ConjClasses.card_carrier_mul_zPart`, and specializes it to the class attached to a partition,
+`card_carrier_partitionEquivConjClasses` being the form those orthogonality relations consume.
 
 Mathlib counts permutations of a given *cycle type*, a multiset recording only the cycles of length
 at least two (`Equiv.Perm.nat_card_centralizer`, `Equiv.Perm.card_isConj_mul_eq`).  The translation
@@ -142,6 +142,12 @@ theorem zPart_partition (σ : Equiv.Perm α) :
     Finset.prod_congr rfl (fun i hi => by rw [hcount i hi]), Finset.prod_mul_distrib,
     ← Finset.prod_multiset_count, one_pow, one_mul, hk, Equiv.Perm.sum_cycleType]
   ring
+
+/-- **The weight of the partition of the identity is the order of the group**: the cycle type of
+the identity is empty, so all `Fintype.card α` of its parts equal `1`. -/
+theorem zPart_partition_one (α : Type*) [Fintype α] [DecidableEq α] :
+    zPart ((1 : Equiv.Perm α).partition) = (Fintype.card α)! := by
+  simpa using zPart_partition (1 : Equiv.Perm α)
 
 /-- The centralizer of a permutation has order the weight of its partition. -/
 theorem nat_card_centralizer_eq_zPart (σ : Equiv.Perm α) :
@@ -285,18 +291,12 @@ theorem zPart_partitionEquivConjClasses_symm_mk (n : ℕ) (σ : Equiv.Perm (Fin 
     zPart ((partitionEquivConjClasses n).symm (ConjClasses.mk σ)) = zPart σ.partition :=
   zPart_congr (parts_partitionEquivConjClasses_symm_mk n σ)
 
-/-- **The weight of the partition of the identity is the order of the group**: the cycle type of
-the identity is empty, so all `Fintype.card α` of its parts equal `1`. -/
-theorem zPart_partition_one (α : Type*) [Fintype α] [DecidableEq α] :
-    zPart ((1 : Equiv.Perm α).partition) = (Fintype.card α)! := by
-  simpa using zPart_partition (1 : Equiv.Perm α)
-
 /-- **The multiplicative class-size formula on a conjugacy class**: the cardinality of a
 conjugacy class `C` of permutations of `α`, multiplied by
 `zPart (permConjClassPartition C)`, is `(Fintype.card α)!`. This is
 `TauCeti.card_isConj_mul_zPart` read on the class itself rather than on the permutations conjugate
 to a representative. -/
-theorem card_carrier_mul_zPart (C : ConjClasses (Equiv.Perm α)) :
+theorem _root_.ConjClasses.card_carrier_mul_zPart (C : ConjClasses (Equiv.Perm α)) :
     Nat.card C.carrier * zPart (permConjClassPartition C) = (Fintype.card α)! := by
   obtain ⟨σ, rfl⟩ := ConjClasses.exists_rep C
   have hcarrier : (ConjClasses.mk σ).carrier = {τ : Equiv.Perm α | IsConj σ τ} := by
@@ -311,7 +311,7 @@ of `TauCeti.partitionEquivPermConjClasses α p`, multiplied by `zPart p`, is
 `(Fintype.card α)!`. -/
 theorem card_carrier_partitionEquivPermConjClasses_mul_zPart (p : (Fintype.card α).Partition) :
     Nat.card (partitionEquivPermConjClasses α p).carrier * zPart p = (Fintype.card α)! := by
-  simpa using card_carrier_mul_zPart (partitionEquivPermConjClasses α p)
+  simpa using (partitionEquivPermConjClasses α p).card_carrier_mul_zPart
 
 /-- The quotient form of `TauCeti.card_carrier_partitionEquivPermConjClasses_mul_zPart`. -/
 theorem card_carrier_partitionEquivPermConjClasses (p : (Fintype.card α).Partition) :
@@ -321,12 +321,11 @@ theorem card_carrier_partitionEquivPermConjClasses (p : (Fintype.card α).Partit
 
 /-- The multiplicative class-size formula on the class attached to a partition, for
 `Equiv.Perm (Fin n)`: the cardinality of `TauCeti.partitionEquivConjClasses n ν`, multiplied by
-`zPart ν`, is `n !`. This is
-`TauCeti.card_carrier_mul_zPart` with the transport along `Fintype.card (Fin n) = n` carried out;
-it is the form the orthogonality relations consume. -/
+`zPart ν`, is `n !`. This is `ConjClasses.card_carrier_mul_zPart` with the transport along
+`Fintype.card (Fin n) = n` carried out; it is the form the orthogonality relations consume. -/
 theorem card_carrier_partitionEquivConjClasses_mul_zPart {n : ℕ} (ν : n.Partition) :
     Nat.card (partitionEquivConjClasses n ν).carrier * zPart ν = n ! := by
-  have h := card_carrier_mul_zPart (partitionEquivConjClasses n ν)
+  have h := (partitionEquivConjClasses n ν).card_carrier_mul_zPart
   rwa [permConjClassPartition_partitionEquivConjClasses,
     zPart_congr (parts_equivCast (Fintype.card_fin n).symm ν), Fintype.card_fin] at h
 

--- a/TauCeti/RepresentationTheory/Symmetric/ClassSize.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/ClassSize.lean
@@ -25,7 +25,10 @@ The main results are `nat_card_centralizer_eq_zPart`, the multiplicative class-s
 `card_partition_mul_zPart` with its transported form `card_partition_parts_mul_zPart_fin`, and the
 normalisation `sum_factorial_div_zPart`, which says the class sizes add up to `n !`.  These are the
 weights in the orthogonality relations for the characters of the symmetric group, where the class
-with partition `μ` is weighted by `1 / zPart μ`.
+with partition `μ` is weighted by `1 / zPart μ`.  The last section reads the formula on the
+conjugacy class `partitionEquivConjClasses n ν` itself, as
+`card_carrier_partitionEquivConjClasses`, which is the form those orthogonality relations
+consume.
 
 Mathlib counts permutations of a given *cycle type*, a multiset recording only the cycles of length
 at least two (`Equiv.Perm.nat_card_centralizer`, `Equiv.Perm.card_isConj_mul_eq`).  The translation
@@ -266,5 +269,48 @@ identity `∑_μ 1 / z_μ = 1`, which divides this one by `n !`, is not formalis
 theorem sum_factorial_div_zPart (n : ℕ) : ∑ μ : n.Partition, n ! / zPart μ = n ! :=
   Eq.trans (Finset.sum_congr rfl fun μ _ => (card_partition_parts_div_zPart_fin n μ).symm)
     (sum_card_partition_parts (Fin n) (Fintype.card_fin n))
+
+/-! ### The class attached to a partition -/
+
+/-- The weight of the partition indexing the class of `σ` is the weight of the partition of `σ`:
+the transport `TauCeti.parts_partitionEquivConjClasses_symm_mk` leaves the parts, hence the
+weight, alone. -/
+theorem zPart_partitionEquivConjClasses_symm_mk (n : ℕ) (σ : Equiv.Perm (Fin n)) :
+    zPart ((partitionEquivConjClasses n).symm (ConjClasses.mk σ)) = zPart σ.partition :=
+  zPart_congr (parts_partitionEquivConjClasses_symm_mk n σ)
+
+/-- **The weight of the partition of the identity is the order of the group**: the identity
+commutes with everything, so its centralizer is the whole of `Equiv.Perm α`. -/
+theorem zPart_partition_one (α : Type*) [Fintype α] [DecidableEq α] :
+    zPart ((1 : Equiv.Perm α).partition) = (Fintype.card α)! := by
+  rw [← nat_card_centralizer_eq_zPart,
+    show Subgroup.centralizer {(1 : Equiv.Perm α)} = ⊤ from by
+      ext x; simp [Subgroup.mem_centralizer_iff]]
+  simp [Nat.card_eq_fintype_card, Fintype.card_perm]
+
+/-- **The class-size formula on the conjugacy class attached to a partition**: the class
+`TauCeti.partitionEquivConjClasses n ν` has `n ! / zPart ν` elements.  This is
+`TauCeti.card_partition_parts_mul_zPart_fin` read on the class itself rather than on the
+permutations with the given cycle type; it is stated for `Equiv.Perm (Fin n)` because
+`TauCeti.partitionEquivConjClasses` is. -/
+theorem card_carrier_partitionEquivConjClasses_mul_zPart {n : ℕ} (ν : n.Partition) :
+    Nat.card (partitionEquivConjClasses n ν).carrier * zPart ν = n ! := by
+  obtain ⟨σ, hσ⟩ := ConjClasses.exists_rep (partitionEquivConjClasses n ν)
+  have hν : (partitionEquivConjClasses n).symm (ConjClasses.mk σ) = ν := by
+    rw [hσ, Equiv.symm_apply_apply]
+  have hcarrier : (partitionEquivConjClasses n ν).carrier =
+      {τ : Equiv.Perm (Fin n) | IsConj σ τ} := by
+    rw [← hσ]
+    ext τ
+    rw [ConjClasses.mem_carrier_iff_mk_eq, ConjClasses.mk_eq_mk_iff_isConj, Set.mem_ofPred_eq,
+      isConj_comm]
+  rw [hcarrier, ← hν, zPart_partitionEquivConjClasses_symm_mk]
+  simpa using card_isConj_mul_zPart σ
+
+/-- The quotient form of `TauCeti.card_carrier_partitionEquivConjClasses_mul_zPart`. -/
+theorem card_carrier_partitionEquivConjClasses {n : ℕ} (ν : n.Partition) :
+    Nat.card (partitionEquivConjClasses n ν).carrier = n ! / zPart ν :=
+  (Nat.div_eq_of_eq_mul_left (zPart_pos ν)
+    (card_carrier_partitionEquivConjClasses_mul_zPart ν).symm).symm
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/Symmetric/ClassSize.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/ClassSize.lean
@@ -25,10 +25,10 @@ The main results are `nat_card_centralizer_eq_zPart`, the multiplicative class-s
 `card_partition_mul_zPart` with its transported form `card_partition_parts_mul_zPart_fin`, and the
 normalisation `sum_factorial_div_zPart`, which says the class sizes add up to `n !`.  These are the
 weights in the orthogonality relations for the characters of the symmetric group, where the class
-with partition `μ` is weighted by `1 / zPart μ`.  The last section reads the formula on the
-conjugacy class `partitionEquivConjClasses n ν` itself, as
-`card_carrier_partitionEquivConjClasses`, which is the form those orthogonality relations
-consume.
+with partition `μ` is weighted by `1 / zPart μ`.  The last section reads the formula on a
+conjugacy class itself rather than on a fibre of the partition map, as `card_carrier_mul_zPart`,
+and specializes it to the class attached to a partition, `card_carrier_partitionEquivConjClasses`
+being the form those orthogonality relations consume.
 
 Mathlib counts permutations of a given *cycle type*, a multiset recording only the cycles of length
 at least two (`Equiv.Perm.nat_card_centralizer`, `Equiv.Perm.card_isConj_mul_eq`).  The translation
@@ -49,7 +49,9 @@ public section
 
 namespace TauCeti
 
-open Equiv Nat
+-- `_root_.Nat` is spelled out: importing the named partitions brings `TauCeti.Nat.Partition`,
+-- hence the namespace `TauCeti.Nat`, into scope, which makes a bare `Nat` here ambiguous.
+open Equiv _root_.Nat
 
 variable {α : Type*} [Fintype α] [DecidableEq α]
 
@@ -274,7 +276,11 @@ theorem sum_factorial_div_zPart (n : ℕ) : ∑ μ : n.Partition, n ! / zPart μ
 
 /-- The weight of the partition indexing the class of `σ` is the weight of the partition of `σ`:
 the transport `TauCeti.parts_partitionEquivConjClasses_symm_mk` leaves the parts, hence the
-weight, alone. -/
+weight, alone.
+
+For a general finite type the equivalence carries no transport, and
+`TauCeti.partitionEquivPermConjClasses_symm_mk` already identifies the indexing partition with
+`σ.partition` itself, so no separate statement is needed there. -/
 theorem zPart_partitionEquivConjClasses_symm_mk (n : ℕ) (σ : Equiv.Perm (Fin n)) :
     zPart ((partitionEquivConjClasses n).symm (ConjClasses.mk σ)) = zPart σ.partition :=
   zPart_congr (parts_partitionEquivConjClasses_symm_mk n σ)
@@ -285,24 +291,41 @@ theorem zPart_partition_one (α : Type*) [Fintype α] [DecidableEq α] :
     zPart ((1 : Equiv.Perm α).partition) = (Fintype.card α)! := by
   simpa using zPart_partition (1 : Equiv.Perm α)
 
-/-- **The class-size formula on the conjugacy class attached to a partition**: the class
-`TauCeti.partitionEquivConjClasses n ν` has `n ! / zPart ν` elements.  This is
-`TauCeti.card_partition_parts_mul_zPart_fin` read on the class itself rather than on the
-permutations with the given cycle type; it is stated for `Equiv.Perm (Fin n)` because
-`TauCeti.partitionEquivConjClasses` is. -/
-theorem card_carrier_partitionEquivConjClasses_mul_zPart {n : ℕ} (ν : n.Partition) :
-    Nat.card (partitionEquivConjClasses n ν).carrier * zPart ν = n ! := by
-  obtain ⟨σ, hσ⟩ := ConjClasses.exists_rep (partitionEquivConjClasses n ν)
-  have hν : (partitionEquivConjClasses n).symm (ConjClasses.mk σ) = ν := by
-    rw [hσ, Equiv.symm_apply_apply]
-  have hcarrier : (partitionEquivConjClasses n ν).carrier =
-      {τ : Equiv.Perm (Fin n) | IsConj σ τ} := by
-    rw [← hσ]
+/-- **The class-size formula on a conjugacy class**: a conjugacy class `C` of permutations of `α`
+has `(Fintype.card α)! / zPart (permConjClassPartition C)` elements.  This is
+`TauCeti.card_isConj_mul_zPart` read on the class itself rather than on the permutations conjugate
+to a representative. -/
+theorem card_carrier_mul_zPart (C : ConjClasses (Equiv.Perm α)) :
+    Nat.card C.carrier * zPart (permConjClassPartition C) = (Fintype.card α)! := by
+  obtain ⟨σ, rfl⟩ := ConjClasses.exists_rep C
+  have hcarrier : (ConjClasses.mk σ).carrier = {τ : Equiv.Perm α | IsConj σ τ} := by
     ext τ
     rw [ConjClasses.mem_carrier_iff_mk_eq, ConjClasses.mk_eq_mk_iff_isConj, Set.mem_ofPred_eq,
       isConj_comm]
-  rw [hcarrier, ← hν, zPart_partitionEquivConjClasses_symm_mk]
+  rw [hcarrier, permConjClassPartition_mk]
   simpa using card_isConj_mul_zPart σ
+
+/-- The class-size formula on the class attached to a partition: the class
+`TauCeti.partitionEquivPermConjClasses α p` has `(Fintype.card α)! / zPart p` elements. -/
+theorem card_carrier_partitionEquivPermConjClasses_mul_zPart (p : (Fintype.card α).Partition) :
+    Nat.card (partitionEquivPermConjClasses α p).carrier * zPart p = (Fintype.card α)! := by
+  simpa using card_carrier_mul_zPart (partitionEquivPermConjClasses α p)
+
+/-- The quotient form of `TauCeti.card_carrier_partitionEquivPermConjClasses_mul_zPart`. -/
+theorem card_carrier_partitionEquivPermConjClasses (p : (Fintype.card α).Partition) :
+    Nat.card (partitionEquivPermConjClasses α p).carrier = (Fintype.card α)! / zPart p :=
+  (Nat.div_eq_of_eq_mul_left (zPart_pos p)
+    (card_carrier_partitionEquivPermConjClasses_mul_zPart p).symm).symm
+
+/-- The class-size formula on the class attached to a partition, for `Equiv.Perm (Fin n)`: the
+class `TauCeti.partitionEquivConjClasses n ν` has `n ! / zPart ν` elements.  This is
+`TauCeti.card_carrier_mul_zPart` with the transport along `Fintype.card (Fin n) = n` carried out;
+it is the form the orthogonality relations consume. -/
+theorem card_carrier_partitionEquivConjClasses_mul_zPart {n : ℕ} (ν : n.Partition) :
+    Nat.card (partitionEquivConjClasses n ν).carrier * zPart ν = n ! := by
+  have h := card_carrier_mul_zPart (partitionEquivConjClasses n ν)
+  rwa [permConjClassPartition_partitionEquivConjClasses,
+    zPart_congr (parts_equivCast (Fintype.card_fin n).symm ν), Fintype.card_fin] at h
 
 /-- The quotient form of `TauCeti.card_carrier_partitionEquivConjClasses_mul_zPart`. -/
 theorem card_carrier_partitionEquivConjClasses {n : ℕ} (ν : n.Partition) :

--- a/TauCeti/RepresentationTheory/Symmetric/Partitions.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Partitions.lean
@@ -15,6 +15,10 @@ This file gives the equivalence between partitions and conjugacy classes of perm
 proved for permutations of any finite type and specialized to `Equiv.Perm (Fin n)` for the roadmap
 API.  Mathlib's partition of a permutation includes the fixed points as parts of size one.
 
+The specialization to `Fin n` carries a transport along `Fintype.card (Fin n) = n`, which
+`TauCeti.parts_partitionEquivConjClasses_symm_mk` discharges on the parts: the partition indexing
+the class of `σ` has the parts of the cycle type of `σ`.
+
 ## References
 
 * [Schur--Weyl roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md),
@@ -142,6 +146,21 @@ theorem partitionEquivConjClasses_symm_mk (n : ℕ) (σ : Equiv.Perm (Fin n)) :
       (Equiv.cast (congrArg Nat.Partition (Fintype.card_fin n).symm)).symm
         σ.partition := by
   simp [partitionEquivConjClasses]
+
+/-- Transporting a partition along an equality of the number being partitioned does not change
+its parts.  This is the bookkeeping behind
+`TauCeti.parts_partitionEquivConjClasses_symm_mk`, where the cast is the one built into
+`TauCeti.partitionEquivConjClasses`. -/
+private theorem parts_equivCast_symm {m l : ℕ} (h : m = l) (p : l.Partition) :
+    ((Equiv.cast (congrArg Nat.Partition h)).symm p).parts = p.parts := by
+  subst h; rfl
+
+/-- **The partition indexing the class of `σ` has the parts of the cycle type of `σ`.**  This is
+`TauCeti.partitionEquivConjClasses_symm_mk` with the transport along `Fintype.card (Fin n) = n`
+carried out on the parts, which is the form in which the partition is compared with `σ` itself. -/
+theorem parts_partitionEquivConjClasses_symm_mk (n : ℕ) (σ : Equiv.Perm (Fin n)) :
+    ((partitionEquivConjClasses n).symm (ConjClasses.mk σ)).parts = σ.partition.parts := by
+  rw [partitionEquivConjClasses_symm_mk, parts_equivCast_symm (Fintype.card_fin n).symm]
 
 /-- The number of conjugacy classes of permutations of a finite type is the number of partitions
 of its cardinality. -/

--- a/TauCeti/RepresentationTheory/Symmetric/Partitions.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Partitions.lean
@@ -147,12 +147,11 @@ theorem partitionEquivConjClasses_symm_mk (n : ℕ) (σ : Equiv.Perm (Fin n)) :
         σ.partition := by
   simp [partitionEquivConjClasses]
 
-/-- Transporting a partition along an equality of the number being partitioned does not change
-its parts.  This is the bookkeeping behind
-`TauCeti.parts_partitionEquivConjClasses_symm_mk`, where the cast is the one built into
-`TauCeti.partitionEquivConjClasses`. -/
-private theorem parts_equivCast_symm {m l : ℕ} (h : m = l) (p : l.Partition) :
-    ((Equiv.cast (congrArg Nat.Partition h)).symm p).parts = p.parts := by
+/-- **Transporting a partition along an equality of the number being partitioned does not change
+its parts.**  This is the bookkeeping behind `TauCeti.parts_partitionEquivConjClasses_symm_mk`,
+where the cast is the one built into `TauCeti.partitionEquivConjClasses`. -/
+theorem parts_equivCast {m l : ℕ} (h : m = l) (p : m.Partition) :
+    (Equiv.cast (congrArg Nat.Partition h) p).parts = p.parts := by
   subst h; rfl
 
 /-- **The partition indexing the class of `σ` has the parts of the cycle type of `σ`.**  This is
@@ -160,7 +159,8 @@ private theorem parts_equivCast_symm {m l : ℕ} (h : m = l) (p : l.Partition) :
 carried out on the parts, which is the form in which the partition is compared with `σ` itself. -/
 theorem parts_partitionEquivConjClasses_symm_mk (n : ℕ) (σ : Equiv.Perm (Fin n)) :
     ((partitionEquivConjClasses n).symm (ConjClasses.mk σ)).parts = σ.partition.parts := by
-  rw [partitionEquivConjClasses_symm_mk, parts_equivCast_symm (Fintype.card_fin n).symm]
+  rw [partitionEquivConjClasses_symm_mk]
+  exact parts_equivCast (Fintype.card_fin n) _
 
 /-- The number of conjugacy classes of permutations of a finite type is the number of partitions
 of its cardinality. -/

--- a/TauCeti/RepresentationTheory/Symmetric/Partitions.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Partitions.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Algebra.Group.ConjFinite
 public import Mathlib.GroupTheory.Perm.Cycle.PossibleTypes
+public import TauCeti.Combinatorics.Enumerative.Partition.Basic
 
 /-!
 # Partitions and conjugacy classes of permutations
@@ -146,13 +147,6 @@ theorem partitionEquivConjClasses_symm_mk (n : ℕ) (σ : Equiv.Perm (Fin n)) :
       (Equiv.cast (congrArg Nat.Partition (Fintype.card_fin n).symm)).symm
         σ.partition := by
   simp [partitionEquivConjClasses]
-
-/-- **Transporting a partition along an equality of the number being partitioned does not change
-its parts.**  This is the bookkeeping behind `TauCeti.parts_partitionEquivConjClasses_symm_mk`,
-where the cast is the one built into `TauCeti.partitionEquivConjClasses`. -/
-theorem parts_equivCast {m l : ℕ} (h : m = l) (p : m.Partition) :
-    (Equiv.cast (congrArg Nat.Partition h) p).parts = p.parts := by
-  subst h; rfl
 
 /-- **The partition indexing the class of `σ` has the parts of the cycle type of `σ`.**  This is
 `TauCeti.partitionEquivConjClasses_symm_mk` with the transport along `Fintype.card (Fin n) = n`

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/Character.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/Character.lean
@@ -32,10 +32,11 @@ column of the identity holds the degrees.
 The general half of the argument is stated for an arbitrary rational representation of a finite
 group, as `TauCeti.FDRep.intCharacter`, and is what this file specializes. Nothing here computes
 an entry of the table: the recursion that does is the Murnaghan--Nakayama rule, which needs rim
-hooks and is not proved here. Neither is `symmetricCharacterTable n` compared with the library's
-general `TauCeti.characterTable k G`, which lives over an algebraically closed field and enumerates
-its rows by `Fin (Nat.card (ConjClasses G))`, nor is any of the table properties that one carries —
-the orthogonality relations, the specification `TauCeti.IsCharacterTableSpec` — proved for it.
+hooks and is not proved here. The comparison with the library's general
+`TauCeti.characterTable k G`, which lives over an algebraically closed field and enumerates its
+rows by `Fin (Nat.card (ConjClasses G))`, and the table properties that one carries — the
+orthogonality relations and the specification `TauCeti.IsCharacterTableSpec` — are in
+`TauCeti/RepresentationTheory/Symmetric/Specht/Orthogonality.lean`.
 
 ## Main definitions
 
@@ -168,9 +169,10 @@ Implementation note: this is not the library's general `TauCeti.characterTable k
 defined over an algebraically closed field, takes values there, and enumerates its rows by
 `Fin (Nat.card (ConjClasses G))` through an arbitrary choice of ordering of the irreducible
 characters. This matrix is the `ℤ`-valued table of `Sₙ` re-indexed on both sides by the partitions
-of `n`. No comparison with `TauCeti.characterTable ℂ (Equiv.Perm (Fin n))` is proved here, and
-neither are any of the table properties — the orthogonality relations, or the character-table
-specification `TauCeti.IsCharacterTableSpec` — which the general table carries. -/
+of `n`; the comparison with `TauCeti.characterTable ℂ (Equiv.Perm (Fin n))` and the table
+properties the general table carries — the orthogonality relations and the character-table
+specification `TauCeti.IsCharacterTableSpec` — are proved in
+`TauCeti/RepresentationTheory/Symmetric/Specht/Orthogonality.lean`. -/
 noncomputable def symmetricCharacterTable (n : ℕ) : Matrix n.Partition n.Partition ℤ :=
   Matrix.of fun μ ν => spechtCharValue μ ν
 

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/Extremes.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/Extremes.lean
@@ -318,15 +318,11 @@ theorem spechtCharValue_ones (n : ℕ) (ν : n.Partition) :
     spechtCharValue (Nat.Partition.ones n) ν = (-1) ^ (n + Multiset.card ν.parts) := by
   obtain ⟨σ, hσ⟩ := ConjClasses.mk_surjective (partitionEquivConjClasses n ν)
   have hparts : Multiset.card σ.partition.parts = Multiset.card ν.parts := by
-    have hcast : ∀ {m : ℕ} (e : n = m) (p : n.Partition),
-        (Equiv.cast (congrArg Nat.Partition e) p).parts = p.parts := by
-      rintro m rfl p
-      rfl
     have hσpart : σ.partition =
         Equiv.cast (congrArg Nat.Partition (Fintype.card_fin n).symm) ν := by
       rw [← permConjClassPartition_mk, hσ, permConjClassPartition_partitionEquivConjClasses]
     rw [hσpart]
-    exact congrArg Multiset.card (hcast (Fintype.card_fin n).symm ν)
+    exact congrArg Multiset.card (parts_equivCast (Fintype.card_fin n).symm ν)
   rw [spechtCharValue_eq_spechtChar _ _ hσ, spechtChar_ones,
     Equiv.Perm.sign_of_parts_partition, hparts, Fintype.card_fin]
   simp

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/Orthogonality.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/Orthogonality.lean
@@ -37,15 +37,15 @@ its conjugate coincide.
 
 ## Main definitions
 
-* `TauCeti.spechtCharIndex`: the row of the complex character table of `Sₙ` carrying `χ^μ`, with
-  `TauCeti.partitionEquivIrreducibleIndex` the bijection it defines.
+* `TauCeti.partitionEquivIrreducibleIndex`: the bijection sending `μ` to the row of the complex
+  character table of `Sₙ` carrying `χ^μ`.
 * `TauCeti.symmetricCharacterTableℂ`: the integer character table of `Sₙ` read in `ℂ` and
   reindexed on both sides into the shape `TauCeti.IsCharacterTableSpec` asks for.
 
 ## Main results
 
-* `TauCeti.characterTable_spechtCharIndex`: the entries of the complex character table of `Sₙ` are
-  the entries of `TauCeti.symmetricCharacterTable`.
+* `TauCeti.characterTable_partitionEquivIrreducibleIndex`: the entries of the complex character
+  table of `Sₙ` are the entries of `TauCeti.symmetricCharacterTable`.
 * `TauCeti.symmetricCharacterTableℂ_eq_characterTable` and
   `TauCeti.isCharacterTableSpec_symmetricCharacterTableℂ`: **the character table of `Sₙ` is the
   complex character table of `Sₙ`, and satisfies the character-table specification.**
@@ -87,68 +87,66 @@ theorem spechtChar_mem_irreducibleCharacters (μ : n.Partition) :
   rw [hcharacter] at h
   exact h
 
-/-- **The row of the complex character table of `Sₙ` carrying `χ^μ`.** The enumeration
+/-- The row of the complex character table of `Sₙ` carrying `χ^μ`. The enumeration
 `TauCeti.irreducibleCharacter` of the irreducible characters is an arbitrary one, so this index is
-found rather than computed; what matters is that it is a bijection
-(`TauCeti.partitionEquivIrreducibleIndex`). -/
-noncomputable def spechtCharIndex (μ : n.Partition) :
+found rather than computed; only the bijection it defines,
+`TauCeti.partitionEquivIrreducibleIndex`, is part of the API. -/
+private noncomputable def spechtCharIndex (μ : n.Partition) :
     Fin (Nat.card (ConjClasses (Equiv.Perm (Fin n)))) :=
   (exists_irreducibleCharacter_eq ℂ (spechtChar_mem_irreducibleCharacters μ)).choose
 
-/-- The character enumerated at `TauCeti.spechtCharIndex μ` is `χ^μ`. -/
-theorem irreducibleCharacter_spechtCharIndex (μ : n.Partition) :
-    irreducibleCharacter ℂ (spechtCharIndex μ) = fun σ ↦ (spechtChar μ σ : ℂ) :=
-  (exists_irreducibleCharacter_eq ℂ (spechtChar_mem_irreducibleCharacters μ)).choose_spec
-
-@[simp]
-theorem irreducibleCharacter_spechtCharIndex_apply (μ : n.Partition) (σ : Equiv.Perm (Fin n)) :
+/-- The character enumerated at `spechtCharIndex μ` is `χ^μ`. -/
+private theorem irreducibleCharacter_spechtCharIndex (μ : n.Partition)
+    (σ : Equiv.Perm (Fin n)) :
     irreducibleCharacter ℂ (spechtCharIndex μ) σ = (spechtChar μ σ : ℂ) :=
-  congrFun (irreducibleCharacter_spechtCharIndex μ) σ
+  congrFun (exists_irreducibleCharacter_eq ℂ (spechtChar_mem_irreducibleCharacters μ)).choose_spec σ
 
 /-- **Distinct partitions occupy distinct rows**: a complex Specht module is determined by its
 character. -/
-theorem spechtCharIndex_injective : Function.Injective (spechtCharIndex (n := n)) := by
+private theorem spechtCharIndex_injective : Function.Injective (spechtCharIndex (n := n)) := by
   intro μ ν h
   have hchar : (spechtModuleℂ μ).character = (spechtModuleℂ ν).character := funext fun σ ↦ by
     rw [character_spechtModuleℂ_intCast, character_spechtModuleℂ_intCast]
-    exact (irreducibleCharacter_spechtCharIndex_apply μ σ).symm.trans
-      (h ▸ irreducibleCharacter_spechtCharIndex_apply ν σ)
+    exact (irreducibleCharacter_spechtCharIndex μ σ).symm.trans
+      (h ▸ irreducibleCharacter_spechtCharIndex ν σ)
   exact spechtModuleℂ_character_injective hchar
 
 /-- **Every row is occupied**: there are as many partitions of `n` as conjugacy classes of `Sₙ`,
-so the injection of `TauCeti.spechtCharIndex_injective` is a bijection. -/
-theorem spechtCharIndex_bijective : Function.Bijective (spechtCharIndex (n := n)) := by
+so the injection `spechtCharIndex_injective` is a bijection. -/
+private theorem spechtCharIndex_bijective : Function.Bijective (spechtCharIndex (n := n)) := by
   refine (Fintype.bijective_iff_injective_and_card _).2 ⟨spechtCharIndex_injective, ?_⟩
   rw [Fintype.card_fin, Fintype.card_eq_nat_card]
   exact Nat.card_congr (partitionEquivConjClasses n)
 
 /-- **The partitions of `n` index the rows of the complex character table of `Sₙ`**, by
-`μ ↦ χ^μ`. -/
+`μ ↦ χ^μ`: the row `partitionEquivIrreducibleIndex n μ` carries the character `χ^μ`
+(`TauCeti.irreducibleCharacter_partitionEquivIrreducibleIndex`), and every row is of this form
+exactly once. -/
 noncomputable def partitionEquivIrreducibleIndex (n : ℕ) :
     n.Partition ≃ Fin (Nat.card (ConjClasses (Equiv.Perm (Fin n)))) :=
   Equiv.ofBijective _ spechtCharIndex_bijective
 
+/-- **The character enumerated at the row `TauCeti.partitionEquivIrreducibleIndex n μ` is
+`χ^μ`**, the character of the complex Specht module `S^μ`. -/
 @[simp]
-theorem partitionEquivIrreducibleIndex_apply (μ : n.Partition) :
-    partitionEquivIrreducibleIndex n μ = spechtCharIndex μ := (rfl)
-
-@[simp]
-theorem partitionEquivIrreducibleIndex_symm_spechtCharIndex (μ : n.Partition) :
-    (partitionEquivIrreducibleIndex n).symm (spechtCharIndex μ) = μ :=
-  (partitionEquivIrreducibleIndex n).symm_apply_apply μ
+theorem irreducibleCharacter_partitionEquivIrreducibleIndex (μ : n.Partition)
+    (σ : Equiv.Perm (Fin n)) :
+    irreducibleCharacter ℂ (partitionEquivIrreducibleIndex n μ) σ = (spechtChar μ σ : ℂ) :=
+  irreducibleCharacter_spechtCharIndex μ σ
 
 /-! ### The integer table is the complex character table -/
 
 /-- **The complex character table of `Sₙ` has the entries of `TauCeti.symmetricCharacterTable`**,
-once its rows are indexed by `TauCeti.spechtCharIndex` and its columns by
+once its rows are indexed by `TauCeti.partitionEquivIrreducibleIndex` and its columns by
 `TauCeti.partitionEquivConjClasses`. The entry at a representative `σ` of the class,
 `χ^μ(σ)`, is `TauCeti.characterTable_apply` followed by
-`TauCeti.irreducibleCharacter_spechtCharIndex_apply`, which `simp` does on its own. -/
-theorem characterTable_spechtCharIndex (μ ν : n.Partition) :
-    characterTable ℂ (Equiv.Perm (Fin n)) (spechtCharIndex μ) (partitionEquivConjClasses n ν)
+`TauCeti.irreducibleCharacter_partitionEquivIrreducibleIndex`. -/
+theorem characterTable_partitionEquivIrreducibleIndex (μ ν : n.Partition) :
+    characterTable ℂ (Equiv.Perm (Fin n)) (partitionEquivIrreducibleIndex n μ)
+        (partitionEquivConjClasses n ν)
       = (symmetricCharacterTable n μ ν : ℂ) := by
   obtain ⟨σ, hσ⟩ := ConjClasses.exists_rep (partitionEquivConjClasses n ν)
-  rw [← hσ, characterTable_apply, irreducibleCharacter_spechtCharIndex_apply,
+  rw [← hσ, characterTable_apply, irreducibleCharacter_partitionEquivIrreducibleIndex,
     symmetricCharacterTable_apply, spechtCharValue_eq_spechtChar μ ν hσ]
 
 /-- **The character table of `Sₙ` in the shape the specification asks for**: the integer entries
@@ -177,10 +175,8 @@ theorem symmetricCharacterTableℂ_apply (n : ℕ)
 theorem symmetricCharacterTableℂ_eq_characterTable (n : ℕ) :
     symmetricCharacterTableℂ n = characterTable ℂ (Equiv.Perm (Fin n)) := by
   ext i C
-  have hi : spechtCharIndex ((partitionEquivIrreducibleIndex n).symm i) = i := by
-    rw [← partitionEquivIrreducibleIndex_apply, Equiv.apply_symm_apply]
-  rw [symmetricCharacterTableℂ_apply, ← characterTable_spechtCharIndex]
-  rw [hi, Equiv.apply_symm_apply]
+  rw [symmetricCharacterTableℂ_apply, ← characterTable_partitionEquivIrreducibleIndex,
+    Equiv.apply_symm_apply, Equiv.apply_symm_apply]
 
 /-- **The character table of `Sₙ` satisfies the character-table specification**: its identity
 column consists of positive divisors of `n !` whose squares sum to `n !`, its rows are orthonormal
@@ -194,11 +190,6 @@ theorem isCharacterTableSpec_symmetricCharacterTableℂ (n : ℕ) :
 
 /-! ### The orthogonality relations -/
 
-/-- The order of `Sₙ`, as a `Nat.card`: this is `Fintype.card_perm`, in the counting the character
-table is stated with. -/
-private theorem nat_card_perm_fin (n : ℕ) : Nat.card (Equiv.Perm (Fin n)) = n ! := by
-  simp [Nat.card_eq_fintype_card, Fintype.card_perm]
-
 /-- A column pairing of `TauCeti.symmetricCharacterTable`, read in `ℂ` as the corresponding
 pairing of the complex character table. Conjugation is invisible: the entries are integers. -/
 private theorem intCast_sum_symmetricCharacterTable (ν ν' : n.Partition) :
@@ -210,8 +201,8 @@ private theorem intCast_sum_symmetricCharacterTable (ν ν' : n.Partition) :
   rw [← Equiv.sum_comp (partitionEquivIrreducibleIndex n)]
   push_cast
   exact Finset.sum_congr rfl fun μ _ ↦ by
-    rw [partitionEquivIrreducibleIndex_apply, characterTable_spechtCharIndex,
-      characterTable_spechtCharIndex, map_intCast]
+    rw [characterTable_partitionEquivIrreducibleIndex,
+      characterTable_partitionEquivIrreducibleIndex, map_intCast]
 
 /-- **Second (column) orthogonality for `Sₙ`**: two columns of the character table pair to the
 weight `z_ν` of their common cycle type, and to `0` when the cycle types differ. The weight is the
@@ -224,12 +215,10 @@ theorem symmetricCharacterTable_column_orthogonality (ν ν' : n.Partition) :
   · rw [ite_eq_left rfl]
     refine Int.cast_injective (α := ℂ) ?_
     rw [intCast_sum_symmetricCharacterTable, sum_characterTable_mul_conj, ite_eq_left rfl,
-      nat_card_perm_fin]
+      Nat.card_perm, Nat.card_fin]
     have hmul := card_carrier_partitionEquivConjClasses_mul_zPart ν
-    have hne0 : (Nat.card (partitionEquivConjClasses n ν).carrier : ℂ) ≠ 0 := by
-      refine Nat.cast_ne_zero.mpr fun h ↦ ?_
-      rw [h, zero_mul] at hmul
-      exact (Nat.factorial_pos n).ne' hmul.symm
+    have hne0 : (Nat.card (partitionEquivConjClasses n ν).carrier : ℂ) ≠ 0 :=
+      Nat.cast_ne_zero.mpr (ConjClasses.card_carrier_pos _).ne'
     rw [div_eq_iff hne0, mul_comm]
     exact_mod_cast hmul.symm
   · rw [ite_eq_right hne]
@@ -245,18 +234,18 @@ theorem symmetricCharacterTable_row_orthogonality (μ μ' : n.Partition) :
         symmetricCharacterTable n μ' ν = if μ = μ' then (n ! : ℤ) else 0 := by
   have hfac : (n ! : ℂ) ≠ 0 := Nat.cast_ne_zero.mpr (Nat.factorial_pos n).ne'
   have key := card_inv_mul_sum_card_conjClass_mul_characterTable_mul_conj
-    (spechtCharIndex μ) (spechtCharIndex μ')
+    (partitionEquivIrreducibleIndex n μ) (partitionEquivIrreducibleIndex n μ')
   rw [← Equiv.sum_comp (partitionEquivConjClasses n)] at key
-  simp only [characterTable_spechtCharIndex, map_intCast,
+  simp only [characterTable_partitionEquivIrreducibleIndex, map_intCast,
     card_carrier_partitionEquivConjClasses] at key
-  rw [nat_card_perm_fin, inv_mul_eq_iff_eq_mul₀ hfac] at key
+  rw [Nat.card_perm, Nat.card_fin, inv_mul_eq_iff_eq_mul₀ hfac] at key
   rcases eq_or_ne μ μ' with rfl | hne
   · rw [ite_eq_left rfl, mul_one] at key
     rw [ite_eq_left rfl]
     refine Int.cast_injective (α := ℂ) ?_
     push_cast
     exact key
-  · rw [ite_eq_right fun h ↦ hne (spechtCharIndex_injective h), mul_zero] at key
+  · rw [ite_eq_right fun h ↦ hne ((partitionEquivIrreducibleIndex n).injective h), mul_zero] at key
     rw [ite_eq_right hne]
     refine Int.cast_injective (α := ℂ) ?_
     push_cast

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/Orthogonality.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/Orthogonality.lean
@@ -12,12 +12,11 @@ public import TauCeti.RepresentationTheory.Symmetric.Specht.Complex
 /-!
 # The character table of `Sₙ` is a character table, and its orthogonality relations
 
-The integer matrix `TauCeti.symmetricCharacterTable n`, whose `(μ, ν)` entry is the value
-`χ^μ(ν)` of the character of the Specht module `S^μ` on the class of cycle type `ν`, was built
-without any of the properties a character table carries: it was not compared with the library's
-complex character table `TauCeti.characterTable ℂ (Equiv.Perm (Fin n))`, and neither the
-orthogonality relations nor the specification `TauCeti.IsCharacterTableSpec` were proved for it.
-This file supplies both.
+This file identifies the integer matrix `TauCeti.symmetricCharacterTable n`, whose `(μ, ν)` entry
+is the value `χ^μ(ν)` of the character of the Specht module `S^μ` on the class of cycle type `ν`,
+with the library's complex character table `TauCeti.characterTable ℂ (Equiv.Perm (Fin n))`. It then
+proves the specification `TauCeti.IsCharacterTableSpec` and the row and column orthogonality
+relations for the table.
 
 The bridge is that the complex Specht modules are exactly the irreducible complex representations
 of `Sₙ` (`TauCeti.existsUnique_character_eq_spechtChar`), so each `χ^μ`, read in `ℂ`, is one of the
@@ -62,11 +61,6 @@ its conjugate coincide.
 
 * [G. D. James, *The Representation Theory of the Symmetric Groups*][james1978], Chapter 6.
 * B. E. Sagan, *The Symmetric Group*, 2nd ed. (2001), Sections 1.9 and 4.7.
-* [Schur--Weyl roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md),
-  Layer 6, "The Specht character", whose remaining half — assembling the character table of `Sₙ`
-  and proving it satisfies the `IsCharacterTableSpec` of the character-theory roadmap — is what
-  this file supplies, together with the orthogonality relations that the class-size weights of
-  that layer's "Class sizes" item exist for.
 -/
 
 public section
@@ -87,8 +81,11 @@ theorem spechtChar_mem_irreducibleCharacters (μ : n.Partition) :
     (fun σ ↦ ((spechtChar μ σ : ℤ) : ℂ)) ∈ irreducibleCharacters ℂ (Equiv.Perm (Fin n)) := by
   have := FDRep.isIrreducible_of_simple (spechtModuleℂ μ)
   have h := character_mem_irreducibleCharacters (spechtModuleℂ μ).ρ
-  rwa [show Representation.character (spechtModuleℂ μ).ρ =
-    fun σ ↦ ((spechtChar μ σ : ℤ) : ℂ) from funext (character_spechtModuleℂ_intCast μ)] at h
+  have hcharacter : Representation.character (spechtModuleℂ μ).ρ =
+      fun σ ↦ ((spechtChar μ σ : ℤ) : ℂ) :=
+    funext (character_spechtModuleℂ_intCast μ)
+  rw [hcharacter] at h
+  exact h
 
 /-- **The row of the complex character table of `Sₙ` carrying `χ^μ`.** The enumeration
 `TauCeti.irreducibleCharacter` of the irreducible characters is an arbitrary one, so this index is
@@ -165,15 +162,25 @@ noncomputable def symmetricCharacterTableℂ (n : ℕ) :
   Matrix.of fun i C ↦ (symmetricCharacterTable n ((partitionEquivIrreducibleIndex n).symm i)
     ((partitionEquivConjClasses n).symm C) : ℂ)
 
+/-- The entries of the reindexed complex character table are the integer Specht character values
+read in `ℂ`. -/
+@[simp]
+theorem symmetricCharacterTableℂ_apply (n : ℕ)
+    (i : Fin (Nat.card (ConjClasses (Equiv.Perm (Fin n)))))
+    (C : ConjClasses (Equiv.Perm (Fin n))) :
+    symmetricCharacterTableℂ n i C =
+      (symmetricCharacterTable n ((partitionEquivIrreducibleIndex n).symm i)
+        ((partitionEquivConjClasses n).symm C) : ℂ) := by
+  simp [symmetricCharacterTableℂ]
+
 /-- **The reindexed integer character table of `Sₙ` is the complex character table of `Sₙ`.** -/
 theorem symmetricCharacterTableℂ_eq_characterTable (n : ℕ) :
     symmetricCharacterTableℂ n = characterTable ℂ (Equiv.Perm (Fin n)) := by
   ext i C
-  rw [show i = spechtCharIndex ((partitionEquivIrreducibleIndex n).symm i) from by
-      rw [← partitionEquivIrreducibleIndex_apply, Equiv.apply_symm_apply],
-    show C = partitionEquivConjClasses n ((partitionEquivConjClasses n).symm C) from
-      (Equiv.apply_symm_apply _ _).symm, characterTable_spechtCharIndex]
-  simp [symmetricCharacterTableℂ]
+  have hi : spechtCharIndex ((partitionEquivIrreducibleIndex n).symm i) = i := by
+    rw [← partitionEquivIrreducibleIndex_apply, Equiv.apply_symm_apply]
+  rw [symmetricCharacterTableℂ_apply, ← characterTable_spechtCharIndex]
+  rw [hi, Equiv.apply_symm_apply]
 
 /-- **The character table of `Sₙ` satisfies the character-table specification**: its identity
 column consists of positive divisors of `n !` whose squares sum to `n !`, its rows are orthonormal

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/Orthogonality.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/Orthogonality.lean
@@ -61,8 +61,6 @@ its conjugate coincide.
 
 * [G. D. James, *The Representation Theory of the Symmetric Groups*][james1978], Chapter 6.
 * B. E. Sagan, *The Symmetric Group*, 2nd ed. (2001), Sections 1.9 and 4.7.
-* [Schur--Weyl roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md),
-  Layer 6, "The Specht character".
 -/
 
 public section

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/Orthogonality.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/Orthogonality.lean
@@ -1,0 +1,298 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.RepresentationTheory.CharacterTable.Specification
+public import TauCeti.RepresentationTheory.Symmetric.ClassSize
+public import TauCeti.RepresentationTheory.Symmetric.Specht.Complex
+
+/-!
+# The character table of `Sₙ` is a character table, and its orthogonality relations
+
+The integer matrix `TauCeti.symmetricCharacterTable n`, whose `(μ, ν)` entry is the value
+`χ^μ(ν)` of the character of the Specht module `S^μ` on the class of cycle type `ν`, was built
+without any of the properties a character table carries: it was not compared with the library's
+complex character table `TauCeti.characterTable ℂ (Equiv.Perm (Fin n))`, and neither the
+orthogonality relations nor the specification `TauCeti.IsCharacterTableSpec` were proved for it.
+This file supplies both.
+
+The bridge is that the complex Specht modules are exactly the irreducible complex representations
+of `Sₙ` (`TauCeti.existsUnique_character_eq_spechtChar`), so each `χ^μ`, read in `ℂ`, is one of the
+enumerated irreducible characters, and `μ ↦ (its index)` is a bijection onto the row index of the
+complex character table. Both index sets have as many elements as `Sₙ` has conjugacy classes, so
+injectivity — which is the distinctness of the complex Specht modules — already gives the
+bijection. Reindexing the rows by that bijection and the columns by
+`TauCeti.partitionEquivConjClasses` turns the integer table into `characterTable ℂ Sₙ` on the nose,
+whence the specification and, entry by entry, the two orthogonality relations.
+
+The orthogonality relations are stated over `ℤ`, where the values live: division by class sizes is
+avoided by weighting with the class size `n ! / z_ν` itself, which is exact by
+`TauCeti.zPart_dvd_factorial`. The rational form with the classical weights `1 / z_ν`,
+`TauCeti.sum_symmetricCharacterTable_mul_div_zPart`, is the shape the Hall inner product of
+symmetric-function theory uses, and follows by dividing by `n !`. Complex conjugation, which is
+what the general relations over `ℂ` carry, disappears here: the entries are integers, so a row and
+its conjugate coincide.
+
+## Main definitions
+
+* `TauCeti.spechtCharIndex`: the row of the complex character table of `Sₙ` carrying `χ^μ`, with
+  `TauCeti.partitionEquivIrreducibleIndex` the bijection it defines.
+* `TauCeti.symmetricCharacterTableℂ`: the integer character table of `Sₙ` read in `ℂ` and
+  reindexed on both sides into the shape `TauCeti.IsCharacterTableSpec` asks for.
+
+## Main results
+
+* `TauCeti.characterTable_spechtCharIndex`: the entries of the complex character table of `Sₙ` are
+  the entries of `TauCeti.symmetricCharacterTable`.
+* `TauCeti.symmetricCharacterTableℂ_eq_characterTable` and
+  `TauCeti.isCharacterTableSpec_symmetricCharacterTableℂ`: **the character table of `Sₙ` is the
+  complex character table of `Sₙ`, and satisfies the character-table specification.**
+* `TauCeti.symmetricCharacterTable_column_orthogonality`: **second (column) orthogonality**,
+  `∑_μ χ^μ(ν) χ^μ(ν') = z_ν` when `ν = ν'` and `0` otherwise.
+* `TauCeti.symmetricCharacterTable_row_orthogonality`: **first (row) orthogonality**,
+  `∑_ν (n !/z_ν) χ^μ(ν) χ^μ'(ν) = n !` when `μ = μ'` and `0` otherwise, with
+  `TauCeti.sum_symmetricCharacterTable_mul_div_zPart` its rational form `∑_ν χ^μ(ν) χ^μ'(ν)/z_ν`.
+* `TauCeti.sum_finrank_spechtModule_sq`: **`∑_{μ ⊢ n} (f^μ)² = n !`**, column orthogonality at the
+  identity class.
+
+## References
+
+* [G. D. James, *The Representation Theory of the Symmetric Groups*][james1978], Chapter 6.
+* B. E. Sagan, *The Symmetric Group*, 2nd ed. (2001), Sections 1.9 and 4.7.
+* [Schur--Weyl roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md),
+  Layer 6, "The Specht character", whose remaining half — assembling the character table of `Sₙ`
+  and proving it satisfies the `IsCharacterTableSpec` of the character-theory roadmap — is what
+  this file supplies, together with the orthogonality relations that the class-size weights of
+  that layer's "Class sizes" item exist for.
+-/
+
+public section
+
+open Nat
+
+namespace TauCeti
+
+open Module
+
+variable {n : ℕ}
+
+/-! ### The Specht character as an enumerated irreducible character -/
+
+/-- **The integer character `χ^μ`, read in `ℂ`, is an irreducible character of `Sₙ`.** The complex
+Specht module is simple (`TauCeti.instSimpleSpechtModuleℂ`) and its character is `χ^μ`. -/
+theorem spechtChar_mem_irreducibleCharacters (μ : n.Partition) :
+    (fun σ ↦ ((spechtChar μ σ : ℤ) : ℂ)) ∈ irreducibleCharacters ℂ (Equiv.Perm (Fin n)) := by
+  have := FDRep.isIrreducible_of_simple (spechtModuleℂ μ)
+  have h := character_mem_irreducibleCharacters (spechtModuleℂ μ).ρ
+  rwa [show Representation.character (spechtModuleℂ μ).ρ =
+    fun σ ↦ ((spechtChar μ σ : ℤ) : ℂ) from funext (character_spechtModuleℂ_intCast μ)] at h
+
+/-- **The row of the complex character table of `Sₙ` carrying `χ^μ`.** The enumeration
+`TauCeti.irreducibleCharacter` of the irreducible characters is an arbitrary one, so this index is
+found rather than computed; what matters is that it is a bijection
+(`TauCeti.partitionEquivIrreducibleIndex`). -/
+noncomputable def spechtCharIndex (μ : n.Partition) :
+    Fin (Nat.card (ConjClasses (Equiv.Perm (Fin n)))) :=
+  (exists_irreducibleCharacter_eq ℂ (spechtChar_mem_irreducibleCharacters μ)).choose
+
+/-- The character enumerated at `TauCeti.spechtCharIndex μ` is `χ^μ`. -/
+theorem irreducibleCharacter_spechtCharIndex (μ : n.Partition) :
+    irreducibleCharacter ℂ (spechtCharIndex μ) = fun σ ↦ (spechtChar μ σ : ℂ) :=
+  (exists_irreducibleCharacter_eq ℂ (spechtChar_mem_irreducibleCharacters μ)).choose_spec
+
+@[simp]
+theorem irreducibleCharacter_spechtCharIndex_apply (μ : n.Partition) (σ : Equiv.Perm (Fin n)) :
+    irreducibleCharacter ℂ (spechtCharIndex μ) σ = (spechtChar μ σ : ℂ) :=
+  congrFun (irreducibleCharacter_spechtCharIndex μ) σ
+
+/-- **Distinct partitions occupy distinct rows**: a complex Specht module is determined by its
+character. -/
+theorem spechtCharIndex_injective : Function.Injective (spechtCharIndex (n := n)) := by
+  intro μ ν h
+  have hchar : (spechtModuleℂ μ).character = (spechtModuleℂ ν).character := funext fun σ ↦ by
+    rw [character_spechtModuleℂ_intCast, character_spechtModuleℂ_intCast]
+    exact (irreducibleCharacter_spechtCharIndex_apply μ σ).symm.trans
+      (h ▸ irreducibleCharacter_spechtCharIndex_apply ν σ)
+  exact spechtModuleℂ_character_injective hchar
+
+/-- **Every row is occupied**: there are as many partitions of `n` as conjugacy classes of `Sₙ`,
+so the injection of `TauCeti.spechtCharIndex_injective` is a bijection. -/
+theorem spechtCharIndex_bijective : Function.Bijective (spechtCharIndex (n := n)) := by
+  refine (Fintype.bijective_iff_injective_and_card _).2 ⟨spechtCharIndex_injective, ?_⟩
+  rw [Fintype.card_fin, Fintype.card_eq_nat_card]
+  exact Nat.card_congr (partitionEquivConjClasses n)
+
+/-- **The partitions of `n` index the rows of the complex character table of `Sₙ`**, by
+`μ ↦ χ^μ`. -/
+noncomputable def partitionEquivIrreducibleIndex (n : ℕ) :
+    n.Partition ≃ Fin (Nat.card (ConjClasses (Equiv.Perm (Fin n)))) :=
+  Equiv.ofBijective _ spechtCharIndex_bijective
+
+@[simp]
+theorem partitionEquivIrreducibleIndex_apply (μ : n.Partition) :
+    partitionEquivIrreducibleIndex n μ = spechtCharIndex μ := (rfl)
+
+@[simp]
+theorem partitionEquivIrreducibleIndex_symm_spechtCharIndex (μ : n.Partition) :
+    (partitionEquivIrreducibleIndex n).symm (spechtCharIndex μ) = μ :=
+  (partitionEquivIrreducibleIndex n).symm_apply_apply μ
+
+/-! ### The integer table is the complex character table -/
+
+/-- **The complex character table of `Sₙ` has the entries of `TauCeti.symmetricCharacterTable`**,
+once its rows are indexed by `TauCeti.spechtCharIndex` and its columns by
+`TauCeti.partitionEquivConjClasses`. The entry at a representative `σ` of the class,
+`χ^μ(σ)`, is `TauCeti.characterTable_apply` followed by
+`TauCeti.irreducibleCharacter_spechtCharIndex_apply`, which `simp` does on its own. -/
+theorem characterTable_spechtCharIndex (μ ν : n.Partition) :
+    characterTable ℂ (Equiv.Perm (Fin n)) (spechtCharIndex μ) (partitionEquivConjClasses n ν)
+      = (symmetricCharacterTable n μ ν : ℂ) := by
+  obtain ⟨σ, hσ⟩ := ConjClasses.exists_rep (partitionEquivConjClasses n ν)
+  rw [← hσ, characterTable_apply, irreducibleCharacter_spechtCharIndex_apply,
+    symmetricCharacterTable_apply, spechtCharValue_eq_spechtChar μ ν hσ]
+
+/-- **The character table of `Sₙ` in the shape the specification asks for**: the integer entries
+of `TauCeti.symmetricCharacterTable` read in `ℂ`, with the rows indexed by
+`Fin (Nat.card (ConjClasses (Equiv.Perm (Fin n))))` and the columns by the conjugacy classes
+themselves. It is the complex character table
+(`TauCeti.symmetricCharacterTableℂ_eq_characterTable`). -/
+noncomputable def symmetricCharacterTableℂ (n : ℕ) :
+    Matrix (Fin (Nat.card (ConjClasses (Equiv.Perm (Fin n)))))
+      (ConjClasses (Equiv.Perm (Fin n))) ℂ :=
+  Matrix.of fun i C ↦ (symmetricCharacterTable n ((partitionEquivIrreducibleIndex n).symm i)
+    ((partitionEquivConjClasses n).symm C) : ℂ)
+
+/-- **The reindexed integer character table of `Sₙ` is the complex character table of `Sₙ`.** -/
+theorem symmetricCharacterTableℂ_eq_characterTable (n : ℕ) :
+    symmetricCharacterTableℂ n = characterTable ℂ (Equiv.Perm (Fin n)) := by
+  ext i C
+  rw [show i = spechtCharIndex ((partitionEquivIrreducibleIndex n).symm i) from by
+      rw [← partitionEquivIrreducibleIndex_apply, Equiv.apply_symm_apply],
+    show C = partitionEquivConjClasses n ((partitionEquivConjClasses n).symm C) from
+      (Equiv.apply_symm_apply _ _).symm, characterTable_spechtCharIndex]
+  simp [symmetricCharacterTableℂ]
+
+/-- **The character table of `Sₙ` satisfies the character-table specification**: its identity
+column consists of positive divisors of `n !` whose squares sum to `n !`, its rows are orthonormal
+for the class-size weighted Hermitian pairing, and its normalized rows are common left eigenrows of
+the class-multiplication matrices. By `TauCeti.characterTable_unique_rows` this pins the table down
+up to a permutation of its rows. -/
+theorem isCharacterTableSpec_symmetricCharacterTableℂ (n : ℕ) :
+    IsCharacterTableSpec (Equiv.Perm (Fin n)) (symmetricCharacterTableℂ n) := by
+  rw [symmetricCharacterTableℂ_eq_characterTable]
+  exact isCharacterTableSpec_characterTable (Equiv.Perm (Fin n))
+
+/-! ### The orthogonality relations -/
+
+/-- The order of `Sₙ`, as a `Nat.card`: this is `Fintype.card_perm`, in the counting the character
+table is stated with. -/
+private theorem nat_card_perm_fin (n : ℕ) : Nat.card (Equiv.Perm (Fin n)) = n ! := by
+  simp [Nat.card_eq_fintype_card, Fintype.card_perm]
+
+/-- A column pairing of `TauCeti.symmetricCharacterTable`, read in `ℂ` as the corresponding
+pairing of the complex character table. Conjugation is invisible: the entries are integers. -/
+private theorem intCast_sum_symmetricCharacterTable (ν ν' : n.Partition) :
+    ((∑ μ : n.Partition, symmetricCharacterTable n μ ν *
+        symmetricCharacterTable n μ ν' : ℤ) : ℂ)
+      = ∑ i, characterTable ℂ (Equiv.Perm (Fin n)) i (partitionEquivConjClasses n ν) *
+          (starRingEnd ℂ) (characterTable ℂ (Equiv.Perm (Fin n)) i
+            (partitionEquivConjClasses n ν')) := by
+  rw [← Equiv.sum_comp (partitionEquivIrreducibleIndex n)]
+  push_cast
+  exact Finset.sum_congr rfl fun μ _ ↦ by
+    rw [partitionEquivIrreducibleIndex_apply, characterTable_spechtCharIndex,
+      characterTable_spechtCharIndex, map_intCast]
+
+/-- **Second (column) orthogonality for `Sₙ`**: two columns of the character table pair to the
+weight `z_ν` of their common cycle type, and to `0` when the cycle types differ. The weight is the
+order of the centralizer of a permutation of that cycle type
+(`TauCeti.nat_card_centralizer_eq_zPart`), which is `n !` divided by the size of the class. -/
+theorem symmetricCharacterTable_column_orthogonality (ν ν' : n.Partition) :
+    ∑ μ : n.Partition, symmetricCharacterTable n μ ν * symmetricCharacterTable n μ ν'
+      = if ν = ν' then (zPart ν : ℤ) else 0 := by
+  rcases eq_or_ne ν ν' with rfl | hne
+  · rw [ite_eq_left rfl]
+    refine Int.cast_injective (α := ℂ) ?_
+    rw [intCast_sum_symmetricCharacterTable, sum_characterTable_mul_conj, ite_eq_left rfl,
+      nat_card_perm_fin]
+    have hmul := card_carrier_partitionEquivConjClasses_mul_zPart ν
+    have hne0 : (Nat.card (partitionEquivConjClasses n ν).carrier : ℂ) ≠ 0 := by
+      refine Nat.cast_ne_zero.mpr fun h ↦ ?_
+      rw [h, zero_mul] at hmul
+      exact (Nat.factorial_pos n).ne' hmul.symm
+    rw [div_eq_iff hne0, mul_comm]
+    exact_mod_cast hmul.symm
+  · rw [ite_eq_right hne]
+    refine Int.cast_injective (α := ℂ) ?_
+    rw [intCast_sum_symmetricCharacterTable, sum_characterTable_mul_conj,
+      ite_eq_right fun h ↦ hne ((partitionEquivConjClasses n).injective h), Int.cast_zero]
+
+/-- **First (row) orthogonality for `Sₙ`**, in a form free of division: two rows of the character
+table, paired with the class sizes `n !/z_ν` as weights, give `n !` on the diagonal and `0` off
+it. -/
+theorem symmetricCharacterTable_row_orthogonality (μ μ' : n.Partition) :
+    ∑ ν : n.Partition, ((n ! / zPart ν : ℕ) : ℤ) * symmetricCharacterTable n μ ν *
+        symmetricCharacterTable n μ' ν = if μ = μ' then (n ! : ℤ) else 0 := by
+  have hfac : (n ! : ℂ) ≠ 0 := Nat.cast_ne_zero.mpr (Nat.factorial_pos n).ne'
+  have key := card_inv_mul_sum_card_conjClass_mul_characterTable_mul_conj
+    (spechtCharIndex μ) (spechtCharIndex μ')
+  rw [← Equiv.sum_comp (partitionEquivConjClasses n)] at key
+  simp only [characterTable_spechtCharIndex, map_intCast,
+    card_carrier_partitionEquivConjClasses] at key
+  rw [nat_card_perm_fin, inv_mul_eq_iff_eq_mul₀ hfac] at key
+  rcases eq_or_ne μ μ' with rfl | hne
+  · rw [ite_eq_left rfl, mul_one] at key
+    rw [ite_eq_left rfl]
+    refine Int.cast_injective (α := ℂ) ?_
+    push_cast
+    exact key
+  · rw [ite_eq_right fun h ↦ hne (spechtCharIndex_injective h), mul_zero] at key
+    rw [ite_eq_right hne]
+    refine Int.cast_injective (α := ℂ) ?_
+    push_cast
+    exact key
+
+/-- **First (row) orthogonality for `Sₙ` in its classical rational form**: the characters are
+orthonormal for the pairing `⟨f, g⟩ = ∑_ν f(ν) g(ν) / z_ν`. This is
+`TauCeti.symmetricCharacterTable_row_orthogonality` divided by `n !`, the divisions being exact by
+`TauCeti.zPart_dvd_factorial`. -/
+theorem sum_symmetricCharacterTable_mul_div_zPart (μ μ' : n.Partition) :
+    ∑ ν : n.Partition,
+        (symmetricCharacterTable n μ ν * symmetricCharacterTable n μ' ν : ℚ) / zPart ν
+      = if μ = μ' then 1 else 0 := by
+  have hfac : (n ! : ℚ) ≠ 0 := Nat.cast_ne_zero.mpr (Nat.factorial_pos n).ne'
+  refine mul_left_cancel₀ hfac ?_
+  have h1 : (n ! : ℚ) * ∑ ν : n.Partition,
+      (symmetricCharacterTable n μ ν * symmetricCharacterTable n μ' ν : ℚ) / zPart ν
+      = ((∑ ν : n.Partition, ((n ! / zPart ν : ℕ) : ℤ) * symmetricCharacterTable n μ ν *
+        symmetricCharacterTable n μ' ν : ℤ) : ℚ) := by
+    rw [Finset.mul_sum, Int.cast_sum]
+    refine Finset.sum_congr rfl fun ν _ ↦ ?_
+    rw [Int.cast_mul, Int.cast_mul, Int.cast_natCast,
+      Nat.cast_div (zPart_dvd_factorial ν) (Nat.cast_ne_zero.mpr (zPart_pos ν).ne')]
+    ring
+  rw [h1, symmetricCharacterTable_row_orthogonality]
+  rcases eq_or_ne μ μ' with rfl | hne
+  · rw [ite_eq_left rfl, ite_eq_left rfl, mul_one, Int.cast_natCast]
+  · rw [ite_eq_right hne, ite_eq_right hne, mul_zero, Int.cast_zero]
+
+/-- **The dimensions of the Specht modules square-sum to `n !`.** This is column orthogonality at
+the class of the identity, whose weight `z` is the order of `Sₙ` and whose column holds the
+degrees `f^μ = dim_ℚ S^μ`. -/
+theorem sum_finrank_spechtModule_sq (n : ℕ) :
+    ∑ μ : n.Partition, finrank ℚ (spechtModule μ) ^ 2 = n ! := by
+  have hz : zPart ((partitionEquivConjClasses n).symm (ConjClasses.mk 1)) = n ! := by
+    rw [zPart_partitionEquivConjClasses_symm_mk, zPart_partition_one, Fintype.card_fin]
+  have hcol := symmetricCharacterTable_column_orthogonality
+    ((partitionEquivConjClasses n).symm (ConjClasses.mk 1))
+    ((partitionEquivConjClasses n).symm (ConjClasses.mk 1))
+  rw [ite_eq_left rfl, hz] at hcol
+  refine Nat.cast_injective (R := ℤ) ?_
+  push_cast
+  rw [← hcol]
+  exact Finset.sum_congr rfl fun μ _ ↦ by rw [symmetricCharacterTable_one]; ring
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/Orthogonality.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/Orthogonality.lean
@@ -61,6 +61,8 @@ its conjugate coincide.
 
 * [G. D. James, *The Representation Theory of the Symmetric Groups*][james1978], Chapter 6.
 * B. E. Sagan, *The Symmetric Group*, 2nd ed. (2001), Sections 1.9 and 4.7.
+* [Schur--Weyl roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md),
+  Layer 6, "The Specht character".
 -/
 
 public section
@@ -141,6 +143,7 @@ once its rows are indexed by `TauCeti.partitionEquivIrreducibleIndex` and its co
 `TauCeti.partitionEquivConjClasses`. The entry at a representative `σ` of the class,
 `χ^μ(σ)`, is `TauCeti.characterTable_apply` followed by
 `TauCeti.irreducibleCharacter_partitionEquivIrreducibleIndex`. -/
+@[simp]
 theorem characterTable_partitionEquivIrreducibleIndex (μ ν : n.Partition) :
     characterTable ℂ (Equiv.Perm (Fin n)) (partitionEquivIrreducibleIndex n μ)
         (partitionEquivConjClasses n ν)


### PR DESCRIPTION
This PR proves that the integer character table of the symmetric group is a character table. `TauCeti.symmetricCharacterTable n` was built in TauCeti#3169 as a bare `Matrix (Nat.Partition n) (Nat.Partition n) ℤ` of Specht character values, with — as its own docstring said — no comparison to the library's `TauCeti.characterTable ℂ (Equiv.Perm (Fin n))` and none of the properties that table carries. Identify the two: the complex Specht modules are exactly the irreducible complex representations of `Sₙ` (TauCeti#5649, `TauCeti.existsUnique_character_eq_spechtChar`), so each `χ^μ` read in `ℂ` occupies one row of the complex character table, injectively by distinctness of the complex Specht modules and hence bijectively, there being as many partitions of `n` as conjugacy classes of `Sₙ`. Reindexing rows by that bijection (`TauCeti.partitionEquivIrreducibleIndex`) and columns by `TauCeti.partitionEquivConjClasses` makes the integer table into `characterTable ℂ Sₙ` on the nose (`TauCeti.symmetricCharacterTableℂ_eq_characterTable`), whence `TauCeti.isCharacterTableSpec_symmetricCharacterTableℂ` and, entry by entry, both orthogonality relations.

This is the second half of the "The Specht character" item of Layer 6 ("characters and the Murnaghan-Nakayama rule") of `TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md`, whose text asks to "assemble the character table of `Sₙ` as `Matrix (Nat.Partition n) (Nat.Partition n) ℤ`, `X λ μ = χ^λ(cycle type μ)`, and prove it satisfies the `IsCharacterTableSpec` of `../CharacterTheory`". The orthogonality relations are stated in the weights `z_ν = ∏ᵢ i^{mᵢ} mᵢ!` that the same layer's "Class sizes" item exists to supply (`TauCeti.zPart`, TauCeti#5240's neighbourhood): column orthogonality `∑_μ χ^μ(ν) χ^μ(ν') = z_ν · δ_{νν'}` over `ℤ`, row orthogonality `∑_ν (n!/z_ν) χ^μ(ν) χ^{μ'}(ν) = n! · δ_{μμ'}` free of division, and its classical rational form `∑_ν χ^μ(ν) χ^{μ'}(ν)/z_ν = δ_{μμ'}`, which is the Hall pairing that Layer 7's Frobenius characteristic uses. Complex conjugation, which the general relations over `ℂ` carry, disappears because the entries are integers. Column orthogonality at the identity class gives `∑_{μ ⊢ n} (f^μ)² = n!`, the corollary Layer 7 records for RSK. What remains in Layer 6 after this PR is rim hooks and the Murnaghan-Nakayama recursion itself, which is what computes the entries.

Two prerequisites go to their canonical homes rather than to the new file. `TauCeti.parts_partitionEquivConjClasses_symm_mk` in `Symmetric/Partitions.lean` discharges, on the parts, the transport along `Fintype.card (Fin n) = n` built into `partitionEquivConjClasses`; `TauCeti.zPart_partition_one` and `TauCeti.card_carrier_partitionEquivConjClasses` in `Symmetric/ClassSize.lean` read the class-size formula already there on the conjugacy class attached to a partition, which is the form the orthogonality weights need. The docstrings in `Symmetric/Specht/Character.lean` that recorded the two gaps this PR closes are updated to point at the new file. Nothing is vendored from Mathlib; the arguments follow James, *The Representation Theory of the Symmetric Groups*, Chapter 6 and Sagan, *The Symmetric Group*, Sections 1.9 and 4.7, both cited in the new module.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"symmetric-character-table-spec"}-->

🤖 Prepared with Claude Code
