### PR TITLE
feat: give G0 its simple-class basis

### DIFF
--- a/TauCeti/RepresentationTheory/GrothendieckGroup/SimpleBasis.lean
+++ b/TauCeti/RepresentationTheory/GrothendieckGroup/SimpleBasis.lean
@@ -52,7 +52,7 @@ namespace TauCeti
 
 open CategoryTheory CategoryTheory.Limits CategoryTheory.ObjectProperty
 
-universe u v
+universe u v w w'
 
 variable {R : Type u} [Ring R] [IsArtinianRing R]
 
@@ -60,7 +60,7 @@ variable {R : Type u} [Ring R] [IsArtinianRing R]
 
 section Coordinate
 
-variable (R) (S : Type u) [AddCommGroup S] [Module R S]
+variable (R) (S : Type w) [AddCommGroup S] [Module R S]
 
 private noncomputable def jordanHolderInvariant :
     ExactK0.AdditiveInvariant (finiteModulesExactStructure R) ℤ where
@@ -88,15 +88,22 @@ theorem jordanHolderCoordinate_of (M : FGModuleCat.{u} R) :
 
 /-- Isomorphic modules define the same Jordan--Hölder coordinate. -/
 theorem jordanHolderCoordinate_congr
-    {T : Type u} [AddCommGroup T] [Module R T] (e : S ≃ₗ[R] T) :
+    {T : Type w'} [AddCommGroup T] [Module R T] (e : S ≃ₗ[R] T) :
     jordanHolderCoordinate R S = jordanHolderCoordinate R T := by
   refine ExactK0.hom_ext fun M ↦ ?_
   simp only [jordanHolderCoordinate_of]
   exact congrArg Int.ofNat (jordanHolderMultiplicity_congr e)
 
+end Coordinate
+
+section CoordinateClasses
+
+variable (R)
+
 /-- A simple module has coordinate one on its own class. -/
 @[simp high]
-theorem jordanHolderCoordinate_self [IsSimpleModule R S] [Module.Finite R S] :
+theorem jordanHolderCoordinate_self (S : Type u) [AddCommGroup S] [Module R S]
+    [IsSimpleModule R S] [Module.Finite R S] :
     jordanHolderCoordinate R S (ExactK0.of (FGModuleCat.of R S)) = 1 := by
   rw [jordanHolderCoordinate_of]
   exact_mod_cast jordanHolderMultiplicity_eq_one_of_isSimpleModule_of_linearEquiv S
@@ -105,13 +112,14 @@ theorem jordanHolderCoordinate_self [IsSimpleModule R S] [Module.Finite R S] :
 /-- Two nonisomorphic simple modules have zero mutual Jordan--Hölder coordinate. -/
 @[simp high]
 theorem jordanHolderCoordinate_of_eq_zero_of_isEmpty_linearEquiv
+    (S : Type w) [AddCommGroup S] [Module R S]
     {T : Type u} [AddCommGroup T] [Module R T] [Module.Finite R T] [IsSimpleModule R T]
     (h : IsEmpty (T ≃ₗ[R] S)) :
     jordanHolderCoordinate R S (ExactK0.of (FGModuleCat.of R T)) = 0 := by
   rw [jordanHolderCoordinate_of]
   exact_mod_cast jordanHolderMultiplicity_eq_zero_of_isEmpty_linearEquiv_of_isSimpleModule S h
 
-end Coordinate
+end CoordinateClasses
 
 /-! ### Linear independence and spanning -/
 

--- a/TauCeti/RepresentationTheory/GrothendieckGroup/SimpleBasis.lean
+++ b/TauCeti/RepresentationTheory/GrothendieckGroup/SimpleBasis.lean
@@ -35,9 +35,9 @@ the projective/simple coordinates used to express the Cartan map as a matrix.
 
 * `TauCeti.jordanHolderCoordinate_of`: the coordinate of an object class is its
   Jordan--Hölder multiplicity.
-* `TauCeti.linearIndependent_exactK0Of_simple`: pairwise nonisomorphic simple classes are
+* `TauCeti.linearIndependent_exactK0OfFamily`: pairwise nonisomorphic simple classes are
   linearly independent.
-* `TauCeti.span_range_exactK0Of_simple_eq_top`: an exhaustive family of simple classes spans.
+* `TauCeti.span_range_exactK0OfFamily_eq_top`: an exhaustive family of simple classes spans.
 
 ## References
 
@@ -147,34 +147,14 @@ theorem jordanHolderCoordinate_exactK0OfFamily
     exact jordanHolderCoordinate_exactK0OfFamily_eq_zero S (hnoniso hji)
 
 /-- **Pairwise nonisomorphic simple classes are linearly independent in `G₀(mod R)`.** -/
-theorem linearIndependent_exactK0Of_simple
+theorem linearIndependent_exactK0OfFamily
     (hnoniso : Pairwise fun i j ↦ IsEmpty ((S i : Type u) ≃ₗ[R] S j)) :
     LinearIndependent ℤ (exactK0OfFamily S) := by
-  rw [linearIndependent_iff]
-  classical
-  intro l
-  have heval (i : I) :
-      jordanHolderCoordinate R (S i) ((Finsupp.linearCombination ℤ (exactK0OfFamily S)) l) =
-        l i := by
-    induction l using Finsupp.induction with
-    | zero => simp
-    | single_add j a l hj ha ih =>
-        rw [(Finsupp.linearCombination ℤ (exactK0OfFamily S)).map_add,
-          Finsupp.linearCombination_single,
-          (jordanHolderCoordinate R (S i)).map_add,
-          (jordanHolderCoordinate R (S i)).map_zsmul, ih, Finsupp.add_apply]
-        by_cases hji : j = i
-        · subst j
-          simp
-        · have hzero : jordanHolderCoordinate R (S i) (exactK0OfFamily S j) = 0 :=
-            jordanHolderCoordinate_exactK0OfFamily_eq_zero S (hnoniso hji)
-          rw [hzero, smul_zero, zero_add, Finsupp.single_eq_of_ne (Ne.symm hji), zero_add]
-  intro hl
-  apply Finsupp.ext
-  intro i
-  have hi := congrArg (jordanHolderCoordinate R (S i)) hl
-  rw [heval i, map_zero] at hi
-  exact hi
+  apply LinearIndependent.of_pairwise_dual_eq_zero_one (exactK0OfFamily S)
+    (fun i ↦ (jordanHolderCoordinate R (S i)).toIntLinearMap)
+  · intro i j hij
+    exact jordanHolderCoordinate_exactK0OfFamily_eq_zero S (hnoniso hij.symm)
+  · exact jordanHolderCoordinate_exactK0OfFamily_self S
 
 variable (hnoniso : Pairwise fun i j ↦ IsEmpty ((S i : Type u) ≃ₗ[R] S j))
 
@@ -251,7 +231,7 @@ omit hS in
 /-- **An exhaustive family of simple classes spans `G₀(mod R)`.** Every finitely generated
 module over an Artinian ring has finite length, and induction on a simple-quotient filtration
 expresses its class as a sum of simple classes. -/
-theorem span_range_exactK0Of_simple_eq_top
+theorem span_range_exactK0OfFamily_eq_top
     (hexhaustive : IsExhaustiveSimpleFamily S) :
     Submodule.span ℤ (Set.range (exactK0OfFamily S)) = ⊤ := by
   apply top_unique
@@ -268,8 +248,8 @@ The hypotheses say precisely that the chosen modules are simple, pairwise noniso
 exhaust all simple finitely generated modules. -/
 noncomputable def simpleClassBasis (hexhaustive : IsExhaustiveSimpleFamily S) :
     Module.Basis I ℤ (ExactK0 (finiteModulesExactStructure R)) :=
-  Module.Basis.mk (linearIndependent_exactK0Of_simple S hnoniso)
-    (span_range_exactK0Of_simple_eq_top S hexhaustive).ge
+  Module.Basis.mk (linearIndependent_exactK0OfFamily S hnoniso)
+    (span_range_exactK0OfFamily_eq_top S hexhaustive).ge
 
 /-- The basis vector indexed by `i` is the Grothendieck class `[S i]`. -/
 @[simp]
@@ -279,6 +259,7 @@ theorem simpleClassBasis_apply (hexhaustive : IsExhaustiveSimpleFamily S) (i : I
 
 /-- The `i`th coefficient in the simple-class basis is the Jordan--Hölder multiplicity
 coordinate attached to `S i`. -/
+@[simp]
 theorem simpleClassBasis_repr_apply (hexhaustive : IsExhaustiveSimpleFamily S)
     (x : ExactK0 (finiteModulesExactStructure R)) (i : I) :
     (simpleClassBasis S hnoniso hexhaustive).repr x i = jordanHolderCoordinate R (S i) x := by
@@ -288,7 +269,8 @@ theorem simpleClassBasis_repr_apply (hexhaustive : IsExhaustiveSimpleFamily S)
       (jordanHolderCoordinate R (S i)).toIntLinearMap := by
     apply b.ext
     intro j
-    change (b.repr (b j)) i = jordanHolderCoordinate R (S i) (b j)
+    simp only [LinearMap.comp_apply, LinearEquiv.coe_coe, Finsupp.lapply_apply,
+      AddMonoidHom.coe_toIntLinearMap]
     rw [b.repr_self]
     have hb : b j = exactK0OfFamily S j := by
       simp [b, exactK0OfFamily]

--- a/TauCeti/RepresentationTheory/GrothendieckGroup/SimpleBasis.lean
+++ b/TauCeti/RepresentationTheory/GrothendieckGroup/SimpleBasis.lean
@@ -1,0 +1,304 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.LinearAlgebra.Basis.Basic
+public import Mathlib.RingTheory.HopkinsLevitzki
+public import TauCeti.Algebra.Category.ModuleCat.CartanMap
+public import TauCeti.RingTheory.CompositionSeries.Additivity
+
+/-!
+# Simple classes in the Grothendieck group of finite-length modules
+
+Let `R` be an Artinian ring. Every finitely generated left `R`-module has finite length, and its
+Jordan--Hölder multiplicities are additive in short exact sequences. Consequently, multiplicity
+of a fixed simple module descends to an integer-valued coordinate on the exact Grothendieck group
+`G₀(mod R)`.
+
+These coordinates show that the classes of any pairwise nonisomorphic family of simple modules
+are linearly independent. If the family contains a representative of every simple finitely
+generated module, finite-length induction also shows that the classes span, giving a canonical
+`\mathbb Z`-basis of `G₀(mod R)` indexed by that family. The basis is the simple-module side of
+the projective/simple coordinates used to express the Cartan map as a matrix.
+
+## Main definitions
+
+* `TauCeti.jordanHolderCoordinate`: the homomorphism from `G₀(mod R)` which reads the
+  Jordan--Hölder multiplicity of a fixed simple module.
+* `TauCeti.simpleClassBasis`: the basis of `G₀(mod R)` given by an exhaustive family of
+  pairwise nonisomorphic simple modules.
+
+## Main results
+
+* `TauCeti.jordanHolderCoordinate_of`: the coordinate of an object class is its
+  Jordan--Hölder multiplicity.
+* `TauCeti.linearIndependent_exactK0Of_simple`: pairwise nonisomorphic simple classes are
+  linearly independent.
+* `TauCeti.span_range_exactK0Of_simple_eq_top`: an exhaustive family of simple classes spans.
+
+## References
+
+* Charles A. Weibel, *The K-book: An Introduction to Algebraic K-theory*, Chapter II, Section 6.
+* Ibrahim Assem, Daniel Simson, and Andrzej Skowroński, *Elements of the Representation Theory
+  of Associative Algebras I*, Chapter III, Section 3.
+-/
+
+public section
+
+namespace TauCeti
+
+open CategoryTheory CategoryTheory.Limits CategoryTheory.ObjectProperty
+
+universe u v
+
+variable {R : Type u} [Ring R] [IsArtinianRing R]
+
+/-! ### Jordan--Hölder coordinates -/
+
+section Coordinate
+
+variable (R) (S : Type u) [AddCommGroup S] [Module R S]
+
+private noncomputable def jordanHolderInvariant :
+    ExactK0.AdditiveInvariant (finiteModulesExactStructure R) ℤ where
+  obj M := jordanHolderMultiplicity R M S
+  map_iso {_ _} e := congrArg Int.ofNat
+    (jordanHolderMultiplicity_eq_of_linearEquiv (FGModuleCat.isoToLinearEquiv e) S)
+  map_conflation {T} hT := by
+    have hshort := (finiteModulesExactStructure_conflation_iff R T).mp hT
+    have hexact := (ShortComplex.ShortExact.moduleCat_exact_iff_function_exact _).mp hshort.exact
+    exact_mod_cast jordanHolderMultiplicity_eq_add_of_exact T.f.hom.hom T.g.hom.hom
+      hshort.moduleCat_injective_f hshort.moduleCat_surjective_g hexact
+
+/-- The **Jordan--Hölder coordinate** of a fixed module `S` on `G₀(mod R)`. On the class of
+`M` it is the multiplicity `[M : S]`. It is useful as a simple coordinate when `S` is simple, but
+the construction is valid for arbitrary `S` (and is then identically zero if `S` is not simple). -/
+noncomputable def jordanHolderCoordinate :
+    ExactK0 (finiteModulesExactStructure R) →+ ℤ :=
+  ExactK0.lift (jordanHolderInvariant R S)
+
+/-- The Jordan--Hölder coordinate of an object class is its multiplicity in that module. -/
+@[simp]
+theorem jordanHolderCoordinate_of (M : FGModuleCat.{u} R) :
+    jordanHolderCoordinate R S (ExactK0.of M) = jordanHolderMultiplicity R M S :=
+  ExactK0.lift_of (jordanHolderInvariant R S) M
+
+/-- Isomorphic modules define the same Jordan--Hölder coordinate. -/
+theorem jordanHolderCoordinate_congr
+    {T : Type u} [AddCommGroup T] [Module R T] (e : S ≃ₗ[R] T) :
+    jordanHolderCoordinate R S = jordanHolderCoordinate R T := by
+  refine ExactK0.hom_ext fun M ↦ ?_
+  simp only [jordanHolderCoordinate_of]
+  exact congrArg Int.ofNat (jordanHolderMultiplicity_congr e)
+
+/-- A simple module has coordinate one on its own class. -/
+theorem jordanHolderCoordinate_self [IsSimpleModule R S] [Module.Finite R S] :
+    jordanHolderCoordinate R S (ExactK0.of (FGModuleCat.of R S)) = 1 := by
+  rw [jordanHolderCoordinate_of]
+  exact_mod_cast jordanHolderMultiplicity_eq_one_of_isSimpleModule_of_linearEquiv S
+    (LinearEquiv.refl R S)
+
+/-- Two nonisomorphic simple modules have zero mutual Jordan--Hölder coordinate. -/
+theorem jordanHolderCoordinate_of_eq_zero_of_isEmpty_linearEquiv
+    {T : Type u} [AddCommGroup T] [Module R T] [Module.Finite R T] [IsSimpleModule R T]
+    (h : IsEmpty (T ≃ₗ[R] S)) :
+    jordanHolderCoordinate R S (ExactK0.of (FGModuleCat.of R T)) = 0 := by
+  rw [jordanHolderCoordinate_of]
+  exact_mod_cast jordanHolderMultiplicity_eq_zero_of_isEmpty_linearEquiv_of_isSimpleModule S h
+
+end Coordinate
+
+/-! ### Linear independence and spanning -/
+
+section SimpleFamily
+
+variable {I : Type v} (S : I → FGModuleCat.{u} R)
+variable [hS : ∀ i, IsSimpleModule R (S i)]
+
+/-- The classes in `G₀(mod R)` of an indexed family of finitely generated modules. -/
+noncomputable def exactK0OfFamily (i : I) : ExactK0 (finiteModulesExactStructure R) :=
+  ExactK0.of (S i)
+
+@[simp]
+theorem jordanHolderCoordinate_exactK0OfFamily_self (i : I) :
+    jordanHolderCoordinate R (S i) (exactK0OfFamily S i) = 1 :=
+  jordanHolderCoordinate_self R (S i)
+
+/-- A Jordan--Hölder coordinate is zero on a nonisomorphic member of a simple family. -/
+theorem jordanHolderCoordinate_exactK0OfFamily_eq_zero {i j : I}
+    (hij : IsEmpty ((S j : Type u) ≃ₗ[R] S i)) :
+    jordanHolderCoordinate R (S i) (exactK0OfFamily S j) = 0 :=
+  jordanHolderCoordinate_of_eq_zero_of_isEmpty_linearEquiv R (S i) hij
+
+/-- On a pairwise nonisomorphic simple family, the Jordan--Hölder coordinates form the
+Kronecker-delta matrix. -/
+theorem jordanHolderCoordinate_exactK0OfFamily
+    [DecidableEq I]
+    (hnoniso : Pairwise fun i j ↦ IsEmpty ((S i : Type u) ≃ₗ[R] S j)) (i j : I) :
+    jordanHolderCoordinate R (S i) (exactK0OfFamily S j) = if j = i then 1 else 0 := by
+  classical
+  by_cases hji : j = i
+  · subst j
+    simp
+  · simp only [hji, ↓reduceIte]
+    exact jordanHolderCoordinate_exactK0OfFamily_eq_zero S (hnoniso hji)
+
+/-- **Pairwise nonisomorphic simple classes are linearly independent in `G₀(mod R)`.** -/
+theorem linearIndependent_exactK0Of_simple
+    (hnoniso : Pairwise fun i j ↦ IsEmpty ((S i : Type u) ≃ₗ[R] S j)) :
+    LinearIndependent ℤ (exactK0OfFamily S) := by
+  rw [linearIndependent_iff]
+  classical
+  intro l
+  have heval (i : I) :
+      jordanHolderCoordinate R (S i) ((Finsupp.linearCombination ℤ (exactK0OfFamily S)) l) =
+        l i := by
+    induction l using Finsupp.induction with
+    | zero => simp
+    | single_add j a l hj ha ih =>
+        rw [(Finsupp.linearCombination ℤ (exactK0OfFamily S)).map_add,
+          Finsupp.linearCombination_single,
+          (jordanHolderCoordinate R (S i)).map_add,
+          (jordanHolderCoordinate R (S i)).map_zsmul, ih, Finsupp.add_apply]
+        by_cases hji : j = i
+        · subst j
+          simp
+        · have hzero : jordanHolderCoordinate R (S i) (exactK0OfFamily S j) = 0 :=
+            jordanHolderCoordinate_exactK0OfFamily_eq_zero S (hnoniso hji)
+          rw [hzero, smul_zero, zero_add, Finsupp.single_eq_of_ne (Ne.symm hji), zero_add]
+  intro hl
+  apply Finsupp.ext
+  intro i
+  have hi := congrArg (jordanHolderCoordinate R (S i)) hl
+  rw [heval i, map_zero] at hi
+  exact hi
+
+variable (hnoniso : Pairwise fun i j ↦ IsEmpty ((S i : Type u) ≃ₗ[R] S j))
+
+/-- A family of simple modules is exhaustive if every simple finitely generated module is
+isomorphic to one of its members. -/
+def IsExhaustiveSimpleFamily : Prop :=
+  ∀ (M : FGModuleCat.{u} R), IsSimpleModule R M →
+    ∃ i, Nonempty ((M : Type u) ≃ₗ[R] S i)
+
+omit [IsArtinianRing R] hS in
+theorem isExhaustiveSimpleFamily_iff : IsExhaustiveSimpleFamily S ↔
+    ∀ (M : FGModuleCat.{u} R), IsSimpleModule R M →
+      ∃ i, Nonempty ((M : Type u) ≃ₗ[R] S i) :=
+  Iff.rfl
+
+omit hS in
+private theorem exactK0_of_type_mem_span_range_simple
+    (hexhaustive : IsExhaustiveSimpleFamily S)
+    {M : Type u} [AddCommGroup M] [Module R M] [Module.Finite R M] :
+    ExactK0.of (FGModuleCat.of R M) ∈
+      Submodule.span ℤ (Set.range (exactK0OfFamily S)) := by
+  let G := Submodule.span ℤ (Set.range (exactK0OfFamily S))
+  have hfinite : IsFiniteLength R M :=
+    isFiniteLength_iff_isNoetherian_isArtinian.mpr ⟨inferInstance, inferInstance⟩
+  refine IsFiniteLength.rec (motive := fun (M : Type u) [AddCommGroup M] [Module R M] _ ↦
+      ∀ hM : Module.Finite R M,
+        ExactK0.of (@FGModuleCat.of R _ M _ _ hM) ∈ G) ?_ ?_ hfinite inferInstance
+  · intro M _ _ _ hM
+    let _ : Module.Finite R M := hM
+    have hzero : IsZero (FGModuleCat.of R M) := IsZero.of_full_of_faithful_of_isZero
+        (ModuleCat.isFG R).ι (FGModuleCat.of R M)
+          (ModuleCat.isZero_of_subsingleton (ModuleCat.of R M))
+    rw [ExactK0.of_eq_zero_of_isZero hzero]
+    exact G.zero_mem
+  · intro M _ _ N _ hN ih hM
+    let _ : Module.Finite R M := hM
+    let _ : IsNoetherian R N :=
+        (isFiniteLength_iff_isNoetherian_isArtinian.mp hN).1
+    let _ : IsArtinian R N :=
+        (isFiniteLength_iff_isNoetherian_isArtinian.mp hN).2
+    let _ : Module.Finite R N := inferInstance
+    let Q := M ⧸ N
+    let _ : IsSimpleModule R Q := inferInstance
+    let _ : Module.Finite R Q := inferInstance
+    obtain ⟨i, ⟨e⟩⟩ := hexhaustive (FGModuleCat.of R Q) inferInstance
+    have hQ : ExactK0.of (FGModuleCat.of R Q) ∈ G := by
+      rw [ExactK0.of_congr e.toFGModuleCatIso]
+      exact Submodule.subset_span (Set.mem_range_self i)
+    have hNmem : ExactK0.of (FGModuleCat.of R N) ∈ G := ih inferInstance
+    let T : ShortComplex (FGModuleCat R) :=
+      ShortComplex.mk (FGModuleCat.ofHom N.subtype) (FGModuleCat.ofHom N.mkQ) (by
+        apply FGModuleCat.hom_ext
+        exact (LinearMap.exact_subtype_mkQ N).linearMap_comp_eq_zero)
+    have hconf : (finiteModulesExactStructure R).Conflation T :=
+      (finiteModulesExactStructure_conflation_iff R T).mpr <| by
+        apply ModuleCat.shortComplex_shortExact
+        · exact LinearMap.exact_subtype_mkQ N
+        · exact N.injective_subtype
+        · exact N.mkQ_surjective
+    have hrel :
+        (ExactK0.of (FGModuleCat.of R M) : ExactK0 (finiteModulesExactStructure R)) =
+          ExactK0.of (FGModuleCat.of R N) + ExactK0.of (FGModuleCat.of R Q) := by
+      simpa only [T, Q] using ExactK0.of_conflation hconf
+    rw [hrel]
+    exact G.add_mem hNmem hQ
+
+omit hS in
+private theorem exactK0_of_mem_span_range_simple
+    (hexhaustive : IsExhaustiveSimpleFamily S) (M : FGModuleCat.{u} R) :
+    ExactK0.of M ∈ Submodule.span ℤ (Set.range (exactK0OfFamily S)) :=
+  exactK0_of_type_mem_span_range_simple S hexhaustive
+
+omit hS in
+/-- **An exhaustive family of simple classes spans `G₀(mod R)`.** Every finitely generated
+module over an Artinian ring has finite length, and induction on a simple-quotient filtration
+expresses its class as a sum of simple classes. -/
+theorem span_range_exactK0Of_simple_eq_top
+    (hexhaustive : IsExhaustiveSimpleFamily S) :
+    Submodule.span ℤ (Set.range (exactK0OfFamily S)) = ⊤ := by
+  apply top_unique
+  intro x hx
+  clear hx
+  induction x using ExactK0.induction_on with
+  | zero => exact Submodule.zero_mem _
+  | of M => exact exactK0_of_mem_span_range_simple S hexhaustive M
+  | add x y hx hy => exact Submodule.add_mem _ hx hy
+  | neg x hx => exact Submodule.neg_mem _ hx
+
+/-- **The simple-class basis of `G₀(mod R)`.** Its basis vector at `i` is the class `[S i]`.
+The hypotheses say precisely that the chosen modules are simple, pairwise nonisomorphic, and
+exhaust all simple finitely generated modules. -/
+noncomputable def simpleClassBasis (hexhaustive : IsExhaustiveSimpleFamily S) :
+    Module.Basis I ℤ (ExactK0 (finiteModulesExactStructure R)) :=
+  Module.Basis.mk (linearIndependent_exactK0Of_simple S hnoniso)
+    (span_range_exactK0Of_simple_eq_top S hexhaustive).ge
+
+/-- The basis vector indexed by `i` is the Grothendieck class `[S i]`. -/
+@[simp]
+theorem simpleClassBasis_apply (hexhaustive : IsExhaustiveSimpleFamily S) (i : I) :
+    simpleClassBasis S hnoniso hexhaustive i = ExactK0.of (S i) :=
+  Module.Basis.mk_apply _ _ i
+
+/-- The `i`th coefficient in the simple-class basis is the Jordan--Hölder multiplicity
+coordinate attached to `S i`. -/
+theorem simpleClassBasis_repr_apply (hexhaustive : IsExhaustiveSimpleFamily S)
+    (x : ExactK0 (finiteModulesExactStructure R)) (i : I) :
+    (simpleClassBasis S hnoniso hexhaustive).repr x i = jordanHolderCoordinate R (S i) x := by
+  classical
+  let b := simpleClassBasis S hnoniso hexhaustive
+  have hlin : (Finsupp.lapply i).comp b.repr.toLinearMap =
+      (jordanHolderCoordinate R (S i)).toIntLinearMap := by
+    apply b.ext
+    intro j
+    change (b.repr (b j)) i = jordanHolderCoordinate R (S i) (b j)
+    rw [b.repr_self]
+    have hb : b j = exactK0OfFamily S j := by
+      simp [b, exactK0OfFamily]
+    rw [hb, jordanHolderCoordinate_exactK0OfFamily S hnoniso]
+    by_cases hji : j = i
+    · subst j
+      simp
+    · simp [hji, Ne.symm hji]
+  exact DFunLike.congr_fun hlin x
+
+end SimpleFamily
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/GrothendieckGroup/SimpleBasis.lean
+++ b/TauCeti/RepresentationTheory/GrothendieckGroup/SimpleBasis.lean
@@ -124,12 +124,22 @@ variable [hS : ∀ i, IsSimpleModule R (S i)]
 noncomputable def exactK0OfFamily (i : I) : ExactK0 (finiteModulesExactStructure R) :=
   ExactK0.of (S i)
 
+omit [IsArtinianRing R] hS in
+/-- A member of the family maps to its class in the exact Grothendieck group.
+
+This is a rewrite lemma rather than a simp lemma because simplifying through it makes the
+specialized Jordan--Hölder coordinate simp lemmas fail the `simpNF` linter. -/
+theorem exactK0OfFamily_apply (i : I) :
+    exactK0OfFamily S i = ExactK0.of (S i) :=
+  (Eq.refl _)
+
 @[simp]
 theorem jordanHolderCoordinate_exactK0OfFamily_self (i : I) :
     jordanHolderCoordinate R (S i) (exactK0OfFamily S i) = 1 :=
   jordanHolderCoordinate_self R (S i)
 
 /-- A Jordan--Hölder coordinate is zero on a nonisomorphic member of a simple family. -/
+@[simp]
 theorem jordanHolderCoordinate_exactK0OfFamily_eq_zero {i j : I}
     (hij : IsEmpty ((S j : Type u) ≃ₗ[R] S i)) :
     jordanHolderCoordinate R (S i) (exactK0OfFamily S j) = 0 :=
@@ -227,12 +237,6 @@ private theorem exactK0_of_type_mem_span_range_simple
     exact G.add_mem hNmem hQ
 
 omit hS in
-private theorem exactK0_of_mem_span_range_simple
-    (hexhaustive : IsExhaustiveSimpleFamily S) (M : FGModuleCat.{u} R) :
-    ExactK0.of M ∈ Submodule.span ℤ (Set.range (exactK0OfFamily S)) :=
-  exactK0_of_type_mem_span_range_simple S hexhaustive
-
-omit hS in
 /-- **An exhaustive family of simple classes spans `G₀(mod R)`.** Every finitely generated
 module over an Artinian ring has finite length, and induction on a simple-quotient filtration
 expresses its class as a sum of simple classes. -/
@@ -244,7 +248,7 @@ theorem span_range_exactK0OfFamily_eq_top
   clear hx
   induction x using ExactK0.induction_on with
   | zero => exact Submodule.zero_mem _
-  | of M => exact exactK0_of_mem_span_range_simple S hexhaustive M
+  | of M => exact exactK0_of_type_mem_span_range_simple S hexhaustive
   | add x y hx hy => exact Submodule.add_mem _ hx hy
   | neg x hx => exact Submodule.neg_mem _ hx
 

--- a/TauCeti/RepresentationTheory/GrothendieckGroup/SimpleBasis.lean
+++ b/TauCeti/RepresentationTheory/GrothendieckGroup/SimpleBasis.lean
@@ -95,6 +95,7 @@ theorem jordanHolderCoordinate_congr
   exact congrArg Int.ofNat (jordanHolderMultiplicity_congr e)
 
 /-- A simple module has coordinate one on its own class. -/
+@[simp high]
 theorem jordanHolderCoordinate_self [IsSimpleModule R S] [Module.Finite R S] :
     jordanHolderCoordinate R S (ExactK0.of (FGModuleCat.of R S)) = 1 := by
   rw [jordanHolderCoordinate_of]
@@ -102,6 +103,7 @@ theorem jordanHolderCoordinate_self [IsSimpleModule R S] [Module.Finite R S] :
     (LinearEquiv.refl R S)
 
 /-- Two nonisomorphic simple modules have zero mutual Jordan--Hölder coordinate. -/
+@[simp high]
 theorem jordanHolderCoordinate_of_eq_zero_of_isEmpty_linearEquiv
     {T : Type u} [AddCommGroup T] [Module R T] [Module.Finite R T] [IsSimpleModule R T]
     (h : IsEmpty (T ≃ₗ[R] S)) :
@@ -135,6 +137,7 @@ theorem jordanHolderCoordinate_exactK0OfFamily_eq_zero {i j : I}
 
 /-- On a pairwise nonisomorphic simple family, the Jordan--Hölder coordinates form the
 Kronecker-delta matrix. -/
+@[simp]
 theorem jordanHolderCoordinate_exactK0OfFamily
     [DecidableEq I]
     (hnoniso : Pairwise fun i j ↦ IsEmpty ((S i : Type u) ≃ₗ[R] S j)) (i j : I) :
@@ -165,10 +168,12 @@ def IsExhaustiveSimpleFamily : Prop :=
     ∃ i, Nonempty ((M : Type u) ≃ₗ[R] S i)
 
 omit [IsArtinianRing R] hS in
+/-- Unfolding lemma for `IsExhaustiveSimpleFamily`: its body is not exposed outside this
+module, so consumers need this to build or use the predicate. -/
 theorem isExhaustiveSimpleFamily_iff : IsExhaustiveSimpleFamily S ↔
     ∀ (M : FGModuleCat.{u} R), IsSimpleModule R M →
       ∃ i, Nonempty ((M : Type u) ≃ₗ[R] S i) :=
-  Iff.rfl
+  (Iff.rfl)
 
 omit hS in
 private theorem exactK0_of_type_mem_span_range_simple
@@ -264,22 +269,11 @@ theorem simpleClassBasis_repr_apply (hexhaustive : IsExhaustiveSimpleFamily S)
     (x : ExactK0 (finiteModulesExactStructure R)) (i : I) :
     (simpleClassBasis S hnoniso hexhaustive).repr x i = jordanHolderCoordinate R (S i) x := by
   classical
-  let b := simpleClassBasis S hnoniso hexhaustive
-  have hlin : (Finsupp.lapply i).comp b.repr.toLinearMap =
-      (jordanHolderCoordinate R (S i)).toIntLinearMap := by
-    apply b.ext
-    intro j
-    simp only [LinearMap.comp_apply, LinearEquiv.coe_coe, Finsupp.lapply_apply,
-      AddMonoidHom.coe_toIntLinearMap]
-    rw [b.repr_self]
-    have hb : b j = exactK0OfFamily S j := by
-      simp [b, exactK0OfFamily]
-    rw [hb, jordanHolderCoordinate_exactK0OfFamily S hnoniso]
-    by_cases hji : j = i
-    · subst j
-      simp
-    · simp [hji, Ne.symm hji]
-  exact DFunLike.congr_fun hlin x
+  refine (simpleClassBasis S hnoniso hexhaustive).repr_apply_eq
+    (fun x i ↦ jordanHolderCoordinate R (S i) x) (fun x y ↦ funext fun i ↦ map_add _ x y)
+    (fun c x ↦ funext fun i ↦ map_zsmul _ c x) (fun j ↦ funext fun k ↦ ?_) x i
+  rw [simpleClassBasis_apply, Finsupp.single_apply]
+  exact jordanHolderCoordinate_exactK0OfFamily S hnoniso k j
 
 end SimpleFamily
 

--- a/TauCeti/RepresentationTheory/GrothendieckGroup/SimpleBasis.lean
+++ b/TauCeti/RepresentationTheory/GrothendieckGroup/SimpleBasis.lean
@@ -125,14 +125,14 @@ noncomputable def exactK0OfFamily (i : I) : ExactK0 (finiteModulesExactStructure
   ExactK0.of (S i)
 
 omit [IsArtinianRing R] hS in
-/-- A member of the family maps to its class in the exact Grothendieck group.
-
-This is a rewrite lemma rather than a simp lemma because simplifying through it makes the
-specialized Jordan--Hölder coordinate simp lemmas fail the `simpNF` linter. -/
+/-- The characteristic equation of `exactK0OfFamily`: the member at `i` is the class `[S i]` in
+the exact Grothendieck group. Intended for explicit rewriting; the specialized Jordan--Hölder
+coordinate lemmas below are the `simp` normal forms. -/
 theorem exactK0OfFamily_apply (i : I) :
     exactK0OfFamily S i = ExactK0.of (S i) :=
   (Eq.refl _)
 
+/-- A member of a simple family has Jordan--Hölder coordinate one on its own class. -/
 @[simp]
 theorem jordanHolderCoordinate_exactK0OfFamily_self (i : I) :
     jordanHolderCoordinate R (S i) (exactK0OfFamily S i) = 1 :=
@@ -178,8 +178,10 @@ def IsExhaustiveSimpleFamily : Prop :=
     ∃ i, Nonempty ((M : Type u) ≃ₗ[R] S i)
 
 omit [IsArtinianRing R] hS in
-/-- Unfolding lemma for `IsExhaustiveSimpleFamily`: its body is not exposed outside this
-module, so consumers need this to build or use the predicate. -/
+/-- Characterization of `IsExhaustiveSimpleFamily`: the family is exhaustive exactly when every
+simple finitely generated module is isomorphic to one of its members. Importing modules build and
+use the predicate through this lemma, since the body of the definition above is not exposed to
+them. -/
 theorem isExhaustiveSimpleFamily_iff : IsExhaustiveSimpleFamily S ↔
     ∀ (M : FGModuleCat.{u} R), IsSimpleModule R M →
       ∃ i, Nonempty ((M : Type u) ≃ₗ[R] S i) :=

--- a/TauCeti/RepresentationTheory/GrothendieckGroup/SimpleBasis.lean
+++ b/TauCeti/RepresentationTheory/GrothendieckGroup/SimpleBasis.lean
@@ -111,7 +111,7 @@ theorem jordanHolderCoordinate_self (S : Type u) [AddCommGroup S] [Module R S]
 
 /-- Two nonisomorphic simple modules have zero mutual Jordan--Hölder coordinate. -/
 @[simp high]
-theorem jordanHolderCoordinate_of_eq_zero_of_isEmpty_linearEquiv
+theorem jordanHolderCoordinate_eq_zero_of_isEmpty_linearEquiv
     (S : Type w) [AddCommGroup S] [Module R S]
     {T : Type u} [AddCommGroup T] [Module R T] [Module.Finite R T] [IsSimpleModule R T]
     (h : IsEmpty (T ≃ₗ[R] S)) :
@@ -151,7 +151,7 @@ theorem jordanHolderCoordinate_exactK0OfFamily_self (i : I) :
 theorem jordanHolderCoordinate_exactK0OfFamily_eq_zero {i j : I}
     (hij : IsEmpty ((S j : Type u) ≃ₗ[R] S i)) :
     jordanHolderCoordinate R (S i) (exactK0OfFamily S j) = 0 :=
-  jordanHolderCoordinate_of_eq_zero_of_isEmpty_linearEquiv R (S i) hij
+  jordanHolderCoordinate_eq_zero_of_isEmpty_linearEquiv R (S i) hij
 
 /-- On a pairwise nonisomorphic simple family, the Jordan--Hölder coordinates form the
 Kronecker-delta matrix. -/


### PR DESCRIPTION
This PR proves that an exhaustive pairwise nonisomorphic family of simple finitely generated modules gives a `ℤ`-basis of `G₀(mod R)` for an Artinian ring. It packages Jordan–Hölder multiplicity as an additive homomorphism out of exact `K₀`, proves the resulting Kronecker-delta coordinate formula and linear independence, and uses finite-length induction through simple quotients to prove spanning. The result is stated at the more general Artinian-ring level; finite-dimensional algebras acquire the needed hypothesis via `IsArtinianRing.of_finite`.

The designated milestone is Layer 4, “The two groups.” This PR completes its simple-class-basis step and supplies the codomain coordinates needed by the projective/simple pairing and the Cartan matrix. After this PR, the indecomposable-projective basis, perfect pairing, and Cartan-map matrix comparison remain, together with the graded counterparts later in Layer 4.

The implementation reuses Tau Ceti's exact Grothendieck group and finite-module exact structure, plus its Jordan–Hölder multiplicity and short-exact-sequence additivity API. No upstream source is vendored.

Roadmap: GrothendieckEulerForms

<!--tauceti-target:v1 {"focus":"GrothendieckEulerForms","id":"simple-classes-basis-g0"}-->

🤖 Prepared with Codex
