### PR TITLE
feat(ArithmeticDirichletSeries): log-weighted ideal terms stay summable

### DIFF
--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/Estimates.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/Estimates.lean
@@ -48,8 +48,6 @@ of a convergent series of nonnegative terms must become arbitrarily small.
 * `TauCeti.summable_idealTerm_of_bounded_of_one_lt_re`: a uniformly bounded weight has an
   absolutely convergent ideal-indexed Dirichlet series on `Re s > 1`, and
   `TauCeti.summable_idealTerm_of_unitary_of_one_lt_re` is its unitary specialization.
-* `TauCeti.summable_log_mul_norm_idealTerm_of_re_lt_re`: weighting the ideal terms by
-  `log N(I)` keeps them summable strictly to the right of a point of absolute convergence.
 
 ## Implementation notes
 
@@ -496,40 +494,5 @@ theorem LSeriesSummable_dedekindZetaCoeff_iff {s : ℂ} :
     LSeriesSummable (fun n ↦ (dedekindZetaCoeff K n : ℂ)) s ↔ 1 < s.re := by
   rw [← LSeriesSummable_normCoeff_one_iff K]
   exact LSeriesSummable_congr s fun {n} hn ↦ by rw [normCoeff_one_apply, ite_eq_right hn]
-
-/-- **Log-weighted ideal terms stay summable strictly to the right.** If the ideal-indexed
-Dirichlet series of `f` converges absolutely at `s`, then weighting each term by `log N(I)` leaves
-it summable at every `s'` with `Re s < Re s'`.
-
-This is the ideal-indexed counterpart of Mathlib's `LSeriesSummable_logMul_of_lt_re`. The
-logarithmic weight is what appears when the terms of such a series are differentiated in `s`, so
-this is the dominating bound a termwise differentiation argument runs on; the strict inequality is
-needed, since at `Re s' = Re s` the weight can destroy summability. -/
-theorem summable_log_mul_norm_idealTerm_of_re_lt_re {K : Type*} [Field K] [NumberField K]
-    {f : IdealArithmeticFunction K} {s s' : ℂ} (h : s.re < s'.re)
-    (hs : Summable (idealTerm K f s)) :
-    Summable fun I : (Ideal (𝓞 K))⁰ ↦
-      Real.log (Ideal.absNorm (I : Ideal (𝓞 K))) * ‖idealTerm K f s' I‖ := by
-  have hδ : 0 < s'.re - s.re := sub_pos.2 h
-  refine Summable.of_nonneg_of_le (fun I ↦ ?_) (fun I ↦ ?_)
-    ((summable_norm_iff.2 hs).mul_left (s'.re - s.re)⁻¹)
-  · have h1 : (1:ℝ) ≤ (Ideal.absNorm (I : Ideal (𝓞 K)) : ℝ) := by
-      exact_mod_cast Ideal.absNorm_pos_of_nonZeroDivisors I
-    exact mul_nonneg (Real.log_nonneg h1) (norm_nonneg _)
-  · have hN : (0:ℝ) < (Ideal.absNorm (I : Ideal (𝓞 K)) : ℝ) := by
-      exact_mod_cast Ideal.absNorm_pos_of_nonZeroDivisors I
-    rw [norm_idealTerm, norm_idealTerm]
-    -- `log x ≤ x ^ δ / δ` with `δ = Re s' - Re s`; the extra `N(I) ^ δ` is exactly what turns the
-    -- term at `s'` into the term at `s`.
-    have hlog := Real.log_le_rpow_div hN.le hδ
-    rw [Real.rpow_sub hN] at hlog
-    calc Real.log (Ideal.absNorm (I : Ideal (𝓞 K)) : ℝ)
-            * (‖f I‖ / (Ideal.absNorm (I : Ideal (𝓞 K)) : ℝ) ^ s'.re)
-        ≤ ((Ideal.absNorm (I : Ideal (𝓞 K)) : ℝ) ^ s'.re
-            / (Ideal.absNorm (I : Ideal (𝓞 K)) : ℝ) ^ s.re / (s'.re - s.re))
-            * (‖f I‖ / (Ideal.absNorm (I : Ideal (𝓞 K)) : ℝ) ^ s'.re) := by
-          gcongr
-      _ = (s'.re - s.re)⁻¹ * (‖f I‖ / (Ideal.absNorm (I : Ideal (𝓞 K)) : ℝ) ^ s.re) := by
-          field_simp
 
 end TauCeti

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/Estimates.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/Estimates.lean
@@ -48,6 +48,8 @@ of a convergent series of nonnegative terms must become arbitrarily small.
 * `TauCeti.summable_idealTerm_of_bounded_of_one_lt_re`: a uniformly bounded weight has an
   absolutely convergent ideal-indexed Dirichlet series on `Re s > 1`, and
   `TauCeti.summable_idealTerm_of_unitary_of_one_lt_re` is its unitary specialization.
+* `TauCeti.summable_log_mul_norm_idealTerm_of_re_lt_re`: weighting the ideal terms by
+  `log N(I)` keeps them summable strictly to the right of a point of absolute convergence.
 
 ## Implementation notes
 
@@ -494,5 +496,40 @@ theorem LSeriesSummable_dedekindZetaCoeff_iff {s : ℂ} :
     LSeriesSummable (fun n ↦ (dedekindZetaCoeff K n : ℂ)) s ↔ 1 < s.re := by
   rw [← LSeriesSummable_normCoeff_one_iff K]
   exact LSeriesSummable_congr s fun {n} hn ↦ by rw [normCoeff_one_apply, ite_eq_right hn]
+
+/-- **Log-weighted ideal terms stay summable strictly to the right.** If the ideal-indexed
+Dirichlet series of `f` converges absolutely at `s`, then weighting each term by `log N(I)` leaves
+it summable at every `s'` with `Re s < Re s'`.
+
+This is the ideal-indexed counterpart of Mathlib's `LSeriesSummable_logMul_of_lt_re`. The
+logarithmic weight is what appears when the terms of such a series are differentiated in `s`, so
+this is the dominating bound a termwise differentiation argument runs on; the strict inequality is
+needed, since at `Re s' = Re s` the weight can destroy summability. -/
+theorem summable_log_mul_norm_idealTerm_of_re_lt_re {K : Type*} [Field K] [NumberField K]
+    {f : IdealArithmeticFunction K} {s s' : ℂ} (h : s.re < s'.re)
+    (hs : Summable (idealTerm K f s)) :
+    Summable fun I : (Ideal (𝓞 K))⁰ ↦
+      Real.log (Ideal.absNorm (I : Ideal (𝓞 K))) * ‖idealTerm K f s' I‖ := by
+  have hδ : 0 < s'.re - s.re := sub_pos.2 h
+  refine Summable.of_nonneg_of_le (fun I ↦ ?_) (fun I ↦ ?_)
+    ((summable_norm_iff.2 hs).mul_left (s'.re - s.re)⁻¹)
+  · have h1 : (1:ℝ) ≤ (Ideal.absNorm (I : Ideal (𝓞 K)) : ℝ) := by
+      exact_mod_cast Ideal.absNorm_pos_of_nonZeroDivisors I
+    exact mul_nonneg (Real.log_nonneg h1) (norm_nonneg _)
+  · have hN : (0:ℝ) < (Ideal.absNorm (I : Ideal (𝓞 K)) : ℝ) := by
+      exact_mod_cast Ideal.absNorm_pos_of_nonZeroDivisors I
+    rw [norm_idealTerm, norm_idealTerm]
+    -- `log x ≤ x ^ δ / δ` with `δ = Re s' - Re s`; the extra `N(I) ^ δ` is exactly what turns the
+    -- term at `s'` into the term at `s`.
+    have hlog := Real.log_le_rpow_div hN.le hδ
+    rw [Real.rpow_sub hN] at hlog
+    calc Real.log (Ideal.absNorm (I : Ideal (𝓞 K)) : ℝ)
+            * (‖f I‖ / (Ideal.absNorm (I : Ideal (𝓞 K)) : ℝ) ^ s'.re)
+        ≤ ((Ideal.absNorm (I : Ideal (𝓞 K)) : ℝ) ^ s'.re
+            / (Ideal.absNorm (I : Ideal (𝓞 K)) : ℝ) ^ s.re / (s'.re - s.re))
+            * (‖f I‖ / (Ideal.absNorm (I : Ideal (𝓞 K)) : ℝ) ^ s'.re) := by
+          gcongr
+      _ = (s'.re - s.re)⁻¹ * (‖f I‖ / (Ideal.absNorm (I : Ideal (𝓞 K)) : ℝ) ^ s.re) := by
+          field_simp
 
 end TauCeti

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/Regroup.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/Regroup.lean
@@ -31,8 +31,8 @@ sum.
 * `TauCeti.regroupByNorm`: if the ideal-indexed series has sum `L` at `s`, then so does the
   `LSeries` of `TauCeti.normCoeff f`; `TauCeti.LSeriesSummable_normCoeff` and
   `TauCeti.LSeries_normCoeff` are the summability and value statements it packages.
-* `TauCeti.summable_log_mul_norm_idealTerm_of_re_lt_re`: weighting the ideal terms by `log N(I)`
-  keeps them summable strictly to the right of a point of absolute convergence.
+* `TauCeti.summable_log_absNorm_mul_norm_idealTerm_of_re_lt_re`: weighting the ideal terms
+  by `log N(I)` keeps them summable strictly to the right of a point of absolute convergence.
 * `TauCeti.abscissaOfAbsConv_normCoeff_le`: consequently the grouped abscissa of absolute
   convergence is at most the ideal-indexed one.
 * `TauCeti.summable_idealTerm_of_norm_normCoeff_eq_sum_norm`: the converse holds whenever no
@@ -131,7 +131,8 @@ propagates unweighted convergence along `Re s ≤ Re s'`: the logarithmic weight
 summability at `Re s' = Re s`.  This is the ideal-indexed counterpart of Mathlib's
 `LSeriesSummable_logMul_of_lt_re`, and the logarithmic weight is what appears when the terms are
 differentiated in `s`. -/
-theorem summable_log_mul_norm_idealTerm_of_re_lt_re {f : IdealArithmeticFunction K} {s s' : ℂ}
+theorem summable_log_absNorm_mul_norm_idealTerm_of_re_lt_re
+    {f : IdealArithmeticFunction K} {s s' : ℂ}
     (h : s.re < s'.re) (hs : Summable (idealTerm K f s)) :
     Summable fun I : (Ideal (𝓞 K))⁰ ↦
       Real.log (Ideal.absNorm (I : Ideal (𝓞 K))) * ‖idealTerm K f s' I‖ := by

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/Regroup.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/Regroup.lean
@@ -31,6 +31,8 @@ sum.
 * `TauCeti.regroupByNorm`: if the ideal-indexed series has sum `L` at `s`, then so does the
   `LSeries` of `TauCeti.normCoeff f`; `TauCeti.LSeriesSummable_normCoeff` and
   `TauCeti.LSeries_normCoeff` are the summability and value statements it packages.
+* `TauCeti.summable_log_mul_norm_idealTerm_of_re_lt_re`: weighting the ideal terms by `log N(I)`
+  keeps them summable strictly to the right of a point of absolute convergence.
 * `TauCeti.abscissaOfAbsConv_normCoeff_le`: consequently the grouped abscissa of absolute
   convergence is at most the ideal-indexed one.
 * `TauCeti.summable_idealTerm_of_norm_normCoeff_eq_sum_norm`: the converse holds whenever no
@@ -119,6 +121,41 @@ theorem summable_idealTerm_of_re_le_re {f : IdealArithmeticFunction K} {s s' : �
 theorem summable_idealTerm_iff_of_re_eq_re {f : IdealArithmeticFunction K} {s s' : ℂ}
     (h : s.re = s'.re) : Summable (idealTerm K f s) ↔ Summable (idealTerm K f s') :=
   ⟨summable_idealTerm_of_re_le_re K h.le, summable_idealTerm_of_re_le_re K h.ge⟩
+
+/-- **Log-weighted ideal terms stay summable strictly to the right.**  If the ideal-indexed
+Dirichlet series of `f` converges absolutely at `s`, then weighting each term by `log N(I)` leaves
+it summable at every `s'` with `Re s < Re s'`.
+
+The strict inequality is what separates this from `summable_idealTerm_of_re_le_re`, which
+propagates unweighted convergence along `Re s ≤ Re s'`: the logarithmic weight can destroy
+summability at `Re s' = Re s`.  This is the ideal-indexed counterpart of Mathlib's
+`LSeriesSummable_logMul_of_lt_re`, and the logarithmic weight is what appears when the terms are
+differentiated in `s`. -/
+theorem summable_log_mul_norm_idealTerm_of_re_lt_re {f : IdealArithmeticFunction K} {s s' : ℂ}
+    (h : s.re < s'.re) (hs : Summable (idealTerm K f s)) :
+    Summable fun I : (Ideal (𝓞 K))⁰ ↦
+      Real.log (Ideal.absNorm (I : Ideal (𝓞 K))) * ‖idealTerm K f s' I‖ := by
+  have hδ : 0 < s'.re - s.re := sub_pos.2 h
+  refine Summable.of_nonneg_of_le (fun I ↦ ?_) (fun I ↦ ?_)
+    ((summable_norm_iff.2 hs).mul_left (s'.re - s.re)⁻¹)
+  · have h1 : (1:ℝ) ≤ (Ideal.absNorm (I : Ideal (𝓞 K)) : ℝ) := by
+      exact_mod_cast Ideal.absNorm_pos_of_nonZeroDivisors I
+    exact mul_nonneg (Real.log_nonneg h1) (norm_nonneg _)
+  · have hN : (0:ℝ) < (Ideal.absNorm (I : Ideal (𝓞 K)) : ℝ) := by
+      exact_mod_cast Ideal.absNorm_pos_of_nonZeroDivisors I
+    rw [norm_idealTerm, norm_idealTerm]
+    -- `log x ≤ x ^ δ / δ` with `δ = Re s' - Re s`; the extra `N(I) ^ δ` is exactly what turns the
+    -- term at `s'` into the term at `s`.
+    have hlog := Real.log_le_rpow_div hN.le hδ
+    rw [Real.rpow_sub hN] at hlog
+    calc Real.log (Ideal.absNorm (I : Ideal (𝓞 K)) : ℝ)
+            * (‖f I‖ / (Ideal.absNorm (I : Ideal (𝓞 K)) : ℝ) ^ s'.re)
+        ≤ ((Ideal.absNorm (I : Ideal (𝓞 K)) : ℝ) ^ s'.re
+            / (Ideal.absNorm (I : Ideal (𝓞 K)) : ℝ) ^ s.re / (s'.re - s.re))
+            * (‖f I‖ / (Ideal.absNorm (I : Ideal (𝓞 K)) : ℝ) ^ s'.re) := by
+          gcongr
+      _ = (s'.re - s.re)⁻¹ * (‖f I‖ / (Ideal.absNorm (I : Ideal (𝓞 K)) : ℝ) ^ s.re) := by
+          field_simp
 
 /-! ### Regrouping -/
 


### PR DESCRIPTION
If the ideal-indexed Dirichlet series of `f` converges absolutely at `s`, then weighting each term
by `log N(I)` leaves it summable at every `s'` strictly to the right.

```lean
theorem TauCeti.summable_log_absNorm_mul_norm_idealTerm_of_re_lt_re (K : Type*) [Field K] [NumberField K]
    {f : IdealArithmeticFunction K} {s s' : ℂ} (h : s.re < s'.re)
    (hs : Summable (idealTerm K f s)) :
    Summable fun I : (Ideal (𝓞 K))⁰ ↦
      Real.log (Ideal.absNorm (I : Ideal (𝓞 K))) * ‖idealTerm K f s' I‖
```

It lives in `ArithmeticDirichletSeries/Regroup.lean`, directly after
`summable_idealTerm_of_re_le_re`, which is its unweighted form. Placing them together makes the one
real difference visible: unweighted convergence propagates along `Re s ≤ Re s'`, while the
logarithmic weight needs the inequality strict.

This is the ideal-indexed counterpart of Mathlib's `LSeriesSummable_logMul_of_lt_re`, which is
stated for `ℕ`-indexed series and does not transfer: the ideals of `𝓞 K` have repeating norms and
are not indexed by `ℕ`.

### Why the proof is short

No asymptotic argument is needed. Mathlib's `Real.log_le_rpow_div` gives `log x ≤ x ^ δ / δ`, and
at `δ = Re s' - Re s` the factor `N(I) ^ δ` is exactly what converts the term at `s'` into the term
at `s`:

```text
log N(I) * ‖f I‖ / N(I) ^ Re s'  ≤  δ⁻¹ * ‖f I‖ / N(I) ^ Re s
```

so the whole family is dominated by `δ⁻¹` times the series assumed summable. The strict inequality
is load-bearing — at `Re s' = Re s` the logarithmic weight can destroy summability, which is why the
statement compares two points rather than quantifying over a half-plane.

### What it is for

`TauCetiRoadmap/ArithmeticDirichletSeries/README.md` Layer 3.4 asks for the prime-power logarithmic
expansion **and its derivative**. #6051 merged the expansion; the derivative needs the sum
differentiated termwise, and `hasDerivAt_tsum_of_isPreconnected` requires a uniform summable bound
on the differentiated terms. Differentiating `f I · N(I)^{-s}` in `s` produces exactly the factor
`log N(I)`, so this is that bound. It is also what #5572 is parked behind.

This PR carries **no `tauceti-target:v1` marker**. It supplies an analytic input that Layer 3.4's
derivative needs rather than authoring 3.4's declaration, so the layer's id belongs on the PR that
delivers the derivative itself — claiming it here would collide with that one.

Roadmap: ArithmeticDirichletSeries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011dmwkBnj4rJc75STgbwsLF


