### PR TITLE
feat(SpecialLinearGroup): make reduction functorial, and use it for Γ antitonicity

### DIFF
--- a/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Basic.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Basic.lean
@@ -16,7 +16,10 @@ import TauCeti.Data.ZMod.Units
 
 The natural reduction map `SL₂(ℤ) → SL₂(ℤ/dℤ)` is surjective (strong approximation for
 `SL₂`; Shimura §1.6, Serre Ch. VII), and the base-change map `SL(n, R) → GL(n, S)` sends
-`-I` to `-I`. Basic coordinate descriptions for `SL₂` and its image under `mapGL` are also
+`-I` to `-I`. Base change is functorial: `SL(n, -)` carries a composite of ring homs to the
+composite of the induced group homs, and the identity to the identity, which is what lets a
+congruence on a whole matrix be reduced along a further ring map in one step rather than entry
+by entry. Basic coordinate descriptions for `SL₂` and its image under `mapGL` are also
 recorded here for downstream matrix computations, together with what the determinant says about
 a matrix with a prescribed bottom row `(N, p)`: it is the Bézout relation `m p - n N = 1`.
 
@@ -36,6 +39,9 @@ diamond operators of the ModularForms roadmap (Layer 0), where it realizes every
 ## Main results
 
 * `Matrix.SpecialLinearGroup.map_intCast_zmod_surjective`: strong approximation for `SL₂`.
+* `Matrix.SpecialLinearGroup.map_comp` and `Matrix.SpecialLinearGroup.map_id`: the two functor
+  laws for base change, which support whole-matrix reduction arguments such as the level
+  antitonicity of the principal congruence subgroups.
 * `Matrix.SpecialLinearGroup.mapGL_neg_one`: `mapGL S (-1) = -1`.
 * `Matrix.SpecialLinearGroup.fin_two_mul_sub_mul_eq_one`: the determinant-one identity in
   coordinates.
@@ -74,8 +80,16 @@ variable {d : ℕ}
 
 namespace Matrix.SpecialLinearGroup
 
-/-- **Functoriality of the induced map on special linear groups.** Reducing along `f` and then
-along `g` is reducing along `g ∘ f`. -/
+/-- **Functoriality of the induced map on special linear groups, identity law.** Base change
+along the identity ring hom is the identity. -/
+@[simp]
+theorem map_id {R : Type*} [CommRing R] {n : Type*} [Fintype n] [DecidableEq n] :
+    map (n := n) (RingHom.id R) = MonoidHom.id (SpecialLinearGroup n R) := rfl
+
+/-- **Functoriality of the induced map on special linear groups, composition law.** Base change
+along `f` and then along `g` is base change along `g ∘ f`, so a composite of induced maps is
+again a single induced map. -/
+@[simp]
 theorem map_comp {R S T : Type*} [CommRing R] [CommRing S] [CommRing T] {n : Type*} [Fintype n]
     [DecidableEq n] (f : R →+* S) (g : S →+* T) :
     (map (n := n) g).comp (map f) = map (g.comp f) := rfl

--- a/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Basic.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Basic.lean
@@ -74,6 +74,12 @@ variable {d : ℕ}
 
 namespace Matrix.SpecialLinearGroup
 
+/-- **Functoriality of the induced map on special linear groups.** Reducing along `f` and then
+along `g` is reducing along `g ∘ f`. -/
+theorem map_comp {R S T : Type*} [CommRing R] [CommRing S] [CommRing T] {n : Type*} [Fintype n]
+    [DecidableEq n] (f : R →+* S) (g : S →+* T) :
+    (map (n := n) g).comp (map f) = map (g.comp f) := rfl
+
 /-- The determinant-one identity for an element of `SL₂(R)`, written in coordinates. -/
 lemma fin_two_mul_sub_mul_eq_one {R : Type*} [CommRing R] (g : SL(2, R)) :
     g 0 0 * g 1 1 - g 0 1 * g 1 0 = 1 := by

--- a/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups/Basic.lean
@@ -112,8 +112,11 @@ theorem Gamma1_le_Gamma1_of_dvd {M N : ℕ} (h : M ∣ N) : Gamma1 N ≤ Gamma1 
     by simpa [map_intCast, map_one, map_zero] using congr_arg (ZMod.castHom h (ZMod M)) hA.2.1,
     by simpa [map_intCast, map_one, map_zero] using congr_arg (ZMod.castHom h (ZMod M)) hA.2.2⟩
 
-/-- `Γ` is antitone in the level: if `M ∣ N` then `Γ(N) ≤ Γ(M)`, by reducing the four
-congruences along `ZMod N → ZMod M`. The `Γ₀`/`Γ₁` cases are below and above. -/
+/-- `Γ` is antitone in the level: if `M ∣ N` then `Γ(N) ≤ Γ(M)`. Reduction modulo `M` factors
+through reduction modulo `N`, so a matrix congruent to the identity modulo `N` is congruent to
+the identity modulo `M`. `CongruenceSubgroup.Gamma1_le_Gamma1_of_dvd` and
+`CongruenceSubgroup.Gamma0_le_Gamma0_of_dvd` are the corresponding statements for the other
+two families. -/
 theorem Gamma_le_Gamma_of_dvd {M N : ℕ} (h : M ∣ N) : Gamma N ≤ Gamma M := fun A hA ↦
   Gamma_mem'.mpr <| by
     -- `ℤ` is initial, so reduction mod `M` *is* reduction mod `N` followed by `ZMod N → ZMod M`

