### PR TITLE
feat: identify genus-field Frobenius classes

### DIFF
--- a/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Relative/Artin.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Relative/Artin.lean
@@ -58,8 +58,6 @@ theorem candidateGenusFieldRelativeAut_comm (hd : Squarefree d)
     (σ τ : candidateGenusField hd ≃ₐ[candidateGenusFieldBase hd] candidateGenusField hd) :
     σ * τ = τ * σ := by
   apply AlgEquiv.restrictScalars_injective ℚ
-  change σ.restrictScalars ℚ * τ.restrictScalars ℚ =
-    τ.restrictScalars ℚ * σ.restrictScalars ℚ
   exact IsMulCommutative.is_comm.comm (σ.restrictScalars ℚ) (τ.restrictScalars ℚ)
 
 /-- **The genus-field isomorphism sends Frobenius to the prime class.**
@@ -72,7 +70,7 @@ theorem autCandidateGenusFieldEquivNarrowElementaryTwoQuotient_frobenius
     {q : ℕ} [Fact q.Prime] (hodd : q ≠ 2)
     (hqD : ¬ (q : ℤ) ∣ fundamentalDiscriminant d)
     (qIdeal : Ideal (𝓞 (candidateGenusFieldBase hd)))
-    [qIdeal.LiesOver (Ideal.span {(q : ℤ)})] (hnorm : Ideal.absNorm qIdeal = q)
+    (hnorm : Ideal.absNorm qIdeal = q)
     (Q : Ideal (𝓞 (candidateGenusField hd))) [Q.LiesOver qIdeal]
     (σ : candidateGenusField hd ≃ₐ[candidateGenusFieldBase hd] candidateGenusField hd)
     (hσ : IsArithFrobAt (𝓞 (candidateGenusFieldBase hd)) σ Q) :
@@ -83,6 +81,13 @@ theorem autCandidateGenusFieldEquivNarrowElementaryTwoQuotient_frobenius
             ⟨qIdeal, by
               rw [← Ideal.absNorm_ne_zero_iff_mem_nonZeroDivisors, hnorm]
               exact (Fact.out : q.Prime).ne_zero⟩)) := by
+  have hprimeNorm : (Ideal.absNorm qIdeal).Prime := by
+    rw [hnorm]
+    exact Fact.out
+  let _ : qIdeal.IsPrime := Ideal.isPrime_of_irreducible_absNorm hprimeNorm
+  let _ : qIdeal.LiesOver (Ideal.span {(q : ℤ)}) := ⟨by
+    simpa [hnorm, Ideal.under_def] using
+      Ideal.span_singleton_absNorm (I := qIdeal) hprimeNorm⟩
   have hqIdeal : qIdeal ∈ (Ideal (𝓞 (candidateGenusFieldBase hd)))⁰ := by
     rw [← Ideal.absNorm_ne_zero_iff_mem_nonZeroDivisors, hnorm]
     exact (Fact.out : q.Prime).ne_zero
@@ -172,8 +177,16 @@ theorem autCandidateGenusFieldEquivNarrowElementaryTwoQuotient_artinElement
     (hd : Squarefree d) (hnsq : ¬ IsSquare ((d : ℤ) : ℚ))
     {q : ℕ} [Fact q.Prime] (hodd : q ≠ 2)
     (hqD : ¬ (q : ℤ) ∣ fundamentalDiscriminant d)
-    (qIdeal : Ideal (𝓞 (candidateGenusFieldBase hd))) [qIdeal.IsMaximal]
-    [qIdeal.LiesOver (Ideal.span {(q : ℤ)})] (hnorm : Ideal.absNorm qIdeal = q) :
+    (qIdeal : Ideal (𝓞 (candidateGenusFieldBase hd)))
+    (hnorm : Ideal.absNorm qIdeal = q) :
+    let hprimeNorm : (Ideal.absNorm qIdeal).Prime := by
+      rw [hnorm]
+      exact Fact.out
+    let _ : qIdeal.IsPrime := Ideal.isPrime_of_irreducible_absNorm hprimeNorm
+    let _ : qIdeal.IsMaximal := Ideal.IsPrime.isMaximal inferInstance (by
+      intro hbot
+      rw [hbot, Ideal.absNorm_bot] at hnorm
+      exact (Fact.out : q.Prime).ne_zero hnorm.symm)
     autCandidateGenusFieldEquivNarrowElementaryTwoQuotient hd hnsq
         (NumberFieldArithmetic.artinElement
           (candidateGenusFieldRelativeAut_comm hd) qIdeal
@@ -185,6 +198,17 @@ theorem autCandidateGenusFieldEquivNarrowElementaryTwoQuotient_artinElement
             ⟨qIdeal, by
               rw [← Ideal.absNorm_ne_zero_iff_mem_nonZeroDivisors, hnorm]
               exact (Fact.out : q.Prime).ne_zero⟩)) := by
+  have hprimeNorm : (Ideal.absNorm qIdeal).Prime := by
+    rw [hnorm]
+    exact Fact.out
+  let _ : qIdeal.IsPrime := Ideal.isPrime_of_irreducible_absNorm hprimeNorm
+  let _ : qIdeal.LiesOver (Ideal.span {(q : ℤ)}) := ⟨by
+    simpa [hnorm, Ideal.under_def] using
+      Ideal.span_singleton_absNorm (I := qIdeal) hprimeNorm⟩
+  let _ : qIdeal.IsMaximal := Ideal.IsPrime.isMaximal inferInstance (by
+    intro hbot
+    rw [hbot, Ideal.absNorm_bot] at hnorm
+    exact (Fact.out : q.Prime).ne_zero hnorm.symm)
   obtain ⟨Q, hQprime, hQlies⟩ :=
     (inferInstance :
       Nonempty (qIdeal.primesOver (𝓞 (candidateGenusField hd))))

--- a/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Relative/Artin.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Relative/Artin.lean
@@ -52,14 +52,6 @@ namespace TauCeti.Multiquadratic
 
 variable {d : ℤ}
 
-/-- Relative automorphisms of the candidate genus field commute because their restrictions to
-the abelian Galois group over `ℚ` commute. -/
-theorem candidateGenusFieldRelativeAut_comm (hd : Squarefree d)
-    (σ τ : candidateGenusField hd ≃ₐ[candidateGenusFieldBase hd] candidateGenusField hd) :
-    σ * τ = τ * σ := by
-  apply AlgEquiv.restrictScalars_injective ℚ
-  exact IsMulCommutative.is_comm.comm (σ.restrictScalars ℚ) (τ.restrictScalars ℚ)
-
 /-- **The genus-field isomorphism sends Frobenius to the prime class.**
 Let q be an odd rational prime not dividing the discriminant of K = ℚ(√d), let qIdeal be a
 degree-one prime of K above q, and let Q be a prime of the candidate genus field above qIdeal.
