### PR TITLE
feat(EulerProduct): the L-series is nonzero where the ideal series converges absolutely

### DIFF
--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Analytic.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Analytic.lean
@@ -41,9 +41,9 @@ product of the Dedekind zeta function.
 * `TauCeti.dedekindZeta_eulerProduct_hasProd`: the **Euler product of the Dedekind zeta
   function**, valid on `Re s > 1`.
 
-The nonvanishing is not formal: an unconditionally convergent product of nonzero factors may still
-vanish. It comes from the reciprocal product converging as well, so that the two products multiply
-to `1`. Nothing is claimed off the region of absolute convergence.
+The nonvanishing is pointwise, at each `s` where the ideal-indexed series converges absolutely, and
+nothing is claimed off that region. It is not a formality: an unconditionally convergent product of
+nonzero factors may still vanish.
 
 ## References
 
@@ -349,21 +349,21 @@ theorem hasProd_eulerFactor (hs : Summable (idealTerm K χ.toIdealArithmeticFunc
 /-- **The Euler product does not vanish.** Where the ideal-indexed Dirichlet series converges
 absolutely, the `L`-series of the norm coefficients is nonzero.
 
-This is the nonvanishing that convergence of the reciprocal product supplies, and no more: it says
-nothing about `s` where the series does not converge absolutely. -/
+This is pointwise nonvanishing at such an `s` and no more: it says nothing where the series does not
+converge absolutely, and does not by itself furnish a holomorphic logarithm on a region. -/
 theorem LSeries_ne_zero_of_summable_idealTerm
     (hs : Summable (idealTerm K χ.toIdealArithmeticFunction s)) :
     LSeries (normCoeff K χ.toIdealArithmeticFunction) s ≠ 0 := by
   have hsum : Summable fun P : HeightOneSpectrum (𝓞 K) ↦
       ‖χ P.asIdeal / (Ideal.absNorm P.asIdeal : ℂ) ^ s‖ :=
     summable_norm_iff.2 (summable_div_of_summable_idealTerm χ hs)
-  have hmul := (hasProd_eulerFactor χ hs).mul (multipliable_one_sub_of_summable hsum).hasProd
-  have hone : (fun P : HeightOneSpectrum (𝓞 K) ↦
-      (1 - χ P.asIdeal / (Ideal.absNorm P.asIdeal : ℂ) ^ s)⁻¹ *
-        (1 - χ P.asIdeal / (Ideal.absNorm P.asIdeal : ℂ) ^ s)) = fun _ ↦ 1 :=
-    funext fun P ↦ inv_mul_cancel₀ (one_sub_div_ne_zero_of_summable_idealTerm χ hs P)
-  rw [hone] at hmul
-  exact left_ne_zero_of_mul_eq_one (hmul.unique hasProd_one)
+  have h0 : ∏' P : HeightOneSpectrum (𝓞 K),
+      (1 - χ P.asIdeal / (Ideal.absNorm P.asIdeal : ℂ) ^ s) ≠ 0 := by
+    refine tprod_one_add_ne_zero_of_summable (f := fun P : HeightOneSpectrum (𝓞 K) ↦
+      -(χ P.asIdeal / (Ideal.absNorm P.asIdeal : ℂ) ^ s)) (fun P ↦ ?_) (by simpa using hsum)
+    simpa [sub_eq_add_neg] using one_sub_div_ne_zero_of_summable_idealTerm χ hs P
+  rw [(hasProd_eulerFactor χ hs).unique ((multipliable_one_sub_of_summable hsum).hasProd.inv₀ h0)]
+  exact inv_ne_zero h0
 
 end MultiplicativeIdealWeight
 

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Analytic.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Analytic.lean
@@ -9,6 +9,7 @@ public import Mathlib.Analysis.Normed.Group.Tannery
 public import Mathlib.NumberTheory.LSeries.Convolution
 public import TauCeti.NumberTheory.ArithmeticDirichletSeries.Estimates
 public import TauCeti.NumberTheory.ArithmeticDirichletSeries.EulerProduct.Data
+import Mathlib.Analysis.SpecialFunctions.Log.Summable
 
 /-!
 # The analytic Euler product of an ideal arithmetic function
@@ -35,12 +36,14 @@ product of the Dedekind zeta function.
   ideal-indexed Dirichlet series converges absolutely at `s`.
 * `TauCeti.MultiplicativeIdealWeight.hasProd_eulerFactor`: the same product, with the local factors
   in the closed geometric form available for a completely multiplicative weight.
+* `TauCeti.MultiplicativeIdealWeight.LSeries_ne_zero_of_summable_idealTerm`: the `L`-series is
+  **nonzero** wherever the ideal-indexed series converges absolutely.
 * `TauCeti.dedekindZeta_eulerProduct_hasProd`: the **Euler product of the Dedekind zeta
   function**, valid on `Re s > 1`.
 
-No nonvanishing statement is made here. An unconditionally convergent product of nonzero factors
-may still vanish, so nonvanishing requires additional hypotheses such as convergence of the
-reciprocal product.
+The nonvanishing is not formal: an unconditionally convergent product of nonzero factors may still
+vanish. It comes from the reciprocal product converging as well, so that the two products multiply
+to `1`. Nothing is claimed off the region of absolute convergence.
 
 ## References
 
@@ -305,6 +308,16 @@ theorem summable_div_of_summable_idealTerm
   (IdealArithmeticFunction.summable_idealTerm_primeIdealPow_one hs).congr fun P ↦ by
     simp [idealTerm_toIdealArithmeticFunction_primeIdealPow χ P 1 s]
 
+/-- Absolute convergence puts every local ratio `χ(P) N(P)⁻ˢ` strictly inside the unit disc, so no
+local Euler factor has a vanishing denominator. -/
+theorem one_sub_div_ne_zero_of_summable_idealTerm
+    (hs : Summable (idealTerm K χ.toIdealArithmeticFunction s)) (P : HeightOneSpectrum (𝓞 K)) :
+    1 - χ P.asIdeal / (Ideal.absNorm P.asIdeal : ℂ) ^ s ≠ 0 := fun h ↦ by
+  have hlt := norm_div_lt_one_of_summable_idealTerm χ hs P
+  rw [sub_eq_zero] at h
+  rw [← h] at hlt
+  simp at hlt
+
 /-- The local Euler factor of a completely multiplicative weight is the geometric closed form
 `(1 - χ(P) N(P)⁻ˢ)⁻¹`. -/
 theorem eulerFactor_ofMultiplicativeIdealWeight
@@ -332,6 +345,25 @@ theorem hasProd_eulerFactor (hs : Summable (idealTerm K χ.toIdealArithmeticFunc
     (s := s) (by
       simpa only [EulerProductData.toIdealArithmeticFunction_ofMultiplicativeIdealWeight] using hs)
   simpa only [EulerProductData.toIdealArithmeticFunction_ofMultiplicativeIdealWeight] using hprod
+
+/-- **The Euler product does not vanish.** Where the ideal-indexed Dirichlet series converges
+absolutely, the `L`-series of the norm coefficients is nonzero.
+
+This is the nonvanishing that convergence of the reciprocal product supplies, and no more: it says
+nothing about `s` where the series does not converge absolutely. -/
+theorem LSeries_ne_zero_of_summable_idealTerm
+    (hs : Summable (idealTerm K χ.toIdealArithmeticFunction s)) :
+    LSeries (normCoeff K χ.toIdealArithmeticFunction) s ≠ 0 := by
+  have hsum : Summable fun P : HeightOneSpectrum (𝓞 K) ↦
+      ‖χ P.asIdeal / (Ideal.absNorm P.asIdeal : ℂ) ^ s‖ :=
+    summable_norm_iff.2 (summable_div_of_summable_idealTerm χ hs)
+  have hmul := (hasProd_eulerFactor χ hs).mul (multipliable_one_sub_of_summable hsum).hasProd
+  have hone : (fun P : HeightOneSpectrum (𝓞 K) ↦
+      (1 - χ P.asIdeal / (Ideal.absNorm P.asIdeal : ℂ) ^ s)⁻¹ *
+        (1 - χ P.asIdeal / (Ideal.absNorm P.asIdeal : ℂ) ^ s)) = fun _ ↦ 1 :=
+    funext fun P ↦ inv_mul_cancel₀ (one_sub_div_ne_zero_of_summable_idealTerm χ hs P)
+  rw [hone] at hmul
+  exact left_ne_zero_of_mul_eq_one (hmul.unique hasProd_one)
 
 end MultiplicativeIdealWeight
 

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Analytic.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Analytic.lean
@@ -400,9 +400,8 @@ theorem dedekindZeta_eulerProduct_hasProd {s : ℂ} (hs : 1 < s.re) :
   rw [hfun]
   exact hprod
 
-/-- **The Dedekind zeta function does not vanish on `Re s > 1`.** This is the trivial-weight case
-of `MultiplicativeIdealWeight.LSeries_ne_zero_of_summable_idealTerm`, read through the
-identification of `dedekindZeta` with the `L`-series of the trivial weight's norm coefficients.
+/-- **The Dedekind zeta function does not vanish on `Re s > 1`.** For every `s` with `1 < s.re`,
+`NumberField.dedekindZeta K s ≠ 0`.
 
 Nothing is claimed on `Re s ≤ 1`; in particular this says nothing about the line
 `Re s = 1`. -/

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Analytic.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Analytic.lean
@@ -371,6 +371,12 @@ end MultiplicativeIdealWeight
 
 /-! ### The Dedekind zeta function -/
 
+/-- The trivial weight's ideal-indexed series converges absolutely on `Re s > 1`. -/
+private theorem summable_idealTerm_one_of_one_lt_re {s : ℂ} (hs : 1 < s.re) :
+    Summable (idealTerm K (1 : MultiplicativeIdealWeight K).toIdealArithmeticFunction s) := by
+  rw [MultiplicativeIdealWeight.toIdealArithmeticFunction_one]
+  exact summable_idealTerm_one_iff.mpr hs
+
 /-- **The Euler product of the Dedekind zeta function.** For `Re s > 1` the Dedekind zeta function
 of `K` is the unrestricted product over the height-one primes of `𝓞 K` of the local factors
 `(1 - N(𝔭) ^ (-s))⁻¹`.
@@ -378,11 +384,6 @@ of `K` is the unrestricted product over the height-one primes of `𝓞 K` of the
 This is the ideal-theoretic counterpart of Mathlib's `riemannZeta_eulerProduct_hasProd`, and it
 is not obtained from it: the product is indexed by the primes of `𝓞 K`, whose norms repeat and
 whose count above a rational prime is the splitting behaviour of `K`. -/
-private theorem summable_idealTerm_one_of_one_lt_re {s : ℂ} (hs : 1 < s.re) :
-    Summable (idealTerm K (1 : MultiplicativeIdealWeight K).toIdealArithmeticFunction s) := by
-  rw [MultiplicativeIdealWeight.toIdealArithmeticFunction_one]
-  exact summable_idealTerm_one_iff.mpr hs
-
 theorem dedekindZeta_eulerProduct_hasProd {s : ℂ} (hs : 1 < s.re) :
     HasProd (fun P : HeightOneSpectrum (𝓞 K) ↦ (1 - (Ideal.absNorm P.asIdeal : ℂ) ^ (-s))⁻¹)
       (NumberField.dedekindZeta K s) := by

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Analytic.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Analytic.lean
@@ -40,6 +40,8 @@ product of the Dedekind zeta function.
   **nonzero** wherever the ideal-indexed series converges absolutely.
 * `TauCeti.dedekindZeta_eulerProduct_hasProd`: the **Euler product of the Dedekind zeta
   function**, valid on `Re s > 1`.
+* `TauCeti.dedekindZeta_ne_zero_of_one_lt_re`: the Dedekind zeta function is **nonzero** on
+  `Re s > 1`.
 
 The nonvanishing is pointwise, at each `s` where the ideal-indexed series converges absolutely, and
 nothing is claimed off that region. It is not a formality: an unconditionally convergent product of
@@ -376,14 +378,16 @@ of `K` is the unrestricted product over the height-one primes of `𝓞 K` of the
 This is the ideal-theoretic counterpart of Mathlib's `riemannZeta_eulerProduct_hasProd`, and it
 is not obtained from it: the product is indexed by the primes of `𝓞 K`, whose norms repeat and
 whose count above a rational prime is the splitting behaviour of `K`. -/
+private theorem summable_idealTerm_one_of_one_lt_re {s : ℂ} (hs : 1 < s.re) :
+    Summable (idealTerm K (1 : MultiplicativeIdealWeight K).toIdealArithmeticFunction s) := by
+  rw [MultiplicativeIdealWeight.toIdealArithmeticFunction_one]
+  exact summable_idealTerm_one_iff.mpr hs
+
 theorem dedekindZeta_eulerProduct_hasProd {s : ℂ} (hs : 1 < s.re) :
     HasProd (fun P : HeightOneSpectrum (𝓞 K) ↦ (1 - (Ideal.absNorm P.asIdeal : ℂ) ^ (-s))⁻¹)
       (NumberField.dedekindZeta K s) := by
-  have hsum : Summable (idealTerm K
-      (1 : MultiplicativeIdealWeight K).toIdealArithmeticFunction s) := by
-    rw [MultiplicativeIdealWeight.toIdealArithmeticFunction_one]
-    exact summable_idealTerm_one_iff.mpr hs
-  have hprod := MultiplicativeIdealWeight.hasProd_eulerFactor (1 : MultiplicativeIdealWeight K) hsum
+  have hprod := MultiplicativeIdealWeight.hasProd_eulerFactor (1 : MultiplicativeIdealWeight K)
+    (summable_idealTerm_one_of_one_lt_re hs)
   rw [MultiplicativeIdealWeight.toIdealArithmeticFunction_one,
     ← dedekindZeta_eq_LSeries_normCoeff_one K s] at hprod
   have hfun : (fun P : HeightOneSpectrum (𝓞 K) ↦
@@ -395,5 +399,18 @@ theorem dedekindZeta_eulerProduct_hasProd {s : ℂ} (hs : 1 < s.re) :
     rw [MultiplicativeIdealWeight.one_apply, ite_eq_right P.ne_bot, Complex.cpow_neg, one_div]
   rw [hfun]
   exact hprod
+
+/-- **The Dedekind zeta function does not vanish on `Re s > 1`.** This is the trivial-weight case
+of `MultiplicativeIdealWeight.LSeries_ne_zero_of_summable_idealTerm`, read through the
+identification of `dedekindZeta` with the `L`-series of the trivial weight's norm coefficients.
+
+Nothing is claimed on `Re s ≤ 1`; in particular this says nothing about the line
+`Re s = 1`. -/
+theorem dedekindZeta_ne_zero_of_one_lt_re {s : ℂ} (hs : 1 < s.re) :
+    NumberField.dedekindZeta K s ≠ 0 := by
+  have h := MultiplicativeIdealWeight.LSeries_ne_zero_of_summable_idealTerm
+    (1 : MultiplicativeIdealWeight K) (summable_idealTerm_one_of_one_lt_re hs)
+  rwa [MultiplicativeIdealWeight.toIdealArithmeticFunction_one,
+    ← dedekindZeta_eq_LSeries_normCoeff_one K s] at h
 
 end TauCeti

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Logarithm.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Logarithm.lean
@@ -23,9 +23,10 @@ is defined without choosing anything.
 
 **What this does not give.** `exp` is not injective, so an identity of the form `exp t = L`
 determines `t` only modulo `2πi ℤ`; these theorems therefore do not exhibit a logarithm *of* the
-`L`-series, and in particular are not a holomorphic branch on a region. Obtaining one needs the
-series to be nonvanishing there first, which
-`TauCeti.NumberTheory.ArithmeticDirichletSeries.EulerProduct.Analytic` states it does not supply.
+`L`-series, and in particular are not a holomorphic branch on a region.
+`TauCeti.MultiplicativeIdealWeight.LSeries_ne_zero_of_summable_idealTerm` supplies nonvanishing
+pointwise, wherever the ideal-indexed series converges absolutely; a branch needs more than that —
+a simply connected zero-free region on which to choose one — and is not constructed here.
 
 ## Main results
 

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Logarithm.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Logarithm.lean
@@ -59,12 +59,7 @@ theorem exp_tsum_neg_log_one_sub_eq_LSeries
     exp (∑' P : HeightOneSpectrum (𝓞 K),
         -log (1 - χ P.asIdeal / (Ideal.absNorm P.asIdeal : ℂ) ^ s)) =
       LSeries (normCoeff K χ.toIdealArithmeticFunction) s := by
-  have hne (P : HeightOneSpectrum (𝓞 K)) :
-      1 - χ P.asIdeal / (Ideal.absNorm P.asIdeal : ℂ) ^ s ≠ 0 := fun h ↦ by
-    have hlt := χ.norm_div_lt_one_of_summable_idealTerm hs P
-    rw [sub_eq_zero] at h
-    rw [← h] at hlt
-    simp at hlt
+  have hne := χ.one_sub_div_ne_zero_of_summable_idealTerm hs
   have H := (Summable.clog_one_sub
     (χ.summable_div_of_summable_idealTerm hs)).neg.hasSum.cexp.tprod_eq
   simp only [Function.comp_apply, exp_neg, exp_log (hne _)] at H


### PR DESCRIPTION
Layer 3.3 of the arithmetic Dirichlet series roadmap ends: *"State nonvanishing only where
absolute convergence of the reciprocal product proves it."* Everything else in 3.3 is on `main` —
`hasProd_eulerFactor` already identifies the unrestricted product of the local factors with
`LSeries (normCoeff f)`, in both the bundled and the completely-multiplicative form. This adds the
sentence that was missing, and `Analytic.lean`'s module docstring said so in as many words:

> No nonvanishing statement is made here. An unconditionally convergent product of nonzero factors
> may still vanish, so nonvanishing requires additional hypotheses such as convergence of the
> reciprocal product.

## What is added

`MultiplicativeIdealWeight.LSeries_ne_zero_of_summable_idealTerm` — where the ideal-indexed
Dirichlet series converges absolutely at `s`, `LSeries (normCoeff K f) s ≠ 0`.

`dedekindZeta_ne_zero_of_one_lt_re` — its Dedekind-zeta case, so consumers of the zeta API do not
have to rebuild the trivial-weight specialisation. The summability step the two zeta theorems now
share is named once, privately.

The proof reuses Mathlib's `tprod_one_add_ne_zero_of_summable`, which is exactly this statement for
an absolutely convergent product of nonzero factors `1 + f i`; here `f P := -(χ(P) N(P)⁻ˢ)`. That
gives `∏' P, (1 - χ(P) N(P)⁻ˢ) ≠ 0`, and `HasProd.inv₀` against `hasProd_eulerFactor` identifies the
`L`-series with its inverse. Nothing is claimed off the region of absolute convergence, and no
logarithm is chosen — this does not touch Layer 3.4.

`Logarithm.lean`'s module docstring is updated in the same commit: it asserted that `Analytic`
supplies no nonvanishing, which this PR makes false. The distinction it was drawing survives —
pointwise nonvanishing is not a holomorphic branch on a region.

`one_sub_div_ne_zero_of_summable_idealTerm` is extracted alongside it: the fact that no local factor
has a vanishing denominator was already inlined inside `exp_tsum_neg_log_one_sub_eq_LSeries`, and
this proof needs it too. `Logarithm.lean` now uses the named lemma instead of its own copy.

## Why now

#6051 was blocked by `scope` for building Layer 3.4 material ahead of this stage. That block is
correct, and this is the prerequisite it asked for; #6051 stays parked until this lands.

Mathlib has `DirichletCharacter.LSeries_ne_zero_of_one_lt_re`, which is the `ℕ`-indexed analogue
proved from the Möbius convolution rather than from a product, and no Euler-product nonvanishing of
its own — its `EulerProduct/ExpLog.lean` exports only `Summable.clog_one_sub` and
`exp_tsum_primes_log_eq_tsum`. The naming here follows that precedent.

Roadmap: ArithmeticDirichletSeries
<!--tauceti-target:v1 {"focus":"ArithmeticDirichletSeries","id":"ArithmeticDirichletSeries/README.md:Layer-3.3"}-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011dmwkBnj4rJc75STgbwsLF


