### PR TITLE
feat(ArithmeticDirichletSeries): regrouping absorbs a norm-indexed factor

### DIFF
--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/NormCoeff.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/NormCoeff.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.Algebra.CharZero.Infinite
 public import TauCeti.NumberTheory.ArithmeticDirichletSeries.Basic
 public import Mathlib.Analysis.Complex.Basic
+public import Mathlib.Analysis.SpecialFunctions.Pow.Complex
 public import Mathlib.Analysis.Complex.Order
 public import Mathlib.NumberTheory.ArithmeticFunction.Defs
 public import Mathlib.RingTheory.Ideal.Norm.AbsNorm
@@ -142,6 +143,23 @@ theorem normCoeff_star_apply (f : IdealArithmeticFunction K) (n : ℕ) :
     normCoeff K (fun I ↦ (starRingEnd ℂ) (f I)) n = star (normCoeff K f n) := by
   simp only [normCoeff_apply]
   exact ((starAddEquiv : ℂ ≃+ ℂ).map_finsum_mem f (finite_normFiber K n)).symm
+
+/-- **A factor depending on the ideal only through its norm pulls out of the regrouping.** The
+fibre summed over is exactly the ideals of absolute norm `n`, so such a factor is constant on it. -/
+theorem normCoeff_mul_of_apply_absNorm (f : IdealArithmeticFunction K) (g : ℕ → ℂ) (n : ℕ) :
+    normCoeff K (fun I ↦ f I * g (Ideal.absNorm (I : Ideal (𝓞 K)))) n = normCoeff K f n * g n := by
+  rw [normCoeff_eq_sum_normFiber, normCoeff_eq_sum_normFiber, Finset.sum_mul]
+  exact Finset.sum_congr rfl fun I hI ↦ by rw [(mem_normFiber K).1 hI]
+
+/-- **Regrouping absorbs a norm twist.** Twisting an ideal arithmetic function by `N(I) ^ (-z)`
+twists its `n`-th norm coefficient by `n ^ (-z)`. This is the compatibility of `normCoeff` with the
+norm twists of a weight, general and purely imaginary alike, since the unitary twist is the
+multiplicative one. -/
+@[simp]
+theorem normCoeff_mul_absNorm_cpow (f : IdealArithmeticFunction K) (z : ℂ) (n : ℕ) :
+    normCoeff K (fun I ↦ f I * (Ideal.absNorm (I : Ideal (𝓞 K)) : ℂ) ^ (-z)) n =
+      normCoeff K f n * (n : ℂ) ^ (-z) :=
+  normCoeff_mul_of_apply_absNorm K f (fun m ↦ (m : ℂ) ^ (-z)) n
 
 /-- **Absence of cancellation inside norm fibres**, for a nonnegative ideal arithmetic function:
 the absolute value of a norm coefficient is the sum of the absolute values over the fibre. -/

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/NormCoeff.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/NormCoeff.lean
@@ -146,7 +146,8 @@ theorem normCoeff_star_apply (f : IdealArithmeticFunction K) (n : ℕ) :
 
 /-- **A factor depending on the ideal only through its norm pulls out of the regrouping.** The
 fibre summed over is exactly the ideals of absolute norm `n`, so such a factor is constant on it. -/
-theorem normCoeff_mul_of_apply_absNorm (f : IdealArithmeticFunction K) (g : ℕ → ℂ) (n : ℕ) :
+@[simp]
+theorem normCoeff_fun_mul_comp_absNorm (f : IdealArithmeticFunction K) (g : ℕ → ℂ) (n : ℕ) :
     normCoeff K (fun I ↦ f I * g (Ideal.absNorm (I : Ideal (𝓞 K)))) n = normCoeff K f n * g n := by
   rw [normCoeff_eq_sum_normFiber, normCoeff_eq_sum_normFiber, Finset.sum_mul]
   exact Finset.sum_congr rfl fun I hI ↦ by rw [(mem_normFiber K).1 hI]
