### PR TITLE
feat: make the formal point map additive

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Point/AdicCompletion.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Point/AdicCompletion.lean
@@ -14,7 +14,9 @@ public import TauCeti.RingTheory.DedekindDomain.AdicValuation.Completion
 For a Weierstrass curve over the ring of integers `O_v` in the completion of a Dedekind domain at
 a height-one prime, the maximal ideal has enough auxiliary parameters to apply the generic formal
 point homomorphism construction. This file packages the resulting unconditional additive and
-injective map from the formal group on that maximal ideal into the points over the completion.
+injective map from the formal group on that maximal ideal into the points over the completion. It
+is the discrete adic-completion specialization; the generic construction, conditional on the
+existence of auxiliary parameters, is in `Point.Hom`.
 
 ## Main definitions
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Point/AdicCompletion.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Point/AdicCompletion.lean
@@ -1,0 +1,300 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.Point.Hom
+public import TauCeti.RingTheory.DedekindDomain.AdicValuation.Completion
+
+/-!
+# Formal points over a Dedekind adic completion
+
+For a Weierstrass curve over the ring of integers `O_v` in the completion of a Dedekind domain at
+a height-one prime, the maximal ideal has enough auxiliary parameters to apply the generic formal
+point homomorphism construction. This file packages the resulting unconditional additive and
+injective map from the formal group on that maximal ideal into the points over the completion.
+
+## Main definitions
+
+* `WeierstrassCurve.formalPointHomAdicCompletion`: the additive homomorphism from formal-group
+  parameters in the maximal ideal of `O_v` to points over the completion.
+
+## Main results
+
+* `WeierstrassCurve.formalPoint_add_adicCompletion`: the parametrisation preserves addition.
+* `WeierstrassCurve.formalPointHomAdicCompletion_injective`: the homomorphism is injective.
+
+## References
+
+* [J. Silverman, *The Arithmetic of Elliptic Curves*][silverman2009], IV.1 and VII.2.
+
+## Provenance
+
+Adapted from Michael Stoll's elliptic-curve development
+(`github.com/MichaelStollBayreuth/EllipticCurves` @ `66889eada51a`, Apache-2.0), files
+`EllipticCurves/WeierstrassFormalGroup/Foundations.lean` and
+`EllipticCurves/WeierstrassFormalGroup/Filtration.lean`, declarations `exists_aux_param`,
+`exists_aux_point`, `formalPoint_add_self` and `formalPoint_add`. The source works with its own
+multivariable formal-group points; here the argument is rebased onto
+`WeierstrassCurve.FormalGroupPoint` and the one-dimensional formal-group API already in Mathlib and
+Tau Ceti.
+-/
+
+public section
+
+open IsDedekindDomain WithZero
+
+namespace WeierstrassCurve
+
+variable {R : Type*} [CommRing R] [IsDedekindDomain R]
+  {K : Type*} [Field K] [Algebra R K] [IsFractionRing R K]
+  (v : HeightOneSpectrum R)
+
+local notation "O_v" => v.adicCompletionIntegers K
+local notation "K_v" => v.adicCompletion K
+local notation "m_v" => IsLocalRing.maximalIdeal O_v
+
+local instance : IsLinearTopology O_v O_v :=
+  v.isAdic_maximalIdeal_adicCompletionIntegers (K := K) ▸ Ideal.isLinearTopology m_v
+
+local instance : Fact (IsAdic m_v) :=
+  ⟨v.isAdic_maximalIdeal_adicCompletionIntegers (K := K)⟩
+
+variable (W : WeierstrassCurve (v.adicCompletionIntegers K))
+
+private theorem valued_coe_isUnit {a : O_v} (ha : IsUnit a) :
+    Valued.v (a : K_v) = 1 :=
+  (Valuation.integer.integers
+    (Valued.v : Valuation K_v (WithZero (Multiplicative ℤ)))).isUnit_iff_valuation_eq_one.mp ha
+
+private theorem valued_formalInverseEval {t : O_v} (ht : t ∈ m_v) :
+    Valued.v (W.formalInverseEval t : K_v) = Valued.v (t : K_v) := by
+  have hE : PowerSeries.HasEval t :=
+    (v.isAdic_maximalIdeal_adicCompletionIntegers (K := K)).isTopologicallyNilpotent_of_mem ht
+  rw [WeierstrassCurve.formalInverseEval_eq W hE]
+  push_cast
+  rw [Valuation.map_neg, map_mul, valued_coe_isUnit v
+      (WeierstrassCurve.isUnit_formalInverseDenomInvEval W hE), mul_one]
+
+private theorem valued_formalWEval {t : O_v} (ht : t ∈ m_v) :
+    Valued.v (W.formalWEval t : K_v) = Valued.v (t : K_v) ^ 3 := by
+  have hE : PowerSeries.HasEval t :=
+    (v.isAdic_maximalIdeal_adicCompletionIntegers (K := K)).isTopologicallyNilpotent_of_mem ht
+  rw [WeierstrassCurve.formalWEval_eq_pow_mul_formalUEval W hE]
+  push_cast
+  rw [map_mul, map_pow, valued_coe_isUnit v
+      (WeierstrassCurve.isUnit_formalUEval W
+        (v.isAdic_maximalIdeal_adicCompletionIntegers (K := K)) ht), mul_one]
+
+private theorem ne_of_valued_lt {a b : O_v}
+    (h : Valued.v (a : K_v) < Valued.v (b : K_v)) : a ≠ b :=
+  fun hab ↦ h.ne (by rw [hab])
+
+private theorem eq_two_of_formalInverseEval_self {t : O_v} (ht : t ∈ m_v) (ht0 : t ≠ 0)
+    (hfix : t = W.formalInverseEval t) :
+    2 = W.a₁ * t + W.a₃ * W.formalWEval t := by
+  have hE : PowerSeries.HasEval t :=
+    (v.isAdic_maximalIdeal_adicCompletionIntegers (K := K)).isTopologicallyNilpotent_of_mem ht
+  have h := WeierstrassCurve.formalInverseEval_mul_formalInverseDenomEval W hE
+  rw [← hfix, WeierstrassCurve.formalInverseDenomEval_eq W hE] at h
+  apply mul_left_cancel₀ ht0
+  linear_combination h
+
+private theorem ne_formalInverseEval_self {t : O_v} (ht : t ∈ m_v) (ht0 : t ≠ 0)
+    (h2 : Valued.v (t : K_v) < Valued.v ((2 : O_v) : K_v)) :
+    t ≠ W.formalInverseEval t := by
+  intro hfix
+  have hw_le : Valued.v (W.formalWEval t : K_v) ≤ Valued.v (t : K_v) := by
+    rw [valued_formalWEval v W ht]
+    calc
+      Valued.v (t : K_v) ^ 3 = Valued.v (t : K_v) * Valued.v (t : K_v) ^ 2 :=
+        pow_succ' _ 2
+      _ ≤ Valued.v (t : K_v) * 1 :=
+        mul_le_mul' le_rfl (pow_le_one' t.property 2)
+      _ = Valued.v (t : K_v) := mul_one _
+  have hcoe := congrArg (fun a : O_v ↦ (a : K_v))
+    (eq_two_of_formalInverseEval_self v W ht ht0 hfix)
+  push_cast at hcoe
+  have hval : Valued.v ((2 : O_v) : K_v) ≤ Valued.v (t : K_v) := by
+    rw [hcoe]
+    refine (Valued.v.map_add _ _).trans (max_le ?_ ?_)
+    · rw [map_mul]
+      exact (mul_le_mul' W.a₁.property le_rfl).trans_eq (one_mul _)
+    · rw [map_mul]
+      exact (mul_le_mul' W.a₃.property hw_le).trans_eq (one_mul _)
+  exact (not_le_of_gt h2) hval
+
+private theorem exists_aux_param [(W.baseChange K_v).IsElliptic] {t : O_v}
+    (ht : t ∈ m_v) (ht0 : t ≠ 0) :
+    ∃ s : O_v, s ∈ m_v ∧ s ≠ 0 ∧ s ≠ t ∧ s ≠ W.formalInverseEval t ∧
+      s ≠ W.formalInverseEval s := by
+  by_cases htwo : (2 : K_v) = 0
+  -- In characteristic two, ellipticity forces at least one of `a₁` and `a₃` to be nonzero.
+  -- A sufficiently small parameter then cannot satisfy the formal-inverse fixed-point equation.
+  · let _ : CharP K_v 2 :=
+      (CharP.charP_iff_prime_eq_zero Nat.prime_two).2 htwo
+    have htwo' : ((2 : O_v) : K_v) = 0 := by
+      calc
+        ((2 : O_v) : K_v) = algebraMap O_v K_v (2 : O_v) :=
+          (Algebra.algebraMap_ofSubsemiring_apply
+            (Valued.v : Valuation K_v (WithZero (Multiplicative ℤ))).valuationSubring _).symm
+        _ = (2 : K_v) := map_ofNat (algebraMap O_v K_v) 2
+        _ = 0 := htwo
+    have ha₁a₃ : (W.a₁ : K_v) ≠ 0 ∨ (W.a₃ : K_v) ≠ 0 := by
+      by_contra h
+      push Not at h
+      have hΔ : (W.baseChange K_v).Δ = 0 := by
+        rw [(W.baseChange K_v).Δ_of_char_two]
+        simp [h.1, h.2]
+      exact (W.baseChange K_v).isUnit_Δ.ne_zero hΔ
+    by_cases ha₁ : (W.a₁ : K_v) = 0
+    · have ha₃ := ha₁a₃.resolve_left (fun h ↦ h ha₁)
+      have ha₃O : W.a₃ ≠ 0 := fun h ↦ ha₃ (by simp [h])
+      obtain ⟨s, hsm, hs0, hst, _, _⟩ :=
+        v.exists_ne_zero_mem_maximalIdeal_valued_lt ht ht0 ha₃O
+      refine ⟨s, hsm, hs0, ne_of_valued_lt v hst,
+        ne_of_valued_lt v (valued_formalInverseEval v W ht ▸ hst), ?_⟩
+      intro hfix
+      have hcoe := congrArg (fun a : O_v ↦ (a : K_v))
+        (eq_two_of_formalInverseEval_self v W hsm hs0 hfix)
+      push_cast at hcoe
+      rw [htwo', ha₁, zero_mul, zero_add] at hcoe
+      have hw0 : (W.formalWEval s : K_v) ≠ 0 :=
+        W.algebraMap_formalWEval_ne_zero (Fact.out : IsAdic m_v) hsm
+          ((FaithfulSMul.algebraMap_injective O_v K_v).ne hs0)
+      exact (mul_ne_zero ha₃ hw0) hcoe.symm
+    · have ha₁O : W.a₁ ≠ 0 := fun h ↦ ha₁ (by simp [h])
+      obtain ⟨s, hsm, hs0, hst, hsa₁, hsone⟩ :=
+        v.exists_ne_zero_mem_maximalIdeal_valued_lt ht ht0 ha₁O
+      refine ⟨s, hsm, hs0, ne_of_valued_lt v hst,
+        ne_of_valued_lt v (valued_formalInverseEval v W ht ▸ hst), ?_⟩
+      intro hfix
+      have hcoe := congrArg (fun a : O_v ↦ (a : K_v))
+        (eq_two_of_formalInverseEval_self v W hsm hs0 hfix)
+      push_cast at hcoe
+      rw [htwo'] at hcoe
+      have hsval0 : Valued.v (s : K_v) ≠ 0 := by
+        exact (_root_.map_eq_zero (Valued.v :
+          Valuation K_v (WithZero (Multiplicative ℤ)))).not.mpr
+            (fun h ↦ hs0 (ZeroMemClass.coe_eq_zero.mp h))
+      have hsq : Valued.v (s : K_v) ^ 2 < Valued.v (W.a₁ : K_v) := by
+        calc
+          Valued.v (s : K_v) ^ 2 = Valued.v (s : K_v) * Valued.v (s : K_v) :=
+            pow_two _
+          _ < 1 * Valued.v (s : K_v) :=
+            mul_lt_mul_of_pos_right hsone (pos_iff_ne_zero.mpr hsval0)
+          _ = Valued.v (s : K_v) := one_mul _
+          _ < Valued.v (W.a₁ : K_v) := hsa₁
+      have hw_le : Valued.v (W.a₃ * W.formalWEval s : K_v) ≤
+          Valued.v (s : K_v) ^ 3 := by
+        rw [map_mul, valued_formalWEval v W hsm]
+        exact (mul_le_mul' W.a₃.property le_rfl).trans_eq (one_mul _)
+      have hval : Valued.v (W.a₃ * W.formalWEval s : K_v) <
+          Valued.v (W.a₁ * s : K_v) := hw_le.trans_lt (by
+        rw [map_mul, pow_succ]
+        exact mul_lt_mul_of_pos_right hsq (pos_iff_ne_zero.mpr hsval0))
+      have heq : (W.a₁ * s : K_v) = -(W.a₃ * W.formalWEval s : K_v) :=
+        eq_neg_of_add_eq_zero_left hcoe.symm
+      exact hval.ne (by rw [heq, Valuation.map_neg])
+  · have htwoO : (2 : O_v) ≠ 0 := fun h ↦ htwo (by
+      calc
+        (2 : K_v) = algebraMap O_v K_v (2 : O_v) :=
+          (map_ofNat (algebraMap O_v K_v) 2).symm
+        _ = ((2 : O_v) : K_v) := Algebra.algebraMap_ofSubsemiring_apply
+          (Valued.v : Valuation K_v (WithZero (Multiplicative ℤ))).valuationSubring _
+        _ = 0 := congrArg (fun a : O_v ↦ (a : K_v)) h)
+    obtain ⟨s, hsm, hs0, hst, hs2, _⟩ :=
+      v.exists_ne_zero_mem_maximalIdeal_valued_lt ht ht0 htwoO
+    refine ⟨s, hsm, hs0, ne_of_valued_lt v hst,
+      ne_of_valued_lt v (valued_formalInverseEval v W ht ▸ hst),
+      ne_formalInverseEval_self v W hsm hs0 hs2⟩
+
+private theorem exists_aux_point [(W.baseChange K_v).IsElliptic]
+    {P : FormalGroupPoint W m_v} (hP0 : P ≠ 0) :
+    ∃ U : FormalGroupPoint W m_v, U ≠ 0 ∧ U ≠ P ∧ U ≠ -P ∧ -U ≠ P ∧
+      -U ≠ -P ∧ U ≠ -U := by
+  have hPval0 : P.val ≠ 0 := fun h ↦ hP0 (FormalGroupPoint.ext (by simpa using h))
+  obtain ⟨u, hu, hu0, huP, huInvP, huInv⟩ := exists_aux_param v W P.property hPval0
+  let U : FormalGroupPoint W m_v := ⟨u, hu⟩
+  refine ⟨U, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  · exact fun h ↦ hu0 (congrArg FormalGroupPoint.val h)
+  · exact fun h ↦ huP (congrArg FormalGroupPoint.val h)
+  · exact fun h ↦ huInvP (by simpa [U] using congrArg FormalGroupPoint.val h)
+  · intro h
+    apply huInvP
+    simpa [U] using congrArg FormalGroupPoint.val (congrArg Neg.neg h)
+  · intro h
+    apply huP
+    simpa [U] using congrArg FormalGroupPoint.val (neg_injective h)
+  · exact fun h ↦ huInv (by simpa [U] using congrArg FormalGroupPoint.val h)
+
+section AdicCompletion
+
+variable {A : Type*} [CommRing A] [IsDedekindDomain A]
+  {F : Type*} [Field F] [Algebra A F] [IsFractionRing A F]
+  (u : HeightOneSpectrum A)
+
+variable (C : WeierstrassCurve (u.adicCompletionIntegers F))
+  [(C.baseChange (u.adicCompletion F)).IsElliptic]
+
+private theorem exists_aux_point_simple
+    {P : FormalGroupPoint C (IsLocalRing.maximalIdeal (u.adicCompletionIntegers F))}
+    (hPneg : P ≠ -P) :
+    ∃ U : FormalGroupPoint C (IsLocalRing.maximalIdeal (u.adicCompletionIntegers F)),
+      U ≠ P ∧ U ≠ -P ∧ U ≠ -U := by
+  have hP0 : P ≠ 0 := by
+    rintro rfl
+    exact hPneg (by simp)
+  obtain ⟨U, _, hUP, hUnP, _, _, hUnegn⟩ := exists_aux_point u C hP0
+  exact ⟨U, hUP, hUnP, hUnegn⟩
+
+open Classical in
+/-- **The formal parametrisation preserves addition in an adic completion.** -/
+@[simp]
+theorem formalPoint_add_adicCompletion
+    (P Q : FormalGroupPoint C (IsLocalRing.maximalIdeal (u.adicCompletionIntegers F))) :
+    C.formalPoint (K := u.adicCompletion F)
+        (u.isAdic_maximalIdeal_adicCompletionIntegers (K := F))
+        (P + Q).property =
+      C.formalPoint (K := u.adicCompletion F)
+          (u.isAdic_maximalIdeal_adicCompletionIntegers (K := F))
+          P.property +
+        C.formalPoint (K := u.adicCompletion F)
+          (u.isAdic_maximalIdeal_adicCompletionIntegers (K := F))
+          Q.property :=
+  formalPoint_add (IsLocalRing.maximalIdeal (u.adicCompletionIntegers F)) C
+    (fun P hP ↦ exists_aux_point_simple u C (P := P) hP) P Q
+
+open Classical in
+/-- **The formal parameter map for an adic completion**, as an additive homomorphism. -/
+noncomputable def formalPointHomAdicCompletion :
+    FormalGroupPoint C (IsLocalRing.maximalIdeal (u.adicCompletionIntegers F)) →+
+      (C.baseChange (u.adicCompletion F)).toAffine.Point :=
+  C.formalPointHom (IsLocalRing.maximalIdeal (u.adicCompletionIntegers F))
+    (fun P hP ↦ exists_aux_point_simple u C (P := P) hP)
+
+open Classical in
+/-- The adic-completion formal point homomorphism evaluates to the usual parametrisation. -/
+@[simp]
+theorem formalPointHomAdicCompletion_apply
+    (P : FormalGroupPoint C (IsLocalRing.maximalIdeal (u.adicCompletionIntegers F))) :
+    C.formalPointHomAdicCompletion u P =
+      C.formalPoint (K := u.adicCompletion F)
+        (u.isAdic_maximalIdeal_adicCompletionIntegers (K := F)) P.property :=
+  formalPointHom_apply (IsLocalRing.maximalIdeal (u.adicCompletionIntegers F)) C
+    (fun P hP ↦ exists_aux_point_simple u C (P := P) hP) P
+
+open Classical in
+/-- **The adic-completion formal point homomorphism is injective.** -/
+theorem formalPointHomAdicCompletion_injective :
+    Function.Injective (C.formalPointHomAdicCompletion u) :=
+  formalPointHom_injective (IsLocalRing.maximalIdeal (u.adicCompletionIntegers F)) C
+    (fun P hP ↦ exists_aux_point_simple u C (P := P) hP)
+
+end AdicCompletion
+
+end WeierstrassCurve
+
+end

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Point/AdicCompletion.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Point/AdicCompletion.lean
@@ -155,7 +155,7 @@ private theorem exists_aux_param [(W.baseChange K_v).IsElliptic] {t : O_v}
     · have ha₃ := ha₁a₃.resolve_left (fun h ↦ h ha₁)
       have ha₃O : W.a₃ ≠ 0 := fun h ↦ ha₃ (by simp [h])
       obtain ⟨s, hsm, hs0, hst, _, _⟩ :=
-        v.exists_ne_zero_mem_maximalIdeal_valued_lt ht ht0 ha₃O
+        v.exists_ne_zero_mem_maximalIdeal_valued_lt ht0 ha₃O
       refine ⟨s, hsm, hs0, ne_of_valued_lt v hst,
         ne_of_valued_lt v (valued_formalInverseEval v W ht ▸ hst), ?_⟩
       intro hfix
@@ -169,7 +169,7 @@ private theorem exists_aux_param [(W.baseChange K_v).IsElliptic] {t : O_v}
       exact (mul_ne_zero ha₃ hw0) hcoe.symm
     · have ha₁O : W.a₁ ≠ 0 := fun h ↦ ha₁ (by simp [h])
       obtain ⟨s, hsm, hs0, hst, hsa₁, hsone⟩ :=
-        v.exists_ne_zero_mem_maximalIdeal_valued_lt ht ht0 ha₁O
+        v.exists_ne_zero_mem_maximalIdeal_valued_lt ht0 ha₁O
       refine ⟨s, hsm, hs0, ne_of_valued_lt v hst,
         ne_of_valued_lt v (valued_formalInverseEval v W ht ▸ hst), ?_⟩
       intro hfix
@@ -208,7 +208,7 @@ private theorem exists_aux_param [(W.baseChange K_v).IsElliptic] {t : O_v}
           (Valued.v : Valuation K_v (WithZero (Multiplicative ℤ))).valuationSubring _
         _ = 0 := congrArg (fun a : O_v ↦ (a : K_v)) h)
     obtain ⟨s, hsm, hs0, hst, hs2, _⟩ :=
-      v.exists_ne_zero_mem_maximalIdeal_valued_lt ht ht0 htwoO
+      v.exists_ne_zero_mem_maximalIdeal_valued_lt ht0 htwoO
     refine ⟨s, hsm, hs0, ne_of_valued_lt v hst,
       ne_of_valued_lt v (valued_formalInverseEval v W ht ▸ hst),
       ne_formalInverseEval_self v W hsm hs0 hs2⟩

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Point/Hom.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Point/Hom.lean
@@ -12,24 +12,30 @@ public import TauCeti.RingTheory.DedekindDomain.AdicValuation.Completion
 /-!
 # The formal parameter map is additive
 
-For a height-one prime `v` of a Dedekind domain, the maximal ideal of the ring of integers
-`O_v` of the completion is an adic ideal.  The Weierstrass formal group law therefore makes its
-elements into `WeierstrassCurve.FormalGroupPoint W m_v`.  The usual parametrisation sends zero to
-the point at infinity and, for a nonzero parameter, is given by
+For an adic ideal `I` of a complete ring `O` mapping injectively to a field `K`, the Weierstrass
+formal group law makes its elements into `WeierstrassCurve.FormalGroupPoint W I`.  The usual
+parametrisation sends zero to the point at infinity and, for a nonzero parameter, is given by
 
 `t ↦ (t / w(t), -1 / w(t))`
 
 This file proves that this map is an additive homomorphism into the points of the base-changed
-curve, in every characteristic.
+curve whenever every nonzero parameter admits an auxiliary parameter distinct from it, its
+inverse, and its own inverse.  It then establishes that property for the maximal ideal in the
+completion at a height-one prime of a Dedekind domain, in every characteristic.
 
 ## Main definitions
 
-* `WeierstrassCurve.formalPointHom`: the additive homomorphism from formal-group parameters in the
-  maximal ideal of `O_v` to points of the curve over the completion.
+* `WeierstrassCurve.formalPointHom`: the additive homomorphism from formal-group parameters in an
+  adic ideal to points of the curve over a field.
+* `WeierstrassCurve.formalPointHomAdicCompletion`: its specialization to the maximal ideal in an
+  adic completion.
 
 ## Main results
 
-* `WeierstrassCurve.formalPoint_add`: the parametrisation preserves addition.
+* `WeierstrassCurve.formalPoint_add`: the parametrisation preserves addition when auxiliary
+  parameters exist.
+* `WeierstrassCurve.formalPoint_add_adicCompletion`: the unconditional adic-completion
+  specialization.
 * `WeierstrassCurve.formalPointHom_injective`: the resulting homomorphism is injective.
 
 ## References
@@ -143,18 +149,10 @@ private theorem exists_small_param {a b : O_v} (ha : a ∈ m_v) (ha0 : a ≠ 0) 
   have haval0 : Valued.v (a : K_v) ≠ 0 := by
     simp only [ne_eq, _root_.map_eq_zero, ZeroMemClass.coe_eq_zero]
     exact ha0
-  obtain ⟨i, hi⟩ : ∃ i : ℤ, Valued.v (a : K_v) = exp i :=
-    ⟨_, (exp_log haval0).symm⟩
-  have hi_le : i ≤ -1 := by
-    have h := v.mem_maximalIdeal_pow_iff (K := K) (n := 1) |>.mp (pow_one m_v ▸ ha)
-    rwa [hi, exp_le_exp] at h
   have hbval0 : Valued.v (b : K_v) ≠ 0 := by
     simp only [ne_eq, _root_.map_eq_zero, ZeroMemClass.coe_eq_zero]
     exact hb0
-  obtain ⟨j, hj⟩ : ∃ j : ℤ, Valued.v (b : K_v) = exp j :=
-    ⟨_, (exp_log hbval0).symm⟩
-  obtain ⟨n, hn⟩ : ∃ n : ℕ, (n : ℤ) = max (-i) (-j) + 1 :=
-    ⟨(max (-i) (-j) + 1).toNat, Int.toNat_of_nonneg (by omega)⟩
+  obtain ⟨n, hna, hnb⟩ := exists_exp_neg_natCast_lt_and_lt haval0 hbval0
   let s : O_v := π ^ n
   have hsv : Valued.v (s : K_v) = exp (-(n : ℤ)) := by
     simp only [s]
@@ -162,23 +160,22 @@ private theorem exists_small_param {a b : O_v} (ha : a ∈ m_v) (ha0 : a ≠ 0) 
     rw [map_pow, hπv, ← exp_nsmul, nsmul_eq_mul]
     congr 1
     ring
-  have hni : -(n : ℤ) < i := by omega
-  have hnj : -(n : ℤ) < j := by omega
+  have ha_le : Valued.v (a : K_v) ≤ exp (-1) := by
+    apply (v.mem_maximalIdeal_pow_iff (K := K) (x := a) (n := 1)).mp
+    simpa using ha
   have hsm : s ∈ m_v := by
     have h := v.mem_maximalIdeal_pow_iff (K := K) (x := s) (n := 1)
     rw [pow_one] at h
     apply h.mpr
-    rw [hsv, exp_le_exp]
-    omega
+    rw [hsv]
+    exact (hna.trans_le ha_le).le
   have hs0 : s ≠ 0 := by
     exact pow_ne_zero _ hπ.ne_zero
   refine ⟨s, hsm, hs0, ?_, ?_, ?_⟩
-  · rw [hsv, hi, exp_lt_exp]
-    exact hni
-  · rw [hsv, hj, exp_lt_exp]
-    exact hnj
+  · rwa [hsv]
+  · rwa [hsv]
   · rw [hsv, ← exp_zero, exp_lt_exp]
-    omega
+    exact (exp_lt_exp.mp (hna.trans_le ha_le)).trans_le (by omega)
 
 private theorem exists_aux_param [(W.baseChange K_v).IsElliptic] {t : O_v}
     (ht : t ∈ m_v) (ht0 : t ≠ 0) :
@@ -284,111 +281,186 @@ private theorem exists_aux_point [(W.baseChange K_v).IsElliptic]
 
 section PointMap
 
-variable [(W.baseChange (v.adicCompletion K)).IsElliptic]
+variable {O : Type*} [CommRing O] [UniformSpace O] [IsUniformAddGroup O] [CompleteSpace O]
+  [T2Space O] [IsTopologicalRing O] [IsLinearTopology O O]
+  {S : Type*} [Field S] [Algebra O S] [FaithfulSMul O S]
+  (I : Ideal O) [Fact (IsAdic I)] (E : WeierstrassCurve O) [(E.baseChange S).IsElliptic]
 
-private noncomputable def formalPointMap (P : FormalGroupPoint W m_v) :
-    (W.baseChange K_v).toAffine.Point :=
-  W.formalPoint (K := K_v) (v.isAdic_maximalIdeal_adicCompletionIntegers (K := K)) P.property
+private noncomputable def formalPointMap (P : FormalGroupPoint E I) :
+    (E.baseChange S).toAffine.Point :=
+  E.formalPoint (K := S) (Fact.out : IsAdic I) P.property
 
-private theorem formalPointMap_injective : Function.Injective (formalPointMap v W) := by
+private theorem formalPointMap_injective :
+    Function.Injective (formalPointMap (S := S) I E) := by
   intro P Q hPQ
-  have hPQ' : W.formalPoint (K := K_v)
-      (v.isAdic_maximalIdeal_adicCompletionIntegers (K := K)) P.property =
-        W.formalPoint (K := K_v)
-          (v.isAdic_maximalIdeal_adicCompletionIntegers (K := K)) Q.property := by
+  have hPQ' : E.formalPoint (K := S) (Fact.out : IsAdic I) P.property =
+      E.formalPoint (K := S) (Fact.out : IsAdic I) Q.property := by
     simpa only [formalPointMap] using hPQ
-  have hinj := W.formalPoint_injective (K := K_v)
-    (v.isAdic_maximalIdeal_adicCompletionIntegers (K := K))
-  have heq := hinj (a₁ := (⟨P.val, P.property⟩ : m_v))
-    (a₂ := (⟨Q.val, Q.property⟩ : m_v)) hPQ'
+  have hinj := E.formalPoint_injective (K := S) (Fact.out : IsAdic I)
+  have heq := hinj (a₁ := (⟨P.val, P.property⟩ : I))
+    (a₂ := (⟨Q.val, Q.property⟩ : I)) hPQ'
   exact FormalGroupPoint.ext (congrArg Subtype.val heq)
 
-private theorem formalPointMap_neg (P : FormalGroupPoint W m_v) :
-    formalPointMap v W (-P) = -formalPointMap v W P := by
-  let hI := v.isAdic_maximalIdeal_adicCompletionIntegers (K := K)
+private theorem formalPointMap_neg (P : FormalGroupPoint E I) :
+    formalPointMap (S := S) I E (-P) = -formalPointMap (S := S) I E P := by
   simp only [formalPointMap, FormalGroupPoint.coe_neg]
-  exact W.formalPoint_formalInverseEval hI P.property
+  exact E.formalPoint_formalInverseEval (Fact.out : IsAdic I) P.property
 
 open Classical in
-private theorem formalPointMap_add_of_ne (P Q : FormalGroupPoint W m_v)
+private theorem formalPointMap_add_of_ne (P Q : FormalGroupPoint E I)
     (hne : Q ≠ P) (hnneg : Q ≠ -P) :
-    formalPointMap v W (P + Q) = formalPointMap v W P + formalPointMap v W Q := by
-  exact (W.add_eq_formalPoint_formalAddEval_of_ne_of_ne_formalInverseEval
-    (K := K_v) (Fact.out : IsAdic m_v) P.property Q.property
+    formalPointMap (S := S) I E (P + Q) =
+      formalPointMap (S := S) I E P + formalPointMap (S := S) I E Q := by
+  exact (E.add_eq_formalPoint_formalAddEval_of_ne_of_ne_formalInverseEval
+    (K := S) (Fact.out : IsAdic I) P.property Q.property
     (fun _ _ h ↦ hne (FormalGroupPoint.ext h))
     (fun _ _ h ↦ hnneg (FormalGroupPoint.ext (by simpa using h)))).symm
 
 open Classical in
-private theorem formalPointMap_add_self (P : FormalGroupPoint W m_v) (hP0 : P ≠ 0)
-    (hself : P ≠ -P) :
-    formalPointMap v W (P + P) = formalPointMap v W P + formalPointMap v W P := by
-  obtain ⟨U, _, hUP, hUnP, hnUP, hnUnP, hUnegn⟩ := exists_aux_point v W hP0
-  have c1 := formalPointMap_add_of_ne v W P U hUP hUnP
-  have c2 := formalPointMap_add_of_ne v W P (-U) hnUP hnUnP
+private theorem formalPointMap_add_self (P : FormalGroupPoint E I) (hself : P ≠ -P)
+    (haux : ∃ U : FormalGroupPoint E I, U ≠ P ∧ U ≠ -P ∧ U ≠ -U) :
+    formalPointMap (S := S) I E (P + P) =
+      formalPointMap (S := S) I E P + formalPointMap (S := S) I E P := by
+  obtain ⟨U, hUP, hUnP, hUnegn⟩ := haux
+  have hnUP : -U ≠ P := fun h ↦ hUnP (by simpa using congrArg Neg.neg h)
+  have hnUnP : -U ≠ -P := fun h ↦ hUP (neg_injective h)
+  have c1 := formalPointMap_add_of_ne (S := S) I E P U hUP hUnP
+  have c2 := formalPointMap_add_of_ne (S := S) I E P (-U) hnUP hnUnP
   have hne : P + -U ≠ P + U := by
     intro h
-    have h' := congrArg (formalPointMap v W) h
+    have h' := congrArg (formalPointMap (S := S) I E) h
     rw [c1, c2] at h'
-    exact hUnegn (formalPointMap_injective v W (add_left_cancel h').symm)
+    exact hUnegn (formalPointMap_injective (S := S) I E (add_left_cancel h').symm)
   have hnneg : P + -U ≠ -(P + U) := by
     intro h
-    have h' := congrArg (formalPointMap v W) h
-    rw [c2, formalPointMap_neg v W, formalPointMap_neg v W, c1, neg_add] at h'
+    have h' := congrArg (formalPointMap (S := S) I E) h
+    rw [c2, formalPointMap_neg (S := S) I E, formalPointMap_neg (S := S) I E,
+      c1, neg_add] at h'
     have h'' := add_right_cancel h'
-    rw [← formalPointMap_neg v W] at h''
-    exact hself (formalPointMap_injective v W h'')
-  have c3 := formalPointMap_add_of_ne v W (P + U) (P + -U) hne hnneg
+    rw [← formalPointMap_neg (S := S) I E] at h''
+    exact hself (formalPointMap_injective (S := S) I E h'')
+  have c3 := formalPointMap_add_of_ne (S := S) I E (P + U) (P + -U) hne hnneg
   have hkey : (P + U) + (P + -U) = P + P := by abel
-  rw [← hkey, c3, c1, c2, formalPointMap_neg v W]
+  rw [← hkey, c3, c1, c2, formalPointMap_neg (S := S) I E]
   abel
 
 open Classical in
-/-- **The formal parametrisation preserves addition.** -/
-@[simp]
-theorem formalPoint_add (P Q : FormalGroupPoint W m_v) :
-    W.formalPoint (K := K_v) (v.isAdic_maximalIdeal_adicCompletionIntegers (K := K))
-        (P + Q).property =
-      W.formalPoint (K := K_v) (v.isAdic_maximalIdeal_adicCompletionIntegers (K := K))
-          P.property +
-        W.formalPoint (K := K_v) (v.isAdic_maximalIdeal_adicCompletionIntegers (K := K))
-          Q.property := by
-  suffices h : formalPointMap v W (P + Q) =
-      formalPointMap v W P + formalPointMap v W Q by
+/-- **The formal parametrisation preserves addition** whenever every nonzero parameter has an
+auxiliary parameter distinct from it, its inverse, and the auxiliary parameter's own inverse. -/
+theorem formalPoint_add
+    (haux : ∀ P : FormalGroupPoint E I, P ≠ 0 →
+      ∃ U : FormalGroupPoint E I, U ≠ P ∧ U ≠ -P ∧ U ≠ -U)
+    (P Q : FormalGroupPoint E I) :
+    E.formalPoint (K := S) (Fact.out : IsAdic I) (P + Q).property =
+      E.formalPoint (K := S) (Fact.out : IsAdic I) P.property +
+        E.formalPoint (K := S) (Fact.out : IsAdic I) Q.property := by
+  suffices h : formalPointMap (S := S) I E (P + Q) =
+      formalPointMap (S := S) I E P + formalPointMap (S := S) I E Q by
     simpa only [formalPointMap] using h
   rcases eq_or_ne P 0 with rfl | hP0
   · simp [formalPointMap]
   rcases eq_or_ne Q 0 with rfl | hQ0
   · simp [formalPointMap]
   rcases eq_or_ne Q (-P) with rfl | hQneg
-  · rw [add_neg_cancel, formalPointMap_neg v W]
+  · rw [add_neg_cancel, formalPointMap_neg (S := S) I E]
     simp [formalPointMap]
   rcases eq_or_ne Q P with hQP | hQP
   · subst Q
-    exact formalPointMap_add_self v W P hP0 hQneg
-  · exact formalPointMap_add_of_ne v W P Q hQP hQneg
+    exact formalPointMap_add_self (S := S) I E P hQneg (haux P hP0)
+  · exact formalPointMap_add_of_ne (S := S) I E P Q hQP hQneg
 
 open Classical in
-/-- **The formal parameter map into the curve's points**, as an additive homomorphism. -/
-noncomputable def formalPointHom :
-    FormalGroupPoint W m_v →+ (W.baseChange K_v).toAffine.Point where
-  toFun := formalPointMap v W
+/-- **The formal parameter map into the curve's points**, as an additive homomorphism whenever
+the required auxiliary parameters exist. -/
+noncomputable def formalPointHom
+    (haux : ∀ P : FormalGroupPoint E I, P ≠ 0 →
+      ∃ U : FormalGroupPoint E I, U ≠ P ∧ U ≠ -P ∧ U ≠ -U) :
+    FormalGroupPoint E I →+ (E.baseChange S).toAffine.Point where
+  toFun := formalPointMap (S := S) I E
   map_zero' := by simp [formalPointMap]
-  map_add' := formalPoint_add v W
+  map_add' := formalPoint_add I E haux
 
 open Classical in
 /-- The formal point homomorphism evaluates to the usual formal parametrisation. -/
 @[simp]
-theorem formalPointHom_apply (P : FormalGroupPoint W m_v) :
-    W.formalPointHom v P =
-      W.formalPoint (K := K_v) (v.isAdic_maximalIdeal_adicCompletionIntegers (K := K)) P.property :=
+theorem formalPointHom_apply
+    (haux : ∀ P : FormalGroupPoint E I, P ≠ 0 →
+      ∃ U : FormalGroupPoint E I, U ≠ P ∧ U ≠ -P ∧ U ≠ -U)
+    (P : FormalGroupPoint E I) :
+    E.formalPointHom I haux P =
+      E.formalPoint (K := S) (Fact.out : IsAdic I) P.property :=
   (rfl)
 
 open Classical in
 /-- **The formal point homomorphism is injective.** -/
-theorem formalPointHom_injective : Function.Injective (W.formalPointHom v) :=
-  formalPointMap_injective v W
+theorem formalPointHom_injective
+    (haux : ∀ P : FormalGroupPoint E I, P ≠ 0 →
+      ∃ U : FormalGroupPoint E I, U ≠ P ∧ U ≠ -P ∧ U ≠ -U) :
+    Function.Injective (E.formalPointHom (S := S) I haux) :=
+  formalPointMap_injective (S := S) I E
 
 end PointMap
+
+section AdicCompletion
+
+variable {A : Type*} [CommRing A] [IsDedekindDomain A]
+  {F : Type*} [Field F] [Algebra A F] [IsFractionRing A F]
+  (u : HeightOneSpectrum A)
+
+variable (C : WeierstrassCurve (u.adicCompletionIntegers F))
+  [(C.baseChange (u.adicCompletion F)).IsElliptic]
+
+private theorem exists_aux_point_simple
+    {P : FormalGroupPoint C (IsLocalRing.maximalIdeal (u.adicCompletionIntegers F))}
+    (hP0 : P ≠ 0) :
+    ∃ U : FormalGroupPoint C (IsLocalRing.maximalIdeal (u.adicCompletionIntegers F)),
+      U ≠ P ∧ U ≠ -P ∧ U ≠ -U := by
+  obtain ⟨U, _, hUP, hUnP, _, _, hUnegn⟩ := exists_aux_point u C hP0
+  exact ⟨U, hUP, hUnP, hUnegn⟩
+
+open Classical in
+/-- **The formal parametrisation preserves addition in an adic completion.** -/
+@[simp]
+theorem formalPoint_add_adicCompletion
+    (P Q : FormalGroupPoint C (IsLocalRing.maximalIdeal (u.adicCompletionIntegers F))) :
+    C.formalPoint (K := u.adicCompletion F)
+        (u.isAdic_maximalIdeal_adicCompletionIntegers (K := F))
+        (P + Q).property =
+      C.formalPoint (K := u.adicCompletion F)
+          (u.isAdic_maximalIdeal_adicCompletionIntegers (K := F))
+          P.property +
+        C.formalPoint (K := u.adicCompletion F)
+          (u.isAdic_maximalIdeal_adicCompletionIntegers (K := F))
+          Q.property :=
+  formalPoint_add (IsLocalRing.maximalIdeal (u.adicCompletionIntegers F)) C
+    (fun P hP ↦ exists_aux_point_simple u C (P := P) hP) P Q
+
+open Classical in
+/-- **The formal parameter map for an adic completion**, as an additive homomorphism. -/
+noncomputable def formalPointHomAdicCompletion :
+    FormalGroupPoint C (IsLocalRing.maximalIdeal (u.adicCompletionIntegers F)) →+
+      (C.baseChange (u.adicCompletion F)).toAffine.Point :=
+  C.formalPointHom (IsLocalRing.maximalIdeal (u.adicCompletionIntegers F))
+    (fun P hP ↦ exists_aux_point_simple u C (P := P) hP)
+
+open Classical in
+/-- The adic-completion formal point homomorphism evaluates to the usual parametrisation. -/
+@[simp]
+theorem formalPointHomAdicCompletion_apply
+    (P : FormalGroupPoint C (IsLocalRing.maximalIdeal (u.adicCompletionIntegers F))) :
+    C.formalPointHomAdicCompletion u P =
+      C.formalPoint (K := u.adicCompletion F)
+        (u.isAdic_maximalIdeal_adicCompletionIntegers (K := F)) P.property :=
+  (rfl)
+
+open Classical in
+/-- **The adic-completion formal point homomorphism is injective.** -/
+theorem formalPointHomAdicCompletion_injective :
+    Function.Injective (C.formalPointHomAdicCompletion u) :=
+  formalPointHom_injective (IsLocalRing.maximalIdeal (u.adicCompletionIntegers F)) C
+    (fun P hP ↦ exists_aux_point_simple u C (P := P) hP)
+
+end AdicCompletion
 
 end WeierstrassCurve
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Point/Hom.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Point/Hom.lean
@@ -14,12 +14,13 @@ public import TauCeti.RingTheory.DedekindDomain.AdicValuation.Completion
 
 For a height-one prime `v` of a Dedekind domain, the maximal ideal of the ring of integers
 `O_v` of the completion is an adic ideal.  The Weierstrass formal group law therefore makes its
-elements into `WeierstrassCurve.FormalGroupPoint W m_v`.  This file proves that the usual
-parametrisation
+elements into `WeierstrassCurve.FormalGroupPoint W m_v`.  The usual parametrisation sends zero to
+the point at infinity and, for a nonzero parameter, is given by
 
 `t ↦ (t / w(t), -1 / w(t))`
 
-is an additive homomorphism into the points of the base-changed curve.
+This file proves that this map is an additive homomorphism into the points of the base-changed
+curve.
 
 The chord case is `WeierstrassCurve.add_eq_formalPoint_formalAddEval_of_ne_of_ne_formalInverseEval`.
 The inverse case follows from the already established compatibility with negation.  For doubling,
@@ -149,7 +150,8 @@ private theorem exists_aux_param [NeZero (2 : v.adicCompletion K)] {t : O_v}
   have htwo : ((2 : O_v) : K_v) ≠ 0 := NeZero.ne (2 : K_v)
   obtain ⟨π, hπ⟩ := IsDiscreteValuationRing.exists_irreducible O_v
   have hπv : Valued.v (π : K_v) = exp (-1) := by
-    change Valued.v (algebraMap O_v K_v π) = exp (-1)
+    rw [← Algebra.algebraMap_ofSubsemiring_apply
+      (Valued.v : Valuation K_v (WithZero (Multiplicative ℤ))).valuationSubring π]
     exact v.valued_algebraMap_eq_exp_neg_one_of_irreducible hπ
   have htval0 : Valued.v (t : K_v) ≠ 0 := by
     simp only [ne_eq, _root_.map_eq_zero, ZeroMemClass.coe_eq_zero]
@@ -221,14 +223,15 @@ private noncomputable def formalPointMap (P : FormalGroupPoint W m_v) :
 
 private theorem formalPointMap_injective : Function.Injective (formalPointMap v W) := by
   intro P Q hPQ
-  change W.formalPoint (K := K_v)
-    (v.isAdic_maximalIdeal_adicCompletionIntegers (K := K)) P.property =
-      W.formalPoint (K := K_v)
-        (v.isAdic_maximalIdeal_adicCompletionIntegers (K := K)) Q.property at hPQ
+  have hPQ' : W.formalPoint (K := K_v)
+      (v.isAdic_maximalIdeal_adicCompletionIntegers (K := K)) P.property =
+        W.formalPoint (K := K_v)
+          (v.isAdic_maximalIdeal_adicCompletionIntegers (K := K)) Q.property := by
+    simpa only [formalPointMap] using hPQ
   have hinj := W.formalPoint_injective (K := K_v)
     (v.isAdic_maximalIdeal_adicCompletionIntegers (K := K))
   have heq := hinj (a₁ := (⟨P.val, P.property⟩ : m_v))
-    (a₂ := (⟨Q.val, Q.property⟩ : m_v)) hPQ
+    (a₂ := (⟨Q.val, Q.property⟩ : m_v)) hPQ'
   exact FormalGroupPoint.ext (congrArg Subtype.val heq)
 
 private theorem formalPointMap_neg (P : FormalGroupPoint W m_v) :
@@ -282,7 +285,9 @@ theorem formalPoint_add (P Q : FormalGroupPoint W m_v) :
           P.property +
         W.formalPoint (K := K_v) (v.isAdic_maximalIdeal_adicCompletionIntegers (K := K))
           Q.property := by
-  change formalPointMap v W (P + Q) = formalPointMap v W P + formalPointMap v W Q
+  suffices h : formalPointMap v W (P + Q) =
+      formalPointMap v W P + formalPointMap v W Q by
+    simpa only [formalPointMap] using h
   rcases eq_or_ne P 0 with rfl | hP0
   · simp [formalPointMap]
   rcases eq_or_ne Q 0 with rfl | hQ0

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Point/Hom.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Point/Hom.lean
@@ -19,9 +19,9 @@ parametrisation sends zero to the point at infinity and, for a nonzero parameter
 `t ↦ (t / w(t), -1 / w(t))`
 
 This file proves that this map is an additive homomorphism into the points of the base-changed
-curve whenever every nonzero parameter admits an auxiliary parameter distinct from it, its
-inverse, and its own inverse.  It then establishes that property for the maximal ideal in the
-completion at a height-one prime of a Dedekind domain, in every characteristic.
+curve whenever every parameter distinct from its inverse admits an auxiliary parameter distinct
+from it, its inverse, and its own inverse.  It then establishes that property for the maximal ideal
+in the completion at a height-one prime of a Dedekind domain, in every characteristic.
 
 ## Main definitions
 
@@ -345,10 +345,11 @@ private theorem formalPointMap_add_self (P : FormalGroupPoint E I) (hself : P �
   abel
 
 open Classical in
-/-- **The formal parametrisation preserves addition** whenever every nonzero parameter has an
-auxiliary parameter distinct from it, its inverse, and the auxiliary parameter's own inverse. -/
+/-- **The formal parametrisation preserves addition** whenever every parameter distinct from its
+inverse has an auxiliary parameter distinct from it, its inverse, and the auxiliary parameter's
+own inverse. -/
 theorem formalPoint_add
-    (haux : ∀ P : FormalGroupPoint E I, P ≠ 0 →
+    (haux : ∀ P : FormalGroupPoint E I, P ≠ -P →
       ∃ U : FormalGroupPoint E I, U ≠ P ∧ U ≠ -P ∧ U ≠ -U)
     (P Q : FormalGroupPoint E I) :
     E.formalPoint (K := S) (Fact.out : IsAdic I) (P + Q).property =
@@ -366,14 +367,14 @@ theorem formalPoint_add
     simp [formalPointMap]
   rcases eq_or_ne Q P with hQP | hQP
   · subst Q
-    exact formalPointMap_add_self (S := S) I E P hQneg (haux P hP0)
+    exact formalPointMap_add_self (S := S) I E P hQneg (haux P hQneg)
   · exact formalPointMap_add_of_ne (S := S) I E P Q hQP hQneg
 
 open Classical in
 /-- **The formal parameter map into the curve's points**, as an additive homomorphism whenever
 the required auxiliary parameters exist. -/
 noncomputable def formalPointHom
-    (haux : ∀ P : FormalGroupPoint E I, P ≠ 0 →
+    (haux : ∀ P : FormalGroupPoint E I, P ≠ -P →
       ∃ U : FormalGroupPoint E I, U ≠ P ∧ U ≠ -P ∧ U ≠ -U) :
     FormalGroupPoint E I →+ (E.baseChange S).toAffine.Point where
   toFun := formalPointMap (S := S) I E
@@ -384,7 +385,7 @@ open Classical in
 /-- The formal point homomorphism evaluates to the usual formal parametrisation. -/
 @[simp]
 theorem formalPointHom_apply
-    (haux : ∀ P : FormalGroupPoint E I, P ≠ 0 →
+    (haux : ∀ P : FormalGroupPoint E I, P ≠ -P →
       ∃ U : FormalGroupPoint E I, U ≠ P ∧ U ≠ -P ∧ U ≠ -U)
     (P : FormalGroupPoint E I) :
     E.formalPointHom I haux P =
@@ -394,7 +395,7 @@ theorem formalPointHom_apply
 open Classical in
 /-- **The formal point homomorphism is injective.** -/
 theorem formalPointHom_injective
-    (haux : ∀ P : FormalGroupPoint E I, P ≠ 0 →
+    (haux : ∀ P : FormalGroupPoint E I, P ≠ -P →
       ∃ U : FormalGroupPoint E I, U ≠ P ∧ U ≠ -P ∧ U ≠ -U) :
     Function.Injective (E.formalPointHom (S := S) I haux) :=
   formalPointMap_injective (S := S) I E
@@ -412,9 +413,12 @@ variable (C : WeierstrassCurve (u.adicCompletionIntegers F))
 
 private theorem exists_aux_point_simple
     {P : FormalGroupPoint C (IsLocalRing.maximalIdeal (u.adicCompletionIntegers F))}
-    (hP0 : P ≠ 0) :
+    (hPneg : P ≠ -P) :
     ∃ U : FormalGroupPoint C (IsLocalRing.maximalIdeal (u.adicCompletionIntegers F)),
       U ≠ P ∧ U ≠ -P ∧ U ≠ -U := by
+  have hP0 : P ≠ 0 := by
+    rintro rfl
+    exact hPneg (by simp)
   obtain ⟨U, _, hUP, hUnP, _, _, hUnegn⟩ := exists_aux_point u C hP0
   exact ⟨U, hUP, hUnP, hUnegn⟩
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Point/Hom.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Point/Hom.lean
@@ -19,16 +19,8 @@ the point at infinity and, for a nonzero parameter, is given by
 
 `t ↦ (t / w(t), -1 / w(t))`
 
-This file proves that this map is an additive homomorphism into the points of the base-changed
-curve.
-
-The chord case is `WeierstrassCurve.add_eq_formalPoint_formalAddEval_of_ne_of_ne_formalInverseEval`.
-The inverse case follows from the already established compatibility with negation.  For doubling,
-one chooses a sufficiently high power of a uniformizer, so its valuation avoids the original
-parameter, both formal inverses, and its own formal inverse.  Three chord additions and cancellation
-then give the tangent case without a second coordinate computation.  The hypothesis `2 ≠ 0` in
-the completed field is used only to ensure that the auxiliary parameter can be chosen with
-valuation strictly below that of `2`.
+When `2 ≠ 0` in the completed field, this file proves that this map is an additive homomorphism
+into the points of the base-changed curve.
 
 ## Main definitions
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Point/Hom.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Point/Hom.lean
@@ -7,7 +7,6 @@ module
 
 public import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.AdicPoint
 public import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.Point.Add
-public import TauCeti.RingTheory.DedekindDomain.AdicValuation.Completion
 
 /-!
 # The formal parameter map is additive
@@ -20,22 +19,17 @@ parametrisation sends zero to the point at infinity and, for a nonzero parameter
 
 This file proves that this map is an additive homomorphism into the points of the base-changed
 curve whenever every parameter distinct from its inverse admits an auxiliary parameter distinct
-from it, its inverse, and its own inverse.  It then establishes that property for the maximal ideal
-in the completion at a height-one prime of a Dedekind domain, in every characteristic.
+from it, its inverse, and its own inverse.
 
 ## Main definitions
 
 * `WeierstrassCurve.formalPointHom`: the additive homomorphism from formal-group parameters in an
   adic ideal to points of the curve over a field.
-* `WeierstrassCurve.formalPointHomAdicCompletion`: its specialization to the maximal ideal in an
-  adic completion.
 
 ## Main results
 
 * `WeierstrassCurve.formalPoint_add`: the parametrisation preserves addition when auxiliary
   parameters exist.
-* `WeierstrassCurve.formalPoint_add_adicCompletion`: the unconditional adic-completion
-  specialization.
 * `WeierstrassCurve.formalPointHom_injective`: the resulting homomorphism is injective.
 
 ## References
@@ -56,228 +50,7 @@ Tau Ceti.
 
 public section
 
-open IsDedekindDomain WithZero
-
 namespace WeierstrassCurve
-
-variable {R : Type*} [CommRing R] [IsDedekindDomain R]
-  {K : Type*} [Field K] [Algebra R K] [IsFractionRing R K]
-  (v : HeightOneSpectrum R)
-
-local notation "O_v" => v.adicCompletionIntegers K
-local notation "K_v" => v.adicCompletion K
-local notation "m_v" => IsLocalRing.maximalIdeal O_v
-
-local instance : IsLinearTopology O_v O_v :=
-  v.isAdic_maximalIdeal_adicCompletionIntegers (K := K) ▸ Ideal.isLinearTopology m_v
-
-local instance : Fact (IsAdic m_v) :=
-  ⟨v.isAdic_maximalIdeal_adicCompletionIntegers (K := K)⟩
-
-variable (W : WeierstrassCurve (v.adicCompletionIntegers K))
-
-private theorem valued_coe_isUnit {a : O_v} (ha : IsUnit a) :
-    Valued.v (a : K_v) = 1 :=
-  (Valuation.integer.integers
-    (Valued.v : Valuation K_v (WithZero (Multiplicative ℤ)))).isUnit_iff_valuation_eq_one.mp ha
-
-private theorem valued_formalInverseEval {t : O_v} (ht : t ∈ m_v) :
-    Valued.v (W.formalInverseEval t : K_v) = Valued.v (t : K_v) := by
-  have hE : PowerSeries.HasEval t :=
-    (v.isAdic_maximalIdeal_adicCompletionIntegers (K := K)).isTopologicallyNilpotent_of_mem ht
-  rw [WeierstrassCurve.formalInverseEval_eq W hE]
-  push_cast
-  rw [Valuation.map_neg, map_mul, valued_coe_isUnit v
-      (WeierstrassCurve.isUnit_formalInverseDenomInvEval W hE), mul_one]
-
-private theorem valued_formalWEval {t : O_v} (ht : t ∈ m_v) :
-    Valued.v (W.formalWEval t : K_v) = Valued.v (t : K_v) ^ 3 := by
-  have hE : PowerSeries.HasEval t :=
-    (v.isAdic_maximalIdeal_adicCompletionIntegers (K := K)).isTopologicallyNilpotent_of_mem ht
-  rw [WeierstrassCurve.formalWEval_eq_pow_mul_formalUEval W hE]
-  push_cast
-  rw [map_mul, map_pow, valued_coe_isUnit v
-      (WeierstrassCurve.isUnit_formalUEval W
-        (v.isAdic_maximalIdeal_adicCompletionIntegers (K := K)) ht), mul_one]
-
-private theorem ne_of_valued_lt {a b : O_v}
-    (h : Valued.v (a : K_v) < Valued.v (b : K_v)) : a ≠ b :=
-  fun hab ↦ h.ne (by rw [hab])
-
-private theorem eq_two_of_formalInverseEval_self {t : O_v} (ht : t ∈ m_v) (ht0 : t ≠ 0)
-    (hfix : t = W.formalInverseEval t) :
-    2 = W.a₁ * t + W.a₃ * W.formalWEval t := by
-  have hE : PowerSeries.HasEval t :=
-    (v.isAdic_maximalIdeal_adicCompletionIntegers (K := K)).isTopologicallyNilpotent_of_mem ht
-  have h := WeierstrassCurve.formalInverseEval_mul_formalInverseDenomEval W hE
-  rw [← hfix, WeierstrassCurve.formalInverseDenomEval_eq W hE] at h
-  apply mul_left_cancel₀ ht0
-  linear_combination h
-
-private theorem ne_formalInverseEval_self {t : O_v} (ht : t ∈ m_v) (ht0 : t ≠ 0)
-    (h2 : Valued.v (t : K_v) < Valued.v ((2 : O_v) : K_v)) :
-    t ≠ W.formalInverseEval t := by
-  intro hfix
-  have hw_le : Valued.v (W.formalWEval t : K_v) ≤ Valued.v (t : K_v) := by
-    rw [valued_formalWEval v W ht]
-    calc
-      Valued.v (t : K_v) ^ 3 = Valued.v (t : K_v) * Valued.v (t : K_v) ^ 2 :=
-        pow_succ' _ 2
-      _ ≤ Valued.v (t : K_v) * 1 :=
-        mul_le_mul' le_rfl (pow_le_one' t.property 2)
-      _ = Valued.v (t : K_v) := mul_one _
-  have hcoe := congrArg (fun a : O_v ↦ (a : K_v))
-    (eq_two_of_formalInverseEval_self v W ht ht0 hfix)
-  push_cast at hcoe
-  have hval : Valued.v ((2 : O_v) : K_v) ≤ Valued.v (t : K_v) := by
-    rw [hcoe]
-    refine (Valued.v.map_add _ _).trans (max_le ?_ ?_)
-    · rw [map_mul]
-      exact (mul_le_mul' W.a₁.property le_rfl).trans_eq (one_mul _)
-    · rw [map_mul]
-      exact (mul_le_mul' W.a₃.property hw_le).trans_eq (one_mul _)
-  exact (not_le_of_gt h2) hval
-
-private theorem exists_small_param {a b : O_v} (ha : a ∈ m_v) (ha0 : a ≠ 0) (hb0 : b ≠ 0) :
-    ∃ s : O_v, s ∈ m_v ∧ s ≠ 0 ∧ Valued.v (s : K_v) < Valued.v (a : K_v) ∧
-      Valued.v (s : K_v) < Valued.v (b : K_v) ∧ Valued.v (s : K_v) < 1 := by
-  obtain ⟨π, hπ⟩ := IsDiscreteValuationRing.exists_irreducible O_v
-  have hπv : Valued.v (π : K_v) = exp (-1) := by
-    rw [← Algebra.algebraMap_ofSubsemiring_apply
-      (Valued.v : Valuation K_v (WithZero (Multiplicative ℤ))).valuationSubring π]
-    exact v.valued_algebraMap_eq_exp_neg_one_of_irreducible hπ
-  have haval0 : Valued.v (a : K_v) ≠ 0 := by
-    simp only [ne_eq, _root_.map_eq_zero, ZeroMemClass.coe_eq_zero]
-    exact ha0
-  have hbval0 : Valued.v (b : K_v) ≠ 0 := by
-    simp only [ne_eq, _root_.map_eq_zero, ZeroMemClass.coe_eq_zero]
-    exact hb0
-  obtain ⟨n, hna, hnb⟩ := exists_exp_neg_natCast_lt_and_lt haval0 hbval0
-  let s : O_v := π ^ n
-  have hsv : Valued.v (s : K_v) = exp (-(n : ℤ)) := by
-    simp only [s]
-    push_cast
-    rw [map_pow, hπv, ← exp_nsmul, nsmul_eq_mul]
-    congr 1
-    ring
-  have ha_le : Valued.v (a : K_v) ≤ exp (-1) := by
-    apply (v.mem_maximalIdeal_pow_iff (K := K) (x := a) (n := 1)).mp
-    simpa using ha
-  have hsm : s ∈ m_v := by
-    have h := v.mem_maximalIdeal_pow_iff (K := K) (x := s) (n := 1)
-    rw [pow_one] at h
-    apply h.mpr
-    rw [hsv]
-    exact (hna.trans_le ha_le).le
-  have hs0 : s ≠ 0 := by
-    exact pow_ne_zero _ hπ.ne_zero
-  refine ⟨s, hsm, hs0, ?_, ?_, ?_⟩
-  · rwa [hsv]
-  · rwa [hsv]
-  · rw [hsv, ← exp_zero, exp_lt_exp]
-    exact (exp_lt_exp.mp (hna.trans_le ha_le)).trans_le (by omega)
-
-private theorem exists_aux_param [(W.baseChange K_v).IsElliptic] {t : O_v}
-    (ht : t ∈ m_v) (ht0 : t ≠ 0) :
-    ∃ s : O_v, s ∈ m_v ∧ s ≠ 0 ∧ s ≠ t ∧ s ≠ W.formalInverseEval t ∧
-      s ≠ W.formalInverseEval s := by
-  by_cases htwo : (2 : K_v) = 0
-  -- In characteristic two, ellipticity forces at least one of `a₁` and `a₃` to be nonzero.
-  -- A sufficiently small parameter then cannot satisfy the formal-inverse fixed-point equation.
-  · let _ : CharP K_v 2 :=
-      (CharP.charP_iff_prime_eq_zero Nat.prime_two).2 htwo
-    have htwo' : ((2 : O_v) : K_v) = 0 := by
-      calc
-        ((2 : O_v) : K_v) = algebraMap O_v K_v (2 : O_v) :=
-          (Algebra.algebraMap_ofSubsemiring_apply
-            (Valued.v : Valuation K_v (WithZero (Multiplicative ℤ))).valuationSubring _).symm
-        _ = (2 : K_v) := map_ofNat (algebraMap O_v K_v) 2
-        _ = 0 := htwo
-    have ha₁a₃ : (W.a₁ : K_v) ≠ 0 ∨ (W.a₃ : K_v) ≠ 0 := by
-      by_contra h
-      push Not at h
-      have hΔ : (W.baseChange K_v).Δ = 0 := by
-        rw [(W.baseChange K_v).Δ_of_char_two]
-        simp [h.1, h.2]
-      exact (W.baseChange K_v).isUnit_Δ.ne_zero hΔ
-    by_cases ha₁ : (W.a₁ : K_v) = 0
-    · have ha₃ := ha₁a₃.resolve_left (fun h ↦ h ha₁)
-      have ha₃O : W.a₃ ≠ 0 := fun h ↦ ha₃ (by simp [h])
-      obtain ⟨s, hsm, hs0, hst, _, _⟩ := exists_small_param v ht ht0 ha₃O
-      refine ⟨s, hsm, hs0, ne_of_valued_lt v hst,
-        ne_of_valued_lt v (valued_formalInverseEval v W ht ▸ hst), ?_⟩
-      intro hfix
-      have hcoe := congrArg (fun a : O_v ↦ (a : K_v))
-        (eq_two_of_formalInverseEval_self v W hsm hs0 hfix)
-      push_cast at hcoe
-      rw [htwo', ha₁, zero_mul, zero_add] at hcoe
-      have hw0 : (W.formalWEval s : K_v) ≠ 0 :=
-        W.algebraMap_formalWEval_ne_zero (Fact.out : IsAdic m_v) hsm
-          ((FaithfulSMul.algebraMap_injective O_v K_v).ne hs0)
-      exact (mul_ne_zero ha₃ hw0) hcoe.symm
-    · have ha₁O : W.a₁ ≠ 0 := fun h ↦ ha₁ (by simp [h])
-      obtain ⟨s, hsm, hs0, hst, hsa₁, hsone⟩ :=
-        exists_small_param v ht ht0 ha₁O
-      refine ⟨s, hsm, hs0, ne_of_valued_lt v hst,
-        ne_of_valued_lt v (valued_formalInverseEval v W ht ▸ hst), ?_⟩
-      intro hfix
-      have hcoe := congrArg (fun a : O_v ↦ (a : K_v))
-        (eq_two_of_formalInverseEval_self v W hsm hs0 hfix)
-      push_cast at hcoe
-      rw [htwo'] at hcoe
-      have hsval0 : Valued.v (s : K_v) ≠ 0 := by
-        exact (_root_.map_eq_zero (Valued.v :
-          Valuation K_v (WithZero (Multiplicative ℤ)))).not.mpr
-            (fun h ↦ hs0 (ZeroMemClass.coe_eq_zero.mp h))
-      have hsq : Valued.v (s : K_v) ^ 2 < Valued.v (W.a₁ : K_v) := by
-        calc
-          Valued.v (s : K_v) ^ 2 = Valued.v (s : K_v) * Valued.v (s : K_v) :=
-            pow_two _
-          _ < 1 * Valued.v (s : K_v) :=
-            mul_lt_mul_of_pos_right hsone (pos_iff_ne_zero.mpr hsval0)
-          _ = Valued.v (s : K_v) := one_mul _
-          _ < Valued.v (W.a₁ : K_v) := hsa₁
-      have hw_le : Valued.v (W.a₃ * W.formalWEval s : K_v) ≤
-          Valued.v (s : K_v) ^ 3 := by
-        rw [map_mul, valued_formalWEval v W hsm]
-        exact (mul_le_mul' W.a₃.property le_rfl).trans_eq (one_mul _)
-      have hval : Valued.v (W.a₃ * W.formalWEval s : K_v) <
-          Valued.v (W.a₁ * s : K_v) := hw_le.trans_lt (by
-        rw [map_mul, pow_succ]
-        exact mul_lt_mul_of_pos_right hsq (pos_iff_ne_zero.mpr hsval0))
-      have heq : (W.a₁ * s : K_v) = -(W.a₃ * W.formalWEval s : K_v) :=
-        eq_neg_of_add_eq_zero_left hcoe.symm
-      exact hval.ne (by rw [heq, Valuation.map_neg])
-  · have htwoO : (2 : O_v) ≠ 0 := fun h ↦ htwo (by
-      calc
-        (2 : K_v) = algebraMap O_v K_v (2 : O_v) :=
-          (map_ofNat (algebraMap O_v K_v) 2).symm
-        _ = ((2 : O_v) : K_v) := Algebra.algebraMap_ofSubsemiring_apply
-          (Valued.v : Valuation K_v (WithZero (Multiplicative ℤ))).valuationSubring _
-        _ = 0 := congrArg (fun a : O_v ↦ (a : K_v)) h)
-    obtain ⟨s, hsm, hs0, hst, hs2, _⟩ := exists_small_param v ht ht0 htwoO
-    refine ⟨s, hsm, hs0, ne_of_valued_lt v hst,
-      ne_of_valued_lt v (valued_formalInverseEval v W ht ▸ hst),
-      ne_formalInverseEval_self v W hsm hs0 hs2⟩
-
-private theorem exists_aux_point [(W.baseChange K_v).IsElliptic]
-    {P : FormalGroupPoint W m_v} (hP0 : P ≠ 0) :
-    ∃ U : FormalGroupPoint W m_v, U ≠ 0 ∧ U ≠ P ∧ U ≠ -P ∧ -U ≠ P ∧
-      -U ≠ -P ∧ U ≠ -U := by
-  have hPval0 : P.val ≠ 0 := fun h ↦ hP0 (FormalGroupPoint.ext (by simpa using h))
-  obtain ⟨u, hu, hu0, huP, huInvP, huInv⟩ := exists_aux_param v W P.property hPval0
-  let U : FormalGroupPoint W m_v := ⟨u, hu⟩
-  refine ⟨U, ?_, ?_, ?_, ?_, ?_, ?_⟩
-  · exact fun h ↦ hu0 (congrArg FormalGroupPoint.val h)
-  · exact fun h ↦ huP (congrArg FormalGroupPoint.val h)
-  · exact fun h ↦ huInvP (by simpa [U] using congrArg FormalGroupPoint.val h)
-  · intro h
-    apply huInvP
-    simpa [U] using congrArg FormalGroupPoint.val (congrArg Neg.neg h)
-  · intro h
-    apply huP
-    simpa [U] using congrArg FormalGroupPoint.val (neg_injective h)
-  · exact fun h ↦ huInv (by simpa [U] using congrArg FormalGroupPoint.val h)
 
 section PointMap
 
@@ -401,70 +174,6 @@ theorem formalPointHom_injective
   formalPointMap_injective (S := S) I E
 
 end PointMap
-
-section AdicCompletion
-
-variable {A : Type*} [CommRing A] [IsDedekindDomain A]
-  {F : Type*} [Field F] [Algebra A F] [IsFractionRing A F]
-  (u : HeightOneSpectrum A)
-
-variable (C : WeierstrassCurve (u.adicCompletionIntegers F))
-  [(C.baseChange (u.adicCompletion F)).IsElliptic]
-
-private theorem exists_aux_point_simple
-    {P : FormalGroupPoint C (IsLocalRing.maximalIdeal (u.adicCompletionIntegers F))}
-    (hPneg : P ≠ -P) :
-    ∃ U : FormalGroupPoint C (IsLocalRing.maximalIdeal (u.adicCompletionIntegers F)),
-      U ≠ P ∧ U ≠ -P ∧ U ≠ -U := by
-  have hP0 : P ≠ 0 := by
-    rintro rfl
-    exact hPneg (by simp)
-  obtain ⟨U, _, hUP, hUnP, _, _, hUnegn⟩ := exists_aux_point u C hP0
-  exact ⟨U, hUP, hUnP, hUnegn⟩
-
-open Classical in
-/-- **The formal parametrisation preserves addition in an adic completion.** -/
-@[simp]
-theorem formalPoint_add_adicCompletion
-    (P Q : FormalGroupPoint C (IsLocalRing.maximalIdeal (u.adicCompletionIntegers F))) :
-    C.formalPoint (K := u.adicCompletion F)
-        (u.isAdic_maximalIdeal_adicCompletionIntegers (K := F))
-        (P + Q).property =
-      C.formalPoint (K := u.adicCompletion F)
-          (u.isAdic_maximalIdeal_adicCompletionIntegers (K := F))
-          P.property +
-        C.formalPoint (K := u.adicCompletion F)
-          (u.isAdic_maximalIdeal_adicCompletionIntegers (K := F))
-          Q.property :=
-  formalPoint_add (IsLocalRing.maximalIdeal (u.adicCompletionIntegers F)) C
-    (fun P hP ↦ exists_aux_point_simple u C (P := P) hP) P Q
-
-open Classical in
-/-- **The formal parameter map for an adic completion**, as an additive homomorphism. -/
-noncomputable def formalPointHomAdicCompletion :
-    FormalGroupPoint C (IsLocalRing.maximalIdeal (u.adicCompletionIntegers F)) →+
-      (C.baseChange (u.adicCompletion F)).toAffine.Point :=
-  C.formalPointHom (IsLocalRing.maximalIdeal (u.adicCompletionIntegers F))
-    (fun P hP ↦ exists_aux_point_simple u C (P := P) hP)
-
-open Classical in
-/-- The adic-completion formal point homomorphism evaluates to the usual parametrisation. -/
-@[simp]
-theorem formalPointHomAdicCompletion_apply
-    (P : FormalGroupPoint C (IsLocalRing.maximalIdeal (u.adicCompletionIntegers F))) :
-    C.formalPointHomAdicCompletion u P =
-      C.formalPoint (K := u.adicCompletion F)
-        (u.isAdic_maximalIdeal_adicCompletionIntegers (K := F)) P.property :=
-  (rfl)
-
-open Classical in
-/-- **The adic-completion formal point homomorphism is injective.** -/
-theorem formalPointHomAdicCompletion_injective :
-    Function.Injective (C.formalPointHomAdicCompletion u) :=
-  formalPointHom_injective (IsLocalRing.maximalIdeal (u.adicCompletionIntegers F)) C
-    (fun P hP ↦ exists_aux_point_simple u C (P := P) hP)
-
-end AdicCompletion
 
 end WeierstrassCurve
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Point/Hom.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Point/Hom.lean
@@ -1,0 +1,323 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.AdicPoint
+public import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.Point.Add
+public import TauCeti.RingTheory.DedekindDomain.AdicValuation.Completion
+
+/-!
+# The formal parameter map is additive
+
+For a height-one prime `v` of a Dedekind domain, the maximal ideal of the ring of integers
+`O_v` of the completion is an adic ideal.  The Weierstrass formal group law therefore makes its
+elements into `WeierstrassCurve.FormalGroupPoint W m_v`.  This file proves that the usual
+parametrisation
+
+`t ↦ (t / w(t), -1 / w(t))`
+
+is an additive homomorphism into the points of the base-changed curve.
+
+The chord case is `WeierstrassCurve.add_eq_formalPoint_formalAddEval_of_ne_of_ne_formalInverseEval`.
+The inverse case follows from the already established compatibility with negation.  For doubling,
+one chooses a sufficiently high power of a uniformizer, so its valuation avoids the original
+parameter, both formal inverses, and its own formal inverse.  Three chord additions and cancellation
+then give the tangent case without a second coordinate computation.  The hypothesis `2 ≠ 0` in
+the completed field is used only to ensure that the auxiliary parameter can be chosen with
+valuation strictly below that of `2`.
+
+## Main definitions
+
+* `WeierstrassCurve.formalPointHom`: the additive homomorphism from formal-group parameters in the
+  maximal ideal of `O_v` to points of the curve over the completion.
+
+## Main results
+
+* `WeierstrassCurve.formalPoint_add`: the parametrisation preserves addition.
+* `WeierstrassCurve.formalPointHom_injective`: the resulting homomorphism is injective.
+
+## References
+
+* [J. Silverman, *The Arithmetic of Elliptic Curves*][silverman2009], IV.1 and VII.2.
+
+## Provenance
+
+Adapted from Michael Stoll's elliptic-curve development
+(`github.com/MichaelStollBayreuth/EllipticCurves` @ `66889eada51a`, Apache-2.0), files
+`EllipticCurves/WeierstrassFormalGroup/Foundations.lean` and
+`EllipticCurves/WeierstrassFormalGroup/Filtration.lean`, declarations `exists_aux_param`,
+`exists_aux_point`, `formalPoint_add_self` and `formalPoint_add`.  The source works with its own
+multivariable formal-group points; here the argument is rebased onto
+`WeierstrassCurve.FormalGroupPoint` and the one-dimensional formal-group API already in Mathlib and
+Tau Ceti.
+-/
+
+public section
+
+open IsDedekindDomain WithZero
+
+namespace WeierstrassCurve
+
+variable {R : Type*} [CommRing R] [IsDedekindDomain R]
+  {K : Type*} [Field K] [Algebra R K] [IsFractionRing R K]
+  (v : HeightOneSpectrum R)
+
+local notation "O_v" => v.adicCompletionIntegers K
+local notation "K_v" => v.adicCompletion K
+local notation "m_v" => IsLocalRing.maximalIdeal O_v
+
+local instance : IsLinearTopology O_v O_v :=
+  v.isAdic_maximalIdeal_adicCompletionIntegers (K := K) ▸ Ideal.isLinearTopology m_v
+
+local instance : Fact (IsAdic m_v) :=
+  ⟨v.isAdic_maximalIdeal_adicCompletionIntegers (K := K)⟩
+
+variable (W : WeierstrassCurve (v.adicCompletionIntegers K))
+
+private theorem valued_coe_le_one (a : O_v) : Valued.v (a : K_v) ≤ 1 :=
+  a.property
+
+private theorem valued_coe_isUnit {a : O_v} (ha : IsUnit a) :
+    Valued.v (a : K_v) = 1 :=
+  (Valuation.integer.integers
+    (Valued.v : Valuation K_v (WithZero (Multiplicative ℤ)))).isUnit_iff_valuation_eq_one.mp ha
+
+private theorem valued_formalInverseEval {t : O_v} (ht : t ∈ m_v) :
+    Valued.v (W.formalInverseEval t : K_v) = Valued.v (t : K_v) := by
+  have hE : PowerSeries.HasEval t :=
+    (v.isAdic_maximalIdeal_adicCompletionIntegers (K := K)).isTopologicallyNilpotent_of_mem ht
+  rw [WeierstrassCurve.formalInverseEval_eq W hE]
+  push_cast
+  rw [Valuation.map_neg, map_mul, valued_coe_isUnit v
+      (WeierstrassCurve.isUnit_formalInverseDenomInvEval W hE), mul_one]
+
+private theorem valued_formalWEval {t : O_v} (ht : t ∈ m_v) :
+    Valued.v (W.formalWEval t : K_v) = Valued.v (t : K_v) ^ 3 := by
+  have hE : PowerSeries.HasEval t :=
+    (v.isAdic_maximalIdeal_adicCompletionIntegers (K := K)).isTopologicallyNilpotent_of_mem ht
+  rw [WeierstrassCurve.formalWEval_eq_pow_mul_formalUEval W hE]
+  push_cast
+  rw [map_mul, map_pow, valued_coe_isUnit v
+      (WeierstrassCurve.isUnit_formalUEval W
+        (v.isAdic_maximalIdeal_adicCompletionIntegers (K := K)) ht), mul_one]
+
+private theorem ne_of_valued_lt {a b : O_v}
+    (h : Valued.v (a : K_v) < Valued.v (b : K_v)) : a ≠ b :=
+  fun hab ↦ h.ne (by rw [hab])
+
+private theorem eq_two_of_formalInverseEval_self {t : O_v} (ht : t ∈ m_v) (ht0 : t ≠ 0)
+    (hfix : t = W.formalInverseEval t) :
+    2 = W.a₁ * t + W.a₃ * W.formalWEval t := by
+  have hE : PowerSeries.HasEval t :=
+    (v.isAdic_maximalIdeal_adicCompletionIntegers (K := K)).isTopologicallyNilpotent_of_mem ht
+  have h := WeierstrassCurve.formalInverseEval_mul_formalInverseDenomEval W hE
+  rw [← hfix, WeierstrassCurve.formalInverseDenomEval_eq W hE] at h
+  apply mul_left_cancel₀ ht0
+  linear_combination h
+
+private theorem ne_formalInverseEval_self {t : O_v} (ht : t ∈ m_v) (ht0 : t ≠ 0)
+    (h2 : Valued.v (t : K_v) < Valued.v ((2 : O_v) : K_v)) :
+    t ≠ W.formalInverseEval t := by
+  intro hfix
+  have hw_le : Valued.v (W.formalWEval t : K_v) ≤ Valued.v (t : K_v) := by
+    rw [valued_formalWEval v W ht]
+    calc
+      Valued.v (t : K_v) ^ 3 = Valued.v (t : K_v) * Valued.v (t : K_v) ^ 2 :=
+        pow_succ' _ 2
+      _ ≤ Valued.v (t : K_v) * 1 :=
+        mul_le_mul' le_rfl (pow_le_one' t.property 2)
+      _ = Valued.v (t : K_v) := mul_one _
+  have hcoe := congrArg (fun a : O_v ↦ (a : K_v))
+    (eq_two_of_formalInverseEval_self v W ht ht0 hfix)
+  push_cast at hcoe
+  have hval : Valued.v ((2 : O_v) : K_v) ≤ Valued.v (t : K_v) := by
+    rw [hcoe]
+    refine (Valued.v.map_add _ _).trans (max_le ?_ ?_)
+    · rw [map_mul]
+      exact (mul_le_mul' W.a₁.property le_rfl).trans_eq (one_mul _)
+    · rw [map_mul]
+      exact (mul_le_mul' W.a₃.property hw_le).trans_eq (one_mul _)
+  exact (not_le_of_gt h2) hval
+
+private theorem exists_aux_param [NeZero (2 : v.adicCompletion K)] {t : O_v}
+    (ht : t ∈ m_v) (ht0 : t ≠ 0) :
+    ∃ s : O_v, s ∈ m_v ∧ s ≠ 0 ∧ s ≠ t ∧ s ≠ W.formalInverseEval t ∧
+      s ≠ W.formalInverseEval s := by
+  have htwo : ((2 : O_v) : K_v) ≠ 0 := NeZero.ne (2 : K_v)
+  obtain ⟨π, hπ⟩ := IsDiscreteValuationRing.exists_irreducible O_v
+  have hπv : Valued.v (π : K_v) = exp (-1) := by
+    change Valued.v (algebraMap O_v K_v π) = exp (-1)
+    exact v.valued_algebraMap_eq_exp_neg_one_of_irreducible hπ
+  have htval0 : Valued.v (t : K_v) ≠ 0 := by
+    simp only [ne_eq, _root_.map_eq_zero, ZeroMemClass.coe_eq_zero]
+    exact ht0
+  obtain ⟨a, ha⟩ : ∃ a : ℤ, Valued.v (t : K_v) = exp a :=
+    ⟨_, (exp_log htval0).symm⟩
+  have ha_le : a ≤ -1 := by
+    have h := v.mem_maximalIdeal_pow_iff (K := K) (n := 1) |>.mp (pow_one m_v ▸ ht)
+    rwa [ha, exp_le_exp] at h
+  obtain ⟨b, hb⟩ : ∃ b : ℤ, Valued.v ((2 : O_v) : K_v) = exp b :=
+    ⟨_, (exp_log (by simp [htwo])).symm⟩
+  have hb_le : b ≤ 0 := by
+    have h := valued_coe_le_one v (2 : O_v)
+    rwa [hb, ← exp_zero, exp_le_exp] at h
+  obtain ⟨n, hn⟩ : ∃ n : ℕ, (n : ℤ) = max (-a) (-b) + 1 :=
+    ⟨(max (-a) (-b) + 1).toNat, Int.toNat_of_nonneg (by omega)⟩
+  let s : O_v := π ^ n
+  have hsv : Valued.v (s : K_v) = exp (-(n : ℤ)) := by
+    simp only [s]
+    push_cast
+    rw [map_pow, hπv, ← exp_nsmul, nsmul_eq_mul]
+    congr 1
+    ring
+  have hna : -(n : ℤ) < a := by omega
+  have hnb : -(n : ℤ) < b := by omega
+  have hsm : s ∈ m_v := by
+    have h := v.mem_maximalIdeal_pow_iff (K := K) (x := s) (n := 1)
+    rw [pow_one] at h
+    apply h.mpr
+    rw [hsv, exp_le_exp]
+    omega
+  have hs0 : s ≠ 0 := by
+    exact pow_ne_zero _ hπ.ne_zero
+  refine ⟨s, hsm, hs0, ?_, ?_, ?_⟩
+  · exact ne_of_valued_lt v (by rw [hsv, ha, exp_lt_exp]; exact hna)
+  · exact ne_of_valued_lt v (by
+      rw [valued_formalInverseEval v W ht, hsv, ha, exp_lt_exp]
+      exact hna)
+  · exact ne_formalInverseEval_self v W hsm hs0 (by
+      rw [hsv, hb, exp_lt_exp]
+      exact hnb)
+
+private theorem exists_aux_point [NeZero (2 : v.adicCompletion K)]
+    {P : FormalGroupPoint W m_v} (hP0 : P ≠ 0) :
+    ∃ U : FormalGroupPoint W m_v, U ≠ 0 ∧ U ≠ P ∧ U ≠ -P ∧ -U ≠ P ∧
+      -U ≠ -P ∧ U ≠ -U := by
+  have hPval0 : P.val ≠ 0 := fun h ↦ hP0 (FormalGroupPoint.ext (by simpa using h))
+  obtain ⟨u, hu, hu0, huP, huInvP, huInv⟩ := exists_aux_param v W P.property hPval0
+  let U : FormalGroupPoint W m_v := ⟨u, hu⟩
+  refine ⟨U, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  · exact fun h ↦ hu0 (congrArg FormalGroupPoint.val h)
+  · exact fun h ↦ huP (congrArg FormalGroupPoint.val h)
+  · exact fun h ↦ huInvP (by simpa [U] using congrArg FormalGroupPoint.val h)
+  · intro h
+    apply huInvP
+    simpa [U] using congrArg FormalGroupPoint.val (congrArg Neg.neg h)
+  · intro h
+    apply huP
+    simpa [U] using congrArg FormalGroupPoint.val (neg_injective h)
+  · exact fun h ↦ huInv (by simpa [U] using congrArg FormalGroupPoint.val h)
+
+section PointMap
+
+variable [(W.baseChange (v.adicCompletion K)).IsElliptic]
+
+private noncomputable def formalPointMap (P : FormalGroupPoint W m_v) :
+    (W.baseChange K_v).toAffine.Point :=
+  W.formalPoint (K := K_v) (v.isAdic_maximalIdeal_adicCompletionIntegers (K := K)) P.property
+
+private theorem formalPointMap_injective : Function.Injective (formalPointMap v W) := by
+  intro P Q hPQ
+  change W.formalPoint (K := K_v)
+    (v.isAdic_maximalIdeal_adicCompletionIntegers (K := K)) P.property =
+      W.formalPoint (K := K_v)
+        (v.isAdic_maximalIdeal_adicCompletionIntegers (K := K)) Q.property at hPQ
+  have hinj := W.formalPoint_injective (K := K_v)
+    (v.isAdic_maximalIdeal_adicCompletionIntegers (K := K))
+  have heq := hinj (a₁ := (⟨P.val, P.property⟩ : m_v))
+    (a₂ := (⟨Q.val, Q.property⟩ : m_v)) hPQ
+  exact FormalGroupPoint.ext (congrArg Subtype.val heq)
+
+private theorem formalPointMap_neg (P : FormalGroupPoint W m_v) :
+    formalPointMap v W (-P) = -formalPointMap v W P := by
+  let hI := v.isAdic_maximalIdeal_adicCompletionIntegers (K := K)
+  simp only [formalPointMap, FormalGroupPoint.coe_neg]
+  exact W.formalPoint_formalInverseEval hI P.property
+
+open Classical in
+private theorem formalPointMap_add_of_ne (P Q : FormalGroupPoint W m_v)
+    (hne : Q ≠ P) (hnneg : Q ≠ -P) :
+    formalPointMap v W (P + Q) = formalPointMap v W P + formalPointMap v W Q := by
+  exact (W.add_eq_formalPoint_formalAddEval_of_ne_of_ne_formalInverseEval
+    (K := K_v) (Fact.out : IsAdic m_v) P.property Q.property
+    (fun _ _ h ↦ hne (FormalGroupPoint.ext h))
+    (fun _ _ h ↦ hnneg (FormalGroupPoint.ext (by simpa using h)))).symm
+
+variable [NeZero (2 : v.adicCompletion K)]
+
+open Classical in
+private theorem formalPointMap_add_self (P : FormalGroupPoint W m_v) (hP0 : P ≠ 0)
+    (hself : P ≠ -P) :
+    formalPointMap v W (P + P) = formalPointMap v W P + formalPointMap v W P := by
+  obtain ⟨U, _, hUP, hUnP, hnUP, hnUnP, hUnegn⟩ := exists_aux_point v W hP0
+  have c1 := formalPointMap_add_of_ne v W P U hUP hUnP
+  have c2 := formalPointMap_add_of_ne v W P (-U) hnUP hnUnP
+  have hne : P + -U ≠ P + U := by
+    intro h
+    have h' := congrArg (formalPointMap v W) h
+    rw [c1, c2] at h'
+    exact hUnegn (formalPointMap_injective v W (add_left_cancel h').symm)
+  have hnneg : P + -U ≠ -(P + U) := by
+    intro h
+    have h' := congrArg (formalPointMap v W) h
+    rw [c2, formalPointMap_neg v W, formalPointMap_neg v W, c1, neg_add] at h'
+    have h'' := add_right_cancel h'
+    rw [← formalPointMap_neg v W] at h''
+    exact hself (formalPointMap_injective v W h'')
+  have c3 := formalPointMap_add_of_ne v W (P + U) (P + -U) hne hnneg
+  have hkey : (P + U) + (P + -U) = P + P := by abel
+  rw [← hkey, c3, c1, c2, formalPointMap_neg v W]
+  abel
+
+open Classical in
+/-- **The formal parametrisation preserves addition.** -/
+@[simp]
+theorem formalPoint_add (P Q : FormalGroupPoint W m_v) :
+    W.formalPoint (K := K_v) (v.isAdic_maximalIdeal_adicCompletionIntegers (K := K))
+        (P + Q).property =
+      W.formalPoint (K := K_v) (v.isAdic_maximalIdeal_adicCompletionIntegers (K := K))
+          P.property +
+        W.formalPoint (K := K_v) (v.isAdic_maximalIdeal_adicCompletionIntegers (K := K))
+          Q.property := by
+  change formalPointMap v W (P + Q) = formalPointMap v W P + formalPointMap v W Q
+  rcases eq_or_ne P 0 with rfl | hP0
+  · simp [formalPointMap]
+  rcases eq_or_ne Q 0 with rfl | hQ0
+  · simp [formalPointMap]
+  rcases eq_or_ne Q (-P) with rfl | hQneg
+  · rw [add_neg_cancel, formalPointMap_neg v W]
+    simp [formalPointMap]
+  rcases eq_or_ne Q P with hQP | hQP
+  · subst Q
+    exact formalPointMap_add_self v W P hP0 hQneg
+  · exact formalPointMap_add_of_ne v W P Q hQP hQneg
+
+open Classical in
+/-- **The formal parameter map into the curve's points**, as an additive homomorphism. -/
+noncomputable def formalPointHom :
+    FormalGroupPoint W m_v →+ (W.baseChange K_v).toAffine.Point where
+  toFun := formalPointMap v W
+  map_zero' := by simp [formalPointMap]
+  map_add' := formalPoint_add v W
+
+open Classical in
+/-- The formal point homomorphism evaluates to the usual formal parametrisation. -/
+@[simp]
+theorem formalPointHom_apply (P : FormalGroupPoint W m_v) :
+    W.formalPointHom v P =
+      W.formalPoint (K := K_v) (v.isAdic_maximalIdeal_adicCompletionIntegers (K := K)) P.property :=
+  (rfl)
+
+open Classical in
+/-- **The formal point homomorphism is injective.** -/
+theorem formalPointHom_injective : Function.Injective (W.formalPointHom v) :=
+  formalPointMap_injective v W
+
+end PointMap
+
+end WeierstrassCurve
+
+end

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Point/Hom.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Point/Hom.lean
@@ -19,8 +19,8 @@ the point at infinity and, for a nonzero parameter, is given by
 
 `t ↦ (t / w(t), -1 / w(t))`
 
-When `2 ≠ 0` in the completed field, this file proves that this map is an additive homomorphism
-into the points of the base-changed curve.
+This file proves that this map is an additive homomorphism into the points of the base-changed
+curve, in every characteristic.
 
 ## Main definitions
 
@@ -69,9 +69,6 @@ local instance : Fact (IsAdic m_v) :=
   ⟨v.isAdic_maximalIdeal_adicCompletionIntegers (K := K)⟩
 
 variable (W : WeierstrassCurve (v.adicCompletionIntegers K))
-
-private theorem valued_coe_le_one (a : O_v) : Valued.v (a : K_v) ≤ 1 :=
-  a.property
 
 private theorem valued_coe_isUnit {a : O_v} (ha : IsUnit a) :
     Valued.v (a : K_v) = 1 :=
@@ -135,31 +132,29 @@ private theorem ne_formalInverseEval_self {t : O_v} (ht : t ∈ m_v) (ht0 : t �
       exact (mul_le_mul' W.a₃.property hw_le).trans_eq (one_mul _)
   exact (not_le_of_gt h2) hval
 
-private theorem exists_aux_param [NeZero (2 : v.adicCompletion K)] {t : O_v}
-    (ht : t ∈ m_v) (ht0 : t ≠ 0) :
-    ∃ s : O_v, s ∈ m_v ∧ s ≠ 0 ∧ s ≠ t ∧ s ≠ W.formalInverseEval t ∧
-      s ≠ W.formalInverseEval s := by
-  have htwo : ((2 : O_v) : K_v) ≠ 0 := NeZero.ne (2 : K_v)
+private theorem exists_small_param {a b : O_v} (ha : a ∈ m_v) (ha0 : a ≠ 0) (hb0 : b ≠ 0) :
+    ∃ s : O_v, s ∈ m_v ∧ s ≠ 0 ∧ Valued.v (s : K_v) < Valued.v (a : K_v) ∧
+      Valued.v (s : K_v) < Valued.v (b : K_v) ∧ Valued.v (s : K_v) < 1 := by
   obtain ⟨π, hπ⟩ := IsDiscreteValuationRing.exists_irreducible O_v
   have hπv : Valued.v (π : K_v) = exp (-1) := by
     rw [← Algebra.algebraMap_ofSubsemiring_apply
       (Valued.v : Valuation K_v (WithZero (Multiplicative ℤ))).valuationSubring π]
     exact v.valued_algebraMap_eq_exp_neg_one_of_irreducible hπ
-  have htval0 : Valued.v (t : K_v) ≠ 0 := by
+  have haval0 : Valued.v (a : K_v) ≠ 0 := by
     simp only [ne_eq, _root_.map_eq_zero, ZeroMemClass.coe_eq_zero]
-    exact ht0
-  obtain ⟨a, ha⟩ : ∃ a : ℤ, Valued.v (t : K_v) = exp a :=
-    ⟨_, (exp_log htval0).symm⟩
-  have ha_le : a ≤ -1 := by
-    have h := v.mem_maximalIdeal_pow_iff (K := K) (n := 1) |>.mp (pow_one m_v ▸ ht)
-    rwa [ha, exp_le_exp] at h
-  obtain ⟨b, hb⟩ : ∃ b : ℤ, Valued.v ((2 : O_v) : K_v) = exp b :=
-    ⟨_, (exp_log (by simp [htwo])).symm⟩
-  have hb_le : b ≤ 0 := by
-    have h := valued_coe_le_one v (2 : O_v)
-    rwa [hb, ← exp_zero, exp_le_exp] at h
-  obtain ⟨n, hn⟩ : ∃ n : ℕ, (n : ℤ) = max (-a) (-b) + 1 :=
-    ⟨(max (-a) (-b) + 1).toNat, Int.toNat_of_nonneg (by omega)⟩
+    exact ha0
+  obtain ⟨i, hi⟩ : ∃ i : ℤ, Valued.v (a : K_v) = exp i :=
+    ⟨_, (exp_log haval0).symm⟩
+  have hi_le : i ≤ -1 := by
+    have h := v.mem_maximalIdeal_pow_iff (K := K) (n := 1) |>.mp (pow_one m_v ▸ ha)
+    rwa [hi, exp_le_exp] at h
+  have hbval0 : Valued.v (b : K_v) ≠ 0 := by
+    simp only [ne_eq, _root_.map_eq_zero, ZeroMemClass.coe_eq_zero]
+    exact hb0
+  obtain ⟨j, hj⟩ : ∃ j : ℤ, Valued.v (b : K_v) = exp j :=
+    ⟨_, (exp_log hbval0).symm⟩
+  obtain ⟨n, hn⟩ : ∃ n : ℕ, (n : ℤ) = max (-i) (-j) + 1 :=
+    ⟨(max (-i) (-j) + 1).toNat, Int.toNat_of_nonneg (by omega)⟩
   let s : O_v := π ^ n
   have hsv : Valued.v (s : K_v) = exp (-(n : ℤ)) := by
     simp only [s]
@@ -167,8 +162,8 @@ private theorem exists_aux_param [NeZero (2 : v.adicCompletion K)] {t : O_v}
     rw [map_pow, hπv, ← exp_nsmul, nsmul_eq_mul]
     congr 1
     ring
-  have hna : -(n : ℤ) < a := by omega
-  have hnb : -(n : ℤ) < b := by omega
+  have hni : -(n : ℤ) < i := by omega
+  have hnj : -(n : ℤ) < j := by omega
   have hsm : s ∈ m_v := by
     have h := v.mem_maximalIdeal_pow_iff (K := K) (x := s) (n := 1)
     rw [pow_one] at h
@@ -178,15 +173,97 @@ private theorem exists_aux_param [NeZero (2 : v.adicCompletion K)] {t : O_v}
   have hs0 : s ≠ 0 := by
     exact pow_ne_zero _ hπ.ne_zero
   refine ⟨s, hsm, hs0, ?_, ?_, ?_⟩
-  · exact ne_of_valued_lt v (by rw [hsv, ha, exp_lt_exp]; exact hna)
-  · exact ne_of_valued_lt v (by
-      rw [valued_formalInverseEval v W ht, hsv, ha, exp_lt_exp]
-      exact hna)
-  · exact ne_formalInverseEval_self v W hsm hs0 (by
-      rw [hsv, hb, exp_lt_exp]
-      exact hnb)
+  · rw [hsv, hi, exp_lt_exp]
+    exact hni
+  · rw [hsv, hj, exp_lt_exp]
+    exact hnj
+  · rw [hsv, ← exp_zero, exp_lt_exp]
+    omega
 
-private theorem exists_aux_point [NeZero (2 : v.adicCompletion K)]
+private theorem exists_aux_param [(W.baseChange K_v).IsElliptic] {t : O_v}
+    (ht : t ∈ m_v) (ht0 : t ≠ 0) :
+    ∃ s : O_v, s ∈ m_v ∧ s ≠ 0 ∧ s ≠ t ∧ s ≠ W.formalInverseEval t ∧
+      s ≠ W.formalInverseEval s := by
+  by_cases htwo : (2 : K_v) = 0
+  -- In characteristic two, ellipticity forces at least one of `a₁` and `a₃` to be nonzero.
+  -- A sufficiently small parameter then cannot satisfy the formal-inverse fixed-point equation.
+  · let _ : CharP K_v 2 :=
+      (CharP.charP_iff_prime_eq_zero Nat.prime_two).2 htwo
+    have htwo' : ((2 : O_v) : K_v) = 0 := by
+      calc
+        ((2 : O_v) : K_v) = algebraMap O_v K_v (2 : O_v) :=
+          (Algebra.algebraMap_ofSubsemiring_apply
+            (Valued.v : Valuation K_v (WithZero (Multiplicative ℤ))).valuationSubring _).symm
+        _ = (2 : K_v) := map_ofNat (algebraMap O_v K_v) 2
+        _ = 0 := htwo
+    have ha₁a₃ : (W.a₁ : K_v) ≠ 0 ∨ (W.a₃ : K_v) ≠ 0 := by
+      by_contra h
+      push Not at h
+      have hΔ : (W.baseChange K_v).Δ = 0 := by
+        rw [(W.baseChange K_v).Δ_of_char_two]
+        simp [h.1, h.2]
+      exact (W.baseChange K_v).isUnit_Δ.ne_zero hΔ
+    by_cases ha₁ : (W.a₁ : K_v) = 0
+    · have ha₃ := ha₁a₃.resolve_left (fun h ↦ h ha₁)
+      have ha₃O : W.a₃ ≠ 0 := fun h ↦ ha₃ (by simp [h])
+      obtain ⟨s, hsm, hs0, hst, _, _⟩ := exists_small_param v ht ht0 ha₃O
+      refine ⟨s, hsm, hs0, ne_of_valued_lt v hst,
+        ne_of_valued_lt v (valued_formalInverseEval v W ht ▸ hst), ?_⟩
+      intro hfix
+      have hcoe := congrArg (fun a : O_v ↦ (a : K_v))
+        (eq_two_of_formalInverseEval_self v W hsm hs0 hfix)
+      push_cast at hcoe
+      rw [htwo', ha₁, zero_mul, zero_add] at hcoe
+      have hw0 : (W.formalWEval s : K_v) ≠ 0 :=
+        W.algebraMap_formalWEval_ne_zero (Fact.out : IsAdic m_v) hsm
+          ((FaithfulSMul.algebraMap_injective O_v K_v).ne hs0)
+      exact (mul_ne_zero ha₃ hw0) hcoe.symm
+    · have ha₁O : W.a₁ ≠ 0 := fun h ↦ ha₁ (by simp [h])
+      obtain ⟨s, hsm, hs0, hst, hsa₁, hsone⟩ :=
+        exists_small_param v ht ht0 ha₁O
+      refine ⟨s, hsm, hs0, ne_of_valued_lt v hst,
+        ne_of_valued_lt v (valued_formalInverseEval v W ht ▸ hst), ?_⟩
+      intro hfix
+      have hcoe := congrArg (fun a : O_v ↦ (a : K_v))
+        (eq_two_of_formalInverseEval_self v W hsm hs0 hfix)
+      push_cast at hcoe
+      rw [htwo'] at hcoe
+      have hsval0 : Valued.v (s : K_v) ≠ 0 := by
+        exact (_root_.map_eq_zero (Valued.v :
+          Valuation K_v (WithZero (Multiplicative ℤ)))).not.mpr
+            (fun h ↦ hs0 (ZeroMemClass.coe_eq_zero.mp h))
+      have hsq : Valued.v (s : K_v) ^ 2 < Valued.v (W.a₁ : K_v) := by
+        calc
+          Valued.v (s : K_v) ^ 2 = Valued.v (s : K_v) * Valued.v (s : K_v) :=
+            pow_two _
+          _ < 1 * Valued.v (s : K_v) :=
+            mul_lt_mul_of_pos_right hsone (pos_iff_ne_zero.mpr hsval0)
+          _ = Valued.v (s : K_v) := one_mul _
+          _ < Valued.v (W.a₁ : K_v) := hsa₁
+      have hw_le : Valued.v (W.a₃ * W.formalWEval s : K_v) ≤
+          Valued.v (s : K_v) ^ 3 := by
+        rw [map_mul, valued_formalWEval v W hsm]
+        exact (mul_le_mul' W.a₃.property le_rfl).trans_eq (one_mul _)
+      have hval : Valued.v (W.a₃ * W.formalWEval s : K_v) <
+          Valued.v (W.a₁ * s : K_v) := hw_le.trans_lt (by
+        rw [map_mul, pow_succ]
+        exact mul_lt_mul_of_pos_right hsq (pos_iff_ne_zero.mpr hsval0))
+      have heq : (W.a₁ * s : K_v) = -(W.a₃ * W.formalWEval s : K_v) :=
+        eq_neg_of_add_eq_zero_left hcoe.symm
+      exact hval.ne (by rw [heq, Valuation.map_neg])
+  · have htwoO : (2 : O_v) ≠ 0 := fun h ↦ htwo (by
+      calc
+        (2 : K_v) = algebraMap O_v K_v (2 : O_v) :=
+          (map_ofNat (algebraMap O_v K_v) 2).symm
+        _ = ((2 : O_v) : K_v) := Algebra.algebraMap_ofSubsemiring_apply
+          (Valued.v : Valuation K_v (WithZero (Multiplicative ℤ))).valuationSubring _
+        _ = 0 := congrArg (fun a : O_v ↦ (a : K_v)) h)
+    obtain ⟨s, hsm, hs0, hst, hs2, _⟩ := exists_small_param v ht ht0 htwoO
+    refine ⟨s, hsm, hs0, ne_of_valued_lt v hst,
+      ne_of_valued_lt v (valued_formalInverseEval v W ht ▸ hst),
+      ne_formalInverseEval_self v W hsm hs0 hs2⟩
+
+private theorem exists_aux_point [(W.baseChange K_v).IsElliptic]
     {P : FormalGroupPoint W m_v} (hP0 : P ≠ 0) :
     ∃ U : FormalGroupPoint W m_v, U ≠ 0 ∧ U ≠ P ∧ U ≠ -P ∧ -U ≠ P ∧
       -U ≠ -P ∧ U ≠ -U := by
@@ -240,8 +317,6 @@ private theorem formalPointMap_add_of_ne (P Q : FormalGroupPoint W m_v)
     (K := K_v) (Fact.out : IsAdic m_v) P.property Q.property
     (fun _ _ h ↦ hne (FormalGroupPoint.ext h))
     (fun _ _ h ↦ hnneg (FormalGroupPoint.ext (by simpa using h)))).symm
-
-variable [NeZero (2 : v.adicCompletion K)]
 
 open Classical in
 private theorem formalPointMap_add_self (P : FormalGroupPoint W m_v) (hP0 : P ≠ 0)

--- a/TauCeti/RingTheory/DedekindDomain/AdicValuation/Completion.lean
+++ b/TauCeti/RingTheory/DedekindDomain/AdicValuation/Completion.lean
@@ -27,6 +27,8 @@ Everything here concerns one completion. The comparison of two completions along
   prime lying under the maximal ideal of `𝒪_v`.
 * `IsDedekindDomain.HeightOneSpectrum.mem_maximalIdeal_pow_iff`: membership in `𝔪 ^ n` is the
   valuation bound `≤ exp (-n)`, identifying the ideal filtration with the valuation filtration.
+* `IsDedekindDomain.HeightOneSpectrum.exists_ne_zero_mem_maximalIdeal_valued_lt`: the maximal
+  ideal contains a nonzero element whose valuation is below two prescribed nonzero bounds.
 * `IsDedekindDomain.HeightOneSpectrum.isAdic_maximalIdeal_adicCompletionIntegers`: the subspace
   topology on `𝒪_v` is the `𝔪`-adic one.
 * `IsDedekindDomain.HeightOneSpectrum.henselianLocalRing_adicCompletionIntegers`: `𝒪_v` is a
@@ -123,6 +125,51 @@ theorem mem_maximalIdeal_pow_iff {x : v.adicCompletionIntegers K} {n : ℕ} :
     simp
   rw [← hπn]
   exact Set.ext_iff.mp (hint.maximalIdeal_pow_eq_setOfPred_le_v_algebraMap_pow hπ n) x
+
+/-- The maximal ideal of the ring of integers of an adic completion contains a nonzero element
+whose valuation is below the valuations of `a` and `b`, and below `1`. -/
+theorem exists_ne_zero_mem_maximalIdeal_valued_lt {a b : v.adicCompletionIntegers K}
+    (ha : a ∈ IsLocalRing.maximalIdeal (v.adicCompletionIntegers K)) (ha0 : a ≠ 0)
+    (hb0 : b ≠ 0) :
+    ∃ s : v.adicCompletionIntegers K,
+      s ∈ IsLocalRing.maximalIdeal (v.adicCompletionIntegers K) ∧ s ≠ 0 ∧
+        Valued.v (s : v.adicCompletion K) < Valued.v (a : v.adicCompletion K) ∧
+        Valued.v (s : v.adicCompletion K) < Valued.v (b : v.adicCompletion K) ∧
+        Valued.v (s : v.adicCompletion K) < 1 := by
+  obtain ⟨π, hπ⟩ := IsDiscreteValuationRing.exists_irreducible (v.adicCompletionIntegers K)
+  have hπv : Valued.v (π : v.adicCompletion K) = exp (-1) := by
+    rw [← Algebra.algebraMap_ofSubsemiring_apply
+      (Valued.v : Valuation (v.adicCompletion K) (WithZero (Multiplicative ℤ))).valuationSubring π]
+    exact v.valued_algebraMap_eq_exp_neg_one_of_irreducible hπ
+  have haval0 : Valued.v (a : v.adicCompletion K) ≠ 0 := by
+    simp only [ne_eq, _root_.map_eq_zero, ZeroMemClass.coe_eq_zero]
+    exact ha0
+  have hbval0 : Valued.v (b : v.adicCompletion K) ≠ 0 := by
+    simp only [ne_eq, _root_.map_eq_zero, ZeroMemClass.coe_eq_zero]
+    exact hb0
+  obtain ⟨n, hna, hnb⟩ := exists_exp_neg_natCast_lt_and_lt haval0 hbval0
+  let s : v.adicCompletionIntegers K := π ^ n
+  have hsv : Valued.v (s : v.adicCompletion K) = exp (-(n : ℤ)) := by
+    simp only [s]
+    push_cast
+    rw [map_pow, hπv, ← exp_nsmul, nsmul_eq_mul]
+    congr 1
+    ring
+  have ha_le : Valued.v (a : v.adicCompletion K) ≤ exp (-1) := by
+    apply (v.mem_maximalIdeal_pow_iff (K := K) (x := a) (n := 1)).mp
+    simpa using ha
+  have hsm : s ∈ IsLocalRing.maximalIdeal (v.adicCompletionIntegers K) := by
+    have h := v.mem_maximalIdeal_pow_iff (K := K) (x := s) (n := 1)
+    rw [pow_one] at h
+    apply h.mpr
+    rw [hsv]
+    exact (hna.trans_le ha_le).le
+  have hs0 : s ≠ 0 := pow_ne_zero _ hπ.ne_zero
+  refine ⟨s, hsm, hs0, ?_, ?_, ?_⟩
+  · rwa [hsv]
+  · rwa [hsv]
+  · rw [hsv, ← exp_zero, exp_lt_exp]
+    exact (exp_lt_exp.mp (hna.trans_le ha_le)).trans_le (by omega)
 
 /-! ### `𝒪_v` is a complete adic Henselian local ring
 

--- a/TauCeti/RingTheory/DedekindDomain/AdicValuation/Completion.lean
+++ b/TauCeti/RingTheory/DedekindDomain/AdicValuation/Completion.lean
@@ -129,8 +129,7 @@ theorem mem_maximalIdeal_pow_iff {x : v.adicCompletionIntegers K} {n : ℕ} :
 /-- The maximal ideal of the ring of integers of an adic completion contains a nonzero element
 whose valuation is below the valuations of `a` and `b`, and below `1`. -/
 theorem exists_ne_zero_mem_maximalIdeal_valued_lt {a b : v.adicCompletionIntegers K}
-    (ha : a ∈ IsLocalRing.maximalIdeal (v.adicCompletionIntegers K)) (ha0 : a ≠ 0)
-    (hb0 : b ≠ 0) :
+    (ha0 : a ≠ 0) (hb0 : b ≠ 0) :
     ∃ s : v.adicCompletionIntegers K,
       s ∈ IsLocalRing.maximalIdeal (v.adicCompletionIntegers K) ∧ s ≠ 0 ∧
         Valued.v (s : v.adicCompletion K) < Valued.v (a : v.adicCompletion K) ∧
@@ -148,28 +147,27 @@ theorem exists_ne_zero_mem_maximalIdeal_valued_lt {a b : v.adicCompletionInteger
     simp only [ne_eq, _root_.map_eq_zero, ZeroMemClass.coe_eq_zero]
     exact hb0
   obtain ⟨n, hna, hnb⟩ := exists_exp_neg_natCast_lt_and_lt haval0 hbval0
-  let s : v.adicCompletionIntegers K := π ^ n
-  have hsv : Valued.v (s : v.adicCompletion K) = exp (-(n : ℤ)) := by
+  let s : v.adicCompletionIntegers K := π ^ (n + 1)
+  have hsv : Valued.v (s : v.adicCompletion K) = exp (-((n + 1 : ℕ) : ℤ)) := by
     simp only [s]
     push_cast
     rw [map_pow, hπv, ← exp_nsmul, nsmul_eq_mul]
     congr 1
-    ring
-  have ha_le : Valued.v (a : v.adicCompletion K) ≤ exp (-1) := by
-    apply (v.mem_maximalIdeal_pow_iff (K := K) (x := a) (n := 1)).mp
-    simpa using ha
+    omega
   have hsm : s ∈ IsLocalRing.maximalIdeal (v.adicCompletionIntegers K) := by
     have h := v.mem_maximalIdeal_pow_iff (K := K) (x := s) (n := 1)
     rw [pow_one] at h
     apply h.mpr
     rw [hsv]
-    exact (hna.trans_le ha_le).le
+    exact exp_le_exp.mpr (by omega)
   have hs0 : s ≠ 0 := pow_ne_zero _ hπ.ne_zero
   refine ⟨s, hsm, hs0, ?_, ?_, ?_⟩
-  · rwa [hsv]
-  · rwa [hsv]
+  · rw [hsv]
+    exact (exp_lt_exp.mpr (by omega)).trans hna
+  · rw [hsv]
+    exact (exp_lt_exp.mpr (by omega)).trans hnb
   · rw [hsv, ← exp_zero, exp_lt_exp]
-    exact (exp_lt_exp.mp (hna.trans_le ha_le)).trans_le (by omega)
+    omega
 
 /-! ### `𝒪_v` is a complete adic Henselian local ring
 


### PR DESCRIPTION
This PR packages the formal parametrisation of the maximal ideal of an adic completion as an injective additive homomorphism into the base-changed elliptic curve, without a characteristic restriction. It completes the inverse and unequal-parameter cases using the existing formal-group API and proves the missing doubling case by choosing a sufficiently small uniformizer power, applying three chord additions, and cancelling in the point group.

This PR advances `TauCetiRoadmap/EllipticCurves/README.md`, Layer 1 formal-group milestone (iii): “Convergence: over a complete valued field, `Ê(𝔪)` as an honest group of points.” It supplies the generic conditional homomorphism and discharges its auxiliary-point hypothesis for height-one-prime adic completions. It does not claim the still-missing nondiscrete complete-valued-field case or milestone (iv), the later identification with the kernel of reduction.

The doubling argument is adapted from Michael Stoll's `EllipticCurves` development at commit `66889eada51a` (Apache-2.0), specifically `WeierstrassFormalGroup/Foundations.lean` (`exists_aux_param`, `exists_aux_point`) and `WeierstrassFormalGroup/Filtration.lean` (`formalPoint_add_self`, `formalPoint_add`), rebased onto Mathlib's affine point group and Tau Ceti's one-dimensional formal-group evaluation API.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"formal-point-hom"}-->

🤖 Prepared with Codex
