### PR TITLE
feat: make unbounded resolvents analytic

### DIFF
--- a/TauCeti/Analysis/Normed/Operator/Resolvent/Analytic.lean
+++ b/TauCeti/Analysis/Normed/Operator/Resolvent/Analytic.lean
@@ -1,0 +1,91 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.Normed.Operator.Resolvent.Unbounded
+public import Mathlib.Analysis.Analytic.Basic
+import Mathlib.Analysis.Analytic.Constructions
+
+/-!
+# Analyticity of an unbounded operator's resolvent
+
+The resolvent of a `LinearPMap` on a complete normed space over a nontrivially normed field is
+analytic on its resolvent set. Locally at a resolvent point `lambda`, the Neumann formula
+identifies it with
+
+`R(mu) = R(lambda) * (1 - (lambda - mu) R(lambda))⁻¹`.
+
+The second factor is analytic near `lambda` because inversion in a complete normed algebra is
+analytic at every unit. This gives analyticity in operator norm, rather than merely pointwise
+analyticity after applying the resolvent to a vector.
+
+## Main results
+
+* `TauCeti.LinearPMap.analyticAt_resolvent`: the resolvent is analytic at each point of its
+  resolvent set.
+* `TauCeti.LinearPMap.analyticOnNhd_resolvent`: the resolvent is analytic throughout its
+  resolvent set.
+
+## References
+
+* K.-J. Engel and R. Nagel, *One-Parameter Semigroups for Linear Evolution Equations*,
+  Section IV.1.
+* A. Pazy, *Semigroups of Linear Operators and Applications to Partial Differential Equations*,
+  Chapter 1, Section 1.3.
+-/
+
+public section
+
+noncomputable section
+
+open scoped Topology
+
+open Filter
+
+namespace TauCeti.LinearPMap
+
+variable {𝕜 X : Type*} [NontriviallyNormedField 𝕜]
+  [NormedAddCommGroup X] [NormedSpace 𝕜 X] [CompleteSpace X]
+
+variable {A : X →ₗ.[𝕜] X} {lambda : 𝕜}
+
+omit [CompleteSpace X] in
+private theorem eventually_norm_sub_mul_norm_resolvent_lt_one :
+    ∀ᶠ mu in 𝓝 lambda, ‖mu - lambda‖ * ‖resolvent A lambda‖ < 1 := by
+  filter_upwards [Metric.ball_mem_nhds lambda
+    (ε := 1 / (‖resolvent A lambda‖ + 1)) (by positivity)] with mu hmu
+  rw [Metric.mem_ball, dist_eq_norm] at hmu
+  have hprod : ‖mu - lambda‖ * (‖resolvent A lambda‖ + 1) < 1 :=
+    (lt_div_iff₀ (by positivity)).mp (by simpa using hmu)
+  exact lt_of_le_of_lt
+    (mul_le_mul_of_nonneg_left (by linarith) (norm_nonneg (mu - lambda))) hprod
+
+/-- The resolvent of a `LinearPMap` is analytic at every point of its resolvent set. -/
+theorem analyticAt_resolvent (h : lambda ∈ resolventSet A) :
+    AnalyticAt 𝕜 (resolvent A) lambda := by
+  let R : X →L[𝕜] X := resolvent A lambda
+  let localResolvent : 𝕜 → X →L[𝕜] X := fun mu =>
+    R * Ring.inverse (1 - (lambda - mu) • R)
+  have heq : resolvent A =ᶠ[𝓝 lambda] localResolvent := by
+    filter_upwards [eventually_norm_sub_mul_norm_resolvent_lt_one
+      (A := A) (lambda := lambda)] with mu hmu
+    simpa only [R, localResolvent] using resolvent_eq_mul_inverse_one_sub h hmu
+  have hinner : AnalyticAt 𝕜 (fun mu : 𝕜 => 1 - (lambda - mu) • R) lambda := by
+    fun_prop
+  have hinv : AnalyticAt 𝕜 (fun mu : 𝕜 => Ring.inverse (1 - (lambda - mu) • R)) lambda := by
+    have hInvAt : AnalyticAt 𝕜 (@Ring.inverse (X →L[𝕜] X) _)
+        (1 : X →L[𝕜] X) := analyticAt_inverse (𝕜 := 𝕜) (1 : (X →L[𝕜] X)ˣ)
+    exact hInvAt.comp_of_eq hinner (by simp)
+  exact (analyticAt_const.mul hinv).congr heq.symm
+
+/-- The resolvent of a `LinearPMap` is analytic in operator norm on its resolvent set. -/
+theorem analyticOnNhd_resolvent (A : X →ₗ.[𝕜] X) :
+    AnalyticOnNhd 𝕜 (resolvent A) (resolventSet A) :=
+  fun _ h => analyticAt_resolvent h
+
+end TauCeti.LinearPMap
+
+end

--- a/TauCeti/Analysis/Normed/Operator/Resolvent/Analytic.lean
+++ b/TauCeti/Analysis/Normed/Operator/Resolvent/Analytic.lean
@@ -56,8 +56,8 @@ variable {A : X →ₗ.[𝕜] X} {lambda : 𝕜}
 omit [CompleteSpace X] in
 private theorem eventually_norm_sub_mul_norm_resolvent_lt_one :
     ∀ᶠ mu in 𝓝 lambda, ‖mu - lambda‖ * ‖resolvent A lambda‖ < 1 := by
-  filter_upwards [eventually_norm_sub_lt lambda
-    (show 0 < 1 / (‖resolvent A lambda‖ + 1) by positivity)] with mu hmu
+  have hradius : 0 < 1 / (‖resolvent A lambda‖ + 1) := by positivity
+  filter_upwards [eventually_norm_sub_lt lambda hradius] with mu hmu
   have hprod : ‖mu - lambda‖ * (‖resolvent A lambda‖ + 1) < 1 :=
     (lt_div_iff₀ (by positivity)).mp (by simpa using hmu)
   exact lt_of_le_of_lt

--- a/TauCeti/Analysis/Normed/Operator/Resolvent/Analytic.lean
+++ b/TauCeti/Analysis/Normed/Operator/Resolvent/Analytic.lean
@@ -8,6 +8,7 @@ module
 public import TauCeti.Analysis.Normed.Operator.Resolvent.Unbounded
 public import Mathlib.Analysis.Analytic.Basic
 import Mathlib.Analysis.Analytic.Constructions
+import Mathlib.Analysis.Normed.Group.Lemmas
 
 /-!
 # Analyticity of an unbounded operator's resolvent
@@ -55,9 +56,8 @@ variable {A : X →ₗ.[𝕜] X} {lambda : 𝕜}
 omit [CompleteSpace X] in
 private theorem eventually_norm_sub_mul_norm_resolvent_lt_one :
     ∀ᶠ mu in 𝓝 lambda, ‖mu - lambda‖ * ‖resolvent A lambda‖ < 1 := by
-  filter_upwards [Metric.ball_mem_nhds lambda
-    (ε := 1 / (‖resolvent A lambda‖ + 1)) (by positivity)] with mu hmu
-  rw [Metric.mem_ball, dist_eq_norm] at hmu
+  filter_upwards [eventually_norm_sub_lt lambda
+    (show 0 < 1 / (‖resolvent A lambda‖ + 1) by positivity)] with mu hmu
   have hprod : ‖mu - lambda‖ * (‖resolvent A lambda‖ + 1) < 1 :=
     (lt_div_iff₀ (by positivity)).mp (by simpa using hmu)
   exact lt_of_le_of_lt

--- a/TauCeti/Analysis/Normed/Operator/Resolvent/Analytic.lean
+++ b/TauCeti/Analysis/Normed/Operator/Resolvent/Analytic.lean
@@ -26,7 +26,7 @@ analyticity after applying the resolvent to a vector.
 
 * `TauCeti.LinearPMap.analyticAt_resolvent`: the resolvent is analytic at each point of its
   resolvent set.
-* `TauCeti.LinearPMap.analyticOnNhd_resolvent`: the resolvent is analytic throughout its
+* `LinearPMap.analyticOnNhd_resolvent`: the resolvent is analytic throughout its
   resolvent set.
 
 ## References
@@ -82,7 +82,7 @@ theorem analyticAt_resolvent (h : lambda ∈ resolventSet A) :
   exact (analyticAt_const.mul hinv).congr heq.symm
 
 /-- The resolvent of a `LinearPMap` is analytic in operator norm on its resolvent set. -/
