### PR TITLE
feat: prove low-rank special orthogonal groups reductive

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/SpecialOrthogonal/LowRank.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialOrthogonal/LowRank.lean
@@ -59,9 +59,8 @@ theorem definingHopfIdeal_zero :
     · simp
   apply HopfIdeal.ext
   intro x
-  change x ∈ (definingHopfIdeal R 0).toIdeal ↔
-    x ∈ (SpecialLinear.definingHopfIdeal R 0).toIdeal
-  rw [definingHopfIdeal_toIdeal, SpecialLinear.definingHopfIdeal_toIdeal]
+  rw [← HopfIdeal.mem_toIdeal, ← HopfIdeal.mem_toIdeal, definingHopfIdeal_toIdeal,
+    SpecialLinear.definingHopfIdeal_toIdeal]
   simp [hempty]
 
 /-- In rank one the special-orthogonal and special-linear defining Hopf ideals agree. -/
@@ -86,24 +85,16 @@ theorem definingHopfIdeal_one :
     have hj : j = 0 := Subsingleton.elim _ _
     subst i
     subst j
-    rw [hrelation, pow_two,
-      show (GeneralLinear.determinantGroupLike R 1 :
-          GeneralLinear.coordinateHopfAlgebra R 1) *
-          GeneralLinear.determinantGroupLike R 1 - 1 =
-        ((GeneralLinear.determinantGroupLike R 1 :
-            GeneralLinear.coordinateHopfAlgebra R 1) + 1) *
-          ((GeneralLinear.determinantGroupLike R 1 :
-            GeneralLinear.coordinateHopfAlgebra R 1) - 1) by ring]
-    exact (Ideal.span
-      {(GeneralLinear.determinantGroupLike R 1 :
-          GeneralLinear.coordinateHopfAlgebra R 1) - 1}).mul_mem_left _
-        (Ideal.mem_span_singleton_self _)
+    rw [hrelation]
+    exact Ideal.mem_of_dvd _
+      (sub_one_dvd_pow_sub_one
+        (GeneralLinear.determinantGroupLike R 1 :
+          GeneralLinear.coordinateHopfAlgebra R 1) 2)
+      (Ideal.mem_span_singleton_self _)
   apply HopfIdeal.ext
   intro x
-  change x ∈ (definingHopfIdeal R 1).toIdeal ↔
-    x ∈ (SpecialLinear.definingHopfIdeal R 1).toIdeal
-  rw [definingHopfIdeal_toIdeal, SpecialLinear.definingHopfIdeal_toIdeal,
-    sup_eq_right.mpr hrel]
+  rw [← HopfIdeal.mem_toIdeal, ← HopfIdeal.mem_toIdeal, definingHopfIdeal_toIdeal,
+    SpecialLinear.definingHopfIdeal_toIdeal, sup_eq_right.mpr hrel]
 
 /-- The finite-type coordinate Hopf algebra of `SO₀` is the one of `SL₀`. -/
 @[simp]
@@ -111,11 +102,8 @@ theorem finiteTypeCoordinateHopfAlgebra_zero :
     finiteTypeCoordinateHopfAlgebra R 0 = SpecialLinear.finiteTypeCoordinateHopfAlgebra R 0 := by
   apply CategoryTheory.ObjectProperty.FullSubcategory.ext
   rw [finiteTypeCoordinateHopfAlgebra_obj, SpecialLinear.finiteTypeCoordinateHopfAlgebra_obj]
-  change CommHopfAlgCat.quotient (GeneralLinear.coordinateHopfAlgebra R 0)
-      (definingHopfIdeal R 0) =
-    CommHopfAlgCat.quotient (GeneralLinear.coordinateHopfAlgebra R 0)
-      (SpecialLinear.definingHopfIdeal R 0)
-  rw [definingHopfIdeal_zero]
+  exact congrArg (CommHopfAlgCat.quotient (GeneralLinear.coordinateHopfAlgebra R 0))
+    (definingHopfIdeal_zero R)
 
 /-- The finite-type coordinate Hopf algebra of `SO₁` is the one of `SL₁`. -/
 @[simp]
