### PR TITLE
feat: characterize closed-subgroup Lie algebra limits

### DIFF
--- a/TauCeti/Geometry/Lie/Subgroup/LimitCriterion.lean
+++ b/TauCeti/Geometry/Lie/Subgroup/LimitCriterion.lean
@@ -1,0 +1,142 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Geometry.Lie.Subgroup.LieAlgebra
+-- Non-public: the natural-floor asymptotic is used only to approximate real parameters by
+-- integer multiples of the sequence of scales.
+import Mathlib.Analysis.SpecificLimits.Basic
+
+/-!
+# A limit criterion for the Lie algebra of a closed subgroup
+
+Let `K` be a closed subgroup of a finite-dimensional Lie group. Its Lie algebra consists exactly
+of the limits `X` for which there are positive real numbers `tₙ → 0` and derivations `Xₙ → X`
+such that
+
+`lieExp (tₙ • Xₙ) ∈ K`.
+
+The reverse implication is the substantive one. For a fixed positive parameter `s`, the integers
+`mₙ = ⌊s / tₙ⌋₊` satisfy `mₙ tₙ → s`. Since `K` contains
+`lieExp (tₙ • Xₙ)`, it also contains its `mₙ`-th power, which is
+`lieExp ((mₙ tₙ) • Xₙ)`. Closedness of `K` and continuity of `lieExp` then give
+`lieExp (s • X) ∈ K`. Negative parameters follow by inversion.
+
+This is the limit criterion used in the local-separation step of the closed-subgroup theorem. In
+that application, a hypothetical sequence of nonzero transverse coordinates `Yₙ → 0` is written
+as
+
+`Yₙ = ‖Yₙ‖ • (‖Yₙ‖⁻¹ • Yₙ)`.
+
+A convergent subsequence of the normalized directions therefore satisfies the criterion below,
+forcing its limit into the subgroup Lie algebra and contradicting transversality.
+
+## Main results
+
+* `TauCeti.Lie.mem_lieSubalgebraOfSubgroup_of_tendsto`: a convergent family of rescaled
+  infinitesimal elements whose exponentials lie in a closed subgroup has its limit in the
+  subgroup Lie algebra.
+* `TauCeti.Lie.mem_lieSubalgebraOfSubgroup_iff_exists_tendsto`: the resulting sequential
+  characterization.
+
+## References
+
+* [Lie groups and the Lie algebra correspondence roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md),
+  Deliverable A, Layer 2, "The closed-subgroup theorem".
+* J. M. Lee, *Introduction to Smooth Manifolds*, 2nd edition (2013), Theorem 20.12.
+-/
+
+public section
+
+noncomputable section
+
+namespace TauCeti.Lie
+
+open Filter
+open scoped ContDiff Manifold Topology
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+  {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
+  {G : Type*} [TopologicalSpace G] [ChartedSpace H G] [Group G]
+  [FiniteDimensional ℝ E] [LieGroup I ∞ G] [T2Space G]
+
+attribute [local instance] LieGroup.minSmoothnessThree
+attribute [local instance] ContMDiffMul.boundarylessManifold
+
+/-- If positive real numbers `uₙ` tend to zero, the largest integer multiple of `uₙ` not
+exceeding a fixed positive `s` tends to `s`. -/
+private theorem tendsto_natFloor_div_mul_of_tendsto_zero
+    {u : ℕ → ℝ} (hu : Tendsto u atTop (𝓝 0)) (hu_pos : ∀ n, 0 < u n)
+    {s : ℝ} (hs : 0 < s) :
+    Tendsto (fun n => (⌊s / u n⌋₊ : ℝ) * u n) atTop (𝓝 s) := by
+  have hu' : Tendsto u atTop (𝓝[>] 0) :=
+    tendsto_nhdsWithin_iff.mpr ⟨hu, Eventually.of_forall hu_pos⟩
+  have hdiv : Tendsto (fun n => s / u n) atTop atTop := by
+    simpa only [div_eq_mul_inv, Pi.inv_apply] using
+      hu'.inv_tendsto_nhdsGT_zero.const_mul_atTop hs
+  have hfloor := (tendsto_nat_floor_div_atTop (R := ℝ)).comp hdiv
+  convert hfloor.mul_const s using 1
+  · funext n
+    simp only [Function.comp_apply]
+    field_simp [ne_of_gt hs, ne_of_gt (hu_pos n)]
+  · simp
+
+/-- A limit criterion for the Lie algebra of a closed subgroup. Suppose positive scales `tₙ`
+tend to zero, derivations `Xₙ` tend to `X`, and every `lieExp (tₙ • Xₙ)` lies in `K`. Then `X`
+belongs to the Lie algebra of `K`.
+
+The positivity assumption makes natural-number powers sufficient to recover all positive
+parameters. The full one-parameter subgroup is then obtained using inverses. -/
+theorem mem_lieSubalgebraOfSubgroup_of_tendsto {K : Subgroup G}
+    (hK : IsClosed (K : Set G)) {X : LeftInvariantDerivation I G} {t : ℕ → ℝ}
+    (ht_pos : ∀ n, 0 < t n) (ht : Tendsto t atTop (𝓝 0))
+    {Xn : ℕ → LeftInvariantDerivation I G} (hXn : Tendsto Xn atTop (𝓝 X))
+    (hmem : ∀ n, lieExp (I := I) (t n • Xn n) ∈ K) :
+    X ∈ lieSubalgebraOfSubgroup (I := I) K := by
+  apply (mem_lieSubalgebraOfSubgroup hK).2
+  intro s
+  by_cases hs0 : s = 0
+  · simp [hs0]
+  have hpos : ∀ {r : ℝ}, 0 < r → lieExp (I := I) (r • X) ∈ K := by
+    intro r hr
+    let m : ℕ → ℕ := fun n => ⌊r / t n⌋₊
+    have hc : Tendsto (fun n => (m n : ℝ) * t n) atTop (𝓝 r) :=
+      tendsto_natFloor_div_mul_of_tendsto_zero ht ht_pos hr
+    have hv : Tendsto (fun n => ((m n : ℝ) * t n) • Xn n) atTop (𝓝 (r • X)) :=
+      hc.smul hXn
+    refine hK.mem_of_tendsto
+      ((contMDiff_lieExp (I := I) (G := G)).continuous.continuousAt.tendsto.comp hv) ?_
+    filter_upwards with n
+    change lieExp (I := I) (((m n : ℝ) * t n) • Xn n) ∈ K
+    have hp := K.pow_mem (hmem n) (m n)
+    rw [← lieExp_nsmul (I := I) (G := G) (t n • Xn n) (m n)] at hp
+    simpa only [Function.comp_apply, ← Nat.cast_smul_eq_nsmul ℝ, smul_smul] using hp
+  by_cases hs : 0 < s
+  · exact hpos hs
+  · have hneg : 0 < -s := neg_pos.mpr (lt_of_le_of_ne (le_of_not_gt hs) hs0)
+    have hm := K.inv_mem (hpos hneg)
+    simpa only [← lieExp_neg, neg_smul, neg_neg] using hm
+
+/-- Membership in the Lie algebra of a closed subgroup is equivalent to being a limit of
+derivations whose exponentials at positive scales tending to zero lie in the subgroup. -/
+theorem mem_lieSubalgebraOfSubgroup_iff_exists_tendsto {K : Subgroup G}
+    (hK : IsClosed (K : Set G)) {X : LeftInvariantDerivation I G} :
+    X ∈ lieSubalgebraOfSubgroup (I := I) K ↔
+      ∃ (t : ℕ → ℝ) (Xn : ℕ → LeftInvariantDerivation I G),
+        (∀ n, 0 < t n) ∧ Tendsto t atTop (𝓝 0) ∧ Tendsto Xn atTop (𝓝 X) ∧
+          ∀ n, lieExp (I := I) (t n • Xn n) ∈ K := by
+  constructor
+  · intro hX
+    refine ⟨fun n => 1 / (n + 1 : ℝ), fun _ => X, ?_, ?_, tendsto_const_nhds, ?_⟩
+    · intro n
+      positivity
+    · exact tendsto_one_div_add_atTop_nhds_zero_nat
+    · intro n
+      exact lieExp_smul_mem_of_mem_lieSubalgebraOfSubgroup hK hX _
+  · rintro ⟨t, Xn, ht_pos, ht, hXn, hmem⟩
+    exact mem_lieSubalgebraOfSubgroup_of_tendsto hK ht_pos ht hXn hmem
+
+end TauCeti.Lie

--- a/TauCeti/Geometry/Lie/Subgroup/LimitCriterion.lean
+++ b/TauCeti/Geometry/Lie/Subgroup/LimitCriterion.lean
@@ -6,9 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Geometry.Lie.Subgroup.LieAlgebra
--- Non-public: the natural-floor asymptotic is used only to approximate real parameters by
--- integer multiples of the sequence of scales.
-import Mathlib.Analysis.SpecificLimits.Basic
 
 /-!
 # A limit criterion for the Lie algebra of a closed subgroup
@@ -66,24 +63,6 @@ variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
 attribute [local instance] LieGroup.minSmoothnessThree
 attribute [local instance] ContMDiffMul.boundarylessManifold
 
-/-- If positive real numbers `uₙ` tend to zero, the largest integer multiple of `uₙ` not
-exceeding a fixed positive `s` tends to `s`. -/
-private theorem tendsto_natFloor_div_mul_of_tendsto_zero
-    {u : ℕ → ℝ} (hu : Tendsto u atTop (𝓝 0)) (hu_pos : ∀ n, 0 < u n)
-    {s : ℝ} (hs : 0 < s) :
-    Tendsto (fun n => (⌊s / u n⌋₊ : ℝ) * u n) atTop (𝓝 s) := by
-  have hu' : Tendsto u atTop (𝓝[>] 0) :=
-    tendsto_nhdsWithin_iff.mpr ⟨hu, Eventually.of_forall hu_pos⟩
-  have hdiv : Tendsto (fun n => s / u n) atTop atTop := by
-    simpa only [div_eq_mul_inv, Pi.inv_apply] using
-      hu'.inv_tendsto_nhdsGT_zero.const_mul_atTop hs
-  have hfloor := (tendsto_nat_floor_div_atTop (R := ℝ)).comp hdiv
-  convert hfloor.mul_const s using 1
-  · funext n
-    simp only [Function.comp_apply]
-    field_simp [ne_of_gt hs, ne_of_gt (hu_pos n)]
-  · simp
-
 /-- A limit criterion for the Lie algebra of a closed subgroup. Suppose positive scales `tₙ`
 tend to zero, derivations `Xₙ` tend to `X`, and every `lieExp (tₙ • Xₙ)` lies in `K`. Then `X`
 belongs to the Lie algebra of `K`.
@@ -103,13 +82,25 @@ theorem mem_lieSubalgebraOfSubgroup_of_tendsto {K : Subgroup G}
   have hpos : ∀ {r : ℝ}, 0 < r → lieExp (I := I) (r • X) ∈ K := by
     intro r hr
     let m : ℕ → ℕ := fun n => ⌊r / t n⌋₊
-    have hc : Tendsto (fun n => (m n : ℝ) * t n) atTop (𝓝 r) :=
-      tendsto_natFloor_div_mul_of_tendsto_zero ht ht_pos hr
+    have hc : Tendsto (fun n => (m n : ℝ) * t n) atTop (𝓝 r) := by
+      have ht' : Tendsto t atTop (𝓝[>] 0) :=
+        tendsto_nhdsWithin_iff.mpr ⟨ht, Eventually.of_forall ht_pos⟩
+      have hdiv : Tendsto (fun n => r / t n) atTop atTop := by
+        simpa only [div_eq_mul_inv, Pi.inv_apply] using
+          ht'.inv_tendsto_nhdsGT_zero.const_mul_atTop hr
+      have hfloor := (tendsto_nat_floor_div_atTop (R := ℝ)).comp hdiv
+      convert hfloor.mul_const r using 1
+      · funext n
+        simp only [m, Function.comp_apply]
+        field_simp [ne_of_gt hr, ne_of_gt (ht_pos n)]
+      · simp
     have hv : Tendsto (fun n => ((m n : ℝ) * t n) • Xn n) atTop (𝓝 (r • X)) :=
       hc.smul hXn
     refine hK.mem_of_tendsto
       ((contMDiff_lieExp (I := I) (G := G)).continuous.continuousAt.tendsto.comp hv) ?_
     filter_upwards with n
+    -- `filter_upwards` exposes membership in the underlying set; restate it as subgroup
+    -- membership so that `Subgroup.pow_mem` applies to the approximating exponential.
     change lieExp (I := I) (((m n : ℝ) * t n) • Xn n) ∈ K
     have hp := K.pow_mem (hmem n) (m n)
     rw [← lieExp_nsmul (I := I) (G := G) (t n • Xn n) (m n)] at hp

--- a/TauCeti/Geometry/Lie/Subgroup/LimitCriterion.lean
+++ b/TauCeti/Geometry/Lie/Subgroup/LimitCriterion.lean
@@ -11,16 +11,10 @@ public import TauCeti.Geometry.Lie.Subgroup.LieAlgebra
 # A limit criterion for the Lie algebra of a closed subgroup
 
 Let `K` be a closed subgroup of a finite-dimensional Lie group. Its Lie algebra consists exactly
-of the limits `X` for which there are positive real numbers `tₙ → 0` and derivations `Xₙ → X`
-such that
+of the limits `X` for which there are eventually positive real numbers `tₙ → 0` and derivations
+`Xₙ → X` such that, eventually,
 
 `lieExp (tₙ • Xₙ) ∈ K`.
-
-The reverse implication is the substantive one. For a fixed positive parameter `s`, the integers
-`mₙ = ⌊s / tₙ⌋₊` satisfy `mₙ tₙ → s`. Since `K` contains
-`lieExp (tₙ • Xₙ)`, it also contains its `mₙ`-th power, which is
-`lieExp ((mₙ tₙ) • Xₙ)`. Closedness of `K` and continuity of `lieExp` then give
-`lieExp (s • X) ∈ K`. Negative parameters follow by inversion.
 
 This is the limit criterion used in the local-separation step of the closed-subgroup theorem. In
 that application, a hypothetical sequence of nonzero transverse coordinates `Yₙ → 0` is written
@@ -33,10 +27,10 @@ forcing its limit into the subgroup Lie algebra and contradicting transversality
 
 ## Main results
 
-* `TauCeti.Lie.mem_lieSubalgebraOfSubgroup_of_tendsto`: a convergent family of rescaled
+* `TauCeti.Lie.mem_lieSubalgebraOfSubgroup_of_seq`: a convergent sequence of rescaled
   infinitesimal elements whose exponentials lie in a closed subgroup has its limit in the
   subgroup Lie algebra.
-* `TauCeti.Lie.mem_lieSubalgebraOfSubgroup_iff_exists_tendsto`: the resulting sequential
+* `TauCeti.Lie.mem_lieSubalgebraOfSubgroup_iff_exists_seq`: the resulting sequential
   characterization.
 
 ## References
@@ -63,11 +57,8 @@ attribute [local instance] ContMDiffMul.boundarylessManifold
 
 /-- A limit criterion for the Lie algebra of a closed subgroup. Suppose eventually positive scales
 `tₙ` tend to zero, derivations `Xₙ` tend to `X`, and eventually `lieExp (tₙ • Xₙ)` lies in
-`K`. Then `X` belongs to the Lie algebra of `K`.
-
-The positivity assumption makes natural-number powers sufficient to recover all positive
-parameters. The full one-parameter subgroup is then obtained using inverses. -/
-theorem mem_lieSubalgebraOfSubgroup_of_tendsto {K : Subgroup G}
+`K`. Then `X` belongs to the Lie algebra of `K`. -/
+theorem mem_lieSubalgebraOfSubgroup_of_seq {K : Subgroup G}
     (hK : IsClosed (K : Set G)) {X : LeftInvariantDerivation I G} {t : ℕ → ℝ}
     (ht_pos : ∀ᶠ n in atTop, 0 < t n) (ht : Tendsto t atTop (𝓝 0))
     {Xn : ℕ → LeftInvariantDerivation I G} (hXn : Tendsto Xn atTop (𝓝 X))
@@ -111,7 +102,7 @@ theorem mem_lieSubalgebraOfSubgroup_of_tendsto {K : Subgroup G}
 /-- Membership in the Lie algebra of a closed subgroup is equivalent to being a limit of
 derivations whose exponentials at eventually positive scales tending to zero eventually lie in the
 subgroup. -/
-theorem mem_lieSubalgebraOfSubgroup_iff_exists_tendsto {K : Subgroup G}
+theorem mem_lieSubalgebraOfSubgroup_iff_exists_seq {K : Subgroup G}
     (hK : IsClosed (K : Set G)) {X : LeftInvariantDerivation I G} :
     X ∈ lieSubalgebraOfSubgroup (I := I) K ↔
       ∃ (t : ℕ → ℝ) (Xn : ℕ → LeftInvariantDerivation I G),
@@ -126,6 +117,6 @@ theorem mem_lieSubalgebraOfSubgroup_iff_exists_tendsto {K : Subgroup G}
     · filter_upwards with n
       exact lieExp_smul_mem_of_mem_lieSubalgebraOfSubgroup hK hX _
   · rintro ⟨t, Xn, ht_pos, ht, hXn, hmem⟩
-    exact mem_lieSubalgebraOfSubgroup_of_tendsto hK ht_pos ht hXn hmem
+    exact mem_lieSubalgebraOfSubgroup_of_seq hK ht_pos ht hXn hmem
 
 end TauCeti.Lie

--- a/TauCeti/Geometry/Lie/Subgroup/LimitCriterion.lean
+++ b/TauCeti/Geometry/Lie/Subgroup/LimitCriterion.lean
@@ -41,8 +41,6 @@ forcing its limit into the subgroup Lie algebra and contradicting transversality
 
 ## References
 
-* [Lie groups and the Lie algebra correspondence roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md),
-  Deliverable A, Layer 2, "The closed-subgroup theorem".
 * J. M. Lee, *Introduction to Smooth Manifolds*, 2nd edition (2013), Theorem 20.12.
 -/
 
@@ -63,17 +61,17 @@ variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
 attribute [local instance] LieGroup.minSmoothnessThree
 attribute [local instance] ContMDiffMul.boundarylessManifold
 
-/-- A limit criterion for the Lie algebra of a closed subgroup. Suppose positive scales `tₙ`
-tend to zero, derivations `Xₙ` tend to `X`, and every `lieExp (tₙ • Xₙ)` lies in `K`. Then `X`
-belongs to the Lie algebra of `K`.
+/-- A limit criterion for the Lie algebra of a closed subgroup. Suppose eventually positive scales
+`tₙ` tend to zero, derivations `Xₙ` tend to `X`, and eventually `lieExp (tₙ • Xₙ)` lies in
+`K`. Then `X` belongs to the Lie algebra of `K`.
 
 The positivity assumption makes natural-number powers sufficient to recover all positive
 parameters. The full one-parameter subgroup is then obtained using inverses. -/
 theorem mem_lieSubalgebraOfSubgroup_of_tendsto {K : Subgroup G}
     (hK : IsClosed (K : Set G)) {X : LeftInvariantDerivation I G} {t : ℕ → ℝ}
-    (ht_pos : ∀ n, 0 < t n) (ht : Tendsto t atTop (𝓝 0))
+    (ht_pos : ∀ᶠ n in atTop, 0 < t n) (ht : Tendsto t atTop (𝓝 0))
     {Xn : ℕ → LeftInvariantDerivation I G} (hXn : Tendsto Xn atTop (𝓝 X))
-    (hmem : ∀ n, lieExp (I := I) (t n • Xn n) ∈ K) :
+    (hmem : ∀ᶠ n in atTop, lieExp (I := I) (t n • Xn n) ∈ K) :
     X ∈ lieSubalgebraOfSubgroup (I := I) K := by
   apply (mem_lieSubalgebraOfSubgroup hK).2
   intro s
@@ -84,25 +82,24 @@ theorem mem_lieSubalgebraOfSubgroup_of_tendsto {K : Subgroup G}
     let m : ℕ → ℕ := fun n => ⌊r / t n⌋₊
     have hc : Tendsto (fun n => (m n : ℝ) * t n) atTop (𝓝 r) := by
       have ht' : Tendsto t atTop (𝓝[>] 0) :=
-        tendsto_nhdsWithin_iff.mpr ⟨ht, Eventually.of_forall ht_pos⟩
+        tendsto_nhdsWithin_iff.mpr ⟨ht, ht_pos⟩
       have hdiv : Tendsto (fun n => r / t n) atTop atTop := by
         simpa only [div_eq_mul_inv, Pi.inv_apply] using
           ht'.inv_tendsto_nhdsGT_zero.const_mul_atTop hr
       have hfloor := (tendsto_nat_floor_div_atTop (R := ℝ)).comp hdiv
-      convert hfloor.mul_const r using 1
-      · funext n
+      simpa only [one_mul] using (hfloor.mul_const r).congr' (by
+        filter_upwards [ht_pos] with n htn
         simp only [m, Function.comp_apply]
-        field_simp [ne_of_gt hr, ne_of_gt (ht_pos n)]
-      · simp
+        field_simp [ne_of_gt hr, ne_of_gt htn])
     have hv : Tendsto (fun n => ((m n : ℝ) * t n) • Xn n) atTop (𝓝 (r • X)) :=
       hc.smul hXn
     refine hK.mem_of_tendsto
       ((contMDiff_lieExp (I := I) (G := G)).continuous.continuousAt.tendsto.comp hv) ?_
