### PR TITLE
feat(Newforms): the descent matrices at a prime

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/Newforms/Descent/Cosets.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Descent/Cosets.lean
@@ -151,6 +151,7 @@ noncomputable def descendCosetRep (p N : ℕ) (hp : p.Prime) (_hpN : p ∣ N) :
 
 /-- The members of the descent family below index `p` are the upper-triangular matrices
 `[1, v; 0, p]`. -/
+@[simp]
 theorem descendCosetRep_of_lt {p N : ℕ} (hp : p.Prime) (hpN : p ∣ N)
     {v : Fin (descendCosetCount p N)} (h : v.val < p) :
     descendCosetRep p N hp hpN v =
@@ -161,6 +162,7 @@ theorem descendCosetRep_of_lt {p N : ℕ} (hp : p.Prime) (hpN : p ∣ N)
 
 /-- The member of the descent family at index `p`, present exactly when `p²` does not divide `N`,
 is `[1, 0; 0, p]` times the extra matrix. -/
+@[simp]
 theorem descendCosetRep_of_le {p N : ℕ} (hp : p.Prime) (hpN : p ∣ N)
     {v : Fin (descendCosetCount p N)} (h : p ≤ v.val) :
     descendCosetRep p N hp hpN v =
@@ -171,8 +173,11 @@ theorem descendCosetRep_of_le {p N : ℕ} (hp : p.Prime) (hpN : p ∣ N)
   · exact absurd h' (Nat.not_lt.mpr h)
   · rfl
 
-/-- **Every member of the descent family has determinant `p`.** This is the determinant condition
-cutting out the double coset `Γ₀(N) diag(1, p) Γ₀(N)` that the descent sum runs over. -/
+/-- **Every member of the descent family has determinant `p`.** Every element of the double coset
+`Γ₀(N) diag(1, p) Γ₀(N)` that the descent sum runs over has determinant `p`, so this is a
+necessary condition for lying in it, not a characterisation of it; that these matrices lie in the
+double coset is not proved here. -/
+@[simp]
 theorem descendCosetRep_det (p N : ℕ) (hp : p.Prime) (hpN : p ∣ N)
     (v : Fin (descendCosetCount p N)) :
     (descendCosetRep p N hp hpN v : Matrix (Fin 2) (Fin 2) ℝ).det = (p : ℝ) := by

--- a/TauCeti/NumberTheory/ModularForms/Newforms/Descent/Cosets.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Descent/Cosets.lean
@@ -39,6 +39,8 @@ identity rather than merely lower-triangular.
 * `TauCeti.descendExtraGamma_mem_Gamma0`, `TauCeti.descendExtraGamma_map_intCast_zmod_eq_S` and
   `TauCeti.descendExtraGamma_map_intCast_zmod_div_eq_one`: those three properties, read back off
   the chosen matrix.
+* `TauCeti.descendExtraGamma_eq_one_of_not`: outside the hypotheses that make the choice, the
+  extra matrix is the identity.
 * `TauCeti.descendMatrixCount_of_sq_dvd` and `TauCeti.descendMatrixCount_of_not_sq_dvd`: the two
   values of the count.
 * `TauCeti.descendMatrix_of_lt` and `TauCeti.descendMatrix_of_le`: the two branches of the
@@ -150,6 +152,14 @@ theorem descendExtraGamma_map_intCast_zmod_div_eq_one {p N : ℕ} (hp : p.Prime)
   rw [descendExtraGamma_eq_choose hp hpN hpsq]
   exact (exists_mem_Gamma0_map_intCast_zmod_eq_S hp hpN hpsq).choose_spec.2.2
 
+/-- **Outside its guard the extra matrix is the identity.** For `p` not prime, or not dividing
+`N`, or with `p²` dividing `N`, the choice is not available and `descendExtraGamma` takes its
+junk value. -/
+@[simp]
+theorem descendExtraGamma_eq_one_of_not {p N : ℕ} (h : ¬ (p.Prime ∧ p ∣ N ∧ ¬ p ^ 2 ∣ N)) :
+    descendExtraGamma p N = 1 := by
+  simp [descendExtraGamma, h]
+
 /-- **The descent family at `p`** (Miyake, Lemma 4.5.11). The `p` upper-triangular matrices
 `[1, v; 0, p]` for `v < p`, together with — when `p²` does not divide `N`, so that
 `descendMatrixCount` is `p + 1` — the further matrix `[1, 0; 0, p] * descendExtraGamma p N`.
@@ -158,24 +168,25 @@ Over `ℚ` the upper-triangular part is `HeckeRing.GL2.upperTriRep`, this reposi
 representative family; the descent family is its image in `GL₂(ℝ)`, where the slash action of a
 modular form lives.
 
-`p ∣ N` is not required: the construction never uses it. It is exactly the hypothesis that makes
-the family the *descent* family — without it `descendExtraGamma p N` is `1` and the extra matrix
-degenerates to `[1, 0; 0, p]`, which the first branch already lists at `v = 0` — so it belongs on
-the later results that establish descent, not on the family itself. -/
-noncomputable def descendMatrix (p N : ℕ) (hp : p.Prime) :
+Neither `p ∣ N` nor primality of `p` is required: the construction uses only `p ≠ 0`, to name the
+zero index of `Fin p`. Those two hypotheses are what make the family the *descent* family at a
+prime — without `p ∣ N` the matrix `descendExtraGamma p N` is `1` and the extra member degenerates
+to `[1, 0; 0, p]`, which the first branch already lists at `v = 0` — so they belong on the later
+results that establish descent, not on the family itself. -/
+noncomputable def descendMatrix (p N : ℕ) [NeZero p] :
     Fin (descendMatrixCount p N) → GL (Fin 2) ℝ := fun v ↦
   if h : v.val < p then
     Matrix.GeneralLinearGroup.map (algebraMap ℚ ℝ) (upperTriRep p ⟨v.val, h⟩)
   else
-    Matrix.GeneralLinearGroup.map (algebraMap ℚ ℝ) (upperTriRep p ⟨0, hp.pos⟩) *
+    Matrix.GeneralLinearGroup.map (algebraMap ℚ ℝ) (upperTriRep p ⟨0, NeZero.pos p⟩) *
       Matrix.SpecialLinearGroup.mapGL ℝ (descendExtraGamma p N)
 
 /-- The members of the descent family below index `p` are the upper-triangular matrices
 `[1, v; 0, p]`. -/
 @[simp]