@@ -189,7 +181,7 @@ theorem autCandidateGenusFieldEquivNarrowElementaryTwoQuotient_artinElement
       exact (Fact.out : q.Prime).ne_zero hnorm.symm)
     autCandidateGenusFieldEquivNarrowElementaryTwoQuotient hd hnsq
         (NumberFieldArithmetic.artinElement
-          (candidateGenusFieldRelativeAut_comm hd) qIdeal
+          IsMulCommutative.is_comm.comm qIdeal
           (fun Q hQ hQl =>
             (isUnramifiedIn_candidateGenusField hd hnsq qIdeal) Q hQ hQl)) =
       Multiplicative.ofAdd
@@ -217,7 +209,7 @@ theorem autCandidateGenusFieldEquivNarrowElementaryTwoQuotient_artinElement
   apply autCandidateGenusFieldEquivNarrowElementaryTwoQuotient_frobenius
     hd hnsq hodd hqD qIdeal hnorm Q
   exact NumberFieldArithmetic.isArithFrobAt_artinElement
-    (candidateGenusFieldRelativeAut_comm hd) qIdeal
+    IsMulCommutative.is_comm.comm qIdeal
       (fun Q hQ hQl =>
         (isUnramifiedIn_candidateGenusField hd hnsq qIdeal) Q hQ hQl) Q
 

