### PR TITLE
feat(ArithmeticDirichletSeries): the derivative of an ideal term

### DIFF
--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/Deriv.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/Deriv.lean
@@ -5,7 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Analysis.SpecialFunctions.Pow.Deriv
+public import Mathlib.NumberTheory.LSeries.Deriv
 public import TauCeti.NumberTheory.ArithmeticDirichletSeries.Regroup
 
 /-!
@@ -15,6 +15,9 @@ Mathlib's `LSeries.hasDerivAt_term` differentiates the term `f n / n ^ s` of an 
 Dirichlet series, producing the same term weighted by `-log n`.  This file records the
 ideal-indexed counterpart: `idealTerm K f s I` is `f I / N(I) ^ s`, and differentiating it in `s`
 weights it by `-log N(I)`.
+
+No new calculus is done here.  An ideal term is an `L`-series term of a constant coefficient at
+the index `N(I)`, so the statement is a specialization rather than a parallel development.
 
 ## Main results
 
@@ -35,27 +38,18 @@ variable (K : Type*) [Field K] [NumberField K]
 /-- **The derivative of an ideal term.**  Differentiating `f I / N(I) ^ s` in `s` returns the same
 term weighted by `-log N(I)`.
 
-This is the ideal-indexed counterpart of Mathlib's `LSeries.hasDerivAt_term`.  The logarithm is the
-complex one, of a positive real argument: `N(I) ≥ 1` for a nonzero ideal, so it agrees with
-`Real.log N(I)` and is real and nonnegative. -/
+This is Mathlib's `LSeries.hasDerivAt_term` at the constant coefficient `fun _ ↦ f I` and the
+index `N(I)`: an ideal term *is* an `L`-series term, once the ideal is replaced by its norm.  The
+logarithm is the complex one, of a positive real argument: `N(I) ≥ 1` for a nonzero ideal, so it
+agrees with `Real.log N(I)` and is real and nonnegative. -/
 theorem hasDerivAt_idealTerm (f : IdealArithmeticFunction K) (I : (Ideal (𝓞 K))⁰) (s : ℂ) :
     HasDerivAt (fun z ↦ idealTerm K f z I)
       (-(Complex.log (Ideal.absNorm (I : Ideal (𝓞 K)) : ℂ) * idealTerm K f s I)) s := by
