### PR TITLE
refactor(MvPowerSeries): name the pair substitution family

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Assoc.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Assoc.lean
@@ -183,7 +183,7 @@ private theorem subst_subst_pair_formalAdd_eq_X {σ' : Type*}
     {g : σ' → MvPowerSeries Unit O} (hg : HasSubst g) {a b : MvPowerSeries σ' O}
     (ha : constantCoeff a = 0) (hb : constantCoeff b = 0)
     (hga : subst g a = PowerSeries.X) (hgb : subst g b = 0) :
-    subst g (subst (Sum.elim (fun _ ↦ a) (fun _ ↦ b) : Unit ⊕ Unit → MvPowerSeries σ' O)
+    subst g (subst (pairSubstitution a b)
       (formalAdd W)) = PowerSeries.X := by
   -- The composite family is pointwise `X` and `0`, but only pointwise: the reshape below is
   -- `funext`, not a definitional equality, and it is needed because `subst_unitR_formalAdd` is
@@ -200,7 +200,7 @@ private theorem subst_subst_pair_formalAdd_eq_zero {σ' : Type*}
     {g : σ' → MvPowerSeries Unit O} (hg : HasSubst g) {a b : MvPowerSeries σ' O}
     (ha : constantCoeff a = 0) (hb : constantCoeff b = 0)
     (hga : subst g a = 0) (hgb : subst g b = 0) :
-    subst g (subst (Sum.elim (fun _ ↦ a) (fun _ ↦ b) : Unit ⊕ Unit → MvPowerSeries σ' O)
+    subst g (subst (pairSubstitution a b)
       (formalAdd W)) = 0 := by
   -- As above, the reshape is `funext` rather than defeq: `g` kills both components pointwise,
   -- and the zero family is what `subst_zero_of_constantCoeff_zero` is stated against.
@@ -280,23 +280,19 @@ group law of an honest Weierstrass curve, applied to the two points, computes `F
 private theorem thetaPoint_add (hΔ : (fracCurve W σ KK).Δ ≠ 0)
     {q₁ q₂ : MvPowerSeries σ O} (h₁ : constantCoeff q₁ = 0) (h₂ : constantCoeff q₂ = 0)
     (hq₁0 : q₁ ≠ 0) (hq₂0 : q₂ ≠ 0)
-    (hN : subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+    (hN : subst (pairSubstitution q₁ q₂)
       (formalIntercept W) ≠ 0)
     (hx : q₁ * PowerSeries.subst q₂ (formalW W) - q₂ * PowerSeries.subst q₁ (formalW W) ≠ 0)
-    (hF : constantCoeff (subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
-      Unit ⊕ Unit → MvPowerSeries σ O) (formalAdd W)) = 0)
-    (hF0 : subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+    (hF : constantCoeff (subst (pairSubstitution q₁ q₂) (formalAdd W)) = 0)
+    (hF0 : subst (pairSubstitution q₁ q₂)
       (formalAdd W) ≠ 0) :
     W.thetaPoint hΔ h₁ hq₁0 + W.thetaPoint hΔ h₂ hq₂0 = W.thetaPoint hΔ hF hF0 := by
   classical
   set ρ := algebraMap (MvPowerSeries σ O) KK with hρ
   have hinj : Function.Injective ρ := IsFractionRing.injective (MvPowerSeries σ O) KK
-  set Λp := subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
-    Unit ⊕ Unit → MvPowerSeries σ O) (formalSlope W) with hΛp
-  set Np := subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
-    Unit ⊕ Unit → MvPowerSeries σ O) (formalIntercept W) with hNp
-  set Tp := subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
-    Unit ⊕ Unit → MvPowerSeries σ O) (formalThirdRoot W) with hTp
+  set Λp := subst (pairSubstitution q₁ q₂) (formalSlope W) with hΛp
+  set Np := subst (pairSubstitution q₁ q₂) (formalIntercept W) with hNp
+  set Tp := subst (pairSubstitution q₁ q₂) (formalThirdRoot W) with hTp
   set w₁ := PowerSeries.subst q₁ (formalW W) with hw₁'
   set w₂ := PowerSeries.subst q₂ (formalW W) with hw₂'
   set wT := PowerSeries.subst Tp (formalW W) with hwT'
@@ -363,13 +359,12 @@ private theorem thetaPoint_add (hΔ : (fracCurve W σ KK).Δ ≠ 0)
     have h := congrArg ρ (subst_pair_formalInverseDenom_eq W h₁ h₂)
     simp only [map_sub, map_mul, map_one, MvPowerSeries.c_eq_algebraMap] at h
     exact h
-  have hFeq : ρ (subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
-      Unit ⊕ Unit → MvPowerSeries σ O) (formalAdd W)) = -(ρ Tp * ρ sp) := by
+  have hFeq : ρ (subst (pairSubstitution q₁ q₂) (formalAdd W)) = -(ρ Tp * ρ sp) := by
     have h := congrArg ρ (subst_pair_formalAdd_eq W h₁ h₂)
     simp only [map_neg, map_mul] at h
     exact h
-  have hwFeq : ρ (PowerSeries.subst (subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
-      Unit ⊕ Unit → MvPowerSeries σ O) (formalAdd W)) (formalW W)) = -(ρ wT * ρ sp) := by
+  have hwFeq : ρ (PowerSeries.subst (subst (pairSubstitution q₁ q₂) (formalAdd W)) (formalW W))
+      = -(ρ wT * ρ sp) := by
     have h := congrArg ρ (subst_pair_formalW_formalAdd W h₁ h₂)
     simp only [map_neg, map_mul] at h
     exact h
@@ -454,7 +449,7 @@ private theorem pair_intercept_ne_zero_of_ne (hΔ : (fracCurve W σ KK).Δ ≠ 0
     {q₁ q₂ : MvPowerSeries σ O} (h₁ : constantCoeff q₁ = 0) (h₂ : constantCoeff q₂ = 0)
     (hq₁0 : q₁ ≠ 0) (hq₂0 : q₂ ≠ 0) (hne₁ : q₁ ≠ q₂)
     (hne₂ : q₁ ≠ PowerSeries.subst q₂ (formalInverse W)) :
-    subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+    subst (pairSubstitution q₁ q₂)
       (formalIntercept W) ≠ 0 := by
   classical
   intro h0
@@ -502,9 +497,8 @@ private theorem thetaPoint_add_of_ne (hΔ : (fracCurve W σ KK).Δ ≠ 0)
     {q₁ q₂ : MvPowerSeries σ O} (h₁ : constantCoeff q₁ = 0) (h₂ : constantCoeff q₂ = 0)
     (hq₁0 : q₁ ≠ 0) (hq₂0 : q₂ ≠ 0) (hne₁ : q₁ ≠ q₂)
     (hne₂ : q₁ ≠ PowerSeries.subst q₂ (formalInverse W))
-    (hF : constantCoeff (subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
-      Unit ⊕ Unit → MvPowerSeries σ O) (formalAdd W)) = 0)
-    (hF0 : subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+    (hF : constantCoeff (subst (pairSubstitution q₁ q₂) (formalAdd W)) = 0)
+    (hF0 : subst (pairSubstitution q₁ q₂)
       (formalAdd W) ≠ 0) :
     W.thetaPoint hΔ h₁ hq₁0 + W.thetaPoint hΔ h₂ hq₂0 = W.thetaPoint hΔ hF hF0 := by
   have hN := W.pair_intercept_ne_zero_of_ne hΔ h₁ h₂ hq₁0 hq₂0 hne₁ hne₂
@@ -525,9 +519,8 @@ private theorem thetaPoint_add_of_subst_separates (hΔ : (fracCurve W σ KK).Δ 
     {q₁ q₂ : MvPowerSeries σ O} (h₁ : constantCoeff q₁ = 0) (h₂ : constantCoeff q₂ = 0)
     (hq₁0 : q₁ ≠ 0) (hq₂0 : q₂ ≠ 0)
     (hg₁ : subst g q₁ = PowerSeries.X) (hg₂ : subst g q₂ = 0)
-    (hF : constantCoeff (subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
-      Unit ⊕ Unit → MvPowerSeries σ O) (formalAdd W)) = 0)
-    (hF0 : subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+    (hF : constantCoeff (subst (pairSubstitution q₁ q₂) (formalAdd W)) = 0)
+    (hF0 : subst (pairSubstitution q₁ q₂)
       (formalAdd W) ≠ 0) :
     W.thetaPoint hΔ h₁ hq₁0 + W.thetaPoint hΔ h₂ hq₂0 = W.thetaPoint hΔ hF hF0 :=
   W.thetaPoint_add_of_ne hΔ h₁ h₂ hq₁0 hq₂0 (ne_of_subst_eq_X_of_subst_eq_zero hg₁ hg₂)

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Inverse.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Inverse.lean
@@ -97,7 +97,7 @@ element — but only the second is syntactically an instance of the general `(q�
 rewriting with this is what lets the specializations below be `exact` applications. -/
 private theorem invPair_eq :
     (Sum.elim X (fun _ ↦ formalInverse W) : Unit ⊕ Unit → MvPowerSeries Unit O) =
-      Sum.elim (fun _ ↦ (X () : MvPowerSeries Unit O)) (fun _ ↦ formalInverse W) :=
+      pairSubstitution (X () : MvPowerSeries Unit O) (formalInverse W) :=
   funext fun j ↦ by rcases j with j | j <;> rfl
 
 /-- The third root at the pair `(z, ι(z))` vanishes at the origin, so it may itself be

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/PairSubst.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/PairSubst.lean
@@ -53,8 +53,9 @@ this file's, specialized; see the Provenance note there.
 
 ## Implementation notes
 
-The pair is the family `Sum.elim (fun _ ↦ q₁) fun _ ↦ q₂` on `Unit ⊕ Unit`, written inline
-throughout as `Add/Inverse.lean` writes its own family inline.
+The pair is the family `MvPowerSeries.pairSubstitution q₁ q₂` on `Unit ⊕ Unit`.
+`Add/Inverse.lean` keeps its own spelling of the pair `(z, ι(z))` and reaches these lemmas
+through its private `invPair_eq` bridge.
 
 Two of Stoll's helpers in this range are not ported, because this repository already has them in
 a more general form. His `subst_pair_rename`, which pushes the substitution through the
@@ -115,37 +116,32 @@ variable {σ : Type*} {q₁ q₂ : MvPowerSeries σ O}
 @[simp]
 theorem subst_pair_toMvPowerSeries_inl (h₁ : constantCoeff q₁ = 0)
     (h₂ : constantCoeff q₂ = 0) :
-    subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+    subst (pairSubstitution q₁ q₂)
       ((formalW W).toMvPowerSeries (Sum.inl ())) = PowerSeries.subst q₁ (formalW W) := by
-  rw [PowerSeries.subst_toMvPowerSeries (hasSubst_pair h₁ h₂), Sum.elim_inl]
+  rw [PowerSeries.subst_toMvPowerSeries (hasSubst_pair h₁ h₂), pairSubstitution, Sum.elim_inl]
 
 /-- The `w`-expansion in the second parameter becomes `w(q₂)`. -/
 @[simp]
 theorem subst_pair_toMvPowerSeries_inr (h₁ : constantCoeff q₁ = 0)
     (h₂ : constantCoeff q₂ = 0) :
-    subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+    subst (pairSubstitution q₁ q₂)
       ((formalW W).toMvPowerSeries (Sum.inr ())) = PowerSeries.subst q₂ (formalW W) := by
-  rw [PowerSeries.subst_toMvPowerSeries (hasSubst_pair h₁ h₂), Sum.elim_inr]
+  rw [PowerSeries.subst_toMvPowerSeries (hasSubst_pair h₁ h₂), pairSubstitution, Sum.elim_inr]
 
 /-! ### The chord through the two parametrized points -/
 
 /-- The defining property of the slope, read at the pair `(q₁, q₂)`:
 `λ(q₁, q₂) * (q₂ - q₁) = w(q₂) - w(q₁)`. -/
 theorem subst_pair_formalSlope_mul (h₁ : constantCoeff q₁ = 0) (h₂ : constantCoeff q₂ = 0) :
-    subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+    subst (pairSubstitution q₁ q₂)
         (formalSlope W) * (q₂ - q₁) =
       PowerSeries.subst q₂ (formalW W) - PowerSeries.subst q₁ (formalW W) := by
-  have h := congrArg (subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
-    Unit ⊕ Unit → MvPowerSeries σ O)) (formalSlope_mul_sub W)
+  have h := congrArg (subst (pairSubstitution q₁ q₂)) (formalSlope_mul_sub W)
   rw [← coe_substAlgHom (hasSubst_pair h₁ h₂)] at h
   simp only [map_mul, map_sub] at h
   simp only [coe_substAlgHom (hasSubst_pair h₁ h₂), subst_pair_toMvPowerSeries_inl W h₁ h₂,
     subst_pair_toMvPowerSeries_inr W h₁ h₂, subst_X (hasSubst_pair h₁ h₂)] at h
-  have h1 : (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
-      Unit ⊕ Unit → MvPowerSeries σ O) (Sum.inr ()) = q₂ := rfl
-  have h2 : (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
-      Unit ⊕ Unit → MvPowerSeries σ O) (Sum.inl ()) = q₁ := rfl
-  rw [h1, h2] at h
+  simp only [pairSubstitution, Sum.elim_inl, Sum.elim_inr] at h
   linear_combination h
 
 /-! ### The third point of the chord lies on the curve -/
@@ -153,13 +149,12 @@ theorem subst_pair_formalSlope_mul (h₁ : constantCoeff q₁ = 0) (h₂ : const
 /-- The on-line identity at the pair `(q₁, q₂)`: reading the `w`-expansion at the third root
 gives the chord line read there. -/
 theorem subst_pair_formalThirdRoot_formalW (h₁ : constantCoeff q₁ = 0) (h₂ : constantCoeff q₂ = 0) :
-    subst (fun _ : Unit ↦ subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
-        Unit ⊕ Unit → MvPowerSeries σ O) (formalThirdRoot W)) (formalW W) =
-      subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+    subst (fun _ : Unit ↦ subst (pairSubstitution q₁ q₂) (formalThirdRoot W)) (formalW W) =
+      subst (pairSubstitution q₁ q₂)
           (formalSlope W) *
-        subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+        subst (pairSubstitution q₁ q₂)
           (formalThirdRoot W) +
-        subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+        subst (pairSubstitution q₁ q₂)
           (formalIntercept W) := by
   have h := congrArg (substAlgHom (hasSubst_pair h₁ h₂)) (subst_formalThirdRoot_formalW W)
   simp only [map_add, map_mul] at h
@@ -172,15 +167,15 @@ theorem subst_pair_formalThirdRoot_formalW (h₁ : constantCoeff q₁ = 0) (h₂
 is `1`. -/
 theorem subst_pair_thirdRootDenom_mul (h₁ : constantCoeff q₁ = 0) (h₂ : constantCoeff q₂ = 0) :
     (1 + C W.a₂ *
-        subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+        subst (pairSubstitution q₁ q₂)
           (formalSlope W) +
         C W.a₄ *
-        subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+        subst (pairSubstitution q₁ q₂)
           (formalSlope W) ^ 2 +
         C W.a₆ *
-        subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+        subst (pairSubstitution q₁ q₂)
           (formalSlope W) ^ 3) *
-      subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+      subst (pairSubstitution q₁ q₂)
         (invOfUnit (1 + C W.a₂ * formalSlope W + C W.a₄ * formalSlope W ^ 2 +
       C W.a₆ * formalSlope W ^ 3) 1) = 1 := by
   have h := congrArg (substAlgHom (hasSubst_pair h₁ h₂))
@@ -196,13 +191,13 @@ computation is needed. -/
 theorem subst_pair_thirdRootDenom_ne_zero [Nontrivial O] (h₁ : constantCoeff q₁ = 0)
     (h₂ : constantCoeff q₂ = 0) :
     (1 + C W.a₂ *
-        subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+        subst (pairSubstitution q₁ q₂)
           (formalSlope W) +
         C W.a₄ *
-        subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+        subst (pairSubstitution q₁ q₂)
           (formalSlope W) ^ 2 +
         C W.a₆ *
-        subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+        subst (pairSubstitution q₁ q₂)
           (formalSlope W) ^ 3) ≠ 0 := by
   intro h
   have hmul := subst_pair_thirdRootDenom_mul W h₁ h₂
@@ -214,56 +209,52 @@ denominator eliminated. -/
 theorem subst_pair_formalThirdRoot_relation (h₁ : constantCoeff q₁ = 0)
     (h₂ : constantCoeff q₂ = 0) :
     (1 + C W.a₂ *
-        subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+        subst (pairSubstitution q₁ q₂)
           (formalSlope W) +
         C W.a₄ *
-        subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+        subst (pairSubstitution q₁ q₂)
           (formalSlope W) ^ 2 +
         C W.a₆ *
-        subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+        subst (pairSubstitution q₁ q₂)
           (formalSlope W) ^ 3) *
-      (subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+      (subst (pairSubstitution q₁ q₂)
           (formalThirdRoot W) + q₁ + q₂) =
       -(C W.a₁ *
-        subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+        subst (pairSubstitution q₁ q₂)
           (formalSlope W) +
         C W.a₂ *
-        subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+        subst (pairSubstitution q₁ q₂)
           (formalIntercept W) +
         C W.a₃ *
-        subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+        subst (pairSubstitution q₁ q₂)
           (formalSlope W) ^ 2 +
         2 * C W.a₄ *
-        subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+        subst (pairSubstitution q₁ q₂)
           (formalSlope W) *
-          subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+          subst (pairSubstitution q₁ q₂)
             (formalIntercept W) +
         3 * C W.a₆ *
-        subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+        subst (pairSubstitution q₁ q₂)
           (formalSlope W) ^ 2 *
-          subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+          subst (pairSubstitution q₁ q₂)
             (formalIntercept W)) := by
   have hexp := congrArg (substAlgHom (hasSubst_pair h₁ h₂)) (formalThirdRoot_def W)
   simp only [map_sub, map_neg, map_mul, map_add, map_pow, map_ofNat] at hexp
   simp only [coe_substAlgHom (hasSubst_pair h₁ h₂), subst_X (hasSubst_pair h₁ h₂),
     subst_C] at hexp
-  have hr : (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
-      Unit ⊕ Unit → MvPowerSeries σ O) (Sum.inr ()) = q₂ := rfl
-  have hl : (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
-      Unit ⊕ Unit → MvPowerSeries σ O) (Sum.inl ()) = q₁ := rfl
-  rw [hr, hl] at hexp
+  simp only [pairSubstitution, Sum.elim_inl, Sum.elim_inr] at hexp
   have hAd := subst_pair_thirdRootDenom_mul W h₁ h₂
   set Lp :=
-    subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+    subst (pairSubstitution q₁ q₂)
       (formalSlope W)
   set Np :=
-    subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+    subst (pairSubstitution q₁ q₂)
       (formalIntercept W)
   set Tp :=
-    subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+    subst (pairSubstitution q₁ q₂)
       (formalThirdRoot W)
   set dp :=
-    subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+    subst (pairSubstitution q₁ q₂)
       (invOfUnit (1 + C W.a₂ * formalSlope W + C W.a₄ * formalSlope W ^ 2 +
       C W.a₆ * formalSlope W ^ 3) 1)
   clear_value Lp Np Tp dp
@@ -278,7 +269,7 @@ is itself a legitimate parameter to substitute into a one-variable series. -/
 @[simp]
 theorem constantCoeff_subst_pair_formalThirdRoot (h₁ : constantCoeff q₁ = 0)
     (h₂ : constantCoeff q₂ = 0) :
-    constantCoeff (subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+    constantCoeff (subst (pairSubstitution q₁ q₂)
       (formalThirdRoot W)) = 0 :=
   constantCoeff_subst_eq_zero (hasSubst_pair h₁ h₂) (by rintro (j | j) <;> simpa)
     (constantCoeff_formalThirdRoot W)
@@ -289,7 +280,7 @@ feed one bracketed sum into another. -/
 @[simp]
 theorem constantCoeff_subst_pair_formalAdd (h₁ : constantCoeff q₁ = 0)
     (h₂ : constantCoeff q₂ = 0) :
-    constantCoeff (subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+    constantCoeff (subst (pairSubstitution q₁ q₂)
       (formalAdd W)) = 0 :=
   constantCoeff_subst_eq_zero (hasSubst_pair h₁ h₂) (by rintro (j | j) <;> simpa)
     (constantCoeff_formalAdd W)
@@ -300,9 +291,9 @@ theorem constantCoeff_subst_pair_formalAdd (h₁ : constantCoeff q₁ = 0)
 This is `formalAdd_def` pushed through the pair substitution, and it is the bridge that turns any
 one-variable identity about `formalInverse` into a statement about the group law at the pair. -/
 theorem subst_pair_formalAdd (h₁ : constantCoeff q₁ = 0) (h₂ : constantCoeff q₂ = 0) :
-    subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O) (formalAdd W) =
-      subst (fun _ : Unit ↦ subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
-        Unit ⊕ Unit → MvPowerSeries σ O) (formalThirdRoot W)) (formalInverse W) := by
+    subst (pairSubstitution q₁ q₂) (formalAdd W) =
+      subst (fun _ : Unit ↦ subst (pairSubstitution q₁ q₂) (formalThirdRoot W))
+          (formalInverse W) := by
   rw [formalAdd_def, subst_comp_subst_apply (hasSubst_formalThirdRoot W) (hasSubst_pair h₁ h₂)]
 
 /-- The `w`-expansion at the addition series, read at the pair `(q₁, q₂)`:
@@ -314,20 +305,15 @@ so the group law's `w` at a pair is never recomputed. The third root is spelled 
 substitution, matching `subst_pair_formalThirdRoot_formalW`, so the two rewrite against each
 other. -/
 theorem subst_pair_formalW_formalAdd (h₁ : constantCoeff q₁ = 0) (h₂ : constantCoeff q₂ = 0) :
-    subst (fun _ : Unit ↦ subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
-        Unit ⊕ Unit → MvPowerSeries σ O) (formalAdd W)) (formalW W) =
-      -(subst (fun _ : Unit ↦ subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
-            Unit ⊕ Unit → MvPowerSeries σ O) (formalThirdRoot W)) (formalW W) *
-        subst (fun _ : Unit ↦ subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
-            Unit ⊕ Unit → MvPowerSeries σ O) (formalThirdRoot W))
+    subst (fun _ : Unit ↦ subst (pairSubstitution q₁ q₂) (formalAdd W)) (formalW W) =
+      -(subst (fun _ : Unit ↦ subst (pairSubstitution q₁ q₂) (formalThirdRoot W)) (formalW W) *
+        subst (fun _ : Unit ↦ subst (pairSubstitution q₁ q₂) (formalThirdRoot W))
           (PowerSeries.invOfUnit (formalInverseDenom W) 1)) := by
-  have hT : HasSubst (fun _ : Unit ↦ subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
-      Unit ⊕ Unit → MvPowerSeries σ O) (formalThirdRoot W)) :=
+  have hT : HasSubst (fun _ : Unit ↦ subst (pairSubstitution q₁ q₂) (formalThirdRoot W)) :=
     hasSubst_of_constantCoeff_zero fun _ ↦ constantCoeff_subst_pair_formalThirdRoot W h₁ h₂
-  have hfam : (fun _ : Unit ↦ subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
-        Unit ⊕ Unit → MvPowerSeries σ O) (formalAdd W)) =
-      fun _ : Unit ↦ subst (fun _ : Unit ↦ subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
-        Unit ⊕ Unit → MvPowerSeries σ O) (formalThirdRoot W)) (formalInverse W) :=
+  have hfam : (fun _ : Unit ↦ subst (pairSubstitution q₁ q₂) (formalAdd W)) =
+      fun _ : Unit ↦ subst (fun _ : Unit ↦ subst (pairSubstitution q₁ q₂) (formalThirdRoot W))
+          (formalInverse W) :=
     funext fun _ ↦ subst_pair_formalAdd W h₁ h₂
   -- `PowerSeries.subst` *is* the `Unit`-indexed `MvPowerSeries.subst` by definition, so the
   -- middle step is `rfl`; it is needed because `subst_formalInverse_formalW` is stated in the
@@ -343,13 +329,11 @@ theorem subst_pair_formalW_formalAdd (h₁ : constantCoeff q₁ = 0) (h₂ : con
 it times its `invOfUnit` is `1`. -/
 theorem subst_pair_formalInverseDenom_mul (h₁ : constantCoeff q₁ = 0)
     (h₂ : constantCoeff q₂ = 0) :
-    subst (fun _ : Unit ↦ subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
-          Unit ⊕ Unit → MvPowerSeries σ O) (formalThirdRoot W)) (formalInverseDenom W) *
-        subst (fun _ : Unit ↦ subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
-          Unit ⊕ Unit → MvPowerSeries σ O) (formalThirdRoot W))
+    subst (fun _ : Unit ↦ subst (pairSubstitution q₁ q₂) (formalThirdRoot W))
+        (formalInverseDenom W) *
+        subst (fun _ : Unit ↦ subst (pairSubstitution q₁ q₂) (formalThirdRoot W))
           (PowerSeries.invOfUnit (formalInverseDenom W) 1) = 1 := by
-  have hT : HasSubst (fun _ : Unit ↦ subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
-      Unit ⊕ Unit → MvPowerSeries σ O) (formalThirdRoot W)) :=
+  have hT : HasSubst (fun _ : Unit ↦ subst (pairSubstitution q₁ q₂) (formalThirdRoot W)) :=
     hasSubst_of_constantCoeff_zero fun _ ↦ constantCoeff_subst_pair_formalThirdRoot W h₁ h₂
   have h := congrArg (substAlgHom hT) (mul_invOfUnit_formalInverseDenom W)
   simp only [map_mul, map_one] at h
@@ -359,14 +343,12 @@ theorem subst_pair_formalInverseDenom_mul (h₁ : constantCoeff q₁ = 0)
 `u(z₃) = 1 - a₁ z₃ - a₃ w(z₃)`. -/
 theorem subst_pair_formalInverseDenom_eq (h₁ : constantCoeff q₁ = 0)
     (h₂ : constantCoeff q₂ = 0) :
-    subst (fun _ : Unit ↦ subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
-        Unit ⊕ Unit → MvPowerSeries σ O) (formalThirdRoot W)) (formalInverseDenom W) =
-      1 - C W.a₁ * subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
-          Unit ⊕ Unit → MvPowerSeries σ O) (formalThirdRoot W) -
-        C W.a₃ * subst (fun _ : Unit ↦ subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
-          Unit ⊕ Unit → MvPowerSeries σ O) (formalThirdRoot W)) (formalW W) := by
-  have hT : HasSubst (fun _ : Unit ↦ subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
-      Unit ⊕ Unit → MvPowerSeries σ O) (formalThirdRoot W)) :=
+    subst (fun _ : Unit ↦ subst (pairSubstitution q₁ q₂) (formalThirdRoot W))
+        (formalInverseDenom W) =
+      1 - C W.a₁ * subst (pairSubstitution q₁ q₂) (formalThirdRoot W) -
+        C W.a₃ * subst (fun _ : Unit ↦ subst (pairSubstitution q₁ q₂) (formalThirdRoot W))
+            (formalW W) := by
+  have hT : HasSubst (fun _ : Unit ↦ subst (pairSubstitution q₁ q₂) (formalThirdRoot W)) :=
     hasSubst_of_constantCoeff_zero fun _ ↦ constantCoeff_subst_pair_formalThirdRoot W h₁ h₂
   rw [formalInverseDenom_def, ← coe_substAlgHom hT]
   simp only [map_sub, map_one, map_mul]
