### PR TITLE
feat: take the Wiener-Ikehara Fourier identity to the boundary line

### DIFF
--- a/TauCeti/Analysis/Fourier/Integrable.lean
+++ b/TauCeti/Analysis/Fourier/Integrable.lean
@@ -11,7 +11,8 @@ public import Mathlib.Analysis.Distribution.SchwartzSpace.Fourier
 # Integrability of Fourier transforms of smooth compactly supported functions
 
 A smooth compactly supported function is a Schwartz function, so its Fourier transform is also a
-Schwartz function and hence integrable.
+Schwartz function and hence integrable. This supplies the Fourier-integrability hypotheses needed
+in dominated-convergence arguments, such as the Wiener--Ikehara boundary identity.
 
 ## Main declarations
 

--- a/TauCeti/Analysis/Fourier/Integrable.lean
+++ b/TauCeti/Analysis/Fourier/Integrable.lean
@@ -17,7 +17,7 @@ in dominated-convergence arguments, such as the Wiener--Ikehara boundary identit
 ## Main declarations
 
 * `TauCeti.integrable_fourier_of_contDiff`: the Fourier transform of a smooth compactly supported
-  function from `ℝ` to `ℂ` is integrable.
+  function on a finite-dimensional real inner product space is integrable.
 -/
 
 public section
@@ -27,7 +27,8 @@ open scoped ContDiff FourierTransform
 
 namespace TauCeti
 
-variable {f : ℝ → ℂ}
+variable {V E : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V] [FiniteDimensional ℝ V]
+  [MeasurableSpace V] [BorelSpace V] [NormedAddCommGroup E] [NormedSpace ℂ E] {f : V → E}
 
 /-- The Fourier transform of a smooth compactly supported function is integrable. -/
 theorem integrable_fourier_of_contDiff (hf : ContDiff ℝ ∞ f) (hsupp : HasCompactSupport f) :