-    filter_upwards with n
+    filter_upwards [hmem] with n hn
     -- `filter_upwards` exposes membership in the underlying set; restate it as subgroup
     -- membership so that `Subgroup.pow_mem` applies to the approximating exponential.
     change lieExp (I := I) (((m n : ℝ) * t n) • Xn n) ∈ K
-    have hp := K.pow_mem (hmem n) (m n)
+    have hp := K.pow_mem hn (m n)
     rw [← lieExp_nsmul (I := I) (G := G) (t n • Xn n) (m n)] at hp
     simpa only [Function.comp_apply, ← Nat.cast_smul_eq_nsmul ℝ, smul_smul] using hp
   by_cases hs : 0 < s
@@ -112,20 +109,21 @@ theorem mem_lieSubalgebraOfSubgroup_of_tendsto {K : Subgroup G}
     simpa only [← lieExp_neg, neg_smul, neg_neg] using hm
 
 /-- Membership in the Lie algebra of a closed subgroup is equivalent to being a limit of
-derivations whose exponentials at positive scales tending to zero lie in the subgroup. -/
+derivations whose exponentials at eventually positive scales tending to zero eventually lie in the
+subgroup. -/
 theorem mem_lieSubalgebraOfSubgroup_iff_exists_tendsto {K : Subgroup G}
     (hK : IsClosed (K : Set G)) {X : LeftInvariantDerivation I G} :
     X ∈ lieSubalgebraOfSubgroup (I := I) K ↔
       ∃ (t : ℕ → ℝ) (Xn : ℕ → LeftInvariantDerivation I G),
