### PR TITLE
feat: the dimension formula of Clifford's theorem

### DIFF
--- a/TauCeti/RepresentationTheory/Induction/Clifford/Dimension.lean
+++ b/TauCeti/RepresentationTheory/Induction/Clifford/Dimension.lean
@@ -1,0 +1,147 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.RepresentationTheory.Induction.Clifford.Decomposition
+
+/-!
+# The dimension formula of Clifford's theorem
+
+Let `N` be a normal subgroup of a finite group `G` and let `W` be an irreducible representation of
+`G` over an algebraically closed field of characteristic zero.  Clifford's theorem describes the
+restriction of `W` to `N`: its irreducible constituents form a single `G`-orbit, indexed by the
+left cosets of the inertia group of any one of them, and they all occur with one common positive
+multiplicity `e`.  Counting dimensions in that description gives
+
+`dim W = e · [G : inertia V] · dim V`
+
+for an irreducible constituent `V` of `Res_N W`.  This file proves that identity and reads off the
+two divisibilities it contains: both the index of the inertia group of a constituent and the
+dimension of the constituent divide the dimension of `W`.  The index of the inertia group also
+divides `[G : N]`, since the inertia group contains `N`, so the count of distinct conjugates is
+constrained from both sides.
+
+The proof is the character form of Clifford's theorem
+(`TauCeti.clifford_restrict_character`) evaluated at the identity.  There the restriction character
+is exhibited as `e` times the sum of the characters of the conjugates `{}^g V` over a left
+transversal `reps` of `inertia V`, so at the identity the left-hand side is `dim W` and each of the
+`reps.card` summands on the right is `dim V`, a conjugate having the same dimension.  Two small
+steps finish it: the transversal has `[G : inertia V]` elements, because a finite set meeting every
+left coset of a subgroup exactly once is a complement of it in the sense of
+`Subgroup.IsComplement`; and the resulting identity in `k` is an identity of natural
+numbers, because `k` has characteristic zero.
+
+Characteristic zero is used only for that last cast.  The character identity itself needs no more
+than Maschke's condition `IsUnit (Nat.card G : k)`, but in characteristic `p` the identity in `k`
+determines the dimensions only modulo `p`, so the natural-number equation below would not follow.
+
+## Main statements
+
+* `TauCeti.clifford_finrank`: **Clifford's dimension formula**,
+  `dim W = e · [G : inertia V] · dim V` for a simple constituent `V` of the restriction and its
+  multiplicity `e`.
+* `TauCeti.clifford_dvd_finrank`: the divisibilities it contains, `[G : inertia V] ∣ dim W` and
+  `dim V ∣ dim W`, together with `[G : inertia V] ∣ [G : N]`.
+* `TauCeti.clifford_inertia_eq_top_of_finrank_eq_one`: a one-dimensional representation of `G`
+  restricts to a one-dimensional representation of `N` whose inertia group is all of `G`.
+
+## References
+
+This is the numerical half of the **Clifford's theorem** milestone of Layer 5 of
+`TauCetiRoadmap/RepresentationTheory/InductionRestriction/README.md`, which asks for the
+consequence that "`t = [G : inertia V]` divides `finrank W / (e · finrank V)`".  The packaged
+decomposition `Res_N W ≅ e · ⨁ᵢ {}^{gᵢ} V` as an isomorphism of representations is a separate
+target and is not proved here.
+
+* I. M. Isaacs, *Character Theory of Finite Groups*, Theorem 6.2 and its corollaries.
+* C. W. Curtis and I. Reiner, *Representation Theory of Finite Groups and Associative Algebras*,
+  §49.
+-/
+
+public section
+
+open CategoryTheory
+
+universe u v
+
+namespace TauCeti
+
+variable {k : Type u} {G : Type v} [Field k] [Group G] {N : Subgroup G} [N.Normal]
+
+/-- A finite set meeting every left coset of `H` exactly once has `H.index` elements.  This is
+`Subgroup.IsComplement.card_left` read for the transversal condition in the form
+`TauCeti.clifford_restrict_character` states it, `∃! r ∈ reps, g⁻¹ * r ∈ H`; the inversion is
+harmless because `H` is closed under inverses. -/
+private theorem card_eq_index_of_forall_existsUnique {H : Subgroup G} {reps : Finset G}
+    (h : ∀ g : G, ∃! r, r ∈ reps ∧ g⁻¹ * r ∈ H) : reps.card = H.index := by
+  have hcompl : Subgroup.IsComplement (reps : Set G) (H : Set G) := by
+    refine Subgroup.isComplement_iff_existsUnique_inv_mul_mem.mpr fun g => ?_
+    obtain ⟨r, ⟨hr, hrH⟩, huniq⟩ := h g
+    refine ⟨⟨r, hr⟩, ?_, ?_⟩
+    · simpa using (Subgroup.inv_mem_iff H).mpr hrH
+    · rintro ⟨s, hs⟩ hsH
+      have : s = r := huniq s ⟨hs, by simpa using (Subgroup.inv_mem_iff H).mpr hsH⟩
+      exact Subtype.ext this
+  simpa using hcompl.card_left
+
+/-- **Clifford's dimension formula.**  The dimension of an irreducible representation `W` of a
+finite group `G` is the product of the common multiplicity `e` of the irreducible constituents of
+`Res_N W`, the index of the inertia group of one such constituent `V`, and the dimension of `V`.
+
+The three factors are exactly the three pieces of Clifford's theorem: `e` is the multiplicity, the
+index counts the distinct conjugates `{}^g V` occurring, and `dim V` is the size of each. -/
+theorem clifford_finrank [Finite G] [IsAlgClosed k] [CharZero k] (W : FDRep k G) [Simple W] :
+    ∃ (V : FDRep k N) (_ : Simple V) (e : ℕ), e ≠ 0 ∧
+      Module.finrank k W = e * (inertia V).index * Module.finrank k V := by
+  have hG : IsUnit (Nat.card G : k) :=
+    isUnit_iff_ne_zero.mpr (Nat.cast_ne_zero.mpr Nat.card_pos.ne')
+  obtain ⟨V, hV, e, reps, he, htrans, hchar⟩ := clifford_restrict_character (N := N) hG W
+  refine ⟨V, hV, e, he, ?_⟩
+  have hconj : ∀ g : G, (conjNormalFDRep g V).character (1 : N) = (Module.finrank k V : k) := by
+    intro g
+    rw [char_conjNormalFDRep, map_one, FDRep.char_one]
+  have h1 := hchar 1
+  rw [OneMemClass.coe_one, FDRep.char_one] at h1
+  simp only [hconj, Finset.sum_const, nsmul_eq_mul,
+    card_eq_index_of_forall_existsUnique htrans] at h1
+  have hcast : ((Module.finrank k W : ℕ) : k) =
+      ((e * (inertia V).index * Module.finrank k V : ℕ) : k) := by
+    rw [h1]
+    push_cast
+    ring
+  exact Nat.cast_injective hcast
+
+/-- **The divisibilities in Clifford's theorem.**  For an irreducible constituent `V` of the
+restriction of an irreducible `W` to a normal subgroup, both the index of the inertia group of `V`
+and the dimension of `V` divide the dimension of `W`; the index divides `[G : N]` as well.
+
+This is the form in which the dimension formula is used.  The number of distinct conjugates
+occurring in the restriction is `[G : inertia V]`, and it is constrained from two sides at once:
+by the degree of `W`, through the dimension formula, and by the index of `N`, through
+`TauCeti.inertia_index_dvd_index`.  Neither constraint mentions the multiplicity `e`. -/
+theorem clifford_dvd_finrank [Finite G] [IsAlgClosed k] [CharZero k] (W : FDRep k G) [Simple W] :
+    ∃ (V : FDRep k N) (_ : Simple V),
+      (inertia V).index ∣ Module.finrank k W ∧ Module.finrank k V ∣ Module.finrank k W ∧
+        (inertia V).index ∣ N.index := by
+  obtain ⟨V, hV, e, -, hEq⟩ := clifford_finrank (N := N) W
+  exact ⟨V, hV, ⟨e * Module.finrank k V, by rw [hEq]; ring⟩,
+    ⟨e * (inertia V).index, by rw [hEq]; ring⟩, inertia_index_dvd_index V⟩
+
+/-- **A linear character restricts to an invariant linear character.**  If `W` is one-dimensional,
+then an irreducible constituent of its restriction to a normal subgroup is one-dimensional and is
+fixed by the conjugation action of the whole group, its inertia group being all of `G`.
+
+The right-hand side of the dimension formula is a product of natural numbers, so its being `1`
+forces each of the three factors to be `1`. -/
+theorem clifford_inertia_eq_top_of_finrank_eq_one [Finite G] [IsAlgClosed k] [CharZero k]
+    (W : FDRep k G) [Simple W] (hW : Module.finrank k W = 1) :
+    ∃ (V : FDRep k N) (_ : Simple V), inertia V = ⊤ ∧ Module.finrank k V = 1 := by
+  obtain ⟨V, hV, e, -, hEq⟩ := clifford_finrank (N := N) W
+  rw [hW] at hEq
+  obtain ⟨hleft, hright⟩ := mul_eq_one.mp hEq.symm
+  exact ⟨V, hV, Subgroup.index_eq_one.mp (mul_eq_one.mp hleft).2, hright⟩
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Induction/Inertia.lean
+++ b/TauCeti/RepresentationTheory/Induction/Inertia.lean
@@ -43,7 +43,8 @@ theorem identifies the constituents of a restriction with a single `G`-orbit.
 
 * `TauCeti.mem_inertia_iff`: membership in the inertia group is the existence of an isomorphism
   `{}^g A ≅ A`.
-* `TauCeti.le_inertia`: the inertia group contains `N`.
+* `TauCeti.le_inertia`: the inertia group contains `N`, so its index divides `[G : N]`
+  (`TauCeti.inertia_index_dvd_index`).
 * `TauCeti.inertia_congr`: isomorphic representations have the same inertia group, so the inertia
   group is an invariant of the isomorphism class.
 * `TauCeti.inertia_conjNormalFDRep`: conjugating the representation conjugates its inertia group.
@@ -99,6 +100,12 @@ theorem stabilizer_le_inertia (A : FDRep k N) :
 inner twist, so it fixes the isomorphism class. -/
 theorem le_inertia (A : FDRep k N) : N ≤ inertia A :=
   fun n hn => mem_inertia_iff.2 ⟨conjNormalFDRepIso A ⟨n, hn⟩⟩
+
+/-- **The index of the inertia group divides the index of `N`.**  The inertia group lies between
+`N` and `G`, so the number of its cosets, which is the number of distinct conjugates `{}^g A` in
+Clifford's theorem, divides `[G : N]`. -/
+theorem inertia_index_dvd_index (A : FDRep k N) : (inertia A).index ∣ N.index :=
+  Subgroup.index_dvd_of_le (le_inertia A)
 
 /-- Isomorphic representations have the same inertia group: the inertia group depends only on the
 isomorphism class of `A`, which — once `A` is irreducible — is a point of `Irr(N)`. -/


### PR DESCRIPTION
This PR reads off the divisibilities in Clifford's dimension formula.

When this branch was opened, `TauCeti/RepresentationTheory/Induction/Clifford/Dimension.lean` did not exist and this PR created it, proving `dim W = e · [G : inertia V] · dim V` from the character form of Clifford's theorem evaluated at the identity. In the meantime `main` landed its own `Dimension.lean` at the same path, deriving that same identity — as `FDRep.clifford_restrict_finrank` — from the packaged isomorphism `Res_N W ≅ V.cliffordSum e` instead, with strictly weaker hypotheses: no `[Finite G]` and no `[CharZero k]`, and with the decomposition returned alongside the identity. That version supersedes the one this PR wrote, so the merge keeps `main`'s theorem and its proof and drops this PR's duplicate (together with its private transversal-counting helper, which only the discarded proof used).

What survives, and is what this PR now contributes, are the two corollaries `main` does not state, both re-proved on top of `FDRep.clifford_restrict_finrank` and therefore also free of the `[Finite G]` and `[CharZero k]` hypotheses they originally carried:

* `FDRep.clifford_restrict_dvd_finrank` packages the divisibilities the identity contains — `[G : inertia V] ∣ dim W` and `dim V ∣ dim W`, together with `[G : inertia V] ∣ [G : N]` and the roadmap's own form of the count, `[G : inertia V] ∣ dim W / (e * dim V)`, with the multiplicity divided out. This is the roadmap's stated numerical consequence, "`t = [G : inertia V]` divides `finrank W / (e · finrank V)`": the number of distinct conjugates occurring in the restriction is constrained from two sides at once, by the degree of `W` and by the index of `N`, and neither constraint mentions the multiplicity `e` — which the quotient divisibility divides out. `main` derives the first and third of these inline inside `clifford_restrict_inertia_eq_top_of_coprime`; nothing names them, and nothing states the quotient form.  Like `clifford_restrict_finrank`, it returns the decomposition `Res_N W ≅ V.cliffordSum e` alongside, so that `V` is exhibited as a constituent of the restriction rather than merely named by the existential.
* `FDRep.clifford_restrict_inertia_eq_top_of_finrank_eq_one` records the degenerate case: a one-dimensional representation of `G` restricts to a one-dimensional representation of `N` that the whole group fixes. The right-hand side of the identity is a product of natural numbers, so its being `1` forces each of the three factors to be `1` — the multiplicity included, so the decomposition it returns takes the sharper form `Res_N W ≅ V.cliffordSum 1`.

An earlier revision of this PR also added a lemma `TauCeti.inertia_index_dvd_index` to `TauCeti/RepresentationTheory/Induction/Inertia.lean`. The reuse review was right that it only restated `Subgroup.index_dvd_of_le (le_inertia A)`, so it has been dropped and both call sites use the Mathlib lemma directly; `Inertia.lean` is now byte-identical to `main` and this PR touches `Dimension.lean` alone.

The new declarations are placed in `namespace FDRep` alongside `main`'s, under the `clifford_restrict_` prefix the file already uses, and the module docstring is extended to cover them. Nothing was renamed, moved or removed beyond the superseded duplicate described above.

The exact roadmap target is the "Clifford's theorem" milestone of Layer 5 (Clifford theory over a normal subgroup) of `TauCetiRoadmap/RepresentationTheory/InductionRestriction/README.md`, whose statement ends "In particular `t = [G : inertia V]` divides `finrank W / (e · finrank V)`". The mathematics is the classical argument of I. M. Isaacs, *Character Theory of Finite Groups*, Theorem 6.2, and C. W. Curtis and I. Reiner, *Representation Theory of Finite Groups and Associative Algebras*, §49, both cited in the file.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"clifford-finrank"}-->

🤖 Prepared with Claude Code


