### PR TITLE
feat: topologize transitive orbit-stabilizer

### DIFF
--- a/TauCeti/Topology/Algebra/GroupAction/Quotient.lean
+++ b/TauCeti/Topology/Algebra/GroupAction/Quotient.lean
@@ -1,0 +1,40 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Topology.Algebra.Group.Quotient
+
+/-!
+# Continuous maps from group quotients
+
+This file records continuity results for maps out of group quotients that do not require
+transitivity of an action.
+
+## Main results
+
+* `TauCeti.continuous_ofQuotientStabilizer` proves continuity of the orbit map descended to a
+  stabilizer quotient when the corresponding orbit map is continuous.
+-/
+
+public section
+
+open MulAction
+
+namespace TauCeti
+
+variable (G : Type*) {X : Type*} [Group G] [TopologicalSpace G] [TopologicalSpace X]
+  [MulAction G X]
+
+/-- The orbit map descended to the stabilizer quotient is continuous when the orbit map is. -/
+@[fun_prop]
+theorem continuous_ofQuotientStabilizer (b : X) (hb : Continuous fun g : G => g • b) :
+    Continuous (ofQuotientStabilizer G b) := by
+  apply (QuotientGroup.isQuotientMap_mk (stabilizer G b)).continuous_iff.mpr
+  convert hb using 1
+  funext g
+  exact ofQuotientStabilizer_mk G b g
+
+end TauCeti