@@ -380,14 +362,12 @@ theorem subst_pair_formalInverseDenom_eq (h₁ : constantCoeff q₁ = 0)
 
 /-- The addition series at the pair, written out: `F(q₁, q₂) = -(z₃ * u(z₃)⁻¹)`. -/
 theorem subst_pair_formalAdd_eq (h₁ : constantCoeff q₁ = 0) (h₂ : constantCoeff q₂ = 0) :
-    subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O) (formalAdd W) =
-      -(subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+    subst (pairSubstitution q₁ q₂) (formalAdd W) =
+      -(subst (pairSubstitution q₁ q₂)
           (formalThirdRoot W) *
-        subst (fun _ : Unit ↦ subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
-          Unit ⊕ Unit → MvPowerSeries σ O) (formalThirdRoot W))
+        subst (fun _ : Unit ↦ subst (pairSubstitution q₁ q₂) (formalThirdRoot W))
           (PowerSeries.invOfUnit (formalInverseDenom W) 1)) := by
-  have hT : HasSubst (fun _ : Unit ↦ subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
-      Unit ⊕ Unit → MvPowerSeries σ O) (formalThirdRoot W)) :=
+  have hT : HasSubst (fun _ : Unit ↦ subst (pairSubstitution q₁ q₂) (formalThirdRoot W)) :=
     hasSubst_of_constantCoeff_zero fun _ ↦ constantCoeff_subst_pair_formalThirdRoot W h₁ h₂
   rw [subst_pair_formalAdd W h₁ h₂, formalInverse_def, ← coe_substAlgHom hT]
   simp only [map_neg, map_mul]
