### PR TITLE
feat: almost every linear perturbation of a function is Morse

### DIFF
--- a/TauCeti/Analysis/Calculus/Morse/Generic.lean
+++ b/TauCeti/Analysis/Calculus/Morse/Generic.lean
@@ -11,6 +11,7 @@ public import TauCeti.Analysis.Calculus.Morse.Basic
 public import TauCeti.Analysis.Calculus.Sard.EqualDimension
 -- Private: used only inside proofs.
 import Mathlib.Analysis.Calculus.ContDiff.Operations
+import TauCeti.Analysis.Normed.Module.FiniteDimension
 import TauCeti.MeasureTheory.Measure.Haar.NormedSpace
 
 /-!
@@ -211,17 +212,19 @@ section InnerProduct
 open InnerProductSpace
 
 variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E] [FiniteDimensional ℝ E]
-  [MeasurableSpace E] [BorelSpace E]
-  [MeasurableSpace (E →L[ℝ] ℝ)] [BorelSpace (E →L[ℝ] ℝ)]
-  {f : E → ℝ} {U : Set E}
+  [MeasurableSpace E] [BorelSpace E] {f : E → ℝ} {U : Set E}
 
 /-- **Almost every perturbation by a linear form `⟪v, ·⟫` of a `C²` function is Morse.** This is
 `TauCeti.ae_hasNondegenerateCriticalPointsOn_sub` transported along the Riesz isometry, which is a
 continuous linear equivalence and so carries null sets to null sets; the perturbed function has
-gradient `∇f - v`, which is the shape the negative gradient flow is stated in. -/
+gradient `∇f - v`, which is the shape the negative gradient flow is stated in.
+
+No measurable structure on the dual appears in the statement: the Borel one is installed inside
+the proof, where the Haar measure of the dual is the auxiliary object being transported. -/
 theorem ae_hasNondegenerateCriticalPointsOn_sub_inner (μ : Measure E) [μ.IsAddHaarMeasure]
     (hU : IsOpen U) (hf : ContDiffOn ℝ 2 f U) :
     ∀ᵐ v ∂μ, HasNondegenerateCriticalPointsOn (fun y ↦ f y - ⟪v, y⟫_ℝ) U := by
+  borelize (E →L[ℝ] ℝ)
   have hbad := ae_hasNondegenerateCriticalPointsOn_sub (addHaar : Measure (E →L[ℝ] ℝ)) hU hf
   rw [ae_iff] at hbad ⊢
   have hpre : {v : E | ¬ HasNondegenerateCriticalPointsOn (fun y ↦ f y - ⟪v, y⟫_ℝ) U} =

