### PR TITLE
feat: work out the skew-zigzag algebras of the cycles

### DIFF
--- a/TauCeti/Combinatorics/SimpleGraph/CycleGraph.lean
+++ b/TauCeti/Combinatorics/SimpleGraph/CycleGraph.lean
@@ -20,7 +20,7 @@ distinct and really are neighbours.
 ## Main results
 
 * `TauCeti.eq_add_one_or_eq_add_one_of_cycleGraph_adj`: adjacent vertices differ by one.
-* `TauCeti.cycleGraph_eq_or_eq_or_eq_of_adj`: no vertex has three pairwise distinct neighbours,
+* `TauCeti.eq_or_eq_or_eq_of_cycleGraph_adj`: no vertex has three pairwise distinct neighbours,
   that is, every degree is at most two.
 * `TauCeti.cycleGraph_adj_add_one`: on at least three vertices a vertex is adjacent to its
   successor.
@@ -50,7 +50,7 @@ theorem eq_add_one_or_eq_add_one_of_cycleGraph_adj {u v : Fin m} (h : (cycleGrap
 
 /-- **No vertex of a cycle graph has three pairwise distinct neighbours**: every degree is at most
 two. -/
-theorem cycleGraph_eq_or_eq_or_eq_of_adj {i j j' j'' : Fin m} (h : (cycleGraph m).Adj i j)
+theorem eq_or_eq_or_eq_of_cycleGraph_adj {i j j' j'' : Fin m} (h : (cycleGraph m).Adj i j)
     (h' : (cycleGraph m).Adj i j') (h'' : (cycleGraph m).Adj i j'') :
     j = j' ∨ j' = j'' ∨ j'' = j := by
   rcases eq_add_one_or_eq_add_one_of_cycleGraph_adj h with hj | hj <;>

--- a/TauCeti/Combinatorics/SimpleGraph/CycleGraph.lean
+++ b/TauCeti/Combinatorics/SimpleGraph/CycleGraph.lean
@@ -6,16 +6,16 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Combinatorics.SimpleGraph.CycleGraph
+public import TauCeti.Data.Fin.Basic
 
 /-!
 # Neighbours in a cycle graph
 
-Mathlib's `SimpleGraph.cycleGraph m` joins two elements of `Fin m` exactly when they differ by one,
-records the neighbour set of a vertex as the pair `{v - 1, v + 1}` and computes the degree of a
-cycle graph on at least three vertices to be two. This file reads those two facts in the form a
-consumer usually wants: a neighbour of a vertex is its successor or its predecessor, so a vertex
-has at most the two neighbours `v + 1` and `v - 1`, and on at least three vertices those two are
-distinct and really are neighbours.
+For `m ≥ 2`, Mathlib's `SimpleGraph.cycleGraph m` joins two elements of `Fin m` exactly when they
+differ by one and records the neighbour set of a vertex as the pair `{v - 1, v + 1}`; for `m ≥ 3`,
+it computes the degree to be two. This file derives the weaker fact valid for every nonzero `m`
+that an adjacent vertex is the successor or predecessor, and shows that there are at most the two
+neighbours `v + 1` and `v - 1`; when `m ≥ 3`, they are distinct and really are neighbours.
 
 ## Main results
 
@@ -24,8 +24,6 @@ distinct and really are neighbours.
   that is, every degree is at most two.
 * `TauCeti.cycleGraph_adj_add_one`: on at least three vertices a vertex is adjacent to its
   successor.
-* `TauCeti.add_one_add_one_ne_self`: on at least three vertices the two neighbours of a vertex are
-  distinct.
 -/
 
 public section
@@ -72,14 +70,5 @@ theorem cycleGraph_adj_add_one (hm : 3 ≤ m) (v : Fin m) : (cycleGraph m).Adj v
     rw [cycleGraph_neighborSet]
     exact Set.mem_insert_of_mem _ rfl
   exact hv
-
-/-- **Adding one twice in `Fin m` never returns to the same element** when `3 ≤ m`.  For a cycle
-graph this says that the two neighbours of a vertex are distinct, and it is read off from
-Mathlib's computation of the degree of a cycle graph on at least three vertices. -/
-theorem add_one_add_one_ne_self (hm : 3 ≤ m) (v : Fin m) : v + 1 + 1 ≠ v := by
-  obtain ⟨n, rfl⟩ : ∃ n, m = n + 3 := ⟨m - 3, by omega⟩
-  have hne : v - 1 ≠ v + 1 :=
-    Finset.card_pair_eq_two_iff.mp (cycleGraph_degree_two_le.symm.trans cycleGraph_degree_three_le)
-  exact fun hv => hne (eq_sub_of_add_eq hv).symm
 
 end TauCeti

--- a/TauCeti/Combinatorics/SimpleGraph/CycleGraph.lean
+++ b/TauCeti/Combinatorics/SimpleGraph/CycleGraph.lean
@@ -11,7 +11,8 @@ public import Mathlib.Combinatorics.SimpleGraph.CycleGraph
 # Neighbours in a cycle graph
 
 Mathlib's `SimpleGraph.cycleGraph m` joins two elements of `Fin m` exactly when they differ by one,
-and states that adjacency as a difference. This file reads the same adjacency in the form a
+records the neighbour set of a vertex as the pair `{v - 1, v + 1}` and computes the degree of a
+cycle graph on at least three vertices to be two. This file reads those two facts in the form a
 consumer usually wants: a neighbour of a vertex is its successor or its predecessor, so a vertex
 has at most the two neighbours `v + 1` and `v - 1`, and on at least three vertices those two are
 distinct and really are neighbours.
@@ -41,9 +42,11 @@ theorem eq_add_one_or_eq_add_one_of_cycleGraph_adj {u v : Fin m} (h : (cycleGrap
   obtain ⟨n, rfl⟩ : ∃ n, m = n + 1 := ⟨m - 1, by have := NeZero.ne m; omega⟩
   obtain _ | n := n
   · exact absurd h cycleGraph_one_adj
-  · rcases cycleGraph_adj.mp h with hd | hd
-    · exact Or.inr ((sub_eq_iff_eq_add.mp hd).trans (add_comm 1 v))
-    · exact Or.inl ((sub_eq_iff_eq_add.mp hd).trans (add_comm 1 u))
+  · have hv : v ∈ (cycleGraph (n + 2)).neighborSet u := h
+    rw [cycleGraph_neighborSet, Set.mem_insert_iff, Set.mem_singleton_iff] at hv
+    rcases hv with hv | hv
+    · exact Or.inr (by rw [hv, sub_add_cancel])
+    · exact Or.inl hv
 
 /-- **No vertex of a cycle graph has three pairwise distinct neighbours**: every degree is at most
 two. -/
@@ -65,22 +68,18 @@ theorem cycleGraph_eq_or_eq_or_eq_of_adj {i j j' j'' : Fin m} (h : (cycleGraph m
 /-- **Consecutive vertices of a cycle graph on at least three vertices are adjacent.** -/
 theorem cycleGraph_adj_add_one (hm : 3 ≤ m) (v : Fin m) : (cycleGraph m).Adj v (v + 1) := by
   obtain ⟨n, rfl⟩ : ∃ n, m = n + 2 := ⟨m - 2, by omega⟩
-  exact cycleGraph_adj.mpr (Or.inr (add_sub_cancel_left v 1))
-
-/-- The underlying natural number of a successor in `Fin m`. -/
-private theorem val_add_one (v : Fin m) : ((v + 1 : Fin m) : ℕ) = (v.val + 1) % m := by
-  rw [Fin.val_add, Fin.val_one', Nat.add_mod_mod]
-
-private theorem one_add_one_ne_zero (hm : 3 ≤ m) : (1 : Fin m) + 1 ≠ 0 := by
-  have h1 : ((1 : Fin m) : ℕ) = 1 := by rw [Fin.val_one', Nat.mod_eq_of_lt (by omega)]
-  rw [Ne, Fin.ext_iff, val_add_one, h1, Fin.val_zero, Nat.mod_eq_of_lt (by omega)]
-  omega
+  have hv : v + 1 ∈ (cycleGraph (n + 2)).neighborSet v := by
+    rw [cycleGraph_neighborSet]
+    exact Set.mem_insert_of_mem _ rfl
+  exact hv
 
 /-- **Adding one twice in `Fin m` never returns to the same element** when `3 ≤ m`.  For a cycle
-graph this says that the two neighbours of a vertex are distinct. -/
+graph this says that the two neighbours of a vertex are distinct, and it is read off from
+Mathlib's computation of the degree of a cycle graph on at least three vertices. -/
 theorem add_one_add_one_ne_self (hm : 3 ≤ m) (v : Fin m) : v + 1 + 1 ≠ v := by
-  intro h
-  refine one_add_one_ne_zero hm (add_left_cancel (a := v) ?_)
-  rw [add_zero, ← add_assoc, h]
+  obtain ⟨n, rfl⟩ : ∃ n, m = n + 3 := ⟨m - 3, by omega⟩
+  have hne : v - 1 ≠ v + 1 :=
+    Finset.card_pair_eq_two_iff.mp (cycleGraph_degree_two_le.symm.trans cycleGraph_degree_three_le)
+  exact fun hv => hne (eq_sub_of_add_eq hv).symm
 
 end TauCeti

--- a/TauCeti/Combinatorics/SimpleGraph/CycleGraph.lean
+++ b/TauCeti/Combinatorics/SimpleGraph/CycleGraph.lean
@@ -1,0 +1,86 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Combinatorics.SimpleGraph.CycleGraph
+
+/-!
+# Neighbours in a cycle graph
+
+Mathlib's `SimpleGraph.cycleGraph m` joins two elements of `Fin m` exactly when they differ by one,
+and states that adjacency as a difference. This file reads the same adjacency in the form a
+consumer usually wants: a neighbour of a vertex is its successor or its predecessor, so a vertex
+has at most the two neighbours `v + 1` and `v - 1`, and on at least three vertices those two are
+distinct and really are neighbours.
+
+## Main results
+
+* `TauCeti.eq_add_one_or_eq_add_one_of_cycleGraph_adj`: adjacent vertices differ by one.
+* `TauCeti.cycleGraph_eq_or_eq_or_eq_of_adj`: no vertex has three pairwise distinct neighbours,
+  that is, every degree is at most two.
+* `TauCeti.cycleGraph_adj_add_one`: on at least three vertices a vertex is adjacent to its
+  successor.
+* `TauCeti.add_one_add_one_ne_self`: on at least three vertices the two neighbours of a vertex are
+  distinct.
+-/
+
+public section
+
+namespace TauCeti
+
+open SimpleGraph
+
+variable {m : ℕ} [NeZero m]
+
+/-- **Adjacent vertices of a cycle graph differ by one.** -/
+theorem eq_add_one_or_eq_add_one_of_cycleGraph_adj {u v : Fin m} (h : (cycleGraph m).Adj u v) :
+    v = u + 1 ∨ u = v + 1 := by
+  obtain ⟨n, rfl⟩ : ∃ n, m = n + 1 := ⟨m - 1, by have := NeZero.ne m; omega⟩
+  obtain _ | n := n
+  · exact absurd h cycleGraph_one_adj
+  · rcases cycleGraph_adj.mp h with hd | hd
+    · exact Or.inr ((sub_eq_iff_eq_add.mp hd).trans (add_comm 1 v))
+    · exact Or.inl ((sub_eq_iff_eq_add.mp hd).trans (add_comm 1 u))
+
+/-- **No vertex of a cycle graph has three pairwise distinct neighbours**: every degree is at most
+two. -/
+theorem cycleGraph_eq_or_eq_or_eq_of_adj {i j j' j'' : Fin m} (h : (cycleGraph m).Adj i j)
+    (h' : (cycleGraph m).Adj i j') (h'' : (cycleGraph m).Adj i j'') :
+    j = j' ∨ j' = j'' ∨ j'' = j := by
+  rcases eq_add_one_or_eq_add_one_of_cycleGraph_adj h with hj | hj <;>
+    rcases eq_add_one_or_eq_add_one_of_cycleGraph_adj h' with hj' | hj' <;>
+      rcases eq_add_one_or_eq_add_one_of_cycleGraph_adj h'' with hj'' | hj''
+  · exact Or.inl (hj.trans hj'.symm)
+  · exact Or.inl (hj.trans hj'.symm)
+  · exact Or.inr (Or.inr (hj''.trans hj.symm))
+  · exact Or.inr (Or.inl (add_right_cancel (hj'.symm.trans hj'')))
+  · exact Or.inr (Or.inl (hj'.trans hj''.symm))
+  · exact Or.inr (Or.inr (add_right_cancel (hj''.symm.trans hj)))
+  · exact Or.inl (add_right_cancel (hj.symm.trans hj'))
+  · exact Or.inl (add_right_cancel (hj.symm.trans hj'))
+
+/-- **Consecutive vertices of a cycle graph on at least three vertices are adjacent.** -/
+theorem cycleGraph_adj_add_one (hm : 3 ≤ m) (v : Fin m) : (cycleGraph m).Adj v (v + 1) := by
+  obtain ⟨n, rfl⟩ : ∃ n, m = n + 2 := ⟨m - 2, by omega⟩
+  exact cycleGraph_adj.mpr (Or.inr (add_sub_cancel_left v 1))
+
+/-- The underlying natural number of a successor in `Fin m`. -/
+private theorem val_add_one (v : Fin m) : ((v + 1 : Fin m) : ℕ) = (v.val + 1) % m := by
+  rw [Fin.val_add, Fin.val_one', Nat.add_mod_mod]
+
+private theorem one_add_one_ne_zero (hm : 3 ≤ m) : (1 : Fin m) + 1 ≠ 0 := by
+  have h1 : ((1 : Fin m) : ℕ) = 1 := by rw [Fin.val_one', Nat.mod_eq_of_lt (by omega)]
+  rw [Ne, Fin.ext_iff, val_add_one, h1, Fin.val_zero, Nat.mod_eq_of_lt (by omega)]
+  omega
+
+/-- **Adding one twice in `Fin m` never returns to the same element** when `3 ≤ m`.  For a cycle
+graph this says that the two neighbours of a vertex are distinct. -/
+theorem add_one_add_one_ne_self (hm : 3 ≤ m) (v : Fin m) : v + 1 + 1 ≠ v := by
+  intro h
+  refine one_add_one_ne_zero hm (add_left_cancel (a := v) ?_)
+  rw [add_zero, ← add_assoc, h]
+
+end TauCeti

--- a/TauCeti/Data/Fin/Basic.lean
+++ b/TauCeti/Data/Fin/Basic.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.Algebra.BigOperators.Fin
 public import Mathlib.Algebra.Group.End
 
+import Mathlib.Algebra.Group.Fin.Basic
 import Mathlib.Tactic.FinCases
 
 /-!
@@ -28,6 +29,7 @@ range, so the value is a `dite` rather than a plain application.
   transposition.
 * `Fin.partialProd_last`: the final partial product is the product of all the entries.
 * `Fin.partialSum_last`: the final partial sum is the sum of all the entries.
+* `TauCeti.add_one_add_one_ne_self`: adding one twice in `Fin n` is nontrivial when `3 ≤ n`.
 * `TauCeti.sum_ite_val_add`: a sum against the indicator of `b = k + j` picks out the summand at
   `b - j`, or vanishes when there is no such index.
 -/
@@ -46,6 +48,16 @@ theorem partialProd_last {M : Type*} [CommMonoid M] {n : ℕ} (f : Fin n → M) 
 end Fin
 
 namespace TauCeti
+
+/-- **Adding one twice in `Fin n` never returns to the same element** when `3 ≤ n`. -/
+theorem add_one_add_one_ne_self {n : ℕ} [NeZero n] (hn : 3 ≤ n) (i : Fin n) :
+    i + 1 + 1 ≠ i := by
+  intro h
+  have htwo : (1 + 1 : Fin n) = 0 := by
+    apply add_left_cancel (a := i)
+    simpa [add_assoc] using h
+  have hval := congrArg Fin.val htwo
+  simp [Fin.val_add, Nat.mod_eq_of_lt (by omega : 2 < n)] at hval
 
 /-- A permutation of `Fin 2` is either the identity or the transposition. -/
 theorem perm_fin_two_eq_one_or_swap (e : Equiv.Perm (Fin 2)) :

--- a/TauCeti/Data/Fin/Basic.lean
+++ b/TauCeti/Data/Fin/Basic.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Algebra.BigOperators.Fin
 public import Mathlib.Algebra.Group.End
+public import Mathlib.Algebra.Ring.Parity
 
 import Mathlib.Algebra.Group.Fin.Basic
 import Mathlib.Tactic.FinCases
@@ -30,6 +31,8 @@ range, so the value is a `dite` rather than a plain application.
 * `Fin.partialProd_last`: the final partial product is the product of all the entries.
 * `Fin.partialSum_last`: the final partial sum is the sum of all the entries.
 * `TauCeti.add_one_add_one_ne_self`: adding one twice in `Fin n` is nontrivial when `3 ≤ n`.
+* `TauCeti.neg_one_pow_val_add_one`: for `n` even, adding one in `Fin n` flips the sign `(-1) ^ ·`
+  read off the value.
 * `TauCeti.sum_ite_val_add`: a sum against the indicator of `b = k + j` picks out the summand at
   `b - j`, or vanishes when there is no such index.
 -/
@@ -58,6 +61,20 @@ theorem add_one_add_one_ne_self {n : ℕ} [NeZero n] (hn : 3 ≤ n) (i : Fin n) 
     simpa [add_assoc] using h
   have hval := congrArg Fin.val htwo
   simp [Fin.val_add, Nat.mod_eq_of_lt (by omega : 2 < n)] at hval
+
+/-- **Adding one in `Fin n` flips the sign `(-1) ^ ·` read off the value** when `n` is even.  The
+wraparound at the last index respects the sign exactly because `n` is even. -/
+theorem neg_one_pow_val_add_one {M : Type*} [Monoid M] [HasDistribNeg M] {n : ℕ} [NeZero n]
+    (hn : Even n) (i : Fin n) : (-1 : M) ^ ((i + 1 : Fin n) : ℕ) = -(-1 : M) ^ (i : ℕ) := by
+  have hval : ((i + 1 : Fin n) : ℕ) = (i.val + 1) % n := by
+    rw [Fin.val_add, Fin.val_one', Nat.add_mod_mod]
+  rw [hval]
+  rcases Nat.lt_or_ge (i.val + 1) n with h1 | h1
+  · rw [Nat.mod_eq_of_lt h1, pow_succ, mul_neg_one]
+  · have hi : i.val + 1 = n := by have := i.isLt; omega
+    have hn' : Even (i.val + 1) := by rw [hi]; exact hn
+    have hodd : Odd i.val := Nat.not_even_iff_odd.mp (Nat.even_add_one.mp hn')
+    rw [hi, Nat.mod_self, pow_zero, hodd.neg_one_pow, neg_neg]
 
 /-- A permutation of `Fin 2` is either the identity or the transposition. -/
 theorem perm_fin_two_eq_one_or_swap (e : Equiv.Perm (Fin 2)) :

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/Cycle.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/Cycle.lean
@@ -122,18 +122,6 @@ private theorem backtrackScale_cycleLabelling (hm : 3 ≤ m) (v : Fin m)
   simp only [vertexEquiv_symm_vertex]
   rw [ite_eq_left trivial, ite_eq_right (add_one_add_one_ne_self hm v).symm, mul_one]
 
-private theorem neg_one_pow_val_add_one (hev : Even m) (v : Fin m) :
-    (-1 : kˣ) ^ ((v + 1 : Fin m) : ℕ) = -((-1 : kˣ) ^ (v : ℕ)) := by
-  have hval : ((v + 1 : Fin m) : ℕ) = (v.val + 1) % m := by
-    rw [Fin.val_add, Fin.val_one', Nat.add_mod_mod]
-  rw [hval]
-  rcases Nat.lt_or_ge (v.val + 1) m with h1 | h1
-  · rw [Nat.mod_eq_of_lt h1, pow_succ, mul_neg_one]
-  · have hv : v.val + 1 = m := by have := v.isLt; omega
-    have hev' : Even (v.val + 1) := by rw [hv]; exact hev
-    have hodd : Odd v.val := Nat.not_even_iff_odd.mp (Nat.even_add_one.mp hev')
-    rw [hv, Nat.mod_self, pow_zero, hodd.neg_one_pow, neg_neg]
-
 /-- **On an even cycle with at least three vertices the exterior parameter is gauge equivalent to
 the constant parameter**, and so presents the ordinary zigzag relations.  The gauge is the
 alternating sign on the edges of the cycle, which closes up exactly because the number of vertices

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/Cycle.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/Cycle.lean
@@ -18,13 +18,14 @@ unit-valued ratio between the two backtracks they carry, and gauge equivalent pa
 isomorphic algebras.  This file settles the cycles, the invariant detecting that a parameter is
 *not* gauge trivial being the monodromy around a closed edge cycle.
 
-Around a cycle graph on `m` vertices the monodromy of the exterior parameter is `(-1) ^ m`, and
-consequently:
+Around a cycle graph on `m ≥ 3` vertices the monodromy of the exterior parameter is `(-1) ^ m`,
+and consequently:
 
-* on an even cycle it is gauge equivalent to the constant parameter, the gauge being the
-  alternating sign on the edges of the cycle, so it presents the ordinary zigzag algebra;
-* on an odd cycle, over a coefficient ring in which `2` is not zero, it is not gauge equivalent to
-  the constant parameter.
+* on an even cycle with at least three vertices it is gauge equivalent to the constant parameter,
+  the gauge being the alternating sign on the edges of the cycle, so it presents the ordinary
+  zigzag algebra;
+* on an odd cycle with at least three vertices, over a coefficient ring in which `2` is not zero,
+  it is not gauge equivalent to the constant parameter.
 
 In characteristic two the exterior parameter *is* the constant parameter, on any graph, so the two
 presentations agree identically by `TauCeti.SkewZigzagParameter.exterior_eq_one`.
@@ -42,12 +43,13 @@ vertex-fixing graded isomorphism classes with `H¹(G, kˣ)`.
 * `TauCeti.SkewZigzagParameter.exteriorCycle_ratio`: the exterior ratio of two incident edges of
   a cycle graph is one when they agree and minus one otherwise.
 * `TauCeti.SkewZigzagParameter.monodromy_exteriorCycle`: the monodromy of the exterior parameter
-  around a cycle graph on `m` vertices is `(-1) ^ m`.
+  around a cycle graph on `m ≥ 3` vertices is `(-1) ^ m`.
 * `TauCeti.SkewZigzagParameter.isGaugeEquivalent_one_exteriorCycle` and
-  `TauCeti.nonempty_algEquiv_zigzagAlgebra_exteriorCycle`: on an even cycle the exterior parameter
-  is gauge trivial, and therefore presents the ordinary zigzag algebra.
-* `TauCeti.SkewZigzagParameter.not_isGaugeEquivalent_one_exteriorCycle`: on an odd cycle, over a
-  ring in which `2` is not zero, it is not gauge trivial.
+  `TauCeti.nonempty_algEquiv_zigzagAlgebra_exteriorCycle`: on an even cycle with at least three
+  vertices the exterior parameter is gauge trivial, and therefore presents the ordinary zigzag
+  algebra.
+* `TauCeti.SkewZigzagParameter.not_isGaugeEquivalent_one_exteriorCycle`: on an odd cycle with at
+  least three vertices, over a ring in which `2` is not zero, it is not gauge trivial.
 
 ## References
 
@@ -75,9 +77,10 @@ section ExteriorCycle
 
 variable (k : Type w) [CommRing k] (m : ℕ) [NeZero m]
 
-/-- The **exterior skew-zigzag parameter of a cycle graph**: the two backtracks at a vertex of the
-cycle sum to zero.  On an odd cycle over a field of characteristic other than two this is the
-nontrivial skew class; on an even cycle it is gauge equivalent to the constant parameter. -/
+/-- The **exterior skew-zigzag parameter of a cycle graph**.  On a cycle with at least three
+vertices, the two backtracks at a vertex sum to zero.  On such an odd cycle over a field of
+characteristic other than two this is the nontrivial skew class; on such an even cycle it is gauge
+equivalent to the constant parameter. -/
 def exteriorCycle : SkewZigzagParameter k (cycleGraph m) :=
   exterior k (Or.inr fun _ _ _ _ h h' h'' => eq_or_eq_or_eq_of_cycleGraph_adj h h' h'')
 
@@ -131,9 +134,10 @@ private theorem neg_one_pow_val_add_one (hev : Even m) (v : Fin m) :
     have hodd : Odd v.val := Nat.not_even_iff_odd.mp (Nat.even_add_one.mp hev')
     rw [hv, Nat.mod_self, pow_zero, hodd.neg_one_pow, neg_neg]
 
-/-- **On an even cycle the exterior parameter is gauge equivalent to the constant parameter**, and
-so presents the ordinary zigzag relations.  The gauge is the alternating sign on the edges of the
-cycle, which closes up exactly because the number of vertices is even. -/
+/-- **On an even cycle with at least three vertices the exterior parameter is gauge equivalent to
+the constant parameter**, and so presents the ordinary zigzag relations.  The gauge is the
+alternating sign on the edges of the cycle, which closes up exactly because the number of vertices
+is even. -/
 theorem isGaugeEquivalent_one_exteriorCycle (hm : 3 ≤ m) (hev : Even m) :
     IsGaugeEquivalent (1 : SkewZigzagParameter k (cycleGraph m)) (exteriorCycle k m) := by
   rw [isGaugeEquivalent_iff]
@@ -172,9 +176,9 @@ theorem isGaugeEquivalent_one_exteriorCycle (hm : 3 ≤ m) (hev : Even m) :
     subst hjj
     exact ((exteriorCycle k m).ratio_self h).trans (div_self' _).symm
 
-/-- **On an odd cycle, over a coefficient ring in which `2` is not zero, the exterior parameter is
-not gauge equivalent to the constant parameter**: its monodromy around the cycle is `-1`.  For a
-field this is the hypothesis that the characteristic is not two. -/
+/-- **On an odd cycle with at least three vertices, over a coefficient ring in which `2` is not
+zero, the exterior parameter is not gauge equivalent to the constant parameter**: its monodromy
+around the cycle is `-1`.  For a field this is the hypothesis that the characteristic is not two. -/
 theorem not_isGaugeEquivalent_one_exteriorCycle (hm : 3 ≤ m) (hodd : Odd m) (h2 : (2 : k) ≠ 0) :
     ¬ IsGaugeEquivalent (1 : SkewZigzagParameter k (cycleGraph m)) (exteriorCycle k m) := by
   intro hgauge
@@ -194,15 +198,16 @@ section ExteriorCycleAlgebra
 
 variable (k : Type w) [CommRing k] (m : ℕ) [NeZero m]
 
-/-- **On an even cycle the exterior skew-zigzag relation quotient is the ordinary zigzag relation
-quotient.** -/
+/-- **On an even cycle with at least three vertices the exterior skew-zigzag relation quotient is
+the ordinary zigzag relation quotient.** -/
 theorem nonempty_algEquiv_nonisolatedZigzagQuotient_exteriorCycle (hm : 3 ≤ m) (hev : Even m) :
     Nonempty (skewZigzagQuotient k (cycleGraph m) (SkewZigzagParameter.exteriorCycle k m) ≃ₐ[k]
       nonisolatedZigzagQuotient k (cycleGraph m)) :=
   nonempty_algEquiv_nonisolatedZigzagQuotient_of_isGaugeEquivalent_one k (cycleGraph m)
     (SkewZigzagParameter.isGaugeEquivalent_one_exteriorCycle hm hev)
 
-/-- **On an even cycle the exterior skew-zigzag algebra is the public zigzag algebra.** -/
+/-- **On an even cycle with at least three vertices the exterior skew-zigzag algebra is the public
+zigzag algebra.** -/
 theorem nonempty_algEquiv_zigzagAlgebra_exteriorCycle (hm : 3 ≤ m) (hev : Even m) :
     Nonempty (skewZigzagQuotient k (cycleGraph m) (SkewZigzagParameter.exteriorCycle k m) ≃ₐ[k]
       zigzagAlgebra k (cycleGraph m)) := by

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/Cycle.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/Cycle.lean
@@ -8,7 +8,6 @@ module
 public import TauCeti.Combinatorics.SimpleGraph.CycleGraph
 public import TauCeti.RepresentationTheory.Quiver.Zigzag.Componentwise
 public import TauCeti.RepresentationTheory.Quiver.Zigzag.Exterior
-public import TauCeti.RepresentationTheory.Quiver.Zigzag.Gauge
 public import TauCeti.RepresentationTheory.Quiver.Zigzag.Monodromy
 
 /-!

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/Cycle.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/Cycle.lean
@@ -39,6 +39,8 @@ vertex-fixing graded isomorphism classes with `H¹(G, kˣ)`.
 
 ## Main results
 
+* `TauCeti.SkewZigzagParameter.exteriorCycle_ratio`: the exterior ratio of two incident edges of
+  a cycle graph is one when they agree and minus one otherwise.
 * `TauCeti.SkewZigzagParameter.monodromy_exteriorCycle`: the monodromy of the exterior parameter
   around a cycle graph on `m` vertices is `(-1) ^ m`.
 * `TauCeti.SkewZigzagParameter.isGaugeEquivalent_one_exteriorCycle` and
@@ -77,7 +79,15 @@ variable (k : Type w) [CommRing k] (m : ℕ) [NeZero m]
 cycle sum to zero.  On an odd cycle over a field of characteristic other than two this is the
 nontrivial skew class; on an even cycle it is gauge equivalent to the constant parameter. -/
 def exteriorCycle : SkewZigzagParameter k (cycleGraph m) :=
-  exterior k fun _ _ _ _ h h' h'' => eq_or_eq_or_eq_of_cycleGraph_adj h h' h''
+  exterior k (Or.inr fun _ _ _ _ h h' h'' => eq_or_eq_or_eq_of_cycleGraph_adj h h' h'')
+
+/-- **The exterior ratio of two incident edges of a cycle graph** is one when they agree and minus
+one otherwise. -/
+@[simp]
+theorem exteriorCycle_ratio {i j j' : Fin m} (h : (cycleGraph m).Adj i j)
+    (h' : (cycleGraph m).Adj i j') :
+    (exteriorCycle k m).ratio h h' = if j = j' then 1 else -1 :=
+  exterior_ratio _ h h'
 
 variable {k m}
 
@@ -88,7 +98,7 @@ theorem monodromy_exteriorCycle (hm : 3 ≤ m) :
     monodromy (exteriorCycle k m) (cycleGraph_adj_add_one hm) = (-1 : kˣ) ^ m := by
   have hratio (i : Fin m) : (exteriorCycle k m).ratio (cycleGraph_adj_add_one hm i).symm
       (cycleGraph_adj_add_one hm (i + 1)) = -1 :=
-    exterior_ratio_of_ne _ _ _ (add_one_add_one_ne_self hm i).symm
+    (exteriorCycle_ratio k m _ _).trans (ite_eq_right (add_one_add_one_ne_self hm i).symm)
   rw [monodromy_def, Finset.prod_congr rfl fun i _ => hratio i,
     Finset.prod_const, Finset.card_univ, Fintype.card_fin]
 
@@ -143,7 +153,7 @@ theorem isGaugeEquivalent_one_exteriorCycle (hm : 3 ≤ m) (hev : Even m) :
       rw [← backtrackScale_symm (cycleGraph m) (cycleLabelling k m) h',
         backtrackScale_cycleLabelling hm _ h'.symm]
     have hratio : (exteriorCycle k m).ratio h h' = -1 :=
-      exterior_ratio_of_ne _ h h' (add_one_add_one_ne_self hm j')
+      (exteriorCycle_ratio k m h h').trans (ite_eq_right (add_one_add_one_ne_self hm j'))
     rw [hratio, hS, hS',
       eq_div_iff_mul_eq', neg_one_mul, neg_neg]
   · subst hv
@@ -154,7 +164,7 @@ theorem isGaugeEquivalent_one_exteriorCycle (hm : 3 ≤ m) (hev : Even m) :
     have hS' : backtrackScale (cycleGraph m) (cycleLabelling k m) h' = -((-1 : kˣ) ^ (j : ℕ)) := by
       rw [backtrackScale_cycleLabelling hm _ h', neg_one_pow_val_add_one hev]
     have hratio : (exteriorCycle k m).ratio h h' = -1 :=
-      exterior_ratio_of_ne _ h h' (add_one_add_one_ne_self hm j).symm
+      (exteriorCycle_ratio k m h h').trans (ite_eq_right (add_one_add_one_ne_self hm j).symm)
     rw [hratio, hS, hS',
       eq_div_iff_mul_eq', neg_one_mul]
   · subst hv

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/Cycle.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/Cycle.lean
@@ -9,20 +9,15 @@ public import TauCeti.Combinatorics.SimpleGraph.CycleGraph
 public import TauCeti.RepresentationTheory.Quiver.Zigzag.Componentwise
 public import TauCeti.RepresentationTheory.Quiver.Zigzag.Exterior
 public import TauCeti.RepresentationTheory.Quiver.Zigzag.Gauge
+public import TauCeti.RepresentationTheory.Quiver.Zigzag.Monodromy
 
 /-!
 # The skew-zigzag algebras of the cycles
 
 A skew-zigzag parameter labels each ordered pair of incident edges of a simple graph by the
 unit-valued ratio between the two backtracks they carry, and gauge equivalent parameters present
-isomorphic algebras.  This file supplies the invariant which detects that a parameter is *not*
-gauge trivial, and settles the cycles.
-
-The invariant is the **monodromy** of a closed edge cycle: the product, over the vertices of the
-cycle, of the ratio from the edge along which the cycle arrives at a vertex to the edge along
-which it leaves.  A gauge transform multiplies each factor by the quotient of two backtrack
-scales, and consecutive factors share those scales, so the correction telescopes around the cycle
-and the monodromy depends only on the gauge class.  It is one for the constant parameter.
+isomorphic algebras.  This file settles the cycles, the invariant detecting that a parameter is
+*not* gauge trivial being the monodromy around a closed edge cycle.
 
 Around a cycle graph on `m` vertices the monodromy of the exterior parameter is `(-1) ^ m`, and
 consequently:
@@ -42,13 +37,10 @@ vertex-fixing graded isomorphism classes with `H¹(G, kˣ)`.
 
 ## Main definitions
 
-* `TauCeti.SkewZigzagParameter.monodromy`: the monodromy of a parameter around a closed edge
-  cycle.
 * `TauCeti.SkewZigzagParameter.exteriorCycle`: the exterior parameter of a cycle graph.
 
 ## Main results
 
-* `TauCeti.SkewZigzagParameter.monodromy_gauge`: the monodromy is a gauge invariant.
 * `TauCeti.SkewZigzagParameter.monodromy_exteriorCycle`: the monodromy of the exterior parameter
   around a cycle graph on `m` vertices is `(-1) ^ m`.
 * `TauCeti.SkewZigzagParameter.isGaugeEquivalent_one_exteriorCycle` and
@@ -76,56 +68,6 @@ open DoubledQuiver SimpleGraph
 universe u w
 
 namespace SkewZigzagParameter
-
-/-! ### The monodromy of a closed edge cycle -/
-
-section Monodromy
-
-variable {k : Type w} [CommMonoid k] {V : Type u} {G : SimpleGraph V} {m : ℕ} [NeZero m]
-  {x : Fin m → V}
-
-/-- The **monodromy** of a skew-zigzag parameter around a closed edge cycle `x`, a cyclically
-indexed family of vertices consecutive ones of which are adjacent: the product, over the vertices
-of the cycle, of the ratio from the edge along which the cycle arrives at a vertex to the edge
-along which it leaves.  It is unchanged by a gauge transform and is one for the constant
-parameter, so it obstructs gauge triviality. -/
-def monodromy (c : SkewZigzagParameter k G) (hx : ∀ i : Fin m, G.Adj (x i) (x (i + 1))) : kˣ :=
-  ∏ i : Fin m, c.ratio (hx i).symm (hx (i + 1))
-
-/-- **The constant parameter has trivial monodromy.** -/
-@[simp]
-theorem monodromy_one (hx : ∀ i : Fin m, G.Adj (x i) (x (i + 1))) :
-    monodromy (1 : SkewZigzagParameter k G) hx = 1 :=
-  Finset.prod_eq_one fun _ _ => one_ratio _ _
-
-/-- **The monodromy is a gauge invariant**: the backtrack scales a gauge transform contributes at
-a vertex of the cycle cancel against those it contributes at the neighbouring vertices. -/
-@[simp]
-theorem monodromy_gauge (c : SkewZigzagParameter k G)
-    (u : ∀ ⦃y z : DoubledQuiver G⦄, (y ⟶ z) → kˣ)
-    (hx : ∀ i : Fin m, G.Adj (x i) (x (i + 1))) :
-    monodromy (c.gauge u) hx = monodromy c hx := by
-  have hshift : ∏ i : Fin m, backtrackScale G u (hx (i + 1)) =
-      ∏ i : Fin m, backtrackScale G u (hx i).symm :=
-    Fintype.prod_equiv (Equiv.addRight 1) _ _ fun i =>
-      (backtrackScale_symm G u (hx (i + 1))).symm
-  simp only [monodromy, gauge_ratio]
-  rw [Finset.prod_mul_distrib, Finset.prod_div_distrib, hshift, div_self', mul_one]
-
-/-- **Gauge equivalent parameters have the same monodromy.** -/
-theorem monodromy_eq_of_isGaugeEquivalent {c c' : SkewZigzagParameter k G}
-    (hc : c.IsGaugeEquivalent c') (hx : ∀ i : Fin m, G.Adj (x i) (x (i + 1))) :
-    monodromy c hx = monodromy c' hx := by
-  obtain ⟨u, rfl⟩ := isGaugeEquivalent_iff.mp hc
-  rw [monodromy_gauge]
-
-/-- **A gauge-trivial parameter has trivial monodromy around every closed edge cycle.** -/
-theorem monodromy_eq_one_of_isGaugeEquivalent_one {c : SkewZigzagParameter k G}
-    (hc : IsGaugeEquivalent (1 : SkewZigzagParameter k G) c)
-    (hx : ∀ i : Fin m, G.Adj (x i) (x (i + 1))) : monodromy c hx = 1 := by
-  rw [← monodromy_eq_of_isGaugeEquivalent hc hx, monodromy_one]
-
-end Monodromy
 
 /-! ### The exterior parameter of a cycle -/
 
@@ -163,7 +105,7 @@ theorem exteriorCycle_eq_one (h2 : (2 : k) = 0) : exteriorCycle k m = 1 :=
 incident edges. -/
 theorem monodromy_exteriorCycle (hm : 3 ≤ m) :
     monodromy (exteriorCycle k m) (cycleGraph_adj_add_one hm) = (-1 : kˣ) ^ m := by
-  rw [monodromy, Finset.prod_congr rfl fun i _ =>
+  rw [monodromy_eq_prod, Finset.prod_congr rfl fun i _ =>
     exteriorCycle_ratio_of_ne (k := k) _ _ (add_one_add_one_ne_self hm i).symm,
     Finset.prod_const, Finset.card_univ, Fintype.card_fin]
 

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/Cycle.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/Cycle.lean
@@ -5,12 +5,13 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Combinatorics.SimpleGraph.CycleGraph
+public import TauCeti.Combinatorics.SimpleGraph.CycleGraph
 public import TauCeti.RepresentationTheory.Quiver.Zigzag.Componentwise
+public import TauCeti.RepresentationTheory.Quiver.Zigzag.Exterior
 public import TauCeti.RepresentationTheory.Quiver.Zigzag.Gauge
 
 /-!
-# The exterior skew-zigzag parameter and the skew-zigzag algebras of cycles
+# The skew-zigzag algebras of the cycles
 
 A skew-zigzag parameter labels each ordered pair of incident edges of a simple graph by the
 unit-valued ratio between the two backtracks they carry, and gauge equivalent parameters present
@@ -23,18 +24,17 @@ which it leaves.  A gauge transform multiplies each factor by the quotient of tw
 scales, and consecutive factors share those scales, so the correction telescopes around the cycle
 and the monodromy depends only on the gauge class.  It is one for the constant parameter.
 
-The **exterior** parameter of a graph in which no vertex has three pairwise distinct neighbours
-gives distinct incident edges the ratio `-1`, so its relation makes the two backtracks at a vertex
-sum to zero.  This is the parameter carried by the basic algebra of the exterior skew group algebra
-of an odd cyclic group.  Around a cycle graph on `m` vertices its monodromy is `(-1) ^ m`, and
+Around a cycle graph on `m` vertices the monodromy of the exterior parameter is `(-1) ^ m`, and
 consequently:
 
 * on an even cycle it is gauge equivalent to the constant parameter, the gauge being the
   alternating sign on the edges of the cycle, so it presents the ordinary zigzag algebra;
 * on an odd cycle, over a coefficient ring in which `2` is not zero, it is not gauge equivalent to
-  the constant parameter;
-* when `2` is zero the exterior parameter *is* the constant parameter, on any graph, so the two
-  presentations agree identically in characteristic two.
+  the constant parameter.
+
+In characteristic two the exterior parameter *is* the constant parameter, on any graph, so the two
+presentations agree identically; `TauCeti.SkewZigzagParameter.exteriorCycle_eq_one` records that
+identification for a cycle.
 
 The odd-cycle statement is a statement about gauge classes.  Whether inequivalent classes present
 nonisomorphic algebras is the separate classification question, which needs the identification of
@@ -44,17 +44,11 @@ vertex-fixing graded isomorphism classes with `H¹(G, kˣ)`.
 
 * `TauCeti.SkewZigzagParameter.monodromy`: the monodromy of a parameter around a closed edge
   cycle.
-* `TauCeti.SkewZigzagParameter.exterior`: the exterior skew-zigzag parameter of a graph whose
-  degrees are at most two.
 * `TauCeti.SkewZigzagParameter.exteriorCycle`: the exterior parameter of a cycle graph.
 
 ## Main results
 
 * `TauCeti.SkewZigzagParameter.monodromy_gauge`: the monodromy is a gauge invariant.
-* `TauCeti.skewZigzagMk_backtrackElem_add_backtrackElem`: in the exterior relation quotient the two
-  backtracks at a vertex sum to zero.
-* `TauCeti.skewZigzagIdeal_exterior_eq_zigzagIdeal`: in characteristic two the exterior parameter
-  presents the ordinary zigzag relations.
 * `TauCeti.SkewZigzagParameter.monodromy_exteriorCycle`: the monodromy of the exterior parameter
   around a cycle graph on `m` vertices is `(-1) ^ m`.
 * `TauCeti.SkewZigzagParameter.isGaugeEquivalent_one_exteriorCycle` and
@@ -133,147 +127,6 @@ theorem monodromy_eq_one_of_isGaugeEquivalent_one {c : SkewZigzagParameter k G}
 
 end Monodromy
 
-/-! ### The exterior parameter -/
-
-section Exterior
-
-variable (k : Type w) [CommRing k] {V : Type u} [DecidableEq V] {G : SimpleGraph V}
-  (hG : ∀ ⦃i j j' j'' : V⦄, G.Adj i j → G.Adj i j' → G.Adj i j'' → j = j' ∨ j' = j'' ∨ j'' = j)
-
-/-- The two signs comparing a pair of neighbours in either order cancel. -/
-private theorem exteriorSign_mul_exteriorSign (a b : V) :
-    (if a = b then (1 : kˣ) else -1) * (if b = a then 1 else -1) = 1 := by
-  rcases eq_or_ne a b with rfl | hne
-  · rw [ite_eq_left rfl, one_mul]
-  · rw [ite_eq_right hne, ite_eq_right hne.symm, neg_mul_neg, one_mul]
-
-/-- The **exterior skew-zigzag parameter** of a graph no vertex of which has three pairwise
-distinct neighbours, that is, of a graph all of whose degrees are at most two: the ratio between
-the backtracks along two distinct incident edges is `-1`, so the relation it imposes makes the two
-backtracks at a vertex sum to zero.  The degree hypothesis is what makes the ratios a cocycle: at
-a vertex with three pairwise distinct neighbours the three signs would multiply to `-1`.
-
-The odd cycles are the McKay graphs of the odd cyclic subgroups of `SU(2)`, and it is this
-relation, rather than the ordinary one, that the exterior skew group algebras of those subgroups
-carry. -/
-def exterior : SkewZigzagParameter k G where
-  ratio _ j j' _ _ := if j = j' then 1 else -1
-  ratio_self := by intro i j h; exact ite_eq_left rfl
-  ratio_inv := by
-    intro i j j' h h'
-    exact exteriorSign_mul_exteriorSign k j j'
-  ratio_cocycle := by
-    intro i j j' j'' h h' h''
-    rcases hG h h' h'' with rfl | rfl | rfl
-    · rw [ite_eq_left rfl, one_mul, exteriorSign_mul_exteriorSign]
-    · rw [ite_eq_left rfl, mul_one, exteriorSign_mul_exteriorSign]
-    · rw [ite_eq_left rfl, mul_one, exteriorSign_mul_exteriorSign]
-
-variable {k}
-
-/-- **The exterior ratio of two distinct incident edges is minus one.** -/
-theorem exterior_ratio_of_ne {i j j' : V} (h : G.Adj i j) (h' : G.Adj i j') (hne : j ≠ j') :
-    (exterior k hG).ratio h h' = -1 :=
-  ite_eq_right hne
-
-/-- **In characteristic two the exterior parameter is the constant parameter.** The sign
-distinguishing the two backtracks at a vertex collapses, so the exterior and the ordinary zigzag
-presentations agree identically. -/
-theorem exterior_eq_one (h2 : (2 : k) = 0) : exterior k hG = 1 := by
-  have hneg : (-1 : kˣ) = 1 :=
-    Units.ext (by rw [Units.val_neg, Units.val_one]; linear_combination -h2)
-  ext i j j' h h'
-  rw [← Units.ext_iff]
-  rcases eq_or_ne j j' with rfl | hne
-  · rw [one_ratio]
-    exact (exterior k hG).ratio_self h
-  · rw [exterior_ratio_of_ne hG h h' hne, one_ratio, hneg]
-
-end Exterior
-
-end SkewZigzagParameter
-
-section ExteriorRelations
-
-variable (k : Type w) [CommRing k] {V : Type u} [DecidableEq V] [Finite V] (G : SimpleGraph V)
-  (hG : ∀ ⦃i j j' j'' : V⦄, G.Adj i j → G.Adj i j' → G.Adj i j'' → j = j' ∨ j' = j'' ∨ j'' = j)
-
-/-- **In the exterior relation quotient the two backtracks at a vertex sum to zero.** This is the
-shape in which the exterior relation appears for the basic algebra of an exterior skew group
-algebra. -/
-theorem skewZigzagMk_backtrackElem_add_backtrackElem {i j j' : V} (h : G.Adj i j)
-    (h' : G.Adj i j') (hne : j ≠ j') :
-    skewZigzagMk k G (SkewZigzagParameter.exterior k hG) (backtrackElem G k h) +
-        skewZigzagMk k G (SkewZigzagParameter.exterior k hG) (backtrackElem G k h') = 0 := by
-  rw [skewZigzagMk_backtrackElem_eq_smul k G _ h h',
-    SkewZigzagParameter.exterior_ratio_of_ne hG h h' hne, Units.val_neg, Units.val_one,
-    neg_one_smul, neg_add_cancel]
-
-/-- **In characteristic two the exterior parameter presents the ordinary zigzag relations.** -/
-theorem skewZigzagIdeal_exterior_eq_zigzagIdeal (h2 : (2 : k) = 0) :
-    skewZigzagIdeal k G (SkewZigzagParameter.exterior k hG) = zigzagIdeal k G := by
-  rw [SkewZigzagParameter.exterior_eq_one hG h2, skewZigzagIdeal_one_eq_zigzagIdeal]
-
-end ExteriorRelations
-
-/-! ### Cycle graphs -/
-
-section CycleGraph
-
-variable {m : ℕ} [NeZero m]
-
-/-- **Adjacent vertices of a cycle graph differ by one.** -/
-theorem eq_add_one_or_eq_add_one_of_cycleGraph_adj {u v : Fin m} (h : (cycleGraph m).Adj u v) :
-    v = u + 1 ∨ u = v + 1 := by
-  obtain ⟨n, rfl⟩ : ∃ n, m = n + 1 := ⟨m - 1, by have := NeZero.ne m; omega⟩
-  obtain _ | n := n
-  · exact absurd h cycleGraph_one_adj
-  · rcases cycleGraph_adj.mp h with hd | hd
-    · exact Or.inr ((sub_eq_iff_eq_add.mp hd).trans (add_comm 1 v))
-    · exact Or.inl ((sub_eq_iff_eq_add.mp hd).trans (add_comm 1 u))
-
-/-- **No vertex of a cycle graph has three pairwise distinct neighbours**: every degree is at most
-two. -/
-theorem cycleGraph_eq_or_eq_or_eq_of_adj {i j j' j'' : Fin m} (h : (cycleGraph m).Adj i j)
-    (h' : (cycleGraph m).Adj i j') (h'' : (cycleGraph m).Adj i j'') :
-    j = j' ∨ j' = j'' ∨ j'' = j := by
-  rcases eq_add_one_or_eq_add_one_of_cycleGraph_adj h with hj | hj <;>
-    rcases eq_add_one_or_eq_add_one_of_cycleGraph_adj h' with hj' | hj' <;>
-      rcases eq_add_one_or_eq_add_one_of_cycleGraph_adj h'' with hj'' | hj''
-  · exact Or.inl (hj.trans hj'.symm)
-  · exact Or.inl (hj.trans hj'.symm)
-  · exact Or.inr (Or.inr (hj''.trans hj.symm))
-  · exact Or.inr (Or.inl (add_right_cancel (hj'.symm.trans hj'')))
-  · exact Or.inr (Or.inl (hj'.trans hj''.symm))
-  · exact Or.inr (Or.inr (add_right_cancel (hj''.symm.trans hj)))
-  · exact Or.inl (add_right_cancel (hj.symm.trans hj'))
-  · exact Or.inl (add_right_cancel (hj.symm.trans hj'))
-
-/-- **Consecutive vertices of a cycle graph on at least three vertices are adjacent.** -/
-theorem cycleGraph_adj_add_one (hm : 3 ≤ m) (v : Fin m) : (cycleGraph m).Adj v (v + 1) := by
-  obtain ⟨n, rfl⟩ : ∃ n, m = n + 2 := ⟨m - 2, by omega⟩
-  exact cycleGraph_adj.mpr (Or.inr (add_sub_cancel_left v 1))
-
-/-- The underlying natural number of a successor in `Fin m`. -/
-private theorem val_add_one (v : Fin m) : ((v + 1 : Fin m) : ℕ) = (v.val + 1) % m := by
-  rw [Fin.val_add, Fin.val_one', Nat.add_mod_mod]
-
-private theorem one_add_one_ne_zero (hm : 3 ≤ m) : (1 : Fin m) + 1 ≠ 0 := by
-  have h1 : ((1 : Fin m) : ℕ) = 1 := by rw [Fin.val_one', Nat.mod_eq_of_lt (by omega)]
-  rw [Ne, Fin.ext_iff, val_add_one, h1, Fin.val_zero, Nat.mod_eq_of_lt (by omega)]
-  omega
-
-/-- **Adding one twice in `Fin m` never returns to the same element** when `3 ≤ m`.  For a cycle
-graph this says that the two neighbours of a vertex are distinct. -/
-theorem add_one_add_one_ne_self (hm : 3 ≤ m) (v : Fin m) : v + 1 + 1 ≠ v := by
-  intro h
-  refine one_add_one_ne_zero hm (add_left_cancel (a := v) ?_)
-  rw [add_zero, ← add_assoc, h]
-
-end CycleGraph
-
-namespace SkewZigzagParameter
-
 /-! ### The exterior parameter of a cycle -/
 
 section ExteriorCycle
@@ -287,6 +140,14 @@ def exteriorCycle : SkewZigzagParameter k (cycleGraph m) :=
   exterior k fun _ _ _ _ h h' h'' => cycleGraph_eq_or_eq_or_eq_of_adj h h' h''
 
 variable {k m}
+
+/-- **The exterior ratio of two edges at a vertex of a cycle** is one when they agree and minus one
+otherwise. -/
+@[simp]
+theorem exteriorCycle_ratio {i j j' : Fin m} (h : (cycleGraph m).Adj i j)
+    (h' : (cycleGraph m).Adj i j') :
+    (exteriorCycle k m).ratio h h' = if j = j' then 1 else -1 :=
+  exterior_ratio _ h h'
 
 /-- **The exterior ratio of the two distinct edges at a vertex of a cycle is minus one.** -/
 theorem exteriorCycle_ratio_of_ne {i j j' : Fin m} (h : (cycleGraph m).Adj i j)
@@ -325,7 +186,9 @@ private theorem backtrackScale_cycleLabelling (hm : 3 ≤ m) (v : Fin m)
 
 private theorem neg_one_pow_val_add_one (hev : Even m) (v : Fin m) :
     (-1 : kˣ) ^ ((v + 1 : Fin m) : ℕ) = -((-1 : kˣ) ^ (v : ℕ)) := by
-  rw [val_add_one]
+  have hval : ((v + 1 : Fin m) : ℕ) = (v.val + 1) % m := by
+    rw [Fin.val_add, Fin.val_one', Nat.add_mod_mod]
+  rw [hval]
   rcases Nat.lt_or_ge (v.val + 1) m with h1 | h1
   · rw [Nat.mod_eq_of_lt h1, pow_succ, mul_neg_one]
   · have hv : v.val + 1 = m := by have := v.isLt; omega

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/Cycle.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/Cycle.lean
@@ -27,8 +27,7 @@ consequently:
   the constant parameter.
 
 In characteristic two the exterior parameter *is* the constant parameter, on any graph, so the two
-presentations agree identically; `TauCeti.SkewZigzagParameter.exteriorCycle_eq_one` records that
-identification for a cycle.
+presentations agree identically by `TauCeti.SkewZigzagParameter.exterior_eq_one`.
 
 The odd-cycle statement is a statement about gauge classes.  Whether inequivalent classes present
 nonisomorphic algebras is the separate classification question, which needs the identification of
@@ -78,34 +77,19 @@ variable (k : Type w) [CommRing k] (m : ℕ) [NeZero m]
 cycle sum to zero.  On an odd cycle over a field of characteristic other than two this is the
 nontrivial skew class; on an even cycle it is gauge equivalent to the constant parameter. -/
 def exteriorCycle : SkewZigzagParameter k (cycleGraph m) :=
-  exterior k fun _ _ _ _ h h' h'' => cycleGraph_eq_or_eq_or_eq_of_adj h h' h''
+  exterior k fun _ _ _ _ h h' h'' => eq_or_eq_or_eq_of_cycleGraph_adj h h' h''
 
 variable {k m}
-
-/-- **The exterior ratio of two edges at a vertex of a cycle** is one when they agree and minus one
-otherwise. -/
-@[simp]
-theorem exteriorCycle_ratio {i j j' : Fin m} (h : (cycleGraph m).Adj i j)
-    (h' : (cycleGraph m).Adj i j') :
-    (exteriorCycle k m).ratio h h' = if j = j' then 1 else -1 :=
-  exterior_ratio _ h h'
-
-/-- **The exterior ratio of the two distinct edges at a vertex of a cycle is minus one.** -/
-theorem exteriorCycle_ratio_of_ne {i j j' : Fin m} (h : (cycleGraph m).Adj i j)
-    (h' : (cycleGraph m).Adj i j') (hne : j ≠ j') : (exteriorCycle k m).ratio h h' = -1 :=
-  exterior_ratio_of_ne _ h h' hne
-
-/-- **In characteristic two the exterior parameter of a cycle is the constant parameter.** -/
-theorem exteriorCycle_eq_one (h2 : (2 : k) = 0) : exteriorCycle k m = 1 :=
-  exterior_eq_one _ h2
 
 /-- **The monodromy of the exterior parameter around a cycle graph on `m` vertices is
 `(-1) ^ m`.** Every one of the `m` vertices contributes the sign between its two distinct
 incident edges. -/
 theorem monodromy_exteriorCycle (hm : 3 ≤ m) :
     monodromy (exteriorCycle k m) (cycleGraph_adj_add_one hm) = (-1 : kˣ) ^ m := by
-  rw [monodromy_eq_prod, Finset.prod_congr rfl fun i _ =>
-    exteriorCycle_ratio_of_ne (k := k) _ _ (add_one_add_one_ne_self hm i).symm,
+  have hratio (i : Fin m) : (exteriorCycle k m).ratio (cycleGraph_adj_add_one hm i).symm
+      (cycleGraph_adj_add_one hm (i + 1)) = -1 :=
+    exterior_ratio_of_ne _ _ _ (add_one_add_one_ne_self hm i).symm
+  rw [monodromy_def, Finset.prod_congr rfl fun i _ => hratio i,
     Finset.prod_const, Finset.card_univ, Fintype.card_fin]
 
 /-- The alternating sign on the edges of a cycle graph, carried by the arrow which increases the
@@ -158,7 +142,9 @@ theorem isGaugeEquivalent_one_exteriorCycle (hm : 3 ≤ m) (hev : Even m) :
     have hS' : backtrackScale (cycleGraph m) (cycleLabelling k m) h' = (-1 : kˣ) ^ (j' : ℕ) := by
       rw [← backtrackScale_symm (cycleGraph m) (cycleLabelling k m) h',
         backtrackScale_cycleLabelling hm _ h'.symm]
-    rw [exteriorCycle_ratio_of_ne h h' (add_one_add_one_ne_self hm j'), hS, hS',
+    have hratio : (exteriorCycle k m).ratio h h' = -1 :=
+      exterior_ratio_of_ne _ h h' (add_one_add_one_ne_self hm j')
+    rw [hratio, hS, hS',
       eq_div_iff_mul_eq', neg_one_mul, neg_neg]
   · subst hv
     subst hj'
@@ -167,7 +153,9 @@ theorem isGaugeEquivalent_one_exteriorCycle (hm : 3 ≤ m) (hev : Even m) :
         backtrackScale_cycleLabelling hm _ h.symm]
     have hS' : backtrackScale (cycleGraph m) (cycleLabelling k m) h' = -((-1 : kˣ) ^ (j : ℕ)) := by
       rw [backtrackScale_cycleLabelling hm _ h', neg_one_pow_val_add_one hev]
-    rw [exteriorCycle_ratio_of_ne h h' (add_one_add_one_ne_self hm j).symm, hS, hS',
+    have hratio : (exteriorCycle k m).ratio h h' = -1 :=
+      exterior_ratio_of_ne _ h h' (add_one_add_one_ne_self hm j).symm
+    rw [hratio, hS, hS',
       eq_div_iff_mul_eq', neg_one_mul]
   · subst hv
     have hjj : j = j' := add_right_cancel hv'

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/Cycle.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/Cycle.lean
@@ -1,0 +1,414 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Combinatorics.SimpleGraph.CycleGraph
+public import TauCeti.RepresentationTheory.Quiver.Zigzag.Componentwise
+public import TauCeti.RepresentationTheory.Quiver.Zigzag.Gauge
+
+/-!
+# The exterior skew-zigzag parameter and the skew-zigzag algebras of cycles
+
+A skew-zigzag parameter labels each ordered pair of incident edges of a simple graph by the
+unit-valued ratio between the two backtracks they carry, and gauge equivalent parameters present
+isomorphic algebras.  This file supplies the invariant which detects that a parameter is *not*
+gauge trivial, and settles the cycles.
+
+The invariant is the **monodromy** of a closed edge cycle: the product, over the vertices of the
+cycle, of the ratio from the edge along which the cycle arrives at a vertex to the edge along
+which it leaves.  A gauge transform multiplies each factor by the quotient of two backtrack
+scales, and consecutive factors share those scales, so the correction telescopes around the cycle
+and the monodromy depends only on the gauge class.  It is one for the constant parameter.
+
+The **exterior** parameter of a graph in which no vertex has three pairwise distinct neighbours
+gives distinct incident edges the ratio `-1`, so its relation makes the two backtracks at a vertex
+sum to zero.  This is the parameter carried by the basic algebra of the exterior skew group algebra
+of an odd cyclic group.  Around a cycle graph on `m` vertices its monodromy is `(-1) ^ m`, and
+consequently:
+
+* on an even cycle it is gauge equivalent to the constant parameter, the gauge being the
+  alternating sign on the edges of the cycle, so it presents the ordinary zigzag algebra;
+* on an odd cycle, over a coefficient ring in which `2` is not zero, it is not gauge equivalent to
+  the constant parameter;
+* when `2` is zero the exterior parameter *is* the constant parameter, on any graph, so the two
+  presentations agree identically in characteristic two.
+
+The odd-cycle statement is a statement about gauge classes.  Whether inequivalent classes present
+nonisomorphic algebras is the separate classification question, which needs the identification of
+vertex-fixing graded isomorphism classes with `H¹(G, kˣ)`.
+
+## Main definitions
+
+* `TauCeti.SkewZigzagParameter.monodromy`: the monodromy of a parameter around a closed edge
+  cycle.
+* `TauCeti.SkewZigzagParameter.exterior`: the exterior skew-zigzag parameter of a graph whose
+  degrees are at most two.
+* `TauCeti.SkewZigzagParameter.exteriorCycle`: the exterior parameter of a cycle graph.
+
+## Main results
+
+* `TauCeti.SkewZigzagParameter.monodromy_gauge`: the monodromy is a gauge invariant.
+* `TauCeti.skewZigzagMk_backtrackElem_add_backtrackElem`: in the exterior relation quotient the two
+  backtracks at a vertex sum to zero.
+* `TauCeti.skewZigzagIdeal_exterior_eq_zigzagIdeal`: in characteristic two the exterior parameter
+  presents the ordinary zigzag relations.
+* `TauCeti.SkewZigzagParameter.monodromy_exteriorCycle`: the monodromy of the exterior parameter
+  around a cycle graph on `m` vertices is `(-1) ^ m`.
+* `TauCeti.SkewZigzagParameter.isGaugeEquivalent_one_exteriorCycle` and
+  `TauCeti.nonempty_algEquiv_zigzagAlgebra_exteriorCycle`: on an even cycle the exterior parameter
+  is gauge trivial, and therefore presents the ordinary zigzag algebra.
+* `TauCeti.SkewZigzagParameter.not_isGaugeEquivalent_one_exteriorCycle`: on an odd cycle, over a
+  ring in which `2` is not zero, it is not gauge trivial.
+
+## References
+
+C. Couture, *Skew-Zigzag Algebras*, Sections 3 and 4, https://arxiv.org/abs/1509.08405, for the
+gauge relation on skew parameters and its cohomological classification.
+
+S. Huerfano and M. Khovanov, *A category for the adjoint representation*, Section 3,
+https://arxiv.org/abs/math/0002060, for the skew-zigzag relations of the cycles and the exterior
+skew group algebras they match.
+-/
+
+public section
+
+namespace TauCeti
+
+open DoubledQuiver SimpleGraph
+
+universe u w
+
+namespace SkewZigzagParameter
+
+/-! ### The monodromy of a closed edge cycle -/
+
+section Monodromy
+
+variable {k : Type w} [CommMonoid k] {V : Type u} {G : SimpleGraph V} {m : ℕ} [NeZero m]
+  {x : Fin m → V}
+
+/-- The **monodromy** of a skew-zigzag parameter around a closed edge cycle `x`, a cyclically
+indexed family of vertices consecutive ones of which are adjacent: the product, over the vertices
+of the cycle, of the ratio from the edge along which the cycle arrives at a vertex to the edge
+along which it leaves.  It is unchanged by a gauge transform and is one for the constant
+parameter, so it obstructs gauge triviality. -/
+def monodromy (c : SkewZigzagParameter k G) (hx : ∀ i : Fin m, G.Adj (x i) (x (i + 1))) : kˣ :=
+  ∏ i : Fin m, c.ratio (hx i).symm (hx (i + 1))
+
+/-- **The constant parameter has trivial monodromy.** -/
+@[simp]
+theorem monodromy_one (hx : ∀ i : Fin m, G.Adj (x i) (x (i + 1))) :
+    monodromy (1 : SkewZigzagParameter k G) hx = 1 :=
+  Finset.prod_eq_one fun _ _ => one_ratio _ _
+
+/-- **The monodromy is a gauge invariant**: the backtrack scales a gauge transform contributes at
+a vertex of the cycle cancel against those it contributes at the neighbouring vertices. -/
+@[simp]
+theorem monodromy_gauge (c : SkewZigzagParameter k G)
+    (u : ∀ ⦃y z : DoubledQuiver G⦄, (y ⟶ z) → kˣ)
+    (hx : ∀ i : Fin m, G.Adj (x i) (x (i + 1))) :
+    monodromy (c.gauge u) hx = monodromy c hx := by
+  have hshift : ∏ i : Fin m, backtrackScale G u (hx (i + 1)) =
+      ∏ i : Fin m, backtrackScale G u (hx i).symm :=
+    Fintype.prod_equiv (Equiv.addRight 1) _ _ fun i =>
+      (backtrackScale_symm G u (hx (i + 1))).symm
+  simp only [monodromy, gauge_ratio]
+  rw [Finset.prod_mul_distrib, Finset.prod_div_distrib, hshift, div_self', mul_one]
+
+/-- **Gauge equivalent parameters have the same monodromy.** -/
+theorem monodromy_eq_of_isGaugeEquivalent {c c' : SkewZigzagParameter k G}
+    (hc : c.IsGaugeEquivalent c') (hx : ∀ i : Fin m, G.Adj (x i) (x (i + 1))) :
+    monodromy c hx = monodromy c' hx := by
+  obtain ⟨u, rfl⟩ := isGaugeEquivalent_iff.mp hc
+  rw [monodromy_gauge]
+
+/-- **A gauge-trivial parameter has trivial monodromy around every closed edge cycle.** -/
+theorem monodromy_eq_one_of_isGaugeEquivalent_one {c : SkewZigzagParameter k G}
+    (hc : IsGaugeEquivalent (1 : SkewZigzagParameter k G) c)
+    (hx : ∀ i : Fin m, G.Adj (x i) (x (i + 1))) : monodromy c hx = 1 := by
+  rw [← monodromy_eq_of_isGaugeEquivalent hc hx, monodromy_one]
+
+end Monodromy
+
+/-! ### The exterior parameter -/
+
+section Exterior
+
+variable (k : Type w) [CommRing k] {V : Type u} [DecidableEq V] {G : SimpleGraph V}
+  (hG : ∀ ⦃i j j' j'' : V⦄, G.Adj i j → G.Adj i j' → G.Adj i j'' → j = j' ∨ j' = j'' ∨ j'' = j)
+
+/-- The two signs comparing a pair of neighbours in either order cancel. -/
+private theorem exteriorSign_mul_exteriorSign (a b : V) :
+    (if a = b then (1 : kˣ) else -1) * (if b = a then 1 else -1) = 1 := by
+  rcases eq_or_ne a b with rfl | hne
+  · rw [ite_eq_left rfl, one_mul]
+  · rw [ite_eq_right hne, ite_eq_right hne.symm, neg_mul_neg, one_mul]
+
+/-- The **exterior skew-zigzag parameter** of a graph no vertex of which has three pairwise
+distinct neighbours, that is, of a graph all of whose degrees are at most two: the ratio between
+the backtracks along two distinct incident edges is `-1`, so the relation it imposes makes the two
+backtracks at a vertex sum to zero.  The degree hypothesis is what makes the ratios a cocycle: at
+a vertex with three pairwise distinct neighbours the three signs would multiply to `-1`.
+
+The odd cycles are the McKay graphs of the odd cyclic subgroups of `SU(2)`, and it is this
+relation, rather than the ordinary one, that the exterior skew group algebras of those subgroups
+carry. -/
+def exterior : SkewZigzagParameter k G where
+  ratio _ j j' _ _ := if j = j' then 1 else -1
+  ratio_self := by intro i j h; exact ite_eq_left rfl
+  ratio_inv := by
+    intro i j j' h h'
+    exact exteriorSign_mul_exteriorSign k j j'
+  ratio_cocycle := by
+    intro i j j' j'' h h' h''
+    rcases hG h h' h'' with rfl | rfl | rfl
+    · rw [ite_eq_left rfl, one_mul, exteriorSign_mul_exteriorSign]
+    · rw [ite_eq_left rfl, mul_one, exteriorSign_mul_exteriorSign]
+    · rw [ite_eq_left rfl, mul_one, exteriorSign_mul_exteriorSign]
+
+variable {k}
+
+/-- **The exterior ratio of two distinct incident edges is minus one.** -/
+theorem exterior_ratio_of_ne {i j j' : V} (h : G.Adj i j) (h' : G.Adj i j') (hne : j ≠ j') :
+    (exterior k hG).ratio h h' = -1 :=
+  ite_eq_right hne
+
+/-- **In characteristic two the exterior parameter is the constant parameter.** The sign
+distinguishing the two backtracks at a vertex collapses, so the exterior and the ordinary zigzag
+presentations agree identically. -/
+theorem exterior_eq_one (h2 : (2 : k) = 0) : exterior k hG = 1 := by
+  have hneg : (-1 : kˣ) = 1 :=
+    Units.ext (by rw [Units.val_neg, Units.val_one]; linear_combination -h2)
+  ext i j j' h h'
+  rw [← Units.ext_iff]
+  rcases eq_or_ne j j' with rfl | hne
+  · rw [one_ratio]
+    exact (exterior k hG).ratio_self h
+  · rw [exterior_ratio_of_ne hG h h' hne, one_ratio, hneg]
+
+end Exterior
+
+end SkewZigzagParameter
+
+section ExteriorRelations
+
+variable (k : Type w) [CommRing k] {V : Type u} [DecidableEq V] [Finite V] (G : SimpleGraph V)
+  (hG : ∀ ⦃i j j' j'' : V⦄, G.Adj i j → G.Adj i j' → G.Adj i j'' → j = j' ∨ j' = j'' ∨ j'' = j)
+
+/-- **In the exterior relation quotient the two backtracks at a vertex sum to zero.** This is the
+shape in which the exterior relation appears for the basic algebra of an exterior skew group
+algebra. -/
+theorem skewZigzagMk_backtrackElem_add_backtrackElem {i j j' : V} (h : G.Adj i j)
+    (h' : G.Adj i j') (hne : j ≠ j') :
+    skewZigzagMk k G (SkewZigzagParameter.exterior k hG) (backtrackElem G k h) +
+        skewZigzagMk k G (SkewZigzagParameter.exterior k hG) (backtrackElem G k h') = 0 := by
+  rw [skewZigzagMk_backtrackElem_eq_smul k G _ h h',
+    SkewZigzagParameter.exterior_ratio_of_ne hG h h' hne, Units.val_neg, Units.val_one,
+    neg_one_smul, neg_add_cancel]
+
+/-- **In characteristic two the exterior parameter presents the ordinary zigzag relations.** -/
+theorem skewZigzagIdeal_exterior_eq_zigzagIdeal (h2 : (2 : k) = 0) :
+    skewZigzagIdeal k G (SkewZigzagParameter.exterior k hG) = zigzagIdeal k G := by
+  rw [SkewZigzagParameter.exterior_eq_one hG h2, skewZigzagIdeal_one_eq_zigzagIdeal]
+
+end ExteriorRelations
+
+/-! ### Cycle graphs -/
+
+section CycleGraph
+
+variable {m : ℕ} [NeZero m]
+
+/-- **Adjacent vertices of a cycle graph differ by one.** -/
+theorem eq_add_one_or_eq_add_one_of_cycleGraph_adj {u v : Fin m} (h : (cycleGraph m).Adj u v) :
+    v = u + 1 ∨ u = v + 1 := by
+  obtain ⟨n, rfl⟩ : ∃ n, m = n + 1 := ⟨m - 1, by have := NeZero.ne m; omega⟩
+  obtain _ | n := n
+  · exact absurd h cycleGraph_one_adj
+  · rcases cycleGraph_adj.mp h with hd | hd
+    · exact Or.inr ((sub_eq_iff_eq_add.mp hd).trans (add_comm 1 v))
+    · exact Or.inl ((sub_eq_iff_eq_add.mp hd).trans (add_comm 1 u))
+
+/-- **No vertex of a cycle graph has three pairwise distinct neighbours**: every degree is at most
+two. -/
+theorem cycleGraph_eq_or_eq_or_eq_of_adj {i j j' j'' : Fin m} (h : (cycleGraph m).Adj i j)
+    (h' : (cycleGraph m).Adj i j') (h'' : (cycleGraph m).Adj i j'') :
+    j = j' ∨ j' = j'' ∨ j'' = j := by
+  rcases eq_add_one_or_eq_add_one_of_cycleGraph_adj h with hj | hj <;>
+    rcases eq_add_one_or_eq_add_one_of_cycleGraph_adj h' with hj' | hj' <;>
+      rcases eq_add_one_or_eq_add_one_of_cycleGraph_adj h'' with hj'' | hj''
+  · exact Or.inl (hj.trans hj'.symm)
+  · exact Or.inl (hj.trans hj'.symm)
+  · exact Or.inr (Or.inr (hj''.trans hj.symm))
+  · exact Or.inr (Or.inl (add_right_cancel (hj'.symm.trans hj'')))
+  · exact Or.inr (Or.inl (hj'.trans hj''.symm))
+  · exact Or.inr (Or.inr (add_right_cancel (hj''.symm.trans hj)))
+  · exact Or.inl (add_right_cancel (hj.symm.trans hj'))
+  · exact Or.inl (add_right_cancel (hj.symm.trans hj'))
+
+/-- **Consecutive vertices of a cycle graph on at least three vertices are adjacent.** -/
+theorem cycleGraph_adj_add_one (hm : 3 ≤ m) (v : Fin m) : (cycleGraph m).Adj v (v + 1) := by
+  obtain ⟨n, rfl⟩ : ∃ n, m = n + 2 := ⟨m - 2, by omega⟩
+  exact cycleGraph_adj.mpr (Or.inr (add_sub_cancel_left v 1))
+
+/-- The underlying natural number of a successor in `Fin m`. -/
+private theorem val_add_one (v : Fin m) : ((v + 1 : Fin m) : ℕ) = (v.val + 1) % m := by
+  rw [Fin.val_add, Fin.val_one', Nat.add_mod_mod]
+
+private theorem one_add_one_ne_zero (hm : 3 ≤ m) : (1 : Fin m) + 1 ≠ 0 := by
+  have h1 : ((1 : Fin m) : ℕ) = 1 := by rw [Fin.val_one', Nat.mod_eq_of_lt (by omega)]
+  rw [Ne, Fin.ext_iff, val_add_one, h1, Fin.val_zero, Nat.mod_eq_of_lt (by omega)]
+  omega
+
+/-- **Adding one twice in `Fin m` never returns to the same element** when `3 ≤ m`.  For a cycle
+graph this says that the two neighbours of a vertex are distinct. -/
+theorem add_one_add_one_ne_self (hm : 3 ≤ m) (v : Fin m) : v + 1 + 1 ≠ v := by
+  intro h
+  refine one_add_one_ne_zero hm (add_left_cancel (a := v) ?_)
+  rw [add_zero, ← add_assoc, h]
+
+end CycleGraph
+
+namespace SkewZigzagParameter
+
+/-! ### The exterior parameter of a cycle -/
+
+section ExteriorCycle
+
+variable (k : Type w) [CommRing k] (m : ℕ) [NeZero m]
+
+/-- The **exterior skew-zigzag parameter of a cycle graph**: the two backtracks at a vertex of the
+cycle sum to zero.  On an odd cycle over a field of characteristic other than two this is the
+nontrivial skew class; on an even cycle it is gauge equivalent to the constant parameter. -/
+def exteriorCycle : SkewZigzagParameter k (cycleGraph m) :=
+  exterior k fun _ _ _ _ h h' h'' => cycleGraph_eq_or_eq_or_eq_of_adj h h' h''
+
+variable {k m}
+
+/-- **The exterior ratio of the two distinct edges at a vertex of a cycle is minus one.** -/
+theorem exteriorCycle_ratio_of_ne {i j j' : Fin m} (h : (cycleGraph m).Adj i j)
+    (h' : (cycleGraph m).Adj i j') (hne : j ≠ j') : (exteriorCycle k m).ratio h h' = -1 :=
+  exterior_ratio_of_ne _ h h' hne
+
+/-- **In characteristic two the exterior parameter of a cycle is the constant parameter.** -/
+theorem exteriorCycle_eq_one (h2 : (2 : k) = 0) : exteriorCycle k m = 1 :=
+  exterior_eq_one _ h2
+
+/-- **The monodromy of the exterior parameter around a cycle graph on `m` vertices is
+`(-1) ^ m`.** Every one of the `m` vertices contributes the sign between its two distinct
+incident edges. -/
+theorem monodromy_exteriorCycle (hm : 3 ≤ m) :
+    monodromy (exteriorCycle k m) (cycleGraph_adj_add_one hm) = (-1 : kˣ) ^ m := by
+  rw [monodromy, Finset.prod_congr rfl fun i _ =>
+    exteriorCycle_ratio_of_ne (k := k) _ _ (add_one_add_one_ne_self hm i).symm,
+    Finset.prod_const, Finset.card_univ, Fintype.card_fin]
+
+/-- The alternating sign on the edges of a cycle graph, carried by the arrow which increases the
+vertex index. -/
+private def cycleLabelling (k : Type w) [CommRing k] (m : ℕ) [NeZero m] :
+    ∀ ⦃y z : DoubledQuiver (cycleGraph m)⦄, (y ⟶ z) → kˣ :=
+  fun ⦃y z⦄ _ =>
+    if (vertexEquiv (cycleGraph m)).symm z = (vertexEquiv (cycleGraph m)).symm y + 1 then
+      (-1 : kˣ) ^ (((vertexEquiv (cycleGraph m)).symm y : Fin m) : ℕ)
+    else 1
+
+private theorem backtrackScale_cycleLabelling (hm : 3 ≤ m) (v : Fin m)
+    (hv : (cycleGraph m).Adj v (v + 1)) :
+    backtrackScale (cycleGraph m) (cycleLabelling k m) hv = (-1 : kˣ) ^ (v : ℕ) := by
+  rw [backtrackScale_apply]
+  unfold cycleLabelling
+  simp only [vertexEquiv_symm_vertex]
+  rw [ite_eq_left trivial, ite_eq_right (add_one_add_one_ne_self hm v).symm, mul_one]
+
+private theorem neg_one_pow_val_add_one (hev : Even m) (v : Fin m) :
+    (-1 : kˣ) ^ ((v + 1 : Fin m) : ℕ) = -((-1 : kˣ) ^ (v : ℕ)) := by
+  rw [val_add_one]
+  rcases Nat.lt_or_ge (v.val + 1) m with h1 | h1
+  · rw [Nat.mod_eq_of_lt h1, pow_succ, mul_neg_one]
+  · have hv : v.val + 1 = m := by have := v.isLt; omega
+    have hev' : Even (v.val + 1) := by rw [hv]; exact hev
+    have hodd : Odd v.val := Nat.not_even_iff_odd.mp (Nat.even_add_one.mp hev')
+    rw [hv, Nat.mod_self, pow_zero, hodd.neg_one_pow, neg_neg]
+
+/-- **On an even cycle the exterior parameter is gauge equivalent to the constant parameter**, and
+so presents the ordinary zigzag relations.  The gauge is the alternating sign on the edges of the
+cycle, which closes up exactly because the number of vertices is even. -/
+theorem isGaugeEquivalent_one_exteriorCycle (hm : 3 ≤ m) (hev : Even m) :
+    IsGaugeEquivalent (1 : SkewZigzagParameter k (cycleGraph m)) (exteriorCycle k m) := by
+  rw [isGaugeEquivalent_iff]
+  refine ⟨cycleLabelling k m, ?_⟩
+  ext v j j' h h'
+  rw [← Units.ext_iff, gauge_ratio, one_ratio, one_mul]
+  rcases eq_add_one_or_eq_add_one_of_cycleGraph_adj h with hj | hv <;>
+    rcases eq_add_one_or_eq_add_one_of_cycleGraph_adj h' with hj' | hv'
+  · subst hj
+    subst hj'
+    exact ((exteriorCycle k m).ratio_self h).trans (div_self' _).symm
+  · subst hj
+    subst hv'
+    have hS : backtrackScale (cycleGraph m) (cycleLabelling k m) h = -((-1 : kˣ) ^ (j' : ℕ)) := by
+      rw [backtrackScale_cycleLabelling hm _ h, neg_one_pow_val_add_one hev]
+    have hS' : backtrackScale (cycleGraph m) (cycleLabelling k m) h' = (-1 : kˣ) ^ (j' : ℕ) := by
+      rw [← backtrackScale_symm (cycleGraph m) (cycleLabelling k m) h',
+        backtrackScale_cycleLabelling hm _ h'.symm]
+    rw [exteriorCycle_ratio_of_ne h h' (add_one_add_one_ne_self hm j'), hS, hS',
+      eq_div_iff_mul_eq', neg_one_mul, neg_neg]
+  · subst hv
+    subst hj'
+    have hS : backtrackScale (cycleGraph m) (cycleLabelling k m) h = (-1 : kˣ) ^ (j : ℕ) := by
+      rw [← backtrackScale_symm (cycleGraph m) (cycleLabelling k m) h,
+        backtrackScale_cycleLabelling hm _ h.symm]
+    have hS' : backtrackScale (cycleGraph m) (cycleLabelling k m) h' = -((-1 : kˣ) ^ (j : ℕ)) := by
+      rw [backtrackScale_cycleLabelling hm _ h', neg_one_pow_val_add_one hev]
+    rw [exteriorCycle_ratio_of_ne h h' (add_one_add_one_ne_self hm j).symm, hS, hS',
+      eq_div_iff_mul_eq', neg_one_mul]
+  · subst hv
+    have hjj : j = j' := add_right_cancel hv'
+    subst hjj
+    exact ((exteriorCycle k m).ratio_self h).trans (div_self' _).symm
+
+/-- **On an odd cycle, over a coefficient ring in which `2` is not zero, the exterior parameter is
+not gauge equivalent to the constant parameter**: its monodromy around the cycle is `-1`.  For a
+field this is the hypothesis that the characteristic is not two. -/
+theorem not_isGaugeEquivalent_one_exteriorCycle (hm : 3 ≤ m) (hodd : Odd m) (h2 : (2 : k) ≠ 0) :
+    ¬ IsGaugeEquivalent (1 : SkewZigzagParameter k (cycleGraph m)) (exteriorCycle k m) := by
+  intro hgauge
+  refine h2 ?_
+  have hone : (-1 : kˣ) = 1 := by
+    rw [← hodd.neg_one_pow, ← monodromy_exteriorCycle (k := k) hm]
+    exact monodromy_eq_one_of_isGaugeEquivalent_one hgauge _
+  have := congrArg (Units.val (α := k)) hone
+  rw [Units.val_neg, Units.val_one] at this
+  linear_combination -this
+
+end ExteriorCycle
+
+end SkewZigzagParameter
+
+section ExteriorCycleAlgebra
+
+variable (k : Type w) [CommRing k] (m : ℕ) [NeZero m]
+
+/-- **On an even cycle the exterior skew-zigzag relation quotient is the ordinary zigzag relation
+quotient.** -/
+theorem nonempty_algEquiv_nonisolatedZigzagQuotient_exteriorCycle (hm : 3 ≤ m) (hev : Even m) :
+    Nonempty (skewZigzagQuotient k (cycleGraph m) (SkewZigzagParameter.exteriorCycle k m) ≃ₐ[k]
+      nonisolatedZigzagQuotient k (cycleGraph m)) :=
+  nonempty_algEquiv_nonisolatedZigzagQuotient_of_isGaugeEquivalent_one k (cycleGraph m)
+    (SkewZigzagParameter.isGaugeEquivalent_one_exteriorCycle hm hev)
+
+/-- **On an even cycle the exterior skew-zigzag algebra is the public zigzag algebra.** -/
+theorem nonempty_algEquiv_zigzagAlgebra_exteriorCycle (hm : 3 ≤ m) (hev : Even m) :
+    Nonempty (skewZigzagQuotient k (cycleGraph m) (SkewZigzagParameter.exteriorCycle k m) ≃ₐ[k]
+      zigzagAlgebra k (cycleGraph m)) := by
+  have : Nontrivial (Fin m) := Fin.nontrivial_iff_two_le.mpr (by omega)
+  obtain ⟨e⟩ := nonempty_algEquiv_nonisolatedZigzagQuotient_exteriorCycle k m hm hev
+  obtain ⟨n, rfl⟩ : ∃ n, m = n + 1 := ⟨m - 1, by omega⟩
+  exact ⟨e.trans (zigzagAlgebraEquivNonisolated k _ cycleGraph_connected).symm⟩
+
+end ExteriorCycleAlgebra
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/Exterior.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/Exterior.lean
@@ -1,0 +1,145 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.RepresentationTheory.Quiver.Zigzag.Skew
+
+/-!
+# The exterior skew-zigzag parameter
+
+A skew-zigzag parameter labels each ordered pair of incident edges of a simple graph by the
+unit-valued ratio between the two backtracks they carry.  The **exterior** parameter of a graph in
+which no vertex has three pairwise distinct neighbours, that is of a graph all of whose degrees are
+at most two, gives distinct incident edges the ratio `-1`, so its relation makes the two backtracks
+at a vertex sum to zero.  The degree hypothesis is exactly what makes the signs a cocycle: at a
+vertex with three pairwise distinct neighbours the three signs would multiply to `-1`.
+
+This is the parameter carried by the basic algebra of the exterior skew group algebra of an odd
+cyclic subgroup of `SU(2)`.  When `2` is zero in the coefficient ring the sign collapses, the
+exterior parameter is the constant parameter, and its relation ideal is the ordinary zigzag ideal.
+
+## Main definitions
+
+* `TauCeti.SkewZigzagParameter.exterior`: the exterior skew-zigzag parameter of a graph whose
+  degrees are at most two.
+
+## Main results
+
+* `TauCeti.SkewZigzagParameter.exterior_ratio`: the exterior ratio of two incident edges is `1` if
+  they agree and `-1` otherwise.
+* `TauCeti.SkewZigzagParameter.exterior_eq_one`: in characteristic two the exterior parameter is
+  the constant parameter.
+* `TauCeti.skewZigzagMk_exterior_backtrackElem_add_backtrackElem`: in the exterior relation
+  quotient the two backtracks at a vertex sum to zero.
+* `TauCeti.skewZigzagIdeal_exterior_eq_zigzagIdeal`: in characteristic two the exterior parameter
+  presents the ordinary zigzag relations.
+
+## References
+
+C. Couture, *Skew-Zigzag Algebras*, Sections 3 and 4, https://arxiv.org/abs/1509.08405, for the
+skew parameters and their gauge relation.
+
+S. Huerfano and M. Khovanov, *A category for the adjoint representation*, Section 3,
+https://arxiv.org/abs/math/0002060, for the exterior skew group algebras this relation matches.
+-/
+
+public section
+
+namespace TauCeti
+
+open DoubledQuiver
+
+universe u w
+
+namespace SkewZigzagParameter
+
+section Exterior
+
+variable (k : Type w) [CommRing k] {V : Type u} [DecidableEq V] {G : SimpleGraph V}
+  (hG : ∀ ⦃i j j' j'' : V⦄, G.Adj i j → G.Adj i j' → G.Adj i j'' → j = j' ∨ j' = j'' ∨ j'' = j)
+
+/-- The two signs comparing a pair of neighbours in either order cancel. -/
+private theorem exteriorSign_mul_exteriorSign (a b : V) :
+    (if a = b then (1 : kˣ) else -1) * (if b = a then 1 else -1) = 1 := by
+  rcases eq_or_ne a b with rfl | hne
+  · rw [ite_eq_left rfl, one_mul]
+  · rw [ite_eq_right hne, ite_eq_right hne.symm, neg_mul_neg, one_mul]
+
+/-- The **exterior skew-zigzag parameter** of a graph no vertex of which has three pairwise
+distinct neighbours, that is, of a graph all of whose degrees are at most two: the ratio between
+the backtracks along two distinct incident edges is `-1`, so the relation it imposes makes the two
+backtracks at a vertex sum to zero.  The degree hypothesis is what makes the ratios a cocycle: at
+a vertex with three pairwise distinct neighbours the three signs would multiply to `-1`.
+
+The odd cycles are the McKay graphs of the odd cyclic subgroups of `SU(2)`, and it is this
+relation, rather than the ordinary one, that the exterior skew group algebras of those subgroups
+carry. -/
+def exterior : SkewZigzagParameter k G where
+  ratio _ j j' _ _ := if j = j' then 1 else -1
+  ratio_self := by intro i j h; exact ite_eq_left rfl
+  ratio_inv := by
+    intro i j j' h h'
+    exact exteriorSign_mul_exteriorSign k j j'
+  ratio_cocycle := by
+    intro i j j' j'' h h' h''
+    rcases hG h h' h'' with rfl | rfl | rfl
+    · rw [ite_eq_left rfl, one_mul, exteriorSign_mul_exteriorSign]
+    · rw [ite_eq_left rfl, mul_one, exteriorSign_mul_exteriorSign]
+    · rw [ite_eq_left rfl, mul_one, exteriorSign_mul_exteriorSign]
+
+variable {k}
+
+/-- **The exterior ratio of two incident edges** is one when they agree and minus one otherwise. -/
+@[simp]
+theorem exterior_ratio {i j j' : V} (h : G.Adj i j) (h' : G.Adj i j') :
+    (exterior k hG).ratio h h' = if j = j' then 1 else -1 := (rfl)
+
+/-- **The exterior ratio of two distinct incident edges is minus one.** -/
+theorem exterior_ratio_of_ne {i j j' : V} (h : G.Adj i j) (h' : G.Adj i j') (hne : j ≠ j') :
+    (exterior k hG).ratio h h' = -1 :=
+  (exterior_ratio hG h h').trans (ite_eq_right hne)
+
+/-- **In characteristic two the exterior parameter is the constant parameter.** The sign
+distinguishing the two backtracks at a vertex collapses, so the exterior and the ordinary zigzag
+presentations agree identically. -/
+theorem exterior_eq_one (h2 : (2 : k) = 0) : exterior k hG = 1 := by
+  have hneg : (-1 : kˣ) = 1 :=
+    Units.ext (by rw [Units.val_neg, Units.val_one]; linear_combination -h2)
+  ext i j j' h h'
+  rw [← Units.ext_iff]
+  rcases eq_or_ne j j' with rfl | hne
+  · rw [one_ratio]
+    exact (exterior k hG).ratio_self h
+  · rw [exterior_ratio_of_ne hG h h' hne, one_ratio, hneg]
+
+end Exterior
+
+end SkewZigzagParameter
+
+section ExteriorRelations
+
+variable (k : Type w) [CommRing k] {V : Type u} [DecidableEq V] [Finite V] (G : SimpleGraph V)
+  (hG : ∀ ⦃i j j' j'' : V⦄, G.Adj i j → G.Adj i j' → G.Adj i j'' → j = j' ∨ j' = j'' ∨ j'' = j)
+
+/-- **In the exterior relation quotient the two backtracks at a vertex sum to zero.** This is the
+shape in which the exterior relation appears for the basic algebra of an exterior skew group
+algebra. -/
+theorem skewZigzagMk_exterior_backtrackElem_add_backtrackElem {i j j' : V} (h : G.Adj i j)
+    (h' : G.Adj i j') (hne : j ≠ j') :
+    skewZigzagMk k G (SkewZigzagParameter.exterior k hG) (backtrackElem G k h) +
+        skewZigzagMk k G (SkewZigzagParameter.exterior k hG) (backtrackElem G k h') = 0 := by
+  rw [skewZigzagMk_backtrackElem_eq_smul k G _ h h',
+    SkewZigzagParameter.exterior_ratio_of_ne hG h h' hne, Units.val_neg, Units.val_one,
+    neg_one_smul, neg_add_cancel]
+
+/-- **In characteristic two the exterior parameter presents the ordinary zigzag relations.** -/
+theorem skewZigzagIdeal_exterior_eq_zigzagIdeal (h2 : (2 : k) = 0) :
+    skewZigzagIdeal k G (SkewZigzagParameter.exterior k hG) = zigzagIdeal k G := by
+  rw [SkewZigzagParameter.exterior_eq_one hG h2, skewZigzagIdeal_one_eq_zigzagIdeal]
+
+end ExteriorRelations
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/Exterior.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/Exterior.lean
@@ -34,8 +34,8 @@ exterior parameter is the constant parameter, and its relation ideal is the ordi
   they agree and `-1` otherwise.
 * `TauCeti.SkewZigzagParameter.exterior_eq_one`: in characteristic two the exterior parameter is
   the constant parameter.
-* `TauCeti.skewZigzagMk_exterior_backtrackElem_add_backtrackElem`: in the exterior relation
-  quotient the two backtracks at a vertex sum to zero.
+* `TauCeti.skewZigzagMk_exterior_backtrackElem_add_backtrackElem_eq_zero`: in the exterior
+  relation quotient the two backtracks at a vertex sum to zero.
 * `TauCeti.skewZigzagIdeal_exterior_eq_zigzagIdeal`: in characteristic two the exterior parameter
   presents the ordinary zigzag relations.
 
@@ -131,8 +131,8 @@ variable (k : Type w) [CommRing k] {V : Type u} [DecidableEq V] [Finite V] (G : 
 /-- **In the exterior relation quotient the two backtracks at a vertex sum to zero.** This is the
 shape in which the exterior relation appears for the basic algebra of an exterior skew group
 algebra. -/
-theorem skewZigzagMk_exterior_backtrackElem_add_backtrackElem {i j j' : V} (h : G.Adj i j)
-    (h' : G.Adj i j') (hne : j ≠ j') :
+theorem skewZigzagMk_exterior_backtrackElem_add_backtrackElem_eq_zero {i j j' : V}
+    (h : G.Adj i j) (h' : G.Adj i j') (hne : j ≠ j') :
     skewZigzagMk k G (SkewZigzagParameter.exterior k hG) (backtrackElem G k h) +
         skewZigzagMk k G (SkewZigzagParameter.exterior k hG) (backtrackElem G k h') = 0 := by
   rw [skewZigzagMk_backtrackElem_eq_smul k G _ h h',

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/Exterior.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/Exterior.lean
@@ -14,8 +14,10 @@ A skew-zigzag parameter labels each ordered pair of incident edges of a simple g
 unit-valued ratio between the two backtracks they carry.  The **exterior** parameter of a graph in
 which no vertex has three pairwise distinct neighbours, that is of a graph all of whose degrees are
 at most two, gives distinct incident edges the ratio `-1`, so its relation makes the two backtracks
-at a vertex sum to zero.  The degree hypothesis is exactly what makes the signs a cocycle: at a
-vertex with three pairwise distinct neighbours the three signs would multiply to `-1`.
+at a vertex sum to zero.  The degree hypothesis is what guarantees the signs are a cocycle over
+every coefficient ring: at a vertex with three pairwise distinct neighbours the three signs would
+multiply to `-1`, which obstructs the cocycle identity unless `2` is zero, where the sign collapses
+anyway.
 
 This is the parameter carried by the basic algebra of the exterior skew group algebra of an odd
 cyclic subgroup of `SU(2)`.  When `2` is zero in the coefficient ring the sign collapses, the
@@ -71,8 +73,10 @@ private theorem exteriorSign_mul_exteriorSign (a b : V) :
 /-- The **exterior skew-zigzag parameter** of a graph no vertex of which has three pairwise
 distinct neighbours, that is, of a graph all of whose degrees are at most two: the ratio between
 the backtracks along two distinct incident edges is `-1`, so the relation it imposes makes the two
-backtracks at a vertex sum to zero.  The degree hypothesis is what makes the ratios a cocycle: at
-a vertex with three pairwise distinct neighbours the three signs would multiply to `-1`.
+backtracks at a vertex sum to zero.  The degree hypothesis is what makes the ratios a cocycle over
+every coefficient ring: at a vertex with three pairwise distinct neighbours the three signs would
+multiply to `-1`, which obstructs the cocycle identity unless `2` is zero, where the sign collapses
+anyway.
 
 The odd cycles are the McKay graphs of the odd cyclic subgroups of `SU(2)`, and it is this
 relation, rather than the ordinary one, that the exterior skew group algebras of those subgroups

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/Exterior.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/Exterior.lean
@@ -64,11 +64,6 @@ variable (k : Type w) [CommRing k] {V : Type u} [DecidableEq V] {G : SimpleGraph
   (hG : (2 : k) = 0 ∨
     ∀ ⦃i j j' j'' : V⦄, G.Adj i j → G.Adj i j' → G.Adj i j'' → j = j' ∨ j' = j'' ∨ j'' = j)
 
-/-- When `2` is zero in the coefficient ring the sign distinguishing two incident edges
-collapses. -/
-private theorem neg_one_eq_one (h2 : (2 : k) = 0) : (-1 : kˣ) = 1 :=
-  Units.ext (by rw [Units.val_neg, Units.val_one]; linear_combination -h2)
-
 /-- The two signs comparing a pair of neighbours in either order cancel. -/
 private theorem exteriorSign_mul_exteriorSign (a b : V) :
     (if a = b then (1 : kˣ) else -1) * (if b = a then 1 else -1) = 1 := by
@@ -97,7 +92,10 @@ def exterior : SkewZigzagParameter k G where
   ratio_cocycle := by
     intro i j j' j'' h h' h''
     rcases hG with h2 | hdeg
-    · simp only [neg_one_eq_one k h2, ite_self, one_mul]
+    · -- When `2` is zero the sign distinguishing two incident edges collapses.
+      have hneg : (-1 : kˣ) = 1 :=
+        Units.ext (by rw [Units.val_neg, Units.val_one]; linear_combination -h2)
+      simp only [hneg, ite_self, one_mul]
     · rcases hdeg h h' h'' with rfl | rfl | rfl
       · rw [ite_eq_left rfl, one_mul, exteriorSign_mul_exteriorSign]
       · rw [ite_eq_left rfl, mul_one, exteriorSign_mul_exteriorSign]
@@ -124,7 +122,9 @@ theorem exterior_eq_one (h2 : (2 : k) = 0) : exterior k hG = 1 := by
   rcases eq_or_ne j j' with rfl | hne
   · rw [one_ratio]
     exact (exterior k hG).ratio_self h
-  · rw [exterior_ratio_of_ne hG h h' hne, one_ratio, neg_one_eq_one k h2]
+  · have hneg : (-1 : kˣ) = 1 :=
+      Units.ext (by rw [Units.val_neg, Units.val_one]; linear_combination -h2)
+    rw [exterior_ratio_of_ne hG h h' hne, one_ratio, hneg]
 
 end Exterior
 

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/Exterior.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/Exterior.lean
@@ -11,22 +11,22 @@ public import TauCeti.RepresentationTheory.Quiver.Zigzag.Skew
 # The exterior skew-zigzag parameter
 
 A skew-zigzag parameter labels each ordered pair of incident edges of a simple graph by the
-unit-valued ratio between the two backtracks they carry.  The **exterior** parameter of a graph in
-which no vertex has three pairwise distinct neighbours, that is of a graph all of whose degrees are
-at most two, gives distinct incident edges the ratio `-1`, so its relation makes the two backtracks
-at a vertex sum to zero.  The degree hypothesis is what guarantees the signs are a cocycle over
-every coefficient ring: at a vertex with three pairwise distinct neighbours the three signs would
-multiply to `-1`, which obstructs the cocycle identity unless `2` is zero, where the sign collapses
-anyway.
+unit-valued ratio between the two backtracks they carry.  The **exterior** parameter gives
+distinct incident edges the ratio `-1`, so its relation makes the two backtracks at a vertex sum
+to zero.  Those signs are a cocycle under either of two hypotheses, which is the disjunction the
+construction takes: no vertex of the graph has three pairwise distinct neighbours, that is all of
+its degrees are at most two, or `2` is zero in the coefficient ring.  One of the two is needed,
+since at a vertex with three pairwise distinct neighbours the three signs multiply to `-1`, which
+obstructs the cocycle identity unless the sign collapses.
 
 This is the parameter carried by the basic algebra of the exterior skew group algebra of an odd
-cyclic subgroup of `SU(2)`.  When `2` is zero in the coefficient ring the sign collapses, the
-exterior parameter is the constant parameter, and its relation ideal is the ordinary zigzag ideal.
+cyclic subgroup of `SU(2)`.  When `2` is zero the sign collapses, the exterior parameter of any
+graph is the constant parameter, and its relation ideal is the ordinary zigzag ideal.
 
 ## Main definitions
 
 * `TauCeti.SkewZigzagParameter.exterior`: the exterior skew-zigzag parameter of a graph whose
-  degrees are at most two.
+  degrees are at most two, or of an arbitrary graph over a ring in which `2` is zero.
 
 ## Main results
 
@@ -61,7 +61,13 @@ namespace SkewZigzagParameter
 section Exterior
 
 variable (k : Type w) [CommRing k] {V : Type u} [DecidableEq V] {G : SimpleGraph V}
-  (hG : ∀ ⦃i j j' j'' : V⦄, G.Adj i j → G.Adj i j' → G.Adj i j'' → j = j' ∨ j' = j'' ∨ j'' = j)
+  (hG : (2 : k) = 0 ∨
+    ∀ ⦃i j j' j'' : V⦄, G.Adj i j → G.Adj i j' → G.Adj i j'' → j = j' ∨ j' = j'' ∨ j'' = j)
+
+/-- When `2` is zero in the coefficient ring the sign distinguishing two incident edges
+collapses. -/
+private theorem neg_one_eq_one (h2 : (2 : k) = 0) : (-1 : kˣ) = 1 :=
+  Units.ext (by rw [Units.val_neg, Units.val_one]; linear_combination -h2)
 
 /-- The two signs comparing a pair of neighbours in either order cancel. -/
 private theorem exteriorSign_mul_exteriorSign (a b : V) :
@@ -70,13 +76,14 @@ private theorem exteriorSign_mul_exteriorSign (a b : V) :
   · rw [ite_eq_left rfl, one_mul]
   · rw [ite_eq_right hne, ite_eq_right hne.symm, neg_mul_neg, one_mul]
 
-/-- The **exterior skew-zigzag parameter** of a graph no vertex of which has three pairwise
-distinct neighbours, that is, of a graph all of whose degrees are at most two: the ratio between
-the backtracks along two distinct incident edges is `-1`, so the relation it imposes makes the two
-backtracks at a vertex sum to zero.  The degree hypothesis is what makes the ratios a cocycle over
-every coefficient ring: at a vertex with three pairwise distinct neighbours the three signs would
-multiply to `-1`, which obstructs the cocycle identity unless `2` is zero, where the sign collapses
-anyway.
+/-- The **exterior skew-zigzag parameter**: the ratio between the backtracks along two distinct
+incident edges is `-1`, so the relation it imposes makes the two backtracks at a vertex sum to
+zero.  The hypothesis is the disjunction under which those signs are a cocycle: either no vertex
+has three pairwise distinct neighbours, that is all degrees are at most two, or `2` is zero in the
+coefficient ring.  One of the two is needed, since at a vertex with three pairwise distinct
+neighbours the three signs multiply to `-1`, which obstructs the cocycle identity unless the sign
+collapses.  Over a ring in which `2` is zero, `Or.inl` therefore supplies the hypothesis for every
+graph.
 
 The odd cycles are the McKay graphs of the odd cyclic subgroups of `SU(2)`, and it is this
 relation, rather than the ordinary one, that the exterior skew group algebras of those subgroups
@@ -89,10 +96,12 @@ def exterior : SkewZigzagParameter k G where
     exact exteriorSign_mul_exteriorSign k j j'
   ratio_cocycle := by
     intro i j j' j'' h h' h''
-    rcases hG h h' h'' with rfl | rfl | rfl
-    · rw [ite_eq_left rfl, one_mul, exteriorSign_mul_exteriorSign]
-    · rw [ite_eq_left rfl, mul_one, exteriorSign_mul_exteriorSign]
-    · rw [ite_eq_left rfl, mul_one, exteriorSign_mul_exteriorSign]
+    rcases hG with h2 | hdeg
+    · simp only [neg_one_eq_one k h2, ite_self, one_mul]
+    · rcases hdeg h h' h'' with rfl | rfl | rfl
+      · rw [ite_eq_left rfl, one_mul, exteriorSign_mul_exteriorSign]
+      · rw [ite_eq_left rfl, mul_one, exteriorSign_mul_exteriorSign]
+      · rw [ite_eq_left rfl, mul_one, exteriorSign_mul_exteriorSign]
 
 variable {k}
 
@@ -108,16 +117,14 @@ theorem exterior_ratio_of_ne {i j j' : V} (h : G.Adj i j) (h' : G.Adj i j') (hne
 
 /-- **In characteristic two the exterior parameter is the constant parameter.** The sign
 distinguishing the two backtracks at a vertex collapses, so the exterior and the ordinary zigzag
-presentations agree identically. -/
+presentations agree identically.  The graph is arbitrary here: `Or.inl h2` supplies `hG`. -/
 theorem exterior_eq_one (h2 : (2 : k) = 0) : exterior k hG = 1 := by
-  have hneg : (-1 : kˣ) = 1 :=
-    Units.ext (by rw [Units.val_neg, Units.val_one]; linear_combination -h2)
   ext i j j' h h'
   rw [← Units.ext_iff]
   rcases eq_or_ne j j' with rfl | hne
   · rw [one_ratio]
     exact (exterior k hG).ratio_self h
-  · rw [exterior_ratio_of_ne hG h h' hne, one_ratio, hneg]
+  · rw [exterior_ratio_of_ne hG h h' hne, one_ratio, neg_one_eq_one k h2]
 
 end Exterior
 
@@ -126,7 +133,8 @@ end SkewZigzagParameter
 section ExteriorRelations
 
 variable (k : Type w) [CommRing k] {V : Type u} [DecidableEq V] [Finite V] (G : SimpleGraph V)
-  (hG : ∀ ⦃i j j' j'' : V⦄, G.Adj i j → G.Adj i j' → G.Adj i j'' → j = j' ∨ j' = j'' ∨ j'' = j)
+  (hG : (2 : k) = 0 ∨
+    ∀ ⦃i j j' j'' : V⦄, G.Adj i j → G.Adj i j' → G.Adj i j'' → j = j' ∨ j' = j'' ∨ j'' = j)
 
 /-- **In the exterior relation quotient the two backtracks at a vertex sum to zero.** This is the
 shape in which the exterior relation appears for the basic algebra of an exterior skew group
@@ -139,7 +147,8 @@ theorem skewZigzagMk_exterior_backtrackElem_add_backtrackElem_eq_zero {i j j' : 
     SkewZigzagParameter.exterior_ratio_of_ne hG h h' hne, Units.val_neg, Units.val_one,
     neg_one_smul, neg_add_cancel]
 
-/-- **In characteristic two the exterior parameter presents the ordinary zigzag relations.** -/
+/-- **In characteristic two the exterior parameter presents the ordinary zigzag relations.** The
+graph is arbitrary here: `Or.inl h2` supplies `hG`. -/
 theorem skewZigzagIdeal_exterior_eq_zigzagIdeal (h2 : (2 : k) = 0) :
     skewZigzagIdeal k G (SkewZigzagParameter.exterior k hG) = zigzagIdeal k G := by
   rw [SkewZigzagParameter.exterior_eq_one hG h2, skewZigzagIdeal_one_eq_zigzagIdeal]

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/Monodromy.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/Monodromy.lean
@@ -1,0 +1,105 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.RepresentationTheory.Quiver.Zigzag.Gauge
+
+/-!
+# The monodromy of a skew-zigzag parameter around a closed edge cycle
+
+A skew-zigzag parameter labels each ordered pair of incident edges of a simple graph by the
+unit-valued ratio between the two backtracks they carry, and gauge equivalent parameters present
+isomorphic algebras.  This file supplies the invariant which detects that a parameter is *not*
+gauge trivial.
+
+The invariant is the **monodromy** of a closed edge cycle: the product, over the vertices of the
+cycle, of the ratio from the edge along which the cycle arrives at a vertex to the edge along
+which it leaves.  A gauge transform multiplies each factor by the quotient of two backtrack
+scales, and consecutive factors share those scales, so the correction telescopes around the cycle
+and the monodromy depends only on the gauge class.  It is one for the constant parameter, so a
+parameter whose monodromy around some closed edge cycle is not one is not gauge trivial.
+
+## Main definitions
+
+* `TauCeti.SkewZigzagParameter.monodromy`: the monodromy of a parameter around a closed edge
+  cycle.
+
+## Main results
+
+* `TauCeti.SkewZigzagParameter.monodromy_eq_prod`: the monodromy as a product around the cycle.
+* `TauCeti.SkewZigzagParameter.monodromy_gauge`: the monodromy is a gauge invariant.
+* `TauCeti.SkewZigzagParameter.monodromy_eq_one_of_isGaugeEquivalent_one`: a gauge-trivial
+  parameter has trivial monodromy.
+
+## References
+
+C. Couture, *Skew-Zigzag Algebras*, Section 4, https://arxiv.org/abs/1509.08405, for the gauge
+relation on skew parameters and its cohomological classification.
+-/
+
+public section
+
+namespace TauCeti
+
+open DoubledQuiver SimpleGraph
+
+universe u w
+
+namespace SkewZigzagParameter
+
+variable {k : Type w} [CommMonoid k] {V : Type u} {G : SimpleGraph V} {m : ℕ} [NeZero m]
+  {x : Fin m → V}
+
+/-- The **monodromy** of a skew-zigzag parameter around a closed edge cycle `x`, a cyclically
+indexed family of vertices consecutive ones of which are adjacent: the product, over the vertices
+of the cycle, of the ratio from the edge along which the cycle arrives at a vertex to the edge
+along which it leaves.  It is unchanged by a gauge transform and is one for the constant
+parameter, so it obstructs gauge triviality. -/
+def monodromy (c : SkewZigzagParameter k G) (hx : ∀ i : Fin m, G.Adj (x i) (x (i + 1))) : kˣ :=
+  ∏ i : Fin m, c.ratio (hx i).symm (hx (i + 1))
+
+/-- **The monodromy is the product, over the vertices of the cycle, of the ratio between the
+edge along which the cycle arrives and the edge along which it leaves.** -/
+theorem monodromy_eq_prod (c : SkewZigzagParameter k G)
+    (hx : ∀ i : Fin m, G.Adj (x i) (x (i + 1))) :
+    monodromy c hx = ∏ i : Fin m, c.ratio (hx i).symm (hx (i + 1)) := (rfl)
+
+/-- **The constant parameter has trivial monodromy.** -/
+@[simp]
+theorem monodromy_one (hx : ∀ i : Fin m, G.Adj (x i) (x (i + 1))) :
+    monodromy (1 : SkewZigzagParameter k G) hx = 1 :=
+  Finset.prod_eq_one fun _ _ => one_ratio _ _
+
+/-- **The monodromy is a gauge invariant**: the backtrack scales a gauge transform contributes at
+a vertex of the cycle cancel against those it contributes at the neighbouring vertices. -/
+@[simp]
+theorem monodromy_gauge (c : SkewZigzagParameter k G)
+    (u : ∀ ⦃y z : DoubledQuiver G⦄, (y ⟶ z) → kˣ)
+    (hx : ∀ i : Fin m, G.Adj (x i) (x (i + 1))) :
+    monodromy (c.gauge u) hx = monodromy c hx := by
+  have hshift : ∏ i : Fin m, backtrackScale G u (hx (i + 1)) =
+      ∏ i : Fin m, backtrackScale G u (hx i).symm :=
+    Fintype.prod_equiv (Equiv.addRight 1) _ _ fun i =>
+      (backtrackScale_symm G u (hx (i + 1))).symm
+  simp only [monodromy, gauge_ratio]
+  rw [Finset.prod_mul_distrib, Finset.prod_div_distrib, hshift, div_self', mul_one]
+
+/-- **Gauge equivalent parameters have the same monodromy.** -/
+theorem monodromy_eq_of_isGaugeEquivalent {c c' : SkewZigzagParameter k G}
+    (hc : c.IsGaugeEquivalent c') (hx : ∀ i : Fin m, G.Adj (x i) (x (i + 1))) :
+    monodromy c hx = monodromy c' hx := by
+  obtain ⟨u, rfl⟩ := isGaugeEquivalent_iff.mp hc
+  rw [monodromy_gauge]
+
+/-- **A gauge-trivial parameter has trivial monodromy around every closed edge cycle.** -/
+theorem monodromy_eq_one_of_isGaugeEquivalent_one {c : SkewZigzagParameter k G}
+    (hc : IsGaugeEquivalent (1 : SkewZigzagParameter k G) c)
+    (hx : ∀ i : Fin m, G.Adj (x i) (x (i + 1))) : monodromy c hx = 1 := by
+  rw [← monodromy_eq_of_isGaugeEquivalent hc hx, monodromy_one]
+
+end SkewZigzagParameter
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/Monodromy.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/Monodromy.lean
@@ -29,7 +29,10 @@ parameter whose monodromy around some closed edge cycle is not one is not gauge 
 
 ## Main results
 
-* `TauCeti.SkewZigzagParameter.monodromy_eq_prod`: the monodromy as a product around the cycle.
+* `TauCeti.SkewZigzagParameter.monodromy_def`: the defining product for monodromy.
+* `TauCeti.SkewZigzagParameter.monodromy_rotate`: changing the starting vertex does not change
+  monodromy.
+* `TauCeti.SkewZigzagParameter.monodromy_reverse`: reversing orientation inverts monodromy.
 * `TauCeti.SkewZigzagParameter.monodromy_gauge`: the monodromy is a gauge invariant.
 * `TauCeti.SkewZigzagParameter.monodromy_eq_one_of_isGaugeEquivalent_one`: a gauge-trivial
   parameter has trivial monodromy.
@@ -63,9 +66,47 @@ def monodromy (c : SkewZigzagParameter k G) (hx : ∀ i : Fin m, G.Adj (x i) (x 
 
 /-- **The monodromy is the product, over the vertices of the cycle, of the ratio between the
 edge along which the cycle arrives and the edge along which it leaves.** -/
-theorem monodromy_eq_prod (c : SkewZigzagParameter k G)
+theorem monodromy_def (c : SkewZigzagParameter k G)
     (hx : ∀ i : Fin m, G.Adj (x i) (x (i + 1))) :
     monodromy c hx = ∏ i : Fin m, c.ratio (hx i).symm (hx (i + 1)) := (rfl)
+
+/-- **Changing the starting vertex of a closed edge cycle does not change its monodromy.** -/
+theorem monodromy_rotate (c : SkewZigzagParameter k G)
+    (hx : ∀ i : Fin m, G.Adj (x i) (x (i + 1))) (n : Fin m) :
+    monodromy (x := fun i => x (i + n)) c (fun i => by
+      simpa only [add_assoc, add_comm, add_left_comm] using hx (i + n)) = monodromy c hx := by
+  unfold monodromy
+  exact Fintype.prod_equiv (Equiv.addRight n) _ _ fun i => by
+    -- Reindexing changes the endpoints definitionally but leaves different adjacency proofs.
+    change c.ratio _ _ = c.ratio (hx (i + n)).symm (hx (i + n + 1))
+    congr 1
+    all_goals
+      apply congrArg x
+      abel_nf
+
+/-- **Reversing the orientation of a closed edge cycle inverts its monodromy.** -/
+theorem monodromy_reverse (c : SkewZigzagParameter k G)
+    (hx : ∀ i : Fin m, G.Adj (x i) (x (i + 1))) :
+    monodromy (x := fun i => x (-i)) c (fun i => by
+      convert (hx (-i - 1)).symm using 1 <;> congr 1 <;> abel) =
+      (monodromy c hx)⁻¹ := by
+  unfold monodromy
+  rw [← Finset.prod_inv_distrib]
+  let e : Fin m ≃ Fin m :=
+    { toFun := fun i => -i - 1 - 1
+      invFun := fun i => -i - 1 - 1
+      left_inv := by intro i; dsimp; abel
+      right_inv := by intro i; dsimp; abel }
+  exact Fintype.prod_equiv e _ _ fun i => by
+    -- Align the reversed edge proofs with the original ratio in the opposite order.
+    change c.ratio _ _ = (c.ratio (hx (-i - 1 - 1)).symm (hx (-i - 1 - 1 + 1)))⁻¹
+    apply eq_inv_of_mul_eq_one_right
+    convert c.ratio_inv (hx (-i - 1 - 1)).symm (hx (-i - 1 - 1 + 1)) using 1
+    congr 1
+    all_goals congr 1
+    all_goals
+      apply congrArg x
+      abel
 
 /-- **The constant parameter has trivial monodromy.** -/
 @[simp]


### PR DESCRIPTION
This PR works out the skew-zigzag algebras of the cycles. It introduces the **monodromy** of a skew-zigzag parameter around a closed edge cycle — the product, over the vertices of the cycle, of the ratio from the edge along which the cycle arrives at a vertex to the edge along which it leaves — and proves it is a gauge invariant, the backtrack scales a gauge transform contributes at one vertex cancelling against those at its neighbours. It then defines the **exterior** skew-zigzag parameter: distinct incident edges get the ratio `-1`, so its relation makes the two backtracks at a vertex sum to zero.  Its hypothesis is the disjunction under which those signs are a cocycle — either no vertex of the graph has three pairwise distinct neighbours, that is the graph has degree at most two, or `2` is zero in the coefficient ring, where the sign collapses; over such a ring `Or.inl` supplies it for every graph. Around `SimpleGraph.cycleGraph m` the monodromy of that parameter is `(-1) ^ m`, and the three cases follow: on an even cycle the alternating sign on the edges of the cycle gauges the exterior parameter to the constant one, so its relation quotient is the ordinary zigzag relation quotient and the public componentwise zigzag algebra; on an odd cycle, over a coefficient ring in which `2` is not zero, the monodromy is `-1` and the exterior parameter is not gauge trivial; and when `2` is zero the exterior parameter *is* the constant parameter, on any graph, so its relation ideal is the ordinary zigzag ideal.

It advances the Layer 1 milestone "strict ordinary and skew zigzag algebras" of `ZigzagPreprojective/README.md`, whose fourth bullet reads: "Work out cycles explicitly. On an even cycle the exterior-skew relation is gauge-equivalent to the ordinary zigzag relation; on an odd cycle over characteristic different from two it is the nontrivial skew class. Record the characteristic-two identification." The three statements are `TauCeti.nonempty_algEquiv_zigzagAlgebra_exteriorCycle`, `TauCeti.SkewZigzagParameter.not_isGaugeEquivalent_one_exteriorCycle` and `TauCeti.skewZigzagIdeal_exterior_eq_zigzagIdeal`. This continues the skew lane opened by the parameter quotient (#5001), the gauge action (#5891) and the trivialisation on trees (#5981), and the odd-cycle exterior parameter is the object the roadmap's downstream skew-group convention asks be kept distinct from the ordinary odd-cycle zigzag algebra.

The odd-cycle theorem is deliberately a statement about gauge classes: it says the exterior parameter is not in the gauge class of the constant one, not that the two present nonisomorphic algebras. Deducing the latter needs Couture's identification of vertex-fixing graded isomorphism classes with `H¹(G, k^×)`, which is not claimed here. The `2 ≠ 0` hypothesis is stated over an arbitrary commutative ring, where it is the exact negation of the characteristic-two hypothesis under which the two parameters coincide; over a field it is the roadmap's "characteristic different from two".

After this PR the skew half of Layer 1 still needs Couture's `H¹(G, k^×)` classification of gauge classes, the scalar extension of parameters along a field homomorphism, and the skew Frobenius trace normalisation.

Four files are added: `TauCeti/Combinatorics/SimpleGraph/CycleGraph.lean` (85 lines) reads Mathlib's cycle-graph adjacency as "a neighbour is the successor or the predecessor"; `TauCeti/RepresentationTheory/Quiver/Zigzag/Monodromy.lean` (146 lines) carries the monodromy of a parameter around a closed walk and its gauge invariance; `TauCeti/RepresentationTheory/Quiver/Zigzag/Exterior.lean` (158 lines) carries the graph-general exterior parameter and its relation results; and `TauCeti/RepresentationTheory/Quiver/Zigzag/Cycle.lean` (216 lines) carries the cycle results. No Mathlib infrastructure is vendored; the cycle graphs, their adjacency and connectedness are Mathlib's `SimpleGraph.cycleGraph`. The mathematical conventions follow C. Couture, *Skew-Zigzag Algebras*, Sections 3 and 4, and S. Huerfano and M. Khovanov, *A category for the adjoint representation*, Section 3, as cited in the module documentation.

Roadmap: ZigzagPreprojective

<!--tauceti-target:v1 {"focus":"ZigzagPreprojective","id":"skew-zigzag-cycles"}-->

🤖 Prepared with Claude Code

