### PR TITLE
feat: add the gl_n single-weight isotypy criterion

### DIFF
--- a/TauCeti/Algebra/Lie/GeneralLinear/Isotypic.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/Isotypic.lean
@@ -26,13 +26,17 @@ algebra unless its centre acts semisimply.
 
 * `isIsotypic_of_forall_irreducible_exists_isGlHighestWeightVector`: a criterion using a supplied
   highest-weight vector in every irreducible submodule.
+* `isIsotypicOfType_of_forall_irreducible_exists_isGlHighestWeightVector`: the supplied-vector
+  criterion identifying an arbitrary irreducible type.
 * `isIsotypic_of_forall_isGlHighestWeightVector`: the finite-dimensional criterion over an
   algebraically closed field.
 * `isIsotypicOfType_of_forall_isGlHighestWeightVector`: the criterion identifying an arbitrary
   irreducible type from one highest-weight vector.
+* `isGlDominantIntegral_of_forall_isGlHighestWeightVector`: the dominance consequence of the
+  finite-dimensional single-weight hypothesis for a nonzero module.
 * `isIsotypicOfType_glIrreducible_of_forall_isGlHighestWeightVector`: the fixed-carrier criterion.
 * `nonempty_lieModuleEquiv_directSum_glIrreducible_of_forall_isGlHighestWeightVector`: the counted
-  direct-sum criterion for a completely reducible nonzero module.
+  direct-sum criterion for a completely reducible module.
 
 ## References
 
@@ -52,6 +56,50 @@ attribute [local instance 100] LieRing.ofAssociativeRing
 universe u v w
 
 variable {K : Type u} [Field K] [CharZero K]
+variable {n : Type*} [DecidableEq n] [Fintype n] [LinearOrder n]
+variable {M : Type v} [AddCommGroup M] [Module K M]
+  [LieRingModule (Matrix n n K) M]
+  [LieModule K (Matrix n n K) M]
+variable {S : Type w} [AddCommGroup S] [Module K S]
+  [LieRingModule (Matrix n n K) S]
+  [LieModule K (Matrix n n K) S]
+variable {mu : n → K}
+
+/-- If every irreducible submodule of a `gl_n`-module carries a highest-weight vector of weight
+`mu`, and an irreducible module `S` carries one too, then the original module is isotypic of type
+`S`.
+
+This supplied-vector form does not require finite-dimensionality or an algebraically closed
+field. -/
+theorem isIsotypicOfType_of_forall_irreducible_exists_isGlHighestWeightVector
+    [_root_.LieModule.IsIrreducible K (Matrix n n K) S]
+    {w : S} (hw : IsGlHighestWeightVector mu w)
+    (h : ∀ (P : LieSubmodule K (Matrix n n K) M)
+      [_root_.LieModule.IsIrreducible K (Matrix n n K) P],
+      ∃ v : P, IsGlHighestWeightVector mu v) :
+    _root_.LieModule.IsIsotypicOfType K (Matrix n n K) M S := by
+  rw [_root_.LieModule.isIsotypicOfType_iff]
+  intro P _
+  obtain ⟨v, hv⟩ := h P
+  exact nonempty_lieModuleEquiv_of_isGlHighestWeightVector hv hw
+
+/-- If every irreducible submodule of a `gl_n`-module carries a highest-weight vector of weight
+`mu`, then the module is isotypic.
+
+This form does not require finite-dimensionality or an algebraically closed field: those
+hypotheses are only needed to produce the highest-weight vectors, which are supplied here. -/
+theorem isIsotypic_of_forall_irreducible_exists_isGlHighestWeightVector
+    (h : ∀ (P : LieSubmodule K (Matrix n n K) M)
+      [_root_.LieModule.IsIrreducible K (Matrix n n K) P],
+      ∃ v : P, IsGlHighestWeightVector mu v) :
+    _root_.LieModule.IsIsotypic K (Matrix n n K) M := by
+  rw [_root_.LieModule.isIsotypic_iff]
+  intro P _
+  obtain ⟨v, hv⟩ := h P
+  exact isIsotypicOfType_of_forall_irreducible_exists_isGlHighestWeightVector hv h
+
+section Fin
+
 variable {N : ℕ}
 variable {M : Type v} [AddCommGroup M] [Module K M]
   [LieRingModule (Matrix (Fin N) (Fin N) K) M]
@@ -60,24 +108,6 @@ variable {S : Type w} [AddCommGroup S] [Module K S]
   [LieRingModule (Matrix (Fin N) (Fin N) K) S]
   [LieModule K (Matrix (Fin N) (Fin N) K) S]
 variable {mu : Fin N → K}
-
-/-- If every irreducible submodule of a `gl_N`-module carries a highest-weight vector of weight
-`mu`, then the module is isotypic.
-
-This form does not require finite-dimensionality or an algebraically closed field: those
-hypotheses are only needed to produce the highest-weight vectors, which are supplied here. -/
-theorem isIsotypic_of_forall_irreducible_exists_isGlHighestWeightVector
-    (h : ∀ (P : LieSubmodule K (Matrix (Fin N) (Fin N) K) M)
-      [_root_.LieModule.IsIrreducible K (Matrix (Fin N) (Fin N) K) P],
-      ∃ v : P, IsGlHighestWeightVector mu v) :
-    _root_.LieModule.IsIsotypic K (Matrix (Fin N) (Fin N) K) M := by
-  rw [_root_.LieModule.isIsotypic_iff]
-  intro P _
-  rw [_root_.LieModule.isIsotypicOfType_iff]
-  intro Q _
-  obtain ⟨v, hv⟩ := h P
-  obtain ⟨w, hw⟩ := h Q
-  exact nonempty_lieModuleEquiv_of_isGlHighestWeightVector hw hv
 
 /-- **The single-weight isotypy criterion for `gl_N`.** If every highest-weight vector in a
 finite-dimensional `gl_N`-module over an algebraically closed field has weight `mu`, then every
