### PR TITLE
feat: identify the special-orthogonal last-vector stabilizer

### DIFF
--- a/TauCeti/LinearAlgebra/QuadraticForm/Prod.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/Prod.lean
@@ -6,9 +6,10 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.LinearAlgebra.QuadraticForm.Prod
+public import TauCeti.LinearAlgebra.QuadraticForm.OrthogonalGroup
 
 /-!
-# Structural isometries of orthogonal products of quadratic maps
+# Structural isometries and special orthogonal groups of quadratic-map products
 
 Mathlib records the commutativity isometries of `QuadraticMap.prod`
 (`QuadraticMap.IsometryEquiv.prodComm` and `QuadraticMap.IsometryEquiv.prodProdProdComm`). This
@@ -16,10 +17,14 @@ file adds the two remaining structural ones: the associator, and the deletion of
 module is trivial. Together with `QuadraticMap.IsometryEquiv.prodComm` they are what makes
 orthogonal sum a commutative monoid operation on isometry classes of quadratic forms.
 
+It also combines special orthogonal transformations of two finite free quadratic maps with a
+common codomain into a special orthogonal transformation of their product.
+
 ## Main definitions
 
 * `QuadraticMap.IsometryEquiv.prodAssoc`: `LinearEquiv.prodAssoc` is isometric.
 * `QuadraticMap.IsometryEquiv.uniqueProd`: `LinearEquiv.uniqueProd` is isometric.
+* `QuadraticMap.specialOrthogonalGroupProd`: combine two special orthogonal transformations.
 -/
 
 public section