--- a/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups/Basic.lean
@@ -114,15 +114,12 @@ theorem Gamma1_le_Gamma1_of_dvd {M N : ℕ} (h : M ∣ N) : Gamma1 N ≤ Gamma1 
 
 /-- `Γ` is antitone in the level: if `M ∣ N` then `Γ(N) ≤ Γ(M)`, by reducing the four
 congruences along `ZMod N → ZMod M`. The `Γ₀`/`Γ₁` cases are below and above. -/
-theorem Gamma_le_Gamma_of_dvd {M N : ℕ} (h : M ∣ N) : Gamma N ≤ Gamma M := by
-  intro A hA
-  rw [Gamma_mem] at hA ⊢
-  exact ⟨by simpa [map_intCast, map_one, map_zero] using congr_arg (ZMod.castHom h (ZMod M)) hA.1,
-    by simpa [map_intCast, map_one, map_zero] using congr_arg (ZMod.castHom h (ZMod M)) hA.2.1,
-    by simpa [map_intCast, map_one, map_zero] using
-      congr_arg (ZMod.castHom h (ZMod M)) hA.2.2.1,
-    by simpa [map_intCast, map_one, map_zero] using
-      congr_arg (ZMod.castHom h (ZMod M)) hA.2.2.2⟩
+theorem Gamma_le_Gamma_of_dvd {M N : ℕ} (h : M ∣ N) : Gamma N ≤ Gamma M := fun A hA ↦
+  Gamma_mem'.mpr <| by
+    -- `ℤ` is initial, so reduction mod `M` *is* reduction mod `N` followed by `ZMod N → ZMod M`
+    rw [show (Int.castRingHom (ZMod M) : ℤ →+* ZMod M) =
+        (ZMod.castHom h (ZMod M)).comp (Int.castRingHom (ZMod N)) from Subsingleton.elim _ _,
+      ← Matrix.SpecialLinearGroup.map_comp, MonoidHom.comp_apply, Gamma_mem'.mp hA, map_one]
 
 /-- `Γ(N) ≤ Γ₁(N)`: the principal congruence subgroup sits inside `Γ₁(N)`, since the three
 congruences `a ≡ 1`, `d ≡ 1`, `c ≡ 0` that `Γ₁(N)` imposes are three of the four that `Γ(N)`


### PR DESCRIPTION
`Matrix.SpecialLinearGroup.map` sends a ring hom `R →+* S` to a group hom
`SL(n, R) →* SL(n, S)`. It is a functor, but **neither functor law is recorded anywhere** —
Mathlib's `SpecialLinearGroup.lean` defines `map` (with `@[simps]`, giving only
`map_apply_coe`) and stops. This PR adds the composition law and puts it to work.

```lean
theorem map_comp {R S T : Type*} [CommRing R] [CommRing S] [CommRing T] {n : Type*} [Fintype n]
    [DecidableEq n] (f : R →+* S) (g : S →+* T) :
    (map (n := n) g).comp (map f) = map (g.comp f) := rfl
```

### The consumer it was missing from

`CongruenceSubgroup.Gamma_le_Gamma_of_dvd` — `Γ(N) ≤ Γ(M)` for `M ∣ N` — was proved by
reducing all four entry congruences separately along `ZMod N → ZMod M`, four near-identical
`simpa … congr_arg (ZMod.castHom h (ZMod M))` blocks. But `Gamma N` is by definition the
**kernel of a whole-matrix reduction**, so the statement is functoriality, not four coordinate
facts. With `map_comp` the proof is the argument itself:

```lean
theorem Gamma_le_Gamma_of_dvd {M N : ℕ} (h : M ∣ N) : Gamma N ≤ Gamma M := fun A hA ↦
  Gamma_mem'.mpr <| by
    -- `ℤ` is initial, so reduction mod `M` *is* reduction mod `N` followed by `ZMod N → ZMod M`
    rw [show (Int.castRingHom (ZMod M) : ℤ →+* ZMod M) =
        (ZMod.castHom h (ZMod M)).comp (Int.castRingHom (ZMod N)) from Subsingleton.elim _ _,
      ← Matrix.SpecialLinearGroup.map_comp, MonoidHom.comp_apply, Gamma_mem'.mp hA, map_one]
```

Nine lines become six, and the six say why the inclusion holds rather than checking it entry by
entry. The sibling lemmas `Gamma0_le_Gamma0_of_dvd` and `Gamma1_le_Gamma1_of_dvd` are left alone:
those are conditions on individual entries, not on the whole matrix, so functoriality does not
apply to them and rewriting them would be churn.

### Absence

* untruncated full-name grep over pinned Mathlib and all of `TauCeti/` for
  `SpecialLinearGroup.map_comp`, `SpecialLinearGroup.map_map` and `map_id` — no matches;
* a compiled `exact?` probe on the statement, which reported only
  `Eq.symm (MonoidHom.ext (congrFun rfl))` — no named lemma exists.

The law is definitionally true, so this is a **rewriting lemma**, not new mathematics: `rfl` is
the proof, and the value is that `rw`/`simp` can now use it, as the consumer above does.

### No target marker

Canonical library completion motivated by Layer 5 rather than a PR authoring a roadmap target,
so no `tauceti-target:v1` marker — the same call as #6029 and #6072. Inventing an id for work
that advances no specific target is what the contract warns against.

Roadmap: ModularForms

Provenance: statement and proof newly written for TauCeti. No AINTLIB counterpart — the source
(`github.com/CBirkbeck/AINTLIB` @ `340875ad`, Apache-2.0) works entrywise throughout and never
states functoriality of `SpecialLinearGroup.map`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQieFQn95rzgvYRvNdX3hR
