### PR TITLE
feat: derive odd coderivation squares from homogeneity

### DIFF
--- a/TauCeti/Algebra/Module/GradedModule/Internal.lean
+++ b/TauCeti/Algebra/Module/GradedModule/Internal.lean
@@ -45,6 +45,8 @@ the letterwise tuple operation that applies it on a half-open index interval.
 * `TauCeti.InternalGrading.koszulTwist_apply_of_mem`: the twist acts by the Koszul scalar on
   each homogeneous piece.
 * `TauCeti.InternalGrading.koszulTwist_comp`: twists compose by adding the twist parameters.
+* `TauCeti.LinearMap.IsHomogeneous.koszulTwist_comp`: a homogeneous linear map commutes with
+  Koszul twists up to the sign determined by its degree.
 
 This is the first graded-module target in Layer 0 of the `DGAInfinity` roadmap.  Later files use
 Mathlib's decomposition API to define maps of nonzero degree, shifts, tensor-product gradings, and
@@ -357,6 +359,33 @@ theorem InternalGrading.koszulTwist_comp_self (G : InternalGrading R M) (q : ℤ
     rw [koszulTwist_apply_of_mem G hx (2 * q), mul_assoc, Int.negOnePow_two_mul]
     simp
   simpa [LinearMap.comp_apply] using this
+
+namespace LinearMap.IsHomogeneous
+
+variable {N : Type w} [AddCommMonoid N] [Module R N]
+
+/-- A homogeneous linear map of degree `r` commutes with the Koszul twist of parameter `q` up to
+the scalar `(-1)^(q * r)`. This is the operator form of the sign acquired by moving a degree-`r`
+map past a homogeneous input. -/
+theorem koszulTwist_comp {G : InternalGrading R M} {H : InternalGrading R N}
+    {f : M →ₗ[R] N} {r : ℤ} (hf : LinearMap.IsHomogeneous f G.piece H.piece r) (q : ℤ) :
+    H.koszulTwist q ∘ₗ f =
+      ((((q * r).negOnePow : ℤ) : R) • (f ∘ₗ G.koszulTwist q)) := by
+  refine DirectSum.decompose_lhom_ext (ℳ := G.piece) fun p ↦ ?_
+  ext x
+  have hx : (x : M) ∈ G.piece p := Submodule.coe_mem x
+  have hfx : f (x : M) ∈ H.piece (p + r) := hf.map_mem hx
+  have hcalc : H.koszulTwist q (f (x : M)) =
+      (((q * r).negOnePow : ℤ) : R) • f (G.koszulTwist q (x : M)) := by
+    rw [H.koszulTwist_apply_of_mem hfx q, G.koszulTwist_apply_of_mem hx q, map_smul,
+      smul_smul]
+    congr 1
+    rw [← Int.cast_mul, ← Units.val_mul, ← Int.negOnePow_add]
+    congr 2
+    ring_nf
+  simpa only [LinearMap.comp_apply, LinearMap.smul_apply, Submodule.coe_subtype] using hcalc
+
+end LinearMap.IsHomogeneous
 
 /-- Evaluation of `twistedTuple` on an index inside the twisted interval `[a, a + p)`. -/
 @[simp]

--- a/TauCeti/Algebra/Ring/NegOnePow.lean
+++ b/TauCeti/Algebra/Ring/NegOnePow.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import Mathlib.Algebra.BigOperators.Group.Finset.Defs
 public import Mathlib.Algebra.Ring.NegOnePow
 public import Mathlib.Algebra.Module.Defs
 
@@ -20,13 +21,14 @@ This file provides the cast to a ground ring of Mathlib's unit-valued sign chara
 
 ## Main results
 
+* `TauCeti.negOnePowCast_sum`: the sign of a finite sum is the product of the signs of its terms.
 * `TauCeti.negOnePow_smul_eq_negOnePowCast_smul`: the unit-valued sign and its ground-ring cast
   induce the same scalar action on a module.
 -/
 
 public section
 
-universe uR uA
+universe uR uA uI
 
 namespace TauCeti
 
@@ -92,5 +94,20 @@ theorem negOnePowCast_smul_eq_zero_iff (e : ℤ) (a : A) :
   rw [← negOnePowCast_smul_negOnePowCast_smul (R := R) e a, h, smul_zero]
 
 end NegOnePowCast
+
+section CommRing
+
+variable {R : Type uR} [CommRing R]
+
+/-- The sign of a finite sum is the product of the signs of its terms: the sign character turns
+addition into multiplication, so it distributes over `Finset.sum`. -/
+theorem negOnePowCast_sum {ι : Type uI} (s : Finset ι) (f : ι → ℤ) :
+    negOnePowCast R (∑ i ∈ s, f i) = ∏ i ∈ s, negOnePowCast R (f i) := by
+  induction s using Finset.cons_induction with
+  | empty => simp
+  | cons a s ha ih =>
+      rw [Finset.sum_cons, Finset.prod_cons, negOnePowCast_add, ih]
+
+end CommRing
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/TensorCoalgebra/GradedCoderivation.lean
+++ b/TauCeti/LinearAlgebra/TensorCoalgebra/GradedCoderivation.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.Algebra.BigOperators.Finset.Range
 public import TauCeti.Algebra.Module.GradedModule.Internal
+public import TauCeti.Algebra.Ring.NegOnePow
 public import TauCeti.LinearAlgebra.TensorCoalgebra.Coderivation
 public import TauCeti.LinearAlgebra.Graded.LinearMap
 
@@ -56,6 +57,12 @@ by `isHomogeneous_gradedCoderiv` and `IsGradedCoderivation.isHomogeneous`.
   coderivation with letter component `F`.
 * `TauCeti.ReducedTensorWords.IsGradedCoderivation.eq_of_letter_comp_eq`: a graded coderivation is
   determined by its letter component.
+* `TauCeti.ReducedTensorWords.iSup_gradedPiece_eq_top`: the total-degree pieces span the reduced
+  tensor coalgebra.
+* `TauCeti.ReducedTensorWords.map_koszulTwist_apply_of_mem`: the letterwise twist has the expected
+  scalar action on each total-degree piece.
+* `TauCeti.LinearMap.IsHomogeneous.map_koszulTwist_comp`: a homogeneous endomorphism of reduced
+  tensor words commutes with the letterwise twist up to the sign given by its degree.
 * `TauCeti.ReducedTensorWords.IsGradedCoderivation.isCoderivation_comp_self`: a graded coderivation
   anticommuting with its letterwise Koszul twist has an ordinary coderivation as its square.
 * `TauCeti.ReducedTensorWords.isHomogeneous_gradedCoderiv`: if `F` raises degrees by `r` then so
@@ -153,15 +160,6 @@ theorem ReducedTensorWords.gradedCoderiv_of_tprod (G : InternalGrading R M)
       LinearMap.zero_apply]
     exact (splice_eq_zero R (twistedTuple G q x 0 p) _ (by tauto)).symm
 