@@ -407,9 +387,9 @@ clears the intercept but leaves the slope behind. Combining the two readings is 
 slope, and that combination is already packaged as `subst_pair_formalIntercept_mul_sub`, so a
 consumer that wants the slope gone should reach for it rather than for these two. -/
 theorem subst_pair_formalIntercept_eq_inl (h₁ : constantCoeff q₁ = 0) (h₂ : constantCoeff q₂ = 0) :
-    subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+    subst (pairSubstitution q₁ q₂)
         (formalIntercept W) = PowerSeries.subst q₁ (formalW W) -
-      subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+      subst (pairSubstitution q₁ q₂)
         (formalSlope W) * q₁ := by
   simp [formalIntercept_def, subst_sub (hasSubst_pair h₁ h₂), subst_mul (hasSubst_pair h₁ h₂),
     subst_pair_toMvPowerSeries_inl W h₁ h₂, subst_X (hasSubst_pair h₁ h₂)]
@@ -422,9 +402,9 @@ The two readings differ only in which parameter appears on the right, and rewrit
 one clears the intercept but leaves the slope behind; a consumer that wants the slope gone should
 reach for `subst_pair_formalIntercept_mul_sub`, which packages the combination that cancels it. -/
 theorem subst_pair_formalIntercept_eq_inr (h₁ : constantCoeff q₁ = 0) (h₂ : constantCoeff q₂ = 0) :
