### PR TITLE
feat(OptimalTransport): separate Wasserstein pseudometric laws

### DIFF
--- a/TauCeti/MeasureTheory/Measure/Dirac.lean
+++ b/TauCeti/MeasureTheory/Measure/Dirac.lean
@@ -5,10 +5,11 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import Mathlib.MeasureTheory.Constructions.BorelSpace.Basic
 public import Mathlib.MeasureTheory.Measure.Dirac.Basic
 
 /-!
-# Pushing a Dirac measure forward along an a.e. measurable map
+# Dirac measures and their pushforwards
 
 Mathlib's `MeasureTheory.Measure.map_dirac'` computes `(Measure.dirac x).map T = Measure.dirac
 (T x)` for a measurable `T`. A Dirac measure leaves a map no room to be modified on a null set:
@@ -21,6 +22,7 @@ under that weaker hypothesis, which is the one a.e.-measurable interfaces such a
 
 * `Measure.map_dirac_of_aemeasurable` — the Dirac pushforward formula for a map that is
   only a.e. measurable.
+* `Measure.dirac_eq_dirac_of_inseparable` — inseparable points have equal Borel Dirac measures.
 -/
 
 public section
@@ -42,5 +44,12 @@ theorem map_dirac_of_aemeasurable {x : X} (hT : AEMeasurable T (Measure.dirac x)
     rw [Measure.dirac_apply_of_mem hne] at h0
     exact one_ne_zero h0
   rw [Measure.map_congr hT.ae_eq_mk, Measure.map_dirac' hT.measurable_mk, ← hx]
+
+/-- Dirac measures at topologically inseparable points agree: Borel measurable sets cannot
+separate the points. -/
+theorem dirac_eq_dirac_of_inseparable [TopologicalSpace X] [BorelSpace X]
+    {x y : X} (hxy : Inseparable x y) : Measure.dirac x = Measure.dirac y := by
+  apply MeasureTheory.dirac_eq_dirac_iff_forall_mem_iff_mem.2
+  exact fun _ hs ↦ hxy.mem_measurableSet_iff hs
 
 end Measure

--- a/TauCeti/MeasureTheory/Measure/SeparationQuotient.lean
+++ b/TauCeti/MeasureTheory/Measure/SeparationQuotient.lean
@@ -1,0 +1,74 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.MeasureTheory.Constructions.BorelSpace.Basic
+public import Mathlib.MeasureTheory.Measure.Typeclasses.Finite
+public import Mathlib.Topology.Separation.Basic
+
+/-!
+# Measures on the topological separation quotient
+
+Pushforward to `SeparationQuotient` preserves the information in a finite Borel measure:
+open sets are saturated under topological inseparability and determine finite Borel measures.
+
+The quotient carries its Borel measurable structure. `Measure.separationQuotient_def` exposes
+its pushforward formula, and `Measure.separationQuotient_inj` simplifies equality of quotient laws.
+-/
+
+public section
+
+open Set
+
+universe u
+
+namespace MeasureTheory.Measure
+
+variable {X : Type u} [TopologicalSpace X] [MeasurableSpace X]
+
+/-- The pushforward of a measure to the topological separation quotient, carrying the quotient's
+Borel measurable structure. -/
+noncomputable def separationQuotient (μ : Measure X) :
+    @Measure (SeparationQuotient X) (borel (SeparationQuotient X)) :=
+  @Measure.map X (SeparationQuotient X) _ (borel (SeparationQuotient X))
+    SeparationQuotient.mk μ
+
+/-- The separation-quotient measure is the pushforward along the quotient map. -/
+theorem separationQuotient_def (μ : Measure X) :
+    separationQuotient μ =
+      @Measure.map X (SeparationQuotient X) _ (borel (SeparationQuotient X))
+        SeparationQuotient.mk μ := by rfl
+
+variable [BorelSpace X]
+
+/-- Pushforward to the topological separation quotient is injective on finite Borel measures on a
+topological space. Equivalently, such measures agree exactly when their quotient laws agree.
+
+Every open set in `X` is saturated under the inseparability relation, so it is the preimage of its
+open image in `SeparationQuotient X`. Equality of the pushforwards therefore gives equality on
+open sets, which determine finite Borel measures. -/
+@[simp]
+theorem separationQuotient_inj (μ ν : Measure X) [IsFiniteMeasure μ] :
+    separationQuotient μ = separationQuotient ν ↔ μ = ν := by
+  let _ : MeasurableSpace (SeparationQuotient X) := borel (SeparationQuotient X)
+  let _ : BorelSpace (SeparationQuotient X) := ⟨rfl⟩
+  have hmk : Measurable (SeparationQuotient.mk : X → SeparationQuotient X) :=
+    SeparationQuotient.continuous_mk.measurable
+  refine ⟨fun h ↦ ?_, fun h ↦ by rw [h]⟩
+  rw [separationQuotient_def, separationQuotient_def] at h
+  apply ext_of_generate_finite {s : Set X | IsOpen s}
+    BorelSpace.measurable_eq isPiSystem_isOpen
+  · intro s hs
+    have hqs : MeasurableSet (SeparationQuotient.mk '' s) :=
+      (SeparationQuotient.isOpenMap_mk s hs).measurableSet
+    have heval := congrArg (fun m : Measure (SeparationQuotient X) ↦
+      m (SeparationQuotient.mk '' s)) h
+    simpa only [Measure.map_apply hmk hqs, SeparationQuotient.preimage_image_mk_open hs] using heval
+  · have heval := congrArg (fun m : Measure (SeparationQuotient X) ↦ m univ) h
+    simpa only [Measure.map_apply_of_aemeasurable hmk.aemeasurable MeasurableSet.univ,
+      preimage_univ] using heval
+
+end MeasureTheory.Measure

--- a/TauCeti/MeasureTheory/OptimalTransport/Wasserstein/Basic.lean
+++ b/TauCeti/MeasureTheory/OptimalTransport/Wasserstein/Basic.lean
@@ -323,6 +323,22 @@ theorem wassersteinEDist_self [MeasurableEq X] (p : ℝ≥0∞) (μ : Measure X)
   filter_upwards [ae_snd_eq_graphPlan (T := (id : X → X)) (μ := μ) aemeasurable_id] with z hz
   simp [hz]
 
+/-- Wasserstein distance from a measure to itself vanishes when the ground extended distance is
+measurable. Unlike `TauCeti.wassersteinEDist_self`, this form does not require a measurable
+diagonal, which need not exist on a non-separated pseudometric Borel space. -/
+theorem wassersteinEDist_self_of_measurable_edist
+    (hd : Measurable fun z : X × X ↦ edist z.1 z.2) (p : ℝ≥0∞) (μ : Measure X) :
+    wassersteinEDist p μ μ = 0 := by
+  apply nonpos_iff_eq_zero.mp
+  refine (wassersteinEDist_le (isCoupling_graphPlan_id μ) p).trans_eq ?_
+  have hgraph : AEMeasurable (fun x : X ↦ (x, id x)) μ := by fun_prop
+  calc
+    eLpNorm (fun z : X × X ↦ edist z.1 z.2) p (graphPlan id μ) =
+        eLpNorm ((fun z : X × X ↦ edist z.1 z.2) ∘ fun x : X ↦ (x, id x)) p μ := by
+      rw [graphPlan_def]
+      exact eLpNorm_map_measure hd.aestronglyMeasurable hgraph
+    _ = 0 := eLpNorm_eq_zero_of_ae_zero (.of_forall fun z ↦ by simp)
+
 /-- **Symmetry.** Exchanging the two measures does not change their Wasserstein distance. -/
 theorem wassersteinEDist_comm (hd : Measurable fun z : X × X ↦ edist z.1 z.2) (p : ℝ≥0∞)
     (μ ν : Measure X) : wassersteinEDist p μ ν = wassersteinEDist p ν μ := by

--- a/TauCeti/MeasureTheory/OptimalTransport/Wasserstein/Quotient.lean
+++ b/TauCeti/MeasureTheory/OptimalTransport/Wasserstein/Quotient.lean
@@ -28,9 +28,9 @@ transport roadmap.
 
 ## Main statements
 
-* `TauCeti.Measure.separationQuotient` is pushforward along Mathlib's separation-quotient map,
+* `MeasureTheory.Measure.separationQuotient` is pushforward along Mathlib's separation-quotient map,
   carrying the quotient's Borel measurable structure.
-* `TauCeti.Measure.separationQuotient_eq_iff` says that two finite Borel measures on a
+* `MeasureTheory.Measure.separationQuotient_eq_iff` says that two finite Borel measures on a
   pseudometric space have the same quotient pushforward exactly when they agree.
 * `TauCeti.wassersteinEDist_eq_zero_iff_map_separationQuotient_mk` characterizes zero Wasserstein
   distance by equality after pushforward to the metric separation quotient, for every nonzero
@@ -50,11 +50,9 @@ noncomputable section
 open MeasureTheory Set
 open scoped ENNReal
 
-namespace TauCeti
-
 universe u
 
-namespace Measure
+namespace MeasureTheory.Measure
 
 variable {X : Type u} [PseudoMetricSpace X] [MeasurableSpace X] [BorelSpace X]
 
@@ -103,7 +101,9 @@ theorem dirac_eq_dirac_of_dist_eq_zero {x y : X} (hxy : dist x y = 0) :
     exact if_congr ((Metric.inseparable_iff.2 hxy).mem_open_iff hs) rfl rfl
   · simp
 
-end Measure
+end MeasureTheory.Measure
+
+namespace TauCeti
 
 variable {X : Type u} [PseudoMetricSpace X] [MeasurableSpace X] [BorelSpace X]
   [SecondCountableTopology X] {p : ℝ≥0∞}

--- a/TauCeti/MeasureTheory/OptimalTransport/Wasserstein/Quotient.lean
+++ b/TauCeti/MeasureTheory/OptimalTransport/Wasserstein/Quotient.lean
@@ -1,0 +1,171 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.MeasureTheory.Measure.Typeclasses.Finite
+public import TauCeti.MeasureTheory.OptimalTransport.Wasserstein.Basic
+
+/-!
+# Wasserstein separation on pseudometric spaces
+
+On a pseudometric ground space, zero Wasserstein distance identifies probability laws only after
+the ground space itself is separated. This file expresses that statement using Mathlib's
+`SeparationQuotient`: for a complete second-countable pseudometric space carrying its Borel
+sigma-algebra, `W_p μ ν = 0` if and only if the pushforwards of `μ` and `ν` to the separation
+quotient agree.
+
+The reverse implication uses a feature of the Borel measurable structure of a pseudometric space:
+every open set is saturated under zero distance. Since open sets generate the Borel sigma-algebra,
+pushforward along `SeparationQuotient.mk` is injective on finite Borel measures. The forward
+implication contracts Wasserstein distance along the quotient map and applies metric separation on
+the complete separable metric quotient.
+
+This completes the pseudometric-base separation requirement in Layer 3, item 1 of the optimal
+transport roadmap.
+
+## Main statements
+
+* `TauCeti.Measure.separationQuotient` is pushforward along Mathlib's separation-quotient map,
+  carrying the quotient's Borel measurable structure.
+* `TauCeti.Measure.separationQuotient_eq_iff` says that two finite Borel measures on a
+  pseudometric space have the same quotient pushforward exactly when they agree.
+* `TauCeti.wassersteinEDist_eq_zero_iff_map_separationQuotient_mk` characterizes zero Wasserstein
+  distance by equality after pushforward to the metric separation quotient, for every nonzero
+  exponent, including `p = ∞`.
+* `TauCeti.wassersteinEDist_dirac_eq_zero_of_dist_eq_zero` records the pseudometric
+  regression case of two zero-distance points.
+
+## References
+
+* C. Villani, *Optimal Transport: Old and New*, Grundlehren 338, Springer 2009, Chapter 6.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory Set
+open scoped ENNReal
+
+namespace TauCeti
+
+universe u
+
+namespace Measure
+
+variable {X : Type u} [PseudoMetricSpace X] [MeasurableSpace X] [BorelSpace X]
+
+/-- The pushforward of a measure to the metric separation quotient, carrying the quotient's
+Borel measurable structure. -/
+noncomputable def separationQuotient (μ : Measure X) :
+    @Measure (SeparationQuotient X) (borel (SeparationQuotient X)) :=
+  @Measure.map X (SeparationQuotient X) _ (borel (SeparationQuotient X))
+    SeparationQuotient.mk μ
+
+/-- Pushforward to the metric separation quotient is injective on finite Borel measures on a
+pseudometric space. Equivalently, such measures agree exactly when their quotient laws agree.
+
+Every open set in `X` is saturated under the zero-distance relation, so it is the preimage of its
+open image in `SeparationQuotient X`. Equality of the pushforwards therefore gives equality on
+open sets, which determine finite Borel measures. -/
+theorem separationQuotient_eq_iff (μ ν : Measure X) [IsFiniteMeasure μ] :
+    separationQuotient μ = separationQuotient ν ↔ μ = ν := by
+  let _ : MeasurableSpace (SeparationQuotient X) := borel (SeparationQuotient X)
+  let _ : BorelSpace (SeparationQuotient X) := ⟨rfl⟩
+  have hmk : Measurable (SeparationQuotient.mk : X → SeparationQuotient X) :=
+    SeparationQuotient.continuous_mk.measurable
+  refine ⟨fun h ↦ ?_, fun h ↦ by rw [h]⟩
+  change μ.map SeparationQuotient.mk = ν.map SeparationQuotient.mk at h
+  apply ext_of_generate_finite {s : Set X | IsOpen s}
+    BorelSpace.measurable_eq isPiSystem_isOpen
+  · intro s hs
+    have hqs : MeasurableSet (SeparationQuotient.mk '' s) :=
+      (SeparationQuotient.isOpenMap_mk s hs).measurableSet
+    have heval := congrArg (fun m : Measure (SeparationQuotient X) ↦
+      m (SeparationQuotient.mk '' s)) h
+    simpa only [Measure.map_apply hmk hqs, SeparationQuotient.preimage_image_mk_open hs] using heval
+  · have heval := congrArg (fun m : Measure (SeparationQuotient X) ↦ m univ) h
+    simpa only [Measure.map_apply_of_aemeasurable hmk.aemeasurable MeasurableSet.univ,
+      preimage_univ] using heval
+
+/-- Dirac measures at zero-distance points of a Borel pseudometric space agree. This does not
+require measurable singletons: every Borel set is saturated under the zero-distance relation. -/
+theorem dirac_eq_dirac_of_dist_eq_zero {x y : X} (hxy : dist x y = 0) :
+    Measure.dirac x = Measure.dirac y := by
+  classical
+  apply ext_of_generate_finite {s : Set X | IsOpen s}
+    BorelSpace.measurable_eq isPiSystem_isOpen
+  · intro s hs
+    rw [Measure.dirac_apply' _ hs.measurableSet, Measure.dirac_apply' _ hs.measurableSet]
+    exact if_congr ((Metric.inseparable_iff.2 hxy).mem_open_iff hs) rfl rfl
+  · simp
+
+end Measure
+
+variable {X : Type u} [PseudoMetricSpace X] [MeasurableSpace X] [BorelSpace X]
+  [SecondCountableTopology X] {p : ℝ≥0∞}
+
+omit [BorelSpace X] [SecondCountableTopology X] in
+/-- Wasserstein distance from a measure to itself vanishes when the ground extended distance is
+measurable. Unlike `TauCeti.wassersteinEDist_self`, this form does not require a measurable
+diagonal, which need not exist on a non-separated pseudometric Borel space. -/
+theorem wassersteinEDist_self_of_measurable_edist
+    (hd : Measurable fun z : X × X ↦ edist z.1 z.2) (p : ℝ≥0∞) (μ : Measure X) :
+    wassersteinEDist p μ μ = 0 := by
+  apply nonpos_iff_eq_zero.mp
+  refine (wassersteinEDist_le (isCoupling_graphPlan_id μ) p).trans_eq ?_
+  have hgraph : AEMeasurable (fun x : X ↦ (x, id x)) μ := by fun_prop
+  calc
+    eLpNorm (fun z : X × X ↦ edist z.1 z.2) p (graphPlan id μ) =
+        eLpNorm ((fun z : X × X ↦ edist z.1 z.2) ∘ fun x : X ↦ (x, id x)) p μ := by
+      rw [graphPlan_def]
+      exact eLpNorm_map_measure hd.aestronglyMeasurable hgraph
+    _ = 0 := eLpNorm_eq_zero_of_ae_zero (.of_forall fun z ↦ by simp)
+
+/-- **Separation on a pseudometric base.** For every nonzero exponent, Wasserstein distance
+vanishes exactly when the two laws have equal pushforwards to the metric separation quotient.
+The statement includes the essential-supremum endpoint `p = ∞`. -/
+theorem wassersteinEDist_eq_zero_iff_map_separationQuotient_mk (hp : p ≠ 0)
+    (μ ν : Measure X) [CompleteSpace X] [IsFiniteMeasure μ] :
+    wassersteinEDist p μ ν = 0 ↔
+      Measure.separationQuotient μ = Measure.separationQuotient ν := by
+  let _ : TopologicalSpace.SeparableSpace (SeparationQuotient X) :=
+    SeparationQuotient.surjective_mk.denseRange.separableSpace
+      SeparationQuotient.continuous_mk
+  let _ : SecondCountableTopology (SeparationQuotient X) :=
+    UniformSpace.secondCountable_of_separable (SeparationQuotient X)
+  let _ : MeasurableSpace (SeparationQuotient X) := borel (SeparationQuotient X)
+  let _ : BorelSpace (SeparationQuotient X) := ⟨rfl⟩
+  have hmk : Measurable (SeparationQuotient.mk : X → SeparationQuotient X) :=
+    SeparationQuotient.continuous_mk.measurable
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+  · change μ.map SeparationQuotient.mk = ν.map SeparationQuotient.mk
+    have hmap : wassersteinEDist p (μ.map SeparationQuotient.mk)
+        (ν.map SeparationQuotient.mk) = 0 := by
+      apply nonpos_iff_eq_zero.mp
+      refine (le_wassersteinEDist fun π hπ ↦ ?_).trans_eq h
+      calc
+        wassersteinEDist p (μ.map SeparationQuotient.mk) (ν.map SeparationQuotient.mk)
+            ≤ eLpNorm (fun z : SeparationQuotient X × SeparationQuotient X ↦
+                edist z.1 z.2) p (π.map (Prod.map SeparationQuotient.mk SeparationQuotient.mk)) :=
+          wassersteinEDist_le (hπ.map hmk hmk) p
+        _ = eLpNorm (fun z : X × X ↦ edist z.1 z.2) p π := by
+          rw [eLpNorm_map_measure measurable_edist.aestronglyMeasurable
+            (hmk.prodMap hmk).aemeasurable]
+          exact eLpNorm_congr_ae (.of_forall fun z ↦ SeparationQuotient.edist_mk z.1 z.2)
+    exact eq_of_wassersteinEDist_eq_zero hp _ _ hmap
+  · have hμν : μ = ν := (Measure.separationQuotient_eq_iff μ ν).1 h
+    subst ν
+    exact wassersteinEDist_self_of_measurable_edist measurable_edist p μ
+
+/-- **Pseudometric regression.** Dirac laws at two zero-distance points have zero Wasserstein
+distance for every exponent, even when the points are not equal. -/
+theorem wassersteinEDist_dirac_eq_zero_of_dist_eq_zero {x y : X} (hxy : dist x y = 0) :
+    wassersteinEDist p (Measure.dirac x) (Measure.dirac y) = 0 := by
+  rw [Measure.dirac_eq_dirac_of_dist_eq_zero hxy]
+  exact wassersteinEDist_self_of_measurable_edist measurable_edist p (Measure.dirac y)
+
+end TauCeti

--- a/TauCeti/MeasureTheory/OptimalTransport/Wasserstein/Quotient.lean
+++ b/TauCeti/MeasureTheory/OptimalTransport/Wasserstein/Quotient.lean
@@ -5,8 +5,9 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.MeasureTheory.Measure.Typeclasses.Finite
-public import TauCeti.MeasureTheory.OptimalTransport.Wasserstein.Basic
+public import TauCeti.MeasureTheory.Measure.Dirac
+public import TauCeti.MeasureTheory.Measure.SeparationQuotient
+public import TauCeti.MeasureTheory.OptimalTransport.Wasserstein.Pushforward
 
 /-!
 # Wasserstein separation on pseudometric spaces
@@ -23,16 +24,13 @@ pushforward along `SeparationQuotient.mk` is injective on finite Borel measures.
 implication contracts Wasserstein distance along the quotient map and applies metric separation on
 the complete separable metric quotient.
 
-This completes the pseudometric-base separation requirement in Layer 3, item 1 of the optimal
-transport roadmap.
-
 ## Main statements
 
 * `MeasureTheory.Measure.separationQuotient` is pushforward along Mathlib's separation-quotient map,
   carrying the quotient's Borel measurable structure.
-* `MeasureTheory.Measure.separationQuotient_eq_iff` says that two finite Borel measures on a
+* `MeasureTheory.Measure.separationQuotient_inj` says that two finite Borel measures on a
   pseudometric space have the same quotient pushforward exactly when they agree.
-* `TauCeti.wassersteinEDist_eq_zero_iff_map_separationQuotient_mk` characterizes zero Wasserstein
+* `TauCeti.wassersteinEDist_eq_zero_iff_separationQuotient_eq` characterizes zero Wasserstein
   distance by equality after pushforward to the metric separation quotient, for every nonzero
   exponent, including `p = ∞`.
 * `TauCeti.wassersteinEDist_dirac_eq_zero_of_dist_eq_zero` records the pseudometric
@@ -52,83 +50,15 @@ open scoped ENNReal
 
 universe u
 
-namespace MeasureTheory.Measure
-
-variable {X : Type u} [PseudoMetricSpace X] [MeasurableSpace X] [BorelSpace X]
-
-/-- The pushforward of a measure to the metric separation quotient, carrying the quotient's
-Borel measurable structure. -/
-noncomputable def separationQuotient (μ : Measure X) :
-    @Measure (SeparationQuotient X) (borel (SeparationQuotient X)) :=
-  @Measure.map X (SeparationQuotient X) _ (borel (SeparationQuotient X))
-    SeparationQuotient.mk μ
-
-/-- Pushforward to the metric separation quotient is injective on finite Borel measures on a
-pseudometric space. Equivalently, such measures agree exactly when their quotient laws agree.
-
-Every open set in `X` is saturated under the zero-distance relation, so it is the preimage of its
-open image in `SeparationQuotient X`. Equality of the pushforwards therefore gives equality on
-open sets, which determine finite Borel measures. -/
-theorem separationQuotient_eq_iff (μ ν : Measure X) [IsFiniteMeasure μ] :
-    separationQuotient μ = separationQuotient ν ↔ μ = ν := by
-  let _ : MeasurableSpace (SeparationQuotient X) := borel (SeparationQuotient X)
-  let _ : BorelSpace (SeparationQuotient X) := ⟨rfl⟩
-  have hmk : Measurable (SeparationQuotient.mk : X → SeparationQuotient X) :=
-    SeparationQuotient.continuous_mk.measurable
-  refine ⟨fun h ↦ ?_, fun h ↦ by rw [h]⟩
-  change μ.map SeparationQuotient.mk = ν.map SeparationQuotient.mk at h
-  apply ext_of_generate_finite {s : Set X | IsOpen s}
-    BorelSpace.measurable_eq isPiSystem_isOpen
-  · intro s hs
-    have hqs : MeasurableSet (SeparationQuotient.mk '' s) :=
-      (SeparationQuotient.isOpenMap_mk s hs).measurableSet
-    have heval := congrArg (fun m : Measure (SeparationQuotient X) ↦
-      m (SeparationQuotient.mk '' s)) h
-    simpa only [Measure.map_apply hmk hqs, SeparationQuotient.preimage_image_mk_open hs] using heval
-  · have heval := congrArg (fun m : Measure (SeparationQuotient X) ↦ m univ) h
-    simpa only [Measure.map_apply_of_aemeasurable hmk.aemeasurable MeasurableSet.univ,
-      preimage_univ] using heval
-
-/-- Dirac measures at zero-distance points of a Borel pseudometric space agree. This does not
-require measurable singletons: every Borel set is saturated under the zero-distance relation. -/
-theorem dirac_eq_dirac_of_dist_eq_zero {x y : X} (hxy : dist x y = 0) :
-    Measure.dirac x = Measure.dirac y := by
-  classical
-  apply ext_of_generate_finite {s : Set X | IsOpen s}
-    BorelSpace.measurable_eq isPiSystem_isOpen
-  · intro s hs
-    rw [Measure.dirac_apply' _ hs.measurableSet, Measure.dirac_apply' _ hs.measurableSet]
-    exact if_congr ((Metric.inseparable_iff.2 hxy).mem_open_iff hs) rfl rfl
-  · simp
-
-end MeasureTheory.Measure
-
 namespace TauCeti
 
 variable {X : Type u} [PseudoMetricSpace X] [MeasurableSpace X] [BorelSpace X]
   [SecondCountableTopology X] {p : ℝ≥0∞}
 
-omit [BorelSpace X] [SecondCountableTopology X] in
-/-- Wasserstein distance from a measure to itself vanishes when the ground extended distance is
-measurable. Unlike `TauCeti.wassersteinEDist_self`, this form does not require a measurable
-diagonal, which need not exist on a non-separated pseudometric Borel space. -/
-theorem wassersteinEDist_self_of_measurable_edist
-    (hd : Measurable fun z : X × X ↦ edist z.1 z.2) (p : ℝ≥0∞) (μ : Measure X) :
-    wassersteinEDist p μ μ = 0 := by
-  apply nonpos_iff_eq_zero.mp
-  refine (wassersteinEDist_le (isCoupling_graphPlan_id μ) p).trans_eq ?_
-  have hgraph : AEMeasurable (fun x : X ↦ (x, id x)) μ := by fun_prop
-  calc
-    eLpNorm (fun z : X × X ↦ edist z.1 z.2) p (graphPlan id μ) =
-        eLpNorm ((fun z : X × X ↦ edist z.1 z.2) ∘ fun x : X ↦ (x, id x)) p μ := by
-      rw [graphPlan_def]
-      exact eLpNorm_map_measure hd.aestronglyMeasurable hgraph
-    _ = 0 := eLpNorm_eq_zero_of_ae_zero (.of_forall fun z ↦ by simp)
-
 /-- **Separation on a pseudometric base.** For every nonzero exponent, Wasserstein distance
 vanishes exactly when the two laws have equal pushforwards to the metric separation quotient.
 The statement includes the essential-supremum endpoint `p = ∞`. -/
-theorem wassersteinEDist_eq_zero_iff_map_separationQuotient_mk (hp : p ≠ 0)
+theorem wassersteinEDist_eq_zero_iff_separationQuotient_eq (hp : p ≠ 0)
     (μ ν : Measure X) [CompleteSpace X] [IsFiniteMeasure μ] :
     wassersteinEDist p μ ν = 0 ↔
       Measure.separationQuotient μ = Measure.separationQuotient ν := by
@@ -142,22 +72,15 @@ theorem wassersteinEDist_eq_zero_iff_map_separationQuotient_mk (hp : p ≠ 0)
   have hmk : Measurable (SeparationQuotient.mk : X → SeparationQuotient X) :=
     SeparationQuotient.continuous_mk.measurable
   refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
-  · change μ.map SeparationQuotient.mk = ν.map SeparationQuotient.mk
-    have hmap : wassersteinEDist p (μ.map SeparationQuotient.mk)
-        (ν.map SeparationQuotient.mk) = 0 := by
-      apply nonpos_iff_eq_zero.mp
-      refine (le_wassersteinEDist fun π hπ ↦ ?_).trans_eq h
-      calc
-        wassersteinEDist p (μ.map SeparationQuotient.mk) (ν.map SeparationQuotient.mk)
-            ≤ eLpNorm (fun z : SeparationQuotient X × SeparationQuotient X ↦
-                edist z.1 z.2) p (π.map (Prod.map SeparationQuotient.mk SeparationQuotient.mk)) :=
-          wassersteinEDist_le (hπ.map hmk hmk) p
-        _ = eLpNorm (fun z : X × X ↦ edist z.1 z.2) p π := by
-          rw [eLpNorm_map_measure measurable_edist.aestronglyMeasurable
-            (hmk.prodMap hmk).aemeasurable]
-          exact eLpNorm_congr_ae (.of_forall fun z ↦ SeparationQuotient.edist_mk z.1 z.2)
-    exact eq_of_wassersteinEDist_eq_zero hp _ _ hmap
-  · have hμν : μ = ν := (Measure.separationQuotient_eq_iff μ ν).1 h
+  · rw [Measure.separationQuotient_def, Measure.separationQuotient_def]
+    have hLip : LipschitzWith 1 (SeparationQuotient.mk : X → SeparationQuotient X) := by
+      intro x y
+      simp only [SeparationQuotient.edist_mk, ENNReal.coe_one, one_mul, le_refl]
+    have hmap := wassersteinEDist_map_le_mul_of_ne_zero (p := p)
+      measurable_edist hmk hLip one_ne_zero μ ν
+    rw [h, mul_zero] at hmap
+    exact eq_of_wassersteinEDist_eq_zero hp _ _ (nonpos_iff_eq_zero.mp hmap)
+  · have hμν : μ = ν := (Measure.separationQuotient_inj μ ν).1 h
     subst ν
     exact wassersteinEDist_self_of_measurable_edist measurable_edist p μ
 
@@ -165,7 +88,7 @@ theorem wassersteinEDist_eq_zero_iff_map_separationQuotient_mk (hp : p ≠ 0)
 distance for every exponent, even when the points are not equal. -/
 theorem wassersteinEDist_dirac_eq_zero_of_dist_eq_zero {x y : X} (hxy : dist x y = 0) :
     wassersteinEDist p (Measure.dirac x) (Measure.dirac y) = 0 := by
-  rw [Measure.dirac_eq_dirac_of_dist_eq_zero hxy]
+  rw [Measure.dirac_eq_dirac_of_inseparable (Metric.inseparable_iff.2 hxy)]
   exact wassersteinEDist_self_of_measurable_edist measurable_edist p (Measure.dirac y)
 
 end TauCeti


### PR DESCRIPTION
## Summary

For a complete second-countable Borel pseudometric space and every nonzero exponent, including `p = ∞`, characterize zero Wasserstein extended distance by equality of the laws pushed forward to Mathlib's metric `SeparationQuotient`. This implements the pseudometric-base separation requirement in [OptimalTransport/README.md, Layer 3, item 1](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/OptimalTransport/README.md).

The separation proof uses the existing Lipschitz pushforward estimate. General topological quotient-measure infrastructure lives in `Measure/SeparationQuotient.lean`, with an explicit pushforward rewrite lemma and a simp injectivity lemma. `Measure/Dirac.lean` proves equality of Dirac measures at topologically inseparable points using Mathlib's measurable-set characterization. The measurable-distance self law lives beside the existing self law in `Wasserstein/Basic.lean` and supports pseudoemetric spaces. The quotient module also gives the zero-distance Dirac regression theorem. Public names follow their conclusions; mathematical source documentation contains no roadmap completion metadata.

No external code was adapted.

## Validation

- Focused quotient build passed (3,085 jobs), including a rebuild after the final simp-attribute correction.
- Full repository build passed (10,769 jobs).
- Axiom audit passed for 104,201 declarations, using only `propext`, `Classical.choice`, and `Quot.sound`.
- Environment linters passed with no new violations.
- Repository-wide header and text-style checks passed; header arguments were batched for Windows.
- Dot-notation lint passed with zero new violations.
- Module-system check passed for all 4,645 modules.
- A separate Lean importing file checked quotient dot notation and simp behavior, topological Dirac equality, pseudoemetric self distance, and the `p = ∞` separation theorem.
- `git diff --check` passed. No tracked validation scripts or dependency pins changed.

Closes TauCetiProject/TauCetiRoadmap#345

Roadmap: OptimalTransport

<!--tauceti-target:v1 {"focus":"OptimalTransport","id":"wasserstein-pseudometric-separation"}-->

Prepared with Codex.