### PR TITLE
feat: add cycle data for permutation triples

### DIFF
--- a/TauCeti/Combinatorics/PermutationTriple/CycleData.lean
+++ b/TauCeti/Combinatorics/PermutationTriple/CycleData.lean
@@ -77,7 +77,7 @@ theorem cycleCounts_eq_card_cycleData (t : PermutationTriple n) :
   simp only [cycleCounts, cycleData, orbitCount_eq_card_parts_partition]
 
 /-- Each full cycle partition of a degree-`n` triple sums to `n`. -/
-theorem cycleData_sums (t : PermutationTriple n) :
+theorem sum_cycleData (t : PermutationTriple n) :
     (t.cycleData.1.sum, t.cycleData.2.1.sum, t.cycleData.2.2.sum) = (n, n, n) := by
   simp only [cycleData]
   rw [t.σ0.partition.parts_sum, t.σ1.partition.parts_sum, t.σinf.partition.parts_sum]

--- a/TauCeti/Combinatorics/PermutationTriple/CycleData.lean
+++ b/TauCeti/Combinatorics/PermutationTriple/CycleData.lean
@@ -1,0 +1,137 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Combinatorics.PermutationTriple.Basic
+public import TauCeti.GroupTheory.Perm.OrbitCount
+
+/-!
+# Cycle data of permutation triples
+
+The cycle data of a permutation triple records, in the ordered branch-point convention
+`0, 1, ∞`, the full cycle partition of each component. These are the parts of Mathlib's
+`Equiv.Perm.partition`, rather than `Equiv.Perm.cycleType`: fixed points therefore appear as
+parts equal to one.
+
+`TauCeti.PermutationTriple.cycleData` packages the three partitions and
+`TauCeti.PermutationTriple.cycleCounts` packages their numbers of parts. The latter is expressed
+using `TauCeti.orbitCount`, and `cycleCounts_eq_card_cycleData` identifies the two descriptions.
+The remaining results record that every partition sums to the degree and that both invariants are
+unchanged by simultaneous relabeling, transport of the sheet type, inversion of the convention,
+and isomorphism of triples.
+
+## References
+
+* S. K. Lando, A. K. Zvonkin, *Graphs on Surfaces and Their Applications*, Encyclopaedia of
+  Mathematical Sciences 141, Springer 2004, §1.1 and §1.5.
+-/
+
+public section
+
+namespace TauCeti
+
+open Equiv Equiv.Perm
+
+namespace PermutationTriple
+
+variable {n m : ℕ}
+
+/-- The ordered full cycle partitions of the three components of a permutation triple. Fixed
+points occur as parts equal to one. -/
+noncomputable def cycleData (t : PermutationTriple n) :
+    Multiset ℕ × Multiset ℕ × Multiset ℕ :=
+  (t.σ0.partition.parts, t.σ1.partition.parts, t.σinf.partition.parts)
+
+@[simp]
+theorem cycleData_σ0 (t : PermutationTriple n) :
+    t.cycleData.1 = t.σ0.partition.parts := (rfl)
+
+@[simp]
+theorem cycleData_σ1 (t : PermutationTriple n) :
+    t.cycleData.2.1 = t.σ1.partition.parts := (rfl)
+
+@[simp]
+theorem cycleData_σinf (t : PermutationTriple n) :
+    t.cycleData.2.2 = t.σinf.partition.parts := (rfl)
+
+/-- The ordered numbers of cycles of the three components, with fixed points included. -/
+noncomputable def cycleCounts (t : PermutationTriple n) : ℕ × ℕ × ℕ :=
+  (orbitCount t.σ0, orbitCount t.σ1, orbitCount t.σinf)
+
+@[simp]
+theorem cycleCounts_σ0 (t : PermutationTriple n) : t.cycleCounts.1 = orbitCount t.σ0 := (rfl)
+
+@[simp]
+theorem cycleCounts_σ1 (t : PermutationTriple n) : t.cycleCounts.2.1 = orbitCount t.σ1 := (rfl)
+
+@[simp]
+theorem cycleCounts_σinf (t : PermutationTriple n) :
+    t.cycleCounts.2.2 = orbitCount t.σinf := (rfl)
+
+/-- The cycle counts of a triple are the cardinalities of its three full cycle partitions. -/
+theorem cycleCounts_eq_card_cycleData (t : PermutationTriple n) :
+    t.cycleCounts = (t.cycleData.1.card, t.cycleData.2.1.card, t.cycleData.2.2.card) := by
+  simp only [cycleCounts, cycleData, orbitCount_eq_card_parts_partition]
+
+/-- Each full cycle partition of a degree-`n` triple sums to `n`. -/
+theorem cycleData_sums (t : PermutationTriple n) :
+    (t.cycleData.1.sum, t.cycleData.2.1.sum, t.cycleData.2.2.sum) = (n, n, n) := by
+  change (t.σ0.partition.parts.sum, t.σ1.partition.parts.sum,
+    t.σinf.partition.parts.sum) = (n, n, n)
+  rw [t.σ0.partition.parts_sum, t.σ1.partition.parts_sum, t.σinf.partition.parts_sum]
+  simp
+
+/-- Simultaneous relabeling leaves the ordered cycle data unchanged. -/
+@[simp]
+theorem cycleData_smul (τ : Perm (Fin n)) (t : PermutationTriple n) :
+    cycleData (τ • t) = cycleData t := by
+  simp [cycleData]
+
+/-- Simultaneous relabeling leaves all three cycle counts unchanged. -/
+@[simp]
+theorem cycleCounts_smul (τ : Perm (Fin n)) (t : PermutationTriple n) :
+    cycleCounts (τ • t) = cycleCounts t := by
+  simp [cycleCounts]
+
+/-- Transporting the labels of the sheets leaves the ordered cycle data unchanged. -/
+@[simp]
+theorem cycleData_transport (e : Fin n ≃ Fin m) (t : PermutationTriple n) :
+    cycleData (transport e t) = cycleData t := by
+  simp [cycleData]
+
+/-- Transporting the labels of the sheets leaves all three cycle counts unchanged. -/
+@[simp]
+theorem cycleCounts_transport (e : Fin n ≃ Fin m) (t : PermutationTriple n) :
+    cycleCounts (transport e t) = cycleCounts t := by
+  simp [cycleCounts]
+
+/-- Inverting all three components, as in the passage to the opposite composition convention,
+leaves the ordered cycle data unchanged. -/
+theorem cycleData_inv_components (t : PermutationTriple n) :
+    (t.σ0⁻¹.partition.parts, t.σ1⁻¹.partition.parts, t.σinf⁻¹.partition.parts) =
+      cycleData t := by
+  simp [cycleData]
+
+/-- Inverting all three components leaves their ordered numbers of cycles unchanged. -/
+theorem cycleCounts_inv_components (t : PermutationTriple n) :
+    (orbitCount t.σ0⁻¹, orbitCount t.σ1⁻¹, orbitCount t.σinf⁻¹) = cycleCounts t := by
+  simp [cycleCounts]
+
+/-- Isomorphic permutation triples have the same ordered cycle data. -/
+theorem cycleData_eq_of_equivalent {t t' : PermutationTriple n} (h : Equivalent t t') :
+    cycleData t = cycleData t' := by
+  obtain ⟨τ, rfl⟩ := equivalent_iff_exists_smul_eq.mp h
+  exact (cycleData_smul τ t).symm
+
+/-- Isomorphic permutation triples have the same ordered numbers of cycles. -/
+theorem cycleCounts_eq_of_equivalent {t t' : PermutationTriple n} (h : Equivalent t t') :
+    cycleCounts t = cycleCounts t' := by
+  obtain ⟨τ, rfl⟩ := equivalent_iff_exists_smul_eq.mp h
+  exact (cycleCounts_smul τ t).symm
+
+end PermutationTriple
+
+end TauCeti

