### PR TITLE
feat: prove Hopf base change for weight Levis

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Weight/Levi/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Weight/Levi/BaseChange.lean
@@ -23,9 +23,9 @@ on scalar tensors of quotient coordinates is explicit. Repeated weights and rank
 allowed. The universe restriction on the bundled isomorphism is inherited from
 `coordinateHopfAlgebraBaseChangeIso`.
 
-The quotient-transport construction follows
-`TauCeti.SpecialLinear.coordinateHopfAlgebraBaseChangeIso`, using the two opposite
-weight-parabolic relation sets in place of the determinant-one relation.
+The two opposite weight parabolics impose vanishing of entries in opposite strict weight
+directions. Together their relations kill exactly the entries between distinct weight blocks,
+so their intersection is the weight Levi.
 
 ## References
 
@@ -83,6 +83,9 @@ theorem map_baseChangeHopfIdeal_weightLeviDefiningHopfIdeal :
       obtain ⟨i, j, hij, rfl⟩ := (mem_weightParabolicRelationSet_iff K a x).mp hx
       exact ⟨_, X_mem_weightParabolicRelationSet R a hij, hentry i j⟩
   rw [Set.image_union, hrel, hrel]
+
+-- The quotient-transport construction is adapted from
+-- `TauCeti.SpecialLinear.coordinateHopfAlgebraBaseChangeIso`.
 
 /-- Scalar extension of a weight-Levi coordinate Hopf algebra is canonically the weight-Levi
 coordinate Hopf algebra over the new base. -/

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Weight/Levi/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Weight/Levi/BaseChange.lean
@@ -68,8 +68,11 @@ theorem map_baseChangeHopfIdeal_weightLeviDefiningHopfIdeal :
             (coordinateRingMap R N (MvPolynomial.X (i, j)))) =
         coordinateHopfAlgebraAlgEquiv K N
           (coordinateRingMap K N (MvPolynomial.X (i, j))) := by