--- a/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Relative/Artin.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Relative/Artin.lean
@@ -1,0 +1,197 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.NumberTheory.Multiquadratic.CandidateGenusField.Relative.GenusCharacter
+public import TauCeti.NumberTheory.Multiquadratic.CandidateGenusField.Relative.Ramification
+public import TauCeti.NumberTheory.NumberField.Ideal.ArtinMap
+import TauCeti.NumberTheory.NumberField.Frobenius.Tower
+import TauCeti.NumberTheory.Multiquadratic.Quadratic.GenusCharacter.SplitPrime
+import TauCeti.NumberTheory.Multiquadratic.Legendre.PrimeDiscriminants
+
+/-!
+# The genus-field isomorphism on Artin symbols
+
+For a squarefree nonsquare integer \(d\), the candidate genus field is an unramified abelian
+extension of its embedded quadratic base \(K = \mathbb{Q}(\sqrt d)\). The isomorphism
+
+\[
+  \operatorname{Gal}(K_{\mathrm{gen}}/K) \cong \mathrm{Cl}^+(K)/\mathrm{Cl}^+(K)^2
+\]
+
+constructed from sign patterns and genus characters agrees with the inverse Artin map on every
+degree-one prime above an odd rational prime away from the discriminant. Namely, the Frobenius at
+such a prime is sent to the elementary-2 class of that prime.
+
+The proof compares both sides coordinate by coordinate. A relative Frobenius at a degree-one
+prime is also a Frobenius over the underlying rational prime, hence acts on the chosen square root
+of each prime discriminant by the corresponding Legendre symbol. The genus character of the
+prime's narrow class has the same value.
+
+This is the local compatibility that determines the Artin map on ideals. The classical account is
+in D. A. Cox, *Primes of the Form x² + ny²*, §6.A, and F. Lemmermeyer,
+*Reciprocity Laws: From Euler to Eisenstein*, §2.2.
+
+## Main results
+
+* `TauCeti.Multiquadratic.autCandidateGenusFieldEquivNarrowElementaryTwoQuotient_frobenius`:
+  the genus-field isomorphism sends a relative Frobenius to the class of its degree-one prime.
+* `TauCeti.Multiquadratic.autCandidateGenusFieldEquivNarrowElementaryTwoQuotient_artinElement`:
+  the same statement for the canonical Artin automorphism.
+-/
+
+public section
+
+open NumberField
+open scoped IsMulCommutative NumberField nonZeroDivisors
+
+namespace TauCeti.Multiquadratic
+
+variable {d : ℤ}
+
+/-- **The genus-field isomorphism sends Frobenius to the prime class.**
+Let q be an odd rational prime not dividing the discriminant of K = ℚ(√d), let qIdeal be a
+degree-one prime of K above q, and let Q be a prime of the candidate genus field above qIdeal.
+Every relative arithmetic Frobenius σ at Q is sent by the genus-field isomorphism to the class
+of qIdeal in the maximal elementary-2 quotient of the narrow class group. -/
+theorem autCandidateGenusFieldEquivNarrowElementaryTwoQuotient_frobenius
+    (hd : Squarefree d) (hnsq : ¬ IsSquare ((d : ℤ) : ℚ))
+    {q : ℕ} [Fact q.Prime] (hodd : q ≠ 2)
+    (hqD : ¬ (q : ℤ) ∣ fundamentalDiscriminant d)
+    (qIdeal : Ideal (𝓞 (candidateGenusFieldBase hd)))
+    [qIdeal.LiesOver (Ideal.span {(q : ℤ)})] (hnorm : Ideal.absNorm qIdeal = q)
+    (Q : Ideal (𝓞 (candidateGenusField hd))) [Q.LiesOver qIdeal]
+    (σ : candidateGenusField hd ≃ₐ[candidateGenusFieldBase hd] candidateGenusField hd)
+    (hσ : IsArithFrobAt (𝓞 (candidateGenusFieldBase hd)) σ Q) :
+    autCandidateGenusFieldEquivNarrowElementaryTwoQuotient hd hnsq σ =
+      Multiplicative.ofAdd
+        (TauCeti.elementaryTwoQuotientMk
+          (NarrowClassGroup.mk0
+            ⟨qIdeal, by
+              rw [← Ideal.absNorm_ne_zero_iff_mem_nonZeroDivisors, hnorm]
+              exact (Fact.out : q.Prime).ne_zero⟩)) := by
+  have hqIdeal : qIdeal ∈ (Ideal (𝓞 (candidateGenusFieldBase hd)))⁰ := by
+    rw [← Ideal.absNorm_ne_zero_iff_mem_nonZeroDivisors, hnorm]
+    exact (Fact.out : q.Prime).ne_zero
+  have hcop : IsCoprime (q : ℤ) (∏ P ∈ genusPrimeDiscriminants hd, P) := by
+    rw [(genusPrimeDiscriminants_spec hd).2.2]
+    exact (Nat.prime_iff_prime_int.mp Fact.out).coprime_iff_not_dvd.mpr hqD
+  let _ : Q.LiesOver (Ideal.span {(q : ℤ)}) :=
+    Ideal.LiesOver.trans Q qIdeal (Ideal.span {(q : ℤ)})
+  have hσint : IsArithFrobAt ℤ (σ.restrictScalars ℚ) Q :=
+    NumberField.isArithFrobAt_int_of_absNorm_eq qIdeal hnorm Q hσ
+  have heq :
+      (narrowElementaryTwoQuotientEquivRelativeSign hd hnsq).symm
+          ⟨candidateGenusFieldRelativeSignPattern hd σ,
+            candidateGenusFieldRelativeSignPattern_mem hd σ⟩ =
+        TauCeti.elementaryTwoQuotientMk
+          (NarrowClassGroup.mk0 ⟨qIdeal, hqIdeal⟩) := by
+    apply (narrowElementaryTwoQuotientEquivRelativeSign hd hnsq).injective
+    rw [(narrowElementaryTwoQuotientEquivRelativeSign hd hnsq).apply_symm_apply]
+    apply Subtype.ext
+    funext P
+    let u : ℤˣ :=
+      genusCharFunNarrowClassGroupHom
+        (genusPrimeDiscriminants_spec hd).1 (genusPrimeDiscriminants_spec hd).2.1
+        (genusPrimeDiscriminants_spec hd).2.2
+        (minpoly_candidateGenusFieldBaseGen hd hnsq)
+        (adjoin_candidateGenusFieldBaseGen_eq_top hd) hd
+        (Finset.singleton_subset_iff.mpr P.property)
+        (NarrowClassGroup.mk0 ⟨qIdeal, hqIdeal⟩)
+    change candidateGenusFieldRelativeSignPattern hd σ P = _
+    rw [narrowElementaryTwoQuotientEquivRelativeSign_apply_coe,
+      candidateGenusFieldBaseGenusCharLinearMap_apply,
+      genusCharFunElementaryTwoQuotientFamilyLinearMap_apply,
+      genusCharFunElementaryTwoQuotientLinearMap_mk,
+      candidateGenusFieldRelativeSignPattern_apply,
+      TauCeti.additiveIntUnitsLinearEquiv_apply]
+    -- The two sign encodings are definitionally if-expressions; name the genus-character unit
+    -- above so their equality reduces to equivalence of their respective fixed-sign tests.
+    change (if σ (candidateGenusFieldGen hd P) = candidateGenusFieldGen hd P then 0 else 1) =
+      if u = 1 then 0 else 1
+    have hqRadicand : ¬ (q : ℤ) ∣ primeDiscriminantRadicand P.val := by
+      intro hdiv
+      apply hqD
+      exact ((dvd_primeDiscriminant_iff_dvd_radicand P.val hodd).mpr hdiv).trans
+        ((genusPrimeDiscriminants_spec hd).2.2 ▸
+          Finset.dvd_prod_of_mem (fun P => P) P.property)
+    have hroot : candidateGenusFieldGen hd P ^ 2 =
+        algebraMap ℤ (candidateGenusField hd) (primeDiscriminantRadicand P.val) := by
+      rw [candidateGenusFieldGen_sq]
+      simp
+    have hfix :
+        σ (candidateGenusFieldGen hd P) = candidateGenusFieldGen hd P ↔
+          legendreSym q (primeDiscriminantRadicand P.val) = 1 :=
+      NumberField.isArithFrobAt_apply_sqrt_eq_self_iff
+        hodd hqRadicand hroot Q hσint
+    have hchar : (u : ℤ) =
+          legendreSym q (primeDiscriminantRadicand P.val) := by
+      dsimp only [u]
+      rw [genusCharFunNarrowClassGroupHom_mk0_eq_primeDiscriminantCharFun_absNorm
+        (genusPrimeDiscriminants_spec hd).1 (genusPrimeDiscriminants_spec hd).2.1
+        (genusPrimeDiscriminants_spec hd).2.2
+        (minpoly_candidateGenusFieldBaseGen hd hnsq)
+        (adjoin_candidateGenusFieldBaseGen_eq_top hd) hd qIdeal hqIdeal (by rwa [hnorm])
+        P.val P.property,
+        hnorm,
+        primeDiscriminantCharFun_eq_legendreSym
+          ((genusPrimeDiscriminants_spec hd).1 P.val P.property) hodd,
+        legendreSym_eq_legendreSym_primeDiscriminantRadicand P.val hodd]
+    have hunit :
+        u = 1 ↔ legendreSym q (primeDiscriminantRadicand P.val) = 1 := by
+      rw [← Units.val_eq_one, hchar]
+    simp only [hfix, hunit]
+  rw [autCandidateGenusFieldEquivNarrowElementaryTwoQuotient_apply]
+  exact congrArg (fun x : NarrowClassGroup.ElementaryTwoQuotient
+    (candidateGenusFieldBase hd) => Multiplicative.ofAdd x) heq
+
+/-- **The genus-field isomorphism sends the Artin automorphism to the prime class.**
+Under the hypotheses of the Frobenius theorem, the canonical Artin element at qIdeal maps to the
+elementary-2 class of qIdeal. Thus the sign-pattern/genus-character isomorphism agrees locally
+with the inverse ideal-theoretic Artin map. -/
+theorem autCandidateGenusFieldEquivNarrowElementaryTwoQuotient_artinElement
+    (hd : Squarefree d) (hnsq : ¬ IsSquare ((d : ℤ) : ℚ))
+    {q : ℕ} [Fact q.Prime] (hodd : q ≠ 2)
+    (hqD : ¬ (q : ℤ) ∣ fundamentalDiscriminant d)
+    (qIdeal : Ideal (𝓞 (candidateGenusFieldBase hd))) [qIdeal.IsMaximal]
+    [qIdeal.LiesOver (Ideal.span {(q : ℤ)})] (hnorm : Ideal.absNorm qIdeal = q) :
+    autCandidateGenusFieldEquivNarrowElementaryTwoQuotient hd hnsq
+        (NumberFieldArithmetic.artinElement
+          (fun σ τ => by
+            apply AlgEquiv.restrictScalars_injective ℚ
+            -- Restriction of scalars is a monoid homomorphism, so commutativity follows from the
+            -- abelian absolute Galois group after exposing the two products.
+            change σ.restrictScalars ℚ * τ.restrictScalars ℚ =
+              τ.restrictScalars ℚ * σ.restrictScalars ℚ
+            exact IsMulCommutative.is_comm.comm
+              (σ.restrictScalars ℚ) (τ.restrictScalars ℚ)) qIdeal
+          (fun Q hQ hQl =>
+            (isUnramifiedIn_candidateGenusField hd hnsq qIdeal) Q hQ hQl)) =
+      Multiplicative.ofAdd
+        (TauCeti.elementaryTwoQuotientMk
+          (NarrowClassGroup.mk0
+            ⟨qIdeal, by
+              rw [← Ideal.absNorm_ne_zero_iff_mem_nonZeroDivisors, hnorm]
+              exact (Fact.out : q.Prime).ne_zero⟩)) := by
+  obtain ⟨Q, hQprime, hQlies⟩ :=
+    (inferInstance :
+      Nonempty (qIdeal.primesOver (𝓞 (candidateGenusField hd))))
+  let _ : Q.IsPrime := hQprime
+  let _ : Q.LiesOver qIdeal := hQlies
+  apply autCandidateGenusFieldEquivNarrowElementaryTwoQuotient_frobenius
+    hd hnsq hodd hqD qIdeal hnorm Q
+  exact NumberFieldArithmetic.isArithFrobAt_artinElement
+    (fun σ τ => by
+      apply AlgEquiv.restrictScalars_injective ℚ
+      -- As in the Artin element above, compare the two products after restricting to ℚ.
+      change σ.restrictScalars ℚ * τ.restrictScalars ℚ =
+        τ.restrictScalars ℚ * σ.restrictScalars ℚ
+      exact IsMulCommutative.is_comm.comm
+        (σ.restrictScalars ℚ) (τ.restrictScalars ℚ)) qIdeal
+      (fun Q hQ hQl =>
+        (isUnramifiedIn_candidateGenusField hd hnsq qIdeal) Q hQ hQl) Q
+
+end TauCeti.Multiquadratic

