### PR TITLE
feat: compute the ADE zigzag dimensions and centres

### DIFF
--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/ADE.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/ADE.lean
@@ -27,8 +27,8 @@ dim centre Z(G)       5     9        10.
 ```
 
 The definitions retain the established node labels: finite nodes use the indices of
-`TauCeti.DynkinType.cartanMatrix`, and the affine nodes use
-`TauCeti.AffineDynkinType.graph`.
+`TauCeti.DynkinType.cartanMatrix`. The affine graph uses Tau Ceti's arm-coordinate numbering:
+node `0` is trivalent, and the three arms are `1`, `2, 3`, and `4, 5, 6, 7, 8`, numbered outwards.
 
 ## Main definitions
 
@@ -48,8 +48,8 @@ The definitions retain the established node labels: finite nodes use the indices
 
 The zigzag conventions and invariant formulas follow Huerfano--Khovanov, *A category for the
 adjoint representation*, Section 3, and Ehrig--Tubbenhauer, *Algebraic properties of zigzag
-algebras*, Section 2. The affine `E₈ = T_{2,3,6}` labelling follows Kac, *Infinite dimensional Lie
-algebras*, Chapter 4.
+algebras*, Section 2. The affine `E₈ = T_{2,3,6}` graph shape follows Kac, *Infinite dimensional
+Lie algebras*, Chapter 4; its node numbering here is the arm-coordinate convention described above.
 -/
 
 public section
@@ -57,28 +57,58 @@ public section
 namespace TauCeti
 
 /-- The `D₄` graph, read from its Bourbaki-numbered standard Cartan matrix. -/
-abbrev zigzagD4Graph : SimpleGraph (Fin 4) :=
+def zigzagD4Graph : SimpleGraph (Fin 4) :=
   diagramGraph (DynkinType.D 4).cartanMatrix
 
 /-- The `E₈` graph, read from its Bourbaki-numbered standard Cartan matrix. -/
-abbrev zigzagE8Graph : SimpleGraph (Fin 8) :=
+def zigzagE8Graph : SimpleGraph (Fin 8) :=
   diagramGraph DynkinType.E8.cartanMatrix
 
-/-- The affine `E₈` graph `T_{2,3,6}`, with the affine-diagram numbering. -/
-abbrev zigzagAffineE8Graph : SimpleGraph (Fin 9) :=
+/-- The affine `E₈` graph `T_{2,3,6}`, with node `0` trivalent and each arm numbered outwards. -/
+def zigzagAffineE8Graph : SimpleGraph (Fin 9) :=
   AffineDynkinType.E8.graph
 
+/-- **Adjacency in the Bourbaki-labelled `D₄` graph**: node `1` is joined to each of the other
+three nodes. -/
+@[simp]
+theorem zigzagD4Graph_adj (i j : Fin 4) : zigzagD4Graph.Adj i j ↔
+    (min (i : ℕ) (j : ℕ), max (i : ℕ) (j : ℕ)) ∈
+      [((0 : ℕ), (1 : ℕ)), (1, 2), (1, 3)] := by
+  rw [zigzagD4Graph, DynkinType.cartanMatrix_D, diagramGraph_adj]
+  fin_cases i <;> fin_cases j <;> decide
+
+/-- **Adjacency in the Bourbaki-labelled `E₈` graph**: the seven edges, listed as the pairs of
+node indices they join, smaller index first. -/
+@[simp]
+theorem zigzagE8Graph_adj (i j : Fin 8) : zigzagE8Graph.Adj i j ↔
+    (min (i : ℕ) (j : ℕ), max (i : ℕ) (j : ℕ)) ∈
+      [((0 : ℕ), (2 : ℕ)), (1, 3), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7)] := by
+  rw [zigzagE8Graph, DynkinType.cartanMatrix_E8, diagramGraph_adj]
+  fin_cases i <;> fin_cases j <;> decide
+
+/-- **Adjacency in the arm-labelled affine `E₈ = T_{2,3,6}` graph**: the eight edges, listed
+as the pairs of node indices they join, smaller index first. -/
+@[simp]
+theorem zigzagAffineE8Graph_adj (i j : Fin 9) : zigzagAffineE8Graph.Adj i j ↔
+    (min (i : ℕ) (j : ℕ), max (i : ℕ) (j : ℕ)) ∈
+      [((0 : ℕ), (1 : ℕ)), (0, 2), (2, 3), (0, 4), (4, 5), (5, 6), (6, 7), (7, 8)] := by
+  rw [zigzagAffineE8Graph]
+  exact AffineDynkinType.graph_E8_adj i j
+
 -- `SimpleGraph.Adj` is not an instance-reducible head, so instance synthesis does not see through
--- the graph abbreviations on its own: without these three declarations every `edgeFinset` and
+-- the graph definitions on its own: without these three declarations every `edgeFinset` and
 -- `finrank` statement below fails to elaborate.
-instance : DecidableRel zigzagD4Graph.Adj :=
-  inferInstanceAs (DecidableRel (diagramGraph (DynkinType.D 4).cartanMatrix).Adj)
+/-- Decidable adjacency for `zigzagD4Graph`. -/
+instance : DecidableRel zigzagD4Graph.Adj := fun i j ↦
+  decidable_of_iff _ (zigzagD4Graph_adj i j).symm
 
-instance : DecidableRel zigzagE8Graph.Adj :=
-  inferInstanceAs (DecidableRel (diagramGraph DynkinType.E8.cartanMatrix).Adj)
+/-- Decidable adjacency for `zigzagE8Graph`. -/
+instance : DecidableRel zigzagE8Graph.Adj := fun i j ↦
+  decidable_of_iff _ (zigzagE8Graph_adj i j).symm
 
-instance : DecidableRel zigzagAffineE8Graph.Adj :=
-  AffineDynkinType.E8.instDecidableRelFinNodesAdjGraph
+/-- Decidable adjacency for `zigzagAffineE8Graph`. -/
+instance : DecidableRel zigzagAffineE8Graph.Adj := fun i j ↦
+  decidable_of_iff _ (zigzagAffineE8Graph_adj i j).symm
 
 /-! ### Graph structure -/
 
@@ -114,20 +144,20 @@ theorem card_edgeFinset_zigzagAffineE8Graph : zigzagAffineE8Graph.edgeFinset.car
     [(0, 1), (0, 2), (2, 3), (0, 4), (4, 5), (5, 6), (6, 7), (7, 8)]
   have hfilter :
       (Finset.univ.filter fun x : Fin 9 × Fin 9 ↦
-        AffineDynkinType.E8.graph.Adj x.1 x.2) =
+        zigzagAffineE8Graph.Adj x.1 x.2) =
       Finset.univ.filter fun x : Fin 9 × Fin 9 ↦
         (min (x.1 : ℕ) (x.2 : ℕ), max (x.1 : ℕ) (x.2 : ℕ)) ∈ edgePairs := by
     ext x
     simp only [Finset.mem_filter, Finset.mem_univ, true_and]
-    simpa only [edgePairs] using AffineDynkinType.graph_E8_adj x.1 x.2
+    simpa only [edgePairs] using zigzagAffineE8Graph_adj x.1 x.2
   have hcard :
       (Finset.univ.filter fun x : Fin 9 × Fin 9 ↦
         (min (x.1 : ℕ) (x.2 : ℕ), max (x.1 : ℕ) (x.2 : ℕ)) ∈ edgePairs).card = 16 := by
     decide
   have h' : 2 * zigzagAffineE8Graph.edgeFinset.card =
       (Finset.univ.filter fun x : Fin 9 × Fin 9 ↦
-        AffineDynkinType.E8.graph.Adj x.1 x.2).card := by
-    simpa only [zigzagAffineE8Graph] using h
+        zigzagAffineE8Graph.Adj x.1 x.2).card := by
+    simpa only using h
   rw [hfilter, hcard] at h'
   omega
 

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/ADE.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/ADE.lean
@@ -151,21 +151,18 @@ theorem card_edgeFinset_zigzagE8Graph : zigzagE8Graph.edgeFinset.card = 7 := by
 /-! ### Zigzag dimensions -/
 
 /-- The zigzag algebra of `D₄` has dimension `14`. -/
-@[simp]
 theorem finrank_zigzagAlgebra_D4 (k : Type*) [CommRing k] [Nontrivial k] :
     Module.finrank k (zigzagAlgebra k zigzagD4Graph) = 14 := by
   rw [finrank_zigzagAlgebra]
   norm_num
 
 /-- The zigzag algebra of `E₈` has dimension `30`. -/
-@[simp]
 theorem finrank_zigzagAlgebra_E8 (k : Type*) [CommRing k] [Nontrivial k] :
     Module.finrank k (zigzagAlgebra k zigzagE8Graph) = 30 := by
   rw [finrank_zigzagAlgebra]
   norm_num
 
 /-- The zigzag algebra of affine `E₈` has dimension `34`. -/
-@[simp]
 theorem finrank_zigzagAlgebra_affineE8 (k : Type*) [CommRing k] [Nontrivial k] :
     Module.finrank k (zigzagAlgebra k zigzagAffineE8Graph) = 34 := by
   rw [finrank_zigzagAlgebra]

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/ADE.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/ADE.lean
@@ -46,10 +46,6 @@ The definitions retain the established node labels: finite nodes use the indices
 
 ## References
 
-This file implements the named-example dimension and centre targets in
-`TauCetiRoadmap/ZigzagPreprojective/README.md`, following the prototype graph presentations in
-`TauCetiRoadmap/ZigzagPreprojective/Suggested.lean`.
-
 The zigzag conventions and invariant formulas follow Huerfano--Khovanov, *A category for the
 adjoint representation*, Section 3, and Ehrig--Tubbenhauer, *Algebraic properties of zigzag
 algebras*, Section 2. The affine `E₈ = T_{2,3,6}` labelling follows Kac, *Infinite dimensional Lie
@@ -72,6 +68,9 @@ abbrev zigzagE8Graph : SimpleGraph (Fin 8) :=
 abbrev zigzagAffineE8Graph : SimpleGraph (Fin 9) :=
   AffineDynkinType.E8.graph
 
+-- `SimpleGraph.Adj` is not an instance-reducible head, so instance synthesis does not see through
+-- the graph abbreviations on its own: without these three declarations every `edgeFinset` and
+-- `finrank` statement below fails to elaborate.
 instance : DecidableRel zigzagD4Graph.Adj :=
   inferInstanceAs (DecidableRel (diagramGraph (DynkinType.D 4).cartanMatrix).Adj)
 

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/ADE.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/ADE.lean
@@ -175,21 +175,21 @@ theorem finrank_zigzagAlgebra_affineE8 (k : Type*) [CommRing k] [Nontrivial k] :
 /-! ### Centre dimensions -/
 
 /-- The centre of the zigzag algebra of `D₄` has dimension `5`. -/
-@[simp]
+@[simp high]
 theorem finrank_center_zigzagAlgebra_D4 (k : Type*) [CommRing k] [Nontrivial k] :
     Module.finrank k (Subalgebra.center k (zigzagAlgebra k zigzagD4Graph)) = 5 := by
   rw [finrank_center_zigzagAlgebra_of_connected k zigzagD4Graph connected_zigzagD4Graph]
   norm_num
 
 /-- The centre of the zigzag algebra of `E₈` has dimension `9`. -/
-@[simp]
+@[simp high]
 theorem finrank_center_zigzagAlgebra_E8 (k : Type*) [CommRing k] [Nontrivial k] :
     Module.finrank k (Subalgebra.center k (zigzagAlgebra k zigzagE8Graph)) = 9 := by
   rw [finrank_center_zigzagAlgebra_of_connected k zigzagE8Graph connected_zigzagE8Graph]
   norm_num
 
 /-- The centre of the zigzag algebra of affine `E₈` has dimension `10`. -/
-@[simp]
+@[simp high]
 theorem finrank_center_zigzagAlgebra_affineE8 (k : Type*) [CommRing k] [Nontrivial k] :
     Module.finrank k (Subalgebra.center k (zigzagAlgebra k zigzagAffineE8Graph)) = 10 := by
   rw [finrank_center_zigzagAlgebra_of_connected k zigzagAffineE8Graph

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/ADE.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/ADE.lean
@@ -169,21 +169,18 @@ theorem card_edgeFinset_zigzagE8Graph : zigzagE8Graph.edgeFinset.card = 7 := by
 /-! ### Zigzag dimensions -/
 
 /-- The zigzag algebra of `D₄` has dimension `14`. -/
-@[simp]
 theorem finrank_zigzagAlgebra_D4 (k : Type*) [Field k] :
     Module.finrank k (zigzagAlgebra k zigzagD4Graph) = 14 := by
   rw [finrank_zigzagAlgebra]
   norm_num
 
 /-- The zigzag algebra of `E₈` has dimension `30`. -/
-@[simp]
 theorem finrank_zigzagAlgebra_E8 (k : Type*) [Field k] :
     Module.finrank k (zigzagAlgebra k zigzagE8Graph) = 30 := by
   rw [finrank_zigzagAlgebra]
   norm_num
 
 /-- The zigzag algebra of affine `E₈` has dimension `34`. -/
-@[simp]
 theorem finrank_zigzagAlgebra_affineE8 (k : Type*) [Field k] :
     Module.finrank k (zigzagAlgebra k zigzagAffineE8Graph) = 34 := by
   rw [finrank_zigzagAlgebra]

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/ADE.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/ADE.lean
@@ -68,40 +68,6 @@ abbrev zigzagE8Graph : SimpleGraph (Fin 8) :=
 abbrev zigzagAffineE8Graph : SimpleGraph (Fin 9) :=
   AffineDynkinType.E8.graph
 
-/-- A computational edge-list model of the affine `E₈` graph. -/
-private def affineE8ArmRel (i j : Fin 9) : Prop :=
-  (i.1, j.1) = (0, 1) ∨ (i.1, j.1) = (0, 2) ∨ (i.1, j.1) = (2, 3) ∨
-    (i.1, j.1) = (0, 4) ∨ (i.1, j.1) = (4, 5) ∨ (i.1, j.1) = (5, 6) ∨
-      (i.1, j.1) = (6, 7) ∨ (i.1, j.1) = (7, 8)
-
-private instance : DecidableRel affineE8ArmRel := by
-  intro i j
-  unfold affineE8ArmRel
-  infer_instance
-
-private abbrev affineE8ArmGraph : SimpleGraph (Fin 9) :=
-  SimpleGraph.fromRel affineE8ArmRel
-
-private instance : DecidableRel affineE8ArmGraph.Adj := by
-  unfold affineE8ArmGraph
-  infer_instance
-
-/-- The computational edge list has the canonical affine `E₈` adjacency. -/
-private theorem zigzagAffineE8Graph_eq_fromRel :
-    zigzagAffineE8Graph = affineE8ArmGraph := by
-  ext i j
-  refine (AffineDynkinType.graph_E8_adj i j).trans ?_
-  change (min (i : ℕ) (j : ℕ), max (i : ℕ) (j : ℕ)) ∈
-      [((0 : ℕ), (1 : ℕ)), (0, 2), (2, 3), (0, 4), (4, 5), (5, 6), (6, 7), (7, 8)] ↔
-    (SimpleGraph.fromRel affineE8ArmRel).Adj i j
-  rw [SimpleGraph.fromRel_adj]
-  unfold affineE8ArmRel
-  fin_cases i <;> fin_cases j <;> decide
-
-private noncomputable def zigzagAffineE8GraphIsoFromRel :
-    zigzagAffineE8Graph ≃g affineE8ArmGraph :=
-  zigzagAffineE8Graph_eq_fromRel ▸ SimpleGraph.Iso.refl
-
 instance : DecidableRel zigzagD4Graph.Adj :=
   inferInstanceAs (DecidableRel (diagramGraph (DynkinType.D 4).cartanMatrix).Adj)
 
@@ -140,10 +106,26 @@ theorem isTree_zigzagE8Graph : zigzagE8Graph.IsTree :=
 /-- The affine `E₈` graph has eight edges. -/
 @[simp]
 theorem card_edgeFinset_zigzagAffineE8Graph : zigzagAffineE8Graph.edgeFinset.card = 8 := by
-  calc
-    _ = affineE8ArmGraph.edgeFinset.card :=
-      zigzagAffineE8GraphIsoFromRel.card_edgeFinset_eq
-    _ = 8 := by unfold affineE8ArmGraph; decide
+  have h := zigzagAffineE8Graph.two_mul_card_edgeFinset
+  let edgePairs : List (ℕ × ℕ) :=
+    [(0, 1), (0, 2), (2, 3), (0, 4), (4, 5), (5, 6), (6, 7), (7, 8)]
+  have hfilter :
+      (Finset.univ.filter fun x : Fin 9 × Fin 9 ↦
+        AffineDynkinType.E8.graph.Adj x.1 x.2) =
+      Finset.univ.filter fun x : Fin 9 × Fin 9 ↦
+        (min (x.1 : ℕ) (x.2 : ℕ), max (x.1 : ℕ) (x.2 : ℕ)) ∈ edgePairs := by
+    ext x
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and]
+    simpa only [edgePairs] using AffineDynkinType.graph_E8_adj x.1 x.2
+  have hcard :
+      (Finset.univ.filter fun x : Fin 9 × Fin 9 ↦
+        (min (x.1 : ℕ) (x.2 : ℕ), max (x.1 : ℕ) (x.2 : ℕ)) ∈ edgePairs).card = 16 := by
+    decide
+  change 2 * zigzagAffineE8Graph.edgeFinset.card =
+    (Finset.univ.filter fun x : Fin 9 × Fin 9 ↦
+      AffineDynkinType.E8.graph.Adj x.1 x.2).card at h
+  rw [hfilter, hcard] at h
+  omega
 
 /-- The affine `E₈ = T_{2,3,6}` graph is a tree. -/
 theorem isTree_zigzagAffineE8Graph : zigzagAffineE8Graph.IsTree := by
@@ -169,19 +151,22 @@ theorem card_edgeFinset_zigzagE8Graph : zigzagE8Graph.edgeFinset.card = 7 := by
 /-! ### Zigzag dimensions -/
 
 /-- The zigzag algebra of `D₄` has dimension `14`. -/
-theorem finrank_zigzagAlgebra_D4 (k : Type*) [Field k] :
+@[simp]
+theorem finrank_zigzagAlgebra_D4 (k : Type*) [CommRing k] [Nontrivial k] :
     Module.finrank k (zigzagAlgebra k zigzagD4Graph) = 14 := by
   rw [finrank_zigzagAlgebra]
   norm_num
 
 /-- The zigzag algebra of `E₈` has dimension `30`. -/
-theorem finrank_zigzagAlgebra_E8 (k : Type*) [Field k] :
+@[simp]
+theorem finrank_zigzagAlgebra_E8 (k : Type*) [CommRing k] [Nontrivial k] :
     Module.finrank k (zigzagAlgebra k zigzagE8Graph) = 30 := by
   rw [finrank_zigzagAlgebra]
   norm_num
 
 /-- The zigzag algebra of affine `E₈` has dimension `34`. -/
-theorem finrank_zigzagAlgebra_affineE8 (k : Type*) [Field k] :
+@[simp]
+theorem finrank_zigzagAlgebra_affineE8 (k : Type*) [CommRing k] [Nontrivial k] :
     Module.finrank k (zigzagAlgebra k zigzagAffineE8Graph) = 34 := by
   rw [finrank_zigzagAlgebra]
   norm_num
@@ -190,21 +175,21 @@ theorem finrank_zigzagAlgebra_affineE8 (k : Type*) [Field k] :
 
 /-- The centre of the zigzag algebra of `D₄` has dimension `5`. -/
 @[simp]
-theorem finrank_center_zigzagAlgebra_D4 (k : Type*) [Field k] :
+theorem finrank_center_zigzagAlgebra_D4 (k : Type*) [CommRing k] [Nontrivial k] :
     Module.finrank k (Subalgebra.center k (zigzagAlgebra k zigzagD4Graph)) = 5 := by
   rw [finrank_center_zigzagAlgebra_of_connected k zigzagD4Graph connected_zigzagD4Graph]
   norm_num
 
 /-- The centre of the zigzag algebra of `E₈` has dimension `9`. -/
 @[simp]
-theorem finrank_center_zigzagAlgebra_E8 (k : Type*) [Field k] :
+theorem finrank_center_zigzagAlgebra_E8 (k : Type*) [CommRing k] [Nontrivial k] :
     Module.finrank k (Subalgebra.center k (zigzagAlgebra k zigzagE8Graph)) = 9 := by
   rw [finrank_center_zigzagAlgebra_of_connected k zigzagE8Graph connected_zigzagE8Graph]
   norm_num
 
 /-- The centre of the zigzag algebra of affine `E₈` has dimension `10`. -/
 @[simp]
-theorem finrank_center_zigzagAlgebra_affineE8 (k : Type*) [Field k] :
+theorem finrank_center_zigzagAlgebra_affineE8 (k : Type*) [CommRing k] [Nontrivial k] :
     Module.finrank k (Subalgebra.center k (zigzagAlgebra k zigzagAffineE8Graph)) = 10 := by
   rw [finrank_center_zigzagAlgebra_of_connected k zigzagAffineE8Graph
     connected_zigzagAffineE8Graph]

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/ADE.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/ADE.lean
@@ -46,6 +46,10 @@ The definitions retain the established node labels: finite nodes use the indices
 
 ## References
 
+This file implements the named-example dimension and centre targets in
+`TauCetiRoadmap/ZigzagPreprojective/README.md`, following the prototype graph presentations in
+`TauCetiRoadmap/ZigzagPreprojective/Suggested.lean`.
+
 The zigzag conventions and invariant formulas follow Huerfano--Khovanov, *A category for the
 adjoint representation*, Section 3, and Ehrig--Tubbenhauer, *Algebraic properties of zigzag
 algebras*, Section 2. The affine `E₈ = T_{2,3,6}` labelling follows Kac, *Infinite dimensional Lie
@@ -121,10 +125,11 @@ theorem card_edgeFinset_zigzagAffineE8Graph : zigzagAffineE8Graph.edgeFinset.car
       (Finset.univ.filter fun x : Fin 9 × Fin 9 ↦
         (min (x.1 : ℕ) (x.2 : ℕ), max (x.1 : ℕ) (x.2 : ℕ)) ∈ edgePairs).card = 16 := by
     decide
-  change 2 * zigzagAffineE8Graph.edgeFinset.card =
-    (Finset.univ.filter fun x : Fin 9 × Fin 9 ↦
-      AffineDynkinType.E8.graph.Adj x.1 x.2).card at h
-  rw [hfilter, hcard] at h
+  have h' : 2 * zigzagAffineE8Graph.edgeFinset.card =
+      (Finset.univ.filter fun x : Fin 9 × Fin 9 ↦
+        AffineDynkinType.E8.graph.Adj x.1 x.2).card := by
+    simpa only [zigzagAffineE8Graph] using h
+  rw [hfilter, hcard] at h'
   omega
 
 /-- The affine `E₈ = T_{2,3,6}` graph is a tree. -/

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/ADE.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/ADE.lean
@@ -1,0 +1,216 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.LinearAlgebra.RootSystem.AffineDynkinType.Basic
+public import TauCeti.LinearAlgebra.RootSystem.FiniteType.Classical
+public import TauCeti.LinearAlgebra.RootSystem.FiniteType.Dynkin
+public import TauCeti.LinearAlgebra.RootSystem.FiniteType.Irreducible
+public import TauCeti.RepresentationTheory.Quiver.Zigzag.Center
+public import TauCeti.RepresentationTheory.Quiver.Zigzag.Dimension
+
+/-!
+# Zigzag algebras of `D₄`, `E₈`, and affine `E₈`
+
+This file constructs the three ADE graphs used as named zigzag examples from Tau Ceti's standard
+Cartan-matrix and affine-diagram APIs. The finite graphs are the diagrams of the Bourbaki-numbered
+Cartan matrices, while affine `E₈` is the already constructed tree `T_{2,3,6}`. Their tree
+structures determine their edge counts, and the general dimension and centre theorems then give
+
+```text
+                     D₄    E₈    affine E₈
+dim Z(G)             14    30        34
+dim centre Z(G)       5     9        10.
+```
+
+The definitions retain the established node labels: finite nodes use the indices of
+`TauCeti.DynkinType.cartanMatrix`, and the affine nodes use
+`TauCeti.AffineDynkinType.graph`.
+
+## Main definitions
+
+* `TauCeti.zigzagD4Graph`, `TauCeti.zigzagE8Graph`, and `TauCeti.zigzagAffineE8Graph`: the three
+  named graphs.
+
+## Main results
+
+* `TauCeti.isTree_zigzagD4Graph`, `TauCeti.isTree_zigzagE8Graph`, and
+  `TauCeti.isTree_zigzagAffineE8Graph`: the graphs are trees.
+* `TauCeti.finrank_zigzagAlgebra_D4`, `TauCeti.finrank_zigzagAlgebra_E8`, and
+  `TauCeti.finrank_zigzagAlgebra_affineE8`: the three zigzag dimensions.
+* `TauCeti.finrank_center_zigzagAlgebra_D4`, `TauCeti.finrank_center_zigzagAlgebra_E8`, and
+  `TauCeti.finrank_center_zigzagAlgebra_affineE8`: the three centre dimensions.
+
+## References
+
+The zigzag conventions and invariant formulas follow Huerfano--Khovanov, *A category for the
+adjoint representation*, Section 3, and Ehrig--Tubbenhauer, *Algebraic properties of zigzag
+algebras*, Section 2. The affine `E₈ = T_{2,3,6}` labelling follows Kac, *Infinite dimensional Lie
+algebras*, Chapter 4.
+-/
+
+public section
+
+namespace TauCeti
+
+/-- The `D₄` graph, read from its Bourbaki-numbered standard Cartan matrix. -/
+abbrev zigzagD4Graph : SimpleGraph (Fin 4) :=
+  diagramGraph (DynkinType.D 4).cartanMatrix
+
+/-- The `E₈` graph, read from its Bourbaki-numbered standard Cartan matrix. -/
+abbrev zigzagE8Graph : SimpleGraph (Fin 8) :=
+  diagramGraph DynkinType.E8.cartanMatrix
+
+/-- The affine `E₈` graph `T_{2,3,6}`, with the affine-diagram numbering. -/
+abbrev zigzagAffineE8Graph : SimpleGraph (Fin 9) :=
+  AffineDynkinType.E8.graph
+
+/-- A computational edge-list model of the affine `E₈` graph. -/
+private def affineE8ArmRel (i j : Fin 9) : Prop :=
+  (i.1, j.1) = (0, 1) ∨ (i.1, j.1) = (0, 2) ∨ (i.1, j.1) = (2, 3) ∨
+    (i.1, j.1) = (0, 4) ∨ (i.1, j.1) = (4, 5) ∨ (i.1, j.1) = (5, 6) ∨
+      (i.1, j.1) = (6, 7) ∨ (i.1, j.1) = (7, 8)
+
+private instance : DecidableRel affineE8ArmRel := by
+  intro i j
+  unfold affineE8ArmRel
+  infer_instance
+
+private abbrev affineE8ArmGraph : SimpleGraph (Fin 9) :=
+  SimpleGraph.fromRel affineE8ArmRel
+
+private instance : DecidableRel affineE8ArmGraph.Adj := by
+  unfold affineE8ArmGraph
+  infer_instance
+
+/-- The computational edge list has the canonical affine `E₈` adjacency. -/
+private theorem zigzagAffineE8Graph_eq_fromRel :
+    zigzagAffineE8Graph = affineE8ArmGraph := by
+  ext i j
+  refine (AffineDynkinType.graph_E8_adj i j).trans ?_
+  change (min (i : ℕ) (j : ℕ), max (i : ℕ) (j : ℕ)) ∈
+      [((0 : ℕ), (1 : ℕ)), (0, 2), (2, 3), (0, 4), (4, 5), (5, 6), (6, 7), (7, 8)] ↔
+    (SimpleGraph.fromRel affineE8ArmRel).Adj i j
+  rw [SimpleGraph.fromRel_adj]
+  unfold affineE8ArmRel
+  fin_cases i <;> fin_cases j <;> decide
+
+private noncomputable def zigzagAffineE8GraphIsoFromRel :
+    zigzagAffineE8Graph ≃g affineE8ArmGraph :=
+  zigzagAffineE8Graph_eq_fromRel ▸ SimpleGraph.Iso.refl
+
+instance : DecidableRel zigzagD4Graph.Adj :=
+  inferInstanceAs (DecidableRel (diagramGraph (DynkinType.D 4).cartanMatrix).Adj)
+
+instance : DecidableRel zigzagE8Graph.Adj :=
+  inferInstanceAs (DecidableRel (diagramGraph DynkinType.E8.cartanMatrix).Adj)
+
+instance : DecidableRel zigzagAffineE8Graph.Adj :=
+  AffineDynkinType.E8.instDecidableRelFinNodesAdjGraph
+
+/-! ### Graph structure -/
+
+/-- The `D₄` graph is connected. -/
+theorem connected_zigzagD4Graph : zigzagD4Graph.Connected :=
+  DynkinType.connected_diagramGraph_cartanMatrix (by simp)
+
+/-- The `E₈` graph is connected. -/
+theorem connected_zigzagE8Graph : zigzagE8Graph.Connected :=
+  DynkinType.connected_diagramGraph_cartanMatrix (by simp)
+
+/-- The affine `E₈` graph is connected. -/
+theorem connected_zigzagAffineE8Graph : zigzagAffineE8Graph.Connected :=
+  AffineDynkinType.graph_connected (by simp)
+
+/-- The `D₄` graph is a tree. -/
+theorem isTree_zigzagD4Graph : zigzagD4Graph.IsTree := by
+  rw [zigzagD4Graph, DynkinType.cartanMatrix_D]
+  have hconn : (diagramGraph (CartanMatrix.D 4)).Connected := by
+    rw [← DynkinType.cartanMatrix_D]
+    exact connected_zigzagD4Graph
+  exact (isFiniteType_cartanMatrix_D 4).isTree_diagramGraph hconn
+
+/-- The `E₈` graph is a tree. -/
+theorem isTree_zigzagE8Graph : zigzagE8Graph.IsTree :=
+  DynkinType.isFiniteType_cartanMatrix_E8.isTree_diagramGraph connected_zigzagE8Graph
+
+/-- The affine `E₈` graph has eight edges. -/
+@[simp]
+theorem card_edgeFinset_zigzagAffineE8Graph : zigzagAffineE8Graph.edgeFinset.card = 8 := by
+  calc
+    _ = affineE8ArmGraph.edgeFinset.card :=
+      zigzagAffineE8GraphIsoFromRel.card_edgeFinset_eq
+    _ = 8 := by unfold affineE8ArmGraph; decide
+
+/-- The affine `E₈ = T_{2,3,6}` graph is a tree. -/
+theorem isTree_zigzagAffineE8Graph : zigzagAffineE8Graph.IsTree := by
+  rw [SimpleGraph.isTree_iff_connected_and_card]
+  exact ⟨connected_zigzagAffineE8Graph, by
+    rw [Nat.card_eq_fintype_card, ← SimpleGraph.edgeFinset_card,
+      card_edgeFinset_zigzagAffineE8Graph, Nat.card_fin]⟩
+
+/-- The `D₄` graph has three edges. -/
+@[simp]
+theorem card_edgeFinset_zigzagD4Graph : zigzagD4Graph.edgeFinset.card = 3 := by
+  have h := isTree_zigzagD4Graph.card_edgeFinset
+  norm_num at h ⊢
+  omega
+
+/-- The `E₈` graph has seven edges. -/
+@[simp]
+theorem card_edgeFinset_zigzagE8Graph : zigzagE8Graph.edgeFinset.card = 7 := by
+  have h := isTree_zigzagE8Graph.card_edgeFinset
+  norm_num at h ⊢
+  omega
+
+/-! ### Zigzag dimensions -/
+
+/-- The zigzag algebra of `D₄` has dimension `14`. -/
+@[simp]
+theorem finrank_zigzagAlgebra_D4 (k : Type*) [Field k] :
+    Module.finrank k (zigzagAlgebra k zigzagD4Graph) = 14 := by
+  rw [finrank_zigzagAlgebra]
+  norm_num
+
+/-- The zigzag algebra of `E₈` has dimension `30`. -/
+@[simp]
+theorem finrank_zigzagAlgebra_E8 (k : Type*) [Field k] :
+    Module.finrank k (zigzagAlgebra k zigzagE8Graph) = 30 := by
+  rw [finrank_zigzagAlgebra]
+  norm_num
+
+/-- The zigzag algebra of affine `E₈` has dimension `34`. -/
+@[simp]
+theorem finrank_zigzagAlgebra_affineE8 (k : Type*) [Field k] :
+    Module.finrank k (zigzagAlgebra k zigzagAffineE8Graph) = 34 := by
+  rw [finrank_zigzagAlgebra]
+  norm_num
+
+/-! ### Centre dimensions -/
+
+/-- The centre of the zigzag algebra of `D₄` has dimension `5`. -/
+@[simp]
+theorem finrank_center_zigzagAlgebra_D4 (k : Type*) [Field k] :
+    Module.finrank k (Subalgebra.center k (zigzagAlgebra k zigzagD4Graph)) = 5 := by
+  rw [finrank_center_zigzagAlgebra_of_connected k zigzagD4Graph connected_zigzagD4Graph]
+  norm_num
+
+/-- The centre of the zigzag algebra of `E₈` has dimension `9`. -/
+@[simp]
+theorem finrank_center_zigzagAlgebra_E8 (k : Type*) [Field k] :
+    Module.finrank k (Subalgebra.center k (zigzagAlgebra k zigzagE8Graph)) = 9 := by
+  rw [finrank_center_zigzagAlgebra_of_connected k zigzagE8Graph connected_zigzagE8Graph]
+  norm_num
+
+/-- The centre of the zigzag algebra of affine `E₈` has dimension `10`. -/
+@[simp]
+theorem finrank_center_zigzagAlgebra_affineE8 (k : Type*) [Field k] :
+    Module.finrank k (Subalgebra.center k (zigzagAlgebra k zigzagAffineE8Graph)) = 10 := by
+  rw [finrank_center_zigzagAlgebra_of_connected k zigzagAffineE8Graph
+    connected_zigzagAffineE8Graph]
+  norm_num
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/Center.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/Center.lean
@@ -509,21 +509,20 @@ private noncomputable def zigzagAlgebraPiAlgEquiv :
   map_add' x y := funext fun C => map_add (zigzagComponentProjection k G C) x y
   commutes' r := funext fun C => (zigzagComponentProjection k G C).commutes r
 
--- Mathlib exposes `DualNumber k` as `TrivSqZeroExt k k`, whose carrier is `k × k` and whose module
--- structure is `inferInstanceAs <| Module k (k × k)`; both are public and `@[expose]`d.  There is
--- no `Module.Free`/`Module.Finite` instance, basis or linear equivalence for `TrivSqZeroExt` in
--- Mathlib, so this definitional identification is the only route to the dual-number dimension, and
--- collecting it here keeps it to a single place.
-private noncomputable def uliftDualNumberLinearEquiv :
-    ULift.{u} (DualNumber k) ≃ₗ[k] ULift.{u} (k × k) :=
-  LinearEquiv.refl k (ULift.{u} (k × k))
-
-/-- The centre of a universe lift of the dual numbers is the whole algebra: the dual numbers are
-commutative. -/
-private noncomputable def centerULiftDualNumberAlgEquiv :
-    Subalgebra.center k (ULift.{u} (DualNumber k)) ≃ₐ[k] ULift.{u} (DualNumber k) :=
-  (Subalgebra.equivOfEq _ _
-    (Subalgebra.center_eq_top (R := k) (ULift.{u} (DualNumber k)))).trans Subalgebra.topEquiv
+-- The centre of a singleton component factor is the whole factor, since the dual numbers are
+-- commutative, and Mathlib exposes `DualNumber k` as `TrivSqZeroExt k k`, whose carrier is `k × k`
+-- and whose module structure is `inferInstanceAs <| Module k (k × k)`, both of them public and
+-- `@[expose]`d.  There is no `Module.Free`/`Module.Finite` instance, basis or linear equivalence
+-- for `TrivSqZeroExt` in Mathlib, so that definitional identification is the only route to the
+-- dual-number dimension; stating the equivalence directly for the component factor confines the
+-- dependence on Mathlib's representation of `TrivSqZeroExt` to this one declaration.
+private noncomputable def centerZigzagComponentAlgebraSubsingletonLinearEquiv
+    (C : G.ConnectedComponent) [Subsingleton C] :
+    Subalgebra.center k (zigzagComponentAlgebra k G C) ≃ₗ[k] ULift.{u} (k × k) :=
+  ((centerCongr (zigzagComponentAlgebraEquivULiftDualNumber k G C)).trans
+    ((Subalgebra.equivOfEq _ _
+      (Subalgebra.center_eq_top (R := k) (ULift.{u} (DualNumber k)))).trans
+        Subalgebra.topEquiv)).toLinearEquiv
 
 /-- The centre of a component factor of the zigzag algebra is free over the coefficient ring. -/
 instance instFreeCenterZigzagComponentAlgebra (C : G.ConnectedComponent) :
@@ -538,12 +537,8 @@ instance instFreeCenterZigzagComponentAlgebra (C : G.ConnectedComponent) :
     exact Module.Free.of_equiv
       (centerCongr (zigzagComponentAlgebraEquivNonisolated k G C)).symm.toLinearEquiv
   · let _ : Subsingleton C := not_nontrivial_iff_subsingleton.mp hC
-    have : Module.Free k (ULift.{u} (DualNumber k)) :=
-      Module.Free.of_equiv (uliftDualNumberLinearEquiv k).symm
-    have : Module.Free k (Subalgebra.center k (ULift.{u} (DualNumber k))) :=
-      Module.Free.of_equiv (centerULiftDualNumberAlgEquiv k).symm.toLinearEquiv
     exact Module.Free.of_equiv
-      (centerCongr (zigzagComponentAlgebraEquivULiftDualNumber k G C)).symm.toLinearEquiv
+      (centerZigzagComponentAlgebraSubsingletonLinearEquiv k G C).symm
 
 /-- The centre of a component factor of the zigzag algebra is finite over the coefficient ring. -/
 instance instFiniteCenterZigzagComponentAlgebra (C : G.ConnectedComponent) :
@@ -560,16 +555,13 @@ instance instFiniteCenterZigzagComponentAlgebra (C : G.ConnectedComponent) :
   · let _ : Subsingleton C := not_nontrivial_iff_subsingleton.mp hC
     have : Module.Finite k (ULift.{u} (k × k)) :=
       Module.Finite.equiv (ULift.moduleEquiv (R := k) (M := k × k)).symm
-    have : Module.Finite k (ULift.{u} (DualNumber k)) :=
-      Module.Finite.equiv (uliftDualNumberLinearEquiv k).symm
-    have : Module.Finite k (Subalgebra.center k (ULift.{u} (DualNumber k))) :=
-      Module.Finite.equiv (centerULiftDualNumberAlgEquiv k).symm.toLinearEquiv
     exact Module.Finite.equiv
-      (centerCongr (zigzagComponentAlgebraEquivULiftDualNumber k G C)).symm.toLinearEquiv
+      (centerZigzagComponentAlgebraSubsingletonLinearEquiv k G C).symm
 
 /-- **The dimension of the centre of a component factor.** A component with an edge has the unit
 and one volume class at each of its vertices as a basis of its centre, while a singleton component
 carries the commutative dual numbers, whose centre is all two dimensions of it. -/
+@[simp]
 theorem finrank_center_zigzagComponentAlgebra [Nontrivial k] (C : G.ConnectedComponent) :
     Module.finrank k (Subalgebra.center k (zigzagComponentAlgebra k G C)) = Nat.card C + 1 := by
   classical
@@ -583,14 +575,13 @@ theorem finrank_center_zigzagComponentAlgebra [Nontrivial k] (C : G.ConnectedCom
     let c : C := ⟨C.nonempty_supp.some, C.nonempty_supp.some_mem⟩
     let _ : Inhabited C := ⟨c⟩
     let _ : Unique C := Unique.mk' C
-    rw [(centerCongr (zigzagComponentAlgebraEquivULiftDualNumber k G C)).toLinearEquiv.finrank_eq,
-      (centerULiftDualNumberAlgEquiv k).toLinearEquiv.finrank_eq,
-      (uliftDualNumberLinearEquiv k).finrank_eq, finrank_ulift, Module.finrank_prod,
-      Module.finrank_self, Nat.card_unique]
+    rw [(centerZigzagComponentAlgebraSubsingletonLinearEquiv k G C).finrank_eq, finrank_ulift,
+      Module.finrank_prod, Module.finrank_self, Nat.card_unique]
 
 /-- **The dimension of the centre of the public zigzag algebra.** For every finite simple graph the
 centre has dimension `|V|` plus the number of connected components: each component contributes its
 own unit together with one volume class at each of its vertices. -/
+@[simp]
 theorem finrank_center_zigzagAlgebra [Nontrivial k] :
     Module.finrank k (Subalgebra.center k (zigzagAlgebra k G)) =
       Nat.card V + Nat.card G.ConnectedComponent := by

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/Center.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/Center.lean
@@ -5,6 +5,8 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.Algebra.Subalgebra.Center
+public import TauCeti.RepresentationTheory.Quiver.Zigzag.Componentwise
 public import TauCeti.RepresentationTheory.Quiver.Zigzag.Multiplication
 
 /-!
@@ -52,6 +54,8 @@ becomes the standard basis of `Option V → k`.
   classes span the centre and are independent.
 * `TauCeti.finrank_center_nonisolatedZigzagQuotient`: the centre of the zigzag algebra of a
   connected graph with at least two vertices has dimension `|V| + 1`.
+* `TauCeti.finrank_center_zigzagAlgebra_of_connected`: the same dimension formula for the public
+  componentwise zigzag algebra.
 
 ## References
 
@@ -484,5 +488,16 @@ theorem finrank_center_nonisolatedZigzagQuotient [Nontrivial k] [Fintype V] [Non
     Module.finrank k (Subalgebra.center k (nonisolatedZigzagQuotient k G))
       = Fintype.card V + 1 := by
   rw [Module.finrank_eq_card_basis (zigzagCenterBasis k G hconn), Fintype.card_option]
+
+/-! ### The centre of the public algebra -/
+
+/-- **The centre of the public zigzag algebra of a connected nontrivial graph has dimension
+`|V| + 1`.** This transports the basis calculation for the relation quotient across the canonical
+comparison with the componentwise public algebra. -/
+theorem finrank_center_zigzagAlgebra_of_connected [Nontrivial k] [Fintype V] [Nontrivial V]
+    (hconn : G.Connected) :
+    Module.finrank k (Subalgebra.center k (zigzagAlgebra k G)) = Fintype.card V + 1 := by
+  rw [(centerCongr (zigzagAlgebraEquivNonisolated k G hconn)).toLinearEquiv.finrank_eq,
+    finrank_center_nonisolatedZigzagQuotient k G hconn.preconnected]
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/Center.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/Center.lean
@@ -602,12 +602,13 @@ theorem finrank_center_zigzagAlgebra [Nontrivial k] :
 
 /-- **The centre of the public zigzag algebra of a connected graph has dimension `|V| + 1`.**
 This includes the one-vertex case, where the public algebra is the dual numbers. -/
-theorem finrank_center_zigzagAlgebra_of_connected [Nontrivial k] [Fintype V]
+theorem finrank_center_zigzagAlgebra_of_connected [Nontrivial k]
     (hconn : G.Connected) :
-    Module.finrank k (Subalgebra.center k (zigzagAlgebra k G)) = Fintype.card V + 1 := by
+    Module.finrank k (Subalgebra.center k (zigzagAlgebra k G)) = Nat.card V + 1 := by
   obtain ⟨v⟩ := hconn.nonempty
   let _ : Nonempty G.ConnectedComponent := ⟨G.connectedComponentMk v⟩
   let _ : Subsingleton G.ConnectedComponent := hconn.preconnected.subsingleton_connectedComponent
-  rw [finrank_center_zigzagAlgebra k G, Nat.card_eq_fintype_card (α := V), Nat.card_unique]
+  rw [finrank_center_zigzagAlgebra k G,
+    Nat.card_unique (α := G.ConnectedComponent)]
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/Center.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/Center.lean
@@ -491,12 +491,27 @@ theorem finrank_center_nonisolatedZigzagQuotient [Nontrivial k] [Fintype V] [Non
 
 /-! ### The centre of the public algebra -/
 
-/-- **The centre of the public zigzag algebra of a connected nontrivial graph has dimension
-`|V| + 1`.** This applies to finite connected graphs with at least two vertices. -/
-theorem finrank_center_zigzagAlgebra_of_connected [Nontrivial k] [Fintype V] [Nontrivial V]
+/-- **The centre of the public zigzag algebra of a connected graph has dimension `|V| + 1`.**
+This includes the one-vertex case, where the public algebra is the dual numbers. -/
+theorem finrank_center_zigzagAlgebra_of_connected [Nontrivial k] [Fintype V]
     (hconn : G.Connected) :
     Module.finrank k (Subalgebra.center k (zigzagAlgebra k G)) = Fintype.card V + 1 := by
-  rw [(centerCongr (zigzagAlgebraEquivNonisolated k G hconn)).toLinearEquiv.finrank_eq,
-    finrank_center_nonisolatedZigzagQuotient k G hconn.preconnected]
+  cases subsingleton_or_nontrivial V with
+  | inr _ =>
+      rw [(centerCongr (zigzagAlgebraEquivNonisolated k G hconn)).toLinearEquiv.finrank_eq,
+        finrank_center_nonisolatedZigzagQuotient k G hconn.preconnected]
+  | inl hV =>
+      let _ : Subsingleton V := hV
+      let _ : Unique V := { default := hconn.nonempty.some, uniq := fun _ => Subsingleton.elim _ _ }
+      let e : G ≃g (⊥ : SimpleGraph (Fin 1)) :=
+        { Equiv.ofUnique V (Fin 1) with
+          map_rel_iff' := by
+            intro i j
+            simp [Subsingleton.elim i j] }
+      rw [(centerCongr ((zigzagAlgebraEquiv k G e).trans
+        (zigzagAlgebraEquivA1 k))).toLinearEquiv.finrank_eq, Subalgebra.center_eq_top]
+      rw [(Subalgebra.topEquiv (R := k) (A := DualNumber k)).toLinearEquiv.finrank_eq]
+      change Module.finrank k (k × k) = Fintype.card V + 1
+      simp
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/Center.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/Center.lean
@@ -492,8 +492,7 @@ theorem finrank_center_nonisolatedZigzagQuotient [Nontrivial k] [Fintype V] [Non
 /-! ### The centre of the public algebra -/
 
 /-- **The centre of the public zigzag algebra of a connected nontrivial graph has dimension
-`|V| + 1`.** This transports the basis calculation for the relation quotient across the canonical
-comparison with the componentwise public algebra. -/
+`|V| + 1`.** This applies to finite connected graphs with at least two vertices. -/
 theorem finrank_center_zigzagAlgebra_of_connected [Nontrivial k] [Fintype V] [Nontrivial V]
     (hconn : G.Connected) :
     Module.finrank k (Subalgebra.center k (zigzagAlgebra k G)) = Fintype.card V + 1 := by

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/Center.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/Center.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import Mathlib.RingTheory.Finiteness.Prod
 public import TauCeti.Algebra.Subalgebra.Center
 public import TauCeti.RepresentationTheory.Quiver.Zigzag.Componentwise
 public import TauCeti.RepresentationTheory.Quiver.Zigzag.Multiplication
@@ -54,8 +55,12 @@ becomes the standard basis of `Option V → k`.
   classes span the centre and are independent.
 * `TauCeti.finrank_center_nonisolatedZigzagQuotient`: the centre of the zigzag algebra of a
   connected graph with at least two vertices has dimension `|V| + 1`.
-* `TauCeti.finrank_center_zigzagAlgebra_of_connected`: the same dimension formula for the public
-  componentwise zigzag algebra.
+* `TauCeti.finrank_center_zigzagComponentAlgebra`: the centre of one component factor of the
+  public componentwise zigzag algebra has dimension `|C| + 1`.
+* `TauCeti.finrank_center_zigzagAlgebra`: the centre of the public componentwise zigzag algebra of
+  an arbitrary finite graph has dimension `|V|` plus the number of connected components.
+* `TauCeti.finrank_center_zigzagAlgebra_of_connected`: the same dimension formula for a connected
+  graph, where it reads `|V| + 1`.
 
 ## References
 
@@ -491,27 +496,127 @@ theorem finrank_center_nonisolatedZigzagQuotient [Nontrivial k] [Fintype V] [Non
 
 /-! ### The centre of the public algebra -/
 
+-- The carrier of `zigzagAlgebra k G` is the dependent product of its component algebras, but that
+-- product is opaque across the public import, so the equivalence with the product is rebuilt from
+-- the public component projections and the reconstruction map.
+private noncomputable def zigzagAlgebraPiAlgEquiv :
+    zigzagAlgebra k G ≃ₐ[k] ∀ C : G.ConnectedComponent, zigzagComponentAlgebra k G C where
+  toFun x C := zigzagComponentProjection k G C x
+  invFun := zigzagAlgebraMk k G
+  left_inv := zigzagAlgebra.mk_projections k G
+  right_inv _ := funext fun _ => zigzagComponentProjection_zigzagAlgebraMk k G _ _
+  map_mul' x y := funext fun C => map_mul (zigzagComponentProjection k G C) x y
+  map_add' x y := funext fun C => map_add (zigzagComponentProjection k G C) x y
+  commutes' r := funext fun C => (zigzagComponentProjection k G C).commutes r
+
+-- Mathlib exposes `DualNumber k` as `TrivSqZeroExt k k`, whose carrier is `k × k` and whose module
+-- structure is `inferInstanceAs <| Module k (k × k)`; both are public and `@[expose]`d.  There is
+-- no `Module.Free`/`Module.Finite` instance, basis or linear equivalence for `TrivSqZeroExt` in
+-- Mathlib, so this definitional identification is the only route to the dual-number dimension, and
+-- collecting it here keeps it to a single place.
+private noncomputable def uliftDualNumberLinearEquiv :
+    ULift.{u} (DualNumber k) ≃ₗ[k] ULift.{u} (k × k) :=
+  LinearEquiv.refl k (ULift.{u} (k × k))
+
+/-- The centre of a universe lift of the dual numbers is the whole algebra: the dual numbers are
+commutative. -/
+private noncomputable def centerULiftDualNumberAlgEquiv :
+    Subalgebra.center k (ULift.{u} (DualNumber k)) ≃ₐ[k] ULift.{u} (DualNumber k) :=
+  (Subalgebra.equivOfEq _ _
+    (Subalgebra.center_eq_top (R := k) (ULift.{u} (DualNumber k)))).trans Subalgebra.topEquiv
+
+/-- The centre of a component factor of the zigzag algebra is free over the coefficient ring. -/
+instance instFreeCenterZigzagComponentAlgebra (C : G.ConnectedComponent) :
+    Module.Free k (Subalgebra.center k (zigzagComponentAlgebra k G C)) := by
+  classical
+  by_cases hC : Nontrivial C
+  · let _ : Nontrivial C := hC
+    let _ : Fintype C := Fintype.ofFinite C
+    have : Module.Free k (Subalgebra.center k (nonisolatedZigzagQuotient k C.toSimpleGraph)) :=
+      Module.Free.of_basis
+        (zigzagCenterBasis k C.toSimpleGraph C.connected_toSimpleGraph.preconnected)
+    exact Module.Free.of_equiv
+      (centerCongr (zigzagComponentAlgebraEquivNonisolated k G C)).symm.toLinearEquiv
+  · let _ : Subsingleton C := not_nontrivial_iff_subsingleton.mp hC
+    have : Module.Free k (ULift.{u} (DualNumber k)) :=
+      Module.Free.of_equiv (uliftDualNumberLinearEquiv k).symm
+    have : Module.Free k (Subalgebra.center k (ULift.{u} (DualNumber k))) :=
+      Module.Free.of_equiv (centerULiftDualNumberAlgEquiv k).symm.toLinearEquiv
+    exact Module.Free.of_equiv
+      (centerCongr (zigzagComponentAlgebraEquivULiftDualNumber k G C)).symm.toLinearEquiv
+
+/-- The centre of a component factor of the zigzag algebra is finite over the coefficient ring. -/
+instance instFiniteCenterZigzagComponentAlgebra (C : G.ConnectedComponent) :
+    Module.Finite k (Subalgebra.center k (zigzagComponentAlgebra k G C)) := by
+  classical
+  by_cases hC : Nontrivial C
+  · let _ : Nontrivial C := hC
+    let _ : Fintype C := Fintype.ofFinite C
+    have : Module.Finite k (Subalgebra.center k (nonisolatedZigzagQuotient k C.toSimpleGraph)) :=
+      Module.Finite.of_basis
+        (zigzagCenterBasis k C.toSimpleGraph C.connected_toSimpleGraph.preconnected)
+    exact Module.Finite.equiv
+      (centerCongr (zigzagComponentAlgebraEquivNonisolated k G C)).symm.toLinearEquiv
+  · let _ : Subsingleton C := not_nontrivial_iff_subsingleton.mp hC
+    have : Module.Finite k (ULift.{u} (k × k)) :=
+      Module.Finite.equiv (ULift.moduleEquiv (R := k) (M := k × k)).symm
+    have : Module.Finite k (ULift.{u} (DualNumber k)) :=
+      Module.Finite.equiv (uliftDualNumberLinearEquiv k).symm
+    have : Module.Finite k (Subalgebra.center k (ULift.{u} (DualNumber k))) :=
+      Module.Finite.equiv (centerULiftDualNumberAlgEquiv k).symm.toLinearEquiv
+    exact Module.Finite.equiv
+      (centerCongr (zigzagComponentAlgebraEquivULiftDualNumber k G C)).symm.toLinearEquiv
+
+/-- **The dimension of the centre of a component factor.** A component with an edge has the unit
+and one volume class at each of its vertices as a basis of its centre, while a singleton component
+carries the commutative dual numbers, whose centre is all two dimensions of it. -/
+theorem finrank_center_zigzagComponentAlgebra [Nontrivial k] (C : G.ConnectedComponent) :
+    Module.finrank k (Subalgebra.center k (zigzagComponentAlgebra k G C)) = Nat.card C + 1 := by
+  classical
+  by_cases hC : Nontrivial C
+  · let _ : Nontrivial C := hC
+    let _ : Fintype C := Fintype.ofFinite C
+    rw [(centerCongr (zigzagComponentAlgebraEquivNonisolated k G C)).toLinearEquiv.finrank_eq,
+      finrank_center_nonisolatedZigzagQuotient k C.toSimpleGraph
+        C.connected_toSimpleGraph.preconnected, Nat.card_eq_fintype_card]
+  · let _ : Subsingleton C := not_nontrivial_iff_subsingleton.mp hC
+    let c : C := ⟨C.nonempty_supp.some, C.nonempty_supp.some_mem⟩
+    let _ : Inhabited C := ⟨c⟩
+    let _ : Unique C := Unique.mk' C
+    rw [(centerCongr (zigzagComponentAlgebraEquivULiftDualNumber k G C)).toLinearEquiv.finrank_eq,
+      (centerULiftDualNumberAlgEquiv k).toLinearEquiv.finrank_eq,
+      (uliftDualNumberLinearEquiv k).finrank_eq, finrank_ulift, Module.finrank_prod,
+      Module.finrank_self, Nat.card_unique]
+
+/-- **The dimension of the centre of the public zigzag algebra.** For every finite simple graph the
+centre has dimension `|V|` plus the number of connected components: each component contributes its
+own unit together with one volume class at each of its vertices. -/
+theorem finrank_center_zigzagAlgebra [Nontrivial k] :
+    Module.finrank k (Subalgebra.center k (zigzagAlgebra k G)) =
+      Nat.card V + Nat.card G.ConnectedComponent := by
+  classical
+  let _ : Fintype V := Fintype.ofFinite V
+  let _ : Fintype G.ConnectedComponent := Fintype.ofFinite _
+  have hvertex : ∑ C : G.ConnectedComponent, Nat.card C = Nat.card V := by
+    rw [← Nat.card_sigma]
+    exact Nat.card_congr (Equiv.sigmaFiberEquiv G.connectedComponentMk)
+  let e : Subalgebra.center k (∀ C : G.ConnectedComponent, (zigzagComponentAlgebra k G C).carrier)
+      ≃ₐ[k] ∀ C : G.ConnectedComponent,
+        Subalgebra.center k (zigzagComponentAlgebra k G C).carrier := centerPiAlgEquiv
+  rw [(centerCongr (zigzagAlgebraPiAlgEquiv k G)).toLinearEquiv.finrank_eq,
+    e.toLinearEquiv.finrank_eq, Module.finrank_pi_fintype]
+  simp_rw [finrank_center_zigzagComponentAlgebra k G]
+  rw [Finset.sum_add_distrib, hvertex]
+  simp [Nat.card_eq_fintype_card]
+
 /-- **The centre of the public zigzag algebra of a connected graph has dimension `|V| + 1`.**
 This includes the one-vertex case, where the public algebra is the dual numbers. -/
 theorem finrank_center_zigzagAlgebra_of_connected [Nontrivial k] [Fintype V]
     (hconn : G.Connected) :
     Module.finrank k (Subalgebra.center k (zigzagAlgebra k G)) = Fintype.card V + 1 := by
-  cases subsingleton_or_nontrivial V with
-  | inr _ =>
-      rw [(centerCongr (zigzagAlgebraEquivNonisolated k G hconn)).toLinearEquiv.finrank_eq,
-        finrank_center_nonisolatedZigzagQuotient k G hconn.preconnected]
-  | inl hV =>
-      let _ : Subsingleton V := hV
-      let _ : Unique V := { default := hconn.nonempty.some, uniq := fun _ => Subsingleton.elim _ _ }
-      let e : G ≃g (⊥ : SimpleGraph (Fin 1)) :=
-        { Equiv.ofUnique V (Fin 1) with
-          map_rel_iff' := by
-            intro i j
-            simp [Subsingleton.elim i j] }
-      rw [(centerCongr ((zigzagAlgebraEquiv k G e).trans
-        (zigzagAlgebraEquivA1 k))).toLinearEquiv.finrank_eq, Subalgebra.center_eq_top]
-      rw [(Subalgebra.topEquiv (R := k) (A := DualNumber k)).toLinearEquiv.finrank_eq]
-      change Module.finrank k (k × k) = Fintype.card V + 1
-      simp
+  obtain ⟨v⟩ := hconn.nonempty
+  let _ : Nonempty G.ConnectedComponent := ⟨G.connectedComponentMk v⟩
+  let _ : Subsingleton G.ConnectedComponent := hconn.preconnected.subsingleton_connectedComponent
+  rw [finrank_center_zigzagAlgebra k G, Nat.card_eq_fintype_card (α := V), Nat.card_unique]
 
 end TauCeti


### PR DESCRIPTION
This PR constructs the canonical Bourbaki-labelled `D₄` and `E₈` graphs from `DynkinType.cartanMatrix`, uses the landed `AffineDynkinType.E8.graph = T_{2,3,6}` for affine `E₈`, and proves the six named zigzag-algebra dimension and centre-dimension calculations.

It advances the `ZigzagPreprojective/README.md` milestone “Named examples and acceptance criteria / `D₄`, `E₈`, and affine `E₈`”, specifically the target requiring `dim Z(D₄)=14`, `dim Z(E₈)=30`, `dim Z(Ẽ₈)=34` and centre dimensions `5`, `9`, and `10`. The finite edge counts follow from the finite-type and connected-diagram APIs; affine `E₈` is checked against the roadmap's eight-edge `T_{2,3,6}` presentation, and all algebra dimensions then follow from the general public zigzag formulas.

The connected centre calculation is also transported across `zigzagAlgebraEquivNonisolated`, closing the API gap between the relation quotient and the public componentwise algebra used by the named results. The mathematical conventions and invariant formulas follow Huerfano–Khovanov, *A category for the adjoint representation*, Section 3, Ehrig–Tubbenhauer, *Algebraic properties of zigzag algebras*, Section 2, and Kac, *Infinite dimensional Lie algebras*, Chapter 4, as recorded in the module documentation. No Mathlib infrastructure is vendored.

After this PR, the `D₄`/`E₈`/affine-`E₈` milestone still needs the named graded Cartan matrices and their specializations, chosen source–sink orientations and preprojective comparisons, and the intrinsic-formality instances.

Roadmap: ZigzagPreprojective

<!--tauceti-target:v1 {"focus":"ZigzagPreprojective","id":"zigzag-d4-e8-affine-e8-dimensions-centers"}-->

🤖 Prepared with Codex
