### PR TITLE
feat: topologize the compact Spin stabilizer equivalence

### DIFF
--- a/TauCeti/Topology/Algebra/CliffordAlgebra/Spin.lean
+++ b/TauCeti/Topology/Algebra/CliffordAlgebra/Spin.lean
@@ -264,9 +264,11 @@ theorem realCliffordSpinContinuousMulEquivLastStabilizer_apply
 
 /-- The multiplicative equivalence underlying the topological stabilizer equivalence is the
 canonical algebraic stabilizer equivalence. -/
+@[simp]
 theorem realCliffordSpinContinuousMulEquivLastStabilizer_toMulEquiv
     (n : ℕ) [NeZero n] :
-    (realCliffordSpinContinuousMulEquivLastStabilizer n).toMulEquiv =
+    (realCliffordSpinContinuousMulEquivLastStabilizer n :
+        realCliffordSpinGroupZero n ≃* realCliffordSpinLastStabilizer n) =
       realCliffordSpinEquivLastStabilizer n := by
   apply MulEquiv.ext
   intro x

--- a/TauCeti/Topology/Algebra/CliffordAlgebra/Spin.lean
+++ b/TauCeti/Topology/Algebra/CliffordAlgebra/Spin.lean
@@ -65,6 +65,8 @@ topologized special orthogonal group.
 * `CliffordAlgebra.isClosed_realCliffordSpinLastStabilizer` proves that this stabilizer is closed.
 * `CliffordAlgebra.continuous_realCliffordSpinStabilizerInclusion` proves continuity after
   restricting the inclusion's codomain to the last-vector stabilizer.
+* `CliffordAlgebra.realCliffordSpinContinuousMulEquivLastStabilizer` identifies the lower-rank
+  Spin group with the full last-vector stabilizer as a topological group.
 
 ## References
 
@@ -240,6 +242,46 @@ to the last-vector stabilizer. -/
 theorem continuous_realCliffordSpinStabilizerInclusion (n : ℕ) :
     Continuous (realCliffordSpinStabilizerInclusion n) :=
   (isEmbedding_realCliffordSpinStabilizerInclusion n).continuous
+
+/-- For positive `n`, the lower-rank compact Spin group is isomorphic as a topological group to
+the full last-vector stabilizer in `Spin(n + 1)`. -/
+noncomputable def realCliffordSpinContinuousMulEquivLastStabilizer
+    (n : ℕ) [NeZero n] :
+    realCliffordSpinGroupZero n ≃ₜ* realCliffordSpinLastStabilizer n :=
+  ContinuousMulEquiv.mk'
+    ((isEmbedding_realCliffordSpinStabilizerInclusion n).toHomeomorphOfSurjective
+      (realCliffordSpinStabilizerInclusion_surjective n))
+    (map_mul (realCliffordSpinStabilizerInclusion n))
+
+/-- The forward map of the topological stabilizer equivalence is the canonical lower-rank Spin
+inclusion into the stabilizer. -/
+@[simp]
+theorem realCliffordSpinContinuousMulEquivLastStabilizer_apply
+    (n : ℕ) [NeZero n] (x : realCliffordSpinGroupZero n) :
+    realCliffordSpinContinuousMulEquivLastStabilizer n x =
+      realCliffordSpinStabilizerInclusion n x :=
+  (rfl)
+
+/-- The multiplicative equivalence underlying the topological stabilizer equivalence is the
+canonical algebraic stabilizer equivalence. -/
+theorem realCliffordSpinContinuousMulEquivLastStabilizer_toMulEquiv
+    (n : ℕ) [NeZero n] :
+    (realCliffordSpinContinuousMulEquivLastStabilizer n).toMulEquiv =
+      realCliffordSpinEquivLastStabilizer n := by
+  apply MulEquiv.ext
+  intro x
+  exact (realCliffordSpinContinuousMulEquivLastStabilizer_apply n x).trans
+    (realCliffordSpinEquivLastStabilizer_apply n x).symm
+
+/-- The inverse topological stabilizer equivalence sends an included element back to the original
+lower-rank Spin element. -/
+@[simp]
+theorem realCliffordSpinContinuousMulEquivLastStabilizer_symm_apply_inclusion
+    (n : ℕ) [NeZero n] (x : realCliffordSpinGroupZero n) :
+    (realCliffordSpinContinuousMulEquivLastStabilizer n).symm
+      (realCliffordSpinStabilizerInclusion n x) = x := by
+  rw [← realCliffordSpinContinuousMulEquivLastStabilizer_apply]
+  exact (realCliffordSpinContinuousMulEquivLastStabilizer n).symm_apply_apply x
 
 end
 