-theorem analyticOnNhd_resolvent (A : X →ₗ.[𝕜] X) :
+theorem _root_.LinearPMap.analyticOnNhd_resolvent (A : X →ₗ.[𝕜] X) :
     AnalyticOnNhd 𝕜 (resolvent A) (resolventSet A) :=
   fun _ h => analyticAt_resolvent h
 

--- a/TauCeti/Analysis/Normed/Operator/Resolvent/Perturbation.lean
+++ b/TauCeti/Analysis/Normed/Operator/Resolvent/Perturbation.lean
@@ -57,41 +57,8 @@ theorem isResolventAt_vadd (B : X →L[ℝ] X) (h : lambda ∈ resolventSet A)
     (hr : ‖resolvent A lambda‖ ≤ r) (hB : ‖B‖ * r < 1) :
     IsResolventAt ((B : X →ₗ[ℝ] X) +ᵥ A) lambda
       (resolvent A lambda * Ring.inverse (1 - B * resolvent A lambda)) := by
-  set R := resolvent A lambda with hRdef
-  have hnorm : ‖B * R‖ < 1 :=
-    lt_of_le_of_lt ((norm_mul_le B R).trans
-      (mul_le_mul_of_nonneg_left hr (norm_nonneg B))) hB
-  obtain ⟨u, hu⟩ := isUnit_one_sub_of_norm_lt_one hnorm
-  have hinv : Ring.inverse (1 - B * R) = ((u⁻¹ : (X →L[ℝ] X)ˣ) : X →L[ℝ] X) := by
-    rw [← hu, Ring.inverse_unit]
-  rw [hinv, ContinuousLinearMap.mul_def]
-  set U : X →L[ℝ] X := ((u⁻¹ : (X →L[ℝ] X)ˣ) : X →L[ℝ] X) with hUdef
-  have hcancel : ∀ y : X, U y - B (R (U y)) = y := by
-    intro y
-    have h1 : (u : X →L[ℝ] X) * U = 1 := u.mul_inv
-    rw [hu] at h1
-    simpa using congrArg (fun S : X →L[ℝ] X => S y) h1
-  have hsolve : ∀ y : X, U (y - B (R y)) = y := by
-    intro y
-    have h1 : U * (u : X →L[ℝ] X) = 1 := u.inv_mul
-    rw [hu] at h1
-    simpa using congrArg (fun S : X →L[ℝ] X => S y) h1
-  refine ⟨fun y => resolvent_mem_domain h (U y), fun y => ?_, fun x => ?_⟩
-  · have hstep : lambda • (R ∘L U) y -
-        ((B : X →ₗ[ℝ] X) +ᵥ A) ⟨(R ∘L U) y, resolvent_mem_domain h (U y)⟩
-        = (lambda • R (U y) - A ⟨R (U y), resolvent_mem_domain h (U y)⟩) - B (R (U y)) := by
-      rw [LinearPMap.vadd_apply]
-      simp only [ContinuousLinearMap.comp_apply, ContinuousLinearMap.coe_coe]
-      abel
-    rw [hstep, smul_sub_apply_resolvent h (U y), hcancel y]
-  · have hx : R (lambda • (x : X) - A x) = (x : X) :=
-      resolvent_smul_sub_apply h ⟨(x : X), x.2⟩
-    have hstep : lambda • (x : X) - ((B : X →ₗ[ℝ] X) +ᵥ A) x
-        = (lambda • (x : X) - A x) - B (R (lambda • (x : X) - A x)) := by
-      rw [LinearPMap.vadd_apply, hx]
-      simp only [ContinuousLinearMap.coe_coe]
-      abel
-    rw [ContinuousLinearMap.comp_apply, hstep, hsolve, hx]
+  apply isResolventAt_vadd_of_norm_mul_resolvent_lt_one B h
+  exact lt_of_le_of_lt (mul_le_mul_of_nonneg_left hr (norm_nonneg B)) hB
 
 /-- **A resolvent point survives a small bounded perturbation.** If `lambda` lies in the
 resolvent set of `A` and the bounded operator `B` satisfies `‖B‖ * r < 1` for some bound `r` on

--- a/TauCeti/Analysis/Normed/Operator/Resolvent/Perturbation.lean
+++ b/TauCeti/Analysis/Normed/Operator/Resolvent/Perturbation.lean
@@ -58,7 +58,8 @@ theorem isResolventAt_vadd (B : X →L[ℝ] X) (h : lambda ∈ resolventSet A)
     IsResolventAt ((B : X →ₗ[ℝ] X) +ᵥ A) lambda
       (resolvent A lambda * Ring.inverse (1 - B * resolvent A lambda)) := by
   apply isResolventAt_vadd_of_norm_mul_resolvent_lt_one B h
-  exact lt_of_le_of_lt (mul_le_mul_of_nonneg_left hr (norm_nonneg B)) hB
+  exact lt_of_le_of_lt (norm_mul_le _ _)
+    (lt_of_le_of_lt (mul_le_mul_of_nonneg_left hr (norm_nonneg B)) hB)
 
 /-- **A resolvent point survives a small bounded perturbation.** If `lambda` lies in the
 resolvent set of `A` and the bounded operator `B` satisfies `‖B‖ * r < 1` for some bound `r` on

