### PR TITLE
refactor(Analysis): root the `TauCeti.ContinuousLinearMap` namespace

### DIFF
--- a/TauCeti/Analysis/Calculus/Bilinear.lean
+++ b/TauCeti/Analysis/Calculus/Bilinear.lean
@@ -20,13 +20,13 @@ critical point, but it depends on nothing beyond the bilinear chain rule
 
 ## Main results
 
-* `TauCeti.ContinuousLinearMap.contDiff_apply_self`: `z ↦ B z z` is `C^n` for every `n`, and its
-  corollary `TauCeti.ContinuousLinearMap.differentiable_apply_self`.
-* `TauCeti.ContinuousLinearMap.hasStrictFDerivAt_apply_self`: `z ↦ B z z` is strictly
+* `ContinuousLinearMap.contDiff_apply_self`: `z ↦ B z z` is `C^n` for every `n`, and its
+  corollary `ContinuousLinearMap.differentiable_apply_self`.
+* `ContinuousLinearMap.hasStrictFDerivAt_apply_self`: `z ↦ B z z` is strictly
   differentiable at `y`, with derivative the polarization of `B` evaluated at `y`.
-* `TauCeti.ContinuousLinearMap.hasFDerivAt_apply_self`, and its `fderiv` form
-  `TauCeti.ContinuousLinearMap.fderiv_apply_self`.
-* `TauCeti.ContinuousLinearMap.fderiv_fderiv_apply_self`: the second derivative of `z ↦ B z z` is
+* `ContinuousLinearMap.hasFDerivAt_apply_self`, and its `fderiv` form
+  `ContinuousLinearMap.fderiv_apply_self`.
+* `ContinuousLinearMap.fderiv_fderiv_apply_self`: the second derivative of `z ↦ B z z` is
   the constant `B.flip + B`.
 -/
 
@@ -37,19 +37,20 @@ namespace TauCeti
 variable {𝕜 E F : Type*} [NontriviallyNormedField 𝕜] [NormedAddCommGroup E] [NormedSpace 𝕜 E]
   [NormedAddCommGroup F] [NormedSpace 𝕜 F] {n : WithTop ℕ∞}
 
-namespace ContinuousLinearMap
 
 /-- The map `z ↦ B z z` attached to a continuous bilinear map `B` is `C^n` for every `n`. -/
-theorem contDiff_apply_self (B : E →L[𝕜] E →L[𝕜] F) : ContDiff 𝕜 n (fun z ↦ B z z) :=
+theorem _root_.ContinuousLinearMap.contDiff_apply_self (B : E →L[𝕜] E →L[𝕜] F) : ContDiff 𝕜 n
+    (fun z ↦ B z z) :=
   B.isBoundedBilinearMap.contDiff.comp₂ contDiff_id contDiff_id
 
 /-- The map `z ↦ B z z` attached to a continuous bilinear map `B` is differentiable. -/
-theorem differentiable_apply_self (B : E →L[𝕜] E →L[𝕜] F) : Differentiable 𝕜 (fun z ↦ B z z) :=
-  (contDiff_apply_self (n := 1) B).differentiable one_ne_zero
+theorem _root_.ContinuousLinearMap.differentiable_apply_self (B : E →L[𝕜] E →L[𝕜] F) :
+    Differentiable 𝕜 (fun z ↦ B z z) :=
+  (ContinuousLinearMap.contDiff_apply_self (n := 1) B).differentiable one_ne_zero
 
 /-- The map `z ↦ B z z` attached to a continuous bilinear map `B` is strictly differentiable at
 `y`, with derivative the polarization of `B` evaluated at `y`. -/