-theorem descendMatrix_of_lt {p N : ℕ} (hp : p.Prime)
+theorem descendMatrix_of_lt {p N : ℕ} [NeZero p]
     {v : Fin (descendMatrixCount p N)} (h : v.val < p) :
-    descendMatrix p N hp v =
+    descendMatrix p N v =
       Matrix.GeneralLinearGroup.map (algebraMap ℚ ℝ) (upperTriRep p ⟨v.val, h⟩) := by
   rw [descendMatrix]
   split_ifs
@@ -184,10 +195,10 @@ theorem descendMatrix_of_lt {p N : ℕ} (hp : p.Prime)
 /-- The member of the descent family at index `p`, present exactly when `p²` does not divide `N`,
 is `[1, 0; 0, p]` times the extra matrix. -/
 @[simp]
-theorem descendMatrix_of_le {p N : ℕ} (hp : p.Prime)
+theorem descendMatrix_of_le {p N : ℕ} [NeZero p]
     {v : Fin (descendMatrixCount p N)} (h : p ≤ v.val) :
-    descendMatrix p N hp v =
-      Matrix.GeneralLinearGroup.map (algebraMap ℚ ℝ) (upperTriRep p ⟨0, hp.pos⟩) *
+    descendMatrix p N v =
+      Matrix.GeneralLinearGroup.map (algebraMap ℚ ℝ) (upperTriRep p ⟨0, NeZero.pos p⟩) *
         Matrix.SpecialLinearGroup.mapGL ℝ (descendExtraGamma p N) := by
   rw [descendMatrix]
   split_ifs with h'
@@ -199,9 +210,9 @@ theorem descendMatrix_of_le {p N : ℕ} (hp : p.Prime)
 necessary condition for lying in it, not a characterisation of it; that these matrices lie in the
 double coset is not proved here. -/
 @[simp]
-theorem descendMatrix_det (p N : ℕ) (hp : p.Prime)
+theorem descendMatrix_det (p N : ℕ) [NeZero p]
     (v : Fin (descendMatrixCount p N)) :
