### PR TITLE
feat: prove reducedness of finite-type tensor products

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Center/Finite.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Center/Finite.lean
@@ -6,6 +6,7 @@ Authors: Codex
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.Center.Reduced
+public import TauCeti.RingTheory.FiniteType.TensorProduct
 public import TauCeti.Algebra.AlgebraicGroup.Connected.Comultiplication
 import Mathlib.RingTheory.Finiteness.NilpotentKer
 import TauCeti.Algebra.AlgebraicGroup.Connected.ComponentGroup.TrivialIdentity
@@ -29,8 +30,8 @@ that identity component.
 * `moduleFinite_centerCoordinate_of_reducedCenter`: a center is finite when its reduction is
   finite and the tensor square of the reduced center coordinate algebra is reduced.
 * `moduleFinite_centerCoordinate_of_reducedCenter_identityComponent_eq_augmentation`:
-  a center is finite when its reduction has trivial identity component and the tensor square of
-  the reduced center coordinate algebra is reduced.
+  over an algebraically closed field, a center is finite when its reduction has trivial identity
+  component; no tensor-reducedness hypothesis is needed.
 
 ## References
 
@@ -49,20 +50,24 @@ universe u
 variable {k : Type u} [Field k]
 variable (H : FiniteTypeCommHopfAlgCat.{u, u} k)
 
-variable [IsReduced
-  ((((CommHopfAlgCat.centerCoordinateHopfAlgebra H.obj :
-        _root_.CommHopfAlgCat.{u} k) : Type u) ⧸
-      nilradical
-        ((CommHopfAlgCat.centerCoordinateHopfAlgebra H.obj :
-          _root_.CommHopfAlgCat.{u} k) : Type u)) ⊗[k]
-    (((CommHopfAlgCat.centerCoordinateHopfAlgebra H.obj :
-        _root_.CommHopfAlgCat.{u} k) : Type u) ⧸
-      nilradical ((CommHopfAlgCat.centerCoordinateHopfAlgebra H.obj :
-        _root_.CommHopfAlgCat.{u} k) : Type u)))]
+/-- The center coordinate algebra modulo its nilradical is reduced. -/
+local instance : IsReduced ((CommHopfAlgCat.centerCoordinateHopfAlgebra H.obj) ⧸
+    nilradical (CommHopfAlgCat.centerCoordinateHopfAlgebra H.obj)) :=
+  (Ideal.isRadical_iff_quotient_reduced _).mp (Ideal.radical_isRadical ⊥)
 
 /-- Assuming that the tensor square of the reduced center coordinate algebra is reduced, a
 finite-type affine group's center is finite when its reduced center is finite. -/
 theorem moduleFinite_centerCoordinate_of_reducedCenter
+    [IsReduced
+      ((((CommHopfAlgCat.centerCoordinateHopfAlgebra H.obj :
+            _root_.CommHopfAlgCat.{u} k) : Type u) ⧸
+          nilradical
+            ((CommHopfAlgCat.centerCoordinateHopfAlgebra H.obj :
+              _root_.CommHopfAlgCat.{u} k) : Type u)) ⊗[k]
+        (((CommHopfAlgCat.centerCoordinateHopfAlgebra H.obj :
+            _root_.CommHopfAlgCat.{u} k) : Type u) ⧸
+          nilradical ((CommHopfAlgCat.centerCoordinateHopfAlgebra H.obj :
+            _root_.CommHopfAlgCat.{u} k) : Type u)))]
     [Module.Finite k (CommHopfAlgCat.reducedCenterCoordinateHopfAlgebra H.obj)] :
     Module.Finite k (CommHopfAlgCat.centerCoordinateHopfAlgebra H.obj) := by
   let C := CommHopfAlgCat.centerCoordinateHopfAlgebra H.obj
@@ -83,9 +88,8 @@ theorem moduleFinite_centerCoordinate_of_reducedCenter
   · rw [hker]
     exact IsNoetherian.noetherian _
 
-/-- Assuming that the tensor square of the reduced center coordinate algebra is reduced, a
-finite-type affine group's center is finite when the identity component of its reduced center is
-the trivial subgroup scheme. -/
+/-- Over an algebraically closed field, a finite-type affine group's center is finite when
+the identity component of its reduced center is the trivial subgroup scheme. -/
 theorem
     moduleFinite_centerCoordinate_of_reducedCenter_identityComponent_eq_augmentation
     [IsAlgClosed k]