--- a/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Relative/Artin.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Relative/Artin.lean
@@ -9,7 +9,7 @@ public import TauCeti.NumberTheory.Multiquadratic.CandidateGenusField.Relative.G
 public import TauCeti.NumberTheory.Multiquadratic.CandidateGenusField.Relative.Ramification
 public import TauCeti.NumberTheory.NumberField.Ideal.ArtinMap
 import TauCeti.NumberTheory.NumberField.Frobenius.Tower
-import TauCeti.NumberTheory.Multiquadratic.Quadratic.GenusCharacter.SplitPrime
+import TauCeti.NumberTheory.Multiquadratic.Quadratic.GenusCharacter.NarrowClassGroup
 import TauCeti.NumberTheory.Multiquadratic.Legendre.PrimeDiscriminants
 
 /-!
@@ -26,10 +26,10 @@ constructed from sign patterns and genus characters agrees with the inverse Arti
 degree-one prime above an odd rational prime away from the discriminant. Namely, the Frobenius at
 such a prime is sent to the elementary-2 class of that prime.
 
-The proof compares both sides coordinate by coordinate. A relative Frobenius at a degree-one
-prime is also a Frobenius over the underlying rational prime, hence acts on the chosen square root
-of each prime discriminant by the corresponding Legendre symbol. The genus character of the
-prime's narrow class has the same value.
+This module exposes the local compatibility between relative Frobenius elements and singleton
+genus characters: both associate to each prime discriminant the same quadratic character value.
+Consequently, the sign-pattern isomorphism identifies Frobenius and Artin elements with the
+elementary-2 narrow ideal classes of the primes below them.
 
 This is the local compatibility that determines the Artin map on ideals. The classical account is
 in D. A. Cox, *Primes of the Form x² + ny²*, §6.A, and F. Lemmermeyer,
@@ -51,6 +51,16 @@ open scoped IsMulCommutative NumberField nonZeroDivisors
 namespace TauCeti.Multiquadratic
 
 variable {d : ℤ}
+
+/-- Relative automorphisms of the candidate genus field commute because their restrictions to
+the abelian Galois group over `ℚ` commute. -/
+theorem candidateGenusFieldRelativeAut_comm (hd : Squarefree d)
+    (σ τ : candidateGenusField hd ≃ₐ[candidateGenusFieldBase hd] candidateGenusField hd) :
+    σ * τ = τ * σ := by
+  apply AlgEquiv.restrictScalars_injective ℚ
+  change σ.restrictScalars ℚ * τ.restrictScalars ℚ =
+    τ.restrictScalars ℚ * σ.restrictScalars ℚ
+  exact IsMulCommutative.is_comm.comm (σ.restrictScalars ℚ) (τ.restrictScalars ℚ)
 
 /-- **The genus-field isomorphism sends Frobenius to the prime class.**
 Let q be an odd rational prime not dividing the discriminant of K = ℚ(√d), let qIdeal be a
@@ -92,6 +102,13 @@ theorem autCandidateGenusFieldEquivNarrowElementaryTwoQuotient_frobenius
     apply (narrowElementaryTwoQuotientEquivRelativeSign hd hnsq).injective
     rw [(narrowElementaryTwoQuotientEquivRelativeSign hd hnsq).apply_symm_apply]
     apply Subtype.ext