@@ -159,7 +160,7 @@ multiplicative one. -/
 theorem normCoeff_mul_absNorm_cpow (f : IdealArithmeticFunction K) (z : ℂ) (n : ℕ) :
     normCoeff K (fun I ↦ f I * (Ideal.absNorm (I : Ideal (𝓞 K)) : ℂ) ^ (-z)) n =
       normCoeff K f n * (n : ℂ) ^ (-z) :=
-  normCoeff_mul_of_apply_absNorm K f (fun m ↦ (m : ℂ) ^ (-z)) n
+  normCoeff_fun_mul_comp_absNorm K f (fun m ↦ (m : ℂ) ^ (-z)) n
 
 /-- **Absence of cancellation inside norm fibres**, for a nonnegative ideal arithmetic function:
 the absolute value of a norm coefficient is the sum of the absolute values over the fibre. -/

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/Weight.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/Weight.lean
@@ -841,8 +841,9 @@ theorem toIdealArithmeticFunction_apply (χ : UnitaryIdealWeight K) (I : (Ideal 
 @[simp]
 theorem normCoeff_normTwist (z : ℂ) (hz : z.re = 0) (χ : UnitaryIdealWeight K) (n : ℕ) :
     normCoeff K (normTwist z hz χ).toIdealArithmeticFunction n =
-      normCoeff K χ.toIdealArithmeticFunction n * (n : ℂ) ^ (-z) :=
-  MultiplicativeIdealWeight.normCoeff_normTwist z χ.1 n
+      normCoeff K χ.toIdealArithmeticFunction n * (n : ℂ) ^ (-z) := by
+  simpa only [toIdealArithmeticFunction, val_normTwist] using
+    MultiplicativeIdealWeight.normCoeff_normTwist z χ.1 n
 
 /-- The ideal arithmetic function underlying a unitary ideal weight is multiplicative on
 relatively prime ideals. -/

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/Weight.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/Weight.lean
@@ -836,8 +836,8 @@ def toIdealArithmeticFunction (χ : UnitaryIdealWeight K) : IdealArithmeticFunct
 theorem toIdealArithmeticFunction_apply (χ : UnitaryIdealWeight K) (I : (Ideal (𝓞 K))⁰) :
     χ.toIdealArithmeticFunction I = χ.1 I := (rfl)
 
-/-- **Regrouping absorbs an imaginary norm twist.** The unitary twist is the multiplicative one, so
-this reads `MultiplicativeIdealWeight.normCoeff_normTwist` through the unitary carrier. -/
+/-- **Regrouping absorbs an imaginary norm twist.** For `z.re = 0`, twisting a unitary weight by
+`N(I) ^ (-z)` multiplies its `n`-th norm coefficient by `n ^ (-z)`. -/
 @[simp]
 theorem normCoeff_normTwist (z : ℂ) (hz : z.re = 0) (χ : UnitaryIdealWeight K) (n : ℕ) :
     normCoeff K (normTwist z hz χ).toIdealArithmeticFunction n =

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/Weight.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/Weight.lean
@@ -10,6 +10,7 @@ public import Mathlib.Analysis.SpecialFunctions.Pow.Complex
 public import Mathlib.Analysis.SpecialFunctions.Pow.Real
 public import Mathlib.RingTheory.Ideal.Norm.AbsNorm
 public import TauCeti.NumberTheory.ArithmeticDirichletSeries.Basic
+public import TauCeti.NumberTheory.ArithmeticDirichletSeries.NormCoeff
 public import TauCeti.RingTheory.DedekindDomain.Ideal
 
 /-!
@@ -405,6 +406,17 @@ def toIdealArithmeticFunction (χ : MultiplicativeIdealWeight K) : IdealArithmet
 @[simp]
 theorem toIdealArithmeticFunction_apply (χ : MultiplicativeIdealWeight K) (I : (Ideal (𝓞 K))⁰) :
     χ.toIdealArithmeticFunction I = χ I := (rfl)
+
+/-- **Regrouping absorbs a norm twist.** Twisting a weight by `N(I) ^ (-z)` twists its `n`-th norm
+coefficient by `n ^ (-z)`. -/
+@[simp]
+theorem normCoeff_normTwist (z : ℂ) (χ : MultiplicativeIdealWeight K) (n : ℕ) :
+    normCoeff K (normTwist z χ).toIdealArithmeticFunction n =
+      normCoeff K χ.toIdealArithmeticFunction n * (n : ℂ) ^ (-z) := by
+  have h : (normTwist z χ).toIdealArithmeticFunction =
+      fun I ↦ χ.toIdealArithmeticFunction I * (Ideal.absNorm (I : Ideal (𝓞 K)) : ℂ) ^ (-z) :=
+    funext fun I ↦ by simp [normTwist_apply]
+  rw [h, normCoeff_mul_absNorm_cpow]
 
 /-- The ideal arithmetic function underlying a completely multiplicative ideal weight is
 multiplicative on relatively prime ideals. -/
@@ -823,6 +835,14 @@ def toIdealArithmeticFunction (χ : UnitaryIdealWeight K) : IdealArithmeticFunct
 @[simp]
 theorem toIdealArithmeticFunction_apply (χ : UnitaryIdealWeight K) (I : (Ideal (𝓞 K))⁰) :
     χ.toIdealArithmeticFunction I = χ.1 I := (rfl)
+
+/-- **Regrouping absorbs an imaginary norm twist.** The unitary twist is the multiplicative one, so
+this reads `MultiplicativeIdealWeight.normCoeff_normTwist` through the unitary carrier. -/
+@[simp]
+theorem normCoeff_normTwist (z : ℂ) (hz : z.re = 0) (χ : UnitaryIdealWeight K) (n : ℕ) :
+    normCoeff K (normTwist z hz χ).toIdealArithmeticFunction n =
+      normCoeff K χ.toIdealArithmeticFunction n * (n : ℂ) ^ (-z) :=
+  MultiplicativeIdealWeight.normCoeff_normTwist z χ.1 n
 
 /-- The ideal arithmetic function underlying a unitary ideal weight is multiplicative on
 relatively prime ideals. -/


### PR DESCRIPTION
Layer 1.1 asks `normCoeff` to be proved compatible with "conjugation, general versus imaginary norm
twists, and field equivalence". Conjugation is on `main` as `normCoeff_star_apply`; the twists are
this PR; field equivalence is #6110.

## What is added

`normCoeff_fun_mul_comp_absNorm` — if a factor depends on the ideal only through its absolute norm,
it pulls out of the regrouping:

```
normCoeff K (fun I ↦ f I * g (absNorm I)) n = normCoeff K f n * g n
```

That is the whole mathematical content: the fibre being summed over is exactly the ideals of
absolute norm `n`, so `g (absNorm I)` is the constant `g n` on it. Nothing about complex powers,
weights, or twisting is used. `normCoeff_mul_absNorm_cpow` specialises it to `g = (· : ℂ) ^ (-z)`.

On top of that, the compatibility the roadmap actually names, stated on the weight API so consumers
need not unfold it:

* `MultiplicativeIdealWeight.normCoeff_normTwist` — the general twist.
* `UnitaryIdealWeight.normCoeff_normTwist` — the imaginary twist, which is the same theorem read
  through the unitary carrier, since `UnitaryIdealWeight.normTwist z hz` is by definition
  `MultiplicativeIdealWeight.normTwist z` with `hz : z.re = 0` carried only to re-establish
  unitarity.

All four are `@[simp]`.

## Placement

The two weight-level lemmas live in `Weight.lean`, beside `toIdealArithmeticFunction`, and
`Weight.lean` gains an import of `NormCoeff.lean`. The other direction — importing `Weight.lean`
into `NormCoeff.lean` — would make the lower-level file depend on the weight hierarchy for two
corollaries, which is the wrong way round.

## Note for review

`#6110` also edits `NormCoeff.lean` and `#6105` also edits `Weight.lean`, both with different
declarations. None of them duplicate each other; they will conflict textually at merge, which is a
rebase.

Roadmap: ArithmeticDirichletSeries
<!--tauceti-target:v1 {"focus":"ArithmeticDirichletSeries","id":"ArithmeticDirichletSeries/README.md:Layer-1.1"}-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011dmwkBnj4rJc75STgbwsLF