--- a/TauCeti/Algebra/AlgebraicGroup/GeometricallyReduced/Product.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeometricallyReduced/Product.lean
@@ -6,7 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.FiniteType.Product
-public import TauCeti.Algebra.AlgebraicGroup.Smooth.AlgebraicallyClosed
+public import TauCeti.Algebra.AlgebraicGroup.Smooth.GeometricallyReduced
 public import TauCeti.Algebra.AlgebraicGroup.Smooth.Product
 
 /-!
@@ -18,17 +18,10 @@ equivalent to smoothness, and smoothness is preserved by products. It follows th
 product of two geometrically reduced coordinate Hopf algebras of finite type is geometrically
 reduced.
 
-Over an algebraically closed field, a reduced affine group of finite type is smooth. Thus the
-ordinary tensor product of two reduced coordinate algebras is reduced. In particular, the tensor
-square of a reduced closed subgroup remains reduced, as required when its defining ideal is
-transported through comultiplication.
-
 ## Main declarations
 
 * `TauCeti.geometricallyReducedCommHopfAlgProperty.tensorProduct`: finite-type geometrically
   reduced affine groups are closed under direct products.
-* `TauCeti.CommHopfAlgCat.isReduced_tensorProduct_of_isAlgClosed`: over an algebraically closed
-  field, the tensor product of two reduced finite-type coordinate Hopf algebras is reduced.
 
 ## References
 
@@ -64,22 +57,6 @@ theorem tensorProduct (H K : CommHopfAlgCat.{v} k)
   exact smoothCommHopfAlgProperty.tensorProduct H K hH hK
 
 end geometricallyReducedCommHopfAlgProperty
-
-namespace CommHopfAlgCat
-
-/-- Over an algebraically closed field, the tensor product of two reduced finite-type coordinate
-Hopf algebras is reduced. -/
-theorem isReduced_tensorProduct_of_isAlgClosed
-    {k : Type u} [Field k] [IsAlgClosed k] (H K : CommHopfAlgCat.{v} k)
-    [Algebra.FiniteType k H] [Algebra.FiniteType k K] [IsReduced H] [IsReduced K] :
-    IsReduced (H ⊗[k] K) := by
-  have hH : geometricallyReducedCommHopfAlgProperty k H :=
-    (geometricallyReducedCommHopfAlgProperty_iff_isReduced_of_isAlgClosed k H).2 inferInstance
-  have hK : geometricallyReducedCommHopfAlgProperty k K :=
-    (geometricallyReducedCommHopfAlgProperty_iff_isReduced_of_isAlgClosed k K).2 inferInstance
-  exact (geometricallyReducedCommHopfAlgProperty.tensorProduct H K hH hK).isReduced
-
-end CommHopfAlgCat
 
 end
 

