### PR TITLE
refactor(Newforms): tighten the prime split in `cuspFormsOld_le_of_prime`

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/Newforms/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Basic.lean
@@ -174,29 +174,23 @@ theorem cuspFormsOld_le_of_prime [NeZero N]
   · -- `V₁` from a proper divisor level `M`: split off a prime factor `p` of `N / M`
     obtain ⟨m, hm⟩ : M ∣ N := by rwa [one_mul] at hdvd
     have hm1 : m ≠ 1 := fun h ↦ hM (by rw [hm, h, mul_one])
-    obtain ⟨p, hp, t, ht⟩ : ∃ p, p.Prime ∧ ∃ t, m = p * t := by
-      obtain ⟨p, hp, q, hq⟩ := Nat.exists_prime_and_dvd hm1
-      exact ⟨p, hp, q, hq⟩
-    have hpL : p * (M * t) = N := by rw [hm, ht]; ring
-    have : NeZero (M * t) := ⟨fun h ↦ NeZero.ne N (by rw [← hpL, h, mul_zero])⟩
+    obtain ⟨p, hp, t, rfl⟩ := Nat.exists_prime_and_dvd hm1
+    have hpL : p * (M * t) = N := by rw [hm]; ring
+    have : NeZero (M * t) := NeZero.of_dvd (Dvd.intro_left p hpL)
     have h1M : 1 * M ∣ M * t := ⟨t, by rw [one_mul]⟩
     have hmem := hV p (M * t) hp hpL 1 (Or.inl rfl)
       (CuspForm.levelRaise 1 (Gamma1_map_le_conjAct_scaleGL_of_dvd h1M) f)
     simpa only [CuspForm.levelRaise_levelRaise, one_mul] using hmem
   · -- `V_d` with `d ≠ 1`: split off a prime factor `q` of `d`
-    obtain ⟨q, hq, e, he⟩ : ∃ q, q.Prime ∧ ∃ e, d = q * e := by
-      obtain ⟨q, hq, e, hqe⟩ := Nat.exists_prime_and_dvd hd1
-      exact ⟨q, hq, e, hqe⟩
+    obtain ⟨q, hq, e, rfl⟩ := Nat.exists_prime_and_dvd hd1
     obtain ⟨s, hs⟩ := id hdvd
-    have : NeZero q := ⟨hq.ne_zero⟩
-    have : NeZero e := ⟨fun h ↦ NeZero.ne N (by rw [hs, he, h]; simp)⟩
-    have hqL : q * (e * M * s) = N := by rw [hs, he]; ring
-    have : NeZero (e * M * s) := ⟨fun h ↦ NeZero.ne N (by rw [← hqL, h, mul_zero])⟩
+    have hqL : q * (e * M * s) = N := by rw [hs]; ring
+    have : NeZero e := NeZero.of_dvd (show e ∣ N from ⟨q * M * s, by rw [← hqL]; ring⟩)
+    have : NeZero (e * M * s) := NeZero.of_dvd (Dvd.intro_left q hqL)
     have heM : e * M ∣ e * M * s := ⟨s, rfl⟩
     have hmem := hV q (e * M * s) hq hqL q (Or.inr rfl)
       (CuspForm.levelRaise e (Gamma1_map_le_conjAct_scaleGL_of_dvd heM) f)
-    have levelRaise_index : e * q = d := by rw [he, Nat.mul_comm]
-    simpa only [CuspForm.levelRaise_levelRaise, levelRaise_index] using hmem
+    simpa only [CuspForm.levelRaise_levelRaise, Nat.mul_comm e q] using hmem
 
 /-! ### The new subspace -/
 

--- a/TauCeti/NumberTheory/ModularForms/Newforms/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Basic.lean
@@ -185,7 +185,8 @@ theorem cuspFormsOld_le_of_prime [NeZero N]
     obtain ⟨q, hq, e, rfl⟩ := Nat.exists_prime_and_dvd hd1
     obtain ⟨s, hs⟩ := id hdvd
     have hqL : q * (e * M * s) = N := by rw [hs]; ring
-    have : NeZero e := NeZero.of_dvd (show e ∣ N from ⟨q * M * s, by rw [← hqL]; ring⟩)
+    have heN : e ∣ N := ⟨q * M * s, by rw [← hqL]; ring⟩
+    have : NeZero e := NeZero.of_dvd heN
     have : NeZero (e * M * s) := NeZero.of_dvd (Dvd.intro_left q hqL)
     have heM : e * M ∣ e * M * s := ⟨s, rfl⟩
     have hmem := hV q (e * M * s) hq hqL q (Or.inr rfl)


### PR DESCRIPTION
Roadmap: ModularForms

A proof-only tightening of `TauCeti.cuspFormsOld_le_of_prime`, the sharper
elimination rule for the old subspace in which only the two degeneracy maps
`S_k(Γ₁(N/p)) → S_k(Γ₁(N))` at each prime `p ∣ N` are tested. The statement,
its hypotheses and the two-branch structure of the proof are unchanged.

Three things, all inside the one proof:

**The prime split.** Both branches did

```lean
obtain ⟨p, hp, t, ht⟩ : ∃ p, p.Prime ∧ ∃ t, m = p * t := by
  obtain ⟨p, hp, q, hq⟩ := Nat.exists_prime_and_dvd hm1
  exact ⟨p, hp, q, hq⟩
```

— restating `Nat.exists_prime_and_dvd`'s conclusion in order to name the
cofactor. But `p ∣ m` already *is* `∃ t, m = p * t`, so the round trip is
`exact`-by-`rfl` and the destructuring can happen in the `obtain` itself:

```lean
obtain ⟨p, hp, t, rfl⟩ := Nat.exists_prime_and_dvd hm1
```

Substituting the factorisation rather than carrying `ht`/`he` alongside it also
retires the two rewrites that consumed them, including the `levelRaise_index`
step of the second branch, which becomes `Nat.mul_comm e q` at the point of use.

**The `NeZero` side conditions.** The intermediate levels were shown nonzero by
unfolding `NeZero` and rewriting the level equation to `0`. They are divisors of
`N`, so `NeZero.of_dvd` says it directly — the same idiom the statement of this
very theorem uses one screen above, and the one `cuspFormsOld_le` uses.

**One unused hypothesis.** `NeZero q` was never needed: `hV` derives the
`NeZero` of its own degeneracy index internally.

Net `-6` lines, and the two branches now read in parallel: split off a prime,
name the intermediate level, feed `hV`, compose the two level-raises.

No new declarations, so no roadmap target is claimed and no `tauceti-target`
marker is present; `Roadmap: ModularForms` is attribution for the roadmap this
file serves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQieFQn95rzgvYRvNdX3hR
