### PR TITLE
feat(StandardDistributions): directional exponential transforms of the multinomial law

### DIFF
--- a/TauCeti/Probability/Distributions/Multinomial/Basic.lean
+++ b/TauCeti/Probability/Distributions/Multinomial/Basic.lean
@@ -60,6 +60,13 @@ the multinomial measure specializes them to the weights of a probability vector.
 def multinomialWeightReal (w : ι → NNReal) (k : ι → ℕ) : ℝ :=
   (Nat.multinomial Finset.univ k : ℝ) * ∏ i, (w i : ℝ) ^ k i
 
+-- The parentheses in `(rfl)` opt out of the exported-theorem exposure check, so that the
+-- defining formula can be stated without exposing the body of `multinomialWeightReal`.
+/-- The defining formula of the real multinomial weight, for use across module boundaries. -/
+theorem multinomialWeightReal_def (w : ι → NNReal) (k : ι → ℕ) :
+    multinomialWeightReal w k = (Nat.multinomial Finset.univ k : ℝ) * ∏ i, (w i : ℝ) ^ k i :=
+  (rfl)
+
 /-- Every real multinomial weight is nonnegative. -/
 theorem multinomialWeightReal_nonneg (w : ι → NNReal) (k : ι → ℕ) :
     0 ≤ multinomialWeightReal w k := by

--- a/TauCeti/Probability/Distributions/Multinomial/Basic.lean
+++ b/TauCeti/Probability/Distributions/Multinomial/Basic.lean
@@ -8,6 +8,8 @@ module
 public import Mathlib.Data.Nat.Choose.Multinomial
 public import Mathlib.Geometry.Convex.ConvexSpace.Defs
 public import Mathlib.MeasureTheory.Integral.Bochner.SumMeasure
+public import Mathlib.Analysis.InnerProductSpace.PiL2
+public import Mathlib.Analysis.Normed.Lp.MeasurableSpace
 
 /-!
 # The multinomial distribution
@@ -33,6 +35,8 @@ numbers summing to one.
 * `TauCeti.Probability.multinomialMeasure_singleton`: the exact singleton mass.
 * `TauCeti.Probability.multinomialMeasure_singleton_ne_zero_iff`: the exact support.
 * `TauCeti.Probability.integral_multinomialMeasure`: integration as a finite weighted sum.
+* `TauCeti.Probability.multinomialToEuclidean`: the cast of count vectors into Euclidean space,
+  the carrier of the law's mean, covariance and transforms.
 
 ## References
 