--- a/TauCeti/RingTheory/FiniteType/TensorProduct.lean
+++ b/TauCeti/RingTheory/FiniteType/TensorProduct.lean
@@ -1,0 +1,68 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.RingTheory.FiniteType.PointSeparation
+import Mathlib.LinearAlgebra.TensorProduct.Basis
+public import Mathlib.RingTheory.TensorProduct.Maps
+
+/-!
+# Reduced tensor products over an algebraically closed field
+
+A reduced finite-type algebra over an algebraically closed field stays reduced after tensoring
+with any reduced algebra. This applies in particular to the tensor square of a coordinate ring
+modulo its nilradical, before any Hopf structure has been constructed on that quotient.
+
+The argument uses the Nullstellensatz point-separation theorem from
+`TauCeti.RingTheory.FiniteType.PointSeparation`. Specializing the finite-type factor at each
+rational point kills a nilpotent tensor. Expanding in a basis of the other factor then shows
+that every coefficient vanishes at all rational points, hence is zero.
+
+## References
+
+* W. C. Waterhouse, *Introduction to Affine Group Schemes*, §11.4, for the application to
+  reductions of affine groups.
+-/
+
+public section
+
+open scoped TensorProduct
+
+namespace TauCeti
+
+universe u v w
+
+/-- The tensor product of a reduced finite-type algebra over an algebraically closed field
+with any reduced algebra is reduced. Only the first factor needs to be of finite type. -/
+instance instIsReducedTensorProductOfIsAlgClosed
+    (k : Type u) [Field k] [IsAlgClosed k]
+    (A : Type v) [CommRing A] [Algebra k A] [Algebra.FiniteType k A] [IsReduced A]
+    (B : Type w) [CommRing B] [Algebra k B] [IsReduced B] :
+    IsReduced (A ⊗[k] B) := by
+  classical
+  let b := Module.Free.chooseBasis k B
+  let c := b.baseChange A
+  refine ⟨fun x hx ↦ ?_⟩
+  apply c.repr.injective
+  ext i
+  simp only [map_zero, Finsupp.zero_apply]
+  apply eq_of_forall_algHom_apply_eq (k := k) (K := k)
+  intro f
+  let F : A ⊗[k] B →ₐ[k] B := Algebra.TensorProduct.lift
+    ((Algebra.ofId k B).comp f) (AlgHom.id k B) (fun _ _ ↦ Commute.all _ _)
+  have hcoord (z : A ⊗[k] B) : b.repr (F z) i = f (c.repr z i) := by
+    induction z using TensorProduct.induction_on with
+    | zero => simp
+    | add z z' hz hz' => simp [hz, hz']
+    | tmul a d =>
+      simp only [F, Algebra.TensorProduct.lift_tmul, AlgHom.comp_apply,
+        Algebra.ofId_apply, AlgHom.id_apply, ← Algebra.smul_def, c,
+        Module.Basis.baseChange_repr_tmul]
+      simp [mul_comm]
+  have hzero : F x = 0 := (hx.map F).eq_zero
+  simpa [hzero] using (hcoord x).symm
+
+end TauCeti


### PR DESCRIPTION
This PR proves that a reduced finite-type algebra over an algebraically closed field has reduced tensor product with any reduced algebra, and removes the tensor-reducedness hypothesis from the finite-center criterion. It advances [ReductiveGroups/README.md, Layer 6, “Reductive and semisimple groups”](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/ReductiveGroups/README.md#layer-6-reductive-and-semisimple-groups), specifically “Develop the radical, the centre `Z(G)`, the derived group `G_der`, central isogenies, and the simply connected and adjoint forms.”

The immediate consumer is `FiniteTypeCommHopfAlgCat.moduleFinite_centerCoordinate_of_reducedCenter_identityComponent_eq_augmentation`: over an algebraically closed field, it now deduces finiteness of the center from triviality of its reduced identity component without assuming that the reduced center's tensor square is reduced. This discharges the commutative-algebra prerequisite explicitly retained by the reduced-center construction and #6059. The former tensor-reducedness result required both factors to already carry Hopf structures, so it could not construct the nilradical Hopf quotient without circular reasoning. No open PR in the duplicate scan supplies this missing input.

The new instance `TauCeti.instIsReducedTensorProductOfIsAlgClosed` uses rational-point separation on the finite-type factor and basis coordinates on the other factor. Neither factor needs a Hopf structure, only the first needs finite type, and the field and two algebras may occupy independent universes. The center proof locally activates Mathlib's existing radical-quotient reducedness criterion. The superseded, unused `TauCeti.CommHopfAlgCat.isReduced_tensorProduct_of_isAlgClosed` is removed with its obsolete documentation and import; no compatibility declaration remains.

After this PR, the finite-center step of Layer 6 still needs geometric connectedness of the reduced center's identity component, then its trivialization using `semisimpleCommHopfAlgProperty.eq_augmentation_of_isCentral`; the broader milestone also retains the adjoint-form and central-isogeny constructions.

The change adds `TauCeti/RingTheory/FiniteType/TensorProduct.lean` (68 lines) and updates `Center/Finite.lean` and `GeometricallyReduced/Product.lean`, for 88 added and 39 removed lines in total. The proof reuses Tau Ceti's Nullstellensatz point-separation theorem, Mathlib's `Module.Basis.baseChange`, and `Algebra.TensorProduct.lift`. No Mathlib infrastructure or external formalization is vendored. The application follows Waterhouse, *Introduction to Affine Group Schemes*, §11.4, as cited in the module; the existing center argument cites Milne, *Algebraic Groups*, §§1.f and 21.10.

Self-review against api-design, reuse, and generality removed the superseded Hopf-only theorem, kept the quotient-reducedness activation local, and confirmed that no stronger finite-type or universe hypotheses are needed.

Validation: targeted `lake build` passes for all three changed modules. `tauceti-axioms --changed-since-merge-base origin/main` audits all seven declarations within the allowed axioms. `git diff --check` passes. The prescribed lint wrapper stops at its freshness guard because its fixed list omits the newly default `tacticAlt`; a temporary copy with that linter added runs the full current default set and passes all three changed modules with zero violations and zero grandfathered findings. No repository script or linter configuration is modified.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"reduced-finite-type-tensor-product"}-->

🤖 Prepared with Codex