-theorem hasStrictFDerivAt_apply_self (B : E →L[𝕜] E →L[𝕜] F) (y : E) :
+theorem _root_.ContinuousLinearMap.hasStrictFDerivAt_apply_self (B : E →L[𝕜] E →L[𝕜] F) (y : E) :
     HasStrictFDerivAt (fun z ↦ B z z) (B.flip y + B y) y := by
   have h : HasStrictFDerivAt (fun z ↦ B z z)
       (B.precompR E y (ContinuousLinearMap.id 𝕜 E) +
@@ -61,27 +62,26 @@ theorem hasStrictFDerivAt_apply_self (B : E →L[𝕜] E →L[𝕜] F) (y : E) :
 
 /-- The map `z ↦ B z z` attached to a continuous bilinear map `B` is differentiable at `y`, with
 derivative the polarization of `B` evaluated at `y`. -/
-theorem hasFDerivAt_apply_self (B : E →L[𝕜] E →L[𝕜] F) (y : E) :
+theorem _root_.ContinuousLinearMap.hasFDerivAt_apply_self (B : E →L[𝕜] E →L[𝕜] F) (y : E) :
     HasFDerivAt (fun z ↦ B z z) (B.flip y + B y) y :=
-  (hasStrictFDerivAt_apply_self B y).hasFDerivAt
+  (ContinuousLinearMap.hasStrictFDerivAt_apply_self B y).hasFDerivAt
 
 /-- At `y`, the differential of `z ↦ B z z` is `B.flip y + B y`. -/
 @[simp]
-theorem fderiv_apply_self (B : E →L[𝕜] E →L[𝕜] F) (y : E) :
+theorem _root_.ContinuousLinearMap.fderiv_apply_self (B : E →L[𝕜] E →L[𝕜] F) (y : E) :
     fderiv 𝕜 (fun z ↦ B z z) y = B.flip y + B y :=
-  (hasFDerivAt_apply_self B y).fderiv
+  (ContinuousLinearMap.hasFDerivAt_apply_self B y).fderiv
 
 /-- The second derivative of `z ↦ B z z` is the constant `B.flip + B`. -/
 @[simp]
-theorem fderiv_fderiv_apply_self (B : E →L[𝕜] E →L[𝕜] F) (y : E) :
+theorem _root_.ContinuousLinearMap.fderiv_fderiv_apply_self (B : E →L[𝕜] E →L[𝕜] F) (y : E) :
     fderiv 𝕜 (fderiv 𝕜 fun z ↦ B z z) y = B.flip + B := by
   have hEq : (fderiv 𝕜 fun z ↦ B z z) = fun z ↦ (B.flip + B) z := by
     funext z
-    rw [fderiv_apply_self, add_apply]
+    rw [ContinuousLinearMap.fderiv_apply_self, add_apply]
   rw [hEq]
   exact (B.flip + B).fderiv
 
-end ContinuousLinearMap
 
 end TauCeti
 

--- a/TauCeti/Analysis/Calculus/Morse/Basic.lean
+++ b/TauCeti/Analysis/Calculus/Morse/Basic.lean
@@ -77,10 +77,10 @@ the notion be read off in any chart.
   locus is finite on a compact set on which `fderiv ℝ f` is continuous.
 * `TauCeti.isNondegenerateCriticalPoint_comp_iff` and `TauCeti.IsNondegenerateCriticalPoint.comp`:
   nondegeneracy is invariant under a change of coordinates with invertible differential.
-* `TauCeti.ContinuousLinearMap.isNondegenerateCriticalPoint_apply_self`: the local model. A
+* `ContinuousLinearMap.isNondegenerateCriticalPoint_apply_self`: the local model. A
   continuous bilinear form `B` whose polarization `B.flip + B` is invertible makes `z ↦ B z z` a
   function with a nondegenerate critical point at the origin.
-* `TauCeti.ContinuousLinearMap.isNondegenerateCriticalPoint_apply_self_of_flip_eq_self`: the
+* `ContinuousLinearMap.isNondegenerateCriticalPoint_apply_self_of_flip_eq_self`: the
   symmetric case of the model, where the polarization is `2 • B`, so an invertible symmetric `B`
   suffices.
 
@@ -269,23 +269,23 @@ section Model
 
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
 
-namespace ContinuousLinearMap
 
 /-- **The local model of a nondegenerate critical point.** If the polarization `B.flip + B` of a
 continuous bilinear form `B` on `E` is invertible as a map into the dual space, then the quadratic
 function `z ↦ B z z` has a nondegenerate critical point at the origin. -/
-theorem isNondegenerateCriticalPoint_apply_self (B : E →L[ℝ] E →L[ℝ] ℝ)
+theorem _root_.ContinuousLinearMap.isNondegenerateCriticalPoint_apply_self (B : E →L[ℝ] E →L[ℝ] ℝ)
     (hB : (B.flip + B).IsInvertible) : IsNondegenerateCriticalPoint (fun z ↦ B z z) 0 :=
-  ⟨(contDiff_apply_self B).contDiffAt, by simp,
-    by rw [fderiv_fderiv_apply_self]; exact hB⟩
+  ⟨(ContinuousLinearMap.contDiff_apply_self B).contDiffAt, by simp,
+    by rw [ContinuousLinearMap.fderiv_fderiv_apply_self]; exact hB⟩
 
 /-- A symmetric continuous bilinear form `B` on `E` which is invertible as a map into the dual
 space makes `z ↦ B z z` a function with a nondegenerate critical point at the origin: its
 polarization is then `2 • B`. -/
-theorem isNondegenerateCriticalPoint_apply_self_of_flip_eq_self (B : E →L[ℝ] E →L[ℝ] ℝ)
+theorem _root_.ContinuousLinearMap.isNondegenerateCriticalPoint_apply_self_of_flip_eq_self
+    (B : E →L[ℝ] E →L[ℝ] ℝ)
     (hsymm : B.flip = B) (hB : B.IsInvertible) :
     IsNondegenerateCriticalPoint (fun z ↦ B z z) 0 := by
-  refine isNondegenerateCriticalPoint_apply_self B ?_
+  refine ContinuousLinearMap.isNondegenerateCriticalPoint_apply_self B ?_
   obtain ⟨e, rfl⟩ := hB
   have hflip : (e : E →L[ℝ] E →L[ℝ] ℝ).flip + (e : E →L[ℝ] E →L[ℝ] ℝ) =
       (2 : ℝ) • (e : E →L[ℝ] E →L[ℝ] ℝ) := by
@@ -295,7 +295,6 @@ theorem isNondegenerateCriticalPoint_apply_self_of_flip_eq_self (B : E →L[ℝ]
   refine _root_.ContinuousLinearMap.IsInvertible.of_inverse
     (g := (2 : ℝ)⁻¹ • (e.symm : (E →L[ℝ] ℝ) →L[ℝ] E)) ?_ ?_ <;> ext v <;> simp [smul_smul]
 
-end ContinuousLinearMap
 
 end Model
 

--- a/TauCeti/Analysis/Fredholm/Adjoint.lean
+++ b/TauCeti/Analysis/Fredholm/Adjoint.lean
@@ -25,14 +25,14 @@ surjective, which removes the closure from Mathlib's general identity
 
 ## Main declarations
 
-* `TauCeti.ContinuousLinearMap.orthogonalKerEquivRange`: the restriction of a closed-range
+* `ContinuousLinearMap.orthogonalKerEquivRange`: the restriction of a closed-range
   operator to the orthogonal complement of its kernel.
-* `TauCeti.ContinuousLinearMap.range_adjoint_eq_orthogonal_ker_of_isClosed_range`: the
+* `ContinuousLinearMap.range_adjoint_eq_orthogonal_ker_of_isClosed_range`: the
   closed-range theorem for adjoints.
-* `TauCeti.ContinuousLinearMap.isClosed_range_adjoint_iff`: an operator has closed range if and
+* `ContinuousLinearMap.isClosed_range_adjoint_iff`: an operator has closed range if and
   only if its adjoint does.
 * `ContinuousLinearMap.IsFredholm.adjoint`: the adjoint of a Fredholm operator is Fredholm.
-* `TauCeti.ContinuousLinearMap.index_adjoint`: taking the adjoint negates the Fredholm index.
+* `ContinuousLinearMap.index_adjoint`: taking the adjoint negates the Fredholm index.
 
 The argument and index convention follow McDuff--Salamon,
 *J-holomorphic Curves and Symplectic Topology*, Appendix A.1.
@@ -49,7 +49,7 @@ variable {𝕜 E F : Type*} [RCLike 𝕜]
 variable [NormedAddCommGroup E] [InnerProductSpace 𝕜 E] [CompleteSpace E]
 variable [NormedAddCommGroup F]
 
-namespace ContinuousLinearMap
+section
 
 section Restriction
 
@@ -57,7 +57,7 @@ variable [NormedSpace 𝕜 F] [CompleteSpace F]
 
 /-- The restriction of a closed-range operator to the orthogonal complement of its kernel is a
 continuous linear equivalence onto its range. -/
-noncomputable def orthogonalKerEquivRange (T : E →L[𝕜] F)
+noncomputable def _root_.ContinuousLinearMap.orthogonalKerEquivRange (T : E →L[𝕜] F)
     (hT : IsClosed (LinearMap.range (T : E →ₗ[𝕜] F) : Set F)) :
     (LinearMap.ker (T : E →ₗ[𝕜] F))ᗮ ≃L[𝕜]
       LinearMap.range (T : E →ₗ[𝕜] F) := by
@@ -71,9 +71,9 @@ noncomputable def orthogonalKerEquivRange (T : E →L[𝕜] F)
 
 /-- The closed-range restriction equivalence acts by the original operator. -/
 @[simp]
-theorem orthogonalKerEquivRange_apply (T : E →L[𝕜] F)
+theorem _root_.ContinuousLinearMap.orthogonalKerEquivRange_apply (T : E →L[𝕜] F)
     (hT : IsClosed (LinearMap.range (T : E →ₗ[𝕜] F) : Set F))
-    (x : (LinearMap.ker (T : E →ₗ[𝕜] F))ᗮ) : (orthogonalKerEquivRange T hT x :
+    (x : (LinearMap.ker (T : E →ₗ[𝕜] F))ᗮ) : (ContinuousLinearMap.orthogonalKerEquivRange T hT x :
       F) = T x := by
   let : CompleteSpace (LinearMap.ker (T : E →ₗ[𝕜] F))ᗮ :=
     (LinearMap.ker (T : E →ₗ[𝕜] F)).isClosed_orthogonal.completeSpace_coe
@@ -92,25 +92,24 @@ theorem orthogonalKerEquivRange_apply (T : E →L[𝕜] F)
 /-- Applying a closed-range operator to the inverse of its orthogonal-kernel restriction
 recovers the given range element. -/
 @[simp]
-theorem orthogonalKerEquivRange_symm_apply (T : E →L[𝕜] F)
+theorem _root_.ContinuousLinearMap.orthogonalKerEquivRange_symm_apply (T : E →L[𝕜] F)
     (hT : IsClosed (LinearMap.range (T : E →ₗ[𝕜] F) : Set F))
     (y : LinearMap.range (T : E →ₗ[𝕜] F)) :
-    T ((orthogonalKerEquivRange T hT).symm y) = (y : F) :=
-  (orthogonalKerEquivRange_apply T hT _).symm.trans <|
-    congr_arg Subtype.val ((orthogonalKerEquivRange T hT).apply_symm_apply y)
+    T ((ContinuousLinearMap.orthogonalKerEquivRange T hT).symm y) = (y : F) :=
+  (ContinuousLinearMap.orthogonalKerEquivRange_apply T hT _).symm.trans <|
+    congr_arg Subtype.val ((ContinuousLinearMap.orthogonalKerEquivRange T hT).apply_symm_apply y)
 
 end Restriction
 
-end ContinuousLinearMap
+end
 
 section HilbertCodomain
 
 variable [InnerProductSpace 𝕜 F] [CompleteSpace F]
 
-namespace ContinuousLinearMap
 
 /-- The adjoint of a continuous linear equivalence is bijective. -/
-private theorem adjoint_bijective (e : E ≃L[𝕜] F) :
+private theorem _root_.ContinuousLinearMap.adjoint_bijective (e : E ≃L[𝕜] F) :
     Function.Bijective ((e : E →L[𝕜] F)†) := by
   let A : F →L[𝕜] E := ((e : E →L[𝕜] F)†)
   let B : E →L[𝕜] F := ((e.symm : F →L[𝕜] E)†)
@@ -137,7 +136,7 @@ private theorem adjoint_bijective (e : E ≃L[𝕜] F) :
 /-- The adjoint maps into the orthogonal complement of the kernel. Mathlib's
 `ContinuousLinearMap.orthogonal_ker` identifies `(ker T)ᗮ` with the *closure* of the adjoint's
 range, and the range is contained in its closure. -/
-private theorem adjoint_mem_orthogonal_ker (T : E →L[𝕜] F) (y : F) :
+private theorem _root_.ContinuousLinearMap.adjoint_mem_orthogonal_ker (T : E →L[𝕜] F) (y : F) :
     (T†) y ∈ (LinearMap.ker (T : E →ₗ[𝕜] F))ᗮ := by
   rw [T.orthogonal_ker]
   exact Submodule.le_topologicalClosure _ (LinearMap.mem_range_self _ y)
@@ -145,68 +144,70 @@ private theorem adjoint_mem_orthogonal_ker (T : E →L[𝕜] F) (y : F) :
 /-- The adjoint of `T`, restricted to the range of `T` and corestricted to `(ker T)ᗮ`, is
 surjective: it *is* the adjoint of the isomorphism `(ker T)ᗮ ≃L range T`, and the adjoint of an
 isomorphism is bijective. -/
-private theorem codRestrict_domRestrict_adjoint_surjective (T : E →L[𝕜] F)
+private theorem _root_.ContinuousLinearMap.codRestrict_domRestrict_adjoint_surjective
+    (T : E →L[𝕜] F)
     (hT : IsClosed (LinearMap.range (T : E →ₗ[𝕜] F) : Set F)) :
     Function.Surjective
       (((T†).domRestrict (LinearMap.range (T : E →ₗ[𝕜] F))).codRestrict
-        (LinearMap.ker (T : E →ₗ[𝕜] F))ᗮ fun y => adjoint_mem_orthogonal_ker T y) := by
+        (LinearMap.ker (T : E →ₗ[𝕜] F))ᗮ fun y => ContinuousLinearMap.adjoint_mem_orthogonal_ker T
+          y) := by
   set K := LinearMap.ker (T : E →ₗ[𝕜] F) with hK
   set R := LinearMap.range (T : E →ₗ[𝕜] F) with hR
-  set e : Kᗮ ≃L[𝕜] R := orthogonalKerEquivRange T hT with he
+  set e : Kᗮ ≃L[𝕜] R := ContinuousLinearMap.orthogonalKerEquivRange T hT with he
   have he_apply (x : Kᗮ) : (e x : F) = T (x : E) := by
-    simpa only [he] using orthogonalKerEquivRange_apply T hT x
+    simpa only [he] using ContinuousLinearMap.orthogonalKerEquivRange_apply T hT x
   -- Peeling both restriction wrappers off the corestricted adjoint, once and by name.
   have hcoe (y : R) :
-      ((((T†).domRestrict R).codRestrict Kᗮ (fun y => adjoint_mem_orthogonal_ker T y)) y : E)
+      ((((T†).domRestrict R).codRestrict Kᗮ
+          (fun y => ContinuousLinearMap.adjoint_mem_orthogonal_ker T y)) y : E)
         = (T†) (y : F) :=
     (ContinuousLinearMap.coe_codRestrict_apply _ _ _ y).trans
       (congrFun (ContinuousLinearMap.coe_domRestrict (T†) R) y)
-  have hB : ((T†).domRestrict R).codRestrict Kᗮ (fun y => adjoint_mem_orthogonal_ker T y)
+  have hB : ((T†).domRestrict R).codRestrict Kᗮ
+    (fun y => ContinuousLinearMap.adjoint_mem_orthogonal_ker T y)
       = ((e : Kᗮ →L[𝕜] R)†) :=
     (ContinuousLinearMap.eq_adjoint_iff _ _).2 fun y x => by
       rw [Submodule.coe_inner, hcoe, Submodule.coe_inner, T.adjoint_inner_left,
         ContinuousLinearEquiv.coe_coe, he_apply]
   rw [hB]
-  exact (adjoint_bijective e).2
+  exact (ContinuousLinearMap.adjoint_bijective e).2
 
 /-- A continuous linear map with closed range has adjoint range equal to the orthogonal
 complement of its kernel. -/
-theorem range_adjoint_eq_orthogonal_ker_of_isClosed_range (T : E →L[𝕜] F)
+theorem _root_.ContinuousLinearMap.range_adjoint_eq_orthogonal_ker_of_isClosed_range (T : E →L[𝕜] F)
     (hT : IsClosed (LinearMap.range (T : E →ₗ[𝕜] F) : Set F)) :
     LinearMap.range (T† : F →ₗ[𝕜] E) =
       (LinearMap.ker (T : E →ₗ[𝕜] F))ᗮ := by
   refine le_antisymm ?_ fun x hx => ?_
   · rintro _ ⟨y, rfl⟩
-    exact adjoint_mem_orthogonal_ker T y
-  · obtain ⟨y, hy⟩ := codRestrict_domRestrict_adjoint_surjective T hT ⟨x, hx⟩
+    exact ContinuousLinearMap.adjoint_mem_orthogonal_ker T y
+  · obtain ⟨y, hy⟩ := ContinuousLinearMap.codRestrict_domRestrict_adjoint_surjective T hT ⟨x, hx⟩
     exact ⟨(y : F), congr_arg Subtype.val hy⟩
 
 /-- If a continuous linear map between Hilbert spaces has closed range, then so does its
 adjoint. -/
-theorem isClosed_range_adjoint_of_isClosed_range (T : E →L[𝕜] F)
+theorem _root_.ContinuousLinearMap.isClosed_range_adjoint_of_isClosed_range (T : E →L[𝕜] F)
     (hT : IsClosed (LinearMap.range (T : E →ₗ[𝕜] F) : Set F)) :
     IsClosed (LinearMap.range (T† : F →ₗ[𝕜] E) : Set E) := by
-  rw [range_adjoint_eq_orthogonal_ker_of_isClosed_range T hT]
+  rw [ContinuousLinearMap.range_adjoint_eq_orthogonal_ker_of_isClosed_range T hT]
   exact (LinearMap.ker (T : E →ₗ[𝕜] F)).isClosed_orthogonal
 
 /-- A continuous linear map between Hilbert spaces has closed range if and only if its adjoint
 does. -/
 @[simp]
-theorem isClosed_range_adjoint_iff (T : E →L[𝕜] F) :
+theorem _root_.ContinuousLinearMap.isClosed_range_adjoint_iff (T : E →L[𝕜] F) :
     IsClosed (LinearMap.range (T† : F →ₗ[𝕜] E) : Set E) ↔
       IsClosed (LinearMap.range (T : E →ₗ[𝕜] F) : Set F) := by
   constructor
   · intro hT
-    simpa using isClosed_range_adjoint_of_isClosed_range (T†) hT
-  · exact isClosed_range_adjoint_of_isClosed_range T
+    simpa using ContinuousLinearMap.isClosed_range_adjoint_of_isClosed_range (T†) hT
+  · exact ContinuousLinearMap.isClosed_range_adjoint_of_isClosed_range T
 
-end ContinuousLinearMap
 
-namespace ContinuousLinearMap
 
 /-- The cokernel of a closed-range operator is continuously linearly equivalent to the kernel of
 its adjoint. -/
-noncomputable def cokerEquivKerAdjoint (T : E →L[𝕜] F)
+noncomputable def _root_.ContinuousLinearMap.cokerEquivKerAdjoint (T : E →L[𝕜] F)
     (hT : IsClosed (LinearMap.range (T : E →ₗ[𝕜] F) : Set F)) :
     (F ⧸ LinearMap.range (T : E →ₗ[𝕜] F)) ≃L[𝕜]
       LinearMap.ker (T† : F →ₗ[𝕜] E) := by
@@ -218,50 +219,51 @@ noncomputable def cokerEquivKerAdjoint (T : E →L[𝕜] F)
 /-- On quotient representatives, the cokernel--adjoint-kernel equivalence is orthogonal
 projection onto the orthogonal complement of the range. -/
 @[simp]
-theorem coe_cokerEquivKerAdjoint_apply_mk (T : E →L[𝕜] F)
+theorem _root_.ContinuousLinearMap.coe_cokerEquivKerAdjoint_apply_mk (T : E →L[𝕜] F)
     (hT : IsClosed (LinearMap.range (T : E →ₗ[𝕜] F) : Set F)) (y : F) :
-    (cokerEquivKerAdjoint T hT (Submodule.Quotient.mk y) : F) =
+    (ContinuousLinearMap.cokerEquivKerAdjoint T hT (Submodule.Quotient.mk y) : F) =
       ((LinearMap.range (T : E →ₗ[𝕜] F))ᗮ.orthogonalProjectionOnto y : F) := by
-  simp [cokerEquivKerAdjoint,
+  simp [ContinuousLinearMap.cokerEquivKerAdjoint,
     Submodule.orthogonalProjectionOnto_apply_eq_projectionOnto]
 
 /-- The inverse cokernel--adjoint-kernel equivalence sends a kernel vector to its quotient
 class. -/
 @[simp]
-theorem cokerEquivKerAdjoint_symm_apply (T : E →L[𝕜] F)
+theorem _root_.ContinuousLinearMap.cokerEquivKerAdjoint_symm_apply (T : E →L[𝕜] F)
     (hT : IsClosed (LinearMap.range (T : E →ₗ[𝕜] F) : Set F)) (y : LinearMap.ker (T† : F →ₗ[𝕜] E)) :
-    (cokerEquivKerAdjoint T hT).symm y = Submodule.Quotient.mk (y : F) := by
+    (ContinuousLinearMap.cokerEquivKerAdjoint T hT).symm y = Submodule.Quotient.mk (y : F) := by
   let range := LinearMap.range (T : E →ₗ[𝕜] F)
   let : CompleteSpace range := hT.completeSpace_coe
-  simp [cokerEquivKerAdjoint]
+  simp [ContinuousLinearMap.cokerEquivKerAdjoint]
 
 /-- The cokernel of the adjoint of a closed-range operator is continuously linearly equivalent to
 the original kernel. -/
-noncomputable def cokerAdjointEquivKer (T : E →L[𝕜] F)
+noncomputable def _root_.ContinuousLinearMap.cokerAdjointEquivKer (T : E →L[𝕜] F)
     (hT : IsClosed (LinearMap.range (T : E →ₗ[𝕜] F) : Set F)) :
     (E ⧸ LinearMap.range (T† : F →ₗ[𝕜] E)) ≃L[𝕜]
       LinearMap.ker (T : E →ₗ[𝕜] F) :=
-  (cokerEquivKerAdjoint (T†) (isClosed_range_adjoint_of_isClosed_range T hT)).trans
+  (ContinuousLinearMap.cokerEquivKerAdjoint (T†)
+      (ContinuousLinearMap.isClosed_range_adjoint_of_isClosed_range T hT)).trans
     (LinearIsometryEquiv.ofEq _ _ <| by simp).toContinuousLinearEquiv
 
 /-- On quotient representatives, the adjoint-cokernel--kernel equivalence is orthogonal
 projection onto the orthogonal complement of the adjoint range. -/
 @[simp]
-theorem coe_cokerAdjointEquivKer_apply_mk (T : E →L[𝕜] F)
+theorem _root_.ContinuousLinearMap.coe_cokerAdjointEquivKer_apply_mk (T : E →L[𝕜] F)
     (hT : IsClosed (LinearMap.range (T : E →ₗ[𝕜] F) : Set F)) (x : E) :
-    (cokerAdjointEquivKer T hT (Submodule.Quotient.mk x) : E) =
+    (ContinuousLinearMap.cokerAdjointEquivKer T hT (Submodule.Quotient.mk x) : E) =
       ((LinearMap.range (T† : F →ₗ[𝕜] E))ᗮ.orthogonalProjectionOnto x : E) := by
-  simp [cokerAdjointEquivKer, coe_cokerEquivKerAdjoint_apply_mk]
+  simp [ContinuousLinearMap.cokerAdjointEquivKer,
+    ContinuousLinearMap.coe_cokerEquivKerAdjoint_apply_mk]
 
 /-- The inverse adjoint-cokernel--kernel equivalence sends a kernel vector to its quotient
 class. -/
 @[simp]
-theorem cokerAdjointEquivKer_symm_apply (T : E →L[𝕜] F)
+theorem _root_.ContinuousLinearMap.cokerAdjointEquivKer_symm_apply (T : E →L[𝕜] F)
     (hT : IsClosed (LinearMap.range (T : E →ₗ[𝕜] F) : Set F)) (x : LinearMap.ker (T : E →ₗ[𝕜] F)) :
-    (cokerAdjointEquivKer T hT).symm x = Submodule.Quotient.mk (x : E) := by
-  simp [cokerAdjointEquivKer]
+    (ContinuousLinearMap.cokerAdjointEquivKer T hT).symm x = Submodule.Quotient.mk (x : E) := by
+  simp [ContinuousLinearMap.cokerAdjointEquivKer]
 
-end ContinuousLinearMap
 
 /-- The adjoint of a Fredholm operator between Hilbert spaces is Fredholm. -/
 theorem _root_.ContinuousLinearMap.IsFredholm.adjoint {T : E →L[𝕜] F}
@@ -285,18 +287,19 @@ theorem isFredholm_adjoint_iff (T : E →L[𝕜] F) :
     simpa using hT.adjoint
   · exact ContinuousLinearMap.IsFredholm.adjoint
 
-namespace ContinuousLinearMap
 
 /-- Taking the adjoint of a Fredholm operator negates its index. -/
 @[simp]
-theorem index_adjoint (T : E →L[𝕜] F) (hT : ContinuousLinearMap.IsFredholm T) :
-    index (T†) = -index T := by
-  rw [index_eq_finrank_sub, index_eq_finrank_sub,
-    ← LinearEquiv.finrank_eq (cokerEquivKerAdjoint T hT.isClosed_range).toLinearEquiv,
-    LinearEquiv.finrank_eq (cokerAdjointEquivKer T hT.isClosed_range).toLinearEquiv]
+theorem _root_.ContinuousLinearMap.index_adjoint (T : E →L[𝕜] F)
+    (hT : ContinuousLinearMap.IsFredholm T) :
+    ContinuousLinearMap.index (T†) = -ContinuousLinearMap.index T := by
+  rw [ContinuousLinearMap.index_eq_finrank_sub, ContinuousLinearMap.index_eq_finrank_sub,
+    ← LinearEquiv.finrank_eq
+      (ContinuousLinearMap.cokerEquivKerAdjoint T hT.isClosed_range).toLinearEquiv,
+    LinearEquiv.finrank_eq
+      (ContinuousLinearMap.cokerAdjointEquivKer T hT.isClosed_range).toLinearEquiv]
   omega
 
-end ContinuousLinearMap
 
 end HilbertCodomain
 

--- a/TauCeti/Analysis/Fredholm/ClosedRange.lean
+++ b/TauCeti/Analysis/Fredholm/ClosedRange.lean
@@ -34,7 +34,7 @@ check.
 
 ## Main declarations
 
-* `TauCeti.ContinuousLinearMap.isClosed_range_of_finite_coker`: a continuous linear map
+* `ContinuousLinearMap.isClosed_range_of_finite_coker`: a continuous linear map
   between Banach spaces with finite-dimensional cokernel has closed range.
 * `ContinuousLinearMap.IsFredholm.of_finite_ker_coker`: over Banach spaces over an
   `IsRCLikeNormedField`, finite-dimensional kernel and cokernel suffice for Fredholmness.
@@ -58,7 +58,6 @@ variable {E F : Type*}
 variable [NormedAddCommGroup E] [NormedSpace 𝕜 E] [CompleteSpace E]
 variable [NormedAddCommGroup F] [NormedSpace 𝕜 F] [CompleteSpace F]
 
-namespace ContinuousLinearMap
 
 omit [IsRCLikeNormedField 𝕜] in
 /-- A continuous linear map between Banach spaces whose cokernel `F ⧸ range T` is finite
@@ -68,7 +67,7 @@ Closedness of the range is therefore not an independent hypothesis in the Banach
 forced by finite dimensionality of the cokernel. The proof runs the Banach open mapping theorem on
 the surjection `Φ(x, n) = T x + n` from `E × N`, where `N` is a finite-dimensional algebraic
 complement of `range T`. -/
-theorem isClosed_range_of_finite_coker (T : E →L[𝕜] F)
+theorem _root_.ContinuousLinearMap.isClosed_range_of_finite_coker (T : E →L[𝕜] F)
     [FiniteDimensional 𝕜 (F ⧸ LinearMap.range (T : E →ₗ[𝕜] F))] :
     IsClosed (LinearMap.range (T : E →ₗ[𝕜] F) : Set F) := by
   set R := LinearMap.range (T : E →ₗ[𝕜] F) with hR
@@ -102,7 +101,6 @@ theorem isClosed_range_of_finite_coker (T : E →L[𝕜] F)
     rw [hpre]; exact isClosed_eq continuous_snd continuous_const
   exact (Φ.isQuotientMap hsurj).isClosed_preimage.mp hclosed
 
-end ContinuousLinearMap
 
 /-- Over Banach spaces over an `IsRCLikeNormedField`, a continuous linear map with
 finite-dimensional kernel and cokernel is Fredholm: the closed-range condition is automatic.

--- a/TauCeti/Analysis/Fredholm/Comp.lean
+++ b/TauCeti/Analysis/Fredholm/Comp.lean
@@ -26,9 +26,9 @@ Lane F0 of the analytic Heegaard Floer roadmap.
 
 ## Main declarations
 
-* `TauCeti.ContinuousLinearMap.index_comp`: the index of a composite is the sum of the indices.
+* `ContinuousLinearMap.index_comp`: the index of a composite is the sum of the indices.
 * `ContinuousLinearMap.IsFredholm.pow`: every power of a Fredholm endomorphism is Fredholm.
-* `TauCeti.ContinuousLinearMap.index_pow`: the index of the `n`th power is `n` times the index.
+* `ContinuousLinearMap.index_pow`: the index of the `n`th power is `n` times the index.
 
 The conventions and the composition theorem follow McDuff--Salamon,
 *J-holomorphic Curves and Symplectic Topology*, Appendix A.1.
@@ -46,22 +46,21 @@ variable [NormedAddCommGroup E] [NormedSpace 𝕜 E]
 variable [NormedAddCommGroup F] [NormedSpace 𝕜 F]
 variable [NormedAddCommGroup G] [NormedSpace 𝕜 G]
 
-namespace ContinuousLinearMap
 
 omit [CompleteSpace 𝕜] in
 /-- The Fredholm index is additive under composition. -/
 @[simp]
-theorem index_comp (S : F →L[𝕜] G) (T : E →L[𝕜] F)
+theorem _root_.ContinuousLinearMap.index_comp (S : F →L[𝕜] G) (T : E →L[𝕜] F)
     (hS : ContinuousLinearMap.IsFredholm S) (hT : ContinuousLinearMap.IsFredholm T) :
-    index (S.comp T) = index S + index T := by
+    ContinuousLinearMap.index (S.comp T) = ContinuousLinearMap.index S + ContinuousLinearMap.index T
+      := by
   let := hT.finite_ker
   let := hT.finite_coker
   let := hS.finite_ker
   let := hS.finite_coker
-  simpa only [index_def, ContinuousLinearMap.toLinearMap_comp] using
+  simpa only [ContinuousLinearMap.index_def, ContinuousLinearMap.toLinearMap_comp] using
     (LinearMap.index_comp (f := (T : E →ₗ[𝕜] F)) (S : F →ₗ[𝕜] G))
 
-end ContinuousLinearMap
 
 section Pow
 
@@ -79,22 +78,22 @@ theorem _root_.ContinuousLinearMap.IsFredholm.pow (hA : ContinuousLinearMap.IsFr
       rw [pow_succ, ContinuousLinearMap.mul_def]
       exact (hA.pow n).comp hA
 
-namespace ContinuousLinearMap
 
 /-- The index of the `n`th power of a Fredholm endomorphism is `n` times its index. -/
 @[simp]
-theorem index_pow (A : X →L[𝕜] X) (hA : ContinuousLinearMap.IsFredholm A) (n : ℕ) :
-    index (A ^ n) = (n : ℤ) * index A := by
+theorem _root_.ContinuousLinearMap.index_pow (A : X →L[𝕜] X) (hA : ContinuousLinearMap.IsFredholm A)
+    (n : ℕ) :
+    ContinuousLinearMap.index (A ^ n) = (n : ℤ) * ContinuousLinearMap.index A := by
   induction n with
   | zero =>
-      simp only [pow_zero, ContinuousLinearMap.one_def, index_id, Nat.cast_zero, zero_mul]
+      simp only [pow_zero, ContinuousLinearMap.one_def, ContinuousLinearMap.index_id, Nat.cast_zero,
+        zero_mul]
   | succ n ih =>
       rw [pow_succ, ContinuousLinearMap.mul_def,
-        index_comp (A ^ n) A (hA.pow n) hA, ih]
+        ContinuousLinearMap.index_comp (A ^ n) A (hA.pow n) hA, ih]
       push_cast
       ring
 
-end ContinuousLinearMap
 
 end Pow
 

--- a/TauCeti/Analysis/Fredholm/CompactPerturbation.lean
+++ b/TauCeti/Analysis/Fredholm/CompactPerturbation.lean
@@ -40,10 +40,10 @@ forces the values at `c = 0` and `c = 1` to agree.
   for `K` compact.
 * `ContinuousLinearMap.IsFredholm.add_of_isCompactOperator`: a compact perturbation of a Fredholm
   operator is Fredholm.
-* `TauCeti.ContinuousLinearMap.index_add_of_isCompactOperator`: a compact perturbation leaves the
+* `ContinuousLinearMap.index_add_of_isCompactOperator`: a compact perturbation leaves the
   index unchanged.
-* `TauCeti.ContinuousLinearMap.index_one_sub_eq_zero` and
-  `TauCeti.ContinuousLinearMap.index_one_add_eq_zero`: `1 - K` and `1 + K` have index `0` for `K`
+* `ContinuousLinearMap.index_one_sub_eq_zero` and
+  `ContinuousLinearMap.index_one_add_eq_zero`: `1 - K` and `1 + K` have index `0` for `K`
   compact.
 
 The conventions follow McDuff--Salamon, *J-holomorphic Curves and Symplectic Topology*, Appendix
@@ -128,15 +128,16 @@ theorem _root_.ContinuousLinearMap.IsFredholm.add_of_isCompactOperator
     exact FiniteDimensional.of_surjective (Submodule.factor hrange)
       (Submodule.factor_surjective hrange)
 
-namespace ContinuousLinearMap
 
 /-- A compact perturbation leaves the Fredholm index unchanged.
 
 The scalar family `c ↦ T + c • C` is a continuous family of Fredholm operators over the
 preconnected parameter space `𝕜`, so its index is constant; comparing `c = 0` with `c = 1` gives
 the claim. -/
-theorem index_add_of_isCompactOperator (hT : ContinuousLinearMap.IsFredholm T)
-    (hC : IsCompactOperator C) : index (T + C) = index T := by
+theorem _root_.ContinuousLinearMap.index_add_of_isCompactOperator
+    (hT : ContinuousLinearMap.IsFredholm T)
+    (hC : IsCompactOperator C) : ContinuousLinearMap.index (T + C) = ContinuousLinearMap.index T :=
+      by
   let _i := IsRCLikeNormedField.rclike 𝕜
   have hpre : PreconnectedSpace 𝕜 :=
     ⟨(convex_univ : Convex ℝ (Set.univ : Set 𝕜)).isPreconnected⟩
@@ -147,23 +148,25 @@ theorem index_add_of_isCompactOperator (hT : ContinuousLinearMap.IsFredholm T)
 
 /-- A compact perturbation of the identity has index `0`. -/
 @[simp]
-theorem index_one_sub_eq_zero {K : E →L[𝕜] E} (hK : IsCompactOperator K) :
-    index (1 - K : E →L[𝕜] E) = 0 := by
+theorem _root_.ContinuousLinearMap.index_one_sub_eq_zero {K : E →L[𝕜] E} (hK : IsCompactOperator K)
+    :
+    ContinuousLinearMap.index (1 - K : E →L[𝕜] E) = 0 := by
   have hneg : IsCompactOperator (-K : E →L[𝕜] E) := by
     simpa only [FunLike.coe_neg] using hK.neg
   have hrw : (1 - K : E →L[𝕜] E) = ContinuousLinearMap.id 𝕜 E + (-K) := by
     ext x
     simp [sub_eq_add_neg]
-  rw [hrw, index_add_of_isCompactOperator .id hneg, index_id]
+  rw [hrw, ContinuousLinearMap.index_add_of_isCompactOperator .id hneg,
+    ContinuousLinearMap.index_id]
 
 /-- A compact perturbation of the identity has index `0`, in additive form. -/
 @[simp]
-theorem index_one_add_eq_zero {K : E →L[𝕜] E} (hK : IsCompactOperator K) :
-    index (1 + K : E →L[𝕜] E) = 0 := by
+theorem _root_.ContinuousLinearMap.index_one_add_eq_zero {K : E →L[𝕜] E} (hK : IsCompactOperator K)
+    :
+    ContinuousLinearMap.index (1 + K : E →L[𝕜] E) = 0 := by
   have hrw : (1 + K : E →L[𝕜] E) = ContinuousLinearMap.id 𝕜 E + K := rfl
-  rw [hrw, index_add_of_isCompactOperator .id hK, index_id]
+  rw [hrw, ContinuousLinearMap.index_add_of_isCompactOperator .id hK, ContinuousLinearMap.index_id]
 
-end ContinuousLinearMap
 
 end TauCeti
 

--- a/TauCeti/Analysis/Fredholm/Criteria.lean
+++ b/TauCeti/Analysis/Fredholm/Criteria.lean
@@ -29,11 +29,11 @@ kernel of an operator of finite rank is Fredholm.
   criterion.
 * `TauCeti.isFredholm_ker_subtypeL`: the inclusion of the kernel of an operator of finite rank is
   Fredholm.
-* `TauCeti.ContinuousLinearMap.index_of_surjective` and
-  `TauCeti.ContinuousLinearMap.index_of_injective`: the index in the two one-sided cases.
-* `TauCeti.ContinuousLinearMap.finrank_ker_eq_iff_index_eq`: for a surjective operator, index `n`
+* `ContinuousLinearMap.index_of_surjective` and
+  `ContinuousLinearMap.index_of_injective`: the index in the two one-sided cases.
+* `ContinuousLinearMap.finrank_ker_eq_iff_index_eq`: for a surjective operator, index `n`
   and kernel dimension `n` are the same statement.
-* `TauCeti.ContinuousLinearMap.bijective_of_surjective_of_index_eq_zero`: a surjective operator of
+* `ContinuousLinearMap.bijective_of_surjective_of_index_eq_zero`: a surjective operator of
   index zero with finite-dimensional kernel is bijective.
 * `ContinuousLinearMap.IsFredholm.of_bijective`: a bijective continuous linear map between Banach
   spaces is Fredholm.
@@ -132,43 +132,43 @@ lemma isFredholm_ker_subtypeL (hT : LinearMap.HasFiniteRange (T : E →ₗ[K] F)
   · rw [Submodule.toLinearMap_subtypeL, Submodule.ker_subtype]
     exact Submodule.closedComplemented_bot
 
-namespace ContinuousLinearMap
 
 omit [IsRCLikeNormedField K] [CompleteSpace E] [CompleteSpace F] in
 /-- A surjective continuous linear map has index the dimension of its kernel. -/
-lemma index_of_surjective (T : E →L[K] F) (hT : Function.Surjective T) :
-    index T = (finrank K (LinearMap.ker (T : E →ₗ[K] F)) : ℤ) := by
-  rw [index_def, LinearMap.index_of_surjective hT]
+lemma _root_.ContinuousLinearMap.index_of_surjective (T : E →L[K] F) (hT : Function.Surjective T) :
+    ContinuousLinearMap.index T = (finrank K (LinearMap.ker (T : E →ₗ[K] F)) : ℤ) := by
+  rw [ContinuousLinearMap.index_def, LinearMap.index_of_surjective hT]
 
 omit [IsRCLikeNormedField K] [CompleteSpace E] [CompleteSpace F] in
 /-- For a surjective continuous linear map, having index `n` and having a kernel of dimension `n`
-are the same statement. This is `TauCeti.ContinuousLinearMap.index_of_surjective` with the cast to
+are the same statement. This is `ContinuousLinearMap.index_of_surjective` with the cast to
 `ℤ` discharged. -/
-lemma finrank_ker_eq_iff_index_eq {n : ℕ} (T : E →L[K] F) (hT : Function.Surjective T) :
-    finrank K (LinearMap.ker (T : E →ₗ[K] F)) = n ↔ index T = n := by
-  rw [index_of_surjective T hT, Nat.cast_inj]
+lemma _root_.ContinuousLinearMap.finrank_ker_eq_iff_index_eq {n : ℕ} (T : E →L[K] F)
+    (hT : Function.Surjective T) :
+    finrank K (LinearMap.ker (T : E →ₗ[K] F)) = n ↔ ContinuousLinearMap.index T = n := by
+  rw [ContinuousLinearMap.index_of_surjective T hT, Nat.cast_inj]
 
 omit [IsRCLikeNormedField K] [CompleteSpace E] [CompleteSpace F] in
 /-- A surjective operator of index zero with finite-dimensional kernel is bijective: its index is
 the dimension of that kernel, so a vanishing index makes the kernel trivial. Only finiteness of the
 kernel is used, not the full Fredholm property, which for a surjective operator is anyway
 equivalent to it by `TauCeti.isFredholm_iff_finite_ker_of_surjective`. This is the converse of
-`TauCeti.ContinuousLinearMap.index_eq_zero_of_bijective` for a surjective operator. -/
-lemma bijective_of_surjective_of_index_eq_zero (T : E →L[K] F)
+`ContinuousLinearMap.index_eq_zero_of_bijective` for a surjective operator. -/
+lemma _root_.ContinuousLinearMap.bijective_of_surjective_of_index_eq_zero (T : E →L[K] F)
     (hfin : FiniteDimensional K (LinearMap.ker (T : E →ₗ[K] F))) (hT : Function.Surjective T)
-    (hindex : index T = 0) : Function.Bijective T := by
+    (hindex : ContinuousLinearMap.index T = 0) : Function.Bijective T := by
   have := hfin
   have hker : LinearMap.ker (T : E →ₗ[K] F) = ⊥ :=
-    Submodule.finrank_eq_zero.1 ((finrank_ker_eq_iff_index_eq T hT).2 (by exact_mod_cast hindex))
+    Submodule.finrank_eq_zero.1
+      ((ContinuousLinearMap.finrank_ker_eq_iff_index_eq T hT).2 (by exact_mod_cast hindex))
   exact ⟨LinearMap.ker_eq_bot.1 hker, hT⟩
 
 omit [IsRCLikeNormedField K] [CompleteSpace E] [CompleteSpace F] in
 /-- An injective continuous linear map has index the negative of the dimension of its cokernel. -/
-lemma index_of_injective (T : E →L[K] F) (hT : Function.Injective T) :
-    index T = -(finrank K (F ⧸ LinearMap.range (T : E →ₗ[K] F)) : ℤ) := by
-  rw [index_def, LinearMap.index_of_injective hT]
+lemma _root_.ContinuousLinearMap.index_of_injective (T : E →L[K] F) (hT : Function.Injective T) :
+    ContinuousLinearMap.index T = -(finrank K (F ⧸ LinearMap.range (T : E →ₗ[K] F)) : ℤ) := by
+  rw [ContinuousLinearMap.index_def, LinearMap.index_of_injective hT]
 
-end ContinuousLinearMap
 
 omit [IsRCLikeNormedField K] in
 /-- A bijective continuous linear map between Banach spaces is Fredholm. This formulation does not

--- a/TauCeti/Analysis/Fredholm/FiniteRank.lean
+++ b/TauCeti/Analysis/Fredholm/FiniteRank.lean
@@ -20,7 +20,7 @@ hypothesis of `ContinuousLinearMap.IsFredholm.add_hasFiniteRange`.
 
 ## Main declarations
 
-* `TauCeti.ContinuousLinearMap.index_add_of_hasFiniteRange`: over a complete nontrivially normed
+* `ContinuousLinearMap.index_add_of_hasFiniteRange`: over a complete nontrivially normed
   field, adding an operator of finite rank preserves the Fredholm index.
 -/
 
@@ -35,27 +35,26 @@ variable [NormedAddCommGroup E] [NormedSpace 𝕜 E]
 variable [NormedAddCommGroup F] [NormedSpace 𝕜 F]
 variable {T K : E →L[𝕜] F}
 
-namespace ContinuousLinearMap
 
 /-- Over a complete nontrivially normed field, perturbing a Fredholm operator by an operator of
 finite rank leaves its index unchanged: both operators restrict to the same map on the closed,
 finite-codimensional subspace `ker K`, and additivity of the index cancels the index shift of that
 restriction. -/
-theorem index_add_of_hasFiniteRange (hT : ContinuousLinearMap.IsFredholm T)
+theorem _root_.ContinuousLinearMap.index_add_of_hasFiniteRange
+    (hT : ContinuousLinearMap.IsFredholm T)
     (hK : LinearMap.HasFiniteRange (K : E →ₗ[𝕜] F)) :
-    index (T + K) = index T := by
+    ContinuousLinearMap.index (T + K) = ContinuousLinearMap.index T := by
   set ι := (LinearMap.ker (K : E →ₗ[𝕜] F)).subtypeL with hι
   have hιF : ContinuousLinearMap.IsFredholm ι := isFredholm_ker_subtypeL hK
   have hcomp : (T + K).comp ι = T.comp ι := by
     ext x
     have hx : K (x : E) = 0 := LinearMap.mem_ker.mp x.2
     simp [hι, hx]
-  have h₁ := index_comp (T + K) ι (hT.add_hasFiniteRange hK) hιF
-  have h₂ := index_comp T ι hT hιF
+  have h₁ := ContinuousLinearMap.index_comp (T + K) ι (hT.add_hasFiniteRange hK) hιF
+  have h₂ := ContinuousLinearMap.index_comp T ι hT hιF
   rw [hcomp, h₂] at h₁
   omega
 
-end ContinuousLinearMap
 
 end TauCeti
 

--- a/TauCeti/Analysis/Fredholm/Index.lean
+++ b/TauCeti/Analysis/Fredholm/Index.lean
@@ -18,16 +18,16 @@ following Mathlib's convention for `LinearMap.index`.
 
 ## Main declarations
 
-* `TauCeti.ContinuousLinearMap.index`: the index of a continuous linear map.
-* `TauCeti.ContinuousLinearMap.index_eq_finrank_sub`: the defining dimension formula.
-* `TauCeti.ContinuousLinearMap.index_eq_of_finiteDimensional`: between finite-dimensional spaces,
+* `ContinuousLinearMap.index`: the index of a continuous linear map.
+* `ContinuousLinearMap.index_eq_finrank_sub`: the defining dimension formula.
+* `ContinuousLinearMap.index_eq_of_finiteDimensional`: between finite-dimensional spaces,
   the index is the dimension of the domain minus the dimension of the codomain.
-* `TauCeti.ContinuousLinearMap.index_id`, `index_continuousLinearEquiv_eq_zero`, and
+* `ContinuousLinearMap.index_id`, `index_continuousLinearEquiv_eq_zero`, and
   `index_eq_zero_of_bijective`: identities, continuous linear equivalences, and bijective maps have
   index zero.
-* `TauCeti.ContinuousLinearMap.index_smul` and `index_neg`: nonzero rescaling and negation preserve
+* `ContinuousLinearMap.index_smul` and `index_neg`: nonzero rescaling and negation preserve
   the index.
-* `TauCeti.ContinuousLinearMap.index_equiv_comp` and `index_comp_equiv`: composition with a
+* `ContinuousLinearMap.index_equiv_comp` and `index_comp_equiv`: composition with a
   continuous linear equivalence preserves the index.
 The sign convention follows McDuff--Salamon, *J-holomorphic Curves and Symplectic Topology*,
 Appendix A.1.
@@ -45,66 +45,76 @@ variable [NormedAddCommGroup E] [NormedSpace 𝕜 E]
 variable [NormedAddCommGroup F] [NormedSpace 𝕜 F]
 variable [NormedAddCommGroup G] [NormedSpace 𝕜 G]
 
-namespace ContinuousLinearMap
+section
 
 /-- The **index** of a continuous linear map, `dim ker T − dim coker T`, defined as the index of
 the underlying linear map. -/
-noncomputable def index (T : E →L[𝕜] F) : ℤ := (T : E →ₗ[𝕜] F).index
+noncomputable def _root_.ContinuousLinearMap.index (T : E →L[𝕜] F) : ℤ := (T : E →ₗ[𝕜] F).index
 
 /-- The index as the algebraic index of the underlying linear map. -/
-lemma index_def (T : E →L[𝕜] F) : index T = (T : E →ₗ[𝕜] F).index := (rfl)
+lemma _root_.ContinuousLinearMap.index_def (T : E →L[𝕜] F) : ContinuousLinearMap.index T =
+    (T : E →ₗ[𝕜] F).index := (rfl)
 
 /-- The index is `dim ker T − dim coker T`. -/
-lemma index_eq_finrank_sub (T : E →L[𝕜] F) :
-    index T = (finrank 𝕜 (LinearMap.ker (T : E →ₗ[𝕜] F)) : ℤ) -
+lemma _root_.ContinuousLinearMap.index_eq_finrank_sub (T : E →L[𝕜] F) :
+    ContinuousLinearMap.index T = (finrank 𝕜 (LinearMap.ker (T : E →ₗ[𝕜] F)) : ℤ) -
       finrank 𝕜 (F ⧸ LinearMap.range (T : E →ₗ[𝕜] F)) := by
-  rw [index_def]
+  rw [ContinuousLinearMap.index_def]
   exact LinearMap.index_eq_finrank_sub
 
 /-- A bijective continuous linear map has index zero. -/
-lemma index_eq_zero_of_bijective (T : E →L[𝕜] F) (hT : Function.Bijective T) : index T = 0 := by
-  rw [index_def]
+lemma _root_.ContinuousLinearMap.index_eq_zero_of_bijective (T : E →L[𝕜] F)
+    (hT : Function.Bijective T) : ContinuousLinearMap.index T = 0 := by
+  rw [ContinuousLinearMap.index_def]
   exact LinearEquiv.index_eq_zero (e := LinearEquiv.ofBijective (T : E →ₗ[𝕜] F) hT)
 
 /-- The identity operator has index `0`. -/
-@[simp] lemma index_id : index (ContinuousLinearMap.id 𝕜 E) = 0 := by
-  rw [index_def, ContinuousLinearMap.coe_id, LinearMap.index_id]
+@[simp] lemma _root_.ContinuousLinearMap.index_id : ContinuousLinearMap.index
+    (ContinuousLinearMap.id 𝕜 E) = 0 := by
+  rw [ContinuousLinearMap.index_def, ContinuousLinearMap.coe_id, LinearMap.index_id]
 
 /-- A continuous linear equivalence has index `0`. -/
-@[simp] lemma index_continuousLinearEquiv_eq_zero (e : E ≃L[𝕜] F) :
-    index (e : E →L[𝕜] F) = 0 := by
-  rw [index_def, ContinuousLinearEquiv.toLinearMap_toContinuousLinearMap]
+@[simp] lemma _root_.ContinuousLinearMap.index_continuousLinearEquiv_eq_zero (e : E ≃L[𝕜] F) :
+    ContinuousLinearMap.index (e : E →L[𝕜] F) = 0 := by
+  rw [ContinuousLinearMap.index_def, ContinuousLinearEquiv.toLinearMap_toContinuousLinearMap]
   exact LinearEquiv.index_eq_zero
 
 /-- Between finite-dimensional spaces the index is `dim E − dim F`, for any operator. -/
-lemma index_eq_of_finiteDimensional [FiniteDimensional 𝕜 E] [FiniteDimensional 𝕜 F]
-    (T : E →L[𝕜] F) : index T = (finrank 𝕜 E : ℤ) - finrank 𝕜 F := by
-  rw [index_def, LinearMap.index_eq_of_finiteDimensional]
+lemma _root_.ContinuousLinearMap.index_eq_of_finiteDimensional [FiniteDimensional 𝕜 E]
+    [FiniteDimensional 𝕜 F]
+    (T : E →L[𝕜] F) : ContinuousLinearMap.index T = (finrank 𝕜 E : ℤ) - finrank 𝕜 F := by
+  rw [ContinuousLinearMap.index_def, LinearMap.index_eq_of_finiteDimensional]
 
 /-- The index is unchanged by a nonzero scalar multiple. -/
-lemma index_smul (T : E →L[𝕜] F) {c : 𝕜} (hc : c ≠ 0) : index (c • T) = index T := by
-  rw [index_def, index_def, ContinuousLinearMap.toLinearMap_smul, LinearMap.index_smul _ hc]
+lemma _root_.ContinuousLinearMap.index_smul (T : E →L[𝕜] F) {c : 𝕜} (hc : c ≠ 0) :
+    ContinuousLinearMap.index (c • T) = ContinuousLinearMap.index T := by
+  rw [ContinuousLinearMap.index_def, ContinuousLinearMap.index_def,
+    ContinuousLinearMap.toLinearMap_smul, LinearMap.index_smul _ hc]
 
 /-- The index is unchanged by negation. -/
-@[simp] lemma index_neg (T : E →L[𝕜] F) : index (-T) = index T := by
-  rw [index_def, index_def, ContinuousLinearMap.toLinearMap_neg, LinearMap.index_neg]
+@[simp] lemma _root_.ContinuousLinearMap.index_neg (T : E →L[𝕜] F) : ContinuousLinearMap.index (-T)
+    = ContinuousLinearMap.index T := by
+  rw [ContinuousLinearMap.index_def, ContinuousLinearMap.index_def,
+    ContinuousLinearMap.toLinearMap_neg, LinearMap.index_neg]
 
 variable {T : E →L[𝕜] F}
 
 /-- Postcomposing with a continuous linear equivalence leaves the index unchanged. -/
-@[simp] lemma index_equiv_comp (e : F ≃L[𝕜] G) :
-    index ((e : F →L[𝕜] G).comp T) = index T := by
-  rw [index_def, index_def, ContinuousLinearMap.toLinearMap_comp,
+@[simp] lemma _root_.ContinuousLinearMap.index_equiv_comp (e : F ≃L[𝕜] G) :
+    ContinuousLinearMap.index ((e : F →L[𝕜] G).comp T) = ContinuousLinearMap.index T := by
+  rw [ContinuousLinearMap.index_def, ContinuousLinearMap.index_def,
+    ContinuousLinearMap.toLinearMap_comp,
     ContinuousLinearEquiv.toLinearMap_toContinuousLinearMap]
   rw [LinearMap.index_equiv_comp]
 
 /-- Precomposing with a continuous linear equivalence leaves the index unchanged. -/
-@[simp] lemma index_comp_equiv (e : G ≃L[𝕜] E) :
-    index (T.comp (e : G →L[𝕜] E)) = index T := by
-  rw [index_def, index_def, ContinuousLinearMap.toLinearMap_comp,
+@[simp] lemma _root_.ContinuousLinearMap.index_comp_equiv (e : G ≃L[𝕜] E) :
+    ContinuousLinearMap.index (T.comp (e : G →L[𝕜] E)) = ContinuousLinearMap.index T := by
+  rw [ContinuousLinearMap.index_def, ContinuousLinearMap.index_def,
+    ContinuousLinearMap.toLinearMap_comp,
     ContinuousLinearEquiv.toLinearMap_toContinuousLinearMap]
   rw [LinearMap.index_comp_equiv]
 
-end ContinuousLinearMap
+end
 
 end TauCeti

--- a/TauCeti/Analysis/Fredholm/LevelSet/Basic.lean
+++ b/TauCeti/Analysis/Fredholm/LevelSet/Basic.lean
@@ -27,7 +27,7 @@ Heegaard Floer roadmap asks for (McDuff--Salamon, *J-holomorphic Curves and Symp
 Appendix A.3). The linear half of that lane is already available:
 `ContinuousLinearMap.IsFredholm` provides the
 finite-dimensional, topologically complemented kernel, and
-`TauCeti.ContinuousLinearMap.index_of_surjective` identifies its dimension with the index. What is
+`ContinuousLinearMap.index_of_surjective` identifies its dimension with the index. What is
 added here is the nonlinear half, which is Mathlib's implicit function theorem for a map with
 surjective derivative and complemented kernel,
 `HasStrictFDerivAt.implicitToOpenPartialHomeomorphOfComplemented`, restricted to the level set:
@@ -63,7 +63,7 @@ already cut down to `TauCeti.levelSetImplicitCoordSource` so that they can be co
   preferred chart there is cut down.
 * `TauCeti.levelSetChartedSpace`: a regular level set on which the index is constantly `n` is a
   charted space modelled on `Fin n → 𝕜`; by
-  `TauCeti.ContinuousLinearMap.index_of_surjective` the model dimension is the Fredholm index.
+  `ContinuousLinearMap.index_of_surjective` the model dimension is the Fredholm index.
 * `TauCeti.not_accPt_levelSet_of_injective_of_isClosed_range` and
   `TauCeti.not_accPt_levelSet_of_index_eq_zero`: a point where the derivative is injective with
   closed range, in particular a regular point of index `0`, is isolated in the level set through
@@ -266,7 +266,7 @@ variable [CompleteSpace 𝕜]
 
 /-- The identification of the kernel of a continuous linear map with the model space `Fin n → 𝕜`,
 when that kernel is finite-dimensional of dimension `n` — by
-`TauCeti.ContinuousLinearMap.index_of_surjective`, for a surjective Fredholm operator, the Fredholm
+`ContinuousLinearMap.index_of_surjective`, for a surjective Fredholm operator, the Fredholm
 index. -/
 noncomputable def _root_.ContinuousLinearMap.kerModelEquiv {n : ℕ} (T : E →L[𝕜] F)
     (hfin : FiniteDimensional 𝕜 ↥T.ker) (hn : finrank 𝕜 ↥T.ker = n) :

--- a/TauCeti/Analysis/Fredholm/Parametric.lean
+++ b/TauCeti/Analysis/Fredholm/Parametric.lean
@@ -69,7 +69,7 @@ cokernel of `D₁` (`TauCeti.quotientRangeParameterProjEquiv`), and the surjecti
 the degenerate case of that identification.
 
 The index statement needs neither completeness nor the Fredholm property, because
-`TauCeti.ContinuousLinearMap.index` is a difference of two `Module.finrank`s and the sequence
+`ContinuousLinearMap.index` is a difference of two `Module.finrank`s and the sequence
 matches both of them. The Fredholm statement additionally assumes that `D₁` is Fredholm and asks
 for Banach spaces, then certifies the two dimensions finite through
 `ContinuousLinearMap.IsFredholm.of_finite_ker_coker`.

--- a/TauCeti/Analysis/Fredholm/Prod.lean
+++ b/TauCeti/Analysis/Fredholm/Prod.lean
@@ -23,7 +23,7 @@ individual kernels and ranges, and counts the cokernel with `Submodule.finrank_q
 ## Main declarations
 
 * `ContinuousLinearMap.IsFredholm.prodMap`: a product of Fredholm operators is Fredholm.
-* `TauCeti.ContinuousLinearMap.index_prodMap`: the Fredholm index is additive under products.
+* `ContinuousLinearMap.index_prodMap`: the Fredholm index is additive under products.
 -/
 
 public section
@@ -75,17 +75,18 @@ lemma _root_.ContinuousLinearMap.IsFredholm.prodMap
         Prod.map_apply, Submodule.subtypeL_apply, Submodule.subtypeL_apply, hPT ⟨x, hx⟩,
         hPS ⟨y, hy⟩]
 
-namespace ContinuousLinearMap
 
 /-- The index is additive under Cartesian products when both kernels and cokernels are finite
 dimensional. -/
-private lemma index_prodMap_of_finiteDimensional (T : E₁ →L[K] F₁) (S : E₂ →L[K] F₂)
+private lemma _root_.ContinuousLinearMap.index_prodMap_of_finiteDimensional (T : E₁ →L[K] F₁)
+    (S : E₂ →L[K] F₂)
     [FiniteDimensional K (LinearMap.ker (T : E₁ →ₗ[K] F₁))]
     [FiniteDimensional K (LinearMap.ker (S : E₂ →ₗ[K] F₂))]
     [FiniteDimensional K (F₁ ⧸ LinearMap.range (T : E₁ →ₗ[K] F₁))]
     [FiniteDimensional K (F₂ ⧸ LinearMap.range (S : E₂ →ₗ[K] F₂))] :
-    index (T.prodMap S) = index T + index S := by
-  simp only [index_eq_finrank_sub]
+    ContinuousLinearMap.index (T.prodMap S) = ContinuousLinearMap.index T +
+      ContinuousLinearMap.index S := by
+  simp only [ContinuousLinearMap.index_eq_finrank_sub]
   rw [ContinuousLinearMap.coe_prodMap T S, LinearMap.ker_prodMap, LinearMap.range_prodMap]
   simp only [(Submodule.prodEquiv _ _).finrank_eq,
     Submodule.finrank_quotient_prod, finrank_prod]
@@ -93,15 +94,15 @@ private lemma index_prodMap_of_finiteDimensional (T : E₁ →L[K] F₁) (S : E�
 
 /-- The Fredholm index is additive under Cartesian products of Fredholm operators. -/
 @[simp]
-lemma index_prodMap (T : E₁ →L[K] F₁) (S : E₂ →L[K] F₂)
+lemma _root_.ContinuousLinearMap.index_prodMap (T : E₁ →L[K] F₁) (S : E₂ →L[K] F₂)
     (hT : ContinuousLinearMap.IsFredholm T) (hS : ContinuousLinearMap.IsFredholm S) :
-    index (T.prodMap S) = index T + index S := by
+    ContinuousLinearMap.index (T.prodMap S) = ContinuousLinearMap.index T +
+      ContinuousLinearMap.index S := by
   let := hT.finite_ker
   let := hS.finite_ker
   let := hT.finite_coker
   let := hS.finite_coker
-  exact index_prodMap_of_finiteDimensional T S
+  exact ContinuousLinearMap.index_prodMap_of_finiteDimensional T S
 
-end ContinuousLinearMap
 
 end TauCeti

--- a/TauCeti/Analysis/Fredholm/Restriction.lean
+++ b/TauCeti/Analysis/Fredholm/Restriction.lean
@@ -21,7 +21,7 @@ after discarding finitely many modes.
 
 ## Main declarations
 
-* `TauCeti.ContinuousLinearMap.index_restrict`: the index formula for the restriction of a
+* `ContinuousLinearMap.index_restrict`: the index formula for the restriction of a
   continuous linear map to closed finite-codimensional subspaces.
 
 The finite-codimension reduction and index convention follow McDuff--Salamon,
@@ -40,34 +40,33 @@ variable [NormedAddCommGroup E] [NormedSpace K E]
 variable [NormedAddCommGroup F] [NormedSpace K F]
 variable {T : E →L[K] F} {E₁ : Submodule K E} {F₁ : Submodule K F}
 
-namespace ContinuousLinearMap
 
 /-- The index of the restriction of a continuous linear map from `E` to `F` to closed
 finite-codimensional subspaces `E₁` and `F₁` is the index of the full operator minus `codim E₁`
 plus `codim F₁`. -/
 @[simp]
-theorem index_restrict (hE₁ : IsClosed (E₁ : Set E)) [E₁.CoFG]
+theorem _root_.ContinuousLinearMap.index_restrict (hE₁ : IsClosed (E₁ : Set E)) [E₁.CoFG]
     (hF₁ : IsClosed (F₁ : Set F)) [F₁.CoFG] (hT : Set.MapsTo T E₁ F₁)
     (hT₁ : ContinuousLinearMap.IsFredholm (T.restrict hT)) :
-    index (T.restrict hT) = index T - (finrank K (E ⧸ E₁) : ℤ) + finrank K (F ⧸ F₁) := by
+    ContinuousLinearMap.index (T.restrict hT) = ContinuousLinearMap.index T -
+      (finrank K (E ⧸ E₁) : ℤ) + finrank K (F ⧸ F₁) := by
   have hTfull := ContinuousLinearMap.IsFredholm.of_restrict hE₁ hF₁ hT hT₁
   have hιE := Submodule.isFredholm_subtypeL hE₁
   have hιF := Submodule.isFredholm_subtypeL hF₁
   have hfactor : T.comp E₁.subtypeL = F₁.subtypeL.comp (T.restrict hT) := by
     ext x
     exact (congrArg Subtype.val (ContinuousLinearMap.restrict_apply hT x)).symm
-  have hdom := index_comp T E₁.subtypeL hTfull hιE
-  have hcod := index_comp F₁.subtypeL (T.restrict hT) hιF hT₁
-  have hEindex : index E₁.subtypeL = -(finrank K (E ⧸ E₁) : ℤ) := by
-    rw [index_of_injective E₁.subtypeL Subtype.val_injective,
+  have hdom := ContinuousLinearMap.index_comp T E₁.subtypeL hTfull hιE
+  have hcod := ContinuousLinearMap.index_comp F₁.subtypeL (T.restrict hT) hιF hT₁
+  have hEindex : ContinuousLinearMap.index E₁.subtypeL = -(finrank K (E ⧸ E₁) : ℤ) := by
+    rw [ContinuousLinearMap.index_of_injective E₁.subtypeL Subtype.val_injective,
       Submodule.toLinearMap_subtypeL, Submodule.range_subtype]
-  have hFindex : index F₁.subtypeL = -(finrank K (F ⧸ F₁) : ℤ) := by
-    rw [index_of_injective F₁.subtypeL Subtype.val_injective,
+  have hFindex : ContinuousLinearMap.index F₁.subtypeL = -(finrank K (F ⧸ F₁) : ℤ) := by
+    rw [ContinuousLinearMap.index_of_injective F₁.subtypeL Subtype.val_injective,
       Submodule.toLinearMap_subtypeL, Submodule.range_subtype]
   rw [hfactor, hcod, hEindex, hFindex] at hdom
   omega
 
-end ContinuousLinearMap
 
 end TauCeti
 

--- a/TauCeti/Analysis/Fredholm/SelfAdjoint.lean
+++ b/TauCeti/Analysis/Fredholm/SelfAdjoint.lean
@@ -80,7 +80,7 @@ theorem _root_.ContinuousLinearMap.index_eq_zero_of_isSymmetric {T : E →L[𝕜
     (hT : ContinuousLinearMap.IsFredholm T)
     (hsymm : T.IsSymmetric) : ContinuousLinearMap.index T = 0 :=
   ContinuousLinearMap.index_eq_zero_of_isSelfAdjoint hT
-    (TypeVec.Arrow.mpr hsymm)
+    (ContinuousLinearMap.isSelfAdjoint_iff_isSymmetric.mpr hsymm)
 
 
 end TauCeti

--- a/TauCeti/Analysis/Fredholm/SelfAdjoint.lean
+++ b/TauCeti/Analysis/Fredholm/SelfAdjoint.lean
@@ -20,11 +20,11 @@ kernel-equality hypothesis, it identifies the cokernel with the original kernel.
 
 * `ContinuousLinearMap.IsFredholm.cokerEquivKerOfKerAdjointEq`: identify the cokernel with the
   kernel when the operator and its adjoint have equal kernels.
-* `TauCeti.ContinuousLinearMap.index_eq_zero_of_ker_adjoint_eq`: the corresponding index-zero
+* `ContinuousLinearMap.index_eq_zero_of_ker_adjoint_eq`: the corresponding index-zero
   criterion.
-* `TauCeti.ContinuousLinearMap.index_eq_zero_of_isSelfAdjoint`: a self-adjoint Fredholm operator
+* `ContinuousLinearMap.index_eq_zero_of_isSelfAdjoint`: a self-adjoint Fredholm operator
   has index zero.
-* `TauCeti.ContinuousLinearMap.index_eq_zero_of_isSymmetric`: the same result in terms of
+* `ContinuousLinearMap.index_eq_zero_of_isSymmetric`: the same result in terms of
   symmetry of the underlying linear map.
 
 This is the elementary self-adjoint index computation in the Fredholm package needed by the
@@ -47,7 +47,7 @@ noncomputable def _root_.ContinuousLinearMap.IsFredholm.cokerEquivKerOfKerAdjoin
     (hT : ContinuousLinearMap.IsFredholm T) (hker : (ContinuousLinearMap.adjoint T).ker = T.ker) :
     (E ⧸ LinearMap.range (T : E →ₗ[𝕜] E)) ≃ₗ[𝕜]
       LinearMap.ker (T : E →ₗ[𝕜] E) :=
-  (TauCeti.ContinuousLinearMap.cokerEquivKerAdjoint T hT.isClosed_range).toLinearEquiv.trans
+  (ContinuousLinearMap.cokerEquivKerAdjoint T hT.isClosed_range).toLinearEquiv.trans
     (LinearEquiv.ofEq _ _ hker)
 
 /-- The cokernel of a self-adjoint Fredholm operator is linearly equivalent to its kernel. -/
@@ -57,29 +57,30 @@ noncomputable def _root_.ContinuousLinearMap.IsFredholm.cokerEquivKer {T : E →
       LinearMap.ker (T : E →ₗ[𝕜] E) :=
   hT.cokerEquivKerOfKerAdjointEq <| by rw [hself.adjoint_eq]
 
-namespace ContinuousLinearMap
 
 /-- A Fredholm operator has index zero if it and its adjoint have the same kernel. -/
-theorem index_eq_zero_of_ker_adjoint_eq {T : E →L[𝕜] E} (hT : ContinuousLinearMap.IsFredholm T)
+theorem _root_.ContinuousLinearMap.index_eq_zero_of_ker_adjoint_eq {T : E →L[𝕜] E}
+    (hT : ContinuousLinearMap.IsFredholm T)
     (hker : (ContinuousLinearMap.adjoint T).ker = T.ker) :
-    index T = 0 := by
-  rw [index_eq_finrank_sub,
+    ContinuousLinearMap.index T = 0 := by
+  rw [ContinuousLinearMap.index_eq_finrank_sub,
     ← LinearEquiv.finrank_eq (hT.cokerEquivKerOfKerAdjointEq hker)]
   omega
 
 /-- A self-adjoint Fredholm operator on a Hilbert space has Fredholm index zero. -/
 @[simp]
-theorem index_eq_zero_of_isSelfAdjoint {T : E →L[𝕜] E} (hT : ContinuousLinearMap.IsFredholm T)
-    (hself : IsSelfAdjoint T) : index T = 0 :=
-  index_eq_zero_of_ker_adjoint_eq hT <| by rw [hself.adjoint_eq]
+theorem _root_.ContinuousLinearMap.index_eq_zero_of_isSelfAdjoint {T : E →L[𝕜] E}
+    (hT : ContinuousLinearMap.IsFredholm T)
+    (hself : IsSelfAdjoint T) : ContinuousLinearMap.index T = 0 :=
+  ContinuousLinearMap.index_eq_zero_of_ker_adjoint_eq hT <| by rw [hself.adjoint_eq]
 
 /-- A symmetric Fredholm operator on a Hilbert space has Fredholm index zero. -/
 @[simp]
-theorem index_eq_zero_of_isSymmetric {T : E →L[𝕜] E} (hT : ContinuousLinearMap.IsFredholm T)
-    (hsymm : T.IsSymmetric) : index T = 0 :=
-  index_eq_zero_of_isSelfAdjoint hT
-    (ContinuousLinearMap.isSelfAdjoint_iff_isSymmetric.mpr hsymm)
+theorem _root_.ContinuousLinearMap.index_eq_zero_of_isSymmetric {T : E →L[𝕜] E}
+    (hT : ContinuousLinearMap.IsFredholm T)
+    (hsymm : T.IsSymmetric) : ContinuousLinearMap.index T = 0 :=
+  ContinuousLinearMap.index_eq_zero_of_isSelfAdjoint hT
+    (TypeVec.Arrow.mpr hsymm)
 
-end ContinuousLinearMap
 
 end TauCeti

--- a/TauCeti/Analysis/Fredholm/Zero.lean
+++ b/TauCeti/Analysis/Fredholm/Zero.lean
@@ -22,7 +22,7 @@ remaining zero block records precisely the finite-dimensional kernel and cokerne
 
 * `TauCeti.isFredholm_zero_iff`: the zero operator is Fredholm exactly when its domain and
   codomain are finite dimensional.
-* `TauCeti.ContinuousLinearMap.index_zero`: the index of the zero operator is the difference of
+* `ContinuousLinearMap.index_zero`: the index of the zero operator is the difference of
   the dimensions of its domain and codomain.
 
 The conventions follow McDuff--Salamon, *J-holomorphic Curves and Symplectic Topology*, Appendix
@@ -82,17 +82,15 @@ lemma isFredholm_zero_iff :
           rw [ContinuousLinearMap.toLinearMap_zero, LinearMap.ker_zero]
           exact Submodule.closedComplemented_top }
 
-namespace ContinuousLinearMap
 
 /-- The index of the zero continuous linear map is the dimension of its domain minus the
 dimension of its codomain. -/
 @[simp]
-lemma index_zero :
-    index (0 : E →L[𝕜] F) = (finrank 𝕜 E : ℤ) - finrank 𝕜 F := by
-  simpa only [index_def, ContinuousLinearMap.toLinearMap_zero] using
+lemma _root_.ContinuousLinearMap.index_zero :
+    ContinuousLinearMap.index (0 : E →L[𝕜] F) = (finrank 𝕜 E : ℤ) - finrank 𝕜 F := by
+  simpa only [ContinuousLinearMap.index_def, ContinuousLinearMap.toLinearMap_zero] using
     (LinearMap.index_zero (R := 𝕜) (M := E) (N := F))
 
-end ContinuousLinearMap
 
 end TauCeti
 

--- a/TauCeti/Analysis/Normed/Algebra/SquareRoot.lean
+++ b/TauCeti/Analysis/Normed/Algebra/SquareRoot.lean
@@ -60,7 +60,7 @@ private theorem hasStrictFDerivAt_mul_self_one :
     HasStrictFDerivAt (fun a : A ↦ a * a)
       ((ContinuousLinearEquiv.smulLeft (Units.mk0 (2 : ℝ) two_ne_zero) : A ≃L[ℝ] A) :
         A →L[ℝ] A) 1 := by
-  have h := TauCeti.ContinuousLinearMap.hasStrictFDerivAt_apply_self
+  have h := ContinuousLinearMap.hasStrictFDerivAt_apply_self
     (ContinuousLinearMap.mul ℝ A) 1
   have he : (ContinuousLinearMap.mul ℝ A).flip 1 + ContinuousLinearMap.mul ℝ A 1 =
       ((ContinuousLinearEquiv.smulLeft (Units.mk0 (2 : ℝ) two_ne_zero) : A ≃L[ℝ] A) :

--- a/TauCeti/Analysis/Normed/Operator/Basic.lean
+++ b/TauCeti/Analysis/Normed/Operator/Basic.lean
@@ -29,11 +29,10 @@ variable {𝕜 X Y : Type*} [NontriviallyNormedField 𝕜]
 variable [NormedAddCommGroup X] [NormedSpace 𝕜 X]
 variable [NormedAddCommGroup Y] [NormedSpace 𝕜 Y]
 
-namespace ContinuousLinearMap
 
 /-- If `T i` is eventually uniformly bounded, `T i z` tends to `w`, and `g i` tends to `z`, then
 the moving evaluations `T i (g i)` tend to `w`. -/
-theorem tendsto_apply_of_eventually_norm_le {ι : Type*} {l : Filter ι}
+theorem _root_.ContinuousLinearMap.tendsto_apply_of_eventually_norm_le {ι : Type*} {l : Filter ι}
     {T : ι → X →L[𝕜] Y} {C : ℝ} {g : ι → X} {z : X} {w : Y}
     (hT : ∀ᶠ i in l, ‖T i‖ ≤ C) (hz : Tendsto (fun i => T i z) l (𝓝 w))
     (hg : Tendsto g l (𝓝 z)) : Tendsto (fun i => T i (g i)) l (𝓝 w) := by
@@ -47,7 +46,6 @@ theorem tendsto_apply_of_eventually_norm_le {ι : Type*} {l : Filter ι}
     rw [← ContinuousLinearMap.map_add, sub_add_cancel]
   simpa using (hmove.add hz).congr fun i => (hsplit i).symm
 
-end ContinuousLinearMap
 
 end TauCeti
 

--- a/TauCeti/Analysis/Normed/Operator/Dense.lean
+++ b/TauCeti/Analysis/Normed/Operator/Dense.lean
@@ -14,7 +14,7 @@ public import Mathlib.Topology.UniformSpace.UniformConvergence
 This file records two standard density arguments for uniformly bounded families of continuous
 linear maps. Pointwise convergence on a dense subset extends to pointwise convergence everywhere,
 and uniform Cauchy convergence on a parameter set does likewise. Both rest on the same estimate
-`TauCeti.ContinuousLinearMap.norm_sub_apply_le_of_norm_le`, which moves the point at which a
+`ContinuousLinearMap.norm_sub_apply_le_of_norm_le`, which moves the point at which a
 difference of two uniformly bounded operators is evaluated to a nearby point of the dense subset.
 -/
 
@@ -28,12 +28,12 @@ variable {𝕜 X Y : Type*} [NontriviallyNormedField 𝕜]
 variable [NormedAddCommGroup X] [NormedSpace 𝕜 X]
 variable [NormedAddCommGroup Y] [NormedSpace 𝕜 Y]
 
-namespace ContinuousLinearMap
 
 /-- Comparing two continuous linear maps of norm at most `K` at `x` costs at most `2 K ‖x - y‖`
 more than comparing them at `y`. This is the shared estimate of the two density arguments below:
 `y` is chosen in the dense subset, close to the arbitrary vector `x`. -/
-theorem norm_sub_apply_le_of_norm_le {T S : X →L[𝕜] Y} {K : ℝ} (hT : ‖T‖ ≤ K) (hS : ‖S‖ ≤ K)
+theorem _root_.ContinuousLinearMap.norm_sub_apply_le_of_norm_le {T S : X →L[𝕜] Y} {K : ℝ}
+    (hT : ‖T‖ ≤ K) (hS : ‖S‖ ≤ K)
     (x y : X) : ‖T x - S x‖ ≤ ‖T y - S y‖ + 2 * K * ‖x - y‖ := by
   have hleft : ‖T (x - y)‖ ≤ K * ‖x - y‖ :=
     (ContinuousLinearMap.le_opNorm _ _).trans (mul_le_mul_of_nonneg_right hT (norm_nonneg _))
@@ -54,7 +54,7 @@ theorem norm_sub_apply_le_of_norm_le {T S : X →L[𝕜] Y} {K : ℝ} (hT : ‖T
 
 /-- A uniformly bounded family of continuous linear maps that converges pointwise on a dense
 subset converges pointwise everywhere. -/
-theorem tendsto_apply_of_dense {ι : Type*} {l : Filter ι} {D : Set X}
+theorem _root_.ContinuousLinearMap.tendsto_apply_of_dense {ι : Type*} {l : Filter ι} {D : Set X}
     (hD : Dense D) {f : ι → X →L[𝕜] Y} {g : X →L[𝕜] Y} {C : ℝ}
     (hbound : ∀ᶠ i in l, ‖f i‖ ≤ C)
     (htendsto : ∀ x ∈ D, Tendsto (fun i => f i x) l (nhds (g x))) (x : X) :
@@ -81,12 +81,13 @@ theorem tendsto_apply_of_dense {ι : Type*} {l : Filter ι} {D : Set X}
   have hy := (Metric.tendsto_nhds.mp (htendsto y hyD)) (epsilon / 3) (by positivity)
   filter_upwards [hbound, hy] with i hi hiy
   rw [dist_eq_norm] at hiy ⊢
-  have hmain := norm_sub_apply_le_of_norm_le (hi.trans hC_le) hg_le x y
+  have hmain := ContinuousLinearMap.norm_sub_apply_le_of_norm_le (hi.trans hC_le) hg_le x y
   linarith
 
 /-- A uniformly bounded family of continuous linear maps that is uniformly Cauchy on a parameter
 set at every vector in a dense subset is uniformly Cauchy there at every vector. -/
-theorem uniformCauchySeqOn_apply_of_dense {ι Z : Type*} {p : Filter ι} {D : Set X}
+theorem _root_.ContinuousLinearMap.uniformCauchySeqOn_apply_of_dense {ι Z : Type*} {p : Filter ι}
+    {D : Set X}
     (hD : Dense D) {f : ι → Z → X →L[𝕜] Y} {s : Set Z} {C : ℝ}
     (hbound : ∀ᶠ i in p, ∀ z ∈ s, ‖f i z‖ ≤ C)
     (hcauchy : ∀ x ∈ D, UniformCauchySeqOn (fun i z => f i z x) p s) (x : X) :
@@ -112,11 +113,11 @@ theorem uniformCauchySeqOn_apply_of_dense {ι Z : Type*} {p : Filter ι} {D : Se
   filter_upwards [hbound.prod_inl p, hbound.prod_inr p, hmiddle] with m hi hj hm z hz
   refine hball ?_
   rw [dist_eq_norm]
-  have hmain := norm_sub_apply_le_of_norm_le ((hi z hz).trans hC_le) ((hj z hz).trans hC_le) x y
+  have hmain := ContinuousLinearMap.norm_sub_apply_le_of_norm_le ((hi z hz).trans hC_le)
+    ((hj z hz).trans hC_le) x y
   have hmid : ‖f m.1 z y - f m.2 z y‖ < epsilon / 3 := by
     simpa only [dist_eq_norm] using hm z hz
   linarith
 
-end ContinuousLinearMap
 
 end TauCeti

--- a/TauCeti/Analysis/Normed/Operator/Exponential.lean
+++ b/TauCeti/Analysis/Normed/Operator/Exponential.lean
@@ -62,11 +62,11 @@ theorem exp_add_smul [CompleteSpace X] (A : X →L[ℝ] X) (s t : ℝ) :
   rw [add_smul, exp_add_of_commute (((Commute.refl A).smul_left _).smul_right _),
     ContinuousLinearMap.mul_def]
 
-namespace ContinuousLinearMap
 
 /-- If every power of a bounded operator `B` has norm at most `M`, then
 `‖exp (s B)‖ ≤ M exp s` for every `s ≥ 0`. -/
-theorem norm_exp_smul_le_mul_exp_of_norm_pow_le [CompleteSpace X] {B : X →L[ℝ] X} {M s : ℝ}
+theorem _root_.ContinuousLinearMap.norm_exp_smul_le_mul_exp_of_norm_pow_le [CompleteSpace X]
+    {B : X →L[ℝ] X} {M s : ℝ}
     (hs : 0 ≤ s) (hpow : ∀ n : ℕ, ‖B ^ n‖ ≤ M) :
     ‖exp (s • B)‖ ≤ M * Real.exp s := by
   have hseries : HasSum
@@ -94,7 +94,7 @@ theorem norm_exp_smul_le_mul_exp_of_norm_pow_le [CompleteSpace X] {B : X →L[�
 /-- The exponential of a real scalar multiple of the identity operator is the corresponding
 scalar exponential times the identity. -/
 @[simp]
-theorem exp_smul_one (c : ℝ) :
+theorem _root_.ContinuousLinearMap.exp_smul_one (c : ℝ) :
     exp (c • (1 : X →L[ℝ] X)) = Real.exp c • 1 := by
   calc
     exp (c • (1 : X →L[ℝ] X)) = exp (algebraMap ℝ (X →L[ℝ] X) c) := by
@@ -105,9 +105,10 @@ theorem exp_smul_one (c : ℝ) :
 
 /-- The norm of the exponential of a real scalar multiple of the identity operator is at most
 the corresponding scalar exponential. -/
-theorem norm_exp_smul_one_le (c : ℝ) :
+theorem _root_.ContinuousLinearMap.norm_exp_smul_one_le (c : ℝ) :
     ‖exp (c • (1 : X →L[ℝ] X))‖ ≤ Real.exp c := by
-  rw [exp_smul_one, norm_smul, Real.norm_eq_abs, abs_of_nonneg (Real.exp_nonneg _)]
+  rw [ContinuousLinearMap.exp_smul_one, norm_smul, Real.norm_eq_abs,
+    abs_of_nonneg (Real.exp_nonneg _)]
   simpa only [ContinuousLinearMap.one_def, mul_one] using
     mul_le_mul_of_nonneg_left ContinuousLinearMap.norm_id_le (Real.exp_nonneg c)
 
@@ -116,7 +117,8 @@ theorem norm_exp_smul_one_le (c : ℝ) :
 
 This is the fundamental theorem of calculus applied to the differentiable orbit
 `u ↦ exp (u B) x`, whose derivative is the continuous function `u ↦ exp (u B) (B x)`. -/
-theorem exp_smul_apply_sub_eq_intervalIntegral [CompleteSpace X] (B : X →L[ℝ] X) (t : ℝ) (x : X) :
+theorem _root_.ContinuousLinearMap.exp_smul_apply_sub_eq_intervalIntegral [CompleteSpace X]
+    (B : X →L[ℝ] X) (t : ℝ) (x : X) :
     exp (t • B) x - x = ∫ u in (0 : ℝ)..t, exp (u • B) (B x) := by
   have hderiv : ∀ u : ℝ, HasDerivAt (fun v : ℝ => exp (v • B) x) (exp (u • B) (B x)) u := by
     intro u
@@ -128,7 +130,6 @@ theorem exp_smul_apply_sub_eq_intervalIntegral [CompleteSpace X] (B : X →L[ℝ
     (hcont.intervalIntegrable 0 t)]
   simp
 
-end ContinuousLinearMap
 
 end TauCeti
 

--- a/TauCeti/Analysis/Semigroups/Generation/LimitSemigroup.lean
+++ b/TauCeti/Analysis/Semigroups/Generation/LimitSemigroup.lean
@@ -178,7 +178,7 @@ private theorem yosidaLimit_time_add_of_tendsto_of_norm_le {A : X →ₗ.[ℝ] X
     (hbound_s : ∀ᶠ lambda in atTop, ‖exp (s • yosidaApproximation A lambda)‖ ≤ M) :
     yosidaLimit A (s + t) x = yosidaLimit A s (yosidaLimit A t x) := by
   refine tendsto_nhds_unique htend_st ?_
-  have hcomp := TauCeti.ContinuousLinearMap.tendsto_apply_of_eventually_norm_le
+  have hcomp := ContinuousLinearMap.tendsto_apply_of_eventually_norm_le
     hbound_s htend_s htend_t
   simpa only [exp_add_smul_apply] using hcomp
 

--- a/TauCeti/Analysis/Semigroups/Generator/IteratedDomain.lean
+++ b/TauCeti/Analysis/Semigroups/Generator/IteratedDomain.lean
@@ -152,7 +152,7 @@ private theorem tendsto_smul_resolventFun_comp (hb : S.HasGrowthBound omega M) {
     filter_upwards [eventually_ge_atTop (2 * |omega| + 1)] with lambda hlambda
     exact S.norm_smul_resolventFun_le hb hlambda
   simpa only [smul_apply] using
-    (TauCeti.ContinuousLinearMap.tendsto_apply_of_eventually_norm_le hbound
+    (ContinuousLinearMap.tendsto_apply_of_eventually_norm_le hbound
       (S.tendsto_smul_resolventFun_apply hb x) hf)
 
 /-- **The iterated scaled resolvents converge strongly to the identity**:

--- a/TauCeti/Analysis/Semigroups/Group/Basic.lean
+++ b/TauCeti/Analysis/Semigroups/Group/Basic.lean
@@ -356,7 +356,7 @@ theorem tendsto_apply {ι : Type*} {l : Filter ι} (U : StronglyContinuousGroup 
   -- The time moves: this is continuity of the orbit of the fixed vector `z`.
   have h2 : Tendsto (fun i => U (f i) z) l (𝓝 (U r z)) :=
     ((U.continuous_orbit z).tendsto r).comp hf
-  exact TauCeti.ContinuousLinearMap.tendsto_apply_of_eventually_norm_le hbound h2 hg
+  exact ContinuousLinearMap.tendsto_apply_of_eventually_norm_le hbound h2 hg
 
 end StronglyContinuousGroup
 

--- a/TauCeti/Analysis/Semigroups/GrowthBound.lean
+++ b/TauCeti/Analysis/Semigroups/GrowthBound.lean
@@ -227,7 +227,7 @@ theorem StronglyContinuousSemigroup.tendsto_realOperator_apply {ι : Type*} {l :
     have hfw : Filter.Tendsto f l (𝓝[Set.Ici 0] r) :=
       tendsto_nhdsWithin_iff.mpr ⟨hf, hf0⟩
     simpa [Function.comp_def] using (S.realOperator_continuousWithinAt z r hr).tendsto.comp hfw
-  exact TauCeti.ContinuousLinearMap.tendsto_apply_of_eventually_norm_le hbound h2 hg
+  exact ContinuousLinearMap.tendsto_apply_of_eventually_norm_le hbound h2 hg
 
 /-- The `ContinuousOn` form of joint strong continuity: a continuous nonnegative time
 reparametrization applied to a continuous vector-valued map gives a continuous orbit. -/

--- a/TauCeti/Topology/Algebra/Module/BilinearForm.lean
+++ b/TauCeti/Topology/Algebra/Module/BilinearForm.lean
@@ -24,9 +24,9 @@ itself, rather than with any of its users.
 
 ## Main results
 
-* `TauCeti.ContinuousLinearMap.separatingLeft_toBilinForm_iff_injective`: the bilinear form of a
+* `ContinuousLinearMap.separatingLeft_toBilinForm_iff_injective`: the bilinear form of a
   continuous linear map into the dual is left-separating if and only if the map is injective.
-* `TauCeti.ContinuousLinearMap.isInvertible_of_injective`: in finite dimensions an injective map
+* `ContinuousLinearMap.isInvertible_of_injective`: in finite dimensions an injective map
   into the dual is already invertible, the dual having the same dimension as the space.
 -/
 
@@ -34,13 +34,14 @@ public section
 
 namespace TauCeti
 
-namespace ContinuousLinearMap
+section
 
 variable {𝕜 E : Type*} [NormedField 𝕜] [AddCommGroup E] [Module 𝕜 E] [TopologicalSpace E]
 
 /-- The bilinear form of a continuous linear map into the dual space is left-separating exactly
 when the map is injective. -/
-theorem separatingLeft_toBilinForm_iff_injective (L : E →L[𝕜] E →L[𝕜] 𝕜) :
+theorem _root_.ContinuousLinearMap.separatingLeft_toBilinForm_iff_injective (L : E →L[𝕜] E →L[𝕜] 𝕜)
+    :
     L.toBilinForm.SeparatingLeft ↔ Function.Injective L := by
   rw [LinearMap.separatingLeft_iff_ker_eq_bot, LinearMap.ker_eq_bot]
   exact ⟨fun h v w hvw ↦ h (LinearMap.ext fun u ↦ by simp [hvw]),
@@ -49,7 +50,8 @@ theorem separatingLeft_toBilinForm_iff_injective (L : E →L[𝕜] E →L[𝕜] 
 /-- In finite dimensions an injective continuous linear map into the dual is invertible: injectivity
 makes it a linear equivalence onto its range, and the dual has the same finite dimension as the
 space, so that range is everything. -/
-theorem isInvertible_of_injective {𝕜 E : Type*} [NontriviallyNormedField 𝕜] [CompleteSpace 𝕜]
+theorem _root_.ContinuousLinearMap.isInvertible_of_injective {𝕜 E : Type*}
+    [NontriviallyNormedField 𝕜] [CompleteSpace 𝕜]
     [NormedAddCommGroup E] [NormedSpace 𝕜 E] [FiniteDimensional 𝕜 E] {L : E →L[𝕜] E →L[𝕜] 𝕜}
     (hinj : Function.Injective L) : L.IsInvertible := by
   have hrank : Module.finrank 𝕜 E = Module.finrank 𝕜 (E →L[𝕜] 𝕜) := by
@@ -59,7 +61,7 @@ theorem isInvertible_of_injective {𝕜 E : Type*} [NontriviallyNormedField 𝕜
   exact ⟨((L : E →ₗ[𝕜] E →L[𝕜] 𝕜).linearEquivOfInjective hinj hrank).toContinuousLinearEquiv,
     by ext v; simp⟩
 
-end ContinuousLinearMap
+end
 
 end TauCeti
 


### PR DESCRIPTION
Sixty-three declarations move from `TauCeti.ContinuousLinearMap` to Mathlib's root
`ContinuousLinearMap` namespace, so that dot notation on a continuous linear map reaches them.

The namespace is **flat** — it has no children — and every one of its declarations moves, so
nothing is left behind and no sibling namespace is half-rooted. Twenty-one wrapper blocks are
retired across seventeen files: three carry `variable` lines of their own and become `section`,
and eighteen are deleted outright. The references those wrappers were resolving are qualified.

Emptying the namespace makes every mention of it false, so forty-four module-docstring paths lose
their `TauCeti.` prefix — including in files this change does not otherwise touch. A docstring
naming a namespace that no longer exists misdirects the next reader exactly as a dead code path
would.

`lint-dot-notation`: **946 → 905**, no new findings.

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYwXN9WBAPasmBQXr6iQcp