@@ -123,11 +111,8 @@ theorem finiteTypeCoordinateHopfAlgebra_one :
     finiteTypeCoordinateHopfAlgebra R 1 = SpecialLinear.finiteTypeCoordinateHopfAlgebra R 1 := by
   apply CategoryTheory.ObjectProperty.FullSubcategory.ext
   rw [finiteTypeCoordinateHopfAlgebra_obj, SpecialLinear.finiteTypeCoordinateHopfAlgebra_obj]
-  change CommHopfAlgCat.quotient (GeneralLinear.coordinateHopfAlgebra R 1)
-      (definingHopfIdeal R 1) =
-    CommHopfAlgCat.quotient (GeneralLinear.coordinateHopfAlgebra R 1)
-      (SpecialLinear.definingHopfIdeal R 1)
-  rw [definingHopfIdeal_one]
+  exact congrArg (CommHopfAlgCat.quotient (GeneralLinear.coordinateHopfAlgebra R 1))
+    (definingHopfIdeal_one R)
 
 /-- **The rank-zero special orthogonal group is reductive over every field.** -/
 theorem reductiveCommHopfAlgProperty_finiteTypeCoordinateHopfAlgebra_zero

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialOrthogonal/LowRank.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialOrthogonal/LowRank.lean
@@ -1,0 +1,148 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.SpecialLinear.Reductive
+public import TauCeti.Algebra.AlgebraicGroup.SpecialOrthogonal.Basic
+
+/-!
+# Special orthogonal groups in ranks zero and one
+
+The standard special orthogonal groups `SO₀` and `SO₁` are trivial over every commutative base
+ring. In Hopf coordinates, their defining ideals agree with the corresponding special-linear
+ideals. In rank zero there are no orthogonality relations. In rank one, the single relation
+`x² - 1` is a multiple of the determinant-one relation `x - 1`.
+
+The resulting equality identifies the finite-type coordinate Hopf algebras with those of `SL₀`
+and `SL₁`. Since the special linear groups are reductive in every rank and characteristic, this
+settles reductivity of the two low-rank special orthogonal groups without a hypothesis on `2`.
+
+## Main declarations
+
+* `TauCeti.SpecialOrthogonal.definingHopfIdeal_zero`: the rank-zero defining ideal agrees with
+  the special-linear ideal.
+* `TauCeti.SpecialOrthogonal.definingHopfIdeal_one`: the rank-one defining ideal agrees with the
+  special-linear ideal.
+* `TauCeti.SpecialOrthogonal.reductiveCommHopfAlgProperty_finiteTypeCoordinateHopfAlgebra_zero`
+  and `TauCeti.SpecialOrthogonal.reductiveCommHopfAlgProperty_finiteTypeCoordinateHopfAlgebra_one`:
+  `SO₀` and `SO₁` are reductive over every field.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), §§2.3 and 21, for the standard orthogonal groups and
+  reductivity.
+-/
+
+public section
+
+namespace TauCeti.SpecialOrthogonal
+
+universe u
+
+noncomputable section
+
+variable (R : Type u) [CommRing R]
+
+/-- In rank zero the special-orthogonal and special-linear defining Hopf ideals agree. -/
+@[simp]
+theorem definingHopfIdeal_zero :
+    definingHopfIdeal R 0 = SpecialLinear.definingHopfIdeal R 0 := by
+  have hempty : Orthogonal.relationSet R 0 = ∅ := by
+    ext x
+    rw [ConstantForm.mem_relationSet_iff]
+    constructor
+    · rintro ⟨i, -⟩
+      exact Fin.elim0 i
+    · simp
+  apply HopfIdeal.ext
+  intro x
+  change x ∈ (definingHopfIdeal R 0).toIdeal ↔
+    x ∈ (SpecialLinear.definingHopfIdeal R 0).toIdeal
+  rw [definingHopfIdeal_toIdeal, SpecialLinear.definingHopfIdeal_toIdeal]
+  simp [hempty]
+
+/-- In rank one the special-orthogonal and special-linear defining Hopf ideals agree. -/
+@[simp]
+theorem definingHopfIdeal_one :
+    definingHopfIdeal R 1 = SpecialLinear.definingHopfIdeal R 1 := by
+  have hrelation :
+      ConstantForm.relationMatrix R 1 1 0 0 =
+        (GeneralLinear.determinantGroupLike R 1 :
+            GeneralLinear.coordinateHopfAlgebra R 1) ^ 2 - 1 := by
+    rw [ConstantForm.relationMatrix_def]
+    simp [Matrix.mul_apply, pow_two]
+  have hrel : Ideal.span (Orthogonal.relationSet R 1) ≤
+      Ideal.span
+        {(GeneralLinear.determinantGroupLike R 1 :
+            GeneralLinear.coordinateHopfAlgebra R 1) - 1} := by
+    rw [Ideal.span_le]
+    intro y hy
+    rw [ConstantForm.mem_relationSet_iff] at hy
+    obtain ⟨i, j, rfl⟩ := hy
+    have hi : i = 0 := Subsingleton.elim _ _
+    have hj : j = 0 := Subsingleton.elim _ _
+    subst i
+    subst j
+    rw [hrelation, pow_two,
+      show (GeneralLinear.determinantGroupLike R 1 :
+          GeneralLinear.coordinateHopfAlgebra R 1) *
+          GeneralLinear.determinantGroupLike R 1 - 1 =
+        ((GeneralLinear.determinantGroupLike R 1 :
+            GeneralLinear.coordinateHopfAlgebra R 1) + 1) *
+          ((GeneralLinear.determinantGroupLike R 1 :
+            GeneralLinear.coordinateHopfAlgebra R 1) - 1) by ring]
+    exact (Ideal.span
+      {(GeneralLinear.determinantGroupLike R 1 :
+          GeneralLinear.coordinateHopfAlgebra R 1) - 1}).mul_mem_left _
+        (Ideal.mem_span_singleton_self _)
+  apply HopfIdeal.ext
+  intro x
+  change x ∈ (definingHopfIdeal R 1).toIdeal ↔
+    x ∈ (SpecialLinear.definingHopfIdeal R 1).toIdeal
+  rw [definingHopfIdeal_toIdeal, SpecialLinear.definingHopfIdeal_toIdeal,
+    sup_eq_right.mpr hrel]
+
+/-- The finite-type coordinate Hopf algebra of `SO₀` is the one of `SL₀`. -/
+@[simp]
+theorem finiteTypeCoordinateHopfAlgebra_zero :
+    finiteTypeCoordinateHopfAlgebra R 0 = SpecialLinear.finiteTypeCoordinateHopfAlgebra R 0 := by
+  apply CategoryTheory.ObjectProperty.FullSubcategory.ext
+  rw [finiteTypeCoordinateHopfAlgebra_obj, SpecialLinear.finiteTypeCoordinateHopfAlgebra_obj]
+  change CommHopfAlgCat.quotient (GeneralLinear.coordinateHopfAlgebra R 0)
+      (definingHopfIdeal R 0) =
+    CommHopfAlgCat.quotient (GeneralLinear.coordinateHopfAlgebra R 0)
+      (SpecialLinear.definingHopfIdeal R 0)
+  rw [definingHopfIdeal_zero]
+
+/-- The finite-type coordinate Hopf algebra of `SO₁` is the one of `SL₁`. -/
+@[simp]
+theorem finiteTypeCoordinateHopfAlgebra_one :
+    finiteTypeCoordinateHopfAlgebra R 1 = SpecialLinear.finiteTypeCoordinateHopfAlgebra R 1 := by
+  apply CategoryTheory.ObjectProperty.FullSubcategory.ext
+  rw [finiteTypeCoordinateHopfAlgebra_obj, SpecialLinear.finiteTypeCoordinateHopfAlgebra_obj]
+  change CommHopfAlgCat.quotient (GeneralLinear.coordinateHopfAlgebra R 1)
+      (definingHopfIdeal R 1) =
+    CommHopfAlgCat.quotient (GeneralLinear.coordinateHopfAlgebra R 1)
+      (SpecialLinear.definingHopfIdeal R 1)
+  rw [definingHopfIdeal_one]
+
+/-- **The rank-zero special orthogonal group is reductive over every field.** -/
+theorem reductiveCommHopfAlgProperty_finiteTypeCoordinateHopfAlgebra_zero
+    (k : Type u) [Field k] :
+    reductiveCommHopfAlgProperty k (finiteTypeCoordinateHopfAlgebra k 0) := by
+  rw [finiteTypeCoordinateHopfAlgebra_zero]
+  exact SpecialLinear.reductiveCommHopfAlgProperty_finiteTypeCoordinateHopfAlgebra k 0
+
+/-- **The rank-one special orthogonal group is reductive over every field.** -/
+theorem reductiveCommHopfAlgProperty_finiteTypeCoordinateHopfAlgebra_one
+    (k : Type u) [Field k] :
+    reductiveCommHopfAlgProperty k (finiteTypeCoordinateHopfAlgebra k 1) := by
+  rw [finiteTypeCoordinateHopfAlgebra_one]
+  exact SpecialLinear.reductiveCommHopfAlgProperty_finiteTypeCoordinateHopfAlgebra k 1
+
+end
+
+end TauCeti.SpecialOrthogonal