--- a/TauCeti/Analysis/Normed/Operator/Resolvent/Unbounded.lean
+++ b/TauCeti/Analysis/Normed/Operator/Resolvent/Unbounded.lean
@@ -291,74 +291,100 @@ theorem resolvent_comm (hl : lambda ∈ resolventSet A) (hm : mu ∈ resolventSe
     have h4 := congrArg (fun T : X →L[𝕜] X => (mu - lambda)⁻¹ • T) h3
     simpa only [smul_smul, inv_mul_cancel₀ hsub, one_smul] using h4
 
-/-! ## Openness of the resolvent set -/
+/-! ## Neumann perturbations and openness of the resolvent set -/
 
 section CompleteSpace
 
 variable [CompleteSpace X]
 
-/-- The Neumann inverse. When `‖mu - lambda‖ * ‖R(lambda)‖ < 1`, the operator
-`1 - (lambda - mu) • R(lambda)` is invertible, and its inverse `U` is two-sided and commutes with
-`R(lambda)` — the latter because `1 - (lambda - mu) • R(lambda)` is a polynomial in `R(lambda)`.
+/-- **The common Neumann perturbation witness.** If `lambda` lies in the resolvent set of `A`
+and `B` is small against its resolvent, then
+`R(lambda, A) (I - B R(lambda, A))⁻¹` inverts `lambda • I - (B + A)`.
 
-Nothing here needs `lambda` to be in the resolvent set: the statement is about the bounded operator
-`resolvent A lambda` alone. -/
-private theorem exists_inverse_one_sub_smul_resolvent
-    (hmu : ‖mu - lambda‖ * ‖resolvent A lambda‖ < 1) :
-    ∃ U : X →L[𝕜] X,
-      (∀ y : X, U y - (lambda - mu) • resolvent A lambda (U y) = y) ∧
-      (∀ y : X, U (y - (lambda - mu) • resolvent A lambda y) = y) ∧
-      ∀ y : X, resolvent A lambda (U y) = U (resolvent A lambda y) := by
-  have hnorm : ‖(lambda - mu) • resolvent A lambda‖ < 1 := by
-    rw [norm_smul, norm_sub_rev]
-    exact hmu
+This is the lower-level construction shared by bounded perturbations and perturbations of the
+spectral parameter. -/
+theorem isResolventAt_vadd_of_norm_mul_resolvent_lt_one (B : X →L[𝕜] X)
+    (h : lambda ∈ resolventSet A) (hB : ‖B‖ * ‖resolvent A lambda‖ < 1) :
+    IsResolventAt ((B : X →ₗ[𝕜] X) +ᵥ A) lambda
+      (resolvent A lambda * Ring.inverse (1 - B * resolvent A lambda)) := by
+  set R := resolvent A lambda with hRdef
+  have hnorm : ‖B * R‖ < 1 :=
+    lt_of_le_of_lt (norm_mul_le B R) hB
   obtain ⟨u, hu⟩ := isUnit_one_sub_of_norm_lt_one hnorm
-  set B : X →L[𝕜] X := (lambda - mu) • resolvent A lambda with hB
-  refine ⟨((u⁻¹ : (X →L[𝕜] X)ˣ) : X →L[𝕜] X), fun y => ?_, fun y => ?_, fun y => ?_⟩
-  · have h1 : ((u : X →L[𝕜] X) * (u⁻¹ : (X →L[𝕜] X)ˣ)) = 1 := u.mul_inv
+  have hinv : Ring.inverse (1 - B * R) = ((u⁻¹ : (X →L[𝕜] X)ˣ) : X →L[𝕜] X) := by
+    rw [← hu, Ring.inverse_unit]
+  rw [hinv, ContinuousLinearMap.mul_def]
+  set U : X →L[𝕜] X := ((u⁻¹ : (X →L[𝕜] X)ˣ) : X →L[𝕜] X) with hUdef
+  have hcancel : ∀ y : X, U y - B (R (U y)) = y := by
+    intro y
+    have h1 : ((u : X →L[𝕜] X) * U) = 1 := u.mul_inv
     rw [hu] at h1
-    simpa [hB] using congrArg (fun S : X →L[𝕜] X => S y) h1
-  · have h1 : (((u⁻¹ : (X →L[𝕜] X)ˣ) : X →L[𝕜] X) * (u : X →L[𝕜] X)) = 1 := u.inv_mul
+    simpa using congrArg (fun S : X →L[𝕜] X => S y) h1
+  have hsolve : ∀ y : X, U (y - B (R y)) = y := by
+    intro y
+    have h1 : (U * (u : X →L[𝕜] X)) = 1 := u.inv_mul
     rw [hu] at h1
-    simpa [hB] using congrArg (fun S : X →L[𝕜] X => S y) h1
-  · -- `1 - (lambda - mu) • R(lambda)` is a polynomial in `R(lambda)`, hence commutes with it.
-    have hcomm : Commute ((u : X →L[𝕜] X)) (resolvent A lambda) := by
-      rw [hu, hB]
-      exact (Commute.one_left _).sub_left
-        ((Commute.refl (resolvent A lambda)).smul_left (lambda - mu))
-    simpa [mul_apply_eq_comp] using
-      congrArg (fun S : X →L[𝕜] X => S y) hcomm.units_inv_left.symm
-
-omit [CompleteSpace X] in
-private theorem isResolventAt_resolvent_comp_of_inverse (h : lambda ∈ resolventSet A)
-    {U : X →L[𝕜] X}
-    (hUright : ∀ y : X, U y - (lambda - mu) • resolvent A lambda (U y) = y)
-    (hUleft : ∀ y : X, U (y - (lambda - mu) • resolvent A lambda y) = y)
-    (hcomm : ∀ y : X, resolvent A lambda (U y) = U (resolvent A lambda y)) :
-    IsResolventAt A mu (resolvent A lambda ∘L U) := by
+    simpa using congrArg (fun S : X →L[𝕜] X => S y) h1
   refine ⟨fun y => resolvent_mem_domain h (U y), fun y => ?_, fun x => ?_⟩
-  · have h2 : mu • resolvent A lambda (U y) -
-        A ⟨resolvent A lambda (U y), resolvent_mem_domain h (U y)⟩
-      = (lambda • resolvent A lambda (U y) -
-          A ⟨resolvent A lambda (U y), resolvent_mem_domain h (U y)⟩) -
-        (lambda - mu) • resolvent A lambda (U y) := by module
-    simp only [ContinuousLinearMap.comp_apply]
-    rw [h2, smul_sub_apply_resolvent h (U y)]
-    exact hUright y
-  · have hsplit : mu • (x : X) - A x
-      = (lambda • (x : X) - A x) - (lambda - mu) • (x : X) := by module
-    have h1 : resolvent A lambda (mu • (x : X) - A x)
-        = (x : X) - (lambda - mu) • resolvent A lambda (x : X) := by
-      rw [hsplit, map_sub, map_smul, resolvent_smul_sub_apply h x]
-    simp only [ContinuousLinearMap.comp_apply]
-    rw [hcomm (mu • (x : X) - A x), h1, hUleft]
+  · have hstep : lambda • (R ∘L U) y -
+        ((B : X →ₗ[𝕜] X) +ᵥ A) ⟨(R ∘L U) y, resolvent_mem_domain h (U y)⟩
+        = (lambda • R (U y) - A ⟨R (U y), resolvent_mem_domain h (U y)⟩) - B (R (U y)) := by
+      rw [LinearPMap.vadd_apply]
+      simp only [ContinuousLinearMap.comp_apply, ContinuousLinearMap.coe_coe]
+      abel
+    rw [hstep, smul_sub_apply_resolvent h (U y), hcancel y]
+  · have hx : R (lambda • (x : X) - A x) = (x : X) :=
+      resolvent_smul_sub_apply h ⟨(x : X), x.2⟩
+    have hstep : lambda • (x : X) - ((B : X →ₗ[𝕜] X) +ᵥ A) x
+        = (lambda • (x : X) - A x) - B (R (lambda • (x : X) - A x)) := by
+      rw [LinearPMap.vadd_apply, hx]
+      simp only [ContinuousLinearMap.coe_coe]
+      abel
+    rw [ContinuousLinearMap.comp_apply, hstep, hsolve, hx]
+
+private theorem isResolventAt_of_norm_mul_lt_one (h : lambda ∈ resolventSet A)
+    (hmu : ‖mu - lambda‖ * ‖resolvent A lambda‖ < 1) :
+    IsResolventAt A mu
+      (resolvent A lambda * Ring.inverse (1 - (lambda - mu) • resolvent A lambda)) := by
+  let B : X →L[𝕜] X := (lambda - mu) • 1
+  have hB : ‖B‖ * ‖resolvent A lambda‖ < 1 := by
+    have hBnorm : ‖B‖ ≤ ‖lambda - mu‖ := by
+      dsimp only [B]
+      rw [norm_smul]
+      calc ‖lambda - mu‖ * ‖(1 : X →L[𝕜] X)‖
+          ≤ ‖lambda - mu‖ * 1 :=
+            mul_le_mul_of_nonneg_left ContinuousLinearMap.norm_id_le (norm_nonneg _)
+        _ = ‖lambda - mu‖ := mul_one _
+    exact (mul_le_mul_of_nonneg_right hBnorm (norm_nonneg _)).trans_lt (by rwa [norm_sub_rev])
+  have hBR : B * resolvent A lambda = (lambda - mu) • resolvent A lambda := by
+    simp only [B, smul_mul_assoc, one_mul]
+  let U : X →L[𝕜] X :=
+    resolvent A lambda * Ring.inverse (1 - (lambda - mu) • resolvent A lambda)
+  have hpert : IsResolventAt ((B : X →ₗ[𝕜] X) +ᵥ A) lambda U := by
+    simpa only [U, hBR] using isResolventAt_vadd_of_norm_mul_resolvent_lt_one B h hB
+  change IsResolventAt A mu U
+  refine ⟨hpert.mem_domain, fun y => ?_, fun x => ?_⟩
+  · calc
+      mu • _ - A ⟨_, hpert.mem_domain y⟩ =
+          lambda • _ - ((B : X →ₗ[𝕜] X) +ᵥ A) ⟨_, hpert.mem_domain y⟩ := by
+            rw [LinearPMap.vadd_apply]
+            simp only [B, ContinuousLinearMap.coe_coe, one_apply_eq_self, smul_apply]
+            module
+      _ = y := hpert.smul_sub_apply y
+  · calc
+      U (mu • (x : X) - A x) =
+          U (lambda • (x : X) - ((B : X →ₗ[𝕜] X) +ᵥ A) x) := by
+            congr 1
+            rw [LinearPMap.vadd_apply]
+            simp only [B, ContinuousLinearMap.coe_coe, one_apply_eq_self, smul_apply]
+            module
+      _ = (x : X) := hpert.apply_smul_sub x
 
 /-- **The Neumann perturbation of a resolvent point.** If `lambda` lies in the resolvent set and
 `‖mu - lambda‖ * ‖R(lambda)‖ < 1`, then `mu` lies in it too. -/
 theorem mem_resolventSet_of_norm_mul_lt_one (h : lambda ∈ resolventSet A)
-    (hmu : ‖mu - lambda‖ * ‖resolvent A lambda‖ < 1) : mu ∈ resolventSet A := by
-  obtain ⟨U, hUright, hUleft, hcomm⟩ := exists_inverse_one_sub_smul_resolvent hmu
-  exact (isResolventAt_resolvent_comp_of_inverse h hUright hUleft hcomm).mem_resolventSet
+    (hmu : ‖mu - lambda‖ * ‖resolvent A lambda‖ < 1) : mu ∈ resolventSet A :=
+  (isResolventAt_of_norm_mul_lt_one h hmu).mem_resolventSet
 
 /-- **Local Neumann formula for the resolvent.** Inside the ball
 `‖mu - lambda‖ * ‖R(lambda)‖ < 1`, the resolvent at `mu` is obtained by multiplying
@@ -366,27 +392,8 @@ theorem mem_resolventSet_of_norm_mul_lt_one (h : lambda ∈ resolventSet A)
 theorem resolvent_eq_mul_inverse_one_sub (h : lambda ∈ resolventSet A)
     (hmu : ‖mu - lambda‖ * ‖resolvent A lambda‖ < 1) :
     resolvent A mu = resolvent A lambda *
-      Ring.inverse (1 - (lambda - mu) • resolvent A lambda) := by
-  obtain ⟨U, hUright, hUleft, hcomm⟩ := exists_inverse_one_sub_smul_resolvent hmu
-  rw [resolvent_eq_of_isResolventAt
-    (isResolventAt_resolvent_comp_of_inverse h hUright hUleft hcomm)]
-  let B : X →L[𝕜] X := 1 - (lambda - mu) • resolvent A lambda
-  have hBnorm : ‖(lambda - mu) • resolvent A lambda‖ < 1 := by
-    rw [norm_smul, norm_sub_rev]
-    exact hmu
-  have hBunit : IsUnit B := by
-    exact isUnit_one_sub_of_norm_lt_one hBnorm
-  have hUB : U * B = 1 := by
-    ext y
-    simpa only [mul_apply_eq_comp, one_apply_eq_self, B, sub_apply, smul_apply] using hUleft y
-  have hU : U = Ring.inverse B := by
-    calc U = U * 1 := (mul_one U).symm
-      _ = U * (B * Ring.inverse B) := by rw [Ring.mul_inverse_cancel B hBunit]
-      _ = (U * B) * Ring.inverse B := (mul_assoc _ _ _).symm
-      _ = Ring.inverse B := by rw [hUB, one_mul]
-  rw [hU]
-  ext y
-  simp only [mul_apply_eq_comp, ContinuousLinearMap.comp_apply, B]
+      Ring.inverse (1 - (lambda - mu) • resolvent A lambda) :=
+  resolvent_eq_of_isResolventAt (isResolventAt_of_norm_mul_lt_one h hmu)
 
 /-- **The resolvent set is open.** -/
 theorem isOpen_resolventSet (A : X →ₗ.[𝕜] X) : IsOpen (resolventSet A) := by

--- a/TauCeti/Analysis/Normed/Operator/Resolvent/Unbounded.lean
+++ b/TauCeti/Analysis/Normed/Operator/Resolvent/Unbounded.lean
@@ -385,7 +385,8 @@ theorem resolvent_eq_mul_inverse_one_sub (h : lambda ∈ resolventSet A)
       _ = (U * B) * Ring.inverse B := (mul_assoc _ _ _).symm
       _ = Ring.inverse B := by rw [hUB, one_mul]
   rw [hU]
-  rfl
+  ext y
+  simp only [mul_apply_eq_comp, ContinuousLinearMap.comp_apply, B]
 
 /-- **The resolvent set is open.** -/
 theorem isOpen_resolventSet (A : X →ₗ.[𝕜] X) : IsOpen (resolventSet A) := by

--- a/TauCeti/Analysis/Normed/Operator/Resolvent/Unbounded.lean
+++ b/TauCeti/Analysis/Normed/Operator/Resolvent/Unbounded.lean
@@ -298,18 +298,17 @@ section CompleteSpace
 variable [CompleteSpace X]
 
 /-- **The common Neumann perturbation witness.** If `lambda` lies in the resolvent set of `A`
-and `B` is small against its resolvent, then
+and `‖B R(lambda, A)‖ < 1`, then
 `R(lambda, A) (I - B R(lambda, A))⁻¹` inverts `lambda • I - (B + A)`.
 
 This is the lower-level construction shared by bounded perturbations and perturbations of the
 spectral parameter. -/
 theorem isResolventAt_vadd_of_norm_mul_resolvent_lt_one (B : X →L[𝕜] X)
-    (h : lambda ∈ resolventSet A) (hB : ‖B‖ * ‖resolvent A lambda‖ < 1) :
+    (h : lambda ∈ resolventSet A) (hB : ‖B * resolvent A lambda‖ < 1) :
     IsResolventAt ((B : X →ₗ[𝕜] X) +ᵥ A) lambda
       (resolvent A lambda * Ring.inverse (1 - B * resolvent A lambda)) := by
   set R := resolvent A lambda with hRdef
-  have hnorm : ‖B * R‖ < 1 :=
-    lt_of_le_of_lt (norm_mul_le B R) hB
+  have hnorm : ‖B * R‖ < 1 := by simpa only [hRdef] using hB
   obtain ⟨u, hu⟩ := isUnit_one_sub_of_norm_lt_one hnorm
   have hinv : Ring.inverse (1 - B * R) = ((u⁻¹ : (X →L[𝕜] X)ˣ) : X →L[𝕜] X) := by
     rw [← hu, Ring.inverse_unit]
@@ -347,7 +346,7 @@ private theorem isResolventAt_of_norm_mul_lt_one (h : lambda ∈ resolventSet A)
     IsResolventAt A mu
       (resolvent A lambda * Ring.inverse (1 - (lambda - mu) • resolvent A lambda)) := by
   let B : X →L[𝕜] X := (lambda - mu) • 1
-  have hB : ‖B‖ * ‖resolvent A lambda‖ < 1 := by
+  have hbound : ‖B‖ * ‖resolvent A lambda‖ < 1 := by
     have hBnorm : ‖B‖ ≤ ‖lambda - mu‖ := by
       dsimp only [B]
       rw [norm_smul]
@@ -356,6 +355,8 @@ private theorem isResolventAt_of_norm_mul_lt_one (h : lambda ∈ resolventSet A)
             mul_le_mul_of_nonneg_left ContinuousLinearMap.norm_id_le (norm_nonneg _)
         _ = ‖lambda - mu‖ := mul_one _
     exact (mul_le_mul_of_nonneg_right hBnorm (norm_nonneg _)).trans_lt (by rwa [norm_sub_rev])
+  have hB : ‖B * resolvent A lambda‖ < 1 :=
+    lt_of_le_of_lt (norm_mul_le _ _) hbound
   have hBR : B * resolvent A lambda = (lambda - mu) • resolvent A lambda := by
     simp only [B, smul_mul_assoc, one_mul]
   let U : X →L[𝕜] X :=

--- a/TauCeti/Analysis/Normed/Operator/Resolvent/Unbounded.lean
+++ b/TauCeti/Analysis/Normed/Operator/Resolvent/Unbounded.lean
@@ -362,7 +362,7 @@ private theorem isResolventAt_of_norm_mul_lt_one (h : lambda ∈ resolventSet A)
     resolvent A lambda * Ring.inverse (1 - (lambda - mu) • resolvent A lambda)
   have hpert : IsResolventAt ((B : X →ₗ[𝕜] X) +ᵥ A) lambda U := by
     simpa only [U, hBR] using isResolventAt_vadd_of_norm_mul_resolvent_lt_one B h hB
-  change IsResolventAt A mu U
+  suffices IsResolventAt A mu U by simpa only [U]
   refine ⟨hpert.mem_domain, fun y => ?_, fun x => ?_⟩
   · calc
       mu • _ - A ⟨_, hpert.mem_domain y⟩ =

--- a/TauCeti/Analysis/Normed/Operator/Resolvent/Unbounded.lean
+++ b/TauCeti/Analysis/Normed/Operator/Resolvent/Unbounded.lean
@@ -19,23 +19,24 @@ Mathlib's `resolventSet` and `resolvent` are Banach-algebra notions: they ask th
 of that algebra. The infinitesimal generator of a C₀-semigroup is not such an element — it is
 an unbounded operator, carried here by `LinearPMap` — so it needs its own resolvent notion.
 
-This file supplies it. For `A : X →ₗ.[ℝ] X` and `lambda : ℝ` we say that a *bounded* operator
-`R : X →L[ℝ] X` is a resolvent of `A` at `lambda` (`TauCeti.LinearPMap.IsResolventAt`)
+This file supplies it over an arbitrary nontrivially normed field. For `A : X →ₗ.[𝕜] X` and
+`lambda : 𝕜` we say that a *bounded* operator
+`R : X →L[𝕜] X` is a resolvent of `A` at `lambda` (`TauCeti.LinearPMap.IsResolventAt`)
 when `R` takes values in `D(A)` and is a two-sided inverse of `lambda • I - A : D(A) → X`. Such
 an `R` is unique when it exists, so the *resolvent set*
 `TauCeti.LinearPMap.resolventSet` and the *resolvent*
 `TauCeti.LinearPMap.resolvent` are well defined, and the resolvent obeys the usual
 identities.
 
-Nothing here mentions semigroups: the theory is stated for an arbitrary `A : X →ₗ.[ℝ] X`, which
+Nothing here mentions semigroups: the theory is stated for an arbitrary `A : X →ₗ.[𝕜] X`, which
 is what makes it usable for an operator not yet known to generate anything — the situation of
 the Hille--Yosida generation theorem, whose hypotheses read `(ω, ∞) ⊆ resolventSet A` together
 with a bound on `‖resolvent A l ^ n‖`.
 
 Two bridges keep this from being a parallel universe.
 
-* **To Mathlib's bounded notion.** A bounded operator `T : X →L[ℝ] X`, read as the everywhere
-  defined unbounded operator `(T : X →ₗ[ℝ] X).toPMap ⊤`, has exactly Mathlib's resolvent set
+* **To Mathlib's bounded notion.** A bounded operator `T : X →L[𝕜] X`, read as the everywhere
+  defined unbounded operator `(T : X →ₗ[𝕜] X).toPMap ⊤`, has exactly Mathlib's resolvent set
   and resolvent (`LinearPMap.mem_resolventSet_toPMap_top_iff`,
   `LinearPMap.resolvent_toPMap_top`), proved here.
 * **To the Laplace-transform resolvent.** For a C₀-semigroup `S` with growth bound `(ω, M)`,
@@ -61,6 +62,8 @@ Two bridges keep this from being a parallel universe.
 * `TauCeti.LinearPMap.mem_resolventSet_of_norm_mul_lt_one` and
   `TauCeti.LinearPMap.isOpen_resolventSet`: the Neumann-series perturbation of a
   resolvent point, and the openness of the resolvent set it gives.
+* `TauCeti.LinearPMap.resolvent_eq_mul_inverse_one_sub`: the local Neumann formula for the
+  resolvent itself.
 * `TauCeti.LinearPMap.eq_of_le_of_mem_resolventSet`: an operator has no proper extension
   sharing a resolvent point.
 * `TauCeti.LinearPMap.mem_resolventSet_toPMap_top_iff` and
@@ -79,24 +82,24 @@ noncomputable section
 
 namespace TauCeti
 
-variable {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X]
+variable {𝕜 X : Type*} [NontriviallyNormedField 𝕜] [NormedAddCommGroup X] [NormedSpace 𝕜 X]
 
 namespace LinearPMap
 
-variable {A : X →ₗ.[ℝ] X} {lambda mu : ℝ} {R : X →L[ℝ] X}
+variable {A : X →ₗ.[𝕜] X} {lambda mu : 𝕜} {R : X →L[𝕜] X}
 
 /-! ## Inverting `lambda • I - A` -/
 
-/-- `IsResolventAt A lambda R` says that the **bounded** operator `R : X →L[ℝ] X` inverts
+/-- `IsResolventAt A lambda R` says that the **bounded** operator `R : X →L[𝕜] X` inverts
 `lambda • I - A : D(A) → X`: it takes its values in `D(A)`, is a right inverse of
 `lambda • I - A` on all of `X`, and is a left inverse of it on `D(A)`.
 
 For an unbounded `A` this replaces the Banach-algebra condition
-`IsUnit (algebraMap ℝ (X →L[ℝ] X) lambda - A)` behind Mathlib's `resolventSet`, which cannot be
-formed because `A` is not an element of `X →L[ℝ] X`. The two conditions agree when `A` is a
+`IsUnit (algebraMap 𝕜 (X →L[𝕜] X) lambda - A)` behind Mathlib's `resolventSet`, which cannot be
+formed because `A` is not an element of `X →L[𝕜] X`. The two conditions agree when `A` is a
 bounded operator read as an everywhere defined `LinearPMap`; see
 `TauCeti.LinearPMap.mem_resolventSet_toPMap_top_iff`. -/
-structure IsResolventAt (A : X →ₗ.[ℝ] X) (lambda : ℝ) (R : X →L[ℝ] X) : Prop where
+structure IsResolventAt (A : X →ₗ.[𝕜] X) (lambda : 𝕜) (R : X →L[𝕜] X) : Prop where
   /-- The inverse takes its values in the domain of `A`. -/
   mem_domain (y : X) : R y ∈ A.domain
   /-- `R` is a right inverse: `(lambda • I - A) (R y) = y` for every `y : X`. -/
@@ -106,7 +109,7 @@ structure IsResolventAt (A : X →ₗ.[ℝ] X) (lambda : ℝ) (R : X →L[ℝ] X
 
 /-- An inverse of `lambda • I - A` is unique: a left inverse and a right inverse of the same
 map agree. -/
-theorem IsResolventAt.unique (h : IsResolventAt A lambda R) {R' : X →L[ℝ] X}
+theorem IsResolventAt.unique (h : IsResolventAt A lambda R) {R' : X →L[𝕜] X}
     (h' : IsResolventAt A lambda R') : R = R' := by
   ext y
   have hy : R (lambda • R' y - A ⟨R' y, h'.mem_domain y⟩) = R' y :=
@@ -132,15 +135,15 @@ theorem IsResolventAt.smul_sub_bijective (h : IsResolventAt A lambda R) :
 
 /-! ## The resolvent set and the resolvent -/
 
-/-- The **resolvent set** of an unbounded operator `A : X →ₗ.[ℝ] X`: those `lambda : ℝ` for which
+/-- The **resolvent set** of an unbounded operator `A : X →ₗ.[𝕜] X`: those `lambda : 𝕜` for which
 `lambda • I - A : D(A) → X` is a bijection with bounded inverse. -/
-def resolventSet (A : X →ₗ.[ℝ] X) : Set ℝ :=
-  {lambda | ∃ R : X →L[ℝ] X, IsResolventAt A lambda R}
+def resolventSet (A : X →ₗ.[𝕜] X) : Set 𝕜 :=
+  {lambda | ∃ R : X →L[𝕜] X, IsResolventAt A lambda R}
 
 /-- Membership in the resolvent set unfolds to the existence of a bounded inverse of
 `lambda • I - A`. -/
 theorem mem_resolventSet_iff :
-    lambda ∈ resolventSet A ↔ ∃ R : X →L[ℝ] X, IsResolventAt A lambda R :=
+    lambda ∈ resolventSet A ↔ ∃ R : X →L[𝕜] X, IsResolventAt A lambda R :=
   Iff.rfl
 
 /-- Exhibiting an inverse puts `lambda` in the resolvent set. -/
@@ -151,8 +154,8 @@ theorem IsResolventAt.mem_resolventSet (h : IsResolventAt A lambda R) :
 /-- An inverse of `lambda • I - A` exists conditionally on `lambda` lying in the resolvent set;
 this is what lets `TauCeti.LinearPMap.resolvent` be defined by `Classical.choose`
 without a decidability side-condition. -/
-private theorem exists_isResolventAt_of_mem (A : X →ₗ.[ℝ] X) (lambda : ℝ) :
-    ∃ R : X →L[ℝ] X, lambda ∈ resolventSet A → IsResolventAt A lambda R := by
+private theorem exists_isResolventAt_of_mem (A : X →ₗ.[𝕜] X) (lambda : 𝕜) :
+    ∃ R : X →L[𝕜] X, lambda ∈ resolventSet A → IsResolventAt A lambda R := by
   by_cases h : lambda ∈ resolventSet A
   · exact ⟨h.choose, fun _ => h.choose_spec⟩
   · exact ⟨0, fun h' => absurd h' h⟩
@@ -165,7 +168,7 @@ hypothesis `lambda ∈ resolventSet A`. Uniqueness of the inverse
 (`TauCeti.LinearPMap.IsResolventAt.unique`) makes the choice immaterial on the
 resolvent set: `TauCeti.LinearPMap.resolvent_eq_of_isResolventAt` identifies it with
 any inverse one can exhibit. -/
-noncomputable def resolvent (A : X →ₗ.[ℝ] X) (lambda : ℝ) : X →L[ℝ] X :=
+noncomputable def resolvent (A : X →ₗ.[𝕜] X) (lambda : 𝕜) : X →L[𝕜] X :=
   (exists_isResolventAt_of_mem A lambda).choose
 
 /-- On the resolvent set, `resolvent A lambda` really does invert `lambda • I - A`. -/
@@ -215,7 +218,7 @@ surjectivity for `A`; injectivity for `B` then forces `y = x`, so `D(B) ⊆ D(A)
 
 This is the step that upgrades "`A` is a restriction of the generator" to "`A` *is* the
 generator" in the generation theorems. -/
-theorem eq_of_le_of_mem_resolventSet {A B : X →ₗ.[ℝ] X} (hAB : A ≤ B)
+theorem eq_of_le_of_mem_resolventSet {A B : X →ₗ.[𝕜] X} (hAB : A ≤ B)
     (hA : lambda ∈ resolventSet A) (hB : lambda ∈ resolventSet B) : A = B := by
   refine LinearPMap.eq_of_le_of_domain_eq hAB (le_antisymm hAB.1 fun y hy => ?_)
   obtain ⟨x, hx⟩ := (smul_sub_bijective hA).surjective (lambda • y - B ⟨y, hy⟩)
@@ -285,7 +288,7 @@ theorem resolvent_comm (hl : lambda ∈ resolventSet A) (hm : mu ∈ resolventSe
         = (mu - lambda) • (resolvent A mu ∘L resolvent A lambda) := by
       rw [← h1, ← neg_sub lambda mu, neg_smul, ← h2]
       abel
-    have h4 := congrArg (fun T : X →L[ℝ] X => (mu - lambda)⁻¹ • T) h3
+    have h4 := congrArg (fun T : X →L[𝕜] X => (mu - lambda)⁻¹ • T) h3
     simpa only [smul_smul, inv_mul_cancel₀ hsub, one_smul] using h4
 
 /-! ## Openness of the resolvent set -/
@@ -294,48 +297,46 @@ section CompleteSpace
 
 variable [CompleteSpace X]
 
-/-- The Neumann inverse. When `|mu - lambda| * ‖R(lambda)‖ < 1`, the operator
+/-- The Neumann inverse. When `‖mu - lambda‖ * ‖R(lambda)‖ < 1`, the operator
 `1 - (lambda - mu) • R(lambda)` is invertible, and its inverse `U` is two-sided and commutes with
 `R(lambda)` — the latter because `1 - (lambda - mu) • R(lambda)` is a polynomial in `R(lambda)`.
 
 Nothing here needs `lambda` to be in the resolvent set: the statement is about the bounded operator
 `resolvent A lambda` alone. -/
 private theorem exists_inverse_one_sub_smul_resolvent
-    (hmu : |mu - lambda| * ‖resolvent A lambda‖ < 1) :
-    ∃ U : X →L[ℝ] X,
+    (hmu : ‖mu - lambda‖ * ‖resolvent A lambda‖ < 1) :
+    ∃ U : X →L[𝕜] X,
       (∀ y : X, U y - (lambda - mu) • resolvent A lambda (U y) = y) ∧
       (∀ y : X, U (y - (lambda - mu) • resolvent A lambda y) = y) ∧
       ∀ y : X, resolvent A lambda (U y) = U (resolvent A lambda y) := by
   have hnorm : ‖(lambda - mu) • resolvent A lambda‖ < 1 := by
-    rw [norm_smul, Real.norm_eq_abs, abs_sub_comm]
+    rw [norm_smul, norm_sub_rev]
     exact hmu
   obtain ⟨u, hu⟩ := isUnit_one_sub_of_norm_lt_one hnorm
-  set B : X →L[ℝ] X := (lambda - mu) • resolvent A lambda with hB
-  refine ⟨((u⁻¹ : (X →L[ℝ] X)ˣ) : X →L[ℝ] X), fun y => ?_, fun y => ?_, fun y => ?_⟩
-  · have h1 : ((u : X →L[ℝ] X) * (u⁻¹ : (X →L[ℝ] X)ˣ)) = 1 := u.mul_inv
+  set B : X →L[𝕜] X := (lambda - mu) • resolvent A lambda with hB
+  refine ⟨((u⁻¹ : (X →L[𝕜] X)ˣ) : X →L[𝕜] X), fun y => ?_, fun y => ?_, fun y => ?_⟩
+  · have h1 : ((u : X →L[𝕜] X) * (u⁻¹ : (X →L[𝕜] X)ˣ)) = 1 := u.mul_inv
     rw [hu] at h1
-    simpa [hB] using congrArg (fun S : X →L[ℝ] X => S y) h1
-  · have h1 : (((u⁻¹ : (X →L[ℝ] X)ˣ) : X →L[ℝ] X) * (u : X →L[ℝ] X)) = 1 := u.inv_mul
+    simpa [hB] using congrArg (fun S : X →L[𝕜] X => S y) h1
+  · have h1 : (((u⁻¹ : (X →L[𝕜] X)ˣ) : X →L[𝕜] X) * (u : X →L[𝕜] X)) = 1 := u.inv_mul
     rw [hu] at h1
-    simpa [hB] using congrArg (fun S : X →L[ℝ] X => S y) h1
+    simpa [hB] using congrArg (fun S : X →L[𝕜] X => S y) h1
   · -- `1 - (lambda - mu) • R(lambda)` is a polynomial in `R(lambda)`, hence commutes with it.
-    have hcomm : Commute ((u : X →L[ℝ] X)) (resolvent A lambda) := by
+    have hcomm : Commute ((u : X →L[𝕜] X)) (resolvent A lambda) := by
       rw [hu, hB]
       exact (Commute.one_left _).sub_left
         ((Commute.refl (resolvent A lambda)).smul_left (lambda - mu))
     simpa [mul_apply_eq_comp] using
-      congrArg (fun S : X →L[ℝ] X => S y) hcomm.units_inv_left.symm
+      congrArg (fun S : X →L[𝕜] X => S y) hcomm.units_inv_left.symm
 
-/-- **The Neumann perturbation of a resolvent point.** If `lambda` lies in the resolvent set and
-`|mu - lambda| * ‖R(lambda)‖ < 1`, then `mu` lies in it too.
-
-On `D(A)` one has `mu • I - A = (I - (lambda - mu) R(lambda)) (lambda • I - A)`, and the first
-factor is invertible by the geometric series, so `R(lambda) (I - (lambda - mu) R(lambda))⁻¹`
-inverts `mu • I - A`. -/
-theorem mem_resolventSet_of_norm_mul_lt_one (h : lambda ∈ resolventSet A)
-    (hmu : |mu - lambda| * ‖resolvent A lambda‖ < 1) : mu ∈ resolventSet A := by
-  obtain ⟨U, hUright, hUleft, hcomm⟩ := exists_inverse_one_sub_smul_resolvent hmu
-  refine ⟨resolvent A lambda ∘L U, fun y => resolvent_mem_domain h (U y), fun y => ?_, fun x => ?_⟩
+omit [CompleteSpace X] in
+private theorem isResolventAt_resolvent_comp_of_inverse (h : lambda ∈ resolventSet A)
+    {U : X →L[𝕜] X}
+    (hUright : ∀ y : X, U y - (lambda - mu) • resolvent A lambda (U y) = y)
+    (hUleft : ∀ y : X, U (y - (lambda - mu) • resolvent A lambda y) = y)
+    (hcomm : ∀ y : X, resolvent A lambda (U y) = U (resolvent A lambda y)) :
+    IsResolventAt A mu (resolvent A lambda ∘L U) := by
+  refine ⟨fun y => resolvent_mem_domain h (U y), fun y => ?_, fun x => ?_⟩
   · have h2 : mu • resolvent A lambda (U y) -
         A ⟨resolvent A lambda (U y), resolvent_mem_domain h (U y)⟩
       = (lambda • resolvent A lambda (U y) -
@@ -352,82 +353,116 @@ theorem mem_resolventSet_of_norm_mul_lt_one (h : lambda ∈ resolventSet A)
     simp only [ContinuousLinearMap.comp_apply]
     rw [hcomm (mu • (x : X) - A x), h1, hUleft]
 
+/-- **The Neumann perturbation of a resolvent point.** If `lambda` lies in the resolvent set and
+`‖mu - lambda‖ * ‖R(lambda)‖ < 1`, then `mu` lies in it too. -/
+theorem mem_resolventSet_of_norm_mul_lt_one (h : lambda ∈ resolventSet A)
+    (hmu : ‖mu - lambda‖ * ‖resolvent A lambda‖ < 1) : mu ∈ resolventSet A := by
+  obtain ⟨U, hUright, hUleft, hcomm⟩ := exists_inverse_one_sub_smul_resolvent hmu
+  exact (isResolventAt_resolvent_comp_of_inverse h hUright hUleft hcomm).mem_resolventSet
+
+/-- **Local Neumann formula for the resolvent.** Inside the ball
+`‖mu - lambda‖ * ‖R(lambda)‖ < 1`, the resolvent at `mu` is obtained by multiplying
+`R(lambda)` by the ring inverse of `1 - (lambda - mu) R(lambda)`. -/
+theorem resolvent_eq_mul_inverse_one_sub (h : lambda ∈ resolventSet A)
+    (hmu : ‖mu - lambda‖ * ‖resolvent A lambda‖ < 1) :
+    resolvent A mu = resolvent A lambda *
+      Ring.inverse (1 - (lambda - mu) • resolvent A lambda) := by
+  obtain ⟨U, hUright, hUleft, hcomm⟩ := exists_inverse_one_sub_smul_resolvent hmu
+  rw [resolvent_eq_of_isResolventAt
+    (isResolventAt_resolvent_comp_of_inverse h hUright hUleft hcomm)]
+  let B : X →L[𝕜] X := 1 - (lambda - mu) • resolvent A lambda
+  have hBnorm : ‖(lambda - mu) • resolvent A lambda‖ < 1 := by
+    rw [norm_smul, norm_sub_rev]
+    exact hmu
+  have hBunit : IsUnit B := by
+    exact isUnit_one_sub_of_norm_lt_one hBnorm
+  have hUB : U * B = 1 := by
+    ext y
+    simpa only [mul_apply_eq_comp, one_apply_eq_self, B, sub_apply, smul_apply] using hUleft y
+  have hU : U = Ring.inverse B := by
+    calc U = U * 1 := (mul_one U).symm
+      _ = U * (B * Ring.inverse B) := by rw [Ring.mul_inverse_cancel B hBunit]
+      _ = (U * B) * Ring.inverse B := (mul_assoc _ _ _).symm
+      _ = Ring.inverse B := by rw [hUB, one_mul]
+  rw [hU]
+  rfl
+
 /-- **The resolvent set is open.** -/
-theorem isOpen_resolventSet (A : X →ₗ.[ℝ] X) : IsOpen (resolventSet A) := by
+theorem isOpen_resolventSet (A : X →ₗ.[𝕜] X) : IsOpen (resolventSet A) := by
   rw [Metric.isOpen_iff]
   intro lambda h
   refine ⟨1 / (‖resolvent A lambda‖ + 1), by positivity, fun mu hmu => ?_⟩
-  rw [Metric.mem_ball, Real.dist_eq] at hmu
+  rw [Metric.mem_ball, dist_eq_norm] at hmu
   refine mem_resolventSet_of_norm_mul_lt_one h ?_
-  have hlt : |mu - lambda| * (‖resolvent A lambda‖ + 1) < 1 :=
+  have hlt : ‖mu - lambda‖ * (‖resolvent A lambda‖ + 1) < 1 :=
     (lt_div_iff₀ (by positivity)).mp (by simpa using hmu)
-  calc |mu - lambda| * ‖resolvent A lambda‖
-      ≤ |mu - lambda| * (‖resolvent A lambda‖ + 1) :=
-        mul_le_mul_of_nonneg_left (by linarith) (abs_nonneg _)
+  calc ‖mu - lambda‖ * ‖resolvent A lambda‖
+      ≤ ‖mu - lambda‖ * (‖resolvent A lambda‖ + 1) :=
+        mul_le_mul_of_nonneg_left (by linarith) (norm_nonneg _)
     _ < 1 := hlt
 
 end CompleteSpace
 
 /-! ## The bridge to Mathlib's Banach-algebra resolvent
 
-A bounded operator `T : X →L[ℝ] X` becomes an everywhere defined unbounded operator
-`(T : X →ₗ[ℝ] X).toPMap ⊤`. Its resolvent set and resolvent in the sense above are Mathlib's
-`resolventSet ℝ T` and `resolvent T`, computed in the Banach algebra `X →L[ℝ] X`. -/
+A bounded operator `T : X →L[𝕜] X` becomes an everywhere defined unbounded operator
+`(T : X →ₗ[𝕜] X).toPMap ⊤`. Its resolvent set and resolvent in the sense above are Mathlib's
+`resolventSet 𝕜 T` and `resolvent T`, computed in the Banach algebra `X →L[𝕜] X`. -/
 
 section Bounded
 
-variable {T : X →L[ℝ] X}
+variable {T : X →L[𝕜] X}
 
-/-- `lambda • I - T`, formed in the algebra `X →L[ℝ] X`, applied to a vector. -/
-private theorem algebraMap_sub_apply (T : X →L[ℝ] X) (lambda : ℝ) (y : X) :
-    (algebraMap ℝ (X →L[ℝ] X) lambda - T) y = lambda • y - T y := by
+/-- `lambda • I - T`, formed in the algebra `X →L[𝕜] X`, applied to a vector. -/
+private theorem algebraMap_sub_apply (T : X →L[𝕜] X) (lambda : 𝕜) (y : X) :
+    (algebraMap 𝕜 (X →L[𝕜] X) lambda - T) y = lambda • y - T y := by
   simp [Algebra.algebraMap_eq_smul_one]
 
 /-- An inverse of `lambda • I - T` in the unbounded sense is a two-sided inverse in the algebra
-`X →L[ℝ] X`, so `lambda • I - T` is a unit there. -/
+`X →L[𝕜] X`, so `lambda • I - T` is a unit there. -/
 theorem isUnit_of_isResolventAt_toPMap_top
-    (h : IsResolventAt ((T : X →ₗ[ℝ] X).toPMap ⊤) lambda R) :
-    IsUnit (algebraMap ℝ (X →L[ℝ] X) lambda - T) := by
-  have hright : (algebraMap ℝ (X →L[ℝ] X) lambda - T) * R = 1 := by
+    (h : IsResolventAt ((T : X →ₗ[𝕜] X).toPMap ⊤) lambda R) :
+    IsUnit (algebraMap 𝕜 (X →L[𝕜] X) lambda - T) := by
+  have hright : (algebraMap 𝕜 (X →L[𝕜] X) lambda - T) * R = 1 := by
     ext y
     have h1 : lambda • R y - T (R y) = y := h.smul_sub_apply y
     simpa [algebraMap_sub_apply] using h1
-  have hleft : R * (algebraMap ℝ (X →L[ℝ] X) lambda - T) = 1 := by
+  have hleft : R * (algebraMap 𝕜 (X →L[𝕜] X) lambda - T) = 1 := by
     ext y
     have h1 : R (lambda • y - T y) = y := h.apply_smul_sub ⟨y, Submodule.mem_top⟩
     simpa [algebraMap_sub_apply] using h1
   exact spectrum.mem_resolventSet_of_left_right_inverse hright hleft
 
-/-- A unit `lambda • I - T` of the algebra `X →L[ℝ] X` inverts `lambda • I - T` in the
+/-- A unit `lambda • I - T` of the algebra `X →L[𝕜] X` inverts `lambda • I - T` in the
 unbounded sense, with the algebra inverse as the resolvent. -/
 theorem isResolventAt_toPMap_top_of_isUnit
-    (h : IsUnit (algebraMap ℝ (X →L[ℝ] X) lambda - T)) :
-    IsResolventAt ((T : X →ₗ[ℝ] X).toPMap ⊤) lambda
-      ((h.unit⁻¹ : (X →L[ℝ] X)ˣ) : X →L[ℝ] X) where
+    (h : IsUnit (algebraMap 𝕜 (X →L[𝕜] X) lambda - T)) :
+    IsResolventAt ((T : X →ₗ[𝕜] X).toPMap ⊤) lambda
+      ((h.unit⁻¹ : (X →L[𝕜] X)ˣ) : X →L[𝕜] X) where
   mem_domain _ := Submodule.mem_top
   smul_sub_apply y := by
-    have h1 : (algebraMap ℝ (X →L[ℝ] X) lambda - T)
-        (((h.unit⁻¹ : (X →L[ℝ] X)ˣ) : X →L[ℝ] X) y) = y := by
+    have h1 : (algebraMap 𝕜 (X →L[𝕜] X) lambda - T)
+        (((h.unit⁻¹ : (X →L[𝕜] X)ˣ) : X →L[𝕜] X) y) = y := by
       rw [← mul_apply_eq_comp, h.mul_val_inv, one_apply_eq_self]
     rwa [algebraMap_sub_apply] at h1
   apply_smul_sub x := by
-    have h1 : ((h.unit⁻¹ : (X →L[ℝ] X)ˣ) : X →L[ℝ] X)
-        ((algebraMap ℝ (X →L[ℝ] X) lambda - T) (x : X)) = (x : X) := by
+    have h1 : ((h.unit⁻¹ : (X →L[𝕜] X)ˣ) : X →L[𝕜] X)
+        ((algebraMap 𝕜 (X →L[𝕜] X) lambda - T) (x : X)) = (x : X) := by
       rw [← mul_apply_eq_comp, h.val_inv_mul, one_apply_eq_self]
     rwa [algebraMap_sub_apply] at h1
 
 /-- **The bounded bridge, membership half.** For a bounded operator the unbounded resolvent set
 of `T` and Mathlib's Banach-algebra resolvent set agree. -/
-theorem mem_resolventSet_toPMap_top_iff (T : X →L[ℝ] X) (lambda : ℝ) :
-    lambda ∈ resolventSet ((T : X →ₗ[ℝ] X).toPMap ⊤) ↔ lambda ∈ _root_.resolventSet ℝ T :=
+theorem mem_resolventSet_toPMap_top_iff (T : X →L[𝕜] X) (lambda : 𝕜) :
+    lambda ∈ resolventSet ((T : X →ₗ[𝕜] X).toPMap ⊤) ↔ lambda ∈ _root_.resolventSet 𝕜 T :=
   ⟨fun ⟨_, hR⟩ => isUnit_of_isResolventAt_toPMap_top hR,
     fun h => (isResolventAt_toPMap_top_of_isUnit h).mem_resolventSet⟩
 
 /-- **The bounded bridge, value half.** For a bounded operator the unbounded resolvent is
 Mathlib's Banach-algebra resolvent. -/
-theorem resolvent_toPMap_top (T : X →L[ℝ] X) {lambda : ℝ}
-    (h : lambda ∈ _root_.resolventSet ℝ T) :
-    resolvent ((T : X →ₗ[ℝ] X).toPMap ⊤) lambda = _root_.resolvent T lambda := by
+theorem resolvent_toPMap_top (T : X →L[𝕜] X) {lambda : 𝕜}
+    (h : lambda ∈ _root_.resolventSet 𝕜 T) :
+    resolvent ((T : X →ₗ[𝕜] X).toPMap ⊤) lambda = _root_.resolvent T lambda := by
   rw [resolvent_eq_of_isResolventAt (isResolventAt_toPMap_top_of_isUnit h),
     spectrum.resolvent_eq h]
 

--- a/TauCeti/Analysis/Normed/Operator/Resolvent/Unbounded.lean
+++ b/TauCeti/Analysis/Normed/Operator/Resolvent/Unbounded.lean
@@ -293,36 +293,29 @@ theorem resolvent_comm (hl : lambda ∈ resolventSet A) (hm : mu ∈ resolventSe
 
 /-! ## Neumann perturbations and openness of the resolvent set -/
 
-section CompleteSpace
-
-variable [CompleteSpace X]
-
-/-- **The common Neumann perturbation witness.** If `lambda` lies in the resolvent set of `A`
-and `‖B R(lambda, A)‖ < 1`, then
+/-- **The common invertible perturbation witness.** If `lambda` lies in the resolvent set of `A`
+and `I - B R(lambda, A)` is invertible, then
 `R(lambda, A) (I - B R(lambda, A))⁻¹` inverts `lambda • I - (B + A)`.
 
 This is the lower-level construction shared by bounded perturbations and perturbations of the
 spectral parameter. -/
-theorem isResolventAt_vadd_of_norm_mul_resolvent_lt_one (B : X →L[𝕜] X)
-    (h : lambda ∈ resolventSet A) (hB : ‖B * resolvent A lambda‖ < 1) :
+theorem isResolventAt_vadd_of_isUnit_one_sub_mul_resolvent (B : X →L[𝕜] X)
+    (h : lambda ∈ resolventSet A) (hB : IsUnit (1 - B * resolvent A lambda)) :
     IsResolventAt ((B : X →ₗ[𝕜] X) +ᵥ A) lambda
       (resolvent A lambda * Ring.inverse (1 - B * resolvent A lambda)) := by
   set R := resolvent A lambda with hRdef
-  have hnorm : ‖B * R‖ < 1 := by simpa only [hRdef] using hB
-  obtain ⟨u, hu⟩ := isUnit_one_sub_of_norm_lt_one hnorm
-  have hinv : Ring.inverse (1 - B * R) = ((u⁻¹ : (X →L[𝕜] X)ˣ) : X →L[𝕜] X) := by
-    rw [← hu, Ring.inverse_unit]
-  rw [hinv, ContinuousLinearMap.mul_def]
-  set U : X →L[𝕜] X := ((u⁻¹ : (X →L[𝕜] X)ˣ) : X →L[𝕜] X) with hUdef
+  have hunit : IsUnit (1 - B * R) := by simpa only [hRdef] using hB
+  rw [ContinuousLinearMap.mul_def]
+  set U : X →L[𝕜] X := Ring.inverse (1 - B * R) with hUdef
   have hcancel : ∀ y : X, U y - B (R (U y)) = y := by
     intro y
-    have h1 : ((u : X →L[𝕜] X) * U) = 1 := u.mul_inv
-    rw [hu] at h1
+    have h1 : (1 - B * R) * U = 1 := by
+      rw [hUdef, Ring.mul_inverse_cancel _ hunit]
     simpa using congrArg (fun S : X →L[𝕜] X => S y) h1
   have hsolve : ∀ y : X, U (y - B (R y)) = y := by
     intro y
-    have h1 : (U * (u : X →L[𝕜] X)) = 1 := u.inv_mul
-    rw [hu] at h1
+    have h1 : U * (1 - B * R) = 1 := by
+      rw [hUdef, Ring.inverse_mul_cancel _ hunit]
     simpa using congrArg (fun S : X →L[𝕜] X => S y) h1
   refine ⟨fun y => resolvent_mem_domain h (U y), fun y => ?_, fun x => ?_⟩
   · have hstep : lambda • (R ∘L U) y -
@@ -340,6 +333,19 @@ theorem isResolventAt_vadd_of_norm_mul_resolvent_lt_one (B : X →L[𝕜] X)
       simp only [ContinuousLinearMap.coe_coe]
       abel
     rw [ContinuousLinearMap.comp_apply, hstep, hsolve, hx]
+
+section CompleteSpace
+
+variable [CompleteSpace X]
+
+/-- If `lambda` lies in the resolvent set of `A` and `‖B R(lambda, A)‖ < 1`, then
+`R(lambda, A) (I - B R(lambda, A))⁻¹` inverts `lambda • I - (B + A)`. -/
+theorem isResolventAt_vadd_of_norm_mul_resolvent_lt_one (B : X →L[𝕜] X)
+    (h : lambda ∈ resolventSet A) (hB : ‖B * resolvent A lambda‖ < 1) :
+    IsResolventAt ((B : X →ₗ[𝕜] X) +ᵥ A) lambda
+      (resolvent A lambda * Ring.inverse (1 - B * resolvent A lambda)) :=
+  isResolventAt_vadd_of_isUnit_one_sub_mul_resolvent B h
+    (isUnit_one_sub_of_norm_lt_one hB)
 
 private theorem isResolventAt_of_norm_mul_lt_one (h : lambda ∈ resolventSet A)
     (hmu : ‖mu - lambda‖ * ‖resolvent A lambda‖ < 1) :


### PR DESCRIPTION
This PR generalizes the canonical `LinearPMap` unbounded-resolvent API from `ℝ` to an arbitrary nontrivially normed field, exposes the local Neumann formula `R(μ) = R(λ) * (1 - (λ - μ) R(λ))⁻¹`, and proves that the resolvent is analytic in operator norm at every point of its resolvent set.

The exact target is `OneParameterSemigroups/README.md`, Part A, “Resolvent theory,” the API item “analyticity of `λ ↦ R(λ,A)` on the resolvent set.” This is the next unmet reusable step surrounding the Hille–Yosida milestone: the landed resolvent was real-only, so the roadmap’s complex analytic statement could not even be expressed for an unbounded generator. After this PR, the remaining work for the roadmap’s real-Banach-first formulation is to construct or select the complexification of a real generator, identify its complex resolvent on the required half-plane, and apply this scalar-generic theorem.

The generalization is in place rather than a parallel complex API: every existing real semigroup consumer continues to instantiate the same declarations. The Neumann perturbation proof now factors its inverse verification once, and both resolvent-set openness and the new local formula consume it. The new `TauCeti.Analysis.Normed.Operator.Resolvent.Analytic` module obtains analyticity from that local formula.

No Mathlib code is vendored. The proof directly reuses Mathlib’s `isUnit_one_sub_of_norm_lt_one`, `Ring.inverse`, and `analyticAt_inverse`; the mathematical argument follows Engel–Nagel, Section IV.1, and Pazy, Chapter 1, Section 1.3, as cited in the module documentation.

Roadmap: OneParameterSemigroups

<!--tauceti-target:v1 {"focus":"OneParameterSemigroups","id":"analyticonnhd-resolvent"}-->

🤖 Prepared with Codex