--- a/TauCeti/Combinatorics/PermutationTriple/CycleData.lean
+++ b/TauCeti/Combinatorics/PermutationTriple/CycleData.lean
@@ -79,8 +79,7 @@ theorem cycleCounts_eq_card_cycleData (t : PermutationTriple n) :
 /-- Each full cycle partition of a degree-`n` triple sums to `n`. -/
 theorem cycleData_sums (t : PermutationTriple n) :
     (t.cycleData.1.sum, t.cycleData.2.1.sum, t.cycleData.2.2.sum) = (n, n, n) := by
-  change (t.σ0.partition.parts.sum, t.σ1.partition.parts.sum,
-    t.σinf.partition.parts.sum) = (n, n, n)
+  simp only [cycleData]
   rw [t.σ0.partition.parts_sum, t.σ1.partition.parts_sum, t.σinf.partition.parts_sum]
   simp
 

--- a/TauCeti/GroupTheory/Perm/OrbitCount.lean
+++ b/TauCeti/GroupTheory/Perm/OrbitCount.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.GroupTheory.Perm.Cycle.Basic
 public import Mathlib.SetTheory.Cardinal.NatCard
+public import TauCeti.GroupTheory.Perm.Partition
 import Mathlib.Logic.Equiv.Option
 
 /-!
