### PR TITLE
refactor(RingTheory): the absolute norm is invariant under pullback along a ring equiv

### DIFF
--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/Trivial.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/Trivial.lean
@@ -104,14 +104,6 @@ theorem dedekindZeta_eq_LSeries_normCoeff_one (s : ℂ) :
   intro n hn
   rw [normCoeff_one_apply, ite_eq_right hn]
 
-private theorem absNorm_map_ringEquiv {R S : Type*} [CommRing R] [CommRing S]
-    [IsDedekindDomain R] [IsDedekindDomain S] [Infinite R] [Infinite S]
-    (e : R ≃+* S) (I : Ideal R) :
-    Ideal.absNorm (I.map e) = Ideal.absNorm I := by
-  rw [Ideal.absNorm_apply, Ideal.absNorm_apply, Submodule.cardQuot_apply,
-    Submodule.cardQuot_apply]
-  exact Nat.card_congr (Ideal.quotientEquiv I (I.map e) e rfl).symm
-
 private theorem rat_normFiber_subsingleton (n : ℕ) :
     Subsingleton {I : Ideal (𝓞 ℚ) // Ideal.absNorm I = n} := by
   constructor
@@ -120,8 +112,8 @@ private theorem rat_normFiber_subsingleton (n : ℕ) :
   have hmap : I.1.map Rat.ringOfIntegersEquiv = J.1.map Rat.ringOfIntegersEquiv := by
     rw [← Int.ideal_span_absNorm_eq_self (I.1.map Rat.ringOfIntegersEquiv),
       ← Int.ideal_span_absNorm_eq_self (J.1.map Rat.ringOfIntegersEquiv),
-      absNorm_map_ringEquiv Rat.ringOfIntegersEquiv I.1,
-      absNorm_map_ringEquiv Rat.ringOfIntegersEquiv J.1, I.2, J.2]
+      Ideal.absNorm_map_of_ringEquiv Rat.ringOfIntegersEquiv I.1,
+      Ideal.absNorm_map_of_ringEquiv Rat.ringOfIntegersEquiv J.1, I.2, J.2]
   calc
     I.1 = Ideal.comap Rat.ringOfIntegersEquiv (I.1.map Rat.ringOfIntegersEquiv) :=
       (Ideal.comap_map_of_bijective _ Rat.ringOfIntegersEquiv.bijective).symm