@@ -78,5 +83,83 @@ theorem IsometryEquiv.uniqueProd_symm_apply [Unique M₁] (Q₁ : QuadraticMap R
   -- Expose the underlying linear equivalence so its public inverse application lemma applies.
   change (LinearEquiv.uniqueProd (R := R) (M := M₂) (M₂ := M₁)).symm m = _
   exact LinearEquiv.uniqueProd_symm_apply m
+
+end QuadraticMap
+
+open QuadraticMap
+
+universe u v w
+
+namespace QuadraticMap
+
+open TauCeti.QuadraticMap
+
+noncomputable section
+
+variable {R : Type u} [CommRing R]
+
+private theorem specialOrthogonalProd_mem
+    {M₁ : Type v} [AddCommGroup M₁] [Module R M₁]
+    {M₂ : Type w} [AddCommGroup M₂] [Module R M₂]
+    {N : Type*} [AddCommMonoid N] [Module R N]
+    (Q₁ : QuadraticMap R M₁ N) (Q₂ : QuadraticMap R M₂ N)
+    [Module.Free R M₁] [Module.Finite R M₁]
+    [Module.Free R M₂] [Module.Finite R M₂]
+    (f : specialOrthogonalGroup Q₁) (g : specialOrthogonalGroup Q₂) :
+    (f : M₁ ≃ₗ[R] M₁).prodCongr (g : M₂ ≃ₗ[R] M₂) ∈
+      specialOrthogonalGroup (Q₁.prod Q₂) := by
+  have hf := mem_specialOrthogonalGroup_iff.mp f.2
+  have hg := mem_specialOrthogonalGroup_iff.mp g.2
+  apply mem_specialOrthogonalGroup_iff.mpr
+  constructor
+  · apply mem_orthogonalGroup_iff.mpr
+    intro x
+    let e := (orthogonalGroupEquivIsometryEquiv Q₁
+      ⟨f, specialOrthogonalGroup_le_orthogonalGroup Q₁ f.2⟩).prod
+        (orthogonalGroupEquivIsometryEquiv Q₂
+          ⟨g, specialOrthogonalGroup_le_orthogonalGroup Q₂ g.2⟩)
+    have he : e x = (f.1.prodCongr g.1) x := by
+      apply Prod.ext
+      · exact congrFun (coe_orthogonalGroupEquivIsometryEquiv Q₁ _) x.1
+      · exact congrFun (coe_orthogonalGroupEquivIsometryEquiv Q₂ _) x.2
+    rw [← he]
+    exact e.map_app x
+  · apply Units.ext
+    rw [LinearEquiv.coe_det, LinearEquiv.coe_prodCongr, LinearMap.det_prodMap]
+    simpa only [LinearEquiv.coe_det, Units.val_one, mul_one] using
+      congrArg₂ (fun a b : R ↦ a * b) (congrArg Units.val hf.2) (congrArg Units.val hg.2)
+
+/-- Combine special orthogonal transformations of two finite free quadratic maps with a common
+codomain into a special orthogonal transformation of their product. -/
+def specialOrthogonalGroupProd
+    {M₁ : Type v} [AddCommGroup M₁] [Module R M₁]
+    {M₂ : Type w} [AddCommGroup M₂] [Module R M₂]
+    {N : Type*} [AddCommMonoid N] [Module R N]
+    (Q₁ : QuadraticMap R M₁ N) (Q₂ : QuadraticMap R M₂ N)
+    [Module.Free R M₁] [Module.Finite R M₁]
+    [Module.Free R M₂] [Module.Finite R M₂] :
+    specialOrthogonalGroup Q₁ × specialOrthogonalGroup Q₂ →*
+      specialOrthogonalGroup (Q₁.prod Q₂) where
+  toFun fg := ⟨(fg.1 : M₁ ≃ₗ[R] M₁).prodCongr (fg.2 : M₂ ≃ₗ[R] M₂),
+    specialOrthogonalProd_mem Q₁ Q₂ fg.1 fg.2⟩
+  map_one' := by ext x <;> simp
+  map_mul' f g := by ext x <;> simp
+
+/-- The product of two special orthogonal transformations acts componentwise. -/
+@[simp]
+theorem specialOrthogonalGroupProd_apply
+    {M₁ : Type v} [AddCommGroup M₁] [Module R M₁]
+    {M₂ : Type w} [AddCommGroup M₂] [Module R M₂]
+    {N : Type*} [AddCommMonoid N] [Module R N]
+    (Q₁ : QuadraticMap R M₁ N) (Q₂ : QuadraticMap R M₂ N)
+    [Module.Free R M₁] [Module.Finite R M₁]
+    [Module.Free R M₂] [Module.Finite R M₂]
+    (fg : specialOrthogonalGroup Q₁ × specialOrthogonalGroup Q₂) (x : M₁ × M₂) :
+    ((specialOrthogonalGroupProd Q₁ Q₂ fg : specialOrthogonalGroup _) :
+      (M₁ × M₂) ≃ₗ[R] (M₁ × M₂)) x =
+      ((fg.1 : M₁ ≃ₗ[R] M₁) x.1, (fg.2 : M₂ ≃ₗ[R] M₂) x.2) := by
+  rfl
+
+end
 
 end QuadraticMap

--- a/TauCeti/LinearAlgebra/QuadraticForm/SpecialOrthogonalStabilizer.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/SpecialOrthogonalStabilizer.lean
@@ -28,6 +28,8 @@ transformation.
 
 * `specialOrthogonalGroupProdLastInclusion`: extend a special orthogonal transformation by the
   identity on the square line.
+* `specialOrthogonalGroupProdLastInclusionToStabilizer`: the same extension, codrestricted to the
+  last-vector stabilizer.
 * `specialOrthogonalGroupProdLastStabilizer`: the subgroup fixing `(0, 1)`.
 * `specialOrthogonalGroupEquivProdLastStabilizer`: the extension-restriction equivalence between
   `SO(Q)` and that stabilizer.
@@ -61,9 +63,17 @@ private theorem specialOrthogonalProdLastExtension_mem (Q : QuadraticForm R M)
   constructor
   · apply mem_orthogonalGroup_iff.mpr
     intro x
-    simp only [specialOrthogonalProdLastExtension, LinearEquiv.prodCongr_apply,
-      QuadraticMap.prod_apply, LinearEquiv.refl_apply]
-    rw [map_app_of_mem_orthogonalGroup hf.1]
+    let e := (orthogonalGroupEquivIsometryEquiv Q
+      ⟨f, specialOrthogonalGroup_le_orthogonalGroup Q f.2⟩).prod
+        (QuadraticMap.IsometryEquiv.refl (QuadraticMap.sq (R := R) (A := R)))
+    have he : e x = specialOrthogonalProdLastExtension Q f x := by
+      apply Prod.ext
+      -- Expose the first component so the orthogonal-group/isometry coercion lemma applies.
+      · change (orthogonalGroupEquivIsometryEquiv Q _ x.1) = f.1 x.1
+        exact congrFun (coe_orthogonalGroupEquivIsometryEquiv Q _) x.1
+      · rfl
+    rw [← he]
+    exact e.map_app x
   · apply Units.ext
     rw [LinearEquiv.coe_det, specialOrthogonalProdLastExtension,
       LinearEquiv.coe_prodCongr, LinearMap.det_prodMap]
@@ -128,7 +138,8 @@ theorem mem_specialOrthogonalGroupProdLastStabilizer_iff
       (g : (M × R) ≃ₗ[R] (M × R)) ((0 : M), (1 : R)) = (0, 1) :=
   MulAction.mem_stabilizer_iff
 
-private theorem specialOrthogonalGroupProdLastInclusion_mem_stabilizer
+/-- Extension by the identity on the square line fixes the last basis vector. -/
+theorem specialOrthogonalGroupProdLastInclusion_mem_stabilizer
     (Q : QuadraticForm R M) [Module.Free R M] [Module.Finite R M]
     (f : specialOrthogonalGroup Q) :
     specialOrthogonalGroupProdLastInclusion Q f ∈
@@ -136,7 +147,9 @@ private theorem specialOrthogonalGroupProdLastInclusion_mem_stabilizer
   rw [mem_specialOrthogonalGroupProdLastStabilizer_iff]
   exact Prod.ext (by simp) (by simp)
 
-private theorem snd_eq_zero_of_mem_specialOrthogonalGroupProdLastStabilizer
+/-- A last-vector stabilizer element maps the first summand back into the first summand. -/
+@[simp]
+theorem specialOrthogonalGroupProdLastStabilizer_apply_snd
     (Q : QuadraticForm R M) (h2 : IsRegular (2 : R))
     (g : specialOrthogonalGroupProdLastStabilizer Q) (m : M) :
     (g.1.1 (m, 0)).2 = 0 := by
@@ -162,7 +175,7 @@ private def specialOrthogonalProdLastRestrictionLinearEquiv
   map_smul' c x := by
     simpa using congrArg Prod.fst (g.1.1.map_smul c (x, 0))
   left_inv m := by
-    have hzero := snd_eq_zero_of_mem_specialOrthogonalGroupProdLastStabilizer Q h2 g m
+    have hzero := specialOrthogonalGroupProdLastStabilizer_apply_snd Q h2 g m
     have hpair : g.1.1 (m, 0) = ((g.1.1 (m, 0)).1, 0) := Prod.ext rfl hzero
     -- Unfold the restriction's inverse to expose the ambient inverse action.
     change ((g⁻¹).1.1 ((g.1.1 (m, 0)).1, 0)).1 = m
@@ -170,7 +183,7 @@ private def specialOrthogonalProdLastRestrictionLinearEquiv
     simpa only [Prod.fst, Subgroup.coe_inv, LinearEquiv.coe_inv] using
       congrArg Prod.fst (g.1.1.symm_apply_apply (m, 0))
   right_inv m := by
-    have hzero := snd_eq_zero_of_mem_specialOrthogonalGroupProdLastStabilizer Q h2 g⁻¹ m
+    have hzero := specialOrthogonalGroupProdLastStabilizer_apply_snd Q h2 g⁻¹ m
     have hpair : (g⁻¹).1.1 (m, 0) = (((g⁻¹).1.1 (m, 0)).1, 0) :=
       Prod.ext rfl hzero
     -- Unfold the restriction to expose the ambient forward action.
@@ -186,7 +199,7 @@ private theorem specialOrthogonalProdLast_eq_prodCongr_restriction
       (LinearEquiv.refl R R) := by
   apply LinearEquiv.ext
   intro x
-  have hzero := snd_eq_zero_of_mem_specialOrthogonalGroupProdLastStabilizer Q h2 g x.1
+  have hzero := specialOrthogonalGroupProdLastStabilizer_apply_snd Q h2 g x.1
   have hfix : g.1.1 ((0 : M), (1 : R)) = ((0 : M), (1 : R)) :=
     mem_specialOrthogonalGroupProdLastStabilizer_iff Q |>.mp g.2
   have hline : g.1.1 (0, x.2) = (0, x.2) := by
@@ -209,7 +222,7 @@ private theorem specialOrthogonalProdLastRestriction_mem
   constructor
   · apply mem_orthogonalGroup_iff.mpr
     intro m
-    have hzero := snd_eq_zero_of_mem_specialOrthogonalGroupProdLastStabilizer Q h2 g m
+    have hzero := specialOrthogonalGroupProdLastStabilizer_apply_snd Q h2 g m
     have hmap := map_app_of_mem_orthogonalGroup hg.1 (m, 0)
     simpa [specialOrthogonalProdLastRestrictionLinearEquiv, QuadraticMap.prod_apply,
       hzero] using hmap
@@ -233,11 +246,22 @@ private theorem specialOrthogonalProdLast_eq_extension_restriction
   simpa only [specialOrthogonalProdLastExtension] using
     specialOrthogonalProdLast_eq_prodCongr_restriction Q h2 g
 
-private def specialOrthogonalProdLastInclusionToStabilizer
+/-- Extend a special orthogonal transformation by the identity, as an element of the last-vector
+stabilizer. -/
+def specialOrthogonalGroupProdLastInclusionToStabilizer
     (Q : QuadraticForm R M) [Module.Free R M] [Module.Finite R M] :
     specialOrthogonalGroup Q →* specialOrthogonalGroupProdLastStabilizer Q :=
   (specialOrthogonalGroupProdLastInclusion Q).codRestrict _
     (specialOrthogonalGroupProdLastInclusion_mem_stabilizer Q)
+
+/-- The stabilizer-valued identity extension acts componentwise. -/
+@[simp]
+theorem specialOrthogonalGroupProdLastInclusionToStabilizer_apply
+    (Q : QuadraticForm R M) [Module.Free R M] [Module.Finite R M]
+    (f : specialOrthogonalGroup Q) (x : M × R) :
+    (specialOrthogonalGroupProdLastInclusionToStabilizer Q f).1.1 x =
+      ((f : M ≃ₗ[R] M) x.1, x.2) := by
+  rfl
 
 private def specialOrthogonalProdLastRestriction
     (Q : QuadraticForm R M) (h2 : IsRegular (2 : R))
@@ -255,7 +279,7 @@ private def specialOrthogonalProdLastRestriction
     apply Subtype.ext
     apply LinearEquiv.ext
     intro m
-    have hzero := snd_eq_zero_of_mem_specialOrthogonalGroupProdLastStabilizer Q h2 h m
+    have hzero := specialOrthogonalGroupProdLastStabilizer_apply_snd Q h2 h m
     have hpair : h.1.1 (m, 0) = ((h.1.1 (m, 0)).1, 0) := Prod.ext rfl hzero
     -- Unfold multiplication of the restricted linear equivalences.
     change (g.1.1 (h.1.1 (m, 0))).1 = (g.1.1 ((h.1.1 (m, 0)).1, 0)).1
@@ -270,7 +294,7 @@ def specialOrthogonalGroupEquivProdLastStabilizer
     (Q : QuadraticForm R M) (h2 : IsRegular (2 : R))
     [Module.Free R M] [Module.Finite R M] :
     specialOrthogonalGroup Q ≃* specialOrthogonalGroupProdLastStabilizer Q :=
-  MonoidHom.toMulEquiv (specialOrthogonalProdLastInclusionToStabilizer Q)
+  MonoidHom.toMulEquiv (specialOrthogonalGroupProdLastInclusionToStabilizer Q)
     (specialOrthogonalProdLastRestriction Q h2)
     (MonoidHom.ext fun f => by
       apply Subtype.ext

--- a/TauCeti/LinearAlgebra/QuadraticForm/SpecialOrthogonalStabilizer.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/SpecialOrthogonalStabilizer.lean
@@ -180,7 +180,7 @@ theorem specialOrthogonalGroupProdLastInclusion_mem_stabilizer
 
 /-- An orthogonal transformation fixing the last basis vector maps the first summand back into the
 first summand. -/
-theorem orthogonalGroupProdLast_fixed_apply_snd
+theorem orthogonalGroupProdLast_apply_snd_of_fixed
     (Q : QuadraticForm R M) (h2 : IsRegular (2 : R))
     (g : orthogonalGroup (Q.prod (QuadraticMap.sq (R := R) (A := R))))
     (hfix : (g : (M × R) ≃ₗ[R] (M × R)) ((0 : M), (1 : R)) = (0, 1))
@@ -200,7 +200,7 @@ theorem specialOrthogonalGroupProdLastStabilizer_apply_snd
     (Q : QuadraticForm R M) (h2 : IsRegular (2 : R))
     (g : specialOrthogonalGroupProdLastStabilizer Q) (m : M) :
     (g.1.1 (m, 0)).2 = 0 :=
-  orthogonalGroupProdLast_fixed_apply_snd Q h2
+  orthogonalGroupProdLast_apply_snd_of_fixed Q h2
     ⟨g.1.1, specialOrthogonalGroup_le_orthogonalGroup _ g.1.2⟩
     (mem_specialOrthogonalGroupProdLastStabilizer_iff Q |>.mp g.2) m
 

--- a/TauCeti/LinearAlgebra/QuadraticForm/SpecialOrthogonalStabilizer.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/SpecialOrthogonalStabilizer.lean
@@ -26,8 +26,8 @@ transformation.
 
 ## Main definitions
 
-* `specialOrthogonalGroupProd`: combine special orthogonal transformations of two forms into one
-  of their product.
+* `specialOrthogonalGroupProd`: combine special orthogonal transformations of two quadratic maps
+  with a common codomain into one of their product.
 * `specialOrthogonalGroupProdLastInclusion`: extend a special orthogonal transformation by the
   identity on the square line.
 * `specialOrthogonalGroupProdLastInclusionToStabilizer`: the same extension, codrestricted to the
@@ -55,7 +55,8 @@ variable {R : Type u} [CommRing R]
 private theorem specialOrthogonalProd_mem
     {M₁ : Type v} [AddCommGroup M₁] [Module R M₁]
     {M₂ : Type w} [AddCommGroup M₂] [Module R M₂]
-    (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂)
+    {N : Type*} [AddCommMonoid N] [Module R N]
+    (Q₁ : QuadraticMap R M₁ N) (Q₂ : QuadraticMap R M₂ N)
     [Module.Free R M₁] [Module.Finite R M₁]
     [Module.Free R M₂] [Module.Finite R M₂]
     (f : specialOrthogonalGroup Q₁) (g : specialOrthogonalGroup Q₂) :
@@ -73,10 +74,8 @@ private theorem specialOrthogonalProd_mem
           ⟨g, specialOrthogonalGroup_le_orthogonalGroup Q₂ g.2⟩)
     have he : e x = (f.1.prodCongr g.1) x := by
       apply Prod.ext
-      · change (orthogonalGroupEquivIsometryEquiv Q₁ _ x.1) = f.1 x.1
-        exact congrFun (coe_orthogonalGroupEquivIsometryEquiv Q₁ _) x.1
-      · change (orthogonalGroupEquivIsometryEquiv Q₂ _ x.2) = g.1 x.2
-        exact congrFun (coe_orthogonalGroupEquivIsometryEquiv Q₂ _) x.2
+      · exact congrFun (coe_orthogonalGroupEquivIsometryEquiv Q₁ _) x.1
+      · exact congrFun (coe_orthogonalGroupEquivIsometryEquiv Q₂ _) x.2
     rw [← he]
     exact e.map_app x
   · apply Units.ext
@@ -84,12 +83,13 @@ private theorem specialOrthogonalProd_mem
     simpa only [LinearEquiv.coe_det, Units.val_one, mul_one] using
       congrArg₂ (fun a b : R ↦ a * b) (congrArg Units.val hf.2) (congrArg Units.val hg.2)
 
-/-- Combine special orthogonal transformations of two finite free quadratic forms into a special
-orthogonal transformation of their product. -/
+/-- Combine special orthogonal transformations of two finite free quadratic maps with a common
+codomain into a special orthogonal transformation of their product. -/
 def specialOrthogonalGroupProd
     {M₁ : Type v} [AddCommGroup M₁] [Module R M₁]
     {M₂ : Type w} [AddCommGroup M₂] [Module R M₂]
-    (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂)
+    {N : Type*} [AddCommMonoid N] [Module R N]
+    (Q₁ : QuadraticMap R M₁ N) (Q₂ : QuadraticMap R M₂ N)
     [Module.Free R M₁] [Module.Finite R M₁]
     [Module.Free R M₂] [Module.Finite R M₂] :
     specialOrthogonalGroup Q₁ × specialOrthogonalGroup Q₂ →*
@@ -104,7 +104,8 @@ def specialOrthogonalGroupProd
 theorem specialOrthogonalGroupProd_apply
     {M₁ : Type v} [AddCommGroup M₁] [Module R M₁]
     {M₂ : Type w} [AddCommGroup M₂] [Module R M₂]
-    (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂)
+    {N : Type*} [AddCommMonoid N] [Module R N]
+    (Q₁ : QuadraticMap R M₁ N) (Q₂ : QuadraticMap R M₂ N)
     [Module.Free R M₁] [Module.Finite R M₁]
     [Module.Free R M₂] [Module.Finite R M₂]
     (fg : specialOrthogonalGroup Q₁ × specialOrthogonalGroup Q₂) (x : M₁ × M₂) :

--- a/TauCeti/LinearAlgebra/QuadraticForm/SpecialOrthogonalStabilizer.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/SpecialOrthogonalStabilizer.lean
@@ -1,0 +1,304 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.LinearAlgebra.QuadraticForm.Prod
+public import TauCeti.LinearAlgebra.QuadraticForm.OrthogonalGroup
+
+/-!
+# The last-vector stabilizer in a special orthogonal group
+
+Let `Q` be a quadratic form on a finite free module `M`. Extending an element of `SO(Q)` by the
+identity on a rank-one summand embeds it into `SO(Q.prod QuadraticMap.sq)`. If two is not zero and
+the base ring has no zero divisors, its image is exactly the stabilizer of the last basis vector
+`(0, 1)`.
+
+The inverse map restricts a stabilizer element to the first summand. Orthogonality and fixation of
+`(0, 1)` force that summand to be preserved: polarizing the image of `(m, 0)` against `(0, 1)`
+shows that twice its last coordinate vanishes. The determinant-one condition then descends because
+the original map is the product of its restriction with the identity of the last summand.
+
+This is the special-orthogonal group calculation used in the compact Spin stabilizer
+identification. After applying the Spin action, it turns fixation of the last vector into a
+lower-rank special orthogonal transformation that can be lifted back to the lower-rank Spin group.
+
+## Main definitions
+
+* `specialOrthogonalGroupProdLastInclusion`: extend a special orthogonal transformation by the
+  identity on the square line.
+* `specialOrthogonalGroupProdLastStabilizer`: the subgroup fixing `(0, 1)`.
+* `specialOrthogonalGroupEquivProdLastStabilizer`: the extension-restriction equivalence between
+  `SO(Q)` and that stabilizer.
+
+## References
+
+* [Clifford algebras, Pin and Spin, and spin representations roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md),
+  Layer 7, the compact Spin stabilizer identification.
+-/
+
+public section
+
+open QuadraticMap
+
+universe u v
+
+namespace TauCeti
+
+namespace QuadraticMap
+
+noncomputable section
+
+variable {R : Type u} [CommRing R]
+  {M : Type v} [AddCommGroup M] [Module R M]
+
+private def specialOrthogonalProdLastExtension (Q : QuadraticForm R M)
+    (f : specialOrthogonalGroup Q) : (M × R) ≃ₗ[R] (M × R) :=
+  (f : M ≃ₗ[R] M).prodCongr (LinearEquiv.refl R R)
+
+private theorem specialOrthogonalProdLastExtension_mem (Q : QuadraticForm R M)
+    [Module.Free R M] [Module.Finite R M] (f : specialOrthogonalGroup Q) :
+    specialOrthogonalProdLastExtension Q f ∈ specialOrthogonalGroup
+      (Q.prod (QuadraticMap.sq (R := R) (A := R))) := by
+  have hf := mem_specialOrthogonalGroup_iff.mp f.2
+  apply mem_specialOrthogonalGroup_iff.mpr
+  constructor
+  · apply mem_orthogonalGroup_iff.mpr
+    intro x
+    simp only [specialOrthogonalProdLastExtension, LinearEquiv.prodCongr_apply,
+      QuadraticMap.prod_apply, LinearEquiv.refl_apply]
+    rw [map_app_of_mem_orthogonalGroup hf.1]
+  · apply Units.ext
+    rw [LinearEquiv.coe_det, specialOrthogonalProdLastExtension,
+      LinearEquiv.coe_prodCongr, LinearMap.det_prodMap]
+    have hrefl :
+        LinearMap.det ((LinearEquiv.refl R R : R ≃ₗ[R] R) : R →ₗ[R] R) = 1 := by
+      simp
+    rw [hrefl, mul_one]
+    simpa only [LinearEquiv.coe_det] using congrArg Units.val hf.2
+
+/-- Extend a special orthogonal transformation by the identity on the square line. -/
+def specialOrthogonalGroupProdLastInclusion (Q : QuadraticForm R M)
+    [Module.Free R M] [Module.Finite R M] :
+    specialOrthogonalGroup Q →* specialOrthogonalGroup
+      (Q.prod (QuadraticMap.sq (R := R) (A := R))) where
+  toFun f :=
+    ⟨specialOrthogonalProdLastExtension Q f, specialOrthogonalProdLastExtension_mem Q f⟩
+  map_one' := by
+    ext x <;> simp [specialOrthogonalProdLastExtension]
+  map_mul' f g := by
+    ext x <;> simp [specialOrthogonalProdLastExtension]
+
+/-- Extending a special orthogonal transformation acts componentwise and fixes the square-line
+coordinate. -/
+@[simp]
+theorem specialOrthogonalGroupProdLastInclusion_apply (Q : QuadraticForm R M)
+    [Module.Free R M] [Module.Finite R M] (f : specialOrthogonalGroup Q) (x : M × R) :
+    ((specialOrthogonalGroupProdLastInclusion Q f :
+      specialOrthogonalGroup _) : (M × R) ≃ₗ[R] (M × R)) x =
+      ((f : M ≃ₗ[R] M) x.1, x.2) := by
+  rfl
+
+/-- The stabilizer of the last basis vector `(0, 1)` in the special orthogonal group of
+`Q.prod QuadraticMap.sq`. -/
+def specialOrthogonalGroupProdLastStabilizer (Q : QuadraticForm R M) :
+    Subgroup (specialOrthogonalGroup
+      (Q.prod (QuadraticMap.sq (R := R) (A := R)))) :=
+  MulAction.stabilizer
+    (specialOrthogonalGroup (Q.prod (QuadraticMap.sq (R := R) (A := R))))
+    ((0 : M), (1 : R))
+
+/-- Membership in the last-vector stabilizer means exactly that the underlying linear
+transformation fixes `(0, 1)`. -/
+@[simp]
+theorem mem_specialOrthogonalGroupProdLastStabilizer_iff
+    (Q : QuadraticForm R M)
+    {g : specialOrthogonalGroup (Q.prod (QuadraticMap.sq (R := R) (A := R)))} :
+    g ∈ specialOrthogonalGroupProdLastStabilizer Q ↔
+      (g : (M × R) ≃ₗ[R] (M × R)) ((0 : M), (1 : R)) = (0, 1) :=
+  MulAction.mem_stabilizer_iff
+
+private theorem specialOrthogonalGroupProdLastInclusion_mem_stabilizer
+    (Q : QuadraticForm R M) [Module.Free R M] [Module.Finite R M]
+    (f : specialOrthogonalGroup Q) :
+    specialOrthogonalGroupProdLastInclusion Q f ∈
+      specialOrthogonalGroupProdLastStabilizer Q := by
+  rw [mem_specialOrthogonalGroupProdLastStabilizer_iff]
+  exact Prod.ext (by simp) (by simp)
+
+private theorem snd_eq_zero_of_mem_specialOrthogonalGroupProdLastStabilizer
+    [NoZeroDivisors R] [NeZero (2 : R)] (Q : QuadraticForm R M)
+    (g : specialOrthogonalGroupProdLastStabilizer Q) (m : M) :
+    (g.1.1 (m, 0)).2 = 0 := by
+  have hfix : g.1.1 ((0 : M), (1 : R)) = ((0 : M), (1 : R)) :=
+    mem_specialOrthogonalGroupProdLastStabilizer_iff Q |>.mp g.2
+  have hg := mem_specialOrthogonalGroup_iff.mp g.1.2
+  have hpolar := polar_apply_of_mem_orthogonalGroup hg.1 (m, 0) (0, 1)
+  rw [hfix, QuadraticMap.polar_prod, QuadraticMap.polar_prod] at hpolar
+  simp only [map_zero, add_zero, zero_add, QuadraticMap.sq_apply, QuadraticMap.polar,
+    mul_one, sub_zero] at hpolar
+  ring_nf at hpolar
+  have htwo : (2 : R) * (g.1.1 (m, 0)).2 = 0 := by
+    linear_combination hpolar
+  exact (mul_eq_zero.mp htwo).resolve_left (NeZero.ne (2 : R))
+
+private def specialOrthogonalProdLastRestrictionLinearEquiv
+    [NoZeroDivisors R] [NeZero (2 : R)] (Q : QuadraticForm R M)
+    (g : specialOrthogonalGroupProdLastStabilizer Q) : M ≃ₗ[R] M where
+  toFun m := (g.1.1 (m, 0)).1
+  invFun m := ((g⁻¹).1.1 (m, 0)).1
+  map_add' x y := by
+    simpa using congrArg Prod.fst (g.1.1.map_add (x, 0) (y, 0))
+  map_smul' c x := by
+    simpa using congrArg Prod.fst (g.1.1.map_smul c (x, 0))
+  left_inv m := by
+    have hzero := snd_eq_zero_of_mem_specialOrthogonalGroupProdLastStabilizer Q g m
+    have hpair : g.1.1 (m, 0) = ((g.1.1 (m, 0)).1, 0) := Prod.ext rfl hzero
+    change ((g⁻¹).1.1 ((g.1.1 (m, 0)).1, 0)).1 = m
+    rw [← hpair]
+    simpa only [Prod.fst, Subgroup.coe_inv, LinearEquiv.coe_inv] using
+      congrArg Prod.fst (g.1.1.symm_apply_apply (m, 0))
+  right_inv m := by
+    have hzero := snd_eq_zero_of_mem_specialOrthogonalGroupProdLastStabilizer Q g⁻¹ m
+    have hpair : (g⁻¹).1.1 (m, 0) = (((g⁻¹).1.1 (m, 0)).1, 0) :=
+      Prod.ext rfl hzero
+    change (g.1.1 (((g⁻¹).1.1 (m, 0)).1, 0)).1 = m
+    rw [← hpair]
+    simpa only [Prod.fst, Subgroup.coe_inv, LinearEquiv.coe_inv] using
+      congrArg Prod.fst (g.1.1.apply_symm_apply (m, 0))
+
+private theorem specialOrthogonalProdLast_eq_prodCongr_restriction
+    [NoZeroDivisors R] [NeZero (2 : R)] (Q : QuadraticForm R M)
+    (g : specialOrthogonalGroupProdLastStabilizer Q) :
+    g.1.1 = (specialOrthogonalProdLastRestrictionLinearEquiv Q g).prodCongr
+      (LinearEquiv.refl R R) := by
+  apply LinearEquiv.ext
+  intro x
+  have hzero := snd_eq_zero_of_mem_specialOrthogonalGroupProdLastStabilizer Q g x.1
+  have hfix : g.1.1 ((0 : M), (1 : R)) = ((0 : M), (1 : R)) :=
+    mem_specialOrthogonalGroupProdLastStabilizer_iff Q |>.mp g.2
+  have hline : g.1.1 (0, x.2) = (0, x.2) := by
+    calc
+      g.1.1 (0, x.2) = g.1.1 (x.2 • ((0 : M), (1 : R))) := by simp
+      _ = x.2 • g.1.1 ((0 : M), (1 : R)) := g.1.1.map_smul _ _
+      _ = (0, x.2) := by rw [hfix]; simp
+  rw [show x = (x.1, 0) + (0, x.2) by ext <;> simp, map_add, hline]
+  apply Prod.ext <;>
+    simp [specialOrthogonalProdLastRestrictionLinearEquiv, hzero]
+
+private theorem specialOrthogonalProdLastRestriction_mem
+    [NoZeroDivisors R] [NeZero (2 : R)] (Q : QuadraticForm R M)
+    [Module.Free R M] [Module.Finite R M]
+    (g : specialOrthogonalGroupProdLastStabilizer Q) :
+    specialOrthogonalProdLastRestrictionLinearEquiv Q g ∈ specialOrthogonalGroup Q := by
+  have hg := mem_specialOrthogonalGroup_iff.mp g.1.2
+  apply mem_specialOrthogonalGroup_iff.mpr
+  constructor
+  · apply mem_orthogonalGroup_iff.mpr
+    intro m
+    have hzero := snd_eq_zero_of_mem_specialOrthogonalGroupProdLastStabilizer Q g m
+    have hmap := map_app_of_mem_orthogonalGroup hg.1 (m, 0)
+    simpa [specialOrthogonalProdLastRestrictionLinearEquiv, QuadraticMap.prod_apply,
+      hzero] using hmap
+  · apply Units.ext
+    have hdet := congrArg Units.val hg.2
+    rw [LinearEquiv.coe_det, specialOrthogonalProdLast_eq_prodCongr_restriction Q g,
+      LinearEquiv.coe_prodCongr, LinearMap.det_prodMap] at hdet
+    have hrefl :
+        LinearMap.det ((LinearEquiv.refl R R : R ≃ₗ[R] R) : R →ₗ[R] R) = 1 := by
+      simp
+    rw [hrefl, mul_one] at hdet
+    simpa only [LinearEquiv.coe_det] using hdet
+
+private theorem specialOrthogonalProdLast_eq_extension_restriction
+    [NoZeroDivisors R] [NeZero (2 : R)] (Q : QuadraticForm R M)
+    [Module.Free R M] [Module.Finite R M]
+    (g : specialOrthogonalGroupProdLastStabilizer Q) :
+    g.1.1 = specialOrthogonalProdLastExtension Q
+      ⟨specialOrthogonalProdLastRestrictionLinearEquiv Q g,
+        specialOrthogonalProdLastRestriction_mem Q g⟩ := by
+  simpa only [specialOrthogonalProdLastExtension] using
+    specialOrthogonalProdLast_eq_prodCongr_restriction Q g
+
+private def specialOrthogonalProdLastInclusionToStabilizer
+    (Q : QuadraticForm R M) [Module.Free R M] [Module.Finite R M] :
+    specialOrthogonalGroup Q →* specialOrthogonalGroupProdLastStabilizer Q where
+  toFun f :=
+    ⟨specialOrthogonalGroupProdLastInclusion Q f,
+      specialOrthogonalGroupProdLastInclusion_mem_stabilizer Q f⟩
+  map_one' := by
+    apply Subtype.ext
+    exact (specialOrthogonalGroupProdLastInclusion Q).map_one
+  map_mul' f g := by
+    apply Subtype.ext
+    exact (specialOrthogonalGroupProdLastInclusion Q).map_mul f g
+
+private def specialOrthogonalProdLastRestriction
+    [NoZeroDivisors R] [NeZero (2 : R)] (Q : QuadraticForm R M)
+    [Module.Free R M] [Module.Finite R M] :
+    specialOrthogonalGroupProdLastStabilizer Q →* specialOrthogonalGroup Q where
+  toFun g :=
+    ⟨specialOrthogonalProdLastRestrictionLinearEquiv Q g,
+      specialOrthogonalProdLastRestriction_mem Q g⟩
+  map_one' := by
+    apply Subtype.ext
+    apply LinearEquiv.ext
+    intro m
+    rfl
+  map_mul' g h := by
+    apply Subtype.ext
+    apply LinearEquiv.ext
+    intro m
+    have hzero := snd_eq_zero_of_mem_specialOrthogonalGroupProdLastStabilizer Q h m
+    have hpair : h.1.1 (m, 0) = ((h.1.1 (m, 0)).1, 0) := Prod.ext rfl hzero
+    change (g.1.1 (h.1.1 (m, 0))).1 = (g.1.1 ((h.1.1 (m, 0)).1, 0)).1
+    rw [hpair]
+
+/-- Extension by the identity identifies `SO(Q)` with the last-vector stabilizer in
+`SO(Q.prod QuadraticMap.sq)`.
+
+The inverse sends a stabilizer element `g` to its restriction `m ↦ (g (m, 0)).1`. The assumptions
+that the ring has no zero divisors and that `2 ≠ 0` ensure that fixation of `(0, 1)` forces `g` to
+preserve the first summand. -/
+def specialOrthogonalGroupEquivProdLastStabilizer
+    [NoZeroDivisors R] [NeZero (2 : R)] (Q : QuadraticForm R M)
+    [Module.Free R M] [Module.Finite R M] :
+    specialOrthogonalGroup Q ≃* specialOrthogonalGroupProdLastStabilizer Q :=
+  MonoidHom.toMulEquiv (specialOrthogonalProdLastInclusionToStabilizer Q)
+    (specialOrthogonalProdLastRestriction Q)
+    (MonoidHom.ext fun f => by
+      apply Subtype.ext
+      apply LinearEquiv.ext
+      intro m
+      rfl)
+    (MonoidHom.ext fun g => by
+      apply Subtype.ext
+      apply Subtype.ext
+      exact (specialOrthogonalProdLast_eq_extension_restriction Q g).symm)
+
+/-- The stabilizer equivalence sends `f` to its extension by the identity. -/
+@[simp]
+theorem coe_specialOrthogonalGroupEquivProdLastStabilizer_apply
+    [NoZeroDivisors R] [NeZero (2 : R)] (Q : QuadraticForm R M)
+    [Module.Free R M] [Module.Finite R M] (f : specialOrthogonalGroup Q) (x : M × R) :
+    ((specialOrthogonalGroupEquivProdLastStabilizer Q f).1.1 x) =
+      ((f : M ≃ₗ[R] M) x.1, x.2) := by
+  rfl
+
+/-- The inverse stabilizer equivalence restricts to the first summand. -/
+@[simp]
+theorem coe_specialOrthogonalGroupEquivProdLastStabilizer_symm_apply
+    [NoZeroDivisors R] [NeZero (2 : R)] (Q : QuadraticForm R M)
+    [Module.Free R M] [Module.Finite R M]
+    (g : specialOrthogonalGroupProdLastStabilizer Q) (m : M) :
+    ((specialOrthogonalGroupEquivProdLastStabilizer Q).symm g : M ≃ₗ[R] M) m =
+      (g.1.1 (m, 0)).1 := by
+  rfl
+
+end
+
+end QuadraticMap
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/QuadraticForm/SpecialOrthogonalStabilizer.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/SpecialOrthogonalStabilizer.lean
@@ -5,8 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.LinearAlgebra.QuadraticForm.Prod
-public import TauCeti.LinearAlgebra.QuadraticForm.OrthogonalGroup
+public import TauCeti.LinearAlgebra.QuadraticForm.Prod
 
 /-!
 # The last-vector stabilizer in a special orthogonal group
@@ -26,8 +25,6 @@ transformation.
 
 ## Main definitions
 
-* `specialOrthogonalGroupProd`: combine special orthogonal transformations of two quadratic maps
-  with a common codomain into one of their product.
 * `specialOrthogonalGroupProdLastInclusion`: extend a special orthogonal transformation by the
   identity on the square line.
 * `specialOrthogonalGroupProdLastInclusionToStabilizer`: the same extension, codrestricted to the
@@ -41,7 +38,7 @@ public section
 
 open QuadraticMap
 
-universe u v w
+universe u v
 
 namespace QuadraticMap
 
@@ -51,68 +48,6 @@ noncomputable section
 
 variable {R : Type u} [CommRing R]
   {M : Type v} [AddCommGroup M] [Module R M]
-
-private theorem specialOrthogonalProd_mem
-    {M₁ : Type v} [AddCommGroup M₁] [Module R M₁]
-    {M₂ : Type w} [AddCommGroup M₂] [Module R M₂]
-    {N : Type*} [AddCommMonoid N] [Module R N]
-    (Q₁ : QuadraticMap R M₁ N) (Q₂ : QuadraticMap R M₂ N)
-    [Module.Free R M₁] [Module.Finite R M₁]
-    [Module.Free R M₂] [Module.Finite R M₂]
-    (f : specialOrthogonalGroup Q₁) (g : specialOrthogonalGroup Q₂) :
-    (f : M₁ ≃ₗ[R] M₁).prodCongr (g : M₂ ≃ₗ[R] M₂) ∈
-      specialOrthogonalGroup (Q₁.prod Q₂) := by
-  have hf := mem_specialOrthogonalGroup_iff.mp f.2
-  have hg := mem_specialOrthogonalGroup_iff.mp g.2
-  apply mem_specialOrthogonalGroup_iff.mpr
-  constructor
-  · apply mem_orthogonalGroup_iff.mpr
-    intro x
-    let e := (orthogonalGroupEquivIsometryEquiv Q₁
-      ⟨f, specialOrthogonalGroup_le_orthogonalGroup Q₁ f.2⟩).prod
-        (orthogonalGroupEquivIsometryEquiv Q₂
-          ⟨g, specialOrthogonalGroup_le_orthogonalGroup Q₂ g.2⟩)
-    have he : e x = (f.1.prodCongr g.1) x := by
-      apply Prod.ext
-      · exact congrFun (coe_orthogonalGroupEquivIsometryEquiv Q₁ _) x.1
-      · exact congrFun (coe_orthogonalGroupEquivIsometryEquiv Q₂ _) x.2
-    rw [← he]
-    exact e.map_app x
-  · apply Units.ext
-    rw [LinearEquiv.coe_det, LinearEquiv.coe_prodCongr, LinearMap.det_prodMap]
-    simpa only [LinearEquiv.coe_det, Units.val_one, mul_one] using
-      congrArg₂ (fun a b : R ↦ a * b) (congrArg Units.val hf.2) (congrArg Units.val hg.2)
-
-/-- Combine special orthogonal transformations of two finite free quadratic maps with a common
-codomain into a special orthogonal transformation of their product. -/
-def specialOrthogonalGroupProd
-    {M₁ : Type v} [AddCommGroup M₁] [Module R M₁]
-    {M₂ : Type w} [AddCommGroup M₂] [Module R M₂]
-    {N : Type*} [AddCommMonoid N] [Module R N]
-    (Q₁ : QuadraticMap R M₁ N) (Q₂ : QuadraticMap R M₂ N)
-    [Module.Free R M₁] [Module.Finite R M₁]
-    [Module.Free R M₂] [Module.Finite R M₂] :
-    specialOrthogonalGroup Q₁ × specialOrthogonalGroup Q₂ →*
-      specialOrthogonalGroup (Q₁.prod Q₂) where
-  toFun fg := ⟨(fg.1 : M₁ ≃ₗ[R] M₁).prodCongr (fg.2 : M₂ ≃ₗ[R] M₂),
-    specialOrthogonalProd_mem Q₁ Q₂ fg.1 fg.2⟩
-  map_one' := by ext x <;> simp
-  map_mul' f g := by ext x <;> simp
-
-/-- The product of two special orthogonal transformations acts componentwise. -/
-@[simp]
-theorem specialOrthogonalGroupProd_apply
-    {M₁ : Type v} [AddCommGroup M₁] [Module R M₁]
-    {M₂ : Type w} [AddCommGroup M₂] [Module R M₂]
-    {N : Type*} [AddCommMonoid N] [Module R N]
-    (Q₁ : QuadraticMap R M₁ N) (Q₂ : QuadraticMap R M₂ N)
-    [Module.Free R M₁] [Module.Finite R M₁]
-    [Module.Free R M₂] [Module.Finite R M₂]
-    (fg : specialOrthogonalGroup Q₁ × specialOrthogonalGroup Q₂) (x : M₁ × M₂) :
-    ((specialOrthogonalGroupProd Q₁ Q₂ fg : specialOrthogonalGroup _) :
-      (M₁ × M₂) ≃ₗ[R] (M₁ × M₂)) x =
-      ((fg.1 : M₁ ≃ₗ[R] M₁) x.1, (fg.2 : M₂ ≃ₗ[R] M₂) x.2) := by
-  rfl
 
 private def specialOrthogonalProdLastExtension (Q : QuadraticForm R M)
     (f : specialOrthogonalGroup Q) : (M × R) ≃ₗ[R] (M × R) :=
@@ -134,7 +69,7 @@ theorem specialOrthogonalGroupProdLastInclusion_apply (Q : QuadraticForm R M)
     ((specialOrthogonalGroupProdLastInclusion Q f :
       specialOrthogonalGroup _) : (M × R) ≃ₗ[R] (M × R)) x =
       ((f : M ≃ₗ[R] M) x.1, x.2) := by
-  rfl
+  simp [specialOrthogonalGroupProdLastInclusion]
 
 /-- Extension by the identity on the square line is injective. -/
 theorem specialOrthogonalGroupProdLastInclusion_injective (Q : QuadraticForm R M)
@@ -300,7 +235,7 @@ theorem specialOrthogonalGroupProdLastInclusionToStabilizer_apply
     (f : specialOrthogonalGroup Q) (x : M × R) :
     (specialOrthogonalGroupProdLastInclusionToStabilizer Q f).1.1 x =
       ((f : M ≃ₗ[R] M) x.1, x.2) := by
-  rfl
+  exact specialOrthogonalGroupProdLastInclusion_apply Q f x
 
 private def specialOrthogonalProdLastRestriction
     (Q : QuadraticForm R M) (h2 : IsRegular (2 : R))
@@ -339,11 +274,18 @@ def specialOrthogonalGroupEquivProdLastStabilizer
       apply Subtype.ext
       apply LinearEquiv.ext
       intro m
-      rfl)
+      simp [specialOrthogonalProdLastRestriction,
+        specialOrthogonalProdLastRestrictionLinearEquiv])
     (MonoidHom.ext fun g => by
       apply Subtype.ext
       apply Subtype.ext
-      exact (specialOrthogonalProdLast_eq_extension_restriction Q h2 g).symm)
+      apply LinearEquiv.ext
+      intro x
+      simp only [MonoidHom.comp_apply, MonoidHom.id_apply]
+      rw [specialOrthogonalGroupProdLastInclusionToStabilizer_apply]
+      have h := congrArg (fun e : (M × R) ≃ₗ[R] (M × R) => e x)
+        (specialOrthogonalProdLast_eq_extension_restriction Q h2 g)
+      simpa [specialOrthogonalProdLastRestriction, specialOrthogonalProdLastExtension] using h.symm)
 
 /-- The stabilizer equivalence sends `f` to its extension by the identity. -/
 @[simp]