-  have hne : ((Ideal.absNorm (I : Ideal (𝓞 K)) : ℂ)) ≠ 0 := by
-    exact_mod_cast (Ideal.absNorm_pos_of_nonZeroDivisors I).ne'
-  have hfun : (fun z : ℂ ↦ idealTerm K f z I)
-      = fun z : ℂ ↦ f I * ((Ideal.absNorm (I : Ideal (𝓞 K)) : ℂ) ^ (-z)) := by
-    funext z
-    rw [idealTerm_def, cpow_neg, div_eq_mul_inv]
-  rw [hfun]
-  have hbase := (hasDerivAt_neg' s).const_cpow
-    (c := ((Ideal.absNorm (I : Ideal (𝓞 K)) : ℂ))) (Or.inl hne)
-  have heq : -(Complex.log (Ideal.absNorm (I : Ideal (𝓞 K)) : ℂ) * idealTerm K f s I)
-      = f I * ((Ideal.absNorm (I : Ideal (𝓞 K)) : ℂ) ^ (-s)
-          * Complex.log (Ideal.absNorm (I : Ideal (𝓞 K)) : ℂ) * -1) := by
-    rw [idealTerm_def, cpow_neg, div_eq_mul_inv]
-    ring
-  rw [heq]
-  exact hbase.const_mul (f I)
+  have hn : Ideal.absNorm (I : Ideal (𝓞 K)) ≠ 0 :=
+    (Ideal.absNorm_pos_of_nonZeroDivisors I).ne'
+  -- An ideal term is the `L`-series term of the constant coefficient `f I` at `N(I)`.
+  have h := LSeries.hasDerivAt_term (fun _ ↦ f I) (Ideal.absNorm (I : Ideal (𝓞 K))) s
+  simp only [LSeries.term_of_ne_zero hn, LSeries.logMul] at h
+  simpa [idealTerm_def, mul_div_assoc] using h
 
 end TauCeti

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/Deriv.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/Deriv.lean
@@ -11,13 +11,13 @@ public import TauCeti.NumberTheory.ArithmeticDirichletSeries.Regroup
 /-!
 # Derivatives of ideal-indexed Dirichlet series
 
-Mathlib's `LSeries.hasDerivAt_term` differentiates the term `f n / n ^ s` of an `ℕ`-indexed
-Dirichlet series, producing the same term weighted by `-log n`.  This file records the
-ideal-indexed counterpart: `idealTerm K f s I` is `f I / N(I) ^ s`, and differentiating it in `s`
-weights it by `-log N(I)`.
+Differentiating an ideal term `idealTerm K f s I = f I / N(I) ^ s` in `s` returns the same term
+weighted by `-log N(I)`.
 
-No new calculus is done here.  An ideal term is an `L`-series term of a constant coefficient at
-the index `N(I)`, so the statement is a specialization rather than a parallel development.
+This is the pointwise input to differentiating an ideal-indexed Dirichlet series **termwise**: such
+an argument needs the derivative of each term together with a summable bound on those derivatives,
+and this supplies the first.  The logarithmic weight it produces is also what that bound has to
+absorb.
 
 ## Main results
 
@@ -38,16 +38,16 @@ variable (K : Type*) [Field K] [NumberField K]
 /-- **The derivative of an ideal term.**  Differentiating `f I / N(I) ^ s` in `s` returns the same
 term weighted by `-log N(I)`.
 
-This is Mathlib's `LSeries.hasDerivAt_term` at the constant coefficient `fun _ ↦ f I` and the
-index `N(I)`: an ideal term *is* an `L`-series term, once the ideal is replaced by its norm.  The
-logarithm is the complex one, of a positive real argument: `N(I) ≥ 1` for a nonzero ideal, so it
-agrees with `Real.log N(I)` and is real and nonnegative. -/
+Differentiating a sum of ideal terms termwise needs this at each term.  The logarithm is the
+complex one, of a positive real argument: `N(I) ≥ 1` for a nonzero ideal, so it agrees with
+`Real.log N(I)` and is real and nonnegative. -/
 theorem hasDerivAt_idealTerm (f : IdealArithmeticFunction K) (I : (Ideal (𝓞 K))⁰) (s : ℂ) :
     HasDerivAt (fun z ↦ idealTerm K f z I)
       (-(Complex.log (Ideal.absNorm (I : Ideal (𝓞 K)) : ℂ) * idealTerm K f s I)) s := by
   have hn : Ideal.absNorm (I : Ideal (𝓞 K)) ≠ 0 :=
     (Ideal.absNorm_pos_of_nonZeroDivisors I).ne'
-  -- An ideal term is the `L`-series term of the constant coefficient `f I` at `N(I)`.
+  -- An ideal term is the `L`-series term of the constant coefficient `f I` at `N(I)`, so
+  -- Mathlib's `LSeries.hasDerivAt_term` already does the calculus.
   have h := LSeries.hasDerivAt_term (fun _ ↦ f I) (Ideal.absNorm (I : Ideal (𝓞 K))) s
   simp only [LSeries.term_of_ne_zero hn, LSeries.logMul] at h
   simpa [idealTerm_def, mul_div_assoc] using h

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/Deriv.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/Deriv.lean
@@ -1,0 +1,61 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.SpecialFunctions.Pow.Deriv
+public import TauCeti.NumberTheory.ArithmeticDirichletSeries.Regroup
+
+/-!
+# Derivatives of ideal-indexed Dirichlet series
+
+Mathlib's `LSeries.hasDerivAt_term` differentiates the term `f n / n ^ s` of an `ℕ`-indexed
+Dirichlet series, producing the same term weighted by `-log n`.  This file records the
+ideal-indexed counterpart: `idealTerm K f s I` is `f I / N(I) ^ s`, and differentiating it in `s`
+weights it by `-log N(I)`.
+
+## Main results
+
+* `TauCeti.hasDerivAt_idealTerm`: the derivative in `s` of an ideal term is the term itself,
+  weighted by `-log N(I)`.
+-/
+
+public section
+
+namespace TauCeti
+
+open Complex
+
+open scoped nonZeroDivisors NumberField
+
+variable (K : Type*) [Field K] [NumberField K]
+
+/-- **The derivative of an ideal term.**  Differentiating `f I / N(I) ^ s` in `s` returns the same
+term weighted by `-log N(I)`.
+
+This is the ideal-indexed counterpart of Mathlib's `LSeries.hasDerivAt_term`.  The logarithm is the
+complex one, of a positive real argument: `N(I) ≥ 1` for a nonzero ideal, so it agrees with
+`Real.log N(I)` and is real and nonnegative. -/
+theorem hasDerivAt_idealTerm (f : IdealArithmeticFunction K) (I : (Ideal (𝓞 K))⁰) (s : ℂ) :
+    HasDerivAt (fun z ↦ idealTerm K f z I)
+      (-(Complex.log (Ideal.absNorm (I : Ideal (𝓞 K)) : ℂ) * idealTerm K f s I)) s := by
+  have hne : ((Ideal.absNorm (I : Ideal (𝓞 K)) : ℂ)) ≠ 0 := by
+    exact_mod_cast (Ideal.absNorm_pos_of_nonZeroDivisors I).ne'
+  have hfun : (fun z : ℂ ↦ idealTerm K f z I)
+      = fun z : ℂ ↦ f I * ((Ideal.absNorm (I : Ideal (𝓞 K)) : ℂ) ^ (-z)) := by
+    funext z
+    rw [idealTerm_def, cpow_neg, div_eq_mul_inv]
+  rw [hfun]
+  have hbase := (hasDerivAt_neg' s).const_cpow
+    (c := ((Ideal.absNorm (I : Ideal (𝓞 K)) : ℂ))) (Or.inl hne)
+  have heq : -(Complex.log (Ideal.absNorm (I : Ideal (𝓞 K)) : ℂ) * idealTerm K f s I)
+      = f I * ((Ideal.absNorm (I : Ideal (𝓞 K)) : ℂ) ^ (-s)
+          * Complex.log (Ideal.absNorm (I : Ideal (𝓞 K)) : ℂ) * -1) := by
+    rw [idealTerm_def, cpow_neg, div_eq_mul_inv]
+    ring
+  rw [heq]
+  exact hbase.const_mul (f I)
+
+end TauCeti


### PR DESCRIPTION
Differentiating an ideal term in `s` returns the same term weighted by `-log N(I)`.

```lean
theorem TauCeti.hasDerivAt_idealTerm (K : Type*) [Field K] [NumberField K]
    (f : IdealArithmeticFunction K) (I : (Ideal (𝓞 K))⁰) (s : ℂ) :
    HasDerivAt (fun z ↦ idealTerm K f z I)
      (-(Complex.log (Ideal.absNorm (I : Ideal (𝓞 K)) : ℂ) * idealTerm K f s I)) s
```

It is Mathlib's `LSeries.hasDerivAt_term` specialized, not a parallel development: an ideal term
*is* an `L`-series term of the constant coefficient `fun _ ↦ f I` at the index `N(I)`, so no new
calculus is done here.

### Placement

It goes in a **new** `ArithmeticDirichletSeries/Deriv.lean` rather than into `Regroup.lean`, which
owns `idealTerm`. Mathlib makes the same split for the same reason: `NumberTheory/LSeries/Deriv.lean`
is separate from `LSeries/Convergence.lean` because differentiating needs
`Analysis.SpecialFunctions.Pow.Deriv`. `Regroup.lean` is foundational here, so widening its imports
would reach every consumer of `idealTerm` for the benefit of one lemma.

### What it is for

`TauCetiRoadmap/ArithmeticDirichletSeries/README.md` Layer 3.4 asks for the prime-power logarithmic
expansion **and its derivative**; #6051 merged the expansion. Getting the derivative means
differentiating the series termwise, and this is the per-term step that has to come first —
`hasDerivAt_tsum_of_isPreconnected` needs both a pointwise derivative and a uniform majorant for it.

The other two inputs are already open and **independent of this one and of each other**: #6173
supplies the arithmetic side (the `log N(I)` weight really is summable against the ideal terms) and
#6174 the analytic side (the majorant for a weighted geometric family over `ι × ℕ`). None of the
three depends on another; they meet only in the derivative theorem that will consume all of them.

This PR carries **no `tauceti-target:v1` marker**: it supplies a prerequisite Layer 3.4 needs rather
than authoring 3.4's declaration, so the layer's id belongs on the PR that delivers the derivative.

Roadmap: ArithmeticDirichletSeries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011dmwkBnj4rJc75STgbwsLF

