### PR TITLE
feat: descend finiteness of the center

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Center/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Center/BaseChange.lean
@@ -30,6 +30,8 @@ point of `H`, so it kills every equation of the original center.
   center commutes with extension of the ground field.
 * `TauCeti.CommHopfAlgCat.centerDefiningIdeal_baseChange_eq_augmentation_iff`: a field extension
   preserves and reflects triviality of the center.
+* `TauCeti.CommHopfAlgCat.centerCoordinateBaseChangeIso`: the coordinate isomorphism between
+  the center after base change and the base change of the center.
 
 ## References
 
@@ -42,6 +44,7 @@ This supplies the base-change compatibility of the center `Z(G)` required in Lay
 
 public section
 
+open CategoryTheory
 open WithConv
 
 namespace TauCeti.CommHopfAlgCat
@@ -96,5 +99,36 @@ theorem centerDefiningIdeal_baseChange_eq_augmentation_iff
   rw [← baseChangeHopfIdeal_centerDefiningIdeal,
     ← baseChangeHopfIdeal_augmentation]
   exact baseChangeHopfIdeal_injective.eq_iff
+
+/-- The center after a field extension has the base change of the original center as its
+coordinate Hopf algebra. -/
+noncomputable def centerCoordinateBaseChangeIso (H : _root_.CommHopfAlgCat.{v} k) :
+    centerCoordinateHopfAlgebra (baseChange (K := K) H) ≅
+      baseChange (K := K) (centerCoordinateHopfAlgebra H) :=
+  eqToIso (congrArg (quotient (baseChange (K := K) H))
+    (baseChangeHopfIdeal_centerDefiningIdeal (K := K) H).symm) ≪≫
+      quotientBaseChangeIso (K := K) (centerDefiningIdeal H)
+
+/-- The center base-change comparison respects the quotient coordinate maps. -/
+@[simp]
+theorem mkQuotient_comp_centerCoordinateBaseChangeIso_hom
+    (H : _root_.CommHopfAlgCat.{v} k) :
+    mkQuotient (baseChange (K := K) H) (centerDefiningIdeal (baseChange (K := K) H)) ≫
+        (centerCoordinateBaseChangeIso (K := K) H).hom =
+      baseChangeMap (K := K) (mkQuotient H (centerDefiningIdeal H)) := by
+  rw [centerCoordinateBaseChangeIso, Iso.trans_hom, eqToIso.hom, ← Category.assoc,
+    mkQuotient_comp_eqToHom (baseChangeHopfIdeal_centerDefiningIdeal (K := K) H),
+    mkQuotient_comp_quotientBaseChangeIso_hom]
+
+/-- The inverse center base-change comparison respects the quotient coordinate maps. -/
+@[simp]
+theorem baseChangeMap_mkQuotient_comp_centerCoordinateBaseChangeIso_inv
+    (H : _root_.CommHopfAlgCat.{v} k) :
+    baseChangeMap (K := K) (mkQuotient H (centerDefiningIdeal H)) ≫
+        (centerCoordinateBaseChangeIso (K := K) H).inv =
+      mkQuotient (baseChange (K := K) H)
+        (centerDefiningIdeal (baseChange (K := K) H)) := by
+  rw [← mkQuotient_comp_centerCoordinateBaseChangeIso_hom, Category.assoc,
+    Iso.hom_inv_id, Category.comp_id]
 
 end TauCeti.CommHopfAlgCat