-    simpa only [MvPolynomial.map_X, one_smul] using
-      coordinateHopfAlgebraBaseChangeIso_hom_apply.{u, v} R K N 1 (MvPolynomial.X (i, j))
+    simpa only [Matrix.map_apply, genericMatrix_apply, AlgHom.comp_apply,
+      AlgHom.coe_restrictScalars', BialgHom.coe_toAlgHom,
+      Algebra.TensorProduct.includeRight_apply] using
+      congrArg (fun M ↦ M i j)
+        (coordinateHopfAlgebraBaseChangeIso_hom_genericMatrix.{u, v} R K N)
   have hrel (a : Fin N → ℤ) :
       (fun x : coordinateHopfAlgebra R N ↦
         (coordinateHopfAlgebraBaseChangeIso R K N).hom.hom (1 ⊗ₜ[R] x)) ''

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Weight/Levi/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Weight/Levi/BaseChange.lean
@@ -1,0 +1,141 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Coordinate.BaseChange
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Weight.Levi.Basic
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.BaseChange
+
+/-!
+# Base change of general-linear weight Levis
+
+The weight Levi attached to `w : Fin N → ℤ` commutes with arbitrary extension of the
+commutative base ring as an affine group scheme. Its coordinate Hopf algebra is the quotient
+of `O(GL_N)` by the entries between distinct weight blocks. The general-linear base-change
+isomorphism preserves those entries, so the quotient comparison preserves the Hopf structure.
+This permits transporting closed subgroups and their unipotence to the geometric fibre.
+
+The comparison is compatible with the ambient general-linear coordinate maps, and its action
+on scalar tensors of quotient coordinates is explicit. Repeated weights and rank zero are
+allowed. The universe restriction on the bundled isomorphism is inherited from
+`coordinateHopfAlgebraBaseChangeIso`.
+
+The quotient-transport construction follows
+`TauCeti.SpecialLinear.coordinateHopfAlgebraBaseChangeIso`, using the two opposite
+weight-parabolic relation sets in place of the determinant-one relation.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Chapters 2 and 13.
+* G. R. Kempf, *Instability in invariant theory*, Annals of Mathematics 108 (1978), §2.
+-/
+
+public section
+
+open CategoryTheory
+open scoped TensorProduct
+
+namespace TauCeti.GeneralLinear
+
+universe u v
+
+variable (R : Type u) (K : Type max u v) [CommRing R] [CommRing K] [Algebra R K]
+variable {N : ℕ} (w : Fin N → ℤ)
+
+/-- The ambient general-linear base-change isomorphism carries the scalar extension of the
+weight-Levi defining Hopf ideal onto the defining Hopf ideal over the extended base. -/
+theorem map_baseChangeHopfIdeal_weightLeviDefiningHopfIdeal :
+    (CommHopfAlgCat.baseChangeHopfIdeal (K := K) (weightLeviDefiningHopfIdeal R w)).map
+        (coordinateHopfAlgebraBaseChangeIso R K N).hom.hom =
+      weightLeviDefiningHopfIdeal K w := by
+  refine CommHopfAlgCat.map_baseChangeHopfIdeal_of_toIdeal_eq_span
+    (S := weightParabolicRelationSet R w ∪ weightParabolicRelationSet R (-w))
+    (S' := weightParabolicRelationSet K w ∪ weightParabolicRelationSet K (-w))
+    (weightLeviDefiningHopfIdeal R w) (weightLeviDefiningHopfIdeal K w)
+    (coordinateHopfAlgebraBaseChangeIso R K N)
+    (by rw [weightLeviDefiningHopfIdeal_def, HopfIdeal.sup_toIdeal,
+      weightParabolicDefiningHopfIdeal_toIdeal, weightParabolicDefiningHopfIdeal_toIdeal,
+      Ideal.span_union])
+    (by rw [weightLeviDefiningHopfIdeal_def, HopfIdeal.sup_toIdeal,
+      weightParabolicDefiningHopfIdeal_toIdeal, weightParabolicDefiningHopfIdeal_toIdeal,
+      Ideal.span_union]) ?_
+  have hentry (i j : Fin N) :
+      (coordinateHopfAlgebraBaseChangeIso R K N).hom.hom
+          (1 ⊗ₜ[R] coordinateHopfAlgebraAlgEquiv R N
+            (coordinateRingMap R N (MvPolynomial.X (i, j)))) =
+        coordinateHopfAlgebraAlgEquiv K N
+          (coordinateRingMap K N (MvPolynomial.X (i, j))) := by
+    simpa only [MvPolynomial.map_X, one_smul] using
+      coordinateHopfAlgebraBaseChangeIso_hom_apply.{u, v} R K N 1 (MvPolynomial.X (i, j))
+  have hrel (a : Fin N → ℤ) :
+      (fun x : coordinateHopfAlgebra R N ↦
+        (coordinateHopfAlgebraBaseChangeIso R K N).hom.hom (1 ⊗ₜ[R] x)) ''
+          weightParabolicRelationSet R a = weightParabolicRelationSet K a := by
+    ext x
+    constructor
+    · rintro ⟨y, hy, rfl⟩
+      obtain ⟨i, j, hij, rfl⟩ := (mem_weightParabolicRelationSet_iff R a y).mp hy
+      exact (mem_weightParabolicRelationSet_iff K a _).mpr ⟨i, j, hij, hentry i j⟩
+    · intro hx
+      obtain ⟨i, j, hij, rfl⟩ := (mem_weightParabolicRelationSet_iff K a x).mp hx
+      exact ⟨_, X_mem_weightParabolicRelationSet R a hij, hentry i j⟩
+  rw [Set.image_union, hrel, hrel]
+
+/-- Scalar extension of a weight-Levi coordinate Hopf algebra is canonically the weight-Levi
+coordinate Hopf algebra over the new base. -/
+noncomputable def weightLeviCoordinateHopfAlgebraBaseChangeIso :
+    CommHopfAlgCat.baseChange (K := K) (weightLeviCoordinateHopfAlgebra R w) ≅
+      weightLeviCoordinateHopfAlgebra K w :=
+  CommHopfAlgCat.quotientBaseChangeIsoOfMapEq
+    (weightLeviDefiningHopfIdeal R w) (weightLeviDefiningHopfIdeal K w)
+    (coordinateHopfAlgebraBaseChangeIso R K N)
+    (map_baseChangeHopfIdeal_weightLeviDefiningHopfIdeal R K w)
+
+/-- The weight-Levi base-change isomorphism commutes with restriction of ambient
+general-linear coordinates to the Levi. -/
+@[simp]
+theorem baseChangeMap_mkQuotient_comp_weightLeviCoordinateHopfAlgebraBaseChangeIso_hom :
+    CommHopfAlgCat.baseChangeMap (K := K)
+        (CommHopfAlgCat.mkQuotient _ (weightLeviDefiningHopfIdeal R w)) ≫
+      (weightLeviCoordinateHopfAlgebraBaseChangeIso R K w).hom =
+    (coordinateHopfAlgebraBaseChangeIso R K N).hom ≫
+      CommHopfAlgCat.mkQuotient _ (weightLeviDefiningHopfIdeal K w) := by
+  exact CommHopfAlgCat.baseChangeMap_mkQuotient_comp_quotientBaseChangeIsoOfMapEq_hom
+    (weightLeviDefiningHopfIdeal R w) (weightLeviDefiningHopfIdeal K w)
+    (coordinateHopfAlgebraBaseChangeIso R K N)
+    (map_baseChangeHopfIdeal_weightLeviDefiningHopfIdeal R K w)
+
+/-- On a scalar tensor of a quotient coordinate, the Levi comparison is induced by the
+ambient general-linear comparison. -/
+@[simp]
+theorem weightLeviCoordinateHopfAlgebraBaseChangeIso_hom_tmul_mk
+    (s : K) (x : coordinateHopfAlgebra R N) :
+    (weightLeviCoordinateHopfAlgebraBaseChangeIso R K w).hom
+        (s ⊗ₜ[R] Ideal.Quotient.mk (weightLeviDefiningHopfIdeal R w).toIdeal x) =
+      Ideal.Quotient.mk (weightLeviDefiningHopfIdeal K w).toIdeal
+        ((coordinateHopfAlgebraBaseChangeIso R K N).hom (s ⊗ₜ[R] x)) := by
+  have h := congrArg (fun f ↦ f.hom (s ⊗ₜ[R] x))
+    (baseChangeMap_mkQuotient_comp_weightLeviCoordinateHopfAlgebraBaseChangeIso_hom R K w)
+  simpa only [_root_.CommHopfAlgCat.hom_comp, BialgHom.comp_apply,
+    CommHopfAlgCat.baseChangeMap_apply_tmul (K := K)
+      (CommHopfAlgCat.mkQuotient _ (weightLeviDefiningHopfIdeal R w)),
+    CommHopfAlgCat.mkQuotient_apply _ (weightLeviDefiningHopfIdeal R w),
+    CommHopfAlgCat.mkQuotient_apply _ (weightLeviDefiningHopfIdeal K w),
+    Ideal.Quotient.mkₐ_eq_mk] using h
+
+/-- The inverse Levi comparison sends a quotient of an ambient base-changed coordinate
+back to the corresponding scalar tensor of a quotient coordinate. -/
+@[simp]
+theorem weightLeviCoordinateHopfAlgebraBaseChangeIso_inv_mk
+    (s : K) (x : coordinateHopfAlgebra R N) :
+    (weightLeviCoordinateHopfAlgebraBaseChangeIso R K w).inv
+        (Ideal.Quotient.mk (weightLeviDefiningHopfIdeal K w).toIdeal
+          ((coordinateHopfAlgebraBaseChangeIso R K N).hom (s ⊗ₜ[R] x))) =
+      s ⊗ₜ[R] Ideal.Quotient.mk (weightLeviDefiningHopfIdeal R w).toIdeal x := by
+  rw [← weightLeviCoordinateHopfAlgebraBaseChangeIso_hom_tmul_mk]
+  simp
+
+end TauCeti.GeneralLinear

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Weight/Levi/Geometry.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Weight/Levi/Geometry.lean
@@ -8,7 +8,7 @@ module
 public import Mathlib.RingTheory.Localization.BaseChange
 public import Mathlib.RingTheory.Smooth.Basic
 public import TauCeti.Algebra.AlgebraicGroup.Connected.CommHopfAlgCat
-public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Weight.Levi.Basic
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Weight.Levi.BaseChange
 
 /-!
 # Geometry of general-linear weight Levis
@@ -27,8 +27,6 @@ the weight Levi is geometrically connected.
 
 * `TauCeti.GeneralLinear.WeightLeviIndex`: the matrix entries within equal-weight blocks.
 * `TauCeti.GeneralLinear.weightLeviCoordinateAlgEquiv`: the localized polynomial presentation.
-* `TauCeti.GeneralLinear.weightLeviCoordinateHopfAlgebraBaseChangeRingEquiv`: compatibility of
-  the presentation with scalar extension.
 * `TauCeti.GeneralLinear.instSmoothWeightLeviCoordinateHopfAlgebra`: every weight Levi is smooth.
 * `TauCeti.GeneralLinear.geometricallyConnectedCommHopfAlgProperty_weightLeviCoordinateHopfAlgebra`:
   every weight Levi over a field is geometrically connected.
@@ -458,54 +456,6 @@ theorem weightLeviCoordinateRingBaseChangeAlgEquiv_tmul_algebraMap
     ← IsScalarTower.algebraMap_apply K (MvPolynomial (WeightLeviIndex w) K)]
   rw [Algebra.smul_def]
 
