### PR TITLE
refactor(ArithmeticDirichletSeries): decompose the two-sided ideal count

### DIFF
--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/Estimates.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/Estimates.lean
@@ -136,13 +136,20 @@ structure IdealCountingLinearBounds where
   card_le (x : ℝ) (hx : 1 ≤ x) :
     (Nat.card {I : (Ideal (𝓞 K))⁰ // (Ideal.absNorm (I : Ideal (𝓞 K)) : ℝ) ≤ x} : ℝ) ≤ upper * x
 
-/-- **Two-sided linear ideal counts.** The number of nonzero integral ideals of absolute norm at
-most `x` is bounded above and below by positive multiples of `x`, for every cutoff `x ≥ 1`.
+/-- **Beyond a threshold the count already lies between two multiples of `x`.**  Mathlib's
+asymptotic `NumberField.Ideal.tendsto_norm_le_div_atTop₀` says the ratio tends to the residue `r`,
+which `NumberField.dedekindZeta_residue_pos` makes positive; taking `r / 2` and `r + 1` as strict
+bounds on the limit turns that into an eventual two-sided estimate, and `1 ≤ X` is folded in so the
+threshold is usable as a cutoff.
 
-Both constants come from Mathlib's asymptotic `NumberField.Ideal.tendsto_norm_le_div_atTop₀`,
-whose limit is positive by `NumberField.dedekindZeta_residue_pos`; below the threshold produced by
-that limit the bounds are secured by the unit ideal and by monotonicity of the count. -/
-theorem idealCount_linearBounds : Nonempty (IdealCountingLinearBounds K) := by
+The constants are not optimal and are not meant to be: what matters downstream is only that some
+positive multiples of `x` sandwich the count. -/
+private theorem exists_le_card_and_card_le_of_le :
+    ∃ X : ℝ, 1 ≤ X ∧ ∀ x : ℝ, X ≤ x →
+      NumberField.dedekindZeta_residue K / 2 * x ≤
+          Nat.card {I : (Ideal (𝓞 K))⁰ // (Ideal.absNorm (I : Ideal (𝓞 K)) : ℝ) ≤ x} ∧
+        (Nat.card {I : (Ideal (𝓞 K))⁰ // (Ideal.absNorm (I : Ideal (𝓞 K)) : ℝ) ≤ x} : ℝ) ≤
+          (NumberField.dedekindZeta_residue K + 1) * x := by
   set r : ℝ := NumberField.dedekindZeta_residue K with hr
   have hpos : 0 < r := NumberField.dedekindZeta_residue_pos K
   have htend : Tendsto (fun x : ℝ ↦
@@ -153,19 +160,34 @@ theorem idealCount_linearBounds : Nonempty (IdealCountingLinearBounds K) := by
   obtain ⟨X₀, hX₀⟩ := eventually_atTop.mp
     (((htend.eventually_const_lt (by linarith : r / 2 < r)).and
       (htend.eventually_lt_const (by linarith : r < r + 1))).and (eventually_ge_atTop (1 : ℝ)))
-  set X : ℝ := max X₀ 1
-  have hX1 : 1 ≤ X := le_max_right _ _
+  refine ⟨max X₀ 1, le_max_right _ _, fun x hx ↦ ?_⟩
+  obtain ⟨⟨h₁, h₂⟩, h₃⟩ := hX₀ x ((le_max_left X₀ 1).trans hx)
+  have hxpos : 0 < x := lt_of_lt_of_le zero_lt_one h₃
+  exact ⟨(le_div_iff₀ hxpos).mp h₁.le, (div_le_iff₀ hxpos).mp h₂.le⟩
+
+/-- **Below the threshold the unit ideal alone carries the lower bound.**  For `1 ≤ x ≤ X` the
+multiple `X⁻¹ * x` is at most `1`, and the count is at least `1` because the unit ideal is always
+counted.  No asymptotic input is needed here. -/
+private theorem inv_mul_le_card_of_le_of_le {X x : ℝ} (hXpos : 0 < X) (hx : 1 ≤ x) (hxX : x ≤ X) :
+    X⁻¹ * x ≤ Nat.card {I : (Ideal (𝓞 K))⁰ // (Ideal.absNorm (I : Ideal (𝓞 K)) : ℝ) ≤ x} := by
+  have h1 : X⁻¹ * x ≤ 1 :=
+    calc X⁻¹ * x ≤ X⁻¹ * X := mul_le_mul_of_nonneg_left hxX (inv_nonneg.mpr hXpos.le)
+      _ = 1 := inv_mul_cancel₀ hXpos.ne'
+  exact le_trans h1 (by exact_mod_cast one_le_card_absNorm_real_le K hx)
+
+/-- **Two-sided linear ideal counts.** The number of nonzero integral ideals of absolute norm at
+most `x` is bounded above and below by positive multiples of `x`, for every cutoff `x ≥ 1`.
+
+Both constants come from Mathlib's asymptotic `NumberField.Ideal.tendsto_norm_le_div_atTop₀`,
+whose limit is positive by `NumberField.dedekindZeta_residue_pos`; below the threshold produced by
+that limit the bounds are secured by the unit ideal and by monotonicity of the count. -/
+theorem idealCount_linearBounds : Nonempty (IdealCountingLinearBounds K) := by
+  set r : ℝ := NumberField.dedekindZeta_residue K
+  have hpos : 0 < r := NumberField.dedekindZeta_residue_pos K
+  obtain ⟨X, hX1, hmain⟩ := exists_le_card_and_card_le_of_le K
   have hXpos : 0 < X := lt_of_lt_of_le zero_lt_one hX1
   set M : ℝ :=
     (Nat.card {I : (Ideal (𝓞 K))⁰ // (Ideal.absNorm (I : Ideal (𝓞 K)) : ℝ) ≤ X} : ℝ) with hM
-  have hmain : ∀ x : ℝ, X ≤ x →
-      r / 2 * x ≤ Nat.card {I : (Ideal (𝓞 K))⁰ // (Ideal.absNorm (I : Ideal (𝓞 K)) : ℝ) ≤ x} ∧
-      (Nat.card {I : (Ideal (𝓞 K))⁰ // (Ideal.absNorm (I : Ideal (𝓞 K)) : ℝ) ≤ x} : ℝ) ≤
-        (r + 1) * x := by
-    intro x hx
-    obtain ⟨⟨h₁, h₂⟩, h₃⟩ := hX₀ x ((le_max_left X₀ 1).trans hx)
-    have hxpos : 0 < x := lt_of_lt_of_le zero_lt_one h₃
-    exact ⟨(le_div_iff₀ hxpos).mp h₁.le, (div_le_iff₀ hxpos).mp h₂.le⟩
   have hupos : (0 : ℝ) < max (r + 1) M := lt_of_lt_of_le (by linarith) (le_max_left _ _)
   refine ⟨{
     lower := min (r / 2) X⁻¹
@@ -178,11 +200,8 @@ theorem idealCount_linearBounds : Nonempty (IdealCountingLinearBounds K) := by
     have hxpos : 0 < x := lt_of_lt_of_le zero_lt_one hx
     rcases le_or_gt X x with hxX | hxX
     · exact le_trans (mul_le_mul_of_nonneg_right (min_le_left _ _) hxpos.le) (hmain x hxX).1
-    · refine le_trans (mul_le_mul_of_nonneg_right (min_le_right _ _) hxpos.le) ?_
-      have h1 : X⁻¹ * x ≤ 1 :=
-        calc X⁻¹ * x ≤ X⁻¹ * X := mul_le_mul_of_nonneg_left hxX.le (inv_nonneg.mpr hXpos.le)
-          _ = 1 := inv_mul_cancel₀ hXpos.ne'
-      exact le_trans h1 (by exact_mod_cast one_le_card_absNorm_real_le K hx)
+    · exact le_trans (mul_le_mul_of_nonneg_right (min_le_right _ _) hxpos.le)
+        (inv_mul_le_card_of_le_of_le K hXpos hx hxX.le)
   · intro x hx
     have hxpos : 0 < x := lt_of_lt_of_le zero_lt_one hx
     rcases le_or_gt X x with hxX | hxX

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/Estimates.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/Estimates.lean
@@ -167,12 +167,13 @@ private theorem exists_le_card_and_card_le_of_le :
 
 /-- **Below the threshold the unit ideal alone carries the lower bound.**  For `1 ≤ x ≤ X` the
 multiple `X⁻¹ * x` is at most `1`, and the count is at least `1` because the unit ideal is always
-counted.  No asymptotic input is needed here. -/
-private theorem inv_mul_le_card_of_le_of_le {X x : ℝ} (hXpos : 0 < X) (hx : 1 ≤ x) (hxX : x ≤ X) :
+counted.  No asymptotic input is needed here, and no positivity hypothesis either: `1 ≤ x ≤ X`
+already puts `X` above `1`. -/
+private theorem inv_mul_le_card_of_le_of_le {X x : ℝ} (hx : 1 ≤ x) (hxX : x ≤ X) :
     X⁻¹ * x ≤ Nat.card {I : (Ideal (𝓞 K))⁰ // (Ideal.absNorm (I : Ideal (𝓞 K)) : ℝ) ≤ x} := by
-  have h1 : X⁻¹ * x ≤ 1 :=
-    calc X⁻¹ * x ≤ X⁻¹ * X := mul_le_mul_of_nonneg_left hxX (inv_nonneg.mpr hXpos.le)
-      _ = 1 := inv_mul_cancel₀ hXpos.ne'
+  have hXpos : 0 < X := zero_lt_one.trans_le (hx.trans hxX)
+  have h1 : X⁻¹ * x ≤ 1 := by
+    simpa [div_eq_mul_inv, mul_comm] using (div_le_one hXpos).2 hxX
   exact le_trans h1 (by exact_mod_cast one_le_card_absNorm_real_le K hx)
 
 /-- **Two-sided linear ideal counts.** The number of nonzero integral ideals of absolute norm at
@@ -201,7 +202,7 @@ theorem idealCount_linearBounds : Nonempty (IdealCountingLinearBounds K) := by
     rcases le_or_gt X x with hxX | hxX
     · exact le_trans (mul_le_mul_of_nonneg_right (min_le_left _ _) hxpos.le) (hmain x hxX).1
     · exact le_trans (mul_le_mul_of_nonneg_right (min_le_right _ _) hxpos.le)
-        (inv_mul_le_card_of_le_of_le K hXpos hx hxX.le)
+        (inv_mul_le_card_of_le_of_le K hx hxX.le)
   · intro x hx
     have hxpos : 0 < x := lt_of_lt_of_le zero_lt_one hx
     rcases le_or_gt X x with hxX | hxX

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/Estimates.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/Estimates.lean
@@ -136,14 +136,12 @@ structure IdealCountingLinearBounds where
   card_le (x : ℝ) (hx : 1 ≤ x) :
     (Nat.card {I : (Ideal (𝓞 K))⁰ // (Ideal.absNorm (I : Ideal (𝓞 K)) : ℝ) ≤ x} : ℝ) ≤ upper * x
 
-/-- **Beyond a threshold the count already lies between two multiples of `x`.**  Mathlib's
-asymptotic `NumberField.Ideal.tendsto_norm_le_div_atTop₀` says the ratio tends to the residue `r`,
-which `NumberField.dedekindZeta_residue_pos` makes positive; taking `r / 2` and `r + 1` as strict
-bounds on the limit turns that into an eventual two-sided estimate, and `1 ≤ X` is folded in so the
-threshold is usable as a cutoff.
+/-- **Beyond a threshold the count lies between two multiples of `x`.**  There is a cutoff
+`X ≥ 1` such that every `x ≥ X` has at least `r / 2 * x` and at most `(r + 1) * x` nonzero integral
+ideals of absolute norm at most `x`, where `r` is `NumberField.dedekindZeta_residue K`.
 
-The constants are not optimal and are not meant to be: what matters downstream is only that some
-positive multiples of `x` sandwich the count. -/
+The constants are not optimal and are not meant to be: `idealCount_linearBounds` needs only that
+some positive multiples of `x` sandwich the count above the cutoff. -/
 private theorem exists_le_card_and_card_le_of_le :
     ∃ X : ℝ, 1 ≤ X ∧ ∀ x : ℝ, X ≤ x →
       NumberField.dedekindZeta_residue K / 2 * x ≤
@@ -165,16 +163,14 @@ private theorem exists_le_card_and_card_le_of_le :
   have hxpos : 0 < x := lt_of_lt_of_le zero_lt_one h₃
   exact ⟨(le_div_iff₀ hxpos).mp h₁.le, (div_le_iff₀ hxpos).mp h₂.le⟩
 
-/-- **Below the threshold the unit ideal alone carries the lower bound.**  For `1 ≤ x ≤ X` the
-multiple `X⁻¹ * x` is at most `1`, and the count is at least `1` because the unit ideal is always
-counted.  No asymptotic input is needed here, and no positivity hypothesis either: `1 ≤ x ≤ X`
-already puts `X` above `1`. -/
+/-- **Below the threshold, `X⁻¹` serves as the lower constant.**  For `1 ≤ x ≤ X` there are at
+least `X⁻¹ * x` nonzero integral ideals of absolute norm at most `x`.  This is the half of
+`idealCount_linearBounds`'s lower bound that the asymptotic does not reach, and it asks for nothing
+beyond `1 ≤ x ≤ X`. -/
 private theorem inv_mul_le_card_of_le_of_le {X x : ℝ} (hx : 1 ≤ x) (hxX : x ≤ X) :
-    X⁻¹ * x ≤ Nat.card {I : (Ideal (𝓞 K))⁰ // (Ideal.absNorm (I : Ideal (𝓞 K)) : ℝ) ≤ x} := by
-  have hXpos : 0 < X := zero_lt_one.trans_le (hx.trans hxX)
-  have h1 : X⁻¹ * x ≤ 1 := by
-    simpa [div_eq_mul_inv, mul_comm] using (div_le_one hXpos).2 hxX
-  exact le_trans h1 (by exact_mod_cast one_le_card_absNorm_real_le K hx)
+    X⁻¹ * x ≤ Nat.card {I : (Ideal (𝓞 K))⁰ // (Ideal.absNorm (I : Ideal (𝓞 K)) : ℝ) ≤ x} :=
+  le_trans (inv_mul_le_one_of_le₀ hxX (zero_le_one.trans (hx.trans hxX)))
+    (by exact_mod_cast one_le_card_absNorm_real_le K hx)
 
 /-- **Two-sided linear ideal counts.** The number of nonzero integral ideals of absolute norm at
 most `x` is bounded above and below by positive multiples of `x`, for every cutoff `x ≥ 1`.


### PR DESCRIPTION
`idealCount_linearBounds` — the two-sided linear bound on the number of nonzero integral ideals of
norm at most `x` — ran to 52 lines, mixing the asymptotic input with the assembly of the bounds
package. Two private helpers bring it to 25. The statement is unchanged.

### What came out

* **`exists_le_card_and_card_le_of_le`** — beyond some threshold `X ≥ 1` the count already lies
  between `r / 2 * x` and `(r + 1) * x`. This is the whole of the Mathlib input in one place:
  `NumberField.Ideal.tendsto_norm_le_div_atTop₀`, its limit made positive by
  `NumberField.dedekindZeta_residue_pos`, and the eventual-filter argument that turns a limit into
  an estimate. `1 ≤ X` is folded into the threshold so the caller has one hypothesis, not two.
* **`inv_mul_le_card_of_le_of_le`** — below the threshold the unit ideal alone carries the lower
  bound: `X⁻¹ * x ≤ 1` there, and the count is at least one. It takes **no asymptotic input**,
  which is the point — this half of the argument never needed one, and inlining it next to the
  filter reasoning obscured that. Round 1's `generality` finding then observed it needs no
  positivity hypothesis either, since `1 ≤ x ≤ X` already puts `X` above `1` — the extraction had
  carried `0 < X` out of the enclosing scope without asking whether the new signature earned it.

What remains in the theorem is exactly the assembly: take `min (r / 2) X⁻¹` and `max (r + 1) M`,
then split each of the two fields at the threshold.

### One dead hypothesis removed

With the asymptotic gone into the helper, `set r … with hr` no longer had a use for `hr`; nothing
referenced it. It is now a plain `set`. Neither the build nor `linter.unusedVariables` reports a
`set`-introduced equation that has gone unused, so this is the kind of leftover that only a reading
finds.

### Verification

`Estimates` and its consumer `AbelSummation` both build; `runLinter` clean; maximum line width 99
codepoints. Both helpers are `private`, so the public API and the module docstring are untouched.

Roadmap: ArithmeticDirichletSeries

Provenance: none — this is a refactor of code already on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011dmwkBnj4rJc75STgbwsLF