@@ -132,7 +124,7 @@ private theorem rat_normFiber_subsingleton (n : ℕ) :
 private theorem rat_normFiber_nonempty (n : ℕ) :
     Nonempty {I : Ideal (𝓞 ℚ) // Ideal.absNorm I = n} := by
   refine ⟨⟨(Ideal.span {(n : ℤ)}).map Rat.ringOfIntegersEquiv.symm, ?_⟩⟩
-  rw [absNorm_map_ringEquiv, Ideal.absNorm_span_singleton]
+  rw [Ideal.absNorm_map_of_ringEquiv, Ideal.absNorm_span_singleton]
   simp
 
 /-- There is exactly one integral ideal of `ℚ` of each absolute norm. -/

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/Weight.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/Weight.lean
@@ -11,6 +11,7 @@ public import Mathlib.Analysis.SpecialFunctions.Pow.Real
 public import Mathlib.RingTheory.Ideal.Norm.AbsNorm
 public import TauCeti.NumberTheory.ArithmeticDirichletSeries.Basic
 public import TauCeti.RingTheory.DedekindDomain.Ideal
+public import TauCeti.RingTheory.Ideal.Norm.AbsNorm
 
 /-!
 # Completely multiplicative ideal weights

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/Weight.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/Weight.lean
@@ -465,13 +465,6 @@ private theorem asIdeal_equivOfRingEquiv_symm (e : K ≃+* L) (𝔮 : HeightOneS
     ((HeightOneSpectrum.equivOfRingEquiv (RingOfIntegers.mapRingEquiv e)).symm 𝔮).asIdeal =
       Ideal.comap (RingOfIntegers.mapRingEquiv e) 𝔮.asIdeal := rfl
 
-private theorem absNorm_comap_mapRingEquiv (e : K ≃+* L) (I : Ideal (𝓞 L)) :
-    Ideal.absNorm (Ideal.comap (RingOfIntegers.mapRingEquiv e) I) = Ideal.absNorm I := by
-  rw [Ideal.absNorm_apply, Ideal.absNorm_apply, Submodule.cardQuot_apply,
-    Submodule.cardQuot_apply]
-  exact Nat.card_congr (Ideal.quotientEquiv _ _ (RingOfIntegers.mapRingEquiv e)
-    (Ideal.map_comap_eq_self_of_equiv (RingOfIntegers.mapRingEquiv e) I).symm)
-
 /-- **Transport along an isomorphism of fields.** An isomorphism `e : K ≃+* L` carries a
 multiplicative ideal weight on `K` to one on `L`, by pulling ideals of `𝓞 L` back to `𝓞 K`
 along `NumberField.RingOfIntegers.mapRingEquiv e`. -/
@@ -585,7 +578,7 @@ theorem map_normTwist (e : K ≃+* L) (z : ℂ) (χ : MultiplicativeIdealWeight 
     map e (normTwist z χ) = normTwist z (map e χ) := by
   ext I
   rw [map_apply, normTwist_apply, normTwist_apply, map_apply,
-    absNorm_comap_mapRingEquiv]
+    Ideal.absNorm_comap_of_ringEquiv]
 
 end Transport
 

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/Weight.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/Weight.lean
@@ -8,7 +8,6 @@ module
 public import Mathlib.Algebra.CharZero.Infinite
 public import Mathlib.Analysis.SpecialFunctions.Pow.Complex
 public import Mathlib.Analysis.SpecialFunctions.Pow.Real
-public import Mathlib.RingTheory.Ideal.Norm.AbsNorm
 public import TauCeti.NumberTheory.ArithmeticDirichletSeries.Basic
 public import TauCeti.RingTheory.DedekindDomain.Ideal
 public import TauCeti.RingTheory.Ideal.Norm.AbsNorm

--- a/TauCeti/RingTheory/DedekindDomain/Ideal.lean
+++ b/TauCeti/RingTheory/DedekindDomain/Ideal.lean
@@ -7,7 +7,6 @@ module
 
 public import Mathlib.RingTheory.Valuation.Discrete.IsDiscreteValuationRing
 public import Mathlib.RingTheory.DedekindDomain.Ideal.Lemmas
-public import Mathlib.RingTheory.Ideal.Norm.AbsNorm
 import Mathlib.RingTheory.DedekindDomain.Factorization
 
 /-!
@@ -139,13 +138,6 @@ theorem count_factors_map_of_ringEquiv (e : R ≃+* R') {p I : Ideal R} (hp : Pr
       Associates.mk_le_mk_iff_dvd]
     exact map_pow_dvd_map_iff_of_ringEquiv e p I n
   exact le_antisymm ((key _).mp le_rfl) ((key _).mpr le_rfl)
-
-/-- **The absolute norm is unchanged by pulling back along a ring isomorphism.** The isomorphism
-descends to an isomorphism of the quotients, which have the same cardinality. -/
-theorem absNorm_comap_of_ringEquiv [Infinite R] [Infinite R'] (e : R ≃+* R') (I : Ideal R') :
-    absNorm (Ideal.comap e I) = absNorm I := by
-  rw [absNorm_apply, absNorm_apply, Submodule.cardQuot_apply, Submodule.cardQuot_apply]
-  exact Nat.card_congr (Ideal.quotientEquiv _ _ e (Ideal.map_comap_eq_self_of_equiv e I).symm)
 
 end RingEquivDedekind
 

--- a/TauCeti/RingTheory/DedekindDomain/Ideal.lean
+++ b/TauCeti/RingTheory/DedekindDomain/Ideal.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.RingTheory.Valuation.Discrete.IsDiscreteValuationRing
 public import Mathlib.RingTheory.DedekindDomain.Ideal.Lemmas
+public import Mathlib.RingTheory.Ideal.Norm.AbsNorm
 import Mathlib.RingTheory.DedekindDomain.Factorization
 
 /-!
@@ -138,6 +139,13 @@ theorem count_factors_map_of_ringEquiv (e : R ≃+* R') {p I : Ideal R} (hp : Pr
       Associates.mk_le_mk_iff_dvd]
     exact map_pow_dvd_map_iff_of_ringEquiv e p I n
   exact le_antisymm ((key _).mp le_rfl) ((key _).mpr le_rfl)
+
+/-- **The absolute norm is unchanged by pulling back along a ring isomorphism.** The isomorphism
+descends to an isomorphism of the quotients, which have the same cardinality. -/
+theorem absNorm_comap_of_ringEquiv [Infinite R] [Infinite R'] (e : R ≃+* R') (I : Ideal R') :
+    absNorm (Ideal.comap e I) = absNorm I := by
+  rw [absNorm_apply, absNorm_apply, Submodule.cardQuot_apply, Submodule.cardQuot_apply]
+  exact Nat.card_congr (Ideal.quotientEquiv _ _ e (Ideal.map_comap_eq_self_of_equiv e I).symm)
 
 end RingEquivDedekind
 

--- a/TauCeti/RingTheory/Ideal/Norm/AbsNorm.lean
+++ b/TauCeti/RingTheory/Ideal/Norm/AbsNorm.lean
@@ -39,8 +39,8 @@ Dedekind domains.  This is the form to use when the ideal is given on the source
 @[simp]
 theorem absNorm_map_of_ringEquiv [Infinite R] [Infinite R'] (e : R ≃+* R') (I : Ideal R) :
     absNorm (I.map e) = absNorm I := by
-  rw [absNorm_apply, absNorm_apply, Submodule.cardQuot_apply, Submodule.cardQuot_apply]
-  exact Nat.card_congr (Ideal.quotientEquiv I (I.map e) e rfl).symm
+  rw [← Ideal.comap_symm]
+  exact absNorm_comap_of_ringEquiv e.symm I
 
 end Ideal
 

--- a/TauCeti/RingTheory/Ideal/Norm/AbsNorm.lean
+++ b/TauCeti/RingTheory/Ideal/Norm/AbsNorm.lean
@@ -1,0 +1,47 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RingTheory.Ideal.Norm.AbsNorm
+
+/-!
+# The absolute ideal norm under a ring isomorphism
+
+Identifying two rings along an isomorphism identifies their ideals, and the absolute norm is
+insensitive to that identification.
+
+## Main results
+
+* `Ideal.absNorm_comap_of_ringEquiv`, `Ideal.absNorm_map_of_ringEquiv`: the absolute norm of an
+  ideal is unchanged by transporting it along a ring isomorphism, in either direction.
+-/
+
+public section
+
+namespace Ideal
+
+variable {R R' : Type*} [CommRing R] [CommRing R'] [IsDedekindDomain R] [IsDedekindDomain R']
+
+/-- The absolute norm is invariant under transporting an ideal backwards along an isomorphism of
+Dedekind domains.  Use this to move a norm computation to whichever of two identified rings it is
+easier to carry out in. -/
+@[simp]
+theorem absNorm_comap_of_ringEquiv [Infinite R] [Infinite R'] (e : R ≃+* R') (I : Ideal R') :
+    absNorm (Ideal.comap e I) = absNorm I := by
+  rw [absNorm_apply, absNorm_apply, Submodule.cardQuot_apply, Submodule.cardQuot_apply]
+  exact Nat.card_congr (Ideal.quotientEquiv _ _ e (Ideal.map_comap_eq_self_of_equiv e I).symm)
+
+/-- The absolute norm is invariant under transporting an ideal forwards along an isomorphism of
+Dedekind domains.  This is the form to use when the ideal is given on the source side. -/
+@[simp]
+theorem absNorm_map_of_ringEquiv [Infinite R] [Infinite R'] (e : R ≃+* R') (I : Ideal R) :
+    absNorm (I.map e) = absNorm I := by
+  rw [absNorm_apply, absNorm_apply, Submodule.cardQuot_apply, Submodule.cardQuot_apply]
+  exact Nat.card_congr (Ideal.quotientEquiv I (I.map e) e rfl).symm
+
+end Ideal
+
+


### PR DESCRIPTION
`Weight.lean` carried a private lemma saying the absolute norm of an ideal is unchanged by pulling
back along `NumberField.RingOfIntegers.mapRingEquiv e`. Nothing in its proof is specific to rings of
integers, to number fields, or to that particular isomorphism — it descends the isomorphism to the
quotients and counts:

```
rw [absNorm_apply, absNorm_apply, Submodule.cardQuot_apply, Submodule.cardQuot_apply]
exact Nat.card_congr (Ideal.quotientEquiv _ _ e (Ideal.map_comap_eq_self_of_equiv e I).symm)
```

## What changes

`Ideal.absNorm_comap_of_ringEquiv` — for any ring isomorphism `e : R ≃+* R'` of Dedekind domains and
any `I : Ideal R'`, `absNorm (comap e I) = absNorm I`.

It goes in `TauCeti/RingTheory/DedekindDomain/Ideal.lean`, in the `RingEquivDedekind` section that
already collects `map_dvd_map_iff_of_ringEquiv`, `map_pow_dvd_map_iff_of_ringEquiv` and
`count_factors_map_of_ringEquiv` — the same shape of statement, transporting an ideal-theoretic
invariant along an isomorphism. `Weight.lean` loses its private copy and uses the general lemma at
its one call site, in `map_normTwist`.

Mathlib's `RingTheory/Ideal/Norm/AbsNorm.lean` has no transport of `absNorm` along a ring
isomorphism, so there is nothing upstream to reuse here.

## Note for review

I first stated this with `[Ring.HasFiniteQuotients R]` and `[Ring.HasFiniteQuotients R']` carried over
from where `absNorm` is introduced in Mathlib. `runLinter`'s `unusedArguments` showed both are
redundant here, so they are gone; only `[Infinite R]` and `[Infinite R']` remain beyond the section's
Dedekind assumptions.

This is groundwork for the field-equivalence half of Layer 1.1 (`normCoeff` transported along
`K ≃+* L`), which needs exactly this fact and a bijection of norm fibres; that is a separate PR.

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011dmwkBnj4rJc75STgbwsLF
