### PR TITLE
feat(CongruenceSubgroups): nest the principal congruence subgroup in Γ₁

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups/Basic.lean
@@ -27,7 +27,8 @@ prime-power levels — the degree count of Shimura, Theorem 3.24 — which lives
 is congruence-subgroup arithmetic consumed by, but independent of, the Hecke-ring layer.
 
 A final section records how the *principal* congruence subgroups compose with the arithmetic
-of the level: `Γ` is antitone in the level like the other two families, and the join of two
+of the level: `Γ` is antitone in the level like the other two families, it sits inside those
+two at the same level along the chain `Γ(N) ≤ Γ₁(N) ≤ Γ₀(N)`, and the join of two
 of them is the principal congruence subgroup of the gcd, `Γ(gcd a b) = Γ(a) ⊔ Γ(b)`. That
 identity is Shimura's Lemma 3.28; it is the Chinese remainder theorem for `SL₂`, and it is
 what lets a Hecke operator at level `ab` be analysed one prime at a time.
@@ -46,6 +47,8 @@ infrastructure independent of the diamond operators.
 * `CongruenceSubgroup.Gamma1_le_Gamma1_of_dvd`, `CongruenceSubgroup.Gamma0_le_Gamma0_of_dvd`,
   `CongruenceSubgroup.Gamma_le_Gamma_of_dvd`: all three families are antitone in the level,
   `Γ(N) ≤ Γ(M)` whenever `M ∣ N`.
+* `CongruenceSubgroup.Gamma_le_Gamma1`, `CongruenceSubgroup.Gamma_le_Gamma0`: at a fixed level
+  the three families are nested, `Γ(N) ≤ Γ₁(N) ≤ Γ₀(N)`.
 * `CongruenceSubgroup.mem_Gamma1_iff`: `Γ₁(N)` is cut out inside `Γ₀(N)` by the
   single congruence `d ≡ 1`.
 * `CongruenceSubgroup.isUnit_intCast_apply_zero_zero_of_mem_Gamma0`: a `Γ₀(N)` matrix has
@@ -121,10 +124,16 @@ theorem Gamma_le_Gamma_of_dvd {M N : ℕ} (h : M ∣ N) : Gamma N ≤ Gamma M :=
     by simpa [map_intCast, map_one, map_zero] using
       congr_arg (ZMod.castHom h (ZMod M)) hA.2.2.2⟩
 
-/-- `Γ(N) ≤ Γ₀(N)`: the principal congruence subgroup sits inside `Γ₀(N)`, since `c ≡ 0` is
-one of the four congruences it imposes. -/
-theorem Gamma_le_Gamma0 (N : ℕ) : Gamma N ≤ Gamma0 N := fun _ hA ↦
-  Gamma0_mem.mpr (Gamma_mem.mp hA).2.2.1
+/-- `Γ(N) ≤ Γ₁(N)`: the principal congruence subgroup sits inside `Γ₁(N)`, since the three
+congruences `a ≡ 1`, `d ≡ 1`, `c ≡ 0` that `Γ₁(N)` imposes are three of the four that `Γ(N)`
+does. -/
+theorem Gamma_le_Gamma1 (N : ℕ) : Gamma N ≤ Gamma1 N := fun _ hA ↦
+  (Gamma1_mem _ _).mpr ⟨(Gamma_mem.mp hA).1, (Gamma_mem.mp hA).2.2.2, (Gamma_mem.mp hA).2.2.1⟩
+
+/-- `Γ(N) ≤ Γ₀(N)`: the principal congruence subgroup sits inside `Γ₀(N)`, along the chain
+`Γ(N) ≤ Γ₁(N) ≤ Γ₀(N)`. -/
+theorem Gamma_le_Gamma0 (N : ℕ) : Gamma N ≤ Gamma0 N :=
+  (Gamma_le_Gamma1 N).trans (Gamma1_in_Gamma0 N)
 
 /-- `Γ₀` is antitone in the level: if `M ∣ N` then `Γ₀(N) ≤ Γ₀(M)`. -/
 theorem Gamma0_le_Gamma0_of_dvd {M N : ℕ} (h : M ∣ N) : Gamma0 N ≤ Gamma0 M := by


### PR DESCRIPTION
`Γ(N) ≤ Γ₁(N)` was the missing middle link of the standard chain `Γ(N) ≤ Γ₁(N) ≤ Γ₀(N)`.
Mathlib states `Gamma1_in_Gamma0 : Γ₁(N) ≤ Γ₀(N)`, and TauCeti's
`CongruenceSubgroups/Basic.lean` states `Gamma_le_Gamma0 : Γ(N) ≤ Γ₀(N)` — but proved
directly from the single congruence `c ≡ 0`, bypassing `Γ₁(N)` entirely. Nothing anywhere
stated the inclusion into `Γ₁(N)`.

This PR adds it, and re-derives `Gamma_le_Gamma0` through it:

```lean
theorem Gamma_le_Gamma1 (N : ℕ) : Gamma N ≤ Gamma1 N := fun _ hA ↦
  (Gamma1_mem _ _).mpr ⟨(Gamma_mem.mp hA).1, (Gamma_mem.mp hA).2.2.2, (Gamma_mem.mp hA).2.2.1⟩

theorem Gamma_le_Gamma0 (N : ℕ) : Gamma N ≤ Gamma0 N :=
  (Gamma_le_Gamma1 N).trans (Gamma1_in_Gamma0 N)
```

The nesting is now the primitive fact rather than a coincidence of two independent proofs,
and `Gamma_le_Gamma0` is a consumer of the new lemma rather than a parallel one. Placement is
beside `Gamma_le_Gamma0` in the file's section on how the principal congruence subgroups
compose with the arithmetic of the level; the module docstring and its `## Main results`
list are updated to record the chain.

### Why this is needed

The strong-multiplicity-one descent repeatedly has a matrix whose reduction modulo `N` is the
identity and needs it inside `Γ₁(N)` — the step AINTLIB's `HeckeDescent.lean` isolates as
`gamma1_conjugate_in_gamma1`. TauCeti already has the reduction characterisation
(`Gamma_mem'`), so once this inclusion exists that step is `Gamma_le_Gamma1 N (Gamma_mem'.mpr h)`
and needs no declaration of its own. This PR therefore supplies only the missing link, not a
wrapper around it.

### Absence

Verified two ways, since a typeclass-derived or auto-generated result can be text nowhere:

* untruncated full-name grep over pinned Mathlib and all of `TauCeti/` for `Gamma_le_Gamma1`,
  and for the statement `Gamma N ≤ Gamma1` however named — no matches;
* a compiled probe `example (N : ℕ) : Gamma N ≤ Gamma1 N := by exact?` in this very file,
  placed before the new declaration, which reported `exact? could not close the goal`.

### No target marker

This is library completion motivated by Layer 5 rather than a PR authoring a roadmap target,
so it carries no `tauceti-target:v1` marker — the same call as #6029. The contract requires a
deterministic target id, not a free-form slug, and inventing one here would put a fabricated id
in front of the duplicate sweeper.

Roadmap: ModularForms

Provenance: statement and proof newly written for TauCeti. Motivated by
github.com/CBirkbeck/AINTLIB @ `340875ad` (Apache-2.0),
`projects/LeanModularForms/LeanModularForms/StrongMultiplicityOne/HeckeDescent.lean`,
`gamma1_conjugate_in_gamma1` (line 57), whose content this inclusion supplies; AINTLIB proves
that statement inline from `Gamma1_mem` and never states the inclusion itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQieFQn95rzgvYRvNdX3hR
