### PR TITLE
feat: the simply-laced Cartan matrices are positive definite

### DIFF
--- a/TauCeti/LinearAlgebra/Matrix/PosDef.lean
+++ b/TauCeti/LinearAlgebra/Matrix/PosDef.lean
@@ -30,6 +30,7 @@ it as `Bᴴ * B` for an explicit `B`, and check that it is invertible.
 
 ## Main results
 
+* `TauCeti.Matrix.posDef_of_isEmpty`: a matrix on an empty index type is positive definite.
 * `TauCeti.Matrix.posDef_map_intCast`: an integer matrix that is positive definite over `ℤ` is
   positive definite over `ℚ`.
 * `TauCeti.Matrix.posDef_conjTranspose_mul_self_of_isUnit`: an invertible rational matrix of the
@@ -65,6 +66,13 @@ private theorem exists_intCast_eq_mul_of_ne_zero [Finite n] {x : n → ℚ} (hx 
     rw [h] at hi
     simpa [hc0] using hi.symm
   exact ⟨(c : ℤ), z, nonZeroDivisors.coe_ne_zero c, hzne, hz⟩
+
+/-- **A matrix on an empty index type is positive definite**: it is Hermitian and there is no
+nonzero test vector. This is the rank-zero member of every family of Cartan matrices. -/
+theorem posDef_of_isEmpty {R : Type*} [CommRing R] [PartialOrder R] [StarRing R] [IsEmpty n]
+    (A : _root_.Matrix n n R) : A.PosDef :=
+  ⟨_root_.Matrix.ext fun i _ ↦ isEmptyElim i,
+    fun _ hx ↦ (hx (Finsupp.ext fun i ↦ isEmptyElim i)).elim⟩
 
 /-- The finite case of `TauCeti.Matrix.posDef_map_intCast`, where positive definiteness can be
 tested against ordinary vectors. -/

--- a/TauCeti/LinearAlgebra/Matrix/PosDef.lean
+++ b/TauCeti/LinearAlgebra/Matrix/PosDef.lean
@@ -30,7 +30,7 @@ it as `Bᴴ * B` for an explicit `B`, and check that it is invertible.
 
 ## Main results
 
-* `TauCeti.Matrix.posDef_of_isEmpty`: a matrix on an empty index type is positive definite.
+* `Matrix.posDef_of_isEmpty`: a matrix on an empty index type is positive definite.
 * `TauCeti.Matrix.posDef_map_intCast`: an integer matrix that is positive definite over `ℤ` is
   positive definite over `ℚ`.
 * `TauCeti.Matrix.posDef_conjTranspose_mul_self_of_isUnit`: an invertible rational matrix of the
@@ -69,8 +69,8 @@ private theorem exists_intCast_eq_mul_of_ne_zero [Finite n] {x : n → ℚ} (hx 
 
 /-- **A matrix on an empty index type is positive definite**: it is Hermitian and there is no
 nonzero test vector. This is the rank-zero member of every family of Cartan matrices. -/
-theorem posDef_of_isEmpty {R : Type*} [CommRing R] [PartialOrder R] [StarRing R] [IsEmpty n]
-    (A : _root_.Matrix n n R) : A.PosDef :=
+theorem _root_.Matrix.posDef_of_isEmpty {R : Type*} [Ring R] [PartialOrder R] [StarRing R]
+    [IsEmpty n] (A : _root_.Matrix n n R) : A.PosDef :=
   ⟨_root_.Matrix.ext fun i _ ↦ isEmptyElim i,
     fun _ hx ↦ (hx (Finsupp.ext fun i ↦ isEmptyElim i)).elim⟩
 

--- a/TauCeti/LinearAlgebra/Matrix/PosDef.lean
+++ b/TauCeti/LinearAlgebra/Matrix/PosDef.lean
@@ -26,7 +26,10 @@ denominator, which is positive. The index type need not be finite: a test vector
 the principal submatrix on the support of the vector.
 
 The file also records the standard way of certifying a rational matrix as positive definite: write
-it as `Bᴴ * B` for an explicit `B`, and check that it is invertible.
+it as `Bᴴ * B` for an explicit `B`, and check that it is invertible. One general fact about
+`Matrix.PosDef` over any ring is recorded alongside, since Mathlib does not state it: a matrix on
+an empty index type is positive definite, which is what the rank-zero members of the classical
+Cartan families need.
 
 ## Main results
 
@@ -67,8 +70,8 @@ private theorem exists_intCast_eq_mul_of_ne_zero [Finite n] {x : n → ℚ} (hx 
     simpa [hc0] using hi.symm
   exact ⟨(c : ℤ), z, nonZeroDivisors.coe_ne_zero c, hzne, hz⟩
 
-/-- **A matrix on an empty index type is positive definite**: it is Hermitian and there is no
-nonzero test vector. This is the rank-zero member of every family of Cartan matrices. -/
+/-- **A matrix on an empty index type is vacuously positive definite.** This is what the
+rank-zero members of the classical Cartan families `A 0`, `B 0`, `C 0` and `D 0` need. -/
 theorem _root_.Matrix.posDef_of_isEmpty {R : Type*} [Ring R] [PartialOrder R] [StarRing R]
     [IsEmpty n] (A : _root_.Matrix n n R) : A.PosDef :=
   ⟨_root_.Matrix.ext fun i _ ↦ isEmptyElim i,

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/Basic.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/Basic.lean
@@ -37,9 +37,9 @@ denominators. The symmetrization itself is not redone here: Mathlib packages it 
 
 * `TauCeti.isFiniteType_of`: a constructor that does not ask for the symmetric vanishing pattern,
   which the symmetrizer already forces.
-* `TauCeti.of_one_mul_intCast_eq_map`: with the constant-one symmetrizer, the symmetrization of
-  `A` is `A` itself read over `ℚ`. This is the symmetrizer of every simply-laced Cartan matrix, and
-  it is how positive definiteness of such a matrix and its being of finite type are exchanged.
+* `TauCeti.isFiniteType_of_posDef_map`: the constructor for a generalized Cartan matrix whose
+  rational cast is itself positive definite, with the constant-one symmetrizer. The simply-laced
+  Cartan matrices are of this kind.
 * `TauCeti.isFiniteType_of_conjTranspose_mul_self_of_det_ne_zero`: the constructor used for a
   matrix presented by its entries. Positive definiteness of the symmetrization is certified by an
   explicit Gram model `Cᴴ * C` together with nonsingularity, both of which are finite
@@ -122,15 +122,6 @@ def IsFiniteType [Fintype B] (A : Matrix B B ℤ) : Prop :=
   (∀ i, A i i = 2) ∧ (∀ i j, i ≠ j → A i j ≤ 0) ∧ (∀ i j, A i j = 0 → A j i = 0) ∧
     ∃ d : B → ℚ, (∀ i, 0 < d i) ∧ (Matrix.of fun i j ↦ d i * (A i j : ℚ)).PosDef
 
-/-- **The constant-one symmetrizer.** The symmetrization of `A` by the vector `fun _ ↦ 1` is `A`
-itself, read over `ℚ`. Whenever `A` is symmetric this is a valid choice of symmetrizer, so
-positive definiteness of `A.map Int.cast` and finite type are then the same condition
-(`TauCeti.isFiniteType_of`). -/
-theorem of_one_mul_intCast_eq_map (A : Matrix B B ℤ) :
-    (Matrix.of fun i j ↦ (1 : ℚ) * ((A i j : ℤ) : ℚ)) = A.map (Int.cast : ℤ → ℚ) := by
-  ext i j
-  simp
-
 variable [Fintype B]
 
 /-- **Building a finite-type matrix.** The symmetric vanishing pattern demanded by
@@ -147,6 +138,19 @@ theorem isFiniteType_of (h2 : ∀ i, A i i = 2) (hle : ∀ i j, i ≠ j → A i 
   rw [hij] at hsymm
   have : ((A j i : ℤ) : ℚ) = 0 := by simpa [(hd j).ne'] using hsymm
   exact_mod_cast this
+
+/-- **A generalized Cartan matrix that is positive definite over `ℚ` is of finite type.** The
+symmetrizer is the constant-one vector, whose symmetrization of `A` is `A` itself read over `ℚ`;
+so the diagonal and sign conditions of `TauCeti.isFiniteType_of` are still required, and only
+the symmetrizer is fixed. This is the constructor for the simply-laced Cartan matrices, which are
+symmetric and are the Gram matrices of their own simple roots. -/
+theorem isFiniteType_of_posDef_map (h2 : ∀ i, A i i = 2) (hle : ∀ i j, i ≠ j → A i j ≤ 0)
+    (hpd : (A.map (Int.cast : ℤ → ℚ)).PosDef) : IsFiniteType A := by
+  refine isFiniteType_of h2 hle (d := fun _ ↦ 1) (fun _ ↦ one_pos) ?_
+  have h1 : (Matrix.of fun i j ↦ (1 : ℚ) * ((A i j : ℤ) : ℚ)) = A.map (Int.cast : ℤ → ℚ) :=
+    Matrix.ext fun i j ↦ by simp
+  rw [h1]
+  exact hpd
 
 /-- **A nonsingular generalized Cartan matrix with a rational Gram model is of finite type.** This
 is the working form of `TauCeti.isFiniteType_of` for a matrix given by an explicit list of entries:

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/Basic.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/Basic.lean
@@ -37,9 +37,9 @@ denominators. The symmetrization itself is not redone here: Mathlib packages it 
 
 * `TauCeti.isFiniteType_of`: a constructor that does not ask for the symmetric vanishing pattern,
   which the symmetrizer already forces.
-* `TauCeti.isFiniteType_of_posDef_map`: the constructor for a generalized Cartan matrix whose
-  rational cast is itself positive definite, with the constant-one symmetrizer. The simply-laced
-  Cartan matrices are of this kind.
+* `TauCeti.isFiniteType_of_posDef_map_intCast`: the constructor for a generalized Cartan matrix
+  whose rational cast is itself positive definite, with the constant-one symmetrizer. The
+  simply-laced Cartan matrices are of this kind.
 * `TauCeti.isFiniteType_of_conjTranspose_mul_self_of_det_ne_zero`: the constructor used for a
   matrix presented by its entries. Positive definiteness of the symmetrization is certified by an
   explicit Gram model `Cᴴ * C` together with nonsingularity, both of which are finite
@@ -144,7 +144,7 @@ symmetrizer is the constant-one vector, whose symmetrization of `A` is `A` itsel
 so the diagonal and sign conditions of `TauCeti.isFiniteType_of` are still required, and only
 the symmetrizer is fixed. This is the constructor for the simply-laced Cartan matrices, which are
 symmetric and are the Gram matrices of their own simple roots. -/
-theorem isFiniteType_of_posDef_map (h2 : ∀ i, A i i = 2) (hle : ∀ i j, i ≠ j → A i j ≤ 0)
+theorem isFiniteType_of_posDef_map_intCast (h2 : ∀ i, A i i = 2) (hle : ∀ i j, i ≠ j → A i j ≤ 0)
     (hpd : (A.map (Int.cast : ℤ → ℚ)).PosDef) : IsFiniteType A := by
   refine isFiniteType_of h2 hle (d := fun _ ↦ 1) (fun _ ↦ one_pos) ?_
   have h1 : (Matrix.of fun i j ↦ (1 : ℚ) * ((A i j : ℤ) : ℚ)) = A.map (Int.cast : ℤ → ℚ) :=

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/Basic.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/Basic.lean
@@ -37,6 +37,9 @@ denominators. The symmetrization itself is not redone here: Mathlib packages it 
 
 * `TauCeti.isFiniteType_of`: a constructor that does not ask for the symmetric vanishing pattern,
   which the symmetrizer already forces.
+* `TauCeti.of_one_mul_intCast_eq_map`: with the constant-one symmetrizer, the symmetrization of
+  `A` is `A` itself read over `ℚ`. This is the symmetrizer of every simply-laced Cartan matrix, and
+  it is how positive definiteness of such a matrix and its being of finite type are exchanged.
 * `TauCeti.isFiniteType_of_conjTranspose_mul_self_of_det_ne_zero`: the constructor used for a
   matrix presented by its entries. Positive definiteness of the symmetrization is certified by an
   explicit Gram model `Cᴴ * C` together with nonsingularity, both of which are finite
@@ -118,6 +121,15 @@ irreducibility; `TauCeti.isFiniteType_cartanMatrix` proves one direction. -/
 def IsFiniteType [Fintype B] (A : Matrix B B ℤ) : Prop :=
   (∀ i, A i i = 2) ∧ (∀ i j, i ≠ j → A i j ≤ 0) ∧ (∀ i j, A i j = 0 → A j i = 0) ∧
     ∃ d : B → ℚ, (∀ i, 0 < d i) ∧ (Matrix.of fun i j ↦ d i * (A i j : ℚ)).PosDef
+
+/-- **The constant-one symmetrizer.** The symmetrization of `A` by the vector `fun _ ↦ 1` is `A`
+itself, read over `ℚ`. Whenever `A` is symmetric this is a valid choice of symmetrizer, so
+positive definiteness of `A.map Int.cast` and finite type are then the same condition
+(`TauCeti.isFiniteType_of`). -/
+theorem of_one_mul_intCast_eq_map (A : Matrix B B ℤ) :
+    (Matrix.of fun i j ↦ (1 : ℚ) * ((A i j : ℤ) : ℚ)) = A.map (Int.cast : ℤ → ℚ) := by
+  ext i j
+  simp
 
 variable [Fintype B]
 

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/Classical.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/Classical.lean
@@ -170,11 +170,11 @@ private lemma simpleCorootsA_apply (n : ℕ) (i : Fin n) (j : Fin (n + 1)) :
 /-- The Gram matrix of the simple coroots of type `Aₙ` is the Cartan matrix itself: the family is
 simply laced, so it is its own symmetrisation. -/
 private lemma simpleCorootsA_mul_conjTranspose (n : ℕ) :
-    simpleCorootsA n * (simpleCorootsA n)ᴴ =
-      Matrix.of fun i j ↦ (1 : ℚ) * ((CartanMatrix.A n i j : ℤ) : ℚ) := by
+    simpleCorootsA n * (simpleCorootsA n)ᴴ = (CartanMatrix.A n).map (Int.cast : ℤ → ℚ) := by
   ext i j
   rw [simpleCorootsA, twoTermRows_mul_conjTranspose_apply]
-  simp only [Matrix.of_apply, CartanMatrix.A, Fin.ext_iff, Fin.val_castSucc, Fin.val_succ]
+  simp only [Matrix.map_apply, Matrix.of_apply, CartanMatrix.A, Fin.ext_iff, Fin.val_castSucc,
+    Fin.val_succ]
   split_ifs <;> first | (exfalso; omega) | norm_num
 
 /-- The simple coroots of type `Aₙ` are independent: dropping the last coordinate leaves the
@@ -191,18 +191,15 @@ private lemma simpleCorootsA_vecMul_injective (n : ℕ) :
 Gram matrix of the simple coroots, which are independent. -/
 theorem posDef_cartanMatrix_A (n : ℕ) :
     ((CartanMatrix.A n).map (Int.cast : ℤ → ℚ)).PosDef := by
-  rw [← of_one_mul_intCast_eq_map, ← simpleCorootsA_mul_conjTranspose]
+  rw [← simpleCorootsA_mul_conjTranspose]
   exact Matrix.PosDef.mul_conjTranspose_self _ (simpleCorootsA_vecMul_injective n)
 
 /-- **The Cartan matrix of type `Aₙ` is of finite type**, at every rank. The family is simply
 laced, so the constant-one vector is a symmetriser and `TauCeti.posDef_cartanMatrix_A` is the
 positive definiteness of its symmetrisation. -/
-theorem isFiniteType_cartanMatrix_A (n : ℕ) : IsFiniteType (CartanMatrix.A n) := by
-  refine isFiniteType_of (fun i ↦ by simp [CartanMatrix.A])
-    (fun i j hij ↦ CartanMatrix.A_apply_le_zero_of_ne n i j hij) (d := fun _ ↦ 1)
-    (fun _ ↦ one_pos) ?_
-  rw [of_one_mul_intCast_eq_map]
-  exact posDef_cartanMatrix_A n
+theorem isFiniteType_cartanMatrix_A (n : ℕ) : IsFiniteType (CartanMatrix.A n) :=
+  isFiniteType_of_posDef_map (fun i ↦ by simp [CartanMatrix.A])
+    (fun i j hij ↦ CartanMatrix.A_apply_le_zero_of_ne n i j hij) (posDef_cartanMatrix_A n)
 
 /-! ### Type `Bₙ` -/
 
@@ -278,21 +275,20 @@ private lemma simpleCorootsD_apply (k : ℕ) (i j : Fin (k + 2)) :
 /-- The Gram matrix of the simple coroots of type `Dₙ` is the Cartan matrix itself: the family is
 simply laced, so it is its own symmetrisation. -/
 private lemma simpleCorootsD_mul_conjTranspose (k : ℕ) :
-    simpleCorootsD k * (simpleCorootsD k)ᴴ =
-      Matrix.of fun i j ↦ (1 : ℚ) * ((CartanMatrix.D (k + 2) i j : ℤ) : ℚ) := by
+    simpleCorootsD k * (simpleCorootsD k)ᴴ = (CartanMatrix.D (k + 2)).map (Int.cast : ℤ → ℚ) := by
   ext i j
   have hi := i.isLt
   have hj := j.isLt
   rw [simpleCorootsD, twoTermRows_mul_conjTranspose_apply]
   rcases Nat.eq_zero_or_pos k with rfl | hk
   · have hk2 : 0 + 2 ≤ 2 := by omega
-    simp only [Matrix.of_apply, CartanMatrix.D, Fin.ext_iff, forkIndex_val, orderSucc_val,
-      ite_eq_left hk2]
+    simp only [Matrix.map_apply, Matrix.of_apply, CartanMatrix.D, Fin.ext_iff, forkIndex_val,
+      orderSucc_val, ite_eq_left hk2]
     split_ifs <;> first | (exfalso; omega) | norm_num
   · have hk2 : ¬(k + 2 ≤ 2) := by omega
     by_cases hin : i.val + 1 < k + 2 <;> by_cases hjn : j.val + 1 < k + 2 <;>
-        simp only [Matrix.of_apply, CartanMatrix.D, hin, hjn, ite_true, ite_false, Fin.ext_iff,
-          forkIndex_val, orderSucc_val, ite_eq_right hk2] <;>
+        simp only [Matrix.map_apply, Matrix.of_apply, CartanMatrix.D, hin, hjn, ite_true,
+          ite_false, Fin.ext_iff, forkIndex_val, orderSucc_val, ite_eq_right hk2] <;>
         split_ifs <;> first | (exfalso; omega) | norm_num
 
 /-- **The simple coroots of type `Dₙ` are independent.** No coordinate makes the matrix
@@ -376,25 +372,17 @@ Gram matrix of the simple coroots, which are independent. The ranks `0` and `1`,
 family degenerates to the empty matrix and to `A 1`, are read off Mathlib's identities rather than
 from the coordinate model, whose fork needs two coordinates. -/
 theorem posDef_cartanMatrix_D : ∀ n : ℕ, ((CartanMatrix.D n).map (Int.cast : ℤ → ℚ)).PosDef
-  | 0 => by
-      have hD0 : CartanMatrix.D 0 = CartanMatrix.A 0 := by
-        ext i
-        exact i.elim0
-      rw [hD0]
-      exact posDef_cartanMatrix_A 0
+  | 0 => TauCeti.Matrix.posDef_of_isEmpty _
   | 1 => by rw [CartanMatrix.D_one]; exact posDef_cartanMatrix_A 1
   | (k + 2) => by
-      rw [← of_one_mul_intCast_eq_map, ← simpleCorootsD_mul_conjTranspose]
+      rw [← simpleCorootsD_mul_conjTranspose]
       exact Matrix.PosDef.mul_conjTranspose_self _ (simpleCorootsD_vecMul_injective k)
 
 /-- **The Cartan matrix of type `Dₙ` is of finite type**, at every rank. The family is simply
 laced, so the constant-one vector is a symmetriser and `TauCeti.posDef_cartanMatrix_D` is the
 positive definiteness of its symmetrisation. -/
-theorem isFiniteType_cartanMatrix_D (n : ℕ) : IsFiniteType (CartanMatrix.D n) := by
-  refine isFiniteType_of (fun i ↦ CartanMatrix.D_diag n i)
-    (fun i j hij ↦ CartanMatrix.D_off_diag_nonpos n i j hij) (d := fun _ ↦ 1)
-    (fun _ ↦ one_pos) ?_
-  rw [of_one_mul_intCast_eq_map]
-  exact posDef_cartanMatrix_D n
+theorem isFiniteType_cartanMatrix_D (n : ℕ) : IsFiniteType (CartanMatrix.D n) :=
+  isFiniteType_of_posDef_map (fun i ↦ CartanMatrix.D_diag n i)
+    (fun i j hij ↦ CartanMatrix.D_off_diag_nonpos n i j hij) (posDef_cartanMatrix_D n)
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/Classical.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/Classical.lean
@@ -57,11 +57,14 @@ again.
   matrix of each classical family is of finite type, at every rank. No rank restriction is imposed:
   the low-rank coincidences `B 1 = C 1 = A 1`, `C 2 = B 2` and `D 3 = A 3` are finite-type matrices
   too, and it is `TauCeti.DynkinType.Valid`, not this file, that discards them.
-* `TauCeti.posDef_cartanMatrix_A`, `TauCeti.posDef_cartanMatrix_D`: those two families being
-  simply laced, the constant-one vector is a symmetriser for them, and its symmetrisation is the
-  Cartan matrix itself read over `ℚ`; so the Gram models give positive definiteness of the Cartan
-  matrix with no symmetriser in the way, and the finite-type statements for `A` and `D` are read
-  off these. Types `B` and `C` have no such statement: their Cartan matrices are not symmetric.
+* `TauCeti.posDef_map_intCast_cartanMatrix_A`, `TauCeti.posDef_map_intCast_cartanMatrix_D`:
+  those two families being simply laced, the constant-one vector is a symmetriser for them, and
+  its symmetrisation is the Cartan matrix itself read over `ℚ`; so the Gram models give positive
+  definiteness of the Cartan matrix with no symmetriser in the way, and the finite-type statements
+  for `A` and `D` are read off these. Types `B` and `C` have no such statement at rank `2` and
+  above, where their Cartan matrices are not symmetric; the degenerate ranks `0` and `1`, at which
+  they coincide with `A 0` and `A 1`, are handled in
+  `TauCeti.LinearAlgebra.RootSystem.FiniteType.SimplyLaced`.
 
 Since `TauCeti.DynkinType.cartanMatrix` is Mathlib's matrix on each of these four constructors, a
 consumer that needs the standard Cartan matrix of a classical Dynkin type to be nonsingular reaches
@@ -189,17 +192,18 @@ private lemma simpleCorootsA_vecMul_injective (n : ℕ) :
 
 /-- **The Cartan matrix of type `Aₙ` is positive definite** over `ℚ`, at every rank: it is the
 Gram matrix of the simple coroots, which are independent. -/
-theorem posDef_cartanMatrix_A (n : ℕ) :
+theorem posDef_map_intCast_cartanMatrix_A (n : ℕ) :
     ((CartanMatrix.A n).map (Int.cast : ℤ → ℚ)).PosDef := by
   rw [← simpleCorootsA_mul_conjTranspose]
   exact Matrix.PosDef.mul_conjTranspose_self _ (simpleCorootsA_vecMul_injective n)
 
 /-- **The Cartan matrix of type `Aₙ` is of finite type**, at every rank. The family is simply
-laced, so the constant-one vector is a symmetriser and `TauCeti.posDef_cartanMatrix_A` is the
-positive definiteness of its symmetrisation. -/
+laced, so the constant-one vector is a symmetriser and `TauCeti.posDef_map_intCast_cartanMatrix_A`
+is the positive definiteness of its symmetrisation. -/
 theorem isFiniteType_cartanMatrix_A (n : ℕ) : IsFiniteType (CartanMatrix.A n) :=
-  isFiniteType_of_posDef_map (fun i ↦ by simp [CartanMatrix.A])
-    (fun i j hij ↦ CartanMatrix.A_apply_le_zero_of_ne n i j hij) (posDef_cartanMatrix_A n)
+  isFiniteType_of_posDef_map_intCast (fun i ↦ by simp [CartanMatrix.A])
+    (fun i j hij ↦ CartanMatrix.A_apply_le_zero_of_ne n i j hij)
+    (posDef_map_intCast_cartanMatrix_A n)
 
 /-! ### Type `Bₙ` -/
 
@@ -368,21 +372,23 @@ private lemma simpleCorootsD_vecMul_injective (k : ℕ) :
   · exact congrFun hzero j
 
 /-- **The Cartan matrix of type `Dₙ` is positive definite** over `ℚ`, at every rank: it is the
-Gram matrix of the simple coroots, which are independent. The ranks `0` and `1`, at which the
-family degenerates to the empty matrix and to `A 1`, are read off Mathlib's identities rather than
-from the coordinate model, whose fork needs two coordinates. -/
-theorem posDef_cartanMatrix_D : ∀ n : ℕ, ((CartanMatrix.D n).map (Int.cast : ℤ → ℚ)).PosDef
+Gram matrix of the simple coroots, which are independent. The coordinate model needs two
+coordinates for its fork, so the ranks `0` and `1` are handled apart: at rank `0` the matrix is
+empty and positive definiteness is vacuous, and at rank `1` Mathlib's `CartanMatrix.D_one`
+identifies the matrix with `A 1`. -/
+theorem posDef_map_intCast_cartanMatrix_D :
+    ∀ n : ℕ, ((CartanMatrix.D n).map (Int.cast : ℤ → ℚ)).PosDef
   | 0 => Matrix.posDef_of_isEmpty _
-  | 1 => by rw [CartanMatrix.D_one]; exact posDef_cartanMatrix_A 1
+  | 1 => by rw [CartanMatrix.D_one]; exact posDef_map_intCast_cartanMatrix_A 1
   | (k + 2) => by
       rw [← simpleCorootsD_mul_conjTranspose]
       exact Matrix.PosDef.mul_conjTranspose_self _ (simpleCorootsD_vecMul_injective k)
 
 /-- **The Cartan matrix of type `Dₙ` is of finite type**, at every rank. The family is simply
-laced, so the constant-one vector is a symmetriser and `TauCeti.posDef_cartanMatrix_D` is the
-positive definiteness of its symmetrisation. -/
+laced, so the constant-one vector is a symmetriser and `TauCeti.posDef_map_intCast_cartanMatrix_D`
+is the positive definiteness of its symmetrisation. -/
 theorem isFiniteType_cartanMatrix_D (n : ℕ) : IsFiniteType (CartanMatrix.D n) :=
-  isFiniteType_of_posDef_map (fun i ↦ CartanMatrix.D_diag n i)
-    (fun i j hij ↦ CartanMatrix.D_off_diag_nonpos n i j hij) (posDef_cartanMatrix_D n)
+  isFiniteType_of_posDef_map_intCast (fun i ↦ CartanMatrix.D_diag n i)
+    (fun i j hij ↦ CartanMatrix.D_off_diag_nonpos n i j hij) (posDef_map_intCast_cartanMatrix_D n)
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/Classical.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/Classical.lean
@@ -58,9 +58,10 @@ again.
   the low-rank coincidences `B 1 = C 1 = A 1`, `C 2 = B 2` and `D 3 = A 3` are finite-type matrices
   too, and it is `TauCeti.DynkinType.Valid`, not this file, that discards them.
 * `TauCeti.posDef_cartanMatrix_A`, `TauCeti.posDef_cartanMatrix_D`: those two families being
-  simply laced, their symmetriser is trivial, so the same Gram models give positive definiteness of
-  the Cartan matrix itself over `ℚ`, with no symmetriser in the way. Types `B` and `C` have no such
-  statement: their Cartan matrices are not symmetric.
+  simply laced, the constant-one vector is a symmetriser for them, and its symmetrisation is the
+  Cartan matrix itself read over `ℚ`; so the Gram models give positive definiteness of the Cartan
+  matrix with no symmetriser in the way, and the finite-type statements for `A` and `D` are read
+  off these. Types `B` and `C` have no such statement: their Cartan matrices are not symmetric.
 
 Since `TauCeti.DynkinType.cartanMatrix` is Mathlib's matrix on each of these four constructors, a
 consumer that needs the standard Cartan matrix of a classical Dynkin type to be nonsingular reaches
@@ -186,26 +187,22 @@ private lemma simpleCorootsA_vecMul_injective (n : ℕ) :
     rw [ite_eq_right (by omega), ite_eq_right (by omega), add_zero]
   · simp [simpleCorootsA, Fin.ext_iff, Fin.val_castSucc, Fin.val_succ]
 
-/-- **The Cartan matrix of type `Aₙ` is of finite type**, at every rank. -/
+/-- **The Cartan matrix of type `Aₙ` is positive definite** over `ℚ`, at every rank: it is the
+Gram matrix of the simple coroots, which are independent. -/
+theorem posDef_cartanMatrix_A (n : ℕ) :
+    ((CartanMatrix.A n).map (Int.cast : ℤ → ℚ)).PosDef := by
+  rw [← of_one_mul_intCast_eq_map, ← simpleCorootsA_mul_conjTranspose]
+  exact Matrix.PosDef.mul_conjTranspose_self _ (simpleCorootsA_vecMul_injective n)
+
+/-- **The Cartan matrix of type `Aₙ` is of finite type**, at every rank. The family is simply
+laced, so the constant-one vector is a symmetriser and `TauCeti.posDef_cartanMatrix_A` is the
+positive definiteness of its symmetrisation. -/
 theorem isFiniteType_cartanMatrix_A (n : ℕ) : IsFiniteType (CartanMatrix.A n) := by
   refine isFiniteType_of (fun i ↦ by simp [CartanMatrix.A])
     (fun i j hij ↦ CartanMatrix.A_apply_le_zero_of_ne n i j hij) (d := fun _ ↦ 1)
     (fun _ ↦ one_pos) ?_
-  rw [← simpleCorootsA_mul_conjTranspose]
-  exact Matrix.PosDef.mul_conjTranspose_self _ (simpleCorootsA_vecMul_injective n)
-
-/-- **The Cartan matrix of type `Aₙ` is positive definite** over `ℚ`. The family is simply laced,
-so the matrix is its own symmetrization and the Gram model of the simple coroots proves it
-directly. -/
-theorem posDef_cartanMatrix_A (n : ℕ) :
-    ((CartanMatrix.A n).map (Int.cast : ℤ → ℚ)).PosDef := by
-  have h := Matrix.PosDef.mul_conjTranspose_self _ (simpleCorootsA_vecMul_injective n)
-  rw [simpleCorootsA_mul_conjTranspose] at h
-  have heq : (Matrix.of fun i j ↦ (1 : ℚ) * ((CartanMatrix.A n i j : ℤ) : ℚ))
-      = (CartanMatrix.A n).map (Int.cast : ℤ → ℚ) := by
-    ext i j
-    simp
-  rwa [heq] at h
+  rw [of_one_mul_intCast_eq_map]
+  exact posDef_cartanMatrix_A n
 
 /-! ### Type `Bₙ` -/
 
@@ -374,26 +371,10 @@ private lemma simpleCorootsD_vecMul_injective (k : ℕ) :
   · exact hlast
   · exact congrFun hzero j
 
-/-- **The Cartan matrix of type `Dₙ` is of finite type**, at every rank. The ranks `0` and `1`, at
-which the family degenerates to the empty matrix and to `A 1`, are read off Mathlib's identities
-rather than from the coordinate model, whose fork needs two coordinates. -/
-theorem isFiniteType_cartanMatrix_D : ∀ n : ℕ, IsFiniteType (CartanMatrix.D n)
-  | 0 => by
-      have hD0 : CartanMatrix.D 0 = CartanMatrix.A 0 := by
-        ext i
-        exact i.elim0
-      rw [hD0]
-      exact isFiniteType_cartanMatrix_A 0
-  | 1 => by rw [CartanMatrix.D_one]; exact isFiniteType_cartanMatrix_A 1
-  | (k + 2) => by
-      refine isFiniteType_of (fun i ↦ CartanMatrix.D_diag (k + 2) i)
-        (fun i j hij ↦ CartanMatrix.D_off_diag_nonpos (k + 2) i j hij) (d := fun _ ↦ 1)
-        (fun _ ↦ one_pos) ?_
-      rw [← simpleCorootsD_mul_conjTranspose]
-      exact Matrix.PosDef.mul_conjTranspose_self _ (simpleCorootsD_vecMul_injective k)
-
-/-- **The Cartan matrix of type `Dₙ` is positive definite** over `ℚ`, at every rank. Like type
-`Aₙ` the family is simply laced, so the matrix is its own symmetrization. -/
+/-- **The Cartan matrix of type `Dₙ` is positive definite** over `ℚ`, at every rank: it is the
+Gram matrix of the simple coroots, which are independent. The ranks `0` and `1`, at which the
+family degenerates to the empty matrix and to `A 1`, are read off Mathlib's identities rather than
+from the coordinate model, whose fork needs two coordinates. -/
 theorem posDef_cartanMatrix_D : ∀ n : ℕ, ((CartanMatrix.D n).map (Int.cast : ℤ → ℚ)).PosDef
   | 0 => by
       have hD0 : CartanMatrix.D 0 = CartanMatrix.A 0 := by
@@ -403,12 +384,17 @@ theorem posDef_cartanMatrix_D : ∀ n : ℕ, ((CartanMatrix.D n).map (Int.cast :
       exact posDef_cartanMatrix_A 0
   | 1 => by rw [CartanMatrix.D_one]; exact posDef_cartanMatrix_A 1
   | (k + 2) => by
-      have h := Matrix.PosDef.mul_conjTranspose_self _ (simpleCorootsD_vecMul_injective k)
-      rw [simpleCorootsD_mul_conjTranspose] at h
-      have heq : (Matrix.of fun i j ↦ (1 : ℚ) * ((CartanMatrix.D (k + 2) i j : ℤ) : ℚ))
-          = (CartanMatrix.D (k + 2)).map (Int.cast : ℤ → ℚ) := by
-        ext i j
-        simp
-      rwa [heq] at h
+      rw [← of_one_mul_intCast_eq_map, ← simpleCorootsD_mul_conjTranspose]
+      exact Matrix.PosDef.mul_conjTranspose_self _ (simpleCorootsD_vecMul_injective k)
+
+/-- **The Cartan matrix of type `Dₙ` is of finite type**, at every rank. The family is simply
+laced, so the constant-one vector is a symmetriser and `TauCeti.posDef_cartanMatrix_D` is the
+positive definiteness of its symmetrisation. -/
+theorem isFiniteType_cartanMatrix_D (n : ℕ) : IsFiniteType (CartanMatrix.D n) := by
+  refine isFiniteType_of (fun i ↦ CartanMatrix.D_diag n i)
+    (fun i j hij ↦ CartanMatrix.D_off_diag_nonpos n i j hij) (d := fun _ ↦ 1)
+    (fun _ ↦ one_pos) ?_
+  rw [of_one_mul_intCast_eq_map]
+  exact posDef_cartanMatrix_D n
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/Classical.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/Classical.lean
@@ -190,6 +190,19 @@ theorem isFiniteType_cartanMatrix_A (n : ℕ) : IsFiniteType (CartanMatrix.A n) 
   rw [← simpleCorootsA_mul_conjTranspose]
   exact Matrix.PosDef.mul_conjTranspose_self _ (simpleCorootsA_vecMul_injective n)
 
+/-- **The Cartan matrix of type `Aₙ` is positive definite** over `ℚ`. The family is simply laced,
+so the matrix is its own symmetrization and the Gram model of the simple coroots proves it
+directly. -/
+theorem posDef_cartanMatrix_A (n : ℕ) :
+    ((CartanMatrix.A n).map (Int.cast : ℤ → ℚ)).PosDef := by
+  have h := Matrix.PosDef.mul_conjTranspose_self _ (simpleCorootsA_vecMul_injective n)
+  rw [simpleCorootsA_mul_conjTranspose] at h
+  have heq : (Matrix.of fun i j ↦ (1 : ℚ) * ((CartanMatrix.A n i j : ℤ) : ℚ))
+      = (CartanMatrix.A n).map (Int.cast : ℤ → ℚ) := by
+    ext i j
+    simp
+  rwa [heq] at h
+
 /-! ### Type `Bₙ` -/
 
 /-- **The simple coroots of type `Bₙ`**: the `i`-th row is `eᵢ - eᵢ₊₁` in `ℚ^n`, except for the last
@@ -374,5 +387,24 @@ theorem isFiniteType_cartanMatrix_D : ∀ n : ℕ, IsFiniteType (CartanMatrix.D 
         (fun _ ↦ one_pos) ?_
       rw [← simpleCorootsD_mul_conjTranspose]
       exact Matrix.PosDef.mul_conjTranspose_self _ (simpleCorootsD_vecMul_injective k)
+
+/-- **The Cartan matrix of type `Dₙ` is positive definite** over `ℚ`, at every rank. Like type
+`Aₙ` the family is simply laced, so the matrix is its own symmetrization. -/
+theorem posDef_cartanMatrix_D : ∀ n : ℕ, ((CartanMatrix.D n).map (Int.cast : ℤ → ℚ)).PosDef
+  | 0 => by
+      have hD0 : CartanMatrix.D 0 = CartanMatrix.A 0 := by
+        ext i
+        exact i.elim0
+      rw [hD0]
+      exact posDef_cartanMatrix_A 0
+  | 1 => by rw [CartanMatrix.D_one]; exact posDef_cartanMatrix_A 1
+  | (k + 2) => by
+      have h := Matrix.PosDef.mul_conjTranspose_self _ (simpleCorootsD_vecMul_injective k)
+      rw [simpleCorootsD_mul_conjTranspose] at h
+      have heq : (Matrix.of fun i j ↦ (1 : ℚ) * ((CartanMatrix.D (k + 2) i j : ℤ) : ℚ))
+          = (CartanMatrix.D (k + 2)).map (Int.cast : ℤ → ℚ) := by
+        ext i j
+        simp
+      rwa [heq] at h
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/Classical.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/Classical.lean
@@ -372,7 +372,7 @@ Gram matrix of the simple coroots, which are independent. The ranks `0` and `1`,
 family degenerates to the empty matrix and to `A 1`, are read off Mathlib's identities rather than
 from the coordinate model, whose fork needs two coordinates. -/
 theorem posDef_cartanMatrix_D : ∀ n : ℕ, ((CartanMatrix.D n).map (Int.cast : ℤ → ℚ)).PosDef
-  | 0 => TauCeti.Matrix.posDef_of_isEmpty _
+  | 0 => Matrix.posDef_of_isEmpty _
   | 1 => by rw [CartanMatrix.D_one]; exact posDef_cartanMatrix_A 1
   | (k + 2) => by
       rw [← simpleCorootsD_mul_conjTranspose]

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/Classical.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/Classical.lean
@@ -11,7 +11,7 @@ public import TauCeti.LinearAlgebra.Matrix.Triangular
 public import TauCeti.LinearAlgebra.RootSystem.FiniteType.Basic
 
 /-!
-# The classical Cartan matrices are of finite type
+# The classical Cartan matrices are of finite type, and the simply-laced ones positive definite
 
 `TauCeti.IsFiniteType` asks of an integer matrix that it be a generalized Cartan matrix carrying a
 positive rational symmetriser whose symmetrisation is positive definite. This file certifies the
@@ -57,6 +57,10 @@ again.
   matrix of each classical family is of finite type, at every rank. No rank restriction is imposed:
   the low-rank coincidences `B 1 = C 1 = A 1`, `C 2 = B 2` and `D 3 = A 3` are finite-type matrices
   too, and it is `TauCeti.DynkinType.Valid`, not this file, that discards them.
+* `TauCeti.posDef_cartanMatrix_A`, `TauCeti.posDef_cartanMatrix_D`: those two families being
+  simply laced, their symmetriser is trivial, so the same Gram models give positive definiteness of
+  the Cartan matrix itself over `ℚ`, with no symmetriser in the way. Types `B` and `C` have no such
+  statement: their Cartan matrices are not symmetric.
 
 Since `TauCeti.DynkinType.cartanMatrix` is Mathlib's matrix on each of these four constructors, a
 consumer that needs the standard Cartan matrix of a classical Dynkin type to be nonsingular reaches

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/Dynkin.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/Dynkin.lean
@@ -14,10 +14,12 @@ import Mathlib.Data.Rat.Star
 
 This file proves that the five exceptional Cartan matrices in `TauCeti.DynkinType` are of finite
 type, and that the three simply-laced ones are positive definite over `ℚ` -- for those the
-symmetriser is trivial, so the Gram model below proves positive definiteness of the Cartan matrix
-itself.  The proof exhibits each symmetrized Cartan matrix as `Bᴴ * B` for an explicit rational
-matrix `B` and reads off positive definiteness from
-`TauCeti.isFiniteType_of_conjTranspose_mul_self_of_det_ne_zero`.
+constant-one vector is a symmetriser, whose symmetrisation is the Cartan matrix itself read over
+`ℚ`, so the Gram model below proves positive definiteness of the Cartan matrix directly.  The
+proof exhibits each symmetrized Cartan matrix as `Bᴴ * B` for an explicit rational matrix `B` and
+reads off positive definiteness from
+`TauCeti.isFiniteType_of_conjTranspose_mul_self_of_det_ne_zero`, or, for `E₈`, from
+`TauCeti.Matrix.posDef_conjTranspose_mul_self_of_isUnit` followed by `TauCeti.isFiniteType_of`.
 
 The columns of `B` are the simple **coroots** `αᵢ^∨ = 2 αᵢ / (αᵢ, αᵢ)`, in orthonormal rational
 coordinates and up to one common positive scale, rather than the simple roots themselves.  That is
@@ -72,10 +74,10 @@ whose rows are twice them. -/
 private def rootsE8 : _root_.Matrix (Fin 8) (Fin 8) ℚ :=
   (2 : ℚ)⁻¹ • (e8DoubledSimpleRoot.map ((↑) : ℤ → ℚ))ᵀ
 
-/-- The Gram matrix of the coordinate model of `E₈` is the `E₈` Cartan matrix: the family is
-simply laced, so no symmetrizer is needed. -/
+/-- The Gram matrix of the coordinate model of `E₈` is the `E₈` Cartan matrix read over `ℚ`: the
+family is simply laced, so no symmetrizer is needed. -/
 private theorem gram_rootsE8 :
-    _root_.Matrix.of (fun i j ↦ (1 : ℚ) * (CartanMatrix.E 8 i j : ℚ)) = rootsE8ᴴ * rootsE8 := by
+    (CartanMatrix.E 8).map (Int.cast : ℤ → ℚ) = rootsE8ᴴ * rootsE8 := by
     ext i j
     -- The `(i, j)` entry of the Gram matrix of the doubled rows is four times the Cartan entry.
     have hrowQ : ∑ k, (e8DoubledSimpleRoot i k : ℚ) * (e8DoubledSimpleRoot j k : ℚ)
@@ -86,36 +88,36 @@ private theorem gram_rootsE8 :
         ((2 : ℚ)⁻¹ * (e8DoubledSimpleRoot j k : ℚ))
         = 4⁻¹ * ((e8DoubledSimpleRoot i k : ℚ) * (e8DoubledSimpleRoot j k : ℚ)) :=
       fun k ↦ by ring
-    simp only [rootsE8, _root_.Matrix.of_apply, _root_.Matrix.mul_apply,
+    simp only [rootsE8, _root_.Matrix.map_apply, _root_.Matrix.mul_apply,
       _root_.Matrix.conjTranspose_apply, _root_.Matrix.smul_apply, _root_.Matrix.transpose_apply,
-      _root_.Matrix.map_apply, star_trivial, smul_eq_mul]
+      star_trivial, smul_eq_mul]
     rw [Finset.sum_congr rfl fun k _ ↦ hpoint k, ← Finset.mul_sum, hrowQ]
     ring
-/-- The standard Cartan matrix of type `E₈` is of finite type. -/
-theorem isFiniteType_cartanMatrix_E8 : IsFiniteType E8.cartanMatrix := by
-  have hdet : (CartanMatrix.E 8).det ≠ 0 := by rw [CartanMatrix.E₈_det]; norm_num
-  rw [cartanMatrix_E8]
-  exact isFiniteType_of_conjTranspose_mul_self_of_det_ne_zero (CartanMatrix.E_diag 8)
-    (CartanMatrix.E_off_diag_nonpos 8) (d := fun _ ↦ 1) (fun _ ↦ by positivity) gram_rootsE8 hdet
 
-/-- The `E₈` Cartan matrix, read over `ℚ`, is the Gram matrix of the coordinate model. -/
-private theorem map_cartanMatrix_E8 :
-    ((CartanMatrix.E 8).map (Int.cast : ℤ → ℚ)) = rootsE8ᴴ * rootsE8 := by
-  rw [← gram_rootsE8]
-  ext i j
-  simp
-
-/-- **The `E₈` Cartan matrix is positive definite** over `ℚ`. -/
+/-- **The `E₈` Cartan matrix is positive definite** over `ℚ`: it is the Gram matrix of the
+coordinate model, and it is nonsingular. -/
 theorem posDef_cartanMatrix_E8 : ((CartanMatrix.E 8).map (Int.cast : ℤ → ℚ)).PosDef := by
-  rw [map_cartanMatrix_E8]
+  rw [gram_rootsE8]
   refine TauCeti.Matrix.posDef_conjTranspose_mul_self_of_isUnit _ ?_
   have hmap : (CartanMatrix.E 8).map (Int.cast : ℤ → ℚ)
       = (Int.castRingHom ℚ).mapMatrix (CartanMatrix.E 8) := by
     ext i j
     simp [RingHom.mapMatrix_apply]
-  rw [← map_cartanMatrix_E8, _root_.Matrix.isUnit_iff_isUnit_det, isUnit_iff_ne_zero, hmap,
+  rw [← gram_rootsE8, _root_.Matrix.isUnit_iff_isUnit_det, isUnit_iff_ne_zero, hmap,
     ← RingHom.map_det, CartanMatrix.E₈_det]
   norm_num
+
+/-- The standard Cartan matrix of type `E₈` is of finite type: the family is simply laced, so the
+constant-one vector is a symmetriser and `TauCeti.DynkinType.posDef_cartanMatrix_E8` is the
+positive definiteness of its symmetrisation. -/
+theorem isFiniteType_cartanMatrix_E8 : IsFiniteType E8.cartanMatrix := by
+  have h : IsFiniteType (CartanMatrix.E 8) := by
+    refine isFiniteType_of (CartanMatrix.E_diag 8) (CartanMatrix.E_off_diag_nonpos 8)
+      (d := fun _ ↦ 1) (fun _ ↦ one_pos) ?_
+    rw [of_one_mul_intCast_eq_map]
+    exact posDef_cartanMatrix_E8
+  rw [cartanMatrix_E8]
+  exact h
 
 
 /-- The `E₆` Cartan matrix is the principal submatrix of the `E₈` one on the first six nodes: in

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/Dynkin.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/Dynkin.lean
@@ -10,10 +10,12 @@ import TauCeti.LinearAlgebra.RootSystem.E8Coordinates
 import Mathlib.Data.Rat.Star
 
 /-!
-# Exceptional Cartan matrices are of finite type
+# Exceptional Cartan matrices are of finite type, and the simply-laced ones positive definite
 
 This file proves that the five exceptional Cartan matrices in `TauCeti.DynkinType` are of finite
-type.  The proof exhibits each symmetrized Cartan matrix as `Bᴴ * B` for an explicit rational
+type, and that the three simply-laced ones are positive definite over `ℚ` -- for those the
+symmetriser is trivial, so the Gram model below proves positive definiteness of the Cartan matrix
+itself.  The proof exhibits each symmetrized Cartan matrix as `Bᴴ * B` for an explicit rational
 matrix `B` and reads off positive definiteness from
 `TauCeti.isFiniteType_of_conjTranspose_mul_self_of_det_ne_zero`.
 
@@ -40,6 +42,9 @@ recorded in `TauCeti.DynkinType.rootLength_F4` and `TauCeti.DynkinType.rootLengt
 * `TauCeti.DynkinType.isFiniteType_cartanMatrix_E7`
 * `TauCeti.DynkinType.isFiniteType_cartanMatrix_F4`
 * `TauCeti.DynkinType.isFiniteType_cartanMatrix_G2`
+* `TauCeti.DynkinType.posDef_cartanMatrix_E6`, `posDef_cartanMatrix_E7` and
+  `posDef_cartanMatrix_E8`: the exceptional simply-laced Cartan matrices are positive definite
+  over `ℚ`, `E₆` and `E₇` as principal submatrices of `E₈`.
 * `TauCeti.DynkinType.cartanMatrix_E6_eq_submatrix_E8` and
   `TauCeti.DynkinType.cartanMatrix_E7_eq_submatrix_E8`: the nesting `E₆ ⊂ E₇ ⊂ E₈` at the level of
   Cartan matrices, which is what makes the two derivations above possible.
@@ -104,9 +109,11 @@ private theorem map_cartanMatrix_E8 :
 theorem posDef_cartanMatrix_E8 : ((CartanMatrix.E 8).map (Int.cast : ℤ → ℚ)).PosDef := by
   rw [map_cartanMatrix_E8]
   refine TauCeti.Matrix.posDef_conjTranspose_mul_self_of_isUnit _ ?_
-  rw [← map_cartanMatrix_E8, _root_.Matrix.isUnit_iff_isUnit_det, isUnit_iff_ne_zero,
-    show ((CartanMatrix.E 8).map (Int.cast : ℤ → ℚ))
-      = (Int.castRingHom ℚ).mapMatrix (CartanMatrix.E 8) from rfl,
+  have hmap : (CartanMatrix.E 8).map (Int.cast : ℤ → ℚ)
+      = (Int.castRingHom ℚ).mapMatrix (CartanMatrix.E 8) := by
+    ext i j
+    simp [RingHom.mapMatrix_apply]
+  rw [← map_cartanMatrix_E8, _root_.Matrix.isUnit_iff_isUnit_det, isUnit_iff_ne_zero, hmap,
     ← RingHom.map_det, CartanMatrix.E₈_det]
   norm_num
 

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/Dynkin.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/Dynkin.lean
@@ -19,7 +19,8 @@ constant-one vector is a symmetriser, whose symmetrisation is the Cartan matrix 
 proof exhibits each symmetrized Cartan matrix as `Bᴴ * B` for an explicit rational matrix `B` and
 reads off positive definiteness from
 `TauCeti.isFiniteType_of_conjTranspose_mul_self_of_det_ne_zero`, or, for `E₈`, from
-`TauCeti.Matrix.posDef_conjTranspose_mul_self_of_isUnit` followed by `TauCeti.isFiniteType_of`.
+`TauCeti.Matrix.posDef_conjTranspose_mul_self_of_isUnit` followed by
+`TauCeti.isFiniteType_of_posDef_map`.
 
 The columns of `B` are the simple **coroots** `αᵢ^∨ = 2 αᵢ / (αᵢ, αᵢ)`, in orthonormal rational
 coordinates and up to one common positive scale, rather than the simple roots themselves.  That is
@@ -44,9 +45,11 @@ recorded in `TauCeti.DynkinType.rootLength_F4` and `TauCeti.DynkinType.rootLengt
 * `TauCeti.DynkinType.isFiniteType_cartanMatrix_E7`
 * `TauCeti.DynkinType.isFiniteType_cartanMatrix_F4`
 * `TauCeti.DynkinType.isFiniteType_cartanMatrix_G2`
-* `TauCeti.DynkinType.posDef_cartanMatrix_E6`, `posDef_cartanMatrix_E7` and
-  `posDef_cartanMatrix_E8`: the exceptional simply-laced Cartan matrices are positive definite
-  over `ℚ`, `E₆` and `E₇` as principal submatrices of `E₈`.
+* `TauCeti.posDef_cartanMatrix_E6`, `TauCeti.posDef_cartanMatrix_E7` and
+  `TauCeti.posDef_cartanMatrix_E8`: the exceptional simply-laced Cartan matrices
+  `CartanMatrix.E 6`, `CartanMatrix.E 7` and `CartanMatrix.E 8` are positive definite over `ℚ`,
+  `E₆` and `E₇` as principal submatrices of `E₈`. Like `TauCeti.posDef_cartanMatrix_A` these are
+  stated for Mathlib's matrices and live in the root namespace, not in `TauCeti.DynkinType`.
 * `TauCeti.DynkinType.cartanMatrix_E6_eq_submatrix_E8` and
   `TauCeti.DynkinType.cartanMatrix_E7_eq_submatrix_E8`: the nesting `E₆ ⊂ E₇ ⊂ E₈` at the level of
   Cartan matrices, which is what makes the two derivations above possible.
@@ -96,28 +99,21 @@ private theorem gram_rootsE8 :
 
 /-- **The `E₈` Cartan matrix is positive definite** over `ℚ`: it is the Gram matrix of the
 coordinate model, and it is nonsingular. -/
-theorem posDef_cartanMatrix_E8 : ((CartanMatrix.E 8).map (Int.cast : ℤ → ℚ)).PosDef := by
+theorem _root_.TauCeti.posDef_cartanMatrix_E8 :
+    ((CartanMatrix.E 8).map (Int.cast : ℤ → ℚ)).PosDef := by
   rw [gram_rootsE8]
   refine TauCeti.Matrix.posDef_conjTranspose_mul_self_of_isUnit _ ?_
-  have hmap : (CartanMatrix.E 8).map (Int.cast : ℤ → ℚ)
-      = (Int.castRingHom ℚ).mapMatrix (CartanMatrix.E 8) := by
-    ext i j
-    simp [RingHom.mapMatrix_apply]
-  rw [← gram_rootsE8, _root_.Matrix.isUnit_iff_isUnit_det, isUnit_iff_ne_zero, hmap,
-    ← RingHom.map_det, CartanMatrix.E₈_det]
+  rw [← gram_rootsE8, _root_.Matrix.isUnit_iff_isUnit_det, isUnit_iff_ne_zero, ← Int.cast_det,
+    CartanMatrix.E₈_det]
   norm_num
 
 /-- The standard Cartan matrix of type `E₈` is of finite type: the family is simply laced, so the
-constant-one vector is a symmetriser and `TauCeti.DynkinType.posDef_cartanMatrix_E8` is the
-positive definiteness of its symmetrisation. -/
+constant-one vector is a symmetriser and `TauCeti.posDef_cartanMatrix_E8` is the positive
+definiteness of its symmetrisation. -/
 theorem isFiniteType_cartanMatrix_E8 : IsFiniteType E8.cartanMatrix := by
-  have h : IsFiniteType (CartanMatrix.E 8) := by
-    refine isFiniteType_of (CartanMatrix.E_diag 8) (CartanMatrix.E_off_diag_nonpos 8)
-      (d := fun _ ↦ 1) (fun _ ↦ one_pos) ?_
-    rw [of_one_mul_intCast_eq_map]
-    exact posDef_cartanMatrix_E8
   rw [cartanMatrix_E8]
-  exact h
+  exact isFiniteType_of_posDef_map (CartanMatrix.E_diag 8) (CartanMatrix.E_off_diag_nonpos 8)
+    posDef_cartanMatrix_E8
 
 
 /-- The `E₆` Cartan matrix is the principal submatrix of the `E₈` one on the first six nodes: in
@@ -150,13 +146,15 @@ theorem isFiniteType_cartanMatrix_E7 : IsFiniteType E7.cartanMatrix := by
 
 /-- **The `E₆` Cartan matrix is positive definite** over `ℚ`: it is a principal submatrix of the
 `E₈` one. -/
-theorem posDef_cartanMatrix_E6 : ((CartanMatrix.E 6).map (Int.cast : ℤ → ℚ)).PosDef := by
+theorem _root_.TauCeti.posDef_cartanMatrix_E6 :
+    ((CartanMatrix.E 6).map (Int.cast : ℤ → ℚ)).PosDef := by
   rw [cartanMatrix_E6_eq_submatrix_E8, ← _root_.Matrix.submatrix_map]
   exact posDef_cartanMatrix_E8.submatrix (Fin.castAdd_injective 6 2)
 
 /-- **The `E₇` Cartan matrix is positive definite** over `ℚ`: it is a principal submatrix of the
 `E₈` one. -/
-theorem posDef_cartanMatrix_E7 : ((CartanMatrix.E 7).map (Int.cast : ℤ → ℚ)).PosDef := by
+theorem _root_.TauCeti.posDef_cartanMatrix_E7 :
+    ((CartanMatrix.E 7).map (Int.cast : ℤ → ℚ)).PosDef := by
   rw [cartanMatrix_E7_eq_submatrix_E8, ← _root_.Matrix.submatrix_map]
   exact posDef_cartanMatrix_E8.submatrix (Fin.castAdd_injective 7 1)
 

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/Dynkin.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/Dynkin.lean
@@ -67,10 +67,10 @@ whose rows are twice them. -/
 private def rootsE8 : _root_.Matrix (Fin 8) (Fin 8) ℚ :=
   (2 : ℚ)⁻¹ • (e8DoubledSimpleRoot.map ((↑) : ℤ → ℚ))ᵀ
 
-/-- The standard Cartan matrix of type `E₈` is of finite type. -/
-theorem isFiniteType_cartanMatrix_E8 : IsFiniteType E8.cartanMatrix := by
-  have hgram : _root_.Matrix.of (fun i j ↦ (1 : ℚ) * (CartanMatrix.E 8 i j : ℚ))
-      = rootsE8ᴴ * rootsE8 := by
+/-- The Gram matrix of the coordinate model of `E₈` is the `E₈` Cartan matrix: the family is
+simply laced, so no symmetrizer is needed. -/
+private theorem gram_rootsE8 :
+    _root_.Matrix.of (fun i j ↦ (1 : ℚ) * (CartanMatrix.E 8 i j : ℚ)) = rootsE8ᴴ * rootsE8 := by
     ext i j
     -- The `(i, j)` entry of the Gram matrix of the doubled rows is four times the Cartan entry.
     have hrowQ : ∑ k, (e8DoubledSimpleRoot i k : ℚ) * (e8DoubledSimpleRoot j k : ℚ)
@@ -86,10 +86,30 @@ theorem isFiniteType_cartanMatrix_E8 : IsFiniteType E8.cartanMatrix := by
       _root_.Matrix.map_apply, star_trivial, smul_eq_mul]
     rw [Finset.sum_congr rfl fun k _ ↦ hpoint k, ← Finset.mul_sum, hrowQ]
     ring
+/-- The standard Cartan matrix of type `E₈` is of finite type. -/
+theorem isFiniteType_cartanMatrix_E8 : IsFiniteType E8.cartanMatrix := by
   have hdet : (CartanMatrix.E 8).det ≠ 0 := by rw [CartanMatrix.E₈_det]; norm_num
   rw [cartanMatrix_E8]
   exact isFiniteType_of_conjTranspose_mul_self_of_det_ne_zero (CartanMatrix.E_diag 8)
-    (CartanMatrix.E_off_diag_nonpos 8) (d := fun _ ↦ 1) (fun _ ↦ by positivity) hgram hdet
+    (CartanMatrix.E_off_diag_nonpos 8) (d := fun _ ↦ 1) (fun _ ↦ by positivity) gram_rootsE8 hdet
+
+/-- The `E₈` Cartan matrix, read over `ℚ`, is the Gram matrix of the coordinate model. -/
+private theorem map_cartanMatrix_E8 :
+    ((CartanMatrix.E 8).map (Int.cast : ℤ → ℚ)) = rootsE8ᴴ * rootsE8 := by
+  rw [← gram_rootsE8]
+  ext i j
+  simp
+
+/-- **The `E₈` Cartan matrix is positive definite** over `ℚ`. -/
+theorem posDef_cartanMatrix_E8 : ((CartanMatrix.E 8).map (Int.cast : ℤ → ℚ)).PosDef := by
+  rw [map_cartanMatrix_E8]
+  refine TauCeti.Matrix.posDef_conjTranspose_mul_self_of_isUnit _ ?_
+  rw [← map_cartanMatrix_E8, _root_.Matrix.isUnit_iff_isUnit_det, isUnit_iff_ne_zero,
+    show ((CartanMatrix.E 8).map (Int.cast : ℤ → ℚ))
+      = (Int.castRingHom ℚ).mapMatrix (CartanMatrix.E 8) from rfl,
+    ← RingHom.map_det, CartanMatrix.E₈_det]
+  norm_num
+
 
 /-- The `E₆` Cartan matrix is the principal submatrix of the `E₈` one on the first six nodes: in
 Bourbaki's numbering the exceptional `E` diagrams are nested, `E₆ ⊂ E₇ ⊂ E₈`. -/
@@ -118,6 +138,18 @@ theorem isFiniteType_cartanMatrix_E6 : IsFiniteType E6.cartanMatrix := by
 theorem isFiniteType_cartanMatrix_E7 : IsFiniteType E7.cartanMatrix := by
   simp only [cartanMatrix_E7, cartanMatrix_E7_eq_submatrix_E8]
   exact (cartanMatrix_E8 ▸ isFiniteType_cartanMatrix_E8).submatrix (Fin.castAdd_injective 7 1)
+
+/-- **The `E₆` Cartan matrix is positive definite** over `ℚ`: it is a principal submatrix of the
+`E₈` one. -/
+theorem posDef_cartanMatrix_E6 : ((CartanMatrix.E 6).map (Int.cast : ℤ → ℚ)).PosDef := by
+  rw [cartanMatrix_E6_eq_submatrix_E8, ← _root_.Matrix.submatrix_map]
+  exact posDef_cartanMatrix_E8.submatrix (Fin.castAdd_injective 6 2)
+
+/-- **The `E₇` Cartan matrix is positive definite** over `ℚ`: it is a principal submatrix of the
+`E₈` one. -/
+theorem posDef_cartanMatrix_E7 : ((CartanMatrix.E 7).map (Int.cast : ℤ → ℚ)).PosDef := by
+  rw [cartanMatrix_E7_eq_submatrix_E8, ← _root_.Matrix.submatrix_map]
+  exact posDef_cartanMatrix_E8.submatrix (Fin.castAdd_injective 7 1)
 
 /-- The coordinate model of type `F₄`: column `i` is the simple coroot `αᵢ₊₁^∨` of Bourbaki's plate
 VIII, in the orthonormal coordinates `ε₁, ..., ε₄` used there, cyclically relabelled so that `ε₁`

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/Dynkin.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/Dynkin.lean
@@ -20,7 +20,7 @@ proof exhibits each symmetrized Cartan matrix as `Bᴴ * B` for an explicit rati
 reads off positive definiteness from
 `TauCeti.isFiniteType_of_conjTranspose_mul_self_of_det_ne_zero`, or, for `E₈`, from
 `TauCeti.Matrix.posDef_conjTranspose_mul_self_of_isUnit` followed by
-`TauCeti.isFiniteType_of_posDef_map`.
+`TauCeti.isFiniteType_of_posDef_map_intCast`.
 
 The columns of `B` are the simple **coroots** `αᵢ^∨ = 2 αᵢ / (αᵢ, αᵢ)`, in orthonormal rational
 coordinates and up to one common positive scale, rather than the simple roots themselves.  That is
@@ -45,11 +45,12 @@ recorded in `TauCeti.DynkinType.rootLength_F4` and `TauCeti.DynkinType.rootLengt
 * `TauCeti.DynkinType.isFiniteType_cartanMatrix_E7`
 * `TauCeti.DynkinType.isFiniteType_cartanMatrix_F4`
 * `TauCeti.DynkinType.isFiniteType_cartanMatrix_G2`
-* `TauCeti.posDef_cartanMatrix_E6`, `TauCeti.posDef_cartanMatrix_E7` and
-  `TauCeti.posDef_cartanMatrix_E8`: the exceptional simply-laced Cartan matrices
+* `TauCeti.posDef_map_intCast_cartanMatrix_E6`, `TauCeti.posDef_map_intCast_cartanMatrix_E7` and
+  `TauCeti.posDef_map_intCast_cartanMatrix_E8`: the exceptional simply-laced Cartan matrices
   `CartanMatrix.E 6`, `CartanMatrix.E 7` and `CartanMatrix.E 8` are positive definite over `ℚ`,
-  `E₆` and `E₇` as principal submatrices of `E₈`. Like `TauCeti.posDef_cartanMatrix_A` these are
-  stated for Mathlib's matrices and live in the root namespace, not in `TauCeti.DynkinType`.
+  `E₆` and `E₇` as principal submatrices of `E₈`. Like `TauCeti.posDef_map_intCast_cartanMatrix_A`
+  these are stated for Mathlib's matrices and live in the `TauCeti` namespace, not in
+  `TauCeti.DynkinType`.
 * `TauCeti.DynkinType.cartanMatrix_E6_eq_submatrix_E8` and
   `TauCeti.DynkinType.cartanMatrix_E7_eq_submatrix_E8`: the nesting `E₆ ⊂ E₇ ⊂ E₈` at the level of
   Cartan matrices, which is what makes the two derivations above possible.
@@ -79,7 +80,7 @@ private def rootsE8 : _root_.Matrix (Fin 8) (Fin 8) ℚ :=
 
 /-- The Gram matrix of the coordinate model of `E₈` is the `E₈` Cartan matrix read over `ℚ`: the
 family is simply laced, so no symmetrizer is needed. -/
-private theorem gram_rootsE8 :
+private theorem rootsE8_conjTranspose_mul_self :
     (CartanMatrix.E 8).map (Int.cast : ℤ → ℚ) = rootsE8ᴴ * rootsE8 := by
     ext i j
     -- The `(i, j)` entry of the Gram matrix of the doubled rows is four times the Cartan entry.
@@ -99,21 +100,21 @@ private theorem gram_rootsE8 :
 
 /-- **The `E₈` Cartan matrix is positive definite** over `ℚ`: it is the Gram matrix of the
 coordinate model, and it is nonsingular. -/
-theorem _root_.TauCeti.posDef_cartanMatrix_E8 :
+theorem _root_.TauCeti.posDef_map_intCast_cartanMatrix_E8 :
     ((CartanMatrix.E 8).map (Int.cast : ℤ → ℚ)).PosDef := by
-  rw [gram_rootsE8]
+  rw [rootsE8_conjTranspose_mul_self]
   refine TauCeti.Matrix.posDef_conjTranspose_mul_self_of_isUnit _ ?_
-  rw [← gram_rootsE8, _root_.Matrix.isUnit_iff_isUnit_det, isUnit_iff_ne_zero, ← Int.cast_det,
-    CartanMatrix.E₈_det]
+  rw [← rootsE8_conjTranspose_mul_self, _root_.Matrix.isUnit_iff_isUnit_det, isUnit_iff_ne_zero,
+    ← Int.cast_det, CartanMatrix.E₈_det]
   norm_num
 
 /-- The standard Cartan matrix of type `E₈` is of finite type: the family is simply laced, so the
-constant-one vector is a symmetriser and `TauCeti.posDef_cartanMatrix_E8` is the positive
-definiteness of its symmetrisation. -/
+constant-one vector is a symmetriser and `TauCeti.posDef_map_intCast_cartanMatrix_E8` is the
+positive definiteness of its symmetrisation. -/
 theorem isFiniteType_cartanMatrix_E8 : IsFiniteType E8.cartanMatrix := by
   rw [cartanMatrix_E8]
-  exact isFiniteType_of_posDef_map (CartanMatrix.E_diag 8) (CartanMatrix.E_off_diag_nonpos 8)
-    posDef_cartanMatrix_E8
+  exact isFiniteType_of_posDef_map_intCast (CartanMatrix.E_diag 8)
+    (CartanMatrix.E_off_diag_nonpos 8) posDef_map_intCast_cartanMatrix_E8
 
 
 /-- The `E₆` Cartan matrix is the principal submatrix of the `E₈` one on the first six nodes: in
@@ -146,17 +147,17 @@ theorem isFiniteType_cartanMatrix_E7 : IsFiniteType E7.cartanMatrix := by
 
 /-- **The `E₆` Cartan matrix is positive definite** over `ℚ`: it is a principal submatrix of the
 `E₈` one. -/
-theorem _root_.TauCeti.posDef_cartanMatrix_E6 :
+theorem _root_.TauCeti.posDef_map_intCast_cartanMatrix_E6 :
     ((CartanMatrix.E 6).map (Int.cast : ℤ → ℚ)).PosDef := by
   rw [cartanMatrix_E6_eq_submatrix_E8, ← _root_.Matrix.submatrix_map]
-  exact posDef_cartanMatrix_E8.submatrix (Fin.castAdd_injective 6 2)
+  exact posDef_map_intCast_cartanMatrix_E8.submatrix (Fin.castAdd_injective 6 2)
 
 /-- **The `E₇` Cartan matrix is positive definite** over `ℚ`: it is a principal submatrix of the
 `E₈` one. -/
-theorem _root_.TauCeti.posDef_cartanMatrix_E7 :
+theorem _root_.TauCeti.posDef_map_intCast_cartanMatrix_E7 :
     ((CartanMatrix.E 7).map (Int.cast : ℤ → ℚ)).PosDef := by
   rw [cartanMatrix_E7_eq_submatrix_E8, ← _root_.Matrix.submatrix_map]
-  exact posDef_cartanMatrix_E8.submatrix (Fin.castAdd_injective 7 1)
+  exact posDef_map_intCast_cartanMatrix_E8.submatrix (Fin.castAdd_injective 7 1)
 
 /-- The coordinate model of type `F₄`: column `i` is the simple coroot `αᵢ₊₁^∨` of Bourbaki's plate
 VIII, in the orthonormal coordinates `ε₁, ..., ε₄` used there, cyclically relabelled so that `ε₁`

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/SimplyLaced.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/SimplyLaced.lean
@@ -41,7 +41,7 @@ namespace TauCeti.DynkinType
 private theorem posDef_cartanMatrix_B_of_le_one {n : ℕ} (hn : n ≤ 1) :
     ((CartanMatrix.B n).map (Int.cast : ℤ → ℚ)).PosDef := by
   interval_cases n
-  · exact TauCeti.Matrix.posDef_of_isEmpty _
+  · exact Matrix.posDef_of_isEmpty _
   · rw [CartanMatrix.B_one]
     exact posDef_cartanMatrix_A 1
 

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/SimplyLaced.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/SimplyLaced.lean
@@ -1,0 +1,47 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.LinearAlgebra.RootSystem.FiniteType.Classical
+public import TauCeti.LinearAlgebra.RootSystem.FiniteType.Dynkin
+
+/-!
+# Simply-laced Cartan matrices are positive definite
+
+`TauCeti.IsFiniteType` carries a positive definite symmetrization, but behind an existential over
+the symmetrizer, so it says nothing directly about the matrix itself.  For a simply-laced type the
+symmetrizer is trivial and the matrix is its own symmetrization, so positive definiteness holds on
+the nose.  The per-family statements are proved beside the coordinate models they use, in
+`TauCeti.LinearAlgebra.RootSystem.FiniteType.Classical` and
+`TauCeti.LinearAlgebra.RootSystem.FiniteType.Dynkin`; this file collects them into the statement a
+consumer indexing over `TauCeti.DynkinType` wants, so that nobody repeats the case split.
+
+## Main results
+
+* `TauCeti.DynkinType.posDef_cartanMatrix_of_isSimplyLaced`: the Cartan matrix of a simply-laced
+  Dynkin type is positive definite over `ℚ`.
+-/
+
+public section
+
+namespace TauCeti.DynkinType
+
+/-- **The Cartan matrix of a simply-laced Dynkin type is positive definite** over `ℚ`.  The
+simply-laced types are exactly `A`, `D`, `E₆`, `E₇` and `E₈`; the hypothesis rules out the rest. -/
+theorem posDef_cartanMatrix_of_isSimplyLaced (t : DynkinType) (ht : t.IsSimplyLaced) :
+    (t.cartanMatrix.map (Int.cast : ℤ → ℚ)).PosDef := by
+  cases t with
+  | A n => rw [cartanMatrix_A]; exact posDef_cartanMatrix_A n
+  | D n => rw [cartanMatrix_D]; exact posDef_cartanMatrix_D n
+  | E6 => rw [cartanMatrix_E6]; exact posDef_cartanMatrix_E6
+  | E7 => rw [cartanMatrix_E7]; exact posDef_cartanMatrix_E7
+  | E8 => rw [cartanMatrix_E8]; exact posDef_cartanMatrix_E8
+  | B n => exact absurd ht (not_isSimplyLaced_B n)
+  | C n => exact absurd ht (not_isSimplyLaced_C n)
+  | F4 => exact absurd ht not_isSimplyLaced_F4
+  | G2 => exact absurd ht not_isSimplyLaced_G2
+
+end TauCeti.DynkinType

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/SimplyLaced.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/SimplyLaced.lean
@@ -37,6 +37,14 @@ public section
 
 namespace TauCeti.DynkinType
 
+/-- The degenerate types `B 0` and `B 1`, whose Cartan matrices are the empty matrix and `A 1`. -/
+private theorem posDef_cartanMatrix_B_of_le_one {n : ℕ} (hn : n ≤ 1) :
+    ((CartanMatrix.B n).map (Int.cast : ℤ → ℚ)).PosDef := by
+  interval_cases n
+  · exact TauCeti.Matrix.posDef_of_isEmpty _
+  · rw [CartanMatrix.B_one]
+    exact posDef_cartanMatrix_A 1
+
 /-- **A simply-laced standard Cartan matrix is positive definite** over `ℚ`.  The types whose
 matrix is simply laced are `A`, `D`, `E₆`, `E₇`, `E₈` and the degenerate `B 0`, `B 1`, `C 0`,
 `C 1` (`TauCeti.DynkinType.isSimplyLaced_cartanMatrix_iff`); the last four have the empty matrix or
@@ -51,27 +59,13 @@ theorem posDef_cartanMatrix_of_isSimplyLaced (t : DynkinType) (ht : t.cartanMatr
   | E7 => rw [cartanMatrix_E7]; exact posDef_cartanMatrix_E7
   | E8 => rw [cartanMatrix_E8]; exact posDef_cartanMatrix_E8
   | B n =>
-    have hn : n ≤ 1 := by simpa using ht
     rw [cartanMatrix_B]
-    interval_cases n
-    · have hB0 : CartanMatrix.B 0 = CartanMatrix.A 0 := by
-        ext i
-        exact i.elim0
-      rw [hB0]
-      exact posDef_cartanMatrix_A 0
-    · rw [CartanMatrix.B_one]
-      exact posDef_cartanMatrix_A 1
+    exact posDef_cartanMatrix_B_of_le_one (by simpa using ht)
   | C n =>
-    have hn : n ≤ 1 := by simpa using ht
+    have h := (posDef_cartanMatrix_B_of_le_one (n := n) (by simpa using ht)).transpose
+    rw [← Matrix.transpose_map, CartanMatrix.B_transpose] at h
     rw [cartanMatrix_C]
-    interval_cases n
-    · have hC0 : CartanMatrix.C 0 = CartanMatrix.A 0 := by
-        ext i
-        exact i.elim0
-      rw [hC0]
-      exact posDef_cartanMatrix_A 0
-    · rw [CartanMatrix.C_one]
-      exact posDef_cartanMatrix_A 1
+    exact h
   | F4 => simp at ht
   | G2 => simp at ht
 

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/SimplyLaced.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/SimplyLaced.lean
@@ -12,16 +12,24 @@ public import TauCeti.LinearAlgebra.RootSystem.FiniteType.Dynkin
 # Simply-laced Cartan matrices are positive definite
 
 `TauCeti.IsFiniteType` carries a positive definite symmetrization, but behind an existential over
-the symmetrizer, so it says nothing directly about the matrix itself.  For a simply-laced type the
-symmetrizer is trivial and the matrix is its own symmetrization, so positive definiteness holds on
-the nose.  The per-family statements are proved beside the coordinate models they use, in
-`TauCeti.LinearAlgebra.RootSystem.FiniteType.Classical` and
+the symmetrizer, so it says nothing directly about the matrix itself.  For a simply-laced Cartan
+matrix the constant-one vector is a symmetrizer, and its symmetrization is the matrix itself read
+over `ℚ`, so positive definiteness holds on the nose.  The per-family statements are proved beside
+the coordinate models they use, in `TauCeti.LinearAlgebra.RootSystem.FiniteType.Classical` and
 `TauCeti.LinearAlgebra.RootSystem.FiniteType.Dynkin`; this file collects them into the statement a
 consumer indexing over `TauCeti.DynkinType` wants, so that nobody repeats the case split.
 
+The hypothesis is placed on the matrix rather than on the type.  By
+`TauCeti.DynkinType.isSimplyLaced_cartanMatrix_iff` that is the weaker of the two: besides the
+simply-laced types `A`, `D`, `E₆`, `E₇` and `E₈` it admits `B 0`, `B 1`, `C 0` and `C 1`, whose
+matrices are the empty matrix and `A 1`.  The statement for a simply-laced type is the corollary
+`TauCeti.DynkinType.IsSimplyLaced.posDef_cartanMatrix`.
+
 ## Main results
 
-* `TauCeti.DynkinType.posDef_cartanMatrix_of_isSimplyLaced`: the Cartan matrix of a simply-laced
+* `TauCeti.DynkinType.posDef_cartanMatrix_of_isSimplyLaced`: a simply-laced standard Cartan matrix
+  is positive definite over `ℚ`.
+* `TauCeti.DynkinType.IsSimplyLaced.posDef_cartanMatrix`: the Cartan matrix of a simply-laced
   Dynkin type is positive definite over `ℚ`.
 -/
 
@@ -29,19 +37,48 @@ public section
 
 namespace TauCeti.DynkinType
 
-/-- **The Cartan matrix of a simply-laced Dynkin type is positive definite** over `ℚ`.  The
-simply-laced types are exactly `A`, `D`, `E₆`, `E₇` and `E₈`; the hypothesis rules out the rest. -/
-theorem posDef_cartanMatrix_of_isSimplyLaced (t : DynkinType) (ht : t.IsSimplyLaced) :
+/-- **A simply-laced standard Cartan matrix is positive definite** over `ℚ`.  The types whose
+matrix is simply laced are `A`, `D`, `E₆`, `E₇`, `E₈` and the degenerate `B 0`, `B 1`, `C 0`,
+`C 1` (`TauCeti.DynkinType.isSimplyLaced_cartanMatrix_iff`); the last four have the empty matrix or
+`A 1` as their Cartan matrix. -/
+theorem posDef_cartanMatrix_of_isSimplyLaced (t : DynkinType) (ht : t.cartanMatrix.IsSimplyLaced) :
     (t.cartanMatrix.map (Int.cast : ℤ → ℚ)).PosDef := by
+  rw [isSimplyLaced_cartanMatrix_iff] at ht
   cases t with
   | A n => rw [cartanMatrix_A]; exact posDef_cartanMatrix_A n
   | D n => rw [cartanMatrix_D]; exact posDef_cartanMatrix_D n
   | E6 => rw [cartanMatrix_E6]; exact posDef_cartanMatrix_E6
   | E7 => rw [cartanMatrix_E7]; exact posDef_cartanMatrix_E7
   | E8 => rw [cartanMatrix_E8]; exact posDef_cartanMatrix_E8
-  | B n => exact absurd ht (not_isSimplyLaced_B n)
-  | C n => exact absurd ht (not_isSimplyLaced_C n)
-  | F4 => exact absurd ht not_isSimplyLaced_F4
-  | G2 => exact absurd ht not_isSimplyLaced_G2
+  | B n =>
+    have hn : n ≤ 1 := by simpa using ht
+    rw [cartanMatrix_B]
+    interval_cases n
+    · have hB0 : CartanMatrix.B 0 = CartanMatrix.A 0 := by
+        ext i
+        exact i.elim0
+      rw [hB0]
+      exact posDef_cartanMatrix_A 0
+    · rw [CartanMatrix.B_one]
+      exact posDef_cartanMatrix_A 1
+  | C n =>
+    have hn : n ≤ 1 := by simpa using ht
+    rw [cartanMatrix_C]
+    interval_cases n
+    · have hC0 : CartanMatrix.C 0 = CartanMatrix.A 0 := by
+        ext i
+        exact i.elim0
+      rw [hC0]
+      exact posDef_cartanMatrix_A 0
+    · rw [CartanMatrix.C_one]
+      exact posDef_cartanMatrix_A 1
+  | F4 => simp at ht
+  | G2 => simp at ht
+
+/-- **The Cartan matrix of a simply-laced Dynkin type is positive definite** over `ℚ`.  The
+simply-laced types are exactly `A`, `D`, `E₆`, `E₇` and `E₈`. -/
+theorem IsSimplyLaced.posDef_cartanMatrix {t : DynkinType} (ht : t.IsSimplyLaced) :
+    (t.cartanMatrix.map (Int.cast : ℤ → ℚ)).PosDef :=
+  posDef_cartanMatrix_of_isSimplyLaced t ((isSimplyLaced_cartanMatrix_iff t).mpr (Or.inl ht))
 
 end TauCeti.DynkinType

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/SimplyLaced.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/SimplyLaced.lean
@@ -23,14 +23,14 @@ The hypothesis is placed on the matrix rather than on the type.  By
 `TauCeti.DynkinType.isSimplyLaced_cartanMatrix_iff` that is the weaker of the two: besides the
 simply-laced types `A`, `D`, `E₆`, `E₇` and `E₈` it admits `B 0`, `B 1`, `C 0` and `C 1`, whose
 matrices are the empty matrix and `A 1`.  The statement for a simply-laced type is the corollary
-`TauCeti.DynkinType.IsSimplyLaced.posDef_cartanMatrix`.
+`TauCeti.DynkinType.IsSimplyLaced.posDef_map_intCast_cartanMatrix`.
 
 ## Main results
 
-* `TauCeti.DynkinType.posDef_cartanMatrix_of_isSimplyLaced`: a simply-laced standard Cartan matrix
-  is positive definite over `ℚ`.
-* `TauCeti.DynkinType.IsSimplyLaced.posDef_cartanMatrix`: the Cartan matrix of a simply-laced
-  Dynkin type is positive definite over `ℚ`.
+* `TauCeti.DynkinType.posDef_map_intCast_cartanMatrix_of_isSimplyLaced`: a simply-laced standard
+  Cartan matrix is positive definite over `ℚ`.
+* `TauCeti.DynkinType.IsSimplyLaced.posDef_map_intCast_cartanMatrix`: the Cartan matrix of a
+  simply-laced Dynkin type is positive definite over `ℚ`.
 -/
 
 public section
@@ -38,31 +38,31 @@ public section
 namespace TauCeti.DynkinType
 
 /-- The degenerate types `B 0` and `B 1`, whose Cartan matrices are the empty matrix and `A 1`. -/
-private theorem posDef_cartanMatrix_B_of_le_one {n : ℕ} (hn : n ≤ 1) :
+private theorem posDef_map_intCast_cartanMatrix_B_of_le_one {n : ℕ} (hn : n ≤ 1) :
     ((CartanMatrix.B n).map (Int.cast : ℤ → ℚ)).PosDef := by
   interval_cases n
   · exact Matrix.posDef_of_isEmpty _
   · rw [CartanMatrix.B_one]
-    exact posDef_cartanMatrix_A 1
+    exact posDef_map_intCast_cartanMatrix_A 1
 
 /-- **A simply-laced standard Cartan matrix is positive definite** over `ℚ`.  The types whose
 matrix is simply laced are `A`, `D`, `E₆`, `E₇`, `E₈` and the degenerate `B 0`, `B 1`, `C 0`,
 `C 1` (`TauCeti.DynkinType.isSimplyLaced_cartanMatrix_iff`); the last four have the empty matrix or
 `A 1` as their Cartan matrix. -/
-theorem posDef_cartanMatrix_of_isSimplyLaced (t : DynkinType) (ht : t.cartanMatrix.IsSimplyLaced) :
-    (t.cartanMatrix.map (Int.cast : ℤ → ℚ)).PosDef := by
+theorem posDef_map_intCast_cartanMatrix_of_isSimplyLaced (t : DynkinType)
+    (ht : t.cartanMatrix.IsSimplyLaced) : (t.cartanMatrix.map (Int.cast : ℤ → ℚ)).PosDef := by
   rw [isSimplyLaced_cartanMatrix_iff] at ht
   cases t with
-  | A n => rw [cartanMatrix_A]; exact posDef_cartanMatrix_A n
-  | D n => rw [cartanMatrix_D]; exact posDef_cartanMatrix_D n
-  | E6 => rw [cartanMatrix_E6]; exact posDef_cartanMatrix_E6
-  | E7 => rw [cartanMatrix_E7]; exact posDef_cartanMatrix_E7
-  | E8 => rw [cartanMatrix_E8]; exact posDef_cartanMatrix_E8
+  | A n => rw [cartanMatrix_A]; exact posDef_map_intCast_cartanMatrix_A n
+  | D n => rw [cartanMatrix_D]; exact posDef_map_intCast_cartanMatrix_D n
+  | E6 => rw [cartanMatrix_E6]; exact posDef_map_intCast_cartanMatrix_E6
+  | E7 => rw [cartanMatrix_E7]; exact posDef_map_intCast_cartanMatrix_E7
+  | E8 => rw [cartanMatrix_E8]; exact posDef_map_intCast_cartanMatrix_E8
   | B n =>
     rw [cartanMatrix_B]
-    exact posDef_cartanMatrix_B_of_le_one (by simpa using ht)
+    exact posDef_map_intCast_cartanMatrix_B_of_le_one (by simpa using ht)
   | C n =>
-    have h := (posDef_cartanMatrix_B_of_le_one (n := n) (by simpa using ht)).transpose
+    have h := (posDef_map_intCast_cartanMatrix_B_of_le_one (n := n) (by simpa using ht)).transpose
     rw [← Matrix.transpose_map, CartanMatrix.B_transpose] at h
     rw [cartanMatrix_C]
     exact h
@@ -71,8 +71,9 @@ theorem posDef_cartanMatrix_of_isSimplyLaced (t : DynkinType) (ht : t.cartanMatr
 
 /-- **The Cartan matrix of a simply-laced Dynkin type is positive definite** over `ℚ`.  The
 simply-laced types are exactly `A`, `D`, `E₆`, `E₇` and `E₈`. -/
-theorem IsSimplyLaced.posDef_cartanMatrix {t : DynkinType} (ht : t.IsSimplyLaced) :
+theorem IsSimplyLaced.posDef_map_intCast_cartanMatrix {t : DynkinType} (ht : t.IsSimplyLaced) :
     (t.cartanMatrix.map (Int.cast : ℤ → ℚ)).PosDef :=
-  posDef_cartanMatrix_of_isSimplyLaced t ((isSimplyLaced_cartanMatrix_iff t).mpr (Or.inl ht))
+  posDef_map_intCast_cartanMatrix_of_isSimplyLaced t
+    ((isSimplyLaced_cartanMatrix_iff t).mpr (Or.inl ht))
 
 end TauCeti.DynkinType


### PR DESCRIPTION
This PR records `PosDef` over `ℚ` for the Cartan matrices of types `A`, `D`, `E₆`, `E₇` and `E₈`.

`IsFiniteType` already carries a positive definite symmetrization, but behind an existential over
the symmetrizer, so it does not hand back positive definiteness of the matrix itself. For a simply
laced family the symmetrizer is trivial, and the Gram models the finite-type proofs already build
-- the simple coroots for `A` and `D`, Bourbaki's plate VII coordinates for `E₈` -- give the
statement directly. `E₆` and `E₇` inherit it from `E₈` as principal submatrices, through the
nesting identities already in the file.

The Gram identity for the `E₈` coordinate model moves out of `isFiniteType_cartanMatrix_E8` into
its own private lemma, so that the finite-type proof and the positive-definiteness proof consume
the same computation.

This is what the `IntegralLattices` roadmap needs to say that its ADE root lattices are positive
definite, which its Layer 5 asks for and which nothing in the library currently states.

Roadmap: IntegralLattices

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JWWVfWFEtnf4sF4vwbYn96