### PR TITLE
feat: eliminate normal unipotent subgroups of higher-rank SO

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/SpecialOrthogonal/Reductive.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialOrthogonal/Reductive.lean
@@ -1,0 +1,142 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Reductive.Basic
+public import TauCeti.Algebra.AlgebraicGroup.SpecialOrthogonal.Irreducible
+public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Radical.Faithful
+import TauCeti.Algebra.AlgebraicGroup.SpecialOrthogonal.BaseChange
+import TauCeti.Algebra.AlgebraicGroup.SpecialOrthogonal.Smooth
+import TauCeti.RingTheory.Smooth.GeometricallyReduced
+
+/-!
+# The unipotent radical obstruction for higher-rank special orthogonal groups
+
+Let `SOₙ` be the special orthogonal group of the standard symmetric form over a field of
+characteristic different from two. In dimension at least three, every normal smooth unipotent
+closed subgroup of `SOₙ` is trivial. Equivalently, its unipotent radical is trivial.
+
+The standard representation supplies the decisive input. It is faithful in every dimension and
+simple in dimension at least three, hence completely reducible. The general normal-invariants
+theorem then forces a normal smooth unipotent subgroup to act trivially, and faithfulness
+identifies its defining Hopf ideal with the augmentation ideal.
+
+Smoothness is already known away from characteristic two. Consequently reductivity of `SOₙ`
+in dimension at least three is equivalent to the one remaining geometric condition,
+connectedness. This isolates exactly what is still needed for the higher-rank standard
+special-orthogonal groups.
+
+## Main declarations
+
+* `TauCeti.SpecialOrthogonal.eq_augmentation_of_isNormal_of_smoothUnipotent_of_three_le`:
+  every normal smooth unipotent closed subgroup of `SOₙ` is trivial when `3 ≤ n`.
+* `TauCeti.SpecialOrthogonal.unipotentRadicalDefiningIdeal_eq_augmentation_of_three_le`:
+  the unipotent radical of `SOₙ` is trivial when `3 ≤ n`.
+* `TauCeti.SpecialOrthogonal.reductiveCommHopfAlgProperty_iff_geometricallyConnected_of_three_le`:
+  in these dimensions and characteristics, `SOₙ` is reductive exactly when it is geometrically
+  connected.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), §§ 4.a, 19.b, and 21.
+* T. A. Springer, *Linear Algebraic Groups*, §§ 2.2, 2.4, and Chapter 8.
+
+The formal assembly follows the corresponding standard-representation argument in
+`TauCeti.Algebra.AlgebraicGroup.Symplectic.Reductive`, using the shared normal-unipotent
+elimination theorem rather than repeating its invariant-subspace proof.
+-/
+
+public section
+
+open CategoryTheory
+
+namespace TauCeti.SpecialOrthogonal
+
+universe u
+
+noncomputable section
+
+open HopfIdeal
+
+/-- The coordinate Hopf algebra and the underlying object of its finite-type package are
+canonically identical. -/
+private noncomputable def coordinateHopfAlgebraFiniteTypeObjIso
+    (R : Type u) [CommRing R] (n : Nat) :
+    coordinateHopfAlgebra R n ≅ (finiteTypeCoordinateHopfAlgebra R n).obj :=
+  eqToIso (finiteTypeCoordinateHopfAlgebra_obj R n).symm
+
+/-- **Every normal smooth unipotent closed subgroup of `SOₙ` is trivial in dimension at least
+three**, over an algebraically closed field of characteristic different from two.
+
+The conclusion is contravariant: the defining Hopf ideal of the subgroup is the augmentation
+ideal of the special-orthogonal coordinate algebra. -/
+theorem eq_augmentation_of_isNormal_of_smoothUnipotent_of_three_le
+    (k : Type u) [Field k] [IsAlgClosed k] [NeZero (2 : k)] (n : Nat) (hn : 3 ≤ n)
+    (I : HopfIdeal k (finiteTypeCoordinateHopfAlgebra k n)) (hI : I.IsNormal)
+    (hU : smoothUnipotentCommHopfAlgProperty k
+      (FiniteTypeCommHopfAlgCat.quotient (finiteTypeCoordinateHopfAlgebra k n) I)) :
+    I = HopfIdeal.augmentation k (finiteTypeCoordinateHopfAlgebra k n) := by
+  let _ : Invertible (2 : k) := invertibleOfNonzero (NeZero.ne _)
+  let e := coordinateHopfAlgebraFiniteTypeObjIso k n
+  let H : FiniteTypeCommHopfAlgCat k :=
+    ⟨coordinateHopfAlgebra k n, by
+      rw [← finiteTypeCoordinateHopfAlgebra_obj]
+      exact (finiteTypeCoordinateHopfAlgebra k n).property⟩
+  let _ : IsReduced H := by
+    change IsReduced (coordinateHopfAlgebra k n)
+    exact isReduced_of_smooth_of_field k _
+  let _ : Comodule k (coordinateHopfAlgebra k n) (Fin n → k) := standardComodule k n
+  exact HopfIdeal.eq_augmentation_of_isNormal_of_smoothUnipotent_of_isFaithful_of_iso
+    k H (Fin n → k) (finiteTypeCoordinateHopfAlgebra k n) e
+      (isCompletelyReducible_standardComodule_of_three_le k n hn)
+      (isFaithful_standardComodule k n) I hI hU
+
+/-- **The unipotent radical of `SOₙ` is trivial in dimension at least three** over an
+algebraically closed field of characteristic different from two. -/
+theorem unipotentRadicalDefiningIdeal_eq_augmentation_of_three_le
+    (k : Type u) [Field k] [IsAlgClosed k] [NeZero (2 : k)] (n : Nat) (hn : 3 ≤ n) :
+    FiniteTypeCommHopfAlgCat.unipotentRadicalDefiningIdeal
+        (finiteTypeCoordinateHopfAlgebra k n) =
+      HopfIdeal.augmentation k (finiteTypeCoordinateHopfAlgebra k n) := by
+  rw [FiniteTypeCommHopfAlgCat.unipotentRadicalDefiningIdeal_eq_augmentation_iff]
+  intro I hI
+  exact eq_augmentation_of_isNormal_of_smoothUnipotent_of_three_le
+    k n hn I hI.isNormal hI.smoothUnipotent
+
+/-- **In dimension at least three and characteristic different from two, `SOₙ` is reductive
+if and only if it is geometrically connected.**
+
+Smoothness and triviality of every normal smooth unipotent subgroup of the geometric fibre are
+automatic under these hypotheses, so geometric connectedness is the only remaining condition. -/
+theorem reductiveCommHopfAlgProperty_iff_geometricallyConnected_of_three_le
+    (k : Type u) [Field k] [NeZero (2 : k)] (n : Nat) (hn : 3 ≤ n) :
+    reductiveCommHopfAlgProperty k (finiteTypeCoordinateHopfAlgebra k n) ↔
+      geometricallyConnectedCommHopfAlgProperty k (coordinateHopfAlgebra k n) := by
+  constructor
+  · intro h
+    rw [← finiteTypeCoordinateHopfAlgebra_obj]
+    exact h.geometricallyConnected
+  · intro hconnected
+    let _ : Invertible (2 : k) := invertibleOfNonzero (NeZero.ne _)
+    have htwo : (2 : AlgebraicClosure k) ≠ 0 := by
+      simpa only [map_ofNat] using
+        (map_ne_zero (algebraMap k (AlgebraicClosure k))).2 (NeZero.ne (2 : k))
+    let _ : NeZero (2 : AlgebraicClosure k) := ⟨htwo⟩
+    let e := coordinateHopfAlgebraFiniteTypeObjIso k n
+    apply reductiveCommHopfAlgProperty_of_geometricFiber_iso k _
+      (finiteTypeCoordinateHopfAlgebra (AlgebraicClosure k) n)
+      ((smoothCommHopfAlgProperty_iff _).mp <|
+        (smoothCommHopfAlgProperty k).prop_of_iso e
+          ((smoothCommHopfAlgProperty_iff _).mpr inferInstance))
+      ((geometricallyConnectedCommHopfAlgProperty k).prop_of_iso e hconnected)
+      (finiteTypeCoordinateHopfAlgebraBaseChangeIso k (AlgebraicClosure k) n)
+    intro I hI hU
+    exact eq_augmentation_of_isNormal_of_smoothUnipotent_of_three_le
+      (AlgebraicClosure k) n hn I hI hU
+
+end
+
+end TauCeti.SpecialOrthogonal

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialOrthogonal/Reductive.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialOrthogonal/Reductive.lean
@@ -10,7 +10,6 @@ public import TauCeti.Algebra.AlgebraicGroup.SpecialOrthogonal.Irreducible
 public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Radical.Faithful
 import TauCeti.Algebra.AlgebraicGroup.SpecialOrthogonal.BaseChange
 import TauCeti.Algebra.AlgebraicGroup.SpecialOrthogonal.Smooth
