### PR TITLE
feat: the genus-field isomorphism Gal(K_gen/K) ≅ Cl⁺(K)/Cl⁺(K)²

### DIFF
--- a/TauCeti/Data/ZMod/IntUnitsPower.lean
+++ b/TauCeti/Data/ZMod/IntUnitsPower.lean
@@ -10,7 +10,9 @@ public import Mathlib.LinearAlgebra.Dimension.Finrank
 import Mathlib.Algebra.Field.ZMod
 public import Mathlib.Algebra.Module.Equiv.Basic
 public import Mathlib.Algebra.Module.ZMod
+import Mathlib.LinearAlgebra.Dimension.Constructions
 import Mathlib.LinearAlgebra.FiniteDimensional.Basic
+import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
 
 /-!
 # The sign group as a line over `ZMod 2`
@@ -35,7 +37,7 @@ namespace TauCeti
 /-- **The sign group is the line `ZMod 2`.** The additive form of `ℤˣ = {±1}` is isomorphic to
 `ZMod 2`, by the map sending `1` to `0` and `-1` to `1`. This is the unique isomorphism between
 the two groups, so no choice is involved. -/
-@[expose] def additiveIntUnitsAddEquiv : Additive ℤˣ ≃+ ZMod 2 where
+def additiveIntUnitsAddEquiv : Additive ℤˣ ≃+ ZMod 2 where
   toFun u := if Additive.toMul u = 1 then 0 else 1
   invFun z := Additive.ofMul (if z = 0 then 1 else -1)
   left_inv u := by
@@ -46,21 +48,53 @@ the two groups, so no choice is involved. -/
 
 @[simp] theorem additiveIntUnitsAddEquiv_apply (u : Additive ℤˣ) :
     additiveIntUnitsAddEquiv u = if Additive.toMul u = 1 then 0 else 1 :=
-  rfl
+  (rfl)
 
 /-- **The sign group is the line `ZMod 2`, linearly.** `TauCeti.additiveIntUnitsAddEquiv` is
 automatically `ZMod 2`-linear, every additive map between `ZMod 2`-modules being so. -/
-@[expose] def additiveIntUnitsLinearEquiv : Additive ℤˣ ≃ₗ[ZMod 2] ZMod 2 :=
+def additiveIntUnitsLinearEquiv : Additive ℤˣ ≃ₗ[ZMod 2] ZMod 2 :=
   additiveIntUnitsAddEquiv.toLinearEquiv fun c u =>
     _root_.ZMod.map_smul (additiveIntUnitsAddEquiv : Additive ℤˣ →+ ZMod 2) c u
 
 @[simp] theorem additiveIntUnitsLinearEquiv_apply (u : Additive ℤˣ) :
     additiveIntUnitsLinearEquiv u = if Additive.toMul u = 1 then 0 else 1 :=
-  rfl
+  (rfl)
 
 /-- The sign group `Additive ℤˣ` is one-dimensional over `ZMod 2`. -/
 @[simp] theorem finrank_zmod_two_additive_intUnits :
     Module.finrank (ZMod 2) (Additive ℤˣ) = 1 := by
   rw [additiveIntUnitsLinearEquiv.finrank_eq, Module.finrank_self]
+
+/-- The sum of the coordinates of a finite family of signs, as a `ZMod 2`-linear functional. -/
+noncomputable def additiveIntUnitsCoordinateSum (ι : Type*) [Fintype ι] :
+    (ι → Additive ℤˣ) →ₗ[ZMod 2] Additive ℤˣ := by
+  classical
+  exact ∑ i : ι, LinearMap.proj i
+
+/-- The coordinate-sum functional is the sum of the coordinates. -/
+theorem additiveIntUnitsCoordinateSum_apply (ι : Type*) [Fintype ι]
+    (v : ι → Additive ℤˣ) :
+    additiveIntUnitsCoordinateSum ι v = ∑ i : ι, v i := by
+  classical
+  simp [additiveIntUnitsCoordinateSum]
+
+/-- The hyperplane of sign vectors of coordinate sum zero has dimension one less than the number
+of coordinates. -/
+theorem finrank_ker_additiveIntUnitsCoordinateSum (ι : Type*) [Fintype ι] [Nonempty ι] :
+    Module.finrank (ZMod 2) (LinearMap.ker (additiveIntUnitsCoordinateSum ι)) =
+      Fintype.card ι - 1 := by
+  classical
+  let i₀ : ι := Classical.choice inferInstance
+  have hpi : Module.finrank (ZMod 2) (ι → Additive ℤˣ) = Fintype.card ι := by
+    rw [Module.finrank_pi_fintype, finrank_zmod_two_additive_intUnits]
+    simp
+  have hsurj : Function.Surjective (additiveIntUnitsCoordinateSum ι) := fun w =>
+    ⟨Pi.single i₀ w, by rw [additiveIntUnitsCoordinateSum_apply]; simp⟩
+  have hrange :
+      Module.finrank (ZMod 2) (LinearMap.range (additiveIntUnitsCoordinateSum ι)) = 1 := by
+    rw [LinearMap.range_eq_top.mpr hsurj, finrank_top, finrank_zmod_two_additive_intUnits]
+  have hrn := LinearMap.finrank_range_add_finrank_ker (additiveIntUnitsCoordinateSum ι)
+  rw [hpi, hrange] at hrn
+  omega
 
 end TauCeti

--- a/TauCeti/Data/ZMod/IntUnitsPower.lean
+++ b/TauCeti/Data/ZMod/IntUnitsPower.lean
@@ -8,18 +8,23 @@ module
 public import Mathlib.Data.ZMod.IntUnitsPower
 public import Mathlib.LinearAlgebra.Dimension.Finrank
 import Mathlib.Algebra.Field.ZMod
+public import Mathlib.Algebra.Module.Equiv.Basic
+public import Mathlib.Algebra.Module.ZMod
 import Mathlib.LinearAlgebra.FiniteDimensional.Basic
 
 /-!
 # The sign group as a line over `ZMod 2`
 
 Mathlib makes the two-element group `ℤˣ = {±1}`, written additively, a module over `ZMod 2`
-(`Mathlib.Data.ZMod.IntUnitsPower`). This file records that it is a line: its `ZMod 2`-dimension
-is `1`. This is what lets a family of `±1`-valued characters indexed by a finite set `ι` be read
-as a linear map into a `ZMod 2`-space of dimension `#ι`.
+(`Mathlib.Data.ZMod.IntUnitsPower`). This file records that it *is* the line `ZMod 2`: the map
+sending `-1` to `1` is a `ZMod 2`-linear equivalence, so in particular the dimension is `1`. This
+is what lets a family of `±1`-valued characters indexed by a finite set `ι` be read as a linear
+map into a `ZMod 2`-space of dimension `#ι`, and lets such a family be compared with a family of
+`ZMod 2`-valued sign patterns.
 
-## Main result
+## Main results
 
+* `TauCeti.additiveIntUnitsLinearEquiv`: the linear equivalence `Additive ℤˣ ≃ₗ[ZMod 2] ZMod 2`.
 * `TauCeti.finrank_zmod_two_additive_intUnits`: `Module.finrank (ZMod 2) (Additive ℤˣ) = 1`.
 -/
 
@@ -27,13 +32,35 @@ public section
 
 namespace TauCeti
 
+/-- **The sign group is the line `ZMod 2`.** The additive form of `ℤˣ = {±1}` is isomorphic to
+`ZMod 2`, by the map sending `1` to `0` and `-1` to `1`. This is the unique isomorphism between
+the two groups, so no choice is involved. -/
+@[expose] def additiveIntUnitsAddEquiv : Additive ℤˣ ≃+ ZMod 2 where
+  toFun u := if Additive.toMul u = 1 then 0 else 1
+  invFun z := Additive.ofMul (if z = 0 then 1 else -1)
+  left_inv u := by
+    obtain ⟨v, rfl⟩ := Additive.ofMul.surjective u
+    revert v; decide
+  right_inv z := by revert z; decide
+  map_add' u w := by revert u w; decide
+
+@[simp] theorem additiveIntUnitsAddEquiv_apply (u : Additive ℤˣ) :
+    additiveIntUnitsAddEquiv u = if Additive.toMul u = 1 then 0 else 1 :=
+  rfl
+
+/-- **The sign group is the line `ZMod 2`, linearly.** `TauCeti.additiveIntUnitsAddEquiv` is
+automatically `ZMod 2`-linear, every additive map between `ZMod 2`-modules being so. -/
+@[expose] def additiveIntUnitsLinearEquiv : Additive ℤˣ ≃ₗ[ZMod 2] ZMod 2 :=
+  additiveIntUnitsAddEquiv.toLinearEquiv fun c u =>
+    _root_.ZMod.map_smul (additiveIntUnitsAddEquiv : Additive ℤˣ →+ ZMod 2) c u
+
+@[simp] theorem additiveIntUnitsLinearEquiv_apply (u : Additive ℤˣ) :
+    additiveIntUnitsLinearEquiv u = if Additive.toMul u = 1 then 0 else 1 :=
+  rfl
+
 /-- The sign group `Additive ℤˣ` is one-dimensional over `ZMod 2`. -/
 @[simp] theorem finrank_zmod_two_additive_intUnits :
     Module.finrank (ZMod 2) (Additive ℤˣ) = 1 := by