-/-- Scalar extension of the weight-Levi coordinate Hopf algebra is ring-equivalent to the
-weight-Levi coordinate Hopf algebra over the extended base ring. -/
-def weightLeviCoordinateHopfAlgebraBaseChangeRingEquiv
-    (k : Type u) (K : Type v) [CommRing k] [CommRing K] [Algebra k K] (w : Fin N → ℤ) :
-    weightLeviCoordinateHopfAlgebra k w ⊗[k] K ≃+*
-      weightLeviCoordinateHopfAlgebra K w :=
-  (Algebra.TensorProduct.congr (weightLeviCoordinateAlgEquiv k w)
-    (AlgEquiv.refl : K ≃ₐ[k] K)).toRingEquiv.trans <|
-  (Algebra.TensorProduct.comm k (WeightLeviCoordinateRing k w) K).toRingEquiv.trans <|
-  (weightLeviCoordinateRingBaseChangeAlgEquiv k K w).toRingEquiv.trans <|
-  (weightLeviCoordinateAlgEquiv K w).symm.toRingEquiv
-
-/-- Base change carries each quotient generic-matrix entry of the weight Levi to the
-corresponding quotient generic-matrix entry over the new base. -/
-@[simp]
-theorem weightLeviCoordinateHopfAlgebraBaseChangeRingEquiv_tmul_mk_genericMatrix_apply
-    (k : Type u) (K : Type v) [CommRing k] [CommRing K] [Algebra k K] (w : Fin N → ℤ)
-    (i j : Fin N) :
-    weightLeviCoordinateHopfAlgebraBaseChangeRingEquiv k K w
-        (Ideal.Quotient.mk (weightLeviDefiningHopfIdeal k w).toIdeal
-          (coordinateHopfAlgebraAlgEquiv k N
-            (coordinateRingMap k N (MvPolynomial.X (i, j)))) ⊗ₜ[k] (1 : K)) =
-      Ideal.Quotient.mk (weightLeviDefiningHopfIdeal K w).toIdeal
-        (coordinateHopfAlgebraAlgEquiv K N
-          (coordinateRingMap K N (MvPolynomial.X (i, j)))) := by
-  rw [← genericMatrix_apply (R := k) (n := N) i j,
-    ← genericMatrix_apply (R := K) (n := N) i j,
-    ← Ideal.Quotient.mkₐ_eq_mk (R₁ := k),
-    ← Ideal.Quotient.mkₐ_eq_mk (R₁ := K)]
-  by_cases hij : w i = w j
-  · -- Unfold the composed ring equivalence just enough to expose its presentation and
-    -- localization base-change stages, whose generator computation lemmas apply below.
-    change (weightLeviCoordinateAlgEquiv K w).symm
-        (weightLeviCoordinateRingBaseChangeAlgEquiv k K w
-          ((1 : K) ⊗ₜ[k] weightLeviCoordinateAlgEquiv k w
-            (Ideal.Quotient.mkₐ k (weightLeviDefiningHopfIdeal k w).toIdeal
-              ((genericMatrix k N) i j)))) = _
-    rw [genericMatrix_apply, Ideal.Quotient.mkₐ_eq_mk,
-      weightLeviCoordinateAlgEquiv_mk_genericMatrix_apply,
-      weightLeviLocalizedGenericMatrix_apply_of_eq k w hij,
-      IsScalarTower.toAlgHom_apply,
-      weightLeviCoordinateRingBaseChangeAlgEquiv_tmul_algebraMap,
-      MvPolynomial.map_X, one_smul,
-      weightLeviCoordinateAlgEquiv_symm_algebraMap_X]
-  · simp [weightLeviCoordinateHopfAlgebraBaseChangeRingEquiv,
-      weightLeviQuotient_mk_genericMatrix_apply_of_ne k w hij,
-      weightLeviQuotient_mk_genericMatrix_apply_of_ne K w hij]
-
 /-- The weight Levi is geometrically connected over every field. -/
 theorem geometricallyConnectedCommHopfAlgProperty_weightLeviCoordinateHopfAlgebra
     (k : Type u) [Field k] (w : Fin N → ℤ) :