-import TauCeti.RingTheory.Smooth.GeometricallyReduced
 
 /-!
 # The unipotent radical obstruction for higher-dimensional special orthogonal groups
@@ -43,6 +42,7 @@ standard special-orthogonal groups.
 
 * J. S. Milne, *Algebraic Groups* (2017), §§ 4.a, 19.b, and 21.
 * T. A. Springer, *Linear Algebraic Groups*, §§ 2.2, 2.4, and Chapter 8.
+* Formal proof architecture: `TauCeti.Algebra.AlgebraicGroup.Symplectic.Reductive`.
 -/
 
 public section

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialOrthogonal/Reductive.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialOrthogonal/Reductive.lean
@@ -13,7 +13,7 @@ import TauCeti.Algebra.AlgebraicGroup.SpecialOrthogonal.Smooth
 import TauCeti.RingTheory.Smooth.GeometricallyReduced
 
 /-!
-# The unipotent radical obstruction for higher-rank special orthogonal groups
+# The unipotent radical obstruction for higher-dimensional special orthogonal groups
 
 Let `SOₙ` be the special orthogonal group of the standard symmetric form over a field of
 characteristic different from two. In dimension at least three, every normal smooth unipotent
@@ -26,8 +26,8 @@ identifies its defining Hopf ideal with the augmentation ideal.
 
 Smoothness is already known away from characteristic two. Consequently reductivity of `SOₙ`
 in dimension at least three is equivalent to the one remaining geometric condition,
