### PR TITLE
feat(Analysis): a weighted geometric family is summable over index and exponent

### DIFF
--- a/TauCeti/Analysis/SpecialFunctions/Complex/LogBounds.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Complex/LogBounds.lean
@@ -44,12 +44,13 @@ theorem summable_taylorSeries_neg_log {ι : Type*} {r : ι → ℂ} (hr : Summab
     Summable fun ie : ι × ℕ ↦ r ie.1 ^ (ie.2 + 1) / ((ie.2 : ℂ) + 1) := by
   -- The majorant is the weighted geometric bound at weight `1`; summability of `r` supplies its
   -- eventual bound with `ε = 1 / 2`.
-  have hbd : ∃ ε > 0, ∀ᶠ i in Filter.cofinite, ‖r i‖ ≤ 1 - ε :=
-    ⟨1 / 2, by norm_num, by
-      simpa using hr.tendsto_cofinite_zero.norm.eventually_le_const (by norm_num)⟩
+  have hhalf : ∀ᶠ i in Filter.cofinite, ‖r i‖ ≤ 1 / 2 :=
+    hr.tendsto_cofinite_zero.norm.eventually_le_const (by norm_num)
+  have hbd : ∃ ε > 0, ∀ᶠ i in Filter.cofinite, (1 : ℝ) ≠ 0 → ‖r i‖ ≤ 1 - ε :=
+    ⟨1 / 2, by norm_num, by filter_upwards [hhalf] with i hi _; linarith⟩
   have hmaj : Summable fun ie : ι × ℕ ↦ ‖r ie.1‖ ^ (ie.2 + 1) := by
     simpa using TauCeti.summable_mul_norm_pow_succ (w := fun _ ↦ (1 : ℝ)) hbd
-      (by simpa using hr.norm) h1
+      (by simpa using hr.norm) (fun i _ ↦ h1 i)
   refine hmaj.of_norm_bounded ?_
   rintro ⟨i, e⟩
   rw [norm_div, norm_pow]

--- a/TauCeti/Analysis/SpecialFunctions/Complex/LogBounds.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Complex/LogBounds.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Analysis.SpecialFunctions.Complex.LogBounds
+public import TauCeti.Topology.Algebra.InfiniteSum.Real
 
 /-!
 # The Taylor series of `-log (1 - ·)` summed over a family
@@ -17,15 +18,15 @@ prime-power-style sum over pairs equals the sum of local logarithms.
 
 Both hypotheses are needed.  `∀ i, ‖r i‖ < 1` alone does not suffice: the fibre at `i` sums to
 `‖r i‖ / (1 - ‖r i‖)`, which is dominated by `‖r i‖` only when `‖r i‖` is bounded away from `1`,
-and summability of `r` is what supplies that uniformity.
+and summability of `r` is what supplies that uniformity.  That fibrewise argument is not carried out
+here: it is `summable_mul_norm_pow_succ`, stated for a normed group and an arbitrary real weight,
+and this file uses it at weight `1`.
 
 ## Main results
 
 * `Complex.summable_taylorSeries_neg_log`: for a summable `r : ι → ℂ` with every `‖r i‖ < 1`, the
   family `(i, e) ↦ r i ^ (e + 1) / (e + 1)` is summable over `ι × ℕ`.
 * `Complex.tsum_taylorSeries_neg_log`: its sum over `ι × ℕ` is `∑' i, -log (1 - r i)`.
-* `Complex.summable_mul_norm_pow_succ`: the same family with the `1 / (e + 1)` replaced by a
-  nonnegative weight `w i` is summable, given that `w · * ‖r ·‖` is.
 -/
 
 public section
@@ -41,20 +42,9 @@ Both hypotheses are needed, and neither is arithmetic: see the module docstring 
 theorem summable_taylorSeries_neg_log {ι : Type*} {r : ι → ℂ} (hr : Summable r)
     (h1 : ∀ i, ‖r i‖ < 1) :
     Summable fun ie : ι × ℕ ↦ r ie.1 ^ (ie.2 + 1) / ((ie.2 : ℂ) + 1) := by
-  have hhalf : ∀ᶠ i in Filter.cofinite, ‖r i‖ ≤ 1 / 2 :=
-    hr.tendsto_cofinite_zero.norm.eventually_le_const (by norm_num)
+  -- The majorant is the weighted geometric bound at weight `1`.
   have hmaj : Summable fun ie : ι × ℕ ↦ ‖r ie.1‖ ^ (ie.2 + 1) := by
-    have hfib : ∀ i, Summable fun e : ℕ ↦ ‖r i‖ ^ (e + 1) := fun i ↦
-      ((summable_geometric_of_lt_one (norm_nonneg _) (h1 i)).mul_left ‖r i‖).congr fun e ↦ by ring
-    have hval : ∀ i, ∑' e : ℕ, ‖r i‖ ^ (e + 1) = ‖r i‖ / (1 - ‖r i‖) := fun i ↦ by
-      rw [tsum_congr fun e ↦ pow_succ' ‖r i‖ e, tsum_mul_left,
-        tsum_geometric_of_lt_one (norm_nonneg _) (h1 i), div_eq_mul_inv]
-    have houter : Summable fun i ↦ ∑' e : ℕ, ‖r i‖ ^ (e + 1) := by
-      refine Summable.of_norm_bounded_eventually (g := fun i ↦ 2 * ‖r i‖) (hr.norm.mul_left 2) ?_
-      filter_upwards [hhalf] with i hi
-      rw [Real.norm_of_nonneg (by positivity), hval i, div_le_iff₀ (by linarith [h1 i])]
-      nlinarith [norm_nonneg (r i)]
-    exact (summable_prod_of_nonneg fun ie ↦ pow_nonneg (norm_nonneg _) _).mpr ⟨hfib, houter⟩
+    simpa using summable_mul_norm_pow_succ (w := fun _ ↦ (1 : ℝ)) hr (by simpa using hr.norm) h1
   refine hmaj.of_norm_bounded ?_
   rintro ⟨i, e⟩
   rw [norm_div, norm_pow]
@@ -73,41 +63,5 @@ theorem tsum_taylorSeries_neg_log {ι : Type*} {r : ι → ℂ} (hr : Summable r
   have hfib : ∀ i, HasSum (fun e : ℕ ↦ r i ^ (e + 1) / ((e : ℂ) + 1))
       (-Complex.log (1 - r i)) := fun i ↦ hasSum_taylorSeries_neg_log' (h1 i)
   exact ((summable_taylorSeries_neg_log hr h1).hasSum.prod_fiberwise hfib).tsum_eq.symm
-
-/-- **A weighted geometric family is summable over index and exponent together.**  For a summable
-family `r` of complex numbers, all of modulus less than one, and nonnegative weights `w` with
-`i ↦ w i * ‖r i‖` summable, the double family `(i, e) ↦ w i * ‖r i‖ ^ (e + 1)` is summable over
-`ι × ℕ`.
-
-Compare `summable_taylorSeries_neg_log`: dropping the `1 / (e + 1)` costs nothing, because the
-fibre at `i` is still geometric, but the weight has to be paid for by its own hypothesis. This is
-the shape a majorant takes when the Taylor family is differentiated in a parameter, since
-differentiating `rᵢ ^ (e + 1) / (e + 1)` cancels the `e + 1` and leaves a factor depending only on
-`i`. -/
-theorem summable_mul_norm_pow_succ {ι : Type*} {r : ι → ℂ} {w : ι → ℝ} (hr : Summable r)
-    (hw : ∀ i, 0 ≤ w i) (hwr : Summable fun i ↦ w i * ‖r i‖) (h1 : ∀ i, ‖r i‖ < 1) :
-    Summable fun ie : ι × ℕ ↦ w ie.1 * ‖r ie.1‖ ^ (ie.2 + 1) := by
-  have hhalf : ∀ᶠ i in Filter.cofinite, ‖r i‖ ≤ 1 / 2 :=
-    hr.tendsto_cofinite_zero.norm.eventually_le_const (by norm_num)
-  have hfib : ∀ i, Summable fun e : ℕ ↦ w i * ‖r i‖ ^ (e + 1) := fun i ↦
-    (((summable_geometric_of_lt_one (norm_nonneg _) (h1 i)).mul_left ‖r i‖).congr
-      fun e ↦ by ring).mul_left (w i)
-  have hval : ∀ i, ∑' e : ℕ, w i * ‖r i‖ ^ (e + 1) = w i * (‖r i‖ / (1 - ‖r i‖)) := fun i ↦ by
-    rw [tsum_mul_left, tsum_congr fun e ↦ pow_succ' ‖r i‖ e, tsum_mul_left,
-      tsum_geometric_of_lt_one (norm_nonneg _) (h1 i), div_eq_mul_inv]
-  have houter : Summable fun i ↦ ∑' e : ℕ, w i * ‖r i‖ ^ (e + 1) := by
-    refine Summable.of_norm_bounded_eventually (g := fun i ↦ 2 * (w i * ‖r i‖))
-      (hwr.mul_left 2) ?_
-    filter_upwards [hhalf] with i hi
-    rw [Real.norm_of_nonneg (tsum_nonneg fun e ↦ mul_nonneg (hw i) (by positivity)), hval i]
-    -- Below `1 / 2` the fibre sum `‖r i‖ / (1 - ‖r i‖)` is at most `2 ‖r i‖`.
-    have hd : ‖r i‖ / (1 - ‖r i‖) ≤ 2 * ‖r i‖ := by
-      rw [div_le_iff₀ (by linarith)]
-      nlinarith [norm_nonneg (r i)]
-    calc w i * (‖r i‖ / (1 - ‖r i‖)) ≤ w i * (2 * ‖r i‖) :=
-          mul_le_mul_of_nonneg_left hd (hw i)
-      _ = 2 * (w i * ‖r i‖) := by ring
-  exact (summable_prod_of_nonneg fun ie ↦
-    mul_nonneg (hw ie.1) (by positivity)).mpr ⟨hfib, houter⟩
 
 end Complex

--- a/TauCeti/Analysis/SpecialFunctions/Complex/LogBounds.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Complex/LogBounds.lean
@@ -24,6 +24,8 @@ and summability of `r` is what supplies that uniformity.
 * `Complex.summable_taylorSeries_neg_log`: for a summable `r : ι → ℂ` with every `‖r i‖ < 1`, the
   family `(i, e) ↦ r i ^ (e + 1) / (e + 1)` is summable over `ι × ℕ`.
 * `Complex.tsum_taylorSeries_neg_log`: its sum over `ι × ℕ` is `∑' i, -log (1 - r i)`.
+* `Complex.summable_mul_norm_pow_succ`: the same family with the `1 / (e + 1)` replaced by a
+  nonnegative weight `w i` is summable, given that `w · * ‖r ·‖` is.
 -/
 
 public section
@@ -71,5 +73,41 @@ theorem tsum_taylorSeries_neg_log {ι : Type*} {r : ι → ℂ} (hr : Summable r
   have hfib : ∀ i, HasSum (fun e : ℕ ↦ r i ^ (e + 1) / ((e : ℂ) + 1))
       (-Complex.log (1 - r i)) := fun i ↦ hasSum_taylorSeries_neg_log' (h1 i)
   exact ((summable_taylorSeries_neg_log hr h1).hasSum.prod_fiberwise hfib).tsum_eq.symm
+
+/-- **A weighted geometric family is summable over index and exponent together.**  For a summable
+family `r` of complex numbers, all of modulus less than one, and nonnegative weights `w` with
+`i ↦ w i * ‖r i‖` summable, the double family `(i, e) ↦ w i * ‖r i‖ ^ (e + 1)` is summable over
+`ι × ℕ`.
+
+Compare `summable_taylorSeries_neg_log`: dropping the `1 / (e + 1)` costs nothing, because the
+fibre at `i` is still geometric, but the weight has to be paid for by its own hypothesis. This is
+the shape a majorant takes when the Taylor family is differentiated in a parameter, since
+differentiating `rᵢ ^ (e + 1) / (e + 1)` cancels the `e + 1` and leaves a factor depending only on
+`i`. -/
+theorem summable_mul_norm_pow_succ {ι : Type*} {r : ι → ℂ} {w : ι → ℝ} (hr : Summable r)
+    (hw : ∀ i, 0 ≤ w i) (hwr : Summable fun i ↦ w i * ‖r i‖) (h1 : ∀ i, ‖r i‖ < 1) :
+    Summable fun ie : ι × ℕ ↦ w ie.1 * ‖r ie.1‖ ^ (ie.2 + 1) := by
+  have hhalf : ∀ᶠ i in Filter.cofinite, ‖r i‖ ≤ 1 / 2 :=
+    hr.tendsto_cofinite_zero.norm.eventually_le_const (by norm_num)
+  have hfib : ∀ i, Summable fun e : ℕ ↦ w i * ‖r i‖ ^ (e + 1) := fun i ↦
+    (((summable_geometric_of_lt_one (norm_nonneg _) (h1 i)).mul_left ‖r i‖).congr
+      fun e ↦ by ring).mul_left (w i)
+  have hval : ∀ i, ∑' e : ℕ, w i * ‖r i‖ ^ (e + 1) = w i * (‖r i‖ / (1 - ‖r i‖)) := fun i ↦ by
+    rw [tsum_mul_left, tsum_congr fun e ↦ pow_succ' ‖r i‖ e, tsum_mul_left,
+      tsum_geometric_of_lt_one (norm_nonneg _) (h1 i), div_eq_mul_inv]
+  have houter : Summable fun i ↦ ∑' e : ℕ, w i * ‖r i‖ ^ (e + 1) := by
+    refine Summable.of_norm_bounded_eventually (g := fun i ↦ 2 * (w i * ‖r i‖))
+      (hwr.mul_left 2) ?_
+    filter_upwards [hhalf] with i hi
+    rw [Real.norm_of_nonneg (tsum_nonneg fun e ↦ mul_nonneg (hw i) (by positivity)), hval i]
+    -- Below `1 / 2` the fibre sum `‖r i‖ / (1 - ‖r i‖)` is at most `2 ‖r i‖`.
+    have hd : ‖r i‖ / (1 - ‖r i‖) ≤ 2 * ‖r i‖ := by
+      rw [div_le_iff₀ (by linarith)]
+      nlinarith [norm_nonneg (r i)]
+    calc w i * (‖r i‖ / (1 - ‖r i‖)) ≤ w i * (2 * ‖r i‖) :=
+          mul_le_mul_of_nonneg_left hd (hw i)
+      _ = 2 * (w i * ‖r i‖) := by ring
+  exact (summable_prod_of_nonneg fun ie ↦
+    mul_nonneg (hw ie.1) (by positivity)).mpr ⟨hfib, houter⟩
 
 end Complex

--- a/TauCeti/Analysis/SpecialFunctions/Complex/LogBounds.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Complex/LogBounds.lean
@@ -19,8 +19,8 @@ prime-power-style sum over pairs equals the sum of local logarithms.
 Both hypotheses are needed.  `∀ i, ‖r i‖ < 1` alone does not suffice: the fibre at `i` sums to
 `‖r i‖ / (1 - ‖r i‖)`, which is dominated by `‖r i‖` only when `‖r i‖` is bounded away from `1`,
 and summability of `r` is what supplies that uniformity.  That fibrewise argument is not carried out
-here: it is `TauCeti.summable_mul_norm_pow_succ`, stated for a normed group and an arbitrary real
-weight, and this file uses it at weight `1`.
+here: it is `TauCeti.summable_mul_norm_pow_succ`, stated for a seminormed additive group and an
+arbitrary real weight, and this file uses it at weight `1`.
 
 ## Main results
 

--- a/TauCeti/Analysis/SpecialFunctions/Complex/LogBounds.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Complex/LogBounds.lean
@@ -19,8 +19,8 @@ prime-power-style sum over pairs equals the sum of local logarithms.
 Both hypotheses are needed.  `∀ i, ‖r i‖ < 1` alone does not suffice: the fibre at `i` sums to
 `‖r i‖ / (1 - ‖r i‖)`, which is dominated by `‖r i‖` only when `‖r i‖` is bounded away from `1`,
 and summability of `r` is what supplies that uniformity.  That fibrewise argument is not carried out
-here: it is `summable_mul_norm_pow_succ`, stated for a normed group and an arbitrary real weight,
-and this file uses it at weight `1`.
+here: it is `TauCeti.summable_mul_norm_pow_succ`, stated for a normed group and an arbitrary real
+weight, and this file uses it at weight `1`.
 
 ## Main results
 
@@ -42,9 +42,14 @@ Both hypotheses are needed, and neither is arithmetic: see the module docstring 
 theorem summable_taylorSeries_neg_log {ι : Type*} {r : ι → ℂ} (hr : Summable r)
     (h1 : ∀ i, ‖r i‖ < 1) :
     Summable fun ie : ι × ℕ ↦ r ie.1 ^ (ie.2 + 1) / ((ie.2 : ℂ) + 1) := by
-  -- The majorant is the weighted geometric bound at weight `1`.
+  -- The majorant is the weighted geometric bound at weight `1`; summability of `r` supplies its
+  -- eventual bound with `ε = 1 / 2`.
+  have hbd : ∃ ε > 0, ∀ᶠ i in Filter.cofinite, ‖r i‖ ≤ 1 - ε :=
+    ⟨1 / 2, by norm_num, by
+      simpa using hr.tendsto_cofinite_zero.norm.eventually_le_const (by norm_num)⟩
   have hmaj : Summable fun ie : ι × ℕ ↦ ‖r ie.1‖ ^ (ie.2 + 1) := by
-    simpa using summable_mul_norm_pow_succ (w := fun _ ↦ (1 : ℝ)) hr (by simpa using hr.norm) h1
+    simpa using TauCeti.summable_mul_norm_pow_succ (w := fun _ ↦ (1 : ℝ)) hbd
+      (by simpa using hr.norm) h1
   refine hmaj.of_norm_bounded ?_
   rintro ⟨i, e⟩
   rw [norm_div, norm_pow]

--- a/TauCeti/Topology/Algebra/InfiniteSum/Real.lean
+++ b/TauCeti/Topology/Algebra/InfiniteSum/Real.lean
@@ -6,40 +6,43 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Analysis.SpecificLimits.Normed
-public import Mathlib.Topology.Algebra.InfiniteSum.Real
 
 /-!
 # Weighted geometric majorants over an index and an exponent
 
-For a summable family `r : ι → E` in a normed group, all of norm less than one, the double family
-`(i, e) ↦ w i * ‖r i‖ ^ (e + 1)` is summable over `ι × ℕ` as soon as `i ↦ w i * ‖r i‖` is summable.
-Each fibre is geometric, so it sums to `w i * ‖r i‖ / (1 - ‖r i‖)`, and summability of `r` bounds
-`1 / (1 - ‖r i‖)` off a finite set.
+For a family `r : ι → E` in a normed group, all of norm less than one and eventually of norm at
+most `1 - ε`, the double family `(i, e) ↦ w i * ‖r i‖ ^ (e + 1)` is summable over `ι × ℕ` as soon
+as `i ↦ w i * ‖r i‖` is summable. Each fibre is geometric, so it sums to
+`w i * ‖r i‖ / (1 - ‖r i‖)`, and the eventual bound keeps `1 / (1 - ‖r i‖)` under `ε⁻¹` off a
+finite set.
 
 ## Main results
 
-* `summable_mul_norm_pow_succ`: the weighted double family is summable over `ι × ℕ`.
+* `TauCeti.summable_mul_norm_pow_succ`: the weighted double family is summable over `ι × ℕ`.
 -/
 
 public section
 
-/-- **A weighted geometric family is summable over index and exponent together.**  For a summable
-family `r` in a normed group, all of norm less than one, and real weights `w` with
-`i ↦ w i * ‖r i‖` summable, the double family `(i, e) ↦ w i * ‖r i‖ ^ (e + 1)` is summable over
-`ι × ℕ`.
+namespace TauCeti
 
-The weights are unrestricted in sign: only `|w i|` enters the majorant. Summability of `r` is
-needed beyond `∀ i, ‖r i‖ < 1`, since the fibre at `i` sums to `w i * ‖r i‖ / (1 - ‖r i‖)`, which
-is comparable to `w i * ‖r i‖` only where `‖r i‖` stays away from `1`.
+/-- **A weighted geometric family is summable over index and exponent together.**  For a family
+`r` in a normed group, all of norm less than one and eventually of norm at most `1 - ε`, and real
+weights `w` with `i ↦ w i * ‖r i‖` summable, the double family `(i, e) ↦ w i * ‖r i‖ ^ (e + 1)` is
+summable over `ι × ℕ`.
+
+The weights are unrestricted in sign: only `|w i|` enters the majorant. The eventual bound is what
+the fibres need — the fibre at `i` sums to `w i * ‖r i‖ / (1 - ‖r i‖)`, which is comparable to
+`w i * ‖r i‖` only where `‖r i‖` stays away from `1`. Summability of `r` would give this, but is
+far stronger: it rules out a family of constant norm with summable weights.
 
 This is the bound a termwise differentiation argument runs on whenever the differentiated terms are
 an index-only weight times a norm power; it says nothing on its own about which families have that
 form. -/
 theorem summable_mul_norm_pow_succ {ι E : Type*} [NormedAddCommGroup E] {r : ι → E} {w : ι → ℝ}
-    (hr : Summable r) (hwr : Summable fun i ↦ w i * ‖r i‖) (h1 : ∀ i, ‖r i‖ < 1) :
+    (hbd : ∃ ε > 0, ∀ᶠ i in Filter.cofinite, ‖r i‖ ≤ 1 - ε)
+    (hwr : Summable fun i ↦ w i * ‖r i‖) (h1 : ∀ i, ‖r i‖ < 1) :
     Summable fun ie : ι × ℕ ↦ w ie.1 * ‖r ie.1‖ ^ (ie.2 + 1) := by
-  have hhalf : ∀ᶠ i in Filter.cofinite, ‖r i‖ ≤ 1 / 2 :=
-    hr.tendsto_cofinite_zero.norm.eventually_le_const (by norm_num)
+  obtain ⟨ε, hε, hfar⟩ := hbd
   have habs : Summable fun i ↦ |w i| * ‖r i‖ := by
     refine (summable_abs_iff.2 hwr).congr fun i ↦ ?_
     rw [abs_mul, abs_of_nonneg (norm_nonneg (r i))]
@@ -51,19 +54,22 @@ theorem summable_mul_norm_pow_succ {ι E : Type*} [NormedAddCommGroup E] {r : ι
     rw [tsum_mul_left, tsum_congr fun e ↦ pow_succ' ‖r i‖ e, tsum_mul_left,
       tsum_geometric_of_lt_one (norm_nonneg _) (h1 i), div_eq_mul_inv]
   have houter : Summable fun i ↦ ∑' e : ℕ, |w i| * ‖r i‖ ^ (e + 1) := by
-    refine Summable.of_norm_bounded_eventually (g := fun i ↦ 2 * (|w i| * ‖r i‖))
-      (habs.mul_left 2) ?_
-    filter_upwards [hhalf] with i hi
+    refine Summable.of_norm_bounded_eventually (g := fun i ↦ ε⁻¹ * (|w i| * ‖r i‖))
+      (habs.mul_left ε⁻¹) ?_
+    filter_upwards [hfar] with i hi
     rw [Real.norm_of_nonneg (tsum_nonneg fun e ↦ by positivity), hval i]
-    -- Below `1 / 2` the fibre sum `‖r i‖ / (1 - ‖r i‖)` is at most `2 ‖r i‖`.
-    have hd : ‖r i‖ / (1 - ‖r i‖) ≤ 2 * ‖r i‖ := by
-      rw [div_le_iff₀ (by linarith)]
-      nlinarith [norm_nonneg (r i)]
-    calc |w i| * (‖r i‖ / (1 - ‖r i‖)) ≤ |w i| * (2 * ‖r i‖) :=
+    -- Where `‖r i‖ ≤ 1 - ε` the fibre sum `‖r i‖ / (1 - ‖r i‖)` is at most `ε⁻¹ ‖r i‖`.
+    have hd : ‖r i‖ / (1 - ‖r i‖) ≤ ε⁻¹ * ‖r i‖ := by
+      rw [div_le_iff₀ (by linarith [h1 i])]
+      have hεi : ε * (ε⁻¹ * ‖r i‖) = ‖r i‖ := by field_simp
+      nlinarith [norm_nonneg (r i), inv_pos.2 hε]
+    calc |w i| * (‖r i‖ / (1 - ‖r i‖)) ≤ |w i| * (ε⁻¹ * ‖r i‖) :=
           mul_le_mul_of_nonneg_left hd (abs_nonneg _)
-      _ = 2 * (|w i| * ‖r i‖) := by ring
+      _ = ε⁻¹ * (|w i| * ‖r i‖) := by ring
   have hmaj : Summable fun ie : ι × ℕ ↦ |w ie.1| * ‖r ie.1‖ ^ (ie.2 + 1) :=
     (summable_prod_of_nonneg fun ie ↦ by positivity).mpr ⟨hfib, houter⟩
   refine hmaj.of_norm_bounded fun ie ↦ ?_
   rw [Real.norm_eq_abs, abs_mul,
     abs_of_nonneg (by positivity : (0:ℝ) ≤ ‖r ie.1‖ ^ (ie.2 + 1))]
+
+end TauCeti

--- a/TauCeti/Topology/Algebra/InfiniteSum/Real.lean
+++ b/TauCeti/Topology/Algebra/InfiniteSum/Real.lean
@@ -1,0 +1,69 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.SpecificLimits.Normed
+public import Mathlib.Topology.Algebra.InfiniteSum.Real
+
+/-!
+# Weighted geometric majorants over an index and an exponent
+
+For a summable family `r : ι → E` in a normed group, all of norm less than one, the double family
+`(i, e) ↦ w i * ‖r i‖ ^ (e + 1)` is summable over `ι × ℕ` as soon as `i ↦ w i * ‖r i‖` is summable.
+Each fibre is geometric, so it sums to `w i * ‖r i‖ / (1 - ‖r i‖)`, and summability of `r` bounds
+`1 / (1 - ‖r i‖)` off a finite set.
+
+## Main results
+
+* `summable_mul_norm_pow_succ`: the weighted double family is summable over `ι × ℕ`.
+-/
+
+public section
+
+/-- **A weighted geometric family is summable over index and exponent together.**  For a summable
+family `r` in a normed group, all of norm less than one, and real weights `w` with
+`i ↦ w i * ‖r i‖` summable, the double family `(i, e) ↦ w i * ‖r i‖ ^ (e + 1)` is summable over
+`ι × ℕ`.
+
+The weights are unrestricted in sign: only `|w i|` enters the majorant. Summability of `r` is
+needed beyond `∀ i, ‖r i‖ < 1`, since the fibre at `i` sums to `w i * ‖r i‖ / (1 - ‖r i‖)`, which
+is comparable to `w i * ‖r i‖` only where `‖r i‖` stays away from `1`.
+
+This is the bound a termwise differentiation argument runs on whenever the differentiated terms are
+an index-only weight times a norm power; it says nothing on its own about which families have that
+form. -/
+theorem summable_mul_norm_pow_succ {ι E : Type*} [NormedAddCommGroup E] {r : ι → E} {w : ι → ℝ}
+    (hr : Summable r) (hwr : Summable fun i ↦ w i * ‖r i‖) (h1 : ∀ i, ‖r i‖ < 1) :
+    Summable fun ie : ι × ℕ ↦ w ie.1 * ‖r ie.1‖ ^ (ie.2 + 1) := by
+  have hhalf : ∀ᶠ i in Filter.cofinite, ‖r i‖ ≤ 1 / 2 :=
+    hr.tendsto_cofinite_zero.norm.eventually_le_const (by norm_num)
+  have habs : Summable fun i ↦ |w i| * ‖r i‖ := by
+    refine (summable_abs_iff.2 hwr).congr fun i ↦ ?_
+    rw [abs_mul, abs_of_nonneg (norm_nonneg (r i))]
+  -- The absolute-value family is nonnegative, so it can be assembled fibrewise.
+  have hfib : ∀ i, Summable fun e : ℕ ↦ |w i| * ‖r i‖ ^ (e + 1) := fun i ↦
+    (((summable_geometric_of_lt_one (norm_nonneg _) (h1 i)).mul_left ‖r i‖).congr
+      fun e ↦ by ring).mul_left |w i|
+  have hval : ∀ i, ∑' e : ℕ, |w i| * ‖r i‖ ^ (e + 1) = |w i| * (‖r i‖ / (1 - ‖r i‖)) := fun i ↦ by
+    rw [tsum_mul_left, tsum_congr fun e ↦ pow_succ' ‖r i‖ e, tsum_mul_left,
+      tsum_geometric_of_lt_one (norm_nonneg _) (h1 i), div_eq_mul_inv]
+  have houter : Summable fun i ↦ ∑' e : ℕ, |w i| * ‖r i‖ ^ (e + 1) := by
+    refine Summable.of_norm_bounded_eventually (g := fun i ↦ 2 * (|w i| * ‖r i‖))
+      (habs.mul_left 2) ?_
+    filter_upwards [hhalf] with i hi
+    rw [Real.norm_of_nonneg (tsum_nonneg fun e ↦ by positivity), hval i]
+    -- Below `1 / 2` the fibre sum `‖r i‖ / (1 - ‖r i‖)` is at most `2 ‖r i‖`.
+    have hd : ‖r i‖ / (1 - ‖r i‖) ≤ 2 * ‖r i‖ := by
+      rw [div_le_iff₀ (by linarith)]
+      nlinarith [norm_nonneg (r i)]
+    calc |w i| * (‖r i‖ / (1 - ‖r i‖)) ≤ |w i| * (2 * ‖r i‖) :=
+          mul_le_mul_of_nonneg_left hd (abs_nonneg _)
+      _ = 2 * (|w i| * ‖r i‖) := by ring
+  have hmaj : Summable fun ie : ι × ℕ ↦ |w ie.1| * ‖r ie.1‖ ^ (ie.2 + 1) :=
+    (summable_prod_of_nonneg fun ie ↦ by positivity).mpr ⟨hfib, houter⟩
+  refine hmaj.of_norm_bounded fun ie ↦ ?_
+  rw [Real.norm_eq_abs, abs_mul,
+    abs_of_nonneg (by positivity : (0:ℝ) ≤ ‖r ie.1‖ ^ (ie.2 + 1))]

--- a/TauCeti/Topology/Algebra/InfiniteSum/Real.lean
+++ b/TauCeti/Topology/Algebra/InfiniteSum/Real.lean
@@ -5,14 +5,16 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Analysis.SpecificLimits.Normed
+public import Mathlib.Analysis.Normed.Group.InfiniteSum
+public import Mathlib.Analysis.SpecificLimits.Basic
 
 /-!
 # Weighted geometric majorants over an index and an exponent
 
-For a family `r : ι → E` in a seminormed group whose norms are less than one, and eventually at most
-`1 - ε`, wherever the weight `w` is nonzero, the double family `(i, e) ↦ w i * ‖r i‖ ^ (e + 1)` is
-summable over `ι × ℕ` as soon as `i ↦ w i * ‖r i‖` is summable. Each fibre is geometric, so it
+For a family `r : ι → E` in a seminormed additive group whose norms are less than one, and
+eventually at most `1 - ε`, wherever the weight `w` is nonzero, the double family
+`(i, e) ↦ w i * ‖r i‖ ^ (e + 1)` is summable over `ι × ℕ` as soon as `i ↦ w i * ‖r i‖` is
+summable. Each fibre is geometric, so it
 sums to `w i * ‖r i‖ / (1 - ‖r i‖)`, and the eventual bound keeps `1 / (1 - ‖r i‖)` under `ε⁻¹`
 off a finite set; a fibre where the weight vanishes is zero and needs no bound at all.
 
@@ -25,14 +27,14 @@ public section
 
 namespace TauCeti
 
-/-- **A weighted geometric family is summable over index and exponent together.**  For a family
-`r` in a seminormed group, all of norm less than one and eventually of norm at most `1 - ε`,
-and real weights `w` with `i ↦ w i * ‖r i‖` summable, the double family
-`(i, e) ↦ w i * ‖r i‖ ^ (e + 1)` is summable over `ι × ℕ`.
+/-- **A weighted geometric family is summable over index and exponent together.**  Let `w : ι → ℝ`
+be weights with `i ↦ w i * ‖r i‖` summable, and let `r` be a family in a seminormed additive group
+which, *at every index where `w` is nonzero*, has norm less than one and eventually norm at most
+`1 - ε`.  Then the double family `(i, e) ↦ w i * ‖r i‖ ^ (e + 1)` is summable over `ι × ℕ`.
 
-The weights are unrestricted in sign: only `|w i|` enters the majorant. Both hypotheses on `r` are
-imposed only on the support of `w`, since a fibre with `w i = 0` is identically zero whatever
-`r i` is.
+Both conditions on `r` are restricted to the support of `w`, and off that support nothing is asked
+of `r` at all: a fibre with `w i = 0` is identically zero whatever `r i` is.  The weights are
+unrestricted in sign, since only `|w i|` enters the majorant.
 
 The eventual bound is what the fibres need — the fibre at `i` sums to `w i * ‖r i‖ / (1 - ‖r i‖)`,
 which is comparable to `w i * ‖r i‖` only where `‖r i‖` stays away from `1`. Summability of `r`

--- a/TauCeti/Topology/Algebra/InfiniteSum/Real.lean
+++ b/TauCeti/Topology/Algebra/InfiniteSum/Real.lean
@@ -10,7 +10,7 @@ public import Mathlib.Analysis.SpecificLimits.Normed
 /-!
 # Weighted geometric majorants over an index and an exponent
 
-For a family `r : ι → E` in a normed group whose norms are less than one, and eventually at most
+For a family `r : ι → E` in a seminormed group whose norms are less than one, and eventually at most
 `1 - ε`, wherever the weight `w` is nonzero, the double family `(i, e) ↦ w i * ‖r i‖ ^ (e + 1)` is
 summable over `ι × ℕ` as soon as `i ↦ w i * ‖r i‖` is summable. Each fibre is geometric, so it
 sums to `w i * ‖r i‖ / (1 - ‖r i‖)`, and the eventual bound keeps `1 / (1 - ‖r i‖)` under `ε⁻¹`
@@ -26,7 +26,7 @@ public section
 namespace TauCeti
 
 /-- **A weighted geometric family is summable over index and exponent together.**  For a family
-`r` in a normed group, all of norm less than one and eventually of norm at most `1 - ε`, and real
+`r` in a seminormed group, all of norm less than one and eventually of norm at most `1 - ε`, and real
 weights `w` with `i ↦ w i * ‖r i‖` summable, the double family `(i, e) ↦ w i * ‖r i‖ ^ (e + 1)` is
 summable over `ι × ℕ`.
 
@@ -42,7 +42,7 @@ weights.
 This is the bound a termwise differentiation argument runs on whenever the differentiated terms are
 an index-only weight times a norm power; it says nothing on its own about which families have that
 form. -/
-theorem summable_mul_norm_pow_succ {ι E : Type*} [NormedAddCommGroup E] {r : ι → E} {w : ι → ℝ}
+theorem summable_mul_norm_pow_succ {ι E : Type*} [SeminormedAddGroup E] {r : ι → E} {w : ι → ℝ}
     (hbd : ∃ ε > 0, ∀ᶠ i in Filter.cofinite, w i ≠ 0 → ‖r i‖ ≤ 1 - ε)
     (hwr : Summable fun i ↦ w i * ‖r i‖) (h1 : ∀ i, w i ≠ 0 → ‖r i‖ < 1) :
     Summable fun ie : ι × ℕ ↦ w ie.1 * ‖r ie.1‖ ^ (ie.2 + 1) := by

--- a/TauCeti/Topology/Algebra/InfiniteSum/Real.lean
+++ b/TauCeti/Topology/Algebra/InfiniteSum/Real.lean
@@ -10,11 +10,11 @@ public import Mathlib.Analysis.SpecificLimits.Normed
 /-!
 # Weighted geometric majorants over an index and an exponent
 
-For a family `r : ι → E` in a normed group, all of norm less than one and eventually of norm at
-most `1 - ε`, the double family `(i, e) ↦ w i * ‖r i‖ ^ (e + 1)` is summable over `ι × ℕ` as soon
-as `i ↦ w i * ‖r i‖` is summable. Each fibre is geometric, so it sums to
-`w i * ‖r i‖ / (1 - ‖r i‖)`, and the eventual bound keeps `1 / (1 - ‖r i‖)` under `ε⁻¹` off a
-finite set.
+For a family `r : ι → E` in a normed group whose norms are less than one, and eventually at most
+`1 - ε`, wherever the weight `w` is nonzero, the double family `(i, e) ↦ w i * ‖r i‖ ^ (e + 1)` is
+summable over `ι × ℕ` as soon as `i ↦ w i * ‖r i‖` is summable. Each fibre is geometric, so it
+sums to `w i * ‖r i‖ / (1 - ‖r i‖)`, and the eventual bound keeps `1 / (1 - ‖r i‖)` under `ε⁻¹`
+off a finite set; a fibre where the weight vanishes is zero and needs no bound at all.
 
 ## Main results
 
@@ -30,42 +30,51 @@ namespace TauCeti
 weights `w` with `i ↦ w i * ‖r i‖` summable, the double family `(i, e) ↦ w i * ‖r i‖ ^ (e + 1)` is
 summable over `ι × ℕ`.
 
-The weights are unrestricted in sign: only `|w i|` enters the majorant. The eventual bound is what
-the fibres need — the fibre at `i` sums to `w i * ‖r i‖ / (1 - ‖r i‖)`, which is comparable to
-`w i * ‖r i‖` only where `‖r i‖` stays away from `1`. Summability of `r` would give this, but is
-far stronger: it rules out a family of constant norm with summable weights.
+The weights are unrestricted in sign: only `|w i|` enters the majorant. Both hypotheses on `r` are
+imposed only on the support of `w`, since a fibre with `w i = 0` is identically zero whatever
+`r i` is.
+
+The eventual bound is what the fibres need — the fibre at `i` sums to `w i * ‖r i‖ / (1 - ‖r i‖)`,
+which is comparable to `w i * ‖r i‖` only where `‖r i‖` stays away from `1`. Summability of `r`
+would give this, but is far stronger: it rules out a family of constant norm with summable
+weights.
 
 This is the bound a termwise differentiation argument runs on whenever the differentiated terms are
 an index-only weight times a norm power; it says nothing on its own about which families have that
 form. -/
 theorem summable_mul_norm_pow_succ {ι E : Type*} [NormedAddCommGroup E] {r : ι → E} {w : ι → ℝ}
-    (hbd : ∃ ε > 0, ∀ᶠ i in Filter.cofinite, ‖r i‖ ≤ 1 - ε)
-    (hwr : Summable fun i ↦ w i * ‖r i‖) (h1 : ∀ i, ‖r i‖ < 1) :
+    (hbd : ∃ ε > 0, ∀ᶠ i in Filter.cofinite, w i ≠ 0 → ‖r i‖ ≤ 1 - ε)
+    (hwr : Summable fun i ↦ w i * ‖r i‖) (h1 : ∀ i, w i ≠ 0 → ‖r i‖ < 1) :
     Summable fun ie : ι × ℕ ↦ w ie.1 * ‖r ie.1‖ ^ (ie.2 + 1) := by
   obtain ⟨ε, hε, hfar⟩ := hbd
   have habs : Summable fun i ↦ |w i| * ‖r i‖ := by
     refine (summable_abs_iff.2 hwr).congr fun i ↦ ?_
     rw [abs_mul, abs_of_nonneg (norm_nonneg (r i))]
-  -- The absolute-value family is nonnegative, so it can be assembled fibrewise.
-  have hfib : ∀ i, Summable fun e : ℕ ↦ |w i| * ‖r i‖ ^ (e + 1) := fun i ↦
-    (((summable_geometric_of_lt_one (norm_nonneg _) (h1 i)).mul_left ‖r i‖).congr
-      fun e ↦ by ring).mul_left |w i|
-  have hval : ∀ i, ∑' e : ℕ, |w i| * ‖r i‖ ^ (e + 1) = |w i| * (‖r i‖ / (1 - ‖r i‖)) := fun i ↦ by
-    rw [tsum_mul_left, tsum_congr fun e ↦ pow_succ' ‖r i‖ e, tsum_mul_left,
-      tsum_geometric_of_lt_one (norm_nonneg _) (h1 i), div_eq_mul_inv]
+  -- The absolute-value family is nonnegative, so it can be assembled fibrewise.  A fibre with
+  -- `w i = 0` is identically zero, so it needs no hypothesis on `‖r i‖`.
+  have hfib : ∀ i, Summable fun e : ℕ ↦ |w i| * ‖r i‖ ^ (e + 1) := fun i ↦ by
+    rcases eq_or_ne (w i) 0 with h | h
+    · simp [h]
+    · exact (((summable_geometric_of_lt_one (norm_nonneg _) (h1 i h)).mul_left ‖r i‖).congr
+        fun e ↦ by ring).mul_left |w i|
   have houter : Summable fun i ↦ ∑' e : ℕ, |w i| * ‖r i‖ ^ (e + 1) := by
     refine Summable.of_norm_bounded_eventually (g := fun i ↦ ε⁻¹ * (|w i| * ‖r i‖))
       (habs.mul_left ε⁻¹) ?_
     filter_upwards [hfar] with i hi
-    rw [Real.norm_of_nonneg (tsum_nonneg fun e ↦ by positivity), hval i]
-    -- Where `‖r i‖ ≤ 1 - ε` the fibre sum `‖r i‖ / (1 - ‖r i‖)` is at most `ε⁻¹ ‖r i‖`.
-    have hd : ‖r i‖ / (1 - ‖r i‖) ≤ ε⁻¹ * ‖r i‖ := by
-      rw [div_le_iff₀ (by linarith [h1 i])]
-      have hεi : ε * (ε⁻¹ * ‖r i‖) = ‖r i‖ := by field_simp
-      nlinarith [norm_nonneg (r i), inv_pos.2 hε]
-    calc |w i| * (‖r i‖ / (1 - ‖r i‖)) ≤ |w i| * (ε⁻¹ * ‖r i‖) :=
-          mul_le_mul_of_nonneg_left hd (abs_nonneg _)
-      _ = ε⁻¹ * (|w i| * ‖r i‖) := by ring
+    rcases eq_or_ne (w i) 0 with h | h
+    · simp [h]
+    · have hval : ∑' e : ℕ, |w i| * ‖r i‖ ^ (e + 1) = |w i| * (‖r i‖ / (1 - ‖r i‖)) := by
+        rw [tsum_mul_left, tsum_congr fun e ↦ pow_succ' ‖r i‖ e, tsum_mul_left,
+          tsum_geometric_of_lt_one (norm_nonneg _) (h1 i h), div_eq_mul_inv]
+      rw [Real.norm_of_nonneg (tsum_nonneg fun e ↦ by positivity), hval]
+      -- Where `‖r i‖ ≤ 1 - ε` the fibre sum `‖r i‖ / (1 - ‖r i‖)` is at most `ε⁻¹ ‖r i‖`.
+      have hd : ‖r i‖ / (1 - ‖r i‖) ≤ ε⁻¹ * ‖r i‖ := by
+        rw [div_le_iff₀ (by linarith [h1 i h])]
+        have hεi : ε * (ε⁻¹ * ‖r i‖) = ‖r i‖ := by field_simp
+        nlinarith [norm_nonneg (r i), inv_pos.2 hε, hi h]
+      calc |w i| * (‖r i‖ / (1 - ‖r i‖)) ≤ |w i| * (ε⁻¹ * ‖r i‖) :=
+            mul_le_mul_of_nonneg_left hd (abs_nonneg _)
+        _ = ε⁻¹ * (|w i| * ‖r i‖) := by ring
   have hmaj : Summable fun ie : ι × ℕ ↦ |w ie.1| * ‖r ie.1‖ ^ (ie.2 + 1) :=
     (summable_prod_of_nonneg fun ie ↦ by positivity).mpr ⟨hfib, houter⟩
   refine hmaj.of_norm_bounded fun ie ↦ ?_

--- a/TauCeti/Topology/Algebra/InfiniteSum/Real.lean
+++ b/TauCeti/Topology/Algebra/InfiniteSum/Real.lean
@@ -26,9 +26,9 @@ public section
 namespace TauCeti
 
 /-- **A weighted geometric family is summable over index and exponent together.**  For a family
-`r` in a seminormed group, all of norm less than one and eventually of norm at most `1 - ε`, and real
-weights `w` with `i ↦ w i * ‖r i‖` summable, the double family `(i, e) ↦ w i * ‖r i‖ ^ (e + 1)` is
-summable over `ι × ℕ`.
+`r` in a seminormed group, all of norm less than one and eventually of norm at most `1 - ε`,
+and real weights `w` with `i ↦ w i * ‖r i‖` summable, the double family
+`(i, e) ↦ w i * ‖r i‖ ^ (e + 1)` is summable over `ι × ℕ`.
 
 The weights are unrestricted in sign: only `|w i|` enters the majorant. Both hypotheses on `r` are
 imposed only on the support of `w`, since a fibre with `w i = 0` is identically zero whatever


### PR DESCRIPTION
For real weights `w` with `i ↦ w i * ‖r i‖` summable, and a family `r : ι → E` in a seminormed
additive group which — *at every index where `w` is nonzero* — has norm below one and eventually
norm at most `1 - ε`, the double family is summable over index and exponent together.

```lean
theorem TauCeti.summable_mul_norm_pow_succ {ι E : Type*} [SeminormedAddGroup E]
    {r : ι → E} {w : ι → ℝ}
    (hbd : ∃ ε > 0, ∀ᶠ i in Filter.cofinite, w i ≠ 0 → ‖r i‖ ≤ 1 - ε)
    (hwr : Summable fun i ↦ w i * ‖r i‖) (h1 : ∀ i, w i ≠ 0 → ‖r i‖ < 1) :
    Summable fun ie : ι × ℕ ↦ w ie.1 * ‖r ie.1‖ ^ (ie.2 + 1)
```

It lives in the root namespace in a new `TauCeti/Topology/Algebra/InfiniteSum/Real.lean`, mirroring
the Mathlib module that owns `summable_prod_of_nonneg`. Nothing in it is complex-analytic: the
weights are unrestricted in sign, since only `|w i|` enters the majorant, and `E` is any
seminormed additive group.

Each fibre is geometric and sums to `w i * ‖r i‖ / (1 - ‖r i‖)`, so something beyond
`∀ i, ‖r i‖ < 1` is needed: that quotient is comparable to `w i * ‖r i‖` only where `‖r i‖` stays
away from `1`. The hypothesis is exactly that eventual gap, and only where the weight is nonzero — a fibre with
`w i = 0` is identically zero whatever `r i` is. It is deliberately weaker than
`Summable r`, which would exclude a family of constant norm `1 / 2` with summable weights — a
family the majorant applies to perfectly well.

### It replaces a duplicated proof

`Complex.summable_taylorSeries_neg_log`, in
`TauCeti/Analysis/SpecialFunctions/Complex/LogBounds.lean`, carried the same fibrewise construction
inline. It now obtains its majorant from this lemma at weight `1`, and the file keeps only the
Taylor-specific part. That is a net simplification of existing code, not just an addition.

### What it is for

`TauCetiRoadmap/ArithmeticDirichletSeries/README.md` Layer 3.4 asks for the prime-power logarithmic
expansion **and its derivative**; #6051 merged the expansion. Termwise differentiation via
`hasDerivAt_tsum_of_isPreconnected` needs a uniform summable bound on the differentiated terms, and
this is that bound **whenever those terms are an index-only weight times a norm power** — which is
the case for the prime-power family, where the weight is `log N(P)`. The lemma itself claims nothing
about which families have that form.

The other two inputs are open and **independent of this one and of each other**: #6173 (the
arithmetic side — `log N(I)` really is summable against the ideal terms) and #6180 (the pointwise
side — the derivative of a single ideal term). None of the three depends on another.

This PR carries **no `tauceti-target:v1` marker**: it supplies a prerequisite Layer 3.4 needs rather
than authoring 3.4's declaration, so the layer's id belongs on the PR that delivers the derivative.

### Round 2

`documentation` was right on both counts. The declaration docstring opened by asserting every
`r i` has norm below one and only qualified it two paragraphs later, when in fact `h1` and `hbd`
are both conditional on `w i ≠ 0`; the support restriction now leads the sentence stating the
hypotheses, here and in this description. And "normed group" misnamed `SeminormedAddGroup` — both
files now say "seminormed additive group".

`placement` was right that `Mathlib.Analysis.SpecificLimits.Normed` is much broader than the proof
needs. It is replaced by `Mathlib.Analysis.Normed.Group.InfiniteSum` and
`Mathlib.Analysis.SpecificLimits.Basic`; the module now builds against **2771 jobs rather than
3667**. Since this is a `public import` being narrowed, the three downstream importers of
`LogBounds` were rebuilt to confirm none of them was leaning on the wider import transitively.

Roadmap: ArithmeticDirichletSeries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011dmwkBnj4rJc75STgbwsLF




