### PR TITLE
refactor(HeckeSlash): name the pair fiber the multiplicity counts

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Composition.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Composition.lean
@@ -103,6 +103,8 @@ it is what makes the Hecke ring commutative there (Shimura's Proposition 3.8).
   representatives lands in — the map the double sum is fibred over.
 * `HeckeRing.GL2.pairCoset_eq_iff`: a pair lies in the fibre over `D` exactly when the product
   of its two representatives lies in `D`'s double coset.
+* `HeckeRing.GL2.PairCosetFibre`: among the pairs lying over `D`, those whose product spans the
+  right coset `Γ₁ x` — the type the multiplicity counts.
 * `HeckeRing.GL2.card_pairs_pairCoset_rightCoset_eq_multiplicity`: each right coset of a double
   coset `D` is met by `m(D₁, D₂; D)` of the pairs, whichever right coset of `D` is chosen.
 * `HeckeRing.GL2.heckeSlashSum_heckeSlashSum_eq_sum_nsmul`: **the multiplicity-weighted
@@ -310,14 +312,23 @@ private lemma pairCoset_eq_of_mem_rightCoset {x : GL (Fin 2) ℚ}
   rw [← doubleCoset_eq_of_mem hx]
   exact mem_doubleCoset.mpr ⟨_, (mem_rightCoset_iff x).mp hp, 1, one_mem _, by group⟩
 
+/-- **The pairs over `D` whose product spans the right coset `Γ₁ x`.** Among the index pairs
+whose product lies in the double coset `D`, those whose product generates the same right coset
+of `Γ₁` as `x` does. `card_pairs_pairCoset_rightCoset_eq_multiplicity` counts this type, and
+`HeckeRing.GL2.image_pairCoset_eq_support_structureConstants` reads its nonemptiness off the
+structure constants. -/
+abbrev PairCosetFibre (D₁ : HeckeCoset Δ Γ₁ Γ₂) (D₂ : HeckeCoset Δ Γ₂ Γ₃)
+    (D : HeckeCoset Δ Γ₁ Γ₃) (x : GL (Fin 2) ℚ) : Type :=
+  {i : {q // pairCoset D₁ D₂ q = D} //
+    MulOpposite.op (rightCosetRep D₁ i.1.1 * rightCosetRep D₂ i.1.2) •
+        (Γ₁ : Set (GL (Fin 2) ℚ)) = MulOpposite.op x • (Γ₁ : Set (GL (Fin 2) ℚ))}
+
 /-- **Each right coset of a double coset `D` is met by Shimura's multiplicity `m(D₁, D₂; D)`
 many pairs**, whichever `x ∈ D` names that right coset: among the pairs lying over `D`, the
 number whose product spans the right coset `Γ₁ x` does not depend on `x`. -/
 lemma card_pairs_pairCoset_rightCoset_eq_multiplicity {x : GL (Fin 2) ℚ}
     (hx : x ∈ doubleCoset (D.out : GL (Fin 2) ℚ) (Γ₁ : Set (GL (Fin 2) ℚ)) Γ₃) :
-    Nat.card {i : {q // pairCoset D₁ D₂ q = D} //
-        MulOpposite.op (rightCosetRep D₁ i.1.1 * rightCosetRep D₂ i.1.2) •
-            (Γ₁ : Set (GL (Fin 2) ℚ)) = MulOpposite.op x • (Γ₁ : Set (GL (Fin 2) ℚ))} =
+    Nat.card (PairCosetFibre D₁ D₂ D x) =
       DoubleCoset.multiplicity Γ₃ Γ₂ Γ₁ (D₂.out : GL (Fin 2) ℚ)⁻¹ (D₁.out : GL (Fin 2) ℚ)⁻¹
         (D.out : GL (Fin 2) ℚ)⁻¹ := by
   have hiff (y : GL (Fin 2) ℚ) :

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Composition.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Composition.lean
@@ -103,7 +103,7 @@ it is what makes the Hecke ring commutative there (Shimura's Proposition 3.8).
   representatives lands in — the map the double sum is fibred over.
 * `HeckeRing.GL2.pairCoset_eq_iff`: a pair lies in the fibre over `D` exactly when the product
   of its two representatives lies in `D`'s double coset.
-* `HeckeRing.GL2.PairCosetFibre`: among the pairs lying over `D`, those whose product spans the
+* `HeckeRing.GL2.PairCosetFiber`: among the pairs lying over `D`, those whose product spans the
   right coset `Γ₁ x` — the type the multiplicity counts.
 * `HeckeRing.GL2.card_pairs_pairCoset_rightCoset_eq_multiplicity`: each right coset of a double
   coset `D` is met by `m(D₁, D₂; D)` of the pairs, whichever right coset of `D` is chosen.
@@ -314,10 +314,9 @@ private lemma pairCoset_eq_of_mem_rightCoset {x : GL (Fin 2) ℚ}
 
 /-- **The pairs over `D` whose product spans the right coset `Γ₁ x`.** Among the index pairs
 whose product lies in the double coset `D`, those whose product generates the same right coset
-of `Γ₁` as `x` does. `card_pairs_pairCoset_rightCoset_eq_multiplicity` counts this type, and
-`HeckeRing.GL2.image_pairCoset_eq_support_structureConstants` reads its nonemptiness off the
-structure constants. -/
-abbrev PairCosetFibre (D₁ : HeckeCoset Δ Γ₁ Γ₂) (D₂ : HeckeCoset Δ Γ₂ Γ₃)
+of `Γ₁` as `x` does. `card_pairs_pairCoset_rightCoset_eq_multiplicity` counts this type; its
+nonemptiness is what identifies the support of the Hecke structure constants downstream. -/
+abbrev PairCosetFiber (D₁ : HeckeCoset Δ Γ₁ Γ₂) (D₂ : HeckeCoset Δ Γ₂ Γ₃)
     (D : HeckeCoset Δ Γ₁ Γ₃) (x : GL (Fin 2) ℚ) : Type :=
   {i : {q // pairCoset D₁ D₂ q = D} //
     MulOpposite.op (rightCosetRep D₁ i.1.1 * rightCosetRep D₂ i.1.2) •
@@ -328,7 +327,7 @@ many pairs**, whichever `x ∈ D` names that right coset: among the pairs lying 
 number whose product spans the right coset `Γ₁ x` does not depend on `x`. -/
 lemma card_pairs_pairCoset_rightCoset_eq_multiplicity {x : GL (Fin 2) ℚ}
     (hx : x ∈ doubleCoset (D.out : GL (Fin 2) ℚ) (Γ₁ : Set (GL (Fin 2) ℚ)) Γ₃) :
-    Nat.card (PairCosetFibre D₁ D₂ D x) =
+    Nat.card (PairCosetFiber D₁ D₂ D x) =
       DoubleCoset.multiplicity Γ₃ Γ₂ Γ₁ (D₂.out : GL (Fin 2) ℚ)⁻¹ (D₁.out : GL (Fin 2) ℚ)⁻¹
         (D.out : GL (Fin 2) ℚ)⁻¹ := by
   have hiff (y : GL (Fin 2) ℚ) :

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Action.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Action.lean
@@ -130,14 +130,14 @@ private lemma image_pairCoset_eq_support_structureConstants (D₁ D₂ : Coset�
     have hx := pairCoset_eq_iff.mp hp
     have hcard := card_pairs_pairCoset_rightCoset_eq_multiplicity (D₁ := D₁) (D₂ := D₂) hx
     have : Nonempty
-        (PairCosetFibre D₁ D₂ D (rightCosetRep D₁ p.1 * rightCosetRep D₂ p.2)) :=
+        (PairCosetFiber D₁ D₂ D (rightCosetRep D₁ p.1 * rightCosetRep D₂ p.2)) :=
       ⟨⟨⟨p, hp⟩, rfl⟩⟩
     have hne : multiplicity (Γ₀Q(N)) (Γ₀Q(N)) (Γ₀Q(N))
         (D₂.out : GL (Fin 2) ℚ)⁻¹ (D₁.out : GL (Fin 2) ℚ)⁻¹
           (D.out : GL (Fin 2) ℚ)⁻¹ ≠ 0 := by
       rw [← hcard]
       exact (Nat.card_pos (α :=
-        PairCosetFibre D₁ D₂ D (rightCosetRep D₁ p.1 * rightCosetRep D₂ p.2))).ne'
+        PairCosetFiber D₁ D₂ D (rightCosetRep D₁ p.1 * rightCosetRep D₂ p.2))).ne'
     rwa [multiplicity_inv_reverse_eq D₁ D₂ D] at hne
   · intro hne
     have hne' : multiplicity (Γ₀Q(N)) (Γ₀Q(N)) (Γ₀Q(N))
@@ -147,7 +147,7 @@ private lemma image_pairCoset_eq_support_structureConstants (D₁ D₂ : Coset�
     have hcard := card_pairs_pairCoset_rightCoset_eq_multiplicity (D₁ := D₁) (D₂ := D₂)
       (mem_doubleCoset_self (Γ₀Q(N)) (Γ₀Q(N)) (D.out : GL (Fin 2) ℚ))
     have hcardne :
-        Nat.card (PairCosetFibre D₁ D₂ D (D.out : GL (Fin 2) ℚ)) ≠ 0 := by
+        Nat.card (PairCosetFiber D₁ D₂ D (D.out : GL (Fin 2) ℚ)) ≠ 0 := by
       rwa [hcard]
     obtain ⟨i⟩ := (Nat.card_ne_zero.mp hcardne).1
     exact ⟨i.1.1, i.1.2⟩

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Action.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Action.lean
@@ -129,21 +129,15 @@ private lemma image_pairCoset_eq_support_structureConstants (D₁ D₂ : Coset�
   · rintro ⟨p, hp⟩
     have hx := pairCoset_eq_iff.mp hp
     have hcard := card_pairs_pairCoset_rightCoset_eq_multiplicity (D₁ := D₁) (D₂ := D₂) hx
-    have : Nonempty {i : {q // pairCoset D₁ D₂ q = D} //
-        MulOpposite.op (rightCosetRep D₁ i.1.1 * rightCosetRep D₂ i.1.2) •
-            ((Γ₀Q(N)) : Set (GL (Fin 2) ℚ)) =
-          MulOpposite.op (rightCosetRep D₁ p.1 * rightCosetRep D₂ p.2) •
-            ((Γ₀Q(N)) : Set (GL (Fin 2) ℚ))} :=
+    have : Nonempty
+        (PairCosetFibre D₁ D₂ D (rightCosetRep D₁ p.1 * rightCosetRep D₂ p.2)) :=
       ⟨⟨⟨p, hp⟩, rfl⟩⟩
     have hne : multiplicity (Γ₀Q(N)) (Γ₀Q(N)) (Γ₀Q(N))
         (D₂.out : GL (Fin 2) ℚ)⁻¹ (D₁.out : GL (Fin 2) ℚ)⁻¹
           (D.out : GL (Fin 2) ℚ)⁻¹ ≠ 0 := by
       rw [← hcard]
-      exact (Nat.card_pos (α := {i : {q // pairCoset D₁ D₂ q = D} //
-        MulOpposite.op (rightCosetRep D₁ i.1.1 * rightCosetRep D₂ i.1.2) •
-            ((Γ₀Q(N)) : Set (GL (Fin 2) ℚ)) =
-          MulOpposite.op (rightCosetRep D₁ p.1 * rightCosetRep D₂ p.2) •
-            ((Γ₀Q(N)) : Set (GL (Fin 2) ℚ))})).ne'
+      exact (Nat.card_pos (α :=
+        PairCosetFibre D₁ D₂ D (rightCosetRep D₁ p.1 * rightCosetRep D₂ p.2))).ne'
     rwa [multiplicity_inv_reverse_eq D₁ D₂ D] at hne
   · intro hne
     have hne' : multiplicity (Γ₀Q(N)) (Γ₀Q(N)) (Γ₀Q(N))
@@ -152,11 +146,8 @@ private lemma image_pairCoset_eq_support_structureConstants (D₁ D₂ : Coset�
       rwa [multiplicity_inv_reverse_eq D₁ D₂ D]
     have hcard := card_pairs_pairCoset_rightCoset_eq_multiplicity (D₁ := D₁) (D₂ := D₂)
       (mem_doubleCoset_self (Γ₀Q(N)) (Γ₀Q(N)) (D.out : GL (Fin 2) ℚ))
-    have hcardne : Nat.card {i : {q // pairCoset D₁ D₂ q = D} //
-        MulOpposite.op (rightCosetRep D₁ i.1.1 * rightCosetRep D₂ i.1.2) •
-            ((Γ₀Q(N)) : Set (GL (Fin 2) ℚ)) =
-          MulOpposite.op (D.out : GL (Fin 2) ℚ) •
-            ((Γ₀Q(N)) : Set (GL (Fin 2) ℚ))} ≠ 0 := by
+    have hcardne :
+        Nat.card (PairCosetFibre D₁ D₂ D (D.out : GL (Fin 2) ℚ)) ≠ 0 := by
       rwa [hcard]
     obtain ⟨i⟩ := (Nat.card_ne_zero.mp hcardne).1
     exact ⟨i.1.1, i.1.2⟩


### PR DESCRIPTION
Roadmap: ModularForms

The subtype of index pairs lying over a double coset `D` whose product spans the right coset
`Γ₁ x` was spelled out in full **five times** — twice in `HeckeSlash/Composition.lean` and
three times in `HeckeSlash/Nebentypus/Action.lean`, six lines apiece:

```lean
{i : {q // pairCoset D₁ D₂ q = D} //
  MulOpposite.op (rightCosetRep D₁ i.1.1 * rightCosetRep D₂ i.1.2) •
      (Γ₁ : Set (GL (Fin 2) ℚ)) = MulOpposite.op x • (Γ₁ : Set (GL (Fin 2) ℚ))}
```

This names it once, as `HeckeRing.GL2.PairCosetFiber`, beside
`card_pairs_pairCoset_rightCoset_eq_multiplicity` — the lemma whose whole content is that this
type has `m(D₁, D₂; D)` elements, independent of which `x ∈ D` names the right coset.

Because the abbreviation is reducible, every statement it appears in is definitionally what it
was. That is why the three existing call sites of that lemma — `Composition.lean:376`,
`Nebentypus/Composition.lean:233` and `Nebentypus/Action.lean` — needed no edit at all; only the
places that *spelled the type out* changed.

The visible payoff is in `image_pairCoset_eq_support_structureConstants`, whose proof drops from
38 lines to 30 — back under the decompose threshold — and now reads as the argument it is (a
nonempty fibre gives a nonzero cardinality gives a nonzero multiplicity, and back) rather than
as a wall of repeated type ascriptions.

No new mathematics: nothing is proved that was not proved before, and no statement changed up to
definitional equality. Accordingly there is no `tauceti-target` marker; `Roadmap: ModularForms`
is attribution for the roadmap this Hecke-slash machinery serves.

Provenance: refactor of existing TauCeti code. Swept github.com/CBirkbeck/AINTLIB @
`2baa76f742bdb4fb8ee323fabba41203bd390e08` for `pairCoset`, `PairCosetFiber` and
`structureConstants`: its `LeanModularForms` project has no counterpart of this fibring, so
there was nothing upstream to adopt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQieFQn95rzgvYRvNdX3hR