@@ -352,7 +294,7 @@ theorem coe_specialOrthogonalGroupEquivProdLastStabilizer_apply
     [Module.Free R M] [Module.Finite R M] (f : specialOrthogonalGroup Q) (x : M × R) :
     ((specialOrthogonalGroupEquivProdLastStabilizer Q h2 f).1.1 x) =
       ((f : M ≃ₗ[R] M) x.1, x.2) := by
-  rfl
+  exact specialOrthogonalGroupProdLastInclusionToStabilizer_apply Q f x
 
 /-- The inverse stabilizer equivalence restricts to the first summand. -/
 @[simp]

--- a/TauCeti/LinearAlgebra/QuadraticForm/SpecialOrthogonalStabilizer.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/SpecialOrthogonalStabilizer.lean
@@ -12,18 +12,17 @@ public import TauCeti.LinearAlgebra.QuadraticForm.OrthogonalGroup
 # The last-vector stabilizer in a special orthogonal group
 
 Let `Q` be a quadratic form on a finite free module `M`. Extending an element of `SO(Q)` by the
-identity on a rank-one summand embeds it into `SO(Q.prod QuadraticMap.sq)`. If two is not zero and
-the base ring has no zero divisors, its image is exactly the stabilizer of the last basis vector
-`(0, 1)`.
+identity on a rank-one summand embeds it into `SO(Q.prod QuadraticMap.sq)`. If two acts regularly on
+the base ring, its image is exactly the stabilizer of the last basis vector `(0, 1)`.
 
 The inverse map restricts a stabilizer element to the first summand. Orthogonality and fixation of
 `(0, 1)` force that summand to be preserved: polarizing the image of `(m, 0)` against `(0, 1)`
 shows that twice its last coordinate vanishes. The determinant-one condition then descends because
 the original map is the product of its restriction with the identity of the last summand.
 
