### PR TITLE
feat: construct the CAR highest-weight vector

### DIFF
--- a/TauCeti/Algebra/Lie/GeneralLinear/CAR/HighestWeight.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/CAR/HighestWeight.lean
@@ -73,11 +73,33 @@ theorem mem_carPositiveRootPairs {n : Type*} [Fintype n] [LinearOrder n] {i j : 
   let _ : LinearOrder (n ×ₗ n) := Prod.Lex.instLinearOrder n n
   exact LinearOrder.lift' toLex (Equiv.injective toLex)
 
+/-- The increasing enumeration of positive-root pairs, valued in the lexicographically ordered
+pair type. -/
+noncomputable def carPositiveRootPairOrderEmbedding
+    (n : Type*) [Fintype n] [LinearOrder n] :
+    Fin (carPositiveRootPairs n).card ↪o n ×ₗ n := by
+  let _ : LinearOrder (n ×ₗ n) := Prod.Lex.instLinearOrder n n
+  let _ : LinearOrder (n × n) := carPairLinearOrder n
+  exact ((carPositiveRootPairs n).orderEmbOfFin rfl).trans
+    { toFun := toLex
+      inj' := Equiv.injective toLex
+      map_rel_iff' := Iff.rfl }
+
 /-- The positive-root pair at a given place in the canonical lexicographic enumeration. -/
 noncomputable def carPositiveRootPair (n : Type*) [Fintype n] [LinearOrder n]
     (r : Fin (carPositiveRootPairs n).card) : n × n := by
   let _ := carPairLinearOrder n
   exact (carPositiveRootPairs n).orderEmbOfFin rfl r
+
+/-- The order embedding enumerates the same pair as `carPositiveRootPair`. -/
+@[simp]
+theorem carPositiveRootPairOrderEmbedding_apply (n : Type*) [Fintype n] [LinearOrder n]
+    (r : Fin (carPositiveRootPairs n).card) :
+    ofLex (carPositiveRootPairOrderEmbedding n r) = carPositiveRootPair n r := by
+  let _ : LinearOrder (n ×ₗ n) := Prod.Lex.instLinearOrder n n
+  let _ : LinearOrder (n × n) := carPairLinearOrder n
+  rw [carPositiveRootPair.eq_def]
+  rfl
 
 /-- Every pair in the canonical enumeration is a positive-root pair. -/
 @[simp]
@@ -87,6 +109,23 @@ theorem carPositiveRootPair_mem (n : Type*) [Fintype n] [LinearOrder n]
   let _ := carPairLinearOrder n
   rw [carPositiveRootPair.eq_def]
   exact Finset.orderEmbOfFin_mem (carPositiveRootPairs n) rfl r
+
+/-- The canonical enumeration ranges over exactly the positive-root pairs. -/
+theorem range_carPositiveRootPair (n : Type*) [Fintype n] [LinearOrder n] :
+    Set.range (carPositiveRootPair n) = carPositiveRootPairs n := by
+  let _ : LinearOrder (n ×ₗ n) := Prod.Lex.instLinearOrder n n
+  let _ : LinearOrder (n × n) := carPairLinearOrder n
+  ext p
+  constructor
+  · rintro ⟨r, rfl⟩
+    exact carPositiveRootPair_mem n r
+  · intro hp
+    have hp' : p ∈ (carPositiveRootPairs n : Set (n × n)) := hp
+    rw [← Finset.range_orderEmbOfFin (carPositiveRootPairs n) rfl] at hp'
+    obtain ⟨r, hr⟩ := hp'
+    refine ⟨r, ?_⟩
+    rw [carPositiveRootPair.eq_def]
+    exact hr
 
 /-- The positive matrix units in the lexicographic order on their index pairs. -/
 noncomputable def carPositiveMatrixUnitFamily (K : Type*) [CommRing K]

--- a/TauCeti/Algebra/Lie/GeneralLinear/CAR/HighestWeight.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/CAR/HighestWeight.lean
@@ -112,19 +112,10 @@ theorem carPositiveRootPair_mem (n : Type*) [Fintype n] [LinearOrder n]
 /-- The canonical enumeration ranges over exactly the positive-root pairs. -/
 theorem range_carPositiveRootPair (n : Type*) [Fintype n] [LinearOrder n] :
     Set.range (carPositiveRootPair n) = carPositiveRootPairs n := by
-  let _ : LinearOrder (n ×ₗ n) := Prod.Lex.instLinearOrder n n
   let _ : LinearOrder (n × n) := carPairLinearOrder n
-  ext p
-  constructor
-  · rintro ⟨r, rfl⟩
-    exact carPositiveRootPair_mem n r
-  · intro hp
-    have hp' : p ∈ (carPositiveRootPairs n : Set (n × n)) := hp
-    rw [← Finset.range_orderEmbOfFin (carPositiveRootPairs n) rfl] at hp'
-    obtain ⟨r, hr⟩ := hp'
-    refine ⟨r, ?_⟩
-    rw [carPositiveRootPair.eq_def]
-    exact hr
+  rw [show carPositiveRootPair n = (carPositiveRootPairs n).orderEmbOfFin rfl by
+    funext r
+    rw [carPositiveRootPair.eq_def], Finset.range_orderEmbOfFin]
 
 /-- The positive matrix units in the lexicographic order on their index pairs. -/
 noncomputable def carPositiveMatrixUnitFamily (K : Type*) [CommRing K]
@@ -140,8 +131,8 @@ theorem carPositiveMatrixUnitFamily_apply (K : Type*) [CommRing K]
     carPositiveMatrixUnitFamily K n r = Matrix.stdBasis K n n (carPositiveRootPair n r) :=
   carPositiveMatrixUnitFamily.eq_def K n r
 
-/-- The ordered product candidate formed from all positive matrix-unit Clifford generators. It is
-proved below to be a highest-weight vector over a field when `2` is invertible. -/
+/-- The ordered product candidate formed from all positive matrix-unit Clifford generators. Over a
+field with invertible `2`, it is a highest-weight vector. -/
 noncomputable def carHighestWeightVector (K : Type*) [CommRing K]
     (n : Type*) [Fintype n] [LinearOrder n] :
     CliffordAlgebra (traceQuadraticForm K n) :=
@@ -178,16 +169,14 @@ theorem carHighestWeightVector_eq_one_of_subsingleton (K : Type*) [CommRing K]
 theorem carPositiveMatrixUnitFamily_mem {K n : Type*} [CommRing K] [Fintype n] [LinearOrder n]
     {i j : n} (hij : i < j) :
     Matrix.single i j (1 : K) ∈ List.ofFn (carPositiveMatrixUnitFamily K n) := by
-  let _ := carPairLinearOrder n
   rw [List.mem_ofFn]
   have hp : (i, j) ∈ carPositiveRootPairs n := by
     exact mem_carPositiveRootPairs.mpr hij
   have hp' : (i, j) ∈ (carPositiveRootPairs n : Set (n × n)) := hp
-  rw [← Finset.range_orderEmbOfFin (carPositiveRootPairs n) rfl] at hp'
+  rw [← range_carPositiveRootPair n] at hp'
   obtain ⟨r, hr⟩ := hp'
   refine ⟨r, ?_⟩
-  rw [carPositiveMatrixUnitFamily_apply, carPositiveRootPair.eq_def, hr,
-    Matrix.stdBasis_eq_single]
+  rw [carPositiveMatrixUnitFamily_apply, hr, Matrix.stdBasis_eq_single]
 
 section Field
 
@@ -399,13 +388,14 @@ the rational staircase `TauCeti.glStaircase N`. -/
 theorem isGlHighestWeightVector_glStaircase_carHighestWeightVector (N : ℕ) :
     IsGlHighestWeightVector (fun i => algebraMap ℚ K (glStaircase N i))
       (carHighestWeightVector K (Fin N)) := by
+  let _ : DecidableEq (Fin N) := inferInstance
   have h := isGlHighestWeightVector_carHighestWeightVector (K := K) (n := Fin N)
   rw [isGlHighestWeightVector_iff] at h ⊢
   refine ⟨h.1, ?_, ?_⟩
   · intro i
-    simpa [half_diagonalScalarSum, Matrix.single] using h.2.1 i
+    simpa [half_diagonalScalarSum] using h.2.1 i
   · intro i j hij
-    simpa [Matrix.single] using h.2.2 i j hij
+    exact h.2.2 i j hij
 
 end CharZero
 

--- a/TauCeti/Algebra/Lie/GeneralLinear/CAR/HighestWeight.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/CAR/HighestWeight.lean
@@ -7,7 +7,7 @@ module
 
 public import TauCeti.Algebra.Lie.GeneralLinear.Fock
 public import TauCeti.Algebra.Lie.GeneralLinear.HighestWeight
-import TauCeti.LinearAlgebra.CliffordAlgebra.FiltrationGradedEquiv
+import TauCeti.LinearAlgebra.CliffordAlgebra.PBW
 
 /-!
 # A highest-weight vector in the CAR algebra
@@ -17,8 +17,8 @@ constructs the ordered-product candidate
 
 `∏_{i < j} dᵢⱼ`,
 
-where `dᵢⱼ = ι(Eᵢⱼ)`, for any finite linearly ordered index type. Over a field in which
-the candidate is nonzero. When `2` is invertible, it is a highest-weight vector of weight
+where `dᵢⱼ = ι(Eᵢⱼ)`, for any finite linearly ordered index type. Over any field, the candidate
+is nonzero. When `2` is invertible, it is a highest-weight vector of weight
 `i ↦ 1/2 * (1 + 2 * #{j | i < j})`. For `n = Fin N` in characteristic zero, this is the
 staircase `(N - 1/2, N - 3/2, …, 1/2)` required by the later CAR simple-submodule and isotypy
 results.

--- a/TauCeti/Algebra/Lie/GeneralLinear/CAR/HighestWeight.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/CAR/HighestWeight.lean
@@ -18,7 +18,7 @@ constructs the ordered-product candidate
 `∏_{i < j} dᵢⱼ`,
 
 where `dᵢⱼ = ι(Eᵢⱼ)`, for any finite linearly ordered index type. Over a field in which
-`2` is invertible, the candidate is nonzero and is a highest-weight vector of weight
+the candidate is nonzero. When `2` is invertible, it is a highest-weight vector of weight
 `i ↦ 1/2 * (1 + 2 * #{j | i < j})`. For `n = Fin N` in characteristic zero, this is the
 staircase `(N - 1/2, N - 3/2, …, 1/2)` required by the later CAR simple-submodule and isotypy
 results.
@@ -30,8 +30,7 @@ results.
 
 ## Main results
 
-* `TauCeti.carHighestWeightVector_ne_zero`: the candidate is nonzero over a field when `2` is
-  invertible.
+* `TauCeti.carHighestWeightVector_ne_zero`: the candidate is nonzero over any field.
 * `TauCeti.carHighestWeightVector_eq_one_of_subsingleton`: in ranks zero and one the empty
   ordered product is `1`.
 * `TauCeti.isGlHighestWeightVector_carHighestWeightVector`: its direct highest-weight equation.
@@ -175,12 +174,9 @@ theorem carHighestWeightVector_eq_one_of_subsingleton (K : Type*) [CommRing K]
   rw [hroots]
   simp
 
-section Field
-
-variable {K n : Type*} [Field K] [Fintype n] [LinearOrder n]
-
 /-- Every positive matrix unit occurs in the canonical family. -/
-theorem carPositiveMatrixUnitFamily_mem {i j : n} (hij : i < j) :
+theorem carPositiveMatrixUnitFamily_mem {K n : Type*} [CommRing K] [Fintype n] [LinearOrder n]
+    {i j : n} (hij : i < j) :
     Matrix.single i j (1 : K) ∈ List.ofFn (carPositiveMatrixUnitFamily K n) := by
   let _ := carPairLinearOrder n
   rw [List.mem_ofFn]
@@ -192,6 +188,10 @@ theorem carPositiveMatrixUnitFamily_mem {i j : n} (hij : i < j) :
   refine ⟨r, ?_⟩
   rw [carPositiveMatrixUnitFamily_apply, carPositiveRootPair.eq_def, hr,
     Matrix.stdBasis_eq_single]
+
+section Field
+
+variable {K n : Type*} [Field K] [Fintype n] [LinearOrder n]
 
 private theorem carPositiveUnits_ortho {i j k l : n}
     (hij : i < j) (hkl : k < l) :
@@ -228,8 +228,8 @@ private theorem iota_mul_prod_eq_zero_of_mem
         rw [← mul_assoc, CliffordAlgebra.ι_mul_ι_comm_of_isOrtho hab, neg_mul,
           mul_assoc, ih ha hol, mul_zero, neg_zero]
 
-/-- The ordered positive-root product is nonzero over a field when `2` is invertible. -/
-theorem carHighestWeightVector_ne_zero [Invertible (2 : K)] :
+/-- The ordered positive-root product is nonzero over any field. -/
+theorem carHighestWeightVector_ne_zero :
     carHighestWeightVector K n ≠ 0 := by
   let _ := carPairLinearOrder n
   have hpositive : LinearIndependent K (carPositiveMatrixUnitFamily K n) := by

--- a/TauCeti/Algebra/Lie/GeneralLinear/CAR/HighestWeight.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/CAR/HighestWeight.lean
@@ -8,45 +8,40 @@ module
 public import TauCeti.Algebra.Lie.GeneralLinear.Fock
 public import TauCeti.Algebra.Lie.GeneralLinear.HighestWeight
 import TauCeti.LinearAlgebra.CliffordAlgebra.FiltrationGradedEquiv
-import Mathlib.LinearAlgebra.ExteriorPower.Basis
-import Mathlib.LinearAlgebra.Matrix.StdBasis
 
 /-!
 # A highest-weight vector in the CAR algebra
 
-For the left `gl_N`-action on the Clifford algebra of the trace quadratic form, this file
-constructs the ordered product
+For the left `gl_n`-action on the Clifford algebra of the trace quadratic form, this file
+constructs the ordered-product candidate
 
-`d₀₁ d₀₂ ⋯ d₀,N₋₁ d₁₂ ⋯ d_N₋₂,N₋₁`,
+`∏_{i < j} dᵢⱼ`,
 
-where `dᵢⱼ = ι(Eᵢⱼ)`, and proves that it is a highest-weight vector of staircase weight
-`(N - 1/2, N - 3/2, …, 1/2)`.
-
-The proof has three ingredients. First, every positive generator `dᵢⱼ`, `i < j`, kills the
-product on the left: it anticommutes through the other positive generators until it meets its own
-copy, whose square is zero. Consequently every summand in the normal-ordered formula
-
-`Eᵢⱼ ↦ 1/2 ∑ₖ dᵢₖ dₖⱼ`
-
-kills the product when `i < j`. For a diagonal matrix unit, the `k`th summand contributes `0`,
-`1`, or `2` according as `k < i`, `k = i`, or `i < k`; after multiplication by `1/2`, this is
-`N - 1/2 - i`. Finally, the product is nonzero because its leading Clifford-filtration term is
-the exterior product of distinct standard matrix units. The PBW equivalence identifies that
-leading term with a nonzero exterior basis vector.
+where `dᵢⱼ = ι(Eᵢⱼ)`, for any finite linearly ordered index type. Over a field in which
+`2` is invertible, the candidate is nonzero and is a highest-weight vector of weight
+`i ↦ 1/2 * (1 + 2 * #{j | i < j})`. For `n = Fin N` in characteristic zero, this is the
+staircase `(N - 1/2, N - 3/2, …, 1/2)` required by the later CAR simple-submodule and isotypy
+results.
 
 ## Main definitions
 
-* `TauCeti.carHighestWeightVector`: the ordered product of the positive matrix-unit Clifford
-  generators.
+* `TauCeti.carPositiveRootFamily`: the canonically ordered positive matrix units.
+* `TauCeti.carHighestWeightVector`: their ordered Clifford product candidate.
 
 ## Main results
 
-* `TauCeti.isGlHighestWeightVector_carHighestWeightVector`: this product is a highest-weight
-  vector for the scalar extension of `TauCeti.glStaircase`.
+* `TauCeti.carHighestWeightVector_ne_zero`: the candidate is nonzero over a field when `2` is
+  invertible.
+* `TauCeti.carHighestWeightVector_eq_one_of_subsingleton`: in ranks zero and one the empty
+  ordered product is `1`.
+* `TauCeti.isGlHighestWeightVector_carHighestWeightVector`: its direct highest-weight equation.
+* `TauCeti.isGlHighestWeightVector_carHighestWeightVector_fin`: the `Fin N` staircase form.
 
 ## References
 
-* W. Fulton, J. Harris, *Representation Theory: A First Course*, Springer GTM 129 (1991), §20.
+* D. Panyushev, *The exterior algebra and "spin" of an orthogonal g-module*, Transform. Groups 6
+  (2001), Proposition 2.4 and Example 2.5(1). The construction below formalizes its `gl_N` on
+  `M_N` worked instance.
 * C. Chevalley, *The Algebraic Theory of Spinors* (1954), Chapter II.
 -/
 
@@ -59,54 +54,79 @@ namespace TauCeti
 noncomputable section
 
 attribute [local instance 100] LieRing.ofAssociativeRing
-attribute [local instance] Classical.decEq
-
 /-! ### The ordered positive-root product -/
 
-/-- The strict upper-triangular matrix units, encoded in a finite linearly ordered type so their
-Clifford generators have a canonical order. -/
-private def carPositiveRootCodes (N : ℕ) : Finset (Fin (N * N)) :=
-  Finset.univ.filter fun p =>
-    let ij := finProdFinEquiv.symm p
-    ij.1 < ij.2
+/-- The positive roots of `gl_n`, represented by strictly upper-triangular index pairs. -/
+@[expose] def carPositiveRootPairs (n : Type*) [Fintype n] [LinearOrder n] : Finset (n × n) :=
+  Finset.univ.filter fun ij => ij.1 < ij.2
 
-/-- The standard matrix unit indexed by an encoded pair. -/
-private noncomputable def carRootMatrix (K : Type*) [CommRing K] (N : ℕ)
-    (p : Fin (N * N)) : Matrix (Fin N) (Fin N) K :=
-  Matrix.stdBasis K (Fin N) (Fin N) (finProdFinEquiv.symm p)
+/-- The lexicographic linear order used to enumerate pairs of ordered indices. -/
+@[instance_reducible] private noncomputable def carPairLinearOrder
+    (n : Type*) [LinearOrder n] : LinearOrder (n × n) := by
+  let _ : LinearOrder (n ×ₗ n) := Prod.Lex.instLinearOrder n n
+  exact LinearOrder.lift' toLex (Equiv.injective toLex)
 
-/-- The increasing enumeration of the positive matrix units. -/
-private noncomputable def carPositiveRootFamily (K : Type*) [CommRing K] (N : ℕ) :
-    Fin (carPositiveRootCodes N).card → Matrix (Fin N) (Fin N) K := fun r =>
-  carRootMatrix K N ((carPositiveRootCodes N).orderEmbOfFin rfl r)
+/-- The positive matrix units in the lexicographic order on their index pairs. -/
+@[expose] noncomputable def carPositiveRootFamily (K : Type*) [CommRing K]
+    (n : Type*) [Fintype n] [LinearOrder n] :
+    Fin (carPositiveRootPairs n).card → Matrix n n K := by
+  let _ : LinearOrder (n ×ₗ n) := Prod.Lex.instLinearOrder n n
+  let _ : LinearOrder (n × n) := LinearOrder.lift' toLex (Equiv.injective toLex)
+  exact fun r => Matrix.stdBasis K n n ((carPositiveRootPairs n).orderEmbOfFin rfl r)
 
-/-- The ordered product of all strictly upper-triangular matrix-unit generators in the Clifford
-algebra of the trace quadratic form. This is the canonical highest-weight vector for the left
-`gl_N`-action on the CAR algebra. -/
-noncomputable def carHighestWeightVector (K : Type*) [CommRing K] (N : ℕ) :
-    CliffordAlgebra (traceQuadraticForm K (Fin N)) :=
-  ((List.ofFn (carPositiveRootFamily K N)).map
-    (CliffordAlgebra.ι (traceQuadraticForm K (Fin N)))).prod
+/-- The ordered product candidate formed from all positive matrix-unit Clifford generators. It is
+proved below to be a highest-weight vector over a field when `2` is invertible. -/
+@[expose] noncomputable def carHighestWeightVector (K : Type*) [CommRing K]
+    (n : Type*) [Fintype n] [LinearOrder n] :
+    CliffordAlgebra (traceQuadraticForm K n) :=
+  ((List.ofFn (carPositiveRootFamily K n)).map
+    (CliffordAlgebra.ι (traceQuadraticForm K n))).prod
+
+/-- The defining ordered-product equation for `carHighestWeightVector`. -/
+theorem carHighestWeightVector_def (K : Type*) [CommRing K]
+    (n : Type*) [Fintype n] [LinearOrder n] :
+    carHighestWeightVector K n =
+      ((List.ofFn (carPositiveRootFamily K n)).map
+        (CliffordAlgebra.ι (traceQuadraticForm K n))).prod :=
+  rfl
+
+/-- If the index type has at most one element, there are no positive roots and the ordered-product
+candidate is `1`. This includes both the rank-zero and rank-one boundary cases. -/
+@[simp]
+theorem carHighestWeightVector_eq_one_of_subsingleton (K : Type*) [CommRing K]
+    (n : Type*) [Fintype n] [LinearOrder n] [Subsingleton n] :
+    carHighestWeightVector K n = 1 := by
+  have hpairs : carPositiveRootPairs n = ∅ := by
+    ext ⟨i, j⟩
+    simp only [carPositiveRootPairs, Finset.mem_filter, Finset.mem_univ, true_and,
+      Finset.notMem_empty, iff_false]
+    exact fun hij => (lt_irrefl j) (Subsingleton.elim i j ▸ hij)
+  rw [carHighestWeightVector_def]
+  have hroots : List.ofFn (carPositiveRootFamily K n) = [] := by
+    apply List.eq_nil_of_length_eq_zero
+    simp only [List.length_ofFn, hpairs, Finset.card_empty]
+  rw [hroots]
+  simp
 
 section Field
 
-variable {K : Type*} [Field K]
+variable {K n : Type*} [Field K] [Fintype n] [LinearOrder n]
 
-private theorem carPositiveRootFamily_mem {N : ℕ} {i j : Fin N} (hij : i < j) :
-    Matrix.single i j (1 : K) ∈ List.ofFn (carPositiveRootFamily K N) := by
+private theorem carPositiveRootFamily_mem {i j : n} (hij : i < j) :
+    Matrix.single i j (1 : K) ∈ List.ofFn (carPositiveRootFamily K n) := by
+  let _ := carPairLinearOrder n
   rw [List.mem_ofFn]
-  have hp : finProdFinEquiv (i, j) ∈ carPositiveRootCodes N := by
-    simp only [carPositiveRootCodes, Finset.mem_filter, Finset.mem_univ, true_and]
-    simpa only [Equiv.symm_apply_apply] using hij
-  have hp' : finProdFinEquiv (i, j) ∈ (carPositiveRootCodes N : Set (Fin (N * N))) := hp
-  rw [← Finset.range_orderEmbOfFin (carPositiveRootCodes N) rfl] at hp'
+  have hp : (i, j) ∈ carPositiveRootPairs n := by
+    simpa only [carPositiveRootPairs, Finset.mem_filter, Finset.mem_univ, true_and] using hij
+  have hp' : (i, j) ∈ (carPositiveRootPairs n : Set (n × n)) := hp
+  rw [← Finset.range_orderEmbOfFin (carPositiveRootPairs n) rfl] at hp'
   obtain ⟨r, hr⟩ := hp'
   refine ⟨r, ?_⟩
-  simp [carPositiveRootFamily, carRootMatrix, hr, Matrix.stdBasis_eq_single]
+  simp [carPositiveRootFamily, hr, Matrix.stdBasis_eq_single]
 
-private theorem carPositiveUnits_ortho {N : ℕ} {i j k l : Fin N}
+private theorem carPositiveUnits_ortho {i j k l : n}
     (hij : i < j) (hkl : k < l) :
-    (traceQuadraticForm K (Fin N)).IsOrtho
+    (traceQuadraticForm K n).IsOrtho
       (Matrix.single i j 1) (Matrix.single k l 1) := by
   rw [← QuadraticMap.isOrtho_polarBilin, polarBilin_traceQuadraticForm,
     Matrix.trace_single_mul, Matrix.single_apply]
@@ -118,13 +138,13 @@ private theorem carPositiveUnits_ortho {N : ℕ} {i j k l : Fin N}
       · simp [hkj, hli]
     · simp [hkj]
 
+omit [LinearOrder n] in
 private theorem iota_mul_prod_eq_zero_of_mem
-    {N : ℕ} {a : Matrix (Fin N) (Fin N) K}
-    {l : List (Matrix (Fin N) (Fin N) K)}
-    (ha : a ∈ l) (hQ : traceQuadraticForm K (Fin N) a = 0)
-    (ho : ∀ b ∈ l, (traceQuadraticForm K (Fin N)).IsOrtho a b) :
-    CliffordAlgebra.ι (traceQuadraticForm K (Fin N)) a
-        * (l.map (CliffordAlgebra.ι (traceQuadraticForm K (Fin N)))).prod = 0 := by
+    {a : Matrix n n K} {l : List (Matrix n n K)}
+    (ha : a ∈ l) (hQ : traceQuadraticForm K n a = 0)
+    (ho : ∀ b ∈ l, (traceQuadraticForm K n).IsOrtho a b) :
+    CliffordAlgebra.ι (traceQuadraticForm K n) a
+        * (l.map (CliffordAlgebra.ι (traceQuadraticForm K n))).prod = 0 := by
   induction l with
   | nil => simp at ha
   | cons b l ih =>
@@ -133,88 +153,52 @@ private theorem iota_mul_prod_eq_zero_of_mem
       · simp only [List.map_cons, List.prod_cons]
         rw [← mul_assoc, CliffordAlgebra.ι_sq_scalar, hQ, map_zero, zero_mul]
       · have hab := ho b List.mem_cons_self
-        have hol : ∀ c ∈ l, (traceQuadraticForm K (Fin N)).IsOrtho a c :=
+        have hol : ∀ c ∈ l, (traceQuadraticForm K n).IsOrtho a c :=
           fun c hc => ho c (List.mem_cons_of_mem b hc)
         simp only [List.map_cons, List.prod_cons]
         rw [← mul_assoc, CliffordAlgebra.ι_mul_ι_comm_of_isOrtho hab, neg_mul,
           mul_assoc, ih ha hol, mul_zero, neg_zero]
 
-private theorem prod_iota_ne_zero [Invertible (2 : K)]
-    {M : Type*} [AddCommGroup M] [Module K M]
-    (Q : QuadraticForm K M) {n : ℕ} (v : Fin n → M) (hv : LinearIndependent K v) :
-    (List.ofFn ((CliffordAlgebra.ι Q) ∘ v)).prod ≠ 0 := by
-  cases n with
-  | zero => simp
-  | succ k =>
-      have hx : exteriorPower.ιMulti K (k + 1) v ≠ 0 := by
-        have hfamily := exteriorPower.ιMulti_family_linearIndependent_field (K := K)
-          (k + 1) hv
-        have hne := hfamily.ne_zero
-          (⟨Finset.univ, by simp⟩ : Set.powersetCard (Fin (k + 1)) (k + 1))
-        have hemb : Set.powersetCard.ofFinEmbEquiv.symm
-            (⟨Finset.univ, by simp⟩ : Set.powersetCard (Fin (k + 1)) (k + 1)) =
-            OrderEmbedding.id (Fin (k + 1)) := by
-          symm
-          exact Finset.orderEmbOfFin_unique' (by simp) (fun _ => by simp)
-        simpa [exteriorPower.ιMulti_family, hemb] using hne
-      intro hzero
-      have hlead := CliffordAlgebra.filtrationLeadingTerm_apply_ιMulti Q k v
-      have hmem : (List.ofFn ((CliffordAlgebra.ι Q) ∘ v)).prod ∈
-          CliffordAlgebra.filtration Q (k + 1) := by
-        rw [← List.map_ofFn]
-        exact CliffordAlgebra.prod_map_ι_mem_filtration Q (k := k + 1)
-          (l := List.ofFn v) (by simp)
-      have hsub : (⟨(List.ofFn ((CliffordAlgebra.ι Q) ∘ v)).prod, hmem⟩ :
-          CliffordAlgebra.filtration Q (k + 1)) = 0 := Subtype.ext hzero
-      have hquot := congrArg
-        (fun x : CliffordAlgebra.filtration Q (k + 1) =>
-          (Submodule.Quotient.mk x : TauCeti.Algebra.wordFiltration.GradedPiece
-            (CliffordAlgebra.ι Q) (k + 1))) hsub
-      have himage : CliffordAlgebra.filtrationLeadingTerm Q k
-          (exteriorPower.ιMulti K (k + 1) v) = 0 := hlead.trans (by simpa using hquot)
-      rw [CliffordAlgebra.filtrationLeadingTerm_eq_filtrationGradedEquiv_symm] at himage
-      apply hx
-      apply (CliffordAlgebra.filtrationGradedEquiv Q k).symm.injective
-      rw [map_zero]
-      exact himage
-
-private theorem carHighestWeightVector_ne_zero [Invertible (2 : K)] (N : ℕ) :
-    carHighestWeightVector K N ≠ 0 := by
-  have hfull : LinearIndependent K (carRootMatrix K N) := by
-    change LinearIndependent K (fun p =>
-      Matrix.stdBasis K (Fin N) (Fin N) (finProdFinEquiv.symm p))
-    exact (Matrix.stdBasis K (Fin N) (Fin N)).linearIndependent.comp finProdFinEquiv.symm
-      finProdFinEquiv.symm.injective
-  have hpositive : LinearIndependent K (carPositiveRootFamily K N) := by
-    change LinearIndependent K (fun r =>
-      carRootMatrix K N ((carPositiveRootCodes N).orderEmbOfFin rfl r))
-    exact hfull.comp ((carPositiveRootCodes N).orderEmbOfFin rfl)
-      ((carPositiveRootCodes N).orderEmbOfFin rfl).injective
-  simpa [carHighestWeightVector, List.map_ofFn] using
-    prod_iota_ne_zero (traceQuadraticForm K (Fin N)) (carPositiveRootFamily K N) hpositive
+/-- The ordered positive-root product is nonzero over a field when `2` is invertible. -/
+theorem carHighestWeightVector_ne_zero [Invertible (2 : K)] :
+    carHighestWeightVector K n ≠ 0 := by
+  let _ := carPairLinearOrder n
+  have hpositive : LinearIndependent K (carPositiveRootFamily K n) := by
+    convert
+      (Matrix.stdBasis K n n).linearIndependent.comp
+        ((carPositiveRootPairs n).orderEmbOfFin rfl)
+        ((carPositiveRootPairs n).orderEmbOfFin rfl).injective using 1
+    rfl
+  simpa only [carHighestWeightVector, List.map_ofFn] using
+    CliffordAlgebra.prod_map_ι_ofFn_ne_zero (traceQuadraticForm K n)
+      (carPositiveRootFamily K n) hpositive
 
 private theorem positive_iota_mul_carHighestWeightVector_eq_zero
-    {N : ℕ} {i j : Fin N} (hij : i < j) :
-    CliffordAlgebra.ι (traceQuadraticForm K (Fin N)) (Matrix.single i j 1)
-        * carHighestWeightVector K N = 0 := by
+    {i j : n} (hij : i < j) :
+    CliffordAlgebra.ι (traceQuadraticForm K n) (Matrix.single i j 1)
+        * carHighestWeightVector K n = 0 := by
   apply iota_mul_prod_eq_zero_of_mem (carPositiveRootFamily_mem hij)
   · rw [traceQuadraticForm_apply, Matrix.trace_single_mul, Matrix.single_apply]
     simp [ne_of_lt hij]
   · intro b hb
+    let _ := carPairLinearOrder n
     rw [List.mem_ofFn] at hb
     obtain ⟨r, rfl⟩ := hb
-    have hr := Finset.orderEmbOfFin_mem (carPositiveRootCodes N) rfl r
-    rw [carPositiveRootFamily, carRootMatrix, Matrix.stdBasis_eq_single]
+    have hr := Finset.orderEmbOfFin_mem (carPositiveRootPairs n) rfl r
+    simp only [carPositiveRootFamily]
+    generalize hp : (carPositiveRootPairs n).orderEmbOfFin rfl r = p at hr ⊢
+    rcases p with ⟨k, l⟩
+    rw [Matrix.stdBasis_eq_single]
     apply carPositiveUnits_ortho hij
-    simpa only [carPositiveRootCodes, Finset.mem_filter, Finset.mem_univ, true_and] using hr
+    simpa only [carPositiveRootPairs, Finset.mem_filter, Finset.mem_univ, true_and] using hr
 
-private noncomputable abbrev carD {N : ℕ} (i j : Fin N) :
-    CliffordAlgebra (traceQuadraticForm K (Fin N)) :=
-  CliffordAlgebra.ι (traceQuadraticForm K (Fin N)) (Matrix.single i j 1)
+private noncomputable abbrev carD (i j : n) :
+    CliffordAlgebra (traceQuadraticForm K n) :=
+  CliffordAlgebra.ι (traceQuadraticForm K n) (Matrix.single i j 1)
 
 private theorem raisingTerm_mul_carHighestWeightVector_eq_zero
-    {N : ℕ} {i j : Fin N} (hij : i < j) (k : Fin N) :
-    carD i k * carD k j * carHighestWeightVector K N = 0 := by
+    {i j : n} (hij : i < j) (k : n) :
+    carD i k * carD k j * carHighestWeightVector K n = 0 := by
   by_cases hkj : k < j
   · rw [mul_assoc, positive_iota_mul_carHighestWeightVector_eq_zero hkj, mul_zero]
   · have hik : i < k := lt_of_lt_of_le hij (le_of_not_gt hkj)
@@ -222,10 +206,10 @@ private theorem raisingTerm_mul_carHighestWeightVector_eq_zero
       (by intro h; exact (ne_of_lt hij) h.2.symm), neg_mul, mul_assoc,
       positive_iota_mul_carHighestWeightVector_eq_zero hik, mul_zero, neg_zero]
 
-private theorem diagonalTerm_mul_carHighestWeightVector {N : ℕ} (i k : Fin N) :
-    carD i k * carD k i * carHighestWeightVector K N =
-      if k < i then 0 else if k = i then carHighestWeightVector K N
-      else (2 : K) • carHighestWeightVector K N := by
+private theorem diagonalTerm_mul_carHighestWeightVector (i k : n) :
+    carD i k * carD k i * carHighestWeightVector K n =
+      if k < i then 0 else if k = i then carHighestWeightVector K n
+      else (2 : K) • carHighestWeightVector K n := by
   rcases lt_trichotomy k i with hki | rfl | hik
   · simp only [hki, ↓reduceIte]
     rw [mul_assoc, positive_iota_mul_carHighestWeightVector_eq_zero hki, mul_zero]
@@ -234,129 +218,127 @@ private theorem diagonalTerm_mul_carHighestWeightVector {N : ℕ} (i k : Fin N) 
     have hcar := traceQuadraticForm_ι_single_mul_ι_single_add_swap
       (R := K) i k k i 1 1
     have hmul := congrArg
-      (fun x : CliffordAlgebra (traceQuadraticForm K (Fin N)) =>
-        x * carHighestWeightVector K N) hcar
+      (fun x : CliffordAlgebra (traceQuadraticForm K n) =>
+        x * carHighestWeightVector K n) hcar
     simp only [add_mul, mul_assoc, positive_iota_mul_carHighestWeightVector_eq_zero hik,
       mul_zero, add_zero] at hmul
     rw [mul_assoc]
     simpa [carD, Algebra.smul_def] using hmul
 
-private theorem diagonalScalarSum {N : ℕ} (i : Fin N) :
-    (∑ k : Fin N, if k = i then (1 : K) else if i < k then 2 else 0) =
-      1 + 2 * ((Finset.Ioi i).card : K) := by
+private theorem diagonalScalarSum (i : n) :
+    (∑ k : n, if k = i then (1 : K) else if i < k then 2 else 0) =
+      1 + 2 * ((Finset.univ.filter fun k : n => i < k).card : K) := by
   calc
-    _ = (∑ k : Fin N, if k = i then (1 : K) else 0) +
-        ∑ k : Fin N, if i < k then (2 : K) else 0 := by
+    _ = (∑ k : n, if k = i then (1 : K) else 0) +
+        ∑ k : n, if i < k then (2 : K) else 0 := by
       rw [← Finset.sum_add_distrib]
       apply Finset.sum_congr rfl
       intro k _
       split_ifs <;> simp_all
-    _ = 1 + 2 * ((Finset.Ioi i).card : K) := by
-      have hfirst : (∑ k : Fin N, if k = i then (1 : K) else 0) = 1 := by simp
-      have hsecond : (∑ k : Fin N, if i < k then (2 : K) else 0) =
-          2 * ((Finset.Ioi i).card : K) := by
+    _ = 1 + 2 * ((Finset.univ.filter fun k : n => i < k).card : K) := by
+      have hfirst : (∑ k : n, if k = i then (1 : K) else 0) = 1 := by simp
+      have hsecond : (∑ k : n, if i < k then (2 : K) else 0) =
+          2 * ((Finset.univ.filter fun k : n => i < k).card : K) := by
         rw [← Finset.sum_filter]
-        simp [Finset.filter_lt_eq_Ioi, mul_comm]
+        simp [mul_comm]
       rw [hfirst, hsecond]
 
-private theorem diagonalTerm_mul_carHighestWeightVector_eq_smul {N : ℕ}
-    (i k : Fin N) :
-    carD i k * carD k i * carHighestWeightVector K N =
+private theorem diagonalTerm_mul_carHighestWeightVector_eq_smul (i k : n) :
+    carD i k * carD k i * carHighestWeightVector K n =
       (if k = i then (1 : K) else if i < k then 2 else 0) •
-        carHighestWeightVector K N := by
+        carHighestWeightVector K n := by
   rw [diagonalTerm_mul_carHighestWeightVector]
   rcases lt_trichotomy k i with hki | rfl | hik
   · simp [hki, ne_of_lt hki, not_lt_of_ge hki.le]
   · simp
   · simp [hik, ne_of_gt hik, not_lt_of_ge hik.le]
 
-private theorem diagonalSum_mul_carHighestWeightVector {N : ℕ} (i : Fin N) :
-    (∑ k : Fin N, carD i k * carD k i) * carHighestWeightVector K N =
-      (1 + 2 * ((Finset.Ioi i).card : K)) • carHighestWeightVector K N := by
+private theorem diagonalSum_mul_carHighestWeightVector (i : n) :
+    (∑ k : n, carD i k * carD k i) * carHighestWeightVector K n =
+      (1 + 2 * ((Finset.univ.filter fun k : n => i < k).card : K)) •
+        carHighestWeightVector K n := by
   rw [Finset.sum_mul]
   simp_rw [diagonalTerm_mul_carHighestWeightVector_eq_smul i]
   rw [← Finset.sum_smul, diagonalScalarSum i]
 
 section Action
 
-variable [CharZero K] [h2 : Invertible (2 : K)]
+variable [h2 : Invertible (2 : K)]
 
 /-- The CAR Lie-ring module instance using the fixed invertibility witness. -/
-local instance {N : ℕ} :
-    LieRingModule (Matrix (Fin N) (Fin N) K)
-      (CliffordAlgebra (traceQuadraticForm K (Fin N))) :=
-  @carLieRingModule K (Fin N) inferInstance inferInstance h2
+local instance :
+    LieRingModule (Matrix n n K) (CliffordAlgebra (traceQuadraticForm K n)) :=
+  @carLieRingModule K n inferInstance inferInstance h2
 
 /-- The CAR Lie-module instance using the fixed invertibility witness. -/
-local instance {N : ℕ} :
-    LieModule K (Matrix (Fin N) (Fin N) K)
-      (CliffordAlgebra (traceQuadraticForm K (Fin N))) :=
-  @carLieModule K (Fin N) inferInstance inferInstance h2
+local instance :
+    LieModule K (Matrix n n K) (CliffordAlgebra (traceQuadraticForm K n)) :=
+  @carLieModule K n inferInstance inferInstance h2
 
-omit [CharZero K] in
-/-- `glCliffordHom_single` restated with this file's matrix-unit decidability instance. -/
-private theorem glCliffordHom_single_current {N : ℕ} (i j : Fin N) :
-    (@glCliffordHom K (Fin N) inferInstance inferInstance h2) (Matrix.single i j 1) =
-      (2 : K)⁻¹ • ∑ k : Fin N, carD i k * carD k j := by
-  convert @glCliffordHom_single K (Fin N) inferInstance inferInstance h2 i j using 1
-  · apply congrArg (@glCliffordHom K (Fin N) inferInstance inferInstance h2)
-    ext a b
-    simp [Matrix.single]
-  · apply congrArg ((2 : K)⁻¹ • ·)
-    apply Finset.sum_congr rfl
-    intro k _
-    apply congrArg₂ (· * ·)
-    · apply congrArg (CliffordAlgebra.ι (traceQuadraticForm K (Fin N)))
-      ext a b
-      simp [Matrix.single]
-    · apply congrArg (CliffordAlgebra.ι (traceQuadraticForm K (Fin N)))
-      ext a b
-      simp [Matrix.single]
-
-omit [CharZero K] in
 private theorem glCliffordHom_single_mul_carHighestWeightVector_eq_zero
-    {N : ℕ} {i j : Fin N} (hij : i < j) :
-    (@glCliffordHom K (Fin N) inferInstance inferInstance h2) (Matrix.single i j 1) *
-      carHighestWeightVector K N = 0 := by
-  rw [glCliffordHom_single_current i j, smul_mul_assoc, Finset.sum_mul]
+    {i j : n} (hij : i < j) :
+    (@glCliffordHom K n inferInstance inferInstance h2) (Matrix.single i j 1) *
+      carHighestWeightVector K n = 0 := by
+  rw [glCliffordHom_single, smul_mul_assoc, Finset.sum_mul]
   simp only [raisingTerm_mul_carHighestWeightVector_eq_zero hij,
     Finset.sum_const_zero, smul_zero]
 
-omit [CharZero K] in
 private theorem raising_lie_carHighestWeightVector_eq_zero
-    {N : ℕ} {i j : Fin N} (hij : i < j) :
-    ⁅Matrix.single i j (1 : K), carHighestWeightVector K N⁆ = 0 := by
+    {i j : n} (hij : i < j) :
+    ⁅Matrix.single i j (1 : K), carHighestWeightVector K n⁆ = 0 := by
   rw [car_lie_def]
   exact glCliffordHom_single_mul_carHighestWeightVector_eq_zero hij
 
+private theorem diagonal_lie_carHighestWeightVector (i : n) :
+    ⁅Matrix.single i i (1 : K), carHighestWeightVector K n⁆ =
+      ((2 : K)⁻¹ * (1 + 2 * ((Finset.univ.filter fun k : n => i < k).card : K))) •
+        carHighestWeightVector K n := by
+  rw [car_lie_def, glCliffordHom_single, smul_mul_assoc,
+    diagonalSum_mul_carHighestWeightVector i, smul_smul]
+
+/-- The ordered product of all positive matrix-unit Clifford generators is a highest-weight vector
+for the left `gl_n`-action on the CAR algebra. Its weight at `i` is half of one plus twice the
+number of indices strictly above `i`. -/
+theorem isGlHighestWeightVector_carHighestWeightVector :
+    IsGlHighestWeightVector (fun i : n =>
+      (2 : K)⁻¹ * (1 + 2 * ((Finset.univ.filter fun k : n => i < k).card : K)))
+      (carHighestWeightVector K n) := by
+  rw [isGlHighestWeightVector_iff]
+  exact ⟨carHighestWeightVector_ne_zero, diagonal_lie_carHighestWeightVector,
+    fun i j hij => raising_lie_carHighestWeightVector_eq_zero hij⟩
+
+section CharZero
+
+variable [CharZero K]
+
 omit h2 in
 private theorem half_diagonalScalarSum {N : ℕ} (i : Fin N) :
-    (2 : K)⁻¹ * (1 + 2 * ((Finset.Ioi i).card : K)) =
+    (2 : K)⁻¹ *
+        (1 + 2 * ((Finset.univ.filter fun k : Fin N => i < k).card : K)) =
       algebraMap ℚ K (glStaircase N i) := by
-  rw [Fin.card_Ioi, glStaircase_apply]
+  rw [Finset.filter_lt_eq_Ioi, Fin.card_Ioi, glStaircase_apply]
   have hi : (i : ℕ) < N := i.isLt
-  rw [show N - 1 - (i : ℕ) = N - ((i : ℕ) + 1) by omega,
-    Nat.cast_sub (by omega : (i : ℕ) + 1 ≤ N)]
+  have hsub : N - 1 - (i : ℕ) = N - ((i : ℕ) + 1) := by omega
+  rw [hsub, Nat.cast_sub (by omega : (i : ℕ) + 1 ≤ N)]
   push_cast
   field_simp
   norm_num
   ring
 
-private theorem diagonal_lie_carHighestWeightVector {N : ℕ} (i : Fin N) :
-    ⁅Matrix.single i i (1 : K), carHighestWeightVector K N⁆ =
-      algebraMap ℚ K (glStaircase N i) • carHighestWeightVector K N := by
-  rw [car_lie_def, glCliffordHom_single_current i i, smul_mul_assoc,
-    diagonalSum_mul_carHighestWeightVector i, smul_smul, half_diagonalScalarSum i]
-
-/-- The ordered product of all positive matrix-unit Clifford generators is a highest-weight vector
-for the left `gl_N`-action on the CAR algebra. Its weight is the scalar extension of the rational
-staircase `TauCeti.glStaircase N`. -/
-theorem isGlHighestWeightVector_carHighestWeightVector (N : ℕ) :
+/-- For `Fin N` in characteristic zero, the direct cardinality weight is the scalar extension of
+the rational staircase `TauCeti.glStaircase N`. -/
+theorem isGlHighestWeightVector_carHighestWeightVector_fin (N : ℕ) :
     IsGlHighestWeightVector (fun i => algebraMap ℚ K (glStaircase N i))
-      (carHighestWeightVector K N) := by
-  rw [isGlHighestWeightVector_iff]
-  exact ⟨carHighestWeightVector_ne_zero N, diagonal_lie_carHighestWeightVector,
-    fun i j hij => raising_lie_carHighestWeightVector_eq_zero hij⟩
+      (carHighestWeightVector K (Fin N)) := by
+  have h := isGlHighestWeightVector_carHighestWeightVector (K := K) (n := Fin N)
+  rw [isGlHighestWeightVector_iff] at h ⊢
+  refine ⟨h.1, ?_, ?_⟩
+  · intro i
+    simpa [half_diagonalScalarSum, Matrix.single] using h.2.1 i
+  · intro i j hij
+    simpa [Matrix.single] using h.2.2 i j hij
+
+end CharZero
 
 end Action
 

--- a/TauCeti/Algebra/Lie/GeneralLinear/CAR/HighestWeight.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/CAR/HighestWeight.lean
@@ -25,7 +25,7 @@ results.
 
 ## Main definitions
 
-* `TauCeti.carPositiveRootFamily`: the canonically ordered positive matrix units.
+* `TauCeti.carPositiveMatrixUnitFamily`: the canonically ordered positive matrix units.
 * `TauCeti.carHighestWeightVector`: their ordered Clifford product candidate.
 
 ## Main results
@@ -35,7 +35,7 @@ results.
 * `TauCeti.carHighestWeightVector_eq_one_of_subsingleton`: in ranks zero and one the empty
   ordered product is `1`.
 * `TauCeti.isGlHighestWeightVector_carHighestWeightVector`: its direct highest-weight equation.
-* `TauCeti.isGlHighestWeightVector_carHighestWeightVector_fin`: the `Fin N` staircase form.
+* `TauCeti.isGlHighestWeightVector_glStaircase_carHighestWeightVector`: the `Fin N` staircase form.
 
 ## References
 
@@ -57,8 +57,15 @@ attribute [local instance 100] LieRing.ofAssociativeRing
 /-! ### The ordered positive-root product -/
 
 /-- The positive roots of `gl_n`, represented by strictly upper-triangular index pairs. -/
-@[expose] def carPositiveRootPairs (n : Type*) [Fintype n] [LinearOrder n] : Finset (n × n) :=
+def carPositiveRootPairs (n : Type*) [Fintype n] [LinearOrder n] : Finset (n × n) :=
   Finset.univ.filter fun ij => ij.1 < ij.2
+
+/-- Membership in `carPositiveRootPairs` means that the first index is strictly below the second. -/
+@[simp]
+theorem mem_carPositiveRootPairs {n : Type*} [Fintype n] [LinearOrder n] {i j : n} :
+    (i, j) ∈ carPositiveRootPairs n ↔ i < j := by
+  rw [carPositiveRootPairs.eq_def]
+  simp
 
 /-- The lexicographic linear order used to enumerate pairs of ordered indices. -/
 @[instance_reducible] private noncomputable def carPairLinearOrder
@@ -66,29 +73,50 @@ attribute [local instance 100] LieRing.ofAssociativeRing
   let _ : LinearOrder (n ×ₗ n) := Prod.Lex.instLinearOrder n n
   exact LinearOrder.lift' toLex (Equiv.injective toLex)
 
+/-- The positive-root pair at a given place in the canonical lexicographic enumeration. -/
+noncomputable def carPositiveRootPair (n : Type*) [Fintype n] [LinearOrder n]
+    (r : Fin (carPositiveRootPairs n).card) : n × n := by
+  let _ := carPairLinearOrder n
+  exact (carPositiveRootPairs n).orderEmbOfFin rfl r
+
+/-- Every pair in the canonical enumeration is a positive-root pair. -/
+@[simp]
+theorem carPositiveRootPair_mem (n : Type*) [Fintype n] [LinearOrder n]
+    (r : Fin (carPositiveRootPairs n).card) :
+    carPositiveRootPair n r ∈ carPositiveRootPairs n := by
+  let _ := carPairLinearOrder n
+  rw [carPositiveRootPair.eq_def]
+  exact Finset.orderEmbOfFin_mem (carPositiveRootPairs n) rfl r
+
 /-- The positive matrix units in the lexicographic order on their index pairs. -/
-@[expose] noncomputable def carPositiveRootFamily (K : Type*) [CommRing K]
+noncomputable def carPositiveMatrixUnitFamily (K : Type*) [CommRing K]
     (n : Type*) [Fintype n] [LinearOrder n] :
     Fin (carPositiveRootPairs n).card → Matrix n n K := by
-  let _ : LinearOrder (n ×ₗ n) := Prod.Lex.instLinearOrder n n
-  let _ : LinearOrder (n × n) := LinearOrder.lift' toLex (Equiv.injective toLex)
-  exact fun r => Matrix.stdBasis K n n ((carPositiveRootPairs n).orderEmbOfFin rfl r)
+  exact fun r => Matrix.stdBasis K n n (carPositiveRootPair n r)
+
+/-- The positive matrix-unit family is obtained by applying `Matrix.stdBasis` to the canonical
+positive-root enumeration. -/
+@[simp]
+theorem carPositiveMatrixUnitFamily_apply (K : Type*) [CommRing K]
+    (n : Type*) [Fintype n] [LinearOrder n] (r : Fin (carPositiveRootPairs n).card) :
+    carPositiveMatrixUnitFamily K n r = Matrix.stdBasis K n n (carPositiveRootPair n r) :=
+  carPositiveMatrixUnitFamily.eq_def K n r
 
 /-- The ordered product candidate formed from all positive matrix-unit Clifford generators. It is
 proved below to be a highest-weight vector over a field when `2` is invertible. -/
-@[expose] noncomputable def carHighestWeightVector (K : Type*) [CommRing K]
+noncomputable def carHighestWeightVector (K : Type*) [CommRing K]
     (n : Type*) [Fintype n] [LinearOrder n] :
     CliffordAlgebra (traceQuadraticForm K n) :=
-  ((List.ofFn (carPositiveRootFamily K n)).map
+  ((List.ofFn (carPositiveMatrixUnitFamily K n)).map
     (CliffordAlgebra.ι (traceQuadraticForm K n))).prod
 
 /-- The defining ordered-product equation for `carHighestWeightVector`. -/
 theorem carHighestWeightVector_def (K : Type*) [CommRing K]
     (n : Type*) [Fintype n] [LinearOrder n] :
     carHighestWeightVector K n =
-      ((List.ofFn (carPositiveRootFamily K n)).map
+      ((List.ofFn (carPositiveMatrixUnitFamily K n)).map
         (CliffordAlgebra.ι (traceQuadraticForm K n))).prod :=
-  rfl
+  carHighestWeightVector.eq_def K n
 
 /-- If the index type has at most one element, there are no positive roots and the ordered-product
 candidate is `1`. This includes both the rank-zero and rank-one boundary cases. -/
@@ -102,7 +130,7 @@ theorem carHighestWeightVector_eq_one_of_subsingleton (K : Type*) [CommRing K]
       Finset.notMem_empty, iff_false]
     exact fun hij => (lt_irrefl j) (Subsingleton.elim i j ▸ hij)
   rw [carHighestWeightVector_def]
-  have hroots : List.ofFn (carPositiveRootFamily K n) = [] := by
+  have hroots : List.ofFn (carPositiveMatrixUnitFamily K n) = [] := by
     apply List.eq_nil_of_length_eq_zero
     simp only [List.length_ofFn, hpairs, Finset.card_empty]
   rw [hroots]
@@ -112,17 +140,19 @@ section Field
 
 variable {K n : Type*} [Field K] [Fintype n] [LinearOrder n]
 
-private theorem carPositiveRootFamily_mem {i j : n} (hij : i < j) :
-    Matrix.single i j (1 : K) ∈ List.ofFn (carPositiveRootFamily K n) := by
+/-- Every positive matrix unit occurs in the canonical family. -/
+theorem carPositiveMatrixUnitFamily_mem {i j : n} (hij : i < j) :
+    Matrix.single i j (1 : K) ∈ List.ofFn (carPositiveMatrixUnitFamily K n) := by
   let _ := carPairLinearOrder n
   rw [List.mem_ofFn]
   have hp : (i, j) ∈ carPositiveRootPairs n := by
-    simpa only [carPositiveRootPairs, Finset.mem_filter, Finset.mem_univ, true_and] using hij
+    exact mem_carPositiveRootPairs.mpr hij
   have hp' : (i, j) ∈ (carPositiveRootPairs n : Set (n × n)) := hp
   rw [← Finset.range_orderEmbOfFin (carPositiveRootPairs n) rfl] at hp'
   obtain ⟨r, hr⟩ := hp'
   refine ⟨r, ?_⟩
-  simp [carPositiveRootFamily, hr, Matrix.stdBasis_eq_single]
+  rw [carPositiveMatrixUnitFamily_apply, carPositiveRootPair.eq_def, hr,
+    Matrix.stdBasis_eq_single]
 
 private theorem carPositiveUnits_ortho {i j k l : n}
     (hij : i < j) (hkl : k < l) :
@@ -163,30 +193,30 @@ private theorem iota_mul_prod_eq_zero_of_mem
 theorem carHighestWeightVector_ne_zero [Invertible (2 : K)] :
     carHighestWeightVector K n ≠ 0 := by
   let _ := carPairLinearOrder n
-  have hpositive : LinearIndependent K (carPositiveRootFamily K n) := by
+  have hpositive : LinearIndependent K (carPositiveMatrixUnitFamily K n) := by
     convert
       (Matrix.stdBasis K n n).linearIndependent.comp
         ((carPositiveRootPairs n).orderEmbOfFin rfl)
         ((carPositiveRootPairs n).orderEmbOfFin rfl).injective using 1
     rfl
-  simpa only [carHighestWeightVector, List.map_ofFn] using
+  simpa only [carHighestWeightVector_def, List.map_ofFn] using
     CliffordAlgebra.prod_map_ι_ofFn_ne_zero (traceQuadraticForm K n)
-      (carPositiveRootFamily K n) hpositive
+      (carPositiveMatrixUnitFamily K n) hpositive
 
 private theorem positive_iota_mul_carHighestWeightVector_eq_zero
     {i j : n} (hij : i < j) :
     CliffordAlgebra.ι (traceQuadraticForm K n) (Matrix.single i j 1)
         * carHighestWeightVector K n = 0 := by
-  apply iota_mul_prod_eq_zero_of_mem (carPositiveRootFamily_mem hij)
+  apply iota_mul_prod_eq_zero_of_mem (carPositiveMatrixUnitFamily_mem hij)
   · rw [traceQuadraticForm_apply, Matrix.trace_single_mul, Matrix.single_apply]
     simp [ne_of_lt hij]
   · intro b hb
     let _ := carPairLinearOrder n
     rw [List.mem_ofFn] at hb
     obtain ⟨r, rfl⟩ := hb
-    have hr := Finset.orderEmbOfFin_mem (carPositiveRootPairs n) rfl r
-    simp only [carPositiveRootFamily]
-    generalize hp : (carPositiveRootPairs n).orderEmbOfFin rfl r = p at hr ⊢
+    have hr := carPositiveRootPair_mem n r
+    simp only [carPositiveMatrixUnitFamily_apply]
+    generalize hp : carPositiveRootPair n r = p at hr ⊢
     rcases p with ⟨k, l⟩
     rw [Matrix.stdBasis_eq_single]
     apply carPositiveUnits_ortho hij
@@ -327,7 +357,7 @@ private theorem half_diagonalScalarSum {N : ℕ} (i : Fin N) :
 
 /-- For `Fin N` in characteristic zero, the direct cardinality weight is the scalar extension of
 the rational staircase `TauCeti.glStaircase N`. -/
-theorem isGlHighestWeightVector_carHighestWeightVector_fin (N : ℕ) :
+theorem isGlHighestWeightVector_glStaircase_carHighestWeightVector (N : ℕ) :
     IsGlHighestWeightVector (fun i => algebraMap ℚ K (glStaircase N i))
       (carHighestWeightVector K (Fin N)) := by
   have h := isGlHighestWeightVector_carHighestWeightVector (K := K) (n := Fin N)

--- a/TauCeti/Algebra/Lie/GeneralLinear/CAR/HighestWeight.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/CAR/HighestWeight.lean
@@ -90,6 +90,14 @@ noncomputable def carPositiveRootPair (n : Type*) [Fintype n] [LinearOrder n]
   let _ := carPairLinearOrder n
   exact (carPositiveRootPairs n).orderEmbOfFin rfl r
 
+/-- The positive-root pair enumeration is the increasing enumeration of its defining finset. -/
+private theorem carPositiveRootPair_eq_orderEmbOfFin (n : Type*) [Fintype n] [LinearOrder n]
+    (r : Fin (carPositiveRootPairs n).card) :
+    carPositiveRootPair n r =
+      (@Finset.orderEmbOfFin (n × n) (carPairLinearOrder n) (carPositiveRootPairs n)
+        (carPositiveRootPairs n).card rfl) r := by
+  rw [carPositiveRootPair.eq_def]
+
 /-- The order embedding enumerates the same pair as `carPositiveRootPair`. -/
 @[simp]
 theorem carPositiveRootPairOrderEmbedding_apply (n : Type*) [Fintype n] [LinearOrder n]
@@ -113,9 +121,7 @@ theorem carPositiveRootPair_mem (n : Type*) [Fintype n] [LinearOrder n]
 theorem range_carPositiveRootPair (n : Type*) [Fintype n] [LinearOrder n] :
     Set.range (carPositiveRootPair n) = carPositiveRootPairs n := by
   let _ : LinearOrder (n × n) := carPairLinearOrder n
-  rw [show carPositiveRootPair n = (carPositiveRootPairs n).orderEmbOfFin rfl by
-    funext r
-    rw [carPositiveRootPair.eq_def], Finset.range_orderEmbOfFin]
+  rw [funext (carPositiveRootPair_eq_orderEmbOfFin n), Finset.range_orderEmbOfFin]
 
 /-- The positive matrix units in the lexicographic order on their index pairs. -/
 noncomputable def carPositiveMatrixUnitFamily (K : Type*) [CommRing K]
@@ -222,11 +228,15 @@ theorem carHighestWeightVector_ne_zero :
     carHighestWeightVector K n ≠ 0 := by
   let _ := carPairLinearOrder n
   have hpositive : LinearIndependent K (carPositiveMatrixUnitFamily K n) := by
-    convert
-      (Matrix.stdBasis K n n).linearIndependent.comp
-        ((carPositiveRootPairs n).orderEmbOfFin rfl)
-        ((carPositiveRootPairs n).orderEmbOfFin rfl).injective using 1
-    rfl
+    have hfamily : carPositiveMatrixUnitFamily K n =
+        (Matrix.stdBasis K n n) ∘ (carPositiveRootPairs n).orderEmbOfFin rfl := by
+      funext r
+      rw [Function.comp_apply, carPositiveMatrixUnitFamily_apply,
+        carPositiveRootPair_eq_orderEmbOfFin]
+    rw [hfamily]
+    exact (Matrix.stdBasis K n n).linearIndependent.comp
+      ((carPositiveRootPairs n).orderEmbOfFin rfl)
+      ((carPositiveRootPairs n).orderEmbOfFin rfl).injective
   simpa only [carHighestWeightVector_def, List.map_ofFn] using
     CliffordAlgebra.prod_map_ι_ofFn_ne_zero (traceQuadraticForm K n)
       (carPositiveMatrixUnitFamily K n) hpositive

--- a/TauCeti/Algebra/Lie/GeneralLinear/CAR/HighestWeight.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/CAR/HighestWeight.lean
@@ -1,0 +1,367 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Lie.GeneralLinear.Fock
+public import TauCeti.Algebra.Lie.GeneralLinear.HighestWeight
+import TauCeti.LinearAlgebra.CliffordAlgebra.FiltrationGradedEquiv
+import Mathlib.LinearAlgebra.ExteriorPower.Basis
+import Mathlib.LinearAlgebra.Matrix.StdBasis
+
+/-!
+# A highest-weight vector in the CAR algebra
+
+For the left `gl_N`-action on the Clifford algebra of the trace quadratic form, this file
+constructs the ordered product
+
+`d₀₁ d₀₂ ⋯ d₀,N₋₁ d₁₂ ⋯ d_N₋₂,N₋₁`,
+
+where `dᵢⱼ = ι(Eᵢⱼ)`, and proves that it is a highest-weight vector of staircase weight
+`(N - 1/2, N - 3/2, …, 1/2)`.
+
+The proof has three ingredients. First, every positive generator `dᵢⱼ`, `i < j`, kills the
+product on the left: it anticommutes through the other positive generators until it meets its own
+copy, whose square is zero. Consequently every summand in the normal-ordered formula
+
+`Eᵢⱼ ↦ 1/2 ∑ₖ dᵢₖ dₖⱼ`
+
+kills the product when `i < j`. For a diagonal matrix unit, the `k`th summand contributes `0`,
+`1`, or `2` according as `k < i`, `k = i`, or `i < k`; after multiplication by `1/2`, this is
+`N - 1/2 - i`. Finally, the product is nonzero because its leading Clifford-filtration term is
+the exterior product of distinct standard matrix units. The PBW equivalence identifies that
+leading term with a nonzero exterior basis vector.
+
+## Main definitions
+
+* `TauCeti.carHighestWeightVector`: the ordered product of the positive matrix-unit Clifford
+  generators.
+
+## Main results
+
+* `TauCeti.isGlHighestWeightVector_carHighestWeightVector`: this product is a highest-weight
+  vector for the scalar extension of `TauCeti.glStaircase`.
+
+## References
+
+* W. Fulton, J. Harris, *Representation Theory: A First Course*, Springer GTM 129 (1991), §20.
+* C. Chevalley, *The Algebraic Theory of Spinors* (1954), Chapter II.
+-/
+
+public section
+
+open scoped BigOperators
+
+namespace TauCeti
+
+noncomputable section
+
+attribute [local instance 100] LieRing.ofAssociativeRing
+attribute [local instance] Classical.decEq
+
+/-! ### The ordered positive-root product -/
+
+/-- The strict upper-triangular matrix units, encoded in a finite linearly ordered type so their
+Clifford generators have a canonical order. -/
+private def carPositiveRootCodes (N : ℕ) : Finset (Fin (N * N)) :=
+  Finset.univ.filter fun p =>
+    let ij := finProdFinEquiv.symm p
+    ij.1 < ij.2
+
+/-- The standard matrix unit indexed by an encoded pair. -/
+private noncomputable def carRootMatrix (K : Type*) [CommRing K] (N : ℕ)
+    (p : Fin (N * N)) : Matrix (Fin N) (Fin N) K :=
+  Matrix.stdBasis K (Fin N) (Fin N) (finProdFinEquiv.symm p)
+
+/-- The increasing enumeration of the positive matrix units. -/
+private noncomputable def carPositiveRootFamily (K : Type*) [CommRing K] (N : ℕ) :
+    Fin (carPositiveRootCodes N).card → Matrix (Fin N) (Fin N) K := fun r =>
+  carRootMatrix K N ((carPositiveRootCodes N).orderEmbOfFin rfl r)
+
+/-- The ordered product of all strictly upper-triangular matrix-unit generators in the Clifford
+algebra of the trace quadratic form. This is the canonical highest-weight vector for the left
+`gl_N`-action on the CAR algebra. -/
+noncomputable def carHighestWeightVector (K : Type*) [CommRing K] (N : ℕ) :
+    CliffordAlgebra (traceQuadraticForm K (Fin N)) :=
+  ((List.ofFn (carPositiveRootFamily K N)).map
+    (CliffordAlgebra.ι (traceQuadraticForm K (Fin N)))).prod
+
+section Field
+
+variable {K : Type*} [Field K]
+
+private theorem carPositiveRootFamily_mem {N : ℕ} {i j : Fin N} (hij : i < j) :
+    Matrix.single i j (1 : K) ∈ List.ofFn (carPositiveRootFamily K N) := by
+  rw [List.mem_ofFn]
+  have hp : finProdFinEquiv (i, j) ∈ carPositiveRootCodes N := by
+    simp only [carPositiveRootCodes, Finset.mem_filter, Finset.mem_univ, true_and]
+    simpa only [Equiv.symm_apply_apply] using hij
+  have hp' : finProdFinEquiv (i, j) ∈ (carPositiveRootCodes N : Set (Fin (N * N))) := hp
+  rw [← Finset.range_orderEmbOfFin (carPositiveRootCodes N) rfl] at hp'
+  obtain ⟨r, hr⟩ := hp'
+  refine ⟨r, ?_⟩
+  simp [carPositiveRootFamily, carRootMatrix, hr, Matrix.stdBasis_eq_single]
+
+private theorem carPositiveUnits_ortho {N : ℕ} {i j k l : Fin N}
+    (hij : i < j) (hkl : k < l) :
+    (traceQuadraticForm K (Fin N)).IsOrtho
+      (Matrix.single i j 1) (Matrix.single k l 1) := by
+  rw [← QuadraticMap.isOrtho_polarBilin, polarBilin_traceQuadraticForm,
+    Matrix.trace_single_mul, Matrix.single_apply]
+  by_cases hpair : j = k ∧ l = i
+  · exact absurd (hpair.2 ▸ hpair.1 ▸ hkl) (lt_asymm hij)
+  · by_cases hkj : k = j
+    · by_cases hli : l = i
+      · exact (hpair ⟨hkj.symm, hli⟩).elim
+      · simp [hkj, hli]
+    · simp [hkj]
+
+private theorem iota_mul_prod_eq_zero_of_mem
+    {N : ℕ} {a : Matrix (Fin N) (Fin N) K}
+    {l : List (Matrix (Fin N) (Fin N) K)}
+    (ha : a ∈ l) (hQ : traceQuadraticForm K (Fin N) a = 0)
+    (ho : ∀ b ∈ l, (traceQuadraticForm K (Fin N)).IsOrtho a b) :
+    CliffordAlgebra.ι (traceQuadraticForm K (Fin N)) a
+        * (l.map (CliffordAlgebra.ι (traceQuadraticForm K (Fin N)))).prod = 0 := by
+  induction l with
+  | nil => simp at ha
+  | cons b l ih =>
+      rw [List.mem_cons] at ha
+      rcases ha with rfl | ha
+      · simp only [List.map_cons, List.prod_cons]
+        rw [← mul_assoc, CliffordAlgebra.ι_sq_scalar, hQ, map_zero, zero_mul]
+      · have hab := ho b List.mem_cons_self
+        have hol : ∀ c ∈ l, (traceQuadraticForm K (Fin N)).IsOrtho a c :=
+          fun c hc => ho c (List.mem_cons_of_mem b hc)
+        simp only [List.map_cons, List.prod_cons]
+        rw [← mul_assoc, CliffordAlgebra.ι_mul_ι_comm_of_isOrtho hab, neg_mul,
+          mul_assoc, ih ha hol, mul_zero, neg_zero]
+
+private theorem prod_iota_ne_zero [Invertible (2 : K)]
+    {M : Type*} [AddCommGroup M] [Module K M]
+    (Q : QuadraticForm K M) {n : ℕ} (v : Fin n → M) (hv : LinearIndependent K v) :
+    (List.ofFn ((CliffordAlgebra.ι Q) ∘ v)).prod ≠ 0 := by
+  cases n with
+  | zero => simp
+  | succ k =>
+      have hx : exteriorPower.ιMulti K (k + 1) v ≠ 0 := by
+        have hfamily := exteriorPower.ιMulti_family_linearIndependent_field (K := K)
+          (k + 1) hv
+        have hne := hfamily.ne_zero
+          (⟨Finset.univ, by simp⟩ : Set.powersetCard (Fin (k + 1)) (k + 1))
+        have hemb : Set.powersetCard.ofFinEmbEquiv.symm
+            (⟨Finset.univ, by simp⟩ : Set.powersetCard (Fin (k + 1)) (k + 1)) =
+            OrderEmbedding.id (Fin (k + 1)) := by
+          symm
+          exact Finset.orderEmbOfFin_unique' (by simp) (fun _ => by simp)
+        simpa [exteriorPower.ιMulti_family, hemb] using hne
+      intro hzero
+      have hlead := CliffordAlgebra.filtrationLeadingTerm_apply_ιMulti Q k v
+      have hmem : (List.ofFn ((CliffordAlgebra.ι Q) ∘ v)).prod ∈
+          CliffordAlgebra.filtration Q (k + 1) := by
+        rw [← List.map_ofFn]
+        exact CliffordAlgebra.prod_map_ι_mem_filtration Q (k := k + 1)
+          (l := List.ofFn v) (by simp)
+      have hsub : (⟨(List.ofFn ((CliffordAlgebra.ι Q) ∘ v)).prod, hmem⟩ :
+          CliffordAlgebra.filtration Q (k + 1)) = 0 := Subtype.ext hzero
+      have hquot := congrArg
+        (fun x : CliffordAlgebra.filtration Q (k + 1) =>
+          (Submodule.Quotient.mk x : TauCeti.Algebra.wordFiltration.GradedPiece
+            (CliffordAlgebra.ι Q) (k + 1))) hsub
+      have himage : CliffordAlgebra.filtrationLeadingTerm Q k
+          (exteriorPower.ιMulti K (k + 1) v) = 0 := hlead.trans (by simpa using hquot)
+      rw [CliffordAlgebra.filtrationLeadingTerm_eq_filtrationGradedEquiv_symm] at himage
+      apply hx
+      apply (CliffordAlgebra.filtrationGradedEquiv Q k).symm.injective
+      rw [map_zero]
+      exact himage
+
+private theorem carHighestWeightVector_ne_zero [Invertible (2 : K)] (N : ℕ) :
+    carHighestWeightVector K N ≠ 0 := by
+  have hfull : LinearIndependent K (carRootMatrix K N) := by
+    change LinearIndependent K (fun p =>
+      Matrix.stdBasis K (Fin N) (Fin N) (finProdFinEquiv.symm p))
+    exact (Matrix.stdBasis K (Fin N) (Fin N)).linearIndependent.comp finProdFinEquiv.symm
+      finProdFinEquiv.symm.injective
+  have hpositive : LinearIndependent K (carPositiveRootFamily K N) := by
+    change LinearIndependent K (fun r =>
+      carRootMatrix K N ((carPositiveRootCodes N).orderEmbOfFin rfl r))
+    exact hfull.comp ((carPositiveRootCodes N).orderEmbOfFin rfl)
+      ((carPositiveRootCodes N).orderEmbOfFin rfl).injective
+  simpa [carHighestWeightVector, List.map_ofFn] using
+    prod_iota_ne_zero (traceQuadraticForm K (Fin N)) (carPositiveRootFamily K N) hpositive
+
+private theorem positive_iota_mul_carHighestWeightVector_eq_zero
+    {N : ℕ} {i j : Fin N} (hij : i < j) :
+    CliffordAlgebra.ι (traceQuadraticForm K (Fin N)) (Matrix.single i j 1)
+        * carHighestWeightVector K N = 0 := by
+  apply iota_mul_prod_eq_zero_of_mem (carPositiveRootFamily_mem hij)
+  · rw [traceQuadraticForm_apply, Matrix.trace_single_mul, Matrix.single_apply]
+    simp [ne_of_lt hij]
+  · intro b hb
+    rw [List.mem_ofFn] at hb
+    obtain ⟨r, rfl⟩ := hb
+    have hr := Finset.orderEmbOfFin_mem (carPositiveRootCodes N) rfl r
+    rw [carPositiveRootFamily, carRootMatrix, Matrix.stdBasis_eq_single]
+    apply carPositiveUnits_ortho hij
+    simpa only [carPositiveRootCodes, Finset.mem_filter, Finset.mem_univ, true_and] using hr
+
+private noncomputable abbrev carD {N : ℕ} (i j : Fin N) :
+    CliffordAlgebra (traceQuadraticForm K (Fin N)) :=
+  CliffordAlgebra.ι (traceQuadraticForm K (Fin N)) (Matrix.single i j 1)
+
+private theorem raisingTerm_mul_carHighestWeightVector_eq_zero
+    {N : ℕ} {i j : Fin N} (hij : i < j) (k : Fin N) :
+    carD i k * carD k j * carHighestWeightVector K N = 0 := by
+  by_cases hkj : k < j
+  · rw [mul_assoc, positive_iota_mul_carHighestWeightVector_eq_zero hkj, mul_zero]
+  · have hik : i < k := lt_of_lt_of_le hij (le_of_not_gt hkj)
+    rw [traceQuadraticForm_ι_single_mul_ι_single_comm_of_not_paired i k k j 1 1
+      (by intro h; exact (ne_of_lt hij) h.2.symm), neg_mul, mul_assoc,
+      positive_iota_mul_carHighestWeightVector_eq_zero hik, mul_zero, neg_zero]
+
+private theorem diagonalTerm_mul_carHighestWeightVector {N : ℕ} (i k : Fin N) :
+    carD i k * carD k i * carHighestWeightVector K N =
+      if k < i then 0 else if k = i then carHighestWeightVector K N
+      else (2 : K) • carHighestWeightVector K N := by
+  rcases lt_trichotomy k i with hki | rfl | hik
+  · simp only [hki, ↓reduceIte]
+    rw [mul_assoc, positive_iota_mul_carHighestWeightVector_eq_zero hki, mul_zero]
+  · simp [carD]
+  · simp only [not_lt_of_ge hik.le, ne_of_gt hik, ↓reduceIte]
+    have hcar := traceQuadraticForm_ι_single_mul_ι_single_add_swap
+      (R := K) i k k i 1 1
+    have hmul := congrArg
+      (fun x : CliffordAlgebra (traceQuadraticForm K (Fin N)) =>
+        x * carHighestWeightVector K N) hcar
+    simp only [add_mul, mul_assoc, positive_iota_mul_carHighestWeightVector_eq_zero hik,
+      mul_zero, add_zero] at hmul
+    rw [mul_assoc]
+    simpa [carD, Algebra.smul_def] using hmul
+
+private theorem diagonalScalarSum {N : ℕ} (i : Fin N) :
+    (∑ k : Fin N, if k = i then (1 : K) else if i < k then 2 else 0) =
+      1 + 2 * ((Finset.Ioi i).card : K) := by
+  calc
+    _ = (∑ k : Fin N, if k = i then (1 : K) else 0) +
+        ∑ k : Fin N, if i < k then (2 : K) else 0 := by
+      rw [← Finset.sum_add_distrib]
+      apply Finset.sum_congr rfl
+      intro k _
+      split_ifs <;> simp_all
+    _ = 1 + 2 * ((Finset.Ioi i).card : K) := by
+      have hfirst : (∑ k : Fin N, if k = i then (1 : K) else 0) = 1 := by simp
+      have hsecond : (∑ k : Fin N, if i < k then (2 : K) else 0) =
+          2 * ((Finset.Ioi i).card : K) := by
+        rw [← Finset.sum_filter]
+        simp [Finset.filter_lt_eq_Ioi, mul_comm]
+      rw [hfirst, hsecond]
+
+private theorem diagonalTerm_mul_carHighestWeightVector_eq_smul {N : ℕ}
+    (i k : Fin N) :
+    carD i k * carD k i * carHighestWeightVector K N =
+      (if k = i then (1 : K) else if i < k then 2 else 0) •
+        carHighestWeightVector K N := by
+  rw [diagonalTerm_mul_carHighestWeightVector]
+  rcases lt_trichotomy k i with hki | rfl | hik
+  · simp [hki, ne_of_lt hki, not_lt_of_ge hki.le]
+  · simp
+  · simp [hik, ne_of_gt hik, not_lt_of_ge hik.le]
+
+private theorem diagonalSum_mul_carHighestWeightVector {N : ℕ} (i : Fin N) :
+    (∑ k : Fin N, carD i k * carD k i) * carHighestWeightVector K N =
+      (1 + 2 * ((Finset.Ioi i).card : K)) • carHighestWeightVector K N := by
+  rw [Finset.sum_mul]
+  simp_rw [diagonalTerm_mul_carHighestWeightVector_eq_smul i]
+  rw [← Finset.sum_smul, diagonalScalarSum i]
+
+section Action
+
+variable [CharZero K] [h2 : Invertible (2 : K)]
+
+/-- The CAR Lie-ring module instance using the fixed invertibility witness. -/
+local instance {N : ℕ} :
+    LieRingModule (Matrix (Fin N) (Fin N) K)
+      (CliffordAlgebra (traceQuadraticForm K (Fin N))) :=
+  @carLieRingModule K (Fin N) inferInstance inferInstance h2
+
+/-- The CAR Lie-module instance using the fixed invertibility witness. -/
+local instance {N : ℕ} :
+    LieModule K (Matrix (Fin N) (Fin N) K)
+      (CliffordAlgebra (traceQuadraticForm K (Fin N))) :=
+  @carLieModule K (Fin N) inferInstance inferInstance h2
+
+omit [CharZero K] in
+/-- `glCliffordHom_single` restated with this file's matrix-unit decidability instance. -/
+private theorem glCliffordHom_single_current {N : ℕ} (i j : Fin N) :
+    (@glCliffordHom K (Fin N) inferInstance inferInstance h2) (Matrix.single i j 1) =
+      (2 : K)⁻¹ • ∑ k : Fin N, carD i k * carD k j := by
+  convert @glCliffordHom_single K (Fin N) inferInstance inferInstance h2 i j using 1
+  · apply congrArg (@glCliffordHom K (Fin N) inferInstance inferInstance h2)
+    ext a b
+    simp [Matrix.single]
+  · apply congrArg ((2 : K)⁻¹ • ·)
+    apply Finset.sum_congr rfl
+    intro k _
+    apply congrArg₂ (· * ·)
+    · apply congrArg (CliffordAlgebra.ι (traceQuadraticForm K (Fin N)))
+      ext a b
+      simp [Matrix.single]
+    · apply congrArg (CliffordAlgebra.ι (traceQuadraticForm K (Fin N)))
+      ext a b
+      simp [Matrix.single]
+
+omit [CharZero K] in
+private theorem glCliffordHom_single_mul_carHighestWeightVector_eq_zero
+    {N : ℕ} {i j : Fin N} (hij : i < j) :
+    (@glCliffordHom K (Fin N) inferInstance inferInstance h2) (Matrix.single i j 1) *
+      carHighestWeightVector K N = 0 := by
+  rw [glCliffordHom_single_current i j, smul_mul_assoc, Finset.sum_mul]
+  simp only [raisingTerm_mul_carHighestWeightVector_eq_zero hij,
+    Finset.sum_const_zero, smul_zero]
+
+omit [CharZero K] in
+private theorem raising_lie_carHighestWeightVector_eq_zero
+    {N : ℕ} {i j : Fin N} (hij : i < j) :
+    ⁅Matrix.single i j (1 : K), carHighestWeightVector K N⁆ = 0 := by
+  rw [car_lie_def]
+  exact glCliffordHom_single_mul_carHighestWeightVector_eq_zero hij
+
+omit h2 in
+private theorem half_diagonalScalarSum {N : ℕ} (i : Fin N) :
+    (2 : K)⁻¹ * (1 + 2 * ((Finset.Ioi i).card : K)) =
+      algebraMap ℚ K (glStaircase N i) := by
+  rw [Fin.card_Ioi, glStaircase_apply]
+  have hi : (i : ℕ) < N := i.isLt
+  rw [show N - 1 - (i : ℕ) = N - ((i : ℕ) + 1) by omega,
+    Nat.cast_sub (by omega : (i : ℕ) + 1 ≤ N)]
+  push_cast
+  field_simp
+  norm_num
+  ring
+
+private theorem diagonal_lie_carHighestWeightVector {N : ℕ} (i : Fin N) :
+    ⁅Matrix.single i i (1 : K), carHighestWeightVector K N⁆ =
+      algebraMap ℚ K (glStaircase N i) • carHighestWeightVector K N := by
+  rw [car_lie_def, glCliffordHom_single_current i i, smul_mul_assoc,
+    diagonalSum_mul_carHighestWeightVector i, smul_smul, half_diagonalScalarSum i]
+
+/-- The ordered product of all positive matrix-unit Clifford generators is a highest-weight vector
+for the left `gl_N`-action on the CAR algebra. Its weight is the scalar extension of the rational
+staircase `TauCeti.glStaircase N`. -/
+theorem isGlHighestWeightVector_carHighestWeightVector (N : ℕ) :
+    IsGlHighestWeightVector (fun i => algebraMap ℚ K (glStaircase N i))
+      (carHighestWeightVector K N) := by
+  rw [isGlHighestWeightVector_iff]
+  exact ⟨carHighestWeightVector_ne_zero N, diagonal_lie_carHighestWeightVector,
+    fun i j hij => raising_lie_carHighestWeightVector_eq_zero hij⟩
+
+end Action
+
+end Field
+
+end
+
+end TauCeti

--- a/TauCeti/Algebra/Lie/GeneralLinear/Clifford.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/Clifford.lean
@@ -210,44 +210,25 @@ matrix units rather than a noncanonical internal choice. -/
 theorem glCliffordHom_single [decEq : DecidableEq n] (i j : n) :
     glCliffordHom (K := K) (n := n) (Matrix.single i j (1 : K)) =
       (2⁻¹ : K) • ∑ k : n,
-        ι (traceQuadraticForm K n) (Matrix.single i k 1) *
-          ι (traceQuadraticForm K n) (Matrix.single k j 1) := by
-  let _ : DecidableEq n := Classical.decEq n
-  have hclassical :
-      glCliffordHom (K := K) (n := n) (Matrix.single i j (1 : K)) =
-        (2⁻¹ : K) • ∑ k : n,
           ι (traceQuadraticForm K n) (Matrix.single i k 1) *
-            ι (traceQuadraticForm K n) (Matrix.single k j 1) := by
-    rw [glCliffordHom_normalOrdering]
-    simp_rw [matrixUnit_ι_mul_eq_bivector_add]
-    by_cases h : i = j
-    · subst j
-      simp only [↓reduceIte, map_one]
-      have hcentral :
-          (2⁻¹ : K) • ∑ _ : n, (1 : CliffordAlgebra (traceQuadraticForm K n)) =
-            algebraMap K _ ((Fintype.card n : K) / 2) := by
-        rw [Finset.sum_const, ← Nat.cast_smul_eq_nsmul K, smul_smul,
-          Algebra.algebraMap_eq_smul_one]
-        rw [Finset.card_univ]
-        congr 1
-        ring_nf
-      rw [← hcentral]
-      rw [Finset.sum_add_distrib, smul_add]
-    · simp [h, Finset.smul_sum]
-  convert hclassical using 1
-  · apply congrArg (glCliffordHom (K := K) (n := n))
-    ext a b
-    simp [Matrix.single]
-  · apply congrArg ((2 : K)⁻¹ • ·)
-    apply Finset.sum_congr rfl
-    intro k _
-    apply congrArg₂ (· * ·)
-    · apply congrArg (ι (traceQuadraticForm K n))
-      ext a b
-      simp [Matrix.single]
-    · apply congrArg (ι (traceQuadraticForm K n))
-      ext a b
-      simp [Matrix.single]
+          ι (traceQuadraticForm K n) (Matrix.single k j 1) := by
+  cases Subsingleton.elim decEq (Classical.decEq n)
+  rw [glCliffordHom_normalOrdering]
+  simp_rw [matrixUnit_ι_mul_eq_bivector_add]
+  by_cases h : i = j
+  · subst j
+    simp only [↓reduceIte, map_one]
+    have hcentral :
+        (2⁻¹ : K) • ∑ _ : n, (1 : CliffordAlgebra (traceQuadraticForm K n)) =
+          algebraMap K _ ((Fintype.card n : K) / 2) := by
+      rw [Finset.sum_const, ← Nat.cast_smul_eq_nsmul K, smul_smul,
+        Algebra.algebraMap_eq_smul_one]
+      rw [Finset.card_univ]
+      congr 1
+      ring_nf
+    rw [← hcentral]
+    rw [Finset.sum_add_distrib, smul_add]
+  · simp [h, Finset.smul_sum]
 
 /-! ### Injectivity -/
 

--- a/TauCeti/Algebra/Lie/GeneralLinear/Clifford.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/Clifford.lean
@@ -204,29 +204,50 @@ private theorem matrixUnit_ι_mul_eq_bivector_add (i j k : n) :
   · simp [eq_comm, h]
 
 /-- On a matrix unit, the lift is the normal-ordered quadratic sum
-`Eᵢⱼ ↦ 1/2 ∑ₖ dᵢₖ dₖⱼ`. -/
+`Eᵢⱼ ↦ 1/2 ∑ₖ dᵢₖ dₖⱼ`. The decidable equality is explicit so the equation uses the consumer's
+matrix units rather than a noncanonical internal choice. -/
 @[simp, grind =]
-theorem glCliffordHom_single (i j : n) :
+theorem glCliffordHom_single [decEq : DecidableEq n] (i j : n) :
     glCliffordHom (K := K) (n := n) (Matrix.single i j (1 : K)) =
       (2⁻¹ : K) • ∑ k : n,
         ι (traceQuadraticForm K n) (Matrix.single i k 1) *
           ι (traceQuadraticForm K n) (Matrix.single k j 1) := by
-  rw [glCliffordHom_normalOrdering]
-  simp_rw [matrixUnit_ι_mul_eq_bivector_add]
-  by_cases h : i = j
-  · subst j
-    simp only [↓reduceIte, map_one]
-    have hcentral :
-        (2⁻¹ : K) • ∑ _ : n, (1 : CliffordAlgebra (traceQuadraticForm K n)) =
-          algebraMap K _ ((Fintype.card n : K) / 2) := by
-      rw [Finset.sum_const, ← Nat.cast_smul_eq_nsmul K, smul_smul,
-        Algebra.algebraMap_eq_smul_one]
-      rw [Finset.card_univ]
-      congr 1
-      ring_nf
-    rw [← hcentral]
-    rw [Finset.sum_add_distrib, smul_add]
-  · simp [h, Finset.smul_sum]
+  let _ : DecidableEq n := Classical.decEq n
+  have hclassical :
+      glCliffordHom (K := K) (n := n) (Matrix.single i j (1 : K)) =
+        (2⁻¹ : K) • ∑ k : n,
+          ι (traceQuadraticForm K n) (Matrix.single i k 1) *
+            ι (traceQuadraticForm K n) (Matrix.single k j 1) := by
+    rw [glCliffordHom_normalOrdering]
+    simp_rw [matrixUnit_ι_mul_eq_bivector_add]
+    by_cases h : i = j
+    · subst j
+      simp only [↓reduceIte, map_one]
+      have hcentral :
+          (2⁻¹ : K) • ∑ _ : n, (1 : CliffordAlgebra (traceQuadraticForm K n)) =
+            algebraMap K _ ((Fintype.card n : K) / 2) := by
+        rw [Finset.sum_const, ← Nat.cast_smul_eq_nsmul K, smul_smul,
+          Algebra.algebraMap_eq_smul_one]
+        rw [Finset.card_univ]
+        congr 1
+        ring_nf
+      rw [← hcentral]
+      rw [Finset.sum_add_distrib, smul_add]
+    · simp [h, Finset.smul_sum]
+  convert hclassical using 1
+  · apply congrArg (glCliffordHom (K := K) (n := n))
+    ext a b
+    simp [Matrix.single]
+  · apply congrArg ((2 : K)⁻¹ • ·)
+    apply Finset.sum_congr rfl
+    intro k _
+    apply congrArg₂ (· * ·)
+    · apply congrArg (ι (traceQuadraticForm K n))
+      ext a b
+      simp [Matrix.single]
+    · apply congrArg (ι (traceQuadraticForm K n))
+      ext a b
+      simp [Matrix.single]
 
 /-! ### Injectivity -/
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/FiltrationGradedEquiv.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/FiltrationGradedEquiv.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.LinearAlgebra.CliffordAlgebra.ExteriorFiltration
+import Mathlib.LinearAlgebra.ExteriorPower.Basis
 
 /-!
 # The degree quotients of a Clifford filtration
@@ -38,6 +39,8 @@ construct the total associated-graded algebra or prove multiplication compatibil
   equivalence inverts `Filtration.lean`'s leading-term map, so the two independent routes to the
   degree quotient are the same map, with
   `CliffordAlgebra.filtrationLeadingTerm_eq_filtrationGradedEquiv_symm` the map-level form.
+* `CliffordAlgebra.prod_map_ι_ofFn_ne_zero`: a linearly independent finite family has a nonzero
+  ordered product of Clifford generators.
 
 ## References
 
@@ -193,5 +196,46 @@ theorem filtrationLeadingTerm_eq_filtrationGradedEquiv_symm (k : ℕ) :
   rw [← LinearMap.comp_id (filtrationGradedEquiv Q k).symm.toLinearMap]
   exact (LinearEquiv.eq_toLinearMap_symm_comp _ _).2
     (filtrationGradedEquiv_comp_filtrationLeadingTerm Q k)
+
+/-- An ordered product of Clifford generators from a linearly independent finite family is
+nonzero. This is the multiplicative form of the PBW leading-term calculation: its symbol is the
+corresponding nonzero exterior product. -/
+theorem prod_map_ι_ofFn_ne_zero {K : Type u} [Field K] [Module K M]
+    [Invertible (2 : K)] (Q : QuadraticForm K M) {n : ℕ} (v : Fin n → M)
+    (hv : LinearIndependent K v) :
+    (List.ofFn ((ι Q) ∘ v)).prod ≠ 0 := by
+  cases n with
+  | zero => simp
+  | succ k =>
+      have hx : exteriorPower.ιMulti K (k + 1) v ≠ 0 := by
+        have hfamily := exteriorPower.ιMulti_family_linearIndependent_field (K := K)
+          (k + 1) hv
+        have hne := hfamily.ne_zero
+          (⟨Finset.univ, by simp⟩ : Set.powersetCard (Fin (k + 1)) (k + 1))
+        have hemb : Set.powersetCard.ofFinEmbEquiv.symm
+            (⟨Finset.univ, by simp⟩ : Set.powersetCard (Fin (k + 1)) (k + 1)) =
+            OrderEmbedding.id (Fin (k + 1)) := by
+          symm
+          exact Finset.orderEmbOfFin_unique' (by simp) (fun _ => by simp)
+        simpa [exteriorPower.ιMulti_family, hemb] using hne
+      intro hzero
+      have hlead := filtrationLeadingTerm_apply_ιMulti Q k v
+      have hmem : (List.ofFn ((ι Q) ∘ v)).prod ∈ filtration Q (k + 1) := by
+        rw [← List.map_ofFn]
+        exact prod_map_ι_mem_filtration Q (k := k + 1)
+          (l := List.ofFn v) (by simp)
+      have hsub : (⟨(List.ofFn ((ι Q) ∘ v)).prod, hmem⟩ : filtration Q (k + 1)) = 0 :=
+        Subtype.ext hzero
+      have hquot := congrArg
+        (fun x : filtration Q (k + 1) =>
+          (Submodule.Quotient.mk x : TauCeti.Algebra.wordFiltration.GradedPiece
+            (ι Q) (k + 1))) hsub
+      have himage : filtrationLeadingTerm Q k (exteriorPower.ιMulti K (k + 1) v) = 0 :=
+        hlead.trans (by simpa using hquot)
+      rw [filtrationLeadingTerm_eq_filtrationGradedEquiv_symm] at himage
+      apply hx
+      apply (filtrationGradedEquiv Q k).symm.injective
+      rw [map_zero]
+      exact himage
 
 end CliffordAlgebra

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/FiltrationGradedEquiv.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/FiltrationGradedEquiv.lean
@@ -6,7 +6,8 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.LinearAlgebra.CliffordAlgebra.ExteriorFiltration
-import Mathlib.LinearAlgebra.ExteriorPower.Basis
+import Mathlib.LinearAlgebra.Basis.VectorSpace
+import Mathlib.LinearAlgebra.QuadraticForm.Basis
 
 /-!
 # The degree quotients of a Clifford filtration
@@ -198,44 +199,72 @@ theorem filtrationLeadingTerm_eq_filtrationGradedEquiv_symm (k : ℕ) :
     (filtrationGradedEquiv_comp_filtrationLeadingTerm Q k)
 
 /-- An ordered product of Clifford generators from a linearly independent finite family is
-nonzero. This is the multiplicative form of the PBW leading-term calculation: its symbol is the
-corresponding nonzero exterior product. -/
+nonzero, in every characteristic. This is the multiplicative PBW independence statement; the
+proof successively contracts against coordinate functionals. -/
 theorem prod_map_ι_ofFn_ne_zero {K : Type u} [Field K] [Module K M]
-    [Invertible (2 : K)] (Q : QuadraticForm K M) {n : ℕ} (v : Fin n → M)
-    (hv : LinearIndependent K v) :
+    (Q : QuadraticForm K M) {n : ℕ} (v : Fin n → M) (hv : LinearIndependent K v) :
     (List.ofFn ((ι Q) ∘ v)).prod ≠ 0 := by
-  cases n with
-  | zero => simp
-  | succ k =>
-      have hx : exteriorPower.ιMulti K (k + 1) v ≠ 0 := by
-        have hfamily := exteriorPower.ιMulti_family_linearIndependent_field (K := K)
-          (k + 1) hv
-        have hne := hfamily.ne_zero
-          (⟨Finset.univ, by simp⟩ : Set.powersetCard (Fin (k + 1)) (k + 1))
-        have hemb : Set.powersetCard.ofFinEmbEquiv.symm
-            (⟨Finset.univ, by simp⟩ : Set.powersetCard (Fin (k + 1)) (k + 1)) =
-            OrderEmbedding.id (Fin (k + 1)) := by
-          symm
-          exact Finset.orderEmbOfFin_unique' (by simp) (fun _ => by simp)
-        simpa [exteriorPower.ιMulti_family, hemb] using hne
+  classical
+  have hone : (1 : CliffordAlgebra Q) ≠ 0 := by
+    obtain ⟨B, hB⟩ := LinearMap.BilinMap.toQuadraticMap_surjective (-Q)
+    have hB' : B.toQuadraticMap = 0 - Q := by simpa using hB
+    let _ : Nontrivial (CliffordAlgebra Q) :=
+      (changeFormEquiv hB').symm.injective.nontrivial
+    exact one_ne_zero
+  induction n with
+  | zero => simpa using hone
+  | succ k ih =>
+      let w : Fin k → M := fun i => v i.succ
+      have hw : LinearIndependent K w := hv.comp Fin.succ (Fin.succ_injective k)
+      have hv0 : v 0 ∉ Submodule.span K (Set.range w) := by
+        have h := hv.notMem_span_image (s := Set.range (Fin.succ : Fin k → Fin (k + 1)))
+          (x := 0) (by simp)
+        have hrange : v '' Set.range (Fin.succ : Fin k → Fin (k + 1)) = Set.range w := by
+          ext x
+          constructor
+          · rintro ⟨_, ⟨i, rfl⟩, rfl⟩
+            exact ⟨i, rfl⟩
+          · rintro ⟨i, rfl⟩
+            exact ⟨i.succ, ⟨i, rfl⟩, rfl⟩
+        rw [hrange] at h
+        exact h
+      obtain ⟨d, hd, hd_zero⟩ :=
+        LinearMap.exists_extend_of_notMem
+          (0 : Submodule.span K (Set.range w) →ₗ[K] K) hv0 1
+      have hd_succ (i : Fin k) : d (w i) = 0 := by
+        have h := LinearMap.congr_fun hd
+          (⟨w i, Submodule.subset_span (Set.mem_range_self i)⟩ :
+            Submodule.span K (Set.range w))
+        rw [LinearMap.comp_apply, LinearMap.zero_apply] at h
+        -- Remove the span-subtype coercion from the extension equation.
+        change d (w i) = 0 at h
+        exact h
+      have hcontract (l : List M) (hl : ∀ x ∈ l, d x = 0) :
+          contractLeft d (l.map (ι Q)).prod = 0 := by
+        induction l with
+        | nil => simp
+        | cons x l ih =>
+            rw [List.map_cons, List.prod_cons, contractLeft_ι_mul, hl x List.mem_cons_self,
+              zero_smul, zero_sub]
+            simp only [ih (fun y hy => hl y (List.mem_cons_of_mem x hy)), mul_zero, neg_zero]
       intro hzero
-      have hlead := filtrationLeadingTerm_apply_ιMulti Q k v
-      have hmem : (List.ofFn ((ι Q) ∘ v)).prod ∈ filtration Q (k + 1) := by
+      rw [List.ofFn_succ, List.prod_cons] at hzero
+      simp only [Function.comp_apply] at hzero
+      have hzero' := congrArg (contractLeft d) hzero
+      rw [map_zero, contractLeft_ι_mul, hd_zero, one_smul] at hzero'
+      have htail : contractLeft d (List.ofFn ((ι Q) ∘ w)).prod = 0 := by
         rw [← List.map_ofFn]
-        exact prod_map_ι_mem_filtration Q (k := k + 1)
-          (l := List.ofFn v) (by simp)
-      have hsub : (⟨(List.ofFn ((ι Q) ∘ v)).prod, hmem⟩ : filtration Q (k + 1)) = 0 :=
-        Subtype.ext hzero
-      have hquot := congrArg
-        (fun x : filtration Q (k + 1) =>
-          (Submodule.Quotient.mk x : TauCeti.Algebra.wordFiltration.GradedPiece
-            (ι Q) (k + 1))) hsub
-      have himage : filtrationLeadingTerm Q k (exteriorPower.ιMulti K (k + 1) v) = 0 :=
-        hlead.trans (by simpa using hquot)
-      rw [filtrationLeadingTerm_eq_filtrationGradedEquiv_symm] at himage
-      apply hx
-      apply (filtrationGradedEquiv Q k).symm.injective
-      rw [map_zero]
-      exact himage
+        apply hcontract
+        intro x hx
+        rw [List.mem_ofFn] at hx
+        obtain ⟨i, rfl⟩ := hx
+        exact hd_succ i
+      -- Normalize the local tail abbreviation to the `List.ofFn` shape produced above.
+      change contractLeft d (List.ofFn fun i => ι Q (v i.succ)).prod = 0 at htail
+      rw [htail, mul_zero, sub_zero] at hzero'
+      apply ih w hw
+      -- Normalize the induction hypothesis's composed family to the same tail expression.
+      change (List.ofFn fun i => ι Q (v i.succ)).prod = 0
+      exact hzero'
 
 end CliffordAlgebra

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/FiltrationGradedEquiv.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/FiltrationGradedEquiv.lean
@@ -6,8 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.LinearAlgebra.CliffordAlgebra.ExteriorFiltration
-import Mathlib.LinearAlgebra.Basis.VectorSpace
-import Mathlib.LinearAlgebra.QuadraticForm.Basis
 
 /-!
 # The degree quotients of a Clifford filtration
@@ -40,9 +38,6 @@ construct the total associated-graded algebra or prove multiplication compatibil
   equivalence inverts `Filtration.lean`'s leading-term map, so the two independent routes to the
   degree quotient are the same map, with
   `CliffordAlgebra.filtrationLeadingTerm_eq_filtrationGradedEquiv_symm` the map-level form.
-* `CliffordAlgebra.prod_map_ι_ofFn_ne_zero`: a linearly independent finite family has a nonzero
-  ordered product of Clifford generators.
-
 ## References
 
 * [Clifford algebras, Pin and Spin, and spin representations roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md),
@@ -197,74 +192,5 @@ theorem filtrationLeadingTerm_eq_filtrationGradedEquiv_symm (k : ℕ) :
   rw [← LinearMap.comp_id (filtrationGradedEquiv Q k).symm.toLinearMap]
   exact (LinearEquiv.eq_toLinearMap_symm_comp _ _).2
     (filtrationGradedEquiv_comp_filtrationLeadingTerm Q k)
-
-/-- An ordered product of Clifford generators from a linearly independent finite family is
-nonzero, in every characteristic. This is the multiplicative PBW independence statement; the
-proof successively contracts against coordinate functionals. -/
-theorem prod_map_ι_ofFn_ne_zero {K : Type u} [Field K] [Module K M]
-    (Q : QuadraticForm K M) {n : ℕ} (v : Fin n → M) (hv : LinearIndependent K v) :
-    (List.ofFn ((ι Q) ∘ v)).prod ≠ 0 := by
-  classical
-  have hone : (1 : CliffordAlgebra Q) ≠ 0 := by
-    obtain ⟨B, hB⟩ := LinearMap.BilinMap.toQuadraticMap_surjective (-Q)
-    have hB' : B.toQuadraticMap = 0 - Q := by simpa using hB
-    let _ : Nontrivial (CliffordAlgebra Q) :=
-      (changeFormEquiv hB').symm.injective.nontrivial
-    exact one_ne_zero
-  induction n with
-  | zero => simpa using hone
-  | succ k ih =>
-      let w : Fin k → M := fun i => v i.succ
-      have hw : LinearIndependent K w := hv.comp Fin.succ (Fin.succ_injective k)
-      have hv0 : v 0 ∉ Submodule.span K (Set.range w) := by
-        have h := hv.notMem_span_image (s := Set.range (Fin.succ : Fin k → Fin (k + 1)))
-          (x := 0) (by simp)
-        have hrange : v '' Set.range (Fin.succ : Fin k → Fin (k + 1)) = Set.range w := by
-          ext x
-          constructor
-          · rintro ⟨_, ⟨i, rfl⟩, rfl⟩
-            exact ⟨i, rfl⟩
-          · rintro ⟨i, rfl⟩
-            exact ⟨i.succ, ⟨i, rfl⟩, rfl⟩
-        rw [hrange] at h
-        exact h
-      obtain ⟨d, hd, hd_zero⟩ :=
-        LinearMap.exists_extend_of_notMem
-          (0 : Submodule.span K (Set.range w) →ₗ[K] K) hv0 1
-      have hd_succ (i : Fin k) : d (w i) = 0 := by
-        have h := LinearMap.congr_fun hd
-          (⟨w i, Submodule.subset_span (Set.mem_range_self i)⟩ :
-            Submodule.span K (Set.range w))
-        rw [LinearMap.comp_apply, LinearMap.zero_apply] at h
-        -- Remove the span-subtype coercion from the extension equation.
-        change d (w i) = 0 at h
-        exact h
-      have hcontract (l : List M) (hl : ∀ x ∈ l, d x = 0) :
-          contractLeft d (l.map (ι Q)).prod = 0 := by
-        induction l with
-        | nil => simp
-        | cons x l ih =>
-            rw [List.map_cons, List.prod_cons, contractLeft_ι_mul, hl x List.mem_cons_self,
-              zero_smul, zero_sub]
-            simp only [ih (fun y hy => hl y (List.mem_cons_of_mem x hy)), mul_zero, neg_zero]
-      intro hzero
-      rw [List.ofFn_succ, List.prod_cons] at hzero
-      simp only [Function.comp_apply] at hzero
-      have hzero' := congrArg (contractLeft d) hzero
-      rw [map_zero, contractLeft_ι_mul, hd_zero, one_smul] at hzero'
-      have htail : contractLeft d (List.ofFn ((ι Q) ∘ w)).prod = 0 := by
-        rw [← List.map_ofFn]
-        apply hcontract
-        intro x hx
-        rw [List.mem_ofFn] at hx
-        obtain ⟨i, rfl⟩ := hx
-        exact hd_succ i
-      -- Normalize the local tail abbreviation to the `List.ofFn` shape produced above.
-      change contractLeft d (List.ofFn fun i => ι Q (v i.succ)).prod = 0 at htail
-      rw [htail, mul_zero, sub_zero] at hzero'
-      apply ih w hw
-      -- Normalize the induction hypothesis's composed family to the same tail expression.
-      change (List.ofFn fun i => ι Q (v i.succ)).prod = 0
-      exact hzero'
 
 end CliffordAlgebra

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/PBW.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/PBW.lean
@@ -7,6 +7,8 @@ module
 
 import TauCeti.LinearAlgebra.CliffordAlgebra.Basic
 public import TauCeti.LinearAlgebra.CliffordAlgebra.FiltrationGradedEquiv
+import Mathlib.LinearAlgebra.Basis.VectorSpace
+import Mathlib.LinearAlgebra.QuadraticForm.Basis
 
 /-!
 # PBW equivalence for a Clifford filtration
@@ -22,6 +24,11 @@ This completes the associated-graded-algebra part of Layer 0 in the
 
 * `CliffordAlgebra.associatedGradedEquivExterior`: the algebra equivalence from
   the associated graded of the Clifford filtration to the exterior algebra.
+
+## Main result
+
+* `CliffordAlgebra.prod_map_ι_ofFn_ne_zero`: a linearly independent finite family has a nonzero
+  ordered product of Clifford generators.
 
 ## References
 
@@ -41,6 +48,74 @@ open TauCeti.Algebra.wordFiltration
 
 variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
   (Q : QuadraticForm R M) [Invertible (2 : R)]
+
+/-- An ordered product of Clifford generators from a linearly independent finite family is
+nonzero, in every characteristic. This is the multiplicative PBW independence statement. -/
+theorem prod_map_ι_ofFn_ne_zero {K : Type u} [Field K] [Module K M]
+    (Q : QuadraticForm K M) {n : ℕ} (v : Fin n → M) (hv : LinearIndependent K v) :
+    (List.ofFn ((ι Q) ∘ v)).prod ≠ 0 := by
+  classical
+  have hone : (1 : CliffordAlgebra Q) ≠ 0 := by
+    obtain ⟨B, hB⟩ := LinearMap.BilinMap.toQuadraticMap_surjective (-Q)
+    have hB' : B.toQuadraticMap = 0 - Q := by simpa using hB
+    let _ : Nontrivial (CliffordAlgebra Q) :=
+      (changeFormEquiv hB').symm.injective.nontrivial
+    exact one_ne_zero
+  induction n with
+  | zero => simpa using hone
+  | succ k ih =>
+      let w : Fin k → M := fun i => v i.succ
+      have hw : LinearIndependent K w := hv.comp Fin.succ (Fin.succ_injective k)
+      have hv0 : v 0 ∉ Submodule.span K (Set.range w) := by
+        have h := hv.notMem_span_image (s := Set.range (Fin.succ : Fin k → Fin (k + 1)))
+          (x := 0) (by simp)
+        have hrange : v '' Set.range (Fin.succ : Fin k → Fin (k + 1)) = Set.range w := by
+          ext x
+          constructor
+          · rintro ⟨_, ⟨i, rfl⟩, rfl⟩
+            exact ⟨i, rfl⟩
+          · rintro ⟨i, rfl⟩
+            exact ⟨i.succ, ⟨i, rfl⟩, rfl⟩
+        rw [hrange] at h
+        exact h
+      obtain ⟨d, hd, hd_zero⟩ :=
+        LinearMap.exists_extend_of_notMem
+          (0 : Submodule.span K (Set.range w) →ₗ[K] K) hv0 1
+      have hd_succ (i : Fin k) : d (w i) = 0 := by
+        have h := LinearMap.congr_fun hd
+          (⟨w i, Submodule.subset_span (Set.mem_range_self i)⟩ :
+            Submodule.span K (Set.range w))
+        rw [LinearMap.comp_apply, LinearMap.zero_apply] at h
+        -- Remove the span-subtype coercion from the extension equation.
+        change d (w i) = 0 at h
+        exact h
+      have hcontract (l : List M) (hl : ∀ x ∈ l, d x = 0) :
+          contractLeft d (l.map (ι Q)).prod = 0 := by
+        induction l with
+        | nil => simp
+        | cons x l ih =>
+            rw [List.map_cons, List.prod_cons, contractLeft_ι_mul, hl x List.mem_cons_self,
+              zero_smul, zero_sub]
+            simp only [ih (fun y hy => hl y (List.mem_cons_of_mem x hy)), mul_zero, neg_zero]
+      intro hzero
+      rw [List.ofFn_succ, List.prod_cons] at hzero
+      simp only [Function.comp_apply] at hzero
+      have hzero' := congrArg (contractLeft d) hzero
+      rw [map_zero, contractLeft_ι_mul, hd_zero, one_smul] at hzero'
+      have htail : contractLeft d (List.ofFn ((ι Q) ∘ w)).prod = 0 := by
+        rw [← List.map_ofFn]
+        apply hcontract
+        intro x hx
+        rw [List.mem_ofFn] at hx
+        obtain ⟨i, rfl⟩ := hx
+        exact hd_succ i
+      -- Normalize the local tail abbreviation to the `List.ofFn` shape produced above.
+      change contractLeft d (List.ofFn fun i => ι Q (v i.succ)).prod = 0 at htail
+      rw [htail, mul_zero, sub_zero] at hzero'
+      apply ih w hw
+      -- Normalize the induction hypothesis's composed family to the same tail expression.
+      change (List.ofFn fun i => ι Q (v i.succ)).prod = 0
+      exact hzero'
 
 private noncomputable def scalarEquivFiltrationZero :
     R ≃ₗ[R] filtration Q 0 :=


### PR DESCRIPTION
This PR constructs the canonical positive-root Clifford product and proves its general finite-order weight equation for the Layer 9 CAR isotypy milestone.

Roadmap: RepresentationTheory

## Summary

The ordered product of the strictly upper-triangular matrix-unit generators is nonzero over every field by a characteristic-independent Clifford contraction argument. The normal-ordered `gl_n` lift then shows that every raising matrix unit annihilates it and that `Eᵢᵢ` acts with weight `1/2 · (1 + 2 · #{j | i < j})`; for `Fin N`, this is `N - 1/2 - i`. Review repairs place the generic PBW independence theorem in the canonical PBW API, generalize the CAR construction, expose the product's sign-sensitive lexicographic enumeration as an order embedding with its exact range, reuse that range API in the formation theorem, align the public matrix-unit and staircase equations with the consumer's decidable-equality instance, and make the underlying `Finset.orderEmbOfFin` equation explicit in the range and independence proofs.

## Roadmap target

This advances RepresentationTheory/SpinRepresentations Layer 9, target `car_simple_highestWeight`, by supplying an explicit nonzero ambient CAR highest-weight vector of the required staircase weight. After this PR, it remains to locate a vector of that weight inside every simple CAR submodule; the single-weight criterion can then package those submodules into `car_isotypic`.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"car-highest-weight-vector"}-->

## Verification

- Exact head: `088038378ab3340a6560d2f3a4bccb4059de79a3`
- Local Lean build: `lake build` — pass (`Build completed successfully (10966 jobs).`)
- Axiom audit: `lake exe axioms` — pass (`axioms: audited 108148 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`)
- Lint: `env PATH=/opt/homebrew/opt/gnu-sed/libexec/gnubin:$PATH bash scripts/lint-env.sh && python3 scripts/lint-dot-notation.py && bash scripts/lint-style.sh && lake exe module-system` — pass (`LINT-ENV: PASS`; no new dot-notation violations; 4,812 headers and 4,813 modules checked)
- Public CI: pending for this head

## Scale and generality

The aggregate changes four focused modules: a 418-line CAR highest-weight module, a consumer-stable matrix-unit equation in the existing general-linear Clifford API, a characteristic-independent generic PBW nonvanishing theorem in the canonical PBW module, and removal of that unrelated theorem from the filtration-quotient module. The ordered product and its formation API are defined over any commutative ring and any finite linearly ordered index type; nonvanishing requires only a field. The direct highest-weight theorem retains the existing field and invertibility-of-two boundary, while characteristic zero appears only in the `Fin N` corollary identifying the direct cardinality weight with the rational `glStaircase`.

## Scope

- **Consumes:** `glCliffordHom_single`, `car_lie_def`, the trace-form CAR relations, `CliffordAlgebra.changeFormEquiv`, `CliffordAlgebra.contractLeft`, `LinearIndependent.notMem_span_image`, `LinearMap.exists_extend_of_notMem`, `Finset.orderEmbOfFin`, `Finset.range_orderEmbOfFin`, and `Matrix.stdBasis`.
- **Provides:** the ordered positive-root pair and matrix-unit families, a public lexicographic order embedding and exact-range equation, `carHighestWeightVector` formation API, characteristic-independent generic and CAR nonvanishing theorems, the generic highest-weight equation, and the `Fin N` rational staircase corollary.
- **Fits:** computes the exact staircase weight required by SpinRepresentations Layer 9 before the CAR simple-submodule and isotypy steps.
- **Boundary:** does not claim that every simple CAR submodule contains this ambient vector or an equivalent vector; that remaining submodule-existence argument is the next milestone step.

<sub>🤖 GPT-5.6 Sol high · TauCetiWorker @ [910d954fee75dfafda41f98165ce3a9e6676eae1](https://github.com/utensil/TauCetiWorker/commit/910d954fee75dfafda41f98165ce3a9e6676eae1) · rubrics @ [afb424eda89e8ac96d9eb69f6a88972055a4cd1b](https://github.com/utensil/TauCetiReview/commit/afb424eda89e8ac96d9eb69f6a88972055a4cd1b) · local review @ [b533e561b6d44df071c31335ed4a63ae647507d2](https://github.com/utensil/formal-land/commit/b533e561b6d44df071c31335ed4a63ae647507d2) · fixed: reuse, attribution, api-design, generality, placement, naming, documentation, proof-quality</sub>