@@ -513,9 +463,10 @@ theorem geometricallyConnectedCommHopfAlgProperty_weightLeviCoordinateHopfAlgebr
       (weightLeviCoordinateHopfAlgebra k w) := by
   rw [geometricallyConnectedCommHopfAlgProperty_iff]
   intro K _ _
-  exact (PrimeSpectrum.homeomorphOfRingEquiv
-    (weightLeviCoordinateHopfAlgebraBaseChangeRingEquiv k K w)).connectedSpace_iff.mpr
-      inferInstance
+  let e := (Algebra.TensorProduct.comm k
+    (weightLeviCoordinateHopfAlgebra k w) K).toRingEquiv.trans (CommHopfAlgCat.ofIso
+      (weightLeviCoordinateHopfAlgebraBaseChangeIso k K w)).toAlgEquiv.toRingEquiv
+  exact (PrimeSpectrum.homeomorphOfRingEquiv e).connectedSpace_iff.mpr inferInstance
 
 end
 


### PR DESCRIPTION
Scalar extension of a general-linear weight Levi is canonically the Levi over the new base as a commutative Hopf algebra. The comparison transports the defining Hopf ideal through the ambient general-linear base-change isomorphism and exposes quotient-map compatibility and forward and inverse pure-tensor formulas.

The Hopf isomorphism is the canonical comparison for the quotient coordinate algebra. Geometric connectedness now uses its underlying ring equivalence after tensor commutation; the obsolete ring comparison and its generator formula are deleted. The module introduction explains how the two opposite parabolic relation sets define the Levi, with source credit retained beside the construction.