+    have hsignCoe :
+        (↑(⟨candidateGenusFieldRelativeSignPattern hd σ,
+            candidateGenusFieldRelativeSignPattern_mem hd σ⟩ :
+          ↑(candidateGenusFieldRelativeSignSubmodule hd)) :
+            {P // P ∈ genusPrimeDiscriminants hd} → ZMod 2) =
+          candidateGenusFieldRelativeSignPattern hd σ := rfl
+    rw [hsignCoe, narrowElementaryTwoQuotientEquivRelativeSign_apply_coe]
     funext P
     let u : ℤˣ :=
       genusCharFunNarrowClassGroupHom
@@ -101,9 +118,7 @@ theorem autCandidateGenusFieldEquivNarrowElementaryTwoQuotient_frobenius
         (adjoin_candidateGenusFieldBaseGen_eq_top hd) hd
         (Finset.singleton_subset_iff.mpr P.property)
         (NarrowClassGroup.mk0 ⟨qIdeal, hqIdeal⟩)
-    change candidateGenusFieldRelativeSignPattern hd σ P = _
-    rw [narrowElementaryTwoQuotientEquivRelativeSign_apply_coe,
-      candidateGenusFieldBaseGenusCharLinearMap_apply,
+    rw [candidateGenusFieldBaseGenusCharLinearMap_apply,
       genusCharFunElementaryTwoQuotientFamilyLinearMap_apply,
       genusCharFunElementaryTwoQuotientLinearMap_mk,
       candidateGenusFieldRelativeSignPattern_apply,
@@ -134,8 +149,9 @@ theorem autCandidateGenusFieldEquivNarrowElementaryTwoQuotient_frobenius
         (genusPrimeDiscriminants_spec hd).1 (genusPrimeDiscriminants_spec hd).2.1
         (genusPrimeDiscriminants_spec hd).2.2
         (minpoly_candidateGenusFieldBaseGen hd hnsq)
-        (adjoin_candidateGenusFieldBaseGen_eq_top hd) hd qIdeal hqIdeal (by rwa [hnorm])
-        P.val P.property,
+        (adjoin_candidateGenusFieldBaseGen_eq_top hd) hd qIdeal hqIdeal P.val P.property (by
+          rw [hnorm]
+          exact IsCoprime.prod_right_iff.mp hcop P.val P.property),
         hnorm,
         primeDiscriminantCharFun_eq_legendreSym
           ((genusPrimeDiscriminants_spec hd).1 P.val P.property) hodd,
@@ -160,14 +176,7 @@ theorem autCandidateGenusFieldEquivNarrowElementaryTwoQuotient_artinElement
     [qIdeal.LiesOver (Ideal.span {(q : ℤ)})] (hnorm : Ideal.absNorm qIdeal = q) :
     autCandidateGenusFieldEquivNarrowElementaryTwoQuotient hd hnsq
         (NumberFieldArithmetic.artinElement
-          (fun σ τ => by
-            apply AlgEquiv.restrictScalars_injective ℚ
-            -- Restriction of scalars is a monoid homomorphism, so commutativity follows from the
-            -- abelian absolute Galois group after exposing the two products.
-            change σ.restrictScalars ℚ * τ.restrictScalars ℚ =
-              τ.restrictScalars ℚ * σ.restrictScalars ℚ
-            exact IsMulCommutative.is_comm.comm
-              (σ.restrictScalars ℚ) (τ.restrictScalars ℚ)) qIdeal
+          (candidateGenusFieldRelativeAut_comm hd) qIdeal
           (fun Q hQ hQl =>
             (isUnramifiedIn_candidateGenusField hd hnsq qIdeal) Q hQ hQl)) =
       Multiplicative.ofAdd
@@ -184,13 +193,7 @@ theorem autCandidateGenusFieldEquivNarrowElementaryTwoQuotient_artinElement
   apply autCandidateGenusFieldEquivNarrowElementaryTwoQuotient_frobenius
     hd hnsq hodd hqD qIdeal hnorm Q
   exact NumberFieldArithmetic.isArithFrobAt_artinElement
-    (fun σ τ => by
-      apply AlgEquiv.restrictScalars_injective ℚ
-      -- As in the Artin element above, compare the two products after restricting to ℚ.
-      change σ.restrictScalars ℚ * τ.restrictScalars ℚ =
-        τ.restrictScalars ℚ * σ.restrictScalars ℚ
-      exact IsMulCommutative.is_comm.comm
-        (σ.restrictScalars ℚ) (τ.restrictScalars ℚ)) qIdeal
+    (candidateGenusFieldRelativeAut_comm hd) qIdeal
       (fun Q hQ hQl =>
         (isUnramifiedIn_candidateGenusField hd hnsq qIdeal) Q hQ hQl) Q
 

--- a/TauCeti/NumberTheory/Multiquadratic/Quadratic/GenusCharacter/NarrowClassGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Quadratic/GenusCharacter/NarrowClassGroup.lean
@@ -189,7 +189,7 @@ noncomputable def genusCharFunNarrowClassGroupHom
 Let `D = ∏ P ∈ s, P` be the prime-discriminant factorization for `K = ℚ(√d)`. If a nonzero
 integral ideal `I` has absolute norm coprime to `P`, then the singleton genus character of its
 narrow class at `P ∈ s` is `primeDiscriminantCharFun P (absNorm I)`. -/
-theorem genusCharFunNarrowClassGroupHom_mk0_eq_primeDiscriminantCharFun_absNorm
+@[simp] theorem genusCharFunNarrowClassGroupHom_mk0_eq_primeDiscriminantCharFun_absNorm
     {s : Finset ℤ} (hs : ∀ P ∈ s, IsPrimeDiscriminant P)
     (heven : ∀ P ∈ s, ∀ P' ∈ s,
       IsEvenPrimeDiscriminant P → IsEvenPrimeDiscriminant P' → P = P')

--- a/TauCeti/NumberTheory/Multiquadratic/Quadratic/GenusCharacter/NarrowClassGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Quadratic/GenusCharacter/NarrowClassGroup.lean
@@ -27,6 +27,8 @@ theorem used here are developed in the preceding Tau Ceti modules.
   the map to the narrow class group.
 * `genusCharFunNarrowClassGroupHom`: the descended genus character on `Cl⁺(K)`.
 * `genusCharFunNarrowClassGroupHom_mk0`: its computation on a coprime integral ideal.
+* `genusCharFunNarrowClassGroupHom_mk0_eq_primeDiscriminantCharFun_absNorm`: the singleton
+  character evaluated at an ideal whose norm is coprime to the selected prime discriminant.
 * `genusCharFunNarrowClassGroupHom_eq_prod_singleton`: a subset-indexed narrow genus character is
   the product of its singleton characters.
 -/
@@ -182,6 +184,34 @@ noncomputable def genusCharFunNarrowClassGroupHom
     exact (Con.kerLift_mk (f := q) I).symm
   rw [he]
   exact Con.lift_mk' hχ I
+
+/-- **The genus character of an ideal is its character at the absolute norm.**
+Let `D = ∏ P ∈ s, P` be the prime-discriminant factorization for `K = ℚ(√d)`. If a nonzero
+integral ideal `I` has absolute norm coprime to `P`, then the singleton genus character of its
+narrow class at `P ∈ s` is `primeDiscriminantCharFun P (absNorm I)`. -/
+theorem genusCharFunNarrowClassGroupHom_mk0_eq_primeDiscriminantCharFun_absNorm
+    {s : Finset ℤ} (hs : ∀ P ∈ s, IsPrimeDiscriminant P)
+    (heven : ∀ P ∈ s, ∀ P' ∈ s,
+      IsEvenPrimeDiscriminant P → IsEvenPrimeDiscriminant P' → P = P')
+    (hprod : ∏ P ∈ s, P = fundamentalDiscriminant d)
+    (hmin : minpoly ℤ θ = X ^ 2 - C d) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤)
+    (hsf : Squarefree d) (I : Ideal (𝓞 K)) (hI : I ∈ (Ideal (𝓞 K))⁰)
+    (P : ℤ) (hP : P ∈ s) (hcop : IsCoprime (Ideal.absNorm I : ℤ) P) :
+    ((genusCharFunNarrowClassGroupHom hs heven hprod hmin hgen hsf
+        (Finset.singleton_subset_iff.mpr hP)
+        (NumberField.NarrowClassGroup.mk0 ⟨I, hI⟩) : ℤˣ) : ℤ) =
+      primeDiscriminantCharFun P (Ideal.absNorm I : ℤ) := by
+  have hcopP :
+      IsCoprime ((Ideal.absNorm I : ℤ)) (∏ P' ∈ ({P} : Finset ℤ), P') := by
+    rw [Finset.prod_singleton]
+    exact hcop
+  let I' : genusCharFunCoprimeIdealSubmonoid (K := K) {P} :=
+    ⟨⟨I, hI⟩, (mem_genusCharFunCoprimeIdealSubmonoid_iff _).mpr hcopP⟩
+  rw [← genusCharFun_singleton,
+    ← genusCharFunCoprimeIdealHom_apply
+      (fun P' hP' => hs P' (Finset.mem_singleton.mp hP' ▸ hP)) I',
+    ← genusCharFunNarrowClassGroupHom_mk0 hs heven hprod hmin hgen hsf
+      (Finset.singleton_subset_iff.mpr hP) I']
 
 /-- A genus character indexed by a set `t` of prime discriminants is the product of the
 characters indexed by the singletons in `t`.

--- a/TauCeti/NumberTheory/Multiquadratic/Quadratic/GenusCharacter/SplitPrime.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Quadratic/GenusCharacter/SplitPrime.lean
@@ -81,6 +81,37 @@ theorem ncard_primesOver_eq_finrank_iff_genusCharFun_eq_one {s : Finset ℤ}
     rw [hcard, hfinrank, genusCharFun_natCast_eq_legendreSym hs hprod hq, hleg]
     norm_num
 
+/-- **The genus character of an ideal is its character at the absolute norm.**
+Let `D = ∏ P ∈ s, P` be the prime-discriminant factorization for `K = ℚ(√d)`. If a nonzero
+integral ideal `I` has absolute norm coprime to `D`, then the singleton genus character of its
+narrow class at `P ∈ s` is `primeDiscriminantCharFun P (absNorm I)`.
+
+This is the representative-level form used to compare genus characters with Artin symbols: at a
+degree-one prime above a rational prime `q`, the absolute norm is exactly `q`. -/
+theorem genusCharFunNarrowClassGroupHom_mk0_eq_primeDiscriminantCharFun_absNorm
+    {s : Finset ℤ} (hs : ∀ P ∈ s, IsPrimeDiscriminant P)
+    (heven : ∀ P ∈ s, ∀ P' ∈ s,
+      IsEvenPrimeDiscriminant P → IsEvenPrimeDiscriminant P' → P = P')
+    (hprod : ∏ P ∈ s, P = fundamentalDiscriminant d)
+    (hmin : minpoly ℤ θ = X ^ 2 - C d) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤)
+    (hsf : Squarefree d) (I : Ideal (𝓞 K)) (hI : I ∈ (Ideal (𝓞 K))⁰)
+    (hcop : IsCoprime (Ideal.absNorm I : ℤ) (∏ P ∈ s, P)) (P : ℤ) (hP : P ∈ s) :
+    ((genusCharFunNarrowClassGroupHom hs heven hprod hmin hgen hsf
+        (Finset.singleton_subset_iff.mpr hP)
+        (NumberField.NarrowClassGroup.mk0 ⟨I, hI⟩) : ℤˣ) : ℤ) =
+      primeDiscriminantCharFun P (Ideal.absNorm I : ℤ) := by
+  have hcopP :
+      IsCoprime ((Ideal.absNorm I : ℤ)) (∏ P' ∈ ({P} : Finset ℤ), P') := by
+    rw [Finset.prod_singleton]
+    exact IsCoprime.prod_right_iff.mp hcop P hP
+  let I' : genusCharFunCoprimeIdealSubmonoid (K := K) {P} :=
+    ⟨⟨I, hI⟩, (mem_genusCharFunCoprimeIdealSubmonoid_iff _).mpr hcopP⟩
+  rw [← genusCharFun_singleton,
+    ← genusCharFunCoprimeIdealHom_apply
+      (fun P' hP' => hs P' (Finset.mem_singleton.mp hP' ▸ hP)) I',
+    ← genusCharFunNarrowClassGroupHom_mk0 hs heven hprod hmin hgen hsf
+      (Finset.singleton_subset_iff.mpr hP) I']
+
 /-- **The narrow class of a split prime realizes the prescribed character values.**
 Let `D = ∏ P ∈ s, P` be a prime-discriminant factorization of the discriminant of `K = ℚ(√d)`
 and let `q` be an odd prime with trivial genus character. Then `q` splits in `K`, and the narrow
@@ -118,22 +149,9 @@ theorem exists_forall_genusCharFunNarrowClassGroupHom_eq {s : Finset ℤ}
     rw [hprod, dvd_fundamentalDiscriminant_iff (Int.isCoprime_two_right.mpr hodd)]
     exact hqd
   refine ⟨NumberField.NarrowClassGroup.mk0 ⟨𝔮, h𝔮0⟩, fun P hP => ?_⟩
-  have hcop : IsCoprime ((Ideal.absNorm 𝔮 : ℤ)) (∏ P' ∈ ({P} : Finset ℤ), P') := by
-    rw [Finset.prod_singleton, hnorm]
-    exact IsCoprime.prod_right_iff.mp hcopD P hP
-  -- Evaluate the descended character on an arbitrary coprime ideal, then feed `𝔮` in: the
-  -- coprime-ideal submonoid is a subtype of `(Ideal (𝓞 K))⁰`, so `𝔮` enters as the two nested
-  -- projections of the element built from `hcop`.
-  have key : ∀ I : genusCharFunCoprimeIdealSubmonoid (K := K) {P},
-      ((genusCharFunNarrowClassGroupHom hs heven hprod hmin hgen hsf
-          (Finset.singleton_subset_iff.mpr hP)
-          (NumberField.NarrowClassGroup.mk0 I.1) : ℤˣ) : ℤ) =
-        primeDiscriminantCharFun P
-          (Ideal.absNorm ((I.1 : (Ideal (𝓞 K))⁰) : Ideal (𝓞 K)) : ℤ) := fun I => by
-    rw [genusCharFunNarrowClassGroupHom_mk0, genusCharFunCoprimeIdealHom_apply,
-      genusCharFun_singleton]
   rw [← hnorm]
-  exact key ⟨⟨𝔮, h𝔮0⟩, (mem_genusCharFunCoprimeIdealSubmonoid_iff _).mpr hcop⟩
+  exact genusCharFunNarrowClassGroupHom_mk0_eq_primeDiscriminantCharFun_absNorm
+    hs heven hprod hmin hgen hsf 𝔮 h𝔮0 (by rwa [hnorm]) P hP
 
 /-- **The linear family on `Cl⁺(K)/Cl⁺(K)²` realizes the character values of a split prime.**
 The elementary-`2` form of `exists_forall_genusCharFunNarrowClassGroupHom_eq`: the vector of

--- a/TauCeti/NumberTheory/Multiquadratic/Quadratic/GenusCharacter/SplitPrime.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Quadratic/GenusCharacter/SplitPrime.lean
@@ -81,37 +81,6 @@ theorem ncard_primesOver_eq_finrank_iff_genusCharFun_eq_one {s : Finset ℤ}
     rw [hcard, hfinrank, genusCharFun_natCast_eq_legendreSym hs hprod hq, hleg]
     norm_num
 
-/-- **The genus character of an ideal is its character at the absolute norm.**
-Let `D = ∏ P ∈ s, P` be the prime-discriminant factorization for `K = ℚ(√d)`. If a nonzero
-integral ideal `I` has absolute norm coprime to `D`, then the singleton genus character of its
-narrow class at `P ∈ s` is `primeDiscriminantCharFun P (absNorm I)`.
-
-This is the representative-level form used to compare genus characters with Artin symbols: at a
-degree-one prime above a rational prime `q`, the absolute norm is exactly `q`. -/
-theorem genusCharFunNarrowClassGroupHom_mk0_eq_primeDiscriminantCharFun_absNorm
-    {s : Finset ℤ} (hs : ∀ P ∈ s, IsPrimeDiscriminant P)
-    (heven : ∀ P ∈ s, ∀ P' ∈ s,
-      IsEvenPrimeDiscriminant P → IsEvenPrimeDiscriminant P' → P = P')
-    (hprod : ∏ P ∈ s, P = fundamentalDiscriminant d)
-    (hmin : minpoly ℤ θ = X ^ 2 - C d) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤)
-    (hsf : Squarefree d) (I : Ideal (𝓞 K)) (hI : I ∈ (Ideal (𝓞 K))⁰)
-    (hcop : IsCoprime (Ideal.absNorm I : ℤ) (∏ P ∈ s, P)) (P : ℤ) (hP : P ∈ s) :
-    ((genusCharFunNarrowClassGroupHom hs heven hprod hmin hgen hsf
-        (Finset.singleton_subset_iff.mpr hP)
-        (NumberField.NarrowClassGroup.mk0 ⟨I, hI⟩) : ℤˣ) : ℤ) =
-      primeDiscriminantCharFun P (Ideal.absNorm I : ℤ) := by
-  have hcopP :
-      IsCoprime ((Ideal.absNorm I : ℤ)) (∏ P' ∈ ({P} : Finset ℤ), P') := by
-    rw [Finset.prod_singleton]
-    exact IsCoprime.prod_right_iff.mp hcop P hP
-  let I' : genusCharFunCoprimeIdealSubmonoid (K := K) {P} :=
-    ⟨⟨I, hI⟩, (mem_genusCharFunCoprimeIdealSubmonoid_iff _).mpr hcopP⟩
-  rw [← genusCharFun_singleton,
-    ← genusCharFunCoprimeIdealHom_apply
-      (fun P' hP' => hs P' (Finset.mem_singleton.mp hP' ▸ hP)) I',
-    ← genusCharFunNarrowClassGroupHom_mk0 hs heven hprod hmin hgen hsf
-      (Finset.singleton_subset_iff.mpr hP) I']
-
 /-- **The narrow class of a split prime realizes the prescribed character values.**
 Let `D = ∏ P ∈ s, P` be a prime-discriminant factorization of the discriminant of `K = ℚ(√d)`
 and let `q` be an odd prime with trivial genus character. Then `q` splits in `K`, and the narrow
@@ -151,7 +120,9 @@ theorem exists_forall_genusCharFunNarrowClassGroupHom_eq {s : Finset ℤ}
   refine ⟨NumberField.NarrowClassGroup.mk0 ⟨𝔮, h𝔮0⟩, fun P hP => ?_⟩
   rw [← hnorm]
   exact genusCharFunNarrowClassGroupHom_mk0_eq_primeDiscriminantCharFun_absNorm
-    hs heven hprod hmin hgen hsf 𝔮 h𝔮0 (by rwa [hnorm]) P hP
+    hs heven hprod hmin hgen hsf 𝔮 h𝔮0 P hP (by
+      rw [hnorm]
+      exact IsCoprime.prod_right_iff.mp hcopD P hP)
 
 /-- **The linear family on `Cl⁺(K)/Cl⁺(K)²` realizes the character values of a split prime.**
 The elementary-`2` form of `exists_forall_genusCharFunNarrowClassGroupHom_eq`: the vector of

--- a/TauCeti/NumberTheory/NumberField/Frobenius/Tower.lean
+++ b/TauCeti/NumberTheory/NumberField/Frobenius/Tower.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.NumberTheory.NumberField.Frobenius.DecompositionGroup
+import Mathlib.RingTheory.Ideal.Int
 
 /-!
 # Raising the base field: the tower formula for arithmetic Frobenius elements
@@ -56,6 +57,8 @@ group of `Q` embeds into the automorphism group of the residue extension, so an 
   pointwise.
 * `NumberField.restrictScalars_eq_of_inertiaDeg_eq_one`: at residue degree one the restriction
   of the relative Frobenius is `σ` itself, with no power.
+* `NumberField.isArithFrobAt_int_of_absNorm_eq`: a relative Frobenius at a prime of absolute norm
+  `p` is also a Frobenius over the underlying rational prime `p`.
 
 ## References
 
@@ -73,6 +76,33 @@ namespace NumberField
 variable {K L : Type*} [Field K] [NumberField K] [Field L] [NumberField L] [Algebra K L]
   [IsGalois K L] {M : Type*} [Field M] [NumberField M] [Algebra K M] [Algebra M L]
   [IsScalarTower K M L] {Q : Ideal (𝓞 L)} [Q.IsPrime]
+
+omit [IsGalois K L] [Field M] [NumberField M] [Algebra K M] [Algebra M L]
+  [IsScalarTower K M L] [Q.IsPrime] in
+/-- **A relative Frobenius at a degree-one prime is a rational Frobenius.**
+Let `P` be a prime of a number field `K` above the rational prime `p`, with absolute norm
+`p`. If `Q` lies above `P`, then a Frobenius at `Q` relative to `K` is also a Frobenius
+relative to `ℤ` after restricting its automorphism from `K`-linearity to `ℚ`-linearity.
+
+The norm hypothesis is the residue-degree-one condition: it makes the two residue cardinalities
+in the definitions of the relative and rational Frobenius equal. -/
+theorem isArithFrobAt_int_of_absNorm_eq {p : ℕ}
+    (P : Ideal (𝓞 K)) [P.LiesOver (Ideal.span {(p : ℤ)})]
+    (hnorm : Ideal.absNorm P = p) (Q : Ideal (𝓞 L)) [Q.LiesOver P]
+    {σ : L ≃ₐ[K] L} (hσ : IsArithFrobAt (𝓞 K) σ Q) :
+    IsArithFrobAt ℤ (σ.restrictScalars ℚ) Q := by
+  intro x
+  have hx := hσ x
+  have hunderK : Q.under (𝓞 K) = P := Ideal.LiesOver.over
+  rw [hunderK, ← Submodule.cardQuot_apply, ← Ideal.absNorm_apply, hnorm] at hx
+  let _ : Q.LiesOver (Ideal.span {(p : ℤ)}) :=
+    Ideal.LiesOver.trans Q P (Ideal.span {(p : ℤ)})
+  -- Restricting scalars preserves the action on the top ring; expose that action so only the
+  -- two residue-cardinality expressions remain to compare.
+  change σ • x - x ^ Nat.card (ℤ ⧸ Q.under ℤ) ∈ Q
+  have hunder : Q.under ℤ = Ideal.span {(p : ℤ)} := Ideal.LiesOver.over.symm
+  rw [hunder, Int.card_ideal_quot]
+  exact hx
 
 /-- **Raising the base field raises the Frobenius to the residue degree.** For number fields
 `K ⊆ M ⊆ L` with `L / K` and `L / M` Galois and `Q` a prime of `𝓞 L` unramified over `𝓞 K`, the

--- a/TauCeti/NumberTheory/NumberField/Frobenius/Tower.lean
+++ b/TauCeti/NumberTheory/NumberField/Frobenius/Tower.lean
@@ -57,8 +57,8 @@ group of `Q` embeds into the automorphism group of the residue extension, so an 
   pointwise.
 * `NumberField.restrictScalars_eq_of_inertiaDeg_eq_one`: at residue degree one the restriction
   of the relative Frobenius is `σ` itself, with no power.
-* `NumberField.isArithFrobAt_int_of_absNorm_eq`: a relative Frobenius at a prime of absolute norm
-  `p` is also a Frobenius over the underlying rational prime `p`.
+* `NumberField.isArithFrobAt_int_of_absNorm_eq`: a relative Frobenius above an ideal of absolute
+  norm `p` is also a Frobenius over the ideal `(p)` of `ℤ`.
 
 ## References
 
@@ -79,13 +79,13 @@ variable {K L : Type*} [Field K] [NumberField K] [Field L] [NumberField L] [Alge
 
 omit [IsGalois K L] [Field M] [NumberField M] [Algebra K M] [Algebra M L]
   [IsScalarTower K M L] [Q.IsPrime] in
-/-- **A relative Frobenius at a degree-one prime is a rational Frobenius.**
-Let `P` be a prime of a number field `K` above the rational prime `p`, with absolute norm
-`p`. If `Q` lies above `P`, then a Frobenius at `Q` relative to `K` is also a Frobenius
-relative to `ℤ` after restricting its automorphism from `K`-linearity to `ℚ`-linearity.
+/-- **A relative Frobenius above an ideal of norm `p` is a Frobenius over `(p)`.**
+Let `P` be an ideal of a number field `K` above `(p)` with absolute norm `p`. If `Q` lies above
+`P`, then a Frobenius at `Q` relative to `K` is also a Frobenius relative to `ℤ` after
+restricting its automorphism from `K`-linearity to `ℚ`-linearity.
 
-The norm hypothesis is the residue-degree-one condition: it makes the two residue cardinalities
-in the definitions of the relative and rational Frobenius equal. -/
+The norm equality makes the two residue cardinalities in the definitions equal; no primality
+hypothesis on `p`, `P`, or `Q` is required. -/
 theorem isArithFrobAt_int_of_absNorm_eq {p : ℕ}
     (P : Ideal (𝓞 K)) [P.LiesOver (Ideal.span {(p : ℤ)})]
     (hnorm : Ideal.absNorm P = p) (Q : Ideal (𝓞 L)) [Q.LiesOver P]


### PR DESCRIPTION
This PR proves that the sign-pattern/genus-character isomorphism sends every relative Frobenius at a degree-one odd prime away from the discriminant, and the corresponding canonical Artin element, to the elementary-two class of that prime ideal.

It advances the `Multiquadratic/README.md` Layer 3 milestone “the genus field and the 2-rank theorem (the summit),” specifically the target identifying `Gal(K_gen/K) ≅ Cl(K)/Cl(K)²` (and its narrow real analogue) as the inverse Artin reciprocity isomorphism. After this PR, the milestone still needs these local degree-one identities packaged into a global ideal Artin map factoring through the narrow elementary-two quotient, together with the ordinary imaginary specialization.

The proof compares Frobenius sign changes and genus characters coordinatewise through the same Legendre symbols. It also extracts the reusable evaluation of a singleton genus character on any nonzero coprime ideal and adds the general tower lemma that a relative Frobenius above a degree-one prime is the Frobenius over its underlying rational prime. The mathematical comparison follows Cox, *Primes of the Form x² + ny²*, §6.A, and Lemmermeyer, *Reciprocity Laws: From Euler to Eisenstein*, §2.2, as cited in the module documentation. No Mathlib infrastructure is vendored.

Roadmap: Multiquadratic

<!--tauceti-target:v1 {"focus":"Multiquadratic","id":"genus-field-isomorphism-frobenius"}-->

🤖 Prepared with Codex