@@ -96,15 +126,15 @@ theorem isIsotypic_of_forall_isGlHighestWeightVector [IsAlgClosed K] [FiniteDime
   exact ⟨v, hv⟩
 
 /-- If an irreducible `gl_N`-module `S` carries a highest-weight vector of weight `mu`, then a
-finite-dimensional module whose highest-weight vectors all have weight `mu` is isotypic of type
-`S`. -/
+finite-dimensional module over an algebraically closed field whose highest-weight vectors all have
+weight `mu` is isotypic of type `S`. -/
 theorem isIsotypicOfType_of_forall_isGlHighestWeightVector
     [IsAlgClosed K] [FiniteDimensional K M]
     [_root_.LieModule.IsIrreducible K (Matrix (Fin N) (Fin N) K) S]
     {w : S} (hw : IsGlHighestWeightVector mu w)
     (h : ∀ (nu : Fin N → K) (v : M), IsGlHighestWeightVector nu v → nu = mu) :
     _root_.LieModule.IsIsotypicOfType K (Matrix (Fin N) (Fin N) K) M S := by
-  rw [_root_.LieModule.isIsotypicOfType_iff]
+  apply isIsotypicOfType_of_forall_irreducible_exists_isGlHighestWeightVector hw
   intro P _
   let _ : Nontrivial P :=
     _root_.LieModule.nontrivial_of_isIrreducible
@@ -112,42 +142,62 @@ theorem isIsotypicOfType_of_forall_isGlHighestWeightVector
   obtain ⟨nu, v, hv⟩ := exists_isGlHighestWeightVector (K := K) (N := N) (M := P)
   have hnu : nu = mu := h nu (v : M) (isGlHighestWeightVector_coe_iff.mpr hv)
   subst nu
-  exact nonempty_lieModuleEquiv_of_isGlHighestWeightVector hv hw
+  exact ⟨v, hv⟩
 
-/-- **The single-weight fixed-carrier criterion for `gl_N`.** A nonzero finite-dimensional module
-whose highest-weight vectors all have weight `mu` is isotypic of type `glIrreducible N mu`. -/
-theorem isIsotypicOfType_glIrreducible_of_forall_isGlHighestWeightVector
+/-- If all highest-weight vectors in a nonzero finite-dimensional `gl_N`-module over an
+algebraically closed field have weight `mu`, then `mu` is dominant integral. -/
+theorem isGlDominantIntegral_of_forall_isGlHighestWeightVector
     [IsAlgClosed K] [FiniteDimensional K M] [Nontrivial M]
+    (h : ∀ (nu : Fin N → K) (v : M), IsGlHighestWeightVector nu v → nu = mu) :
+    IsGlDominantIntegral mu := by
+  obtain ⟨nu, v, hv⟩ := exists_isGlHighestWeightVector (K := K) (N := N) (M := M)
+  exact h nu v hv ▸ hv.isGlDominantIntegral
+
+/-- **The single-weight fixed-carrier criterion for `gl_N`.** A finite-dimensional module over an
+algebraically closed field whose highest-weight vectors all have weight `mu` is isotypic of type
+`glIrreducible N mu`. For the zero module this holds vacuously. -/
+theorem isIsotypicOfType_glIrreducible_of_forall_isGlHighestWeightVector
+    [IsAlgClosed K] [FiniteDimensional K M]
     (h : ∀ (nu : Fin N → K) (v : M), IsGlHighestWeightVector nu v → nu = mu) :
     _root_.LieModule.IsIsotypicOfType K (Matrix (Fin N) (Fin N) K) M
       (glIrreducible N mu) := by
-  obtain ⟨nu, v, hv⟩ := exists_isGlHighestWeightVector (K := K) (N := N) (M := M)
-  have hnu : nu = mu := h nu v hv
-  subst nu
-  have hmu := hv.isGlDominantIntegral
+  rcases subsingleton_or_nontrivial M with hM | hM
+  · let _ := hM
+    rw [_root_.LieModule.isIsotypicOfType_iff]
+    intro P _
+    exact (not_nontrivial P
+      (_root_.LieModule.nontrivial_of_isIrreducible
+        (R := K) (L := Matrix (Fin N) (Fin N) K) (M := P))).elim
+  have hmu := isGlDominantIntegral_of_forall_isGlHighestWeightVector h
   let _ := isIrreducible_glIrreducible (K := K) hmu
   exact isIsotypicOfType_of_forall_isGlHighestWeightVector
     (isGlHighestWeightVector_glIrreducibleGenerator hmu) h
 
-/-- **The single-weight direct-sum criterion for `gl_N`.** A nonzero finite-dimensional completely
-reducible `gl_N`-module whose highest-weight vectors all have weight `mu` is the direct sum of
+/-- **The single-weight direct-sum criterion for `gl_N`.** A finite-dimensional completely
+reducible `gl_N`-module over an algebraically closed field whose highest-weight vectors all have
+weight `mu` is the direct sum of
 `LieModule.isotypicMultiplicity` copies of the named irreducible `glIrreducible N mu`.
 
 Complete reducibility is an explicit hypothesis: it is not automatic for a reductive Lie algebra,
-whose centre may act non-semisimply. -/
+whose centre may act non-semisimply. For the zero module the multiplicity is zero. -/
 theorem nonempty_lieModuleEquiv_directSum_glIrreducible_of_forall_isGlHighestWeightVector
-    [IsAlgClosed K] [FiniteDimensional K M] [Nontrivial M]
+    [IsAlgClosed K] [FiniteDimensional K M]
     [ComplementedLattice (LieSubmodule K (Matrix (Fin N) (Fin N) K) M)]
     (h : ∀ (nu : Fin N → K) (v : M), IsGlHighestWeightVector nu v → nu = mu) :
     Nonempty (M ≃ₗ⁅K,Matrix (Fin N) (Fin N) K⁆
       (⨁ (_ : Fin (_root_.LieModule.isotypicMultiplicity K (Matrix (Fin N) (Fin N) K) M
         (glIrreducible N mu))), glIrreducible N mu)) := by
-  obtain ⟨nu, v, hv⟩ := exists_isGlHighestWeightVector (K := K) (N := N) (M := M)
-  have hnu : nu = mu := h nu v hv
-  subst nu
-  have hmu := hv.isGlDominantIntegral
+  rcases subsingleton_or_nontrivial M with hM | hM
+  · let _ := hM
+    rw [_root_.LieModule.isotypicMultiplicity_eq_zero_of_subsingleton_codomain]
+    let f : M →ₗ⁅K,Matrix (Fin N) (Fin N) K⁆ (⨁ (_ : Fin 0), glIrreducible N mu) := 0
+    exact ⟨LieModuleEquiv.ofBijective f
+      ⟨fun _ _ _ => Subsingleton.elim _ _, fun y => ⟨0, Subsingleton.elim _ y⟩⟩⟩
+  have hmu := isGlDominantIntegral_of_forall_isGlHighestWeightVector h
   let _ := isIrreducible_glIrreducible (K := K) hmu
   exact _root_.LieModule.nonempty_lieModuleEquiv_of_isIsotypicOfType _
     (isIsotypicOfType_glIrreducible_of_forall_isGlHighestWeightVector h)
+
+end Fin
 
 end TauCeti

--- a/TauCeti/Algebra/Lie/GeneralLinear/Isotypic.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/Isotypic.lean
@@ -6,9 +6,11 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.Lie.GeneralLinear.Carrier
-public import TauCeti.Algebra.Lie.UniversalEnveloping.Multiplicity
+public import TauCeti.Algebra.Lie.Isotypic
+public import TauCeti.Algebra.Lie.Multiplicity
 -- Non-public: these declarations appear only inside proofs.
 import TauCeti.Algebra.Lie.GeneralLinear.Existence
+import TauCeti.Algebra.Lie.UniversalEnveloping.Multiplicity
 
 /-!
 # The single-weight isotypy criterion for `gl_n`

--- a/TauCeti/Algebra/Lie/GeneralLinear/Isotypic.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/Isotypic.lean
@@ -1,0 +1,90 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Lie.GeneralLinear.HighestWeight
+public import TauCeti.Algebra.Lie.Isotypic
+-- Non-public: these declarations appear only inside proofs.
+import TauCeti.Algebra.Lie.GeneralLinear.Existence
+import TauCeti.Algebra.Lie.GeneralLinear.Uniqueness
+import Mathlib.Algebra.Lie.Semisimple.Basic
+
+/-!
+# The single-weight isotypy criterion for `gl_n`
+
+This file packages highest-weight existence and uniqueness into an isotypy criterion for modules
+over the general linear Lie algebra. If every irreducible submodule has the same highest weight,
+then every pair of irreducible submodules is equivalent.
+
+The resulting `LieModule.IsIsotypic` assertion is deliberately pairwise: a direct-sum
+decomposition into irreducibles additionally requires complete reducibility, which is not automatic
+for representations of a reductive Lie algebra unless its centre acts semisimply.
+
+## Main results
+
+* `gl_isotypic_of_forall_irreducible_exists_isGlHighestWeightVector`: a criterion using a supplied
+  highest-weight vector in every irreducible submodule.
+* `gl_isotypic_of_forall_isGlHighestWeightVector`: the finite-dimensional criterion over an
+  algebraically closed field.
+
+## Roadmap
+
+This is the single-weight criterion in Layer 9 of the Lie highest-weight roadmap. It supplies the
+isotypy step for the CAR module in Layer 9 of the spin-representation roadmap.
+-/
+
+public section
+
+namespace TauCeti
+
+open LieModule Matrix
+
+attribute [local instance 100] LieRing.ofAssociativeRing
+
+universe u v
+
+variable {K : Type u} [Field K] [CharZero K]
+variable {N : ℕ}
+variable {M : Type v} [AddCommGroup M] [Module K M]
+  [LieRingModule (Matrix (Fin N) (Fin N) K) M]
+  [LieModule K (Matrix (Fin N) (Fin N) K) M]
+variable {mu : Fin N → K}
+
+/-- If every irreducible submodule of a `gl_N`-module carries a highest-weight vector of weight
+`mu`, then the module is isotypic.
+
+This form does not require finite-dimensionality or an algebraically closed field: those
+hypotheses are only needed to produce the highest-weight vectors, which are supplied here. -/
+theorem gl_isotypic_of_forall_irreducible_exists_isGlHighestWeightVector
+    (h : ∀ (P : LieSubmodule K (Matrix (Fin N) (Fin N) K) M)
+      [LieModule.IsIrreducible K (Matrix (Fin N) (Fin N) K) P],
+      ∃ v : P, IsGlHighestWeightVector mu v) :
+    LieModule.IsIsotypic K (Matrix (Fin N) (Fin N) K) M := by
+  rw [LieModule.isIsotypic_iff]
+  intro P _
+  rw [LieModule.isIsotypicOfType_iff]
+  intro Q _
+  obtain ⟨v, hv⟩ := h P
+  obtain ⟨w, hw⟩ := h Q
+  exact nonempty_lieModuleEquiv_of_isGlHighestWeightVector hw hv
+
+/-- **The single-weight isotypy criterion for `gl_N`.** If every highest-weight vector in a
+finite-dimensional `gl_N`-module over an algebraically closed field has weight `mu`, then every
+pair of irreducible submodules is equivalent. -/
+theorem gl_isotypic_of_forall_isGlHighestWeightVector [IsAlgClosed K] [FiniteDimensional K M]
+    (h : ∀ (nu : Fin N → K) (v : M), IsGlHighestWeightVector nu v → nu = mu) :
+    LieModule.IsIsotypic K (Matrix (Fin N) (Fin N) K) M := by
+  apply gl_isotypic_of_forall_irreducible_exists_isGlHighestWeightVector (mu := mu)
+  intro P _
+  let _ : Nontrivial P :=
+    LieModule.nontrivial_of_isIrreducible
+      (R := K) (L := Matrix (Fin N) (Fin N) K) (M := P)
+  obtain ⟨nu, v, hv⟩ := exists_isGlHighestWeightVector (K := K) (N := N) (M := P)
+  have hnu : nu = mu := h nu (v : M) (isGlHighestWeightVector_coe_iff.mpr hv)
+  subst nu
+  exact ⟨v, hv⟩
+
+end TauCeti

--- a/TauCeti/Algebra/Lie/GeneralLinear/Isotypic.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/Isotypic.lean
@@ -6,12 +6,9 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.Lie.GeneralLinear.Carrier
-public import TauCeti.Algebra.Lie.Isotypic
 public import TauCeti.Algebra.Lie.UniversalEnveloping.Multiplicity
 -- Non-public: these declarations appear only inside proofs.
 import TauCeti.Algebra.Lie.GeneralLinear.Existence
-import TauCeti.Algebra.Lie.GeneralLinear.Uniqueness
-import Mathlib.Algebra.Lie.Semisimple.Basic
 
 /-!
 # The single-weight isotypy criterion for `gl_n`
@@ -27,17 +24,15 @@ algebra unless its centre acts semisimply.
 
 ## Main results
 
-* `gl_isotypic_of_forall_irreducible_exists_isGlHighestWeightVector`: a criterion using a supplied
+* `isIsotypic_of_forall_irreducible_exists_isGlHighestWeightVector`: a criterion using a supplied
   highest-weight vector in every irreducible submodule.
-* `gl_isotypic_of_forall_isGlHighestWeightVector`: the finite-dimensional criterion over an
+* `isIsotypic_of_forall_isGlHighestWeightVector`: the finite-dimensional criterion over an
   algebraically closed field.
+* `isIsotypicOfType_of_forall_isGlHighestWeightVector`: the criterion identifying an arbitrary
+  irreducible type from one highest-weight vector.
+* `isIsotypicOfType_glIrreducible_of_forall_isGlHighestWeightVector`: the fixed-carrier criterion.
 * `nonempty_lieModuleEquiv_directSum_glIrreducible_of_forall_isGlHighestWeightVector`: the counted
   direct-sum criterion for a completely reducible nonzero module.
-
-## Roadmap
-
-This is the single-weight criterion in Layer 9 of the Lie highest-weight roadmap. It supplies the
-isotypy step for the CAR module in Layer 9 of the spin-representation roadmap.
 
 ## References
 
@@ -54,13 +49,16 @@ open scoped DirectSum
 
 attribute [local instance 100] LieRing.ofAssociativeRing
 
-universe u v
+universe u v w
 
 variable {K : Type u} [Field K] [CharZero K]
 variable {N : ℕ}
 variable {M : Type v} [AddCommGroup M] [Module K M]
   [LieRingModule (Matrix (Fin N) (Fin N) K) M]
   [LieModule K (Matrix (Fin N) (Fin N) K) M]
+variable {S : Type w} [AddCommGroup S] [Module K S]
+  [LieRingModule (Matrix (Fin N) (Fin N) K) S]
+  [LieModule K (Matrix (Fin N) (Fin N) K) S]
 variable {mu : Fin N → K}
 
 /-- If every irreducible submodule of a `gl_N`-module carries a highest-weight vector of weight
@@ -68,7 +66,7 @@ variable {mu : Fin N → K}
 
 This form does not require finite-dimensionality or an algebraically closed field: those
 hypotheses are only needed to produce the highest-weight vectors, which are supplied here. -/
-theorem gl_isotypic_of_forall_irreducible_exists_isGlHighestWeightVector
+theorem isIsotypic_of_forall_irreducible_exists_isGlHighestWeightVector
     (h : ∀ (P : LieSubmodule K (Matrix (Fin N) (Fin N) K) M)
       [_root_.LieModule.IsIrreducible K (Matrix (Fin N) (Fin N) K) P],
       ∃ v : P, IsGlHighestWeightVector mu v) :
@@ -84,10 +82,10 @@ theorem gl_isotypic_of_forall_irreducible_exists_isGlHighestWeightVector
 /-- **The single-weight isotypy criterion for `gl_N`.** If every highest-weight vector in a
 finite-dimensional `gl_N`-module over an algebraically closed field has weight `mu`, then every
 pair of irreducible submodules is equivalent. -/
-theorem gl_isotypic_of_forall_isGlHighestWeightVector [IsAlgClosed K] [FiniteDimensional K M]
+theorem isIsotypic_of_forall_isGlHighestWeightVector [IsAlgClosed K] [FiniteDimensional K M]
     (h : ∀ (nu : Fin N → K) (v : M), IsGlHighestWeightVector nu v → nu = mu) :
     _root_.LieModule.IsIsotypic K (Matrix (Fin N) (Fin N) K) M := by
-  apply gl_isotypic_of_forall_irreducible_exists_isGlHighestWeightVector (mu := mu)
+  apply isIsotypic_of_forall_irreducible_exists_isGlHighestWeightVector (mu := mu)
   intro P _
   let _ : Nontrivial P :=
     _root_.LieModule.nontrivial_of_isIrreducible
@@ -96,6 +94,40 @@ theorem gl_isotypic_of_forall_isGlHighestWeightVector [IsAlgClosed K] [FiniteDim
   have hnu : nu = mu := h nu (v : M) (isGlHighestWeightVector_coe_iff.mpr hv)
   subst nu
   exact ⟨v, hv⟩
+
+/-- If an irreducible `gl_N`-module `S` carries a highest-weight vector of weight `mu`, then a
+finite-dimensional module whose highest-weight vectors all have weight `mu` is isotypic of type
+`S`. -/
+theorem isIsotypicOfType_of_forall_isGlHighestWeightVector
+    [IsAlgClosed K] [FiniteDimensional K M]
+    [_root_.LieModule.IsIrreducible K (Matrix (Fin N) (Fin N) K) S]
+    {w : S} (hw : IsGlHighestWeightVector mu w)
+    (h : ∀ (nu : Fin N → K) (v : M), IsGlHighestWeightVector nu v → nu = mu) :
+    _root_.LieModule.IsIsotypicOfType K (Matrix (Fin N) (Fin N) K) M S := by
+  rw [_root_.LieModule.isIsotypicOfType_iff]
+  intro P _
+  let _ : Nontrivial P :=
+    _root_.LieModule.nontrivial_of_isIrreducible
+      (R := K) (L := Matrix (Fin N) (Fin N) K) (M := P)
+  obtain ⟨nu, v, hv⟩ := exists_isGlHighestWeightVector (K := K) (N := N) (M := P)
+  have hnu : nu = mu := h nu (v : M) (isGlHighestWeightVector_coe_iff.mpr hv)
+  subst nu
+  exact nonempty_lieModuleEquiv_of_isGlHighestWeightVector hv hw
+
+/-- **The single-weight fixed-carrier criterion for `gl_N`.** A nonzero finite-dimensional module
+whose highest-weight vectors all have weight `mu` is isotypic of type `glIrreducible N mu`. -/
+theorem isIsotypicOfType_glIrreducible_of_forall_isGlHighestWeightVector
+    [IsAlgClosed K] [FiniteDimensional K M] [Nontrivial M]
+    (h : ∀ (nu : Fin N → K) (v : M), IsGlHighestWeightVector nu v → nu = mu) :
+    _root_.LieModule.IsIsotypicOfType K (Matrix (Fin N) (Fin N) K) M
+      (glIrreducible N mu) := by
+  obtain ⟨nu, v, hv⟩ := exists_isGlHighestWeightVector (K := K) (N := N) (M := M)
+  have hnu : nu = mu := h nu v hv
+  subst nu
+  have hmu := hv.isGlDominantIntegral
+  let _ := isIrreducible_glIrreducible (K := K) hmu
+  exact isIsotypicOfType_of_forall_isGlHighestWeightVector
+    (isGlHighestWeightVector_glIrreducibleGenerator hmu) h
 
 /-- **The single-weight direct-sum criterion for `gl_N`.** A nonzero finite-dimensional completely
 reducible `gl_N`-module whose highest-weight vectors all have weight `mu` is the direct sum of
@@ -115,15 +147,7 @@ theorem nonempty_lieModuleEquiv_directSum_glIrreducible_of_forall_isGlHighestWei
   subst nu
   have hmu := hv.isGlDominantIntegral
   let _ := isIrreducible_glIrreducible (K := K) hmu
-  apply _root_.LieModule.nonempty_lieModuleEquiv_of_isIsotypicOfType
-  rw [_root_.LieModule.isIsotypicOfType_iff]
-  intro P _
-  let _ : Nontrivial P :=
-    _root_.LieModule.nontrivial_of_isIrreducible
-      (R := K) (L := Matrix (Fin N) (Fin N) K) (M := P)
-  obtain ⟨nu, w, hw⟩ := exists_isGlHighestWeightVector (K := K) (N := N) (M := P)
-  have hnu : nu = mu := h nu (w : M) (isGlHighestWeightVector_coe_iff.mpr hw)
-  subst nu
-  exact nonempty_lieModuleEquiv_glIrreducible hmu hw
+  exact _root_.LieModule.nonempty_lieModuleEquiv_of_isIsotypicOfType _
+    (isIsotypicOfType_glIrreducible_of_forall_isGlHighestWeightVector h)
 
 end TauCeti

--- a/TauCeti/Algebra/Lie/GeneralLinear/Isotypic.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/Isotypic.lean
@@ -5,8 +5,9 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Algebra.Lie.GeneralLinear.HighestWeight
+public import TauCeti.Algebra.Lie.GeneralLinear.Carrier
 public import TauCeti.Algebra.Lie.Isotypic
+public import TauCeti.Algebra.Lie.UniversalEnveloping.Multiplicity
 -- Non-public: these declarations appear only inside proofs.
 import TauCeti.Algebra.Lie.GeneralLinear.Existence
 import TauCeti.Algebra.Lie.GeneralLinear.Uniqueness
@@ -15,13 +16,14 @@ import Mathlib.Algebra.Lie.Semisimple.Basic
 /-!
 # The single-weight isotypy criterion for `gl_n`
 
-This file packages highest-weight existence and uniqueness into an isotypy criterion for modules
-over the general linear Lie algebra. If every irreducible submodule has the same highest weight,
-then every pair of irreducible submodules is equivalent.
+This file packages highest-weight existence and uniqueness into isotypy criteria for modules over
+the general linear Lie algebra. If every irreducible submodule has the same highest weight, then
+every pair of irreducible submodules is equivalent. Under complete reducibility, the module is the
+direct sum of copies of the named irreducible with that weight.
 
-The resulting `LieModule.IsIsotypic` assertion is deliberately pairwise: a direct-sum
-decomposition into irreducibles additionally requires complete reducibility, which is not automatic
-for representations of a reductive Lie algebra unless its centre acts semisimply.
+The foundational `LieModule.IsIsotypic` assertion is pairwise. The counted direct-sum theorem adds
+complete reducibility explicitly, since it is not automatic for representations of a reductive Lie
+algebra unless its centre acts semisimply.
 
 ## Main results
 
@@ -29,6 +31,8 @@ for representations of a reductive Lie algebra unless its centre acts semisimply
   highest-weight vector in every irreducible submodule.
 * `gl_isotypic_of_forall_isGlHighestWeightVector`: the finite-dimensional criterion over an
   algebraically closed field.
+* `nonempty_lieModuleEquiv_directSum_glIrreducible_of_forall_isGlHighestWeightVector`: the counted
+  direct-sum criterion for a completely reducible nonzero module.
 
 ## Roadmap
 
@@ -45,7 +49,8 @@ public section
 
 namespace TauCeti
 
-open LieModule Matrix
+open _root_.LieModule Matrix
+open scoped DirectSum
 
 attribute [local instance 100] LieRing.ofAssociativeRing
 
@@ -65,12 +70,12 @@ This form does not require finite-dimensionality or an algebraically closed fiel
 hypotheses are only needed to produce the highest-weight vectors, which are supplied here. -/
 theorem gl_isotypic_of_forall_irreducible_exists_isGlHighestWeightVector
     (h : ∀ (P : LieSubmodule K (Matrix (Fin N) (Fin N) K) M)
-      [LieModule.IsIrreducible K (Matrix (Fin N) (Fin N) K) P],
+      [_root_.LieModule.IsIrreducible K (Matrix (Fin N) (Fin N) K) P],
       ∃ v : P, IsGlHighestWeightVector mu v) :
-    LieModule.IsIsotypic K (Matrix (Fin N) (Fin N) K) M := by
-  rw [LieModule.isIsotypic_iff]
+    _root_.LieModule.IsIsotypic K (Matrix (Fin N) (Fin N) K) M := by
+  rw [_root_.LieModule.isIsotypic_iff]
   intro P _
-  rw [LieModule.isIsotypicOfType_iff]
+  rw [_root_.LieModule.isIsotypicOfType_iff]
   intro Q _
   obtain ⟨v, hv⟩ := h P
   obtain ⟨w, hw⟩ := h Q
@@ -81,15 +86,44 @@ finite-dimensional `gl_N`-module over an algebraically closed field has weight `
 pair of irreducible submodules is equivalent. -/
 theorem gl_isotypic_of_forall_isGlHighestWeightVector [IsAlgClosed K] [FiniteDimensional K M]
     (h : ∀ (nu : Fin N → K) (v : M), IsGlHighestWeightVector nu v → nu = mu) :
-    LieModule.IsIsotypic K (Matrix (Fin N) (Fin N) K) M := by
+    _root_.LieModule.IsIsotypic K (Matrix (Fin N) (Fin N) K) M := by
   apply gl_isotypic_of_forall_irreducible_exists_isGlHighestWeightVector (mu := mu)
   intro P _
   let _ : Nontrivial P :=
-    LieModule.nontrivial_of_isIrreducible
+    _root_.LieModule.nontrivial_of_isIrreducible
       (R := K) (L := Matrix (Fin N) (Fin N) K) (M := P)
   obtain ⟨nu, v, hv⟩ := exists_isGlHighestWeightVector (K := K) (N := N) (M := P)
   have hnu : nu = mu := h nu (v : M) (isGlHighestWeightVector_coe_iff.mpr hv)
   subst nu
   exact ⟨v, hv⟩
+
+/-- **The single-weight direct-sum criterion for `gl_N`.** A nonzero finite-dimensional completely
+reducible `gl_N`-module whose highest-weight vectors all have weight `mu` is the direct sum of
+`LieModule.isotypicMultiplicity` copies of the named irreducible `glIrreducible N mu`.
+
+Complete reducibility is an explicit hypothesis: it is not automatic for a reductive Lie algebra,
+whose centre may act non-semisimply. -/
+theorem nonempty_lieModuleEquiv_directSum_glIrreducible_of_forall_isGlHighestWeightVector
+    [IsAlgClosed K] [FiniteDimensional K M] [Nontrivial M]
+    [ComplementedLattice (LieSubmodule K (Matrix (Fin N) (Fin N) K) M)]
+    (h : ∀ (nu : Fin N → K) (v : M), IsGlHighestWeightVector nu v → nu = mu) :
+    Nonempty (M ≃ₗ⁅K,Matrix (Fin N) (Fin N) K⁆
+      (⨁ (_ : Fin (_root_.LieModule.isotypicMultiplicity K (Matrix (Fin N) (Fin N) K) M
+        (glIrreducible N mu))), glIrreducible N mu)) := by
+  obtain ⟨nu, v, hv⟩ := exists_isGlHighestWeightVector (K := K) (N := N) (M := M)
+  have hnu : nu = mu := h nu v hv
+  subst nu
+  have hmu := hv.isGlDominantIntegral
+  let _ := isIrreducible_glIrreducible (K := K) hmu
+  apply _root_.LieModule.nonempty_lieModuleEquiv_of_isIsotypicOfType
+  rw [_root_.LieModule.isIsotypicOfType_iff]
+  intro P _
+  let _ : Nontrivial P :=
+    _root_.LieModule.nontrivial_of_isIrreducible
+      (R := K) (L := Matrix (Fin N) (Fin N) K) (M := P)
+  obtain ⟨nu, w, hw⟩ := exists_isGlHighestWeightVector (K := K) (N := N) (M := P)
+  have hnu : nu = mu := h nu (w : M) (isGlHighestWeightVector_coe_iff.mpr hw)
+  subst nu
+  exact nonempty_lieModuleEquiv_glIrreducible hmu hw
 
 end TauCeti

--- a/TauCeti/Algebra/Lie/GeneralLinear/Isotypic.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/Isotypic.lean
@@ -34,6 +34,11 @@ for representations of a reductive Lie algebra unless its centre acts semisimply
 
 This is the single-weight criterion in Layer 9 of the Lie highest-weight roadmap. It supplies the
 isotypy step for the CAR module in Layer 9 of the spin-representation roadmap.
+
+## References
+
+The formal precedent is `TauCeti.isIsotypicOfType_of_forall_isHighestWeightVector` in
+`TauCeti/Algebra/Lie/HighestWeight/Isotypic.lean`.
 -/
 
 public section

--- a/TauCeti/Algebra/Lie/GeneralLinear/Isotypic.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/Isotypic.lean
@@ -16,7 +16,9 @@ import TauCeti.Algebra.Lie.GeneralLinear.Existence
 This file packages highest-weight existence and uniqueness into isotypy criteria for modules over
 the general linear Lie algebra. If every irreducible submodule has the same highest weight, then
 every pair of irreducible submodules is equivalent. Under complete reducibility, the module is the
-direct sum of copies of the named irreducible with that weight.
+direct sum of copies of the named irreducible with that weight when the module is nonzero. For the
+zero module, the result is the empty direct sum and makes no dominance or irreducibility claim
+about the named carrier.
 
 The foundational `LieModule.IsIsotypic` assertion is pairwise. The counted direct-sum theorem adds
 complete reducibility explicitly, since it is not automatic for representations of a reductive Lie
@@ -109,13 +111,12 @@ variable {S : Type w} [AddCommGroup S] [Module K S]
   [LieModule K (Matrix (Fin N) (Fin N) K) S]
 variable {mu : Fin N → K}
 
-/-- **The single-weight isotypy criterion for `gl_N`.** If every highest-weight vector in a
-finite-dimensional `gl_N`-module over an algebraically closed field has weight `mu`, then every
-pair of irreducible submodules is equivalent. -/
-theorem isIsotypic_of_forall_isGlHighestWeightVector [IsAlgClosed K] [FiniteDimensional K M]
+private theorem exists_submodule_isGlHighestWeightVector_of_forall
+    [IsAlgClosed K] [FiniteDimensional K M]
     (h : ∀ (nu : Fin N → K) (v : M), IsGlHighestWeightVector nu v → nu = mu) :
-    _root_.LieModule.IsIsotypic K (Matrix (Fin N) (Fin N) K) M := by
-  apply isIsotypic_of_forall_irreducible_exists_isGlHighestWeightVector (mu := mu)
+    ∀ (P : LieSubmodule K (Matrix (Fin N) (Fin N) K) M)
+      [_root_.LieModule.IsIrreducible K (Matrix (Fin N) (Fin N) K) P],
+      ∃ v : P, IsGlHighestWeightVector mu v := by
   intro P _
   let _ : Nontrivial P :=
     _root_.LieModule.nontrivial_of_isIrreducible
@@ -125,6 +126,15 @@ theorem isIsotypic_of_forall_isGlHighestWeightVector [IsAlgClosed K] [FiniteDime
   subst nu
   exact ⟨v, hv⟩
 
+/-- **The single-weight isotypy criterion for `gl_N`.** If every highest-weight vector in a
+finite-dimensional `gl_N`-module over an algebraically closed field has weight `mu`, then every
+pair of irreducible submodules is equivalent. -/
+theorem isIsotypic_of_forall_isGlHighestWeightVector [IsAlgClosed K] [FiniteDimensional K M]
+    (h : ∀ (nu : Fin N → K) (v : M), IsGlHighestWeightVector nu v → nu = mu) :
+    _root_.LieModule.IsIsotypic K (Matrix (Fin N) (Fin N) K) M :=
+  isIsotypic_of_forall_irreducible_exists_isGlHighestWeightVector
+    (exists_submodule_isGlHighestWeightVector_of_forall h)
+
 /-- If an irreducible `gl_N`-module `S` carries a highest-weight vector of weight `mu`, then a
 finite-dimensional module over an algebraically closed field whose highest-weight vectors all have
 weight `mu` is isotypic of type `S`. -/
@@ -133,16 +143,9 @@ theorem isIsotypicOfType_of_forall_isGlHighestWeightVector
     [_root_.LieModule.IsIrreducible K (Matrix (Fin N) (Fin N) K) S]
     {w : S} (hw : IsGlHighestWeightVector mu w)
     (h : ∀ (nu : Fin N → K) (v : M), IsGlHighestWeightVector nu v → nu = mu) :
-    _root_.LieModule.IsIsotypicOfType K (Matrix (Fin N) (Fin N) K) M S := by
-  apply isIsotypicOfType_of_forall_irreducible_exists_isGlHighestWeightVector hw
-  intro P _
-  let _ : Nontrivial P :=
-    _root_.LieModule.nontrivial_of_isIrreducible
-      (R := K) (L := Matrix (Fin N) (Fin N) K) (M := P)
-  obtain ⟨nu, v, hv⟩ := exists_isGlHighestWeightVector (K := K) (N := N) (M := P)
-  have hnu : nu = mu := h nu (v : M) (isGlHighestWeightVector_coe_iff.mpr hv)
-  subst nu
-  exact ⟨v, hv⟩
+    _root_.LieModule.IsIsotypicOfType K (Matrix (Fin N) (Fin N) K) M S :=
+  isIsotypicOfType_of_forall_irreducible_exists_isGlHighestWeightVector hw
+    (exists_submodule_isGlHighestWeightVector_of_forall h)
 
 /-- If all highest-weight vectors in a nonzero finite-dimensional `gl_N`-module over an
 algebraically closed field have weight `mu`, then `mu` is dominant integral. -/
@@ -179,7 +182,9 @@ weight `mu` is the direct sum of
 `LieModule.isotypicMultiplicity` copies of the named irreducible `glIrreducible N mu`.
 
 Complete reducibility is an explicit hypothesis: it is not automatic for a reductive Lie algebra,
-whose centre may act non-semisimply. For the zero module the multiplicity is zero. -/
+whose centre may act non-semisimply. For a nonzero module the weight is dominant integral, so the
+named carrier is irreducible. For the zero module the multiplicity is zero, and the theorem only
+identifies the empty direct sum without making a claim about the carrier. -/
 theorem nonempty_lieModuleEquiv_directSum_glIrreducible_of_forall_isGlHighestWeightVector
     [IsAlgClosed K] [FiniteDimensional K M]
     [ComplementedLattice (LieSubmodule K (Matrix (Fin N) (Fin N) K) M)]


### PR DESCRIPTION
This PR adds the `gl_n` single-weight isotypy and counted direct-sum criteria for the LieHighestWeight Layer 9 milestone and its CAR consumer.

Roadmap: RepresentationTheory

## Summary

Package the existing `gl_n` highest-weight existence and uniqueness theorems into pairwise and fixed-type `LieModule` isotypy criteria. The supplied-vector core works for matrices over any finite ordered index type and identifies an arbitrary irreducible target carrying the common highest weight. Its finite-dimensional specialization exposes the resulting dominant-integral weight for nonzero modules, identifies `glIrreducible N mu`, and gives the counted direct-sum equivalence under complete reducibility. The zero-module case is the empty direct sum and makes no claim about the named carrier. The canonical module publicly exposes only the general isotypy, multiplicity, and carrier interfaces; its universal-enveloping decomposition dependency is proof-only.

## Roadmap target

This advances RepresentationTheory / LieHighestWeight Layer 9, “the `gl_n` Pieri rule and the single-weight criterion,” for the SpinRepresentations Layer 9 `car_isotypic` and CAR multiplicity consumers. After this PR, the CAR branch still needs the staircase highest-weight calculation inside each simple submodule and a complete-reducibility input for the counted decomposition; the separate reductive complete-reducibility target remains responsible for deriving complements from semisimple central action.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"gl-single-weight-isotypic-criterion"}-->

## Verification

- Exact head: `455f0e4dcf2329daec121262a8e7801f1644219a`
- Local Lean build: `lake build` — pass; `Build completed successfully (10954 jobs).`
- Axiom audit: `lake exe axioms` — pass; `axioms: audited 108027 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`
- Lint: `env PATH=/opt/homebrew/opt/gnu-sed/libexec/gnubin:$PATH bash scripts/lint-env.sh && python3 scripts/lint-dot-notation.py && bash scripts/lint-style.sh && lake exe module-system` — pass with no new violations; all 4,804 source headers conform and all 4,805 modules use the module system
- Proof golf: pinned-source import-boundary pass — replaced the broad public universal-enveloping import with direct public isotypy and multiplicity owners, retained the universal-enveloping decomposition theorem as a private proof dependency, and compiled the unchanged public consumer surface
- Public CI: pending after repair push

## Scale and generality

The aggregate is one 210-line module with seven public criteria. The supplied-vector pairwise and fixed-type theorems work over any characteristic-zero field and any finite linearly ordered matrix index type, without finite-dimensionality or algebraic closure. The global criteria add algebraic closure and finite-dimensionality only where highest-weight existence needs them; the named-carrier result identifies an irreducible carrier for nonzero ambient modules, the zero ambient module is handled vacuously, and only the counted theorem assumes `ComplementedLattice`.

## Scope

- **Consumes:** `exists_isGlHighestWeightVector`, `nonempty_lieModuleEquiv_of_isGlHighestWeightVector`, `isGlHighestWeightVector_glIrreducibleGenerator`, `LieModule.isotypicMultiplicity_eq_zero_of_subsingleton_codomain`, `LieModule.nonempty_lieModuleEquiv_of_isIsotypicOfType`, and the generic highest-weight single-weight criterion as formal precedent
- **Provides:** generic supplied-vector pairwise and arbitrary-type isotypy criteria, finite-dimensional global criteria, the dominant-integral consequence, the `glIrreducible N mu` specialization, and a counted direct-sum equivalence including the empty zero-module decomposition
- **Fits:** the pairwise theorem feeds `car_isotypic`, while the fixed-carrier and complete-reducibility forms supply the reusable classification and exact decomposition shape required by the CAR multiplicity milestone
- **Boundary:** assumes complete reducibility only for the counted equivalence and does not duplicate the separate theorem deriving it from semisimple central action; the CAR staircase-weight and simple-submodule calculation remain separate

<sub>🤖 GPT-5.6 Sol high · TauCetiWorker @ [910d954](https://github.com/utensil/TauCetiWorker/commit/910d954fee75dfafda41f98165ce3a9e6676eae1) · rubrics @ [afb424e](https://github.com/utensil/TauCetiReview/commit/afb424eda89e8ac96d9eb69f6a88972055a4cd1b) · local review @ [b533e56](https://github.com/utensil/formal-land/commit/b533e561b6d44df071c31335ed4a63ae647507d2) · fixed: attribution, correctness, api-design, generality, placement, naming, documentation, proof-quality</sub>