--- a/TauCeti/Topology/Algebra/GroupAction/Quotient.lean
+++ b/TauCeti/Topology/Algebra/GroupAction/Quotient.lean
@@ -32,9 +32,7 @@ variable (G : Type*) {X : Type*} [Group G] [TopologicalSpace G] [TopologicalSpac
 @[fun_prop]
 theorem continuous_ofQuotientStabilizer (b : X) (hb : Continuous fun g : G => g • b) :
     Continuous (ofQuotientStabilizer G b) := by
-  apply (QuotientGroup.isQuotientMap_mk (stabilizer G b)).continuous_iff.mpr
-  convert hb using 1
-  funext g
-  exact ofQuotientStabilizer_mk G b g
+  unfold ofQuotientStabilizer
+  exact hb.quotient_liftOn' _
 
 end TauCeti

--- a/TauCeti/Topology/Algebra/GroupAction/Transitive.lean
+++ b/TauCeti/Topology/Algebra/GroupAction/Transitive.lean
@@ -25,8 +25,6 @@ is compact, so its continuous bijection with the Hausdorff space `X` has continu
   orbit-stabilizer equivalence.
 * `TauCeti.quotientStabilizerHomeomorph` is its canonical topological upgrade for compact quotient
   and Hausdorff `X`.
-* `TauCeti.quotientStabilizerHomeomorph_toEquiv` identifies the underlying equivalence with the
-  algebraic orbit-stabilizer equivalence.
 * `TauCeti.quotientStabilizerHomeomorph_mk` and
   `TauCeti.quotientStabilizerHomeomorph_smul` record its representative and equivariance laws.
 -/
@@ -57,23 +55,14 @@ noncomputable def quotientStabilizerHomeomorph (b : X)
     G ⧸ (stabilizer G b) ≃ₜ X :=
   (continuous_quotientStabilizerEquiv G b hb).homeoOfEquivCompactToT2
 
-/-- The underlying equivalence of the quotient-stabilizer homeomorphism is the algebraic
-orbit-stabilizer equivalence. -/
-@[simp]
-theorem quotientStabilizerHomeomorph_toEquiv (b : X)
-    (hb : Continuous fun g : G => g • b)
-    [CompactSpace (G ⧸ (stabilizer G b))] [T2Space X] :
-    (quotientStabilizerHomeomorph G b hb).toEquiv = quotientStabilizerEquiv G b :=
-  Continuous.toEquiv_homeoOfEquivCompactToT2 (continuous_quotientStabilizerEquiv G b hb)
-
 /-- The quotient-stabilizer homeomorphism sends the coset of `g` to `g • b`. -/
 @[simp]
 theorem quotientStabilizerHomeomorph_mk (b : X)
     (hb : Continuous fun g : G => g • b)
     [CompactSpace (G ⧸ (stabilizer G b))] [T2Space X] (g : G) :
     quotientStabilizerHomeomorph G b hb (QuotientGroup.mk g) = g • b := by
-  change (quotientStabilizerHomeomorph G b hb).toEquiv (QuotientGroup.mk g) = g • b
-  rw [quotientStabilizerHomeomorph_toEquiv, quotientStabilizerEquiv_mk]
+  simp only [quotientStabilizerHomeomorph, ← Homeomorph.coe_toEquiv,
+    Continuous.toEquiv_homeoOfEquivCompactToT2, quotientStabilizerEquiv_mk]
 
 /-- The quotient-stabilizer homeomorphism is equivariant for the canonical left actions. -/
 @[simp]
@@ -83,8 +72,7 @@ theorem quotientStabilizerHomeomorph_smul (b : X)
     (g : G) (q : G ⧸ (stabilizer G b)) :
     quotientStabilizerHomeomorph G b hb (g • q) =
       g • quotientStabilizerHomeomorph G b hb q := by
-  change (quotientStabilizerHomeomorph G b hb).toEquiv (g • q) =
-    g • (quotientStabilizerHomeomorph G b hb).toEquiv q
-  rw [quotientStabilizerHomeomorph_toEquiv, quotientStabilizerEquiv_smul]
+  simp only [quotientStabilizerHomeomorph, ← Homeomorph.coe_toEquiv,
+    Continuous.toEquiv_homeoOfEquivCompactToT2, quotientStabilizerEquiv_smul]
 
 end TauCeti

--- a/TauCeti/Topology/Algebra/GroupAction/Transitive.lean
+++ b/TauCeti/Topology/Algebra/GroupAction/Transitive.lean
@@ -11,8 +11,8 @@ public import TauCeti.GroupTheory.GroupAction.Transitive
 /-!
 # Topological orbit-stabilizer for transitive actions
 
-For a continuous transitive action of a compact group `G` on a Hausdorff space `X`, the
-orbit-stabilizer equivalence is a homeomorphism
+For a continuous transitive action on a Hausdorff space `X`, if the quotient by the stabilizer is
+compact, then the orbit-stabilizer equivalence is a homeomorphism
 
 `G ⧸ MulAction.stabilizer G b ≃ₜ X`.
 
@@ -23,8 +23,8 @@ is compact, so its continuous bijection with the Hausdorff space `X` has continu
 
 * `TauCeti.continuous_quotientStabilizerEquiv` proves continuity of the algebraic
   orbit-stabilizer equivalence.
-* `TauCeti.quotientStabilizerHomeomorph` is its canonical topological upgrade for compact `G` and
-  Hausdorff `X`.
+* `TauCeti.quotientStabilizerHomeomorph` is its canonical topological upgrade for compact quotient
+  and Hausdorff `X`.
 * `TauCeti.quotientStabilizerHomeomorph_mk` and
   `TauCeti.quotientStabilizerHomeomorph_smul` record its representative and equivariance laws.
 -/
@@ -48,25 +48,25 @@ theorem continuous_quotientStabilizerEquiv (b : X) :
   funext g
   exact quotientStabilizerEquiv_mk G b g
 
-/-- For a continuous transitive action of a compact group on a Hausdorff space, the quotient by
-the stabilizer of a point is canonically homeomorphic to the space. -/
-noncomputable def quotientStabilizerHomeomorph [CompactSpace G] [T2Space X] (b : X) :
+/-- For a continuous transitive action on a Hausdorff space, a compact quotient by the stabilizer
+of a point is canonically homeomorphic to the space. -/
+noncomputable def quotientStabilizerHomeomorph (b : X)
+    [CompactSpace (G ⧸ (stabilizer G b))] [T2Space X] :
     G ⧸ (stabilizer G b) ≃ₜ X :=
-  (quotientStabilizerEquiv G b).toHomeomorphOfContinuousClosed
-    (continuous_quotientStabilizerEquiv G b)
-    (continuous_quotientStabilizerEquiv G b).isClosedMap
+  (continuous_quotientStabilizerEquiv G b).homeoOfEquivCompactToT2
 
 /-- The quotient-stabilizer homeomorphism sends the coset of `g` to `g • b`. -/
 @[simp]
-theorem quotientStabilizerHomeomorph_mk [CompactSpace G] [T2Space X]
-    (b : X) (g : G) :
+theorem quotientStabilizerHomeomorph_mk (b : X)
+    [CompactSpace (G ⧸ (stabilizer G b))] [T2Space X] (g : G) :
     quotientStabilizerHomeomorph G b (QuotientGroup.mk g) = g • b :=
   quotientStabilizerEquiv_mk G b g
 
 /-- The quotient-stabilizer homeomorphism is equivariant for the canonical left actions. -/
 @[simp]
-theorem quotientStabilizerHomeomorph_smul [CompactSpace G] [T2Space X]
-    (b : X) (g : G) (q : G ⧸ (stabilizer G b)) :
+theorem quotientStabilizerHomeomorph_smul (b : X)
+    [CompactSpace (G ⧸ (stabilizer G b))] [T2Space X]
+    (g : G) (q : G ⧸ (stabilizer G b)) :
     quotientStabilizerHomeomorph G b (g • q) =
       g • quotientStabilizerHomeomorph G b q :=
   quotientStabilizerEquiv_smul G b g q

--- a/TauCeti/Topology/Algebra/GroupAction/Transitive.lean
+++ b/TauCeti/Topology/Algebra/GroupAction/Transitive.lean
@@ -1,0 +1,74 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Topology.Algebra.Group.Quotient
+public import TauCeti.GroupTheory.GroupAction.Transitive
+
+/-!
+# Topological orbit-stabilizer for transitive actions
+
+For a continuous transitive action of a compact group `G` on a Hausdorff space `X`, the
+orbit-stabilizer equivalence is a homeomorphism
+
+`G ⧸ MulAction.stabilizer G b ≃ₜ X`.
+
+Continuity descends from the orbit map `g ↦ g • b` through the quotient topology. The quotient
+is compact, so its continuous bijection with the Hausdorff space `X` has continuous inverse.
+
+## Main results
+
+* `TauCeti.continuous_quotientStabilizerEquiv` proves continuity of the algebraic
+  orbit-stabilizer equivalence.
+* `TauCeti.quotientStabilizerHomeomorph` is its canonical topological upgrade for compact `G` and
+  Hausdorff `X`.
+* `TauCeti.quotientStabilizerHomeomorph_mk` and
+  `TauCeti.quotientStabilizerHomeomorph_smul` record its representative and equivariance laws.
+-/
+
+public section
+
+open MulAction
+
+namespace TauCeti
+
+variable (G : Type*) {X : Type*} [Group G] [TopologicalSpace G] [TopologicalSpace X]
+  [MulAction G X] [ContinuousSMul G X] [IsPretransitive G X]
+
+/-- The canonical orbit-stabilizer equivalence is continuous for a continuous transitive group
+action. -/
+@[fun_prop]
+theorem continuous_quotientStabilizerEquiv (b : X) :
+    Continuous (quotientStabilizerEquiv G b) := by
+  apply (QuotientGroup.isQuotientMap_mk (stabilizer G b)).continuous_iff.mpr
+  convert continuous_id.smul (continuous_const : Continuous fun _ : G => b) using 1
+  funext g
+  exact quotientStabilizerEquiv_mk G b g
+
+/-- For a continuous transitive action of a compact group on a Hausdorff space, the quotient by
+the stabilizer of a point is canonically homeomorphic to the space. -/
+noncomputable def quotientStabilizerHomeomorph [CompactSpace G] [T2Space X] (b : X) :
+    G ⧸ (stabilizer G b) ≃ₜ X :=
+  (quotientStabilizerEquiv G b).toHomeomorphOfContinuousClosed
+    (continuous_quotientStabilizerEquiv G b)
+    (continuous_quotientStabilizerEquiv G b).isClosedMap
+
+/-- The quotient-stabilizer homeomorphism sends the coset of `g` to `g • b`. -/
+@[simp]
+theorem quotientStabilizerHomeomorph_mk [CompactSpace G] [T2Space X]
+    (b : X) (g : G) :
+    quotientStabilizerHomeomorph G b (QuotientGroup.mk g) = g • b :=
+  quotientStabilizerEquiv_mk G b g
+
+/-- The quotient-stabilizer homeomorphism is equivariant for the canonical left actions. -/
+@[simp]
+theorem quotientStabilizerHomeomorph_smul [CompactSpace G] [T2Space X]
+    (b : X) (g : G) (q : G ⧸ (stabilizer G b)) :
+    quotientStabilizerHomeomorph G b (g • q) =
+      g • quotientStabilizerHomeomorph G b q :=
+  quotientStabilizerEquiv_smul G b g q
+
+end TauCeti

--- a/TauCeti/Topology/Algebra/GroupAction/Transitive.lean
+++ b/TauCeti/Topology/Algebra/GroupAction/Transitive.lean
@@ -5,8 +5,8 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Topology.Algebra.Group.Quotient
 public import TauCeti.GroupTheory.GroupAction.Transitive
+public import TauCeti.Topology.Algebra.GroupAction.Quotient
 
 /-!
 # Topological orbit-stabilizer for transitive actions
@@ -21,12 +21,12 @@ is compact, so its continuous bijection with the Hausdorff space `X` has continu
 
 ## Main results
 
-* `TauCeti.continuous_ofQuotientStabilizer` proves continuity of the orbit map descended to the
-  stabilizer quotient, without requiring transitivity.
 * `TauCeti.continuous_quotientStabilizerEquiv` proves continuity of the algebraic
   orbit-stabilizer equivalence.
 * `TauCeti.quotientStabilizerHomeomorph` is its canonical topological upgrade for compact quotient
   and Hausdorff `X`.
+* `TauCeti.quotientStabilizerHomeomorph_toEquiv` identifies its underlying equivalence with the
+  algebraic orbit-stabilizer equivalence.
 * `TauCeti.quotientStabilizerHomeomorph_mk` and
   `TauCeti.quotientStabilizerHomeomorph_smul` record its representative and equivariance laws.
 -/
@@ -39,15 +39,6 @@ namespace TauCeti
 
 variable (G : Type*) {X : Type*} [Group G] [TopologicalSpace G] [TopologicalSpace X]
   [MulAction G X]
-
-/-- The orbit map descended to the stabilizer quotient is continuous when the orbit map is. -/
-@[fun_prop]
-theorem continuous_ofQuotientStabilizer (b : X) (hb : Continuous fun g : G => g • b) :
-    Continuous (ofQuotientStabilizer G b) := by
-  apply (QuotientGroup.isQuotientMap_mk (stabilizer G b)).continuous_iff.mpr
-  convert hb using 1
-  funext g
-  exact ofQuotientStabilizer_mk G b g
 
 variable [IsPretransitive G X]
 
@@ -67,14 +58,23 @@ noncomputable def quotientStabilizerHomeomorph (b : X)
     G ⧸ (stabilizer G b) ≃ₜ X :=
   (continuous_quotientStabilizerEquiv G b hb).homeoOfEquivCompactToT2
 
+/-- The underlying equivalence of the quotient-stabilizer homeomorphism is the algebraic
+orbit-stabilizer equivalence. -/
+@[simp]
+theorem quotientStabilizerHomeomorph_toEquiv (b : X)
+    (hb : Continuous fun g : G => g • b)
+    [CompactSpace (G ⧸ (stabilizer G b))] [T2Space X] :
+    (quotientStabilizerHomeomorph G b hb).toEquiv = quotientStabilizerEquiv G b :=
+  Continuous.toEquiv_homeoOfEquivCompactToT2 (continuous_quotientStabilizerEquiv G b hb)
+
 /-- The quotient-stabilizer homeomorphism sends the coset of `g` to `g • b`. -/
 @[simp]
 theorem quotientStabilizerHomeomorph_mk (b : X)
     (hb : Continuous fun g : G => g • b)
     [CompactSpace (G ⧸ (stabilizer G b))] [T2Space X] (g : G) :
     quotientStabilizerHomeomorph G b hb (QuotientGroup.mk g) = g • b := by
-  simp only [quotientStabilizerHomeomorph, ← Homeomorph.coe_toEquiv,
-    Continuous.toEquiv_homeoOfEquivCompactToT2, quotientStabilizerEquiv_mk]
+  simpa only [← Homeomorph.coe_toEquiv, quotientStabilizerHomeomorph_toEquiv] using
+    quotientStabilizerEquiv_mk G b g
 
 /-- The quotient-stabilizer homeomorphism is equivariant for the canonical left actions. -/
 @[simp]
@@ -84,7 +84,7 @@ theorem quotientStabilizerHomeomorph_smul (b : X)
     (g : G) (q : G ⧸ (stabilizer G b)) :
     quotientStabilizerHomeomorph G b hb (g • q) =
       g • quotientStabilizerHomeomorph G b hb q := by
-  simp only [quotientStabilizerHomeomorph, ← Homeomorph.coe_toEquiv,
-    Continuous.toEquiv_homeoOfEquivCompactToT2, quotientStabilizerEquiv_smul]
+  simpa only [← Homeomorph.coe_toEquiv, quotientStabilizerHomeomorph_toEquiv] using
+    quotientStabilizerEquiv_smul G b g q
 
 end TauCeti

--- a/TauCeti/Topology/Algebra/GroupAction/Transitive.lean
+++ b/TauCeti/Topology/Algebra/GroupAction/Transitive.lean
@@ -11,8 +11,8 @@ public import TauCeti.GroupTheory.GroupAction.Transitive
 /-!
 # Topological orbit-stabilizer for transitive actions
 
-For a continuous transitive action on a Hausdorff space `X`, if the quotient by the stabilizer is
-compact, then the orbit-stabilizer equivalence is a homeomorphism
+For a transitive action on a Hausdorff space `X`, if the orbit map at `b` is continuous and the
+quotient by the stabilizer is compact, then the orbit-stabilizer equivalence is a homeomorphism
 
 `G ⧸ MulAction.stabilizer G b ≃ₜ X`.
 
@@ -25,6 +25,8 @@ is compact, so its continuous bijection with the Hausdorff space `X` has continu
   orbit-stabilizer equivalence.
 * `TauCeti.quotientStabilizerHomeomorph` is its canonical topological upgrade for compact quotient
   and Hausdorff `X`.
+* `TauCeti.quotientStabilizerHomeomorph_toEquiv` identifies the underlying equivalence with the
+  algebraic orbit-stabilizer equivalence.
 * `TauCeti.quotientStabilizerHomeomorph_mk` and
   `TauCeti.quotientStabilizerHomeomorph_smul` record its representative and equivariance laws.
 -/
@@ -36,39 +38,53 @@ open MulAction
 namespace TauCeti
 
 variable (G : Type*) {X : Type*} [Group G] [TopologicalSpace G] [TopologicalSpace X]
-  [MulAction G X] [ContinuousSMul G X] [IsPretransitive G X]
+  [MulAction G X] [IsPretransitive G X]
 
-/-- The canonical orbit-stabilizer equivalence is continuous for a continuous transitive group
-action. -/
+/-- The canonical orbit-stabilizer equivalence is continuous when its orbit map is continuous. -/
 @[fun_prop]
-theorem continuous_quotientStabilizerEquiv (b : X) :
+theorem continuous_quotientStabilizerEquiv (b : X) (hb : Continuous fun g : G => g • b) :
     Continuous (quotientStabilizerEquiv G b) := by
   apply (QuotientGroup.isQuotientMap_mk (stabilizer G b)).continuous_iff.mpr
-  convert continuous_id.smul (continuous_const : Continuous fun _ : G => b) using 1
+  convert hb using 1
   funext g
   exact quotientStabilizerEquiv_mk G b g
 
-/-- For a continuous transitive action on a Hausdorff space, a compact quotient by the stabilizer
-of a point is canonically homeomorphic to the space. -/
+/-- For a transitive action on a Hausdorff space, if the orbit map at a point is continuous and its
+stabilizer quotient is compact, then that quotient is canonically homeomorphic to the space. -/
 noncomputable def quotientStabilizerHomeomorph (b : X)
+    (hb : Continuous fun g : G => g • b)
     [CompactSpace (G ⧸ (stabilizer G b))] [T2Space X] :
     G ⧸ (stabilizer G b) ≃ₜ X :=
-  (continuous_quotientStabilizerEquiv G b).homeoOfEquivCompactToT2
+  (continuous_quotientStabilizerEquiv G b hb).homeoOfEquivCompactToT2
+
+/-- The underlying equivalence of the quotient-stabilizer homeomorphism is the algebraic
+orbit-stabilizer equivalence. -/
+@[simp]
+theorem quotientStabilizerHomeomorph_toEquiv (b : X)
+    (hb : Continuous fun g : G => g • b)
+    [CompactSpace (G ⧸ (stabilizer G b))] [T2Space X] :
+    (quotientStabilizerHomeomorph G b hb).toEquiv = quotientStabilizerEquiv G b :=
+  Continuous.toEquiv_homeoOfEquivCompactToT2 (continuous_quotientStabilizerEquiv G b hb)
 
 /-- The quotient-stabilizer homeomorphism sends the coset of `g` to `g • b`. -/
 @[simp]
 theorem quotientStabilizerHomeomorph_mk (b : X)
+    (hb : Continuous fun g : G => g • b)
     [CompactSpace (G ⧸ (stabilizer G b))] [T2Space X] (g : G) :
-    quotientStabilizerHomeomorph G b (QuotientGroup.mk g) = g • b :=
-  quotientStabilizerEquiv_mk G b g
+    quotientStabilizerHomeomorph G b hb (QuotientGroup.mk g) = g • b := by
+  change (quotientStabilizerHomeomorph G b hb).toEquiv (QuotientGroup.mk g) = g • b
+  rw [quotientStabilizerHomeomorph_toEquiv, quotientStabilizerEquiv_mk]
 
 /-- The quotient-stabilizer homeomorphism is equivariant for the canonical left actions. -/
 @[simp]
 theorem quotientStabilizerHomeomorph_smul (b : X)
+    (hb : Continuous fun g : G => g • b)
     [CompactSpace (G ⧸ (stabilizer G b))] [T2Space X]
     (g : G) (q : G ⧸ (stabilizer G b)) :
-    quotientStabilizerHomeomorph G b (g • q) =
-      g • quotientStabilizerHomeomorph G b q :=
-  quotientStabilizerEquiv_smul G b g q
+    quotientStabilizerHomeomorph G b hb (g • q) =
+      g • quotientStabilizerHomeomorph G b hb q := by
+  change (quotientStabilizerHomeomorph G b hb).toEquiv (g • q) =
+    g • (quotientStabilizerHomeomorph G b hb).toEquiv q
+  rw [quotientStabilizerHomeomorph_toEquiv, quotientStabilizerEquiv_smul]
 
 end TauCeti

--- a/TauCeti/Topology/Algebra/GroupAction/Transitive.lean
+++ b/TauCeti/Topology/Algebra/GroupAction/Transitive.lean
@@ -29,11 +29,6 @@ is compact, so its continuous bijection with the Hausdorff space `X` has continu
   algebraic orbit-stabilizer equivalence.
 * `TauCeti.quotientStabilizerHomeomorph_mk` and
   `TauCeti.quotientStabilizerHomeomorph_smul` record its representative and equivariance laws.
-
-## References
-
-* [Spin-representations roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md),
-  Layer 7, "Connectivity of the compact spin group".
 -/
 
 public section

--- a/TauCeti/Topology/Algebra/GroupAction/Transitive.lean
+++ b/TauCeti/Topology/Algebra/GroupAction/Transitive.lean
@@ -29,6 +29,11 @@ is compact, so its continuous bijection with the Hausdorff space `X` has continu
   algebraic orbit-stabilizer equivalence.
 * `TauCeti.quotientStabilizerHomeomorph_mk` and
   `TauCeti.quotientStabilizerHomeomorph_smul` record its representative and equivariance laws.
+
+## References
+
+* [Spin-representations roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md),
+  Layer 7, "Connectivity of the compact spin group".
 -/
 
 public section

--- a/TauCeti/Topology/Algebra/GroupAction/Transitive.lean
+++ b/TauCeti/Topology/Algebra/GroupAction/Transitive.lean
@@ -21,6 +21,8 @@ is compact, so its continuous bijection with the Hausdorff space `X` has continu
 
 ## Main results
 
+* `TauCeti.continuous_ofQuotientStabilizer` proves continuity of the orbit map descended to the
+  stabilizer quotient, without requiring transitivity.
 * `TauCeti.continuous_quotientStabilizerEquiv` proves continuity of the algebraic
   orbit-stabilizer equivalence.
 * `TauCeti.quotientStabilizerHomeomorph` is its canonical topological upgrade for compact quotient
@@ -36,16 +38,26 @@ open MulAction
 namespace TauCeti
 
 variable (G : Type*) {X : Type*} [Group G] [TopologicalSpace G] [TopologicalSpace X]
-  [MulAction G X] [IsPretransitive G X]
+  [MulAction G X]
+
+/-- The orbit map descended to the stabilizer quotient is continuous when the orbit map is. -/
+@[fun_prop]
+theorem continuous_ofQuotientStabilizer (b : X) (hb : Continuous fun g : G => g • b) :
+    Continuous (ofQuotientStabilizer G b) := by
+  apply (QuotientGroup.isQuotientMap_mk (stabilizer G b)).continuous_iff.mpr
+  convert hb using 1
+  funext g
+  exact ofQuotientStabilizer_mk G b g
+
+variable [IsPretransitive G X]
 
 /-- The canonical orbit-stabilizer equivalence is continuous when its orbit map is continuous. -/
 @[fun_prop]
 theorem continuous_quotientStabilizerEquiv (b : X) (hb : Continuous fun g : G => g • b) :
     Continuous (quotientStabilizerEquiv G b) := by
-  apply (QuotientGroup.isQuotientMap_mk (stabilizer G b)).continuous_iff.mpr
-  convert hb using 1
-  funext g
-  exact quotientStabilizerEquiv_mk G b g
+  refine (continuous_ofQuotientStabilizer G b hb).congr fun q => ?_
+  induction q using QuotientGroup.induction_on with
+  | _ g => rw [ofQuotientStabilizer_mk, quotientStabilizerEquiv_mk]
 
 /-- For a transitive action on a Hausdorff space, if the orbit map at a point is continuous and its
 stabilizer quotient is compact, then that quotient is canonically homeomorphic to the space. -/


### PR DESCRIPTION
This PR topologizes the transitive orbit-stabilizer equivalence for the SpinRepresentations Layer 7 compact-Spin connectivity milestone.

Roadmap: RepresentationTheory

## Summary

It descends a continuous orbit map `g ↦ g • b` to `G ⧸ MulAction.stabilizer G b` in a quotient-focused module without assuming transitivity. For a transitive action it upgrades the existing algebraic equivalence `G ⧸ MulAction.stabilizer G b ≃ X` to a canonical homeomorphism whenever the stabilizer quotient is compact and `X` is Hausdorff. A public underlying-equivalence theorem connects the bundled homeomorphism to the algebraic API, and the representative and equivariance simp laws use that stable bridge. The Lean module documentation describes only this durable mathematical contract; roadmap attribution remains here in the PR description.

## Roadmap target

This advances SpinRepresentations Layer 7, “Connectivity of the compact spin group,” by supplying the quotient-topology bridge needed for the homogeneous-space identification `Spin(n + 1) / Spin(n) ≃ₜ Sⁿ`. After this PR, the compact Spin sphere action and its transitivity must be assembled, then the resulting sphere bundle must be used to prove connectivity and simple connectivity.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"quotient-stabilizer-homeomorph"}-->