-        (∀ n, 0 < t n) ∧ Tendsto t atTop (𝓝 0) ∧ Tendsto Xn atTop (𝓝 X) ∧
-          ∀ n, lieExp (I := I) (t n • Xn n) ∈ K := by
+        (∀ᶠ n in atTop, 0 < t n) ∧ Tendsto t atTop (𝓝 0) ∧ Tendsto Xn atTop (𝓝 X) ∧
+          ∀ᶠ n in atTop, lieExp (I := I) (t n • Xn n) ∈ K := by
   constructor
   · intro hX
     refine ⟨fun n => 1 / (n + 1 : ℝ), fun _ => X, ?_, ?_, tendsto_const_nhds, ?_⟩
-    · intro n
+    · filter_upwards with n
       positivity
     · exact tendsto_one_div_add_atTop_nhds_zero_nat
-    · intro n
+    · filter_upwards with n
       exact lieExp_smul_mem_of_mem_lieSubalgebraOfSubgroup hK hX _
   · rintro ⟨t, Xn, ht_pos, ht, hXn, hmem⟩
     exact mem_lieSubalgebraOfSubgroup_of_tendsto hK ht_pos ht hXn hmem


### PR DESCRIPTION
This PR adds the eventual-positive sequence limit criterion for the Lie algebra of a closed subgroup for the LieGroups Layer 2 closed-subgroup theorem.

