### PR TITLE
feat: identify the compact Spin last-vector stabilizer

### DIFF
--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Real/Stabilizer.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Real/Stabilizer.lean
@@ -295,12 +295,15 @@ def realCliffordSpinEquivLastStabilizer (n : ℕ) [NeZero n] :
     ⟨realCliffordSpinStabilizerInclusion_injective n,
       realCliffordSpinStabilizerInclusion_surjective n⟩
 
+/-- The forward compact Spin stabilizer equivalence is the lower-rank stabilizer inclusion. -/
 @[simp]
 theorem realCliffordSpinEquivLastStabilizer_apply
     (n : ℕ) [NeZero n] (x : realCliffordSpinGroupZero n) :
     realCliffordSpinEquivLastStabilizer n x = realCliffordSpinStabilizerInclusion n x := by
   rfl
 
+/-- The inverse compact Spin stabilizer equivalence sends an included element back to its
+lower-rank source. -/
 @[simp]
 theorem realCliffordSpinEquivLastStabilizer_symm_apply_inclusion
     (n : ℕ) [NeZero n] (x : realCliffordSpinGroupZero n) :

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Real/Stabilizer.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Real/Stabilizer.lean
@@ -221,10 +221,10 @@ private def realCliffordSpinLastStabilizerProjection (n : ℕ)
     spinToSpecialOrthogonal (realCliffordForm (n + 1) 0) x.1
   let ge : specialOrthogonalGroup
       ((realCliffordForm n 0).prod (QuadraticMap.sq (R := ℝ) (A := ℝ))) :=
-    TauCeti.QuadraticMap.specialOrthogonalGroupCongr e g
+    e.specialOrthogonalGroupCongr g
   refine ⟨ge, ?_⟩
   rw [mem_specialOrthogonalGroupProdLastStabilizer_iff,
-    TauCeti.QuadraticMap.coe_specialOrthogonalGroupCongr_apply]
+    e.coe_specialOrthogonalGroupCongr_apply]
   have hlast : e.symm (0, 1) = Pi.single (Fin.last n) 1 := by
     simpa [e, realCliffordSpinLastIsometry] using realCliffordSpinLastIsometry_one n
   rw [hlast]
@@ -258,7 +258,7 @@ theorem realCliffordSpinStabilizerInclusion_surjective (n : ℕ) [NeZero n] :
       spinVectorAction (realCliffordForm (n + 1) 0)
         (realCliffordSpinInclusion n y) (e.symm m)
     rw [realCliffordSpinInclusion_spinVectorAction_split]
-    have hge := TauCeti.QuadraticMap.coe_specialOrthogonalGroupCongr_apply e
+    have hge := e.coe_specialOrthogonalGroupCongr_apply
       (spinToSpecialOrthogonal (realCliffordForm (n + 1) 0) x.1) m
     have hgx := coe_specialOrthogonalGroupEquivProdLastStabilizer_apply
       (realCliffordForm n 0) (isUnit_of_invertible (2 : ℝ)).isRegular f m

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Real/Stabilizer.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Real/Stabilizer.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.LinearAlgebra.CliffordAlgebra.Spin.Real.Basic
+import TauCeti.LinearAlgebra.QuadraticForm.SpecialOrthogonalStabilizer
 
 /-!
 # The lower-rank subgroup of a compact real Spin group
@@ -16,8 +17,10 @@ an injective homomorphism `Spin(n) → Spin(n + 1)`. Its image fixes the last co
 canonically factors through that vector's stabilizer.
 
 This is the algebraic half of the familiar stabilizer description
-`Spin(n + 1) / Spin(n) ≃ Sⁿ`. The converse identification of the full stabilizer, and the topology
-of the resulting homogeneous space, are separate results.
+`Spin(n + 1) / Spin(n) ≃ Sⁿ`. In positive rank the inclusion is exactly the full stabilizer: the
+special orthogonal stabilizer calculation lifts through the double cover, and its two possible
+lifts differ by the canonical `-1`, which is already in the image. The topology of the resulting
+homogeneous space is a separate result.
 
 The split-coordinate action equation below compares the lower-rank inclusion with the Spin
 projection. When `n > 0`, the projection has kernel `{1, -1}`; since the inclusion preserves the