### PR DESCRIPTION
This PR packages the lower-rank compact Spin inclusion as a continuous multiplicative equivalence with the full last-vector stabilizer for the SpinRepresentations Layer 7 compact-connectivity milestone.

Roadmap: RepresentationTheory

## Summary

It combines the algebraic stabilizer equivalence merged in #6133 with the topological embedding merged in #6140. Mathlib's `Topology.IsEmbedding.toHomeomorphOfSurjective` supplies the inverse continuity, and `ContinuousMulEquiv.mk'` retains the group law. Forward, inverse-on-inclusion, and underlying-`MulEquiv` equations expose the complete boundary without unfolding the construction; the underlying equivalence equation is a simplifier normal form matching the canonical algebraic API. No Mathlib implementation is vendored; the stabilizer construction follows Lawson and Michelsohn, *Spin Geometry*, Chapter I §2, as already cited in the module.

## Roadmap target

This advances RepresentationTheory / SpinRepresentations Layer 7, “Connectivity of the compact spin group,” along the `L7-spinq → L7-con` dependency chain by closing the topological last-stabilizer identification `Spin(n) ≃ₜ* Stab(Spin(n + 1), e_last)` for positive `n`. After this PR, open #6159's generic quotient-stabilizer homeomorphism must be instantiated with a compact Spin sphere action, and the resulting sphere bundle must be used for the connectedness and simple-connectivity induction; closed #5914 is not replayed here.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"real-clifford-spin-continuous-mul-equiv-last-stabilizer"}-->

## Verification

- Exact head: `b13be4a90df2f8f0746fa0c285852c650771af3d`
- Local Lean build: `lake build` — pass; 10,958 jobs
- Axiom audit: `lake exe axioms` — pass; 108,061 declarations use only `propext`, `Classical.choice`, and `Quot.sound`
- Lint: environment lint, dot-notation, style, module-system, and `git diff --check` — pass with no new violations; all 4,809 modules use the module system
- Public CI: pending for the repair head; the prior published head passed its exact-head sandboxed build and workflow-pinned audits

## Scale and generality

The change adds 44 lines to the existing real Spin topology module. It is uniform in every positive natural rank and assumes only `[NeZero n]`, exactly the hypothesis required by the landed full-stabilizer surjectivity theorem. It adds no compactness, Hausdorffness, finite-dimensionality, or topology assumptions beyond the canonical instances already carried by the source and target groups.

## Scope

- **Consumes:** `realCliffordSpinStabilizerInclusion_surjective`, `isEmbedding_realCliffordSpinStabilizerInclusion`, the existing algebraic stabilizer equivalence, and Mathlib's embedded-surjection homeomorphism and continuous multiplicative equivalence constructors
- **Provides:** `realCliffordSpinContinuousMulEquivLastStabilizer` with its forward, inverse-on-inclusion, and simplifier-normalized underlying-algebraic-equivalence laws
- **Fits:** identifies the lower-rank topological group with the exact fibre subgroup used by the Layer 7 compact Spin homogeneous-space and sphere-bundle construction
- **Boundary:** does not define a sphere action, replay closed #5914, prove compactness, construct a bundle, or prove connectedness, simple connectivity, or the universal-cover theorem

<sub>🤖 GPT-5.6 Sol high · TauCetiWorker @ [910d954fee75dfafda41f98165ce3a9e6676eae1](https://github.com/utensil/TauCetiWorker/commit/910d954fee75dfafda41f98165ce3a9e6676eae1) · rubrics @ [afb424eda89e8ac96d9eb69f6a88972055a4cd1b](https://github.com/utensil/TauCetiReview/commit/afb424eda89e8ac96d9eb69f6a88972055a4cd1b) · local review @ [b533e561b6d44df071c31335ed4a63ae647507d2](https://github.com/utensil/formal-land/commit/b533e561b6d44df071c31335ed4a63ae647507d2) · fixed: reuse, api-design</sub>