-  refine (finrank_eq_one_iff_of_nonzero' (K := ZMod 2) (Additive.ofMul (-1 : ℤˣ))
-    (by rw [Ne, ofMul_eq_zero]; decide)).mpr fun w => ?_
-  rcases Int.units_eq_one_or (Additive.toMul w) with h | h
-  · exact ⟨0, by rw [zero_smul, ← ofMul_toMul w, h, ofMul_one]⟩
-  · exact ⟨1, by rw [one_smul, ← ofMul_toMul w, h]⟩
+  rw [additiveIntUnitsLinearEquiv.finrank_eq, Module.finrank_self]
 
 end TauCeti

--- a/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Relative/ClassGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Relative/ClassGroup.lean
@@ -21,14 +21,16 @@ relative Galois group `Gal(K_gen/K)` has the same order as the maximal elementar
 `Cl⁺(K) / Cl⁺(K)²` of the narrow class group, and, for imaginary `K`, as `Cl(K) / Cl(K)²`: all equal
 `2 ^ (t - 1)`, where `t` is the number of rational primes ramifying in `K`.
 
-This is the numerical content of the expected genus-field isomorphisms
+This is the numerical content of the genus-field isomorphisms
 `Gal(K_gen/K) ≅ Cl⁺(K) / Cl⁺(K)²` and, for imaginary `K`, `Gal(K_gen/K) ≅ Cl(K) / Cl(K)²` — the two
 sides have equal cardinality — established **without class field theory**, by combining the
 field-theoretic relative degree `[K_gen : K] = 2 ^ (t - 1)`
 (`card_aut_candidateGenusField_over_base`) with the `2`-rank theorems `2-rank Cl⁺(K) = t - 1`
 (`narrowTwoRank_eq_ncard_ramifiedPrimes_sub_one`) and `2-rank Cl(K) = t - 1` for `d < 0`
-(`twoRank_eq_ncard_ramifiedPrimes_sub_one`). The isomorphisms themselves need the Artin
-reciprocity map and are not proved here.
+(`twoRank_eq_ncard_ramifiedPrimes_sub_one`). The isomorphisms themselves are proved, by matching
+genus characters with sign patterns, in
+`TauCeti.NumberTheory.Multiquadratic.CandidateGenusField.Relative.GenusCharacter`; the counting
+argument recorded here is independent of them.
 
 See D. A. Cox, *Primes of the Form x² + ny²*, §6.A, and F. Lemmermeyer, *Reciprocity Laws: From
 Euler to Eisenstein*, §2.2.
@@ -55,8 +57,9 @@ variable {d : ℤ}
 quadratic field `K = ℚ(√d)` of either signature (`d` squarefree, not a rational square),
 `|Gal(K_gen/K)|`
 equals `|Cl⁺(K)/Cl⁺(K)²|` — both are `2 ^ (t - 1)`, where `t` is the number of rational primes
-ramifying in `K`. This is the cardinality shadow of the expected genus-field isomorphism
-`Gal(K_gen/K) ≅ Cl⁺(K)/Cl⁺(K)²`, established without class field theory. -/
+ramifying in `K`. This is the cardinality shadow of the genus-field isomorphism
+`Gal(K_gen/K) ≅ Cl⁺(K)/Cl⁺(K)²`
+(`autCandidateGenusFieldEquivNarrowElementaryTwoQuotient`), counted here directly. -/
 theorem card_aut_candidateGenusField_over_base_eq_card_narrowElementaryTwoQuotient
     (hd : Squarefree d) (hnsq : ¬ IsSquare ((d : ℤ) : ℚ)) :
     Nat.card (candidateGenusField hd ≃ₐ[candidateGenusFieldBase hd] candidateGenusField hd) =
@@ -74,8 +77,8 @@ theorem card_aut_candidateGenusField_over_base_eq_card_narrowElementaryTwoQuotie
 /-- **The relative candidate-genus-field Galois group and `Cl(K)/Cl(K)²` have equal order.** For an
 imaginary quadratic field `K = ℚ(√d)` (`d < 0` squarefree), `|Gal(K_gen/K)|` equals `|Cl(K)/Cl(K)²|`
 — both are `2 ^ (t - 1)`, where `t` is the number of rational primes ramifying in `K`. This is the
-cardinality shadow of the expected genus-field isomorphism `Gal(K_gen/K) ≅ Cl(K)/Cl(K)²`,
-established without class field theory. -/
+cardinality shadow of the genus-field isomorphism `Gal(K_gen/K) ≅ Cl(K)/Cl(K)²`
+(`autCandidateGenusFieldEquivElementaryTwoQuotient`), counted here directly. -/
 theorem card_aut_candidateGenusField_over_base_eq_card_elementaryTwoQuotient
     (hd : Squarefree d) (hneg : d < 0) :
     Nat.card (candidateGenusField hd ≃ₐ[candidateGenusFieldBase hd] candidateGenusField hd) =

--- a/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Relative/GaloisGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Relative/GaloisGroup.lean
@@ -25,10 +25,12 @@ when its sign vector has even parity. Restriction of scalars then gives
 
 `Gal(candidateGenusField hd / candidateGenusFieldBase hd) ≃* Multiplicative U`.
 
-This is the relative Galois-group side of the genus-field construction. The Layer 3 target will
-identify this relative group, after proving the required ramification statement, with the maximal
-elementary-2 quotient `Cl(ℚ(√d)) / Cl(ℚ(√d))²`. When `d` is nonsquare, its order is already the
-predicted `2 ^ (t - 1)`, where `t` is the number of chosen prime discriminants.
+This is the relative Galois-group side of the genus-field construction; the sign subspace found
+here is matched with the genus characters of `ℚ(√d)`, hence with the maximal elementary-2 quotient
+`Cl⁺(ℚ(√d)) / Cl⁺(ℚ(√d))²`, in
+`TauCeti.NumberTheory.Multiquadratic.CandidateGenusField.Relative.GenusCharacter`. When `d` is
+nonsquare, its order is the predicted `2 ^ (t - 1)`, where `t` is the number of chosen prime
+discriminants.
 
 The prime-discriminant description of the genus field is classical; see D. A. Cox,
 *Primes of the Form x² + ny²*, and F. Lemmermeyer, *Reciprocity Laws*.