@@ -31,6 +34,8 @@ converse stabilizer identification.
 * `CliffordAlgebra.realCliffordSpinLastStabilizer` is the stabilizer of the last unit vector.
 * `CliffordAlgebra.realCliffordSpinStabilizerInclusion` is the injective homomorphism into that
   stabilizer.
+* `CliffordAlgebra.realCliffordSpinEquivLastStabilizer` identifies `Spin(n)` with the full
+  last-vector stabilizer for positive `n`.
 * `CliffordAlgebra.realCliffordSpinInclusion_spinVectorAction_split` computes the full vector
   action of the inclusion in split coordinates.
 * `eq_or_eq_realCliffordSpinInclusion_negOne_mul_of_spinToSpecialOrthogonal_eq`
@@ -49,6 +54,7 @@ open QuadraticMap
 namespace CliffordAlgebra
 
 open TauCeti
+open TauCeti.QuadraticMap
 
 noncomputable section
 
@@ -206,6 +212,94 @@ theorem eq_or_eq_realCliffordSpinInclusion_negOne_mul_of_spinToSpecialOrthogonal
     hOne | hNeg
   · exact Or.inl hOne
   · exact Or.inr (hNeg.trans (by rw [map_mul, realCliffordSpinInclusion_negOne]))
+
+private def realCliffordSpinLastStabilizerProjection (n : ℕ)
+    (x : realCliffordSpinLastStabilizer n) :
+    specialOrthogonalGroupProdLastStabilizer (realCliffordForm n 0) := by
+  let e := realCliffordPositiveSplitIsometry n 0
+  let g : specialOrthogonalGroup (realCliffordForm (n + 1) 0) :=
+    spinToSpecialOrthogonal (realCliffordForm (n + 1) 0) x.1
+  let ge : specialOrthogonalGroup
+      ((realCliffordForm n 0).prod (QuadraticMap.sq (R := ℝ) (A := ℝ))) :=
+    TauCeti.QuadraticMap.specialOrthogonalGroupCongr e g
+  refine ⟨ge, ?_⟩
+  rw [mem_specialOrthogonalGroupProdLastStabilizer_iff,
+    TauCeti.QuadraticMap.coe_specialOrthogonalGroupCongr_apply]
+  have hlast : e.symm (0, 1) = Pi.single (Fin.last n) 1 := by
+    simpa [e, realCliffordSpinLastIsometry] using realCliffordSpinLastIsometry_one n
+  rw [hlast]
+  have hx := mem_realCliffordSpinLastStabilizer_iff.mp x.2
+  rw [← coe_spinToSpecialOrthogonal_apply] at hx
+  rw [hx]
+  exact (congrArg e hlast).symm.trans (e.apply_symm_apply (0, 1))
+
+/-- For positive `n`, every element of `Spin(n + 1)` fixing the last coordinate vector comes from
+the lower-rank inclusion `Spin(n) → Spin(n + 1)`. -/
+theorem realCliffordSpinStabilizerInclusion_surjective (n : ℕ) [NeZero n] :
+    Function.Surjective (realCliffordSpinStabilizerInclusion n) := by
+  intro x
+  let gx := realCliffordSpinLastStabilizerProjection n x
+  let f : specialOrthogonalGroup (realCliffordForm n 0) :=
+    (specialOrthogonalGroupEquivProdLastStabilizer (realCliffordForm n 0)
+      (isUnit_of_invertible (2 : ℝ)).isRegular).symm gx
+  obtain ⟨y, hy⟩ := spinToSpecialOrthogonal_surjective_of_posDef
+    (realCliffordForm n 0) (posDef_realCliffordForm_zero n) f
+  have hproj : spinToSpecialOrthogonal (realCliffordForm (n + 1) 0) x.1 =
+      spinToSpecialOrthogonal (realCliffordForm (n + 1) 0)
+        (realCliffordSpinInclusion n y) := by
+    apply Subtype.ext
+    apply LinearEquiv.ext
+    intro v
+    let e := realCliffordPositiveSplitIsometry n 0
+    obtain ⟨m, rfl⟩ := e.symm.surjective v
+    simp only [coe_spinToSpecialOrthogonal_apply]
+    -- Restate coercions through the named split isometry so its action theorem applies.
+    change spinVectorAction (realCliffordForm (n + 1) 0) x.1 (e.symm m) =
+      spinVectorAction (realCliffordForm (n + 1) 0)
+        (realCliffordSpinInclusion n y) (e.symm m)
+    rw [realCliffordSpinInclusion_spinVectorAction_split]
+    have hge := TauCeti.QuadraticMap.coe_specialOrthogonalGroupCongr_apply e
+      (spinToSpecialOrthogonal (realCliffordForm (n + 1) 0) x.1) m
+    have hgx := coe_specialOrthogonalGroupEquivProdLastStabilizer_apply
+      (realCliffordForm n 0) (isUnit_of_invertible (2 : ℝ)).isRegular f m
+    rw [MulEquiv.apply_symm_apply] at hgx
+    have hleft :
+        e (spinVectorAction (realCliffordForm (n + 1) 0) x.1 (e.symm m)) = gx.1.1 m := by
+      rw [← coe_spinToSpecialOrthogonal_apply]
+      exact hge.symm
+    have hright : gx.1.1 m =
+        (spinVectorAction (realCliffordForm n 0) y m.1, m.2) := by
+      rw [← coe_spinToSpecialOrthogonal_apply, hy]
+      exact hgx
+    apply e.toLinearEquiv.injective
+    calc
+      e.toLinearEquiv
+          (spinVectorAction (realCliffordForm (n + 1) 0) x.1 (e.symm m)) =
+          gx.1.1 m := hleft
+      _ = (spinVectorAction (realCliffordForm n 0) y m.1, m.2) := hright
+      _ = e.toLinearEquiv (e.symm
+          (spinVectorAction (realCliffordForm n 0) y m.1, m.2)) :=
+        (e.apply_symm_apply _).symm
+  rcases eq_or_eq_realCliffordSpinInclusion_negOne_mul_of_spinToSpecialOrthogonal_eq
+      n x.1 y hproj with h | h
+  · exact ⟨y, Subtype.ext h.symm⟩
+  · refine ⟨spinGroup.negOne (realCliffordForm n 0)
+      (nondegenerate_realCliffordForm n 0).ne_zero * y, ?_⟩
+    exact Subtype.ext h.symm
+
+/-- For positive `n`, `Spin(n)` is multiplicatively equivalent to the full stabilizer of the last
+coordinate vector in `Spin(n + 1)`. The forward map is the lower-rank stabilizer inclusion. -/
+def realCliffordSpinEquivLastStabilizer (n : ℕ) [NeZero n] :
+    realCliffordSpinGroupZero n ≃* realCliffordSpinLastStabilizer n :=
+  MulEquiv.ofBijective (realCliffordSpinStabilizerInclusion n)
+    ⟨realCliffordSpinStabilizerInclusion_injective n,
+      realCliffordSpinStabilizerInclusion_surjective n⟩
+
+@[simp]
+theorem realCliffordSpinEquivLastStabilizer_apply
+    (n : ℕ) [NeZero n] (x : realCliffordSpinGroupZero n) :
+    realCliffordSpinEquivLastStabilizer n x = realCliffordSpinStabilizerInclusion n x := by
+  rfl
 
 end
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Real/Stabilizer.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Real/Stabilizer.lean
@@ -301,6 +301,14 @@ theorem realCliffordSpinEquivLastStabilizer_apply
     realCliffordSpinEquivLastStabilizer n x = realCliffordSpinStabilizerInclusion n x := by
   rfl
 