### PR DESCRIPTION
This PR proves the low-rank cases of the standard special orthogonal worked example by identifying `SO₀` and `SO₁` with the corresponding special linear groups in Hopf coordinates, then transporting the existing reductivity theorem. It advances `ReductiveGroups/README.md`, Worked examples, exact target “`SOₙ` … prove [it is] reductive where applicable via `R_u = 1` / root data,” in the Layer 6 milestone “Reductive and semisimple groups.”

In rank zero, the orthogonal relation set is empty. In rank one, the sole relation is `x² - 1`; because the generic determinant is `x`, it factors as `(det + 1)(det - 1)` and already belongs to the determinant-one ideal. Thus the special-orthogonal and special-linear defining Hopf ideals agree in both ranks, as do their bundled finite-type coordinate Hopf algebras. The existing characteristic-free reductivity theorem for `SLₙ` then gives reductivity of `SO₀` and `SO₁` over every field, including characteristic two.

This is the most effective distinct current step because the base-change and faithful-standard-comodule infrastructure is already on `main`, while in-flight work handles rank-two connectedness and rank-at-least-three irreducibility; the two exceptional low ranks require this separate ideal computation rather than those representation arguments. After this PR, the worked-example milestone still needs the rank-two trivial-unipotent-radical argument and, in dimensions at least three, geometric connectedness and the final normal-unipotent elimination assembly.

The new module `TauCeti/Algebra/AlgebraicGroup/SpecialOrthogonal/LowRank.lean` contains 148 lines and six public theorems. It reuses Mathlib’s `Matrix.det_fin_one`, ideal-span API, and polynomial normalization, together with Tau Ceti’s special-linear reductivity theorem; no Mathlib or external formalization is vendored. The mathematical interpretation follows Milne, *Algebraic Groups* (2017), §§2.3 and 21, as cited in the module documentation.

The prescribed lint wrapper currently stops at its trusted-script freshness guard because the pinned environment includes the newly default `tacticAlt` linter. A direct run of the full 14-linter default set over the relevant imported Tau Ceti environment reports no finding on any declaration added here.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"special-orthogonal-low-rank-reductive"}-->

🤖 Prepared with Codex