--- a/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Relative/GenusCharacter.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Relative/GenusCharacter.lean
@@ -144,11 +144,28 @@ noncomputable def narrowElementaryTwoQuotientEquivRelativeSign (hd : Squarefree 
   (LinearEquiv.ofInjective _ (candidateGenusFieldBaseGenusCharLinearMap_injective hd hnsq)).trans
     (LinearEquiv.ofEq _ _ (range_candidateGenusFieldBaseGenusCharLinearMap hd hnsq))
 
+/-- The sign vector attached to a narrow class modulo squares is the vector of its genus
+characters: `narrowElementaryTwoQuotientEquivRelativeSign` is the genus-character map. -/
+theorem narrowElementaryTwoQuotientEquivRelativeSign_apply_coe (hd : Squarefree d)
+    (hnsq : ¬ IsSquare ((d : ℤ) : ℚ))
+    (x : NarrowClassGroup.ElementaryTwoQuotient (candidateGenusFieldBase hd)) :
+    (narrowElementaryTwoQuotientEquivRelativeSign hd hnsq x :
+        {P // P ∈ genusPrimeDiscriminants hd} → ZMod 2) =
+      candidateGenusFieldBaseGenusCharLinearMap hd hnsq x :=
+  (rfl)
+
 /-- **The genus-field isomorphism `Gal(K_gen/K) ≅ Cl⁺(K)/Cl⁺(K)²`.** For a squarefree integer `d`
 that is not a rational square, the Galois group of the candidate genus field over its embedded
 quadratic base `K = ℚ(√d)` is isomorphic to the maximal elementary-`2` quotient of the narrow class
 group of `K`. Both are the space of even-parity sign patterns on the prime discriminants dividing
-`disc K`: the Galois group by its sign patterns, the class group by its genus characters. -/
+`disc K`: the Galois group by its sign patterns, the class group by its genus characters.
+
+The map is pinned down coordinate for coordinate on those prime discriminants: it sends an
+automorphism `σ` to the unique narrow class modulo squares whose genus characters are the signs
+that `σ` puts on the chosen square roots
+(`autCandidateGenusFieldEquivNarrowElementaryTwoQuotient_apply` together with
+`narrowElementaryTwoQuotientEquivRelativeSign_apply_coe`). Its identification with the inverse
+Artin map of `K_gen / K` is not proved here; see the module docstring. -/
 noncomputable def autCandidateGenusFieldEquivNarrowElementaryTwoQuotient (hd : Squarefree d)
     (hnsq : ¬ IsSquare ((d : ℤ) : ℚ)) :
     (candidateGenusField hd ≃ₐ[candidateGenusFieldBase hd] candidateGenusField hd) ≃*
@@ -156,6 +173,19 @@ noncomputable def autCandidateGenusFieldEquivNarrowElementaryTwoQuotient (hd : S
         (NarrowClassGroup.ElementaryTwoQuotient (candidateGenusFieldBase hd)) :=
   (galoisGroupEquivCandidateGenusFieldRelative hd).trans
     (narrowElementaryTwoQuotientEquivRelativeSign hd hnsq).symm.toAddEquiv.toMultiplicative
+
+/-- The genus-field isomorphism sends an automorphism to the narrow class modulo squares that the
+genus characters attach to its sign pattern. -/
+theorem autCandidateGenusFieldEquivNarrowElementaryTwoQuotient_apply (hd : Squarefree d)
+    (hnsq : ¬ IsSquare ((d : ℤ) : ℚ))
+    (σ : candidateGenusField hd ≃ₐ[candidateGenusFieldBase hd] candidateGenusField hd) :
+    autCandidateGenusFieldEquivNarrowElementaryTwoQuotient hd hnsq σ =
+      Multiplicative.ofAdd ((narrowElementaryTwoQuotientEquivRelativeSign hd hnsq).symm
+        ⟨candidateGenusFieldRelativeSignPattern hd σ,
+          candidateGenusFieldRelativeSignPattern_mem hd σ⟩) := by
+  rw [autCandidateGenusFieldEquivNarrowElementaryTwoQuotient, MulEquiv.trans_apply,
+    galoisGroupEquivCandidateGenusFieldRelative_apply]
+  rfl
 
 /-- **The genus-field isomorphism for an imaginary quadratic field,
 `Gal(K_gen/K) ≅ Cl(K)/Cl(K)²`.** For `d < 0` squarefree, the narrow and ordinary class groups of

--- a/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Relative/GenusCharacter.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Relative/GenusCharacter.lean
@@ -1,0 +1,180 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.NumberTheory.Multiquadratic.CandidateGenusField.Relative.GaloisGroup
+public import TauCeti.NumberTheory.Multiquadratic.CandidateGenusField.Relative.Quadratic
+public import TauCeti.NumberTheory.Multiquadratic.Quadratic.GenusCharacter.PrincipalGenus
+import TauCeti.NumberTheory.NumberField.NarrowClassGroup.TotallyComplex
+import TauCeti.NumberTheory.NumberField.Quadratic.InfinitePlace
+
+/-!
+# The genus field of a quadratic field has Galois group `Cl⁺(K)/Cl⁺(K)²`
+
+For a squarefree integer `d` let `K = ℚ(√d)` be the embedded quadratic base of the candidate genus
+field `K_gen = candidateGenusField hd`, the compositum of the quadratic fields of the prime
+discriminants dividing `disc K`. It is the narrow genus field of `K`
+(`isNarrowGenusField_candidateGenusField`), and the genus field of `K` when `d < 0`
+(`isGenusField_candidateGenusField`). This file proves the genus-field isomorphism
+
+`Gal(K_gen / K) ≅ Cl⁺(K) / Cl⁺(K)²`,
+
+and, for imaginary `K`, its ordinary form `Gal(K_gen / K) ≅ Cl(K) / Cl(K)²`. Only the equality of
+the two cardinalities was known before
+(`card_aut_candidateGenusField_over_base_eq_card_narrowElementaryTwoQuotient`).
+
+Both sides are described by the same space of sign patterns on the prime discriminants, and the
+isomorphism is the identification of the two descriptions. On the Galois side, an automorphism is
+recorded by the signs it puts on the chosen square roots, and fixing the base is exactly having an
+even number of sign changes (`galoisGroupEquivCandidateGenusFieldRelative`). On the class-group
+side, a narrow ideal class is recorded by its genus characters, which realize exactly the sign
+patterns of product one and separate the classes modulo squares
+(`mem_range_genusCharFunElementaryTwoQuotientFamilyLinearMap_iff` and
+`genusCharFunElementaryTwoQuotientFamilyLinearMap_injective`). The two sign spaces coincide, so
+the two groups do.
+
+The composite is the inverse of the Artin map of `K_gen / K`: the genus character `χ_P` of the
+class of a degree-one prime `𝔮` above `q` is the Legendre symbol governing the Frobenius of `q` in
+`ℚ(√P)` (`exists_forall_genusCharFunNarrowClassGroupHom_eq`). That identification with Frobenius
+elements is not proved here; what is proved is the isomorphism itself.
+
+See D. A. Cox, *Primes of the Form x² + ny²*, §6.A, and F. Lemmermeyer, *Reciprocity Laws: From
+Euler to Eisenstein*, §2.2.
+
+## Main definitions
+
+* `TauCeti.Multiquadratic.narrowElementaryTwoQuotientEquivRelativeSign`: `Cl⁺(K)/Cl⁺(K)²` is the
+  space of even-parity sign patterns on the prime discriminants of `disc K`.
+* `TauCeti.Multiquadratic.autCandidateGenusFieldEquivNarrowElementaryTwoQuotient`:
+  `Gal(K_gen/K) ≅ Cl⁺(K)/Cl⁺(K)²`.
+* `TauCeti.Multiquadratic.autCandidateGenusFieldEquivElementaryTwoQuotient`: for `d < 0`,
+  `Gal(K_gen/K) ≅ Cl(K)/Cl(K)²`.
+-/
+
+public section
+
+open NumberField
+
+namespace TauCeti.Multiquadratic
+
+variable {d : ℤ}
+
+/-! ### The genus characters of the embedded base, in sign coordinates -/
+
+/-- The genus characters of the embedded quadratic base `ℚ(√d)`, assembled into a `ZMod 2`-linear
+map into the sign patterns on the prime discriminants of its discriminant. This is
+`genusCharFunElementaryTwoQuotientFamilyLinearMap` for the chosen factorization
+`genusPrimeDiscriminants hd`, with the sign group `ℤˣ` written as `ZMod 2` so that the target is
+the one carrying the relative Galois group. -/
+@[expose] noncomputable def candidateGenusFieldBaseGenusCharLinearMap (hd : Squarefree d)
+    (hnsq : ¬ IsSquare ((d : ℤ) : ℚ)) :
+    NarrowClassGroup.ElementaryTwoQuotient (candidateGenusFieldBase hd) →ₗ[ZMod 2]
+      ({P // P ∈ genusPrimeDiscriminants hd} → ZMod 2) :=
+  (LinearEquiv.piCongrRight fun _ => TauCeti.additiveIntUnitsLinearEquiv).toLinearMap ∘ₗ
+    genusCharFunElementaryTwoQuotientFamilyLinearMap (genusPrimeDiscriminants_spec hd).1
+      (genusPrimeDiscriminants_spec hd).2.1 (genusPrimeDiscriminants_spec hd).2.2
+      (minpoly_candidateGenusFieldBaseGen hd hnsq)
+      (adjoin_candidateGenusFieldBaseGen_eq_top hd) hd
+
+/-- The sign pattern recorded by the genus characters is the image of the sign vector of
+`genusCharFunElementaryTwoQuotientFamilyLinearMap` under the identification of `ℤˣ` with
+`ZMod 2`. -/
+theorem candidateGenusFieldBaseGenusCharLinearMap_apply (hd : Squarefree d)
+    (hnsq : ¬ IsSquare ((d : ℤ) : ℚ))
+    (x : NarrowClassGroup.ElementaryTwoQuotient (candidateGenusFieldBase hd))
+    (P : {P // P ∈ genusPrimeDiscriminants hd}) :
+    candidateGenusFieldBaseGenusCharLinearMap hd hnsq x P =
+      TauCeti.additiveIntUnitsLinearEquiv
+        (genusCharFunElementaryTwoQuotientFamilyLinearMap (genusPrimeDiscriminants_spec hd).1
+          (genusPrimeDiscriminants_spec hd).2.1 (genusPrimeDiscriminants_spec hd).2.2
+          (minpoly_candidateGenusFieldBaseGen hd hnsq)
+          (adjoin_candidateGenusFieldBaseGen_eq_top hd) hd x P) :=
+  rfl
+
+/-- **The genus characters of the base realize exactly the even-parity sign patterns.** -/
+theorem range_candidateGenusFieldBaseGenusCharLinearMap (hd : Squarefree d)
+    (hnsq : ¬ IsSquare ((d : ℤ) : ℚ)) :
+    LinearMap.range (candidateGenusFieldBaseGenusCharLinearMap hd hnsq) =
+      candidateGenusFieldRelativeSignSubmodule hd := by
+  refine Submodule.ext fun v => ?_
+  rw [mem_candidateGenusFieldRelativeSignSubmodule_iff]
+  constructor
+  · rintro ⟨x, rfl⟩
+    have hsum := (mem_range_genusCharFunElementaryTwoQuotientFamilyLinearMap_iff
+      (genusPrimeDiscriminants_spec hd).1 (genusPrimeDiscriminants_spec hd).2.1
+      (genusPrimeDiscriminants_spec hd).2.2 (minpoly_candidateGenusFieldBaseGen hd hnsq)
+      (adjoin_candidateGenusFieldBaseGen_eq_top hd) hd _).mp ⟨x, rfl⟩
+    simp only [candidateGenusFieldBaseGenusCharLinearMap_apply]
+    rw [← map_sum, hsum, map_zero]
+  · intro hv
+    set e := TauCeti.additiveIntUnitsLinearEquiv
+    have hsum : ∑ P : {P // P ∈ genusPrimeDiscriminants hd}, e.symm (v P) = 0 := by
+      rw [← map_sum, hv, map_zero]
+    obtain ⟨x, hx⟩ := (mem_range_genusCharFunElementaryTwoQuotientFamilyLinearMap_iff
+      (genusPrimeDiscriminants_spec hd).1 (genusPrimeDiscriminants_spec hd).2.1
+      (genusPrimeDiscriminants_spec hd).2.2 (minpoly_candidateGenusFieldBaseGen hd hnsq)
+      (adjoin_candidateGenusFieldBaseGen_eq_top hd) hd _).mpr hsum
+    refine ⟨x, funext fun P => ?_⟩
+    rw [candidateGenusFieldBaseGenusCharLinearMap_apply, congrFun hx P]
+    exact e.apply_symm_apply (v P)
+
+/-- **The genus characters of the base separate narrow classes modulo squares.** -/
+theorem candidateGenusFieldBaseGenusCharLinearMap_injective (hd : Squarefree d)
+    (hnsq : ¬ IsSquare ((d : ℤ) : ℚ)) :
+    Function.Injective (candidateGenusFieldBaseGenusCharLinearMap hd hnsq) :=
+  (LinearEquiv.piCongrRight fun _ => TauCeti.additiveIntUnitsLinearEquiv).injective.comp
+    (genusCharFunElementaryTwoQuotientFamilyLinearMap_injective
+      (genusPrimeDiscriminants_spec hd).1 (genusPrimeDiscriminants_spec hd).2.1
+      (genusPrimeDiscriminants_spec hd).2.2 (minpoly_candidateGenusFieldBaseGen hd hnsq)
+      (adjoin_candidateGenusFieldBaseGen_eq_top hd) hd)
+
+/-! ### The genus-field isomorphism -/
+
+/-- **`Cl⁺(K)/Cl⁺(K)²` is the even-parity sign space.** For `K = ℚ(√d)` the embedded quadratic base
+of the candidate genus field, the genus characters identify the maximal elementary-`2` quotient of
+the narrow class group with the `𝔽₂`-space of sign patterns of product one on the prime
+discriminants dividing `disc K`. -/
+noncomputable def narrowElementaryTwoQuotientEquivRelativeSign (hd : Squarefree d)
+    (hnsq : ¬ IsSquare ((d : ℤ) : ℚ)) :
+    NarrowClassGroup.ElementaryTwoQuotient (candidateGenusFieldBase hd) ≃ₗ[ZMod 2]
+      ↥(candidateGenusFieldRelativeSignSubmodule hd) :=
+  (LinearEquiv.ofInjective _ (candidateGenusFieldBaseGenusCharLinearMap_injective hd hnsq)).trans
+    (LinearEquiv.ofEq _ _ (range_candidateGenusFieldBaseGenusCharLinearMap hd hnsq))
+
+/-- **The genus-field isomorphism `Gal(K_gen/K) ≅ Cl⁺(K)/Cl⁺(K)²`.** For a squarefree integer `d`
+that is not a rational square, the Galois group of the candidate genus field over its embedded
+quadratic base `K = ℚ(√d)` is isomorphic to the maximal elementary-`2` quotient of the narrow class
+group of `K`. Both are the space of even-parity sign patterns on the prime discriminants dividing
+`disc K`: the Galois group by its sign patterns, the class group by its genus characters. -/
+noncomputable def autCandidateGenusFieldEquivNarrowElementaryTwoQuotient (hd : Squarefree d)
+    (hnsq : ¬ IsSquare ((d : ℤ) : ℚ)) :
+    (candidateGenusField hd ≃ₐ[candidateGenusFieldBase hd] candidateGenusField hd) ≃*
+      Multiplicative
+        (NarrowClassGroup.ElementaryTwoQuotient (candidateGenusFieldBase hd)) :=
+  (galoisGroupEquivCandidateGenusFieldRelative hd).trans
+    (narrowElementaryTwoQuotientEquivRelativeSign hd hnsq).symm.toAddEquiv.toMultiplicative
+
+/-- **The genus-field isomorphism for an imaginary quadratic field,
+`Gal(K_gen/K) ≅ Cl(K)/Cl(K)²`.** For `d < 0` squarefree, the narrow and ordinary class groups of
+`K = ℚ(√d)` agree, so the genus-field isomorphism takes its classical ordinary form. Here
+`K_gen` is the genus field of `K` in the full sense
+(`isGenusField_candidateGenusField`): unramified over `K` at every place, including the infinite
+ones, and abelian over `ℚ`. -/
+noncomputable def autCandidateGenusFieldEquivElementaryTwoQuotient (hd : Squarefree d)
+    (hneg : d < 0) :
+    (candidateGenusField hd ≃ₐ[candidateGenusFieldBase hd] candidateGenusField hd) ≃*
+      Multiplicative
+        (TauCeti.ClassGroup.ElementaryTwoQuotient (𝓞 (candidateGenusFieldBase hd))) :=
+  have hnsq : ¬ IsSquare ((d : ℤ) : ℚ) := fun h =>
+    absurd h.nonneg (not_le.mpr (by exact_mod_cast hneg))
+  haveI : NumberField.IsTotallyComplex (candidateGenusFieldBase hd) :=
+    NumberField.isTotallyComplex_of_minpoly_eq_X_sq_sub_C_of_neg
+      (minpoly_candidateGenusFieldBaseGen hd hnsq) hneg
+  (autCandidateGenusFieldEquivNarrowElementaryTwoQuotient hd hnsq).trans
+    (NarrowClassGroup.toClassGroupElementaryTwoQuotientEquiv
+      (candidateGenusFieldBase hd)).toAddEquiv.toMultiplicative
+
+end TauCeti.Multiquadratic

--- a/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Relative/GenusCharacter.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Relative/GenusCharacter.lean
@@ -6,10 +6,10 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.NumberTheory.Multiquadratic.CandidateGenusField.Relative.GaloisGroup
+public import TauCeti.NumberTheory.Multiquadratic.CandidateGenusField.InfinitePlace
 public import TauCeti.NumberTheory.Multiquadratic.CandidateGenusField.Relative.Quadratic
 public import TauCeti.NumberTheory.Multiquadratic.Quadratic.GenusCharacter.PrincipalGenus
 import TauCeti.NumberTheory.NumberField.NarrowClassGroup.TotallyComplex
-import TauCeti.NumberTheory.NumberField.Quadratic.InfinitePlace
 
 /-!
 # The genus field of a quadratic field has Galois group `Cl⁺(K)/Cl⁺(K)²`
@@ -22,9 +22,7 @@ discriminants dividing `disc K`. It is the narrow genus field of `K`
 
 `Gal(K_gen / K) ≅ Cl⁺(K) / Cl⁺(K)²`,
 
-and, for imaginary `K`, its ordinary form `Gal(K_gen / K) ≅ Cl(K) / Cl(K)²`. Only the equality of
-the two cardinalities was known before
-(`card_aut_candidateGenusField_over_base_eq_card_narrowElementaryTwoQuotient`).
+and, for imaginary `K`, its ordinary form `Gal(K_gen / K) ≅ Cl(K) / Cl(K)²`.
 
 Both sides are described by the same space of sign patterns on the prime discriminants, and the
 isomorphism is the identification of the two descriptions. On the Galois side, an automorphism is
@@ -69,7 +67,7 @@ map into the sign patterns on the prime discriminants of its discriminant. This 
 `genusCharFunElementaryTwoQuotientFamilyLinearMap` for the chosen factorization
 `genusPrimeDiscriminants hd`, with the sign group `ℤˣ` written as `ZMod 2` so that the target is
 the one carrying the relative Galois group. -/
-@[expose] noncomputable def candidateGenusFieldBaseGenusCharLinearMap (hd : Squarefree d)
+noncomputable def candidateGenusFieldBaseGenusCharLinearMap (hd : Squarefree d)
     (hnsq : ¬ IsSquare ((d : ℤ) : ℚ)) :
     NarrowClassGroup.ElementaryTwoQuotient (candidateGenusFieldBase hd) →ₗ[ZMod 2]
       ({P // P ∈ genusPrimeDiscriminants hd} → ZMod 2) :=
@@ -92,7 +90,7 @@ theorem candidateGenusFieldBaseGenusCharLinearMap_apply (hd : Squarefree d)
           (genusPrimeDiscriminants_spec hd).2.1 (genusPrimeDiscriminants_spec hd).2.2
           (minpoly_candidateGenusFieldBaseGen hd hnsq)
           (adjoin_candidateGenusFieldBaseGen_eq_top hd) hd x P) :=
-  rfl
+  (rfl)
 
 /-- **The genus characters of the base realize exactly the even-parity sign patterns.** -/
 theorem range_candidateGenusFieldBaseGenusCharLinearMap (hd : Squarefree d)
@@ -201,10 +199,24 @@ noncomputable def autCandidateGenusFieldEquivElementaryTwoQuotient (hd : Squaref
   have hnsq : ¬ IsSquare ((d : ℤ) : ℚ) := fun h =>
     absurd h.nonneg (not_le.mpr (by exact_mod_cast hneg))
   haveI : NumberField.IsTotallyComplex (candidateGenusFieldBase hd) :=
-    NumberField.isTotallyComplex_of_minpoly_eq_X_sq_sub_C_of_neg
-      (minpoly_candidateGenusFieldBaseGen hd hnsq) hneg
+    isTotallyComplex_candidateGenusFieldBase hd hneg
   (autCandidateGenusFieldEquivNarrowElementaryTwoQuotient hd hnsq).trans
     (NarrowClassGroup.toClassGroupElementaryTwoQuotientEquiv
       (candidateGenusFieldBase hd)).toAddEquiv.toMultiplicative
+
+/-- The imaginary genus-field isomorphism is the narrow genus-field isomorphism followed by the
+identification of the narrow and ordinary class-group quotients. -/
+theorem autCandidateGenusFieldEquivElementaryTwoQuotient_apply (hd : Squarefree d)
+    (hneg : d < 0)
+    (σ : candidateGenusField hd ≃ₐ[candidateGenusFieldBase hd] candidateGenusField hd) :
+    autCandidateGenusFieldEquivElementaryTwoQuotient hd hneg σ =
+      let hnsq : ¬ IsSquare ((d : ℤ) : ℚ) := fun h =>
+        absurd h.nonneg (not_le.mpr (by exact_mod_cast hneg))
+      let _ : NumberField.IsTotallyComplex (candidateGenusFieldBase hd) :=
+        isTotallyComplex_candidateGenusFieldBase hd hneg
+      (NarrowClassGroup.toClassGroupElementaryTwoQuotientEquiv
+        (candidateGenusFieldBase hd)).toAddEquiv.toMultiplicative
+          (autCandidateGenusFieldEquivNarrowElementaryTwoQuotient hd hnsq σ) :=
+  (rfl)
 
 end TauCeti.Multiquadratic

--- a/TauCeti/NumberTheory/Multiquadratic/Quadratic/GenusCharacter/Independence.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Quadratic/GenusCharacter/Independence.lean
@@ -32,6 +32,9 @@ Eisenstein*, §2.2.
   genus characters at some narrow class.
 * `TauCeti.Multiquadratic.exists_forall_genusCharFunNarrowClassGroupHom_subset_eq`: the same class
   has the prescribed product of signs as the value of every subset-indexed genus character.
+* `TauCeti.Multiquadratic.exists_genusCharFunElementaryTwoQuotientFamilyLinearMap_eq`: the same
+  statement for the `ZMod 2`-linear family on `Cl⁺(K)/Cl⁺(K)²`, where the product-one condition
+  becomes the vanishing of the coordinate sum.
 -/
 
 public section
@@ -86,5 +89,32 @@ theorem exists_forall_genusCharFunNarrowClassGroupHom_subset_eq
   rw [genusCharFunNarrowClassGroupHom_eq_prod_singleton hs heven hprod hmin hgen hsf hts,
     MonoidHom.finsetProd_apply, ← Finset.prod_coe_sort t]
   exact Finset.prod_congr rfl fun P _ => hA P (hts P.2)
+
+/-- **Every sign vector of coordinate sum zero is a value of the genus characters.** The linear
+form of `exists_forall_genusCharFunNarrowClassGroupHom_singleton_eq`: writing the sign group
+additively, the family of singleton genus characters on `Cl⁺(K)/Cl⁺(K)²` takes every value whose
+coordinates sum to zero. -/
+theorem exists_genusCharFunElementaryTwoQuotientFamilyLinearMap_eq
+    {s : Finset ℤ} (hs : ∀ P ∈ s, IsPrimeDiscriminant P)
+    (heven : ∀ P ∈ s, ∀ P' ∈ s, IsEvenPrimeDiscriminant P → IsEvenPrimeDiscriminant P' → P = P')
+    (hprod : ∏ P ∈ s, P = fundamentalDiscriminant d)
+    (hmin : minpoly ℤ θ = X ^ 2 - C d) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤)
+    (hsf : Squarefree d) (v : ↥s → Additive ℤˣ) (hv : ∑ P : ↥s, v P = 0) :
+    ∃ x : NarrowClassGroup.ElementaryTwoQuotient K,
+      genusCharFunElementaryTwoQuotientFamilyLinearMap hs heven hprod hmin hgen hsf x = v := by
+  classical
+  -- Read the vector as a sign function on `ℤ`, whose product over `s` is one.
+  let ε : ℤ → ℤˣ := fun P => if h : P ∈ s then Additive.toMul (v ⟨P, h⟩) else 1
+  have hε : ∏ P ∈ s, ε P = 1 := by
+    have hprodε : ∏ P ∈ s, ε P = ∏ P : ↥s, Additive.toMul (v P) := by
+      rw [← Finset.prod_coe_sort s]
+      exact Finset.prod_congr rfl fun P _ => by simp [ε, P.2]
+    rw [hprodε, ← toMul_sum, hv, toMul_zero]
+  obtain ⟨A, hA⟩ :=
+    exists_forall_genusCharFunNarrowClassGroupHom_singleton_eq hs heven hprod hmin hgen hsf ε hε
+  refine ⟨TauCeti.elementaryTwoQuotientMk A, funext fun P => ?_⟩
+  rw [genusCharFunElementaryTwoQuotientFamilyLinearMap_apply,
+    genusCharFunElementaryTwoQuotientLinearMap_mk, hA P P.2]
+  simp [ε, P.2]
 
 end TauCeti.Multiquadratic

--- a/TauCeti/NumberTheory/Multiquadratic/Quadratic/GenusCharacter/PrincipalGenus.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Quadratic/GenusCharacter/PrincipalGenus.lean
@@ -54,34 +54,6 @@ namespace TauCeti.Multiquadratic
 
 variable {K : Type*} [Field K] [NumberField K] {θ : 𝓞 K} {d : ℤ}
 
-/-! ### The sum of the sign coordinates -/
-
-/-- The sum of the coordinates of a sign vector indexed by a finite set of prime discriminants,
-as a `ZMod 2`-linear functional. Its kernel is the hyperplane of sign patterns of product one. -/
-private noncomputable def signSum (s : Finset ℤ) :
-    ((P : ↥s) → Additive ℤˣ) →ₗ[ZMod 2] Additive ℤˣ :=
-  ∑ P : ↥s, LinearMap.proj P
-
-/-- The coordinate-sum functional is the sum of the coordinates. -/
-private theorem signSum_apply (s : Finset ℤ) (v : ↥s → Additive ℤˣ) :
-    signSum s v = ∑ P : ↥s, v P := by
-  simp [signSum]
-
-/-- The hyperplane of sign vectors of coordinate sum zero has dimension `#s - 1`. -/
-private theorem finrank_ker_signSum {s : Finset ℤ} (hne : s.Nonempty) :
-    Module.finrank (ZMod 2) (LinearMap.ker (signSum s)) = s.card - 1 := by
-  obtain ⟨P₀, hP₀⟩ := hne
-  have hpi : Module.finrank (ZMod 2) ((P : ↥s) → Additive ℤˣ) = s.card := by
-    rw [Module.finrank_pi_fintype, TauCeti.finrank_zmod_two_additive_intUnits]
-    simp
-  have hsurj : Function.Surjective (signSum s) := fun w =>
-    ⟨Pi.single ⟨P₀, hP₀⟩ w, by rw [signSum_apply]; simp⟩
-  have hrange : Module.finrank (ZMod 2) (LinearMap.range (signSum s)) = 1 := by
-    rw [LinearMap.range_eq_top.mpr hsurj, finrank_top, TauCeti.finrank_zmod_two_additive_intUnits]
-  have hrn := LinearMap.finrank_range_add_finrank_ker (signSum s)
-  rw [hpi, hrange] at hrn
-  omega
-
 /-! ### The image and the kernel of the genus-character family -/
 
 /-- The dimension of `Cl⁺(K)/Cl⁺(K)²` is `#s - 1`, read off the narrow `2`-rank formula. -/
@@ -119,18 +91,20 @@ theorem mem_range_genusCharFunElementaryTwoQuotientFamilyLinearMap_iff {s : Fins
     subst hv
     simp
   · set Φ := genusCharFunElementaryTwoQuotientFamilyLinearMap hs heven hprod hmin hgen hsf
-    have hrange : LinearMap.range Φ = LinearMap.ker (signSum s) := by
+    let _ : Nonempty ↥s := hne.to_subtype
+    have hrange : LinearMap.range Φ =
+        LinearMap.ker (TauCeti.additiveIntUnitsCoordinateSum ↥s) := by
       refine (Submodule.eq_of_le_of_finrank_le ?_ ?_).symm
       · intro w hw
-        rw [LinearMap.mem_ker, signSum_apply] at hw
+        rw [LinearMap.mem_ker, TauCeti.additiveIntUnitsCoordinateSum_apply] at hw
         obtain ⟨x, hx⟩ :=
           exists_genusCharFunElementaryTwoQuotientFamilyLinearMap_eq hs heven hprod hmin hgen hsf
             w hw
         exact ⟨x, hx⟩
-      · rw [finrank_ker_signSum hne]
+      · rw [TauCeti.finrank_ker_additiveIntUnitsCoordinateSum, Fintype.card_coe]
         exact (LinearMap.finrank_range_le Φ).trans
           (finrank_narrowElementaryTwoQuotient_eq hs heven hprod hmin hgen hsf).le
-    rw [hrange, LinearMap.mem_ker, signSum_apply]
+    rw [hrange, LinearMap.mem_ker, TauCeti.additiveIntUnitsCoordinateSum_apply]
 
 /-- **The genus characters separate narrow classes modulo squares.** The `ZMod 2`-linear family of
 singleton genus characters is injective on `Cl⁺(K)/Cl⁺(K)²`. Equivalently, the `#s` genus
@@ -150,12 +124,15 @@ theorem genusCharFunElementaryTwoQuotientFamilyLinearMap_injective {s : Finset �
     have : Subsingleton (NarrowClassGroup.ElementaryTwoQuotient K) :=
       Module.finrank_zero_iff.mp (by simpa using hsrc)
     exact fun a b _ => Subsingleton.elim a b
-  · have hrange : LinearMap.range Φ = LinearMap.ker (signSum s) :=
+  · let _ : Nonempty ↥s := hne.to_subtype
+    have hrange : LinearMap.range Φ =
+        LinearMap.ker (TauCeti.additiveIntUnitsCoordinateSum ↥s) :=
       Submodule.ext fun v =>
         (mem_range_genusCharFunElementaryTwoQuotientFamilyLinearMap_iff hs heven hprod hmin hgen
-          hsf v).trans (by rw [LinearMap.mem_ker, signSum_apply])
+          hsf v).trans
+            (by rw [LinearMap.mem_ker, TauCeti.additiveIntUnitsCoordinateSum_apply])
     have hrn := LinearMap.finrank_range_add_finrank_ker Φ
-    rw [hrange, finrank_ker_signSum hne, hsrc] at hrn
+    rw [hrange, TauCeti.finrank_ker_additiveIntUnitsCoordinateSum, Fintype.card_coe, hsrc] at hrn
     have hker : Module.finrank (ZMod 2) (LinearMap.ker Φ) = 0 := by
       have : 1 ≤ s.card := Finset.card_pos.mpr hne
       omega

--- a/TauCeti/NumberTheory/Multiquadratic/Quadratic/GenusCharacter/PrincipalGenus.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Quadratic/GenusCharacter/PrincipalGenus.lean
@@ -1,0 +1,198 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Data.ZMod.IntUnitsPower
+public import TauCeti.NumberTheory.Multiquadratic.Quadratic.GenusCharacter.ElementaryTwoQuotient
+public import TauCeti.NumberTheory.Multiquadratic.Quadratic.GenusCharacter.Independence
+public import TauCeti.NumberTheory.Multiquadratic.Quadratic.TwoRank
+
+/-!
+# The principal genus theorem
+
+Let `K = ℚ(√d)` with `d` squarefree and let `D = ∏ P ∈ s, P` be the prime-discriminant
+factorization of the fundamental discriminant of `d`, so that `t = #s` is the number of rational
+primes ramifying in `K`. The `t` genus characters `χ_P` assemble into a `ZMod 2`-linear map
+
+`Φ : Cl⁺(K) / Cl⁺(K)² → (P ∈ s) → {±1}`
+
+(`genusCharFunElementaryTwoQuotientFamilyLinearMap`). Two facts about `Φ` are already available:
+its image contains every sign vector whose coordinates sum to zero
+(`exists_genusCharFunElementaryTwoQuotientFamilyLinearMap_eq`, the Dirichlet-theorem input), and
+the source has dimension exactly `t - 1` (`narrowTwoRank_eq_ncard_ramifiedPrimes_sub_one`). Since
+the sum-zero hyperplane has the same dimension `t - 1`, no room is left over: `Φ` is **injective**
+and its image is **exactly** that hyperplane.
+
+Injectivity is the **principal genus theorem**: a narrow ideal class on which every genus character
+is trivial — a class in the principal genus — is a square. Together with the description of the
+image it says that the genus characters are a complete and independent system of invariants for
+narrow ideal classes modulo squares.
+
+See D. A. Cox, *Primes of the Form x² + ny²*, §3.B (Theorem 3.15 and its corollaries), and
+F. Lemmermeyer, *Reciprocity Laws: From Euler to Eisenstein*, §2.2.
+
+## Main results
+
+* `TauCeti.Multiquadratic.mem_range_genusCharFunElementaryTwoQuotientFamilyLinearMap_iff`: the
+  sign vectors realized by the genus characters are exactly those of coordinate sum zero.
+* `TauCeti.Multiquadratic.genusCharFunElementaryTwoQuotientFamilyLinearMap_injective`: the genus
+  characters separate the classes of `Cl⁺(K)/Cl⁺(K)²`.
+* `TauCeti.Multiquadratic.isSquare_iff_forall_genusCharFunNarrowClassGroupHom_eq_one`: **the
+  principal genus theorem**, a narrow ideal class is a square exactly when all its genus
+  characters are trivial.
+-/
+
+public section
+
+open Polynomial NumberField
+open scoped NumberField nonZeroDivisors
+
+namespace TauCeti.Multiquadratic
+
+variable {K : Type*} [Field K] [NumberField K] {θ : 𝓞 K} {d : ℤ}
+
+/-! ### The sum of the sign coordinates -/
+
+/-- The sum of the coordinates of a sign vector indexed by a finite set of prime discriminants,
+as a `ZMod 2`-linear functional. Its kernel is the hyperplane of sign patterns of product one. -/
+private noncomputable def signSum (s : Finset ℤ) :
+    ((P : ↥s) → Additive ℤˣ) →ₗ[ZMod 2] Additive ℤˣ :=
+  ∑ P : ↥s, LinearMap.proj P
+
+/-- The coordinate-sum functional is the sum of the coordinates. -/
+private theorem signSum_apply (s : Finset ℤ) (v : ↥s → Additive ℤˣ) :
+    signSum s v = ∑ P : ↥s, v P := by
+  simp [signSum]
+
+/-- The hyperplane of sign vectors of coordinate sum zero has dimension `#s - 1`. -/
+private theorem finrank_ker_signSum {s : Finset ℤ} (hne : s.Nonempty) :
+    Module.finrank (ZMod 2) (LinearMap.ker (signSum s)) = s.card - 1 := by
+  obtain ⟨P₀, hP₀⟩ := hne
+  have hpi : Module.finrank (ZMod 2) ((P : ↥s) → Additive ℤˣ) = s.card := by
+    rw [Module.finrank_pi_fintype, TauCeti.finrank_zmod_two_additive_intUnits]
+    simp
+  have hsurj : Function.Surjective (signSum s) := fun w =>
+    ⟨Pi.single ⟨P₀, hP₀⟩ w, by rw [signSum_apply]; simp⟩
+  have hrange : Module.finrank (ZMod 2) (LinearMap.range (signSum s)) = 1 := by
+    rw [LinearMap.range_eq_top.mpr hsurj, finrank_top, TauCeti.finrank_zmod_two_additive_intUnits]
+  have hrn := LinearMap.finrank_range_add_finrank_ker (signSum s)
+  rw [hpi, hrange] at hrn
+  omega
+
+/-! ### The image and the kernel of the genus-character family -/
+
+/-- The dimension of `Cl⁺(K)/Cl⁺(K)²` is `#s - 1`, read off the narrow `2`-rank formula. -/
+private theorem finrank_narrowElementaryTwoQuotient_eq {s : Finset ℤ}
+    (hs : ∀ P ∈ s, IsPrimeDiscriminant P)
+    (heven : ∀ P ∈ s, ∀ P' ∈ s, IsEvenPrimeDiscriminant P → IsEvenPrimeDiscriminant P' → P = P')
+    (hprod : ∏ P ∈ s, P = fundamentalDiscriminant d)
+    (hmin : minpoly ℤ θ = X ^ 2 - C d) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤)
+    (hsf : Squarefree d) :
+    Module.finrank (ZMod 2) (NarrowClassGroup.ElementaryTwoQuotient K) = s.card - 1 := by
+  rw [← NarrowClassGroup.twoRank_def, narrowTwoRank_eq_ncard_ramifiedPrimes_sub_one hmin hgen hsf,
+    ncard_ramifiedPrimes_eq_card hmin hgen hsf hs heven hprod]
+
+/-- **The genus characters realize exactly the sign vectors of product one.** For `K = ℚ(√d)` with
+`d` squarefree and `∏ P ∈ s, P = fundamentalDiscriminant d` a prime-discriminant factorization, a
+sign vector indexed by `s` is a value of the family of singleton genus characters on
+`Cl⁺(K)/Cl⁺(K)²` exactly when its coordinates sum to zero — that is, exactly when the product of
+its signs is `1`.
+
+The inclusion "⊇" is the Dirichlet-theorem input
+`exists_genusCharFunElementaryTwoQuotientFamilyLinearMap_eq`; the inclusion "⊆" holds because
+`Cl⁺(K)/Cl⁺(K)²` has dimension `#s - 1`, leaving no room beyond the hyperplane. -/
+theorem mem_range_genusCharFunElementaryTwoQuotientFamilyLinearMap_iff {s : Finset ℤ}
+    (hs : ∀ P ∈ s, IsPrimeDiscriminant P)
+    (heven : ∀ P ∈ s, ∀ P' ∈ s, IsEvenPrimeDiscriminant P → IsEvenPrimeDiscriminant P' → P = P')
+    (hprod : ∏ P ∈ s, P = fundamentalDiscriminant d)
+    (hmin : minpoly ℤ θ = X ^ 2 - C d) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤)
+    (hsf : Squarefree d) (v : ↥s → Additive ℤˣ) :
+    v ∈ LinearMap.range
+        (genusCharFunElementaryTwoQuotientFamilyLinearMap hs heven hprod hmin hgen hsf) ↔
+      ∑ P : ↥s, v P = 0 := by
+  rcases s.eq_empty_or_nonempty with rfl | hne
+  · -- With no prime discriminants there is only the zero vector.
+    have hv : v = 0 := funext fun P => (Finset.notMem_empty _ P.2).elim
+    subst hv
+    simp
+  · set Φ := genusCharFunElementaryTwoQuotientFamilyLinearMap hs heven hprod hmin hgen hsf
+    have hrange : LinearMap.range Φ = LinearMap.ker (signSum s) := by
+      refine (Submodule.eq_of_le_of_finrank_le ?_ ?_).symm
+      · intro w hw
+        rw [LinearMap.mem_ker, signSum_apply] at hw
+        obtain ⟨x, hx⟩ :=
+          exists_genusCharFunElementaryTwoQuotientFamilyLinearMap_eq hs heven hprod hmin hgen hsf
+            w hw
+        exact ⟨x, hx⟩
+      · rw [finrank_ker_signSum hne]
+        exact (LinearMap.finrank_range_le Φ).trans
+          (finrank_narrowElementaryTwoQuotient_eq hs heven hprod hmin hgen hsf).le
+    rw [hrange, LinearMap.mem_ker, signSum_apply]
+
+/-- **The genus characters separate narrow classes modulo squares.** The `ZMod 2`-linear family of
+singleton genus characters is injective on `Cl⁺(K)/Cl⁺(K)²`. Equivalently, the `#s` genus
+characters span the full dual of `Cl⁺(K)/Cl⁺(K)²`. -/
+theorem genusCharFunElementaryTwoQuotientFamilyLinearMap_injective {s : Finset ℤ}
+    (hs : ∀ P ∈ s, IsPrimeDiscriminant P)
+    (heven : ∀ P ∈ s, ∀ P' ∈ s, IsEvenPrimeDiscriminant P → IsEvenPrimeDiscriminant P' → P = P')
+    (hprod : ∏ P ∈ s, P = fundamentalDiscriminant d)
+    (hmin : minpoly ℤ θ = X ^ 2 - C d) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤)
+    (hsf : Squarefree d) :
+    Function.Injective
+      (genusCharFunElementaryTwoQuotientFamilyLinearMap hs heven hprod hmin hgen hsf) := by
+  set Φ := genusCharFunElementaryTwoQuotientFamilyLinearMap hs heven hprod hmin hgen hsf
+  have hsrc := finrank_narrowElementaryTwoQuotient_eq hs heven hprod hmin hgen hsf (s := s)
+  rcases s.eq_empty_or_nonempty with rfl | hne
+  · -- With no prime discriminants the source is already trivial.
+    have : Subsingleton (NarrowClassGroup.ElementaryTwoQuotient K) :=
+      Module.finrank_zero_iff.mp (by simpa using hsrc)
+    exact fun a b _ => Subsingleton.elim a b
+  · have hrange : LinearMap.range Φ = LinearMap.ker (signSum s) :=
+      Submodule.ext fun v =>
+        (mem_range_genusCharFunElementaryTwoQuotientFamilyLinearMap_iff hs heven hprod hmin hgen
+          hsf v).trans (by rw [LinearMap.mem_ker, signSum_apply])
+    have hrn := LinearMap.finrank_range_add_finrank_ker Φ
+    rw [hrange, finrank_ker_signSum hne, hsrc] at hrn
+    have hker : Module.finrank (ZMod 2) (LinearMap.ker Φ) = 0 := by
+      have : 1 ≤ s.card := Finset.card_pos.mpr hne
+      omega
+    rw [← LinearMap.ker_eq_bot, ← Submodule.finrank_eq_zero]
+    exact hker
+
+/-! ### The principal genus theorem -/
+
+/-- **The principal genus theorem.** Let `K = ℚ(√d)` with `d` squarefree and let
+`∏ P ∈ s, P = fundamentalDiscriminant d` be the prime-discriminant factorization of its
+discriminant. A narrow ideal class of `K` is a square exactly when every genus character is
+trivial on it; that is, the principal genus is the group of squares.
+
+This is the classical statement that the genus characters cut out `Cl⁺(K)²` inside `Cl⁺(K)`. -/
+theorem isSquare_iff_forall_genusCharFunNarrowClassGroupHom_eq_one {s : Finset ℤ}
+    (hs : ∀ P ∈ s, IsPrimeDiscriminant P)
+    (heven : ∀ P ∈ s, ∀ P' ∈ s, IsEvenPrimeDiscriminant P → IsEvenPrimeDiscriminant P' → P = P')
+    (hprod : ∏ P ∈ s, P = fundamentalDiscriminant d)
+    (hmin : minpoly ℤ θ = X ^ 2 - C d) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤)
+    (hsf : Squarefree d) (A : NarrowClassGroup K) :
+    IsSquare A ↔ ∀ (P : ℤ) (hP : P ∈ s),
+      genusCharFunNarrowClassGroupHom hs heven hprod hmin hgen hsf
+        (Finset.singleton_subset_iff.mpr hP) A = 1 := by
+  rw [← TauCeti.elementaryTwoQuotientMk_eq_zero_iff]
+  constructor
+  · intro h P hP
+    have hzero := congrArg (genusCharFunElementaryTwoQuotientLinearMap hs heven hprod hmin hgen hsf
+      (Finset.singleton_subset_iff.mpr hP)) h
+    rw [genusCharFunElementaryTwoQuotientLinearMap_mk, map_zero] at hzero
+    exact ofMul_eq_zero.mp hzero
+  · intro h
+    refine genusCharFunElementaryTwoQuotientFamilyLinearMap_injective hs heven hprod hmin hgen hsf
+      ?_
+    rw [map_zero]
+    funext P
+    rw [genusCharFunElementaryTwoQuotientFamilyLinearMap_apply,
+      genusCharFunElementaryTwoQuotientLinearMap_mk, h P P.2]
+    simp
+
+end TauCeti.Multiquadratic

--- a/TauCeti/NumberTheory/Multiquadratic/Quadratic/TwoRank.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Quadratic/TwoRank.lean
@@ -200,26 +200,16 @@ theorem card_sub_one_le_narrowTwoRank {s : Finset ℤ}
   · simp
   obtain ⟨P₀, hP₀⟩ := hne
   -- The family of singleton genus characters, and the coordinate-sum functional.
-  set Φ := genusCharFunElementaryTwoQuotientFamilyLinearMap hs heven hprod hmin hgen hsf with hΦ
+  set Φ := genusCharFunElementaryTwoQuotientFamilyLinearMap hs heven hprod hmin hgen hsf
   let σ : ((P : ↥s) → Additive ℤˣ) →ₗ[ZMod 2] Additive ℤˣ := ∑ P : ↥s, LinearMap.proj P
   have hσ : ∀ v, σ v = ∑ P : ↥s, v P := fun v => by simp [σ]
   -- Every vector of coordinate sum `0` is a value of `Φ`.
   have hker : LinearMap.ker σ ≤ LinearMap.range Φ := by
     intro v hv
     rw [LinearMap.mem_ker, hσ] at hv
-    let ε : ℤ → ℤˣ := fun P => if h : P ∈ s then Additive.toMul (v ⟨P, h⟩) else 1
-    have hε : ∏ P ∈ s, ε P = 1 := by
-      have hprodε : ∏ P ∈ s, ε P = ∏ P : ↥s, Additive.toMul (v P) := by
-        rw [← Finset.prod_coe_sort s]
-        exact Finset.prod_congr rfl fun P _ => by simp [ε, P.2]
-      rw [hprodε, ← toMul_sum, hv, toMul_zero]
-    obtain ⟨A, hA⟩ :=
-      exists_forall_genusCharFunNarrowClassGroupHom_singleton_eq hs heven hprod hmin hgen hsf ε hε
-    refine ⟨TauCeti.elementaryTwoQuotientMk A, ?_⟩
-    funext P
-    rw [hΦ, genusCharFunElementaryTwoQuotientFamilyLinearMap_apply,
-      genusCharFunElementaryTwoQuotientLinearMap_mk, hA P P.2]
-    simp [ε, P.2]
+    obtain ⟨x, hx⟩ :=
+      exists_genusCharFunElementaryTwoQuotientFamilyLinearMap_eq hs heven hprod hmin hgen hsf v hv
+    exact ⟨x, hx⟩
   -- Dimension count: the hyperplane has dimension `t - 1`.
   have hW : Module.finrank (ZMod 2) ((P : ↥s) → Additive ℤˣ) = s.card := by
     rw [Module.finrank_pi_fintype, TauCeti.finrank_zmod_two_additive_intUnits]

--- a/TauCeti/NumberTheory/Multiquadratic/Quadratic/TwoRank.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Quadratic/TwoRank.lean
@@ -198,29 +198,19 @@ theorem card_sub_one_le_narrowTwoRank {s : Finset ℤ}
   classical
   rcases s.eq_empty_or_nonempty with rfl | hne
   · simp
-  obtain ⟨P₀, hP₀⟩ := hne
+  let _ : Nonempty ↥s := hne.to_subtype
   -- The family of singleton genus characters, and the coordinate-sum functional.
   set Φ := genusCharFunElementaryTwoQuotientFamilyLinearMap hs heven hprod hmin hgen hsf
-  let σ : ((P : ↥s) → Additive ℤˣ) →ₗ[ZMod 2] Additive ℤˣ := ∑ P : ↥s, LinearMap.proj P
-  have hσ : ∀ v, σ v = ∑ P : ↥s, v P := fun v => by simp [σ]
+  let σ := TauCeti.additiveIntUnitsCoordinateSum ↥s
   -- Every vector of coordinate sum `0` is a value of `Φ`.
   have hker : LinearMap.ker σ ≤ LinearMap.range Φ := by
     intro v hv
-    rw [LinearMap.mem_ker, hσ] at hv
+    rw [LinearMap.mem_ker, TauCeti.additiveIntUnitsCoordinateSum_apply] at hv
     obtain ⟨x, hx⟩ :=
       exists_genusCharFunElementaryTwoQuotientFamilyLinearMap_eq hs heven hprod hmin hgen hsf v hv
     exact ⟨x, hx⟩
-  -- Dimension count: the hyperplane has dimension `t - 1`.
-  have hW : Module.finrank (ZMod 2) ((P : ↥s) → Additive ℤˣ) = s.card := by
-    rw [Module.finrank_pi_fintype, TauCeti.finrank_zmod_two_additive_intUnits]
-    simp
-  have hσsurj : Function.Surjective σ := fun w =>
-    ⟨Pi.single ⟨P₀, hP₀⟩ w, by rw [hσ]; simp⟩
-  have hrange : Module.finrank (ZMod 2) (LinearMap.range σ) = 1 := by
-    rw [LinearMap.range_eq_top.mpr hσsurj, finrank_top, TauCeti.finrank_zmod_two_additive_intUnits]
-  have hrn := LinearMap.finrank_range_add_finrank_ker σ
-  rw [hW, hrange] at hrn
-  calc s.card - 1 = Module.finrank (ZMod 2) (LinearMap.ker σ) := by omega
+  calc s.card - 1 = Module.finrank (ZMod 2) (LinearMap.ker σ) := by
+        simpa [σ] using (TauCeti.finrank_ker_additiveIntUnitsCoordinateSum ↥s).symm
     _ ≤ Module.finrank (ZMod 2) (LinearMap.range Φ) := Submodule.finrank_mono hker
     _ ≤ Module.finrank (ZMod 2) (NumberField.NarrowClassGroup.ElementaryTwoQuotient K) :=
         LinearMap.finrank_range_le Φ


### PR DESCRIPTION
This PR proves the Layer 3 genus-field isomorphism `Gal(K_gen/K) ≅ Cl⁺(K)/Cl⁺(K)²` for the quadratic field `K = ℚ(√d)`, `d` squarefree, and its ordinary form `Gal(K_gen/K) ≅ Cl(K)/Cl(K)²` when `d < 0`. The roadmap target is the Layer 3 milestone of `Multiquadratic/README.md`, "the genus field and the 2-rank theorem (the summit)", whose second half asks to "prove `Gal(K_gen/K) ≅ Cl(K)/Cl(K)²`"; `STATUS.md` lists it as the frontier item *Galois group versus `Cl/Cl²`*, noting that only equality of the two cardinalities was established. The engine is the **principal genus theorem**, proved here for the narrow class group: a narrow ideal class is a square exactly when every genus character is trivial on it.

Both sides of the isomorphism are the same space of sign patterns on the prime discriminants dividing `disc K`. The Galois side was already available: `galoisGroupEquivCandidateGenusFieldRelative` identifies `Gal(K_gen/K)` with the even-parity sign subspace `candidateGenusFieldRelativeSignSubmodule`. The class-group side is what this PR supplies. The linear family of genus characters `Φ : Cl⁺(K)/Cl⁺(K)² → (P ∈ s) → {±1}` was known to hit every sign vector of product one, by Dirichlet's theorem on primes in arithmetic progressions (`exists_forall_genusCharFunNarrowClassGroupHom_singleton_eq`), and the source was known to have dimension exactly `t - 1` (`narrowTwoRank_eq_ncard_ramifiedPrimes_sub_one`). Since the product-one hyperplane also has dimension `t - 1`, there is no room left over: `Φ` is injective and its image is exactly that hyperplane. Injectivity is the principal genus theorem; the image computation matches the Galois side coordinate for coordinate. Composing gives the isomorphism.

The composite is the inverse of the Artin map of `K_gen/K` — the genus character `χ_P` at the class of a degree-one prime `𝔮` above `q` is the Legendre symbol that governs the Frobenius of `q` in `ℚ(√P)` — but that identification with Frobenius elements is not proved here, and the file says so; what is proved is the isomorphism. After this PR, what remains on the Layer 3 frontier is the Frobenius/Artin compatibility of this map, the ambiguous class number formula in the form Layer 2 requests, and the two outstanding worked examples (`[ℚ(√2,√3):ℚ] = 4` and the Erdős CM family).

Files added:

* `TauCeti/NumberTheory/Multiquadratic/Quadratic/GenusCharacter/PrincipalGenus.lean` (198 lines) — `mem_range_genusCharFunElementaryTwoQuotientFamilyLinearMap_iff`, `genusCharFunElementaryTwoQuotientFamilyLinearMap_injective`, and `isSquare_iff_forall_genusCharFunNarrowClassGroupHom_eq_one` (the principal genus theorem).
* `TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Relative/GenusCharacter.lean` (180 lines) — the genus characters of the embedded base in `ZMod 2` sign coordinates, `narrowElementaryTwoQuotientEquivRelativeSign`, `autCandidateGenusFieldEquivNarrowElementaryTwoQuotient`, and `autCandidateGenusFieldEquivElementaryTwoQuotient`.

Files changed: `TauCeti/Data/ZMod/IntUnitsPower.lean` gains `additiveIntUnitsAddEquiv` and `additiveIntUnitsLinearEquiv`, the (unique) identification of the sign group with the line `ZMod 2`, which is what lets the `ℤˣ`-valued genus characters be compared with the `ZMod 2`-valued sign patterns of the Galois side; `finrank_zmod_two_additive_intUnits` is now a one-line consequence. `Quadratic/GenusCharacter/Independence.lean` gains `exists_genusCharFunElementaryTwoQuotientFamilyLinearMap_eq`, the linear restatement of its own main result, extracted from the proof of `card_sub_one_le_narrowTwoRank` in `Quadratic/TwoRank.lean` so that both consumers share it rather than duplicating the argument; that proof in `TwoRank.lean` shrinks accordingly. `CandidateGenusField/Relative/ClassGroup.lean` and `CandidateGenusField/Relative/GaloisGroup.lean` get documentation corrections only: both said the isomorphism was not proved and pointed at future work, which is no longer accurate. No declaration was renamed, moved or removed.

No Mathlib infrastructure was vendored. The Layer 0 multiquadratic machinery underneath the relative Galois group remains the migration from [kim-em/erdos-unit-distance](https://github.com/kim-em/erdos-unit-distance), written for the formalization of L. Alpöge's disproof of the uniform-constant Erdős unit-distance conjecture, as recorded in the files that use it. The mathematics follows D. A. Cox, *Primes of the Form x² + ny²*, §3.B and §6.A, and F. Lemmermeyer, *Reciprocity Laws: From Euler to Eisenstein*, §2.2.

Roadmap: Multiquadratic

<!--tauceti-target:v1 {"focus":"Multiquadratic","id":"narrow-elementary-two-quotient-equiv-aut-candidate-genus-field"}-->

🤖 Prepared with Claude Code