-This is the special-orthogonal group calculation used in the compact Spin stabilizer
-identification. After applying the Spin action, it turns fixation of the last vector into a
-lower-rank special orthogonal transformation that can be lifted back to the lower-rank Spin group.
+This calculation is useful for inductive comparisons of orthogonal and Spin groups: after applying
+a Spin action, it turns fixation of the last vector into a lower-rank special orthogonal
+transformation.
 
 ## Main definitions
 
@@ -32,11 +31,6 @@ lower-rank special orthogonal transformation that can be lifted back to the lowe
 * `specialOrthogonalGroupProdLastStabilizer`: the subgroup fixing `(0, 1)`.
 * `specialOrthogonalGroupEquivProdLastStabilizer`: the extension-restriction equivalence between
   `SO(Q)` and that stabilizer.
-
-## References
-
-* [Clifford algebras, Pin and Spin, and spin representations roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md),
-  Layer 7, the compact Spin stabilizer identification.
 -/
 
 public section
@@ -45,9 +39,9 @@ open QuadraticMap
 
 universe u v
 
-namespace TauCeti
-
 namespace QuadraticMap
+
+open TauCeti.QuadraticMap
 
 noncomputable section
 
@@ -101,6 +95,20 @@ theorem specialOrthogonalGroupProdLastInclusion_apply (Q : QuadraticForm R M)
       ((f : M ≃ₗ[R] M) x.1, x.2) := by
   rfl
 
