### PR TITLE
feat: decompose Clifford restrictions

### DIFF
--- a/TauCeti/LinearAlgebra/Trace/Pi.lean
+++ b/TauCeti/LinearAlgebra/Trace/Pi.lean
@@ -64,7 +64,7 @@ theorem LinearMap.trace_pi_of_apply_eq (T : (ι → M) →ₗ[k] (ι → M)) (σ
 open scoped Classical in
 /-- The trace of a coordinatewise endomorphism of a finite dependent product is the sum of the
 traces on its factors. -/
-theorem LinearMap.trace_pi_apply_eq {M : ι → Type*}
+theorem _root_.LinearMap.trace_pi_apply_eq {M : ι → Type*}
     [∀ i, AddCommGroup (M i)] [∀ i, Module k (M i)] [∀ i, FiniteDimensional k (M i)]
     (T : ((i : ι) → M i) →ₗ[k] ((i : ι) → M i)) (f : ∀ i, M i →ₗ[k] M i)
     (hT : ∀ x i, T x i = f i (x i)) :

--- a/TauCeti/LinearAlgebra/Trace/Pi.lean
+++ b/TauCeti/LinearAlgebra/Trace/Pi.lean
@@ -39,7 +39,7 @@ variable {k : Type u} {ι : Type v} {M : Type w}
 open scoped Classical in
 /-- The trace of a coordinate-reindexing endomorphism of a finite product is the sum of the
 traces on its fixed coordinates. -/
-theorem LinearMap.trace_pi_of_apply_eq (T : (ι → M) →ₗ[k] (ι → M)) (σ : ι → ι)
+theorem _root_.LinearMap.trace_pi_of_apply_eq (T : (ι → M) →ₗ[k] (ι → M)) (σ : ι → ι)
     (f : ι → M →ₗ[k] M) (hT : ∀ x i, T x i = f i (x (σ i))) :
     LinearMap.trace k (ι → M) T =
       ∑ i : ι, if σ i = i then LinearMap.trace k M (f i) else 0 := by

--- a/TauCeti/LinearAlgebra/Trace/Pi.lean
+++ b/TauCeti/LinearAlgebra/Trace/Pi.lean
@@ -15,7 +15,15 @@ This file computes the trace of an endomorphism of a finite product that selects
 coordinate for each output coordinate and applies a linear endomorphism there. Only fixed
 coordinates contribute to the trace.
 
-The result is the linear-algebra input for character formulas of induced representations.
+The results are linear-algebra inputs for character formulas of induced representations and
+finite direct sums of representations.
+
+## Main results
+
+* `LinearMap.trace_pi_of_apply_eq`: the trace formula for a coordinate-reindexing map on a
+  constant finite product.
+* `LinearMap.trace_pi_apply_eq`: the trace formula for a coordinatewise map on a finite dependent
+  product.
 -/
 
 public section
@@ -52,5 +60,25 @@ theorem LinearMap.trace_pi_of_apply_eq (T : (ι → M) →ₗ[k] (ι → M)) (σ
     apply Finset.sum_eq_zero
     intro j _
     simp [LinearMap.toMatrix_apply, B, b, hT, hi]
+
+open scoped Classical in
+/-- The trace of a coordinatewise endomorphism of a finite dependent product is the sum of the
+traces on its factors. -/
+theorem LinearMap.trace_pi_apply_eq {M : ι → Type*}
+    [∀ i, AddCommGroup (M i)] [∀ i, Module k (M i)] [∀ i, FiniteDimensional k (M i)]
+    (T : ((i : ι) → M i) →ₗ[k] ((i : ι) → M i)) (f : ∀ i, M i →ₗ[k] M i)
+    (hT : ∀ x i, T x i = f i (x i)) :
+    LinearMap.trace k ((i : ι) → M i) T = ∑ i, LinearMap.trace k (M i) (f i) := by
+  let b (i : ι) := Module.Free.chooseBasis k (M i)
+  let _ (i : ι) : Fintype (Module.Free.ChooseBasisIndex k (M i)) := Fintype.ofFinite _
+  let B : Module.Basis (Σ i, Module.Free.ChooseBasisIndex k (M i)) k ((i : ι) → M i) :=
+    Pi.basis b
+  rw [LinearMap.trace_eq_matrix_trace k B, Matrix.trace, Fintype.sum_sigma]
+  apply Finset.sum_congr rfl
+  intro i _
+  rw [LinearMap.trace_eq_matrix_trace k (b i), Matrix.trace]
+  apply Finset.sum_congr rfl
+  intro j _
+  simp [LinearMap.toMatrix_apply, B, b, hT]
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/Trace/Pi.lean
+++ b/TauCeti/LinearAlgebra/Trace/Pi.lean
@@ -22,8 +22,8 @@ finite direct sums of representations.
 
 * `LinearMap.trace_pi_of_apply_eq`: the trace formula for a coordinate-reindexing map on a
   constant finite product.
-* `LinearMap.trace_pi_apply_eq`: the trace formula for a coordinatewise map on a finite dependent
-  product.
+* `LinearMap.trace_pi_of_apply_eq_dependent`: the trace formula for a coordinatewise map on a
+  finite dependent product.
 -/
 
 public section
@@ -64,7 +64,7 @@ theorem _root_.LinearMap.trace_pi_of_apply_eq (T : (ι → M) →ₗ[k] (ι → 
 open scoped Classical in
 /-- The trace of a coordinatewise endomorphism of a finite dependent product is the sum of the
 traces on its factors. -/
-theorem _root_.LinearMap.trace_pi_apply_eq {M : ι → Type*}
+theorem _root_.LinearMap.trace_pi_of_apply_eq_dependent {M : ι → Type*}
     [∀ i, AddCommGroup (M i)] [∀ i, Module k (M i)] [∀ i, FiniteDimensional k (M i)]
     (T : ((i : ι) → M i) →ₗ[k] ((i : ι) → M i)) (f : ∀ i, M i →ₗ[k] M i)
     (hT : ∀ x i, T x i = f i (x i)) :

--- a/TauCeti/RepresentationTheory/Induction/Clifford/Equivalence.lean
+++ b/TauCeti/RepresentationTheory/Induction/Clifford/Equivalence.lean
@@ -10,6 +10,10 @@ import TauCeti.LinearAlgebra.Trace.Pi
 import TauCeti.RepresentationTheory.OfModule
 import TauCeti.RepresentationTheory.Simple.Basic
 
+/-
+Roadmap source: `TauCetiRoadmap/RepresentationTheory/InductionRestriction/README.md`, Layer 5.
+-/
+
 /-!
 # The representation decomposition in Clifford's theorem
 
@@ -43,8 +47,6 @@ representative, while changing that representative changes the summand only up t
 
 ## References
 
-* [Induction and restriction roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/InductionRestriction/README.md),
-  Layer 5.
 * I. M. Isaacs, *Character Theory of Finite Groups*, Chapter 6.
 * C. W. Curtis and I. Reiner, *Representation Theory of Finite Groups and Associative Algebras*,
   §49.

--- a/TauCeti/RepresentationTheory/Induction/Clifford/Equivalence.lean
+++ b/TauCeti/RepresentationTheory/Induction/Clifford/Equivalence.lean
@@ -32,8 +32,6 @@ representative, while changing that representative changes the summand only up t
 
 * `FDRep.cliffordSum`: the finite sum of `e` copies of the conjugate of `V` attached to every
   inertia coset.
-* `FDRep.cliffordSumEquiv`: its public identification with the displayed product representation.
-
 ## Main properties
 
 * `FDRep.finrank_cliffordSum` and `FDRep.character_cliffordSum`: its dimension and character.
@@ -72,16 +70,6 @@ noncomputable def cliffordSum {k : Type u} {G : Type v} [Field k] [Group G]
   FDRep.ofShrink <| Representation.ofModule' (k := k) (G := N)
     ((q : G ⧸ inertia V) → Fin e →
       _root_.Representation.asModule (conjNormalFDRep (Quotient.out q) V).ρ)
-
-/-- The representation carried by `V.cliffordSum e` is the product of the conjugates of `V`,
-with one copy for each element of `Fin e` and one summand for each inertia coset. -/
-noncomputable def cliffordSumEquiv {k : Type u} {G : Type v} [Field k] [Group G]
-    {N : Subgroup G} [N.Normal] (V : FDRep k N) [Finite (G ⧸ inertia V)] (e : ℕ) :
-    _root_.Representation.Equiv (V.cliffordSum e).ρ
-      (_root_.Representation.ofModule' (k := k) (G := N)
-        ((q : G ⧸ inertia V) → Fin e →
-          _root_.Representation.asModule (conjNormalFDRep (Quotient.out q) V).ρ)) :=
-  FDRep.ofShrinkEquiv _
 
 /-- The dimension of `V.cliffordSum e` is the number of inertia cosets times `e` times the
 dimension of `V`. -/
@@ -131,7 +119,7 @@ theorem character_cliffordSum {k : Type u} {G : Type v} [Field k] [Group G]
     rw [Pi.smul_apply, Pi.smul_apply, _root_.Representation.single_smul, one_smul,
       _root_.Representation.asModuleEquiv_apply]
     rfl
-  rw [LinearMap.trace_pi_apply_eq _ f htarget]
+  rw [LinearMap.trace_pi_of_apply_eq_dependent _ f htarget]
   let g (q : G ⧸ inertia V) :
       _root_.Representation.asModule (conjNormalFDRep (Quotient.out q) V).ρ →ₗ[k]
       _root_.Representation.asModule (conjNormalFDRep (Quotient.out q) V).ρ :=

--- a/TauCeti/RepresentationTheory/Induction/Clifford/Equivalence.lean
+++ b/TauCeti/RepresentationTheory/Induction/Clifford/Equivalence.lean
@@ -40,8 +40,8 @@ representative, while changing that representative changes the summand only up t
 
 ## Main result
 
-* `TauCeti.clifford_restrict_iso_of_isAtom`: **Clifford's theorem for a specified constituent**.
-* `TauCeti.clifford_restrict_iso`: **Clifford's theorem, representation form**. It supplies a
+* `FDRep.clifford_restrict_iso_of_isAtom`: **Clifford's theorem for a specified constituent**.
+* `FDRep.clifford_restrict_iso`: **Clifford's theorem, representation form**. It supplies a
   simple constituent, a positive common multiplicity, and an isomorphism from the restriction to
   `cliffordSum`.
 
@@ -67,7 +67,8 @@ open TauCeti
 inertia group. A finite product of modules is their direct sum; `FDRep.ofShrink` only returns its
 possibly larger carrier to the universe in which `FDRep k N` lives. -/
 noncomputable def cliffordSum {k : Type u} {G : Type v} [Field k] [Group G]
-    {N : Subgroup G} [N.Normal] [Finite G] (V : FDRep k N) (e : ℕ) : FDRep k N :=
+    {N : Subgroup G} [N.Normal] (V : FDRep k N) [Finite (G ⧸ inertia V)]
+    (e : ℕ) : FDRep k N :=
   FDRep.ofShrink <| Representation.ofModule' (k := k) (G := N)
     ((q : G ⧸ inertia V) → Fin e →
       _root_.Representation.asModule (conjNormalFDRep (Quotient.out q) V).ρ)
@@ -75,7 +76,7 @@ noncomputable def cliffordSum {k : Type u} {G : Type v} [Field k] [Group G]
 /-- The representation carried by `V.cliffordSum e` is the product of the conjugates of `V`,
 with one copy for each element of `Fin e` and one summand for each inertia coset. -/
 noncomputable def cliffordSumEquiv {k : Type u} {G : Type v} [Field k] [Group G]
-    {N : Subgroup G} [N.Normal] [Finite G] (V : FDRep k N) (e : ℕ) :
+    {N : Subgroup G} [N.Normal] (V : FDRep k N) [Finite (G ⧸ inertia V)] (e : ℕ) :
     _root_.Representation.Equiv (V.cliffordSum e).ρ
       (_root_.Representation.ofModule' (k := k) (G := N)
         ((q : G ⧸ inertia V) → Fin e →
@@ -86,7 +87,7 @@ noncomputable def cliffordSumEquiv {k : Type u} {G : Type v} [Field k] [Group G]
 dimension of `V`. -/
 @[simp]
 theorem finrank_cliffordSum {k : Type u} {G : Type v} [Field k] [Group G]
-    {N : Subgroup G} [N.Normal] [Finite G] (V : FDRep k N) (e : ℕ) :
+    {N : Subgroup G} [N.Normal] (V : FDRep k N) [Finite (G ⧸ inertia V)] (e : ℕ) :
     Module.finrank k (V.cliffordSum e) =
       Nat.card (G ⧸ inertia V) * e * Module.finrank k V := by
   classical
@@ -100,7 +101,8 @@ theorem finrank_cliffordSum {k : Type u} {G : Type v} [Field k] [Group G]
 summands. -/
 @[simp]
 theorem character_cliffordSum {k : Type u} {G : Type v} [Field k] [Group G]
-    {N : Subgroup G} [N.Normal] [Finite G] (V : FDRep k N) (e : ℕ) (x : N) :
+    {N : Subgroup G} [N.Normal] (V : FDRep k N) [Finite (G ⧸ inertia V)]
+    (e : ℕ) (x : N) :
     (V.cliffordSum e).character x =
       (e : k) * ∑ᶠ q : G ⧸ inertia V,
         (conjNormalFDRep (Quotient.out q) V).character x := by
@@ -202,6 +204,12 @@ private noncomputable def componentLinearEquiv
   simpa only [τ, g] using
     eComponent.trans (LinearEquiv.piCongrRight fun _ ↦ eConj)
 
+end TauCeti
+
+namespace FDRep
+
+open TauCeti
+
 /-- **Clifford's theorem for a specified constituent.** Given a simple constituent `σ` of the
 restriction of an irreducible representation to a normal subgroup, the restriction is isomorphic
 to `e` copies of every conjugate of `σ`, with the distinct conjugates indexed by the left cosets
@@ -293,7 +301,7 @@ theorem clifford_restrict_iso {k : Type u} {G : Type v} [Field k] [Group G]
   let _ : Representation.IsIrreducible V.ρ :=
     Representation.isIrreducible_toRepresentation_of_isAtom hσ
   let _ : Simple V := FDRep.simple_of_isIrreducible V
-  obtain ⟨e, he, h⟩ := clifford_restrict_iso_of_isAtom W σ hσ
+  obtain ⟨e, he, h⟩ := W.clifford_restrict_iso_of_isAtom σ hσ
   exact ⟨V, inferInstance, e, he, h⟩
 
-end TauCeti
+end FDRep

--- a/TauCeti/RepresentationTheory/Induction/Clifford/Equivalence.lean
+++ b/TauCeti/RepresentationTheory/Induction/Clifford/Equivalence.lean
@@ -218,14 +218,12 @@ of its inertia group.
 Algebraic closure makes `k` a splitting field, so the Hom-space dimension in the multiplicity
 theorem is the actual number of copies. -/
 theorem clifford_restrict_iso_of_isAtom {k : Type u} {G : Type v} [Field k] [Group G]
-    {N : Subgroup G} [N.Normal] [Finite G] [IsAlgClosed k]
+    {N : Subgroup G} [N.Normal] [IsAlgClosed k]
     (W : FDRep k G) [Simple W] (σ : Subrepresentation (W.ρ.comp N.subtype))
-    (hσ : IsAtom σ) :
+    (hσ : IsAtom σ) [Finite (G ⧸ inertia (FDRep.of σ.toRepresentation))] :
     ∃ e : ℕ, e ≠ 0 ∧
       Nonempty (resFDRep N W ≅ (FDRep.of σ.toRepresentation).cliffordSum e) := by
   classical
-  let _ : Fintype G := Fintype.ofFinite G
-  let _ : Fintype N := Fintype.ofFinite N
   let _ : Representation.IsIrreducible W.ρ := FDRep.isIrreducible_of_simple W
   let _ : IsSemisimpleModule k[N]
       (_root_.Representation.asModule (W.ρ.comp N.subtype)) :=

--- a/TauCeti/RepresentationTheory/Induction/Clifford/Equivalence.lean
+++ b/TauCeti/RepresentationTheory/Induction/Clifford/Equivalence.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.RepresentationTheory.Induction.Clifford.Decomposition
+import TauCeti.LinearAlgebra.Trace.Pi
 import TauCeti.RepresentationTheory.OfModule
 import TauCeti.RepresentationTheory.Simple.Basic
 
@@ -35,12 +36,15 @@ representative, while changing that representative changes the summand only up t
 
 ## Main result
 
+* `TauCeti.clifford_restrict_iso_of_isAtom`: **Clifford's theorem for a specified constituent**.
 * `TauCeti.clifford_restrict_iso`: **Clifford's theorem, representation form**. It supplies a
   simple constituent, a positive common multiplicity, and an isomorphism from the restriction to
   `cliffordSum`.
 
 ## References
 
+* [Induction and restriction roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/InductionRestriction/README.md),
+  Layer 5.
 * I. M. Isaacs, *Character Theory of Finite Groups*, Chapter 6.
 * C. W. Curtis and I. Reiner, *Representation Theory of Finite Groups and Associative Algebras*,
   §49.
@@ -56,27 +60,6 @@ universe u v
 namespace FDRep
 
 open TauCeti
-
-/-- The trace of a coordinatewise endomorphism of a finite dependent product is the sum of the
-traces on its factors. -/
-private theorem trace_pi_apply_same {k : Type u} {ι : Type v} {M : ι → Type*}
-    [Field k] [Fintype ι] [∀ i, AddCommGroup (M i)] [∀ i, Module k (M i)]
-    [∀ i, FiniteDimensional k (M i)]
-    (T : ((i : ι) → M i) →ₗ[k] ((i : ι) → M i)) (f : ∀ i, M i →ₗ[k] M i)
-    (hT : ∀ x i, T x i = f i (x i)) :
-    LinearMap.trace k ((i : ι) → M i) T = ∑ i, LinearMap.trace k (M i) (f i) := by
-  classical
-  let b (i : ι) := Module.Free.chooseBasis k (M i)
-  let _ (i : ι) : Fintype (Module.Free.ChooseBasisIndex k (M i)) := Fintype.ofFinite _
-  let B : Module.Basis (Σ i, Module.Free.ChooseBasisIndex k (M i)) k ((i : ι) → M i) :=
-    Pi.basis b
-  rw [LinearMap.trace_eq_matrix_trace k B, Matrix.trace, Fintype.sum_sigma]
-  apply Finset.sum_congr rfl
-  intro i _
-  rw [LinearMap.trace_eq_matrix_trace k (b i), Matrix.trace]
-  apply Finset.sum_congr rfl
-  intro j _
-  simp [LinearMap.toMatrix_apply, B, b, hT]
 
 /-- The finite sum of `e` copies of every conjugate of `V` indexed by the left cosets of its
 inertia group. A finite product of modules is their direct sum; `FDRep.ofShrink` only returns its
@@ -115,12 +98,13 @@ theorem finrank_cliffordSum {k : Type u} {G : Type v} [Field k] [Group G]
 summands. -/
 @[simp]
 theorem character_cliffordSum {k : Type u} {G : Type v} [Field k] [Group G]
-    {N : Subgroup G} [N.Normal] [Finite G] (V : FDRep k N)
-    [Fintype (G ⧸ inertia V)] (e : ℕ) (x : N) :
+    {N : Subgroup G} [N.Normal] [Finite G] (V : FDRep k N) (e : ℕ) (x : N) :
     (V.cliffordSum e).character x =
-      (e : k) * ∑ q : G ⧸ inertia V,
+      (e : k) * ∑ᶠ q : G ⧸ inertia V,
         (conjNormalFDRep (Quotient.out q) V).character x := by
   classical
+  let _ : Fintype (G ⧸ inertia V) := Fintype.ofFinite _
+  rw [finsum_eq_sum_of_support_subset (s := Finset.univ) _ (by simp)]
   rw [cliffordSum, character_ofShrink, _root_.Representation.character]
   let f (q : G ⧸ inertia V) :
       (Fin e → _root_.Representation.asModule
@@ -138,37 +122,33 @@ theorem character_cliffordSum {k : Type u} {G : Type v} [Field k] [Group G]
         f q (z q) := by
     intro z q
     ext i
-    change
-      (_root_.Representation.ofModule' (k := k) (G := N)
-        ((q : G ⧸ inertia V) → Fin e →
-          _root_.Representation.asModule (conjNormalFDRep (Quotient.out q) V).ρ)) x z q i =
-        (conjNormalFDRep (Quotient.out q) V).ρ x (z q i)
+    simp only [f]
     rw [TauCeti.Representation.ofModule'_apply]
     rw [Pi.smul_apply, Pi.smul_apply, _root_.Representation.single_smul, one_smul,
       _root_.Representation.asModuleEquiv_apply]
-  rw [trace_pi_apply_same _ f htarget]
+    rfl
+  rw [LinearMap.trace_pi_apply_eq _ f htarget]
   let g (q : G ⧸ inertia V) :
       _root_.Representation.asModule (conjNormalFDRep (Quotient.out q) V).ρ →ₗ[k]
-      _root_.Representation.asModule (conjNormalFDRep (Quotient.out q) V).ρ := {
-    toFun z := (conjNormalFDRep (Quotient.out q) V).ρ x z
-    map_add' := map_add _
-    map_smul' := map_smul _
-  }
+      _root_.Representation.asModule (conjNormalFDRep (Quotient.out q) V).ρ :=
+    (_root_.Representation.asModuleEquiv
+      (conjNormalFDRep (Quotient.out q) V).ρ).symm.conj
+        ((conjNormalFDRep (Quotient.out q) V).ρ x)
   have hg (q : G ⧸ inertia V) : LinearMap.trace k _ (g q) =
       (conjNormalFDRep (Quotient.out q) V).character x := by
-    have hconj : g q =
-        (_root_.Representation.asModuleEquiv
-          (conjNormalFDRep (Quotient.out q) V).ρ).symm.conj
-            ((conjNormalFDRep (Quotient.out q) V).ρ x) := by
-      ext z
-      rfl
-    rw [hconj, LinearMap.trace_conj', FDRep.character]
+    simp only [g]
+    rw [LinearMap.trace_conj', FDRep.character]
   have hf (q : G ⧸ inertia V) : LinearMap.trace k _ (f q) =
       (e : k) * (conjNormalFDRep (Quotient.out q) V).character x := by
     have hfg : ∀ z i, f q z i = g q (z i) := by
       intro z i
+      simp only [f, g, LinearEquiv.conj_apply, LinearMap.comp_apply, LinearEquiv.coe_coe,
+        LinearEquiv.symm_symm]
+      apply (_root_.Representation.asModuleEquiv
+        (conjNormalFDRep (Quotient.out q) V).ρ).injective
+      rw [LinearEquiv.apply_symm_apply, _root_.Representation.asModuleEquiv_apply]
       rfl
-    rw [trace_pi_apply_same (f q) (fun _ ↦ g q) hfg]
+    rw [LinearMap.trace_pi_of_apply_eq (f q) id (fun _ ↦ g q) hfg]
     simp [hg]
   simp_rw [hf]
   rw [Finset.mul_sum]
@@ -220,17 +200,19 @@ private noncomputable def componentLinearEquiv
   simpa only [τ, g] using
     eComponent.trans (LinearEquiv.piCongrRight fun _ ↦ eConj)
 
-/-- **Clifford's theorem, representation form.** The restriction of an irreducible
-representation to a normal subgroup is isomorphic to `e` copies of every conjugate of one simple
-constituent, with the distinct conjugates indexed by the left cosets of its inertia group.
+/-- **Clifford's theorem for a specified constituent.** Given a simple constituent `σ` of the
+restriction of an irreducible representation to a normal subgroup, the restriction is isomorphic
+to `e` copies of every conjugate of `σ`, with the distinct conjugates indexed by the left cosets
+of its inertia group.
 
 Algebraic closure makes `k` a splitting field, so the Hom-space dimension in the multiplicity
 theorem is the actual number of copies. -/
-theorem clifford_restrict_iso {k : Type u} {G : Type v} [Field k] [Group G]
+theorem clifford_restrict_iso_of_isAtom {k : Type u} {G : Type v} [Field k] [Group G]
     {N : Subgroup G} [N.Normal] [Finite G] [IsAlgClosed k]
-    (W : FDRep k G) [Simple W] :
-    ∃ (V : FDRep k N) (_ : Simple V) (e : ℕ),
-      e ≠ 0 ∧ Nonempty (resFDRep N W ≅ V.cliffordSum e) := by
+    (W : FDRep k G) [Simple W] (σ : Subrepresentation (W.ρ.comp N.subtype))
+    (hσ : IsAtom σ) :
+    ∃ e : ℕ, e ≠ 0 ∧
+      Nonempty (resFDRep N W ≅ (FDRep.of σ.toRepresentation).cliffordSum e) := by
   classical
   let _ : Fintype G := Fintype.ofFinite G
   let _ : Fintype N := Fintype.ofFinite N
@@ -240,8 +222,6 @@ theorem clifford_restrict_iso {k : Type u} {G : Type v} [Field k] [Group G]
     (_root_.Representation.isSemisimpleRepresentation_iff_isSemisimpleModule_asModule
       (W.ρ.comp N.subtype)).mp
       (Representation.isSemisimpleRepresentation_comp_subtype W.ρ)
-  obtain ⟨σ, hσ, -⟩ :=
-    Representation.exists_isAtom_forall_nonempty_linearEquiv_conjSubrep (N := N) W.ρ
   let V : FDRep k N := FDRep.of σ.toRepresentation
   let _ : Representation.IsIrreducible V.ρ :=
     Representation.isIrreducible_toRepresentation_of_isAtom hσ
@@ -284,6 +264,34 @@ theorem clifford_restrict_iso {k : Type u} {G : Type v} [Field k] [Group G]
   have hfinal : Nonempty (_root_.Representation.Equiv
       (resFDRep N W).ρ (V.cliffordSum e).ρ) :=
     ⟨representationEquiv.trans (FDRep.ofShrinkEquiv target).symm⟩
-  exact ⟨V, inferInstance, e, Nat.ne_of_gt he, nonempty_fdRepIso_iff.mpr hfinal⟩
+  exact ⟨e, Nat.ne_of_gt he, nonempty_fdRepIso_iff.mpr hfinal⟩
+
+/-- **Clifford's theorem, representation form.** The restriction of an irreducible
+representation to a normal subgroup is isomorphic to `e` copies of every conjugate of one simple
+constituent, with the distinct conjugates indexed by the left cosets of its inertia group.
+
+Algebraic closure makes `k` a splitting field, so the Hom-space dimension in the multiplicity
+theorem is the actual number of copies. -/
+theorem clifford_restrict_iso {k : Type u} {G : Type v} [Field k] [Group G]
+    {N : Subgroup G} [N.Normal] [Finite G] [IsAlgClosed k]
+    (W : FDRep k G) [Simple W] :
+    ∃ (V : FDRep k N) (_ : Simple V) (e : ℕ),
+      e ≠ 0 ∧ Nonempty (resFDRep N W ≅ V.cliffordSum e) := by
+  classical
+  let _ : Fintype G := Fintype.ofFinite G
+  let _ : Representation.IsIrreducible W.ρ := FDRep.isIrreducible_of_simple W
+  let _ : IsSemisimpleModule k[N]
+      (_root_.Representation.asModule (W.ρ.comp N.subtype)) :=
+    (_root_.Representation.isSemisimpleRepresentation_iff_isSemisimpleModule_asModule
+      (W.ρ.comp N.subtype)).mp
+      (Representation.isSemisimpleRepresentation_comp_subtype W.ρ)
+  obtain ⟨σ, hσ, -⟩ :=
+    Representation.exists_isAtom_forall_nonempty_linearEquiv_conjSubrep (N := N) W.ρ
+  let V : FDRep k N := FDRep.of σ.toRepresentation
+  let _ : Representation.IsIrreducible V.ρ :=
+    Representation.isIrreducible_toRepresentation_of_isAtom hσ
+  let _ : Simple V := FDRep.simple_of_isIrreducible V
+  obtain ⟨e, he, h⟩ := clifford_restrict_iso_of_isAtom W σ hσ
+  exact ⟨V, inferInstance, e, he, h⟩
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/Induction/Clifford/Equivalence.lean
+++ b/TauCeti/RepresentationTheory/Induction/Clifford/Equivalence.lean
@@ -1,0 +1,172 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.RepresentationTheory.Induction.Clifford.Decomposition
+import TauCeti.GroupTheory.Index
+import TauCeti.RepresentationTheory.AsModule
+import TauCeti.RepresentationTheory.OfModule
+import TauCeti.RepresentationTheory.Simple.Basic
+
+/-!
+# The representation decomposition in Clifford's theorem
+
+Let `N` be a normal subgroup of a finite group `G`, and let `W` be an irreducible
+finite-dimensional representation of `G` over a splitting field. The isotypic components of the
+restriction of `W` to `N` are indexed by the inertia cosets of any one constituent `V`, and every
+component is a power of its constituent with one common positive exponent `e`. Combining these
+two statements gives the classical decomposition
+
+`Res_N W ≅ ⨁ (g : G / inertia V), e · {}^g V`.
+
+The quotient index is preferable to a chosen transversal: `Quotient.out g` supplies the conjugate
+representative, while changing that representative changes the summand only up to isomorphism.
+
+## Main definitions
+
+* `TauCeti.cliffordSum`: the finite sum of `e` copies of the conjugate of `V` attached to every
+  inertia coset.
+
+## Main result
+
+* `TauCeti.clifford_restrict_iso`: **Clifford's theorem, representation form**. It supplies a
+  simple constituent, a positive common multiplicity, and an isomorphism from the restriction to
+  `cliffordSum`.
+
+## References
+
+* I. M. Isaacs, *Character Theory of Finite Groups*, Chapter 6.
+* C. W. Curtis and I. Reiner, *Representation Theory of Finite Groups and Associative Algebras*,
+  §49.
+-/
+
+public section
+
+open CategoryTheory
+open scoped MonoidAlgebra
+
+universe u v
+
+namespace TauCeti
+
+/-- The finite sum of `e` copies of every conjugate of `V` indexed by the left cosets of its
+inertia group. A finite product of modules is their direct sum; `FDRep.ofShrink` only returns its
+possibly larger carrier to the universe in which `FDRep k N` lives. -/
+noncomputable def cliffordSum {k : Type u} {G : Type v} [Field k] [Group G]
+    {N : Subgroup G} [N.Normal] [Finite G] (V : FDRep k N) (e : ℕ) : FDRep k N :=
+  FDRep.ofShrink <| Representation.ofModule' (k := k) (G := N)
+    ((q : G ⧸ inertia V) → Fin e →
+      _root_.Representation.asModule (conjNormalFDRep (Quotient.out q) V).ρ)
+
+/-- The module carried by an isotypic component is `e` copies of the translated constituent that
+defines it, where `e` is the common Clifford multiplicity. -/
+private noncomputable def componentLinearEquiv
+    {k : Type u} {G : Type v} [Field k] [IsAlgClosed k] [Group G]
+    {X : Type u} [AddCommGroup X] [Module k X] {N : Subgroup G} [N.Normal]
+    (ρ : Representation k G X) [FiniteDimensional k X] [ρ.IsIrreducible]
+    (σ : Subrepresentation (ρ.comp N.subtype)) (hσ : IsAtom σ) (e : ℕ)
+    (hcommon : ∀ τ : Subrepresentation (ρ.comp N.subtype), IsAtom τ →
+      Module.finrank k
+        (τ.asSubmodule →ₗ[k[N]] _root_.Representation.asModule (ρ.comp N.subtype)) = e)
+    (q : G ⧸ inertia (FDRep.of σ.toRepresentation)) :
+    ((ρ.isotypicComponentsEquivQuotientInertia σ hσ).symm q).1 ≃ₗ[k[N]]
+      Fin e → _root_.Representation.asModule
+        (conjNormalFDRep (Quotient.out q) (FDRep.of σ.toRepresentation)).ρ := by
+  let g : G := Quotient.out q
+  have hq : QuotientGroup.mk g = q := Quotient.out_eq' q
+  have hc : (ρ.isotypicComponentsEquivQuotientInertia σ hσ).symm q =
+      ρ.conjSubrepIsotypicComponent σ hσ g := by
+    rw [← hq]
+    exact ρ.isotypicComponentsEquivQuotientInertia_symm_mk σ hσ g
+  let τ := Representation.conjSubrep ρ g σ
+  have hτ : IsAtom τ := Representation.isAtom_conjSubrep_iff.mpr hσ
+  let _ : IsSimpleModule k[N] τ.asSubmodule :=
+    Subrepresentation.isSimpleModule_asSubmodule_iff.mpr hτ
+  let _ : FiniteDimensional k τ.asSubmodule :=
+    Module.Finite.of_injective (τ.asSubmodule.subtype.restrictScalars k) Subtype.val_injective
+  let eComponent := (nonempty_linearEquiv_isotypicComponent
+    (k := k) (A := k[N])
+    (M := _root_.Representation.asModule (ρ.comp N.subtype)) (S := τ.asSubmodule)).some
+  have hmultiplicity : Module.finrank k
+      (τ.asSubmodule →ₗ[k[N]] _root_.Representation.asModule (ρ.comp N.subtype)) = e :=
+    hcommon τ hτ
+  rw [hmultiplicity] at eComponent
+  let i := Representation.fdRepIsoConjSubrep ρ g σ
+  let iRep := (nonempty_fdRepIso_iff.mp ⟨i⟩).some
+  let eConj : τ.asSubmodule ≃ₗ[k[N]] _root_.Representation.asModule
+      (conjNormalFDRep g (FDRep.of σ.toRepresentation)).ρ :=
+    (_root_.Subrepresentation.asModuleEquivAsSubmodule τ).symm.trans
+      (Representation.asModuleLinearEquivOfEquiv iRep)
+  rw [hc, Representation.coe_conjSubrepIsotypicComponent]
+  simpa only [τ, g] using
+    eComponent.trans (LinearEquiv.piCongrRight fun _ ↦ eConj)
+
+/-- **Clifford's theorem, representation form.** The restriction of an irreducible
+representation to a normal subgroup is isomorphic to `e` copies of every conjugate of one simple
+constituent, with the distinct conjugates indexed by the left cosets of its inertia group.
+
+The hypothesis on `Nat.card G` is Maschke's condition. Algebraic closure makes `k` a splitting
+field, so the Hom-space dimension in the multiplicity theorem is the actual number of copies. -/
+theorem clifford_restrict_iso {k : Type u} {G : Type v} [Field k] [Group G]
+    {N : Subgroup G} [N.Normal] [Finite G] [IsAlgClosed k]
+    (hG : IsUnit (Nat.card G : k)) (W : FDRep k G) [Simple W] :
+    ∃ (V : FDRep k N) (_ : Simple V) (e : ℕ),
+      e ≠ 0 ∧ Nonempty (resFDRep N W ≅ cliffordSum V e) := by
+  classical
+  let _ : Fintype G := Fintype.ofFinite G
+  let _ : Invertible (Nat.card G : k) := hG.invertible
+  let _ : Fintype N := Fintype.ofFinite N
+  let _ : Invertible (Nat.card N : k) := (isUnit_natCard_subgroup N hG).invertible
+  let _ : Representation.IsIrreducible W.ρ := FDRep.isIrreducible_of_simple W
+  let _ : Representation.IsSemisimpleRepresentation (W.ρ.comp N.subtype) :=
+    Representation.isSemisimpleRepresentation_comp_subtype W.ρ
+  obtain ⟨σ, hσ, -⟩ :=
+    Representation.exists_isAtom_forall_nonempty_linearEquiv_conjSubrep (N := N) W.ρ
+  let V : FDRep k N := FDRep.of σ.toRepresentation
+  let _ : Representation.IsIrreducible V.ρ :=
+    Representation.isIrreducible_toRepresentation_of_isAtom hσ
+  let _ : Simple V := FDRep.simple_of_isIrreducible V
+  obtain ⟨e, he, hcommon⟩ :=
+    Representation.exists_forall_finrank_linearMap_eq (N := N) W.ρ
+  let C := isotypicComponents k[N]
+    (_root_.Representation.asModule (W.ρ.comp N.subtype))
+  let orbitEquiv : C ≃ G ⧸ inertia V :=
+    Representation.isotypicComponentsEquivQuotientInertia W.ρ σ hσ
+  let _ : Finite C := Finite.of_injective orbitEquiv orbitEquiv.injective
+  let _ : Fintype C := Fintype.ofFinite C
+  have hind : iSupIndep (fun c : C ↦ c.1) :=
+    (sSupIndep_iff _).mp (sSupIndep_isotypicComponents k[N]
+      (_root_.Representation.asModule (W.ρ.comp N.subtype)))
+  have htop : ⨆ c : C, c.1 = ⊤ :=
+    (sSup_eq_iSup' C).symm.trans
+      (sSup_isotypicComponents k[N]
+        (_root_.Representation.asModule (W.ρ.comp N.subtype)))
+  let splitComponents :
+      _root_.Representation.asModule (W.ρ.comp N.subtype) ≃ₗ[k[N]] (c : C) → c.1 :=
+    (hind.linearEquiv htop).symm.trans DFinsupp.linearEquivFunOnFintype
+  let indexComponents : ((c : C) → c.1) ≃ₗ[k[N]]
+      (q : G ⧸ inertia V) → (orbitEquiv.symm q).1 :=
+    LinearEquiv.piCongrLeft' k[N] (fun c : C ↦ c.1) orbitEquiv
+  let splitMultiplicity : ((q : G ⧸ inertia V) → (orbitEquiv.symm q).1) ≃ₗ[k[N]]
+      (q : G ⧸ inertia V) → Fin e → _root_.Representation.asModule
+        (conjNormalFDRep (Quotient.out q) V).ρ :=
+    LinearEquiv.piCongrRight fun q ↦ by
+      simpa only [orbitEquiv, V] using componentLinearEquiv W.ρ σ hσ e hcommon q
+  let target := Representation.ofModule' (k := k) (G := N)
+    ((q : G ⧸ inertia V) → Fin e → _root_.Representation.asModule
+      (conjNormalFDRep (Quotient.out q) V).ρ)
+  let moduleEquiv : _root_.Representation.asModule (resFDRep N W).ρ ≃ₗ[k[N]]
+      _root_.Representation.asModule target :=
+    splitComponents.trans indexComponents |>.trans splitMultiplicity |>.trans
+      (Representation.ofModule'AsModuleEquiv _).symm
+  let representationEquiv : _root_.Representation.Equiv (resFDRep N W).ρ target :=
+    Representation.equivOfAsModuleLinearEquiv moduleEquiv
+  have hfinal : Nonempty (_root_.Representation.Equiv
+      (resFDRep N W).ρ (cliffordSum V e).ρ) :=
+    ⟨representationEquiv.trans (FDRep.ofShrinkEquiv target).symm⟩
+  exact ⟨V, inferInstance, e, Nat.ne_of_gt he, nonempty_fdRepIso_iff.mpr hfinal⟩
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Induction/Clifford/Equivalence.lean
+++ b/TauCeti/RepresentationTheory/Induction/Clifford/Equivalence.lean
@@ -17,7 +17,7 @@ Roadmap source: `TauCetiRoadmap/RepresentationTheory/InductionRestriction/README
 /-!
 # The representation decomposition in Clifford's theorem
 
-Let `N` be a normal subgroup of a finite group `G`, and let `W` be an irreducible
+Let `N` be a normal subgroup of a group `G`, and let `W` be an irreducible
 finite-dimensional representation of `G` over a splitting field. The isotypic components of the
 restriction of `W` to `N` are indexed by the inertia cosets of any one constituent `V`, and every
 component is a power of its constituent with one common positive exponent `e`. Combining these
@@ -42,8 +42,8 @@ representative, while changing that representative changes the summand only up t
 
 * `FDRep.clifford_restrict_iso_of_isAtom`: **Clifford's theorem for a specified constituent**.
 * `FDRep.clifford_restrict_iso`: **Clifford's theorem, representation form**. It supplies a
-  simple constituent, a positive common multiplicity, and an isomorphism from the restriction to
-  `cliffordSum`.
+  simple constituent, finiteness of its inertia quotient, a positive common multiplicity, and an
+  isomorphism from the restriction to `cliffordSum`.
 
 ## References
 
@@ -216,13 +216,16 @@ to `e` copies of every conjugate of `σ`, with the distinct conjugates indexed b
 of its inertia group.
 
 Algebraic closure makes `k` a splitting field, so the Hom-space dimension in the multiplicity
-theorem is the actual number of copies. -/
+theorem is the actual number of copies. Finite dimensionality makes the set of isotypic components,
+and hence the inertia quotient indexing the sum, finite. -/
 theorem clifford_restrict_iso_of_isAtom {k : Type u} {G : Type v} [Field k] [Group G]
     {N : Subgroup G} [N.Normal] [IsAlgClosed k]
     (W : FDRep k G) [Simple W] (σ : Subrepresentation (W.ρ.comp N.subtype))
-    (hσ : IsAtom σ) [Finite (G ⧸ inertia (FDRep.of σ.toRepresentation))] :
-    ∃ e : ℕ, e ≠ 0 ∧
-      Nonempty (resFDRep N W ≅ (FDRep.of σ.toRepresentation).cliffordSum e) := by
+    (hσ : IsAtom σ) :
+    ∃ hfinite : Finite (G ⧸ inertia (FDRep.of σ.toRepresentation)),
+      let _ := hfinite
+      ∃ e : ℕ, e ≠ 0 ∧
+        Nonempty (resFDRep N W ≅ (FDRep.of σ.toRepresentation).cliffordSum e) := by
   classical
   let _ : Representation.IsIrreducible W.ρ := FDRep.isIrreducible_of_simple W
   let _ : IsSemisimpleModule k[N]
@@ -230,6 +233,9 @@ theorem clifford_restrict_iso_of_isAtom {k : Type u} {G : Type v} [Field k] [Gro
     (_root_.Representation.isSemisimpleRepresentation_iff_isSemisimpleModule_asModule
       (W.ρ.comp N.subtype)).mp
       (Representation.isSemisimpleRepresentation_comp_subtype W.ρ)
+  let _ : Module.Finite k[N]
+      (_root_.Representation.asModule (W.ρ.comp N.subtype)) :=
+    Module.Finite.of_restrictScalars_finite k k[N] _
   let V : FDRep k N := FDRep.of σ.toRepresentation
   let _ : Representation.IsIrreducible V.ρ :=
     Representation.isIrreducible_toRepresentation_of_isAtom hσ
@@ -240,7 +246,10 @@ theorem clifford_restrict_iso_of_isAtom {k : Type u} {G : Type v} [Field k] [Gro
     (_root_.Representation.asModule (W.ρ.comp N.subtype))
   let orbitEquiv : C ≃ G ⧸ inertia V :=
     Representation.isotypicComponentsEquivQuotientInertia W.ρ σ hσ
-  let _ : Finite C := Finite.of_injective orbitEquiv orbitEquiv.injective
+  let hfinite : Finite (G ⧸ inertia V) :=
+    Finite.of_surjective orbitEquiv orbitEquiv.surjective
+  refine ⟨hfinite, ?_⟩
+  let _ := hfinite
   let _ : Fintype C := Fintype.ofFinite C
   have hind : iSupIndep (fun c : C ↦ c.1) :=
     (sSupIndep_iff _).mp (sSupIndep_isotypicComponents k[N]
@@ -279,27 +288,23 @@ representation to a normal subgroup is isomorphic to `e` copies of every conjuga
 constituent, with the distinct conjugates indexed by the left cosets of its inertia group.
 
 Algebraic closure makes `k` a splitting field, so the Hom-space dimension in the multiplicity
-theorem is the actual number of copies. -/
+theorem is the actual number of copies. The conclusion includes the finite inertia quotient that
+indexes the sum. -/
 theorem clifford_restrict_iso {k : Type u} {G : Type v} [Field k] [Group G]
-    {N : Subgroup G} [N.Normal] [Finite G] [IsAlgClosed k]
+    {N : Subgroup G} [N.Normal] [IsAlgClosed k]
     (W : FDRep k G) [Simple W] :
-    ∃ (V : FDRep k N) (_ : Simple V) (e : ℕ),
-      e ≠ 0 ∧ Nonempty (resFDRep N W ≅ V.cliffordSum e) := by
+    ∃ (V : FDRep k N) (_ : Simple V) (hfinite : Finite (G ⧸ inertia V)),
+      let _ := hfinite
+      ∃ e : ℕ, e ≠ 0 ∧ Nonempty (resFDRep N W ≅ V.cliffordSum e) := by
   classical
-  let _ : Fintype G := Fintype.ofFinite G
   let _ : Representation.IsIrreducible W.ρ := FDRep.isIrreducible_of_simple W
-  let _ : IsSemisimpleModule k[N]
-      (_root_.Representation.asModule (W.ρ.comp N.subtype)) :=
-    (_root_.Representation.isSemisimpleRepresentation_iff_isSemisimpleModule_asModule
-      (W.ρ.comp N.subtype)).mp
-      (Representation.isSemisimpleRepresentation_comp_subtype W.ρ)
   obtain ⟨σ, hσ, -⟩ :=
     Representation.exists_isAtom_forall_nonempty_linearEquiv_conjSubrep (N := N) W.ρ
   let V : FDRep k N := FDRep.of σ.toRepresentation
   let _ : Representation.IsIrreducible V.ρ :=
     Representation.isIrreducible_toRepresentation_of_isAtom hσ
   let _ : Simple V := FDRep.simple_of_isIrreducible V
-  obtain ⟨e, he, h⟩ := W.clifford_restrict_iso_of_isAtom σ hσ
-  exact ⟨V, inferInstance, e, he, h⟩
+  obtain ⟨hfinite, e, he, h⟩ := W.clifford_restrict_iso_of_isAtom σ hσ
+  exact ⟨V, inferInstance, hfinite, e, he, h⟩
 
 end FDRep

--- a/TauCeti/RepresentationTheory/Induction/Clifford/Equivalence.lean
+++ b/TauCeti/RepresentationTheory/Induction/Clifford/Equivalence.lean
@@ -6,8 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.RepresentationTheory.Induction.Clifford.Decomposition
-import TauCeti.GroupTheory.Index
-import TauCeti.RepresentationTheory.AsModule
 import TauCeti.RepresentationTheory.OfModule
 import TauCeti.RepresentationTheory.Simple.Basic
 
@@ -27,8 +25,13 @@ representative, while changing that representative changes the summand only up t
 
 ## Main definitions
 
-* `TauCeti.cliffordSum`: the finite sum of `e` copies of the conjugate of `V` attached to every
+* `FDRep.cliffordSum`: the finite sum of `e` copies of the conjugate of `V` attached to every
   inertia coset.
+* `FDRep.cliffordSumEquiv`: its public identification with the displayed product representation.
+
+## Main properties
+
+* `FDRep.finrank_cliffordSum` and `FDRep.character_cliffordSum`: its dimension and character.
 
 ## Main result
 
@@ -50,7 +53,30 @@ open scoped MonoidAlgebra
 
 universe u v
 
-namespace TauCeti
+namespace FDRep
+
+open TauCeti
+
+/-- The trace of a coordinatewise endomorphism of a finite dependent product is the sum of the
+traces on its factors. -/
+private theorem trace_pi_apply_same {k : Type u} {ι : Type v} {M : ι → Type*}
+    [Field k] [Fintype ι] [∀ i, AddCommGroup (M i)] [∀ i, Module k (M i)]
+    [∀ i, FiniteDimensional k (M i)]
+    (T : ((i : ι) → M i) →ₗ[k] ((i : ι) → M i)) (f : ∀ i, M i →ₗ[k] M i)
+    (hT : ∀ x i, T x i = f i (x i)) :
+    LinearMap.trace k ((i : ι) → M i) T = ∑ i, LinearMap.trace k (M i) (f i) := by
+  classical
+  let b (i : ι) := Module.Free.chooseBasis k (M i)
+  let _ (i : ι) : Fintype (Module.Free.ChooseBasisIndex k (M i)) := Fintype.ofFinite _
+  let B : Module.Basis (Σ i, Module.Free.ChooseBasisIndex k (M i)) k ((i : ι) → M i) :=
+    Pi.basis b
+  rw [LinearMap.trace_eq_matrix_trace k B, Matrix.trace, Fintype.sum_sigma]
+  apply Finset.sum_congr rfl
+  intro i _
+  rw [LinearMap.trace_eq_matrix_trace k (b i), Matrix.trace]
+  apply Finset.sum_congr rfl
+  intro j _
+  simp [LinearMap.toMatrix_apply, B, b, hT]
 
 /-- The finite sum of `e` copies of every conjugate of `V` indexed by the left cosets of its
 inertia group. A finite product of modules is their direct sum; `FDRep.ofShrink` only returns its
@@ -60,6 +86,96 @@ noncomputable def cliffordSum {k : Type u} {G : Type v} [Field k] [Group G]
   FDRep.ofShrink <| Representation.ofModule' (k := k) (G := N)
     ((q : G ⧸ inertia V) → Fin e →
       _root_.Representation.asModule (conjNormalFDRep (Quotient.out q) V).ρ)
+
+/-- The representation carried by `V.cliffordSum e` is the product of the conjugates of `V`,
+with one copy for each element of `Fin e` and one summand for each inertia coset. -/
+noncomputable def cliffordSumEquiv {k : Type u} {G : Type v} [Field k] [Group G]
+    {N : Subgroup G} [N.Normal] [Finite G] (V : FDRep k N) (e : ℕ) :
+    _root_.Representation.Equiv (V.cliffordSum e).ρ
+      (_root_.Representation.ofModule' (k := k) (G := N)
+        ((q : G ⧸ inertia V) → Fin e →
+          _root_.Representation.asModule (conjNormalFDRep (Quotient.out q) V).ρ)) :=
+  FDRep.ofShrinkEquiv _
+
+/-- The dimension of `V.cliffordSum e` is the number of inertia cosets times `e` times the
+dimension of `V`. -/
+@[simp]
+theorem finrank_cliffordSum {k : Type u} {G : Type v} [Field k] [Group G]
+    {N : Subgroup G} [N.Normal] [Finite G] (V : FDRep k N) (e : ℕ) :
+    Module.finrank k (V.cliffordSum e) =
+      Nat.card (G ⧸ inertia V) * e * Module.finrank k V := by
+  classical
+  let _ : Fintype (G ⧸ inertia V) := Fintype.ofFinite _
+  rw [cliffordSum, finrank_ofShrink, Module.finrank_pi_fintype]
+  simp_rw [Module.finrank_pi_fintype,
+    (_root_.Representation.asModuleEquiv _).finrank_eq]
+  simp [Nat.card_eq_fintype_card, mul_assoc]
+
+/-- The character of `V.cliffordSum e` is `e` times the sum of the characters of its conjugate
+summands. -/
+@[simp]
+theorem character_cliffordSum {k : Type u} {G : Type v} [Field k] [Group G]
+    {N : Subgroup G} [N.Normal] [Finite G] (V : FDRep k N)
+    [Fintype (G ⧸ inertia V)] (e : ℕ) (x : N) :
+    (V.cliffordSum e).character x =
+      (e : k) * ∑ q : G ⧸ inertia V,
+        (conjNormalFDRep (Quotient.out q) V).character x := by
+  classical
+  rw [cliffordSum, character_ofShrink, _root_.Representation.character]
+  let f (q : G ⧸ inertia V) :
+      (Fin e → _root_.Representation.asModule
+        (conjNormalFDRep (Quotient.out q) V).ρ) →ₗ[k]
+      (Fin e → _root_.Representation.asModule
+        (conjNormalFDRep (Quotient.out q) V).ρ) := {
+    toFun z i := (conjNormalFDRep (Quotient.out q) V).ρ x (z i)
+    map_add' a b := funext fun i ↦ map_add _ _ _
+    map_smul' a b := funext fun i ↦ map_smul _ _ _
+  }
+  have htarget : ∀ z q,
+      (_root_.Representation.ofModule' (k := k) (G := N)
+        ((q : G ⧸ inertia V) → Fin e →
+          _root_.Representation.asModule (conjNormalFDRep (Quotient.out q) V).ρ)) x z q =
+        f q (z q) := by
+    intro z q
+    ext i
+    change
+      (_root_.Representation.ofModule' (k := k) (G := N)
+        ((q : G ⧸ inertia V) → Fin e →
+          _root_.Representation.asModule (conjNormalFDRep (Quotient.out q) V).ρ)) x z q i =
+        (conjNormalFDRep (Quotient.out q) V).ρ x (z q i)
+    rw [TauCeti.Representation.ofModule'_apply]
+    rw [Pi.smul_apply, Pi.smul_apply, _root_.Representation.single_smul, one_smul,
+      _root_.Representation.asModuleEquiv_apply]
+  rw [trace_pi_apply_same _ f htarget]
+  let g (q : G ⧸ inertia V) :
+      _root_.Representation.asModule (conjNormalFDRep (Quotient.out q) V).ρ →ₗ[k]
+      _root_.Representation.asModule (conjNormalFDRep (Quotient.out q) V).ρ := {
+    toFun z := (conjNormalFDRep (Quotient.out q) V).ρ x z
+    map_add' := map_add _
+    map_smul' := map_smul _
+  }
+  have hg (q : G ⧸ inertia V) : LinearMap.trace k _ (g q) =
+      (conjNormalFDRep (Quotient.out q) V).character x := by
+    have hconj : g q =
+        (_root_.Representation.asModuleEquiv
+          (conjNormalFDRep (Quotient.out q) V).ρ).symm.conj
+            ((conjNormalFDRep (Quotient.out q) V).ρ x) := by
+      ext z
+      rfl
+    rw [hconj, LinearMap.trace_conj', FDRep.character]
+  have hf (q : G ⧸ inertia V) : LinearMap.trace k _ (f q) =
+      (e : k) * (conjNormalFDRep (Quotient.out q) V).character x := by
+    have hfg : ∀ z i, f q z i = g q (z i) := by
+      intro z i
+      rfl
+    rw [trace_pi_apply_same (f q) (fun _ ↦ g q) hfg]
+    simp [hg]
+  simp_rw [hf]
+  rw [Finset.mul_sum]
+
+end FDRep
+
+namespace TauCeti
 
 /-- The module carried by an isotypic component is `e` copies of the translated constituent that
 defines it, where `e` is the common Clifford multiplicity. -/
@@ -108,21 +224,22 @@ private noncomputable def componentLinearEquiv
 representation to a normal subgroup is isomorphic to `e` copies of every conjugate of one simple
 constituent, with the distinct conjugates indexed by the left cosets of its inertia group.
 
-The hypothesis on `Nat.card G` is Maschke's condition. Algebraic closure makes `k` a splitting
-field, so the Hom-space dimension in the multiplicity theorem is the actual number of copies. -/
+Algebraic closure makes `k` a splitting field, so the Hom-space dimension in the multiplicity
+theorem is the actual number of copies. -/
 theorem clifford_restrict_iso {k : Type u} {G : Type v} [Field k] [Group G]
     {N : Subgroup G} [N.Normal] [Finite G] [IsAlgClosed k]
-    (hG : IsUnit (Nat.card G : k)) (W : FDRep k G) [Simple W] :
+    (W : FDRep k G) [Simple W] :
     ∃ (V : FDRep k N) (_ : Simple V) (e : ℕ),
-      e ≠ 0 ∧ Nonempty (resFDRep N W ≅ cliffordSum V e) := by
+      e ≠ 0 ∧ Nonempty (resFDRep N W ≅ V.cliffordSum e) := by
   classical
   let _ : Fintype G := Fintype.ofFinite G
-  let _ : Invertible (Nat.card G : k) := hG.invertible
   let _ : Fintype N := Fintype.ofFinite N
-  let _ : Invertible (Nat.card N : k) := (isUnit_natCard_subgroup N hG).invertible
   let _ : Representation.IsIrreducible W.ρ := FDRep.isIrreducible_of_simple W
-  let _ : Representation.IsSemisimpleRepresentation (W.ρ.comp N.subtype) :=
-    Representation.isSemisimpleRepresentation_comp_subtype W.ρ
+  let _ : IsSemisimpleModule k[N]
+      (_root_.Representation.asModule (W.ρ.comp N.subtype)) :=
+    (_root_.Representation.isSemisimpleRepresentation_iff_isSemisimpleModule_asModule
+      (W.ρ.comp N.subtype)).mp
+      (Representation.isSemisimpleRepresentation_comp_subtype W.ρ)
   obtain ⟨σ, hσ, -⟩ :=
     Representation.exists_isAtom_forall_nonempty_linearEquiv_conjSubrep (N := N) W.ρ
   let V : FDRep k N := FDRep.of σ.toRepresentation
@@ -165,7 +282,7 @@ theorem clifford_restrict_iso {k : Type u} {G : Type v} [Field k] [Group G]
   let representationEquiv : _root_.Representation.Equiv (resFDRep N W).ρ target :=
     Representation.equivOfAsModuleLinearEquiv moduleEquiv
   have hfinal : Nonempty (_root_.Representation.Equiv
-      (resFDRep N W).ρ (cliffordSum V e).ρ) :=
+      (resFDRep N W).ρ (V.cliffordSum e).ρ) :=
     ⟨representationEquiv.trans (FDRep.ofShrinkEquiv target).symm⟩
   exact ⟨V, inferInstance, e, Nat.ne_of_gt he, nonempty_fdRepIso_iff.mpr hfinal⟩
 


### PR DESCRIPTION
This PR packages the existing Clifford orbit and common-multiplicity theorems into the representation isomorphism promised by `RepresentationTheory/InductionRestriction/README.md`, Layer 5, milestone “Clifford's theorem”: for a simple `W`, identify `Res_N W` with `e` copies of each conjugate of a simple constituent `V`, indexed canonically by `G ⧸ inertia V`.

Define `cliffordSum V e` as the finite product—and hence finite direct sum—of the conjugate modules selected by `Quotient.out`. Prove the isomorphism directly at the `k[N]`-module level: split the restriction into its internal isotypic components, reindex them through `Representation.isotypicComponentsEquivQuotientInertia`, use `nonempty_linearEquiv_isotypicComponent` and the common Hom-space dimension to split each component into `e` copies, then rebundle the composite equivalence in `FDRep`.

After this PR, the Clifford-theorem milestone still needs the dimension/index divisibility corollary covered by in-flight PR #6084; the next Layer 5 milestone is the Clifford correspondence.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"clifford-restriction-decomposition"}-->

🤖 Prepared with Codex
