### PR TITLE
feat: align the compact Spin inclusion with its projection

### DIFF
--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Kernel.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Kernel.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.LinearAlgebra.CliffordAlgebra.Spin.SpecialOrthogonal
+public import TauCeti.LinearAlgebra.CliffordAlgebra.Spin.Map
 public import TauCeti.LinearAlgebra.QuadraticForm.Radical
 import TauCeti.LinearAlgebra.CliffordAlgebra.Basic
 
@@ -21,6 +22,10 @@ contraction and the exterior-algebra basis. Unitarity then restricts the scalar 
 
 * `CliffordAlgebra.mem_ker_spinToSpecialOrthogonal_iff`: a Spin element is in the kernel
 exactly when it is `1` or the canonical scalar `-1`.
+* `QuadraticMap.Isometry.spinGroupMap_negOne`: maps induced by quadratic isometries preserve the
+  canonical scalar `-1`.
+* `CliffordAlgebra.eq_or_eq_negOne_mul_of_spinToSpecialOrthogonal_eq`: two Spin elements with the
+  same projection differ by at most the canonical scalar `-1`.
 * `CliffordAlgebra.card_ker_spinToSpecialOrthogonal`: the kernel of the Spin action on
 the special orthogonal group has cardinality two.
 * `CliffordAlgebra.zmodTwoMulEquivKerSpinToSpecialOrthogonal`: the kernel is canonically
@@ -215,6 +220,27 @@ end NegOne
 
 end CliffordAlgebra
 
+namespace QuadraticMap.Isometry
+
+universe u v w
+
+
+variable {K : Type u} [Field K]
+  {M : Type v} [AddCommGroup M] [Module K M]
+  {N : Type w} [AddCommGroup N] [Module K N]
+  {Q : QuadraticForm K M} {P : QuadraticForm K N}
+
+/-- A Spin-group map induced by a quadratic isometry preserves the canonical scalar `-1`. -/
+@[simp]
+theorem spinGroupMap_negOne (f : Q →qᵢ P) (hQ : Q ≠ 0) (hP : P ≠ 0) :
+    f.spinGroupMap (CliffordAlgebra.spinGroup.negOne Q hQ) =
+      CliffordAlgebra.spinGroup.negOne P hP := by
+  apply Subtype.ext
+  rw [coe_spinGroupMap_apply, CliffordAlgebra.spinGroup.coe_negOne,
+    CliffordAlgebra.spinGroup.coe_negOne, map_neg, map_one]
+
+end QuadraticMap.Isometry
+
 namespace CliffordAlgebra
 
 section Kernel
@@ -243,6 +269,25 @@ theorem mem_ker_spinToSpecialOrthogonal_iff
   · rintro (rfl | rfl)
     · exact Subgroup.one_mem _
     · exact spinGroup.negOne_mem_ker_spinToSpecialOrthogonal Q hQ.ne_zero
+
+/-- Two Spin elements with the same special-orthogonal projection are equal or differ by the
+canonical scalar `-1`. -/
+theorem eq_or_eq_negOne_mul_of_spinToSpecialOrthogonal_eq
+    (Q : QuadraticForm K M) [Invertible (2 : K)] [Nontrivial M]
+    (hQ : Q.Nondegenerate) (x z : spinGroup Q)
+    (h : spinToSpecialOrthogonal Q x = spinToSpecialOrthogonal Q z) :
+    x = z ∨ x = spinGroup.negOne Q hQ.ne_zero * z := by
+  have hker : x / z ∈ MonoidHom.ker (spinToSpecialOrthogonal Q) :=
+    (spinToSpecialOrthogonal Q).div_mem_ker_iff.mpr h
+  rcases (mem_ker_spinToSpecialOrthogonal_iff Q hQ (x / z)).mp hker with hOne | hNeg
+  · left
+    calc
+      x = (x / z) * z := (div_mul_cancel x z).symm
+      _ = z := by rw [hOne, one_mul]
+  · right
+    calc
+      x = (x / z) * z := (div_mul_cancel x z).symm
+      _ = spinGroup.negOne Q hQ.ne_zero * z := by rw [hNeg]
 
 /-- A Spin element lies in the kernel of the orthogonal action exactly when it is
 the scalar `1` or the canonical scalar `-1`. -/

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Kernel.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Kernel.lean
@@ -232,9 +232,13 @@ variable {K : Type u} [Field K]
 
 /-- A Spin-group map induced by a quadratic isometry preserves the canonical scalar `-1`. -/
 @[simp]
-theorem spinGroupMap_negOne (f : Q →qᵢ P) (hQ : Q ≠ 0) (hP : P ≠ 0) :
+theorem spinGroupMap_negOne (f : Q →qᵢ P) (hQ : Q ≠ 0) :
     f.spinGroupMap (CliffordAlgebra.spinGroup.negOne Q hQ) =
-      CliffordAlgebra.spinGroup.negOne P hP := by
+      CliffordAlgebra.spinGroup.negOne P (by
+        intro hP
+        apply hQ
+        ext x
+        simpa [hP] using (f.map_app x).symm) := by
   apply Subtype.ext
   rw [coe_spinGroupMap_apply, CliffordAlgebra.spinGroup.coe_negOne,
     CliffordAlgebra.spinGroup.coe_negOne, map_neg, map_one]

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Map.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Map.lean
@@ -29,6 +29,8 @@ summand.
   action.
 * `QuadraticMap.IsometryEquiv.spinGroupMap_fixed_of_prod` proves that the Spin group of one
   summand fixes the other summand.
