### PR TITLE
feat: make regular-form classes a semiring

### DIFF
--- a/TauCeti/LinearAlgebra/QuadraticForm/RegularFormClass/Semiring.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/RegularFormClass/Semiring.lean
@@ -70,46 +70,35 @@ private lemma mk_tmul_zero (p : RegularFormPresentation K) :
     Quotient.mk (regularFormSetoid K) (p.tmul ⟨0, Fin.elim0⟩) =
       (0 : RegularFormClass K) := by
   rw [RegularFormClass.zero_def]
-  let indexEquiv : Fin (p.tmul ⟨0, Fin.elim0⟩).1 ≃ Fin 0 := finCongr (by simp)
-  let _ : IsEmpty (Fin (p.tmul ⟨0, Fin.elim0⟩).1) := Function.isEmpty indexEquiv
-  apply RegularFormClass.mk_eq_mk_iff.mpr
-  exact ⟨{
-    toLinearEquiv := LinearEquiv.funCongrLeft K K indexEquiv.symm
-    map_app' := fun x ↦ by
-      calc
-        presentedForm ⟨0, Fin.elim0⟩
-            (LinearEquiv.funCongrLeft K K indexEquiv.symm x) = 0 := by
-          rw [presentedForm_apply]
-          simp
-        _ = presentedForm (p.tmul ⟨0, Fin.elim0⟩) x := by
-          rw [presentedForm_apply]
-          simp
-  }⟩
+  apply congrArg (Quotient.mk (regularFormSetoid K))
+  let h : (p.tmul ⟨0, Fin.elim0⟩).1 = 0 := by simp
+  refine Sigma.ext (x := p.tmul ⟨0, Fin.elim0⟩) (y := ⟨0, Fin.elim0⟩) h ?_
+  let hf : (Fin (p.tmul ⟨0, Fin.elim0⟩).1 → Kˣ) = (Fin 0 → Kˣ) :=
+    congrArg (fun n ↦ Fin n → Kˣ) h
+  apply (cast_eq_iff_heq (e := hf)).mp
+  exact Subsingleton.elim _ _
 
 /-! ### The commutative semiring -/
 
-/-- Tensor product distributes over orthogonal sum on regular-form classes. -/
-theorem RegularFormClass.mul_add (x y z : RegularFormClass K) :
-    x * (y + z) = x * y + x * z := by
-  refine Quotient.inductionOn₃ x y z fun p q r ↦ ?_
-  rw [RegularFormClass.mk_add_mk, RegularFormClass.mk_mul_mk,
-    RegularFormClass.mk_mul_mk, RegularFormClass.mk_mul_mk,
-    RegularFormClass.mk_add_mk]
-  exact RegularFormClass.mk_eq_mk_iff.mpr (equivalent_presentedForm_tmul_append p q r)
-
-/-- Tensoring a regular-form class with the zero class gives the zero class. -/
-theorem RegularFormClass.mul_zero (x : RegularFormClass K) : x * 0 = 0 := by
-  refine Quotient.inductionOn x fun p ↦ ?_
-  rw [RegularFormClass.zero_def, RegularFormClass.mk_mul_mk]
-  exact mk_tmul_zero p
-
 /-- Orthogonal sum and tensor product make regular-form classes a commutative semiring. -/
-instance instCommSemiringRegularFormClass : CommSemiring (RegularFormClass K) where
-  left_distrib := RegularFormClass.mul_add
-  right_distrib x y z := by
-    rw [mul_comm (x + y), RegularFormClass.mul_add, mul_comm z x, mul_comm z y]
-  zero_mul x := by rw [mul_comm, RegularFormClass.mul_zero]
-  mul_zero := RegularFormClass.mul_zero
+instance instCommSemiringRegularFormClass : CommSemiring (RegularFormClass K) := by
+  let hmul_add (x y z : RegularFormClass K) : x * (y + z) = x * y + x * z := by
+    refine Quotient.inductionOn₃ x y z fun p q r ↦ ?_
+    rw [RegularFormClass.mk_add_mk, RegularFormClass.mk_mul_mk,
+      RegularFormClass.mk_mul_mk, RegularFormClass.mk_mul_mk,
+      RegularFormClass.mk_add_mk]
+    exact RegularFormClass.mk_eq_mk_iff.mpr (equivalent_presentedForm_tmul_append p q r)
+  let hmul_zero (x : RegularFormClass K) : x * 0 = 0 := by
+    refine Quotient.inductionOn x fun p ↦ ?_
+    rw [RegularFormClass.zero_def, RegularFormClass.mk_mul_mk]
+    exact mk_tmul_zero p
+  exact {
+    left_distrib := hmul_add
+    right_distrib := fun x y z ↦ by
+      rw [mul_comm (x + y), hmul_add, mul_comm z x, mul_comm z y]
+    zero_mul := fun x ↦ by rw [mul_comm, hmul_zero]
+    mul_zero := hmul_zero
+  }
 
 /-! ### Rank -/
 