+@[simp]
+theorem realCliffordSpinEquivLastStabilizer_symm_apply_inclusion
+    (n : ℕ) [NeZero n] (x : realCliffordSpinGroupZero n) :
+    (realCliffordSpinEquivLastStabilizer n).symm
+      (realCliffordSpinStabilizerInclusion n x) = x := by
+  rw [← realCliffordSpinEquivLastStabilizer_apply]
+  exact (realCliffordSpinEquivLastStabilizer n).symm_apply_apply x
+
 end
 
 

--- a/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
@@ -64,6 +64,8 @@ negating it and is a transvection rather than a reflection in `v ^ ⊥`.
 * `TauCeti.QuadraticMap.orthogonalGroupCongr`: isometric quadratic maps have isomorphic orthogonal
   groups. Over an algebraically closed field this is what makes `O(Q)` depend only on the rank of
   `Q`.
+* `TauCeti.QuadraticMap.specialOrthogonalGroupCongr`: isometric quadratic maps have isomorphic
+  special orthogonal groups as well.
 * `TauCeti.QuadraticMap.reflection_mem_orthogonalGroup`: the reflection in a vector of invertible
   norm is orthogonal; `TauCeti.QuadraticMap.reflection_mul_self` says it is an involution, and
   `TauCeti.QuadraticMap.reflection_apply_of_isOrtho` that it fixes the orthogonal hyperplane, while