Roadmap: RepresentationTheory

## Summary

Prove that a limit `X` of derivations `Xₙ` belongs to `lieSubalgebraOfSubgroup K` whenever scales `tₙ` tend to zero, are eventually positive, and `lieExp (tₙ • Xₙ)` eventually lies in the closed subgroup `K`. Integer powers and Mathlib's natural-floor asymptotic recover every positive point of the limiting one-parameter subgroup; closedness and `lieExp_neg` supply the limit and negative parameters. Also expose the exact existential sequence characterization used downstream.

## Roadmap target

This advances Deliverable A, Layer 2, “The closed-subgroup theorem,” specifically its stated limit criterion `X ∈ 𝔥 ↔ ∃ tₙ → 0, Xₙ → X, lieExp (tₙ • Xₙ) ∈ H`, which the Cartan local-separation argument consumes. After this PR, the local product chart and separation argument still need to be assembled into the subgroup atlas, followed by the automatic-smoothness corollary and the concrete Spin/SO Lie structures needed for the Spin/SO differential.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"lie-subalgebra-limit-criterion"}-->

## Verification

- Exact head: `7ab17427a2d98e9f414315bfa27f872ea2a958e8`
- Local Lean build: `lake exe cache get` passed with `No files to download` and `Already decompressed 8849 file(s)`; `lake build` passed with `Build completed successfully (10967 jobs).`
- Axiom audit: `lake exe axioms` passed with `axioms: audited 108205 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`
- Lint: `lake exe module-system` passed for all 4818 modules; `scripts/lint-env.sh` passed with no new violations; `scripts/lint-dot-notation.py` reported 0 new violations; `scripts/lint-style.sh` reported conforming headers for all 4817 source files.
- Public CI: pending for this repaired head; the preceding head's sandboxed build passed.