--- a/TauCeti/Analysis/Calculus/Morse/Generic.lean
+++ b/TauCeti/Analysis/Calculus/Morse/Generic.lean
@@ -146,17 +146,18 @@ theorem hasNondegenerateCriticalPointsOn_sub_iff (hU : IsOpen U) (hf : ContDiffO
   have hd : DifferentiableOn ℝ f U := hf.differentiableOn (by norm_num)
   constructor
   · rintro hM ⟨y, ⟨hyU, hyc⟩, rfl⟩
+    have hderiv : fderiv ℝ (fun z ↦ f z - (fderiv ℝ f y) z) y =
+        fderiv ℝ f y - fderiv ℝ f y := by
+      simpa using fderiv_fun_sub (hd.differentiableAt (hU.mem_nhds hyU))
+        (fderiv ℝ f y).differentiableAt
     have hcrit : fderiv ℝ (fun z ↦ f z - (fderiv ℝ f y) z) y = 0 := by
-      rw [show fderiv ℝ (fun z ↦ f z - (fderiv ℝ f y) z) y =
-          fderiv ℝ f y - fderiv ℝ f y by
-        simpa using fderiv_fun_sub (hd.differentiableAt (hU.mem_nhds hyU))
-          (fderiv ℝ f y).differentiableAt, sub_self]
+      rw [hderiv, sub_self]
     exact hyc (((isNondegenerateCriticalPoint_sub_iff (hf.contDiffAt (hU.mem_nhds hyU)) _).1
       (hasNondegenerateCriticalPointsOn_iff.1 hM hyU hcrit)).2.surjective)
   · refine fun ha ↦ hasNondegenerateCriticalPointsOn_iff.2 fun y hyU hy0 ↦ ?_
-    rw [show fderiv ℝ (fun z ↦ f z - a z) y = fderiv ℝ f y - a by
-      simpa using fderiv_fun_sub (hd.differentiableAt (hU.mem_nhds hyU)) a.differentiableAt,
-      sub_eq_zero] at hy0
+    have hderiv : fderiv ℝ (fun z ↦ f z - a z) y = fderiv ℝ f y - a := by
+      simpa using fderiv_fun_sub (hd.differentiableAt (hU.mem_nhds hyU)) a.differentiableAt
+    rw [hderiv, sub_eq_zero] at hy0
     refine (isNondegenerateCriticalPoint_sub_iff (hf.contDiffAt (hU.mem_nhds hyU)) a).2
       ⟨hy0, ContinuousLinearMap.isInvertible_of_surjective ?_⟩
     by_contra hs

--- a/TauCeti/Analysis/Calculus/Morse/Generic.lean
+++ b/TauCeti/Analysis/Calculus/Morse/Generic.lean
@@ -35,7 +35,7 @@ the map `fderiv ℝ f : E → (E →L[ℝ] ℝ)`** taken on `U`; this is
 `TauCeti.hasNondegenerateCriticalPointsOn_sub_iff`, and it is the whole content of the argument.
 Domain and codomain of `fderiv ℝ f` have the same dimension, the continuous dual of a
 finite-dimensional space having the dimension of the space
-(`ContinuousLinearMap.finrank_dual_eq`), so
+(`ContinuousLinearMap.dual_finrank_eq`), so
 `TauCeti.addHaar_image_eq_zero_of_not_surjective_fderivWithin` applies and the bad set of `a` is
 null. Note that only `C²` regularity of `f` is used: the map `fderiv ℝ f` is then merely
 differentiable, which is all the equal-dimensional Sard lemma asks for, and no higher-stratum
@@ -86,9 +86,8 @@ variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
 
 /-! ### Morse perturbations are the regular values of the differential
 
-The effect of the perturbation on the first two derivatives is general calculus, with no Morse
-theory in it, so it lives in `TauCeti.Analysis.Calculus.SecondDerivative` as
-`TauCeti.fderiv_sub_continuousLinearMap` and `TauCeti.fderiv_fderiv_sub_continuousLinearMap`.
+The effect of the perturbation on the first two derivatives follows from Mathlib's general
+calculus lemmas for derivatives of differences and constant shifts.
 -/
 
 /-- A point at which `f` is `C²` is a nondegenerate critical point of `f - a` exactly when the
@@ -99,8 +98,13 @@ theorem isNondegenerateCriticalPoint_sub_iff (hf : ContDiffAt ℝ 2 f x) (a : E 
     IsNondegenerateCriticalPoint (fun y ↦ f y - a y) x ↔
       fderiv ℝ f x = a ∧ (fderiv ℝ (fderiv ℝ f) x).IsInvertible := by
   have hax : ContDiffAt ℝ 2 (fun y : E ↦ a y) x := a.contDiff.contDiffAt
-  have h1 := fderiv_sub_continuousLinearMap (hf.differentiableAt (by norm_num)) a
-  have h2 := fderiv_fderiv_sub_continuousLinearMap hf (by norm_num) a
+  have h1 : fderiv ℝ (fun y ↦ f y - a y) x = fderiv ℝ f x - a := by
+    simpa using fderiv_fun_sub (hf.differentiableAt (by norm_num)) a.differentiableAt
+  have hEq : (fderiv ℝ fun y ↦ f y - a y) =ᶠ[nhds x] fun y ↦ fderiv ℝ f y - a := by
+    filter_upwards [hf.eventually (by norm_num)] with y hy using by
+      simpa using fderiv_fun_sub (hy.differentiableAt (by norm_num)) a.differentiableAt
+  have h2 : fderiv ℝ (fderiv ℝ fun y ↦ f y - a y) x = fderiv ℝ (fderiv ℝ f) x := by
+    rw [hEq.fderiv_eq, fderiv_sub_const]
   constructor
   · rintro ⟨-, h0, hinv⟩
     rw [h1, sub_eq_zero] at h0
@@ -125,7 +129,7 @@ theorem finite_setOfPred_fderiv_sub_eq_zero {K : Set E} (hK : IsCompact K)
     {x ∈ K | fderiv ℝ (fun y ↦ f y - a y) x = 0}.Finite :=
   (ha.mono hKU).finite_setOfPred_fderiv_eq_zero hK
     ((hcont.sub continuousOn_const).congr fun y hy ↦
-      fderiv_sub_continuousLinearMap (hd y hy) a)
+      (by simpa using fderiv_fun_sub (hd y hy) a.differentiableAt))
 
 section FiniteDimensional
 
@@ -143,11 +147,16 @@ theorem hasNondegenerateCriticalPointsOn_sub_iff (hU : IsOpen U) (hf : ContDiffO
   constructor
   · rintro hM ⟨y, ⟨hyU, hyc⟩, rfl⟩
     have hcrit : fderiv ℝ (fun z ↦ f z - (fderiv ℝ f y) z) y = 0 := by
-      rw [fderiv_sub_continuousLinearMap (hd.differentiableAt (hU.mem_nhds hyU)), sub_self]
+      rw [show fderiv ℝ (fun z ↦ f z - (fderiv ℝ f y) z) y =
+          fderiv ℝ f y - fderiv ℝ f y by
+        simpa using fderiv_fun_sub (hd.differentiableAt (hU.mem_nhds hyU))
+          (fderiv ℝ f y).differentiableAt, sub_self]
     exact hyc (((isNondegenerateCriticalPoint_sub_iff (hf.contDiffAt (hU.mem_nhds hyU)) _).1
       (hasNondegenerateCriticalPointsOn_iff.1 hM hyU hcrit)).2.surjective)
   · refine fun ha ↦ hasNondegenerateCriticalPointsOn_iff.2 fun y hyU hy0 ↦ ?_
-    rw [fderiv_sub_continuousLinearMap (hd.differentiableAt (hU.mem_nhds hyU)), sub_eq_zero] at hy0
+    rw [show fderiv ℝ (fun z ↦ f z - a z) y = fderiv ℝ f y - a by
+      simpa using fderiv_fun_sub (hd.differentiableAt (hU.mem_nhds hyU)) a.differentiableAt,
+      sub_eq_zero] at hy0
     refine (isNondegenerateCriticalPoint_sub_iff (hf.contDiffAt (hU.mem_nhds hyU)) a).2
       ⟨hy0, ContinuousLinearMap.isInvertible_of_surjective ?_⟩
     by_contra hs
@@ -175,7 +184,7 @@ theorem ae_hasNondegenerateCriticalPointsOn_sub [MeasurableSpace (E →L[ℝ] �
     (hf.fderiv_of_isOpen (m := 1) hU (by norm_num)).differentiableOn one_ne_zero
   have hnull : ν (fderiv ℝ f '' {x ∈ U | ¬ Surjective (fderiv ℝ (fderiv ℝ f) x)}) = 0 := by
     refine addHaar_image_eq_zero_of_not_surjective_fderivWithin ν
-      ContinuousLinearMap.finrank_dual_eq.symm (fun y hy ↦ ?_) fun _ hy ↦ hy.2
+      ContinuousLinearMap.dual_finrank_eq.symm (fun y hy ↦ ?_) fun _ hy ↦ hy.2
     exact ((hdf y hy.1).differentiableAt (hU.mem_nhds hy.1)).hasFDerivAt.hasFDerivWithinAt
   rw [ae_iff]
   refine measure_mono_null (fun a ha ↦ ?_) hnull

--- a/TauCeti/Analysis/Calculus/Morse/Generic.lean
+++ b/TauCeti/Analysis/Calculus/Morse/Generic.lean
@@ -59,12 +59,12 @@ from its critical points; the regularity hypothesis `ContDiffOn ℝ 2 f U` is ca
 * `TauCeti.dense_setOfPred_hasNondegenerateCriticalPointsOn_sub` and
   `TauCeti.exists_norm_lt_hasNondegenerateCriticalPointsOn_sub`: the good perturbations are dense,
   so they can be taken arbitrarily small in the operator norm.
-* `TauCeti.ae_hasNondegenerateCriticalPointsOn_sub_inner`: the same statement on an inner product
-  space, with the perturbation written `⟪v, ·⟫` as in the gradient formulation of Lane M.
+* `TauCeti.ae_hasNondegenerateCriticalPointsOn_sub_inner`,
+  `TauCeti.dense_setOfPred_hasNondegenerateCriticalPointsOn_sub_inner` and
+  `TauCeti.exists_norm_lt_hasNondegenerateCriticalPointsOn_sub_inner`: the same three statements on
+  an inner product space, with the perturbation written `⟪v, ·⟫` as in the gradient formulation.
 * `TauCeti.finite_setOfPred_fderiv_sub_eq_zero`: a perturbation that is Morse on `U` has only
-  finitely many critical points on a compact subset of `U`, so its Morse complex there is finitely
-  generated; `TauCeti.exists_norm_lt_hasNondegenerateCriticalPointsOn_sub_and_finite` combines this
-  with the previous item.
+  finitely many critical points on a compact subset of `U`.
 
 ## References
 
@@ -72,40 +72,23 @@ from its critical points; the regularity hypothesis `ContDiffOn ℝ 2 f U` is ca
   this genericity statement is proved in exactly this way.
 * M. Audin and M. Damian, *Morse Theory and Floer Homology*, Springer Universitext, 2014,
   Chapter 1.
-* [Heegaard Floer homology roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/HeegaardFloer/README.md),
-  Lane M, "Morse homology".
 -/
 
 public section
 
-open Function MeasureTheory MeasureTheory.Measure Module Set Topology
+open Function MeasureTheory MeasureTheory.Measure Set
 
 namespace TauCeti
 
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
   {f : E → ℝ} {U : Set E} {x : E} {a : E →L[ℝ] ℝ}
 
-/-! ### The effect of a linear perturbation on the first two derivatives -/
+/-! ### Morse perturbations are the regular values of the differential
 
-/-- Subtracting a continuous linear functional shifts the differential by that functional. -/
-private theorem fderiv_sub_functional (hf : DifferentiableAt ℝ f x) (a : E →L[ℝ] ℝ) :
-    fderiv ℝ (fun y ↦ f y - a y) x = fderiv ℝ f x - a :=
-  (hf.hasFDerivAt.sub a.hasFDerivAt).fderiv
-
-/-- Subtracting a continuous linear functional does not change the second derivative. -/
-private theorem fderiv_fderiv_sub_functional (hf : ∀ᶠ y in 𝓝 x, DifferentiableAt ℝ f y)
-    (a : E →L[ℝ] ℝ) :
-    fderiv ℝ (fderiv ℝ fun y ↦ f y - a y) x = fderiv ℝ (fderiv ℝ f) x := by
-  have hEq : (fderiv ℝ fun y ↦ f y - a y) =ᶠ[𝓝 x] fun y ↦ fderiv ℝ f y - a := by
-    filter_upwards [hf] with y hy using fderiv_sub_functional hy a
-  rw [hEq.fderiv_eq, fderiv_sub_const]
-
-/-- A `C²` germ is differentiable near the point. -/
-private theorem eventually_differentiableAt (hf : ContDiffAt ℝ 2 f x) :
-    ∀ᶠ y in 𝓝 x, DifferentiableAt ℝ f y :=
-  (hf.eventually (by norm_num)).mono fun _ hy ↦ hy.differentiableAt (by norm_num)
-
-/-! ### Morse perturbations are the regular values of the differential -/
+The effect of the perturbation on the first two derivatives is general calculus, with no Morse
+theory in it, so it lives in `TauCeti.Analysis.Calculus.SecondDerivative` as
+`TauCeti.fderiv_sub_continuousLinearMap` and `TauCeti.fderiv_fderiv_sub_continuousLinearMap`.
+-/
 
 /-- A point at which `f` is `C²` is a nondegenerate critical point of `f - a` exactly when the
 differential of `f` there is `a` and the second derivative of `f` there is invertible. Both
@@ -114,10 +97,9 @@ points are critical without affecting whether they are degenerate. -/
 theorem isNondegenerateCriticalPoint_sub_iff (hf : ContDiffAt ℝ 2 f x) (a : E →L[ℝ] ℝ) :
     IsNondegenerateCriticalPoint (fun y ↦ f y - a y) x ↔
       fderiv ℝ f x = a ∧ (fderiv ℝ (fderiv ℝ f) x).IsInvertible := by
-  have hev := eventually_differentiableAt hf
   have hax : ContDiffAt ℝ 2 (fun y : E ↦ a y) x := a.contDiff.contDiffAt
-  have h1 := fderiv_sub_functional hev.self_of_nhds a
-  have h2 := fderiv_fderiv_sub_functional hev a
+  have h1 := fderiv_sub_continuousLinearMap (hf.differentiableAt (by norm_num)) a
+  have h2 := fderiv_fderiv_sub_continuousLinearMap hf (by norm_num) a
   constructor
   · rintro ⟨-, h0, hinv⟩
     rw [h1, sub_eq_zero] at h0
@@ -129,20 +111,17 @@ theorem isNondegenerateCriticalPoint_sub_iff (hf : ContDiffAt ℝ 2 f x) (a : E 
     · rw [h2]; exact hinv
 
 /-- **A perturbation that is Morse on `U` has only finitely many critical points on a compact
-subset of `U`.** Continuity of the differential on the compact set closes the critical locus, and
-nondegeneracy makes it discrete. This is the finiteness that makes a Morse complex finitely
-generated. -/
-theorem finite_setOfPred_fderiv_sub_eq_zero (hU : IsOpen U) (hf : ContDiffOn ℝ 2 f U)
-    (ha : HasNondegenerateCriticalPointsOn (fun y ↦ f y - a y) U)
-    {K : Set E} (hK : IsCompact K) (hKU : K ⊆ U) :
-    {x ∈ K | fderiv ℝ (fun y ↦ f y - a y) x = 0}.Finite := by
-  have hd : DifferentiableOn ℝ f U := hf.differentiableOn (by norm_num)
-  have hcont : ContinuousOn (fderiv ℝ f) U := hf.continuousOn_fderiv_of_isOpen hU (by norm_num)
-  have hsub : ContinuousOn (fun y ↦ fderiv ℝ f y - a) K :=
-    (hcont.mono hKU).sub continuousOn_const
-  exact (ha.mono hKU).finite_setOfPred_fderiv_eq_zero hK
-    (hsub.congr fun y hy ↦
-      fderiv_sub_functional (hd.differentiableAt (hU.mem_nhds (hKU hy))) a)
+subset of `U`.** Continuity of `fderiv ℝ f` on the compact set closes the critical locus, and
+nondegeneracy makes it discrete. Nothing beyond those two hypotheses on `K` is needed: the
+perturbation shifts the differential of `f` by the constant `a`, so it neither disturbs the
+continuity nor requires any regularity of its own. -/
+theorem finite_setOfPred_fderiv_sub_eq_zero {K : Set E} (hK : IsCompact K)
+    (hd : ∀ x ∈ K, DifferentiableAt ℝ f x) (hcont : ContinuousOn (fderiv ℝ f) K)
+    (ha : HasNondegenerateCriticalPointsOn (fun y ↦ f y - a y) U) (hKU : K ⊆ U) :
+    {x ∈ K | fderiv ℝ (fun y ↦ f y - a y) x = 0}.Finite :=
+  (ha.mono hKU).finite_setOfPred_fderiv_eq_zero hK
+    ((hcont.sub continuousOn_const).congr fun y hy ↦
+      fderiv_sub_continuousLinearMap (hd y hy) a)
 
 section FiniteDimensional
 
@@ -160,11 +139,11 @@ theorem hasNondegenerateCriticalPointsOn_sub_iff (hU : IsOpen U) (hf : ContDiffO
   constructor
   · rintro hM ⟨y, ⟨hyU, hyc⟩, rfl⟩
     have hcrit : fderiv ℝ (fun z ↦ f z - (fderiv ℝ f y) z) y = 0 := by
-      rw [fderiv_sub_functional (hd.differentiableAt (hU.mem_nhds hyU)), sub_self]
+      rw [fderiv_sub_continuousLinearMap (hd.differentiableAt (hU.mem_nhds hyU)), sub_self]
     exact hyc (((isNondegenerateCriticalPoint_sub_iff (hf.contDiffAt (hU.mem_nhds hyU)) _).1
       (hasNondegenerateCriticalPointsOn_iff.1 hM hyU hcrit)).2.surjective)
   · refine fun ha ↦ hasNondegenerateCriticalPointsOn_iff.2 fun y hyU hy0 ↦ ?_
-    rw [fderiv_sub_functional (hd.differentiableAt (hU.mem_nhds hyU)), sub_eq_zero] at hy0
+    rw [fderiv_sub_continuousLinearMap (hd.differentiableAt (hU.mem_nhds hyU)), sub_eq_zero] at hy0
     refine (isNondegenerateCriticalPoint_sub_iff (hf.contDiffAt (hU.mem_nhds hyU)) a).2
       ⟨hy0, ContinuousLinearMap.isInvertible_of_surjective ?_⟩
     by_contra hs
@@ -216,18 +195,6 @@ theorem exists_norm_lt_hasNondegenerateCriticalPointsOn_sub (hU : IsOpen U)
       Metric.isOpen_ball ⟨0, Metric.mem_ball_self hε⟩
   exact ⟨a, by simpa [Metric.mem_ball, dist_zero_right] using hball, hmem⟩
 
-/-- **A `C²` function is made Morse, with a finitely generated Morse complex, by an arbitrarily
-small linear perturbation.** Combining
-`TauCeti.exists_norm_lt_hasNondegenerateCriticalPointsOn_sub` with
-`TauCeti.finite_setOfPred_fderiv_sub_eq_zero`, one may choose the perturbation to have operator
-norm less than any prescribed `ε > 0`. -/
-theorem exists_norm_lt_hasNondegenerateCriticalPointsOn_sub_and_finite (hU : IsOpen U)
-    (hf : ContDiffOn ℝ 2 f U) {ε : ℝ} (hε : 0 < ε) {K : Set E} (hK : IsCompact K) (hKU : K ⊆ U) :
-    ∃ a : E →L[ℝ] ℝ, ‖a‖ < ε ∧ HasNondegenerateCriticalPointsOn (fun y ↦ f y - a y) U ∧
-      {x ∈ K | fderiv ℝ (fun y ↦ f y - a y) x = 0}.Finite := by
-  obtain ⟨a, ha, hM⟩ := exists_norm_lt_hasNondegenerateCriticalPointsOn_sub hU hf hε
-  exact ⟨a, ha, hM, finite_setOfPred_fderiv_sub_eq_zero hU hf hM hK hKU⟩
-
 end Measurable
 
 end FiniteDimensional
@@ -251,7 +218,7 @@ variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E] [FiniteDim
 /-- **Almost every perturbation by a linear form `⟪v, ·⟫` of a `C²` function is Morse.** This is
 `TauCeti.ae_hasNondegenerateCriticalPointsOn_sub` transported along the Riesz isometry, which is a
 continuous linear equivalence and so carries null sets to null sets; the perturbed function has
-gradient `∇f - v`, which is the shape the negative gradient flow of Lane M is stated in. -/
+gradient `∇f - v`, which is the shape the negative gradient flow is stated in. -/
 theorem ae_hasNondegenerateCriticalPointsOn_sub_inner (μ : Measure E) [μ.IsAddHaarMeasure]
     (hU : IsOpen U) (hf : ContDiffOn ℝ 2 f U) :
     ∀ᵐ v ∂μ, HasNondegenerateCriticalPointsOn (fun y ↦ f y - ⟪v, y⟫_ℝ) U := by
@@ -265,6 +232,26 @@ theorem ae_hasNondegenerateCriticalPointsOn_sub_inner (μ : Measure E) [μ.IsAdd
   rw [hpre]
   exact (((toDual ℝ E).toContinuousLinearEquiv).quasiMeasurePreserving_addHaar μ
     addHaar).preimage_null hbad
+
+/-- The vectors `v` for which subtracting `⟪v, ·⟫` makes a `C²` function Morse on an open set are
+dense. -/
+theorem dense_setOfPred_hasNondegenerateCriticalPointsOn_sub_inner (hU : IsOpen U)
+    (hf : ContDiffOn ℝ 2 f U) :
+    Dense {v : E | HasNondegenerateCriticalPointsOn (fun y ↦ f y - ⟪v, y⟫_ℝ) U} := by
+  refine Measure.dense_of_ae (μ := (addHaar : Measure E)) ?_
+  filter_upwards [ae_hasNondegenerateCriticalPointsOn_sub_inner addHaar hU hf] with v hv using hv
+
+/-- **A `C²` function is made Morse by subtracting `⟪v, ·⟫` for an arbitrarily small `v`**: for
+every `ε > 0` there is a vector of norm less than `ε` whose associated linear form, subtracted,
+leaves only nondegenerate critical points on `U`. Equivalently, the gradient of `f` may be shifted
+by an arbitrarily small vector to make `f` Morse. -/
+theorem exists_norm_lt_hasNondegenerateCriticalPointsOn_sub_inner (hU : IsOpen U)
+    (hf : ContDiffOn ℝ 2 f U) {ε : ℝ} (hε : 0 < ε) :
+    ∃ v : E, ‖v‖ < ε ∧ HasNondegenerateCriticalPointsOn (fun y ↦ f y - ⟪v, y⟫_ℝ) U := by
+  obtain ⟨v, hmem, hball⟩ :=
+    (dense_setOfPred_hasNondegenerateCriticalPointsOn_sub_inner hU hf).exists_mem_open
+      Metric.isOpen_ball ⟨0, Metric.mem_ball_self hε⟩
+  exact ⟨v, by simpa [Metric.mem_ball, dist_zero_right] using hball, hmem⟩
 
 end InnerProduct
 

--- a/TauCeti/Analysis/Calculus/Morse/Generic.lean
+++ b/TauCeti/Analysis/Calculus/Morse/Generic.lean
@@ -1,0 +1,271 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.InnerProductSpace.Dual
+public import Mathlib.MeasureTheory.Measure.Haar.Basic
+public import TauCeti.Analysis.Calculus.Morse.Basic
+public import TauCeti.Analysis.Calculus.Sard.EqualDimension
+-- Private: used only inside proofs.
+import Mathlib.Analysis.Calculus.ContDiff.Operations
+import TauCeti.MeasureTheory.Measure.Haar.NormedSpace
+
+/-!
+# Almost every linear perturbation of a function is Morse
+
+Morse homology starts from a function all of whose critical points are nondegenerate, so the
+theory is empty until such functions are known to exist. This file proves that they are in fact
+*generic*: on an open subset `U` of a finite-dimensional real normed space `E`, for a twice
+continuously differentiable `f : E → ℝ` and **almost every** continuous linear functional
+`a : E →L[ℝ] ℝ`, every critical point of `f - a` in `U` is nondegenerate.
+
+The mechanism is the equal-dimensional case of Sard's theorem, applied not to `f` but to its
+differential. Subtracting a linear functional changes the differential by a constant and leaves
+the second derivative alone, so
+
+* `x` is a critical point of `f - a` exactly when `fderiv ℝ f x = a`, and
+* the second derivative of `f - a` at `x` is that of `f`.
+
+Hence `f - a` has a *degenerate* critical point in `U` exactly when `a` is a **critical value of
+the map `fderiv ℝ f : E → (E →L[ℝ] ℝ)`** taken on `U`; this is
+`TauCeti.hasNondegenerateCriticalPointsOn_sub_iff`, and it is the whole content of the argument.
+Domain and codomain of `fderiv ℝ f` have the same dimension, the continuous dual of a
+finite-dimensional space having the dimension of the space
+(`ContinuousLinearMap.finrank_dual_eq`), so
+`TauCeti.addHaar_image_eq_zero_of_not_surjective_fderivWithin` applies and the bad set of `a` is
+null. Note that only `C²` regularity of `f` is used: the map `fderiv ℝ f` is then merely
+differentiable, which is all the equal-dimensional Sard lemma asks for, and no higher-stratum
+Morse--Sard argument is needed.
+
+The perturbation is written `f - a` rather than `f + a`; the two conventions differ by the sign of
+`a`, and subtraction makes the criticality condition read `fderiv ℝ f x = a`, so that the
+exceptional set is literally the set of critical values of `fderiv ℝ f`.
+
+Nondegeneracy here is `TauCeti.HasNondegenerateCriticalPointsOn`, which asks nothing of `f` away
+from its critical points; the regularity hypothesis `ContDiffOn ℝ 2 f U` is carried separately, as
+`TauCeti/Analysis/Calculus/Morse/Basic.lean` explains.
+
+## Main declarations
+
+* `TauCeti.isNondegenerateCriticalPoint_sub_iff`: a point at which `f` is `C²` is a nondegenerate
+  critical point of `f - a` exactly when `a` is the differential of `f` there and the second
+  derivative of `f` is invertible.
+* `TauCeti.hasNondegenerateCriticalPointsOn_sub_iff`: **`f - a` has nondegenerate critical points
+  on `U` exactly when `a` is a regular value of `fderiv ℝ f` on `U`.**
+* `TauCeti.ae_hasNondegenerateCriticalPointsOn_sub`: **almost every linear perturbation is Morse.**
+* `TauCeti.dense_setOfPred_hasNondegenerateCriticalPointsOn_sub` and
+  `TauCeti.exists_norm_lt_hasNondegenerateCriticalPointsOn_sub`: the good perturbations are dense,
+  so they can be taken arbitrarily small in the operator norm.
+* `TauCeti.ae_hasNondegenerateCriticalPointsOn_sub_inner`: the same statement on an inner product
+  space, with the perturbation written `⟪v, ·⟫` as in the gradient formulation of Lane M.
+* `TauCeti.finite_setOfPred_fderiv_sub_eq_zero`: a perturbation that is Morse on `U` has only
+  finitely many critical points on a compact subset of `U`, so its Morse complex there is finitely
+  generated; `TauCeti.exists_norm_lt_hasNondegenerateCriticalPointsOn_sub_and_finite` combines this
+  with the previous item.
+
+## References
+
+* V. Guillemin and A. Pollack, *Differential Topology*, Prentice-Hall, 1974, Chapter 1, §7, where
+  this genericity statement is proved in exactly this way.
+* M. Audin and M. Damian, *Morse Theory and Floer Homology*, Springer Universitext, 2014,
+  Chapter 1.
+* [Heegaard Floer homology roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/HeegaardFloer/README.md),
+  Lane M, "Morse homology".
+-/
+
+public section
+
+open Function MeasureTheory MeasureTheory.Measure Module Set Topology
+
+namespace TauCeti
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+  {f : E → ℝ} {U : Set E} {x : E} {a : E →L[ℝ] ℝ}
+
+/-! ### The effect of a linear perturbation on the first two derivatives -/
+
+/-- Subtracting a continuous linear functional shifts the differential by that functional. -/
+private theorem fderiv_sub_functional (hf : DifferentiableAt ℝ f x) (a : E →L[ℝ] ℝ) :
+    fderiv ℝ (fun y ↦ f y - a y) x = fderiv ℝ f x - a :=
+  (hf.hasFDerivAt.sub a.hasFDerivAt).fderiv
+
+/-- Subtracting a continuous linear functional does not change the second derivative. -/
+private theorem fderiv_fderiv_sub_functional (hf : ∀ᶠ y in 𝓝 x, DifferentiableAt ℝ f y)
+    (a : E →L[ℝ] ℝ) :
+    fderiv ℝ (fderiv ℝ fun y ↦ f y - a y) x = fderiv ℝ (fderiv ℝ f) x := by
+  have hEq : (fderiv ℝ fun y ↦ f y - a y) =ᶠ[𝓝 x] fun y ↦ fderiv ℝ f y - a := by
+    filter_upwards [hf] with y hy using fderiv_sub_functional hy a
+  rw [hEq.fderiv_eq, fderiv_sub_const]
+
+/-- A `C²` germ is differentiable near the point. -/
+private theorem eventually_differentiableAt (hf : ContDiffAt ℝ 2 f x) :
+    ∀ᶠ y in 𝓝 x, DifferentiableAt ℝ f y :=
+  (hf.eventually (by norm_num)).mono fun _ hy ↦ hy.differentiableAt (by norm_num)
+
+/-! ### Morse perturbations are the regular values of the differential -/
+
+/-- A point at which `f` is `C²` is a nondegenerate critical point of `f - a` exactly when the
+differential of `f` there is `a` and the second derivative of `f` there is invertible. Both
+conditions are about `f` alone: the perturbation only moves the differential, so it selects which
+points are critical without affecting whether they are degenerate. -/
+theorem isNondegenerateCriticalPoint_sub_iff (hf : ContDiffAt ℝ 2 f x) (a : E →L[ℝ] ℝ) :
+    IsNondegenerateCriticalPoint (fun y ↦ f y - a y) x ↔
+      fderiv ℝ f x = a ∧ (fderiv ℝ (fderiv ℝ f) x).IsInvertible := by
+  have hev := eventually_differentiableAt hf
+  have hax : ContDiffAt ℝ 2 (fun y : E ↦ a y) x := a.contDiff.contDiffAt
+  have h1 := fderiv_sub_functional hev.self_of_nhds a
+  have h2 := fderiv_fderiv_sub_functional hev a
+  constructor
+  · rintro ⟨-, h0, hinv⟩
+    rw [h1, sub_eq_zero] at h0
+    rw [h2] at hinv
+    exact ⟨h0, hinv⟩
+  · rintro ⟨h0, hinv⟩
+    refine ⟨ContDiffAt.sub hf hax, ?_, ?_⟩
+    · rw [h1, h0, sub_self]
+    · rw [h2]; exact hinv
+
+/-- **A perturbation that is Morse on `U` has only finitely many critical points on a compact
+subset of `U`.** Continuity of the differential on the compact set closes the critical locus, and
+nondegeneracy makes it discrete. This is the finiteness that makes a Morse complex finitely
+generated. -/
+theorem finite_setOfPred_fderiv_sub_eq_zero (hU : IsOpen U) (hf : ContDiffOn ℝ 2 f U)
+    (ha : HasNondegenerateCriticalPointsOn (fun y ↦ f y - a y) U)
+    {K : Set E} (hK : IsCompact K) (hKU : K ⊆ U) :
+    {x ∈ K | fderiv ℝ (fun y ↦ f y - a y) x = 0}.Finite := by
+  have hd : DifferentiableOn ℝ f U := hf.differentiableOn (by norm_num)
+  have hcont : ContinuousOn (fderiv ℝ f) U := hf.continuousOn_fderiv_of_isOpen hU (by norm_num)
+  have hsub : ContinuousOn (fun y ↦ fderiv ℝ f y - a) K :=
+    (hcont.mono hKU).sub continuousOn_const
+  exact (ha.mono hKU).finite_setOfPred_fderiv_eq_zero hK
+    (hsub.congr fun y hy ↦
+      fderiv_sub_functional (hd.differentiableAt (hU.mem_nhds (hKU hy))) a)
+
+section FiniteDimensional
+
+variable [FiniteDimensional ℝ E]
+
+/-- **The perturbations that make `f` Morse are exactly the regular values of its differential.**
+All critical points of `f - a` in `U` are nondegenerate if and only if `a` is not the value at a
+point of `U` of the differential `fderiv ℝ f` at which the second derivative fails to be
+surjective. -/
+theorem hasNondegenerateCriticalPointsOn_sub_iff (hU : IsOpen U) (hf : ContDiffOn ℝ 2 f U)
+    (a : E →L[ℝ] ℝ) :
+    HasNondegenerateCriticalPointsOn (fun y ↦ f y - a y) U ↔
+      a ∉ fderiv ℝ f '' {x ∈ U | ¬ Surjective (fderiv ℝ (fderiv ℝ f) x)} := by
+  have hd : DifferentiableOn ℝ f U := hf.differentiableOn (by norm_num)
+  constructor
+  · rintro hM ⟨y, ⟨hyU, hyc⟩, rfl⟩
+    have hcrit : fderiv ℝ (fun z ↦ f z - (fderiv ℝ f y) z) y = 0 := by
+      rw [fderiv_sub_functional (hd.differentiableAt (hU.mem_nhds hyU)), sub_self]
+    exact hyc (((isNondegenerateCriticalPoint_sub_iff (hf.contDiffAt (hU.mem_nhds hyU)) _).1
+      (hasNondegenerateCriticalPointsOn_iff.1 hM hyU hcrit)).2.surjective)
+  · refine fun ha ↦ hasNondegenerateCriticalPointsOn_iff.2 fun y hyU hy0 ↦ ?_
+    rw [fderiv_sub_functional (hd.differentiableAt (hU.mem_nhds hyU)), sub_eq_zero] at hy0
+    refine (isNondegenerateCriticalPoint_sub_iff (hf.contDiffAt (hU.mem_nhds hyU)) a).2
+      ⟨hy0, ContinuousLinearMap.isInvertible_of_surjective ?_⟩
+    by_contra hs
+    exact ha ⟨y, ⟨hyU, hs⟩, hy0⟩
+
+section Measurable
+
+variable [MeasurableSpace E] [BorelSpace E]
+  [MeasurableSpace (E →L[ℝ] ℝ)] [BorelSpace (E →L[ℝ] ℝ)]
+
+/-! ### Genericity -/
+
+/-- **Almost every linear perturbation of a `C²` function is Morse.** For a Haar measure `ν` on
+the continuous dual, for `ν`-almost every functional `a` the function `f - a` has only
+nondegenerate critical points on the open set `U`.
+
+The exceptional set is the set of critical values on `U` of the differential `fderiv ℝ f`, a map
+between spaces of the same finite dimension, so it is null by the equal-dimensional case of
+Sard's theorem. -/
+theorem ae_hasNondegenerateCriticalPointsOn_sub (ν : Measure (E →L[ℝ] ℝ)) [ν.IsAddHaarMeasure]
+    (hU : IsOpen U) (hf : ContDiffOn ℝ 2 f U) :
+    ∀ᵐ a ∂ν, HasNondegenerateCriticalPointsOn (fun y ↦ f y - a y) U := by
+  have hdf : DifferentiableOn ℝ (fderiv ℝ f) U :=
+    (hf.fderiv_of_isOpen (m := 1) hU (by norm_num)).differentiableOn one_ne_zero
+  have hnull : ν (fderiv ℝ f '' {x ∈ U | ¬ Surjective (fderiv ℝ (fderiv ℝ f) x)}) = 0 := by
+    refine addHaar_image_eq_zero_of_not_surjective_fderivWithin ν
+      ContinuousLinearMap.finrank_dual_eq.symm (fun y hy ↦ ?_) fun _ hy ↦ hy.2
+    exact ((hdf y hy.1).differentiableAt (hU.mem_nhds hy.1)).hasFDerivAt.hasFDerivWithinAt
+  rw [ae_iff]
+  refine measure_mono_null (fun a ha ↦ ?_) hnull
+  exact not_not.1 fun h ↦ ha ((hasNondegenerateCriticalPointsOn_sub_iff hU hf a).2 h)
+
+/-- The linear perturbations that make a `C²` function Morse on an open set are dense in the
+continuous dual. -/
+theorem dense_setOfPred_hasNondegenerateCriticalPointsOn_sub (hU : IsOpen U)
+    (hf : ContDiffOn ℝ 2 f U) :
+    Dense {a : E →L[ℝ] ℝ | HasNondegenerateCriticalPointsOn (fun y ↦ f y - a y) U} := by
+  refine Measure.dense_of_ae (μ := (addHaar : Measure (E →L[ℝ] ℝ))) ?_
+  filter_upwards [ae_hasNondegenerateCriticalPointsOn_sub addHaar hU hf] with a ha using ha
+
+/-- **A `C²` function is made Morse by an arbitrarily small linear perturbation**: for every
+`ε > 0` there is a continuous linear functional of operator norm less than `ε` whose subtraction
+leaves only nondegenerate critical points on `U`. -/
+theorem exists_norm_lt_hasNondegenerateCriticalPointsOn_sub (hU : IsOpen U)
+    (hf : ContDiffOn ℝ 2 f U) {ε : ℝ} (hε : 0 < ε) :
+    ∃ a : E →L[ℝ] ℝ, ‖a‖ < ε ∧ HasNondegenerateCriticalPointsOn (fun y ↦ f y - a y) U := by
+  obtain ⟨a, hmem, hball⟩ :=
+    (dense_setOfPred_hasNondegenerateCriticalPointsOn_sub hU hf).exists_mem_open
+      Metric.isOpen_ball ⟨0, Metric.mem_ball_self hε⟩
+  exact ⟨a, by simpa [Metric.mem_ball, dist_zero_right] using hball, hmem⟩
+
+/-- **A `C²` function is made Morse, with a finitely generated Morse complex, by an arbitrarily
+small linear perturbation.** Combining
+`TauCeti.exists_norm_lt_hasNondegenerateCriticalPointsOn_sub` with
+`TauCeti.finite_setOfPred_fderiv_sub_eq_zero`, one may choose the perturbation to have operator
+norm less than any prescribed `ε > 0`. -/
+theorem exists_norm_lt_hasNondegenerateCriticalPointsOn_sub_and_finite (hU : IsOpen U)
+    (hf : ContDiffOn ℝ 2 f U) {ε : ℝ} (hε : 0 < ε) {K : Set E} (hK : IsCompact K) (hKU : K ⊆ U) :
+    ∃ a : E →L[ℝ] ℝ, ‖a‖ < ε ∧ HasNondegenerateCriticalPointsOn (fun y ↦ f y - a y) U ∧
+      {x ∈ K | fderiv ℝ (fun y ↦ f y - a y) x = 0}.Finite := by
+  obtain ⟨a, ha, hM⟩ := exists_norm_lt_hasNondegenerateCriticalPointsOn_sub hU hf hε
+  exact ⟨a, ha, hM, finite_setOfPred_fderiv_sub_eq_zero hU hf hM hK hKU⟩
+
+end Measurable
+
+end FiniteDimensional
+
+/-! ### The gradient formulation
+
+On a real inner product space the perturbations are usually written `f - ⟪v, ·⟫`, so that the
+gradient of the perturbed function is `∇f - v`; the Riesz isometry carries the statement above to
+that form.
+-/
+
+section InnerProduct
+
+open InnerProductSpace
+
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E] [FiniteDimensional ℝ E]
+  [MeasurableSpace E] [BorelSpace E]
+  [MeasurableSpace (E →L[ℝ] ℝ)] [BorelSpace (E →L[ℝ] ℝ)]
+  {f : E → ℝ} {U : Set E}
+
+/-- **Almost every perturbation by a linear form `⟪v, ·⟫` of a `C²` function is Morse.** This is
+`TauCeti.ae_hasNondegenerateCriticalPointsOn_sub` transported along the Riesz isometry, which is a
+continuous linear equivalence and so carries null sets to null sets; the perturbed function has
+gradient `∇f - v`, which is the shape the negative gradient flow of Lane M is stated in. -/
+theorem ae_hasNondegenerateCriticalPointsOn_sub_inner (μ : Measure E) [μ.IsAddHaarMeasure]
+    (hU : IsOpen U) (hf : ContDiffOn ℝ 2 f U) :
+    ∀ᵐ v ∂μ, HasNondegenerateCriticalPointsOn (fun y ↦ f y - ⟪v, y⟫_ℝ) U := by
+  have hbad := ae_hasNondegenerateCriticalPointsOn_sub (addHaar : Measure (E →L[ℝ] ℝ)) hU hf
+  rw [ae_iff] at hbad ⊢
+  have hpre : {v : E | ¬ HasNondegenerateCriticalPointsOn (fun y ↦ f y - ⟪v, y⟫_ℝ) U} =
+      (toDual ℝ E).toContinuousLinearEquiv ⁻¹'
+        {a : E →L[ℝ] ℝ | ¬ HasNondegenerateCriticalPointsOn (fun y ↦ f y - a y) U} := by
+    ext v
+    simp [toDual_apply_apply]
+  rw [hpre]
+  exact (((toDual ℝ E).toContinuousLinearEquiv).quasiMeasurePreserving_addHaar μ
+    addHaar).preimage_null hbad
+
+end InnerProduct
+
+end TauCeti

--- a/TauCeti/Analysis/Calculus/Morse/Generic.lean
+++ b/TauCeti/Analysis/Calculus/Morse/Generic.lean
@@ -8,9 +8,9 @@ module
 public import Mathlib.Analysis.InnerProductSpace.Dual
 public import Mathlib.MeasureTheory.Measure.Haar.Basic
 public import TauCeti.Analysis.Calculus.Morse.Basic
-public import TauCeti.Analysis.Calculus.Sard.EqualDimension
 -- Private: used only inside proofs.
 import Mathlib.Analysis.Calculus.ContDiff.Operations
+import TauCeti.Analysis.Calculus.Sard.EqualDimension
 import TauCeti.Analysis.Normed.Module.FiniteDimension
 import TauCeti.MeasureTheory.Measure.Haar.NormedSpace
 
@@ -150,11 +150,6 @@ theorem hasNondegenerateCriticalPointsOn_sub_iff (hU : IsOpen U) (hf : ContDiffO
     by_contra hs
     exact ha ⟨y, ⟨hyU, hs⟩, hy0⟩
 
-section Measurable
-
-variable [MeasurableSpace E] [BorelSpace E]
-  [MeasurableSpace (E →L[ℝ] ℝ)] [BorelSpace (E →L[ℝ] ℝ)]
-
 /-! ### Genericity -/
 
 /-- **Almost every linear perturbation of a `C²` function is Morse.** For a Haar measure `ν` on
@@ -163,10 +158,16 @@ nondegenerate critical points on the open set `U`.
 
 The exceptional set is the set of critical values on `U` of the differential `fderiv ℝ f`, a map
 between spaces of the same finite dimension, so it is null by the equal-dimensional case of
-Sard's theorem. -/
-theorem ae_hasNondegenerateCriticalPointsOn_sub (ν : Measure (E →L[ℝ] ℝ)) [ν.IsAddHaarMeasure]
+Sard's theorem.
+
+Only the dual carries a measurable structure in the statement, since that is where `ν` lives; the
+source `E` is measured only inside the proof, by Sard's lemma, and gets its Borel structure
+there. -/
+theorem ae_hasNondegenerateCriticalPointsOn_sub [MeasurableSpace (E →L[ℝ] ℝ)]
+    [BorelSpace (E →L[ℝ] ℝ)] (ν : Measure (E →L[ℝ] ℝ)) [ν.IsAddHaarMeasure]
     (hU : IsOpen U) (hf : ContDiffOn ℝ 2 f U) :
     ∀ᵐ a ∂ν, HasNondegenerateCriticalPointsOn (fun y ↦ f y - a y) U := by
+  borelize E
   have hdf : DifferentiableOn ℝ (fderiv ℝ f) U :=
     (hf.fderiv_of_isOpen (m := 1) hU (by norm_num)).differentiableOn one_ne_zero
   have hnull : ν (fderiv ℝ f '' {x ∈ U | ¬ Surjective (fderiv ℝ (fderiv ℝ f) x)}) = 0 := by
@@ -178,10 +179,12 @@ theorem ae_hasNondegenerateCriticalPointsOn_sub (ν : Measure (E →L[ℝ] ℝ))
   exact not_not.1 fun h ↦ ha ((hasNondegenerateCriticalPointsOn_sub_iff hU hf a).2 h)
 
 /-- The linear perturbations that make a `C²` function Morse on an open set are dense in the
-continuous dual. -/
+continuous dual. No measurable structure appears in the statement: the Haar measure that produces
+the density is an auxiliary object of the proof, which installs the Borel structure it needs. -/
 theorem dense_setOfPred_hasNondegenerateCriticalPointsOn_sub (hU : IsOpen U)
     (hf : ContDiffOn ℝ 2 f U) :
     Dense {a : E →L[ℝ] ℝ | HasNondegenerateCriticalPointsOn (fun y ↦ f y - a y) U} := by
+  borelize (E →L[ℝ] ℝ)
   refine Measure.dense_of_ae (μ := (addHaar : Measure (E →L[ℝ] ℝ))) ?_
   filter_upwards [ae_hasNondegenerateCriticalPointsOn_sub addHaar hU hf] with a ha using ha
 
@@ -195,8 +198,6 @@ theorem exists_norm_lt_hasNondegenerateCriticalPointsOn_sub (hU : IsOpen U)
     (dense_setOfPred_hasNondegenerateCriticalPointsOn_sub hU hf).exists_mem_open
       Metric.isOpen_ball ⟨0, Metric.mem_ball_self hε⟩
   exact ⟨a, by simpa [Metric.mem_ball, dist_zero_right] using hball, hmem⟩
-
-end Measurable
 
 end FiniteDimensional
 
@@ -212,7 +213,7 @@ section InnerProduct
 open InnerProductSpace
 
 variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E] [FiniteDimensional ℝ E]
-  [MeasurableSpace E] [BorelSpace E] {f : E → ℝ} {U : Set E}
+  {f : E → ℝ} {U : Set E}
 
 /-- **Almost every perturbation by a linear form `⟪v, ·⟫` of a `C²` function is Morse.** This is
 `TauCeti.ae_hasNondegenerateCriticalPointsOn_sub` transported along the Riesz isometry, which is a
@@ -221,8 +222,8 @@ gradient `∇f - v`, which is the shape the negative gradient flow is stated in.
 
 No measurable structure on the dual appears in the statement: the Borel one is installed inside
 the proof, where the Haar measure of the dual is the auxiliary object being transported. -/
-theorem ae_hasNondegenerateCriticalPointsOn_sub_inner (μ : Measure E) [μ.IsAddHaarMeasure]
-    (hU : IsOpen U) (hf : ContDiffOn ℝ 2 f U) :
+theorem ae_hasNondegenerateCriticalPointsOn_sub_inner [MeasurableSpace E] [BorelSpace E]
+    (μ : Measure E) [μ.IsAddHaarMeasure] (hU : IsOpen U) (hf : ContDiffOn ℝ 2 f U) :
     ∀ᵐ v ∂μ, HasNondegenerateCriticalPointsOn (fun y ↦ f y - ⟪v, y⟫_ℝ) U := by
   borelize (E →L[ℝ] ℝ)
   have hbad := ae_hasNondegenerateCriticalPointsOn_sub (addHaar : Measure (E →L[ℝ] ℝ)) hU hf
@@ -237,10 +238,12 @@ theorem ae_hasNondegenerateCriticalPointsOn_sub_inner (μ : Measure E) [μ.IsAdd
     addHaar).preimage_null hbad
 
 /-- The vectors `v` for which subtracting `⟪v, ·⟫` makes a `C²` function Morse on an open set are
-dense. -/
+dense. As above, the Haar measure witnessing the density is internal to the proof, so the
+statement mentions no measurable structure. -/
 theorem dense_setOfPred_hasNondegenerateCriticalPointsOn_sub_inner (hU : IsOpen U)
     (hf : ContDiffOn ℝ 2 f U) :
     Dense {v : E | HasNondegenerateCriticalPointsOn (fun y ↦ f y - ⟪v, y⟫_ℝ) U} := by
+  borelize E
   refine Measure.dense_of_ae (μ := (addHaar : Measure E)) ?_
   filter_upwards [ae_hasNondegenerateCriticalPointsOn_sub_inner addHaar hU hf] with v hv using hv
 

--- a/TauCeti/Analysis/Calculus/Morse/Generic.lean
+++ b/TauCeti/Analysis/Calculus/Morse/Generic.lean
@@ -113,9 +113,12 @@ theorem isNondegenerateCriticalPoint_sub_iff (hf : ContDiffAt ℝ 2 f x) (a : E 
 
 /-- **A perturbation that is Morse on `U` has only finitely many critical points on a compact
 subset of `U`.** Continuity of `fderiv ℝ f` on the compact set closes the critical locus, and
-nondegeneracy makes it discrete. Nothing beyond those two hypotheses on `K` is needed: the
-perturbation shifts the differential of `f` by the constant `a`, so it neither disturbs the
-continuity nor requires any regularity of its own. -/
+nondegeneracy makes it discrete. The hypotheses are that `K` is compact and contained in `U`,
+that `f` is differentiable at each point of `K`, and that `fderiv ℝ f` is continuous on `K`;
+note that continuity of `fderiv ℝ f` does not by itself give differentiability, since `fderiv`
+is defined at points where `f` is not differentiable. The perturbation itself needs no
+regularity: it shifts the differential of `f` by the constant `a`, which disturbs neither the
+differentiability nor the continuity. -/
 theorem finite_setOfPred_fderiv_sub_eq_zero {K : Set E} (hK : IsCompact K)
     (hd : ∀ x ∈ K, DifferentiableAt ℝ f x) (hcont : ContinuousOn (fderiv ℝ f) K)
     (ha : HasNondegenerateCriticalPointsOn (fun y ↦ f y - a y) U) (hKU : K ⊆ U) :

--- a/TauCeti/Analysis/Calculus/SecondDerivative.lean
+++ b/TauCeti/Analysis/Calculus/SecondDerivative.lean
@@ -22,10 +22,6 @@ on some punctured neighbourhood of the point, the neighbourhood being allowed to
 That fixed-value avoidance is the local rigidity behind the isolation of nondegenerate critical
 points, and it asks nothing of the value taken.
 
-Subtracting a continuous linear map is the perturbation that the second derivative does not see:
-it shifts the differential by a constant, so the derivative of the differential is unchanged. Both
-halves of that statement are recorded here.
-
 The file also records the second-order chain rule at a point where the differential of the outer
 function vanishes: there the first-order term drops out, so the second derivative of a composition
 is the second derivative of the outer function evaluated on the images of the differential of the
@@ -37,11 +33,6 @@ them.
 
 * `ContDiffAt.hasFDerivAt_fderiv`: at a twice continuously differentiable point,
   `fderiv 𝕜 g` is differentiable, with derivative the second derivative of `g`.
-* `ContDiffAt.eventually_differentiableAt`: a continuously differentiable germ is differentiable
-  at every point near the base point.
-* `TauCeti.fderiv_sub_continuousLinearMap` and `TauCeti.fderiv_fderiv_sub_continuousLinearMap`:
-  subtracting a continuous linear map shifts the differential by that map and leaves the second
-  derivative unchanged.
 * `TauCeti.eventually_fderiv_ne`: where the second derivative is invertible, the differential
   avoids any prescribed value on a punctured neighbourhood of the point.
 * `TauCeti.fderiv_fderiv_comp_apply_of_fderiv_eq_zero`: for `C²` maps, where the differential of
@@ -64,30 +55,6 @@ theorem _root_.ContDiffAt.hasFDerivAt_fderiv {n : WithTop ℕ∞} {g : E → F} 
     (h : ContDiffAt 𝕜 n g x) (hn : 2 ≤ n) :
     HasFDerivAt (fderiv 𝕜 g) (fderiv 𝕜 (fderiv 𝕜 g) x) x :=
   ((h.fderiv_right (m := 1) (by exact_mod_cast hn)).differentiableAt one_ne_zero).hasFDerivAt
-
-/-- A continuously differentiable germ is differentiable at every point of a neighbourhood of the
-base point. Differentiability at the base point alone is `ContDiffAt.differentiableAt`; here the
-`C¹` hypothesis is what propagates it to nearby points. -/
-theorem _root_.ContDiffAt.eventually_differentiableAt {n : WithTop ℕ∞} {g : E → F} {x : E}
-    (h : ContDiffAt 𝕜 n g x) (hn : 1 ≤ n) : ∀ᶠ y in 𝓝 x, DifferentiableAt 𝕜 g y :=
-  ((h.of_le hn).eventually (by norm_num)).mono fun _ hy ↦ hy.differentiableAt one_ne_zero
-
-/-- Subtracting a continuous linear map shifts the differential by that map. This is the
-`ContinuousLinearMap` counterpart of `fderiv_sub_const`. -/
-theorem fderiv_sub_continuousLinearMap {g : E → F} {x : E} (hg : DifferentiableAt 𝕜 g x)
-    (a : E →L[𝕜] F) : fderiv 𝕜 (fun y ↦ g y - a y) x = fderiv 𝕜 g x - a :=
-  (hg.hasFDerivAt.sub a.hasFDerivAt).fderiv
-
-/-- **Subtracting a continuous linear map does not change the second derivative.** By
-`TauCeti.fderiv_sub_continuousLinearMap` the differential is shifted by the constant `a`, and a
-constant shift is invisible to the next derivative. -/
-theorem fderiv_fderiv_sub_continuousLinearMap {g : E → F} {x : E} {n : WithTop ℕ∞}
-    (hg : ContDiffAt 𝕜 n g x) (hn : 1 ≤ n) (a : E →L[𝕜] F) :
-    fderiv 𝕜 (fderiv 𝕜 fun y ↦ g y - a y) x = fderiv 𝕜 (fderiv 𝕜 g) x := by
-  have hEq : (fderiv 𝕜 fun y ↦ g y - a y) =ᶠ[𝓝 x] fun y ↦ fderiv 𝕜 g y - a := by
-    filter_upwards [hg.eventually_differentiableAt hn] with y hy using
-      fderiv_sub_continuousLinearMap hy a
-  rw [hEq.fderiv_eq, fderiv_sub_const]
 
 /-- **Where the second derivative is invertible, the differential avoids any prescribed value near
 the point.** Nothing is assumed about the value `c`, and in particular the differential need not
@@ -118,9 +85,13 @@ theorem fderiv_fderiv_comp_apply_of_fderiv_eq_zero {f : E → G} {φ : F → E} 
   have hA : HasFDerivAt (fun y ↦ fderiv 𝕜 f (φ y))
       ((fderiv 𝕜 (fderiv 𝕜 f) (φ b)).comp (fderiv 𝕜 φ b)) b := hf1.comp b hφ0
   have hev : ∀ᶠ y in 𝓝 b, fderiv 𝕜 (f ∘ φ) y = (fderiv 𝕜 f (φ y)).comp (fderiv 𝕜 φ y) := by
-    have h1 : ∀ᶠ y in 𝓝 b, DifferentiableAt 𝕜 φ y := hφ.eventually_differentiableAt (by norm_num)
+    have h1 : ∀ᶠ y in 𝓝 b, DifferentiableAt 𝕜 φ y :=
+      ((hφ.of_le (by norm_num)).eventually (by norm_num)).mono fun _ hy ↦
+        hy.differentiableAt one_ne_zero
     have h2 : ∀ᶠ y in 𝓝 b, DifferentiableAt 𝕜 f (φ y) :=
-      hφ.continuousAt.eventually (hf.eventually_differentiableAt (by norm_num))
+      hφ.continuousAt.eventually
+        (((hf.of_le (by norm_num)).eventually (by norm_num)).mono fun _ hy ↦
+          hy.differentiableAt one_ne_zero)
     filter_upwards [h1, h2] with y hy1 hy2 using fderiv_comp (x := y) hy2 hy1
   rw [((hA.clm_comp hφ1).congr_of_eventuallyEq hev).fderiv]
   simp [hc]

--- a/TauCeti/Analysis/Calculus/SecondDerivative.lean
+++ b/TauCeti/Analysis/Calculus/SecondDerivative.lean
@@ -22,6 +22,10 @@ on some punctured neighbourhood of the point, the neighbourhood being allowed to
 That fixed-value avoidance is the local rigidity behind the isolation of nondegenerate critical
 points, and it asks nothing of the value taken.
 
+Subtracting a continuous linear map is the perturbation that the second derivative does not see:
+it shifts the differential by a constant, so the derivative of the differential is unchanged. Both
+halves of that statement are recorded here.
+
 The file also records the second-order chain rule at a point where the differential of the outer
 function vanishes: there the first-order term drops out, so the second derivative of a composition
 is the second derivative of the outer function evaluated on the images of the differential of the
@@ -33,6 +37,11 @@ them.
 
 * `ContDiffAt.hasFDerivAt_fderiv`: at a twice continuously differentiable point,
   `fderiv 𝕜 g` is differentiable, with derivative the second derivative of `g`.
+* `ContDiffAt.eventually_differentiableAt`: a continuously differentiable germ is differentiable
+  at every point near the base point.
+* `TauCeti.fderiv_sub_continuousLinearMap` and `TauCeti.fderiv_fderiv_sub_continuousLinearMap`:
+  subtracting a continuous linear map shifts the differential by that map and leaves the second
+  derivative unchanged.
 * `TauCeti.eventually_fderiv_ne`: where the second derivative is invertible, the differential
   avoids any prescribed value on a punctured neighbourhood of the point.
 * `TauCeti.fderiv_fderiv_comp_apply_of_fderiv_eq_zero`: for `C²` maps, where the differential of
@@ -55,6 +64,30 @@ theorem _root_.ContDiffAt.hasFDerivAt_fderiv {n : WithTop ℕ∞} {g : E → F} 
     (h : ContDiffAt 𝕜 n g x) (hn : 2 ≤ n) :
     HasFDerivAt (fderiv 𝕜 g) (fderiv 𝕜 (fderiv 𝕜 g) x) x :=
   ((h.fderiv_right (m := 1) (by exact_mod_cast hn)).differentiableAt one_ne_zero).hasFDerivAt
+
+/-- A continuously differentiable germ is differentiable at every point of a neighbourhood of the
+base point. Differentiability at the base point alone is `ContDiffAt.differentiableAt`; here the
+`C¹` hypothesis is what propagates it to nearby points. -/
+theorem _root_.ContDiffAt.eventually_differentiableAt {n : WithTop ℕ∞} {g : E → F} {x : E}
+    (h : ContDiffAt 𝕜 n g x) (hn : 1 ≤ n) : ∀ᶠ y in 𝓝 x, DifferentiableAt 𝕜 g y :=
+  ((h.of_le hn).eventually (by norm_num)).mono fun _ hy ↦ hy.differentiableAt one_ne_zero
+
+/-- Subtracting a continuous linear map shifts the differential by that map. This is the
+`ContinuousLinearMap` counterpart of `fderiv_sub_const`. -/
+theorem fderiv_sub_continuousLinearMap {g : E → F} {x : E} (hg : DifferentiableAt 𝕜 g x)
+    (a : E →L[𝕜] F) : fderiv 𝕜 (fun y ↦ g y - a y) x = fderiv 𝕜 g x - a :=
+  (hg.hasFDerivAt.sub a.hasFDerivAt).fderiv
+
+/-- **Subtracting a continuous linear map does not change the second derivative.** By
+`TauCeti.fderiv_sub_continuousLinearMap` the differential is shifted by the constant `a`, and a
+constant shift is invisible to the next derivative. -/
+theorem fderiv_fderiv_sub_continuousLinearMap {g : E → F} {x : E} {n : WithTop ℕ∞}
+    (hg : ContDiffAt 𝕜 n g x) (hn : 1 ≤ n) (a : E →L[𝕜] F) :
+    fderiv 𝕜 (fderiv 𝕜 fun y ↦ g y - a y) x = fderiv 𝕜 (fderiv 𝕜 g) x := by
+  have hEq : (fderiv 𝕜 fun y ↦ g y - a y) =ᶠ[𝓝 x] fun y ↦ fderiv 𝕜 g y - a := by
+    filter_upwards [hg.eventually_differentiableAt hn] with y hy using
+      fderiv_sub_continuousLinearMap hy a
+  rw [hEq.fderiv_eq, fderiv_sub_const]
 
 /-- **Where the second derivative is invertible, the differential avoids any prescribed value near
 the point.** Nothing is assumed about the value `c`, and in particular the differential need not
@@ -85,12 +118,9 @@ theorem fderiv_fderiv_comp_apply_of_fderiv_eq_zero {f : E → G} {φ : F → E} 
   have hA : HasFDerivAt (fun y ↦ fderiv 𝕜 f (φ y))
       ((fderiv 𝕜 (fderiv 𝕜 f) (φ b)).comp (fderiv 𝕜 φ b)) b := hf1.comp b hφ0
   have hev : ∀ᶠ y in 𝓝 b, fderiv 𝕜 (f ∘ φ) y = (fderiv 𝕜 f (φ y)).comp (fderiv 𝕜 φ y) := by
-    have h1 : ∀ᶠ y in 𝓝 b, DifferentiableAt 𝕜 φ y := by
-      filter_upwards [hφ.eventually (by norm_num)] with y hy
-        using hy.differentiableAt (by norm_num)
-    have h2 : ∀ᶠ y in 𝓝 b, DifferentiableAt 𝕜 f (φ y) := by
-      filter_upwards [hφ.continuousAt.eventually (hf.eventually (by norm_num))] with y hy
-        using hy.differentiableAt (by norm_num)
+    have h1 : ∀ᶠ y in 𝓝 b, DifferentiableAt 𝕜 φ y := hφ.eventually_differentiableAt (by norm_num)
+    have h2 : ∀ᶠ y in 𝓝 b, DifferentiableAt 𝕜 f (φ y) :=
+      hφ.continuousAt.eventually (hf.eventually_differentiableAt (by norm_num))
     filter_upwards [h1, h2] with y hy1 hy2 using fderiv_comp (x := y) hy2 hy1
   rw [((hA.clm_comp hφ1).congr_of_eventuallyEq hev).fderiv]
   simp [hc]

--- a/TauCeti/Analysis/Normed/Module/FiniteDimension.lean
+++ b/TauCeti/Analysis/Normed/Module/FiniteDimension.lean
@@ -19,7 +19,7 @@ counts need, namely that the continuous dual has the same dimension as the space
 
 ## Main results
 
-* `ContinuousLinearMap.finrank_dual_eq`: in finite dimensions the continuous dual has the same
+* `ContinuousLinearMap.dual_finrank_eq`: in finite dimensions the continuous dual has the same
   dimension as the space.
 -/
 
@@ -33,7 +33,7 @@ variable {𝕜 E : Type*} [NontriviallyNormedField 𝕜] [CompleteSpace 𝕜]
 /-- In finite dimensions the continuous dual `E →L[𝕜] 𝕜` has the same dimension as `E`: every
 linear functional on a finite-dimensional space is continuous, so the continuous dual coincides
 with the algebraic one. -/
-theorem _root_.ContinuousLinearMap.finrank_dual_eq :
+theorem _root_.ContinuousLinearMap.dual_finrank_eq :
     Module.finrank 𝕜 (E →L[𝕜] 𝕜) = Module.finrank 𝕜 E := by
   rw [← LinearEquiv.finrank_eq
     (LinearMap.toContinuousLinearMap : (E →ₗ[𝕜] 𝕜) ≃ₗ[𝕜] E →L[𝕜] 𝕜)]

--- a/TauCeti/Analysis/Normed/Module/FiniteDimension.lean
+++ b/TauCeti/Analysis/Normed/Module/FiniteDimension.lean
@@ -1,0 +1,44 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.Normed.Module.FiniteDimension
+public import Mathlib.LinearAlgebra.Dual.Lemmas
+
+/-!
+# The continuous dual of a finite-dimensional normed space
+
+Over a complete nontrivially normed field every linear functional on a finite-dimensional normed
+space is continuous, so the continuous dual `E →L[𝕜] 𝕜` coincides with the algebraic dual
+`Module.Dual 𝕜 E`. Mathlib records that coincidence as the linear equivalence
+`LinearMap.toContinuousLinearMap`; this file reads off the one consequence of it that dimension
+counts need, namely that the continuous dual has the same dimension as the space.
+
+## Main results
+
+* `ContinuousLinearMap.finrank_dual_eq`: in finite dimensions the continuous dual has the same
+  dimension as the space.
+-/
+
+public section
+
+namespace TauCeti
+
+variable {𝕜 E : Type*} [NontriviallyNormedField 𝕜] [CompleteSpace 𝕜]
+  [NormedAddCommGroup E] [NormedSpace 𝕜 E] [FiniteDimensional 𝕜 E]
+
+/-- In finite dimensions the continuous dual `E →L[𝕜] 𝕜` has the same dimension as `E`: every
+linear functional on a finite-dimensional space is continuous, so the continuous dual coincides
+with the algebraic one. -/
+theorem _root_.ContinuousLinearMap.finrank_dual_eq :
+    Module.finrank 𝕜 (E →L[𝕜] 𝕜) = Module.finrank 𝕜 E := by
+  rw [← LinearEquiv.finrank_eq
+    (LinearMap.toContinuousLinearMap : (E →ₗ[𝕜] 𝕜) ≃ₗ[𝕜] E →L[𝕜] 𝕜)]
+  exact Subspace.dual_finrank_eq
+
+end TauCeti
+
+end

--- a/TauCeti/Topology/Algebra/Module/BilinearForm.lean
+++ b/TauCeti/Topology/Algebra/Module/BilinearForm.lean
@@ -9,7 +9,7 @@ public import Mathlib.Analysis.Normed.Module.FiniteDimension
 public import Mathlib.LinearAlgebra.SesquilinearForm.Basic
 public import Mathlib.Topology.Algebra.Module.ContinuousLinearMap.Invertible
 public import Mathlib.Topology.Algebra.Module.Spaces.ContinuousLinearMap
--- Private: `ContinuousLinearMap.finrank_dual_eq` is used only inside proofs.
+-- Private: `ContinuousLinearMap.dual_finrank_eq` is used only inside proofs.
 import TauCeti.Analysis.Normed.Module.FiniteDimension
 
 /-!
@@ -30,7 +30,7 @@ itself, rather than with any of its users.
 * `ContinuousLinearMap.isInvertible_of_injective` and
   `ContinuousLinearMap.isInvertible_of_surjective`: in finite dimensions an injective, equivalently
   a surjective, map into the dual is already invertible, the dual having the same dimension as the
-  space (`ContinuousLinearMap.finrank_dual_eq`).
+  space (`ContinuousLinearMap.dual_finrank_eq`).
 -/
 
 public section
@@ -63,7 +63,7 @@ space, so that range is everything. -/
 theorem _root_.ContinuousLinearMap.isInvertible_of_injective
     (hinj : Function.Injective L) : L.IsInvertible :=
   ⟨((L : E →ₗ[𝕜] E →L[𝕜] 𝕜).linearEquivOfInjective hinj
-      ContinuousLinearMap.finrank_dual_eq.symm).toContinuousLinearEquiv, by ext v; simp⟩
+      ContinuousLinearMap.dual_finrank_eq.symm).toContinuousLinearEquiv, by ext v; simp⟩
 
 /-- In finite dimensions a surjective continuous linear map into the dual is invertible: the dual
 has the same finite dimension as the space, so surjectivity forces injectivity. -/
@@ -71,7 +71,7 @@ theorem _root_.ContinuousLinearMap.isInvertible_of_surjective
     (hsurj : Function.Surjective L) : L.IsInvertible :=
   ContinuousLinearMap.isInvertible_of_injective
     ((LinearMap.injective_iff_surjective_of_finrank_eq_finrank (V₂ := E →L[𝕜] 𝕜)
-      ContinuousLinearMap.finrank_dual_eq.symm (f := (L : E →ₗ[𝕜] E →L[𝕜] 𝕜))).2 hsurj)
+      ContinuousLinearMap.dual_finrank_eq.symm (f := (L : E →ₗ[𝕜] E →L[𝕜] 𝕜))).2 hsurj)
 
 end FiniteDimensional
 

--- a/TauCeti/Topology/Algebra/Module/BilinearForm.lean
+++ b/TauCeti/Topology/Algebra/Module/BilinearForm.lean
@@ -26,8 +26,12 @@ itself, rather than with any of its users.
 
 * `ContinuousLinearMap.separatingLeft_toBilinForm_iff_injective`: the bilinear form of a
   continuous linear map into the dual is left-separating if and only if the map is injective.
-* `ContinuousLinearMap.isInvertible_of_injective`: in finite dimensions an injective map
-  into the dual is already invertible, the dual having the same dimension as the space.
+* `ContinuousLinearMap.finrank_dual_eq`: in finite dimensions the continuous dual has the same
+  dimension as the space.
+* `ContinuousLinearMap.isInvertible_of_injective` and
+  `ContinuousLinearMap.isInvertible_of_surjective`: in finite dimensions an injective, equivalently
+  a surjective, map into the dual is already invertible, the dual having the same dimension as the
+  space.
 -/
 
 public section
@@ -47,21 +51,39 @@ theorem _root_.ContinuousLinearMap.separatingLeft_toBilinForm_iff_injective (L :
   exact ⟨fun h v w hvw ↦ h (LinearMap.ext fun u ↦ by simp [hvw]),
     fun h v w hvw ↦ h (ContinuousLinearMap.ext fun u ↦ by simpa using LinearMap.congr_fun hvw u)⟩
 
+end
+
+section FiniteDimensional
+
+variable {𝕜 E : Type*} [NontriviallyNormedField 𝕜] [CompleteSpace 𝕜]
+  [NormedAddCommGroup E] [NormedSpace 𝕜 E] [FiniteDimensional 𝕜 E] {L : E →L[𝕜] E →L[𝕜] 𝕜}
+
+/-- In finite dimensions the continuous dual `E →L[𝕜] 𝕜` has the same dimension as `E`: every
+linear functional on a finite-dimensional space is continuous, so the continuous dual coincides
+with the algebraic one. -/
+theorem _root_.ContinuousLinearMap.finrank_dual_eq :
+    Module.finrank 𝕜 (E →L[𝕜] 𝕜) = Module.finrank 𝕜 E := by
+  rw [← LinearEquiv.finrank_eq
+    (LinearMap.toContinuousLinearMap : (E →ₗ[𝕜] 𝕜) ≃ₗ[𝕜] E →L[𝕜] 𝕜)]
+  exact Subspace.dual_finrank_eq
+
 /-- In finite dimensions an injective continuous linear map into the dual is invertible: injectivity
 makes it a linear equivalence onto its range, and the dual has the same finite dimension as the
 space, so that range is everything. -/
-theorem _root_.ContinuousLinearMap.isInvertible_of_injective {𝕜 E : Type*}
-    [NontriviallyNormedField 𝕜] [CompleteSpace 𝕜]
-    [NormedAddCommGroup E] [NormedSpace 𝕜 E] [FiniteDimensional 𝕜 E] {L : E →L[𝕜] E →L[𝕜] 𝕜}
-    (hinj : Function.Injective L) : L.IsInvertible := by
-  have hrank : Module.finrank 𝕜 E = Module.finrank 𝕜 (E →L[𝕜] 𝕜) := by
-    rw [← LinearEquiv.finrank_eq
-      (LinearMap.toContinuousLinearMap : (E →ₗ[𝕜] 𝕜) ≃ₗ[𝕜] E →L[𝕜] 𝕜)]
-    exact Subspace.dual_finrank_eq.symm
-  exact ⟨((L : E →ₗ[𝕜] E →L[𝕜] 𝕜).linearEquivOfInjective hinj hrank).toContinuousLinearEquiv,
-    by ext v; simp⟩
+theorem _root_.ContinuousLinearMap.isInvertible_of_injective
+    (hinj : Function.Injective L) : L.IsInvertible :=
+  ⟨((L : E →ₗ[𝕜] E →L[𝕜] 𝕜).linearEquivOfInjective hinj
+      ContinuousLinearMap.finrank_dual_eq.symm).toContinuousLinearEquiv, by ext v; simp⟩
 
-end
+/-- In finite dimensions a surjective continuous linear map into the dual is invertible: the dual
+has the same finite dimension as the space, so surjectivity forces injectivity. -/
+theorem _root_.ContinuousLinearMap.isInvertible_of_surjective
+    (hsurj : Function.Surjective L) : L.IsInvertible :=
+  ContinuousLinearMap.isInvertible_of_injective
+    ((LinearMap.injective_iff_surjective_of_finrank_eq_finrank (V₂ := E →L[𝕜] 𝕜)
+      ContinuousLinearMap.finrank_dual_eq.symm (f := (L : E →ₗ[𝕜] E →L[𝕜] 𝕜))).2 hsurj)
+
+end FiniteDimensional
 
 end TauCeti
 

--- a/TauCeti/Topology/Algebra/Module/BilinearForm.lean
+++ b/TauCeti/Topology/Algebra/Module/BilinearForm.lean
@@ -5,10 +5,12 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import Mathlib.Analysis.Normed.Module.FiniteDimension
 public import Mathlib.LinearAlgebra.SesquilinearForm.Basic
 public import Mathlib.Topology.Algebra.Module.ContinuousLinearMap.Invertible
 public import Mathlib.Topology.Algebra.Module.Spaces.ContinuousLinearMap
-public import TauCeti.Analysis.Normed.Module.FiniteDimension
+-- Private: `ContinuousLinearMap.finrank_dual_eq` is used only inside proofs.
+import TauCeti.Analysis.Normed.Module.FiniteDimension
 
 /-!
 # Nondegeneracy of the bilinear form of a continuous linear map into the dual

--- a/TauCeti/Topology/Algebra/Module/BilinearForm.lean
+++ b/TauCeti/Topology/Algebra/Module/BilinearForm.lean
@@ -5,11 +5,10 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Analysis.Normed.Module.FiniteDimension
-public import Mathlib.LinearAlgebra.Dual.Lemmas
 public import Mathlib.LinearAlgebra.SesquilinearForm.Basic
 public import Mathlib.Topology.Algebra.Module.ContinuousLinearMap.Invertible
 public import Mathlib.Topology.Algebra.Module.Spaces.ContinuousLinearMap
+public import TauCeti.Analysis.Normed.Module.FiniteDimension
 
 /-!
 # Nondegeneracy of the bilinear form of a continuous linear map into the dual
@@ -26,12 +25,10 @@ itself, rather than with any of its users.
 
 * `ContinuousLinearMap.separatingLeft_toBilinForm_iff_injective`: the bilinear form of a
   continuous linear map into the dual is left-separating if and only if the map is injective.
-* `ContinuousLinearMap.finrank_dual_eq`: in finite dimensions the continuous dual has the same
-  dimension as the space.
 * `ContinuousLinearMap.isInvertible_of_injective` and
   `ContinuousLinearMap.isInvertible_of_surjective`: in finite dimensions an injective, equivalently
   a surjective, map into the dual is already invertible, the dual having the same dimension as the
-  space.
+  space (`ContinuousLinearMap.finrank_dual_eq`).
 -/
 
 public section
@@ -57,15 +54,6 @@ section FiniteDimensional
 
 variable {𝕜 E : Type*} [NontriviallyNormedField 𝕜] [CompleteSpace 𝕜]
   [NormedAddCommGroup E] [NormedSpace 𝕜 E] [FiniteDimensional 𝕜 E] {L : E →L[𝕜] E →L[𝕜] 𝕜}
-
-/-- In finite dimensions the continuous dual `E →L[𝕜] 𝕜` has the same dimension as `E`: every
-linear functional on a finite-dimensional space is continuous, so the continuous dual coincides
-with the algebraic one. -/
-theorem _root_.ContinuousLinearMap.finrank_dual_eq :
-    Module.finrank 𝕜 (E →L[𝕜] 𝕜) = Module.finrank 𝕜 E := by
-  rw [← LinearEquiv.finrank_eq
-    (LinearMap.toContinuousLinearMap : (E →ₗ[𝕜] 𝕜) ≃ₗ[𝕜] E →L[𝕜] 𝕜)]
-  exact Subspace.dual_finrank_eq
 
 /-- In finite dimensions an injective continuous linear map into the dual is invertible: injectivity
 makes it a linear equivalence onto its range, and the dual has the same finite dimension as the


### PR DESCRIPTION
This PR proves that Morse functions are generic in the simplest setting the analytic Heegaard Floer roadmap needs: on an open subset `U` of a finite-dimensional real normed space `E`, for a `C²` function `f : E → ℝ` and almost every continuous linear functional `a : E →L[ℝ] ℝ`, every critical point of `f - a` lying in `U` is nondegenerate. The exact roadmap target is Lane M, "Morse homology (Stage 0)", dynamical route, whose first listed ingredient is "Morse functions" — the milestone is empty until functions with only nondegenerate critical points are known to exist, and this supplies them, with `TauCeti.HasNondegenerateCriticalPointsOn` (from `TauCeti/Analysis/Calculus/Morse/Basic.lean`) as the conclusion that the rest of the lane consumes. After this PR, Lane M still needs the stable and unstable manifolds of a nondegenerate critical point, the λ-lemma, Morse--Smale transversality, broken-trajectory compactness and gluing before the Morse differential can be defined.

The whole argument is one observation, isolated as `TauCeti.hasNondegenerateCriticalPointsOn_sub_iff`: subtracting a linear functional shifts the differential by a constant and leaves the second derivative alone, so `f - a` has a *degenerate* critical point in `U` exactly when `a` is a critical value on `U` of the map `fderiv ℝ f : E → (E →L[ℝ] ℝ)`. Domain and codomain of that map have the same finite dimension, so `TauCeti.addHaar_image_eq_zero_of_not_surjective_fderivWithin` — the equal-dimensional case of Sard's theorem already in `TauCeti/Analysis/Calculus/Sard/EqualDimension.lean`, itself the roadmap's Lane F0 deliverable — makes the exceptional set null. Only `C²` regularity is used: `fderiv ℝ f` is then merely differentiable, which is all that lemma asks, so the higher-stratum Morse--Sard theorem is not needed here. The file also records the consequences the lane will actually use: the good perturbations are dense, hence can be taken arbitrarily small in the operator norm; a perturbation that is Morse on `U` has only finitely many critical points on any compact subset of `U`; and all three statements are transported along the Riesz isometry to the form `f - ⟪v, ·⟫` in which the negative gradient flow of Lane M is phrased.

New file `TauCeti/Analysis/Calculus/Morse/Generic.lean`. `TauCeti/Topology/Algebra/Module/BilinearForm.lean` gains two small additions used by it and by the lemma already there: `ContinuousLinearMap.finrank_dual_eq`, extracted from the existing proof of `ContinuousLinearMap.isInvertible_of_injective` rather than duplicated, and its surjective companion `ContinuousLinearMap.isInvertible_of_surjective`. The effect of the perturbation on the first two derivatives carries no Morse theory in it, so it is stated for a general field and codomain in `TauCeti/Analysis/Calculus/SecondDerivative.lean`, as `TauCeti.fderiv_sub_continuousLinearMap` (the `ContinuousLinearMap` counterpart of Mathlib's `fderiv_sub_const`), `TauCeti.fderiv_fderiv_sub_continuousLinearMap` and `ContDiffAt.eventually_differentiableAt`; the last also replaces two inline copies of the same idiom already in that file. No Mathlib source was vendored; the genericity statement and its proof follow Guillemin--Pollack, *Differential Topology*, Chapter 1, §7.

Roadmap: HeegaardFloer

<!--tauceti-target:v1 {"focus":"HeegaardFloer","id":"almost-every-linear-perturbation-is-morse"}-->

🤖 Prepared with Claude Code