@@ -295,6 +297,61 @@ instance specialOrthogonalGroup_normal (Q : QuadraticMap R M N) :
     ((specialOrthogonalGroup Q).subgroupOf (orthogonalGroup Q)).Normal := by
   rw [specialOrthogonalGroup, Subgroup.inf_subgroupOf_left]
   infer_instance
+
+section SpecialCongr
+
+variable {M₁ : Type*} {M₂ : Type*} [AddCommGroup M₁] [Module R M₁]
+  [AddCommGroup M₂] [Module R M₂]
+  {Q₁ : QuadraticMap R M₁ N} {Q₂ : QuadraticMap R M₂ N}
+
+/-- Conjugation by an isometric equivalence carries `SO(Q₁)` onto `SO(Q₂)`. -/
+private theorem map_specialOrthogonalGroup (e : Q₁.IsometryEquiv Q₂) :
+    (specialOrthogonalGroup Q₁).map (LinearEquiv.congrAut e.toLinearEquiv : _ →* _) =
+      specialOrthogonalGroup Q₂ := by
+  ext g
+  simp only [Subgroup.mem_map, MonoidHom.coe_coe, mem_specialOrthogonalGroup_iff]
+  constructor
+  · rintro ⟨f, hf, rfl⟩
+    constructor
+    · exact (orthogonalGroupCongr e ⟨f, hf.1⟩).2
+    · rw [show (LinearEquiv.congrAut e.toLinearEquiv) f =
+          (e.toLinearEquiv.symm.trans f).trans e.toLinearEquiv by
+        ext m
+        exact LinearEquiv.congrAut_apply e.toLinearEquiv f m]
+      exact (LinearEquiv.det_conj f e.toLinearEquiv).trans hf.2
+  · intro hg
+    refine ⟨(LinearEquiv.congrAut e.toLinearEquiv).symm g, ?_,
+      (LinearEquiv.congrAut e.toLinearEquiv).apply_symm_apply g⟩
+    constructor
+    · exact ((orthogonalGroupCongr e).symm ⟨g, hg.1⟩).2
+    · rw [show (LinearEquiv.congrAut e.toLinearEquiv).symm g =
+          (e.toLinearEquiv.trans g).trans e.toLinearEquiv.symm by
+        ext m
+        exact LinearEquiv.congrAut_symm_apply e.toLinearEquiv g m]
+      exact (LinearEquiv.det_conj g e.toLinearEquiv.symm).trans hg.2
+
+/-- Isometric quadratic maps have isomorphic special orthogonal groups: conjugation by an
+isometric equivalence `e : Q₁ ≃qᵢ Q₂` carries `SO(Q₁)` onto `SO(Q₂)`. -/
+noncomputable def specialOrthogonalGroupCongr (e : Q₁.IsometryEquiv Q₂) :
+    specialOrthogonalGroup Q₁ ≃* specialOrthogonalGroup Q₂ :=
+  ((LinearEquiv.congrAut e.toLinearEquiv).subgroupMap _).trans
+    (MulEquiv.subgroupCongr (map_specialOrthogonalGroup e))
+
+@[simp]
+theorem coe_specialOrthogonalGroupCongr_apply
+    (e : Q₁.IsometryEquiv Q₂) (f : specialOrthogonalGroup Q₁) (m : M₂) :
+    (specialOrthogonalGroupCongr e f : M₂ ≃ₗ[R] M₂) m =
+      e ((f : M₁ ≃ₗ[R] M₁) (e.symm m)) := by
+  simp [specialOrthogonalGroupCongr, LinearEquiv.congrAut_apply]
+
+@[simp]
+theorem coe_specialOrthogonalGroupCongr_symm_apply
+    (e : Q₁.IsometryEquiv Q₂) (g : specialOrthogonalGroup Q₂) (m : M₁) :
+    ((specialOrthogonalGroupCongr e).symm g : M₁ ≃ₗ[R] M₁) m =
+      e.symm ((g : M₂ ≃ₗ[R] M₂) (e m)) := by
+  simp [specialOrthogonalGroupCongr, LinearEquiv.congrAut_symm_apply]
+
+end SpecialCongr
 
 end Det
 

