### PR TITLE
feat: prove smoothness of the geodesic spray

### DIFF
--- a/TauCeti/Geometry/Manifold/Riemannian/Geodesic/Smoothness.lean
+++ b/TauCeti/Geometry/Manifold/Riemannian/Geodesic/Smoothness.lean
@@ -24,8 +24,6 @@ geodesic equation.
 
 * `TauCeti.Manifold.contMDiff_geodesicSpray`: the geodesic spray is `C^n` when the manifold is
   `C^(n + 2)` and its Riemannian metric is `C^(n + 1)`.
-* `TauCeti.Manifold.contMDiff_geodesicSpray_infty`: the geodesic spray of a smooth Riemannian
-  manifold is smooth.
 
 ## References
 
@@ -140,17 +138,6 @@ theorem contMDiff_geodesicSpray [IsManifold I 2 M] [IsManifold I m M]
     hΓ.comp hproj hmaps
   exact (contMDiffOn_prod_module_iff _).2
     ⟨hv, ((hΓ'.clm_apply hv).clm_apply hv).neg⟩
-
-/-- The geodesic spray of a smooth Riemannian manifold is smooth. -/
-theorem contMDiff_geodesicSpray_infty [IsManifold I ∞ M]
-    [IsContMDiffRiemannianBundle I ∞ E (fun x : M ↦ TangentSpace I x)] :
-    ContMDiff I.tangent I.tangent.tangent ∞
-      (fun z : TangentBundle I M ↦
-        TotalSpace.mk' (E × E) z (geodesicSpray I M z)) := by
-  let _ : IsManifold I 2 M := IsManifold.of_le (n := ∞) (by simp)
-  let _ : IsContMDiffRiemannianBundle I 1 E (fun x : M ↦ TangentSpace I x) :=
-    IsContMDiffRiemannianBundle.of_le (n := ∞) (by simp)
-  exact contMDiff_geodesicSpray (n := ∞) (m := ∞) (k := ∞) le_rfl le_rfl
 
 end TauCeti.Manifold
 

--- a/TauCeti/Geometry/Manifold/Riemannian/Geodesic/Smoothness.lean
+++ b/TauCeti/Geometry/Manifold/Riemannian/Geodesic/Smoothness.lean
@@ -24,6 +24,8 @@ geodesic equation.
 
 * `TauCeti.Manifold.contMDiff_geodesicSpray`: the geodesic spray is `C^n` when the manifold is
   `C^(n + 2)` and its Riemannian metric is `C^(n + 1)`.
+* `TauCeti.Manifold.contMDiff_geodesicSpray_infty`: the geodesic spray of a smooth Riemannian
+  manifold is smooth.
 
 ## References
 
@@ -45,14 +47,14 @@ variable
   {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
   {M : Type*} [TopologicalSpace M] [ChartedSpace H M]
   [RiemannianBundle (fun x : M ↦ TangentSpace I x)] {n m k : ℕ∞ω}
-  [IsManifold I 2 M] [IsManifold I m M]
-  [IsContMDiffRiemannianBundle I 1 E (fun x : M ↦ TangentSpace I x)]
-  [IsContMDiffRiemannianBundle I k E (fun x : M ↦ TangentSpace I x)]
 
 /-- **The geodesic spray is a `C^n` vector field on the tangent bundle.** A `C^(n + 1)` metric
 and `C^(n + 2)` manifold structure suffice. In particular, the spray of a smooth Riemannian
 manifold is smooth. -/
-theorem contMDiff_geodesicSpray (hm : n + 2 ≤ m) (hk : n + 1 ≤ k) :
+theorem contMDiff_geodesicSpray [IsManifold I 2 M] [IsManifold I m M]
+    [IsContMDiffRiemannianBundle I 1 E (fun x : M ↦ TangentSpace I x)]
+    [IsContMDiffRiemannianBundle I k E (fun x : M ↦ TangentSpace I x)]
+    (hm : n + 2 ≤ m) (hk : n + 1 ≤ k) :
     ContMDiff I.tangent I.tangent.tangent n
       (fun z : TangentBundle I M ↦
         TotalSpace.mk' (E × E) z (geodesicSpray I M z)) := by
@@ -123,6 +125,17 @@ theorem contMDiff_geodesicSpray (hm : n + 2 ≤ m) (hk : n + 1 ≤ k) :
     hΓ.comp hproj hmaps
   exact (contMDiffOn_prod_module_iff _).2
     ⟨hv, ((hΓ'.clm_apply hv).clm_apply hv).neg⟩
+
+/-- The geodesic spray of a smooth Riemannian manifold is smooth. -/
+theorem contMDiff_geodesicSpray_infty [IsManifold I ∞ M]
+    [IsContMDiffRiemannianBundle I ∞ E (fun x : M ↦ TangentSpace I x)] :
+    ContMDiff I.tangent I.tangent.tangent ∞
+      (fun z : TangentBundle I M ↦
+        TotalSpace.mk' (E × E) z (geodesicSpray I M z)) := by
+  let _ : IsManifold I 2 M := IsManifold.of_le (n := ∞) (by simp)
+  let _ : IsContMDiffRiemannianBundle I 1 E (fun x : M ↦ TangentSpace I x) :=
+    IsContMDiffRiemannianBundle.of_le (n := ∞) (by simp)
+  exact contMDiff_geodesicSpray (n := ∞) (m := ∞) (k := ∞) le_rfl le_rfl
 
 end TauCeti.Manifold
 

--- a/TauCeti/Geometry/Manifold/Riemannian/Geodesic/Smoothness.lean
+++ b/TauCeti/Geometry/Manifold/Riemannian/Geodesic/Smoothness.lean
@@ -50,9 +50,8 @@ variable
   [IsContMDiffRiemannianBundle I k E (fun x : M ↦ TangentSpace I x)]
 
 /-- **The geodesic spray is a `C^n` vector field on the tangent bundle.** A `C^(n + 1)` metric
-and `C^(n + 2)` manifold structure suffice: one derivative forms the Christoffel map, while one
-more makes the tangent-bundle coordinate changes `C^(n + 1)`. In particular, the spray of a
-smooth Riemannian manifold is smooth. -/
+and `C^(n + 2)` manifold structure suffice. In particular, the spray of a smooth Riemannian
+manifold is smooth. -/
 theorem contMDiff_geodesicSpray (hm : n + 2 ≤ m) (hk : n + 1 ≤ k) :
     ContMDiff I.tangent I.tangent.tangent n
       (fun z : TangentBundle I M ↦
@@ -78,8 +77,8 @@ theorem contMDiff_geodesicSpray (hm : n + 2 ≤ m) (hk : n + 1 ≤ k) :
   have hz₀ : z₀ ∈ eT.baseSet := FiberBundle.mem_baseSet_trivializationAt _ _ _
   rw [eT.contMDiffAt_section_iff hz₀]
   have hz₀e : z₀ ∈ e.source := by
-    change z₀.proj ∈ (chartAt H z₀.proj).source
-    exact mem_chart_source _ _
+    simpa only [e, TangentBundle.trivializationAt_source, mem_preimage] using
+      mem_chart_source H z₀.proj
   have hopen : IsOpen e.source := e.open_source
   suffices hcoord : ContMDiffOn I.tangent 𝓘(ℝ, E × E) n
       (fun z : TangentBundle I M ↦
@@ -88,13 +87,15 @@ theorem contMDiff_geodesicSpray (hm : n + 2 ≤ m) (hk : n + 1 ≤ k) :
           (e z).2 (e z).2)) e.source by
     refine (hcoord z₀ hz₀e).contMDiffAt (hopen.mem_nhds hz₀e) |>.congr_of_eventuallyEq ?_
     · filter_upwards [hopen.mem_nhds hz₀e] with z hz
-      have hzbase : z.proj ∈ (chartAt H z₀.proj).source := hz
+      have hzbase : z.proj ∈ (chartAt H z₀.proj).source := by
+        simpa only [e, TangentBundle.trivializationAt_source, mem_preimage] using hz
       have hbase : z.proj ∈ (extChartAt I z₀.proj).source := by
         rw [extChartAt_source I z₀.proj]
         exact hzbase
-      have hze : z.proj ∈ e.baseSet := hz
+      have hze : z.proj ∈ e.baseSet := by
+        simpa only [e, TangentBundle.trivializationAt_baseSet] using hzbase
       have hzT : z ∈ eT.baseSet := by
-        change z ∈ (chartAt (ModelProd H E) z₀).source
+        rw [TangentBundle.trivializationAt_baseSet]
         exact (TangentBundle.mem_chart_source_iff z z₀).2 hzbase
       rw [← Bundle.Trivialization.continuousLinearMapAt_apply_of_mem ℝ eT hzT,
         ← Bundle.Trivialization.continuousLinearMapAt_apply_of_mem ℝ e hze,
@@ -109,7 +110,8 @@ theorem contMDiff_geodesicSpray (hm : n + 2 ≤ m) (hk : n + 1 ≤ k) :
     exact Bundle.contMDiffOn_proj (E := fun x : M ↦ TangentSpace I x)
   have hmaps : MapsTo (fun z : TangentBundle I M ↦ z.proj) e.source e.baseSet := by
     intro z hz
-    exact hz
+    simpa only [e, TangentBundle.trivializationAt_source, mem_preimage,
+      TangentBundle.trivializationAt_baseSet] using hz
   have hΓ : ContMDiffOn I 𝓘(ℝ, E →L[ℝ] E →L[ℝ] E) n
       (christoffelMap (finBasis ℝ E)
         ((leviCivita I M).isCovariantDerivativeOn (s := e.baseSet))) e.baseSet :=

--- a/TauCeti/Geometry/Manifold/Riemannian/Geodesic/Smoothness.lean
+++ b/TauCeti/Geometry/Manifold/Riemannian/Geodesic/Smoothness.lean
@@ -48,6 +48,33 @@ variable
   {M : Type*} [TopologicalSpace M] [ChartedSpace H M]
   [RiemannianBundle (fun x : M ↦ TangentSpace I x)] {n m k : ℕ∞ω}
 
+/-- In the trivialization of the iterated tangent bundle centred at `z₀`, the geodesic spray has
+the Christoffel-coordinate formula associated to the tangent trivialization centred at `z₀.proj`.
+This isolates the coordinate identification between the two tangent-space wrappers. -/
+private theorem trivializationAt_geodesicSpray_coord [IsManifold I 2 M]
+    [IsContMDiffRiemannianBundle I 1 E (fun x : M ↦ TangentSpace I x)]
+    (z₀ z : TangentBundle I M) (hz : z.proj ∈ (chartAt H z₀.proj).source) :
+    let e := trivializationAt E (TangentSpace I) z₀.proj
+    let eT := trivializationAt (E × E) (TangentSpace I.tangent) z₀
+    (eT (TotalSpace.mk' (E × E) z (geodesicSpray I M z))).2 =
+      ((e z).2, -christoffelMap (finBasis ℝ E)
+        ((leviCivita I M).isCovariantDerivativeOn (s := e.baseSet)) z.proj
+        (e z).2 (e z).2) := by
+  dsimp only
+  have hbase : z.proj ∈ (extChartAt I z₀.proj).source := by
+    rw [extChartAt_source I z₀.proj]
+    exact hz
+  have hze : z.proj ∈ (trivializationAt E (TangentSpace I) z₀.proj).baseSet := by
+    simpa only [TangentBundle.trivializationAt_baseSet] using hz
+  have hzT : z ∈ (trivializationAt (E × E) (TangentSpace I.tangent) z₀).baseSet := by
+    rw [TangentBundle.trivializationAt_baseSet]
+    exact (TangentBundle.mem_chart_source_iff z z₀).2 hz
+  rw [← Bundle.Trivialization.continuousLinearMapAt_apply_of_mem ℝ _ hzT,
+    ← Bundle.Trivialization.continuousLinearMapAt_apply_of_mem ℝ _ hze,
+    TangentBundle.continuousLinearMapAt_trivializationAt_eq_core hz,
+    TangentBundle.continuousLinearMapAt_trivializationAt_eq_core hzT]
+  exact tangentCoordChange_geodesicSpray (I := I) (M := M) hbase z.2
+
 /-- **The geodesic spray is a `C^n` vector field on the tangent bundle.** A `C^(n + 1)` metric
 and `C^(n + 2)` manifold structure suffice. In particular, the spray of a smooth Riemannian
 manifold is smooth. -/
@@ -91,19 +118,7 @@ theorem contMDiff_geodesicSpray [IsManifold I 2 M] [IsManifold I m M]
     · filter_upwards [hopen.mem_nhds hz₀e] with z hz
       have hzbase : z.proj ∈ (chartAt H z₀.proj).source := by
         simpa only [e, TangentBundle.trivializationAt_source, mem_preimage] using hz
-      have hbase : z.proj ∈ (extChartAt I z₀.proj).source := by
-        rw [extChartAt_source I z₀.proj]
-        exact hzbase
-      have hze : z.proj ∈ e.baseSet := by
-        simpa only [e, TangentBundle.trivializationAt_baseSet] using hzbase
-      have hzT : z ∈ eT.baseSet := by
-        rw [TangentBundle.trivializationAt_baseSet]
-        exact (TangentBundle.mem_chart_source_iff z z₀).2 hzbase
-      rw [← Bundle.Trivialization.continuousLinearMapAt_apply_of_mem ℝ eT hzT,
-        ← Bundle.Trivialization.continuousLinearMapAt_apply_of_mem ℝ e hze,
-        TangentBundle.continuousLinearMapAt_trivializationAt_eq_core hzbase,
-        TangentBundle.continuousLinearMapAt_trivializationAt_eq_core hzT]
-      exact tangentCoordChange_geodesicSpray (I := I) (M := M) hbase z.2
+      exact trivializationAt_geodesicSpray_coord z₀ z hzbase
   have hv : ContMDiffOn I.tangent 𝓘(ℝ, E) n (fun z ↦ (e z).2) e.source := by
     intro z hz
     exact (e.contMDiffOn z hz).snd

--- a/TauCeti/Geometry/Manifold/Riemannian/Geodesic/Smoothness.lean
+++ b/TauCeti/Geometry/Manifold/Riemannian/Geodesic/Smoothness.lean
@@ -1,0 +1,127 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Geometry.Manifold.Riemannian.Geodesic.Spray
+public import TauCeti.Geometry.Manifold.VectorBundle.CovariantDerivative.LeviCivita.Regularity
+
+/-!
+# Smoothness of the geodesic spray
+
+The geodesic spray of a smooth Riemannian manifold is a smooth vector field on its tangent
+bundle. In tangent-bundle coordinates it is
+
+`(x, v) ↦ (v, -Γₓ(v, v))`,
+
+so this follows from smoothness of the Christoffel map of the Levi-Civita connection. This is the
+regularity input needed to apply existence and uniqueness theorems for integral curves to the
+geodesic equation.
+
+## Main result
+
+* `TauCeti.Manifold.contMDiff_geodesicSpray`: the geodesic spray is `C^n` when the manifold is
+  `C^(n + 2)` and its Riemannian metric is `C^(n + 1)`.
+
+## References
+
+* M. P. do Carmo, *Riemannian Geometry*, Birkhäuser, 1992, Ch. 3, §2.
+* J. M. Lee, *Introduction to Riemannian Manifolds*, GTM 176, 2018, Ch. 4.
+-/
+
+public section
+
+open Bundle CovariantDerivative Module Set
+open scoped ContDiff Manifold Topology
+
+noncomputable section
+
+namespace TauCeti.Manifold
+
+variable
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [FiniteDimensional ℝ E]
+  {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
+  {M : Type*} [TopologicalSpace M] [ChartedSpace H M]
+  [RiemannianBundle (fun x : M ↦ TangentSpace I x)] {n m k : ℕ∞ω}
+  [IsManifold I 2 M] [IsManifold I m M]
+  [IsContMDiffRiemannianBundle I 1 E (fun x : M ↦ TangentSpace I x)]
+  [IsContMDiffRiemannianBundle I k E (fun x : M ↦ TangentSpace I x)]
+
+/-- **The geodesic spray is a `C^n` vector field on the tangent bundle.** A `C^(n + 1)` metric
+and `C^(n + 2)` manifold structure suffice: one derivative forms the Christoffel map, while one
+more makes the tangent-bundle coordinate changes `C^(n + 1)`. In particular, the spray of a
+smooth Riemannian manifold is smooth. -/
+theorem contMDiff_geodesicSpray (hm : n + 2 ≤ m) (hk : n + 1 ≤ k) :
+    ContMDiff I.tangent I.tangent.tangent n
+      (fun z : TangentBundle I M ↦
+        TotalSpace.mk' (E × E) z (geodesicSpray I M z)) := by
+  let _ : IsManifold I (n + 2) M := IsManifold.of_le (n := m) hm
+  let _ : IsManifold I (n + 1) M :=
+    IsManifold.of_le (n := m) ((by gcongr; norm_num : n + 1 ≤ n + 2).trans hm)
+  let _ : IsManifold I (n + 1 + 1) M :=
+    IsManifold.of_le (n := m) (by rwa [add_assoc, one_add_one_eq_two])
+  let _ : IsContMDiffRiemannianBundle I (n + 1) E (fun x : M ↦ TangentSpace I x) :=
+    IsContMDiffRiemannianBundle.of_le (n := k) hk
+  let _ : ContMDiffVectorBundle (n + 1) E (TangentSpace I : M → Type _) I :=
+    TangentBundle.contMDiffVectorBundle
+  let _ : ContMDiffVectorBundle n E (TangentSpace I : M → Type _) I :=
+    TangentBundle.contMDiffVectorBundle
+  let _ : IsManifold I.tangent (n + 1) (TangentBundle I M) := inferInstance
+  let _ : ContMDiffVectorBundle n (E × E)
+      (TangentSpace I.tangent : TangentBundle I M → Type _) I.tangent :=
+    TangentBundle.contMDiffVectorBundle
+  intro z₀
+  let e := trivializationAt E (TangentSpace I) z₀.proj
+  let eT := trivializationAt (E × E) (TangentSpace I.tangent) z₀
+  have hz₀ : z₀ ∈ eT.baseSet := FiberBundle.mem_baseSet_trivializationAt _ _ _
+  rw [eT.contMDiffAt_section_iff hz₀]
+  have hz₀e : z₀ ∈ e.source := by
+    change z₀.proj ∈ (chartAt H z₀.proj).source
+    exact mem_chart_source _ _
+  have hopen : IsOpen e.source := e.open_source
+  suffices hcoord : ContMDiffOn I.tangent 𝓘(ℝ, E × E) n
+      (fun z : TangentBundle I M ↦
+        ((e z).2, -christoffelMap (finBasis ℝ E)
+          ((leviCivita I M).isCovariantDerivativeOn (s := e.baseSet)) z.proj
+          (e z).2 (e z).2)) e.source by
+    refine (hcoord z₀ hz₀e).contMDiffAt (hopen.mem_nhds hz₀e) |>.congr_of_eventuallyEq ?_
+    · filter_upwards [hopen.mem_nhds hz₀e] with z hz
+      have hzbase : z.proj ∈ (chartAt H z₀.proj).source := hz
+      have hbase : z.proj ∈ (extChartAt I z₀.proj).source := by
+        rw [extChartAt_source I z₀.proj]
+        exact hzbase
+      have hze : z.proj ∈ e.baseSet := hz
+      have hzT : z ∈ eT.baseSet := by
+        change z ∈ (chartAt (ModelProd H E) z₀).source
+        exact (TangentBundle.mem_chart_source_iff z z₀).2 hzbase
+      rw [← Bundle.Trivialization.continuousLinearMapAt_apply_of_mem ℝ eT hzT,
+        ← Bundle.Trivialization.continuousLinearMapAt_apply_of_mem ℝ e hze,
+        TangentBundle.continuousLinearMapAt_trivializationAt_eq_core hzbase,
+        TangentBundle.continuousLinearMapAt_trivializationAt_eq_core hzT]
+      exact tangentCoordChange_geodesicSpray (I := I) (M := M) hbase z.2
+  have hv : ContMDiffOn I.tangent 𝓘(ℝ, E) n (fun z ↦ (e z).2) e.source := by
+    intro z hz
+    exact (e.contMDiffOn z hz).snd
+  have hproj : ContMDiffOn I.tangent I n
+      (fun z : TangentBundle I M ↦ z.proj) e.source := by
+    exact Bundle.contMDiffOn_proj (E := fun x : M ↦ TangentSpace I x)
+  have hmaps : MapsTo (fun z : TangentBundle I M ↦ z.proj) e.source e.baseSet := by
+    intro z hz
+    exact hz
+  have hΓ : ContMDiffOn I 𝓘(ℝ, E →L[ℝ] E →L[ℝ] E) n
+      (christoffelMap (finBasis ℝ E)
+        ((leviCivita I M).isCovariantDerivativeOn (s := e.baseSet))) e.baseSet :=
+    contMDiffOn_christoffelMap_leviCivita (n := n) (m := m) (k := k)
+      (finBasis ℝ E) hm hk
+  have hΓ' : ContMDiffOn I.tangent 𝓘(ℝ, E →L[ℝ] E →L[ℝ] E) n
+      (fun z : TangentBundle I M ↦ christoffelMap (finBasis ℝ E)
+        ((leviCivita I M).isCovariantDerivativeOn (s := e.baseSet)) z.proj) e.source :=
+    hΓ.comp hproj hmaps
+  exact (contMDiffOn_prod_module_iff _).2
+    ⟨hv, ((hΓ'.clm_apply hv).clm_apply hv).neg⟩
+
+end TauCeti.Manifold
+
+end


### PR DESCRIPTION
This PR proves finite-order smoothness of the geodesic spray from the tangent-bundle coordinate formula `(x, v) ↦ (v, -Γₓ(v, v))`. It advances the exact “The geodesic spray” target in `TauCetiRoadmap/HopfRinow/README.md`, Layer 1: prove that `S` is `C^∞`; the theorem is stated at the stronger useful precision that a `C^(n + 2)` manifold and `C^(n + 1)` metric give a `C^n` spray.

This is the most effective current critical-path step because the spray construction, its chart formula, and the integral-curve/geodesic equivalence are already on `main`, while smoothness is the remaining input needed to apply Mathlib's integral-curve existence and uniqueness API. After this PR, the geodesic-spray milestone is complete; Layer 1 still needs the next milestone, local existence and uniqueness of geodesics, followed by smooth dependence, maximal intervals, and the exponential-map API.

Add `TauCeti/Geometry/Manifold/Riemannian/Geodesic/Smoothness.lean` with `contMDiff_geodesicSpray`, reusing the existing Levi-Civita Christoffel-map regularity theorem and tangent-coordinate-change formula. No code or formalization is copied or vendored; the standard mathematical construction is attributed in the module documentation to do Carmo and Lee.

Roadmap: HopfRinow

<!--tauceti-target:v1 {"focus":"HopfRinow","id":"geodesic-spray-smoothness"}-->

🤖 Prepared with Codex
