### PR TITLE
feat(FormalGroup): the chord condition read on the parameters

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Point/Add.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Point/Add.lean
@@ -18,11 +18,12 @@ import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.ThirdPoint
 the case where the chord through the two points is not vertical: the point of the parameter
 `F(t₁, t₂)` is the sum of the points of `t₁` and `t₂`.
 
-This is one case of the additivity of `formalPoint`, not the whole of it. The zero parameter, the
-doubling case `t₁ = t₂`, and the inverse case, where the two points share an `x`-coordinate, each
-need a different argument and are not treated here. Only with all of them does `formalPoint` become
-a homomorphism, and only then are the parameters of an adic ideal a subgroup of the points of `W⁄K`
-rather than an indexed family of them.
+This is one case of the additivity of `formalPoint`, not the whole of it. The doubling case
+`t₁ = t₂` and the inverse case `t₂ = ι(t₁)` — the two ways the points can share an `x`-coordinate —
+each need a different argument and are not treated here. A vanishing parameter is treated, by the
+unit laws. Only with the two remaining cases does `formalPoint` become a homomorphism, and only
+then are the parameters of an adic ideal a subgroup of the points of `W⁄K` rather than an indexed
+family of them.
 
 ## The hypotheses
 
@@ -39,16 +40,28 @@ excludes the zero parameter on either side; the sum is nonzero for the same reas
 `formalPoint` needs of its argument, which is why the conclusion names that term rather than a
 hypothesis.
 
+`mul_formalWEval_eq_mul_formalWEval_iff` in `Point/Basic.lean` characterises the cross-product: it
+holds exactly when a parameter vanishes, or the two are equal, or they are exchanged by `ι`. So
+for two nonzero parameters those two exclusions already give the chord condition. A vanishing
+parameter is the unit law `F(0, t) = t` or `F(t, 0) = t`. That is the second form of the theorem
+below, and the one a caller can discharge without computing `w`.
+
 ## Main results
 
 * `WeierstrassCurve.add_eq_formalPoint_formalAddEval_of_X_ne`: the point of `F(t₁, t₂)` is the
   sum of the points of `t₁` and `t₂`, for parameters whose points have distinct `x`-coordinates.
+* `WeierstrassCurve.add_eq_formalPoint_formalAddEval_of_ne_of_ne_formalInverseEval`: the same
+  conclusion, asked of the parameters themselves — two nonzero parameters must be distinct and not
+  exchanged by `ι`, while a vanishing parameter is asked nothing, being a unit law.
 
 ## Provenance
 
 Adapted from Michael Stoll's `EllipticCurves` project
 (`github.com/MichaelStollBayreuth/EllipticCurves` @ `66889eada51a`, Apache-2.0),
-`EllipticCurves/WeierstrassFormalGroup/Filtration.lean`, declaration `paramPoint_add`.
+`EllipticCurves/WeierstrassFormalGroup/Filtration.lean`, declarations `paramPoint_add` (the chord
+case) and `formalPoint_add_of_ne` (the theorem below). The dichotomy the latter rests on is that
+source's `eq_or_eq_negPoint_of_x_cond`, ported as an iff alongside `formalPoint` in
+`Point/Basic.lean`.
 
 The argument here is a transposition of this repository's own `FormalGroup/Add/Assoc.lean`, whose
 private `thetaPoint_add` runs the same chord computation one level up — over a fraction field of