--- a/TauCeti/Algebra/AlgebraicGroup/Center/Descent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Center/Descent.lean
@@ -1,0 +1,54 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Center.BaseChange
+import Mathlib.RingTheory.Finiteness.Descent
+
+/-!
+# Descent of finiteness of the center
+
+A field extension preserves and reflects finiteness of the scheme-theoretic center of an
+affine group. Thus finiteness may be proved over an algebraic closure and then descended to
+the original field, as in the finite-center theorem for semisimple groups. No smoothness,
+connectedness, or finite-type assumption on the ambient group is needed for this descent.
+
+The coordinate comparison is `CommHopfAlgCat.centerCoordinateBaseChangeIso`. Finiteness of
+its tensor-product side descends by Mathlib's
+`Module.Finite.of_finite_tensorProduct_of_faithfullyFlat`.
+-/
+
+public section
+
+open CategoryTheory
+
+namespace TauCeti.CommHopfAlgCat
+
+universe u v
+
+variable {k : Type u} {K : Type v} [Field k] [Field K] [Algebra k K]
+
+/-- A field extension preserves and reflects finiteness of the full scheme-theoretic center,
+including any non-reduced structure. -/
+@[simp]
+theorem moduleFinite_centerCoordinate_baseChange_iff
+    (H : _root_.CommHopfAlgCat.{v} k) :
+    Module.Finite K (centerCoordinateHopfAlgebra (baseChange (K := K) H)) ↔
+      Module.Finite k (centerCoordinateHopfAlgebra H) := by
+  let e := centerCoordinateBaseChangeIso (K := K) H
+  constructor
+  · intro h
+    let _ := h
+    let _ : Module.Finite K (baseChange (K := K) (centerCoordinateHopfAlgebra H)) :=
+      Module.Finite.of_surjective e.hom.hom.toAlgHom.toLinearMap
+        (ConcreteCategory.bijective_of_isIso e.hom).surjective
+    exact Module.Finite.of_finite_tensorProduct_of_faithfullyFlat K
+  · intro h
+    let _ := h
+    exact Module.Finite.of_surjective e.inv.hom.toAlgHom.toLinearMap
+      (ConcreteCategory.bijective_of_isIso e.inv).surjective
+
+end TauCeti.CommHopfAlgCat


### PR DESCRIPTION
This PR proves that field extension preserves and reflects finiteness of the scheme-theoretic center of an affine group. Identify the center's coordinate algebra after extension with the scalar extension of its original coordinate algebra, record compatibility with both quotient maps, and apply Mathlib's faithfully flat descent of module finiteness. The result includes non-reduced centers and assumes neither smoothness nor finite type of the ambient group.

It advances [ReductiveGroups/README.md, Layer 6, “Reductive and semisimple groups”](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/ReductiveGroups/README.md#layer-6-reductive-and-semisimple-groups), specifically the target to develop the center and adjoint forms. The precise consumer is the finite-center statement: for `H : FiniteTypeCommHopfAlgCat k`, `semisimpleCommHopfAlgProperty k H` implies `Module.Finite k (CommHopfAlgCat.centerCoordinateHopfAlgebra H.obj)`. The new equivalence descends the geometric-fibre conclusion of `FiniteTypeCommHopfAlgCat.moduleFinite_centerCoordinate_of_reducedCenter_identityComponent_eq_augmentation` to that ground-field conclusion.

The center base-change identity and geometric finite-center criterion are already on main. Open PRs #6141, #6146, and #6147 supply the distinct connectedness, smoothness, and central-inclusion inputs for the reduced geometric center's identity component; none supplies this descent. This makes descent the next available independent step in that proof. After this PR, the finite-center theorem still needs those geometric inputs combined with `semisimpleCommHopfAlgProperty.eq_augmentation_of_isCentral` and the existing finiteness criterion; the broader Layer 6 milestone retains central isogenies and adjoint forms.

Add `TauCeti/Algebra/AlgebraicGroup/Center/Descent.lean` (54 lines) and extend `Center/BaseChange.lean` by 34 lines: four new public declarations, 88 added lines in total. The proof reuses Tau Ceti's `baseChangeHopfIdeal_centerDefiningIdeal` and `quotientBaseChangeIso`, and Mathlib's `Module.Finite.of_finite_tensorProduct_of_faithfullyFlat` and `Module.Finite.of_surjective`. No Mathlib infrastructure or external formalization is vendored. The new module identifies the central formal ingredients; the existing base-change module retains its mathematical references.

Self-review against api-design, reuse, and generality found no duplicate theorem or unnecessary hypothesis and required no substantive change. The comparison remains in its canonical base-change module, both quotient-map identities are simplifier lemmas, and the descent result is an equivalence over arbitrary field extensions. All ten rubrics were read: scope, correctness, reuse, attribution, api-design, generality, placement, naming, documentation, and proof-quality.

Validation: the targeted build of both changed modules passes. The axiom audit accepts all 10 declarations in the changed modules, using only the allowed axioms. `git diff --check` passes. The prescribed environment-lint wrapper stops at its freshness guard because its fixed list omits Mathlib's newly default `tacticAlt`; a temporary copy adding that linter passes the full current default set on both modules, with zero violations and zero grandfathered findings. No repository scripts or linter configuration were changed.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"center-finite-base-change"}-->

🤖 Prepared with Codex