## Scale and generality

The new 122-line module works for every closed subgroup of any finite-dimensional smooth real Lie group in the existing `LeftInvariantDerivation` API. The elimination theorem allows the infinitesimal directions to vary with the sequence and ignores finitely many initial failures of positivity or subgroup membership, exactly as normalized transverse-coordinate limit arguments require.

## Scope

- **Consumes:** `mem_lieSubalgebraOfSubgroup`, `lieExp_smul_mem_of_mem_lieSubalgebraOfSubgroup`, `lieExp_nsmul`, `lieExp_neg`, smoothness of `lieExp`, and Mathlib's `tendsto_nat_floor_div_atTop`.
- **Provides:** `mem_lieSubalgebraOfSubgroup_of_seq` and `mem_lieSubalgebraOfSubgroup_iff_exists_seq`, with positivity and exponential membership required only eventually; the one-use floor calculation remains inside the first proof.
- **Fits:** Supplies the exact normalized-limit membership step for Cartan local separation, on the route through the subgroup atlas and automatic smoothness to the Spin/SO differential.
- **Boundary:** Does not construct charts or a smooth structure on the subgroup, and does not introduce a competing logarithm germ or Lie algebra definition.

<sub>🤖 GPT-5.6 Sol high · TauCetiWorker @ [910d954fee75dfafda41f98165ce3a9e6676eae1](https://github.com/utensil/TauCetiWorker/commit/910d954fee75dfafda41f98165ce3a9e6676eae1) · rubrics @ [153ea8a6febe59f492c2f3d48471733e8b550848](https://github.com/utensil/TauCetiReview/commit/153ea8a6febe59f492c2f3d48471733e8b550848) · local review @ [b533e561b6d44df071c31335ed4a63ae647507d2](https://github.com/utensil/formal-land/commit/b533e561b6d44df071c31335ed4a63ae647507d2) · fixed: documentation, generality, naming</sub>