+/-- Extension by the identity on the square line is injective. -/
+theorem specialOrthogonalGroupProdLastInclusion_injective (Q : QuadraticForm R M)
+    [Module.Free R M] [Module.Finite R M] :
+    Function.Injective (specialOrthogonalGroupProdLastInclusion Q) := by
+  intro f g h
+  apply Subtype.ext
+  apply LinearEquiv.ext
+  intro m
+  have h' := congrArg
+    (fun k : specialOrthogonalGroup
+        (Q.prod (QuadraticMap.sq (R := R) (A := R))) =>
+      (((k : (M × R) ≃ₗ[R] (M × R)) (m, 0)).1)) h
+  simpa using h'
+
 /-- The stabilizer of the last basis vector `(0, 1)` in the special orthogonal group of
 `Q.prod QuadraticMap.sq`. -/
 def specialOrthogonalGroupProdLastStabilizer (Q : QuadraticForm R M) :
@@ -129,7 +137,7 @@ private theorem specialOrthogonalGroupProdLastInclusion_mem_stabilizer
   exact Prod.ext (by simp) (by simp)
 
 private theorem snd_eq_zero_of_mem_specialOrthogonalGroupProdLastStabilizer
-    [NoZeroDivisors R] [NeZero (2 : R)] (Q : QuadraticForm R M)
+    (Q : QuadraticForm R M) (h2 : IsRegular (2 : R))
     (g : specialOrthogonalGroupProdLastStabilizer Q) (m : M) :
     (g.1.1 (m, 0)).2 = 0 := by
   have hfix : g.1.1 ((0 : M), (1 : R)) = ((0 : M), (1 : R)) :=
@@ -142,10 +150,10 @@ private theorem snd_eq_zero_of_mem_specialOrthogonalGroupProdLastStabilizer
   ring_nf at hpolar
   have htwo : (2 : R) * (g.1.1 (m, 0)).2 = 0 := by
     linear_combination hpolar
-  exact (mul_eq_zero.mp htwo).resolve_left (NeZero.ne (2 : R))
+  exact (isRegular_iff_eq_zero_of_mul.mp h2).1 _ htwo
 
 private def specialOrthogonalProdLastRestrictionLinearEquiv
-    [NoZeroDivisors R] [NeZero (2 : R)] (Q : QuadraticForm R M)
+    (Q : QuadraticForm R M) (h2 : IsRegular (2 : R))
     (g : specialOrthogonalGroupProdLastStabilizer Q) : M ≃ₗ[R] M where
   toFun m := (g.1.1 (m, 0)).1
   invFun m := ((g⁻¹).1.1 (m, 0)).1
@@ -154,29 +162,31 @@ private def specialOrthogonalProdLastRestrictionLinearEquiv
   map_smul' c x := by
     simpa using congrArg Prod.fst (g.1.1.map_smul c (x, 0))
   left_inv m := by