--- a/TauCeti/LinearAlgebra/QuadraticForm/RegularFormClass/Semiring.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/RegularFormClass/Semiring.lean
@@ -1,0 +1,130 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.LinearAlgebra.QuadraticForm.RegularFormClass.TensorProduct
+
+/-!
+# The semiring of regular-form classes
+
+Orthogonal sum and tensor product make the isometry classes of regular finite-dimensional
+quadratic forms over a field of characteristic different from two into a commutative semiring.
+The essential compatibility is the isometry distributing tensor product over orthogonal product.
+
+The rank is compatible with both operations, so it is packaged as a semiring homomorphism to the
+natural numbers. This is the dimension map from which parity invariants can be obtained by
+composition.
+
+## Main results
+
+* `TauCeti.instCommSemiringRegularFormClass`: the commutative semiring structure.
+* `TauCeti.RegularFormClass.rankHom`: rank as a semiring homomorphism to `ℕ`.
+
+## References
+
+* T. Y. Lam, *Introduction to Quadratic Forms over Fields* (2005), Chapter II, §1.
+-/
+
+public section
+
+open QuadraticMap QuadraticForm
+
+namespace TauCeti
+
+universe u
+
+variable {K : Type u} [Field K] [Invertible (2 : K)]
+
+/-! ### Distributivity -/
+
+/-- Tensor product distributes over concatenation of presentations, up to isometry of the
+presented forms. -/
+theorem equivalent_presentedForm_tmul_append (p q r : RegularFormPresentation K) :
+    (presentedForm (p.tmul (q.append r))).Equivalent
+      (presentedForm ((p.tmul q).append (p.tmul r))) :=
+  QuadraticMap.Equivalent.trans (equivalent_presentedForm_tmul p (q.append r)) <|
+    QuadraticMap.Equivalent.trans
+      (QuadraticMap.Equivalent.tmul
+        (⟨QuadraticMap.IsometryEquiv.refl (presentedForm p)⟩ :
+          (presentedForm p).Equivalent (presentedForm p))
+        (equivalent_presentedForm_append_prod q r)) <|
+      QuadraticMap.Equivalent.trans
+        (⟨QuadraticForm.IsometryEquiv.tmulProd (presentedForm p) (presentedForm q)
+            (presentedForm r)⟩ :
+          ((presentedForm p).tmul ((presentedForm q).prod (presentedForm r))).Equivalent
+            (((presentedForm p).tmul (presentedForm q)).prod
+              ((presentedForm p).tmul (presentedForm r)))) <|
+        QuadraticMap.Equivalent.trans
+          (QuadraticMap.Equivalent.prod
+            (QuadraticMap.Equivalent.symm (equivalent_presentedForm_tmul p q))
+            (QuadraticMap.Equivalent.symm (equivalent_presentedForm_tmul p r)))
+          (QuadraticMap.Equivalent.symm
+            (equivalent_presentedForm_append_prod (p.tmul q) (p.tmul r)))
+
+omit [Invertible (2 : K)] in
+/-- Tensoring a presentation with the empty presentation gives the empty class. -/
+private lemma mk_tmul_zero (p : RegularFormPresentation K) :
+    Quotient.mk (regularFormSetoid K) (p.tmul ⟨0, Fin.elim0⟩) =
+      (0 : RegularFormClass K) := by
+  rw [RegularFormClass.zero_def]
+  let indexEquiv : Fin (p.tmul ⟨0, Fin.elim0⟩).1 ≃ Fin 0 := finCongr (by simp)
+  let _ : IsEmpty (Fin (p.tmul ⟨0, Fin.elim0⟩).1) := Function.isEmpty indexEquiv
+  apply RegularFormClass.mk_eq_mk_iff.mpr
+  exact ⟨{
+    toLinearEquiv := LinearEquiv.funCongrLeft K K indexEquiv.symm
+    map_app' := fun x ↦ by
+      calc
+        presentedForm ⟨0, Fin.elim0⟩
+            (LinearEquiv.funCongrLeft K K indexEquiv.symm x) = 0 := by
+          rw [presentedForm_apply]
+          simp
+        _ = presentedForm (p.tmul ⟨0, Fin.elim0⟩) x := by
+          rw [presentedForm_apply]
+          simp
+  }⟩
+
+/-! ### The commutative semiring -/
+
+/-- Tensor product distributes over orthogonal sum on regular-form classes. -/
+theorem RegularFormClass.mul_add (x y z : RegularFormClass K) :
+    x * (y + z) = x * y + x * z := by
+  refine Quotient.inductionOn₃ x y z fun p q r ↦ ?_
+  rw [RegularFormClass.mk_add_mk, RegularFormClass.mk_mul_mk,
+    RegularFormClass.mk_mul_mk, RegularFormClass.mk_mul_mk,
+    RegularFormClass.mk_add_mk]
+  exact RegularFormClass.mk_eq_mk_iff.mpr (equivalent_presentedForm_tmul_append p q r)
+
+/-- Tensoring a regular-form class with the zero class gives the zero class. -/
+theorem RegularFormClass.mul_zero (x : RegularFormClass K) : x * 0 = 0 := by
+  refine Quotient.inductionOn x fun p ↦ ?_
+  rw [RegularFormClass.zero_def, RegularFormClass.mk_mul_mk]
+  exact mk_tmul_zero p
+
+/-- Orthogonal sum and tensor product make regular-form classes a commutative semiring. -/
+instance instCommSemiringRegularFormClass : CommSemiring (RegularFormClass K) where
+  left_distrib := RegularFormClass.mul_add
+  right_distrib x y z := by
+    rw [mul_comm (x + y), RegularFormClass.mul_add, mul_comm z x, mul_comm z y]
+  zero_mul x := by rw [mul_comm, RegularFormClass.mul_zero]
+  mul_zero := RegularFormClass.mul_zero
+
+/-! ### Rank -/
+
+/-- The rank of a regular-form class, as a semiring homomorphism. Orthogonal sum adds ranks and
+tensor product multiplies them. -/
+def RegularFormClass.rankHom : RegularFormClass K →+* ℕ where
+  toFun := RegularFormClass.rank
+  map_zero' := RegularFormClass.rank_zero
+  map_one' := RegularFormClass.rank_one
+  map_add' := RegularFormClass.rank_add
+  map_mul' := RegularFormClass.rank_mul
+
+/-- Applying the rank homomorphism computes the rank. -/
+@[simp]
+theorem RegularFormClass.rankHom_apply (x : RegularFormClass K) :
+    RegularFormClass.rankHom x = x.rank := (rfl)
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/QuadraticForm/TensorProduct.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/TensorProduct.lean
@@ -105,4 +105,18 @@ theorem _root_.QuadraticForm.IsometryEquiv.tmulProd_tmul
       (m ⊗ₜ[R] np.1, m ⊗ₜ[R] np.2) :=
   TensorProduct.prodRight_tmul R R M N P m np
 