-    subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+    subst (pairSubstitution q₁ q₂)
         (formalIntercept W) = PowerSeries.subst q₂ (formalW W) -
-      subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+      subst (pairSubstitution q₁ q₂)
         (formalSlope W) * q₂ := by
   linear_combination subst_pair_formalIntercept_eq_inl W h₁ h₂ + subst_pair_formalSlope_mul W h₁ h₂
 
@@ -439,7 +419,7 @@ the chord's `x`-coordinates are distinct; reach for it there as a single rewrite
 recombining the two readings by hand. -/
 theorem subst_pair_formalIntercept_mul_sub (h₁ : constantCoeff q₁ = 0) (h₂ : constantCoeff q₂ = 0) :
     q₁ * PowerSeries.subst q₂ (formalW W) - q₂ * PowerSeries.subst q₁ (formalW W) =
-      subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+      subst (pairSubstitution q₁ q₂)
         (formalIntercept W) * (q₁ - q₂) := by
   -- weighting the two readings by `q₂` and `q₁` makes the `λ` terms coincide and cancel
   linear_combination q₂ * subst_pair_formalIntercept_eq_inl W h₁ h₂ -
@@ -448,9 +428,9 @@ theorem subst_pair_formalIntercept_mul_sub (h₁ : constantCoeff q₁ = 0) (h₂
 /-- A nonzero intercept forces a nonzero third root: at `z₃ = 0` the on-line identity
 `w(z₃) = λ z₃ + ν` collapses to `0 = ν`, since `w` has no constant term. -/
 theorem subst_pair_formalThirdRoot_ne_zero (h₁ : constantCoeff q₁ = 0) (h₂ : constantCoeff q₂ = 0)
-    (hN : subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+    (hN : subst (pairSubstitution q₁ q₂)
       (formalIntercept W) ≠ 0) :
-    subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+    subst (pairSubstitution q₁ q₂)
       (formalThirdRoot W) ≠ 0 := by
   intro h
   refine hN ?_

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/PairEval.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/PairEval.lean
@@ -481,18 +481,15 @@ theorem formalAddEval_assoc {t₁ t₂ t₃ : O} (h₁ : PowerSeries.HasEval t�
       (hv : MvPowerSeries.eval₂ (RingHom.id O) T q₂ = v)
       (hu' : PowerSeries.HasEval u) (hv' : PowerSeries.HasEval v) :
       MvPowerSeries.eval₂ (RingHom.id O) T (MvPowerSeries.subst
-        (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
-          Unit ⊕ Unit → MvPowerSeries (Unit ⊕ Unit ⊕ Unit) O) W.formalAdd) =
+        (pairSubstitution q₁ q₂) W.formalAdd) =
         W.formalAddEval u v := by
     have hfam : (fun s : Unit ⊕ Unit ↦ MvPowerSeries.eval₂ (RingHom.id O) T
-          ((Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
-            Unit ⊕ Unit → MvPowerSeries (Unit ⊕ Unit ⊕ Unit) O) s)) =
+          ((pairSubstitution q₁ q₂) s)) =
         Sum.elim (fun _ ↦ u) fun _ ↦ v := by
       funext s
       rcases s with _ | _ <;> simp [hu, hv]
     have hev : MvPowerSeries.HasEval fun s : Unit ⊕ Unit ↦ MvPowerSeries.aeval ht
-        ((Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
-          Unit ⊕ Unit → MvPowerSeries (Unit ⊕ Unit ⊕ Unit) O) s) := by
+        ((pairSubstitution q₁ q₂) s) := by
       simp only [MvPowerSeries.coe_aeval, Algebra.algebraMap_self, hfam]
       exact hasEval_pair hu' hv'
     have h := MvPowerSeries.aeval_subst (MvPowerSeries.hasSubst_pair hq₁ hq₂)

--- a/TauCeti/RingTheory/MvPowerSeries/Substitution.lean
+++ b/TauCeti/RingTheory/MvPowerSeries/Substitution.lean
@@ -155,6 +155,18 @@ section HasSubstPair
 
 variable {O : Type*} [CommRing O] {q₁ q₂ : MvPowerSeries σ O}
 
+/-- The substitution family determined by an ordered pair, for the two variables indexed by
+`Unit ⊕ Unit`: the left variable goes to `q₁` and the right to `q₂`.
+
+Substituting a pair of series into a two-variable one is `subst (pairSubstitution q₁ q₂) f`.
+It is a reducible abbreviation, so `Sum.elim_inl` and `Sum.elim_inr` evaluate it at the two
+variables; `hasSubst_pair` says it is substitutable as soon as both series vanish at the origin. -/
+-- This names the substitution *family* rather than the substitution, so that a substituted term
+-- still has `subst` at its head and Mathlib's generic `subst_add`, `subst_mul`, … remain
+-- reachable by `rw`, which selects candidate subterms by head symbol before it tries unfolding.
+abbrev pairSubstitution (q₁ q₂ : MvPowerSeries σ O) : Unit ⊕ Unit → MvPowerSeries σ O :=
+  Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂)
+
 /-- A pair of series with vanishing constant coefficient is a legitimate substitution family for
 the two variables indexed by `Unit ⊕ Unit`.
 