--- a/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
@@ -66,7 +66,7 @@ negating it and is a transvection rather than a reflection in `v ^ ⊥`.
 * `TauCeti.QuadraticMap.orthogonalGroupCongr`: isometric quadratic maps have isomorphic orthogonal
   groups. Over an algebraically closed field this is what makes `O(Q)` depend only on the rank of
   `Q`.
-* `TauCeti.QuadraticMap.specialOrthogonalGroupCongr`: isometric quadratic maps have isomorphic
+* `QuadraticMap.IsometryEquiv.specialOrthogonalGroupCongr`: isometric quadratic maps have isomorphic
   special orthogonal groups as well.
 * `TauCeti.QuadraticMap.reflection_mem_orthogonalGroup`: the reflection in a vector of invertible
   norm is orthogonal; `TauCeti.QuadraticMap.reflection_mul_self` says it is an involution, and
@@ -336,29 +336,32 @@ private theorem map_specialOrthogonalGroup (e : Q₁.IsometryEquiv Q₂) :
 
 /-- Isometric quadratic maps have isomorphic special orthogonal groups: conjugation by an
 isometric equivalence `e : Q₁ ≃qᵢ Q₂` carries `SO(Q₁)` onto `SO(Q₂)`. -/
-noncomputable def specialOrthogonalGroupCongr (e : Q₁.IsometryEquiv Q₂) :
+noncomputable def _root_.QuadraticMap.IsometryEquiv.specialOrthogonalGroupCongr
+    (e : Q₁.IsometryEquiv Q₂) :
     specialOrthogonalGroup Q₁ ≃* specialOrthogonalGroup Q₂ :=
   Subgroup.congrOfMapEq (LinearEquiv.congrAut e.toLinearEquiv)
     (map_specialOrthogonalGroup e)
 
 /-- Evaluating special-orthogonal transport is conjugation by the isometry `e`. -/
 @[simp]
-theorem coe_specialOrthogonalGroupCongr_apply
+theorem _root_.QuadraticMap.IsometryEquiv.coe_specialOrthogonalGroupCongr_apply
     (e : Q₁.IsometryEquiv Q₂) (f : specialOrthogonalGroup Q₁) (m : M₂) :
-    (specialOrthogonalGroupCongr e f : M₂ ≃ₗ[R] M₂) m =
+    (e.specialOrthogonalGroupCongr f : M₂ ≃ₗ[R] M₂) m =
       e ((f : M₁ ≃ₗ[R] M₁) (e.symm m)) := by
