### PR TITLE
feat(ArithmeticDirichletSeries): a holomorphic logarithm of an ideal L-series

### DIFF
--- a/TauCeti/Analysis/Complex/BranchLogRoot.lean
+++ b/TauCeti/Analysis/Complex/BranchLogRoot.lean
@@ -10,6 +10,7 @@ public import Mathlib.Analysis.Calculus.FDeriv.Defs
 public import Mathlib.Analysis.Analytic.Order
 public import Mathlib.Analysis.SpecialFunctions.Complex.LogDeriv
 import Mathlib.Analysis.Normed.Module.Connected
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Deriv
 import Mathlib.Analysis.Complex.CauchyIntegral
 
 /-!
@@ -242,12 +243,10 @@ theorem deriv_eq_logDeriv_of_eqOn_exp_comp {U : Set ℂ} (hUo : IsOpen U) {f g :
     (hf : DifferentiableOn ℂ f U) (h : EqOn (Complex.exp ∘ f) g U) {z : ℂ} (hz : z ∈ U) :
     deriv f z = logDeriv g z := by
   have hfz : DifferentiableAt ℂ f z := (hf z hz).differentiableAt (hUo.mem_nhds hz)
-  have hgz : g =ᶠ[nhds z] Complex.exp ∘ f :=
-    Filter.eventuallyEq_of_mem (hUo.mem_nhds hz) fun w hw ↦ (h hw).symm
-  have hderiv : deriv g z = Complex.exp (f z) * deriv f z := by
-    rw [hgz.deriv_eq]
-    simpa using (Complex.hasDerivAt_exp (f z)).comp z hfz.hasDerivAt |>.deriv
-  rw [logDeriv_apply, hderiv, ← h hz]
-  exact (mul_div_cancel_left₀ _ (Complex.exp_ne_zero (f z))).symm
+  have heq : (Complex.exp ∘ f) =ᶠ[nhds z] g :=
+    Filter.eventuallyEq_of_mem (hUo.mem_nhds hz) fun w hw ↦ h hw
+  rw [← (logDeriv_congr_nhds heq).eq_of_nhds, logDeriv_comp Complex.differentiableAt_exp hfz,
+    Complex.logDeriv_exp]
+  simp
 
 end TauCeti

--- a/TauCeti/Analysis/Complex/BranchLogRoot.lean
+++ b/TauCeti/Analysis/Complex/BranchLogRoot.lean
@@ -8,7 +8,7 @@ module
 public import Mathlib.Analysis.Complex.BranchLogRoot
 public import Mathlib.Analysis.Calculus.FDeriv.Defs
 public import Mathlib.Analysis.Analytic.Order
-import Mathlib.Analysis.SpecialFunctions.Complex.LogDeriv
+public import Mathlib.Analysis.SpecialFunctions.Complex.LogDeriv
 import Mathlib.Analysis.Normed.Module.Connected
 import Mathlib.Analysis.Complex.CauchyIntegral
 
@@ -86,6 +86,8 @@ vanishes identically near `z₀`, of order `⊤`, is its own `n`-th root.
 * `TauCeti.exists_differentiableOn_pow_eq` — a holomorphic branch of `ⁿ√g`.
 * `TauCeti.exists_eventuallyEq_pow_iff_dvd` — a holomorphic germ has a holomorphic `n`-th root iff
   `n` divides its order of vanishing.
+* `TauCeti.deriv_eq_logDeriv_of_eqOn_exp_comp` — the derivative of a branch of the logarithm is the
+  logarithmic derivative, and so does not depend on which branch was chosen.
 -/
 
 public section
@@ -231,5 +233,21 @@ theorem exists_eventuallyEq_pow_iff_dvd {A : ℂ → ℂ} {z₀ : ℂ} {n : ℕ}
       refine ⟨fun z => (z - z₀) ^ k * h z, ((analyticAt_id.sub analyticAt_const).pow k).mul hh, ?_⟩
       filter_upwards [hgeq, hheq] with z hz hz'
       rw [hz, smul_eq_mul, ← hz', mul_pow, ← pow_mul, mul_comm k n]
+
+/-- **The derivative of a branch is the logarithmic derivative.**  Wherever a holomorphic `f`
+satisfies `exp ∘ f = g` on an open set, `f' = g' / g` there.  This is what makes a branch of the
+logarithm useful even though `exp` determines it only up to `2πi ℤ`: the ambiguity is a locally
+constant additive one, so it disappears on differentiating. -/
+theorem deriv_eq_logDeriv_of_eqOn_exp_comp {U : Set ℂ} (hUo : IsOpen U) {f g : ℂ → ℂ}
+    (hf : DifferentiableOn ℂ f U) (h : EqOn (Complex.exp ∘ f) g U) {z : ℂ} (hz : z ∈ U) :
+    deriv f z = logDeriv g z := by
+  have hfz : DifferentiableAt ℂ f z := (hf z hz).differentiableAt (hUo.mem_nhds hz)
+  have hgz : g =ᶠ[nhds z] Complex.exp ∘ f :=
+    Filter.eventuallyEq_of_mem (hUo.mem_nhds hz) fun w hw ↦ (h hw).symm
+  have hderiv : deriv g z = Complex.exp (f z) * deriv f z := by
+    rw [hgz.deriv_eq]
+    simpa using (Complex.hasDerivAt_exp (f z)).comp z hfz.hasDerivAt |>.deriv
+  rw [logDeriv_apply, hderiv, ← h hz]
+  exact (mul_div_cancel_left₀ _ (Complex.exp_ne_zero (f z))).symm
 
 end TauCeti

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Branch.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Branch.lean
@@ -1,0 +1,66 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.Complex.BranchLogRoot
+public import TauCeti.NumberTheory.ArithmeticDirichletSeries.EulerProduct.Analytic
+
+/-!
+# A holomorphic logarithm of an ideal `L`-series
+
+`TauCeti.MultiplicativeIdealWeight.LSeries_ne_zero_of_summable_idealTerm` gives nonvanishing one
+point at a time, and the exponential form of the Euler product determines a logarithm only modulo
+`2πi ℤ`.  Neither is a branch: a branch is a single holomorphic function on a region, and choosing
+one needs the region to be simply connected as well as zero-free.
+
+This file makes that choice.  On a simply connected open set where the ideal-indexed series
+converges absolutely at every point, the `L`-series has a holomorphic logarithm, and the derivative
+of that logarithm is the logarithmic derivative of the `L`-series — the same function for every
+choice of branch, since two branches differ by a locally constant multiple of `2πi`.
+
+## Main results
+
+* `TauCeti.MultiplicativeIdealWeight.exists_differentiableOn_exp_eq_LSeries`: the branch, together
+  with the identification of its derivative.
+-/
+
+public section
+
+namespace TauCeti
+
+open Complex IsDedekindDomain Set
+
+open scoped NumberField
+
+namespace MultiplicativeIdealWeight
+
+open IdealArithmeticFunction
+
+variable {K : Type*} [Field K] [NumberField K] (χ : MultiplicativeIdealWeight K)
+
+/-- **A holomorphic logarithm of the `L`-series on a simply connected zero-free region.**  Let `U`
+be a simply connected open set on which the `L`-series of the norm coefficients is holomorphic and
+at every point of which the ideal-indexed series converges absolutely.  Then there is a holomorphic
+`L` on `U` with `exp ∘ L` the `L`-series, and `deriv L` is its logarithmic derivative.
+
+Absolute convergence enters only through the Euler product, which is what makes the `L`-series
+zero-free on `U`; simple connectedness is what turns pointwise nonvanishing into a single branch. -/
+theorem exists_differentiableOn_exp_eq_LSeries {U : Set ℂ} (hUc : IsSimplyConnected U)
+    (hUo : IsOpen U)
+    (hdiff : DifferentiableOn ℂ (LSeries (normCoeff K χ.toIdealArithmeticFunction)) U)
+    (hconv : ∀ s ∈ U, Summable (idealTerm K χ.toIdealArithmeticFunction s)) :
+    ∃ L : ℂ → ℂ, DifferentiableOn ℂ L U ∧
+      EqOn (Complex.exp ∘ L) (LSeries (normCoeff K χ.toIdealArithmeticFunction)) U ∧
+      ∀ s ∈ U, deriv L s = logDeriv (LSeries (normCoeff K χ.toIdealArithmeticFunction)) s := by
+  have h₀ : 0 ∉ LSeries (normCoeff K χ.toIdealArithmeticFunction) '' U := by
+    rintro ⟨s, hs, hs0⟩
+    exact χ.LSeries_ne_zero_of_summable_idealTerm (hconv s hs) hs0
+  obtain ⟨L, hL, hLeq⟩ := exists_differentiableOn_eqOn_exp_comp hUc hUo hdiff h₀
+  exact ⟨L, hL, hLeq, fun s hs ↦ deriv_eq_logDeriv_of_eqOn_exp_comp hUo hL hLeq hs⟩
+
+end MultiplicativeIdealWeight
+
+end TauCeti

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Branch.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Branch.lean
@@ -7,6 +7,8 @@ module
 
 public import TauCeti.Analysis.Complex.BranchLogRoot
 public import TauCeti.NumberTheory.ArithmeticDirichletSeries.EulerProduct.Analytic
+import Mathlib.NumberTheory.LSeries.Deriv
+import TauCeti.NumberTheory.ArithmeticDirichletSeries.Regroup
 
 /-!
 # A holomorphic logarithm of an ideal `L`-series
@@ -42,19 +44,32 @@ open IdealArithmeticFunction
 variable {K : Type*} [Field K] [NumberField K] (χ : MultiplicativeIdealWeight K)
 
 /-- **A holomorphic logarithm of the `L`-series on a simply connected zero-free region.**  Let `U`
-be a simply connected open set on which the `L`-series of the norm coefficients is holomorphic and
-at every point of which the ideal-indexed series converges absolutely.  Then there is a holomorphic
-`L` on `U` with `exp ∘ L` the `L`-series, and `deriv L` is its logarithmic derivative.
+be a simply connected open set at every point of which the ideal-indexed series converges
+absolutely.  Then there is a holomorphic `L` on `U` with `exp ∘ L` the `L`-series, and `deriv L` is
+its logarithmic derivative.
 
-Absolute convergence enters only through the Euler product, which is what makes the `L`-series
-zero-free on `U`; simple connectedness is what turns pointwise nonvanishing into a single branch. -/
+Absolute convergence does two jobs: through the Euler product it makes the `L`-series zero-free on
+`U`, and through a point of `U` slightly to the left of each `s` it puts `s` strictly right of the
+abscissa of absolute convergence, which is what makes the `L`-series holomorphic there.  Simple
+connectedness is what turns pointwise nonvanishing into a single branch. -/
 theorem exists_differentiableOn_exp_eq_LSeries {U : Set ℂ} (hUc : IsSimplyConnected U)
     (hUo : IsOpen U)
-    (hdiff : DifferentiableOn ℂ (LSeries (normCoeff K χ.toIdealArithmeticFunction)) U)
     (hconv : ∀ s ∈ U, Summable (idealTerm K χ.toIdealArithmeticFunction s)) :
     ∃ L : ℂ → ℂ, DifferentiableOn ℂ L U ∧
       EqOn (Complex.exp ∘ L) (LSeries (normCoeff K χ.toIdealArithmeticFunction)) U ∧
       ∀ s ∈ U, deriv L s = logDeriv (LSeries (normCoeff K χ.toIdealArithmeticFunction)) s := by
+  have hdiff : DifferentiableOn ℂ (LSeries (normCoeff K χ.toIdealArithmeticFunction)) U := by
+    intro s hs
+    obtain ⟨ε, hε, hball⟩ := Metric.isOpen_iff.1 hUo s hs
+    have hmem : s - ((ε / 2 : ℝ) : ℂ) ∈ U := by
+      refine hball ?_
+      simp only [Metric.mem_ball, dist_eq_norm, sub_sub_cancel_left, norm_neg,
+        Complex.norm_real, Real.norm_eq_abs, abs_of_pos (by linarith : (0 : ℝ) < ε / 2)]
+      linarith
+    refine (LSeries_hasDerivAt ?_).differentiableAt.differentiableWithinAt
+    refine ((LSeriesSummable_normCoeff K (hconv _ hmem)).abscissaOfAbsConv_le).trans_lt ?_
+    rw [Complex.sub_re, Complex.ofReal_re, EReal.coe_lt_coe_iff]
+    linarith
   have h₀ : 0 ∉ LSeries (normCoeff K χ.toIdealArithmeticFunction) '' U := by
     rintro ⟨s, hs, hs0⟩
     exact χ.LSeries_ne_zero_of_summable_idealTerm (hconv s hs) hs0


### PR DESCRIPTION
Layer 3.4: *"On a simply connected zero-free region, choose a logarithm and prove both the
prime-power logarithmic expansion and its derivative."* #6051 landed the expansion in exponential
form and said explicitly what it did not do:

> `LSeries_ne_zero_of_summable_idealTerm` supplies nonvanishing pointwise, wherever the ideal-indexed
> series converges absolutely; a branch needs more than that — a simply connected zero-free region on
> which to choose one — and is not constructed here.

This PR constructs it. That became possible only once #6102 (nonvanishing) merged this morning.

## What is added

**`MultiplicativeIdealWeight.exists_differentiableOn_exp_eq_LSeries`** — on a simply connected open
`U` at every point of which the ideal-indexed series converges absolutely:

```
∃ L, DifferentiableOn ℂ L U
   ∧ EqOn (exp ∘ L) (LSeries (normCoeff K χ.toIdealArithmeticFunction)) U
   ∧ ∀ s ∈ U, deriv L s = logDeriv (LSeries (normCoeff K χ.toIdealArithmeticFunction)) s
```

Absolute convergence does **two** jobs, and the docstring says so. Through the Euler product it makes
the `L`-series zero-free on `U`. And since `U` is open, each `s ∈ U` has a point of `U` slightly to
its left, whose convergence puts `s` strictly right of the abscissa of absolute convergence — so
holomorphy on `U` is *derived*, not assumed. Simple connectedness is what turns pointwise
nonvanishing into a single branch.

The bridge from the ideal-indexed series to the norm-regrouped one is `LSeriesSummable_normCoeff`,
already on `main`; the derivative identification goes through Mathlib's `logDeriv_comp` and
`Complex.logDeriv_exp` rather than differentiating the exponential by hand.

**`deriv_eq_logDeriv_of_eqOn_exp_comp`**, in `BranchLogRoot.lean` where the branch machinery lives —
wherever a holomorphic `f` satisfies `exp ∘ f = g` on an open set, `deriv f = logDeriv g`. This is
what makes a branch useful despite `exp` fixing it only up to `2πi ℤ`: the ambiguity is locally
constant and additive, so it disappears on differentiating. Stated for a general `g`, since nothing
in it is about `L`-series.

## Why the region is a hypothesis, not a construction

Layer 3.4 says "on a simply connected zero-free region", and no such region for an ideal `L`-series
exists anywhere in `main` — that is `ZerosOfLFunctions`' work, and this PR does not pre-empt it.
Zero-freeness is not assumed: it is *derived* on `U` from the convergence hypothesis via the Euler
product, so a caller supplies a region of absolute convergence, not a region it has already had to
prove zero-free.

## What this does not do

It does not prove the prime-power expansion *for this branch*, nor evaluate `logDeriv` as a
prime-power series. Those are the rest of Layer 3.4 and want this theorem first.

Roadmap: ArithmeticDirichletSeries
<!--tauceti-target:v1 {"focus":"ArithmeticDirichletSeries","id":"ArithmeticDirichletSeries/README.md#3.4"}-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011dmwkBnj4rJc75STgbwsLF