-    have hzero := snd_eq_zero_of_mem_specialOrthogonalGroupProdLastStabilizer Q g m
+    have hzero := snd_eq_zero_of_mem_specialOrthogonalGroupProdLastStabilizer Q h2 g m
     have hpair : g.1.1 (m, 0) = ((g.1.1 (m, 0)).1, 0) := Prod.ext rfl hzero
+    -- Unfold the restriction's inverse to expose the ambient inverse action.
     change ((g⁻¹).1.1 ((g.1.1 (m, 0)).1, 0)).1 = m
     rw [← hpair]
     simpa only [Prod.fst, Subgroup.coe_inv, LinearEquiv.coe_inv] using
       congrArg Prod.fst (g.1.1.symm_apply_apply (m, 0))
   right_inv m := by
-    have hzero := snd_eq_zero_of_mem_specialOrthogonalGroupProdLastStabilizer Q g⁻¹ m
+    have hzero := snd_eq_zero_of_mem_specialOrthogonalGroupProdLastStabilizer Q h2 g⁻¹ m
     have hpair : (g⁻¹).1.1 (m, 0) = (((g⁻¹).1.1 (m, 0)).1, 0) :=
       Prod.ext rfl hzero
+    -- Unfold the restriction to expose the ambient forward action.
     change (g.1.1 (((g⁻¹).1.1 (m, 0)).1, 0)).1 = m
     rw [← hpair]
     simpa only [Prod.fst, Subgroup.coe_inv, LinearEquiv.coe_inv] using
       congrArg Prod.fst (g.1.1.apply_symm_apply (m, 0))
 
 private theorem specialOrthogonalProdLast_eq_prodCongr_restriction
-    [NoZeroDivisors R] [NeZero (2 : R)] (Q : QuadraticForm R M)
+    (Q : QuadraticForm R M) (h2 : IsRegular (2 : R))
     (g : specialOrthogonalGroupProdLastStabilizer Q) :
-    g.1.1 = (specialOrthogonalProdLastRestrictionLinearEquiv Q g).prodCongr
+    g.1.1 = (specialOrthogonalProdLastRestrictionLinearEquiv Q h2 g).prodCongr
       (LinearEquiv.refl R R) := by
   apply LinearEquiv.ext
   intro x
-  have hzero := snd_eq_zero_of_mem_specialOrthogonalGroupProdLastStabilizer Q g x.1
+  have hzero := snd_eq_zero_of_mem_specialOrthogonalGroupProdLastStabilizer Q h2 g x.1
   have hfix : g.1.1 ((0 : M), (1 : R)) = ((0 : M), (1 : R)) :=
     mem_specialOrthogonalGroupProdLastStabilizer_iff Q |>.mp g.2
   have hline : g.1.1 (0, x.2) = (0, x.2) := by
@@ -184,27 +194,28 @@ private theorem specialOrthogonalProdLast_eq_prodCongr_restriction
       g.1.1 (0, x.2) = g.1.1 (x.2 • ((0 : M), (1 : R))) := by simp
       _ = x.2 • g.1.1 ((0 : M), (1 : R)) := g.1.1.map_smul _ _
       _ = (0, x.2) := by rw [hfix]; simp
-  rw [show x = (x.1, 0) + (0, x.2) by ext <;> simp, map_add, hline]
+  have hx : x = (x.1, 0) + (0, x.2) := by ext <;> simp
+  rw [hx, map_add, hline]
   apply Prod.ext <;>
     simp [specialOrthogonalProdLastRestrictionLinearEquiv, hzero]
 
 private theorem specialOrthogonalProdLastRestriction_mem
-    [NoZeroDivisors R] [NeZero (2 : R)] (Q : QuadraticForm R M)
+    (Q : QuadraticForm R M) (h2 : IsRegular (2 : R))
     [Module.Free R M] [Module.Finite R M]
     (g : specialOrthogonalGroupProdLastStabilizer Q) :
-    specialOrthogonalProdLastRestrictionLinearEquiv Q g ∈ specialOrthogonalGroup Q := by
+    specialOrthogonalProdLastRestrictionLinearEquiv Q h2 g ∈ specialOrthogonalGroup Q := by
   have hg := mem_specialOrthogonalGroup_iff.mp g.1.2
   apply mem_specialOrthogonalGroup_iff.mpr
   constructor
   · apply mem_orthogonalGroup_iff.mpr
     intro m
-    have hzero := snd_eq_zero_of_mem_specialOrthogonalGroupProdLastStabilizer Q g m
+    have hzero := snd_eq_zero_of_mem_specialOrthogonalGroupProdLastStabilizer Q h2 g m
     have hmap := map_app_of_mem_orthogonalGroup hg.1 (m, 0)
     simpa [specialOrthogonalProdLastRestrictionLinearEquiv, QuadraticMap.prod_apply,
       hzero] using hmap
   · apply Units.ext
     have hdet := congrArg Units.val hg.2