@@ -205,5 +218,38 @@ theorem add_eq_formalPoint_formalAddEval_of_X_ne {I : Ideal O} (hI : IsAdic I) {
   -- `Affine.Point.mk` is the `some` constructor at `-(w(t))⁻¹`
   simpa only [Affine.Point.mk, neg_div, one_div] using
     W.some_add_some_formalAddEval_of_X_ne hI h₁ h₂ h₁0 h₂0 hx (hn h₁ h₁0) (hn h₂ h₂0) (hn hF hF0)
+
+open scoped Classical in
+/-- **The parametrisation carries the group law**, for two parameters that are not equal and not
+exchanged by the formal inverse — conditions asked only of a pair that is nowhere zero.
+
+`add_eq_formalPoint_formalAddEval_of_X_ne` asks instead that the chord through the two points be
+non-vertical, a condition on the product `t₁ * w(t₂)`. For two nonzero parameters the two requests
+agree, by `mul_formalWEval_eq_mul_formalWEval_iff`. The exclusions are guarded on both parameters
+being nonzero because a vanishing one is a unit law and needs no exclusion at all: `t₁ = 0` and
+`t₂ = 0` are both cases of this theorem, `t₁ = t₂ = 0` among them.
+
+Tagged `@[simp]` like the sibling, whose left-hand side it shares. Both carry side conditions
+`simp` cannot invent, so reaching either needs the hypotheses passed in, as `simp [*]` does; the
+gain here is that they are inequalities of parameters rather than of products of `w`-values. -/
+@[simp]
+theorem add_eq_formalPoint_formalAddEval_of_ne_of_ne_formalInverseEval {I : Ideal O}
+    (hI : IsAdic I) {t₁ t₂ : O} (h₁ : t₁ ∈ I) (h₂ : t₂ ∈ I)
+    (hne : t₁ ≠ 0 → t₂ ≠ 0 → t₂ ≠ t₁)
+    (hnι : t₁ ≠ 0 → t₂ ≠ 0 → t₂ ≠ W.formalInverseEval t₁) :
+    W.formalPoint (K := K) hI h₁ + W.formalPoint (K := K) hI h₂ =
+      W.formalPoint (K := K) hI (pow_one I ▸ W.formalAddEval_mem hI (k := 1)
+        ((pow_one I).symm ▸ h₁) ((pow_one I).symm ▸ h₂)) := by
+  rcases eq_or_ne t₁ 0 with rfl | h₁0
+  · rw [W.formalPoint_of_param_eq_zero hI h₁ rfl, zero_add]
+    congr 1
+    exact (W.formalAddEval_zero_left (hI.isTopologicallyNilpotent_of_mem h₂)).symm
+  rcases eq_or_ne t₂ 0 with rfl | h₂0
+  · rw [W.formalPoint_of_param_eq_zero hI h₂ rfl, add_zero]
+    congr 1
+    exact (W.formalAddEval_zero_right (hI.isTopologicallyNilpotent_of_mem h₁)).symm
+  exact W.add_eq_formalPoint_formalAddEval_of_X_ne hI h₁ h₂ fun hx ↦
+    ((((W.mul_formalWEval_eq_mul_formalWEval_iff K hI h₁ h₂).mp hx).resolve_left h₁0).resolve_left
+      h₂0).elim (hne h₁0 h₂0) (hnι h₁0 h₂0)
 
 end WeierstrassCurve

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Point/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Point/Basic.lean
@@ -44,6 +44,9 @@ into pole orders, but no order or valuation hypothesis is assumed here.
 * `WeierstrassCurve.formalPoint_formalInverseEval`: **the parametrisation respects negation** —
   the formal inverse on parameters becomes the group inverse on points, which on a generalised
   Weierstrass curve sends `y` to `-y - a₁x - a₃` rather than to `-y`.
+* `WeierstrassCurve.xRep_formalPoint_eq_iff`: two parameters have points with the same
+  `x`-coordinate exactly when they are equal or exchanged by the formal inverse, with
+  `WeierstrassCurve.mul_formalWEval_eq_mul_formalWEval_iff` its chord form.
 * `WeierstrassCurve.xCoord_formalPoint` and `WeierstrassCurve.yCoord_formalPoint`: the point's
   coordinates, through which the closed forms
   `WeierstrassCurve.xCoord_formalPoint_mul_eq_one` and
@@ -67,6 +70,10 @@ parameters of an adic ideal closed under inverses as *points*, so that the chord
 additivity in `Point/Add.lean` can read the addition series as a negated third root. Its name
 takes this repository's vocabulary, `formalInverseEval` rather than the source's `negPoint`,
 since the object being applied is the evaluated formal inverse.
+
+`mul_formalWEval_eq_mul_formalWEval_iff` is that source's `eq_or_eq_negPoint_of_x_cond`, private
+there and stated in one direction only; `xRep_formalPoint_eq_iff` is the form on `xRep` that it
+specialises.
 
 That development states them over `v.adicCompletion K` for a height-one prime of a Dedekind domain
 and builds nonsingularity from a chord lemma of its own. The declarations below are stated over an
@@ -267,5 +274,65 @@ theorem formalPoint_formalInverseEval {I : Ideal O} (hI : IsAdic I) {t : O} (ht 
   rw [neg_div, one_div] at hy
   rw [hy]
   field_simp
+
+/-- **Two parameters have points with the same `x`-coordinate exactly when they are equal or
+exchanged by the formal inverse.** Over a field the `x`-coordinate determines a point up to
+negation, and the parametrisation respects negation, so `t₁` and `ι(t₁)` are the only candidates.
+
+Stated at equality of `xRep`, Mathlib's projective `x`-coordinate, which asks nothing of either
+parameter: the point at infinity has `xRep = ![1, 0]` and an affine point `![x, 1]`, so the
+left-hand side already forces the two parameters to vanish together. The right-hand side is about
+the parameters alone, so the field the coordinates are read in is an explicit argument. -/
+@[simp]
+theorem xRep_formalPoint_eq_iff (K : Type*) [Field K] [Algebra O K]
+    [(W.baseChange K).IsElliptic] [FaithfulSMul O K] {I : Ideal O} (hI : IsAdic I) {t₁ t₂ : O}
+    (h₁ : t₁ ∈ I) (h₂ : t₂ ∈ I) :
+    (W.formalPoint (K := K) hI h₂).xRep = (W.formalPoint (K := K) hI h₁).xRep ↔
+      t₂ = t₁ ∨ t₂ = W.formalInverseEval t₁ := by
+  have hιmem : W.formalInverseEval t₁ ∈ I := by
+    simpa using W.formalInverseEval_mem (I := I) (k := 1)
+      (hI.isTopologicallyNilpotent_of_mem h₁) (by simpa using h₁)
+  rw [Affine.Point.xRep_eq_xRep_iff]
+  refine ⟨fun hc ↦ ?_, ?_⟩
+  · rcases hc with hc | hc
+    · exact Or.inl (congrArg Subtype.val
+        (W.formalPoint_injective (K := K) hI (a₁ := ⟨t₂, h₂⟩) (a₂ := ⟨t₁, h₁⟩) hc))
+    · rw [← W.formalPoint_formalInverseEval hI h₁] at hc
+      exact Or.inr (congrArg Subtype.val (W.formalPoint_injective (K := K) hI
+        (a₁ := ⟨t₂, h₂⟩) (a₂ := ⟨W.formalInverseEval t₁, hιmem⟩) hc))
+  · rintro (rfl | rfl)
+    · exact Or.inl rfl
+    · exact Or.inr (W.formalPoint_formalInverseEval hI h₁)
+
+/-- The chord form of `xRep_formalPoint_eq_iff`: when the cross-product of parameters against
+`w`-values agrees.
+
+`w` vanishes at `0`, so a vanishing parameter satisfies the cross-product whatever the other one
+is; those two cases are therefore disjuncts of the conclusion rather than hypotheses. With both
+parameters nonzero the remaining two disjuncts are the dichotomy of `xRep_formalPoint_eq_iff`.
+
+Not a `simp` lemma, unlike `xRep_formalPoint_eq_iff`: neither side names the field, so `K` and its
+instances would be left as metavariables that `simp` cannot solve. Rewrite with it explicitly. -/
+theorem mul_formalWEval_eq_mul_formalWEval_iff (K : Type*) [Field K] [Algebra O K]
+    [(W.baseChange K).IsElliptic] [FaithfulSMul O K] {I : Ideal O} (hI : IsAdic I) {t₁ t₂ : O}
+    (h₁ : t₁ ∈ I) (h₂ : t₂ ∈ I) :
+    t₁ * W.formalWEval t₂ = t₂ * W.formalWEval t₁ ↔
+      t₁ = 0 ∨ t₂ = 0 ∨ t₂ = t₁ ∨ t₂ = W.formalInverseEval t₁ := by
+  rcases eq_or_ne t₁ 0 with rfl | h₁0
+  · simp [W.formalWEval_zero]
+  rcases eq_or_ne t₂ 0 with rfl | h₂0
+  · simp [W.formalWEval_zero]
+  have hred : (t₁ = 0 ∨ t₂ = 0 ∨ t₂ = t₁ ∨ t₂ = W.formalInverseEval t₁) ↔
+      (t₂ = t₁ ∨ t₂ = W.formalInverseEval t₁) := by simp [h₁0, h₂0]
+  have hnz : ∀ {s : O}, s ≠ 0 → algebraMap O K s ≠ 0 := fun hs0 ↦ by simpa using hs0
+  have hw₁ : algebraMap O K (W.formalWEval t₁) ≠ 0 :=
+    W.algebraMap_formalWEval_ne_zero hI h₁ (hnz h₁0)
+  have hw₂ : algebraMap O K (W.formalWEval t₂) ≠ 0 :=
+    W.algebraMap_formalWEval_ne_zero hI h₂ (hnz h₂0)
+  rw [hred, ← W.xRep_formalPoint_eq_iff K hI h₁ h₂,
+    W.formalPoint_of_param_ne_zero hI h₂ h₂0, W.formalPoint_of_param_ne_zero hI h₁ h₁0]
+  simp only [Affine.Point.mk, Affine.Point.xRep_some, Matrix.vecCons_inj, and_true]
+  rw [div_eq_div_iff hw₂ hw₁, ← map_mul, ← map_mul,
+    (FaithfulSMul.algebraMap_injective O K).eq_iff, eq_comm]
 
 end WeierstrassCurve


### PR DESCRIPTION
`Point/Add.lean` proves the chord case of additivity: the point of `F(t₁, t₂)` is the sum of the
points of `t₁` and `t₂`, provided `t₁ * w(t₂) ≠ t₂ * w(t₁)`. That hypothesis says the two points
have distinct `x`-coordinates, so the chord through them is not vertical — but it is a condition on
`w`, which a caller has to expand to discharge.

This PR identifies what the condition amounts to on the parameters. In `Point/Basic.lean`, beside
`formalPoint` and its injectivity:

```lean
@[simp]
theorem xRep_formalPoint_eq_iff (K : Type*) [Field K] [Algebra O K]
    [(W.baseChange K).IsElliptic] [FaithfulSMul O K] {I : Ideal O} (hI : IsAdic I) {t₁ t₂ : O}
    (h₁ : t₁ ∈ I) (h₂ : t₂ ∈ I) :
    (W.formalPoint (K := K) hI h₂).xRep = (W.formalPoint (K := K) hI h₁).xRep ↔
      t₂ = t₁ ∨ t₂ = W.formalInverseEval t₁

theorem mul_formalWEval_eq_mul_formalWEval_iff (K : Type*) [Field K] [Algebra O K]
    [(W.baseChange K).IsElliptic] [FaithfulSMul O K] {I : Ideal O} (hI : IsAdic I) {t₁ t₂ : O}
    (h₁ : t₁ ∈ I) (h₂ : t₂ ∈ I) :
    t₁ * W.formalWEval t₂ = t₂ * W.formalWEval t₁ ↔
      t₁ = 0 ∨ t₂ = 0 ∨ t₂ = t₁ ∨ t₂ = W.formalInverseEval t₁
```

Over a field the `x`-coordinate determines a point up to negation, and `formalPoint` respects
negation, so `t₁` and `ι(t₁)` are the only parameters whose point shares the `x`-coordinate of the
point of `t₁`. Stated at `xRep`, Mathlib's projective `x`-coordinate, this asks nothing of either
parameter: the point at infinity has `xRep = ![1, 0]` and an affine point `![x, 1]`, so the
left-hand side already forces the parameters to vanish together. `xRep_formalPoint_eq_iff` is `@[simp]`, matching the file's other characteristic lemma
`formalPoint_eq_zero_iff`: it reduces an opaque coordinate equality to its parameter-level normal
form. The chord form is deliberately not tagged — neither side of it names the field, so `K` and
its instances would be metavariables `simp` cannot solve, and the docstring records that.

The chord form takes the cross-product condition instead, and is unconditional: `w` vanishes at
`0`, so a vanishing parameter satisfies the cross-product whatever the other one is, and those two
cases are disjuncts of the conclusion rather than hypotheses. With both parameters nonzero the
remaining two disjuncts are exactly the dichotomy, which is how the addition theorem uses it.

The chord case in `Point/Add.lean` then also reads:

```lean
@[simp]
theorem add_eq_formalPoint_formalAddEval_of_ne_of_ne_formalInverseEval {I : Ideal O}
    (hI : IsAdic I) {t₁ t₂ : O} (h₁ : t₁ ∈ I) (h₂ : t₂ ∈ I)
    (hne : t₁ ≠ 0 → t₂ ≠ 0 → t₂ ≠ t₁)
    (hnι : t₁ ≠ 0 → t₂ ≠ 0 → t₂ ≠ W.formalInverseEval t₁) :
    W.formalPoint (K := K) hI h₁ + W.formalPoint (K := K) hI h₂ =
      W.formalPoint (K := K) hI (pow_one I ▸ W.formalAddEval_mem hI (k := 1)
        ((pow_one I).symm ▸ h₁) ((pow_one I).symm ▸ h₂))
```

The exclusions are guarded on both parameters being nonzero, because a vanishing one needs no
exclusion at all — it is the unit law `F(0, t) = t` or `F(t, 0) = t`, both already in
`PairEval.lean`. So `t₁ = 0` and `t₂ = 0` are cases of this theorem, `t₁ = t₂ = 0` among them;
unguarded hypotheses would have excluded them.

## What this does not do

It does not widen the *coverage* of additivity. For nonzero parameters the new hypotheses are
equivalent to the chord condition, so the doubling case `t₂ = t₁` and the inverse case
`t₂ = ι(t₁)` remain untreated and still need a different argument, as the module docstring says.
What is new is the dichotomy — the step that separates the chord case from the two degenerate ones
— together with a form of the chord case whose hypotheses a caller can check.

## Placement and proof notes

The dichotomy is a property of `formalPoint`, not of chord addition, so it sits in
`Point/Basic.lean` with `formalPoint_injective` and `formalPoint_formalInverseEval` rather than
forcing a user to import the later addition layer.

Its proof goes through Mathlib's `Affine.Point.eq_or_eq_neg_of_xRep_eq_xRep`: the two points have
equal `xRep`, that lemma splits into equal-or-negated, `formalPoint_formalInverseEval` turns the
negated branch into the point of `ι(t₁)`, and `formalPoint_injective` brings both branches back to
the parameters. This is the same shape TauCeti already runs one level up in
`FormalGroup/Add/Assoc.lean` for `thetaPoint`, which goes via `X_eq_iff` directly; `xRep` is the
packaged form and needs no fold-back of the `some` constructors.

`K` is an explicit argument. The conclusion mentions no field, so `K` cannot be inferred from the
statement; the field is only where the coordinates are read, and naming it is more honest than
distorting the statement to make it inferable.

The two vanishing branches are `congr 1` against the unit laws: `formalPoint` takes a membership
proof, so once the parameters agree the remaining goal closes by proof irrelevance.

Both declarations are public where the source keeps its counterparts private: there they are
superseded by the full additivity `formalPoint_add`, which does not exist here yet. Both are what
the doubling case will consume — Stoll's `formalPoint_add_self` adds an auxiliary parameter of
small valuation so that every addition it needs becomes an instance of the second theorem, and it
uses the dichotomy to discharge the separation hypotheses.

## Relation to open work

#6061 approaches the same milestone from the other side, packaging the *parameters* as a group. It
touches `FormalGroup/AdicPoint.lean`, `FormalGroup/PairEval.lean` and
`RingTheory/MvPowerSeries/Rename.lean`; this PR touches only `FormalGroup/Point/Basic.lean` and
`FormalGroup/Point/Add.lean`. The two do not overlap.

Roadmap: EllipticCurves

New mathematics, so a target is cited: `TauCetiRoadmap/EllipticCurves/README.md`, **Layer 1**,
formal-group milestone **(iii)** — "Convergence: over a complete valued field, `Ê(𝔪)` as an honest
group of points". Splitting the degenerate cases off from the chord case is what makes the case
analysis for the full additivity of `formalPoint` possible.

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"add_eq_formalPoint_formalAddEval_of_ne_of_ne_formalInverseEval"}-->

Provenance: adapted from Michael Stoll's `EllipticCurves` project
(`github.com/MichaelStollBayreuth/EllipticCurves` @ `66889eada51a`, Apache-2.0),
`EllipticCurves/WeierstrassFormalGroup/Filtration.lean`, private lemmas
`eq_or_eq_negPoint_of_x_cond` (the dichotomy) and `formalPoint_add_of_ne` (its consumer). The
source open-codes the `x`-coordinate dichotomy from `Y_eq_of_X_eq` and `Point.some.injEq`; this
version goes through Mathlib's `Affine.Point.eq_or_eq_neg_of_xRep_eq_xRep`, which packages exactly
that, and states the hypothesis-free `xRep` form the source's cross-product version specialises.
The source's two nonzero hypotheses on the consumer are dropped, replaced by exclusions guarded on
both parameters being nonzero. In the source the ambient `hW` fixes `K` from the surrounding section, so its
dichotomy needs no field argument.