-  simp only [specialOrthogonalGroupCongr, Subgroup.coe_congrOfMapEq_apply,
+  simp only [QuadraticMap.IsometryEquiv.specialOrthogonalGroupCongr,
+    Subgroup.coe_congrOfMapEq_apply,
     LinearEquiv.congrAut_apply]
   rfl
 
 /-- Evaluating inverse special-orthogonal transport is conjugation by the inverse isometry
 `e.symm`. -/
 @[simp]
-theorem coe_specialOrthogonalGroupCongr_symm_apply
+theorem _root_.QuadraticMap.IsometryEquiv.coe_specialOrthogonalGroupCongr_symm_apply
     (e : Q₁.IsometryEquiv Q₂) (g : specialOrthogonalGroup Q₂) (m : M₁) :
-    ((specialOrthogonalGroupCongr e).symm g : M₁ ≃ₗ[R] M₁) m =
+    (e.specialOrthogonalGroupCongr.symm g : M₁ ≃ₗ[R] M₁) m =
       e.symm ((g : M₂ ≃ₗ[R] M₂) (e m)) := by
-  simp only [specialOrthogonalGroupCongr, Subgroup.coe_congrOfMapEq_symm_apply,
+  simp only [QuadraticMap.IsometryEquiv.specialOrthogonalGroupCongr,
+    Subgroup.coe_congrOfMapEq_symm_apply,
     LinearEquiv.congrAut_symm_apply]
   rfl
 

--- a/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.LinearAlgebra.QuadraticForm.IsometryEquiv
 public import TauCeti.LinearAlgebra.BilinearForm.Isometry
 public import TauCeti.LinearAlgebra.Reflection
+import Mathlib.LinearAlgebra.SpecialLinearGroup
 import TauCeti.Algebra.Group.Subgroup.Map
 
 /-!
@@ -315,23 +316,23 @@ private theorem map_specialOrthogonalGroup (e : Q₁.IsometryEquiv Q₂) :
   · rintro ⟨f, hf, rfl⟩
     constructor
     · exact (orthogonalGroupCongr e ⟨f, hf.1⟩).2
-    · -- `det_conj` exposes conjugation as a chain of `trans`, unlike `congrAut`.
+    · -- Restate `congrAut` through Mathlib's special-linear congruence.
       rw [show (LinearEquiv.congrAut e.toLinearEquiv) f =
           (e.toLinearEquiv.symm.trans f).trans e.toLinearEquiv by
         ext m
         exact LinearEquiv.congrAut_apply e.toLinearEquiv f m]
-      exact (LinearEquiv.det_conj f e.toLinearEquiv).trans hf.2
+      exact (SpecialLinearGroup.congr_linearEquiv e.toLinearEquiv ⟨f, hf.2⟩).prop
   · intro hg
     refine ⟨(LinearEquiv.congrAut e.toLinearEquiv).symm g, ?_,
       (LinearEquiv.congrAut e.toLinearEquiv).apply_symm_apply g⟩
     constructor
     · exact ((orthogonalGroupCongr e).symm ⟨g, hg.1⟩).2
-    · -- Rewrite inverse conjugation to the `trans` chain expected by `det_conj`.
+    · -- Restate inverse `congrAut` through Mathlib's special-linear congruence.
       rw [show (LinearEquiv.congrAut e.toLinearEquiv).symm g =
           (e.toLinearEquiv.trans g).trans e.toLinearEquiv.symm by
         ext m
         exact LinearEquiv.congrAut_symm_apply e.toLinearEquiv g m]
-      exact (LinearEquiv.det_conj g e.toLinearEquiv.symm).trans hg.2
+      exact (SpecialLinearGroup.congr_linearEquiv e.toLinearEquiv.symm ⟨g, hg.2⟩).prop
 
 /-- Isometric quadratic maps have isomorphic special orthogonal groups: conjugation by an
 isometric equivalence `e : Q₁ ≃qᵢ Q₂` carries `SO(Q₁)` onto `SO(Q₂)`. -/
@@ -340,6 +341,7 @@ noncomputable def specialOrthogonalGroupCongr (e : Q₁.IsometryEquiv Q₂) :
   Subgroup.congrOfMapEq (LinearEquiv.congrAut e.toLinearEquiv)
     (map_specialOrthogonalGroup e)
 
+/-- Evaluating special-orthogonal transport is conjugation by the isometry `e`. -/
 @[simp]
 theorem coe_specialOrthogonalGroupCongr_apply
     (e : Q₁.IsometryEquiv Q₂) (f : specialOrthogonalGroup Q₁) (m : M₂) :
@@ -349,6 +351,8 @@ theorem coe_specialOrthogonalGroupCongr_apply
     LinearEquiv.congrAut_apply]
   rfl
 
+/-- Evaluating inverse special-orthogonal transport is conjugation by the inverse isometry
+`e.symm`. -/
 @[simp]
 theorem coe_specialOrthogonalGroupCongr_symm_apply
     (e : Q₁.IsometryEquiv Q₂) (g : specialOrthogonalGroup Q₂) (m : M₁) :

--- a/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.LinearAlgebra.QuadraticForm.IsometryEquiv
 public import TauCeti.LinearAlgebra.BilinearForm.Isometry
 public import TauCeti.LinearAlgebra.Reflection
+import TauCeti.Algebra.Group.Subgroup.Map
 
 /-!
 # The orthogonal group of a quadratic form
@@ -314,7 +315,8 @@ private theorem map_specialOrthogonalGroup (e : Q₁.IsometryEquiv Q₂) :
   · rintro ⟨f, hf, rfl⟩
     constructor
     · exact (orthogonalGroupCongr e ⟨f, hf.1⟩).2
-    · rw [show (LinearEquiv.congrAut e.toLinearEquiv) f =
+    · -- `det_conj` exposes conjugation as a chain of `trans`, unlike `congrAut`.
+      rw [show (LinearEquiv.congrAut e.toLinearEquiv) f =
           (e.toLinearEquiv.symm.trans f).trans e.toLinearEquiv by
         ext m
         exact LinearEquiv.congrAut_apply e.toLinearEquiv f m]
@@ -324,7 +326,8 @@ private theorem map_specialOrthogonalGroup (e : Q₁.IsometryEquiv Q₂) :
       (LinearEquiv.congrAut e.toLinearEquiv).apply_symm_apply g⟩
     constructor
     · exact ((orthogonalGroupCongr e).symm ⟨g, hg.1⟩).2
-    · rw [show (LinearEquiv.congrAut e.toLinearEquiv).symm g =
+    · -- Rewrite inverse conjugation to the `trans` chain expected by `det_conj`.
+      rw [show (LinearEquiv.congrAut e.toLinearEquiv).symm g =
           (e.toLinearEquiv.trans g).trans e.toLinearEquiv.symm by
         ext m
         exact LinearEquiv.congrAut_symm_apply e.toLinearEquiv g m]
@@ -334,22 +337,26 @@ private theorem map_specialOrthogonalGroup (e : Q₁.IsometryEquiv Q₂) :
 isometric equivalence `e : Q₁ ≃qᵢ Q₂` carries `SO(Q₁)` onto `SO(Q₂)`. -/
 noncomputable def specialOrthogonalGroupCongr (e : Q₁.IsometryEquiv Q₂) :
     specialOrthogonalGroup Q₁ ≃* specialOrthogonalGroup Q₂ :=
-  ((LinearEquiv.congrAut e.toLinearEquiv).subgroupMap _).trans
-    (MulEquiv.subgroupCongr (map_specialOrthogonalGroup e))
+  Subgroup.congrOfMapEq (LinearEquiv.congrAut e.toLinearEquiv)
+    (map_specialOrthogonalGroup e)
 
 @[simp]
 theorem coe_specialOrthogonalGroupCongr_apply
     (e : Q₁.IsometryEquiv Q₂) (f : specialOrthogonalGroup Q₁) (m : M₂) :
     (specialOrthogonalGroupCongr e f : M₂ ≃ₗ[R] M₂) m =
       e ((f : M₁ ≃ₗ[R] M₁) (e.symm m)) := by
-  simp [specialOrthogonalGroupCongr, LinearEquiv.congrAut_apply]
+  simp only [specialOrthogonalGroupCongr, Subgroup.coe_congrOfMapEq_apply,
+    LinearEquiv.congrAut_apply]
+  rfl
 
 @[simp]
 theorem coe_specialOrthogonalGroupCongr_symm_apply
     (e : Q₁.IsometryEquiv Q₂) (g : specialOrthogonalGroup Q₂) (m : M₁) :
     ((specialOrthogonalGroupCongr e).symm g : M₁ ≃ₗ[R] M₁) m =
       e.symm ((g : M₂ ≃ₗ[R] M₂) (e m)) := by
-  simp [specialOrthogonalGroupCongr, LinearEquiv.congrAut_symm_apply]
+  simp only [specialOrthogonalGroupCongr, Subgroup.coe_congrOfMapEq_symm_apply,
+    LinearEquiv.congrAut_symm_apply]
+  rfl
 
 end SpecialCongr
 


### PR DESCRIPTION
This PR identifies the lower-rank compact Spin group with the full last-vector stabilizer for the RepresentationTheory / SpinRepresentations Layer 7 “Connectivity of the compact spin group” milestone.

Roadmap: RepresentationTheory

## Summary

The new `specialOrthogonalGroupCongr` transports determinant-one orthogonal groups along an isometry and exposes forward and inverse pointwise action formulas. Conjugating the projection of a Spin stabilizer element into positive-split coordinates then places it in the existing product special-orthogonal stabilizer. Surjectivity of the positive-definite Spin projection supplies a lower-rank lift, and the existing `{1, -1}` kernel dichotomy shows that either lift already lies in the image because the inclusion preserves the canonical `-1`. This proves surjectivity of the existing stabilizer inclusion and bundles the resulting identification as a multiplicative equivalence.

## Roadmap target

This closes the algebraic full-stabilizer step on the `L7-spinq → L7-con` dependency chain for [Layer 7, “Connectivity of the compact spin group”](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md#layer-7-real-clifford-algebras-bott-periodicity-and-spinp-q). After this PR, the sphere homogeneous-space bundle and its connectivity and simple-connectivity consequences remain.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"compact-spin-last-stabilizer-equivalence"}-->

## Verification

- Exact head: `50b5b3e5488c74dad3ba051db130d88c54e80f23`
- Local Lean build: `lake exe cache get` and `lake build` — pass; full 10,910-job build completed
- Axiom audit: `lake exe axioms` — pass; 107,371 declarations use only `propext`, `Classical.choice`, and `Quot.sound`
- Lint: `env PATH=/opt/homebrew/opt/gnu-sed/libexec/gnubin:$PATH bash scripts/lint-env.sh && python3 scripts/lint-dot-notation.py && bash scripts/lint-style.sh && lake exe module-system` — pass with no new violations; 8,629 public declarations are documented and all 4,774 modules use the module system
- Proof golf: structural replacement and consumer recheck — pass; `orthogonalGroupCongr`, `SpecialLinearGroup.congr_linearEquiv`, and `Subgroup.congrOfMapEq` replace duplicated transport plumbing, and the existing split-last-vector lemma replaces a repeated coordinate calculation
- Public CI: pending for the updated head

## Scale and generality

The change adds 176 net lines across two existing modules. The special-orthogonal transport works for quadratic maps valued in an arbitrary module over a commutative ring, with no finite, free, or rank hypothesis. The compact stabilizer identification assumes `[NeZero n]`, exactly where the existing double-cover kernel comparison needs the source quadratic form to be nonzero; all lower-rank connectivity consumers have positive rank.

## Scope

- **Consumes:** `orthogonalGroupCongr`, `SpecialLinearGroup.congr_linearEquiv`, `specialOrthogonalGroupEquivProdLastStabilizer`, `spinToSpecialOrthogonal_surjective_of_posDef`, the compact split-action theorem, and the existing `{±1}` lift comparison.
- **Provides:** special-orthogonal congruence with documented forward/inverse action formulas, surjectivity of `realCliffordSpinStabilizerInclusion`, and `realCliffordSpinEquivLastStabilizer` with documented forward and inverse-on-inclusion equations.
- **Fits:** supplies the exact full-stabilizer interface consumed by the compact Spin homogeneous-space connectivity induction.
- **Boundary:** does not replay the closed sphere-orbit work or construct quotient topology, the sphere bundle, connectedness, simple-connectivity, or the universal-cover theorem.

<sub>🤖 GPT-5.6 Sol high · TauCetiWorker @ [910d954fee75dfafda41f98165ce3a9e6676eae1](https://github.com/utensil/TauCetiWorker/commit/910d954fee75dfafda41f98165ce3a9e6676eae1) · rubrics @ [afb424eda89e8ac96d9eb69f6a88972055a4cd1b](https://github.com/utensil/TauCetiReview/commit/afb424eda89e8ac96d9eb69f6a88972055a4cd1b) · local review @ [b533e561b6d44df071c31335ed4a63ae647507d2](https://github.com/utensil/formal-land/commit/b533e561b6d44df071c31335ed4a63ae647507d2) · fixed: api-design, documentation, naming, proof-quality, reuse, ut-consumer-contract, ut-aggregate-reuse</sub>