-    rw [LinearEquiv.coe_det, specialOrthogonalProdLast_eq_prodCongr_restriction Q g,
+    rw [LinearEquiv.coe_det, specialOrthogonalProdLast_eq_prodCongr_restriction Q h2 g,
       LinearEquiv.coe_prodCongr, LinearMap.det_prodMap] at hdet
     have hrefl :
         LinearMap.det ((LinearEquiv.refl R R : R ≃ₗ[R] R) : R →ₗ[R] R) = 1 := by
@@ -213,35 +224,28 @@ private theorem specialOrthogonalProdLastRestriction_mem
     simpa only [LinearEquiv.coe_det] using hdet
 
 private theorem specialOrthogonalProdLast_eq_extension_restriction
-    [NoZeroDivisors R] [NeZero (2 : R)] (Q : QuadraticForm R M)
+    (Q : QuadraticForm R M) (h2 : IsRegular (2 : R))
     [Module.Free R M] [Module.Finite R M]
     (g : specialOrthogonalGroupProdLastStabilizer Q) :
     g.1.1 = specialOrthogonalProdLastExtension Q
-      ⟨specialOrthogonalProdLastRestrictionLinearEquiv Q g,
-        specialOrthogonalProdLastRestriction_mem Q g⟩ := by
+      ⟨specialOrthogonalProdLastRestrictionLinearEquiv Q h2 g,
+        specialOrthogonalProdLastRestriction_mem Q h2 g⟩ := by
   simpa only [specialOrthogonalProdLastExtension] using
-    specialOrthogonalProdLast_eq_prodCongr_restriction Q g
+    specialOrthogonalProdLast_eq_prodCongr_restriction Q h2 g
 
 private def specialOrthogonalProdLastInclusionToStabilizer
     (Q : QuadraticForm R M) [Module.Free R M] [Module.Finite R M] :
-    specialOrthogonalGroup Q →* specialOrthogonalGroupProdLastStabilizer Q where
-  toFun f :=
-    ⟨specialOrthogonalGroupProdLastInclusion Q f,
-      specialOrthogonalGroupProdLastInclusion_mem_stabilizer Q f⟩
-  map_one' := by
-    apply Subtype.ext
-    exact (specialOrthogonalGroupProdLastInclusion Q).map_one
-  map_mul' f g := by
-    apply Subtype.ext
-    exact (specialOrthogonalGroupProdLastInclusion Q).map_mul f g
+    specialOrthogonalGroup Q →* specialOrthogonalGroupProdLastStabilizer Q :=
+  (specialOrthogonalGroupProdLastInclusion Q).codRestrict _
+    (specialOrthogonalGroupProdLastInclusion_mem_stabilizer Q)
 
 private def specialOrthogonalProdLastRestriction
-    [NoZeroDivisors R] [NeZero (2 : R)] (Q : QuadraticForm R M)
+    (Q : QuadraticForm R M) (h2 : IsRegular (2 : R))
     [Module.Free R M] [Module.Finite R M] :
     specialOrthogonalGroupProdLastStabilizer Q →* specialOrthogonalGroup Q where
   toFun g :=
-    ⟨specialOrthogonalProdLastRestrictionLinearEquiv Q g,
-      specialOrthogonalProdLastRestriction_mem Q g⟩
+    ⟨specialOrthogonalProdLastRestrictionLinearEquiv Q h2 g,
+      specialOrthogonalProdLastRestriction_mem Q h2 g⟩
   map_one' := by
     apply Subtype.ext
     apply LinearEquiv.ext
@@ -251,23 +255,23 @@ private def specialOrthogonalProdLastRestriction
     apply Subtype.ext
     apply LinearEquiv.ext
     intro m
-    have hzero := snd_eq_zero_of_mem_specialOrthogonalGroupProdLastStabilizer Q h m
+    have hzero := snd_eq_zero_of_mem_specialOrthogonalGroupProdLastStabilizer Q h2 h m
     have hpair : h.1.1 (m, 0) = ((h.1.1 (m, 0)).1, 0) := Prod.ext rfl hzero
+    -- Unfold multiplication of the restricted linear equivalences.
     change (g.1.1 (h.1.1 (m, 0))).1 = (g.1.1 ((h.1.1 (m, 0)).1, 0)).1
     rw [hpair]
 
 /-- Extension by the identity identifies `SO(Q)` with the last-vector stabilizer in
 `SO(Q.prod QuadraticMap.sq)`.
 
-The inverse sends a stabilizer element `g` to its restriction `m ↦ (g (m, 0)).1`. The assumptions
-that the ring has no zero divisors and that `2 ≠ 0` ensure that fixation of `(0, 1)` forces `g` to
-preserve the first summand. -/
+The inverse sends a stabilizer element `g` to its restriction `m ↦ (g (m, 0)).1`. Regularity of
+`2` ensures that fixation of `(0, 1)` forces `g` to preserve the first summand. -/
 def specialOrthogonalGroupEquivProdLastStabilizer
-    [NoZeroDivisors R] [NeZero (2 : R)] (Q : QuadraticForm R M)
+    (Q : QuadraticForm R M) (h2 : IsRegular (2 : R))
     [Module.Free R M] [Module.Finite R M] :
     specialOrthogonalGroup Q ≃* specialOrthogonalGroupProdLastStabilizer Q :=
   MonoidHom.toMulEquiv (specialOrthogonalProdLastInclusionToStabilizer Q)
-    (specialOrthogonalProdLastRestriction Q)
+    (specialOrthogonalProdLastRestriction Q h2)
     (MonoidHom.ext fun f => by
       apply Subtype.ext
       apply LinearEquiv.ext
@@ -276,29 +280,27 @@ def specialOrthogonalGroupEquivProdLastStabilizer
     (MonoidHom.ext fun g => by
       apply Subtype.ext
       apply Subtype.ext
-      exact (specialOrthogonalProdLast_eq_extension_restriction Q g).symm)
+      exact (specialOrthogonalProdLast_eq_extension_restriction Q h2 g).symm)
 
 /-- The stabilizer equivalence sends `f` to its extension by the identity. -/
 @[simp]
 theorem coe_specialOrthogonalGroupEquivProdLastStabilizer_apply
-    [NoZeroDivisors R] [NeZero (2 : R)] (Q : QuadraticForm R M)
+    (Q : QuadraticForm R M) (h2 : IsRegular (2 : R))
     [Module.Free R M] [Module.Finite R M] (f : specialOrthogonalGroup Q) (x : M × R) :
-    ((specialOrthogonalGroupEquivProdLastStabilizer Q f).1.1 x) =
+    ((specialOrthogonalGroupEquivProdLastStabilizer Q h2 f).1.1 x) =
       ((f : M ≃ₗ[R] M) x.1, x.2) := by
   rfl
 
 /-- The inverse stabilizer equivalence restricts to the first summand. -/
 @[simp]
 theorem coe_specialOrthogonalGroupEquivProdLastStabilizer_symm_apply
-    [NoZeroDivisors R] [NeZero (2 : R)] (Q : QuadraticForm R M)
+    (Q : QuadraticForm R M) (h2 : IsRegular (2 : R))
     [Module.Free R M] [Module.Finite R M]
     (g : specialOrthogonalGroupProdLastStabilizer Q) (m : M) :
-    ((specialOrthogonalGroupEquivProdLastStabilizer Q).symm g : M ≃ₗ[R] M) m =
+    ((specialOrthogonalGroupEquivProdLastStabilizer Q h2).symm g : M ≃ₗ[R] M) m =
       (g.1.1 (m, 0)).1 := by
   rfl
 
 end
 
 end QuadraticMap
-
-end TauCeti

--- a/TauCeti/LinearAlgebra/QuadraticForm/SpecialOrthogonalStabilizer.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/SpecialOrthogonalStabilizer.lean
@@ -26,6 +26,8 @@ transformation.
 
 ## Main definitions
 
+* `specialOrthogonalGroupProd`: combine special orthogonal transformations of two forms into one
+  of their product.
 * `specialOrthogonalGroupProdLastInclusion`: extend a special orthogonal transformation by the
   identity on the square line.
 * `specialOrthogonalGroupProdLastInclusionToStabilizer`: the same extension, codrestricted to the
@@ -39,7 +41,7 @@ public section
 
 open QuadraticMap
 
-universe u v
+universe u v w
 
 namespace QuadraticMap
 
@@ -50,50 +52,78 @@ noncomputable section
 variable {R : Type u} [CommRing R]
   {M : Type v} [AddCommGroup M] [Module R M]
 
-private def specialOrthogonalProdLastExtension (Q : QuadraticForm R M)
-    (f : specialOrthogonalGroup Q) : (M × R) ≃ₗ[R] (M × R) :=
-  (f : M ≃ₗ[R] M).prodCongr (LinearEquiv.refl R R)
-
-private theorem specialOrthogonalProdLastExtension_mem (Q : QuadraticForm R M)
-    [Module.Free R M] [Module.Finite R M] (f : specialOrthogonalGroup Q) :
-    specialOrthogonalProdLastExtension Q f ∈ specialOrthogonalGroup
-      (Q.prod (QuadraticMap.sq (R := R) (A := R))) := by
+private theorem specialOrthogonalProd_mem
+    {M₁ : Type v} [AddCommGroup M₁] [Module R M₁]
+    {M₂ : Type w} [AddCommGroup M₂] [Module R M₂]
+    (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂)
+    [Module.Free R M₁] [Module.Finite R M₁]
+    [Module.Free R M₂] [Module.Finite R M₂]
+    (f : specialOrthogonalGroup Q₁) (g : specialOrthogonalGroup Q₂) :
+    (f : M₁ ≃ₗ[R] M₁).prodCongr (g : M₂ ≃ₗ[R] M₂) ∈
+      specialOrthogonalGroup (Q₁.prod Q₂) := by
   have hf := mem_specialOrthogonalGroup_iff.mp f.2
+  have hg := mem_specialOrthogonalGroup_iff.mp g.2
   apply mem_specialOrthogonalGroup_iff.mpr
   constructor
   · apply mem_orthogonalGroup_iff.mpr
     intro x
-    let e := (orthogonalGroupEquivIsometryEquiv Q
-      ⟨f, specialOrthogonalGroup_le_orthogonalGroup Q f.2⟩).prod
-        (QuadraticMap.IsometryEquiv.refl (QuadraticMap.sq (R := R) (A := R)))
-    have he : e x = specialOrthogonalProdLastExtension Q f x := by
+    let e := (orthogonalGroupEquivIsometryEquiv Q₁
+      ⟨f, specialOrthogonalGroup_le_orthogonalGroup Q₁ f.2⟩).prod
+        (orthogonalGroupEquivIsometryEquiv Q₂
+          ⟨g, specialOrthogonalGroup_le_orthogonalGroup Q₂ g.2⟩)
+    have he : e x = (f.1.prodCongr g.1) x := by
       apply Prod.ext
-      -- Expose the first component so the orthogonal-group/isometry coercion lemma applies.
-      · change (orthogonalGroupEquivIsometryEquiv Q _ x.1) = f.1 x.1
-        exact congrFun (coe_orthogonalGroupEquivIsometryEquiv Q _) x.1
-      · rfl
+      · change (orthogonalGroupEquivIsometryEquiv Q₁ _ x.1) = f.1 x.1
+        exact congrFun (coe_orthogonalGroupEquivIsometryEquiv Q₁ _) x.1
+      · change (orthogonalGroupEquivIsometryEquiv Q₂ _ x.2) = g.1 x.2
+        exact congrFun (coe_orthogonalGroupEquivIsometryEquiv Q₂ _) x.2
     rw [← he]
     exact e.map_app x
   · apply Units.ext
-    rw [LinearEquiv.coe_det, specialOrthogonalProdLastExtension,
-      LinearEquiv.coe_prodCongr, LinearMap.det_prodMap]
-    have hrefl :
-        LinearMap.det ((LinearEquiv.refl R R : R ≃ₗ[R] R) : R →ₗ[R] R) = 1 := by
-      simp
-    rw [hrefl, mul_one]
-    simpa only [LinearEquiv.coe_det] using congrArg Units.val hf.2
+    rw [LinearEquiv.coe_det, LinearEquiv.coe_prodCongr, LinearMap.det_prodMap]
+    simpa only [LinearEquiv.coe_det, Units.val_one, mul_one] using
+      congrArg₂ (fun a b : R ↦ a * b) (congrArg Units.val hf.2) (congrArg Units.val hg.2)
+
+/-- Combine special orthogonal transformations of two finite free quadratic forms into a special
+orthogonal transformation of their product. -/
+def specialOrthogonalGroupProd
+    {M₁ : Type v} [AddCommGroup M₁] [Module R M₁]
+    {M₂ : Type w} [AddCommGroup M₂] [Module R M₂]
+    (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂)
+    [Module.Free R M₁] [Module.Finite R M₁]
+    [Module.Free R M₂] [Module.Finite R M₂] :
+    specialOrthogonalGroup Q₁ × specialOrthogonalGroup Q₂ →*
+      specialOrthogonalGroup (Q₁.prod Q₂) where
+  toFun fg := ⟨(fg.1 : M₁ ≃ₗ[R] M₁).prodCongr (fg.2 : M₂ ≃ₗ[R] M₂),
+    specialOrthogonalProd_mem Q₁ Q₂ fg.1 fg.2⟩
+  map_one' := by ext x <;> simp
+  map_mul' f g := by ext x <;> simp
+
+/-- The product of two special orthogonal transformations acts componentwise. -/
+@[simp]
+theorem specialOrthogonalGroupProd_apply
+    {M₁ : Type v} [AddCommGroup M₁] [Module R M₁]
+    {M₂ : Type w} [AddCommGroup M₂] [Module R M₂]
+    (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂)
+    [Module.Free R M₁] [Module.Finite R M₁]
+    [Module.Free R M₂] [Module.Finite R M₂]
+    (fg : specialOrthogonalGroup Q₁ × specialOrthogonalGroup Q₂) (x : M₁ × M₂) :
+    ((specialOrthogonalGroupProd Q₁ Q₂ fg : specialOrthogonalGroup _) :
+      (M₁ × M₂) ≃ₗ[R] (M₁ × M₂)) x =
+      ((fg.1 : M₁ ≃ₗ[R] M₁) x.1, (fg.2 : M₂ ≃ₗ[R] M₂) x.2) := by
+  rfl
+
+private def specialOrthogonalProdLastExtension (Q : QuadraticForm R M)
+    (f : specialOrthogonalGroup Q) : (M × R) ≃ₗ[R] (M × R) :=
+  (f : M ≃ₗ[R] M).prodCongr (LinearEquiv.refl R R)
 
 /-- Extend a special orthogonal transformation by the identity on the square line. -/
 def specialOrthogonalGroupProdLastInclusion (Q : QuadraticForm R M)
     [Module.Free R M] [Module.Finite R M] :
     specialOrthogonalGroup Q →* specialOrthogonalGroup
-      (Q.prod (QuadraticMap.sq (R := R) (A := R))) where
-  toFun f :=
-    ⟨specialOrthogonalProdLastExtension Q f, specialOrthogonalProdLastExtension_mem Q f⟩
-  map_one' := by
-    ext x <;> simp [specialOrthogonalProdLastExtension]
-  map_mul' f g := by
-    ext x <;> simp [specialOrthogonalProdLastExtension]
+      (Q.prod (QuadraticMap.sq (R := R) (A := R))) :=
+  (specialOrthogonalGroupProd Q (QuadraticMap.sq (R := R) (A := R))).comp
+    (MonoidHom.inl _ _)
 
 /-- Extending a special orthogonal transformation acts componentwise and fixes the square-line
 coordinate. -/
@@ -147,23 +177,31 @@ theorem specialOrthogonalGroupProdLastInclusion_mem_stabilizer
   rw [mem_specialOrthogonalGroupProdLastStabilizer_iff]
   exact Prod.ext (by simp) (by simp)
 
+/-- An orthogonal transformation fixing the last basis vector maps the first summand back into the
+first summand. -/
+theorem orthogonalGroupProdLast_fixed_apply_snd
+    (Q : QuadraticForm R M) (h2 : IsRegular (2 : R))
+    (g : orthogonalGroup (Q.prod (QuadraticMap.sq (R := R) (A := R))))
+    (hfix : (g : (M × R) ≃ₗ[R] (M × R)) ((0 : M), (1 : R)) = (0, 1))
+    (m : M) : (g.1 (m, 0)).2 = 0 := by
+  have hpolar := polar_apply_of_mem_orthogonalGroup g.2 (m, 0) (0, 1)
+  rw [hfix, QuadraticMap.polar_prod, QuadraticMap.polar_prod] at hpolar
+  simp only [map_zero, add_zero, zero_add, QuadraticMap.sq_apply, QuadraticMap.polar,
+    mul_one, sub_zero] at hpolar
+  ring_nf at hpolar
+  have htwo : (2 : R) * (g.1 (m, 0)).2 = 0 := by
+    linear_combination hpolar
+  exact (isRegular_iff_eq_zero_of_mul.mp h2).1 _ htwo
+
 /-- A last-vector stabilizer element maps the first summand back into the first summand. -/
 @[simp]
 theorem specialOrthogonalGroupProdLastStabilizer_apply_snd
     (Q : QuadraticForm R M) (h2 : IsRegular (2 : R))
     (g : specialOrthogonalGroupProdLastStabilizer Q) (m : M) :
-    (g.1.1 (m, 0)).2 = 0 := by
-  have hfix : g.1.1 ((0 : M), (1 : R)) = ((0 : M), (1 : R)) :=
-    mem_specialOrthogonalGroupProdLastStabilizer_iff Q |>.mp g.2
-  have hg := mem_specialOrthogonalGroup_iff.mp g.1.2
-  have hpolar := polar_apply_of_mem_orthogonalGroup hg.1 (m, 0) (0, 1)
-  rw [hfix, QuadraticMap.polar_prod, QuadraticMap.polar_prod] at hpolar
-  simp only [map_zero, add_zero, zero_add, QuadraticMap.sq_apply, QuadraticMap.polar,
-    mul_one, sub_zero] at hpolar
-  ring_nf at hpolar
-  have htwo : (2 : R) * (g.1.1 (m, 0)).2 = 0 := by
-    linear_combination hpolar
-  exact (isRegular_iff_eq_zero_of_mul.mp h2).1 _ htwo
+    (g.1.1 (m, 0)).2 = 0 :=
+  orthogonalGroupProdLast_fixed_apply_snd Q h2
+    ⟨g.1.1, specialOrthogonalGroup_le_orthogonalGroup _ g.1.2⟩
+    (mem_specialOrthogonalGroupProdLastStabilizer_iff Q |>.mp g.2) m
 
 private def specialOrthogonalProdLastRestrictionLinearEquiv
     (Q : QuadraticForm R M) (h2 : IsRegular (2 : R))

--- a/TauCeti/LinearAlgebra/QuadraticForm/SpecialOrthogonalStabilizer.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/SpecialOrthogonalStabilizer.lean
@@ -49,10 +49,6 @@ noncomputable section
 variable {R : Type u} [CommRing R]
   {M : Type v} [AddCommGroup M] [Module R M]
 
-private def specialOrthogonalProdLastExtension (Q : QuadraticForm R M)
-    (f : specialOrthogonalGroup Q) : (M × R) ≃ₗ[R] (M × R) :=
-  (f : M ≃ₗ[R] M).prodCongr (LinearEquiv.refl R R)
-
 /-- Extend a special orthogonal transformation by the identity on the square line. -/
 def specialOrthogonalGroupProdLastInclusion (Q : QuadraticForm R M)
     [Module.Free R M] [Module.Finite R M] :
@@ -103,15 +99,6 @@ theorem mem_specialOrthogonalGroupProdLastStabilizer_iff
     g ∈ specialOrthogonalGroupProdLastStabilizer Q ↔
       (g : (M × R) ≃ₗ[R] (M × R)) ((0 : M), (1 : R)) = (0, 1) :=
   MulAction.mem_stabilizer_iff
-
-/-- Extension by the identity on the square line fixes the last basis vector. -/
-theorem specialOrthogonalGroupProdLastInclusion_mem_stabilizer
-    (Q : QuadraticForm R M) [Module.Free R M] [Module.Finite R M]
-    (f : specialOrthogonalGroup Q) :
-    specialOrthogonalGroupProdLastInclusion Q f ∈
-      specialOrthogonalGroupProdLastStabilizer Q := by
-  rw [mem_specialOrthogonalGroupProdLastStabilizer_iff]
-  exact Prod.ext (by simp) (by simp)
 
 /-- An orthogonal transformation fixing the last basis vector maps the first summand back into the
 first summand. -/
@@ -210,23 +197,13 @@ private theorem specialOrthogonalProdLastRestriction_mem
     rw [hrefl, mul_one] at hdet
     simpa only [LinearEquiv.coe_det] using hdet
 
-private theorem specialOrthogonalProdLast_eq_extension_restriction
-    (Q : QuadraticForm R M) (h2 : IsRegular (2 : R))
-    [Module.Free R M] [Module.Finite R M]
-    (g : specialOrthogonalGroupProdLastStabilizer Q) :
-    g.1.1 = specialOrthogonalProdLastExtension Q
-      ⟨specialOrthogonalProdLastRestrictionLinearEquiv Q h2 g,
-        specialOrthogonalProdLastRestriction_mem Q h2 g⟩ := by
-  simpa only [specialOrthogonalProdLastExtension] using
-    specialOrthogonalProdLast_eq_prodCongr_restriction Q h2 g
-
 /-- Extend a special orthogonal transformation by the identity, as an element of the last-vector
 stabilizer. -/
 def specialOrthogonalGroupProdLastInclusionToStabilizer
     (Q : QuadraticForm R M) [Module.Free R M] [Module.Finite R M] :
     specialOrthogonalGroup Q →* specialOrthogonalGroupProdLastStabilizer Q :=
   (specialOrthogonalGroupProdLastInclusion Q).codRestrict _
-    (specialOrthogonalGroupProdLastInclusion_mem_stabilizer Q)
+    (fun f => by simp)
 
 /-- The stabilizer-valued identity extension acts componentwise. -/
 @[simp]
@@ -284,8 +261,8 @@ def specialOrthogonalGroupEquivProdLastStabilizer
       simp only [MonoidHom.comp_apply, MonoidHom.id_apply]
       rw [specialOrthogonalGroupProdLastInclusionToStabilizer_apply]
       have h := congrArg (fun e : (M × R) ≃ₗ[R] (M × R) => e x)
-        (specialOrthogonalProdLast_eq_extension_restriction Q h2 g)
-      simpa [specialOrthogonalProdLastRestriction, specialOrthogonalProdLastExtension] using h.symm)
+        (specialOrthogonalProdLast_eq_prodCongr_restriction Q h2 g)
+      simpa [specialOrthogonalProdLastRestriction] using h.symm)
 
 /-- The stabilizer equivalence sends `f` to its extension by the identity. -/
 @[simp]