@@ -253,6 +257,24 @@ theorem integral_multinomialMeasure {E : Type*} [NormedAddCommGroup E] [NormedSp
   · simp
   · exact fun k _ ↦
       (integrable_dirac (by simp)).smul_measure (multinomialWeight_ne_top p.weights k)
+
+/-- The count vector cast into Euclidean space. -/
+def multinomialToEuclidean (k : ι → ℕ) : EuclideanSpace ℝ ι :=
+  (EuclideanSpace.equiv ι ℝ).symm fun i => (k i : ℝ)
+
+omit [Fintype ι] in
+/-- The coordinates of the cast are the counts, as reals. -/
+@[simp]
+theorem multinomialToEuclidean_apply (k : ι → ℕ) (i : ι) :
+    multinomialToEuclidean k i = (k i : ℝ) := (rfl)
+
+omit [Fintype ι] in
+/-- The cast of count vectors into Euclidean space is measurable. -/
+theorem measurable_multinomialToEuclidean [Finite ι] :
+    Measurable (multinomialToEuclidean (ι := ι)) := by
+  have := Fintype.ofFinite ι
+  refine (EuclideanSpace.equiv ι ℝ).symm.continuous.measurable.comp ?_
+  exact Measurable.of_eval fun i => measurable_from_nat.comp (measurable_pi_apply i)
 
 end Probability
 

--- a/TauCeti/Probability/Distributions/Multinomial/Transforms.lean
+++ b/TauCeti/Probability/Distributions/Multinomial/Transforms.lean
@@ -1,0 +1,129 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Probability.Distributions.Multinomial.Basic
+public import Mathlib.Probability.Moments.Basic
+public import Mathlib.Probability.Moments.IntegrableExpMul
+public import Mathlib.Analysis.InnerProductSpace.PiL2
+public import Mathlib.Analysis.Normed.Lp.MeasurableSpace
+
+/-!
+# Directional exponential transforms of the multinomial distribution
+
+A count vector `k : ι → ℕ` is cast into `EuclideanSpace ℝ ι` by `multinomialToEuclidean`. For
+the pushforward of `multinomialMeasure n p` along that cast and a direction `θ`, the directional
+moment generating function is finite everywhere and equals
+`(∑ i, p i * exp (t * θ i)) ^ n`: the multinomial theorem, with the cell weights tilted by
+`exp (t * θ i)`. The cumulant generating function is its real logarithm.
+
+Every statement holds for `n = 0` (the law is a Dirac mass at zero, and the formula is `1`) and
+for probability vectors with zero cells, which contribute nothing to the tilted sum.
+
+## Main results
+
+* `TauCeti.Probability.multinomialToEuclidean` — the cast of count vectors into Euclidean space;
+* `TauCeti.Probability.integrableExpSet_inner_multinomial` — every direction has full exponential
+  integrability domain;
+* `TauCeti.Probability.mgf_inner_multinomial` — the directional moment generating function;
+* `TauCeti.Probability.cgf_inner_multinomial` — the directional cumulant generating function.
+
+## References
+
+* N. L. Johnson, S. Kotz, N. Balakrishnan, *Discrete Multivariate Distributions*, Wiley, 1997,
+  Chapter 35.
+-/
+
+public section
+
+noncomputable section
+
+open Convexity MeasureTheory ProbabilityTheory Real
+open scoped ENNReal
+
+namespace TauCeti
+
+namespace Probability
+
+variable {ι : Type*} [Fintype ι]
+
+/-- The count vector cast into Euclidean space. -/
+def multinomialToEuclidean (k : ι → ℕ) : EuclideanSpace ℝ ι :=
+  (EuclideanSpace.equiv ι ℝ).symm fun i => (k i : ℝ)
+
+omit [Fintype ι] in
+/-- The coordinates of the cast are the counts, as reals. -/
+@[simp]
+theorem multinomialToEuclidean_apply (k : ι → ℕ) (i : ι) :
+    multinomialToEuclidean k i = (k i : ℝ) := (rfl)
+
+/-- The pointwise identity behind the moment generating function: a multinomial weight times the
+exponential of a directional sum is the multinomial weight of the tilted cells `pᵢ exp (t θᵢ)`. -/
+private theorem multinomialWeightReal_mul_exp (p : ι → NNReal) (θ : ι → ℝ) (t : ℝ)
+    (k : ι → ℕ) :
+    multinomialWeightReal p k * exp (t * ∑ i, θ i * (k i : ℝ)) =
+      (Nat.multinomial Finset.univ k : ℝ) * ∏ i, ((p i : ℝ) * exp (t * θ i)) ^ k i := by
+  rw [multinomialWeightReal_def, Finset.mul_sum, exp_sum, mul_assoc, ← Finset.prod_mul_distrib]
+  congr 1
+  refine Finset.prod_congr rfl fun i _ => ?_
+  rw [mul_pow, ← exp_nat_mul]
+  ring_nf
+
+omit [Fintype ι] in
+/-- The cast of count vectors into Euclidean space is measurable. -/
+theorem measurable_multinomialToEuclidean [Finite ι] :
+    Measurable (multinomialToEuclidean (ι := ι)) := by
+  have := Fintype.ofFinite ι
+  refine (EuclideanSpace.equiv ι ℝ).symm.continuous.measurable.comp ?_
+  exact Measurable.of_eval fun i => measurable_from_nat.comp (measurable_pi_apply i)
+
+/-- The cell weights tilted by `exp (t * θ i)`, as a nonnegative family. -/
+private def tiltedWeights (p : ι → NNReal) (θ : ι → ℝ) (t : ℝ) (i : ι) : NNReal :=
+  p i * ⟨exp (t * θ i), (exp_pos _).le⟩
+
+omit [Fintype ι] in
+/-- The real value of a tilted weight. -/
+private theorem coe_tiltedWeights (p : ι → NNReal) (θ : ι → ℝ) (t : ℝ) (i : ι) :
+    (tiltedWeights p θ t i : ℝ) = (p i : ℝ) * exp (t * θ i) := rfl
+
+/-- **Directional moment generating function of the multinomial law**: for every direction `θ`
+and every `t`, it is `(∑ i, pᵢ exp (t θᵢ)) ^ n`. -/
+theorem mgf_inner_multinomial (n : ℕ) (p : StdSimplex NNReal ι) (θ : EuclideanSpace ℝ ι) (t : ℝ) :
+    mgf (fun x => inner ℝ θ x) ((multinomialMeasure n p).map multinomialToEuclidean) t =
+      (∑ i, (p.weights i : ℝ) * exp (t * θ i)) ^ n := by
+  classical
+  rw [mgf, integral_map measurable_multinomialToEuclidean.aemeasurable
+    (by fun_prop : AEStronglyMeasurable (fun x : EuclideanSpace ℝ ι => exp (t * inner ℝ θ x)) _),
+    integral_multinomialMeasure]
+  have hdot : ∀ k : ι → ℕ, inner ℝ θ (multinomialToEuclidean k) = ∑ i, θ i * (k i : ℝ) := by
+    intro k
+    simp only [EuclideanSpace.inner_eq_star_dotProduct, dotProduct, star_trivial,
+      multinomialToEuclidean_apply, mul_comm]
+  simp_rw [smul_eq_mul, hdot, multinomialWeightReal_mul_exp]
+  simp_rw [← coe_tiltedWeights p.weights θ t]
+  exact (sum_multinomialWeightReal n (tiltedWeights p.weights θ t)).symm ▸
+    Finset.sum_congr rfl fun k _ => (multinomialWeightReal_def _ k).symm
+
+/-- Every direction has full exponential-integrability domain: the law has finite support. -/
+theorem integrableExpSet_inner_multinomial (n : ℕ) (p : StdSimplex NNReal ι)
+    (θ : EuclideanSpace ℝ ι) :
+    integrableExpSet (fun x => inner ℝ θ x) ((multinomialMeasure n p).map multinomialToEuclidean)
+      = Set.univ := by
+  ext t
+  simp only [integrableExpSet, Set.mem_ofPred_eq, Set.mem_univ, iff_true]
+  rw [integrable_map_measure (by fun_prop) measurable_multinomialToEuclidean.aemeasurable]
+  exact integrable_multinomialMeasure _ n p
+
+/-- **Directional cumulant generating function of the multinomial law**: the real logarithm of
+the moment generating function. -/
+theorem cgf_inner_multinomial (n : ℕ) (p : StdSimplex NNReal ι) (θ : EuclideanSpace ℝ ι) (t : ℝ) :
+    cgf (fun x => inner ℝ θ x) ((multinomialMeasure n p).map multinomialToEuclidean) t =
+      Real.log ((∑ i, (p.weights i : ℝ) * exp (t * θ i)) ^ n) := by
+  rw [cgf, mgf_inner_multinomial]
+
+end Probability
+
+end TauCeti

--- a/TauCeti/Probability/Distributions/Multinomial/Transforms.lean
+++ b/TauCeti/Probability/Distributions/Multinomial/Transforms.lean
@@ -18,8 +18,10 @@ finite everywhere and equals
 `(∑ i, p i * exp (t * θ i)) ^ n`: the multinomial theorem, with the cell weights tilted by
 `exp (t * θ i)`. The cumulant generating function is its real logarithm.
 
-Every statement holds for `n = 0` (the law is a Dirac mass at zero, and the formula is `1`) and
-for probability vectors with zero cells, which contribute nothing to the tilted sum.
+A probability vector on `ι` forces `ι` to be nonempty, so the statements need no separate
+hypothesis for it beyond the parameter `p`. Every statement holds for `n = 0`
+(the law is a Dirac mass at zero, and the formula is `1`) and for probability vectors with zero
+cells, which contribute nothing to the tilted sum.
 
 ## Main results
 
@@ -71,7 +73,8 @@ private theorem coe_tiltedWeights (p : ι → NNReal) (θ : ι → ℝ) (t : ℝ
 
 /-- **Directional moment generating function of the multinomial law**: for every direction `θ`
 and every `t`, it is `(∑ i, pᵢ exp (t θᵢ)) ^ n`. -/
-theorem mgf_inner_multinomial (n : ℕ) (p : StdSimplex NNReal ι) (θ : EuclideanSpace ℝ ι) (t : ℝ) :
+theorem mgf_inner_multinomial (n : ℕ) (p : StdSimplex NNReal ι)
+    (θ : EuclideanSpace ℝ ι) (t : ℝ) :
     mgf (fun x => inner ℝ θ x) ((multinomialMeasure n p).map multinomialToEuclidean) t =
       (∑ i, (p.weights i : ℝ) * exp (t * θ i)) ^ n := by
   classical
@@ -106,7 +109,8 @@ theorem integrableExpSet_inner_multinomial (n : ℕ) (p : StdSimplex NNReal ι)
 
 /-- **Directional cumulant generating function of the multinomial law**: the real logarithm of
 the moment generating function. -/
-theorem cgf_inner_multinomial (n : ℕ) (p : StdSimplex NNReal ι) (θ : EuclideanSpace ℝ ι) (t : ℝ) :
+theorem cgf_inner_multinomial (n : ℕ) (p : StdSimplex NNReal ι)
+    (θ : EuclideanSpace ℝ ι) (t : ℝ) :
     cgf (fun x => inner ℝ θ x) ((multinomialMeasure n p).map multinomialToEuclidean) t =
       Real.log ((∑ i, (p.weights i : ℝ) * exp (t * θ i)) ^ n) := by
   rw [cgf, mgf_inner_multinomial]

--- a/TauCeti/Probability/Distributions/Multinomial/Transforms.lean
+++ b/TauCeti/Probability/Distributions/Multinomial/Transforms.lean
@@ -8,15 +8,13 @@ module
 public import TauCeti.Probability.Distributions.Multinomial.Basic
 public import Mathlib.Probability.Moments.Basic
 public import Mathlib.Probability.Moments.IntegrableExpMul
-public import Mathlib.Analysis.InnerProductSpace.PiL2
-public import Mathlib.Analysis.Normed.Lp.MeasurableSpace
 
 /-!
 # Directional exponential transforms of the multinomial distribution
 
-A count vector `k : ι → ℕ` is cast into `EuclideanSpace ℝ ι` by `multinomialToEuclidean`. For
-the pushforward of `multinomialMeasure n p` along that cast and a direction `θ`, the directional
-moment generating function is finite everywhere and equals
+For the pushforward of `multinomialMeasure n p` into `EuclideanSpace ℝ ι` along
+`multinomialToEuclidean` and a direction `θ`, the directional moment generating function is
+finite everywhere and equals
 `(∑ i, p i * exp (t * θ i)) ^ n`: the multinomial theorem, with the cell weights tilted by
 `exp (t * θ i)`. The cumulant generating function is its real logarithm.
 
@@ -25,9 +23,9 @@ for probability vectors with zero cells, which contribute nothing to the tilted 
 
 ## Main results
 
-* `TauCeti.Probability.multinomialToEuclidean` — the cast of count vectors into Euclidean space;
-* `TauCeti.Probability.integrableExpSet_inner_multinomial` — every direction has full exponential
-  integrability domain;
+* `TauCeti.Probability.integrableExpSet_multinomialMeasure` — every real observable has full
+  exponential integrability domain, and `TauCeti.Probability.integrableExpSet_inner_multinomial`
+  for every direction of the Euclidean pushforward;
 * `TauCeti.Probability.mgf_inner_multinomial` — the directional moment generating function;
 * `TauCeti.Probability.cgf_inner_multinomial` — the directional cumulant generating function.
 
@@ -50,16 +48,6 @@ namespace Probability
 
 variable {ι : Type*} [Fintype ι]
 
-/-- The count vector cast into Euclidean space. -/
-def multinomialToEuclidean (k : ι → ℕ) : EuclideanSpace ℝ ι :=
-  (EuclideanSpace.equiv ι ℝ).symm fun i => (k i : ℝ)
-
-omit [Fintype ι] in
-/-- The coordinates of the cast are the counts, as reals. -/
-@[simp]
-theorem multinomialToEuclidean_apply (k : ι → ℕ) (i : ι) :
-    multinomialToEuclidean k i = (k i : ℝ) := (rfl)
-
 /-- The pointwise identity behind the moment generating function: a multinomial weight times the
 exponential of a directional sum is the multinomial weight of the tilted cells `pᵢ exp (t θᵢ)`. -/
 private theorem multinomialWeightReal_mul_exp (p : ι → NNReal) (θ : ι → ℝ) (t : ℝ)
@@ -71,14 +59,6 @@ private theorem multinomialWeightReal_mul_exp (p : ι → NNReal) (θ : ι → �
   refine Finset.prod_congr rfl fun i _ => ?_
   rw [mul_pow, ← exp_nat_mul]
   ring_nf
-
-omit [Fintype ι] in
-/-- The cast of count vectors into Euclidean space is measurable. -/
-theorem measurable_multinomialToEuclidean [Finite ι] :
-    Measurable (multinomialToEuclidean (ι := ι)) := by
-  have := Fintype.ofFinite ι
-  refine (EuclideanSpace.equiv ι ℝ).symm.continuous.measurable.comp ?_
-  exact Measurable.of_eval fun i => measurable_from_nat.comp (measurable_pi_apply i)
 
 /-- The cell weights tilted by `exp (t * θ i)`, as a nonnegative family. -/
 private def tiltedWeights (p : ι → NNReal) (θ : ι → ℝ) (t : ℝ) (i : ι) : NNReal :=
@@ -107,7 +87,13 @@ theorem mgf_inner_multinomial (n : ℕ) (p : StdSimplex NNReal ι) (θ : Euclide
   exact (sum_multinomialWeightReal n (tiltedWeights p.weights θ t)).symm ▸
     Finset.sum_congr rfl fun k _ => (multinomialWeightReal_def _ k).symm
 
-/-- Every direction has full exponential-integrability domain: the law has finite support. -/
+/-- Every real observable of a multinomial law has full exponential-integrability domain: the law
+has finite support. -/
+theorem integrableExpSet_multinomialMeasure (n : ℕ) (p : StdSimplex NNReal ι)
+    (f : (ι → ℕ) → ℝ) : integrableExpSet f (multinomialMeasure n p) = Set.univ :=
+  Set.eq_univ_of_forall fun _ => integrable_multinomialMeasure _ n p
+
+/-- Every direction has full exponential-integrability domain for the Euclidean pushforward. -/
 theorem integrableExpSet_inner_multinomial (n : ℕ) (p : StdSimplex NNReal ι)
     (θ : EuclideanSpace ℝ ι) :
     integrableExpSet (fun x => inner ℝ θ x) ((multinomialMeasure n p).map multinomialToEuclidean)
@@ -115,7 +101,8 @@ theorem integrableExpSet_inner_multinomial (n : ℕ) (p : StdSimplex NNReal ι)
   ext t
   simp only [integrableExpSet, Set.mem_ofPred_eq, Set.mem_univ, iff_true]
   rw [integrable_map_measure (by fun_prop) measurable_multinomialToEuclidean.aemeasurable]
-  exact integrable_multinomialMeasure _ n p
+  exact Set.eq_univ_iff_forall.1
+    (integrableExpSet_multinomialMeasure n p fun k => inner ℝ θ (multinomialToEuclidean k)) t
 
 /-- **Directional cumulant generating function of the multinomial law**: the real logarithm of
 the moment generating function. -/


### PR DESCRIPTION
The directional exponential transforms of the multinomial distribution, in a new `Distributions/Multinomial/Transforms.lean` on top of the foundation merged in #5939.

```lean
def multinomialToEuclidean (k : ι → ℕ) : EuclideanSpace ℝ ι

theorem integrableExpSet_inner_multinomial (n : ℕ) (p : StdSimplex NNReal ι) (θ : EuclideanSpace ℝ ι) :
    integrableExpSet (fun x => inner ℝ θ x) ((multinomialMeasure n p).map multinomialToEuclidean)
      = Set.univ

theorem mgf_inner_multinomial (n : ℕ) (p : StdSimplex NNReal ι) (θ : EuclideanSpace ℝ ι) (t : ℝ) :
    mgf (fun x => inner ℝ θ x) ((multinomialMeasure n p).map multinomialToEuclidean) t =
      (∑ i, (p.weights i : ℝ) * exp (t * θ i)) ^ n

theorem cgf_inner_multinomial … = Real.log ((∑ i, (p.weights i : ℝ) * exp (t * θ i)) ^ n)
```

## The argument

Integrability is immediate: every function is integrable against a finitely supported law (`integrable_multinomialMeasure`), and the pushforward transfers it. The mgf is `integral_multinomialMeasure` followed by one pointwise identity, `weight p k · exp(t⟨θ,k⟩) = multinomial(k) · ∏ (pᵢ exp(tθᵢ))^{kᵢ}`, after which `sum_multinomialWeightReal` at the tilted weights `pᵢ exp(tθᵢ)` is the multinomial theorem in exactly the needed shape. The tilted weights are packaged as an `NNReal`-valued family by a private definition so that existing lemma applies verbatim.

Zero trials and zero-weight cells need no separate treatment: `n` and `p` are arbitrary in every statement.

## One addition to `Multinomial/Basic.lean`

`multinomialWeightReal_def`, the defining formula of the real weight as a `(rfl)` lemma: the definition's body is not exposed, and the pointwise identity above needs it across the module boundary. Same pattern as `studentTMeasure_def` and `blockSigma_def`.

## Not here

Covariance, aggregation along a map of index types, and the characteristic function are later items of the same roadmap target. Parameter measurability waits on the measurable structure of `StdSimplex` that #5939 identified as missing.

## Roadmap

Roadmap: StandardDistributions

Advances `TauCetiRoadmap/StandardDistributions/README.md`, Layer 5, item 5 (multinomial distribution): the Euclidean cast, the directional `integrableExpSet`, the directional mgf and its cgf.

🤖 Directed by Cameron Freer, drafted by Claude