@@ -22,6 +23,10 @@ by one, both stated so that they apply to a permutation of a *different* type th
 are compared with.
 
 * `TauCeti.orbitCount_conj`: conjugation does not change the number of orbits.
+* `TauCeti.orbitCount_eq_card_parts_partition`: on a finite type, the orbit count is the number
+  of parts in Mathlib's full, fixed-point-aware permutation partition.
+* `TauCeti.sign_eq_neg_one_pow_card_sub_orbitCount`: the sign is determined by the parity of
+  the number of points minus the number of orbits.
 * `TauCeti.orbitCount_add_one_eq_of_semiconj`: if `σ : Equiv.Perm α` is carried by an injection
   `f : α → β` to `τ : Equiv.Perm β`, and `f` misses exactly one point `p` of `β`, then `τ` has one
   orbit more than `σ` — the extra orbit is the fixed point `p`.
@@ -81,6 +86,154 @@ theorem orbitCount_conj (g σ : Equiv.Perm α) : orbitCount (g * σ * g⁻¹) = 
     rw [sameCycle_conj]
     simp
   exact h.symm
+
+/-- Inverting a permutation does not change its number of orbits. -/
+@[simp]
+theorem orbitCount_inv (σ : Equiv.Perm α) : orbitCount σ⁻¹ = orbitCount σ := by
+  exact Nat.card_congr (Quotient.congr (ra := SameCycle.setoid σ⁻¹)
+    (rb := SameCycle.setoid σ) (Equiv.refl α) fun _ _ ↦ sameCycle_inv)
+
+/-- Transporting a permutation along an equivalence of its underlying type does not change its
+number of orbits. -/
+@[simp]
+theorem orbitCount_permCongr (e : α ≃ β) (σ : Equiv.Perm α) :
+    orbitCount (e.permCongr σ) = orbitCount σ := by
+  refine (Nat.card_congr (Quotient.congr (ra := SameCycle.setoid σ)
+    (rb := SameCycle.setoid (e.permCongr σ)) e fun x y ↦ ?_)).symm
+  constructor
+  · rintro ⟨i, hi⟩
+    refine ⟨i, ?_⟩
+    have hz : e.permCongr (σ ^ i) = (e.permCongr σ) ^ i := by
+      simpa only [Equiv.permCongrHom_coe] using map_zpow e.permCongrHom σ i
+    rw [← hz, Equiv.permCongr_apply, Equiv.symm_apply_apply, hi]
+  · rintro ⟨i, hi⟩
+    refine ⟨i, e.injective ?_⟩
+    have hz : e.permCongr (σ ^ i) = (e.permCongr σ) ^ i := by
+      simpa only [Equiv.permCongrHom_coe] using map_zpow e.permCongrHom σ i
+    rw [← hz, Equiv.permCongr_apply, Equiv.symm_apply_apply] at hi
+    exact hi
+
+section Finite
+
+variable [Fintype α] [DecidableEq α]
+
+/-- The orbits of a permutation are its nontrivial cycle factors together with its fixed points.
+This is the set-level decomposition underlying the full cycle partition: a nontrivial orbit is
+sent to the unique member of `cycleFactorsFinset`, while a singleton orbit is sent to its fixed
+point. -/
+noncomputable def orbitQuotientEquivCycleFactorsSumFixedPoints (σ : Equiv.Perm α) :
+    Quotient (Equiv.Perm.SameCycle.setoid σ) ≃
+      σ.cycleFactorsFinset ⊕ {x : α // σ x = x} := by
+  classical
+  let toCycleOrFixed (x : α) : σ.cycleFactorsFinset ⊕ {x : α // σ x = x} :=
+    if hx : σ x = x then Sum.inr ⟨x, hx⟩
+    else Sum.inl ⟨σ.cycleOf x, Equiv.Perm.cycleOf_mem_cycleFactorsFinset_iff.mpr
+      (Equiv.Perm.mem_support.mpr hx)⟩
+  let forward : Quotient (Equiv.Perm.SameCycle.setoid σ) →
+      σ.cycleFactorsFinset ⊕ {x : α // σ x = x} :=
+    Quotient.lift toCycleOrFixed fun x y hxy ↦ by
+      have hfixed : σ x = x ↔ σ y = y :=
+        Equiv.Perm.SameCycle.apply_eq_self_iff hxy
+      by_cases hx : σ x = x
+      · have hy : σ y = y := hfixed.mp hx
+        simp only [toCycleOrFixed, hx, hy, ↓reduceDIte]
+        exact congrArg Sum.inr (Subtype.ext (hxy.eq_of_left hx))
+      · have hy : σ y ≠ y := mt hfixed.mpr hx
+        simp only [toCycleOrFixed, hx, hy, ↓reduceDIte]
+        exact congrArg Sum.inl (Subtype.ext hxy.cycleOf_eq)
+  let backward : σ.cycleFactorsFinset ⊕ {x : α // σ x = x} →
+      Quotient (Equiv.Perm.SameCycle.setoid σ)
+    | Sum.inl c => Quotient.mk _ (Classical.choose
+        (Equiv.Perm.IsCycle.nonempty_support
+          (Equiv.Perm.mem_cycleFactorsFinset_iff.mp c.property).1))
+    | Sum.inr x => Quotient.mk _ x.1
+  refine
+    { toFun := forward
+      invFun := backward
+      left_inv := ?_
+      right_inv := ?_ }
+  · intro q
+    induction q using Quotient.ind with
+    | _ x =>
+      simp only [forward, Quotient.lift_mk, backward, toCycleOrFixed]
+      split_ifs with hx
+      · rfl
+      · apply Quotient.sound
+        exact ((Equiv.Perm.mem_support_cycleOf_iff' hx).mp
+          (Classical.choose_spec (Equiv.Perm.IsCycle.nonempty_support
+            (Equiv.Perm.mem_cycleFactorsFinset_iff.mp
+              (Equiv.Perm.cycleOf_mem_cycleFactorsFinset_iff.mpr
+                (Equiv.Perm.mem_support.mpr hx))).1))).symm
+  · rintro (c | x)
+    · simp only [backward, forward, Quotient.lift_mk, toCycleOrFixed]
+      have hc := Classical.choose_spec (Equiv.Perm.IsCycle.nonempty_support
+        (Equiv.Perm.mem_cycleFactorsFinset_iff.mp c.property).1)
+      have hne : σ (Classical.choose (Equiv.Perm.IsCycle.nonempty_support
+          (Equiv.Perm.mem_cycleFactorsFinset_iff.mp c.property).1)) ≠
+          Classical.choose (Equiv.Perm.IsCycle.nonempty_support
+            (Equiv.Perm.mem_cycleFactorsFinset_iff.mp c.property).1) :=
+        Equiv.Perm.mem_support.mp
+          (Equiv.Perm.mem_cycleFactorsFinset_support_le c.property hc)
+      simp only [hne, ↓reduceDIte]
+      exact congrArg Sum.inl (Subtype.ext
+        (Equiv.Perm.cycle_is_cycleOf hc c.property).symm)
+    · simp only [backward, forward, Quotient.lift_mk, toCycleOrFixed]
+      simp only [x.property, ↓reduceDIte]
+
+/-- The number of permutation orbits is the number of parts in its full cycle partition. This
+identifies `orbitCount`, defined from `SameCycle`, with Mathlib's fixed-point-aware cycle data. -/
+theorem orbitCount_eq_card_parts_partition (σ : Equiv.Perm α) :
+    orbitCount σ = σ.partition.parts.card := by
+  classical
+  rw [orbitCount, Nat.card_eq_fintype_card,
+    Fintype.card_congr (orbitQuotientEquivCycleFactorsSumFixedPoints σ), Fintype.card_sum,
+    Fintype.card_coe]
+  have hfixed : Fintype.card {x : α // σ x = x} = Fintype.card α - σ.support.card := by
+    have hp : (fun x : α ↦ σ x = x) = (fun x ↦ x ∈ σ.supportᶜ) := by
+      funext x
+      simp [Equiv.Perm.mem_support]
+    calc
+      _ = Fintype.card {x : α // x ∈ σ.supportᶜ} :=
+        Fintype.card_congr (Equiv.subtypeEquivProp hp)
+      _ = σ.supportᶜ.card := Fintype.card_coe _
+      _ = Fintype.card α - σ.support.card := Finset.card_compl (s := σ.support)
+  rw [hfixed, Equiv.Perm.card_parts_partition, Equiv.Perm.cycleType_def]
+  simp
+
+/-- On a finite type, the number of orbits is the number of nontrivial cycles plus the number of
+fixed points. This is the unbundled bookkeeping form of
+`TauCeti.orbitCount_eq_card_parts_partition`. -/
+theorem orbitCount_eq_card_cycleType_add_card_sub_support (σ : Equiv.Perm α) :
+    orbitCount σ =
+      σ.cycleType.card + (Fintype.card α - σ.support.card) := by
+  rw [orbitCount_eq_card_parts_partition, Equiv.Perm.card_parts_partition]
+
+private theorem card_le_sum_of_pos {s : Multiset ℕ} (hs : ∀ n ∈ s, 0 < n) : s.card ≤ s.sum := by
+  induction s using Multiset.induction_on with
+  | empty => simp
+  | @cons a s ih =>
+    simp only [Multiset.card_cons, Multiset.sum_cons]
+    simpa [Nat.add_comm] using
+      Nat.add_le_add (ih fun n hn ↦ hs n (by simp [hn])) (hs a (by simp))
+
+/-- The sign of a finite permutation is the parity of the number of points minus the number of
+orbits. Fixed points contribute once to both numbers and hence do not affect the sign. -/
+theorem sign_eq_neg_one_pow_card_sub_orbitCount (σ : Equiv.Perm α) :
+    Equiv.Perm.sign σ = (-1 : ℤˣ) ^ (Fintype.card α - orbitCount σ) := by
+  rw [Equiv.Perm.sign_of_parts_partition, ← orbitCount_eq_card_parts_partition]
+  have hle : orbitCount σ ≤ Fintype.card α := by
+    rw [orbitCount_eq_card_parts_partition]
+    calc
+      σ.partition.parts.card ≤ σ.partition.parts.sum :=
+        card_le_sum_of_pos fun n hn ↦ σ.partition.parts_pos hn
+      _ = Fintype.card α := σ.partition.parts_sum
+  have h : Fintype.card α + orbitCount σ =
+      (Fintype.card α - orbitCount σ) + 2 * orbitCount σ := by
+    omega
+  rw [h, pow_add, pow_mul]
+  simp
+
+end Finite
 
 /-- Propagate a one-step comparison over all integer powers: if every point `x` of `β` lies in the
 same `π`-cycle as its image `g x` does after one step of `σ`, then it lies in the same `π`-cycle

--- a/TauCeti/GroupTheory/Perm/OrbitCount.lean
+++ b/TauCeti/GroupTheory/Perm/OrbitCount.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.GroupTheory.Perm.Cycle.Basic
 public import Mathlib.SetTheory.Cardinal.NatCard
 public import TauCeti.GroupTheory.Perm.Partition
 import Mathlib.Logic.Equiv.Option
@@ -23,6 +22,8 @@ by one, both stated so that they apply to a permutation of a *different* type th
 are compared with.
 
 * `TauCeti.orbitCount_conj`: conjugation does not change the number of orbits.
+* `TauCeti.orbitQuotientEquivCycleFactorsSumFixedPoints`: on a finite type, the orbits are the
+  nontrivial cycle factors of the permutation together with its fixed points.
 * `Equiv.Perm.orbitCount_eq_card_parts_partition`: on a finite type, the orbit count is the number
   of parts in Mathlib's full, fixed-point-aware permutation partition.
 * `Equiv.Perm.sign_eq_neg_one_pow_card_sub_orbitCount`: the sign is determined by the parity of
@@ -121,7 +122,7 @@ variable [Fintype α] [DecidableEq α]
 This is the set-level decomposition underlying the full cycle partition: a nontrivial orbit is
 sent to the unique member of `cycleFactorsFinset`, while a singleton orbit is sent to its fixed
 point. -/
-private noncomputable def orbitQuotientEquivCycleFactorsSumFixedPoints (σ : Equiv.Perm α) :
+noncomputable def orbitQuotientEquivCycleFactorsSumFixedPoints (σ : Equiv.Perm α) :
     Quotient (Equiv.Perm.SameCycle.setoid σ) ≃
       σ.cycleFactorsFinset ⊕ {x : α // σ x = x} := by
   classical
@@ -199,15 +200,6 @@ theorem _root_.Equiv.Perm.orbitCount_eq_card_parts_partition (σ : Equiv.Perm α
       _ = Fintype.card α - σ.support.card := Finset.card_compl (s := σ.support)
   rw [hfixed, Equiv.Perm.card_parts_partition, Equiv.Perm.cycleType_def]
   simp
-
-/-- On a finite type, the number of orbits is the number of nontrivial cycles plus the number of
-fixed points. This is the unbundled bookkeeping form of
-`Equiv.Perm.orbitCount_eq_card_parts_partition`. -/
-theorem _root_.Equiv.Perm.orbitCount_eq_card_cycleType_add_card_sub_support
-    (σ : Equiv.Perm α) :
-    orbitCount σ =
-      σ.cycleType.card + (Fintype.card α - σ.support.card) := by
-  rw [orbitCount_eq_card_parts_partition, Equiv.Perm.card_parts_partition]
 
 /-- The sign of a finite permutation is the parity of the number of points minus the number of
 orbits. Fixed points contribute once to both numbers and hence do not affect the sign. -/

--- a/TauCeti/GroupTheory/Perm/OrbitCount.lean
+++ b/TauCeti/GroupTheory/Perm/OrbitCount.lean
@@ -22,7 +22,7 @@ by one, both stated so that they apply to a permutation of a *different* type th
 are compared with.
 
 * `TauCeti.orbitCount_conj`: conjugation does not change the number of orbits.
-* `TauCeti.orbitQuotientEquivCycleFactorsSumFixedPoints`: on a finite type, the orbits are the
+* `Equiv.Perm.orbitQuotientEquivCycleFactorsSumFixedPoints`: on a finite type, the orbits are the
   nontrivial cycle factors of the permutation together with its fixed points.
 * `Equiv.Perm.orbitCount_eq_card_parts_partition`: on a finite type, the orbit count is the number
   of parts in Mathlib's full, fixed-point-aware permutation partition.
@@ -122,7 +122,8 @@ variable [Fintype α] [DecidableEq α]
 This is the set-level decomposition underlying the full cycle partition: a nontrivial orbit is
 sent to the unique member of `cycleFactorsFinset`, while a singleton orbit is sent to its fixed
 point. -/
-noncomputable def orbitQuotientEquivCycleFactorsSumFixedPoints (σ : Equiv.Perm α) :
+noncomputable def _root_.Equiv.Perm.orbitQuotientEquivCycleFactorsSumFixedPoints
+    (σ : Equiv.Perm α) :
     Quotient (Equiv.Perm.SameCycle.setoid σ) ≃
       σ.cycleFactorsFinset ⊕ {x : α // σ x = x} := by
   classical
@@ -187,7 +188,7 @@ theorem _root_.Equiv.Perm.orbitCount_eq_card_parts_partition (σ : Equiv.Perm α
     orbitCount σ = σ.partition.parts.card := by
   classical
   rw [orbitCount, Nat.card_eq_fintype_card,
-    Fintype.card_congr (orbitQuotientEquivCycleFactorsSumFixedPoints σ), Fintype.card_sum,
+    Fintype.card_congr σ.orbitQuotientEquivCycleFactorsSumFixedPoints, Fintype.card_sum,
     Fintype.card_coe]
   have hfixed : Fintype.card {x : α // σ x = x} = Fintype.card α - σ.support.card := by
     have hp : (fun x : α ↦ σ x = x) = (fun x ↦ x ∈ σ.supportᶜ) := by
@@ -209,17 +210,9 @@ theorem _root_.Equiv.Perm.sign_eq_neg_one_pow_card_sub_orbitCount (σ : Equiv.Pe
   have hle : orbitCount σ ≤ Fintype.card α := by
     rw [orbitCount_eq_card_parts_partition]
     calc
-      σ.partition.parts.card = (σ.partition.parts.sort (· ≥ ·)).length := by
-        rw [Multiset.length_sort]
-      _ ≤ (σ.partition.parts.sort (· ≥ ·)).sum :=
-        List.length_le_sum_of_one_le _ fun n hn ↦
-          σ.partition.parts_pos ((Multiset.mem_sort (· ≥ ·)).mp hn)
-      _ = σ.partition.parts.sum := by
-        calc
-          _ = (↑(σ.partition.parts.sort (· ≥ ·)) : Multiset ℕ).sum :=
-            (Multiset.sum_coe _).symm
-          _ = σ.partition.parts.sum :=
-            congrArg Multiset.sum (Multiset.sort_eq σ.partition.parts (· ≥ ·))
+      σ.partition.parts.card = σ.partition.parts.card • 1 := by simp
+      _ ≤ σ.partition.parts.sum :=
+        Multiset.card_nsmul_le_sum fun n hn ↦ σ.partition.parts_pos hn
       _ = Fintype.card α := σ.partition.parts_sum
   have h : Fintype.card α + orbitCount σ =
       (Fintype.card α - orbitCount σ) + 2 * orbitCount σ := by

--- a/TauCeti/GroupTheory/Perm/OrbitCount.lean
+++ b/TauCeti/GroupTheory/Perm/OrbitCount.lean
@@ -23,9 +23,9 @@ by one, both stated so that they apply to a permutation of a *different* type th
 are compared with.
 
 * `TauCeti.orbitCount_conj`: conjugation does not change the number of orbits.
-* `TauCeti.orbitCount_eq_card_parts_partition`: on a finite type, the orbit count is the number
+* `Equiv.Perm.orbitCount_eq_card_parts_partition`: on a finite type, the orbit count is the number
   of parts in Mathlib's full, fixed-point-aware permutation partition.
-* `TauCeti.sign_eq_neg_one_pow_card_sub_orbitCount`: the sign is determined by the parity of
+* `Equiv.Perm.sign_eq_neg_one_pow_card_sub_orbitCount`: the sign is determined by the parity of
   the number of points minus the number of orbits.
 * `TauCeti.orbitCount_add_one_eq_of_semiconj`: if `σ : Equiv.Perm α` is carried by an injection
   `f : α → β` to `τ : Equiv.Perm β`, and `f` misses exactly one point `p` of `β`, then `τ` has one
@@ -89,14 +89,14 @@ theorem orbitCount_conj (g σ : Equiv.Perm α) : orbitCount (g * σ * g⁻¹) = 
 
 /-- Inverting a permutation does not change its number of orbits. -/
 @[simp]
-theorem orbitCount_inv (σ : Equiv.Perm α) : orbitCount σ⁻¹ = orbitCount σ := by
+theorem _root_.Equiv.Perm.orbitCount_inv (σ : Equiv.Perm α) : orbitCount σ⁻¹ = orbitCount σ := by
   exact Nat.card_congr (Quotient.congr (ra := SameCycle.setoid σ⁻¹)
     (rb := SameCycle.setoid σ) (Equiv.refl α) fun _ _ ↦ sameCycle_inv)
 
 /-- Transporting a permutation along an equivalence of its underlying type does not change its
 number of orbits. -/
 @[simp]
-theorem orbitCount_permCongr (e : α ≃ β) (σ : Equiv.Perm α) :
+theorem _root_.Equiv.orbitCount_permCongr (e : α ≃ β) (σ : Equiv.Perm α) :
     orbitCount (e.permCongr σ) = orbitCount σ := by
   refine (Nat.card_congr (Quotient.congr (ra := SameCycle.setoid σ)
     (rb := SameCycle.setoid (e.permCongr σ)) e fun x y ↦ ?_)).symm
@@ -121,7 +121,7 @@ variable [Fintype α] [DecidableEq α]
 This is the set-level decomposition underlying the full cycle partition: a nontrivial orbit is
 sent to the unique member of `cycleFactorsFinset`, while a singleton orbit is sent to its fixed
 point. -/
-noncomputable def orbitQuotientEquivCycleFactorsSumFixedPoints (σ : Equiv.Perm α) :
+private noncomputable def orbitQuotientEquivCycleFactorsSumFixedPoints (σ : Equiv.Perm α) :
     Quotient (Equiv.Perm.SameCycle.setoid σ) ≃
       σ.cycleFactorsFinset ⊕ {x : α // σ x = x} := by
   classical
@@ -182,7 +182,7 @@ noncomputable def orbitQuotientEquivCycleFactorsSumFixedPoints (σ : Equiv.Perm 
 
 /-- The number of permutation orbits is the number of parts in its full cycle partition. This
 identifies `orbitCount`, defined from `SameCycle`, with Mathlib's fixed-point-aware cycle data. -/
-theorem orbitCount_eq_card_parts_partition (σ : Equiv.Perm α) :
+theorem _root_.Equiv.Perm.orbitCount_eq_card_parts_partition (σ : Equiv.Perm α) :
     orbitCount σ = σ.partition.parts.card := by
   classical
   rw [orbitCount, Nat.card_eq_fintype_card,
@@ -202,30 +202,32 @@ theorem orbitCount_eq_card_parts_partition (σ : Equiv.Perm α) :
 
 /-- On a finite type, the number of orbits is the number of nontrivial cycles plus the number of
 fixed points. This is the unbundled bookkeeping form of
-`TauCeti.orbitCount_eq_card_parts_partition`. -/
-theorem orbitCount_eq_card_cycleType_add_card_sub_support (σ : Equiv.Perm α) :
+`Equiv.Perm.orbitCount_eq_card_parts_partition`. -/
+theorem _root_.Equiv.Perm.orbitCount_eq_card_cycleType_add_card_sub_support
+    (σ : Equiv.Perm α) :
     orbitCount σ =
       σ.cycleType.card + (Fintype.card α - σ.support.card) := by
   rw [orbitCount_eq_card_parts_partition, Equiv.Perm.card_parts_partition]
 
-private theorem card_le_sum_of_pos {s : Multiset ℕ} (hs : ∀ n ∈ s, 0 < n) : s.card ≤ s.sum := by
-  induction s using Multiset.induction_on with
-  | empty => simp
-  | @cons a s ih =>
-    simp only [Multiset.card_cons, Multiset.sum_cons]
-    simpa [Nat.add_comm] using
-      Nat.add_le_add (ih fun n hn ↦ hs n (by simp [hn])) (hs a (by simp))
-
 /-- The sign of a finite permutation is the parity of the number of points minus the number of
 orbits. Fixed points contribute once to both numbers and hence do not affect the sign. -/
-theorem sign_eq_neg_one_pow_card_sub_orbitCount (σ : Equiv.Perm α) :
+theorem _root_.Equiv.Perm.sign_eq_neg_one_pow_card_sub_orbitCount (σ : Equiv.Perm α) :
     Equiv.Perm.sign σ = (-1 : ℤˣ) ^ (Fintype.card α - orbitCount σ) := by
   rw [Equiv.Perm.sign_of_parts_partition, ← orbitCount_eq_card_parts_partition]
   have hle : orbitCount σ ≤ Fintype.card α := by
     rw [orbitCount_eq_card_parts_partition]
     calc
-      σ.partition.parts.card ≤ σ.partition.parts.sum :=
-        card_le_sum_of_pos fun n hn ↦ σ.partition.parts_pos hn
+      σ.partition.parts.card = (σ.partition.parts.sort (· ≥ ·)).length := by
+        rw [Multiset.length_sort]
+      _ ≤ (σ.partition.parts.sort (· ≥ ·)).sum :=
+        List.length_le_sum_of_one_le _ fun n hn ↦
+          σ.partition.parts_pos ((Multiset.mem_sort (· ≥ ·)).mp hn)
+      _ = σ.partition.parts.sum := by
+        calc
+          _ = (↑(σ.partition.parts.sort (· ≥ ·)) : Multiset ℕ).sum :=
+            (Multiset.sum_coe _).symm
+          _ = σ.partition.parts.sum :=
+            congrArg Multiset.sum (Multiset.sort_eq σ.partition.parts (· ≥ ·))
       _ = Fintype.card α := σ.partition.parts_sum
   have h : Fintype.card α + orbitCount σ =
       (Fintype.card α - orbitCount σ) + 2 * orbitCount σ := by


### PR DESCRIPTION
This PR equips permutation triples with their ordered, fixed-point-aware cycle data and establishes the orbit-count bookkeeping needed on the BelyiMaps critical path. It reuses Mathlib Equiv.Perm.partition.parts and the existing TauCeti.orbitCount instead of introducing duplicate fullCycleType or cycleCount wrappers.

The generic part identifies SameCycle-orbits with nontrivial cycle factors plus fixed points, proves orbitCount equals the number of full-partition parts, records inversion and transport invariance, and derives the sign formula sign σ = (-1)^(card α - orbitCount σ). The Belyi-specific module packages the three ordered partitions and counts and proves their degree sums and invariance under relabeling, transport, opposite-convention inversion, and triple isomorphism.

Roadmap target: BelyiMaps README, Layer 0.5 Cycle data.

Consumer milestone: BelyiMaps Layer 0.6 Euler characteristic and genus consumes these cycle counts and the sign identity for its parity theorem and connected Euler-characteristic bound.

Prerequisite target: PolynomialGaloisGroups Layer 0 fullCycleType with its basic API, consumed here through the already-landed canonical Equiv.Perm.partition.parts comparison rather than a duplicate declaration.

What remains after this PR: prove the Layer 0.5 transposition merge/split lemma; Layer 0.6 can then use it for the connected bound and define genus.

Roadmap: BelyiMaps

<!--tauceti-target:v1 {"focus":"BelyiMaps","id":"cycle-data"}-->