+* `QuadraticMap.IsometryEquiv.spinGroupMap_spinVectorAction_prod` combines these facts into the
+  full action formula on an orthogonal product.
 -/
 
 public section
@@ -262,5 +264,42 @@ theorem spinGroupMap_fixed_of_prod (e : Q.IsometryEquiv (Q₁.prod Q₂)) [Inver
       star (CliffordAlgebra.map f₁ (x : CliffordAlgebra Q₁)) = CliffordAlgebra.ι Q (f₂ m₂)
   rw [hcomm.eq, mul_assoc, ← CliffordAlgebra.map_star, ← map_mul,
     spinGroup.mul_star_self_of_mem x.2, map_one, mul_one]
+
+/-- Under an orthogonal-product isometry, the image of a Spin element acts on the first summand
+by the original Spin action and fixes the second summand. -/
+@[simp]
+theorem spinGroupMap_spinVectorAction_prod
+    (e : Q.IsometryEquiv (Q₁.prod Q₂)) [Invertible (2 : R)]
+    (x : spinGroup Q₁) (m₁ : M₁) (m₂ : M₂) :
+    CliffordAlgebra.spinVectorAction Q
+        ((e.symm.toIsometry.comp (QuadraticMap.Isometry.inl Q₁ Q₂)).spinGroupMap x)
+        (e.symm (m₁, m₂)) =
+      e.symm (CliffordAlgebra.spinVectorAction Q₁ x m₁, m₂) := by
+  let f₁ := e.symm.toIsometry.comp (QuadraticMap.Isometry.inl Q₁ Q₂)
+  let f₂ := e.symm.toIsometry.comp (QuadraticMap.Isometry.inr Q₁ Q₂)
+  have hsource : (m₁, m₂) = (m₁, 0) + (0, m₂) := by
+    ext <;> simp
+  have hdecomp : e.symm (m₁, m₂) = f₁ m₁ + f₂ m₂ := by
+    calc
+      e.symm (m₁, m₂) = e.symm ((m₁, 0) + (0, m₂)) := congrArg e.symm hsource
+      _ = e.symm (m₁, 0) + e.symm (0, m₂) := map_add e.symm _ _
+      _ = f₁ m₁ + f₂ m₂ := rfl
+  have htargetSource : (CliffordAlgebra.spinVectorAction Q₁ x m₁, m₂) =
+      (CliffordAlgebra.spinVectorAction Q₁ x m₁, 0) + (0, m₂) := by
+    ext <;> simp
+  have htarget : e.symm (CliffordAlgebra.spinVectorAction Q₁ x m₁, m₂) =
+      f₁ (CliffordAlgebra.spinVectorAction Q₁ x m₁) + f₂ m₂ := by
+    calc
+      e.symm (CliffordAlgebra.spinVectorAction Q₁ x m₁, m₂) =
+          e.symm ((CliffordAlgebra.spinVectorAction Q₁ x m₁, 0) + (0, m₂)) :=
+        congrArg e.symm htargetSource
+      _ = e.symm (CliffordAlgebra.spinVectorAction Q₁ x m₁, 0) + e.symm (0, m₂) :=
+        map_add e.symm _ _
+      _ = f₁ (CliffordAlgebra.spinVectorAction Q₁ x m₁) + f₂ m₂ := rfl
+  rw [hdecomp, map_add, htarget]
+  congr 1
+  · simpa [f₁] using
+      (QuadraticMap.Isometry.spinGroupMap_spinVectorAction f₁ x m₁)
+  · simpa [f₁, f₂] using e.spinGroupMap_fixed_of_prod x m₂
 
 end QuadraticMap.IsometryEquiv

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Map.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Map.lean
@@ -277,26 +277,15 @@ theorem spinGroupMap_spinVectorAction_prod
       e.symm (CliffordAlgebra.spinVectorAction Q₁ x m₁, m₂) := by
   let f₁ := e.symm.toIsometry.comp (QuadraticMap.Isometry.inl Q₁ Q₂)
   let f₂ := e.symm.toIsometry.comp (QuadraticMap.Isometry.inr Q₁ Q₂)
-  have hsource : (m₁, m₂) = (m₁, 0) + (0, m₂) := by
-    ext <;> simp
-  have hdecomp : e.symm (m₁, m₂) = f₁ m₁ + f₂ m₂ := by
+  have hdecomp (a : M₁) (b : M₂) : e.symm (a, b) = f₁ a + f₂ b := by
     calc
-      e.symm (m₁, m₂) = e.symm ((m₁, 0) + (0, m₂)) := congrArg e.symm hsource
-      _ = e.symm (m₁, 0) + e.symm (0, m₂) := map_add e.symm _ _
-      _ = f₁ m₁ + f₂ m₂ := rfl
-  have htargetSource : (CliffordAlgebra.spinVectorAction Q₁ x m₁, m₂) =
-      (CliffordAlgebra.spinVectorAction Q₁ x m₁, 0) + (0, m₂) := by
-    ext <;> simp
-  have htarget : e.symm (CliffordAlgebra.spinVectorAction Q₁ x m₁, m₂) =
-      f₁ (CliffordAlgebra.spinVectorAction Q₁ x m₁) + f₂ m₂ := by
-    calc
-      e.symm (CliffordAlgebra.spinVectorAction Q₁ x m₁, m₂) =
-          e.symm ((CliffordAlgebra.spinVectorAction Q₁ x m₁, 0) + (0, m₂)) :=
-        congrArg e.symm htargetSource
-      _ = e.symm (CliffordAlgebra.spinVectorAction Q₁ x m₁, 0) + e.symm (0, m₂) :=
-        map_add e.symm _ _
-      _ = f₁ (CliffordAlgebra.spinVectorAction Q₁ x m₁) + f₂ m₂ := rfl
-  rw [hdecomp, map_add, htarget]
+      e.symm (a, b) = e.symm ((a, 0) + (0, b)) := by simp
+      _ = e.symm (a, 0) + e.symm (0, b) := map_add e.symm _ _
+      _ = f₁ a + f₂ b := by
+        simp only [f₁, f₂, QuadraticMap.Isometry.comp_apply,
+          QuadraticMap.Isometry.inl_apply, QuadraticMap.Isometry.inr_apply,
+          QuadraticMap.IsometryEquiv.toIsometry_apply]
+  rw [hdecomp, map_add, hdecomp]
   congr 1
   · simpa [f₁] using
       (QuadraticMap.Isometry.spinGroupMap_spinVectorAction f₁ x m₁)

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Real/Stabilizer.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Real/Stabilizer.lean
@@ -20,12 +20,21 @@ This is the algebraic half of the familiar stabilizer description
 `Spin(n + 1) / Spin(n) ≃ Sⁿ`. The converse identification of the full stabilizer, and the topology
 of the resulting homogeneous space, are separate results.
 
+The split-coordinate action equation below compares the lower-rank inclusion with the Spin
+projection. Since the projection has kernel `{1, -1}` and the inclusion preserves `-1`, every
+element sharing a projection with an included element is itself included. This is the residual
+kernel calculation needed by the converse stabilizer identification.
+
 ## Main results
 
 * `CliffordAlgebra.realCliffordSpinInclusion` is the lower-rank Spin homomorphism.
 * `CliffordAlgebra.realCliffordSpinLastStabilizer` is the stabilizer of the last unit vector.
 * `CliffordAlgebra.realCliffordSpinStabilizerInclusion` is the injective homomorphism into that
   stabilizer.
+* `CliffordAlgebra.realCliffordSpinInclusion_spinVectorAction_split` computes the full vector
+  action of the inclusion in split coordinates.
+* `eq_realCliffordSpinInclusion_or_eq_realCliffordSpinInclusion_negOne_mul_of_projection_eq`
+  identifies the two possible lifts of the projection of an included element.
 
 ## References
 
@@ -94,6 +103,39 @@ theorem realCliffordSpinInclusion_fixed_last (n : ℕ) (x : realCliffordSpinGrou
   rw [← realCliffordSpinLastIsometry_one]
   exact (realCliffordPositiveSplitIsometry n 0).spinGroupMap_fixed_of_prod x 1
 
+/-- In positive-split coordinates, the lower-rank Spin inclusion acts on the first summand by
+the original Spin element and fixes the complementary line. -/
+theorem realCliffordSpinInclusion_spinVectorAction_split (n : ℕ)
+    (x : realCliffordSpinGroupZero n) (m : Fin n → ℝ) (r : ℝ) :
+    spinVectorAction (realCliffordForm (n + 1) 0) (realCliffordSpinInclusion n x)
+        ((realCliffordPositiveSplitIsometry n 0).symm (m, r)) =
+      (realCliffordPositiveSplitIsometry n 0).symm
+        (spinVectorAction (realCliffordForm n 0) x m, r) := by
+  let e := realCliffordPositiveSplitIsometry n 0
+  let f₁ := e.symm.toIsometry.comp
+    (QuadraticMap.Isometry.inl (realCliffordForm n 0)
+      (QuadraticMap.sq (R := ℝ) (A := ℝ)))
+  let f₂ := e.symm.toIsometry.comp
+    (QuadraticMap.Isometry.inr (realCliffordForm n 0)
+      (QuadraticMap.sq (R := ℝ) (A := ℝ)))
+  have hinclusion : realCliffordSpinInclusion n x = f₁.spinGroupMap x := by
+    apply Subtype.ext
+    rw [coe_realCliffordSpinInclusion_apply,
+      QuadraticMap.Isometry.coe_spinGroupMap_apply]
+  have hdecomp : e.symm (m, r) = f₁ m + f₂ r := by
+    rw [show (m, r) = (m, 0) + (0, r) by ext <;> simp, map_add]
+    rfl
+  have htarget : e.symm (spinVectorAction (realCliffordForm n 0) x m, r) =
+      f₁ (spinVectorAction (realCliffordForm n 0) x m) + f₂ r := by
+    rw [show (spinVectorAction (realCliffordForm n 0) x m, r) =
+      (spinVectorAction (realCliffordForm n 0) x m, 0) + (0, r) by ext <;> simp, map_add]
+    rfl
+  rw [hinclusion, hdecomp, map_add, htarget]
+  congr 1
+  · simpa [f₁] using
+      (QuadraticMap.Isometry.spinGroupMap_spinVectorAction f₁ x m)
+  · simpa [f₁, f₂] using e.spinGroupMap_fixed_of_prod x r
+
 /-- The lower-rank homomorphism `Spin(n) → Spin(n + 1)` is injective. -/
 theorem realCliffordSpinInclusion_injective (n : ℕ) :
     Function.Injective (realCliffordSpinInclusion n) := by
@@ -155,6 +197,55 @@ theorem coe_realCliffordSpinStabilizerInclusion_apply
 theorem realCliffordSpinStabilizerInclusion_injective (n : ℕ) :
     Function.Injective (realCliffordSpinStabilizerInclusion n) :=
   (MonoidHom.injective_codRestrict _ _ _).mpr (realCliffordSpinInclusion_injective n)
+
+/-- The lower-rank compact Spin inclusion sends the canonical nontrivial kernel element to the
+corresponding kernel element in the higher-rank Spin group. -/
+@[simp]
+theorem realCliffordSpinInclusion_negOne (n : ℕ) [NeZero n] :
+    realCliffordSpinInclusion n
+        (spinGroup.negOne (realCliffordForm n 0)
+          (nondegenerate_realCliffordForm n 0).ne_zero) =
+      spinGroup.negOne (realCliffordForm (n + 1) 0)
+        (nondegenerate_realCliffordForm (n + 1) 0).ne_zero := by
+  apply Subtype.ext
+  rw [coe_realCliffordSpinInclusion_apply, spinGroup.coe_negOne,
+    spinGroup.coe_negOne, map_neg, map_one]
+
+/-- An element of `Spin(n + 1)` over the projection of an included element of `Spin(n)` is that
+element or its translate by the canonical nontrivial kernel element. -/
+theorem eq_realCliffordSpinInclusion_or_eq_realCliffordSpinInclusion_negOne_mul_of_projection_eq
+    (n : ℕ) [NeZero n] (x : realCliffordSpinGroupZero (n + 1))
+    (y : realCliffordSpinGroupZero n)
+    (h : spinToSpecialOrthogonal (realCliffordForm (n + 1) 0) x =
+      spinToSpecialOrthogonal (realCliffordForm (n + 1) 0)
+        (realCliffordSpinInclusion n y)) :
+    x = realCliffordSpinInclusion n y ∨
+      x = realCliffordSpinInclusion n
+        (spinGroup.negOne (realCliffordForm n 0)
+          (nondegenerate_realCliffordForm n 0).ne_zero * y) := by
+  have hker : x / realCliffordSpinInclusion n y ∈
+      MonoidHom.ker (spinToSpecialOrthogonal (realCliffordForm (n + 1) 0)) :=
+    (spinToSpecialOrthogonal (realCliffordForm (n + 1) 0)).div_mem_ker_iff.mpr h
+  rcases (mem_ker_spinToSpecialOrthogonal_iff
+      (realCliffordForm (n + 1) 0)
+      (nondegenerate_realCliffordForm (n + 1) 0)
+      (x / realCliffordSpinInclusion n y)).mp hker with hOne | hNeg
+  · left
+    calc
+      x = (x / realCliffordSpinInclusion n y) * realCliffordSpinInclusion n y :=
+        (div_mul_cancel x _).symm
+      _ = realCliffordSpinInclusion n y := by rw [hOne, one_mul]
+  · right
+    calc
+      x = (x / realCliffordSpinInclusion n y) * realCliffordSpinInclusion n y :=
+        (div_mul_cancel x _).symm
+      _ = spinGroup.negOne (realCliffordForm (n + 1) 0)
+          (nondegenerate_realCliffordForm (n + 1) 0).ne_zero *
+            realCliffordSpinInclusion n y := by rw [hNeg]
+      _ = realCliffordSpinInclusion n
+          (spinGroup.negOne (realCliffordForm n 0)
+            (nondegenerate_realCliffordForm n 0).ne_zero * y) := by
+        rw [map_mul, realCliffordSpinInclusion_negOne]
 
 end
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Real/Stabilizer.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Real/Stabilizer.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.LinearAlgebra.CliffordAlgebra.Spin.Map
 public import TauCeti.LinearAlgebra.CliffordAlgebra.Spin.Real.Basic
 
 /-!
@@ -21,9 +20,10 @@ This is the algebraic half of the familiar stabilizer description
 of the resulting homogeneous space, are separate results.
 
 The split-coordinate action equation below compares the lower-rank inclusion with the Spin
-projection. Since the projection has kernel `{1, -1}` and the inclusion preserves `-1`, every
-element sharing a projection with an included element is itself included. This is the residual
-kernel calculation needed by the converse stabilizer identification.
+projection. When `n > 0`, the projection has kernel `{1, -1}`; since the inclusion preserves the
+canonical `-1` whenever its source form is nonzero, every element sharing a projection with an
+included element is itself included. This is the residual kernel calculation needed by the
+converse stabilizer identification.
 
 ## Main results
 
@@ -33,8 +33,8 @@ kernel calculation needed by the converse stabilizer identification.
   stabilizer.
 * `CliffordAlgebra.realCliffordSpinInclusion_spinVectorAction_split` computes the full vector
   action of the inclusion in split coordinates.
-* `eq_realCliffordSpinInclusion_or_eq_realCliffordSpinInclusion_negOne_mul_of_projection_eq`
-  identifies the two possible lifts of the projection of an included element.
+* `eq_or_eq_realCliffordSpinInclusion_negOne_mul_of_spinToSpecialOrthogonal_eq`
+  identifies the two possible lifts of the `spinToSpecialOrthogonal` image of an included element.
 
 ## References
 
@@ -187,11 +187,10 @@ theorem realCliffordSpinInclusion_negOne (n : ℕ) [NeZero n] :
         (nondegenerate_realCliffordForm (n + 1) 0).ne_zero :=
   (realCliffordSpinInclusionIsometry n).spinGroupMap_negOne
     (nondegenerate_realCliffordForm n 0).ne_zero
-    (nondegenerate_realCliffordForm (n + 1) 0).ne_zero
 
 /-- An element of `Spin(n + 1)` over the projection of an included element of `Spin(n)` is that
 element or its translate by the canonical nontrivial kernel element. -/
-theorem eq_realCliffordSpinInclusion_or_eq_realCliffordSpinInclusion_negOne_mul_of_projection_eq
+theorem eq_or_eq_realCliffordSpinInclusion_negOne_mul_of_spinToSpecialOrthogonal_eq
     (n : ℕ) [NeZero n] (x : realCliffordSpinGroupZero (n + 1))
     (y : realCliffordSpinGroupZero n)
     (h : spinToSpecialOrthogonal (realCliffordForm (n + 1) 0) x =

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Real/Stabilizer.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Real/Stabilizer.lean
@@ -105,36 +105,14 @@ theorem realCliffordSpinInclusion_fixed_last (n : ℕ) (x : realCliffordSpinGrou
 
 /-- In positive-split coordinates, the lower-rank Spin inclusion acts on the first summand by
 the original Spin element and fixes the complementary line. -/
+@[simp]
 theorem realCliffordSpinInclusion_spinVectorAction_split (n : ℕ)
     (x : realCliffordSpinGroupZero n) (m : Fin n → ℝ) (r : ℝ) :
     spinVectorAction (realCliffordForm (n + 1) 0) (realCliffordSpinInclusion n x)
         ((realCliffordPositiveSplitIsometry n 0).symm (m, r)) =
       (realCliffordPositiveSplitIsometry n 0).symm
         (spinVectorAction (realCliffordForm n 0) x m, r) := by
-  let e := realCliffordPositiveSplitIsometry n 0
-  let f₁ := e.symm.toIsometry.comp
-    (QuadraticMap.Isometry.inl (realCliffordForm n 0)
-      (QuadraticMap.sq (R := ℝ) (A := ℝ)))
-  let f₂ := e.symm.toIsometry.comp
-    (QuadraticMap.Isometry.inr (realCliffordForm n 0)
-      (QuadraticMap.sq (R := ℝ) (A := ℝ)))
-  have hinclusion : realCliffordSpinInclusion n x = f₁.spinGroupMap x := by
-    apply Subtype.ext
-    rw [coe_realCliffordSpinInclusion_apply,
-      QuadraticMap.Isometry.coe_spinGroupMap_apply]
-  have hdecomp : e.symm (m, r) = f₁ m + f₂ r := by
-    rw [show (m, r) = (m, 0) + (0, r) by ext <;> simp, map_add]
-    rfl
-  have htarget : e.symm (spinVectorAction (realCliffordForm n 0) x m, r) =
-      f₁ (spinVectorAction (realCliffordForm n 0) x m) + f₂ r := by
-    rw [show (spinVectorAction (realCliffordForm n 0) x m, r) =
-      (spinVectorAction (realCliffordForm n 0) x m, 0) + (0, r) by ext <;> simp, map_add]
-    rfl
-  rw [hinclusion, hdecomp, map_add, htarget]
-  congr 1
-  · simpa [f₁] using
-      (QuadraticMap.Isometry.spinGroupMap_spinVectorAction f₁ x m)
-  · simpa [f₁, f₂] using e.spinGroupMap_fixed_of_prod x r
+  exact (realCliffordPositiveSplitIsometry n 0).spinGroupMap_spinVectorAction_prod x m r
 
 /-- The lower-rank homomorphism `Spin(n) → Spin(n + 1)` is injective. -/
 theorem realCliffordSpinInclusion_injective (n : ℕ) :
@@ -206,10 +184,10 @@ theorem realCliffordSpinInclusion_negOne (n : ℕ) [NeZero n] :
         (spinGroup.negOne (realCliffordForm n 0)
           (nondegenerate_realCliffordForm n 0).ne_zero) =
       spinGroup.negOne (realCliffordForm (n + 1) 0)
-        (nondegenerate_realCliffordForm (n + 1) 0).ne_zero := by
-  apply Subtype.ext
-  rw [coe_realCliffordSpinInclusion_apply, spinGroup.coe_negOne,
-    spinGroup.coe_negOne, map_neg, map_one]
+        (nondegenerate_realCliffordForm (n + 1) 0).ne_zero :=
+  (realCliffordSpinInclusionIsometry n).spinGroupMap_negOne
+    (nondegenerate_realCliffordForm n 0).ne_zero
+    (nondegenerate_realCliffordForm (n + 1) 0).ne_zero
 
 /-- An element of `Spin(n + 1)` over the projection of an included element of `Spin(n)` is that
 element or its translate by the canonical nontrivial kernel element. -/
@@ -223,29 +201,12 @@ theorem eq_realCliffordSpinInclusion_or_eq_realCliffordSpinInclusion_negOne_mul_
       x = realCliffordSpinInclusion n
         (spinGroup.negOne (realCliffordForm n 0)
           (nondegenerate_realCliffordForm n 0).ne_zero * y) := by
-  have hker : x / realCliffordSpinInclusion n y ∈
-      MonoidHom.ker (spinToSpecialOrthogonal (realCliffordForm (n + 1) 0)) :=
-    (spinToSpecialOrthogonal (realCliffordForm (n + 1) 0)).div_mem_ker_iff.mpr h
-  rcases (mem_ker_spinToSpecialOrthogonal_iff
+  rcases eq_or_eq_negOne_mul_of_spinToSpecialOrthogonal_eq
       (realCliffordForm (n + 1) 0)
-      (nondegenerate_realCliffordForm (n + 1) 0)
-      (x / realCliffordSpinInclusion n y)).mp hker with hOne | hNeg
-  · left
-    calc
-      x = (x / realCliffordSpinInclusion n y) * realCliffordSpinInclusion n y :=
-        (div_mul_cancel x _).symm
-      _ = realCliffordSpinInclusion n y := by rw [hOne, one_mul]
-  · right
-    calc
-      x = (x / realCliffordSpinInclusion n y) * realCliffordSpinInclusion n y :=
-        (div_mul_cancel x _).symm
-      _ = spinGroup.negOne (realCliffordForm (n + 1) 0)
-          (nondegenerate_realCliffordForm (n + 1) 0).ne_zero *
-            realCliffordSpinInclusion n y := by rw [hNeg]
-      _ = realCliffordSpinInclusion n
-          (spinGroup.negOne (realCliffordForm n 0)
-            (nondegenerate_realCliffordForm n 0).ne_zero * y) := by
-        rw [map_mul, realCliffordSpinInclusion_negOne]
+      (nondegenerate_realCliffordForm (n + 1) 0) x (realCliffordSpinInclusion n y) h with
+    hOne | hNeg
+  · exact Or.inl hOne
+  · exact Or.inr (hNeg.trans (by rw [map_mul, realCliffordSpinInclusion_negOne]))
 
 end
 

--- a/TauCeti/Topology/Algebra/CliffordAlgebra/Basic.lean
+++ b/TauCeti/Topology/Algebra/CliffordAlgebra/Basic.lean
@@ -27,6 +27,8 @@ the topology is Hausdorff.
 
 * `CliffordAlgebra.instTopologicalSpaceRealCliffordAlgebra` installs the real module topology.
 * `CliffordAlgebra.instIsTopologicalAddGroupRealCliffordAlgebra` makes addition continuous.
+* `CliffordAlgebra.continuous_map_realCliffordAlgebra` proves continuity of maps induced by
+  quadratic isometries.
 * `CliffordAlgebra.instIsTopologicalRingRealCliffordAlgebra` makes multiplication continuous.
 * `CliffordAlgebra.instT2SpaceRealCliffordAlgebra` proves the topology is Hausdorff.
 * `CliffordAlgebra.continuous_reverse_realCliffordAlgebra` and
@@ -58,6 +60,15 @@ instance instTopologicalSpaceRealCliffordAlgebra (Q : QuadraticForm ℝ V) :
 instance instIsTopologicalAddGroupRealCliffordAlgebra (Q : QuadraticForm ℝ V) :
     IsTopologicalAddGroup (CliffordAlgebra Q) :=
   IsModuleTopology.isTopologicalAddGroup ℝ _
+
+/-- The Clifford-algebra map induced by an isometry of real quadratic spaces is continuous for
+the canonical module topologies. -/
+@[fun_prop]
+theorem continuous_map_realCliffordAlgebra
+    {W : Type*} [AddCommGroup W] [Module ℝ W]
+    {Q : QuadraticForm ℝ V} {P : QuadraticForm ℝ W} (f : Q →qᵢ P) :
+    Continuous (CliffordAlgebra.map f) :=
+  IsModuleTopology.continuous_of_linearMap (CliffordAlgebra.map f).toLinearMap
 
 /-- Clifford reversal is continuous for the real module topology. -/
 @[fun_prop]

--- a/TauCeti/Topology/Algebra/CliffordAlgebra/Basic.lean
+++ b/TauCeti/Topology/Algebra/CliffordAlgebra/Basic.lean
@@ -27,7 +27,7 @@ the topology is Hausdorff.
 
 * `CliffordAlgebra.instTopologicalSpaceRealCliffordAlgebra` installs the real module topology.
 * `CliffordAlgebra.instIsTopologicalAddGroupRealCliffordAlgebra` makes addition continuous.
-* `CliffordAlgebra.continuous_map_realCliffordAlgebra` proves continuity of maps induced by
+* `QuadraticMap.Isometry.continuous_cliffordAlgebraMap` proves continuity of maps induced by
   quadratic isometries.
 * `CliffordAlgebra.instIsTopologicalRingRealCliffordAlgebra` makes multiplication continuous.
 * `CliffordAlgebra.instT2SpaceRealCliffordAlgebra` proves the topology is Hausdorff.
@@ -64,7 +64,7 @@ instance instIsTopologicalAddGroupRealCliffordAlgebra (Q : QuadraticForm ℝ V) 
 /-- The Clifford-algebra map induced by an isometry of real quadratic spaces is continuous for
 the canonical module topologies. -/
 @[fun_prop]
-theorem continuous_map_realCliffordAlgebra
+theorem _root_.QuadraticMap.Isometry.continuous_cliffordAlgebraMap
     {W : Type*} [AddCommGroup W] [Module ℝ W]
     {Q : QuadraticForm ℝ V} {P : QuadraticForm ℝ W} (f : Q →qᵢ P) :
     Continuous (CliffordAlgebra.map f) :=

--- a/TauCeti/Topology/Algebra/CliffordAlgebra/Spin.lean
+++ b/TauCeti/Topology/Algebra/CliffordAlgebra/Spin.lean
@@ -54,6 +54,8 @@ topologized special orthogonal group.
   the projection field of the packaged compact real double cover.
 * `CliffordAlgebra.continuous_realCliffordSpinInclusion` proves continuity of the lower-rank
   inclusion used in the compact stabilizer construction.
+* `CliffordAlgebra.continuous_realCliffordSpinStabilizerInclusion` proves continuity after
+  restricting the inclusion's codomain to the last-vector stabilizer.
 
 ## References
 
@@ -79,7 +81,7 @@ canonical subtype topologies. -/
 @[fun_prop]
 theorem continuous_spinGroupMap (f : Q →qᵢ P) : Continuous f.spinGroupMap := by
   apply continuous_induced_rng.mpr
-  refine ((CliffordAlgebra.continuous_map_realCliffordAlgebra f).comp
+  refine (f.continuous_cliffordAlgebraMap.comp
     continuous_subtype_val).congr ?_
   exact fun x ↦ (coe_spinGroupMap_apply f x).symm
 
@@ -166,6 +168,16 @@ theorem continuous_realCliffordSpinInclusion (n : ℕ) :
     apply Subtype.ext
     rw [QuadraticMap.Isometry.coe_spinGroupMap_apply,
       coe_realCliffordSpinInclusion_apply]
+
+/-- The canonical inclusion `Spin(n) → Spin(n + 1)` is continuous after restricting its codomain
+to the last-vector stabilizer. -/
+@[fun_prop]
+theorem continuous_realCliffordSpinStabilizerInclusion (n : ℕ) :
+    Continuous (realCliffordSpinStabilizerInclusion n) := by
+  refine ((continuous_realCliffordSpinInclusion n).subtype_mk (fun x ↦ ?_)).congr ?_
+  · rw [← coe_realCliffordSpinStabilizerInclusion_apply n x]
+    exact (realCliffordSpinStabilizerInclusion n x).property
+  · exact fun x ↦ Subtype.ext (coe_realCliffordSpinStabilizerInclusion_apply n x).symm
 
 end
 

--- a/TauCeti/Topology/Algebra/CliffordAlgebra/Spin.lean
+++ b/TauCeti/Topology/Algebra/CliffordAlgebra/Spin.lean
@@ -5,7 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.LinearAlgebra.CliffordAlgebra.Spin.Real.Basic
+public import TauCeti.LinearAlgebra.CliffordAlgebra.Spin.Real.Stabilizer
 public import TauCeti.Topology.Algebra.CliffordAlgebra.Basic
 public import TauCeti.Topology.Algebra.QuadraticForm.SpecialOrthogonal
 
@@ -42,6 +42,8 @@ topologized special orthogonal group.
 
 ## Main results
 
+* `QuadraticMap.Isometry.continuous_spinGroupMap` proves continuity of the Spin-group map induced
+  by an isometry of real quadratic spaces.
 * `CliffordAlgebra.instIsTopologicalGroupRealSpinGroup` equips `spinGroup Q` with a topological
   group structure for its canonical subtype topology.
 * `CliffordAlgebra.continuous_spinVectorAction_apply` proves fixed-vector continuity of the Spin
@@ -50,6 +52,8 @@ topologized special orthogonal group.
   projection for every quadratic form on a finite real coordinate space.
 * `CliffordAlgebra.continuous_realCliffordSpinDoubleCoverZero_rightHom` specializes this result to
   the projection field of the packaged compact real double cover.
+* `CliffordAlgebra.continuous_realCliffordSpinInclusion` proves continuity of the lower-rank
+  inclusion used in the compact stabilizer construction.
 
 ## References
 
@@ -59,6 +63,27 @@ M.-L. Michelsohn, *Spin Geometry* (1989), Chapter I §2.
 -/
 
 public section
+
+
+namespace QuadraticMap.Isometry
+
+universe u v
+
+
+variable {V : Type u} {W : Type v}
+  [AddCommGroup V] [Module ℝ V] [AddCommGroup W] [Module ℝ W]
+  {Q : QuadraticForm ℝ V} {P : QuadraticForm ℝ W}
+
+/-- The Spin-group map induced by an isometry of real quadratic spaces is continuous for the
+canonical subtype topologies. -/
+@[fun_prop]
+theorem continuous_spinGroupMap (f : Q →qᵢ P) : Continuous f.spinGroupMap := by
+  apply continuous_induced_rng.mpr
+  refine ((CliffordAlgebra.continuous_map_realCliffordAlgebra f).comp
+    continuous_subtype_val).congr ?_
+  exact fun x ↦ (coe_spinGroupMap_apply f x).symm
+
+end QuadraticMap.Isometry
 
 
 namespace CliffordAlgebra
@@ -127,6 +152,18 @@ theorem continuous_realCliffordSpinDoubleCoverZero_rightHom (n : ℕ) [NeZero n]
     Continuous (realCliffordSpinDoubleCoverZero n).rightHom := by
   rw [realCliffordSpinDoubleCoverZero_rightHom]
   exact continuous_spinToSpecialOrthogonal_pi (realCliffordForm n 0)
+
+/-- The lower-rank inclusion `Spin(n) → Spin(n + 1)` is continuous for the canonical real
+Clifford-algebra subtype topologies. -/
+@[fun_prop]
+theorem continuous_realCliffordSpinInclusion (n : ℕ) :
+    Continuous (realCliffordSpinInclusion n) := by
+  apply continuous_induced_rng.mpr
+  refine ((CliffordAlgebra.continuous_map_realCliffordAlgebra
+      ((realCliffordPositiveSplitIsometry n 0).symm.toIsometry.comp
+        (QuadraticMap.Isometry.inl (realCliffordForm n 0)
+          (QuadraticMap.sq (R := ℝ) (A := ℝ))))).comp continuous_subtype_val).congr ?_
+  exact fun x ↦ (coe_realCliffordSpinInclusion_apply n x).symm
 
 end
 

--- a/TauCeti/Topology/Algebra/CliffordAlgebra/Spin.lean
+++ b/TauCeti/Topology/Algebra/CliffordAlgebra/Spin.lean
@@ -158,12 +158,14 @@ Clifford-algebra subtype topologies. -/
 @[fun_prop]
 theorem continuous_realCliffordSpinInclusion (n : ℕ) :
     Continuous (realCliffordSpinInclusion n) := by
-  apply continuous_induced_rng.mpr
-  refine ((CliffordAlgebra.continuous_map_realCliffordAlgebra
-      ((realCliffordPositiveSplitIsometry n 0).symm.toIsometry.comp
-        (QuadraticMap.Isometry.inl (realCliffordForm n 0)
-          (QuadraticMap.sq (R := ℝ) (A := ℝ))))).comp continuous_subtype_val).congr ?_
-  exact fun x ↦ (coe_realCliffordSpinInclusion_apply n x).symm
+  refine (QuadraticMap.Isometry.continuous_spinGroupMap
+    ((realCliffordPositiveSplitIsometry n 0).symm.toIsometry.comp
+      (QuadraticMap.Isometry.inl (realCliffordForm n 0)
+        (QuadraticMap.sq (R := ℝ) (A := ℝ))))).congr ?_
+  exact fun x ↦ by
+    apply Subtype.ext
+    rw [QuadraticMap.Isometry.coe_spinGroupMap_apply,
+      coe_realCliffordSpinInclusion_apply]
 
 end
 


### PR DESCRIPTION
This PR computes the compact lower-rank Spin inclusion over the special-orthogonal projection and proves its continuity for the Layer 7 “Connectivity of the compact spin group” milestone.

Roadmap: RepresentationTheory

## Summary

The lower-rank inclusion now acts in positive-split coordinates by the original `Spin(n)` action on the first summand and the identity on the complementary line. Generic product-action, kernel-generator, and equal-projection theorems give the reusable algebraic statements; the compact forms are thin specializations. Generic continuity of real Clifford maps and their induced Spin maps supplies continuity of both the ambient compact inclusion and its restriction to the last-vector stabilizer. The proofs reuse Mathlib’s module-topology linear-map theorem and `MonoidHom.div_mem_ker_iff`, together with Tau Ceti’s Spin action naturality and kernel classification.

## Roadmap target

This advances RepresentationTheory / SpinRepresentations Layer 7, “Connectivity of the compact spin group,” along the `L7-spinq → L7-con` dependency chain. After this PR, the separately developed special-orthogonal last-stabilizer equivalence must be combined with this projection/kernel boundary to identify the full Spin stabilizer, construct the sphere homogeneous-space bundle, and derive connectedness and simple-connectivity in the stated ranks.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"real-clifford-spin-inclusion-projection"}-->

## Verification

- Exact head: `6d1fd9f7a7206092156e10bb3bef3ffa1465f59c`
- Local Lean build: `lake exe cache get && lake build` — pass; full 10,890-job build completed
- Axiom audit: `lake exe axioms` — pass; 106,677 declarations use only `propext`, `Classical.choice`, and `Quot.sound`
- Lint: `env PATH=/opt/homebrew/opt/gnu-sed/libexec/gnubin:$PATH bash scripts/lint-env.sh && python3 scripts/lint-dot-notation.py && bash scripts/lint-style.sh && lake exe module-system` — pass with no new violations; all 4,756 modules use the module system
- Proof golf: structural replacement and consumer probe — pass; one quantified product decomposition replaces two wrapper-level definitional-equality calculations
- Public CI: pending for the updated head

## Scale and generality

The change adds 192 lines across five existing modules. Clifford-map and Spin-map continuity hold for arbitrary real quadratic spaces without finite-dimensional assumptions. The algebraic product-action law works over any commutative ring with invertible `2`; the sign law works for quadratic isometries over any field; and the equal-projection law works for any positive-dimensional finite nondegenerate quadratic space over a field with invertible `2`. The compact inclusion and split-action laws hold for every `n`; both declarations that mention the lower-rank canonical `negOne` assume `[NeZero n]`, exactly where the source form must be nonzero.

## Scope

- **Consumes:** `realCliffordPositiveSplitIsometry`, `spinGroupMap_spinVectorAction`, `spinGroupMap_fixed_of_prod`, `mem_ker_spinToSpecialOrthogonal_iff`, module-topology continuity, and `MonoidHom.div_mem_ker_iff`.
- **Provides:** a generic orthogonal-product Spin action law, generic preservation of `spinGroup.negOne`, a generic exact two-lift projection characterization, their compact real specializations, generic continuity of induced Clifford and Spin maps, and continuity of both the ambient and stabilizer-valued compact inclusions.
- **Fits:** supplies the Spin-side algebraic and topological interface consumed by the full last-vector stabilizer identification and subsequent sphere-bundle argument.
- **Boundary:** does not duplicate the active special-orthogonal stabilizer work or construct the converse Spin stabilizer equivalence, homogeneous space, connectivity, or universal cover.

<sub>🤖 GPT-5.6 Sol high · TauCetiWorker @ [910d954fee75dfafda41f98165ce3a9e6676eae1](https://github.com/utensil/TauCetiWorker/commit/910d954fee75dfafda41f98165ce3a9e6676eae1) · rubrics @ [afb424eda89e8ac96d9eb69f6a88972055a4cd1b](https://github.com/utensil/TauCetiReview/commit/afb424eda89e8ac96d9eb69f6a88972055a4cd1b) · local review @ [b533e561b6d44df071c31335ed4a63ae647507d2](https://github.com/utensil/formal-land/commit/b533e561b6d44df071c31335ed4a63ae647507d2) · fixed: reuse, api-design, generality, placement, naming, documentation, proof-quality, ut-consumer-contract, ut-aggregate-reuse</sub>