-    (descendMatrix p N hp v : Matrix (Fin 2) (Fin 2) ℝ).det = (p : ℝ) := by
+    (descendMatrix p N v : Matrix (Fin 2) (Fin 2) ℝ).det = (p : ℝ) := by
   have hγ : (Matrix.SpecialLinearGroup.mapGL ℝ (descendExtraGamma p N) :
       Matrix (Fin 2) (Fin 2) ℝ).det = 1 := by
     rw [← Matrix.GeneralLinearGroup.val_det_apply, Matrix.SpecialLinearGroup.det_mapGL,

--- a/TauCeti/NumberTheory/ModularForms/Newforms/Descent/Cosets.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Descent/Cosets.lean
@@ -27,21 +27,23 @@ identity rather than merely lower-triangular.
 
 ## Main definitions
 
-* `TauCeti.descendCosetCount`: the size of the family, `p` when `p² ∣ N` and `p + 1` otherwise.
+* `TauCeti.descendMatrixCount`: the size of the family, `p` when `p² ∣ N` and `p + 1` otherwise.
 * `TauCeti.descendExtraGamma`: the extra matrix, with the junk value `1` outside the hypotheses
   that make the choice.
-* `TauCeti.descendCosetRep`: the family itself, indexed by `Fin (descendCosetCount p N)`.
+* `TauCeti.descendMatrix`: the family itself, indexed by `Fin (descendMatrixCount p N)`.
 
 ## Main results
 
 * `TauCeti.exists_mem_Gamma0_map_intCast_zmod_eq_S`: for a prime `p` with `p ∣ N` and `p² ∤ N`,
   some `γ ∈ Γ₀(N / p)` reduces to `S` modulo `p` and to the identity modulo `N / p`.
-* `TauCeti.descendExtraGamma_spec`: those three properties, read back off the chosen matrix.
-* `TauCeti.descendCosetCount_of_sq_dvd` and `TauCeti.descendCosetCount_of_not_sq_dvd`: the two
+* `TauCeti.descendExtraGamma_mem_Gamma0`, `TauCeti.descendExtraGamma_map_intCast_zmod_eq_S` and
+  `TauCeti.descendExtraGamma_map_intCast_zmod_div_eq_one`: those three properties, read back off
+  the chosen matrix.
+* `TauCeti.descendMatrixCount_of_sq_dvd` and `TauCeti.descendMatrixCount_of_not_sq_dvd`: the two
   values of the count.
-* `TauCeti.descendCosetRep_of_lt` and `TauCeti.descendCosetRep_of_le`: the two branches of the
+* `TauCeti.descendMatrix_of_lt` and `TauCeti.descendMatrix_of_le`: the two branches of the
   family, as equations in `GL₂(ℝ)`.
-* `TauCeti.descendCosetRep_det`: every member of the family has determinant `p`.
+* `TauCeti.descendMatrix_det`: every member of the family has determinant `p`.
 
 ## Scope
 
@@ -51,7 +53,8 @@ about the double coset `Γ₀(N) diag(1, p) Γ₀(N)`; neither is proved here. U
 family is the intended list of representatives rather than a formalized one.
 
 Follows the AINTLIB `LeanModularForms` project, whose `descendExtraGamma`, `descendCosetCount`,
-`descendCosetList` and `descendCosetList_det` are the counterparts of the declarations here, and
+`descendCosetList` and `descendCosetList_det` are the counterparts of the declarations here — the
+names differ because nothing here proves these matrices are coset representatives — and
 specializes its `descendExtraGamma_exists`
 (`LeanModularForms/StrongMultiplicityOne/DescentCosets.lean`, Chris Birkbeck, commit
 `2baa76f742bdb4fb8ee323fabba41203bd390e08`, Apache-2.0,
@@ -93,56 +96,74 @@ theorem exists_mem_Gamma0_map_intCast_zmod_eq_S {p N : ℕ} (hp : p.Prime) (hpN 
 
 /-- **The size of the descent family at `p`.** Miyake's count: `p` when `p²` divides `N`, and
 `p + 1` when it does not, the extra member being the one `descendExtraGamma` supplies. -/
-def descendCosetCount (p N : ℕ) : ℕ := if p ^ 2 ∣ N then p else p + 1
+def descendMatrixCount (p N : ℕ) : ℕ := if p ^ 2 ∣ N then p else p + 1
 
 /-- The descent family has `p` members when `p²` divides `N`. -/
 @[simp]
-theorem descendCosetCount_of_sq_dvd {p N : ℕ} (h : p ^ 2 ∣ N) : descendCosetCount p N = p := by
-  simp [descendCosetCount, h]
+theorem descendMatrixCount_of_sq_dvd {p N : ℕ} (h : p ^ 2 ∣ N) : descendMatrixCount p N = p := by
+  simp [descendMatrixCount, h]
 
 /-- The descent family has `p + 1` members when `p²` does not divide `N`. -/
 @[simp]
-theorem descendCosetCount_of_not_sq_dvd {p N : ℕ} (h : ¬ p ^ 2 ∣ N) :
-    descendCosetCount p N = p + 1 := by
-  simp [descendCosetCount, h]
+theorem descendMatrixCount_of_not_sq_dvd {p N : ℕ} (h : ¬ p ^ 2 ∣ N) :
+    descendMatrixCount p N = p + 1 := by
+  simp [descendMatrixCount, h]
 
 /-- **The extra descent matrix.** For a prime `p` exactly dividing `N`, an element of `Γ₀(N / p)`
 reducing to `S` modulo `p` and to the identity modulo `N / p`; the junk value `1` when those
 hypotheses fail, so that the definition is total. Its three defining properties are
-`descendExtraGamma_spec`. -/
+`descendExtraGamma_mem_Gamma0`, `descendExtraGamma_map_intCast_zmod_eq_S` and
+`descendExtraGamma_map_intCast_zmod_div_eq_one`. -/
 noncomputable def descendExtraGamma (p N : ℕ) : Matrix.SpecialLinearGroup (Fin 2) ℤ :=
   if h : p.Prime ∧ p ∣ N ∧ ¬ p ^ 2 ∣ N then
     (exists_mem_Gamma0_map_intCast_zmod_eq_S h.1 h.2.1 h.2.2).choose
   else 1
 
-/-- **The defining property of `descendExtraGamma`.** Under the hypotheses that make the choice,
-it lies in `Γ₀(N / p)`, reduces to `S` modulo `p`, and reduces to the identity modulo `N / p`. -/
-theorem descendExtraGamma_spec {p N : ℕ} (hp : p.Prime) (hpN : p ∣ N) (hpsq : ¬ p ^ 2 ∣ N) :
-    descendExtraGamma p N ∈ Gamma0 (N / p) ∧
-      Matrix.SpecialLinearGroup.map (Int.castRingHom (ZMod p)) (descendExtraGamma p N) =
-          Matrix.SpecialLinearGroup.map (Int.castRingHom (ZMod p)) ModularGroup.S ∧
-        Matrix.SpecialLinearGroup.map (Int.castRingHom (ZMod (N / p)))
-          (descendExtraGamma p N) = 1 := by
+/-- Under the hypotheses that make the choice, `descendExtraGamma` *is* the chosen matrix. -/
+private theorem descendExtraGamma_eq_choose {p N : ℕ} (hp : p.Prime) (hpN : p ∣ N)
+    (hpsq : ¬ p ^ 2 ∣ N) :
+    descendExtraGamma p N = (exists_mem_Gamma0_map_intCast_zmod_eq_S hp hpN hpsq).choose :=
   -- `dif_pos` is deprecated on the current pin, so the guard is discharged the way
   -- `TauCeti.diamondOpNat_of_coprime` does it
-  have h : descendExtraGamma p N =
-      (exists_mem_Gamma0_map_intCast_zmod_eq_S hp hpN hpsq).choose :=
-    dite_eq_left_of_eq_true (by simp [hp, hpN, hpsq])
-  rw [h]
-  exact (exists_mem_Gamma0_map_intCast_zmod_eq_S hp hpN hpsq).choose_spec
+  dite_eq_left_of_eq_true (by simp [hp, hpN, hpsq])
+
+/-- **The extra descent matrix lies in `Γ₀(N / p)`.** -/
+theorem descendExtraGamma_mem_Gamma0 {p N : ℕ} (hp : p.Prime) (hpN : p ∣ N)
+    (hpsq : ¬ p ^ 2 ∣ N) : descendExtraGamma p N ∈ Gamma0 (N / p) := by
+  rw [descendExtraGamma_eq_choose hp hpN hpsq]
+  exact (exists_mem_Gamma0_map_intCast_zmod_eq_S hp hpN hpsq).choose_spec.1
+
+/-- **The extra descent matrix reduces to `S` modulo `p`.** -/
+@[simp]
+theorem descendExtraGamma_map_intCast_zmod_eq_S {p N : ℕ} (hp : p.Prime) (hpN : p ∣ N)
+    (hpsq : ¬ p ^ 2 ∣ N) :
+    Matrix.SpecialLinearGroup.map (Int.castRingHom (ZMod p)) (descendExtraGamma p N) =
+      Matrix.SpecialLinearGroup.map (Int.castRingHom (ZMod p)) ModularGroup.S := by
+  rw [descendExtraGamma_eq_choose hp hpN hpsq]
+  exact (exists_mem_Gamma0_map_intCast_zmod_eq_S hp hpN hpsq).choose_spec.2.1
+
+/-- **The extra descent matrix reduces to the identity modulo `N / p`.** -/
+@[simp]
+theorem descendExtraGamma_map_intCast_zmod_div_eq_one {p N : ℕ} (hp : p.Prime) (hpN : p ∣ N)
+    (hpsq : ¬ p ^ 2 ∣ N) :
+    Matrix.SpecialLinearGroup.map (Int.castRingHom (ZMod (N / p))) (descendExtraGamma p N) = 1 := by
+  rw [descendExtraGamma_eq_choose hp hpN hpsq]
+  exact (exists_mem_Gamma0_map_intCast_zmod_eq_S hp hpN hpsq).choose_spec.2.2
 
 /-- **The descent family at `p`** (Miyake, Lemma 4.5.11). The `p` upper-triangular matrices
 `[1, v; 0, p]` for `v < p`, together with — when `p²` does not divide `N`, so that
-`descendCosetCount` is `p + 1` — the further matrix `[1, 0; 0, p] * descendExtraGamma p N`.
+`descendMatrixCount` is `p + 1` — the further matrix `[1, 0; 0, p] * descendExtraGamma p N`.
 
 Over `ℚ` the upper-triangular part is `HeckeRing.GL2.upperTriRep`, this repository's `T_p`
 representative family; the descent family is its image in `GL₂(ℝ)`, where the slash action of a
 modular form lives.
 
-`p ∣ N` belongs to the interface rather than to the construction: without it the extra matrix
-degenerates to `[1, 0; 0, p]`, which the first branch already lists at `v = 0`. -/
-noncomputable def descendCosetRep (p N : ℕ) (hp : p.Prime) (_hpN : p ∣ N) :
-    Fin (descendCosetCount p N) → GL (Fin 2) ℝ := fun v ↦
+`p ∣ N` is not required: the construction never uses it. It is exactly the hypothesis that makes
+the family the *descent* family — without it `descendExtraGamma p N` is `1` and the extra matrix
+degenerates to `[1, 0; 0, p]`, which the first branch already lists at `v = 0` — so it belongs on
+the later results that establish descent, not on the family itself. -/
+noncomputable def descendMatrix (p N : ℕ) (hp : p.Prime) :
+    Fin (descendMatrixCount p N) → GL (Fin 2) ℝ := fun v ↦
   if h : v.val < p then
     Matrix.GeneralLinearGroup.map (algebraMap ℚ ℝ) (upperTriRep p ⟨v.val, h⟩)
   else
@@ -152,23 +173,23 @@ noncomputable def descendCosetRep (p N : ℕ) (hp : p.Prime) (_hpN : p ∣ N) :
 /-- The members of the descent family below index `p` are the upper-triangular matrices
 `[1, v; 0, p]`. -/
 @[simp]
-theorem descendCosetRep_of_lt {p N : ℕ} (hp : p.Prime) (hpN : p ∣ N)
-    {v : Fin (descendCosetCount p N)} (h : v.val < p) :
-    descendCosetRep p N hp hpN v =
+theorem descendMatrix_of_lt {p N : ℕ} (hp : p.Prime)
+    {v : Fin (descendMatrixCount p N)} (h : v.val < p) :
+    descendMatrix p N hp v =
       Matrix.GeneralLinearGroup.map (algebraMap ℚ ℝ) (upperTriRep p ⟨v.val, h⟩) := by
-  rw [descendCosetRep]
+  rw [descendMatrix]
   split_ifs
   rfl
 
 /-- The member of the descent family at index `p`, present exactly when `p²` does not divide `N`,
 is `[1, 0; 0, p]` times the extra matrix. -/
 @[simp]
-theorem descendCosetRep_of_le {p N : ℕ} (hp : p.Prime) (hpN : p ∣ N)
-    {v : Fin (descendCosetCount p N)} (h : p ≤ v.val) :
-    descendCosetRep p N hp hpN v =
+theorem descendMatrix_of_le {p N : ℕ} (hp : p.Prime)
+    {v : Fin (descendMatrixCount p N)} (h : p ≤ v.val) :
+    descendMatrix p N hp v =
       Matrix.GeneralLinearGroup.map (algebraMap ℚ ℝ) (upperTriRep p ⟨0, hp.pos⟩) *
         Matrix.SpecialLinearGroup.mapGL ℝ (descendExtraGamma p N) := by
-  rw [descendCosetRep]
+  rw [descendMatrix]
   split_ifs with h'
   · exact absurd h' (Nat.not_lt.mpr h)
   · rfl
@@ -178,14 +199,14 @@ theorem descendCosetRep_of_le {p N : ℕ} (hp : p.Prime) (hpN : p ∣ N)
 necessary condition for lying in it, not a characterisation of it; that these matrices lie in the
 double coset is not proved here. -/
 @[simp]
-theorem descendCosetRep_det (p N : ℕ) (hp : p.Prime) (hpN : p ∣ N)
-    (v : Fin (descendCosetCount p N)) :
-    (descendCosetRep p N hp hpN v : Matrix (Fin 2) (Fin 2) ℝ).det = (p : ℝ) := by
+theorem descendMatrix_det (p N : ℕ) (hp : p.Prime)
+    (v : Fin (descendMatrixCount p N)) :
+    (descendMatrix p N hp v : Matrix (Fin 2) (Fin 2) ℝ).det = (p : ℝ) := by
   have hγ : (Matrix.SpecialLinearGroup.mapGL ℝ (descendExtraGamma p N) :
       Matrix (Fin 2) (Fin 2) ℝ).det = 1 := by
     rw [← Matrix.GeneralLinearGroup.val_det_apply, Matrix.SpecialLinearGroup.det_mapGL,
       Units.val_one]
-  rw [descendCosetRep]
+  rw [descendMatrix]
   split_ifs
   · simp [Matrix.det_fin_two]
   · rw [Matrix.GeneralLinearGroup.coe_mul, Matrix.det_mul, hγ, mul_one]

--- a/TauCeti/NumberTheory/ModularForms/Newforms/Descent/Cosets.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Descent/Cosets.lean
@@ -8,12 +8,13 @@ module
 public import TauCeti.NumberTheory.ModularForms.CongruenceSubgroups.Basic
 
 /-!
-# The extra coset representative of the level descent
+# The coset representatives of the level descent
 
-Miyake's level descent at a prime `p` exactly dividing `N` uses, besides the `p` upper-triangular
-representatives, one further coset representative: an element of `Γ₀(N / p)` that reduces to
-`S = [[0, -1], [1, 0]]` modulo `p` and to the identity modulo `N / p`. This file records that
-matrix's **existence**, which is what strong approximation supplies.
+Miyake's level descent at a prime `p` uses `p` upper-triangular representatives `[1, v; 0, p]`
+and, when `p` divides `N` but `p²` does not, one further representative built from an element of
+`Γ₀(N / p)` that reduces to `S = [[0, -1], [1, 0]]` modulo `p` and to the identity modulo `N / p`.
+This file supplies that extra matrix, gives the representatives as a list of `p` or `p + 1`
+elements of `GL₂(ℝ)`, and computes their determinants.
 
 The matrix comes from strong approximation at a coprime pair of levels,
 `CongruenceSubgroup.exists_mem_Gamma_map_intCast_zmod_eq`: for coprime `d` and `d'` the principal
@@ -23,17 +24,29 @@ with `S` as the prescribed reduction modulo `p`. Approximation returns membershi
 which is stronger than the `Γ₀(N / p)` the descent asks for, so the second reduction is the
 identity rather than merely lower-triangular.
 
+## Main definitions
+
+* `TauCeti.descendCosetCount`: the number of representatives, `p` when `p² ∣ N` and `p + 1`
+  otherwise.
+* `TauCeti.descendExtraGamma`: the extra matrix, chosen from the existence statement below, with
+  the junk value `1` outside the hypotheses that make the choice.
+* `TauCeti.descendCosetList`: the representatives themselves.
+
 ## Main results
 
 * `TauCeti.exists_mem_Gamma0_map_intCast_zmod_eq_S`: for a prime `p` with `p ∣ N` and `p² ∤ N`,
   some `γ ∈ Γ₀(N / p)` reduces to `S` modulo `p` and to the identity modulo `N / p`.
+* `TauCeti.descendExtraGamma_spec`: those three properties, read back off the chosen matrix.
+* `TauCeti.descendCosetList_det`: every representative has determinant `p`.
 
 ## Scope
 
-Existence and the two reductions are all that is claimed. The coset system is not formalized
-here, so nothing enumerates the representatives or asserts that the list of them is complete.
+The list is defined and its determinants computed; nothing here proves that these matrices *are*
+a set of coset representatives, nor that the associated slash sum descends the level. Those are
+separate statements about the double coset `Γ₀(N) diag(1, p) Γ₀(N)`.
 
-Specializes `descendExtraGamma_exists` of the AINTLIB `LeanModularForms` project
+Follows `descendExtraGamma`, `descendCosetCount`, `descendCosetList` and `descendCosetList_det`,
+and specializes `descendExtraGamma_exists`, of the AINTLIB `LeanModularForms` project
 (`LeanModularForms/StrongMultiplicityOne/DescentCosets.lean`, Chris Birkbeck, commit
 `2baa76f742bdb4fb8ee323fabba41203bd390e08`, Apache-2.0,
 <https://github.com/CBirkbeck/AINTLIB/tree/main/projects/LeanModularForms>), which proves the
@@ -71,5 +84,70 @@ theorem exists_mem_Gamma0_map_intCast_zmod_eq_S {p N : ℕ} (hp : p.Prime) (hpN 
   obtain ⟨γ, hγ, hγp⟩ := exists_mem_Gamma_map_intCast_zmod_eq hcop
     (Matrix.SpecialLinearGroup.map (Int.castRingHom (ZMod p)) ModularGroup.S)
   exact ⟨γ, Gamma_le_Gamma0 _ hγ, hγp, Gamma_mem'.mp hγ⟩
+
+/-- **The number of coset representatives for the level descent at `p`.** Miyake's count: `p`
+when `p²` divides `N`, and `p + 1` when it does not, the extra representative being the one
+`descendExtraGamma` supplies. -/
+def descendCosetCount (p N : ℕ) : ℕ := if p ^ 2 ∣ N then p else p + 1
+
+/-- **The extra coset representative.** For a prime `p` exactly dividing `N`, a chosen element
+of `Γ₀(N / p)` reducing to `S` modulo `p` and to the identity modulo `N / p`; the junk value `1`
+when those hypotheses fail, so that the definition is total.
+
+The choice is made from `exists_mem_Gamma0_map_intCast_zmod_eq_S`, which is the only thing
+proved about it; `descendExtraGamma_spec` reads the three properties back off. -/
+noncomputable def descendExtraGamma (p N : ℕ) : Matrix.SpecialLinearGroup (Fin 2) ℤ :=
+  if h : p.Prime ∧ p ∣ N ∧ ¬ p ^ 2 ∣ N then
+    (exists_mem_Gamma0_map_intCast_zmod_eq_S h.1 h.2.1 h.2.2).choose
+  else 1
+
+/-- **The defining property of `descendExtraGamma`.** Under the hypotheses that make the choice,
+it lies in `Γ₀(N / p)`, reduces to `S` modulo `p`, and reduces to the identity modulo `N / p`. -/
+theorem descendExtraGamma_spec {p N : ℕ} (hp : p.Prime) (hpN : p ∣ N) (hpsq : ¬ p ^ 2 ∣ N) :
+    descendExtraGamma p N ∈ Gamma0 (N / p) ∧
+      Matrix.SpecialLinearGroup.map (Int.castRingHom (ZMod p)) (descendExtraGamma p N) =
+          Matrix.SpecialLinearGroup.map (Int.castRingHom (ZMod p)) ModularGroup.S ∧
+        Matrix.SpecialLinearGroup.map (Int.castRingHom (ZMod (N / p)))
+          (descendExtraGamma p N) = 1 := by
+  -- `dif_pos` is deprecated on the current pin, so the guard is discharged the way
+  -- `TauCeti.diamondOpNat_of_coprime` does it
+  have h : descendExtraGamma p N =
+      (exists_mem_Gamma0_map_intCast_zmod_eq_S hp hpN hpsq).choose :=
+    dite_eq_left_of_eq_true (by simp [hp, hpN, hpsq])
+  rw [h]
+  exact (exists_mem_Gamma0_map_intCast_zmod_eq_S hp hpN hpsq).choose_spec
+
+/-- **The coset representatives for the level descent at `p`** (Miyake, Lemma 4.5.11). The `p`
+upper-triangular matrices `[1, v; 0, p]` for `v < p`, together with — when `p²` does not divide
+`N`, so that `descendCosetCount` is `p + 1` — one further representative `[1, 0; 0, p]` times the
+matrix `descendExtraGamma` supplies.
+
+Only the list itself is defined here. That these are coset representatives, and that the
+associated slash sum descends, are separate statements and are not proved. -/
+noncomputable def descendCosetList (p N : ℕ) (hp : p.Prime) :
+    Fin (descendCosetCount p N) → GL (Fin 2) ℝ := fun v ↦
+  if v.val < p then
+    Matrix.GeneralLinearGroup.mkOfDetNeZero !![(1 : ℝ), (v.val : ℝ); 0, (p : ℝ)]
+      (by simpa [Matrix.det_fin_two] using (Nat.cast_ne_zero (R := ℝ)).mpr hp.ne_zero)
+  else
+    Matrix.GeneralLinearGroup.mkOfDetNeZero !![(1 : ℝ), 0; 0, (p : ℝ)]
+      (by simpa [Matrix.det_fin_two] using (Nat.cast_ne_zero (R := ℝ)).mpr hp.ne_zero) *
+      Matrix.SpecialLinearGroup.mapGL ℝ (descendExtraGamma p N)
+
+/-- **Every descent representative has determinant `p`.** The upper-triangular ones by
+inspection; the extra one because `descendExtraGamma` has determinant `1`, so multiplying by it
+does not change the determinant. -/
+theorem descendCosetList_det (p N : ℕ) (hp : p.Prime) (v : Fin (descendCosetCount p N)) :
+    (descendCosetList p N hp v : Matrix (Fin 2) (Fin 2) ℝ).det = (p : ℝ) := by
+  rw [descendCosetList]
+  split_ifs
+  · simp [Matrix.det_fin_two]
+  · rw [Matrix.GeneralLinearGroup.coe_mul, Matrix.det_mul,
+      Matrix.SpecialLinearGroup.mapGL_coe_matrix, Matrix.SpecialLinearGroup.map_apply_coe,
+      RingHom.mapMatrix_apply,
+      show ((descendExtraGamma p N).val.map (algebraMap ℤ ℝ)).det = 1 by
+        rw [← RingHom.mapMatrix_apply, ← RingHom.map_det,
+          (descendExtraGamma p N).property, map_one]]
+    simp [Matrix.det_fin_two]
 
 end TauCeti

--- a/TauCeti/NumberTheory/ModularForms/Newforms/Descent/Cosets.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Descent/Cosets.lean
@@ -5,18 +5,19 @@ Authors: Chris Birkbeck
 -/
 module
 
+public import TauCeti.NumberTheory.HeckeRing.GL2.CosetDecomposition
 public import TauCeti.NumberTheory.ModularForms.CongruenceSubgroups.Basic
 
 /-!
-# The coset representatives of the level descent
+# The descent matrices at a prime
 
-Miyake's level descent at a prime `p` uses `p` upper-triangular representatives `[1, v; 0, p]`
-and, when `p` divides `N` but `p²` does not, one further representative built from an element of
-`Γ₀(N / p)` that reduces to `S = [[0, -1], [1, 0]]` modulo `p` and to the identity modulo `N / p`.
-This file supplies that extra matrix, gives the representatives as a list of `p` or `p + 1`
-elements of `GL₂(ℝ)`, and computes their determinants.
+Miyake's level descent at a prime `p` runs over the `p` upper-triangular matrices `[1, v; 0, p]`
+together with, when `p` divides `N` but `p²` does not, one further matrix built from an element
+of `Γ₀(N / p)` reducing to `S = [[0, -1], [1, 0]]` modulo `p` and to the identity modulo `N / p`.
+This file supplies that extra matrix, assembles the family of `p` or `p + 1` elements of `GL₂(ℝ)`
+the descent runs over, and computes their determinants.
 
-The matrix comes from strong approximation at a coprime pair of levels,
+The extra matrix comes from strong approximation at a coprime pair of levels,
 `CongruenceSubgroup.exists_mem_Gamma_map_intCast_zmod_eq`: for coprime `d` and `d'` the principal
 congruence subgroup `Γ(d')` still surjects onto `SL₂(ℤ/dℤ)`. The descent is that statement at
 `d = p` and `d' = N / p` — a coprime pair exactly because `p` divides `N` while `p²` does not —
@@ -26,27 +27,32 @@ identity rather than merely lower-triangular.
 
 ## Main definitions
 
-* `TauCeti.descendCosetCount`: the number of representatives, `p` when `p² ∣ N` and `p + 1`
-  otherwise.
-* `TauCeti.descendExtraGamma`: the extra matrix, chosen from the existence statement below, with
-  the junk value `1` outside the hypotheses that make the choice.
-* `TauCeti.descendCosetList`: the representatives themselves.
+* `TauCeti.descendCosetCount`: the size of the family, `p` when `p² ∣ N` and `p + 1` otherwise.
+* `TauCeti.descendExtraGamma`: the extra matrix, with the junk value `1` outside the hypotheses
+  that make the choice.
+* `TauCeti.descendCosetRep`: the family itself, indexed by `Fin (descendCosetCount p N)`.
 
 ## Main results
 
 * `TauCeti.exists_mem_Gamma0_map_intCast_zmod_eq_S`: for a prime `p` with `p ∣ N` and `p² ∤ N`,
   some `γ ∈ Γ₀(N / p)` reduces to `S` modulo `p` and to the identity modulo `N / p`.
 * `TauCeti.descendExtraGamma_spec`: those three properties, read back off the chosen matrix.
-* `TauCeti.descendCosetList_det`: every representative has determinant `p`.
+* `TauCeti.descendCosetCount_of_sq_dvd` and `TauCeti.descendCosetCount_of_not_sq_dvd`: the two
+  values of the count.
+* `TauCeti.descendCosetRep_of_lt` and `TauCeti.descendCosetRep_of_le`: the two branches of the
+  family, as equations in `GL₂(ℝ)`.
+* `TauCeti.descendCosetRep_det`: every member of the family has determinant `p`.
 
 ## Scope
 
-The list is defined and its determinants computed; nothing here proves that these matrices *are*
-a set of coset representatives, nor that the associated slash sum descends the level. Those are
-separate statements about the double coset `Γ₀(N) diag(1, p) Γ₀(N)`.
+The family is defined and its determinants computed. That its members *are* a set of coset
+representatives, and that the associated slash sum descends the level, are separate statements
+about the double coset `Γ₀(N) diag(1, p) Γ₀(N)`; neither is proved here. Until they are, the
+family is the intended list of representatives rather than a formalized one.
 
-Follows `descendExtraGamma`, `descendCosetCount`, `descendCosetList` and `descendCosetList_det`,
-and specializes `descendExtraGamma_exists`, of the AINTLIB `LeanModularForms` project
+Follows the AINTLIB `LeanModularForms` project, whose `descendExtraGamma`, `descendCosetCount`,
+`descendCosetList` and `descendCosetList_det` are the counterparts of the declarations here, and
+specializes its `descendExtraGamma_exists`
 (`LeanModularForms/StrongMultiplicityOne/DescentCosets.lean`, Chris Birkbeck, commit
 `2baa76f742bdb4fb8ee323fabba41203bd390e08`, Apache-2.0,
 <https://github.com/CBirkbeck/AINTLIB/tree/main/projects/LeanModularForms>), which proves the
@@ -55,7 +61,7 @@ same existence directly; here it is read off the general coprime-level statement
 
 public section
 
-open CongruenceSubgroup
+open CongruenceSubgroup HeckeRing.GL2
 
 open scoped MatrixGroups
 
@@ -85,17 +91,25 @@ theorem exists_mem_Gamma0_map_intCast_zmod_eq_S {p N : ℕ} (hp : p.Prime) (hpN 
     (Matrix.SpecialLinearGroup.map (Int.castRingHom (ZMod p)) ModularGroup.S)
   exact ⟨γ, Gamma_le_Gamma0 _ hγ, hγp, Gamma_mem'.mp hγ⟩
 
-/-- **The number of coset representatives for the level descent at `p`.** Miyake's count: `p`
-when `p²` divides `N`, and `p + 1` when it does not, the extra representative being the one
-`descendExtraGamma` supplies. -/
+/-- **The size of the descent family at `p`.** Miyake's count: `p` when `p²` divides `N`, and
+`p + 1` when it does not, the extra member being the one `descendExtraGamma` supplies. -/
 def descendCosetCount (p N : ℕ) : ℕ := if p ^ 2 ∣ N then p else p + 1
 
-/-- **The extra coset representative.** For a prime `p` exactly dividing `N`, a chosen element
-of `Γ₀(N / p)` reducing to `S` modulo `p` and to the identity modulo `N / p`; the junk value `1`
-when those hypotheses fail, so that the definition is total.
+/-- The descent family has `p` members when `p²` divides `N`. -/
+@[simp]
+theorem descendCosetCount_of_sq_dvd {p N : ℕ} (h : p ^ 2 ∣ N) : descendCosetCount p N = p := by
+  simp [descendCosetCount, h]
 
-The choice is made from `exists_mem_Gamma0_map_intCast_zmod_eq_S`, which is the only thing
-proved about it; `descendExtraGamma_spec` reads the three properties back off. -/
+/-- The descent family has `p + 1` members when `p²` does not divide `N`. -/
+@[simp]
+theorem descendCosetCount_of_not_sq_dvd {p N : ℕ} (h : ¬ p ^ 2 ∣ N) :
+    descendCosetCount p N = p + 1 := by
+  simp [descendCosetCount, h]
+
+/-- **The extra descent matrix.** For a prime `p` exactly dividing `N`, an element of `Γ₀(N / p)`
+reducing to `S` modulo `p` and to the identity modulo `N / p`; the junk value `1` when those
+hypotheses fail, so that the definition is total. Its three defining properties are
+`descendExtraGamma_spec`. -/
 noncomputable def descendExtraGamma (p N : ℕ) : Matrix.SpecialLinearGroup (Fin 2) ℤ :=
   if h : p.Prime ∧ p ∣ N ∧ ¬ p ^ 2 ∣ N then
     (exists_mem_Gamma0_map_intCast_zmod_eq_S h.1 h.2.1 h.2.2).choose
@@ -117,37 +131,59 @@ theorem descendExtraGamma_spec {p N : ℕ} (hp : p.Prime) (hpN : p ∣ N) (hpsq 
   rw [h]
   exact (exists_mem_Gamma0_map_intCast_zmod_eq_S hp hpN hpsq).choose_spec
 
-/-- **The coset representatives for the level descent at `p`** (Miyake, Lemma 4.5.11). The `p`
-upper-triangular matrices `[1, v; 0, p]` for `v < p`, together with — when `p²` does not divide
-`N`, so that `descendCosetCount` is `p + 1` — one further representative `[1, 0; 0, p]` times the
-matrix `descendExtraGamma` supplies.
+/-- **The descent family at `p`** (Miyake, Lemma 4.5.11). The `p` upper-triangular matrices
+`[1, v; 0, p]` for `v < p`, together with — when `p²` does not divide `N`, so that
+`descendCosetCount` is `p + 1` — the further matrix `[1, 0; 0, p] * descendExtraGamma p N`.
 
-Only the list itself is defined here. That these are coset representatives, and that the
-associated slash sum descends, are separate statements and are not proved. -/
-noncomputable def descendCosetList (p N : ℕ) (hp : p.Prime) :
+Over `ℚ` the upper-triangular part is `HeckeRing.GL2.upperTriRep`, this repository's `T_p`
+representative family; the descent family is its image in `GL₂(ℝ)`, where the slash action of a
+modular form lives.
+
+`p ∣ N` belongs to the interface rather than to the construction: without it the extra matrix
+degenerates to `[1, 0; 0, p]`, which the first branch already lists at `v = 0`. -/
+noncomputable def descendCosetRep (p N : ℕ) (hp : p.Prime) (_hpN : p ∣ N) :
     Fin (descendCosetCount p N) → GL (Fin 2) ℝ := fun v ↦
-  if v.val < p then
-    Matrix.GeneralLinearGroup.mkOfDetNeZero !![(1 : ℝ), (v.val : ℝ); 0, (p : ℝ)]
-      (by simpa [Matrix.det_fin_two] using (Nat.cast_ne_zero (R := ℝ)).mpr hp.ne_zero)
+  if h : v.val < p then
+    Matrix.GeneralLinearGroup.map (algebraMap ℚ ℝ) (upperTriRep p ⟨v.val, h⟩)
   else
-    Matrix.GeneralLinearGroup.mkOfDetNeZero !![(1 : ℝ), 0; 0, (p : ℝ)]
-      (by simpa [Matrix.det_fin_two] using (Nat.cast_ne_zero (R := ℝ)).mpr hp.ne_zero) *
+    Matrix.GeneralLinearGroup.map (algebraMap ℚ ℝ) (upperTriRep p ⟨0, hp.pos⟩) *
       Matrix.SpecialLinearGroup.mapGL ℝ (descendExtraGamma p N)
 
-/-- **Every descent representative has determinant `p`.** The upper-triangular ones by
-inspection; the extra one because `descendExtraGamma` has determinant `1`, so multiplying by it
-does not change the determinant. -/
-theorem descendCosetList_det (p N : ℕ) (hp : p.Prime) (v : Fin (descendCosetCount p N)) :
-    (descendCosetList p N hp v : Matrix (Fin 2) (Fin 2) ℝ).det = (p : ℝ) := by
-  rw [descendCosetList]
+/-- The members of the descent family below index `p` are the upper-triangular matrices
+`[1, v; 0, p]`. -/
+theorem descendCosetRep_of_lt {p N : ℕ} (hp : p.Prime) (hpN : p ∣ N)
+    {v : Fin (descendCosetCount p N)} (h : v.val < p) :
+    descendCosetRep p N hp hpN v =
+      Matrix.GeneralLinearGroup.map (algebraMap ℚ ℝ) (upperTriRep p ⟨v.val, h⟩) := by
+  rw [descendCosetRep]
+  split_ifs
+  rfl
+
+/-- The member of the descent family at index `p`, present exactly when `p²` does not divide `N`,
+is `[1, 0; 0, p]` times the extra matrix. -/
+theorem descendCosetRep_of_le {p N : ℕ} (hp : p.Prime) (hpN : p ∣ N)
+    {v : Fin (descendCosetCount p N)} (h : p ≤ v.val) :
+    descendCosetRep p N hp hpN v =
+      Matrix.GeneralLinearGroup.map (algebraMap ℚ ℝ) (upperTriRep p ⟨0, hp.pos⟩) *
+        Matrix.SpecialLinearGroup.mapGL ℝ (descendExtraGamma p N) := by
+  rw [descendCosetRep]
+  split_ifs with h'
+  · exact absurd h' (Nat.not_lt.mpr h)
+  · rfl
+
+/-- **Every member of the descent family has determinant `p`.** This is the determinant condition
+cutting out the double coset `Γ₀(N) diag(1, p) Γ₀(N)` that the descent sum runs over. -/
+theorem descendCosetRep_det (p N : ℕ) (hp : p.Prime) (hpN : p ∣ N)
+    (v : Fin (descendCosetCount p N)) :
+    (descendCosetRep p N hp hpN v : Matrix (Fin 2) (Fin 2) ℝ).det = (p : ℝ) := by
+  have hγ : (Matrix.SpecialLinearGroup.mapGL ℝ (descendExtraGamma p N) :
+      Matrix (Fin 2) (Fin 2) ℝ).det = 1 := by
+    rw [← Matrix.GeneralLinearGroup.val_det_apply, Matrix.SpecialLinearGroup.det_mapGL,
+      Units.val_one]
+  rw [descendCosetRep]
   split_ifs
   · simp [Matrix.det_fin_two]
-  · rw [Matrix.GeneralLinearGroup.coe_mul, Matrix.det_mul,
-      Matrix.SpecialLinearGroup.mapGL_coe_matrix, Matrix.SpecialLinearGroup.map_apply_coe,
-      RingHom.mapMatrix_apply,
-      show ((descendExtraGamma p N).val.map (algebraMap ℤ ℝ)).det = 1 by
-        rw [← RingHom.mapMatrix_apply, ← RingHom.map_det,
-          (descendExtraGamma p N).property, map_one]]
+  · rw [Matrix.GeneralLinearGroup.coe_mul, Matrix.det_mul, hγ, mul_one]
     simp [Matrix.det_fin_two]
 
 end TauCeti


### PR DESCRIPTION
#6029 put the extra descent matrix's **existence** on main. This PR names it and builds Miyake's
representative family on top, which is what the existence statement was for.

| | |
|---|---|
| `descendMatrixCount p N` | `p` when `p² ∣ N`, else `p + 1` |
| `descendMatrixCount_of_sq_dvd`, `..._of_not_sq_dvd` | the two values, as `simp` lemmas |
| `descendExtraGamma p N` | the extra matrix, chosen from `exists_mem_Gamma0_map_intCast_zmod_eq_S` |
| `descendExtraGamma_mem_Gamma0`, `..._map_intCast_zmod_eq_S`, `..._map_intCast_zmod_div_eq_one` | its three properties, read back off the choice; the two reductions are `simp` lemmas |
| `descendExtraGamma_eq_one_of_not` | outside the guard it is the identity |
| `descendMatrix p N` (with `[NeZero p]`) | the family, as `Fin (descendMatrixCount p N) → GL₂(ℝ)` |
| `descendMatrix_of_lt`, `descendMatrix_of_le` | its two branches, as `simp` equations in `GL₂(ℝ)` |
| `descendMatrix_det` | every member has determinant `p` |

The family is `[1, v; 0, p]` for `v < p`, plus — when the count is `p + 1` — one further
`[1, 0; 0, p] * mapGL ℝ (descendExtraGamma p N)`. The upper-triangular part is not rebuilt: it
is `HeckeRing.GL2.upperTriRep`, this repository's `T_p` representative family over `ℚ`, carried
to `GL₂(ℝ)` by `Matrix.GeneralLinearGroup.map (algebraMap ℚ ℝ)` — the same transport
`HeckeSlash/UpperTri/` already uses.

`descendExtraGamma` is total: outside the hypotheses that make the choice (`p` prime, `p ∣ N`,
`p² ∤ N`) it takes the junk value `1`, and `descendExtraGamma_eq_one_of_not` says so publicly.
`descendMatrix` requires neither `p ∣ N` nor primality — the construction uses only `p ≠ 0`, to
name the zero index of `Fin p`. Those two hypotheses are what make this the descent family at a
prime, so they belong on the later results that establish descent; the neutral name says only
what is proved.

Review note, since this reverses an earlier round: `api-design` round 1 required `p ∣ N` on the
family, and `generality` round 3 required removing it. The first was premised on the name —
"although its name and documentation expose it as a level-descent representative list … so every
admitted input denotes the advertised descent list". Renaming to `descendMatrix` withdraws that
advertisement, so both are now satisfiable at once rather than in conflict.

### Where this sits on the roadmap

`TauCetiRoadmap/ModularForms/README.md`, **Layer 4** (*eigenforms, newforms, primitive forms; the
conductor*), the **Atkin–Lehner Main Lemma** bullet: the per-character route
`mainLemma_charSpace_routeB` (`StrongMultiplicityOne.lean`) that the roadmap records as
"Miyake's sieve/conductor descent". That descent is the level-lowering step this file's coset
system serves — `Newforms/Descent/Basic.lean` and `Newforms/AtkinLehner.lean` are the two
already-merged pieces of the same chain. Layer 5's fixed-space strong multiplicity one is the
downstream consumer, through the Layer 4 level-lowering dichotomy.

No `tauceti-target:v1` marker: this is a prerequisite for that node rather than the node itself,
and the contract asks for a deterministic target identifier, not an invented one.

### What this does not claim

The family is defined and its determinants computed. **Nothing here proves these matrices are a
set of coset representatives**, nor that the associated slash sum descends the level. Both are
statements about the double coset `Γ₀(N) diag(1, p) Γ₀(N)` and are left for later PRs, as the
module's `## Scope` section says. The names are the intended reading of the family until then.

### Proofs re-derived, not transcribed

The statements follow AINTLIB, but its `dif_pos` is deprecated on the current pin, so the guard
in `descendExtraGamma_spec` is discharged the way `TauCeti.diamondOpNat_of_coprime` already does
it in this repo, with `dite_eq_left_of_eq_true`. The determinant of the extra branch goes through
`Matrix.SpecialLinearGroup.det_mapGL` rather than unfolding the matrix map.

Roadmap: ModularForms

Provenance: github.com/CBirkbeck/AINTLIB @ `2baa76f742bdb4fb8ee323fabba41203bd390e08`
(Apache-2.0, Chris Birkbeck),
`projects/LeanModularForms/LeanModularForms/StrongMultiplicityOne/DescentCosets.lean` —
`descendCosetCount`, `descendExtraGamma`, `descendCosetList`, `descendCosetList_det`,
`descendExtraGamma_exists`. Statements adapted and renamed; proofs re-derived against the current
Mathlib pin as described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQieFQn95rzgvYRvNdX3hR