+/-- The inverse distributivity isometry combines a pair of pure tensors with the same first
+factor into a pure tensor with product-valued second factor. -/
+@[simp]
+theorem _root_.QuadraticForm.IsometryEquiv.tmulProd_symm_tmul
+    {M N P : Type*}
+    [AddCommGroup M] [Module R M]
+    [AddCommGroup N] [Module R N]
+    [AddCommGroup P] [Module R P]
+    (Q : QuadraticForm R M) (S : QuadraticForm R N) (T : QuadraticForm R P)
+    (m : M) (n : N) (p : P) :
+    (QuadraticForm.IsometryEquiv.tmulProd Q S T).symm (m ⊗ₜ[R] n, m ⊗ₜ[R] p) =
+      m ⊗ₜ[R] (n, p) :=
+  TensorProduct.prodRight_symm_tmul R R M N P m n p
+
 end TauCeti

--- a/TauCeti/LinearAlgebra/QuadraticForm/TensorProduct.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/TensorProduct.lean
@@ -68,19 +68,22 @@ theorem _root_.QuadraticMap.Equivalent.tmul
 
 /-- Tensor product distributes over the orthogonal product of quadratic forms. -/
 def _root_.QuadraticForm.IsometryEquiv.tmulProd
-    {M N P : Type*}
-    [AddCommGroup M] [Module R M]
+    {A M N P : Type*} [CommRing A] [Algebra R A]
+    [AddCommGroup M] [Module R M] [Module A M]
+    [SMulCommClass R A M] [IsScalarTower R A M]
     [AddCommGroup N] [Module R N]
     [AddCommGroup P] [Module R P]
-    (Q : QuadraticForm R M) (S : QuadraticForm R N) (T : QuadraticForm R P) :
+    (Q : QuadraticForm A M) (S : QuadraticForm R N) (T : QuadraticForm R P) :
     (Q.tmul (S.prod T)).IsometryEquiv ((Q.tmul S).prod (Q.tmul T)) where