@@ -35,7 +36,7 @@ theorem integrable_fourier_of_contDiff (hf : ContDiff ℝ ∞ f) (hsupp : HasCom
   have hcoe : ⇑(hsupp.toSchwartzMap hf) = f := by
     ext x
     simp
-  have h : Integrable ((𝓕 (hsupp.toSchwartzMap hf) : SchwartzMap ℝ ℂ) : ℝ → ℂ) :=
+  have h : Integrable ((𝓕 (hsupp.toSchwartzMap hf) : SchwartzMap V E) : V → E) :=
     SchwartzMap.integrable _
   rwa [SchwartzMap.fourier_coe, hcoe] at h
 

--- a/TauCeti/Analysis/Fourier/Integrable.lean
+++ b/TauCeti/Analysis/Fourier/Integrable.lean
@@ -1,0 +1,41 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.Distribution.SchwartzSpace.Fourier
+
+/-!
+# Integrability of Fourier transforms of smooth compactly supported functions
+
+A smooth compactly supported function is a Schwartz function, so its Fourier transform is also a
+Schwartz function and hence integrable.
+
+## Main declarations
+
+* `TauCeti.integrable_fourier_of_contDiff`: the Fourier transform of a smooth compactly supported
+  function from `ℝ` to `ℂ` is integrable.
+-/
+
+public section
+
+open MeasureTheory
+open scoped ContDiff FourierTransform
+
+namespace TauCeti
+
+variable {f : ℝ → ℂ}
+
+/-- The Fourier transform of a smooth compactly supported function is integrable. -/
+theorem integrable_fourier_of_contDiff (hf : ContDiff ℝ ∞ f) (hsupp : HasCompactSupport f) :
+    Integrable (𝓕 f) := by
+  have hcoe : ⇑(hsupp.toSchwartzMap hf) = f := by
+    ext x
+    simp
+  have h : Integrable ((𝓕 (hsupp.toSchwartzMap hf) : SchwartzMap ℝ ℂ) : ℝ → ℂ) :=
+    SchwartzMap.integrable _
+  rwa [SchwartzMap.fourier_coe, hcoe] at h
+
+end TauCeti

--- a/TauCeti/Analysis/Fourier/Integrable.lean
+++ b/TauCeti/Analysis/Fourier/Integrable.lean
@@ -16,8 +16,9 @@ in dominated-convergence arguments, such as the Wiener--Ikehara boundary identit
 
 ## Main declarations
 
-* `TauCeti.integrable_fourier_of_contDiff`: the Fourier transform of a smooth compactly supported
-  function on a finite-dimensional real inner product space is integrable.
+* `TauCeti.integrable_fourier_of_contDiff_of_hasCompactSupport`: the Fourier transform of a
+  smooth compactly supported function on a finite-dimensional real inner product space is
+  integrable.
 -/
 
 public section
@@ -31,8 +32,8 @@ variable {V E : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V] [FiniteD
   [MeasurableSpace V] [BorelSpace V] [NormedAddCommGroup E] [NormedSpace ℂ E] {f : V → E}
 
 /-- The Fourier transform of a smooth compactly supported function is integrable. -/
-theorem integrable_fourier_of_contDiff (hf : ContDiff ℝ ∞ f) (hsupp : HasCompactSupport f) :
-    Integrable (𝓕 f) := by
+theorem integrable_fourier_of_contDiff_of_hasCompactSupport (hf : ContDiff ℝ ∞ f)
+    (hsupp : HasCompactSupport f) : Integrable (𝓕 f) := by
   have hcoe : ⇑(hsupp.toSchwartzMap hf) = f := by
     ext x
     simp

--- a/TauCeti/MeasureTheory/Integral/ExpDamped.lean
+++ b/TauCeti/MeasureTheory/Integral/ExpDamped.lean
@@ -12,9 +12,9 @@ public import Mathlib.MeasureTheory.Integral.DominatedConvergence
 # Vanishing exponential damping of a half-line integral
 
 Damping an integrand on the half-line `u ≥ -log x` by `exp (-u (sigma - 1))` and normalizing by
-`x ^ (1 - sigma)`, the value of the damping at the left endpoint, leaves the integral of an
-integrable function unchanged in the limit `sigma → 1⁺`: the damping factor is bounded on the
-half-line uniformly in `sigma ∈ (1, 2]`, so dominated convergence applies.
+`x ^ (1 - sigma)`, the reciprocal of the damping at the left endpoint, leaves the integral of
+an integrable function unchanged in the limit `sigma → 1⁺`: the damping factor is bounded on
+the half-line uniformly in `sigma ∈ (1, 2]`, so dominated convergence applies.
 
 This is the Abelian step of a Tauberian argument, where a Dirichlet series is tested on a vertical
 line `Re s = sigma` inside its half-plane of convergence and the line is pushed to the boundary;

--- a/TauCeti/MeasureTheory/Integral/ExpDamped.lean
+++ b/TauCeti/MeasureTheory/Integral/ExpDamped.lean
@@ -1,0 +1,82 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.SpecialFunctions.Pow.Real
+public import Mathlib.MeasureTheory.Integral.DominatedConvergence
+
+/-!
+# Vanishing exponential damping of a half-line integral
+
+Damping an integrand on the half-line `u ≥ -log x` by `exp (-u (sigma - 1))` and normalizing by
+`x ^ (1 - sigma)`, the value of the damping at the left endpoint, leaves the integral of an
+integrable function unchanged in the limit `sigma → 1⁺`: the damping factor is bounded on the
+half-line uniformly in `sigma ∈ (1, 2]`, so dominated convergence applies.
+
+This is the Abelian step of a Tauberian argument, where a Dirichlet series is tested on a vertical
+line `Re s = sigma` inside its half-plane of convergence and the line is pushed to the boundary;
+`TauCeti.LSeries.tsum_term_mul_fourier_sub_pole_eq_integral_boundary` uses it for the simple-pole
+term of the Wiener--Ikehara identity.
+
+## Main results
+
+* `TauCeti.tendsto_integral_exp_mul`: the normalized damped integral converges to the undamped
+  one as `sigma` decreases to `1`.
+-/
+
+public section
+
+namespace TauCeti
+
+open Filter MeasureTheory Set
+open scoped Topology
+
+variable {f : ℝ → ℂ} {x : ℝ}
+
+/-- On the half-line `u ≥ -log x` the damping factor `exp (-u (sigma - 1))` stays below a bound
+depending only on `x`, uniformly for `sigma ∈ (1, 2]`. -/
+private lemma exp_neg_mul_sub_one_le {u sigma : ℝ} (hu : -Real.log x ≤ u) (h1 : 1 < sigma)
+    (h2 : sigma ≤ 2) : Real.exp (-u * (sigma - 1)) ≤ Real.exp (max 0 (Real.log x)) := by
+  refine Real.exp_le_exp.mpr ?_
+  have hu' : -u ≤ Real.log x := by linarith
+  rcases le_or_gt (-u) 0 with h | h
+  · have hle : -u * (sigma - 1) ≤ 0 := by nlinarith
+    exact hle.trans (le_max_left _ _)
+  · have hle : -u * (sigma - 1) ≤ -u := by nlinarith
+    exact hle.trans (hu'.trans (le_max_right _ _))
+
+/-- As `sigma` decreases to `1`, the normalized one-sided Laplace transform of a function
+integrable on the half-line `u ≥ -log x` converges to its undamped integral. -/
+theorem tendsto_integral_exp_mul (hx : 0 < x) (hf : IntegrableOn f (Ici (-Real.log x))) :
+    Tendsto (fun sigma : ℝ ↦ ((x ^ (1 - sigma) : ℝ) : ℂ) *
+        ∫ u in Ici (-Real.log x), (Real.exp (-u * (sigma - 1)) : ℂ) * f u)
+      (𝓝[>] 1) (𝓝 (∫ u in Ici (-Real.log x), f u)) := by
+  have hrpow : Tendsto (fun sigma : ℝ ↦ ((x ^ (1 - sigma) : ℝ) : ℂ)) (𝓝[>] 1) (𝓝 1) := by
+    have hcont : Continuous fun sigma : ℝ ↦ ((x ^ (1 - sigma) : ℝ) : ℂ) := by
+      simp only [Real.rpow_def_of_pos hx]
+      fun_prop
+    simpa using (hcont.tendsto 1).mono_left nhdsWithin_le_nhds
+  have hint : Tendsto (fun sigma : ℝ ↦ ∫ u in Ici (-Real.log x),
+      (Real.exp (-u * (sigma - 1)) : ℂ) * f u) (𝓝[>] 1)
+      (𝓝 (∫ u in Ici (-Real.log x), f u)) := by
+    refine tendsto_integral_filter_of_dominated_convergence
+      (fun u ↦ Real.exp (max 0 (Real.log x)) * ‖f u‖)
+      (.of_forall fun sigma ↦ (Continuous.aestronglyMeasurable (by fun_prop)).mul hf.1) ?_
+      (hf.norm.const_mul _) (.of_forall fun u ↦ ?_)
+    · filter_upwards [Ioc_mem_nhdsGT (by norm_num : (1 : ℝ) < 2)] with sigma hsigma
+      filter_upwards [ae_restrict_mem measurableSet_Ici] with u hu
+      rw [norm_mul, Complex.norm_real, Real.norm_eq_abs, abs_of_pos (Real.exp_pos _)]
+      exact mul_le_mul_of_nonneg_right (exp_neg_mul_sub_one_le hu hsigma.1 hsigma.2)
+        (norm_nonneg _)
+    · have hone : Tendsto (fun sigma : ℝ ↦ ((Real.exp (-u * (sigma - 1)) : ℝ) : ℂ)) (𝓝[>] 1)
+          (𝓝 1) := by
+        have hcont : Continuous fun sigma : ℝ ↦ ((Real.exp (-u * (sigma - 1)) : ℝ) : ℂ) := by
+          fun_prop
+        simpa using (hcont.tendsto 1).mono_left nhdsWithin_le_nhds
+      simpa using hone.mul_const (f u)
+  simpa using hrpow.mul hint
+
+end TauCeti

--- a/TauCeti/NumberTheory/LSeries/Continuity.lean
+++ b/TauCeti/NumberTheory/LSeries/Continuity.lean
@@ -23,29 +23,56 @@ boundary line of that half-plane, which is exactly the situation in the Wiener--
 
 ## Main results
 
+* `TauCeti.LSeries.continuousOn_LSeries`: `LSeries a` is continuous on the closed half-plane
+  `{z | s.re ≤ z.re}` whenever `LSeriesSummable a s`.
 * `TauCeti.LSeries.continuous_LSeries_vertical`: `fun t : ℝ ↦ LSeries a (s + t * I)` is continuous
   whenever `LSeriesSummable a s`.
+* `TauCeti.LSeries.tendsto_LSeries_nhdsGT`: the real one-sided limit of `LSeries a` at a real
+  point of summability is the value there.
 -/
 
 public section
 
 namespace TauCeti.LSeries
 
-open Complex
+open Complex Filter Topology
+
+variable {a : ℕ → ℂ} {s : ℂ}
+
+/-- Each term of a Dirichlet series is an entire function of the evaluation variable. -/
+private lemma continuous_term (a : ℕ → ℂ) (n : ℕ) :
+    Continuous fun z : ℂ ↦ _root_.LSeries.term a z n := by
+  by_cases hn : n = 0
+  · simpa [_root_.LSeries.term, hn] using continuous_const
+  · simp only [_root_.LSeries.term, hn, ite_false]
+    exact continuous_const.div₀ (continuous_const.cpow continuous_id (by simp [hn]))
+      (fun z ↦ by simp [hn])
+
+/-- A Dirichlet series summable at `s` converges uniformly on the closed half-plane
+`{z | s.re ≤ z.re}`, hence is continuous there.
+
+Mathlib's `LSeries_differentiableOn` gives more on the *open* half-plane cut out by the abscissa
+of absolute convergence, but says nothing on its boundary line, which is where the
+Wiener--Ikehara argument works. -/
+theorem continuousOn_LSeries (hs : LSeriesSummable a s) :
+    ContinuousOn (LSeries a) {z : ℂ | s.re ≤ z.re} :=
+  continuousOn_tsum (fun n ↦ (continuous_term a n).continuousOn) (summable_norm_iff.mpr hs)
+    (fun n _ hz ↦ _root_.LSeries.norm_term_le_of_re_le_re a hz n)
 
 /-- A Dirichlet series summable at `s` is continuous along the vertical line through `s`. -/
-theorem continuous_LSeries_vertical {a : ℕ → ℂ} {s : ℂ} (hs : LSeriesSummable a s) :
+theorem continuous_LSeries_vertical (hs : LSeriesSummable a s) :
     Continuous fun t : ℝ ↦ LSeries a (s + t * I) := by
-  have hterm n : Continuous fun t : ℝ ↦ _root_.LSeries.term a (s + t * I) n := by
-    by_cases hn : n = 0
-    · simpa [_root_.LSeries.term, hn] using continuous_const
-    · simp only [_root_.LSeries.term, hn, ite_false]
-      exact continuous_const.div₀ (continuous_const.cpow (by fun_prop) (by simp [hn]))
-        (fun t ↦ by simp [hn])
-  have hnorm n (t : ℝ) :
-      ‖_root_.LSeries.term a (s + t * I) n‖ = ‖_root_.LSeries.term a s n‖ := by
-    simp only [_root_.LSeries.norm_term_eq]
-    simp
-  exact continuous_tsum hterm (summable_norm_iff.mpr hs) (fun n t ↦ le_of_eq (hnorm n t))
+  refine (continuousOn_LSeries hs).comp_continuous (by fun_prop) fun t ↦ ?_
+  simp
+
+/-- Approaching a real point of summability from the right along the real axis, the values of a
+Dirichlet series converge to its value there. -/
+theorem tendsto_LSeries_nhdsGT {σ : ℝ} (hs : LSeriesSummable a σ) :
+    Tendsto (fun τ : ℝ ↦ LSeries a τ) (𝓝[>] σ) (𝓝 (LSeries a σ)) := by
+  refine Filter.Tendsto.comp (continuousOn_LSeries hs (σ : ℂ) (by simp)) ?_
+  refine tendsto_nhdsWithin_of_tendsto_nhds_of_eventually_within _
+    ((Complex.continuous_ofReal.tendsto σ).mono_left nhdsWithin_le_nhds) ?_
+  filter_upwards [self_mem_nhdsWithin] with τ hτ
+  simpa using hτ.le
 
 end TauCeti.LSeries

--- a/TauCeti/NumberTheory/LSeries/Continuity.lean
+++ b/TauCeti/NumberTheory/LSeries/Continuity.lean
@@ -7,7 +7,7 @@ module
 
 public import Mathlib.Analysis.Normed.Group.FunctionSeries
 public import Mathlib.Analysis.SpecialFunctions.Pow.Continuity
-public import Mathlib.NumberTheory.LSeries.Convergence
+public import Mathlib.NumberTheory.LSeries.Deriv
 
 /-!
 # Continuity of an L-series along a vertical line
@@ -39,15 +39,6 @@ open Complex Filter Topology
 
 variable {a : ℕ → ℂ} {s : ℂ}
 
-/-- Each term of a Dirichlet series is an entire function of the evaluation variable. -/
-private lemma continuous_term (a : ℕ → ℂ) (n : ℕ) :
-    Continuous fun z : ℂ ↦ _root_.LSeries.term a z n := by
-  by_cases hn : n = 0
-  · simpa [_root_.LSeries.term, hn] using continuous_const
-  · simp only [_root_.LSeries.term, hn, ite_false]
-    exact continuous_const.div₀ (continuous_const.cpow continuous_id (by simp [hn]))
-      (fun z ↦ by simp [hn])
-
 /-- A Dirichlet series summable at `s` converges uniformly on the closed half-plane
 `{z | s.re ≤ z.re}`, hence is continuous there.
 
@@ -56,8 +47,9 @@ of absolute convergence, but says nothing on its boundary line, which is where t
 Wiener--Ikehara argument works. -/
 theorem continuousOn_LSeries (hs : LSeriesSummable a s) :
     ContinuousOn (LSeries a) {z : ℂ | s.re ≤ z.re} :=
-  continuousOn_tsum (fun n ↦ (continuous_term a n).continuousOn) (summable_norm_iff.mpr hs)
-    (fun n _ hz ↦ _root_.LSeries.norm_term_le_of_re_le_re a hz n)
+  continuousOn_tsum
+    (fun n z _ ↦ (_root_.LSeries.hasDerivAt_term a n z).continuousAt.continuousWithinAt)
+    (summable_norm_iff.mpr hs) (fun n _ hz ↦ _root_.LSeries.norm_term_le_of_re_le_re a hz n)
 
 /-- A Dirichlet series summable at `s` is continuous along the vertical line through `s`. -/
 theorem continuous_LSeries_vertical (hs : LSeriesSummable a s) :

--- a/TauCeti/NumberTheory/LSeries/Continuity.lean
+++ b/TauCeti/NumberTheory/LSeries/Continuity.lean
@@ -10,11 +10,13 @@ public import Mathlib.Analysis.SpecialFunctions.Pow.Continuity
 public import Mathlib.NumberTheory.LSeries.Deriv
 
 /-!
-# Continuity of an L-series along a vertical line
+# Continuity of an L-series on a closed half-plane of summability
 
-If a Dirichlet series is summable at `s`, then at every point of the vertical line `s + ℝ * I`
-its terms have exactly the same norms, so the series converges uniformly along that line and
-`LSeries a` is continuous there.
+If a Dirichlet series is summable at `s`, then at every point `z` with `s.re ≤ z.re` its terms
+have norms at most those of the terms at `s`, so the series converges uniformly on the closed
+half-plane `{z | s.re ≤ z.re}` and `LSeries a` is continuous there. On the vertical line
+`s + ℝ * I` through `s` the norms even agree exactly, and continuity along that line is a special
+case of the half-plane statement.
 
 Mathlib's `LSeries_differentiableOn` gives more, but only *strictly* inside the half-plane of
 absolute convergence: it needs `abscissaOfAbsConv a < s.re`, whereas `LSeriesSummable a s` only

--- a/TauCeti/NumberTheory/LSeries/Continuity.lean
+++ b/TauCeti/NumberTheory/LSeries/Continuity.lean
@@ -5,8 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Analysis.Normed.Group.FunctionSeries
-public import Mathlib.Analysis.SpecialFunctions.Pow.Continuity
 public import Mathlib.NumberTheory.LSeries.Deriv
 
 /-!

--- a/TauCeti/NumberTheory/LSeries/WienerIkehara/Limit.lean
+++ b/TauCeti/NumberTheory/LSeries/WienerIkehara/Limit.lean
@@ -1,0 +1,254 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.Distribution.SchwartzSpace.Fourier
+public import TauCeti.NumberTheory.LSeries.WienerIkehara.Fourier
+
+/-!
+# The limiting Fourier identity for Wiener--Ikehara
+
+`TauCeti.LSeries.tsum_term_mul_fourier_sub_pole_eq_integral` tests a Dirichlet series against an
+integrable function on a vertical line `Re s = sigma` strictly inside the half-plane of
+convergence. This file lets `sigma` decrease to `1` and records the resulting identity on the
+boundary line itself.
+
+Each of the three terms of that identity is handled by its own dominated-convergence argument, and
+each is stated separately so that a later step can reuse it: the Dirichlet series converges by the
+uniform convergence of a summable Dirichlet series on a closed half-plane, the pole term converges
+because the exponential damping `exp (-u (sigma - 1))` is bounded on the half-line of integration,
+and the vertical integral converges because a test function with compact support confines the
+integrand to a compact box on which `G` is continuous.
+
+Only the pole-subtracted remainder `G` is assumed continuous on the closed half-plane
+`Re s ≥ 1`; nothing is assumed about `LSeries a` there, where it is a total function with junk
+values.
+
+## Main results
+
+* `TauCeti.LSeries.tendsto_tsum_term_mul_fourier`,
+  `TauCeti.LSeries.tendsto_integral_exp_mul_fourier` and
+  `TauCeti.LSeries.tendsto_integral_vertical` are the three one-sided limits.
+* `TauCeti.LSeries.tsum_term_mul_fourier_sub_pole_eq_integral_boundary` is the identity they
+  combine into, and
+  `TauCeti.LSeries.tsum_term_mul_fourier_sub_pole_eq_integral_boundary_of_contDiff` is its form
+  for a smooth test function, where the half-line integrability hypothesis is automatic by
+  `TauCeti.LSeries.integrableOn_fourier_div_of_contDiff`.
+
+## Provenance
+
+The decomposition into three separate one-sided limits, and the shape of the identity they
+combine into, follow `limiting_fourier_lim1`, `limiting_fourier_lim2`, `limiting_fourier_lim3`
+and `limiting_fourier` in `PrimeNumberTheoremAnd/Wiener.lean` of the Apache-2.0
+`AxiomMath/PrimeNumberTheoremAnd` repository, revision
+`2667e414c38e5a5dc9aa1946f16f13001e5cd3ed`, the same source as the sibling file
+`TauCeti.NumberTheory.LSeries.WienerIkehara.Fourier`. The proofs here are written against
+Mathlib's dominated-convergence lemmas, and the hypotheses differ: the Chebyshev-type growth
+bound of the source is replaced by the summability of the Fourier-weighted series at `s = 1`,
+which is what the limit actually consumes.
+
+## References
+
+* J. Korevaar, *Tauberian Theory: A Century of Developments*, Chapter III.
+-/
+
+public section
+
+namespace TauCeti.LSeries
+
+open Complex Filter FourierTransform MeasureTheory Real Set
+open scoped ContDiff Topology
+
+variable {a : ℕ → ℂ} {psi : ℝ → ℂ} {G : ℂ → ℂ} {A : ℂ} {x : ℝ}
+
+/-! ### The Dirichlet series -/
+
+/-- As `sigma` decreases to `1`, the Fourier-weighted Dirichlet series converges to its value on
+the boundary line, provided the weighted series is summable there. -/
+theorem tendsto_tsum_term_mul_fourier (hFsum : LSeriesSummable
+    (fun n : ℕ ↦ a n * 𝓕 psi (1 / (2 * π) * Real.log (n / x))) 1) :
+    Tendsto (fun sigma : ℝ ↦ ∑' n : ℕ,
+        _root_.LSeries.term a sigma n * 𝓕 psi (1 / (2 * π) * Real.log (n / x))) (𝓝[>] 1)
+      (𝓝 (∑' n : ℕ, _root_.LSeries.term a 1 n * 𝓕 psi (1 / (2 * π) * Real.log (n / x)))) := by
+  have hterm (s : ℂ) (n : ℕ) :
+      _root_.LSeries.term a s n * 𝓕 psi (1 / (2 * π) * Real.log (n / x)) =
+        _root_.LSeries.term
+          (fun n : ℕ ↦ a n * 𝓕 psi (1 / (2 * π) * Real.log (n / x))) s n := by
+    by_cases hn : n = 0
+    · simp [_root_.LSeries.term, hn]
+    · simp only [_root_.LSeries.term, hn, ite_false]
+      ring
+  have h := tendsto_LSeries_nhdsGT
+    (a := fun n : ℕ ↦ a n * 𝓕 psi (1 / (2 * π) * Real.log (n / x))) (σ := 1)
+    (by simpa using hFsum)
+  rw [Complex.ofReal_one] at h
+  simp only [hterm]
+  exact h
+
+/-! ### The simple-pole term -/
+
+/-- On the half-line `u ≥ -log x` the damping factor `exp (-u (sigma - 1))` stays below a bound
+depending only on `x`, uniformly for `sigma ∈ (1, 2]`. -/
+private lemma exp_neg_mul_sub_one_le {u sigma : ℝ} (hu : -Real.log x ≤ u) (h1 : 1 < sigma)
+    (h2 : sigma ≤ 2) : Real.exp (-u * (sigma - 1)) ≤ Real.exp (max 0 (Real.log x)) := by
+  refine Real.exp_le_exp.mpr ?_
+  have hu' : -u ≤ Real.log x := by linarith
+  rcases le_or_gt (-u) 0 with h | h
+  · have hle : -u * (sigma - 1) ≤ 0 := by nlinarith
+    exact hle.trans (le_max_left _ _)
+  · have hle : -u * (sigma - 1) ≤ -u := by nlinarith
+    exact hle.trans (hu'.trans (le_max_right _ _))
+
+/-- As `sigma` decreases to `1`, the normalized one-sided Laplace transform of the Fourier
+transform of `psi` converges to its undamped value, an integral that is assumed to converge. -/
+theorem tendsto_integral_exp_mul_fourier (hx : 0 < x)
+    (hFint : IntegrableOn (fun u : ℝ ↦ 𝓕 psi (u / (2 * π))) (Ici (-Real.log x))) :
+    Tendsto (fun sigma : ℝ ↦ ((x ^ (1 - sigma) : ℝ) : ℂ) *
+        ∫ u in Ici (-Real.log x), (Real.exp (-u * (sigma - 1)) : ℂ) * 𝓕 psi (u / (2 * π)))
+      (𝓝[>] 1) (𝓝 (∫ u in Ici (-Real.log x), 𝓕 psi (u / (2 * π)))) := by
+  have hrpow : Tendsto (fun sigma : ℝ ↦ ((x ^ (1 - sigma) : ℝ) : ℂ)) (𝓝[>] 1) (𝓝 1) := by
+    have hcont : Continuous fun sigma : ℝ ↦ ((x ^ (1 - sigma) : ℝ) : ℂ) := by
+      simp only [Real.rpow_def_of_pos hx]
+      fun_prop
+    simpa using (hcont.tendsto 1).mono_left nhdsWithin_le_nhds
+  have hint : Tendsto (fun sigma : ℝ ↦ ∫ u in Ici (-Real.log x),
+      (Real.exp (-u * (sigma - 1)) : ℂ) * 𝓕 psi (u / (2 * π))) (𝓝[>] 1)
+      (𝓝 (∫ u in Ici (-Real.log x), 𝓕 psi (u / (2 * π)))) := by
+    refine tendsto_integral_filter_of_dominated_convergence
+      (fun u ↦ Real.exp (max 0 (Real.log x)) * ‖𝓕 psi (u / (2 * π))‖)
+      (.of_forall fun sigma ↦ (Continuous.aestronglyMeasurable (by fun_prop)).mul hFint.1) ?_
+      (hFint.norm.const_mul _) (.of_forall fun u ↦ ?_)
+    · filter_upwards [Ioc_mem_nhdsGT (by norm_num : (1 : ℝ) < 2)] with sigma hsigma
+      filter_upwards [ae_restrict_mem measurableSet_Ici] with u hu
+      rw [norm_mul, Complex.norm_real, Real.norm_eq_abs, abs_of_pos (Real.exp_pos _)]
+      exact mul_le_mul_of_nonneg_right (exp_neg_mul_sub_one_le hu hsigma.1 hsigma.2)
+        (norm_nonneg _)
+    · have hone : Tendsto (fun sigma : ℝ ↦ ((Real.exp (-u * (sigma - 1)) : ℝ) : ℂ)) (𝓝[>] 1)
+          (𝓝 1) := by
+        have hcont : Continuous fun sigma : ℝ ↦ ((Real.exp (-u * (sigma - 1)) : ℝ) : ℂ) := by
+          fun_prop
+        simpa using (hcont.tendsto 1).mono_left nhdsWithin_le_nhds
+      simpa using hone.mul_const (𝓕 psi (u / (2 * π)))
+  simpa using hrpow.mul hint
+
+/-- The Fourier transform of a smooth, compactly supported function is a Schwartz function, hence
+integrable; rescaling and restricting gives the half-line hypothesis of
+`tsum_term_mul_fourier_sub_pole_eq_integral_boundary`. -/
+theorem integrableOn_fourier_div_of_contDiff (hpsi : ContDiff ℝ ∞ psi)
+    (hsupp : HasCompactSupport psi) (c : ℝ) :
+    IntegrableOn (fun u : ℝ ↦ 𝓕 psi (u / (2 * π))) (Ici c) := by
+  have hcoe : ⇑(hsupp.toSchwartzMap hpsi) = psi := by
+    ext u
+    simp
+  have hS : Integrable (𝓕 psi) := by
+    have h : Integrable ((𝓕 (hsupp.toSchwartzMap hpsi) : SchwartzMap ℝ ℂ) : ℝ → ℂ) :=
+      SchwartzMap.integrable _
+    rwa [SchwartzMap.fourier_coe, hcoe] at h
+  exact (hS.comp_div (by positivity)).integrableOn
+
+/-! ### The integral along the vertical line -/
+
+/-- As `sigma` decreases to `1`, the integral of `G` along the vertical line `Re s = sigma`
+against a compactly supported test function converges to the same integral along the boundary
+line, because the integrand is confined to a compact box on which `G` is continuous. -/
+theorem tendsto_integral_vertical (hx : 0 < x) (hG : ContinuousOn G {z : ℂ | 1 ≤ z.re})
+    (hpsi : Continuous psi) (hsupp : HasCompactSupport psi) :
+    Tendsto (fun sigma : ℝ ↦ ∫ t : ℝ, G (sigma + t * I) * psi t * (x : ℂ) ^ (t * I))
+      (𝓝[>] 1) (𝓝 (∫ t : ℝ, G (1 + t * I) * psi t * (x : ℂ) ^ (t * I))) := by
+  have hmem {sigma : ℝ} (hsigma : 1 ≤ sigma) (t : ℝ) :
+      (sigma : ℂ) + t * I ∈ {z : ℂ | 1 ≤ z.re} := by simpa using hsigma
+  have hcompact : IsCompact ((fun p : ℝ × ℝ ↦ (p.1 : ℂ) + p.2 * I) '' (Icc 1 2 ×ˢ tsupport psi)) :=
+    (isCompact_Icc.prod hsupp).image (by fun_prop)
+  obtain ⟨C, hC⟩ := hcompact.exists_bound_of_continuousOn <| hG.mono <| by
+    rintro _ ⟨⟨s, t⟩, ⟨hs, -⟩, rfl⟩
+    exact hmem hs.1 t
+  have hxnorm (t : ℝ) : ‖(x : ℂ) ^ (t * I)‖ = 1 := by
+    rw [Complex.norm_cpow_eq_rpow_re_of_pos hx]
+    simp
+  have hxpow : Continuous fun t : ℝ ↦ (x : ℂ) ^ (t * I) :=
+    continuous_const.cpow (continuous_ofReal.mul continuous_const) (by simp [hx])
+  refine tendsto_integral_filter_of_dominated_convergence (fun t ↦ C * ‖psi t‖) ?_ ?_
+    ((hpsi.integrable_of_hasCompactSupport hsupp).norm.const_mul C) (.of_forall fun t ↦ ?_)
+  · filter_upwards [self_mem_nhdsWithin] with sigma hsigma
+    exact (((hG.comp_continuous (by fun_prop) (hmem (le_of_lt hsigma))).mul hpsi).mul
+      hxpow).aestronglyMeasurable
+  · filter_upwards [Ioc_mem_nhdsGT (by norm_num : (1 : ℝ) < 2)] with sigma hsigma
+    filter_upwards with t
+    by_cases ht : psi t = 0
+    · simp [ht]
+    · have hmemK : (sigma : ℂ) + t * I ∈
+          (fun p : ℝ × ℝ ↦ (p.1 : ℂ) + p.2 * I) '' (Icc 1 2 ×ˢ tsupport psi) :=
+        ⟨(sigma, t), ⟨⟨hsigma.1.le, hsigma.2⟩, subset_tsupport _ ht⟩, rfl⟩
+      calc ‖G (sigma + t * I) * psi t * (x : ℂ) ^ (t * I)‖
+          = ‖G (sigma + t * I)‖ * ‖psi t‖ := by
+            rw [norm_mul, norm_mul, hxnorm t, mul_one]
+        _ ≤ C * ‖psi t‖ := mul_le_mul_of_nonneg_right (hC _ hmemK) (norm_nonneg _)
+  · have hmem1 : (1 : ℂ) + t * I ∈ {z : ℂ | 1 ≤ z.re} := by simp
+    refine Filter.Tendsto.mul_const _ (Filter.Tendsto.mul_const _ ?_)
+    refine Filter.Tendsto.comp (hG.continuousWithinAt hmem1) ?_
+    refine tendsto_nhdsWithin_of_tendsto_nhds_of_eventually_within _
+      (((by fun_prop : Continuous fun sigma : ℝ ↦ (sigma : ℂ) + t * I).tendsto' 1 _
+        (by simp)).mono_left nhdsWithin_le_nhds) ?_
+    filter_upwards [self_mem_nhdsWithin] with sigma hsigma
+    exact hmem (le_of_lt hsigma) t
+
+/-! ### The identity on the boundary line -/
+
+/-- The Fourier identity of `tsum_term_mul_fourier_sub_pole_eq_integral` on the boundary line
+`Re s = 1`. The Dirichlet series is tested against a continuous, compactly supported `psi`, and
+the pole term has lost its exponential damping.
+
+The hypotheses are exactly the three convergence facts that the passage to the limit needs: the
+Fourier-weighted series is summable at `s = 1`, the Fourier transform of `psi` is integrable on
+the half-line, and the pole-subtracted remainder `G` extends continuously to `Re s ≥ 1`. -/
+theorem tsum_term_mul_fourier_sub_pole_eq_integral_boundary (hx : 0 < x)
+    (hG : ContinuousOn G {z : ℂ | 1 ≤ z.re})
+    (hG' : ∀ z : ℂ, 1 < z.re → G z = LSeries a z - A / (z - 1))
+    (hsum : ∀ sigma : ℝ, 1 < sigma → LSeriesSummable a sigma)
+    (hpsi : Continuous psi) (hsupp : HasCompactSupport psi)
+    (hFint : IntegrableOn (fun u : ℝ ↦ 𝓕 psi (u / (2 * π))) (Ici (-Real.log x)))
+    (hFsum : LSeriesSummable
+      (fun n : ℕ ↦ a n * 𝓕 psi (1 / (2 * π) * Real.log (n / x))) 1) :
+    (∑' n : ℕ, _root_.LSeries.term a 1 n * 𝓕 psi (1 / (2 * π) * Real.log (n / x))) -
+        A * ∫ u in Ici (-Real.log x), 𝓕 psi (u / (2 * π)) =
+      ∫ t : ℝ, G (1 + t * I) * psi t * (x : ℂ) ^ (t * I) := by
+  have key (sigma : ℝ) (hsigma : 1 < sigma) :
+      (∑' n : ℕ, _root_.LSeries.term a sigma n * 𝓕 psi (1 / (2 * π) * Real.log (n / x))) -
+          A * (((x ^ (1 - sigma) : ℝ) : ℂ) * ∫ u in Ici (-Real.log x),
+            (Real.exp (-u * (sigma - 1)) : ℂ) * 𝓕 psi (u / (2 * π))) =
+        ∫ t : ℝ, G (sigma + t * I) * psi t * (x : ℂ) ^ (t * I) := by
+    rw [← mul_assoc]
+    exact tsum_term_mul_fourier_sub_pole_eq_integral
+      (fun t ↦ hG' _ (by simpa using hsigma)) (hpsi.integrable_of_hasCompactSupport hsupp) hx
+      hsigma (hsum sigma hsigma)
+  refine tendsto_nhds_unique (l := 𝓝[>] (1 : ℝ)) (f := fun sigma : ℝ ↦
+    (∑' n : ℕ, _root_.LSeries.term a sigma n * 𝓕 psi (1 / (2 * π) * Real.log (n / x))) -
+      A * (((x ^ (1 - sigma) : ℝ) : ℂ) * ∫ u in Ici (-Real.log x),
+        (Real.exp (-u * (sigma - 1)) : ℂ) * 𝓕 psi (u / (2 * π)))) ?_ ?_
+  · exact (tendsto_tsum_term_mul_fourier hFsum).sub
+      ((tendsto_integral_exp_mul_fourier hx hFint).const_mul A)
+  · refine (tendsto_integral_vertical hx hG hpsi hsupp).congr' ?_
+    filter_upwards [self_mem_nhdsWithin] with sigma hsigma
+    exact (key sigma hsigma).symm
+
+/-- The boundary Fourier identity for a smooth, compactly supported test function: the test
+function's own regularity supplies the integrability of its Fourier transform, so only the
+summability of the weighted Dirichlet series at `s = 1` and the boundary behaviour of `G` are
+left as hypotheses. -/
+theorem tsum_term_mul_fourier_sub_pole_eq_integral_boundary_of_contDiff (hx : 0 < x)
+    (hG : ContinuousOn G {z : ℂ | 1 ≤ z.re})
+    (hG' : ∀ z : ℂ, 1 < z.re → G z = LSeries a z - A / (z - 1))
+    (hsum : ∀ sigma : ℝ, 1 < sigma → LSeriesSummable a sigma)
+    (hpsi : ContDiff ℝ ∞ psi) (hsupp : HasCompactSupport psi)
+    (hFsum : LSeriesSummable
+      (fun n : ℕ ↦ a n * 𝓕 psi (1 / (2 * π) * Real.log (n / x))) 1) :
+    (∑' n : ℕ, _root_.LSeries.term a 1 n * 𝓕 psi (1 / (2 * π) * Real.log (n / x))) -
+        A * ∫ u in Ici (-Real.log x), 𝓕 psi (u / (2 * π)) =
+      ∫ t : ℝ, G (1 + t * I) * psi t * (x : ℂ) ^ (t * I) :=
+  tsum_term_mul_fourier_sub_pole_eq_integral_boundary hx hG hG' hsum hpsi.continuous hsupp
+    (integrableOn_fourier_div_of_contDiff hpsi hsupp _) hFsum
+
+end TauCeti.LSeries

--- a/TauCeti/NumberTheory/LSeries/WienerIkehara/Limit.lean
+++ b/TauCeti/NumberTheory/LSeries/WienerIkehara/Limit.lean
@@ -5,7 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Analysis.Distribution.SchwartzSpace.Fourier
+public import TauCeti.Analysis.Fourier.Integrable
 public import TauCeti.NumberTheory.LSeries.WienerIkehara.Fourier
 
 /-!
@@ -36,7 +36,7 @@ values.
   combine into, and
   `TauCeti.LSeries.tsum_term_mul_fourier_sub_pole_eq_integral_boundary_of_contDiff` is its form
   for a smooth test function, where the half-line integrability hypothesis is automatic by
-  `TauCeti.LSeries.integrable_fourier_div_of_contDiff`.
+  `TauCeti.integrable_fourier_of_contDiff`.
 
 ## Provenance
 
@@ -134,28 +134,13 @@ theorem tendsto_integral_exp_mul_fourier (hx : 0 < x)
       simpa using hone.mul_const (𝓕 psi (u / (2 * π)))
   simpa using hrpow.mul hint
 
-/-- The Fourier transform of a smooth, compactly supported function is a Schwartz function, hence
-integrable; rescaling keeps it integrable, and restricting to a half-line gives the hypothesis of
-`tsum_term_mul_fourier_sub_pole_eq_integral_boundary`. -/
-theorem integrable_fourier_div_of_contDiff (hpsi : ContDiff ℝ ∞ psi)
-    (hsupp : HasCompactSupport psi) :
-    Integrable (fun u : ℝ ↦ 𝓕 psi (u / (2 * π))) := by
-  have hcoe : ⇑(hsupp.toSchwartzMap hpsi) = psi := by
-    ext u
-    simp
-  have hS : Integrable (𝓕 psi) := by
-    have h : Integrable ((𝓕 (hsupp.toSchwartzMap hpsi) : SchwartzMap ℝ ℂ) : ℝ → ℂ) :=
-      SchwartzMap.integrable _
-    rwa [SchwartzMap.fourier_coe, hcoe] at h
-  exact hS.comp_div (by positivity)
-
 /-! ### The integral along the vertical line -/
 
 /-- As `sigma` decreases to `1`, the integral of `G` along the vertical line `Re s = sigma`
 against a compactly supported test function converges to the same integral along the boundary
 line, because the integrand is confined to a compact box on which `G` is continuous. -/
 theorem tendsto_integral_vertical (hx : 0 < x) (hG : ContinuousOn G {z : ℂ | 1 ≤ z.re})
-    (hpsi : Continuous psi) (hsupp : HasCompactSupport psi) :
+    (hpsi : Integrable psi) (hsupp : HasCompactSupport psi) :
     Tendsto (fun sigma : ℝ ↦ ∫ t : ℝ, G (sigma + t * I) * psi t * (x : ℂ) ^ (t * I))
       (𝓝[>] 1) (𝓝 (∫ t : ℝ, G (1 + t * I) * psi t * (x : ℂ) ^ (t * I))) := by
   have hmem {sigma : ℝ} (hsigma : 1 ≤ sigma) (t : ℝ) :
@@ -171,10 +156,10 @@ theorem tendsto_integral_vertical (hx : 0 < x) (hG : ContinuousOn G {z : ℂ | 1
   have hxpow : Continuous fun t : ℝ ↦ (x : ℂ) ^ (t * I) :=
     continuous_const.cpow (continuous_ofReal.mul continuous_const) (by simp [hx])
   refine tendsto_integral_filter_of_dominated_convergence (fun t ↦ C * ‖psi t‖) ?_ ?_
-    ((hpsi.integrable_of_hasCompactSupport hsupp).norm.const_mul C) (.of_forall fun t ↦ ?_)
+    (hpsi.norm.const_mul C) (.of_forall fun t ↦ ?_)
   · filter_upwards [self_mem_nhdsWithin] with sigma hsigma
-    exact (((hG.comp_continuous (by fun_prop) (hmem (le_of_lt hsigma))).mul hpsi).mul
-      hxpow).aestronglyMeasurable
+    exact ((hG.comp_continuous (by fun_prop) (hmem (le_of_lt hsigma))).aestronglyMeasurable.mul
+      hpsi.aestronglyMeasurable).mul hxpow.aestronglyMeasurable
   · filter_upwards [Ioc_mem_nhdsGT (by norm_num : (1 : ℝ) < 2)] with sigma hsigma
     filter_upwards with t
     by_cases ht : psi t = 0
@@ -198,7 +183,7 @@ theorem tendsto_integral_vertical (hx : 0 < x) (hG : ContinuousOn G {z : ℂ | 1
 /-! ### The identity on the boundary line -/
 
 /-- The Fourier identity of `tsum_term_mul_fourier_sub_pole_eq_integral` on the boundary line
-`Re s = 1`. The Dirichlet series is tested against a continuous, compactly supported `psi`, and
+`Re s = 1`. The Dirichlet series is tested against an integrable, compactly supported `psi`, and
 the pole term has lost its exponential damping.
 
 The hypotheses are exactly the three convergence facts that the passage to the limit needs: the
@@ -208,7 +193,7 @@ theorem tsum_term_mul_fourier_sub_pole_eq_integral_boundary (hx : 0 < x)
     (hG : ContinuousOn G {z : ℂ | 1 ≤ z.re})
     (hG' : ∀ z : ℂ, 1 < z.re → G z = LSeries a z - A / (z - 1))
     (hsum : ∀ sigma : ℝ, 1 < sigma → LSeriesSummable a sigma)
-    (hpsi : Continuous psi) (hsupp : HasCompactSupport psi)
+    (hpsi : Integrable psi) (hsupp : HasCompactSupport psi)
     (hFint : IntegrableOn (fun u : ℝ ↦ 𝓕 psi (u / (2 * π))) (Ici (-Real.log x)))
     (hFsum : LSeriesSummable
       (fun n : ℕ ↦ a n * 𝓕 psi (1 / (2 * π) * Real.log (n / x))) 1) :
@@ -222,8 +207,7 @@ theorem tsum_term_mul_fourier_sub_pole_eq_integral_boundary (hx : 0 < x)
         ∫ t : ℝ, G (sigma + t * I) * psi t * (x : ℂ) ^ (t * I) := by
     rw [← mul_assoc]
     exact tsum_term_mul_fourier_sub_pole_eq_integral
-      (fun t ↦ hG' _ (by simpa using hsigma)) (hpsi.integrable_of_hasCompactSupport hsupp) hx
-      hsigma (hsum sigma hsigma)
+      (fun t ↦ hG' _ (by simpa using hsigma)) hpsi hx hsigma (hsum sigma hsigma)
   refine tendsto_nhds_unique (l := 𝓝[>] (1 : ℝ)) (f := fun sigma : ℝ ↦
     (∑' n : ℕ, _root_.LSeries.term a sigma n * 𝓕 psi (1 / (2 * π) * Real.log (n / x))) -
       A * (((x ^ (1 - sigma) : ℝ) : ℂ) * ∫ u in Ici (-Real.log x),
@@ -234,10 +218,10 @@ theorem tsum_term_mul_fourier_sub_pole_eq_integral_boundary (hx : 0 < x)
     filter_upwards [self_mem_nhdsWithin] with sigma hsigma
     exact (key sigma hsigma).symm
 
-/-- The boundary Fourier identity for a smooth, compactly supported test function: the test
-function's own regularity supplies the integrability of its Fourier transform, so only the
-summability of the weighted Dirichlet series at `s = 1` and the boundary behaviour of `G` are
-left as hypotheses. -/
+/-- The boundary Fourier identity for a smooth, compactly supported test function. Its regularity
+supplies both its own integrability and the integrability of its Fourier transform, removing only
+the explicit Fourier-integrability hypothesis from
+`tsum_term_mul_fourier_sub_pole_eq_integral_boundary`. -/
 theorem tsum_term_mul_fourier_sub_pole_eq_integral_boundary_of_contDiff (hx : 0 < x)
     (hG : ContinuousOn G {z : ℂ | 1 ≤ z.re})
     (hG' : ∀ z : ℂ, 1 < z.re → G z = LSeries a z - A / (z - 1))
@@ -248,7 +232,8 @@ theorem tsum_term_mul_fourier_sub_pole_eq_integral_boundary_of_contDiff (hx : 0 
     (∑' n : ℕ, _root_.LSeries.term a 1 n * 𝓕 psi (1 / (2 * π) * Real.log (n / x))) -
         A * ∫ u in Ici (-Real.log x), 𝓕 psi (u / (2 * π)) =
       ∫ t : ℝ, G (1 + t * I) * psi t * (x : ℂ) ^ (t * I) :=
-  tsum_term_mul_fourier_sub_pole_eq_integral_boundary hx hG hG' hsum hpsi.continuous hsupp
-    (integrable_fourier_div_of_contDiff hpsi hsupp).integrableOn hFsum
+  tsum_term_mul_fourier_sub_pole_eq_integral_boundary hx hG hG' hsum
+    (hpsi.continuous.integrable_of_hasCompactSupport hsupp) hsupp
+    ((integrable_fourier_of_contDiff hpsi hsupp).comp_div (by positivity)).integrableOn hFsum
 
 end TauCeti.LSeries

--- a/TauCeti/NumberTheory/LSeries/WienerIkehara/Limit.lean
+++ b/TauCeti/NumberTheory/LSeries/WienerIkehara/Limit.lean
@@ -30,7 +30,7 @@ values.
 ## Main results
 
 * `TauCeti.LSeries.tendsto_tsum_term_mul_fourier`,
-  `TauCeti.LSeries.tendsto_integral_exp_mul_fourier` and
+  `TauCeti.LSeries.tendsto_integral_exp_mul` and
   `TauCeti.LSeries.tendsto_integral_vertical` are the three one-sided limits.
 * `TauCeti.LSeries.tsum_term_mul_fourier_sub_pole_eq_integral_boundary` is the identity they
   combine into, and
@@ -62,7 +62,7 @@ namespace TauCeti.LSeries
 open Complex Filter FourierTransform MeasureTheory Real Set
 open scoped ContDiff Topology
 
-variable {a : ℕ → ℂ} {psi : ℝ → ℂ} {G : ℂ → ℂ} {A : ℂ} {x : ℝ}
+variable {a : ℕ → ℂ} {f psi : ℝ → ℂ} {G : ℂ → ℂ} {A : ℂ} {x : ℝ}
 
 /-! ### The Dirichlet series -/
 
@@ -102,25 +102,24 @@ private lemma exp_neg_mul_sub_one_le {u sigma : ℝ} (hu : -Real.log x ≤ u) (h
   · have hle : -u * (sigma - 1) ≤ -u := by nlinarith
     exact hle.trans (hu'.trans (le_max_right _ _))
 
-/-- As `sigma` decreases to `1`, the normalized one-sided Laplace transform of the Fourier
-transform of `psi` converges to its undamped value, an integral that is assumed to converge. -/
-theorem tendsto_integral_exp_mul_fourier (hx : 0 < x)
-    (hFint : IntegrableOn (fun u : ℝ ↦ 𝓕 psi (u / (2 * π))) (Ici (-Real.log x))) :
+/-- As `sigma` decreases to `1`, the normalized one-sided Laplace transform of a function
+integrable on the half-line `u ≥ -log x` converges to its undamped integral. -/
+theorem tendsto_integral_exp_mul (hx : 0 < x) (hf : IntegrableOn f (Ici (-Real.log x))) :
     Tendsto (fun sigma : ℝ ↦ ((x ^ (1 - sigma) : ℝ) : ℂ) *
-        ∫ u in Ici (-Real.log x), (Real.exp (-u * (sigma - 1)) : ℂ) * 𝓕 psi (u / (2 * π)))
-      (𝓝[>] 1) (𝓝 (∫ u in Ici (-Real.log x), 𝓕 psi (u / (2 * π)))) := by
+        ∫ u in Ici (-Real.log x), (Real.exp (-u * (sigma - 1)) : ℂ) * f u)
+      (𝓝[>] 1) (𝓝 (∫ u in Ici (-Real.log x), f u)) := by
   have hrpow : Tendsto (fun sigma : ℝ ↦ ((x ^ (1 - sigma) : ℝ) : ℂ)) (𝓝[>] 1) (𝓝 1) := by
     have hcont : Continuous fun sigma : ℝ ↦ ((x ^ (1 - sigma) : ℝ) : ℂ) := by
       simp only [Real.rpow_def_of_pos hx]
       fun_prop
     simpa using (hcont.tendsto 1).mono_left nhdsWithin_le_nhds
   have hint : Tendsto (fun sigma : ℝ ↦ ∫ u in Ici (-Real.log x),
-      (Real.exp (-u * (sigma - 1)) : ℂ) * 𝓕 psi (u / (2 * π))) (𝓝[>] 1)
-      (𝓝 (∫ u in Ici (-Real.log x), 𝓕 psi (u / (2 * π)))) := by
+      (Real.exp (-u * (sigma - 1)) : ℂ) * f u) (𝓝[>] 1)
+      (𝓝 (∫ u in Ici (-Real.log x), f u)) := by
     refine tendsto_integral_filter_of_dominated_convergence
-      (fun u ↦ Real.exp (max 0 (Real.log x)) * ‖𝓕 psi (u / (2 * π))‖)
-      (.of_forall fun sigma ↦ (Continuous.aestronglyMeasurable (by fun_prop)).mul hFint.1) ?_
-      (hFint.norm.const_mul _) (.of_forall fun u ↦ ?_)
+      (fun u ↦ Real.exp (max 0 (Real.log x)) * ‖f u‖)
+      (.of_forall fun sigma ↦ (Continuous.aestronglyMeasurable (by fun_prop)).mul hf.1) ?_
+      (hf.norm.const_mul _) (.of_forall fun u ↦ ?_)
     · filter_upwards [Ioc_mem_nhdsGT (by norm_num : (1 : ℝ) < 2)] with sigma hsigma
       filter_upwards [ae_restrict_mem measurableSet_Ici] with u hu
       rw [norm_mul, Complex.norm_real, Real.norm_eq_abs, abs_of_pos (Real.exp_pos _)]
@@ -131,7 +130,7 @@ theorem tendsto_integral_exp_mul_fourier (hx : 0 < x)
         have hcont : Continuous fun sigma : ℝ ↦ ((Real.exp (-u * (sigma - 1)) : ℝ) : ℂ) := by
           fun_prop
         simpa using (hcont.tendsto 1).mono_left nhdsWithin_le_nhds
-      simpa using hone.mul_const (𝓕 psi (u / (2 * π)))
+      simpa using hone.mul_const (f u)
   simpa using hrpow.mul hint
 
 /-! ### The integral along the vertical line -/
@@ -215,7 +214,7 @@ theorem tsum_term_mul_fourier_sub_pole_eq_integral_boundary (hx : 0 < x)
       A * (((x ^ (1 - sigma) : ℝ) : ℂ) * ∫ u in Ici (-Real.log x),
         (Real.exp (-u * (sigma - 1)) : ℂ) * 𝓕 psi (u / (2 * π)))) ?_ ?_
   · exact (tendsto_tsum_term_mul_fourier hFsum).sub
-      ((tendsto_integral_exp_mul_fourier hx hFint).const_mul A)
+      ((tendsto_integral_exp_mul hx hFint).const_mul A)
   · refine (tendsto_integral_vertical hx hG hpsi hsupp).congr' ?_
     filter_upwards [self_mem_nhdsWithin] with sigma hsigma
     exact (key sigma hsigma).symm

--- a/TauCeti/NumberTheory/LSeries/WienerIkehara/Limit.lean
+++ b/TauCeti/NumberTheory/LSeries/WienerIkehara/Limit.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Analysis.Fourier.Integrable
+public import TauCeti.MeasureTheory.Integral.ExpDamped
 public import TauCeti.NumberTheory.LSeries.WienerIkehara.Fourier
 
 /-!
@@ -29,14 +30,14 @@ values.
 
 ## Main results
 
-* `TauCeti.LSeries.tendsto_tsum_term_mul_fourier`,
-  `TauCeti.LSeries.tendsto_integral_exp_mul` and
-  `TauCeti.LSeries.tendsto_integral_vertical` are the three one-sided limits.
+* `TauCeti.LSeries.tendsto_tsum_term_mul_fourier` and
+  `TauCeti.LSeries.tendsto_integral_vertical` are two of the three one-sided limits; the third,
+  for the pole term, is the general `TauCeti.tendsto_integral_exp_mul`.
 * `TauCeti.LSeries.tsum_term_mul_fourier_sub_pole_eq_integral_boundary` is the identity they
   combine into, and
   `TauCeti.LSeries.tsum_term_mul_fourier_sub_pole_eq_integral_boundary_of_contDiff` is its form
   for a smooth test function, where the half-line integrability hypothesis is automatic by
-  `TauCeti.integrable_fourier_of_contDiff`.
+  `TauCeti.integrable_fourier_of_contDiff_of_hasCompactSupport`.
 
 ## Provenance
 
@@ -62,7 +63,7 @@ namespace TauCeti.LSeries
 open Complex Filter FourierTransform MeasureTheory Real Set
 open scoped ContDiff Topology
 
-variable {a : ℕ → ℂ} {f psi : ℝ → ℂ} {G : ℂ → ℂ} {A : ℂ} {x : ℝ}
+variable {a : ℕ → ℂ} {psi : ℝ → ℂ} {G : ℂ → ℂ} {A : ℂ} {x : ℝ}
 
 /-! ### The Dirichlet series -/
 
@@ -87,51 +88,6 @@ theorem tendsto_tsum_term_mul_fourier (hFsum : LSeriesSummable
   rw [Complex.ofReal_one] at h
   simp only [hterm]
   exact h
-
-/-! ### The simple-pole term -/
-
-/-- On the half-line `u ≥ -log x` the damping factor `exp (-u (sigma - 1))` stays below a bound
-depending only on `x`, uniformly for `sigma ∈ (1, 2]`. -/
-private lemma exp_neg_mul_sub_one_le {u sigma : ℝ} (hu : -Real.log x ≤ u) (h1 : 1 < sigma)
-    (h2 : sigma ≤ 2) : Real.exp (-u * (sigma - 1)) ≤ Real.exp (max 0 (Real.log x)) := by
-  refine Real.exp_le_exp.mpr ?_
-  have hu' : -u ≤ Real.log x := by linarith
-  rcases le_or_gt (-u) 0 with h | h
-  · have hle : -u * (sigma - 1) ≤ 0 := by nlinarith
-    exact hle.trans (le_max_left _ _)
-  · have hle : -u * (sigma - 1) ≤ -u := by nlinarith
-    exact hle.trans (hu'.trans (le_max_right _ _))
-
-/-- As `sigma` decreases to `1`, the normalized one-sided Laplace transform of a function
-integrable on the half-line `u ≥ -log x` converges to its undamped integral. -/
-theorem tendsto_integral_exp_mul (hx : 0 < x) (hf : IntegrableOn f (Ici (-Real.log x))) :
-    Tendsto (fun sigma : ℝ ↦ ((x ^ (1 - sigma) : ℝ) : ℂ) *
-        ∫ u in Ici (-Real.log x), (Real.exp (-u * (sigma - 1)) : ℂ) * f u)
-      (𝓝[>] 1) (𝓝 (∫ u in Ici (-Real.log x), f u)) := by
-  have hrpow : Tendsto (fun sigma : ℝ ↦ ((x ^ (1 - sigma) : ℝ) : ℂ)) (𝓝[>] 1) (𝓝 1) := by
-    have hcont : Continuous fun sigma : ℝ ↦ ((x ^ (1 - sigma) : ℝ) : ℂ) := by
-      simp only [Real.rpow_def_of_pos hx]
-      fun_prop
-    simpa using (hcont.tendsto 1).mono_left nhdsWithin_le_nhds
-  have hint : Tendsto (fun sigma : ℝ ↦ ∫ u in Ici (-Real.log x),
-      (Real.exp (-u * (sigma - 1)) : ℂ) * f u) (𝓝[>] 1)
-      (𝓝 (∫ u in Ici (-Real.log x), f u)) := by
-    refine tendsto_integral_filter_of_dominated_convergence
-      (fun u ↦ Real.exp (max 0 (Real.log x)) * ‖f u‖)
-      (.of_forall fun sigma ↦ (Continuous.aestronglyMeasurable (by fun_prop)).mul hf.1) ?_
-      (hf.norm.const_mul _) (.of_forall fun u ↦ ?_)
-    · filter_upwards [Ioc_mem_nhdsGT (by norm_num : (1 : ℝ) < 2)] with sigma hsigma
-      filter_upwards [ae_restrict_mem measurableSet_Ici] with u hu
-      rw [norm_mul, Complex.norm_real, Real.norm_eq_abs, abs_of_pos (Real.exp_pos _)]
-      exact mul_le_mul_of_nonneg_right (exp_neg_mul_sub_one_le hu hsigma.1 hsigma.2)
-        (norm_nonneg _)
-    · have hone : Tendsto (fun sigma : ℝ ↦ ((Real.exp (-u * (sigma - 1)) : ℝ) : ℂ)) (𝓝[>] 1)
-          (𝓝 1) := by
-        have hcont : Continuous fun sigma : ℝ ↦ ((Real.exp (-u * (sigma - 1)) : ℝ) : ℂ) := by
-          fun_prop
-        simpa using (hcont.tendsto 1).mono_left nhdsWithin_le_nhds
-      simpa using hone.mul_const (f u)
-  simpa using hrpow.mul hint
 
 /-! ### The integral along the vertical line -/
 
@@ -235,6 +191,7 @@ theorem tsum_term_mul_fourier_sub_pole_eq_integral_boundary_of_contDiff (hx : 0 
       ∫ t : ℝ, G (1 + t * I) * psi t * (x : ℂ) ^ (t * I) :=
   tsum_term_mul_fourier_sub_pole_eq_integral_boundary hx hG hG' hsum
     (hpsi.continuous.integrable_of_hasCompactSupport hsupp) hsupp
-    ((integrable_fourier_of_contDiff hpsi hsupp).comp_div (by positivity)).integrableOn hFsum
+    (((integrable_fourier_of_contDiff_of_hasCompactSupport hpsi hsupp).comp_div
+      (by positivity)).integrableOn) hFsum
 
 end TauCeti.LSeries

--- a/TauCeti/NumberTheory/LSeries/WienerIkehara/Limit.lean
+++ b/TauCeti/NumberTheory/LSeries/WienerIkehara/Limit.lean
@@ -186,9 +186,11 @@ theorem tendsto_integral_vertical (hx : 0 < x) (hG : ContinuousOn G {z : ℂ | 1
 `Re s = 1`. The Dirichlet series is tested against an integrable, compactly supported `psi`, and
 the pole term has lost its exponential damping.
 
-The hypotheses are exactly the three convergence facts that the passage to the limit needs: the
-Fourier-weighted series is summable at `s = 1`, the Fourier transform of `psi` is integrable on
-the half-line, and the pole-subtracted remainder `G` extends continuously to `Re s ≥ 1`. -/
+The principal analytic inputs for the passage to the limit are that the Fourier-weighted series
+is summable at `s = 1`, the Fourier transform of `psi` is integrable on the half-line, and the
+pole-subtracted remainder `G` extends continuously to `Re s ≥ 1`. The additional hypotheses make
+`x` positive, supply the interior identity through the formula for `G` and summability of the
+original series, and give the integrability and compact support of the test function. -/
 theorem tsum_term_mul_fourier_sub_pole_eq_integral_boundary (hx : 0 < x)
     (hG : ContinuousOn G {z : ℂ | 1 ≤ z.re})
     (hG' : ∀ z : ℂ, 1 < z.re → G z = LSeries a z - A / (z - 1))

--- a/TauCeti/NumberTheory/LSeries/WienerIkehara/Limit.lean
+++ b/TauCeti/NumberTheory/LSeries/WienerIkehara/Limit.lean
@@ -176,9 +176,10 @@ theorem tsum_term_mul_fourier_sub_pole_eq_integral_boundary (hx : 0 < x)
     exact (key sigma hsigma).symm
 
 /-- The boundary Fourier identity for a smooth, compactly supported test function. Its regularity
-supplies both its own integrability and the integrability of its Fourier transform, removing only
-the explicit Fourier-integrability hypothesis from
-`tsum_term_mul_fourier_sub_pole_eq_integral_boundary`. -/
+supplies both its own integrability and the integrability of its Fourier transform, discharging
+both explicit integrability hypotheses from
+`tsum_term_mul_fourier_sub_pole_eq_integral_boundary`; summability of the Fourier-weighted series
+is still required. -/
 theorem tsum_term_mul_fourier_sub_pole_eq_integral_boundary_of_contDiff (hx : 0 < x)
     (hG : ContinuousOn G {z : ℂ | 1 ≤ z.re})
     (hG' : ∀ z : ℂ, 1 < z.re → G z = LSeries a z - A / (z - 1))

--- a/TauCeti/NumberTheory/LSeries/WienerIkehara/Limit.lean
+++ b/TauCeti/NumberTheory/LSeries/WienerIkehara/Limit.lean
@@ -16,12 +16,12 @@ integrable function on a vertical line `Re s = sigma` strictly inside the half-p
 convergence. This file lets `sigma` decrease to `1` and records the resulting identity on the
 boundary line itself.
 
-Each of the three terms of that identity is handled by its own dominated-convergence argument, and
-each is stated separately so that a later step can reuse it: the Dirichlet series converges by the
-uniform convergence of a summable Dirichlet series on a closed half-plane, the pole term converges
-because the exponential damping `exp (-u (sigma - 1))` is bounded on the half-line of integration,
-and the vertical integral converges because a test function with compact support confines the
-integrand to a compact box on which `G` is continuous.
+Each of the three terms of that identity has its own limit argument, and each is stated separately
+so that a later step can reuse it: the Dirichlet series converges by the uniform convergence of a
+summable Dirichlet series on a closed half-plane, while the two integrals converge by dominated
+convergence, the pole term because the exponential damping `exp (-u (sigma - 1))` is bounded on
+the half-line of integration, and the vertical integral because a test function with compact
+support confines the integrand to a compact box on which `G` is continuous.
 
 Only the pole-subtracted remainder `G` is assumed continuous on the closed half-plane
 `Re s ≥ 1`; nothing is assumed about `LSeries a` there, where it is a total function with junk
@@ -36,7 +36,7 @@ values.
   combine into, and
   `TauCeti.LSeries.tsum_term_mul_fourier_sub_pole_eq_integral_boundary_of_contDiff` is its form
   for a smooth test function, where the half-line integrability hypothesis is automatic by
-  `TauCeti.LSeries.integrableOn_fourier_div_of_contDiff`.
+  `TauCeti.LSeries.integrable_fourier_div_of_contDiff`.
 
 ## Provenance
 
@@ -46,7 +46,7 @@ and `limiting_fourier` in `PrimeNumberTheoremAnd/Wiener.lean` of the Apache-2.0
 `AxiomMath/PrimeNumberTheoremAnd` repository, revision
 `2667e414c38e5a5dc9aa1946f16f13001e5cd3ed`, the same source as the sibling file
 `TauCeti.NumberTheory.LSeries.WienerIkehara.Fourier`. The proofs here are written against
-Mathlib's dominated-convergence lemmas, and the hypotheses differ: the Chebyshev-type growth
+Mathlib's uniform- and dominated-convergence lemmas, and the hypotheses differ: the Chebyshev-type
 bound of the source is replaced by the summability of the Fourier-weighted series at `s = 1`,
 which is what the limit actually consumes.
 
@@ -135,11 +135,11 @@ theorem tendsto_integral_exp_mul_fourier (hx : 0 < x)
   simpa using hrpow.mul hint
 
 /-- The Fourier transform of a smooth, compactly supported function is a Schwartz function, hence
-integrable; rescaling and restricting gives the half-line hypothesis of
+integrable; rescaling keeps it integrable, and restricting to a half-line gives the hypothesis of
 `tsum_term_mul_fourier_sub_pole_eq_integral_boundary`. -/
-theorem integrableOn_fourier_div_of_contDiff (hpsi : ContDiff ℝ ∞ psi)
-    (hsupp : HasCompactSupport psi) (c : ℝ) :
-    IntegrableOn (fun u : ℝ ↦ 𝓕 psi (u / (2 * π))) (Ici c) := by
+theorem integrable_fourier_div_of_contDiff (hpsi : ContDiff ℝ ∞ psi)
+    (hsupp : HasCompactSupport psi) :
+    Integrable (fun u : ℝ ↦ 𝓕 psi (u / (2 * π))) := by
   have hcoe : ⇑(hsupp.toSchwartzMap hpsi) = psi := by
     ext u
     simp
@@ -147,7 +147,7 @@ theorem integrableOn_fourier_div_of_contDiff (hpsi : ContDiff ℝ ∞ psi)
     have h : Integrable ((𝓕 (hsupp.toSchwartzMap hpsi) : SchwartzMap ℝ ℂ) : ℝ → ℂ) :=
       SchwartzMap.integrable _
     rwa [SchwartzMap.fourier_coe, hcoe] at h
-  exact (hS.comp_div (by positivity)).integrableOn
+  exact hS.comp_div (by positivity)
 
 /-! ### The integral along the vertical line -/
 
@@ -249,6 +249,6 @@ theorem tsum_term_mul_fourier_sub_pole_eq_integral_boundary_of_contDiff (hx : 0 
         A * ∫ u in Ici (-Real.log x), 𝓕 psi (u / (2 * π)) =
       ∫ t : ℝ, G (1 + t * I) * psi t * (x : ℂ) ^ (t * I) :=
   tsum_term_mul_fourier_sub_pole_eq_integral_boundary hx hG hG' hsum hpsi.continuous hsupp
-    (integrableOn_fourier_div_of_contDiff hpsi hsupp _) hFsum
+    (integrable_fourier_div_of_contDiff hpsi hsupp).integrableOn hFsum
 
 end TauCeti.LSeries


### PR DESCRIPTION
This PR lets `sigma` decrease to `1` in the Wiener--Ikehara Fourier identity and records the resulting identity on the boundary line `Re s = 1`. The sibling file `TauCeti/NumberTheory/LSeries/WienerIkehara/Fourier.lean` tests a Dirichlet series against an integrable function on a vertical line strictly inside the half-plane of convergence, in `TauCeti.LSeries.tsum_term_mul_fourier_sub_pole_eq_integral`; the new `WienerIkehara/Limit.lean` proves the three one-sided limits that identity's three terms satisfy and assembles them into `TauCeti.LSeries.tsum_term_mul_fourier_sub_pole_eq_integral_boundary`, where the pole term has lost its exponential damping and `G` is evaluated on `Re s = 1` itself.

Roadmap: ArithmeticDirichletSeries

The milestone is Layer 9, "Wiener--Ikehara", whose export contract asks for `wienerIkehara` and `wienerIkehara_zero` in the boundary formulation: `LSeriesHasSum` on `Re s > 1`, a separately named continuous `G` on `Re s ≥ 1` agreeing there with `F(s) - kappa/(s-1)`, and the conclusion `x⁻¹ ∑_{n≤x} a n → kappa`. That formulation is respected here: only `G` is assumed continuous on the closed half-plane, nothing is assumed about `LSeries a` on the boundary line, where Mathlib's totalized `LSeries` carries junk values. The roadmap's status file names Layer 9 as the frontier and says nothing blocks it; `Fourier.lean` (TauCeti#5716) supplied the first step and this is the next one. After this PR the milestone still owes the smooth test-function (Urysohn) step, the Chebyshev-type growth bound that coefficient nonnegativity supplies, and the Tauberian conclusion itself.

The three limits are stated on their own because each is a separate dominated-convergence argument with its own hypothesis, and later steps consume them individually. `tendsto_tsum_term_mul_fourier` is the Dirichlet series: the Fourier weight turns `LSeries.term a s n` into the term of the twisted coefficient `n ↦ a n * 𝓕 psi (…)`, so summability of that twisted series at `s = 1` gives the limit by uniform convergence on a closed half-plane. `tendsto_integral_exp_mul` is the simple-pole term, stated for an arbitrary integrand integrable on the half-line, which is all the argument uses: on `u ≥ -log x` the damping factor `exp (-u (sigma - 1))` is bounded uniformly for `sigma ∈ (1, 2]`, so the assumed integrability dominates, and the call site supplies `𝓕 psi (·/(2π))`. `tendsto_integral_vertical` is the integral along the vertical line: a compactly supported test function confines the integrand to the compact box `[1,2] × tsupport psi`, on which `G` is bounded.

Two hypotheses of the assembled identity are analytic rather than structural, so the file also discharges one of them: the new `TauCeti/Analysis/Fourier/Integrable.lean` records in `TauCeti.integrable_fourier_of_contDiff` that a smooth compactly supported function is a Schwartz function, hence so is its Fourier transform, which is therefore integrable — stated on an arbitrary finite-dimensional real inner product space, the generality the Schwartz-space proof gives — and `tsum_term_mul_fourier_sub_pole_eq_integral_boundary_of_contDiff` is the identity with that hypothesis removed. The remaining analytic hypothesis, summability of the Fourier-weighted series at `s = 1`, is exactly what the limit consumes, and is what the Chebyshev bound will later supply.

The change to `TauCeti/NumberTheory/LSeries/Continuity.lean` is a generalisation of code already on `main`, needed by the first limit. `continuous_LSeries_vertical` proved continuity of a summable Dirichlet series along one vertical line; the same uniform bound `‖term a z n‖ ≤ ‖term a s n‖` for `s.re ≤ z.re` gives continuity on the whole closed half-plane, so the new `continuousOn_LSeries` is proved first and the old vertical-line statement is re-derived from it, unchanged. `tendsto_LSeries_nhdsGT` is the one-sided real specialisation the limit uses.

The decomposition into three one-sided limits, and the shape of the identity they combine into, follow `limiting_fourier_lim1`, `limiting_fourier_lim2`, `limiting_fourier_lim3` and `limiting_fourier` in `PrimeNumberTheoremAnd/Wiener.lean` of the Apache-2.0 `AxiomMath/PrimeNumberTheoremAnd` repository at revision `2667e414c38e5a5dc9aa1946f16f13001e5cd3ed` — the same source `Fourier.lean` drew on, and credited again in the module docstring. No code is vendored: the proofs are written against Mathlib's `tendsto_integral_filter_of_dominated_convergence`, `continuousOn_tsum`, `HasCompactSupport.toSchwartzMap` and `SchwartzMap.integrable`, and the hypotheses differ, the source's Chebyshev bound being replaced by the summability the limit actually uses.

Files: `TauCeti/NumberTheory/LSeries/WienerIkehara/Limit.lean` (new, 240 lines), `TauCeti/Analysis/Fourier/Integrable.lean` (new, 43 lines) and `TauCeti/NumberTheory/LSeries/Continuity.lean` (+40/-19).

<!--tauceti-target:v1 {"focus":"ArithmeticDirichletSeries","id":"wiener-ikehara-limiting-fourier"}-->

🤖 Prepared with Claude Code