### PR DESCRIPTION
This PR identifies the special orthogonal group of a quadratic form with the last-vector stabilizer after adjoining a square line for the Layer 7 compact-Spin connectivity milestone.

Roadmap: RepresentationTheory

## Summary

Combine special orthogonal transformations of two finite-free quadratic maps with a common arbitrary codomain through Mathlib's product isometry, then obtain the scalar-valued square-line inclusion by fixing the second transformation to the identity. The generic product construction lives in the quadratic-form product module; the stabilizer module defines the stabilizer of `(0, 1)` in `SO(Q.prod QuadraticMap.sq)` and constructs the inverse by restricting a stabilizer element to the first summand.

The coordinate-elimination argument is stated at its natural orthogonal-group generality: orthogonality and fixation of `(0, 1)` force the image of `(m, 0)` to have last coordinate zero. The existing stabilizer theorem specializes this boundary, while the product determinant formula proves that the restriction still has determinant one.

## Roadmap target

This advances RepresentationTheory → SpinRepresentations → Layer 7, “Connectivity of the compact spin group,” specifically the converse compact Spin stabilizer identification needed before the homogeneous-space bundle `Spin(n + 1) / Spin(n) ≃ S^n`. After this PR, the route still needs transport through the real positive-coordinate splitting, lifting the restricted special orthogonal transformation to `Spin(n)`, resolving the residual two-element kernel, and then constructing the sphere bundle used for the connectivity induction.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"special-orthogonal-last-stabilizer-equivalence"}-->

## Verification

- Exact head: `ef20bc3add622d9700952d985e79e49ebf6fd994`
- Local Lean build: `lake build` — pass; `Build completed successfully (10836 jobs).`
- Axiom audit: `lake exe axioms` — pass; 105483 TauCeti declarations audited, all within `[propext, Classical.choice, Quot.sound]`
- Lint: GNU-sed `scripts/lint-env.sh`, `bash scripts/lint-style.sh`, `python3 scripts/lint-dot-notation.py`, and `lake exe module-system` — pass with no new violations; all 4706 modules use the module system
- Public CI: pending for this head

## Scale and generality

The aggregate diff adds 372 lines and removes one across two modules. The general product hom accepts two arbitrary finite-free quadratic maps with a common codomain over a commutative ring and resides with the existing product theory. The square-line inclusion specializes its second factor to the identity, while last-coordinate elimination assumes only orthogonality, fixation of `(0, 1)`, and regularity of `2`; determinant one is used only when restricting back into `SO(Q)`. The equivalence assumes neither a domain, nondegeneracy, nor positivity, so compact real Clifford forms and rings with unrelated zero divisors can instantiate the reusable statement.

## Scope

- **Consumes:** the abstract special orthogonal group, Mathlib product isometries, preservation of polarization by orthogonal maps, quadratic-map products, product determinants, and the canonical product-group inclusion
- **Provides:** the arbitrary-codomain special-orthogonal product hom in the product module, its componentwise equation, the ambient and stabilizer-valued square-line inclusions, the orthogonal fixed-vector elimination theorem, and the extension-restriction group equivalence
- **Fits:** supplies the special-orthogonal restriction step consumed by the converse to the compact Spin stabilizer inclusion, on the critical path to the Layer 7 sphere fibration
- **Boundary:** does not add real-coordinate transport, the lower-rank Spin lift, the kernel comparison, an orbit equivalence, local triviality, connectedness, or simple connectivity

<sub>🤖 GPT-5.6 Sol high · TauCetiWorker @ [910d954fee75dfafda41f98165ce3a9e6676eae1](https://github.com/utensil/TauCetiWorker/commit/910d954fee75dfafda41f98165ce3a9e6676eae1) · rubrics @ [153ea8a6febe59f492c2f3d48471733e8b550848](https://github.com/utensil/TauCetiReview/commit/153ea8a6febe59f492c2f3d48471733e8b550848) · local review @ [b533e561b6d44df071c31335ed4a63ae647507d2](https://github.com/utensil/formal-land/commit/b533e561b6d44df071c31335ed4a63ae647507d2) · fixed: reuse, api-design, generality, naming, documentation, proof-quality, placement, ut-consumer-contract, ut-aggregate-reuse</sub>