-  toLinearEquiv := TensorProduct.prodRight R R M N P
+  toLinearEquiv := TensorProduct.prodRight R A M N P
   map_app' x := by
-    rw [← associated_eq_self_apply (S := R), ← associated_eq_self_apply (S := R)]
+    let : Invertible (2 : A) :=
+      (Invertible.map (algebraMap R A) 2).copy 2 (map_ofNat _ _).symm
+    rw [← associated_eq_self_apply (S := A), ← associated_eq_self_apply (S := A)]
     have hassoc :
         (associated ((Q.tmul S).prod (Q.tmul T))).compl₁₂
-            (TensorProduct.prodRight R R M N P).toLinearMap
-            (TensorProduct.prodRight R R M N P).toLinearMap =
+            (TensorProduct.prodRight R A M N P).toLinearMap
+            (TensorProduct.prodRight R A M N P).toLinearMap =
           associated (Q.tmul (S.prod T)) := by
       apply TensorProduct.AlgebraTensorModule.ext
       intro m np
@@ -88,35 +91,37 @@ def _root_.QuadraticForm.IsometryEquiv.tmulProd
       intro m' np'
       rcases np with ⟨n, p⟩
       rcases np' with ⟨n', p'⟩
-      simp [QuadraticMap.associated_prod, QuadraticForm.associated_tmul, add_mul]
+      simp [QuadraticMap.associated_prod, QuadraticForm.associated_tmul, add_smul]
     exact DFunLike.congr_fun (DFunLike.congr_fun hassoc x) x
 
 /-- The distributivity isometry acts on a pure tensor by projecting its product-valued
 factor. -/
 @[simp]
 theorem _root_.QuadraticForm.IsometryEquiv.tmulProd_tmul
-    {M N P : Type*}
-    [AddCommGroup M] [Module R M]
+    {A M N P : Type*} [CommRing A] [Algebra R A]
+    [AddCommGroup M] [Module R M] [Module A M]
+    [SMulCommClass R A M] [IsScalarTower R A M]
     [AddCommGroup N] [Module R N]
     [AddCommGroup P] [Module R P]
-    (Q : QuadraticForm R M) (S : QuadraticForm R N) (T : QuadraticForm R P)
+    (Q : QuadraticForm A M) (S : QuadraticForm R N) (T : QuadraticForm R P)
     (m : M) (np : N × P) :
     QuadraticForm.IsometryEquiv.tmulProd Q S T (m ⊗ₜ[R] np) =
       (m ⊗ₜ[R] np.1, m ⊗ₜ[R] np.2) :=
-  TensorProduct.prodRight_tmul R R M N P m np
+  TensorProduct.prodRight_tmul R A M N P m np
 
 /-- The inverse distributivity isometry combines a pair of pure tensors with the same first
 factor into a pure tensor with product-valued second factor. -/
 @[simp]
 theorem _root_.QuadraticForm.IsometryEquiv.tmulProd_symm_tmul
-    {M N P : Type*}
-    [AddCommGroup M] [Module R M]
+    {A M N P : Type*} [CommRing A] [Algebra R A]
+    [AddCommGroup M] [Module R M] [Module A M]
+    [SMulCommClass R A M] [IsScalarTower R A M]
     [AddCommGroup N] [Module R N]
     [AddCommGroup P] [Module R P]
-    (Q : QuadraticForm R M) (S : QuadraticForm R N) (T : QuadraticForm R P)
+    (Q : QuadraticForm A M) (S : QuadraticForm R N) (T : QuadraticForm R P)
     (m : M) (n : N) (p : P) :
     (QuadraticForm.IsometryEquiv.tmulProd Q S T).symm (m ⊗ₜ[R] n, m ⊗ₜ[R] p) =
       m ⊗ₜ[R] (n, p) :=
-  TensorProduct.prodRight_symm_tmul R R M N P m n p
+  TensorProduct.prodRight_symm_tmul R A M N P m n p
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/QuadraticForm/TensorProduct.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/TensorProduct.lean
@@ -6,6 +6,8 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.LinearAlgebra.QuadraticForm.TensorProduct.Isometries
+public import Mathlib.LinearAlgebra.QuadraticForm.Prod
+public import Mathlib.LinearAlgebra.TensorProduct.Prod
 
 /-!
 # Tensor products of equivalent quadratic forms
@@ -17,6 +19,7 @@ forms. It complements Mathlib's tensor product of quadratic-form isometries.
 
 * `QuadraticMap.IsometryEquiv.tmul`: the tensor product of two isometric equivalences.
 * `QuadraticMap.Equivalent.tmul`: tensor products preserve equivalence of quadratic forms.