-connectedness. This isolates exactly what is still needed for the higher-rank standard
-special-orthogonal groups.
+connectedness. This isolates exactly what is still needed for the dimension-at-least-three
+standard special-orthogonal groups.
 
 ## Main declarations
 
@@ -43,10 +43,6 @@ special-orthogonal groups.
 
 * J. S. Milne, *Algebraic Groups* (2017), §§ 4.a, 19.b, and 21.
 * T. A. Springer, *Linear Algebraic Groups*, §§ 2.2, 2.4, and Chapter 8.
-
-The formal assembly follows the corresponding standard-representation argument in
-`TauCeti.Algebra.AlgebraicGroup.Symplectic.Reductive`, using the shared normal-unipotent
-elimination theorem rather than repeating its invariant-subspace proof.
 -/
 
 public section
@@ -86,6 +82,8 @@ theorem eq_augmentation_of_isNormal_of_smoothUnipotent_of_three_le
       rw [← finiteTypeCoordinateHopfAlgebra_obj]
       exact (finiteTypeCoordinateHopfAlgebra k n).property⟩
   let _ : IsReduced H := by
+    -- `H` packages this coordinate algebra with its finite-type proof, so its carrier is
+    -- definitionally the coordinate algebra on which smoothness supplies reducedness.
     change IsReduced (coordinateHopfAlgebra k n)
     exact isReduced_of_smooth_of_field k _
   let _ : Comodule k (coordinateHopfAlgebra k n) (Fin n → k) := standardComodule k n


### PR DESCRIPTION
This PR proves that every normal smooth unipotent closed subgroup of the standard `SOₙ` is trivial over an algebraically closed field of characteristic different from two when `3 ≤ n`, identifies its unipotent radical with the augmentation ideal, and packages the result over an arbitrary field as reductivity if and only if geometric connectedness.

It advances the exact `ReductiveGroups/README.md` Layer 6 worked-example target “`SOₙ` ... prove [it is] reductive where applicable via `R_u = 1` / root data.” The faithful standard comodule and its higher-rank irreducibility are already on `main`, so applying the shared normal-invariants criterion is the most direct next critical-path step and completes the `R_u = 1` half for every `n ≥ 3`. After this PR, the higher-rank case needs geometric connectedness; combined with the equivalence proved here, that will finish reductivity, while the distinct rank-two case is in flight in #6112.

The proof reuses `HopfIdeal.eq_augmentation_of_isNormal_of_smoothUnipotent_of_isFaithful_of_iso`, `SpecialOrthogonal.isCompletelyReducible_standardComodule_of_three_le`, the faithful standard comodule, smoothness away from characteristic two, and the existing coordinate base-change isomorphism. Its formal assembly follows `Symplectic.Reductive`; no Mathlib infrastructure is vendored. The mathematical argument follows Milne, *Algebraic Groups*, §§ 4.a, 19.b, and 21, and Springer, *Linear Algebraic Groups*, §§ 2.2, 2.4, and Chapter 8, as cited in the module.

The new module `TauCeti/Algebra/AlgebraicGroup/SpecialOrthogonal/Reductive.lean` contains 142 lines and three public theorems.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"special-orthogonal-normal-unipotent-trivial"}-->

🤖 Prepared with Codex
