### PR TITLE
feat: topologize the compact Spin stabilizer

### DIFF
--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Real/Stabilizer.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Real/Stabilizer.lean
@@ -27,7 +27,11 @@ converse stabilizer identification.
 
 ## Main results
 
+* `CliffordAlgebra.realCliffordSpinInclusionIsometry` is the quadratic isometry inducing the
+  lower-rank inclusion.
 * `CliffordAlgebra.realCliffordSpinInclusion` is the lower-rank Spin homomorphism.
+* `CliffordAlgebra.realCliffordSpinInclusionIsometry_map_injective` proves injectivity of the
+  induced Clifford-algebra map.
 * `CliffordAlgebra.realCliffordSpinLastStabilizer` is the stabilizer of the last unit vector.
 * `CliffordAlgebra.realCliffordSpinStabilizerInclusion` is the injective homomorphism into that
   stabilizer.
@@ -53,7 +57,8 @@ open TauCeti
 noncomputable section
 
 
-private def realCliffordSpinInclusionIsometry (n : ℕ) :
+/-- The quadratic isometry inducing the lower-rank inclusion `Spin(n) → Spin(n + 1)`. -/
+def realCliffordSpinInclusionIsometry (n : ℕ) :
     realCliffordForm n 0 →qᵢ realCliffordForm (n + 1) 0 :=
   (realCliffordPositiveSplitIsometry n 0).symm.toIsometry.comp
     (QuadraticMap.Isometry.inl (realCliffordForm n 0)
@@ -75,10 +80,7 @@ def realCliffordSpinInclusion (n : ℕ) :
 @[simp]
 theorem coe_realCliffordSpinInclusion_apply (n : ℕ) (x : realCliffordSpinGroupZero n) :
     (realCliffordSpinInclusion n x : CliffordAlgebra (realCliffordForm (n + 1) 0)) =
-      CliffordAlgebra.map
-        ((realCliffordPositiveSplitIsometry n 0).symm.toIsometry.comp
-          (QuadraticMap.Isometry.inl (realCliffordForm n 0)
-            (QuadraticMap.sq (R := ℝ) (A := ℝ))))
+      CliffordAlgebra.map (realCliffordSpinInclusionIsometry n)
         (x : CliffordAlgebra (realCliffordForm n 0)) :=
   QuadraticMap.Isometry.coe_spinGroupMap_apply _ _
 
@@ -114,10 +116,9 @@ theorem realCliffordSpinInclusion_spinVectorAction_split (n : ℕ)
         (spinVectorAction (realCliffordForm n 0) x m, r) := by
   exact (realCliffordPositiveSplitIsometry n 0).spinGroupMap_spinVectorAction_prod x m r
 
-/-- The lower-rank homomorphism `Spin(n) → Spin(n + 1)` is injective. -/
-theorem realCliffordSpinInclusion_injective (n : ℕ) :
-    Function.Injective (realCliffordSpinInclusion n) := by
-  apply QuadraticMap.Isometry.spinGroupMap_injective
+/-- The Clifford-algebra map induced by the lower-rank inclusion is injective. -/
+theorem realCliffordSpinInclusionIsometry_map_injective (n : ℕ) :
+    Function.Injective (CliffordAlgebra.map (realCliffordSpinInclusionIsometry n)) := by
   rw [realCliffordSpinInclusionIsometry, ← CliffordAlgebra.map_comp_map]
   exact (CliffordAlgebra.leftInverse_map_of_leftInverse
       (realCliffordPositiveSplitIsometry n 0).symm.toIsometry
@@ -125,6 +126,12 @@ theorem realCliffordSpinInclusion_injective (n : ℕ) :
       (realCliffordPositiveSplitIsometry n 0).apply_symm_apply).injective.comp
     (CliffordAlgebra.map_inl_injective (realCliffordForm n 0)
       (QuadraticMap.sq (R := ℝ) (A := ℝ)))
+
+/-- The lower-rank homomorphism `Spin(n) → Spin(n + 1)` is injective. -/
+theorem realCliffordSpinInclusion_injective (n : ℕ) :
+    Function.Injective (realCliffordSpinInclusion n) := by
+  apply QuadraticMap.Isometry.spinGroupMap_injective
+  exact realCliffordSpinInclusionIsometry_map_injective n
 
 /-- The subgroup of `Spin(n + 1)` fixing the last coordinate vector under the vector action. -/
 def realCliffordSpinLastStabilizer (n : ℕ) :

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Real/Stabilizer.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Real/Stabilizer.lean
@@ -84,6 +84,13 @@ theorem coe_realCliffordSpinInclusion_apply (n : ℕ) (x : realCliffordSpinGroup
         (x : CliffordAlgebra (realCliffordForm n 0)) :=
   QuadraticMap.Isometry.coe_spinGroupMap_apply _ _
 
+/-- The lower-rank Spin inclusion is the map induced by its defining quadratic isometry. -/
+theorem realCliffordSpinInclusion_eq_spinGroupMap (n : ℕ) :
+    realCliffordSpinInclusion n = (realCliffordSpinInclusionIsometry n).spinGroupMap := by
+  ext x
+  exact (coe_realCliffordSpinInclusion_apply n x).trans
+    (QuadraticMap.Isometry.coe_spinGroupMap_apply _ x).symm
+
 private theorem realCliffordSpinLastIsometry_one (n : ℕ) :
     realCliffordSpinLastIsometry n 1 = Pi.single (Fin.last n) 1 := by
   funext j
@@ -157,7 +164,8 @@ theorem mem_realCliffordSpinLastStabilizer_iff
         (Pi.single (Fin.last n) 1) = Pi.single (Fin.last n) 1
   rw [coe_spinToOrthogonal_apply]
 
-private theorem realCliffordSpinInclusion_mem_lastStabilizer (n : ℕ)
+/-- The lower-rank Spin inclusion fixes the last coordinate vector. -/
+theorem realCliffordSpinInclusion_mem_lastStabilizer (n : ℕ)
     (x : realCliffordSpinGroupZero n) :
     realCliffordSpinInclusion n x ∈ realCliffordSpinLastStabilizer n :=
   mem_realCliffordSpinLastStabilizer_iff.mpr

--- a/TauCeti/Topology/Algebra/CliffordAlgebra/Spin.lean
+++ b/TauCeti/Topology/Algebra/CliffordAlgebra/Spin.lean
@@ -8,6 +8,7 @@ module
 public import TauCeti.LinearAlgebra.CliffordAlgebra.Spin.Real.Stabilizer
 public import TauCeti.Topology.Algebra.CliffordAlgebra.Basic
 public import TauCeti.Topology.Algebra.QuadraticForm.SpecialOrthogonal
+import Mathlib.Topology.Algebra.Module.FiniteDimension
 
 /-!
 # Topology on finite-dimensional real Spin groups
@@ -44,6 +45,8 @@ topologized special orthogonal group.
 
 * `QuadraticMap.Isometry.continuous_spinGroupMap` proves continuity of the Spin-group map induced
   by an isometry of real quadratic spaces.
+* `QuadraticMap.Isometry.isEmbedding_spinGroupMap` restricts an embedding of the induced Clifford
+  map to the corresponding Spin groups.
 * `CliffordAlgebra.instIsTopologicalGroupRealSpinGroup` equips `spinGroup Q` with a topological
   group structure for its canonical subtype topology.
 * `CliffordAlgebra.continuous_spinVectorAction_apply` proves fixed-vector continuity of the Spin
@@ -54,6 +57,11 @@ topologized special orthogonal group.
   the projection field of the packaged compact real double cover.
 * `CliffordAlgebra.continuous_realCliffordSpinInclusion` proves continuity of the lower-rank
   inclusion used in the compact stabilizer construction.
+* `CliffordAlgebra.isEmbedding_realCliffordSpinInclusion` strengthens this inclusion to a
+  topological embedding.
+* `CliffordAlgebra.isEmbedding_realCliffordSpinStabilizerInclusion` proves that the lower-rank
+  inclusion into the last-vector stabilizer is a topological embedding.
+* `CliffordAlgebra.isClosed_realCliffordSpinLastStabilizer` proves that this stabilizer is closed.
 * `CliffordAlgebra.continuous_realCliffordSpinStabilizerInclusion` proves continuity after
   restricting the inclusion's codomain to the last-vector stabilizer.
 
@@ -69,7 +77,33 @@ public section
 
 namespace QuadraticMap.Isometry
 
-universe u v
+universe u v w
+
+
+section
+
+variable {R : Type u} [CommRing R]
+  {V : Type v} {W : Type w}
+  [AddCommGroup V] [Module R V] [AddCommGroup W] [Module R W]
+  {Q : QuadraticForm R V} {P : QuadraticForm R W}
+  [TopologicalSpace (CliffordAlgebra Q)] [TopologicalSpace (CliffordAlgebra P)]
+
+/-- An embedding of the Clifford-algebra map induced by a quadratic isometry restricts to an
+embedding of the corresponding Spin groups for their subtype topologies. -/
+theorem isEmbedding_spinGroupMap (f : Q →qᵢ P)
+    (hf : Topology.IsEmbedding (CliffordAlgebra.map f)) :
+    Topology.IsEmbedding f.spinGroupMap := by
+  have hmaps : Set.MapsTo (CliffordAlgebra.map f) (spinGroup Q) (spinGroup P) :=
+    fun x hx => f.map_mem_spinGroup ⟨x, hx⟩
+  rw [show (f.spinGroupMap : spinGroup Q → spinGroup P) = hmaps.restrict by
+    funext x
+    exact Subtype.ext (coe_spinGroupMap_apply f x)]
+  exact hf.restrict hmaps
+
+end
+
+
+section Real
 
 
 variable {V : Type u} {W : Type v}
@@ -84,6 +118,8 @@ theorem continuous_spinGroupMap (f : Q →qᵢ P) : Continuous f.spinGroupMap :=
   refine (f.continuous_cliffordAlgebraMap.comp
     continuous_subtype_val).congr ?_
   exact fun x ↦ (coe_spinGroupMap_apply f x).symm
+
+end Real
 
 end QuadraticMap.Isometry
 
@@ -169,15 +205,67 @@ theorem continuous_realCliffordSpinInclusion (n : ℕ) :
     rw [QuadraticMap.Isometry.coe_spinGroupMap_apply,
       coe_realCliffordSpinInclusion_apply]
 
+/-- The canonical inclusion `Spin(n) → Spin(n + 1)` is a topological embedding for every `n`. -/
+theorem isEmbedding_realCliffordSpinInclusion (n : ℕ) :
+    Topology.IsEmbedding (realCliffordSpinInclusion n) := by
+  let f : realCliffordForm n 0 →qᵢ realCliffordForm (n + 1) 0 :=
+    (realCliffordPositiveSplitIsometry n 0).symm.toIsometry.comp
+      (QuadraticMap.Isometry.inl (realCliffordForm n 0)
+        (QuadraticMap.sq (R := ℝ) (A := ℝ)))
+  have hf : Function.Injective (CliffordAlgebra.map f) := by
+    dsimp only [f]
+    rw [← CliffordAlgebra.map_comp_map]
+    exact (CliffordAlgebra.leftInverse_map_of_leftInverse
+        (realCliffordPositiveSplitIsometry n 0).symm.toIsometry
+        (realCliffordPositiveSplitIsometry n 0).toIsometry
+        (realCliffordPositiveSplitIsometry n 0).apply_symm_apply).injective.comp
+      (CliffordAlgebra.map_inl_injective (realCliffordForm n 0)
+        (QuadraticMap.sq (R := ℝ) (A := ℝ)))
+  have hmap : Topology.IsEmbedding (CliffordAlgebra.map f) :=
+    (LinearMap.isClosedEmbedding_of_injective
+      ((CliffordAlgebra.map f).toLinearMap.ker_eq_bot.mpr hf)).isEmbedding
+  rw [show (realCliffordSpinInclusion n :
+      realCliffordSpinGroupZero n → realCliffordSpinGroupZero (n + 1)) =
+      f.spinGroupMap by
+    funext x
+    apply Subtype.ext
+    rw [coe_realCliffordSpinInclusion_apply,
+      QuadraticMap.Isometry.coe_spinGroupMap_apply]]
+  exact f.isEmbedding_spinGroupMap hmap
+
+/-- The subgroup of `Spin(n + 1)` fixing the last coordinate vector is closed. -/
+theorem isClosed_realCliffordSpinLastStabilizer (n : ℕ) :
+    IsClosed (realCliffordSpinLastStabilizer n :
+      Set (realCliffordSpinGroupZero (n + 1))) := by
+  rw [show (realCliffordSpinLastStabilizer n :
+      Set (realCliffordSpinGroupZero (n + 1))) =
+      {x | spinVectorAction (realCliffordForm (n + 1) 0) x
+        (Pi.single (Fin.last n) 1) = Pi.single (Fin.last n) 1} by
+    ext x
+    exact mem_realCliffordSpinLastStabilizer_iff]
+  exact isClosed_eq
+    (continuous_spinVectorAction_apply _ (Pi.single (Fin.last n) 1)) continuous_const
+
+/-- The canonical inclusion `Spin(n) → Spin(n + 1)`, restricted to the last-vector stabilizer, is
+a topological embedding. -/
+theorem isEmbedding_realCliffordSpinStabilizerInclusion (n : ℕ) :
+    Topology.IsEmbedding (realCliffordSpinStabilizerInclusion n) := by
+  let hmem : ∀ x, realCliffordSpinInclusion n x ∈ realCliffordSpinLastStabilizer n :=
+    fun x => mem_realCliffordSpinLastStabilizer_iff.mpr
+      (realCliffordSpinInclusion_fixed_last n x)
+  rw [show (realCliffordSpinStabilizerInclusion n :
+      realCliffordSpinGroupZero n → realCliffordSpinLastStabilizer n) =
+      Set.codRestrict (realCliffordSpinInclusion n) _ hmem by
+    funext x
+    exact Subtype.ext (coe_realCliffordSpinStabilizerInclusion_apply n x)]
+  exact (isEmbedding_realCliffordSpinInclusion n).codRestrict _ hmem
+
 /-- The canonical inclusion `Spin(n) → Spin(n + 1)` is continuous after restricting its codomain
 to the last-vector stabilizer. -/
 @[fun_prop]
 theorem continuous_realCliffordSpinStabilizerInclusion (n : ℕ) :
-    Continuous (realCliffordSpinStabilizerInclusion n) := by
-  refine ((continuous_realCliffordSpinInclusion n).subtype_mk (fun x ↦ ?_)).congr ?_
-  · rw [← coe_realCliffordSpinStabilizerInclusion_apply n x]
-    exact (realCliffordSpinStabilizerInclusion n x).property
-  · exact fun x ↦ Subtype.ext (coe_realCliffordSpinStabilizerInclusion_apply n x).symm
+    Continuous (realCliffordSpinStabilizerInclusion n) :=
+  (isEmbedding_realCliffordSpinStabilizerInclusion n).continuous
 
 end
 

--- a/TauCeti/Topology/Algebra/CliffordAlgebra/Spin.lean
+++ b/TauCeti/Topology/Algebra/CliffordAlgebra/Spin.lean
@@ -51,6 +51,7 @@ topologized special orthogonal group.
   group structure for its canonical subtype topology.
 * `CliffordAlgebra.continuous_spinVectorAction_apply` proves fixed-vector continuity of the Spin
   action.
+* `CliffordAlgebra.isClosed_spinVectorStabilizer` proves that every vector stabilizer is closed.
 * `CliffordAlgebra.continuous_spinToSpecialOrthogonal_pi` proves continuity of the Spin
   projection for every quadratic form on a finite real coordinate space.
 * `CliffordAlgebra.continuous_realCliffordSpinDoubleCoverZero_rightHom` specializes this result to
@@ -95,10 +96,9 @@ theorem isEmbedding_spinGroupMap (f : Q →qᵢ P)
     Topology.IsEmbedding f.spinGroupMap := by
   have hmaps : Set.MapsTo (CliffordAlgebra.map f) (spinGroup Q) (spinGroup P) :=
     fun x hx => f.map_mem_spinGroup ⟨x, hx⟩
-  rw [show (f.spinGroupMap : spinGroup Q → spinGroup P) = hmaps.restrict by
-    funext x
-    exact Subtype.ext (coe_spinGroupMap_apply f x)]
-  exact hf.restrict hmaps
+  convert hf.restrict hmaps using 1
+  ext x
+  exact coe_spinGroupMap_apply f x
 
 end
 
@@ -163,6 +163,12 @@ theorem continuous_spinVectorAction_apply [TopologicalSpace V] [IsModuleTopology
   rw [← ιInv_ι Q (spinVectorAction Q x v), ι_spinVectorAction_apply]
   rfl
 
+/-- The subgroup of a finite-dimensional real Spin group fixing a vector is closed. -/
+theorem isClosed_spinVectorStabilizer [TopologicalSpace V] [IsModuleTopology ℝ V] [T2Space V]
+    (Q : QuadraticForm ℝ V) (v : V) :
+    IsClosed {x : spinGroup Q | spinVectorAction Q x v = v} :=
+  isClosed_eq (continuous_spinVectorAction_apply Q v) continuous_const
+
 /-- The real Spin action of a quadratic form on a finite coordinate space is continuous as a map to
 the special orthogonal group with its standard coordinate topology. -/
 @[fun_prop]
@@ -191,60 +197,38 @@ theorem continuous_realCliffordSpinDoubleCoverZero_rightHom (n : ℕ) [NeZero n]
   rw [realCliffordSpinDoubleCoverZero_rightHom]
   exact continuous_spinToSpecialOrthogonal_pi (realCliffordForm n 0)
 
+/-- The canonical inclusion `Spin(n) → Spin(n + 1)` is a topological embedding for every `n`. -/
+theorem isEmbedding_realCliffordSpinInclusion (n : ℕ) :
+    Topology.IsEmbedding (realCliffordSpinInclusion n) := by
+  have hmap : Topology.IsEmbedding
+      (CliffordAlgebra.map (realCliffordSpinInclusionIsometry n)) :=
+    (LinearMap.isClosedEmbedding_of_injective
+      ((CliffordAlgebra.map (realCliffordSpinInclusionIsometry n)).toLinearMap.ker_eq_bot.mpr
+        (realCliffordSpinInclusionIsometry_map_injective n))).isEmbedding
+  have hIncl : (realCliffordSpinInclusion n :
+      realCliffordSpinGroupZero n → realCliffordSpinGroupZero (n + 1)) =
+      (realCliffordSpinInclusionIsometry n).spinGroupMap := by
+    funext x
+    exact Subtype.ext ((coe_realCliffordSpinInclusion_apply n x).trans
+      (QuadraticMap.Isometry.coe_spinGroupMap_apply _ x).symm)
+  rw [hIncl]
+  exact (realCliffordSpinInclusionIsometry n).isEmbedding_spinGroupMap hmap
+
 /-- The lower-rank inclusion `Spin(n) → Spin(n + 1)` is continuous for the canonical real
 Clifford-algebra subtype topologies. -/
 @[fun_prop]
 theorem continuous_realCliffordSpinInclusion (n : ℕ) :
-    Continuous (realCliffordSpinInclusion n) := by
-  refine (QuadraticMap.Isometry.continuous_spinGroupMap
-    ((realCliffordPositiveSplitIsometry n 0).symm.toIsometry.comp
-      (QuadraticMap.Isometry.inl (realCliffordForm n 0)
-        (QuadraticMap.sq (R := ℝ) (A := ℝ))))).congr ?_
-  exact fun x ↦ by
-    apply Subtype.ext
-    rw [QuadraticMap.Isometry.coe_spinGroupMap_apply,
-      coe_realCliffordSpinInclusion_apply]
-
-/-- The canonical inclusion `Spin(n) → Spin(n + 1)` is a topological embedding for every `n`. -/
-theorem isEmbedding_realCliffordSpinInclusion (n : ℕ) :
-    Topology.IsEmbedding (realCliffordSpinInclusion n) := by
-  let f : realCliffordForm n 0 →qᵢ realCliffordForm (n + 1) 0 :=
-    (realCliffordPositiveSplitIsometry n 0).symm.toIsometry.comp
-      (QuadraticMap.Isometry.inl (realCliffordForm n 0)
-        (QuadraticMap.sq (R := ℝ) (A := ℝ)))
-  have hf : Function.Injective (CliffordAlgebra.map f) := by
-    dsimp only [f]
-    rw [← CliffordAlgebra.map_comp_map]
-    exact (CliffordAlgebra.leftInverse_map_of_leftInverse
-        (realCliffordPositiveSplitIsometry n 0).symm.toIsometry
-        (realCliffordPositiveSplitIsometry n 0).toIsometry
-        (realCliffordPositiveSplitIsometry n 0).apply_symm_apply).injective.comp
-      (CliffordAlgebra.map_inl_injective (realCliffordForm n 0)
-        (QuadraticMap.sq (R := ℝ) (A := ℝ)))
-  have hmap : Topology.IsEmbedding (CliffordAlgebra.map f) :=
-    (LinearMap.isClosedEmbedding_of_injective
-      ((CliffordAlgebra.map f).toLinearMap.ker_eq_bot.mpr hf)).isEmbedding
-  rw [show (realCliffordSpinInclusion n :
-      realCliffordSpinGroupZero n → realCliffordSpinGroupZero (n + 1)) =
-      f.spinGroupMap by
-    funext x
-    apply Subtype.ext
-    rw [coe_realCliffordSpinInclusion_apply,
-      QuadraticMap.Isometry.coe_spinGroupMap_apply]]
-  exact f.isEmbedding_spinGroupMap hmap
+    Continuous (realCliffordSpinInclusion n) :=
+  (isEmbedding_realCliffordSpinInclusion n).continuous
 
 /-- The subgroup of `Spin(n + 1)` fixing the last coordinate vector is closed. -/
 theorem isClosed_realCliffordSpinLastStabilizer (n : ℕ) :
     IsClosed (realCliffordSpinLastStabilizer n :
       Set (realCliffordSpinGroupZero (n + 1))) := by
-  rw [show (realCliffordSpinLastStabilizer n :
-      Set (realCliffordSpinGroupZero (n + 1))) =
-      {x | spinVectorAction (realCliffordForm (n + 1) 0) x
-        (Pi.single (Fin.last n) 1) = Pi.single (Fin.last n) 1} by
-    ext x
-    exact mem_realCliffordSpinLastStabilizer_iff]
-  exact isClosed_eq
-    (continuous_spinVectorAction_apply _ (Pi.single (Fin.last n) 1)) continuous_const
+  convert isClosed_spinVectorStabilizer (realCliffordForm (n + 1) 0)
+    (Pi.single (Fin.last n) 1) using 1
+  ext x
+  exact mem_realCliffordSpinLastStabilizer_iff
 
 /-- The canonical inclusion `Spin(n) → Spin(n + 1)`, restricted to the last-vector stabilizer, is
 a topological embedding. -/
@@ -253,12 +237,9 @@ theorem isEmbedding_realCliffordSpinStabilizerInclusion (n : ℕ) :
   let hmem : ∀ x, realCliffordSpinInclusion n x ∈ realCliffordSpinLastStabilizer n :=
     fun x => mem_realCliffordSpinLastStabilizer_iff.mpr
       (realCliffordSpinInclusion_fixed_last n x)
-  rw [show (realCliffordSpinStabilizerInclusion n :
-      realCliffordSpinGroupZero n → realCliffordSpinLastStabilizer n) =
-      Set.codRestrict (realCliffordSpinInclusion n) _ hmem by
-    funext x
-    exact Subtype.ext (coe_realCliffordSpinStabilizerInclusion_apply n x)]
-  exact (isEmbedding_realCliffordSpinInclusion n).codRestrict _ hmem
+  convert (isEmbedding_realCliffordSpinInclusion n).codRestrict _ hmem using 1
+  ext x
+  exact congrArg Subtype.val (coe_realCliffordSpinStabilizerInclusion_apply n x)
 
 /-- The canonical inclusion `Spin(n) → Spin(n + 1)` is continuous after restricting its codomain
 to the last-vector stabilizer. -/

--- a/TauCeti/Topology/Algebra/CliffordAlgebra/Spin.lean
+++ b/TauCeti/Topology/Algebra/CliffordAlgebra/Spin.lean
@@ -51,7 +51,7 @@ topologized special orthogonal group.
   group structure for its canonical subtype topology.
 * `CliffordAlgebra.continuous_spinVectorAction_apply` proves fixed-vector continuity of the Spin
   action.
-* `CliffordAlgebra.isClosed_spinVectorStabilizer` proves that every vector stabilizer is closed.
+* `QuadraticForm.isClosed_spinVectorStabilizer` proves that every vector stabilizer is closed.
 * `CliffordAlgebra.continuous_spinToSpecialOrthogonal_pi` proves continuity of the Spin
   projection for every quadratic form on a finite real coordinate space.
 * `CliffordAlgebra.continuous_realCliffordSpinDoubleCoverZero_rightHom` specializes this result to
@@ -164,11 +164,11 @@ theorem continuous_spinVectorAction_apply [TopologicalSpace V] [IsModuleTopology
   rfl
 
 /-- The subgroup of a finite-dimensional real Spin group fixing a vector is closed. -/
-theorem isClosed_spinVectorStabilizer [TopologicalSpace V] [IsModuleTopology ℝ V] [T1Space V]
+theorem _root_.QuadraticForm.isClosed_spinVectorStabilizer
+    [TopologicalSpace V] [IsModuleTopology ℝ V] [T1Space V]
     (Q : QuadraticForm ℝ V) (v : V) :
     IsClosed {x : spinGroup Q | spinVectorAction Q x v = v} := by
-  change IsClosed ((fun x : spinGroup Q => spinVectorAction Q x v) ⁻¹' {v})
-  exact isClosed_singleton.preimage (continuous_spinVectorAction_apply Q v)
+  exact isClosed_singleton.preimage (CliffordAlgebra.continuous_spinVectorAction_apply Q v)
 
 /-- The real Spin action of a quadratic form on a finite coordinate space is continuous as a map to
 the special orthogonal group with its standard coordinate topology. -/
@@ -206,13 +206,7 @@ theorem isEmbedding_realCliffordSpinInclusion (n : ℕ) :
     (LinearMap.isClosedEmbedding_of_injective
       ((CliffordAlgebra.map (realCliffordSpinInclusionIsometry n)).toLinearMap.ker_eq_bot.mpr
         (realCliffordSpinInclusionIsometry_map_injective n))).isEmbedding
-  have hIncl : (realCliffordSpinInclusion n :
-      realCliffordSpinGroupZero n → realCliffordSpinGroupZero (n + 1)) =
-      (realCliffordSpinInclusionIsometry n).spinGroupMap := by
-    funext x
-    exact Subtype.ext ((coe_realCliffordSpinInclusion_apply n x).trans
-      (QuadraticMap.Isometry.coe_spinGroupMap_apply _ x).symm)
-  rw [hIncl]
+  rw [realCliffordSpinInclusion_eq_spinGroupMap]
   exact (realCliffordSpinInclusionIsometry n).isEmbedding_spinGroupMap hmap
 
 /-- The lower-rank inclusion `Spin(n) → Spin(n + 1)` is continuous for the canonical real
@@ -226,7 +220,7 @@ theorem continuous_realCliffordSpinInclusion (n : ℕ) :
 theorem isClosed_realCliffordSpinLastStabilizer (n : ℕ) :
     IsClosed (realCliffordSpinLastStabilizer n :
       Set (realCliffordSpinGroupZero (n + 1))) := by
-  convert isClosed_spinVectorStabilizer (realCliffordForm (n + 1) 0)
+  convert QuadraticForm.isClosed_spinVectorStabilizer (realCliffordForm (n + 1) 0)
     (Pi.single (Fin.last n) 1) using 1
   ext x
   exact mem_realCliffordSpinLastStabilizer_iff
@@ -235,10 +229,8 @@ theorem isClosed_realCliffordSpinLastStabilizer (n : ℕ) :
 a topological embedding. -/
 theorem isEmbedding_realCliffordSpinStabilizerInclusion (n : ℕ) :
     Topology.IsEmbedding (realCliffordSpinStabilizerInclusion n) := by
-  let hmem : ∀ x, realCliffordSpinInclusion n x ∈ realCliffordSpinLastStabilizer n :=
-    fun x => mem_realCliffordSpinLastStabilizer_iff.mpr
-      (realCliffordSpinInclusion_fixed_last n x)
-  convert (isEmbedding_realCliffordSpinInclusion n).codRestrict _ hmem using 1
+  convert (isEmbedding_realCliffordSpinInclusion n).codRestrict _
+    (realCliffordSpinInclusion_mem_lastStabilizer n) using 1
   ext x
   exact congrArg Subtype.val (coe_realCliffordSpinStabilizerInclusion_apply n x)
 

--- a/TauCeti/Topology/Algebra/CliffordAlgebra/Spin.lean
+++ b/TauCeti/Topology/Algebra/CliffordAlgebra/Spin.lean
@@ -164,10 +164,11 @@ theorem continuous_spinVectorAction_apply [TopologicalSpace V] [IsModuleTopology
   rfl
 
 /-- The subgroup of a finite-dimensional real Spin group fixing a vector is closed. -/
-theorem isClosed_spinVectorStabilizer [TopologicalSpace V] [IsModuleTopology ℝ V] [T2Space V]
+theorem isClosed_spinVectorStabilizer [TopologicalSpace V] [IsModuleTopology ℝ V] [T1Space V]
     (Q : QuadraticForm ℝ V) (v : V) :
-    IsClosed {x : spinGroup Q | spinVectorAction Q x v = v} :=
-  isClosed_eq (continuous_spinVectorAction_apply Q v) continuous_const
+    IsClosed {x : spinGroup Q | spinVectorAction Q x v = v} := by
+  change IsClosed ((fun x : spinGroup Q => spinVectorAction Q x v) ⁻¹' {v})
+  exact isClosed_singleton.preimage (continuous_spinVectorAction_apply Q v)
 
 /-- The real Spin action of a quadratic form on a finite coordinate space is continuous as a map to
 the special orthogonal group with its standard coordinate topology. -/


### PR DESCRIPTION
This PR establishes the topological embedding and closed-stabilizer inputs for the compact Spin homogeneous-space construction in RepresentationTheory/SpinRepresentations Layer 7.

Roadmap: RepresentationTheory

## Summary

Prove that an embedding of an ambient Clifford-algebra map restricts to an embedding of the induced Spin-group map, then apply it to `Spin(n) → Spin(n + 1)`. The repair exposes and reuses the canonical lower-rank isometry, its Clifford-map injectivity proof, its defining Spin-map equality, and its last-stabilizer membership theorem across the algebraic and topological modules. It also places closedness of every fixed-vector stabilizer in the `QuadraticForm` namespace under the exact `T1Space` assumption and derives the last-coordinate specialization. The active algebraic stabilizer identification in #6133 can therefore be upgraded directly to a homeomorphism after it lands.

## Roadmap target

This advances the SpinRepresentations milestone **Layer 7 — Low-rank identifications and compact-group topology**, specifically the target to use the sphere homogeneous-space bundle to prove connectivity and simple connectivity of compact `Spin(n)` inductively. After this PR, the algebraic stabilizer equivalence from #6133 must land and be combined with this embedding before constructing the quotient/orbit homeomorphism, local bundle structure, and connectivity induction.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"compact-spin-stabilizer-topology"}-->

## Verification

- Exact head: `db75a6bf40f0d6bf0912639e2cad546cb913dcd7`
- Local Lean build: `lake exe cache get`, then `lake build` — pass; `Build completed successfully (10922 jobs).`
- Axiom audit: `lake exe axioms` — pass; `axioms: audited 107523 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`
- Lint: `env PATH=/opt/homebrew/opt/gnu-sed/libexec/gnubin:$PATH bash scripts/lint-env.sh && python3 scripts/lint-dot-notation.py && bash scripts/lint-style.sh && lake exe module-system` — pass with no new violations; all 4,778 modules use the module system
- Public CI: pending on the repaired head

## Scale and generality

The aggregate adds 77 net lines across two existing Spin modules. The structural restriction theorem works over an arbitrary commutative ring and arbitrary topologies on the two Clifford algebras, assuming exactly that the ambient Clifford map is an embedding. Closedness is stated for any vector in any finite-dimensional real quadratic space with its module topology and a T1 carrier. The compact embedding and closedness specializations hold for every `n : ℕ`, including rank zero, with no unnecessary `NeZero`, compactness, Hausdorff, or target-dimension hypothesis.

## Scope

- **Consumes:** the existing Clifford-map functoriality, canonical finite-dimensional real Clifford topology, fixed-vector continuity, and compact lower-rank inclusion/stabilizer API.
- **Provides:** the canonical inclusion isometry and its shared ambient-map injectivity and membership witnesses, the generic Spin-map embedding restriction, general closed vector stabilizers, and the compact inclusion/stabilizer embedding specializations.
- **Fits:** supplies the topological half of the exact stabilizer homeomorphism consumed by the Layer 7 sphere homogeneous-space connectivity induction.
- **Boundary:** does not replay the closed sphere-orbit work or prove algebraic stabilizer surjectivity, quotient/orbit topology, local triviality, connectivity, simple connectivity, or the universal-cover theorem.

<sub>🤖 GPT-5.6 Sol high · TauCetiWorker @ [910d954fee75dfafda41f98165ce3a9e6676eae1](https://github.com/utensil/TauCetiWorker/commit/910d954fee75dfafda41f98165ce3a9e6676eae1) · rubrics @ [afb424eda89e8ac96d9eb69f6a88972055a4cd1b](https://github.com/utensil/TauCetiReview/commit/afb424eda89e8ac96d9eb69f6a88972055a4cd1b) · local review @ [b533e561b6d44df071c31335ed4a63ae647507d2](https://github.com/utensil/formal-land/commit/b533e561b6d44df071c31335ed4a63ae647507d2) · fixed: reuse, generality, naming, proof-quality</sub>