+* `QuadraticForm.IsometryEquiv.tmulProd`: tensor product distributes over orthogonal product.
 -/
 
 public section
@@ -24,6 +27,7 @@ public section
 namespace TauCeti
 
 open scoped TensorProduct
+open QuadraticMap
 
 variable {R : Type*} [CommRing R] [Invertible (2 : R)]
 
@@ -61,5 +65,44 @@ theorem _root_.QuadraticMap.Equivalent.tmul
     (hQ : Q₁.Equivalent Q₂) (hS : S₁.Equivalent S₂) :
     (Q₁.tmul S₁).Equivalent (Q₂.tmul S₂) :=
   Nonempty.map2 QuadraticMap.IsometryEquiv.tmul hQ hS
+
+/-- Tensor product distributes over the orthogonal product of quadratic forms. -/
+def _root_.QuadraticForm.IsometryEquiv.tmulProd
+    {M N P : Type*}
+    [AddCommGroup M] [Module R M]
+    [AddCommGroup N] [Module R N]
+    [AddCommGroup P] [Module R P]
+    (Q : QuadraticForm R M) (S : QuadraticForm R N) (T : QuadraticForm R P) :
+    (Q.tmul (S.prod T)).IsometryEquiv ((Q.tmul S).prod (Q.tmul T)) where
+  toLinearEquiv := TensorProduct.prodRight R R M N P
+  map_app' x := by
+    rw [← associated_eq_self_apply (S := R), ← associated_eq_self_apply (S := R)]
+    have hassoc :
+        (associated ((Q.tmul S).prod (Q.tmul T))).compl₁₂
+            (TensorProduct.prodRight R R M N P).toLinearMap
+            (TensorProduct.prodRight R R M N P).toLinearMap =
+          associated (Q.tmul (S.prod T)) := by
+      apply TensorProduct.AlgebraTensorModule.ext
+      intro m np
+      apply TensorProduct.AlgebraTensorModule.ext
+      intro m' np'
+      rcases np with ⟨n, p⟩
+      rcases np' with ⟨n', p'⟩
+      simp [QuadraticMap.associated_prod, QuadraticForm.associated_tmul, add_mul]
+    exact DFunLike.congr_fun (DFunLike.congr_fun hassoc x) x
+
+/-- The distributivity isometry acts on a pure tensor by projecting its product-valued
+factor. -/
+@[simp]
+theorem _root_.QuadraticForm.IsometryEquiv.tmulProd_tmul
+    {M N P : Type*}
+    [AddCommGroup M] [Module R M]
+    [AddCommGroup N] [Module R N]
+    [AddCommGroup P] [Module R P]
+    (Q : QuadraticForm R M) (S : QuadraticForm R N) (T : QuadraticForm R P)
+    (m : M) (np : N × P) :
+    QuadraticForm.IsometryEquiv.tmulProd Q S T (m ⊗ₜ[R] np) =
+      (m ⊗ₜ[R] np.1, m ⊗ₜ[R] np.2) :=
+  TensorProduct.prodRight_tmul R R M N P m np
 
 end TauCeti


### PR DESCRIPTION
This PR completes the `QuadraticFormInvariants/README.md` Layer 0 carrier milestone target “Orthogonal sum and tensor product of presentations descend to `RegularFormClass K`; the type is a commutative monoid under each operation, and the two distribute” by proving distributivity and packaging the existing operations as a commutative semiring.

Add `QuadraticForm.IsometryEquiv.tmulProd`, with its pure-tensor computation lemma, using the canonical `TensorProduct.prodRight` equivalence. Use this isometry to prove tensor-product distributivity for diagonal presentations and regular-form classes, prove multiplication by the empty class is zero, install `CommSemiring (RegularFormClass K)`, and package rank as `RegularFormClass.rankHom : RegularFormClass K →+* ℕ`.

The generic isometry builds on Mathlib's `TensorProduct.prodRight`, `QuadraticForm.associated_tmul`, and `QuadraticMap.associated_prod`; no Mathlib implementation is vendored.

This is the algebraic prerequisite consumed by the Layer 4 target “The Grothendieck-Witt ring is the Grothendieck group of `(RegularFormClass K, ⊥)` with the multiplication induced by `⊗`.” After this PR, nothing remains in the selected carrier milestone; the later Layer 4 Grothendieck-Witt construction remains to consume the new semiring.

Roadmap: QuadraticFormInvariants

<!--tauceti-target:v1 {"focus":"QuadraticFormInvariants","id":"regular-form-class-commutative-semiring"}-->

🤖 Prepared with Codex
