### PR TITLE
feat: prove profinite Lagrange's theorem

### DIFF
--- a/TauCeti/GroupTheory/QuotientGroup/Index.lean
+++ b/TauCeti/GroupTheory/QuotientGroup/Index.lean
@@ -1,0 +1,36 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.GroupTheory.Index
+
+/-!
+# Indices in quotient groups
+
+This file records how the index of the image of a subgroup in a quotient group is computed in
+the original group.
+
+## Main results
+
+* `Subgroup.index_map_quotient_eq_index_sup`: the index of the image of `H` in `G ⧸ N` is the
+  index of `H ⊔ N` in `G`.
+-/
+
+public section
+
+namespace TauCeti
+
+variable {G : Type*} [Group G]
+
+/-- The index of the image of a subgroup in a quotient is the index of its join with the
+quotienting subgroup. -/
+theorem _root_.Subgroup.index_map_quotient_eq_index_sup (H N : Subgroup G) [N.Normal] :
+    (H.map (QuotientGroup.mk' N)).index = (H ⊔ N).index := by
+  rw [H.index_map, QuotientGroup.ker_mk',
+    (QuotientGroup.mk' N).range_eq_top_of_surjective
+      (QuotientGroup.mk'_surjective N), Subgroup.index_top, mul_one]
+
+end TauCeti

--- a/TauCeti/GroupTheory/QuotientGroup/Index.lean
+++ b/TauCeti/GroupTheory/QuotientGroup/Index.lean
@@ -15,7 +15,7 @@ the original group.
 
 ## Main results
 
-* `Subgroup.index_map_quotient_eq_index_sup`: the index of the image of `H` in `G ⧸ N` is the
+* `Subgroup.index_map_mk'_eq_index_sup`: the index of the image of `H` in `G ⧸ N` is the
   index of `H ⊔ N` in `G`.
 -/
 
@@ -27,7 +27,8 @@ variable {G : Type*} [Group G]
 
 /-- The index of the image of a subgroup in a quotient is the index of its join with the
 quotienting subgroup. -/
-theorem _root_.Subgroup.index_map_quotient_eq_index_sup (H N : Subgroup G) [N.Normal] :
+@[to_additive (attr := simp), simp]
+theorem _root_.Subgroup.index_map_mk'_eq_index_sup (H N : Subgroup G) [N.Normal] :
     (H.map (QuotientGroup.mk' N)).index = (H ⊔ N).index := by
   rw [H.index_map, QuotientGroup.ker_mk',
     (QuotientGroup.mk' N).range_eq_top_of_surjective

--- a/TauCeti/Topology/Algebra/Group/Profinite/Basic.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Basic.lean
@@ -33,6 +33,8 @@ carry the hypothesis, while the clopen-image statement is valid for an arbitrary
 
 * `Subgroup.eq_iInf_sup_openNormalSubgroup`: a closed subgroup is the infimum of the
   subgroups `N ⊔ U` with `U` open normal.
+* `Subgroup.exists_openNormalSubgroup_comap_le`: open normal subgroups of a subgroup are
+  refined by pullbacks of ambient open normal subgroups.
 * `QuotientGroup.connectedComponent_one`, `QuotientGroup.instTotallyDisconnectedSpace`:
   the quotient of a profinite group by a closed normal subgroup is totally disconnected.
 * `Subgroup.iInf_openNormalSubgroup_eq_bot`: the infimum of the open normal subgroups of a
@@ -93,6 +95,21 @@ theorem _root_.Subgroup.eq_iInf_sup_openNormalSubgroup (N : Subgroup G)
   obtain ⟨U₀, hU₀⟩ :=
     ProfiniteGrp.exist_openNormalSubgroup_sub_open_nhds_of_one hKopen (Subgroup.one_mem K)
   exact hxK ((sup_le hKN fun y hy => hU₀ hy) (Subgroup.mem_iInf.mp hx U₀))
+
+/-- Every open normal subgroup of a subgroup of a profinite group contains the pullback of
+an ambient open normal subgroup. -/
+theorem _root_.Subgroup.exists_openNormalSubgroup_comap_le (H : Subgroup G)
+    (V : OpenNormalSubgroup H) :
+    ∃ N : OpenNormalSubgroup G, N.toSubgroup.comap H.subtype ≤ V.toSubgroup := by
+  obtain ⟨s, hs, hpre⟩ := isOpen_induced_iff.mp V.toOpenSubgroup.isOpen
+  have h_one : (1 : G) ∈ s := by
+    have : (1 : H) ∈ V := V.toSubgroup.one_mem
+    exact hpre.symm.subset this
+  obtain ⟨N, hN⟩ :=
+    ProfiniteGrp.exist_openNormalSubgroup_sub_open_nhds_of_one hs h_one
+  refine ⟨N, fun x hx ↦ ?_⟩
+  have : (x : G) ∈ s := hN hx
+  exact hpre.subset this
 
 /-- In a profinite group, an element that lies in every open normal subgroup is `1`. -/
 theorem _root_.Subgroup.eq_one_of_mem_iInf_openNormalSubgroup {x : G}

--- a/TauCeti/Topology/Algebra/Group/Profinite/Index.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Index.lean
@@ -26,8 +26,6 @@ description as the least common multiple of the indices of open overgroups.
 * `Subgroup.profiniteIndex`: the supernatural index of a subgroup of a profinite group.
 * `Subgroup.index_map_quotient_eq_index_sup`: the ordinary index of a subgroup's image in a
   quotient.
-* `Subgroup.index_comap_quotient_eq_card_map`: the index of a pulled-back quotient kernel
-  equals the cardinality of the corresponding image.
 * `Subgroup.profiniteIndex_anti`: subgroup inclusion reverses supernatural indices.
 * `Subgroup.profiniteIndex_eq_iSup_openSubgroup`: the description as the least common
   multiple of the indices of open overgroups.
@@ -66,22 +64,6 @@ theorem _root_.Subgroup.index_map_quotient_eq_index_sup (H : Subgroup G)
   rw [H.index_map, QuotientGroup.ker_mk',
     (QuotientGroup.mk' N.toSubgroup).range_eq_top_of_surjective
       (QuotientGroup.mk'_surjective N.toSubgroup), Subgroup.index_top, mul_one]
-
-/-- The index in a subgroup of the pullback of an open normal subgroup equals the cardinality
-of the subgroup's image in the corresponding quotient. -/
-theorem _root_.Subgroup.index_comap_quotient_eq_card_map (H : Subgroup G)
-    (N : OpenNormalSubgroup G) :
-    (N.toSubgroup.comap H.subtype).index =
-      Nat.card (H.map (QuotientGroup.mk' N.toSubgroup)) := by
-  let f : H →* G ⧸ N.toSubgroup :=
-    (QuotientGroup.mk' N.toSubgroup).comp H.subtype
-  have hker : f.ker = N.toSubgroup.comap H.subtype := by
-    ext x
-    simp [f, Subgroup.mem_subgroupOf]
-  have hrange : f.range = H.map (QuotientGroup.mk' N.toSubgroup) := by
-    ext x
-    simp [f]
-  rw [← hker, Subgroup.index_ker, hrange]
 
 /-- The **index of a subgroup of a profinite group**, as a supernatural number. At a prime
 `ℓ`, it is the supremum over open normal subgroups `N` of the `ℓ`-adic valuations of

--- a/TauCeti/Topology/Algebra/Group/Profinite/Index.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Index.lean
@@ -26,6 +26,8 @@ description as the least common multiple of the indices of open overgroups.
 * `Subgroup.profiniteIndex`: the supernatural index of a subgroup of a profinite group.
 * `Subgroup.index_map_quotient_eq_index_sup`: the ordinary index of a subgroup's image in a
   quotient.
+* `Subgroup.index_comap_quotient_eq_card_map`: the index of a pulled-back quotient kernel
+  equals the cardinality of the corresponding image.
 * `Subgroup.profiniteIndex_anti`: subgroup inclusion reverses supernatural indices.
 * `Subgroup.profiniteIndex_eq_iSup_openSubgroup`: the description as the least common
   multiple of the indices of open overgroups.
@@ -64,6 +66,22 @@ theorem _root_.Subgroup.index_map_quotient_eq_index_sup (H : Subgroup G)
   rw [H.index_map, QuotientGroup.ker_mk',
     (QuotientGroup.mk' N.toSubgroup).range_eq_top_of_surjective
       (QuotientGroup.mk'_surjective N.toSubgroup), Subgroup.index_top, mul_one]
+
+/-- The index in a subgroup of the pullback of an open normal subgroup equals the cardinality
+of the subgroup's image in the corresponding quotient. -/
+theorem _root_.Subgroup.index_comap_quotient_eq_card_map (H : Subgroup G)
+    (N : OpenNormalSubgroup G) :
+    (N.toSubgroup.comap H.subtype).index =
+      Nat.card (H.map (QuotientGroup.mk' N.toSubgroup)) := by
+  let f : H →* G ⧸ N.toSubgroup :=
+    (QuotientGroup.mk' N.toSubgroup).comp H.subtype
+  have hker : f.ker = N.toSubgroup.comap H.subtype := by
+    ext x
+    simp [f, Subgroup.mem_subgroupOf]
+  have hrange : f.range = H.map (QuotientGroup.mk' N.toSubgroup) := by
+    ext x
+    simp [f]
+  rw [← hker, Subgroup.index_ker, hrange]
 
 /-- The **index of a subgroup of a profinite group**, as a supernatural number. At a prime
 `ℓ`, it is the supremum over open normal subgroups `N` of the `ℓ`-adic valuations of

--- a/TauCeti/Topology/Algebra/Group/Profinite/Index.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Index.lean
@@ -132,7 +132,7 @@ theorem _root_.Subgroup.profiniteIndex_eq_iSup_openSubgroup (H : Subgroup G) :
         isOpen' := Subgroup.isOpen_of_openSubgroup _ le_sup_right }
     let V' : {U : OpenSubgroup G // H ≤ U.toSubgroup} := ⟨V, le_sup_left⟩
     have hVpos : 0 < V.toSubgroup.index := by
-      rw [← H.index_map_quotient_eq_index_sup N.toSubgroup]
+      rw [← H.index_map_mk'_eq_index_sup N.toSubgroup]
       exact Nat.zero_lt_of_ne_zero Subgroup.index_ne_zero_of_finite
     calc
       Supernatural.ofNat
@@ -142,7 +142,7 @@ theorem _root_.Subgroup.profiniteIndex_eq_iSup_openSubgroup (H : Subgroup G) :
             (⟨V.toSubgroup.index,
               hVpos⟩ : ℕ+) := by
         apply congrArg Supernatural.ofNat
-        exact Subtype.ext (H.index_map_quotient_eq_index_sup N.toSubgroup)
+        exact Subtype.ext (H.index_map_mk'_eq_index_sup N.toSubgroup)
       _ ≤ ⨆ U : {U : OpenSubgroup G // H ≤ U.toSubgroup},
           Supernatural.ofNat
             (⟨U.1.toSubgroup.index,
@@ -157,7 +157,7 @@ theorem _root_.Subgroup.profiniteIndex_eq_iSup_openSubgroup (H : Subgroup G) :
         U.1.one_mem'
     have hdvd : U.1.toSubgroup.index ∣
         (H.map (QuotientGroup.mk' N.toSubgroup)).index := by
-      rw [H.index_map_quotient_eq_index_sup N.toSubgroup]
+      rw [H.index_map_mk'_eq_index_sup N.toSubgroup]
       exact Subgroup.index_dvd_of_le (sup_le U.2 fun _ hx ↦ hN hx)
     refine le_trans ?_ (le_iSup (fun N : OpenNormalSubgroup G ↦
       Supernatural.ofNat

--- a/TauCeti/Topology/Algebra/Group/Profinite/Index.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Index.lean
@@ -24,6 +24,8 @@ description as the least common multiple of the indices of open overgroups.
 ## Main results
 
 * `Subgroup.profiniteIndex`: the supernatural index of a subgroup of a profinite group.
+* `Subgroup.index_map_quotient_eq_index_sup`: the ordinary index of a subgroup's image in a
+  quotient.
 * `Subgroup.profiniteIndex_anti`: subgroup inclusion reverses supernatural indices.
 * `Subgroup.profiniteIndex_eq_iSup_openSubgroup`: the description as the least common
   multiple of the indices of open overgroups.
@@ -52,6 +54,16 @@ namespace TauCeti
 open scoped ENat
 
 variable {G : Type*} [Group G] [TopologicalSpace G]
+
+/-- The index of the image of a subgroup in a quotient is the index of its join with the
+quotienting subgroup. -/
+theorem _root_.Subgroup.index_map_quotient_eq_index_sup (H : Subgroup G)
+    (N : OpenNormalSubgroup G) :
+    (H.map (QuotientGroup.mk' N.toSubgroup)).index =
+      (H ⊔ N.toSubgroup).index := by
+  rw [H.index_map, QuotientGroup.ker_mk',
+    (QuotientGroup.mk' N.toSubgroup).range_eq_top_of_surjective
+      (QuotientGroup.mk'_surjective N.toSubgroup), Subgroup.index_top, mul_one]
 
 /-- The **index of a subgroup of a profinite group**, as a supernatural number. At a prime
 `ℓ`, it is the supremum over open normal subgroups `N` of the `ℓ`-adic valuations of
@@ -124,12 +136,6 @@ theorem _root_.Subgroup.profiniteIndex_eq_iSup_openSubgroup (H : Subgroup G) :
         (⟨U.1.toSubgroup.index,
           Nat.zero_lt_of_ne_zero Subgroup.index_ne_zero_of_finite⟩ : ℕ+) := by
   rw [Subgroup.profiniteIndex_eq_iSup_ofNat]
-  have index_image_eq (N : OpenNormalSubgroup G) :
-      (H.map (QuotientGroup.mk' N.toSubgroup)).index =
-        (H ⊔ N.toSubgroup).index := by
-    rw [H.index_map, QuotientGroup.ker_mk',
-      (QuotientGroup.mk' N.toSubgroup).range_eq_top_of_surjective
-        (QuotientGroup.mk'_surjective N.toSubgroup), Subgroup.index_top, mul_one]
   apply le_antisymm
   · refine iSup_le fun N ↦ ?_
     let V : OpenSubgroup G :=
@@ -137,7 +143,7 @@ theorem _root_.Subgroup.profiniteIndex_eq_iSup_openSubgroup (H : Subgroup G) :
         isOpen' := Subgroup.isOpen_of_openSubgroup _ le_sup_right }
     let V' : {U : OpenSubgroup G // H ≤ U.toSubgroup} := ⟨V, le_sup_left⟩
     have hVpos : 0 < V.toSubgroup.index := by
-      rw [← index_image_eq N]
+      rw [← H.index_map_quotient_eq_index_sup N]
       exact Nat.zero_lt_of_ne_zero Subgroup.index_ne_zero_of_finite
     calc
       Supernatural.ofNat
@@ -147,7 +153,7 @@ theorem _root_.Subgroup.profiniteIndex_eq_iSup_openSubgroup (H : Subgroup G) :
             (⟨V.toSubgroup.index,
               hVpos⟩ : ℕ+) := by
         apply congrArg Supernatural.ofNat
-        exact Subtype.ext (index_image_eq N)
+        exact Subtype.ext (H.index_map_quotient_eq_index_sup N)
       _ ≤ ⨆ U : {U : OpenSubgroup G // H ≤ U.toSubgroup},
           Supernatural.ofNat
             (⟨U.1.toSubgroup.index,
@@ -162,7 +168,7 @@ theorem _root_.Subgroup.profiniteIndex_eq_iSup_openSubgroup (H : Subgroup G) :
         U.1.one_mem'
     have hdvd : U.1.toSubgroup.index ∣
         (H.map (QuotientGroup.mk' N.toSubgroup)).index := by
-      rw [index_image_eq N]
+      rw [H.index_map_quotient_eq_index_sup N]
       exact Subgroup.index_dvd_of_le (sup_le U.2 fun _ hx ↦ hN hx)
     refine le_trans ?_ (le_iSup (fun N : OpenNormalSubgroup G ↦
       Supernatural.ofNat

--- a/TauCeti/Topology/Algebra/Group/Profinite/Index.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Index.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.GroupTheory.QuotientGroup.Index
 public import TauCeti.NumberTheory.Supernatural
 public import TauCeti.Topology.Algebra.Group.Profinite.Basic
 
@@ -24,8 +25,6 @@ description as the least common multiple of the indices of open overgroups.
 ## Main results
 
 * `Subgroup.profiniteIndex`: the supernatural index of a subgroup of a profinite group.
-* `Subgroup.index_map_quotient_eq_index_sup`: the ordinary index of a subgroup's image in a
-  quotient.
 * `Subgroup.profiniteIndex_anti`: subgroup inclusion reverses supernatural indices.
 * `Subgroup.profiniteIndex_eq_iSup_openSubgroup`: the description as the least common
   multiple of the indices of open overgroups.
@@ -54,16 +53,6 @@ namespace TauCeti
 open scoped ENat
 
 variable {G : Type*} [Group G] [TopologicalSpace G]
-
-/-- The index of the image of a subgroup in a quotient is the index of its join with the
-quotienting subgroup. -/
-theorem _root_.Subgroup.index_map_quotient_eq_index_sup (H : Subgroup G)
-    (N : OpenNormalSubgroup G) :
-    (H.map (QuotientGroup.mk' N.toSubgroup)).index =
-      (H ⊔ N.toSubgroup).index := by
-  rw [H.index_map, QuotientGroup.ker_mk',
-    (QuotientGroup.mk' N.toSubgroup).range_eq_top_of_surjective
-      (QuotientGroup.mk'_surjective N.toSubgroup), Subgroup.index_top, mul_one]
 
 /-- The **index of a subgroup of a profinite group**, as a supernatural number. At a prime
 `ℓ`, it is the supremum over open normal subgroups `N` of the `ℓ`-adic valuations of
@@ -143,7 +132,7 @@ theorem _root_.Subgroup.profiniteIndex_eq_iSup_openSubgroup (H : Subgroup G) :
         isOpen' := Subgroup.isOpen_of_openSubgroup _ le_sup_right }
     let V' : {U : OpenSubgroup G // H ≤ U.toSubgroup} := ⟨V, le_sup_left⟩
     have hVpos : 0 < V.toSubgroup.index := by
-      rw [← H.index_map_quotient_eq_index_sup N]
+      rw [← H.index_map_quotient_eq_index_sup N.toSubgroup]
       exact Nat.zero_lt_of_ne_zero Subgroup.index_ne_zero_of_finite
     calc
       Supernatural.ofNat
@@ -153,7 +142,7 @@ theorem _root_.Subgroup.profiniteIndex_eq_iSup_openSubgroup (H : Subgroup G) :
             (⟨V.toSubgroup.index,
               hVpos⟩ : ℕ+) := by
         apply congrArg Supernatural.ofNat
-        exact Subtype.ext (H.index_map_quotient_eq_index_sup N)
+        exact Subtype.ext (H.index_map_quotient_eq_index_sup N.toSubgroup)
       _ ≤ ⨆ U : {U : OpenSubgroup G // H ≤ U.toSubgroup},
           Supernatural.ofNat
             (⟨U.1.toSubgroup.index,
@@ -168,7 +157,7 @@ theorem _root_.Subgroup.profiniteIndex_eq_iSup_openSubgroup (H : Subgroup G) :
         U.1.one_mem'
     have hdvd : U.1.toSubgroup.index ∣
         (H.map (QuotientGroup.mk' N.toSubgroup)).index := by
-      rw [H.index_map_quotient_eq_index_sup N]
+      rw [H.index_map_quotient_eq_index_sup N.toSubgroup]
       exact Subgroup.index_dvd_of_le (sup_le U.2 fun _ hx ↦ hN hx)
     refine le_trans ?_ (le_iSup (fun N : OpenNormalSubgroup G ↦
       Supernatural.ofNat

--- a/TauCeti/Topology/Algebra/Group/Profinite/Lagrange.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Lagrange.lean
@@ -77,11 +77,10 @@ theorem _root_.Subgroup.profiniteOrder_apply_eq_add_profiniteIndex (H : Subgroup
       · rw [padicValNat_eq_emultiplicity Nat.card_pos.ne',
           padicValNat_eq_emultiplicity Nat.card_pos.ne']
         apply emultiplicity_le_emultiplicity_of_dvd_right
-        rw [← H.index_comap_quotient_eq_card_map N,
-          ← H.index_comap_quotient_eq_card_map K]
-        apply Subgroup.index_dvd_of_le
-        apply Subgroup.comap_mono
-        exact inf_le_left
+        rw [← Subgroup.relIndex_ker H (QuotientGroup.mk' N.toSubgroup),
+          ← Subgroup.relIndex_ker H (QuotientGroup.mk' K.toSubgroup),
+          QuotientGroup.ker_mk', QuotientGroup.ker_mk']
+        exact Subgroup.relIndex_dvd_of_le_left _ inf_le_left
       · rw [padicValNat_eq_emultiplicity Subgroup.index_ne_zero_of_finite,
           padicValNat_eq_emultiplicity Subgroup.index_ne_zero_of_finite]
         apply emultiplicity_le_emultiplicity_of_dvd_right

--- a/TauCeti/Topology/Algebra/Group/Profinite/Lagrange.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Lagrange.lean
@@ -84,8 +84,8 @@ theorem _root_.Subgroup.profiniteOrder_apply_eq_add_profiniteIndex (H : Subgroup
       · rw [padicValNat_eq_emultiplicity Subgroup.index_ne_zero_of_finite,
           padicValNat_eq_emultiplicity Subgroup.index_ne_zero_of_finite]
         apply emultiplicity_le_emultiplicity_of_dvd_right
-        rw [H.index_map_quotient_eq_index_sup M.toSubgroup,
-          H.index_map_quotient_eq_index_sup K.toSubgroup]
+        rw [H.index_map_mk'_eq_index_sup M.toSubgroup,
+          H.index_map_mk'_eq_index_sup K.toSubgroup]
         apply Subgroup.index_dvd_of_le
         exact sup_le_sup_left inf_le_right H
 

--- a/TauCeti/Topology/Algebra/Group/Profinite/Lagrange.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Lagrange.lean
@@ -20,12 +20,9 @@ and directedness of the open normal subgroups lets the two suprema be combined.
 
 ## Main results
 
-* `Subgroup.profiniteOrder_eq_iSup_image`: a closed subgroup's supernatural order is the
-  supremum of the orders of its images in the ambient finite quotients.
-* `Subgroup.profiniteOrder_apply_eq_iSup_image`: the primewise form of this description.
 * `Subgroup.profiniteOrder_apply_eq_add_profiniteIndex`: the primewise profinite Lagrange
   formula.
-* `Subgroup.profiniteOrder_mul_profiniteIndex`: the supernatural-number form of profinite
+* `Subgroup.profiniteOrder_eq_mul_profiniteIndex`: the supernatural-number form of profinite
   Lagrange's theorem.
 
 ## References
@@ -41,26 +38,6 @@ open scoped ENat
 
 variable {G : Type*} [Group G] [TopologicalSpace G]
 
-private theorem index_comap_eq_card_map (H : Subgroup G) (N : OpenNormalSubgroup G) :
-    (N.toSubgroup.comap H.subtype).index =
-      Nat.card (H.map (QuotientGroup.mk' N.toSubgroup)) := by
-  let f : H →* G ⧸ N.toSubgroup :=
-    (QuotientGroup.mk' N.toSubgroup).comp H.subtype
-  have hker : f.ker = N.toSubgroup.comap H.subtype := by
-    ext x
-    simp [f, Subgroup.mem_subgroupOf]
-  have hrange : f.range = H.map (QuotientGroup.mk' N.toSubgroup) := by
-    ext x
-    simp [f]
-  rw [← hker, Subgroup.index_ker, hrange]
-
-private theorem index_map_mk_eq_index_sup (H : Subgroup G) (N : OpenNormalSubgroup G) :
-    (H.map (QuotientGroup.mk' N.toSubgroup)).index =
-      (H ⊔ N.toSubgroup).index := by
-  rw [H.index_map, QuotientGroup.ker_mk',
-    (QuotientGroup.mk' N.toSubgroup).range_eq_top_of_surjective
-      (QuotientGroup.mk'_surjective N.toSubgroup), Subgroup.index_top, mul_one]
-
 private theorem padicValNat_mono_of_dvd (p : Nat.Primes) {m n : ℕ} (hm : m ≠ 0)
     (hn : n ≠ 0) (h : m ∣ n) :
     (padicValNat p m : ℕ∞) ≤ (padicValNat p n : ℕ∞) := by
@@ -73,66 +50,6 @@ private theorem padicValNat_mono_of_dvd (p : Nat.Primes) {m n : ℕ} (hm : m ≠
 section Profinite
 
 variable [IsTopologicalGroup G] [CompactSpace G] [TotallyDisconnectedSpace G]
-
-private theorem exists_openNormalSubgroup_comap_le (H : Subgroup G)
-    (V : OpenNormalSubgroup H) :
-    ∃ N : OpenNormalSubgroup G, N.toSubgroup.comap H.subtype ≤ V.toSubgroup := by
-  obtain ⟨s, hs, hpre⟩ := isOpen_induced_iff.mp V.toOpenSubgroup.isOpen
-  have h_one : (1 : G) ∈ s := by
-    have : (1 : H) ∈ V := V.toSubgroup.one_mem
-    exact hpre.symm.subset this
-  obtain ⟨N, hN⟩ :=
-    ProfiniteGrp.exist_openNormalSubgroup_sub_open_nhds_of_one hs h_one
-  refine ⟨N, fun x hx ↦ ?_⟩
-  have : (x : G) ∈ s := hN hx
-  exact hpre.subset this
-
-/-- The supernatural order of a closed subgroup is the supremum of the orders of its images
-in the ambient finite continuous quotients. -/
-theorem _root_.Subgroup.profiniteOrder_eq_iSup_image (H : Subgroup G)
-    (hH : IsClosed (H : Set G)) :
-    profiniteOrder H = ⨆ N : OpenNormalSubgroup G,
-      Supernatural.ofNat
-        (⟨Nat.card (H.map (QuotientGroup.mk' N.toSubgroup)), Nat.card_pos⟩ : ℕ+) := by
-  let : CompactSpace H := isCompact_iff_compactSpace.mp hH.isCompact
-  rw [profiniteOrder_eq_iSup_ofNat]
-  apply le_antisymm
-  · refine iSup_le fun V ↦ ?_
-    obtain ⟨N, hNV⟩ := exists_openNormalSubgroup_comap_le H V
-    refine le_trans ?_ (le_iSup (fun N : OpenNormalSubgroup G ↦
-      Supernatural.ofNat
-        (⟨Nat.card (H.map (QuotientGroup.mk' N.toSubgroup)), Nat.card_pos⟩ : ℕ+)) N)
-    apply Supernatural.ofNat_le_ofNat_iff.mpr
-    apply PNat.dvd_iff.mpr
-    have hdvd : Nat.card (H ⧸ V.toSubgroup) ∣
-        Nat.card (H.map (QuotientGroup.mk' N.toSubgroup)) := by
-      rw [← V.toSubgroup.index_eq_card, ← index_comap_eq_card_map H N]
-      exact Subgroup.index_dvd_of_le hNV
-    exact hdvd
-  · refine iSup_le fun N ↦ ?_
-    let V := OpenNormalSubgroup.comap N H.subtype continuous_subtype_val
-    refine le_iSup_of_le V ?_
-    apply le_of_eq
-    apply congrArg Supernatural.ofNat
-    apply Subtype.ext
-    have hcard : Nat.card (H ⧸ V.toSubgroup) =
-        Nat.card (H.map (QuotientGroup.mk' N.toSubgroup)) := by
-      rw [← V.toSubgroup.index_eq_card]
-      have hV : V.toSubgroup = N.toSubgroup.comap H.subtype :=
-        OpenNormalSubgroup.toSubgroup_comap N H.subtype continuous_subtype_val
-      rw [hV]
-      exact index_comap_eq_card_map H N
-    exact hcard.symm
-
-/-- Primewise form of `Subgroup.profiniteOrder_eq_iSup_image`. -/
-theorem _root_.Subgroup.profiniteOrder_apply_eq_iSup_image (H : Subgroup G)
-    (hH : IsClosed (H : Set G)) (ℓ : Nat.Primes) :
-    profiniteOrder H ℓ = ⨆ N : OpenNormalSubgroup G,
-      (padicValNat ℓ (Nat.card (H.map (QuotientGroup.mk' N.toSubgroup))) : ℕ∞) := by
-  rw [H.profiniteOrder_eq_iSup_image hH, Supernatural.iSup_apply]
-  congr 1
-  funext N
-  exact Supernatural.ofNat_apply _ _
 
 /-- Primewise Lagrange formula for a closed subgroup of a profinite group: the exponent in
 the ambient order is the exponent in the subgroup order plus the exponent in the index. -/
@@ -167,24 +84,25 @@ theorem _root_.Subgroup.profiniteOrder_apply_eq_add_profiniteIndex (H : Subgroup
       let K : OpenNormalSubgroup G := N ⊓ M
       refine ⟨K, add_le_add ?_ ?_⟩
       · apply padicValNat_mono_of_dvd ℓ Nat.card_pos.ne' Nat.card_pos.ne'
-        rw [← index_comap_eq_card_map H N, ← index_comap_eq_card_map H K]
+        rw [← H.index_comap_quotient_eq_card_map N,
+          ← H.index_comap_quotient_eq_card_map K]
         apply Subgroup.index_dvd_of_le
         apply Subgroup.comap_mono
         exact inf_le_left
       · apply padicValNat_mono_of_dvd ℓ Subgroup.index_ne_zero_of_finite
           Subgroup.index_ne_zero_of_finite
-        rw [index_map_mk_eq_index_sup H M, index_map_mk_eq_index_sup H K]
+        rw [H.index_map_quotient_eq_index_sup M, H.index_map_quotient_eq_index_sup K]
         apply Subgroup.index_dvd_of_le
         exact sup_le_sup_left inf_le_right H
 
-/-- **Lagrange's theorem for profinite groups**: the supernatural order of a closed subgroup,
-times its supernatural index, is the supernatural order of the ambient group. -/
-theorem _root_.Subgroup.profiniteOrder_mul_profiniteIndex (H : Subgroup G)
+/-- **Lagrange's theorem for profinite groups**: the supernatural order of the ambient group
+is the order of a closed subgroup times its supernatural index. -/
+theorem _root_.Subgroup.profiniteOrder_eq_mul_profiniteIndex (H : Subgroup G)
     (hH : IsClosed (H : Set G)) :
-    profiniteOrder H * H.profiniteIndex = profiniteOrder G := by
+    profiniteOrder G = profiniteOrder H * H.profiniteIndex := by
   ext ℓ
   rw [Supernatural.mul_apply]
-  exact (H.profiniteOrder_apply_eq_add_profiniteIndex hH ℓ).symm
+  exact H.profiniteOrder_apply_eq_add_profiniteIndex hH ℓ
 
 end Profinite
 

--- a/TauCeti/Topology/Algebra/Group/Profinite/Lagrange.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Lagrange.lean
@@ -1,0 +1,191 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+import Mathlib.NumberTheory.Padics.PadicVal.Basic
+public import TauCeti.Topology.Algebra.Group.Profinite.Index
+public import TauCeti.Topology.Algebra.Group.Profinite.Order
+
+/-!
+# Lagrange's theorem for profinite groups
+
+For a closed subgroup `H` of a profinite group `G`, the supernatural order of `G` is the
+product of the supernatural order of `H` and its supernatural index in `G`. The proof first
+shows that the finite images of `H` in the quotients of `G` are cofinal among all finite
+continuous quotients of `H`. Finite Lagrange's theorem then applies in every ambient quotient,
+and directedness of the open normal subgroups lets the two suprema be combined.
+
+## Main results
+
+* `Subgroup.profiniteOrder_eq_iSup_image`: a closed subgroup's supernatural order is the
+  supremum of the orders of its images in the ambient finite quotients.
+* `Subgroup.profiniteOrder_apply_eq_iSup_image`: the primewise form of this description.
+* `Subgroup.profiniteOrder_apply_eq_add_profiniteIndex`: the primewise profinite Lagrange
+  formula.
+* `Subgroup.profiniteOrder_mul_profiniteIndex`: the supernatural-number form of profinite
+  Lagrange's theorem.
+
+## References
+
+* L. Ribes and P. Zalesskii, *Profinite Groups*, Section 2.3, Proposition 2.3.2.
+-/
+
+public section
+
+namespace TauCeti
+
+open scoped ENat
+
+variable {G : Type*} [Group G] [TopologicalSpace G]
+
+private theorem index_comap_eq_card_map (H : Subgroup G) (N : OpenNormalSubgroup G) :
+    (N.toSubgroup.comap H.subtype).index =
+      Nat.card (H.map (QuotientGroup.mk' N.toSubgroup)) := by
+  let f : H →* G ⧸ N.toSubgroup :=
+    (QuotientGroup.mk' N.toSubgroup).comp H.subtype
+  have hker : f.ker = N.toSubgroup.comap H.subtype := by
+    ext x
+    simp [f, Subgroup.mem_subgroupOf]
+  have hrange : f.range = H.map (QuotientGroup.mk' N.toSubgroup) := by
+    ext x
+    simp [f]
+  rw [← hker, Subgroup.index_ker, hrange]
+
+private theorem index_map_mk_eq_index_sup (H : Subgroup G) (N : OpenNormalSubgroup G) :
+    (H.map (QuotientGroup.mk' N.toSubgroup)).index =
+      (H ⊔ N.toSubgroup).index := by
+  rw [H.index_map, QuotientGroup.ker_mk',
+    (QuotientGroup.mk' N.toSubgroup).range_eq_top_of_surjective
+      (QuotientGroup.mk'_surjective N.toSubgroup), Subgroup.index_top, mul_one]
+
+private theorem padicValNat_mono_of_dvd (p : Nat.Primes) {m n : ℕ} (hm : m ≠ 0)
+    (hn : n ≠ 0) (h : m ∣ n) :
+    (padicValNat p m : ℕ∞) ≤ (padicValNat p n : ℕ∞) := by
+  have : Fact (p : ℕ).Prime := ⟨p.prop⟩
+  obtain ⟨k, rfl⟩ := h
+  have hk : k ≠ 0 := fun hk ↦ hn (by simp [hk])
+  rw [padicValNat.mul hm hk, Nat.cast_add]
+  exact le_add_right le_rfl
+
+section Profinite
+
+variable [IsTopologicalGroup G] [CompactSpace G] [TotallyDisconnectedSpace G]
+
+private theorem exists_openNormalSubgroup_comap_le (H : Subgroup G)
+    (V : OpenNormalSubgroup H) :
+    ∃ N : OpenNormalSubgroup G, N.toSubgroup.comap H.subtype ≤ V.toSubgroup := by
+  obtain ⟨s, hs, hpre⟩ := isOpen_induced_iff.mp V.toOpenSubgroup.isOpen
+  have h_one : (1 : G) ∈ s := by
+    have : (1 : H) ∈ V := V.toSubgroup.one_mem
+    exact hpre.symm.subset this
+  obtain ⟨N, hN⟩ :=
+    ProfiniteGrp.exist_openNormalSubgroup_sub_open_nhds_of_one hs h_one
+  refine ⟨N, fun x hx ↦ ?_⟩
+  have : (x : G) ∈ s := hN hx
+  exact hpre.subset this
+
+/-- The supernatural order of a closed subgroup is the supremum of the orders of its images
+in the ambient finite continuous quotients. -/
+theorem _root_.Subgroup.profiniteOrder_eq_iSup_image (H : Subgroup G)
+    (hH : IsClosed (H : Set G)) :
+    profiniteOrder H = ⨆ N : OpenNormalSubgroup G,
+      Supernatural.ofNat
+        (⟨Nat.card (H.map (QuotientGroup.mk' N.toSubgroup)), Nat.card_pos⟩ : ℕ+) := by
+  let : CompactSpace H := isCompact_iff_compactSpace.mp hH.isCompact
+  rw [profiniteOrder_eq_iSup_ofNat]
+  apply le_antisymm
+  · refine iSup_le fun V ↦ ?_
+    obtain ⟨N, hNV⟩ := exists_openNormalSubgroup_comap_le H V
+    refine le_trans ?_ (le_iSup (fun N : OpenNormalSubgroup G ↦
+      Supernatural.ofNat
+        (⟨Nat.card (H.map (QuotientGroup.mk' N.toSubgroup)), Nat.card_pos⟩ : ℕ+)) N)
+    apply Supernatural.ofNat_le_ofNat_iff.mpr
+    apply PNat.dvd_iff.mpr
+    have hdvd : Nat.card (H ⧸ V.toSubgroup) ∣
+        Nat.card (H.map (QuotientGroup.mk' N.toSubgroup)) := by
+      rw [← V.toSubgroup.index_eq_card, ← index_comap_eq_card_map H N]
+      exact Subgroup.index_dvd_of_le hNV
+    exact hdvd
+  · refine iSup_le fun N ↦ ?_
+    let V := OpenNormalSubgroup.comap N H.subtype continuous_subtype_val
+    refine le_iSup_of_le V ?_
+    apply le_of_eq
+    apply congrArg Supernatural.ofNat
+    apply Subtype.ext
+    have hcard : Nat.card (H ⧸ V.toSubgroup) =
+        Nat.card (H.map (QuotientGroup.mk' N.toSubgroup)) := by
+      rw [← V.toSubgroup.index_eq_card]
+      have hV : V.toSubgroup = N.toSubgroup.comap H.subtype :=
+        OpenNormalSubgroup.toSubgroup_comap N H.subtype continuous_subtype_val
+      rw [hV]
+      exact index_comap_eq_card_map H N
+    exact hcard.symm
+
+/-- Primewise form of `Subgroup.profiniteOrder_eq_iSup_image`. -/
+theorem _root_.Subgroup.profiniteOrder_apply_eq_iSup_image (H : Subgroup G)
+    (hH : IsClosed (H : Set G)) (ℓ : Nat.Primes) :
+    profiniteOrder H ℓ = ⨆ N : OpenNormalSubgroup G,
+      (padicValNat ℓ (Nat.card (H.map (QuotientGroup.mk' N.toSubgroup))) : ℕ∞) := by
+  rw [H.profiniteOrder_eq_iSup_image hH, Supernatural.iSup_apply]
+  congr 1
+  funext N
+  exact Supernatural.ofNat_apply _ _
+
+/-- Primewise Lagrange formula for a closed subgroup of a profinite group: the exponent in
+the ambient order is the exponent in the subgroup order plus the exponent in the index. -/
+theorem _root_.Subgroup.profiniteOrder_apply_eq_add_profiniteIndex (H : Subgroup G)
+    (hH : IsClosed (H : Set G)) (ℓ : Nat.Primes) :
+    profiniteOrder G ℓ = profiniteOrder H ℓ + H.profiniteIndex ℓ := by
+  have : Fact (ℓ : ℕ).Prime := ⟨ℓ.prop⟩
+  rw [profiniteOrder_apply, H.profiniteOrder_apply_eq_iSup_image hH,
+    Subgroup.profiniteIndex_apply]
+  calc
+    (⨆ N : OpenNormalSubgroup G,
+        (padicValNat ℓ (Nat.card (G ⧸ N.toSubgroup)) : ℕ∞)) =
+        ⨆ N : OpenNormalSubgroup G,
+          (padicValNat ℓ
+              (Nat.card (H.map (QuotientGroup.mk' N.toSubgroup))) : ℕ∞) +
+            (padicValNat ℓ
+              (H.map (QuotientGroup.mk' N.toSubgroup)).index : ℕ∞) := by
+      congr 1
+      funext N
+      have hcard := (H.map (QuotientGroup.mk' N.toSubgroup)).card_mul_index
+      rw [← hcard, padicValNat.mul Nat.card_pos.ne'
+        Subgroup.index_ne_zero_of_finite, Nat.cast_add]
+    _ = (⨆ N : OpenNormalSubgroup G,
+          (padicValNat ℓ
+            (Nat.card (H.map (QuotientGroup.mk' N.toSubgroup))) : ℕ∞)) +
+        ⨆ N : OpenNormalSubgroup G,
+          (padicValNat ℓ
+            (H.map (QuotientGroup.mk' N.toSubgroup)).index : ℕ∞) := by
+      symm
+      apply ENat.iSup_add_iSup
+      intro N M
+      let K : OpenNormalSubgroup G := N ⊓ M
+      refine ⟨K, add_le_add ?_ ?_⟩
+      · apply padicValNat_mono_of_dvd ℓ Nat.card_pos.ne' Nat.card_pos.ne'
+        rw [← index_comap_eq_card_map H N, ← index_comap_eq_card_map H K]
+        apply Subgroup.index_dvd_of_le
+        apply Subgroup.comap_mono
+        exact inf_le_left
+      · apply padicValNat_mono_of_dvd ℓ Subgroup.index_ne_zero_of_finite
+          Subgroup.index_ne_zero_of_finite
+        rw [index_map_mk_eq_index_sup H M, index_map_mk_eq_index_sup H K]
+        apply Subgroup.index_dvd_of_le
+        exact sup_le_sup_left inf_le_right H
+
+/-- **Lagrange's theorem for profinite groups**: the supernatural order of a closed subgroup,
+times its supernatural index, is the supernatural order of the ambient group. -/
+theorem _root_.Subgroup.profiniteOrder_mul_profiniteIndex (H : Subgroup G)
+    (hH : IsClosed (H : Set G)) :
+    profiniteOrder H * H.profiniteIndex = profiniteOrder G := by
+  ext ℓ
+  rw [Supernatural.mul_apply]
+  exact (H.profiniteOrder_apply_eq_add_profiniteIndex hH ℓ).symm
+
+end Profinite
+
+end TauCeti

--- a/TauCeti/Topology/Algebra/Group/Profinite/Lagrange.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Lagrange.lean
@@ -13,10 +13,10 @@ public import TauCeti.Topology.Algebra.Group.Profinite.Order
 # Lagrange's theorem for profinite groups
 
 For a closed subgroup `H` of a profinite group `G`, the supernatural order of `G` is the
-product of the supernatural order of `H` and its supernatural index in `G`. The proof first
-shows that the finite images of `H` in the quotients of `G` are cofinal among all finite
-continuous quotients of `H`. Finite Lagrange's theorem then applies in every ambient quotient,
-and directedness of the open normal subgroups lets the two suprema be combined.
+product of the supernatural order of `H` and its supernatural index in `G`. The order of `H`
+is represented by its finite images in the quotients of `G`, and finite Lagrange formulas in
+these quotients relate their orders to the corresponding finite indices. This yields both the
+primewise additive formula and the multiplicative supernatural-number formula.
 
 ## Main results
 
@@ -84,7 +84,8 @@ theorem _root_.Subgroup.profiniteOrder_apply_eq_add_profiniteIndex (H : Subgroup
       · rw [padicValNat_eq_emultiplicity Subgroup.index_ne_zero_of_finite,
           padicValNat_eq_emultiplicity Subgroup.index_ne_zero_of_finite]
         apply emultiplicity_le_emultiplicity_of_dvd_right
-        rw [H.index_map_quotient_eq_index_sup M, H.index_map_quotient_eq_index_sup K]
+        rw [H.index_map_quotient_eq_index_sup M.toSubgroup,
+          H.index_map_quotient_eq_index_sup K.toSubgroup]
         apply Subgroup.index_dvd_of_le
         exact sup_le_sup_left inf_le_right H
 

--- a/TauCeti/Topology/Algebra/Group/Profinite/Lagrange.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Lagrange.lean
@@ -38,15 +38,6 @@ open scoped ENat
 
 variable {G : Type*} [Group G] [TopologicalSpace G]
 
-private theorem padicValNat_mono_of_dvd (p : Nat.Primes) {m n : ℕ} (hm : m ≠ 0)
-    (hn : n ≠ 0) (h : m ∣ n) :
-    (padicValNat p m : ℕ∞) ≤ (padicValNat p n : ℕ∞) := by
-  have : Fact (p : ℕ).Prime := ⟨p.prop⟩
-  obtain ⟨k, rfl⟩ := h
-  have hk : k ≠ 0 := fun hk ↦ hn (by simp [hk])
-  rw [padicValNat.mul hm hk, Nat.cast_add]
-  exact le_add_right le_rfl
-
 section Profinite
 
 variable [IsTopologicalGroup G] [CompactSpace G] [TotallyDisconnectedSpace G]
@@ -83,14 +74,17 @@ theorem _root_.Subgroup.profiniteOrder_apply_eq_add_profiniteIndex (H : Subgroup
       intro N M
       let K : OpenNormalSubgroup G := N ⊓ M
       refine ⟨K, add_le_add ?_ ?_⟩
-      · apply padicValNat_mono_of_dvd ℓ Nat.card_pos.ne' Nat.card_pos.ne'
+      · rw [padicValNat_eq_emultiplicity Nat.card_pos.ne',
+          padicValNat_eq_emultiplicity Nat.card_pos.ne']
+        apply emultiplicity_le_emultiplicity_of_dvd_right
         rw [← H.index_comap_quotient_eq_card_map N,
           ← H.index_comap_quotient_eq_card_map K]
         apply Subgroup.index_dvd_of_le
         apply Subgroup.comap_mono
         exact inf_le_left
-      · apply padicValNat_mono_of_dvd ℓ Subgroup.index_ne_zero_of_finite
-          Subgroup.index_ne_zero_of_finite
+      · rw [padicValNat_eq_emultiplicity Subgroup.index_ne_zero_of_finite,
+          padicValNat_eq_emultiplicity Subgroup.index_ne_zero_of_finite]
+        apply emultiplicity_le_emultiplicity_of_dvd_right
         rw [H.index_map_quotient_eq_index_sup M, H.index_map_quotient_eq_index_sup K]
         apply Subgroup.index_dvd_of_le
         exact sup_le_sup_left inf_le_right H

--- a/TauCeti/Topology/Algebra/Group/Profinite/Order.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Order.lean
@@ -174,7 +174,9 @@ theorem _root_.Subgroup.profiniteOrder_eq_iSup_image (H : Subgroup G)
     apply PNat.dvd_iff.mpr
     have hdvd : Nat.card (H ⧸ V.toSubgroup) ∣
         Nat.card (H.map (QuotientGroup.mk' N.toSubgroup)) := by
-      rw [← V.toSubgroup.index_eq_card, ← H.index_comap_quotient_eq_card_map N]
+      rw [← V.toSubgroup.index_eq_card,
+        ← Subgroup.relIndex_ker H (QuotientGroup.mk' N.toSubgroup), QuotientGroup.ker_mk',
+        Subgroup.relIndex, ← Subgroup.comap_subtype]
       exact Subgroup.index_dvd_of_le hNV
     exact hdvd
   · refine iSup_le fun N ↦ ?_
@@ -185,11 +187,11 @@ theorem _root_.Subgroup.profiniteOrder_eq_iSup_image (H : Subgroup G)
     apply Subtype.ext
     have hcard : Nat.card (H ⧸ V.toSubgroup) =
         Nat.card (H.map (QuotientGroup.mk' N.toSubgroup)) := by
-      rw [← V.toSubgroup.index_eq_card]
       have hV : V.toSubgroup = N.toSubgroup.comap H.subtype :=
         OpenNormalSubgroup.toSubgroup_comap N H.subtype continuous_subtype_val
-      rw [hV]
-      exact H.index_comap_quotient_eq_card_map N
+      rw [← V.toSubgroup.index_eq_card, hV,
+        ← Subgroup.relIndex_ker H (QuotientGroup.mk' N.toSubgroup), QuotientGroup.ker_mk',
+        Subgroup.relIndex, ← Subgroup.comap_subtype]
     exact hcard.symm
 
 /-- Primewise form of `Subgroup.profiniteOrder_eq_iSup_image`. -/

--- a/TauCeti/Topology/Algebra/Group/Profinite/Order.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Order.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 import TauCeti.Topology.Algebra.Group.Profinite.Basic
-import TauCeti.Topology.Algebra.Group.Profinite.Index
 public import Mathlib.GroupTheory.Index
 public import TauCeti.NumberTheory.Supernatural
 public import TauCeti.Topology.Algebra.Group.OpenNormalSubgroup

--- a/TauCeti/Topology/Algebra/Group/Profinite/Order.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Order.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 import TauCeti.Topology.Algebra.Group.Profinite.Basic
+import TauCeti.Topology.Algebra.Group.Profinite.Index
 public import Mathlib.GroupTheory.Index
 public import TauCeti.NumberTheory.Supernatural
 public import TauCeti.Topology.Algebra.Group.OpenNormalSubgroup
@@ -149,45 +150,10 @@ theorem ofNat_card_quotient_le_profiniteOrder (U : OpenNormalSubgroup G) :
 
 end Profinite
 
-section Quotient
-
-variable {G : Type u} [Group G] [TopologicalSpace G]
-
-/-- The index in a subgroup of the pullback of an open normal subgroup equals the cardinality
-of the subgroup's image in the corresponding quotient. -/
-theorem _root_.Subgroup.index_comap_quotient_eq_card_map (H : Subgroup G)
-    (N : OpenNormalSubgroup G) :
-    (N.toSubgroup.comap H.subtype).index =
-      Nat.card (H.map (QuotientGroup.mk' N.toSubgroup)) := by
-  let f : H →* G ⧸ N.toSubgroup :=
-    (QuotientGroup.mk' N.toSubgroup).comp H.subtype
-  have hker : f.ker = N.toSubgroup.comap H.subtype := by
-    ext x
-    simp [f, Subgroup.mem_subgroupOf]
-  have hrange : f.range = H.map (QuotientGroup.mk' N.toSubgroup) := by
-    ext x
-    simp [f]
-  rw [← hker, Subgroup.index_ker, hrange]
-
-end Quotient
-
 section ClosedSubgroup
 
 variable {G : Type u} [Group G] [TopologicalSpace G] [IsTopologicalGroup G]
   [CompactSpace G] [TotallyDisconnectedSpace G]
-
-private theorem exists_openNormalSubgroup_comap_le (H : Subgroup G)
-    (V : OpenNormalSubgroup H) :
-    ∃ N : OpenNormalSubgroup G, N.toSubgroup.comap H.subtype ≤ V.toSubgroup := by
-  obtain ⟨s, hs, hpre⟩ := isOpen_induced_iff.mp V.toOpenSubgroup.isOpen
-  have h_one : (1 : G) ∈ s := by
-    have : (1 : H) ∈ V := V.toSubgroup.one_mem
-    exact hpre.symm.subset this
-  obtain ⟨N, hN⟩ :=
-    ProfiniteGrp.exist_openNormalSubgroup_sub_open_nhds_of_one hs h_one
-  refine ⟨N, fun x hx ↦ ?_⟩
-  have : (x : G) ∈ s := hN hx
-  exact hpre.subset this
 
 /-- The supernatural order of a closed subgroup is the supremum of the orders of its images
 in the ambient finite continuous quotients. -/
@@ -200,7 +166,7 @@ theorem _root_.Subgroup.profiniteOrder_eq_iSup_image (H : Subgroup G)
   rw [profiniteOrder_eq_iSup_ofNat]
   apply le_antisymm
   · refine iSup_le fun V ↦ ?_
-    obtain ⟨N, hNV⟩ := exists_openNormalSubgroup_comap_le H V
+    obtain ⟨N, hNV⟩ := H.exists_openNormalSubgroup_comap_le V
     refine le_trans ?_ (le_iSup (fun N : OpenNormalSubgroup G ↦
       Supernatural.ofNat
         (⟨Nat.card (H.map (QuotientGroup.mk' N.toSubgroup)), Nat.card_pos⟩ : ℕ+)) N)

--- a/TauCeti/Topology/Algebra/Group/Profinite/Order.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Order.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+import TauCeti.Topology.Algebra.Group.Profinite.Basic
 public import Mathlib.GroupTheory.Index
 public import TauCeti.NumberTheory.Supernatural
 public import TauCeti.Topology.Algebra.Group.OpenNormalSubgroup
@@ -28,6 +29,9 @@ order exactly.
   normal subgroups.
 * `profiniteOrder_eq_iSup_ofNat`: its description as the supremum of the embedded quotient
   orders.
+* `Subgroup.profiniteOrder_eq_iSup_image`: a closed subgroup's order as the supremum of its
+  images in the ambient finite quotients.
+* `Subgroup.profiniteOrder_apply_eq_iSup_image`: the primewise form of this description.
 * `profiniteOrder_le_of_surjective`: continuous surjections do not increase supernatural
   order.
 * `profiniteOrder_congr`: topological group isomorphisms preserve supernatural order.
@@ -144,6 +148,95 @@ theorem ofNat_card_quotient_le_profiniteOrder (U : OpenNormalSubgroup G) :
       Supernatural.ofNat (⟨Nat.card (G ⧸ V.toSubgroup), Nat.card_pos⟩ : ℕ+)) U
 
 end Profinite
+
+section Quotient
+
+variable {G : Type u} [Group G] [TopologicalSpace G]
+
+/-- The index in a subgroup of the pullback of an open normal subgroup equals the cardinality
+of the subgroup's image in the corresponding quotient. -/
+theorem _root_.Subgroup.index_comap_quotient_eq_card_map (H : Subgroup G)
+    (N : OpenNormalSubgroup G) :
+    (N.toSubgroup.comap H.subtype).index =
+      Nat.card (H.map (QuotientGroup.mk' N.toSubgroup)) := by
+  let f : H →* G ⧸ N.toSubgroup :=
+    (QuotientGroup.mk' N.toSubgroup).comp H.subtype
+  have hker : f.ker = N.toSubgroup.comap H.subtype := by
+    ext x
+    simp [f, Subgroup.mem_subgroupOf]
+  have hrange : f.range = H.map (QuotientGroup.mk' N.toSubgroup) := by
+    ext x
+    simp [f]
+  rw [← hker, Subgroup.index_ker, hrange]
+
+end Quotient
+
+section ClosedSubgroup
+
+variable {G : Type u} [Group G] [TopologicalSpace G] [IsTopologicalGroup G]
+  [CompactSpace G] [TotallyDisconnectedSpace G]
+
+private theorem exists_openNormalSubgroup_comap_le (H : Subgroup G)
+    (V : OpenNormalSubgroup H) :
+    ∃ N : OpenNormalSubgroup G, N.toSubgroup.comap H.subtype ≤ V.toSubgroup := by
+  obtain ⟨s, hs, hpre⟩ := isOpen_induced_iff.mp V.toOpenSubgroup.isOpen
+  have h_one : (1 : G) ∈ s := by
+    have : (1 : H) ∈ V := V.toSubgroup.one_mem
+    exact hpre.symm.subset this
+  obtain ⟨N, hN⟩ :=
+    ProfiniteGrp.exist_openNormalSubgroup_sub_open_nhds_of_one hs h_one
+  refine ⟨N, fun x hx ↦ ?_⟩
+  have : (x : G) ∈ s := hN hx
+  exact hpre.subset this
+
+/-- The supernatural order of a closed subgroup is the supremum of the orders of its images
+in the ambient finite continuous quotients. -/
+theorem _root_.Subgroup.profiniteOrder_eq_iSup_image (H : Subgroup G)
+    (hH : IsClosed (H : Set G)) :
+    profiniteOrder H = ⨆ N : OpenNormalSubgroup G,
+      Supernatural.ofNat
+        (⟨Nat.card (H.map (QuotientGroup.mk' N.toSubgroup)), Nat.card_pos⟩ : ℕ+) := by
+  let : CompactSpace H := isCompact_iff_compactSpace.mp hH.isCompact
+  rw [profiniteOrder_eq_iSup_ofNat]
+  apply le_antisymm
+  · refine iSup_le fun V ↦ ?_
+    obtain ⟨N, hNV⟩ := exists_openNormalSubgroup_comap_le H V
+    refine le_trans ?_ (le_iSup (fun N : OpenNormalSubgroup G ↦
+      Supernatural.ofNat
+        (⟨Nat.card (H.map (QuotientGroup.mk' N.toSubgroup)), Nat.card_pos⟩ : ℕ+)) N)
+    apply Supernatural.ofNat_le_ofNat_iff.mpr
+    apply PNat.dvd_iff.mpr
+    have hdvd : Nat.card (H ⧸ V.toSubgroup) ∣
+        Nat.card (H.map (QuotientGroup.mk' N.toSubgroup)) := by
+      rw [← V.toSubgroup.index_eq_card, ← H.index_comap_quotient_eq_card_map N]
+      exact Subgroup.index_dvd_of_le hNV
+    exact hdvd
+  · refine iSup_le fun N ↦ ?_
+    let V := OpenNormalSubgroup.comap N H.subtype continuous_subtype_val
+    refine le_iSup_of_le V ?_
+    apply le_of_eq
+    apply congrArg Supernatural.ofNat
+    apply Subtype.ext
+    have hcard : Nat.card (H ⧸ V.toSubgroup) =
+        Nat.card (H.map (QuotientGroup.mk' N.toSubgroup)) := by
+      rw [← V.toSubgroup.index_eq_card]
+      have hV : V.toSubgroup = N.toSubgroup.comap H.subtype :=
+        OpenNormalSubgroup.toSubgroup_comap N H.subtype continuous_subtype_val
+      rw [hV]
+      exact H.index_comap_quotient_eq_card_map N
+    exact hcard.symm
+
+/-- Primewise form of `Subgroup.profiniteOrder_eq_iSup_image`. -/
+theorem _root_.Subgroup.profiniteOrder_apply_eq_iSup_image (H : Subgroup G)
+    (hH : IsClosed (H : Set G)) (ℓ : Nat.Primes) :
+    profiniteOrder H ℓ = ⨆ N : OpenNormalSubgroup G,
+      (padicValNat ℓ (Nat.card (H.map (QuotientGroup.mk' N.toSubgroup))) : ℕ∞) := by
+  rw [H.profiniteOrder_eq_iSup_image hH, Supernatural.iSup_apply]
+  congr 1
+  funext N
+  exact Supernatural.ofNat_apply _ _
+
+end ClosedSubgroup
 
 section Finite
 


### PR DESCRIPTION
This PR proves the Layer 1 Index API's supernatural Lagrange theorem from `TauCetiRoadmap/ProfiniteProPGroups/README.md`: for every closed subgroup `H` of a profinite group `G`, the primewise order of `G` is the sum of the order of `H` and its index, hence `profiniteOrder H * profiniteIndex H = profiniteOrder G`.

The originally designated Multiquadratic roadmap has its current critical path either merged or represented by the in-flight genus-field Frobenius PR, so this falls back to the next unclaimed prerequisite on the ProfiniteProPGroups critical path. The designated milestone is Layer 1, “Index API”; after this PR, that milestone still needs the topological-isomorphism, tower, and surjective-image laws for profinite index, while its open-subgroup agreement is already available.

The proof identifies the order of `H` with the supremum of its images in the ambient finite quotients, using compactness to show those quotients are cofinal. It then applies finite Lagrange in each quotient and uses directedness of open normal subgroups to combine the two suprema. The implementation reuses Mathlib's `Subgroup.card_mul_index`, `Subgroup.index_ker`, `Subgroup.index_dvd_of_le`, `ENat.iSup_add_iSup`, `ProfiniteGrp.exist_openNormalSubgroup_sub_open_nhds_of_one`, and `padicValNat.mul`; the module documentation cites Ribes–Zalesskii, *Profinite Groups*, §2.3, Proposition 2.3.2.

The new `Topology/Algebra/Group/Profinite/Lagrange.lean` module contains 191 lines and exports both the roadmap's primewise formula and its supernatural-number form.

Roadmap: ProfiniteProPGroups

<!--tauceti-target:v1 {"focus":"ProfiniteProPGroups","id":"profinite-lagrange"}-->

🤖 Prepared with Codex