This advances [TauCetiRoadmap/ReductiveGroups/README.md, Layer 7, “Structure theory”](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/ReductiveGroups/README.md#layer-7-structure-theory), specifically parabolic subgroups and Levi decomposition via the dynamic approach. The Hopf comparison supplies the geometric-fibre identification needed by `reductiveCommHopfAlgProperty_of_geometricFiber_iso` for arbitrary-weight Levi reductivity, which in turn supports the arbitrary-weight unipotent-radical identification.

The comparison works over arbitrary commutative base rings without flatness, characteristic, positive-rank, or distinct-weight hypotheses. Its bundled universe convention is inherited from the ambient general-linear comparison. The construction reuses Hopf-ideal base-change and quotient-transport infrastructure and credits the special-linear construction, Milne, and Kempf in the source.

Validation:

- `lake exe cache get` completed.
- Targeted `lake build` passed for `GeneralLinear.Weight.Levi.BaseChange`, `GeneralLinear.Weight.Levi.Geometry`, and the downstream `GeneralLinear.Dynamic.Weight.Parabolic.Geometry` modules (all under `TauCeti.Algebra.AlgebraicGroup`).
- `tauceti-axioms --changed-since-merge-base origin/main` passed for all 74 declarations in the two changed modules.
- `tauceti-lint-env --changed-since-merge-base origin/main` stopped at its freshness guard because the wrapper omits Mathlib's new default `tacticAlt`. A temporary copy adding exactly that linter passed the full current default set: zero violations, zero grandfathered findings, and all 13 scanned declarations documented. No repository scripts or linter settings were changed.
- `git diff --check` passed.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"weight-levi-hopf-base-change"}-->