-private theorem negOnePow_sum_range {R : Type uR} [CommRing R] (q : ℤ) (deg : ℕ → ℤ) (p : ℕ) :
-    (((q * ∑ j ∈ Finset.range p, deg j).negOnePow : ℤ) : R) =
-      ∏ j ∈ Finset.range p, (((q * deg j).negOnePow : ℤ) : R) := by
-  induction p with
-  | zero => simp
-  | succ p ih =>
-      rw [Finset.sum_range_succ, Finset.prod_range_succ, mul_add, Int.negOnePow_add,
-        Units.val_mul, Int.cast_mul, ih]
-
 /-- Splicing a Koszul-twisted prefix of a homogeneous tuple produces the Koszul sign of that
 prefix times the untwisted splice. -/
 theorem ReducedTensorWords.splice_twistedTuple_smul (G : InternalGrading R M) (q : ℤ)
@@ -215,7 +213,8 @@ theorem ReducedTensorWords.splice_twistedTuple_smul (G : InternalGrading R M) (q
           (if p + (1 + x) < p then (((q * deg (p + (1 + x))).negOnePow : ℤ) : R) else 1) = 1 :=
         Finset.prod_eq_one fun j _ ↦ by simp
       have s3 : (if p + 0 < p then (((q * deg (p + 0)).negOnePow : ℤ) : R) else 1) = 1 := by simp
-      rw [s1, s2, s3, mul_one, mul_one, negOnePow_sum_range]
+      rw [s1, s2, s3, mul_one, mul_one]
+      simp only [← negOnePowCast_eq_intCast, Finset.mul_sum, negOnePowCast_sum]
     simpa [deg] using hprod
   · rw [splice_eq_zero R _ e (by tauto), splice_eq_zero R x e (by tauto), smul_zero]
 
@@ -383,6 +382,95 @@ theorem ReducedTensorWords.splice_mem_gradedPiece (G : InternalGrading R M) {n :
           simpa using h)
     rw [hidx] at step
     exact step
+
+/-- The total-degree pieces span the reduced tensor coalgebra. In particular, an equality of
+linear maps out of reduced tensor words may be checked separately on these pieces. -/
+theorem ReducedTensorWords.iSup_gradedPiece_eq_top (G : InternalGrading R M) :
+    ⨆ D : ℤ, gradedPiece G D = ⊤ := by
+  classical
+  apply le_antisymm le_top
+  rw [← iSup_range_of R M]
+  refine iSup_le fun n ↦ ?_
+  rintro z ⟨z, rfl⟩
+  induction z using PiTensorProduct.induction_on with
+  | smul_tprod r x =>
+      rw [map_smul]
+      apply Submodule.smul_mem
+      let support : Fin n.1 → Finset ℤ := fun i ↦ (DirectSum.decompose G.piece (x i)).support
+      let component : (i : Fin n.1) → ℤ → M :=
+        fun i p ↦ DirectSum.decompose G.piece (x i) p
+      have hx (i : Fin n.1) : ∑ p ∈ support i, component i p = x i := by
+        exact DirectSum.sum_support_decompose G.piece (x i)
+      have htuple :
+          PiTensorProduct.tprod R x =
+            ∑ degree ∈ Fintype.piFinset support,
+              PiTensorProduct.tprod R (fun i ↦ component i (degree i)) := by
+        rw [← (PiTensorProduct.tprod R).map_sum_finset]
+        congr 1
+        funext i
+        exact (hx i).symm
+      rw [htuple, map_sum]
+      refine Submodule.sum_mem _ fun degree _hdegree ↦ ?_
+      refine Submodule.mem_iSup_of_mem (∑ i, degree i) ?_
+      apply mem_gradedPiece_of_tprod G n.2
+      intro i
+      exact (DirectSum.decompose G.piece (x i) (degree i)).property
+  | add x y hx hy =>
+      rw [map_add]
+      exact Submodule.add_mem _ hx hy
+
+/-- On the total-degree-`D` piece of reduced tensor words, applying the Koszul twist to every
+letter is scalar multiplication by `(-1)^(q * D)`. -/
+theorem ReducedTensorWords.map_koszulTwist_apply_of_mem (G : InternalGrading R M) {D : ℤ}
+    {z : ReducedTensorWords R M} (hz : z ∈ gradedPiece G D) (q : ℤ) :
+    ReducedTensorWords.map (R := R) (G.koszulTwist q) z =
+      (((q * D).negOnePow : ℤ) : R) • z := by
+  refine gradedPiece_induction
+    (motive := fun z ↦ ReducedTensorWords.map (R := R) (G.koszulTwist q) z =
+      (((q * D).negOnePow : ℤ) : R) • z) hz ?_ (by simp) ?_ ?_
+  · intro n hn degree x hx hD
+    rw [map_of_tprod]
+    have htuple : (fun i ↦ G.koszulTwist q (x i)) =
+        fun i ↦ ((((q * degree i).negOnePow : ℤ) : R) • x i) := by
+      funext i
+      exact G.koszulTwist_apply_of_mem (hx i) q
+    have hsign :
+        (((q * ∑ i, degree i).negOnePow : ℤ) : R) =
+          ∏ i, (((q * degree i).negOnePow : ℤ) : R) := by
+      simp only [← negOnePowCast_eq_intCast, Finset.mul_sum, negOnePowCast_sum]
+    rw [htuple, (PiTensorProduct.tprod R).map_smul_univ, map_smul, ← hD, ← hsign]
+  · intro u v _ _ hu hv
+    simp only [map_add, hu, hv, smul_add]
+  · intro a u _ hu
+    rw [map_smul, hu, smul_smul, smul_smul, mul_comm a]
+
+/-- A homogeneous endomorphism of reduced tensor words commutes with the letterwise Koszul twist
+up to the sign contributed by its degree. -/
+theorem LinearMap.IsHomogeneous.map_koszulTwist_comp {G : InternalGrading R M}
+    {b : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M} {r : ℤ}
+    (hb : LinearMap.IsHomogeneous b (gradedPiece G) (gradedPiece G) r) (q : ℤ) :
+    ReducedTensorWords.map (R := R) (G.koszulTwist q) ∘ₗ b =
+      ((((q * r).negOnePow : ℤ) : R) •
+        (b ∘ₗ ReducedTensorWords.map (R := R) (G.koszulTwist q))) := by
+  apply LinearMap.ext
+  intro z
+  have hz : z ∈ (⊤ : Submodule R (ReducedTensorWords R M)) := Submodule.mem_top
+  rw [← ReducedTensorWords.iSup_gradedPiece_eq_top G] at hz
+  simp only [LinearMap.comp_apply, LinearMap.smul_apply]
+  refine Submodule.iSup_induction (fun D : ℤ ↦ gradedPiece G D)
+    (motive := fun z ↦
+      ReducedTensorWords.map (R := R) (G.koszulTwist q) (b z) =
+        (((q * r).negOnePow : ℤ) : R) •
+          b (ReducedTensorWords.map (R := R) (G.koszulTwist q) z)) hz ?_ (by simp) ?_
+  · intro D x hx
+    rw [ReducedTensorWords.map_koszulTwist_apply_of_mem G (hb.map_mem hx) q,
+      ReducedTensorWords.map_koszulTwist_apply_of_mem G hx q, map_smul, smul_smul]
+    congr 1
+    rw [← Int.cast_mul, ← Units.val_mul, ← Int.negOnePow_add]
+    congr 2
+    ring_nf
+  · intro x y hx hy
+    simp only [map_add, hx, hy, smul_add]
 
 /-- If `F` raises total degrees by `r`, so does its graded Taylor expansion, independently of
 the twist parameter `q`: for every `D`, the map `gradedCoderiv G F q` sends `gradedPiece G D`

--- a/TauCeti/LinearAlgebra/TensorCoalgebra/OddSquare.lean
+++ b/TauCeti/LinearAlgebra/TensorCoalgebra/OddSquare.lean
@@ -1,0 +1,212 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.LinearAlgebra.TensorCoalgebra.GradedCoderivation
+
+/-!
+# Odd squares of homogeneous tensor-coalgebra coderivations
+
+A degree-one coderivation of the reduced tensor coalgebra is odd: it anticommutes with the
+letterwise Koszul involution. Consequently its square is an ordinary coderivation, whose
+vanishing can then be checked with the existing Taylor-component criterion.
+
+The total-degree pieces `TauCeti.ReducedTensorWords.gradedPiece` were originally introduced only
+to state homogeneity of a graded Taylor expansion. This file proves that they span all reduced
+tensor words and that the letterwise Koszul twist acts on the degree-`D` piece by
+`(-1)^(q * D)`. These two facts turn the usual calculation on a homogeneous word into an equality
+of endomorphisms, with no extra oddness assumption.
+
+## Main results
+
+* `TauCeti.ReducedTensorWords.iSup_gradedPiece_eq_top`: the total-degree pieces span the reduced
+  tensor coalgebra.
+* `TauCeti.ReducedTensorWords.map_koszulTwist_apply_of_mem`: the letterwise twist has the expected
+  scalar action on each total-degree piece.
+* `TauCeti.LinearMap.IsHomogeneous.anticommute_map_koszulTwist_one`: a degree-one endomorphism of
+  reduced tensor words anticommutes with the letterwise Koszul involution.
+* `TauCeti.ReducedTensorWords.IsGradedCoderivation.isCoderivation_comp_self_of_isHomogeneous`:
+  the square of a homogeneous degree-one graded coderivation is an ordinary coderivation.
+
+## References
+
+* E. Getzler and J. D. S. Jones, *A-infinity algebras and the cyclic bar complex*, Sections 1--2.
+* B. Keller, *Introduction to A-infinity algebras and modules*, Sections 3.1 and 3.6.
+-/
+
+public section
+
+open scoped BigOperators DirectSum TensorProduct
+
+universe uR uM
+
+namespace TauCeti
+
+namespace ReducedTensorWords
+
+variable {R : Type uR} {M : Type uM} [CommRing R] [AddCommMonoid M] [Module R M]
+
+private theorem negOnePow_sum_range (q : ℤ) (degree : ℕ → ℤ) (n : ℕ) :
+    (((q * ∑ i ∈ Finset.range n, degree i).negOnePow : ℤ) : R) =
+      ∏ i ∈ Finset.range n, (((q * degree i).negOnePow : ℤ) : R) := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+      rw [Finset.sum_range_succ, Finset.prod_range_succ, mul_add, Int.negOnePow_add,
+        Units.val_mul, Int.cast_mul, ih]
+
+/-- The total-degree pieces span the reduced tensor coalgebra. In particular, an equality of
+linear maps out of reduced tensor words may be checked separately on these pieces. -/
+theorem iSup_gradedPiece_eq_top (G : InternalGrading R M) :
+    ⨆ D : ℤ, gradedPiece G D = ⊤ := by
+  classical
+  apply le_antisymm le_top
+  rw [← iSup_range_of R M]
+  refine iSup_le fun n ↦ ?_
+  rintro z ⟨z, rfl⟩
+  induction z using PiTensorProduct.induction_on with
+  | smul_tprod r x =>
+      rw [map_smul]
+      apply Submodule.smul_mem
+      let support : Fin n.1 → Finset ℤ := fun i ↦ (DirectSum.decompose G.piece (x i)).support
+      let component : (i : Fin n.1) → ℤ → M :=
+        fun i p ↦ DirectSum.decompose G.piece (x i) p
+      have hx (i : Fin n.1) : ∑ p ∈ support i, component i p = x i := by
+        exact DirectSum.sum_support_decompose G.piece (x i)
+      have htuple :
+          PiTensorProduct.tprod R x =
+            ∑ degree ∈ Fintype.piFinset support,
+              PiTensorProduct.tprod R (fun i ↦ component i (degree i)) := by
+        rw [← (PiTensorProduct.tprod R).map_sum_finset]
+        congr 1
+        funext i
+        exact (hx i).symm
+      rw [htuple, map_sum]
+      refine Submodule.sum_mem _ fun degree _hdegree ↦ ?_
+      refine Submodule.mem_iSup_of_mem (∑ i, degree i) ?_
+      apply mem_gradedPiece_of_tprod G n.2
+      intro i
+      exact (DirectSum.decompose G.piece (x i) (degree i)).property
+  | add x y hx hy =>
+      rw [map_add]
+      exact Submodule.add_mem _ hx hy
+
+/-- On the total-degree-`D` piece of reduced tensor words, applying the Koszul twist to every
+letter is scalar multiplication by `(-1)^(q * D)`. -/
+theorem map_koszulTwist_apply_of_mem (G : InternalGrading R M) {D : ℤ}
+    {z : ReducedTensorWords R M} (hz : z ∈ gradedPiece G D) (q : ℤ) :
+    ReducedTensorWords.map (R := R) (G.koszulTwist q) z =
+      (((q * D).negOnePow : ℤ) : R) • z := by
+  refine gradedPiece_induction
+    (motive := fun z ↦ ReducedTensorWords.map (R := R) (G.koszulTwist q) z =
+      (((q * D).negOnePow : ℤ) : R) • z) hz ?_ (by simp) ?_ ?_
+  · intro n hn degree x hx hD
+    rw [map_of_tprod]
+    have htuple : (fun i ↦ G.koszulTwist q (x i)) =
+        fun i ↦ ((((q * degree i).negOnePow : ℤ) : R) • x i) := by
+      funext i
+      exact G.koszulTwist_apply_of_mem (hx i) q
+    have hsign :
+        (((q * ∑ i, degree i).negOnePow : ℤ) : R) =
+          ∏ i, (((q * degree i).negOnePow : ℤ) : R) := by
+      rw [Finset.sum_fin_eq_sum_range, Finset.prod_fin_eq_prod_range]
+      calc
+        (((q * ∑ i ∈ Finset.range n,
+            if h : i < n then degree ⟨i, h⟩ else 0).negOnePow : ℤ) : R) =
+            ∏ i ∈ Finset.range n,
+              (((q * (if h : i < n then degree ⟨i, h⟩ else 0)).negOnePow : ℤ) : R) :=
+          negOnePow_sum_range q (fun i ↦ if h : i < n then degree ⟨i, h⟩ else 0) n
+        _ = ∏ i ∈ Finset.range n,
+            if h : i < n then (((q * degree ⟨i, h⟩).negOnePow : ℤ) : R) else 1 := by
+          apply Finset.prod_congr rfl
+          intro i hi
+          simp [Finset.mem_range.mp hi]
+    rw [htuple, (PiTensorProduct.tprod R).map_smul_univ, map_smul, ← hD, ← hsign]
+  · intro u v _ _ hu hv
+    simp only [map_add, hu, hv, smul_add]
+  · intro a u _ hu
+    rw [map_smul, hu, smul_smul, smul_smul, mul_comm a]
+
+end ReducedTensorWords
+
+namespace LinearMap.IsHomogeneous
+
+open ReducedTensorWords
+
+variable {R : Type uR} {M : Type uM} [CommRing R] [AddCommMonoid M] [Module R M]
+
+/-- A homogeneous endomorphism of reduced tensor words commutes with the letterwise Koszul twist
+up to the sign contributed by its degree. -/
+theorem map_koszulTwist_comp {G : InternalGrading R M}
+    {b : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M} {r : ℤ}
+    (hb : LinearMap.IsHomogeneous b (gradedPiece G) (gradedPiece G) r) (q : ℤ) :
+    ReducedTensorWords.map (R := R) (G.koszulTwist q) ∘ₗ b =
+      ((((q * r).negOnePow : ℤ) : R) •
+        (b ∘ₗ ReducedTensorWords.map (R := R) (G.koszulTwist q))) := by
+  apply LinearMap.ext
+  intro z
+  have hz : z ∈ (⊤ : Submodule R (ReducedTensorWords R M)) := Submodule.mem_top
+  rw [← ReducedTensorWords.iSup_gradedPiece_eq_top G] at hz
+  simp only [LinearMap.comp_apply, LinearMap.smul_apply]
+  refine Submodule.iSup_induction (fun D : ℤ ↦ gradedPiece G D)
+    (motive := fun z ↦
+      ReducedTensorWords.map (R := R) (G.koszulTwist q) (b z) =
+        (((q * r).negOnePow : ℤ) : R) •
+          b (ReducedTensorWords.map (R := R) (G.koszulTwist q) z)) hz ?_ (by simp) ?_
+  · intro D x hx
+    rw [ReducedTensorWords.map_koszulTwist_apply_of_mem G (hb.map_mem hx) q,
+      ReducedTensorWords.map_koszulTwist_apply_of_mem G hx q, map_smul, smul_smul]
+    congr 1
+    rw [← Int.cast_mul, ← Units.val_mul, ← Int.negOnePow_add]
+    congr 2
+    ring_nf
+  · intro x y hx hy
+    simp only [map_add, hx, hy, smul_add]
+
+/-- A homogeneous endomorphism of degree one anticommutes with the letterwise Koszul twist of
+parameter one. -/
+theorem anticommute_map_koszulTwist_one {G : InternalGrading R M}
+    {b : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M}
+    (hb : LinearMap.IsHomogeneous b (gradedPiece G) (gradedPiece G) 1) :
+    b ∘ₗ ReducedTensorWords.map (R := R) (G.koszulTwist 1) +
+        ReducedTensorWords.map (R := R) (G.koszulTwist 1) ∘ₗ b = 0 := by
+  have h := hb.map_koszulTwist_comp 1
+  have hsign : ((((1 : ℤ) * 1).negOnePow : ℤ) : R) = -1 := by norm_num
+  rw [hsign] at h
+  apply LinearMap.ext
+  intro z
+  have hz := LinearMap.congr_fun h z
+  simp only [LinearMap.comp_apply, LinearMap.smul_apply] at hz
+  simp only [LinearMap.add_apply, LinearMap.comp_apply, LinearMap.zero_apply]
+  rw [hz]
+  let x := b (ReducedTensorWords.map (R := R) (G.koszulTwist 1) z)
+  change x + (-1 : R) • x = 0
+  calc
+    x + (-1 : R) • x = (1 : R) • x + (-1 : R) • x := by rw [one_smul]
+    _ = ((1 : R) + (-1 : R)) • x := (add_smul _ _ _).symm
+    _ = 0 := by simp
+
+end LinearMap.IsHomogeneous
+
+namespace ReducedTensorWords.IsGradedCoderivation
+
+open ReducedTensorWords
+
+variable {R : Type uR} {M : Type uM} [CommRing R] [AddCommMonoid M] [Module R M]
+
+/-- The square of a homogeneous degree-one graded coderivation is an ordinary coderivation. The
+degree hypothesis supplies the anticommutation with the Koszul twist required for the two mixed
+terms in the co-Leibniz expansion to cancel. -/
+theorem isCoderivation_comp_self_of_isHomogeneous {G : InternalGrading R M}
+    {b : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M}
+    (hb : IsGradedCoderivation G 1 b)
+    (hhom : LinearMap.IsHomogeneous b (gradedPiece G) (gradedPiece G) 1) :
+    IsCoderivation R (b ∘ₗ b) :=
+  hb.isCoderivation_comp_self hhom.anticommute_map_koszulTwist_one
+
+end ReducedTensorWords.IsGradedCoderivation
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/TensorCoalgebra/OddSquare.lean
+++ b/TauCeti/LinearAlgebra/TensorCoalgebra/OddSquare.lean
@@ -10,26 +10,28 @@ public import TauCeti.LinearAlgebra.TensorCoalgebra.GradedCoderivation
 /-!
 # Odd squares of homogeneous tensor-coalgebra coderivations
 
-A degree-one coderivation of the reduced tensor coalgebra is odd: it anticommutes with the
-letterwise Koszul involution. Consequently its square is an ordinary coderivation, whose
-vanishing can then be checked with the existing Taylor-component criterion.
+A homogeneous endomorphism of the reduced tensor coalgebra whose degree `r` and twist parameter
+`q` satisfy `(-1)^(q * r) = -1` is odd: it anticommutes with the letterwise Koszul involution of
+parameter `q`. Consequently the square of such a graded coderivation is an ordinary coderivation,
+whose vanishing can then be checked with the existing Taylor-component criterion. The degree-one
+case `q = r = 1` is the one the `A∞` sign audit consumes.
 
-The total-degree pieces `TauCeti.ReducedTensorWords.gradedPiece` were originally introduced only
-to state homogeneity of a graded Taylor expansion. This file proves that they span all reduced
-tensor words and that the letterwise Koszul twist acts on the degree-`D` piece by
-`(-1)^(q * D)`. These two facts turn the usual calculation on a homogeneous word into an equality
-of endomorphisms, with no extra oddness assumption.
+Homogeneity is genuinely needed: `TauCeti.ReducedTensorWords.IsGradedCoderivation G q` is the
+`q`-twisted co-Leibniz identity alone and does not by itself constrain degrees. The oddness comes
+from `TauCeti.LinearMap.IsHomogeneous.map_koszulTwist_comp`, which turns the usual calculation on
+a homogeneous word into an equality of endomorphisms.
 
 ## Main results
 
-* `TauCeti.ReducedTensorWords.iSup_gradedPiece_eq_top`: the total-degree pieces span the reduced
-  tensor coalgebra.
-* `TauCeti.ReducedTensorWords.map_koszulTwist_apply_of_mem`: the letterwise twist has the expected
-  scalar action on each total-degree piece.
-* `TauCeti.LinearMap.IsHomogeneous.anticommute_map_koszulTwist_one`: a degree-one endomorphism of
-  reduced tensor words anticommutes with the letterwise Koszul involution.
+* `TauCeti.LinearMap.IsHomogeneous.anticommute_map_koszulTwist`: a homogeneous endomorphism of
+  reduced tensor words anticommutes with the letterwise Koszul involution as soon as the sign
+  `(-1)^(q * r)` of its degree against the twist parameter is `-1`.
+* `TauCeti.LinearMap.IsHomogeneous.anticommute_map_koszulTwist_one`: the degree-one case, at twist
+  parameter one.
 * `TauCeti.ReducedTensorWords.IsGradedCoderivation.isCoderivation_comp_self_of_isHomogeneous`:
-  the square of a homogeneous degree-one graded coderivation is an ordinary coderivation.
+  the square of such a homogeneous graded coderivation is an ordinary coderivation.
+* `TauCeti.ReducedTensorWords.IsGradedCoderivation.isCoderivation_comp_self_of_isHomogeneous_one`:
+  the degree-one case, at twist parameter one.
 
 ## References
 
@@ -45,126 +47,31 @@ universe uR uM
 
 namespace TauCeti
 
-namespace ReducedTensorWords
-
-variable {R : Type uR} {M : Type uM} [CommRing R] [AddCommMonoid M] [Module R M]
-
-private theorem negOnePow_sum_range (q : ℤ) (degree : ℕ → ℤ) (n : ℕ) :
-    (((q * ∑ i ∈ Finset.range n, degree i).negOnePow : ℤ) : R) =
-      ∏ i ∈ Finset.range n, (((q * degree i).negOnePow : ℤ) : R) := by
-  induction n with
-  | zero => simp
-  | succ n ih =>
-      rw [Finset.sum_range_succ, Finset.prod_range_succ, mul_add, Int.negOnePow_add,
-        Units.val_mul, Int.cast_mul, ih]
-
-/-- The total-degree pieces span the reduced tensor coalgebra. In particular, an equality of
-linear maps out of reduced tensor words may be checked separately on these pieces. -/
-theorem iSup_gradedPiece_eq_top (G : InternalGrading R M) :
-    ⨆ D : ℤ, gradedPiece G D = ⊤ := by
-  classical
-  apply le_antisymm le_top
-  rw [← iSup_range_of R M]
-  refine iSup_le fun n ↦ ?_
-  rintro z ⟨z, rfl⟩
-  induction z using PiTensorProduct.induction_on with
-  | smul_tprod r x =>
-      rw [map_smul]
-      apply Submodule.smul_mem
-      let support : Fin n.1 → Finset ℤ := fun i ↦ (DirectSum.decompose G.piece (x i)).support
-      let component : (i : Fin n.1) → ℤ → M :=
-        fun i p ↦ DirectSum.decompose G.piece (x i) p
-      have hx (i : Fin n.1) : ∑ p ∈ support i, component i p = x i := by
-        exact DirectSum.sum_support_decompose G.piece (x i)
-      have htuple :
-          PiTensorProduct.tprod R x =
-            ∑ degree ∈ Fintype.piFinset support,
-              PiTensorProduct.tprod R (fun i ↦ component i (degree i)) := by
-        rw [← (PiTensorProduct.tprod R).map_sum_finset]
-        congr 1
-        funext i
-        exact (hx i).symm
-      rw [htuple, map_sum]
-      refine Submodule.sum_mem _ fun degree _hdegree ↦ ?_
-      refine Submodule.mem_iSup_of_mem (∑ i, degree i) ?_
-      apply mem_gradedPiece_of_tprod G n.2
-      intro i
-      exact (DirectSum.decompose G.piece (x i) (degree i)).property
-  | add x y hx hy =>
-      rw [map_add]
-      exact Submodule.add_mem _ hx hy
-
-/-- On the total-degree-`D` piece of reduced tensor words, applying the Koszul twist to every
-letter is scalar multiplication by `(-1)^(q * D)`. -/
-theorem map_koszulTwist_apply_of_mem (G : InternalGrading R M) {D : ℤ}
-    {z : ReducedTensorWords R M} (hz : z ∈ gradedPiece G D) (q : ℤ) :
-    ReducedTensorWords.map (R := R) (G.koszulTwist q) z =
-      (((q * D).negOnePow : ℤ) : R) • z := by
-  refine gradedPiece_induction
-    (motive := fun z ↦ ReducedTensorWords.map (R := R) (G.koszulTwist q) z =
-      (((q * D).negOnePow : ℤ) : R) • z) hz ?_ (by simp) ?_ ?_
-  · intro n hn degree x hx hD
-    rw [map_of_tprod]
-    have htuple : (fun i ↦ G.koszulTwist q (x i)) =
-        fun i ↦ ((((q * degree i).negOnePow : ℤ) : R) • x i) := by
-      funext i
-      exact G.koszulTwist_apply_of_mem (hx i) q
-    have hsign :
-        (((q * ∑ i, degree i).negOnePow : ℤ) : R) =
-          ∏ i, (((q * degree i).negOnePow : ℤ) : R) := by
-      rw [Finset.sum_fin_eq_sum_range, Finset.prod_fin_eq_prod_range]
-      calc
-        (((q * ∑ i ∈ Finset.range n,
-            if h : i < n then degree ⟨i, h⟩ else 0).negOnePow : ℤ) : R) =
-            ∏ i ∈ Finset.range n,
-              (((q * (if h : i < n then degree ⟨i, h⟩ else 0)).negOnePow : ℤ) : R) :=
-          negOnePow_sum_range q (fun i ↦ if h : i < n then degree ⟨i, h⟩ else 0) n
-        _ = ∏ i ∈ Finset.range n,
-            if h : i < n then (((q * degree ⟨i, h⟩).negOnePow : ℤ) : R) else 1 := by
-          apply Finset.prod_congr rfl
-          intro i hi
-          simp [Finset.mem_range.mp hi]
-    rw [htuple, (PiTensorProduct.tprod R).map_smul_univ, map_smul, ← hD, ← hsign]
-  · intro u v _ _ hu hv
-    simp only [map_add, hu, hv, smul_add]
-  · intro a u _ hu
-    rw [map_smul, hu, smul_smul, smul_smul, mul_comm a]
-
-end ReducedTensorWords
-
 namespace LinearMap.IsHomogeneous
 
 open ReducedTensorWords
 
 variable {R : Type uR} {M : Type uM} [CommRing R] [AddCommMonoid M] [Module R M]
 
-/-- A homogeneous endomorphism of reduced tensor words commutes with the letterwise Koszul twist
-up to the sign contributed by its degree. -/
-theorem map_koszulTwist_comp {G : InternalGrading R M}
-    {b : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M} {r : ℤ}
-    (hb : LinearMap.IsHomogeneous b (gradedPiece G) (gradedPiece G) r) (q : ℤ) :
-    ReducedTensorWords.map (R := R) (G.koszulTwist q) ∘ₗ b =
-      ((((q * r).negOnePow : ℤ) : R) •
-        (b ∘ₗ ReducedTensorWords.map (R := R) (G.koszulTwist q))) := by
+/-- A homogeneous endomorphism of degree `r` anticommutes with the letterwise Koszul twist of
+parameter `q`, provided the sign `(-1)^(q * r)` it commutes past that twist with is `-1`. -/
+theorem anticommute_map_koszulTwist {G : InternalGrading R M}
+    {b : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M} {q r : ℤ}
+    (hb : LinearMap.IsHomogeneous b (gradedPiece G) (gradedPiece G) r)
+    (hqr : (((q * r).negOnePow : ℤ) : R) = -1) :
+    b ∘ₗ ReducedTensorWords.map (R := R) (G.koszulTwist q) +
+        ReducedTensorWords.map (R := R) (G.koszulTwist q) ∘ₗ b = 0 := by
+  have h := hb.map_koszulTwist_comp q
+  rw [hqr] at h
   apply LinearMap.ext
   intro z
-  have hz : z ∈ (⊤ : Submodule R (ReducedTensorWords R M)) := Submodule.mem_top
-  rw [← ReducedTensorWords.iSup_gradedPiece_eq_top G] at hz
-  simp only [LinearMap.comp_apply, LinearMap.smul_apply]
-  refine Submodule.iSup_induction (fun D : ℤ ↦ gradedPiece G D)
-    (motive := fun z ↦
-      ReducedTensorWords.map (R := R) (G.koszulTwist q) (b z) =
-        (((q * r).negOnePow : ℤ) : R) •
-          b (ReducedTensorWords.map (R := R) (G.koszulTwist q) z)) hz ?_ (by simp) ?_
-  · intro D x hx
-    rw [ReducedTensorWords.map_koszulTwist_apply_of_mem G (hb.map_mem hx) q,
-      ReducedTensorWords.map_koszulTwist_apply_of_mem G hx q, map_smul, smul_smul]
-    congr 1
-    rw [← Int.cast_mul, ← Units.val_mul, ← Int.negOnePow_add]
-    congr 2
-    ring_nf
-  · intro x y hx hy
-    simp only [map_add, hx, hy, smul_add]
+  have hz := LinearMap.congr_fun h z
+  simp only [LinearMap.comp_apply, LinearMap.smul_apply] at hz
+  simp only [LinearMap.add_apply, LinearMap.comp_apply, LinearMap.zero_apply]
+  -- reduced tensor words form only an `AddCommMonoid`, so the two terms cancel through the
+  -- scalar identity `1 + (-1) = 0` rather than through additive inverses
+  rw [hz]
+  module
 
 /-- A homogeneous endomorphism of degree one anticommutes with the letterwise Koszul twist of
 parameter one. -/
@@ -172,22 +79,8 @@ theorem anticommute_map_koszulTwist_one {G : InternalGrading R M}
     {b : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M}
     (hb : LinearMap.IsHomogeneous b (gradedPiece G) (gradedPiece G) 1) :
     b ∘ₗ ReducedTensorWords.map (R := R) (G.koszulTwist 1) +
-        ReducedTensorWords.map (R := R) (G.koszulTwist 1) ∘ₗ b = 0 := by
-  have h := hb.map_koszulTwist_comp 1
-  have hsign : ((((1 : ℤ) * 1).negOnePow : ℤ) : R) = -1 := by norm_num
-  rw [hsign] at h
-  apply LinearMap.ext
-  intro z
-  have hz := LinearMap.congr_fun h z
-  simp only [LinearMap.comp_apply, LinearMap.smul_apply] at hz
-  simp only [LinearMap.add_apply, LinearMap.comp_apply, LinearMap.zero_apply]
-  rw [hz]
-  let x := b (ReducedTensorWords.map (R := R) (G.koszulTwist 1) z)
-  change x + (-1 : R) • x = 0
-  calc
-    x + (-1 : R) • x = (1 : R) • x + (-1 : R) • x := by rw [one_smul]
-    _ = ((1 : R) + (-1 : R)) • x := (add_smul _ _ _).symm
-    _ = 0 := by simp
+        ReducedTensorWords.map (R := R) (G.koszulTwist 1) ∘ₗ b = 0 :=
+  hb.anticommute_map_koszulTwist (by norm_num)
 
 end LinearMap.IsHomogeneous
 
@@ -197,15 +90,26 @@ open ReducedTensorWords
 
 variable {R : Type uR} {M : Type uM} [CommRing R] [AddCommMonoid M] [Module R M]
 
-/-- The square of a homogeneous degree-one graded coderivation is an ordinary coderivation. The
-degree hypothesis supplies the anticommutation with the Koszul twist required for the two mixed
-terms in the co-Leibniz expansion to cancel. -/
+/-- The square of a homogeneous graded coderivation is an ordinary coderivation as soon as the
+sign `(-1)^(q * r)` of its degree `r` against the twist parameter `q` is `-1`: homogeneity then
+supplies the anticommutation with the Koszul twist that cancels the two mixed terms in the
+co-Leibniz expansion. A caller holding homogeneity of the letter component instead obtains
+`hhom` from `TauCeti.ReducedTensorWords.IsGradedCoderivation.isHomogeneous`. -/
 theorem isCoderivation_comp_self_of_isHomogeneous {G : InternalGrading R M}
+    {b : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M} {q r : ℤ}
+    (hb : IsGradedCoderivation G q b)
+    (hhom : LinearMap.IsHomogeneous b (gradedPiece G) (gradedPiece G) r)
+    (hqr : (((q * r).negOnePow : ℤ) : R) = -1) :
+    IsCoderivation R (b ∘ₗ b) :=
+  hb.isCoderivation_comp_self (hhom.anticommute_map_koszulTwist hqr)
+
+/-- The square of a homogeneous degree-one graded coderivation is an ordinary coderivation. -/
+theorem isCoderivation_comp_self_of_isHomogeneous_one {G : InternalGrading R M}
     {b : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M}
     (hb : IsGradedCoderivation G 1 b)
     (hhom : LinearMap.IsHomogeneous b (gradedPiece G) (gradedPiece G) 1) :
     IsCoderivation R (b ∘ₗ b) :=
-  hb.isCoderivation_comp_self hhom.anticommute_map_koszulTwist_one
+  hb.isCoderivation_comp_self_of_isHomogeneous hhom (by norm_num)
 
 end ReducedTensorWords.IsGradedCoderivation
 


### PR DESCRIPTION
This PR derives the intrinsic oddness relation for homogeneous degree-one endomorphisms of reduced tensor words and uses it to prove that the square of a homogeneous degree-one graded coderivation is an ordinary coderivation.

The proof adds the general internal-grading identity that a degree-`r` homogeneous linear map commutes with a parameter-`q` Koszul twist up to `(-1)^(qr)`. It then proves that total-degree pieces span the reduced tensor coalgebra, computes the letterwise twist on each piece, and specializes the resulting operator identity to degree one. The square theorem discharges the extra anticommutation premise of the existing coderivation-square API directly from homogeneity.

For the DGAInfinity Layer 0 target “Implement the suspension/unsuspension equivalence fixed above. Prove the general Stasheff component formula and the arity `1`–`4` equations verbatim,” this supplies the missing degree-one sign bridge consumed by the designated “arity `1`–`4` sign audit” milestone identifying those equations with the tensor-length components of `b² = 0`. After this PR, that milestone still needs the existing square-component and Stasheff formulas assembled into the map-level and evaluated arity `1`–`4` equivalences.

Roadmap: DGAInfinity

<!--tauceti-target:v1 {"focus":"DGAInfinity","id":"homogeneous-coderivation-oddness"}-->

🤖 Prepared with Codex