## Verification

- Exact head: `8a108ff6a4681b4fb1d314ea96dc788db3d4062f`
- Local Lean build: `lake exe cache get` — pass (`No files to download`; `Decompressed 8021 already-cached file(s)`); `lake build` — pass (`Build completed successfully (10947 jobs).`)
- Axiom audit: `lake exe axioms` — `axioms: audited 107960 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`
- Lint: GNU-sed `scripts/lint-env.sh`, `scripts/lint-dot-notation.py`, `bash scripts/lint-style.sh`, `lake exe module-system`, and `git diff --check` — pass with no new violations; all 4,798 source headers conform and all 4,799 modules use the module system
- Proof golf: pinned source inspection and exact replacement builds adopted Mathlib's `Continuous.quotient_liftOn'`; the proposed direct proof of equivalence continuity was rejected by Lean because the algebraic equivalence is opaque, so its necessary pointwise bridge remains
- Public CI: `sandboxed-build` — pass on the exact head

## Scale and generality

The quotient-descent lemma is stated for an arbitrary group action and assumes continuity only of the orbit map at the selected base point. It lives independently of transitivity; transitivity is introduced only for the algebraic equivalence and homeomorphism. The homeomorphism requires compactness only of the homogeneous quotient, so compact-group uses remain automatic while noncompact groups with compact homogeneous quotients are supported.

## Scope

- **Consumes:** `MulAction.ofQuotientStabilizer`, `TauCeti.quotientStabilizerEquiv` and its computation/equivariance laws, an explicit continuity proof for the chosen orbit map, and Mathlib's quotient-lift and compact-to-Hausdorff infrastructure.
- **Provides:** quotient-only `continuous_ofQuotientStabilizer`, transitive `continuous_quotientStabilizerEquiv`, `quotientStabilizerHomeomorph`, its public underlying-equivalence theorem, and representative/equivariance simp laws.
- **Fits:** the Layer 7 homogeneous-sphere step that follows the merged compact Spin action and stabilizer identification and precedes the compact Spin sphere bundle and connectivity induction.
- **Boundary:** this PR does not define the compact Spin sphere action, prove its transitivity, or construct the sphere bundle.

<sub>🤖 GPT-5.6 Sol high · TauCetiWorker @ [910d954fee75dfafda41f98165ce3a9e6676eae1](https://github.com/utensil/TauCetiWorker/commit/910d954fee75dfafda41f98165ce3a9e6676eae1) · rubrics @ [153ea8a6febe59f492c2f3d48471733e8b550848](https://github.com/utensil/TauCetiReview/commit/153ea8a6febe59f492c2f3d48471733e8b550848) · local review @ [b533e561b6d44df071c31335ed4a63ae647507d2](https://github.com/utensil/formal-land/commit/b533e561b6d44df071c31335ed4a63ae647507d2) · fixed: api-design, attribution, documentation, generality, placement, proof-quality, reuse</sub>