@@ -162,7 +174,7 @@ This packages the `rintro`-and-`simpa` discharge of `hasSubst_of_constantCoeff_z
 for the two-variable case, which is otherwise repeated at every substitution into a two-variable
 series. -/
 theorem hasSubst_pair (h₁ : constantCoeff q₁ = 0) (h₂ : constantCoeff q₂ = 0) :
-    HasSubst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O) :=
+    HasSubst (pairSubstitution q₁ q₂) :=
   hasSubst_of_constantCoeff_zero (by rintro (j | j) <;> simpa)
 
 end HasSubstPair


### PR DESCRIPTION
Substituting a pair of series for the two variables indexed by `Unit ⊕ Unit` was spelled out
in full at every occurrence — in **statements** as well as proofs:

```lean
subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O) (formalAdd W)
```

`pairSubstitution q₁ q₂` names that family, so the same reads `subst (pairSubstitution q₁ q₂)
(formalAdd W)`. 76 occurrences migrate: 58 in `Add/PairSubst.lean`, 15 in `Add/Assoc.lean`, 3 in `PairEval.lean`.

**The abbreviation is of the family, not of the substitution**, and that is the load-bearing
choice. `rw` selects candidate subterms by head symbol *before* it tries unfolding, so a
wrapper around `subst` itself would put Mathlib's generic `subst_add`, `subst_mul`, … out of
reach of `rw` — reducibility does not rescue it. Naming only the family keeps `subst` as the
head, and every existing `rw` through those lemmas continues to work.

The abbreviation is deliberately reducible and carries **no** projection API of its own:
`Sum.elim_inl` and `Sum.elim_inr` already evaluate it once it unfolds, so the four sites that
evaluate the family name `pairSubstitution` in their `simp` set and then use those. An earlier
revision of this PR added `pairSubstitution_apply_inl`/`_apply_inr`; they were deleted because
they restate `Sum.elim_inl`/`_inr` verbatim.

`Add/Inverse.lean` keeps its own spelling of the pair `(z, ι(z))` and reaches `PairSubst`'s
lemmas through the private bridge `invPair_eq`; that bridge is restated in the new terms, which
is the whole of its diff.

Not done here, deliberately: the index type stays `Unit ⊕ Unit` rather than moving to `Fin 2`.
The sum names the left and right slots, which matters in the nested three-variable associativity
construction, and `unitSumUnitEquivFinTwo` already exists as the interoperability boundary. That
would be a representation change, not an abbreviation, and belongs in its own PR.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"EllipticCurves/README.md:Layer-6-formal-group:pair-substitution-family"}-->

Provenance: no port. `pairSubstitution` is new, and abbreviates a spelling already present in
this repository; the `Unit ⊕ Unit` two-variable convention is this development's own.
