### PR TITLE
feat: compute the adjoint Clifford lift in coordinates

### DIFF
--- a/TauCeti/Algebra/Lie/Killing/DualBasis.lean
+++ b/TauCeti/Algebra/Lie/Killing/DualBasis.lean
@@ -1,0 +1,188 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Lie.Killing
+public import Mathlib.LinearAlgebra.BilinearForm.Properties
+
+/-!
+# Dual bases for the Killing form
+
+For a Lie algebra with nondegenerate Killing form, every basis has a Killing-dual basis. This file
+develops its coordinate equations and the canonical basis-independent contraction of a bilinear map
+against a basis and its Killing dual.
+
+## Main definitions
+
+* `TauCeti.killingDualBasis`: the basis dual to a given one under the Killing form.
+
+## Main results
+
+* `TauCeti.sum_killingForm_killingDualBasis_eq_trace`: contraction against a Killing-dual basis
+  computes the trace.
+* `TauCeti.sum_apply_killingDualBasis_eq`: contraction of a bilinear map against a basis and its
+  Killing dual is independent of the basis.
+* `TauCeti.sum_apply_killingDualBasis_of_isAdjointPair`: a Killing-adjoint pair may be moved between
+  the two slots of the contraction.
+* `TauCeti.sum_apply_lie_killingDualBasis_add_eq_zero`: the canonical contraction is invariant under
+  the adjoint action.
+-/
+
+public section
+
+open Finset LieAlgebra LieModule
+
+namespace TauCeti
+
+universe u v w
+
+variable {K : Type u} {L : Type v} [Field K] [LieRing L] [LieAlgebra K L]
+  [LieAlgebra.IsKilling K L]
+
+/-! ### The Killing-dual basis -/
+
+section DualBasis
+
+variable {ι : Type*} [DecidableEq ι] [Fintype ι]
+
+omit [LieAlgebra.IsKilling K L] in
+/-- The Killing form is symmetric, in the bundled `LinearMap.BilinForm.IsSymm` form that the
+dual-basis API asks for; Mathlib supplies it as the unbundled `LieModule.traceForm_isSymm`. -/
+private theorem killingForm_isSymm : (killingForm K L).IsSymm :=
+  LinearMap.BilinForm.isSymm_def.mpr fun x y ↦ LieModule.traceForm_comm K L L x y
+
+/-- The basis of `L` **dual to `b` under the Killing form**: `κ (b i) (killingDualBasis b j)` is
+`1` when `i = j` and `0` otherwise (`TauCeti.killingForm_killingDualBasis`). -/
+noncomputable def killingDualBasis (b : Module.Basis ι K L) : Module.Basis ι K L :=
+  (killingForm K L).dualBasis (LieAlgebra.IsKilling.killingForm_nondegenerate K L) b
+
+/-- The defining biorthogonality of the Killing-dual basis. -/
+@[simp]
+theorem killingForm_killingDualBasis (b : Module.Basis ι K L) (i j : ι) :
+    killingForm K L (b i) (killingDualBasis b j) = if i = j then 1 else 0 :=
+  LinearMap.BilinForm.apply_dualBasis_right _ killingForm_isSymm b i j
+
+/-- Coordinates in the Killing-dual basis are Killing pairings against `b`. -/
+@[simp]
+theorem killingDualBasis_repr (b : Module.Basis ι K L) (v : L) (i : ι) :
+    (killingDualBasis b).repr v i = killingForm K L (b i) v :=
+  (LinearMap.BilinForm.dualBasis_repr_apply _ b v i).trans
+    (LieModule.traceForm_comm K L L v (b i))
+
+/-- Conjugating twice returns the original basis: the Killing-dual basis of the Killing-dual
+basis of `b` is `b`. -/
+@[simp]
+theorem killingDualBasis_killingDualBasis (b : Module.Basis ι K L) :
+    killingDualBasis (killingDualBasis b) = b :=
+  LinearMap.BilinForm.dualBasis_dualBasis _ killingForm_isSymm b
+
+/-- Coordinates in `b` are Killing pairings against the Killing-dual basis. -/
+theorem repr_eq_killingForm (b : Module.Basis ι K L) (v : L) (i : ι) :
+    b.repr v i = killingForm K L v (killingDualBasis b i) := by
+  conv_lhs => rw [← killingDualBasis_killingDualBasis b]
+  rw [killingDualBasis_repr, LieModule.traceForm_comm]
+
+/-- **Expansion in `b`**, with the coefficients read off by the Killing-dual basis. -/
+theorem sum_killingForm_smul_basis (b : Module.Basis ι K L) (v : L) :
+    ∑ i, killingForm K L v (killingDualBasis b i) • b i = v := by
+  conv_rhs => rw [← b.sum_repr v]
+  exact sum_congr rfl fun i _ ↦ by rw [repr_eq_killingForm]
+
+/-- **Expansion in the Killing-dual basis**, with the coefficients read off by `b`. -/
+theorem sum_killingForm_smul_killingDualBasis (b : Module.Basis ι K L) (v : L) :
+    ∑ i, killingForm K L (b i) v • killingDualBasis b i = v := by
+  conv_rhs => rw [← (killingDualBasis b).sum_repr v]
+  exact sum_congr rfl fun i _ ↦ by rw [killingDualBasis_repr]
+
+/-- **The sum `∑ᵢ κ (p xᵢ) yᵢ` along a basis and its Killing-dual basis is the trace of `p`.**  The
+Killing-dual basis reads off the coordinates in `b` (`TauCeti.repr_eq_killingForm`), so the sum is
+the sum of the diagonal entries of the matrix of `p`. -/
+theorem sum_killingForm_killingDualBasis_eq_trace (b : Module.Basis ι K L) (p : L →ₗ[K] L) :
+    ∑ i, killingForm K L (p (b i)) (killingDualBasis b i) = LinearMap.trace K L p := by
+  rw [LinearMap.trace_eq_matrix_trace K b]
+  simp only [Matrix.trace, Matrix.diag_apply, LinearMap.toMatrix_apply]
+  exact sum_congr rfl fun i _ ↦ (repr_eq_killingForm b (p (b i)) i).symm
+
+end DualBasis
+
+/-! ### The canonical invariant element `∑ᵢ xᵢ ⊗ yᵢ` -/
+
+section Bilinear
+
+variable {W : Type w} [AddCommGroup W] [Module K W] (f : L →ₗ[K] L →ₗ[K] W)
+
+/-- **The sum `∑ᵢ f xᵢ yᵢ` of a bilinear map along a basis and its Killing-dual basis does not
+depend on the basis.**  Expanding each `c j` in the basis `b` produces exactly the coefficients
+that expand `killingDualBasis b i` in `killingDualBasis c`. -/
+theorem sum_apply_killingDualBasis_eq {ι ι' : Type*} [DecidableEq ι] [Fintype ι] [DecidableEq ι']
+    [Fintype ι'] (b : Module.Basis ι K L) (c : Module.Basis ι' K L) :
+    ∑ i, f (b i) (killingDualBasis b i) = ∑ j, f (c j) (killingDualBasis c j) := by
+  have expand : ∀ j : ι', f (c j) (killingDualBasis c j)
+      = ∑ i, killingForm K L (c j) (killingDualBasis b i) • f (b i) (killingDualBasis c j) := by
+    intro j
+    conv_lhs => rw [← sum_killingForm_smul_basis b (c j)]
+    rw [map_sum, LinearMap.sum_apply]
+    exact sum_congr rfl fun i _ ↦ by rw [map_smul, LinearMap.smul_apply]
+  rw [sum_congr rfl fun j _ ↦ expand j, Finset.sum_comm]
+  refine sum_congr rfl fun i _ ↦ ?_
+  conv_lhs => rw [← sum_killingForm_smul_killingDualBasis c (killingDualBasis b i)]
+  rw [map_sum]
+  exact sum_congr rfl fun j _ ↦ map_smul _ _ _
+
+/-- **A Killing-adjoint pair of operators may be moved from one slot to the other.**  If `κ (p x) y`
+is `κ x (q y)` then applying `p` to the basis vectors and applying `q` to their Killing duals give
+the same sum, because both expand to `∑ᵢ ∑ⱼ κ (p xᵢ) yⱼ • f xⱼ yᵢ`. -/
+theorem sum_apply_killingDualBasis_of_isAdjointPair {ι : Type*} [DecidableEq ι] [Fintype ι]
+    (b : Module.Basis ι K L) {p q : L →ₗ[K] L}
+    (hpq : LinearMap.IsAdjointPair (killingForm K L) (killingForm K L) p q) :
+    ∑ i, f (p (b i)) (killingDualBasis b i) = ∑ i, f (b i) (q (killingDualBasis b i)) := by
+  have expand₁ : ∀ i : ι, f (p (b i)) (killingDualBasis b i)
+      = ∑ j, killingForm K L (p (b i)) (killingDualBasis b j) •
+          f (b j) (killingDualBasis b i) := by
+    intro i
+    conv_lhs => rw [← sum_killingForm_smul_basis b (p (b i))]
+    rw [map_sum, LinearMap.sum_apply]
+    exact sum_congr rfl fun j _ ↦ by rw [map_smul, LinearMap.smul_apply]
+  have expand₂ : ∀ i : ι, f (b i) (q (killingDualBasis b i))
+      = ∑ j, killingForm K L (p (b j)) (killingDualBasis b i) •
+          f (b i) (killingDualBasis b j) := by
+    intro i
+    conv_lhs => rw [← sum_killingForm_smul_killingDualBasis b (q (killingDualBasis b i))]
+    rw [map_sum]
+    exact sum_congr rfl fun j _ ↦ by rw [map_smul, hpq (b j) (killingDualBasis b i)]
+  rw [sum_congr rfl fun i _ ↦ expand₁ i, sum_congr rfl fun i _ ↦ expand₂ i, Finset.sum_comm]
+
+/-- **The element `∑ᵢ xᵢ ⊗ yᵢ` is invariant under the adjoint action.**  Read through a bilinear
+map `f`, the Leibniz expansion of the adjoint action of `z` vanishes, because the two coefficient
+families it produces are negatives of each other by the invariance of the Killing form. -/
+theorem sum_apply_lie_killingDualBasis_add_eq_zero {ι : Type*} [DecidableEq ι] [Fintype ι]
+    (b : Module.Basis ι K L) (z : L) :
+    ∑ i, f ⁅z, b i⁆ (killingDualBasis b i) + ∑ i, f (b i) ⁅z, killingDualBasis b i⁆ = 0 := by
+  have expand₁ : ∀ i : ι, f ⁅z, b i⁆ (killingDualBasis b i)
+      = ∑ j, killingForm K L ⁅z, b i⁆ (killingDualBasis b j) •
+          f (b j) (killingDualBasis b i) := by
+    intro i
+    conv_lhs => rw [← sum_killingForm_smul_basis b ⁅z, b i⁆]
+    rw [map_sum, LinearMap.sum_apply]
+    exact sum_congr rfl fun j _ ↦ by rw [map_smul, LinearMap.smul_apply]
+  have expand₂ : ∀ i : ι, f (b i) ⁅z, killingDualBasis b i⁆
+      = ∑ j, killingForm K L (b j) ⁅z, killingDualBasis b i⁆ •
+          f (b i) (killingDualBasis b j) := by
+    intro i
+    conv_lhs => rw [← sum_killingForm_smul_killingDualBasis b ⁅z, killingDualBasis b i⁆]
+    rw [map_sum]
+    exact sum_congr rfl fun j _ ↦ map_smul _ _ _
+  rw [sum_congr rfl fun i _ ↦ expand₁ i, sum_congr rfl fun i _ ↦ expand₂ i, Finset.sum_comm,
+    ← Finset.sum_add_distrib]
+  refine sum_eq_zero fun i _ ↦ ?_
+  rw [← Finset.sum_add_distrib]
+  refine sum_eq_zero fun j _ ↦ ?_
+  rw [← add_smul, LieModule.traceForm_apply_lie_apply' K L L z (b j) (killingDualBasis b i),
+    neg_add_cancel, zero_smul]
+
+end Bilinear
+
+end TauCeti

--- a/TauCeti/Algebra/Lie/Killing/DualBasis.lean
+++ b/TauCeti/Algebra/Lie/Killing/DualBasis.lean
@@ -65,6 +65,13 @@ theorem killingForm_killingDualBasis (b : Module.Basis ι K L) (i j : ι) :
     killingForm K L (b i) (killingDualBasis b j) = if i = j then 1 else 0 :=
   LinearMap.BilinForm.apply_dualBasis_right _ killingForm_isSymm b i j
 
+/-- The symmetric orientation of the defining biorthogonality of the Killing-dual basis. -/
+@[simp]
+theorem killingForm_killingDualBasis_left (b : Module.Basis ι K L) (i j : ι) :
+    killingForm K L (killingDualBasis b i) (b j) = if i = j then 1 else 0 := by
+  rw [LieModule.traceForm_comm, killingForm_killingDualBasis]
+  simp only [eq_comm]
+
 /-- Coordinates in the Killing-dual basis are Killing pairings against `b`. -/
 @[simp]
 theorem killingDualBasis_repr (b : Module.Basis ι K L) (v : L) (i : ι) :

--- a/TauCeti/Algebra/Lie/SkewAdjoint.lean
+++ b/TauCeti/Algebra/Lie/SkewAdjoint.lean
@@ -5,11 +5,12 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Algebra.Lie.Killing
 public import Mathlib.Algebra.Lie.SkewAdjoint
 public import Mathlib.LinearAlgebra.Matrix.BilinearForm
 public import TauCeti.Algebra.Lie.Killing.DualBasis
 public import TauCeti.LinearAlgebra.QuadraticForm.Radical
+
+import TauCeti.LinearAlgebra.BilinearForm.Basic
 
 /-!
 # Skew-adjoint Lie algebras
@@ -362,23 +363,15 @@ theorem dualBasis_polarBilin_killingQuadraticForm_apply {ι : Type w} [Fintype �
           exact QuadraticMap.nondegenerate_polar_iff.mpr
             (_root_.TauCeti.LieAlgebra.killingQuadraticForm_nondegenerate K L)) b i =
       (2 : K)⁻¹ • killingDualBasis b i := by
-  let B := (2 : K) • killingForm K L
-  let hB : LinearMap.BilinForm.Nondegenerate B := by
-    dsimp only [B]
-    rw [← _root_.TauCeti.LieAlgebra.polarBilin_killingQuadraticForm]
-    exact QuadraticMap.nondegenerate_polar_iff.mpr
-      (_root_.TauCeti.LieAlgebra.killingQuadraticForm_nondegenerate K L)
-  let d := LinearMap.BilinForm.dualBasis B hB b
-  apply LinearMap.ker_eq_bot.mp hB.ker_eq_bot
-  apply b.ext
-  intro j
-  simp only [map_smul]
-  rw [LinearMap.BilinForm.apply_dualBasis_left]
-  simp only [B, LinearMap.smul_apply, smul_eq_mul]
-  rw [LieModule.traceForm_comm K L L (killingDualBasis b i) (b j),
-    killingForm_killingDualBasis]
-  split_ifs
-  · simp only [mul_one, inv_mul_cancel₀ (Invertible.ne_zero (2 : K))]
-  · simp only [mul_zero]
+  let hκ := _root_.LieAlgebra.IsKilling.killingForm_nondegenerate K L
+  have hdual (j : ι) :
+      LinearMap.BilinForm.dualBasis (killingForm K L) hκ b j = killingDualBasis b j := by
+    apply LinearMap.ker_eq_bot.mp hκ.ker_eq_bot
+    apply b.ext
+    intro k
+    rw [LinearMap.BilinForm.apply_dualBasis_left, killingForm_killingDualBasis_left]
+    simp only [eq_comm]
+  rw [b.dualBasis_smul_apply (killingForm K L) hκ (2 : K)
+    (Invertible.ne_zero (2 : K)), hdual]
 
 end Module.Basis

--- a/TauCeti/Algebra/Lie/SkewAdjoint.lean
+++ b/TauCeti/Algebra/Lie/SkewAdjoint.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.Algebra.Lie.Killing
 public import Mathlib.Algebra.Lie.SkewAdjoint
 public import Mathlib.LinearAlgebra.Matrix.BilinearForm
+public import TauCeti.Algebra.Lie.Killing.DualBasis
 public import TauCeti.LinearAlgebra.QuadraticForm.Radical
 
 /-!
@@ -73,6 +74,8 @@ composite is not built here.
   form is `2 • killingForm`.
 * `TauCeti.LieAlgebra.killingQuadraticForm_nondegenerate`: over a ring in which `2` is invertible,
   the Killing quadratic form of a Killing-semisimple Lie algebra is nondegenerate.
+* `Module.Basis.dualBasis_polarBilin_killingQuadraticForm_apply`: the basis dual for the polar form
+  is half the Killing-dual basis.
 
 ## Implementation notes
 
@@ -338,3 +341,44 @@ theorem killingAdjointSO_injective_iff :
 end Killing
 
 end TauCeti.LieAlgebra
+
+open TauCeti
+
+namespace Module.Basis
+
+variable {K : Type u} [Field K] [Invertible (2 : K)]
+
+/-- The basis dual to `b` for the polar form of the Killing quadratic form is half the
+Killing-dual basis. The factor records that this polar form is `2 • killingForm K L`. -/
+@[simp]
+theorem dualBasis_polarBilin_killingQuadraticForm_apply {ι : Type w} [Fintype ι]
+    [DecidableEq ι] {L : Type v} [LieRing L] [LieAlgebra K L]
+    [_root_.LieAlgebra.IsKilling K L]
+    (b : Module.Basis ι K L) (i : ι) :
+    LinearMap.BilinForm.dualBasis
+        ((2 : K) • killingForm K L)
+        (by
+          rw [← _root_.TauCeti.LieAlgebra.polarBilin_killingQuadraticForm]
+          exact QuadraticMap.nondegenerate_polar_iff.mpr
+            (_root_.TauCeti.LieAlgebra.killingQuadraticForm_nondegenerate K L)) b i =
+      (2 : K)⁻¹ • killingDualBasis b i := by
+  let B := (2 : K) • killingForm K L
+  let hB : LinearMap.BilinForm.Nondegenerate B := by
+    dsimp only [B]
+    rw [← _root_.TauCeti.LieAlgebra.polarBilin_killingQuadraticForm]
+    exact QuadraticMap.nondegenerate_polar_iff.mpr
+      (_root_.TauCeti.LieAlgebra.killingQuadraticForm_nondegenerate K L)
+  let d := LinearMap.BilinForm.dualBasis B hB b
+  apply LinearMap.ker_eq_bot.mp hB.ker_eq_bot
+  apply b.ext
+  intro j
+  simp only [map_smul]
+  rw [LinearMap.BilinForm.apply_dualBasis_left]
+  simp only [B, LinearMap.smul_apply, smul_eq_mul]
+  rw [LieModule.traceForm_comm K L L (killingDualBasis b i) (b j),
+    killingForm_killingDualBasis]
+  split_ifs
+  · simp only [mul_one, inv_mul_cancel₀ (Invertible.ne_zero (2 : K))]
+  · simp only [mul_zero]
+
+end Module.Basis

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Casimir.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Casimir.lean
@@ -6,9 +6,8 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.Lie.UniversalEnveloping.Basic
+public import TauCeti.Algebra.Lie.Killing.DualBasis
 public import Mathlib.Algebra.Algebra.Subalgebra.Basic
-public import Mathlib.Algebra.Lie.Killing
-public import Mathlib.LinearAlgebra.BilinearForm.Properties
 
 -- Non-public: the enveloping-algebra dictionary appears only inside proofs.
 import TauCeti.Algebra.Lie.UniversalEnveloping.Module
@@ -29,7 +28,8 @@ module by a scalar that separates the trivial module from the others.  Those ext
 needed only for that application; centrality, the statement proved here, needs nothing beyond a
 nondegenerate Killing form.
 
-Two facts make `Ω` an invariant of `L` rather than of the chosen basis, and both are proved here.
+Two facts make `Ω` an invariant of `L` rather than of the chosen basis. They are developed in
+`TauCeti.Algebra.Lie.Killing.DualBasis` and applied here.
 
 * `Ω` does not depend on the basis.  The mechanism is `TauCeti.sum_apply_killingDualBasis_eq`:
   for *every* `K`-bilinear map `f` out of `L × L`, the value `∑ᵢ f xᵢ yᵢ` is the same for all
@@ -51,7 +51,6 @@ canonical choice this development needs and the one the roadmap pins.
 
 ## Main definitions
 
-* `TauCeti.killingDualBasis`: the basis dual to a given one under the Killing form.
 * `TauCeti.casimirElement`: the Casimir element of `U(L)`.
 
 ## Main results
@@ -98,158 +97,10 @@ open Finset LieAlgebra LieModule UniversalEnvelopingAlgebra
 
 namespace TauCeti
 
-universe u v w
+universe u v
 
 variable {K : Type u} {L : Type v} [Field K] [LieRing L] [LieAlgebra K L]
   [LieAlgebra.IsKilling K L]
-
-/-! ### The Killing-dual basis -/
-
-section DualBasis
-
-variable {ι : Type*} [DecidableEq ι] [Fintype ι]
-
-omit [LieAlgebra.IsKilling K L] in
-/-- The Killing form is symmetric, in the bundled `LinearMap.BilinForm.IsSymm` form that the
-dual-basis API asks for; Mathlib supplies it as the unbundled `LieModule.traceForm_isSymm`. -/
-private theorem killingForm_isSymm : (killingForm K L).IsSymm :=
-  LinearMap.BilinForm.isSymm_def.mpr fun x y ↦ LieModule.traceForm_comm K L L x y
-
-/-- The basis of `L` **dual to `b` under the Killing form**: `κ (b i) (killingDualBasis b j)` is
-`1` when `i = j` and `0` otherwise (`TauCeti.killingForm_killingDualBasis`). -/
-noncomputable def killingDualBasis (b : Module.Basis ι K L) : Module.Basis ι K L :=
-  (killingForm K L).dualBasis (LieAlgebra.IsKilling.killingForm_nondegenerate K L) b
-
-/-- The defining biorthogonality of the Killing-dual basis. -/
-@[simp]
-theorem killingForm_killingDualBasis (b : Module.Basis ι K L) (i j : ι) :
-    killingForm K L (b i) (killingDualBasis b j) = if i = j then 1 else 0 :=
-  LinearMap.BilinForm.apply_dualBasis_right _ killingForm_isSymm b i j
-
-/-- Coordinates in the Killing-dual basis are Killing pairings against `b`. -/
-@[simp]
-theorem killingDualBasis_repr (b : Module.Basis ι K L) (v : L) (i : ι) :
-    (killingDualBasis b).repr v i = killingForm K L (b i) v :=
-  (LinearMap.BilinForm.dualBasis_repr_apply _ b v i).trans
-    (LieModule.traceForm_comm K L L v (b i))
-
-/-- Conjugating twice returns the original basis: the Killing-dual basis of the Killing-dual
-basis of `b` is `b`. -/
-@[simp]
-theorem killingDualBasis_killingDualBasis (b : Module.Basis ι K L) :
-    killingDualBasis (killingDualBasis b) = b :=
-  LinearMap.BilinForm.dualBasis_dualBasis _ killingForm_isSymm b
-
-/-- Coordinates in `b` are Killing pairings against the Killing-dual basis. -/
-theorem repr_eq_killingForm (b : Module.Basis ι K L) (v : L) (i : ι) :
-    b.repr v i = killingForm K L v (killingDualBasis b i) := by
-  conv_lhs => rw [← killingDualBasis_killingDualBasis b]
-  rw [killingDualBasis_repr, LieModule.traceForm_comm]
-
-/-- **Expansion in `b`**, with the coefficients read off by the Killing-dual basis. -/
-theorem sum_killingForm_smul_basis (b : Module.Basis ι K L) (v : L) :
-    ∑ i, killingForm K L v (killingDualBasis b i) • b i = v := by
-  conv_rhs => rw [← b.sum_repr v]
-  exact sum_congr rfl fun i _ ↦ by rw [repr_eq_killingForm]
-
-/-- **Expansion in the Killing-dual basis**, with the coefficients read off by `b`. -/
-theorem sum_killingForm_smul_killingDualBasis (b : Module.Basis ι K L) (v : L) :
-    ∑ i, killingForm K L (b i) v • killingDualBasis b i = v := by
-  conv_rhs => rw [← (killingDualBasis b).sum_repr v]
-  exact sum_congr rfl fun i _ ↦ by rw [killingDualBasis_repr]
-
-/-- **The sum `∑ᵢ κ (p xᵢ) yᵢ` along a basis and its Killing-dual basis is the trace of `p`.**  The
-Killing-dual basis reads off the coordinates in `b` (`TauCeti.repr_eq_killingForm`), so the sum is
-the sum of the diagonal entries of the matrix of `p`. -/
-theorem sum_killingForm_killingDualBasis_eq_trace (b : Module.Basis ι K L) (p : L →ₗ[K] L) :
-    ∑ i, killingForm K L (p (b i)) (killingDualBasis b i) = LinearMap.trace K L p := by
-  rw [LinearMap.trace_eq_matrix_trace K b]
-  simp only [Matrix.trace, Matrix.diag_apply, LinearMap.toMatrix_apply]
-  exact sum_congr rfl fun i _ ↦ (repr_eq_killingForm b (p (b i)) i).symm
-
-end DualBasis
-
-/-! ### The canonical invariant element `∑ᵢ xᵢ ⊗ yᵢ`
-
-Both properties of the Casimir element proved below come from two facts about the sum
-`∑ᵢ f (b i) (killingDualBasis b i)` of a bilinear map `f` along a basis and its Killing-dual
-basis: it does not depend on the basis, and it is annihilated by the adjoint action.  Stating them
-for an arbitrary bilinear `f` keeps the arguments free of any computation inside `U(L)`. -/
-
-section Bilinear
-
-variable {W : Type w} [AddCommGroup W] [Module K W] (f : L →ₗ[K] L →ₗ[K] W)
-
-/-- **The sum `∑ᵢ f xᵢ yᵢ` of a bilinear map along a basis and its Killing-dual basis does not
-depend on the basis.**  Expanding each `c j` in the basis `b` produces exactly the coefficients
-that expand `killingDualBasis b i` in `killingDualBasis c`. -/
-theorem sum_apply_killingDualBasis_eq {ι ι' : Type*} [DecidableEq ι] [Fintype ι] [DecidableEq ι']
-    [Fintype ι'] (b : Module.Basis ι K L) (c : Module.Basis ι' K L) :
-    ∑ i, f (b i) (killingDualBasis b i) = ∑ j, f (c j) (killingDualBasis c j) := by
-  have expand : ∀ j : ι', f (c j) (killingDualBasis c j)
-      = ∑ i, killingForm K L (c j) (killingDualBasis b i) • f (b i) (killingDualBasis c j) := by
-    intro j
-    conv_lhs => rw [← sum_killingForm_smul_basis b (c j)]
-    rw [map_sum, LinearMap.sum_apply]
-    exact sum_congr rfl fun i _ ↦ by rw [map_smul, LinearMap.smul_apply]
-  rw [sum_congr rfl fun j _ ↦ expand j, Finset.sum_comm]
-  refine sum_congr rfl fun i _ ↦ ?_
-  conv_lhs => rw [← sum_killingForm_smul_killingDualBasis c (killingDualBasis b i)]
-  rw [map_sum]
-  exact sum_congr rfl fun j _ ↦ map_smul _ _ _
-
-/-- **A Killing-adjoint pair of operators may be moved from one slot to the other.**  If `κ (p x) y`
-is `κ x (q y)` then applying `p` to the basis vectors and applying `q` to their Killing duals give
-the same sum, because both expand to `∑ᵢ ∑ⱼ κ (p xᵢ) yⱼ • f xⱼ yᵢ`. -/
-theorem sum_apply_killingDualBasis_of_isAdjointPair {ι : Type*} [DecidableEq ι] [Fintype ι]
-    (b : Module.Basis ι K L) {p q : L →ₗ[K] L}
-    (hpq : LinearMap.IsAdjointPair (killingForm K L) (killingForm K L) p q) :
-    ∑ i, f (p (b i)) (killingDualBasis b i) = ∑ i, f (b i) (q (killingDualBasis b i)) := by
-  have expand₁ : ∀ i : ι, f (p (b i)) (killingDualBasis b i)
-      = ∑ j, killingForm K L (p (b i)) (killingDualBasis b j) •
-          f (b j) (killingDualBasis b i) := by
-    intro i
-    conv_lhs => rw [← sum_killingForm_smul_basis b (p (b i))]
-    rw [map_sum, LinearMap.sum_apply]
-    exact sum_congr rfl fun j _ ↦ by rw [map_smul, LinearMap.smul_apply]
-  have expand₂ : ∀ i : ι, f (b i) (q (killingDualBasis b i))
-      = ∑ j, killingForm K L (p (b j)) (killingDualBasis b i) •
-          f (b i) (killingDualBasis b j) := by
-    intro i
-    conv_lhs => rw [← sum_killingForm_smul_killingDualBasis b (q (killingDualBasis b i))]
-    rw [map_sum]
-    exact sum_congr rfl fun j _ ↦ by rw [map_smul, hpq (b j) (killingDualBasis b i)]
-  rw [sum_congr rfl fun i _ ↦ expand₁ i, sum_congr rfl fun i _ ↦ expand₂ i, Finset.sum_comm]
-
-/-- **The element `∑ᵢ xᵢ ⊗ yᵢ` is invariant under the adjoint action.**  Read through a bilinear
-map `f`, the Leibniz expansion of the adjoint action of `z` vanishes, because the two coefficient
-families it produces are negatives of each other by the invariance of the Killing form. -/
-theorem sum_apply_lie_killingDualBasis_add_eq_zero {ι : Type*} [DecidableEq ι] [Fintype ι]
-    (b : Module.Basis ι K L) (z : L) :
-    ∑ i, f ⁅z, b i⁆ (killingDualBasis b i) + ∑ i, f (b i) ⁅z, killingDualBasis b i⁆ = 0 := by
-  have expand₁ : ∀ i : ι, f ⁅z, b i⁆ (killingDualBasis b i)
-      = ∑ j, killingForm K L ⁅z, b i⁆ (killingDualBasis b j) •
-          f (b j) (killingDualBasis b i) := by
-    intro i
-    conv_lhs => rw [← sum_killingForm_smul_basis b ⁅z, b i⁆]
-    rw [map_sum, LinearMap.sum_apply]
-    exact sum_congr rfl fun j _ ↦ by rw [map_smul, LinearMap.smul_apply]
-  have expand₂ : ∀ i : ι, f (b i) ⁅z, killingDualBasis b i⁆
-      = ∑ j, killingForm K L (b j) ⁅z, killingDualBasis b i⁆ •
-          f (b i) (killingDualBasis b j) := by
-    intro i
-    conv_lhs => rw [← sum_killingForm_smul_killingDualBasis b ⁅z, killingDualBasis b i⁆]
-    rw [map_sum]
-    exact sum_congr rfl fun j _ ↦ map_smul _ _ _
-  rw [sum_congr rfl fun i _ ↦ expand₁ i, sum_congr rfl fun i _ ↦ expand₂ i, Finset.sum_comm,
-    ← Finset.sum_add_distrib]
-  refine sum_eq_zero fun i _ ↦ ?_
-  rw [← Finset.sum_add_distrib]
-  refine sum_eq_zero fun j _ ↦ ?_
-  rw [← add_smul, LieModule.traceForm_apply_lie_apply' K L L z (b j) (killingDualBasis b i),
-    neg_add_cancel, zero_smul]
-
-end Bilinear
 
 /-! ### The Casimir element -/
 

--- a/TauCeti/LinearAlgebra/BilinearForm/Basic.lean
+++ b/TauCeti/LinearAlgebra/BilinearForm/Basic.lean
@@ -9,7 +9,7 @@ public import Mathlib.LinearAlgebra.BilinearForm.Properties
 public import Mathlib.Tactic.LinearCombination
 
 /-!
-# Basic facts about bilinear forms
+# A form that is both symmetric and alternating
 
 Away from characteristic two a bilinear form cannot be both symmetric and alternating without
 being zero: symmetry and alternation give `B x y = B y x` and `B x y = -B y x`, so `2 * B x y = 0`,
@@ -19,9 +19,6 @@ That cancellation is all the hypothesis on the ring there is: `2` has to be regu
 is asked of any other element, so the statement covers rings with zero divisors elsewhere.  Over a
 field, or over any domain, `IsRegular.of_ne_zero` supplies the hypothesis from `(2 : R) ≠ 0`.
 
-For a nondegenerate symmetric bilinear form over a field, this file also records the two
-reconstruction formulas associated to a finite basis and its dual basis.
-
 ## Main results
 
 * `TauCeti.BilinForm.eq_zero_of_isSymm_of_isAlt`: a symmetric alternating form over a ring in which
@@ -29,8 +26,6 @@ reconstruction formulas associated to a finite basis and its dual basis.
 * `TauCeti.BilinForm.nondegenerate_smul_iff`: scalar multiplication by a regular element
   preserves nondegeneracy.
 * `TauCeti.BilinForm.nondegenerate_neg_iff`: negating a bilinear form preserves nondegeneracy.
-* `TauCeti.sum_dualBasis_smul_basis`: reconstruction from a basis and its dual.
-* `TauCeti.sum_basis_smul_dualBasis`: reconstruction in the dual basis.
 -/
 
 public section
@@ -83,41 +78,5 @@ theorem nondegenerate_neg_iff {R M : Type*} [CommRing R] [AddCommGroup M]
   exact nondegenerate_smul_iff (isUnit_neg_one : IsUnit (-1 : R)).isRegular
 
 end BilinForm
-
-/-- A vector is reconstructed in a basis by pairing it with the dual basis of a nondegenerate
-symmetric bilinear form. -/
-theorem sum_dualBasis_smul_basis {K V ι : Type*} [Field K] [AddCommGroup V] [Module K V]
-    [Fintype ι] [DecidableEq ι] (B : BilinForm K V) (hB : B.Nondegenerate)
-    (hBsymm : B.IsSymm) (b : Module.Basis ι K V) (x : V) :
-    ∑ i, B (B.dualBasis hB b i) x • b i = x := by
-  let d := B.dualBasis hB b
-  calc
-    _ = ∑ i, b.repr x i • b i := by
-      apply Finset.sum_congr rfl
-      intro i _
-      congr 1
-      calc
-        B (d i) x = B x (d i) := hBsymm.eq (d i) x
-        _ = (B.dualBasis hB d).repr x i :=
-          (LinearMap.BilinForm.dualBasis_repr_apply hB d x i).symm
-        _ = b.repr x i := by
-          rw [LinearMap.BilinForm.dualBasis_dualBasis hB hBsymm b]
-    _ = x := b.sum_repr x
-
-/-- A vector is reconstructed in the dual basis by pairing it with the original basis of a
-nondegenerate symmetric bilinear form. -/
-theorem sum_basis_smul_dualBasis {K V ι : Type*} [Field K] [AddCommGroup V] [Module K V]
-    [Fintype ι] [DecidableEq ι] (B : BilinForm K V) (hB : B.Nondegenerate)
-    (hBsymm : B.IsSymm) (b : Module.Basis ι K V) (x : V) :
-    ∑ i, B (b i) x • B.dualBasis hB b i = x := by
-  let d := B.dualBasis hB b
-  calc
-    _ = ∑ i, d.repr x i • d i := by
-      apply Finset.sum_congr rfl
-      intro i _
-      congr 1
-      rw [LinearMap.BilinForm.dualBasis_repr_apply]
-      exact hBsymm.eq (b i) x
-    _ = x := d.sum_repr x
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/BilinearForm/Basic.lean
+++ b/TauCeti/LinearAlgebra/BilinearForm/Basic.lean
@@ -9,7 +9,7 @@ public import Mathlib.LinearAlgebra.BilinearForm.Properties
 public import Mathlib.Tactic.LinearCombination
 
 /-!
-# A form that is both symmetric and alternating
+# Basic facts about bilinear forms
 
 Away from characteristic two a bilinear form cannot be both symmetric and alternating without
 being zero: symmetry and alternation give `B x y = B y x` and `B x y = -B y x`, so `2 * B x y = 0`,
@@ -19,6 +19,9 @@ That cancellation is all the hypothesis on the ring there is: `2` has to be regu
 is asked of any other element, so the statement covers rings with zero divisors elsewhere.  Over a
 field, or over any domain, `IsRegular.of_ne_zero` supplies the hypothesis from `(2 : R) ≠ 0`.
 
+For a nondegenerate symmetric bilinear form over a field, this file also records the two
+reconstruction formulas associated to a finite basis and its dual basis.
+
 ## Main results
 
 * `TauCeti.BilinForm.eq_zero_of_isSymm_of_isAlt`: a symmetric alternating form over a ring in which
@@ -26,6 +29,8 @@ field, or over any domain, `IsRegular.of_ne_zero` supplies the hypothesis from `
 * `TauCeti.BilinForm.nondegenerate_smul_iff`: scalar multiplication by a regular element
   preserves nondegeneracy.
 * `TauCeti.BilinForm.nondegenerate_neg_iff`: negating a bilinear form preserves nondegeneracy.
+* `TauCeti.sum_dualBasis_smul_basis`: reconstruction from a basis and its dual.
+* `TauCeti.sum_basis_smul_dualBasis`: reconstruction in the dual basis.
 -/
 
 public section
@@ -78,5 +83,41 @@ theorem nondegenerate_neg_iff {R M : Type*} [CommRing R] [AddCommGroup M]
   exact nondegenerate_smul_iff (isUnit_neg_one : IsUnit (-1 : R)).isRegular
 
 end BilinForm
+
+/-- A vector is reconstructed in a basis by pairing it with the dual basis of a nondegenerate
+symmetric bilinear form. -/
+theorem sum_dualBasis_smul_basis {K V ι : Type*} [Field K] [AddCommGroup V] [Module K V]
+    [Fintype ι] [DecidableEq ι] (B : BilinForm K V) (hB : B.Nondegenerate)
+    (hBsymm : B.IsSymm) (b : Module.Basis ι K V) (x : V) :
+    ∑ i, B (B.dualBasis hB b i) x • b i = x := by
+  let d := B.dualBasis hB b
+  calc
+    _ = ∑ i, b.repr x i • b i := by
+      apply Finset.sum_congr rfl
+      intro i _
+      congr 1
+      calc
+        B (d i) x = B x (d i) := hBsymm.eq (d i) x
+        _ = (B.dualBasis hB d).repr x i :=
+          (LinearMap.BilinForm.dualBasis_repr_apply hB d x i).symm
+        _ = b.repr x i := by
+          rw [LinearMap.BilinForm.dualBasis_dualBasis hB hBsymm b]
+    _ = x := b.sum_repr x
+
+/-- A vector is reconstructed in the dual basis by pairing it with the original basis of a
+nondegenerate symmetric bilinear form. -/
+theorem sum_basis_smul_dualBasis {K V ι : Type*} [Field K] [AddCommGroup V] [Module K V]
+    [Fintype ι] [DecidableEq ι] (B : BilinForm K V) (hB : B.Nondegenerate)
+    (hBsymm : B.IsSymm) (b : Module.Basis ι K V) (x : V) :
+    ∑ i, B (b i) x • B.dualBasis hB b i = x := by
+  let d := B.dualBasis hB b
+  calc
+    _ = ∑ i, d.repr x i • d i := by
+      apply Finset.sum_congr rfl
+      intro i _
+      congr 1
+      rw [LinearMap.BilinForm.dualBasis_repr_apply]
+      exact hBsymm.eq (b i) x
+    _ = x := d.sum_repr x
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/BilinearForm/Basic.lean
+++ b/TauCeti/LinearAlgebra/BilinearForm/Basic.lean
@@ -26,6 +26,7 @@ field, or over any domain, `IsRegular.of_ne_zero` supplies the hypothesis from `
 * `TauCeti.BilinForm.nondegenerate_smul_iff`: scalar multiplication by a regular element
   preserves nondegeneracy.
 * `TauCeti.BilinForm.nondegenerate_neg_iff`: negating a bilinear form preserves nondegeneracy.
+* `Module.Basis.dualBasis_smul_apply`: the dual basis of a scalar multiple of a form.
 -/
 
 public section
@@ -80,3 +81,29 @@ theorem nondegenerate_neg_iff {R M : Type*} [CommRing R] [AddCommGroup M]
 end BilinForm
 
 end TauCeti
+
+namespace Module.Basis
+
+/-- The basis dual to `b` for a nonzero scalar multiple `c • B` of a nondegenerate bilinear form
+is `c⁻¹` times the basis dual to `b` for `B`. -/
+@[simp]
+theorem dualBasis_smul_apply {K V ι : Type*} [Field K] [AddCommGroup V]
+    [Module K V] [Finite ι] [DecidableEq ι] (b : Module.Basis ι K V)
+    (B : LinearMap.BilinForm K V) (hB : B.Nondegenerate) (c : K) (hc : c ≠ 0) (i : ι) :
+    LinearMap.BilinForm.dualBasis (c • B)
+        ((TauCeti.BilinForm.nondegenerate_smul_iff (IsRegular.of_ne_zero hc)).mpr hB) b i =
+      c⁻¹ • LinearMap.BilinForm.dualBasis B hB b i := by
+  let hBc : (c • B).Nondegenerate :=
+    (TauCeti.BilinForm.nondegenerate_smul_iff (IsRegular.of_ne_zero hc)).mpr hB
+  apply LinearMap.ker_eq_bot.mp hBc.ker_eq_bot
+  apply b.ext
+  intro j
+  simp only [map_smul]
+  rw [LinearMap.BilinForm.apply_dualBasis_left]
+  simp only [LinearMap.smul_apply, smul_eq_mul]
+  rw [LinearMap.BilinForm.apply_dualBasis_left]
+  split_ifs
+  · simp only [mul_one, inv_mul_cancel₀ hc]
+  · simp only [mul_zero]
+
+end Module.Basis

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/Coordinates.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/Coordinates.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Algebra.Lie.Killing.DualBasis
 public import TauCeti.LinearAlgebra.CliffordAlgebra.Quadratic.Lie.Representation
 
 /-!
@@ -183,7 +182,7 @@ theorem adjointCliffordHom_eq_sum_bivector {ι : Type w} [Fintype ι]
         (b i) (killingDualBasis b i) := by
   let _ := b.finiteDimensional_of_finite
   let Q := _root_.TauCeti.LieAlgebra.killingQuadraticForm K L
-  rw [adjointCliffordHom_apply,
+  rw [adjointCliffordHom, quadraticLift_apply,
     soEquivQuadratic_eq_sum_bivector Q
       (_root_.TauCeti.LieAlgebra.killingQuadraticForm_nondegenerate K L) b]
   simp only [_root_.TauCeti.LieAlgebra.coe_killingAdjointSO, _root_.LieAlgebra.ad_apply]

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/Coordinates.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/Coordinates.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.Lie.UniversalEnveloping.Casimir
-public import TauCeti.LinearAlgebra.BilinearForm.Basic
 public import TauCeti.LinearAlgebra.CliffordAlgebra.Quadratic.Lie.Representation
 
 /-!
@@ -115,9 +114,25 @@ theorem soEquivQuadratic_eq_sum_bivector {ι : Type w} [Fintype ι] [DecidableEq
           rw [map_sum]
           simp only [map_smul]
         _ = (f : Module.End K V) x := by
-          rw [sum_dualBasis_smul_basis Q.polarBilin
-            (QuadraticMap.nondegenerate_polar_iff.mpr hQ)
-            (LinearMap.BilinForm.isSymm_def.mpr fun y z ↦ QuadraticMap.polar_comm Q y z) b]
+          congr 1
+          calc
+            _ = ∑ i, b.repr x i • b i := by
+              apply Finset.sum_congr rfl
+              intro i _
+              congr 1
+              calc
+                Q.polarBilin (d i) x = Q.polarBilin x (d i) :=
+                  QuadraticMap.polar_comm Q (d i) x
+                _ = (LinearMap.BilinForm.dualBasis Q.polarBilin
+                    (QuadraticMap.nondegenerate_polar_iff.mpr hQ) d).repr x i :=
+                  (LinearMap.BilinForm.dualBasis_repr_apply
+                    (QuadraticMap.nondegenerate_polar_iff.mpr hQ) d x i).symm
+                _ = b.repr x i := by
+                  rw [LinearMap.BilinForm.dualBasis_dualBasis
+                    (QuadraticMap.nondegenerate_polar_iff.mpr hQ)
+                    (LinearMap.BilinForm.isSymm_def.mpr fun y z ↦
+                      QuadraticMap.polar_comm Q y z) b]
+            _ = x := b.sum_repr x
     have hskew (i : ι) :
         Q.polarBilin ((f : Module.End K V) (b i)) x =
           -Q.polarBilin (b i) ((f : Module.End K V) x) := by
@@ -133,9 +148,15 @@ theorem soEquivQuadratic_eq_sum_bivector {ι : Type w} [Fintype ι] [DecidableEq
         _ = -(∑ i, Q.polarBilin (b i) ((f : Module.End K V) x) • d i) := by
           rw [Finset.sum_neg_distrib]
         _ = -(f : Module.End K V) x := by
-          rw [sum_basis_smul_dualBasis Q.polarBilin
-            (QuadraticMap.nondegenerate_polar_iff.mpr hQ)
-            (LinearMap.BilinForm.isSymm_def.mpr fun y z ↦ QuadraticMap.polar_comm Q y z) b]
+          congr 1
+          calc
+            _ = ∑ i, d.repr ((f : Module.End K V) x) i • d i := by
+              apply Finset.sum_congr rfl
+              intro i _
+              congr 1
+              rw [LinearMap.BilinForm.dualBasis_repr_apply]
+              exact QuadraticMap.polar_comm Q (b i) ((f : Module.End K V) x)
+            _ = (f : Module.End K V) x := d.sum_repr ((f : Module.End K V) x)
     simp only [QuadraticMap.polarBilin_apply_apply] at hfirst hsecond
     rw [hfirst, hsecond, sub_neg_eq_add, ← two_smul K, ← mul_smul,
       inv_mul_cancel₀ (Invertible.ne_zero (2 : K)), one_smul]
@@ -170,20 +191,6 @@ theorem dualBasis_polarBilin_killingQuadraticForm {ι : Type w} [Fintype ι]
   split_ifs
   · simp only [mul_one, inv_mul_cancel₀ (Invertible.ne_zero (2 : K))]
   · simp only [mul_zero]
-
-/-- The dual basis for twice the Killing form is half the Killing-dual basis. This is the
-simp-normal form of `dualBasis_polarBilin_killingQuadraticForm`. -/
-@[simp]
-theorem dualBasis_two_smul_killingForm {ι : Type w} [Fintype ι]
-    [DecidableEq ι] {L : Type v} [LieRing L] [LieAlgebra K L]
-    [_root_.LieAlgebra.IsKilling K L]
-    (b : Module.Basis ι K L) (i : ι) :
-    LinearMap.BilinForm.dualBasis ((2 : K) • _root_.killingForm K L)
-        ((BilinForm.nondegenerate_smul_iff (isUnit_of_invertible (2 : K)).isRegular).mpr
-          (_root_.LieAlgebra.IsKilling.killingForm_nondegenerate K L)) b i =
-      (2 : K)⁻¹ • killingDualBasis b i := by
-  simpa only [_root_.TauCeti.LieAlgebra.polarBilin_killingQuadraticForm] using
-    dualBasis_polarBilin_killingQuadraticForm b i
 
 /-- **The adjoint quadratic lift in Killing-dual coordinates.** For any basis `b` of a
 finite-dimensional Killing-semisimple Lie algebra,

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/Coordinates.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/Coordinates.lean
@@ -182,7 +182,7 @@ theorem adjointCliffordHom_eq_sum_bivector {ι : Type w} [Fintype ι]
         (b i) (killingDualBasis b i) := by
   let _ := b.finiteDimensional_of_finite
   let Q := _root_.TauCeti.LieAlgebra.killingQuadraticForm K L
-  rw [adjointCliffordHom, quadraticLift_apply,
+  rw [adjointCliffordHom_apply,
     soEquivQuadratic_eq_sum_bivector Q
       (_root_.TauCeti.LieAlgebra.killingQuadraticForm_nondegenerate K L) b]
   simp only [_root_.TauCeti.LieAlgebra.coe_killingAdjointSO, _root_.LieAlgebra.ad_apply]

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/Coordinates.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/Coordinates.lean
@@ -32,8 +32,6 @@ the basis-independent Killing contraction and root-space projection API.
 * `CliffordAlgebra.adjointBivector`: the bilinear map `(y, z) ↦ bivector Q [x, y] z`.
 * `CliffordAlgebra.soEquivQuadratic_eq_sum_bivector`: the coordinate formula for an arbitrary
   skew-adjoint endomorphism.
-* `Module.Basis.dualBasis_polarBilin_killingQuadraticForm_apply`: the comparison between the
-  polar-dual and Killing-dual bases.
 * `CliffordAlgebra.adjointCliffordHom_eq_sum_bivector`: the adjoint lift as a `1 / 4`-scaled sum
   against a Killing-dual basis.
 
@@ -168,48 +166,6 @@ theorem soEquivQuadratic_eq_sum_bivector {ι : Type w} [Fintype ι] [DecidableEq
       inv_mul_cancel₀ (Invertible.ne_zero (2 : K)), one_smul]
   simpa [a, d] using congrArg Subtype.val ha
 
-end CliffordAlgebra
-
-namespace Module.Basis
-
-variable {K : Type u} [Field K] [Invertible (2 : K)]
-
-/-- The basis dual to `b` for the polar form of the Killing quadratic form is half the
-Killing-dual basis. The factor records that this polar form is `2 • killingForm K L`. -/
-theorem dualBasis_polarBilin_killingQuadraticForm_apply {ι : Type w} [Fintype ι]
-    [DecidableEq ι] {L : Type v} [LieRing L] [LieAlgebra K L]
-    [_root_.LieAlgebra.IsKilling K L]
-    (b : Module.Basis ι K L) (i : ι) :
-    LinearMap.BilinForm.dualBasis
-        (_root_.TauCeti.LieAlgebra.killingQuadraticForm K L).polarBilin
-        (QuadraticMap.nondegenerate_polar_iff.mpr
-          (_root_.TauCeti.LieAlgebra.killingQuadraticForm_nondegenerate K L)) b i =
-      (2 : K)⁻¹ • killingDualBasis b i := by
-  let Q := _root_.TauCeti.LieAlgebra.killingQuadraticForm K L
-  let B := Q.polarBilin
-  let hB : LinearMap.BilinForm.Nondegenerate B :=
-    QuadraticMap.nondegenerate_polar_iff.mpr
-      (_root_.TauCeti.LieAlgebra.killingQuadraticForm_nondegenerate K L)
-  let d := LinearMap.BilinForm.dualBasis B hB b
-  apply LinearMap.ker_eq_bot.mp hB.ker_eq_bot
-  apply b.ext
-  intro j
-  simp only [map_smul]
-  rw [LinearMap.BilinForm.apply_dualBasis_left]
-  simp only [B, Q, _root_.TauCeti.LieAlgebra.polarBilin_killingQuadraticForm,
-    LinearMap.smul_apply, smul_eq_mul]
-  rw [LieModule.traceForm_comm K L L (killingDualBasis b i) (b j),
-    killingForm_killingDualBasis]
-  split_ifs
-  · simp only [mul_one, inv_mul_cancel₀ (Invertible.ne_zero (2 : K))]
-  · simp only [mul_zero]
-
-end Module.Basis
-
-namespace CliffordAlgebra
-
-variable {K : Type u} [Field K] [Invertible (2 : K)]
-
 /-- **The adjoint quadratic lift in Killing-dual coordinates.** For any basis `b` of a
 finite-dimensional Killing-semisimple Lie algebra,
 `adjointCliffordHom K L x` is one quarter of the sum of the bivectors of `[x, b i]` with the
@@ -235,8 +191,9 @@ theorem adjointCliffordHom_eq_sum_bivector {ι : Type w} [Fintype ι]
       LinearMap.BilinForm.dualBasis Q.polarBilin
           (QuadraticMap.nondegenerate_polar_iff.mpr
             (_root_.TauCeti.LieAlgebra.killingQuadraticForm_nondegenerate K L)) b i =
-        (2 : K)⁻¹ • killingDualBasis b i :=
-    b.dualBasis_polarBilin_killingQuadraticForm_apply i
+        (2 : K)⁻¹ • killingDualBasis b i := by
+    simpa only [Q, _root_.TauCeti.LieAlgebra.polarBilin_killingQuadraticForm] using
+      b.dualBasis_polarBilin_killingQuadraticForm_apply i
   simp_rw [hdual]
   have hbiv (y z : L) : bivector Q y ((2 : K)⁻¹ • z) =
       (2 : K)⁻¹ • bivector Q y z := by

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/Coordinates.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/Coordinates.lean
@@ -5,7 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Algebra.Lie.UniversalEnveloping.Casimir
+public import TauCeti.Algebra.Lie.Killing.DualBasis
 public import TauCeti.LinearAlgebra.CliffordAlgebra.Quadratic.Lie.Representation
 
 /-!
@@ -32,10 +32,16 @@ the basis-independent Killing contraction and root-space projection API.
 * `CliffordAlgebra.adjointBivector`: the bilinear map `(y, z) ↦ bivector Q [x, y] z`.
 * `CliffordAlgebra.soEquivQuadratic_eq_sum_bivector`: the coordinate formula for an arbitrary
   skew-adjoint endomorphism.
-* `CliffordAlgebra.dualBasis_polarBilin_killingQuadraticForm`: the comparison between the
+* `Module.Basis.dualBasis_polarBilin_killingQuadraticForm`: the comparison between the
   polar-dual and Killing-dual bases.
 * `CliffordAlgebra.adjointCliffordHom_eq_sum_bivector`: the adjoint lift as a `1 / 4`-scaled sum
   against a Killing-dual basis.
+
+## References
+
+* E. Meinrenken, *Clifford Algebras and Lie Theory*, Springer Ergebnisse 58 (2013), Chapters
+  5--10, for the quadratic realization and the Killing-form construction underlying Kostant
+  theory.
 -/
 
 public section
@@ -43,9 +49,9 @@ public section
 
 universe u v w
 
-namespace CliffordAlgebra
-
 open TauCeti
+
+namespace CliffordAlgebra
 
 attribute [local instance 100] LieRing.ofAssociativeRing
 
@@ -162,6 +168,12 @@ theorem soEquivQuadratic_eq_sum_bivector {ι : Type w} [Fintype ι] [DecidableEq
       inv_mul_cancel₀ (Invertible.ne_zero (2 : K)), one_smul]
   simpa [a, d] using congrArg Subtype.val ha
 
+end CliffordAlgebra
+
+namespace Module.Basis
+
+variable {K : Type u} [Field K] [Invertible (2 : K)]
+
 /-- The basis dual to `b` for the polar form of the Killing quadratic form is half the
 Killing-dual basis. The factor records that this polar form is `2 • killingForm K L`. -/
 theorem dualBasis_polarBilin_killingQuadraticForm {ι : Type w} [Fintype ι]
@@ -192,6 +204,12 @@ theorem dualBasis_polarBilin_killingQuadraticForm {ι : Type w} [Fintype ι]
   · simp only [mul_one, inv_mul_cancel₀ (Invertible.ne_zero (2 : K))]
   · simp only [mul_zero]
 
+end Module.Basis
+
+namespace CliffordAlgebra
+
+variable {K : Type u} [Field K] [Invertible (2 : K)]
+
 /-- **The adjoint quadratic lift in Killing-dual coordinates.** For any basis `b` of a
 finite-dimensional Killing-semisimple Lie algebra,
 `adjointCliffordHom K L x` is one quarter of the sum of the bivectors of `[x, b i]` with the
@@ -218,7 +236,7 @@ theorem adjointCliffordHom_eq_sum_bivector {ι : Type w} [Fintype ι]
           (QuadraticMap.nondegenerate_polar_iff.mpr
             (_root_.TauCeti.LieAlgebra.killingQuadraticForm_nondegenerate K L)) b i =
         (2 : K)⁻¹ • killingDualBasis b i :=
-    dualBasis_polarBilin_killingQuadraticForm b i
+    b.dualBasis_polarBilin_killingQuadraticForm i
   simp_rw [hdual]
   have hbiv (y z : L) : bivector Q y ((2 : K)⁻¹ • z) =
       (2 : K)⁻¹ • bivector Q y z := by

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/Coordinates.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/Coordinates.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.Lie.UniversalEnveloping.Casimir
+public import TauCeti.LinearAlgebra.BilinearForm.Basic
 public import TauCeti.LinearAlgebra.CliffordAlgebra.Quadratic.Lie.Representation
 
 /-!
@@ -36,11 +37,6 @@ the basis-independent Killing contraction and root-space projection API.
   polar-dual and Killing-dual bases.
 * `CliffordAlgebra.adjointCliffordHom_eq_sum_bivector`: the adjoint lift as a `1 / 4`-scaled sum
   against a Killing-dual basis.
-
-## References
-
-* [Tau Ceti Roadmap](https://github.com/TauCetiProject/TauCetiRoadmap), Representation Theory / Spin
-  Representations, Layer 9, "Kostant's isotypy corollary".
 -/
 
 public section
@@ -55,7 +51,7 @@ open TauCeti
 attribute [local instance 100] LieRing.ofAssociativeRing
 
 variable {K : Type u} [Field K] {V : Type v} [AddCommGroup V] [Module K V]
-  [FiniteDimensional K V] [Invertible (2 : K)]
+  [Invertible (2 : K)]
 
 /-- The bilinear Clifford bivector obtained by applying `ad x` in the first slot.
 
@@ -82,58 +78,18 @@ theorem adjointBivector_apply {R : Type u} [CommRing R] [Invertible (2 : R)]
     adjointBivector Q x y z = bivector Q ⁅x, y⁆ z := by
   rfl
 
-omit [FiniteDimensional K V] in
-private theorem sum_polar_dual_smul_basis {ι : Type w} [Fintype ι] [DecidableEq ι]
-    (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) (b : Module.Basis ι K V) (x : V) :
-    ∑ i, Q.polarBilin (LinearMap.BilinForm.dualBasis Q.polarBilin
-        (QuadraticMap.nondegenerate_polar_iff.mpr hQ) b i) x • b i = x := by
-  let B := Q.polarBilin
-  let hB : B.Nondegenerate := QuadraticMap.nondegenerate_polar_iff.mpr hQ
-  let d := LinearMap.BilinForm.dualBasis B hB b
-  calc
-    _ = ∑ i, b.repr x i • b i := by
-      apply Finset.sum_congr rfl
-      intro i _
-      congr 1
-      calc
-        B (d i) x = B x (d i) := QuadraticMap.polar_comm Q (d i) x
-        _ = (LinearMap.BilinForm.dualBasis B hB d).repr x i :=
-          (LinearMap.BilinForm.dualBasis_repr_apply hB d x i).symm
-        _ = b.repr x i := by
-          rw [LinearMap.BilinForm.dualBasis_dualBasis hB
-            (LinearMap.BilinForm.isSymm_def.mpr fun y z ↦ QuadraticMap.polar_comm Q y z) b]
-    _ = x := b.sum_repr x
-
-omit [FiniteDimensional K V] in
-private theorem sum_polar_basis_smul_dual {ι : Type w} [Fintype ι] [DecidableEq ι]
-    (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) (b : Module.Basis ι K V) (x : V) :
-    ∑ i, Q.polarBilin (b i) x • LinearMap.BilinForm.dualBasis Q.polarBilin
-        (QuadraticMap.nondegenerate_polar_iff.mpr hQ) b i = x := by
-  let B := Q.polarBilin
-  let hB : B.Nondegenerate := QuadraticMap.nondegenerate_polar_iff.mpr hQ
-  let d := LinearMap.BilinForm.dualBasis B hB b
-  calc
-    _ = ∑ i, d.repr x i • d i := by
-      apply Finset.sum_congr rfl
-      intro i _
-      congr 1
-      rw [LinearMap.BilinForm.dualBasis_repr_apply]
-      exact QuadraticMap.polar_comm Q (b i) x
-    _ = x := d.sum_repr x
-
 /-- **The coordinate formula for the quadratic realization.** If `d` is the basis dual to `b`
 for the polar form of `Q`, then the quadratic element realizing a skew-adjoint endomorphism `f` is
-`1 / 2 • ∑ i, bivector Q (f (b i)) (d i)`.
-
-Indeed, commuting the unscaled sum with a Clifford generator gives two copies of `f x`: one by
-expanding `x` in `b`, and one by skew-adjointness followed by expansion in `d`. -/
+`1 / 2 • ∑ i, bivector Q (f (b i)) (d i)`. -/
 theorem soEquivQuadratic_eq_sum_bivector {ι : Type w} [Fintype ι] [DecidableEq ι]
     (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) (b : Module.Basis ι K V)
     (f : skewAdjointLieSubalgebra Q.polarBilin) :
-    (soEquivQuadratic Q hQ f : CliffordAlgebra Q) =
+    (@soEquivQuadratic K _ V _ _ b.finiteDimensional_of_finite _ Q hQ f :
+        CliffordAlgebra Q) =
       (2 : K)⁻¹ • ∑ i, bivector Q ((f : Module.End K V) (b i))
         (LinearMap.BilinForm.dualBasis Q.polarBilin
           (QuadraticMap.nondegenerate_polar_iff.mpr hQ) b i) := by
+  let _ := b.finiteDimensional_of_finite
   let d := LinearMap.BilinForm.dualBasis Q.polarBilin
     (QuadraticMap.nondegenerate_polar_iff.mpr hQ) b
   let a : quadraticLieSubalgebra Q :=
@@ -159,7 +115,9 @@ theorem soEquivQuadratic_eq_sum_bivector {ι : Type w} [Fintype ι] [DecidableEq
           rw [map_sum]
           simp only [map_smul]
         _ = (f : Module.End K V) x := by
-          rw [sum_polar_dual_smul_basis Q hQ b x]
+          rw [sum_dualBasis_smul_basis Q.polarBilin
+            (QuadraticMap.nondegenerate_polar_iff.mpr hQ)
+            (LinearMap.BilinForm.isSymm_def.mpr fun y z ↦ QuadraticMap.polar_comm Q y z) b]
     have hskew (i : ι) :
         Q.polarBilin ((f : Module.End K V) (b i)) x =
           -Q.polarBilin (b i) ((f : Module.End K V) x) := by
@@ -175,7 +133,9 @@ theorem soEquivQuadratic_eq_sum_bivector {ι : Type w} [Fintype ι] [DecidableEq
         _ = -(∑ i, Q.polarBilin (b i) ((f : Module.End K V) x) • d i) := by
           rw [Finset.sum_neg_distrib]
         _ = -(f : Module.End K V) x := by
-          rw [sum_polar_basis_smul_dual Q hQ b]
+          rw [sum_basis_smul_dualBasis Q.polarBilin
+            (QuadraticMap.nondegenerate_polar_iff.mpr hQ)
+            (LinearMap.BilinForm.isSymm_def.mpr fun y z ↦ QuadraticMap.polar_comm Q y z) b]
     simp only [QuadraticMap.polarBilin_apply_apply] at hfirst hsecond
     rw [hfirst, hsecond, sub_neg_eq_add, ← two_smul K, ← mul_smul,
       inv_mul_cancel₀ (Invertible.ne_zero (2 : K)), one_smul]
@@ -211,6 +171,20 @@ theorem dualBasis_polarBilin_killingQuadraticForm {ι : Type w} [Fintype ι]
   · simp only [mul_one, inv_mul_cancel₀ (Invertible.ne_zero (2 : K))]
   · simp only [mul_zero]
 
+/-- The dual basis for twice the Killing form is half the Killing-dual basis. This is the
+simp-normal form of `dualBasis_polarBilin_killingQuadraticForm`. -/
+@[simp]
+theorem dualBasis_two_smul_killingForm {ι : Type w} [Fintype ι]
+    [DecidableEq ι] {L : Type v} [LieRing L] [LieAlgebra K L]
+    [_root_.LieAlgebra.IsKilling K L]
+    (b : Module.Basis ι K L) (i : ι) :
+    LinearMap.BilinForm.dualBasis ((2 : K) • _root_.killingForm K L)
+        ((BilinForm.nondegenerate_smul_iff (isUnit_of_invertible (2 : K)).isRegular).mpr
+          (_root_.LieAlgebra.IsKilling.killingForm_nondegenerate K L)) b i =
+      (2 : K)⁻¹ • killingDualBasis b i := by
+  simpa only [_root_.TauCeti.LieAlgebra.polarBilin_killingQuadraticForm] using
+    dualBasis_polarBilin_killingQuadraticForm b i
+
 /-- **The adjoint quadratic lift in Killing-dual coordinates.** For any basis `b` of a
 finite-dimensional Killing-semisimple Lie algebra,
 `adjointCliffordHom K L x` is one quarter of the sum of the bivectors of `[x, b i]` with the
@@ -220,12 +194,13 @@ The formula is independent of `b`: its sum is the contraction of `adjointBivecto
 the canonical tensor represented by a basis and its Killing dual. -/
 theorem adjointCliffordHom_eq_sum_bivector {ι : Type w} [Fintype ι]
     [DecidableEq ι] {L : Type v} [LieRing L] [LieAlgebra K L]
-    [FiniteDimensional K L] [_root_.LieAlgebra.IsKilling K L]
+    [_root_.LieAlgebra.IsKilling K L]
     (b : Module.Basis ι K L) (x : L) :
-    adjointCliffordHom K L x =
+    @adjointCliffordHom K L _ _ _ b.finiteDimensional_of_finite _ _ x =
       (4 : K)⁻¹ • ∑ i, adjointBivector
         (_root_.TauCeti.LieAlgebra.killingQuadraticForm K L) x
         (b i) (killingDualBasis b i) := by
+  let _ := b.finiteDimensional_of_finite
   let Q := _root_.TauCeti.LieAlgebra.killingQuadraticForm K L
   rw [adjointCliffordHom_apply,
     soEquivQuadratic_eq_sum_bivector Q

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/Coordinates.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/Coordinates.lean
@@ -32,7 +32,7 @@ the basis-independent Killing contraction and root-space projection API.
 * `CliffordAlgebra.adjointBivector`: the bilinear map `(y, z) ↦ bivector Q [x, y] z`.
 * `CliffordAlgebra.soEquivQuadratic_eq_sum_bivector`: the coordinate formula for an arbitrary
   skew-adjoint endomorphism.
-* `Module.Basis.dualBasis_polarBilin_killingQuadraticForm`: the comparison between the
+* `Module.Basis.dualBasis_polarBilin_killingQuadraticForm_apply`: the comparison between the
   polar-dual and Killing-dual bases.
 * `CliffordAlgebra.adjointCliffordHom_eq_sum_bivector`: the adjoint lift as a `1 / 4`-scaled sum
   against a Killing-dual basis.
@@ -176,7 +176,7 @@ variable {K : Type u} [Field K] [Invertible (2 : K)]
 
 /-- The basis dual to `b` for the polar form of the Killing quadratic form is half the
 Killing-dual basis. The factor records that this polar form is `2 • killingForm K L`. -/
-theorem dualBasis_polarBilin_killingQuadraticForm {ι : Type w} [Fintype ι]
+theorem dualBasis_polarBilin_killingQuadraticForm_apply {ι : Type w} [Fintype ι]
     [DecidableEq ι] {L : Type v} [LieRing L] [LieAlgebra K L]
     [_root_.LieAlgebra.IsKilling K L]
     (b : Module.Basis ι K L) (i : ι) :
@@ -236,7 +236,7 @@ theorem adjointCliffordHom_eq_sum_bivector {ι : Type w} [Fintype ι]
           (QuadraticMap.nondegenerate_polar_iff.mpr
             (_root_.TauCeti.LieAlgebra.killingQuadraticForm_nondegenerate K L)) b i =
         (2 : K)⁻¹ • killingDualBasis b i :=
-    b.dualBasis_polarBilin_killingQuadraticForm i
+    b.dualBasis_polarBilin_killingQuadraticForm_apply i
   simp_rw [hdual]
   have hbiv (y z : L) : bivector Q y ((2 : K)⁻¹ • z) =
       (2 : K)⁻¹ • bivector Q y z := by

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/Coordinates.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/Coordinates.lean
@@ -1,0 +1,251 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Lie.UniversalEnveloping.Casimir
+public import TauCeti.LinearAlgebra.CliffordAlgebra.Quadratic.Lie.Representation
+
+/-!
+# Coordinate formulas for quadratic Clifford lifts
+
+The quadratic realization of a skew-adjoint endomorphism has a simple expression after choosing
+a basis: it is half the sum of the bivectors formed from the images of the basis vectors and the
+dual basis for the polar form. This file proves that formula without unfolding the exterior-square
+construction of `CliffordAlgebra.soEquivQuadratic`.
+
+For the adjoint lift associated to the Killing quadratic form, the polar form is twice the Killing
+form. Its polar-dual basis is therefore half the Killing-dual basis, and the two factors of one half
+combine to give the familiar coefficient `1 / 4`:
+
+```text
+adjointCliffordHom K L x = 1 / 4 • ∑ i, bivector Q ([x, b i]) (killingDualBasis b i).
+```
+
+The bundled bilinear map `CliffordAlgebra.adjointBivector` puts the summand in the form consumed by
+the basis-independent Killing contraction and root-space projection API.
+
+## Main results
+
+* `CliffordAlgebra.adjointBivector`: the bilinear map `(y, z) ↦ bivector Q [x, y] z`.
+* `CliffordAlgebra.soEquivQuadratic_eq_sum_bivector`: the coordinate formula for an arbitrary
+  skew-adjoint endomorphism.
+* `CliffordAlgebra.dualBasis_polarBilin_killingQuadraticForm`: the comparison between the
+  polar-dual and Killing-dual bases.
+* `CliffordAlgebra.adjointCliffordHom_eq_sum_bivector`: the adjoint lift as a `1 / 4`-scaled sum
+  against a Killing-dual basis.
+
+## References
+
+* [Tau Ceti Roadmap](https://github.com/TauCetiProject/TauCetiRoadmap), Representation Theory / Spin
+  Representations, Layer 9, "Kostant's isotypy corollary".
+-/
+
+public section
+
+
+universe u v w
+
+namespace CliffordAlgebra
+
+open TauCeti
+
+attribute [local instance 100] LieRing.ofAssociativeRing
+
+variable {K : Type u} [Field K] {V : Type v} [AddCommGroup V] [Module K V]
+  [FiniteDimensional K V] [Invertible (2 : K)]
+
+/-- The bilinear Clifford bivector obtained by applying `ad x` in the first slot.
+
+Bundling the summand in the adjoint coordinate formula lets the canonical Killing-dual contraction
+lemmas, in particular `TauCeti.sum_apply_killingDualBasis_eq`, act on it directly. -/
+noncomputable def adjointBivector {R : Type u} [CommRing R] [Invertible (2 : R)]
+    {L : Type v} [LieRing L] [LieAlgebra R L]
+    (Q : QuadraticForm R L) (x : L) : L →ₗ[R] L →ₗ[R] CliffordAlgebra Q :=
+  LinearMap.mk₂ R (fun y z ↦ bivector Q ⁅x, y⁆ z)
+    (fun y₁ y₂ z ↦ by simp only [lie_add, map_add, add_mul, mul_add, bivector_def]; module)
+    (fun c y z ↦ by
+      simp only [lie_smul, map_smul, smul_mul_assoc, mul_smul_comm, bivector_def]
+      module)
+    (fun y z₁ z₂ ↦ by simp only [map_add, add_mul, mul_add, bivector_def]; module)
+    (fun c y z ↦ by
+      simp only [map_smul, smul_mul_assoc, mul_smul_comm, bivector_def]
+      module)
+
+/-- The adjoint bivector map evaluates to the bivector of `[x, y]` and `z`. -/
+@[simp]
+theorem adjointBivector_apply {R : Type u} [CommRing R] [Invertible (2 : R)]
+    {L : Type v} [LieRing L] [LieAlgebra R L]
+    (Q : QuadraticForm R L) (x y z : L) :
+    adjointBivector Q x y z = bivector Q ⁅x, y⁆ z := by
+  rfl
+
+omit [FiniteDimensional K V] in
+private theorem sum_polar_dual_smul_basis {ι : Type w} [Fintype ι] [DecidableEq ι]
+    (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) (b : Module.Basis ι K V) (x : V) :
+    ∑ i, Q.polarBilin (LinearMap.BilinForm.dualBasis Q.polarBilin
+        (QuadraticMap.nondegenerate_polar_iff.mpr hQ) b i) x • b i = x := by
+  let B := Q.polarBilin
+  let hB : B.Nondegenerate := QuadraticMap.nondegenerate_polar_iff.mpr hQ
+  let d := LinearMap.BilinForm.dualBasis B hB b
+  calc
+    _ = ∑ i, b.repr x i • b i := by
+      apply Finset.sum_congr rfl
+      intro i _
+      congr 1
+      calc
+        B (d i) x = B x (d i) := QuadraticMap.polar_comm Q (d i) x
+        _ = (LinearMap.BilinForm.dualBasis B hB d).repr x i :=
+          (LinearMap.BilinForm.dualBasis_repr_apply hB d x i).symm
+        _ = b.repr x i := by
+          rw [LinearMap.BilinForm.dualBasis_dualBasis hB
+            (LinearMap.BilinForm.isSymm_def.mpr fun y z ↦ QuadraticMap.polar_comm Q y z) b]
+    _ = x := b.sum_repr x
+
+omit [FiniteDimensional K V] in
+private theorem sum_polar_basis_smul_dual {ι : Type w} [Fintype ι] [DecidableEq ι]
+    (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) (b : Module.Basis ι K V) (x : V) :
+    ∑ i, Q.polarBilin (b i) x • LinearMap.BilinForm.dualBasis Q.polarBilin
+        (QuadraticMap.nondegenerate_polar_iff.mpr hQ) b i = x := by
+  let B := Q.polarBilin
+  let hB : B.Nondegenerate := QuadraticMap.nondegenerate_polar_iff.mpr hQ
+  let d := LinearMap.BilinForm.dualBasis B hB b
+  calc
+    _ = ∑ i, d.repr x i • d i := by
+      apply Finset.sum_congr rfl
+      intro i _
+      congr 1
+      rw [LinearMap.BilinForm.dualBasis_repr_apply]
+      exact QuadraticMap.polar_comm Q (b i) x
+    _ = x := d.sum_repr x
+
+/-- **The coordinate formula for the quadratic realization.** If `d` is the basis dual to `b`
+for the polar form of `Q`, then the quadratic element realizing a skew-adjoint endomorphism `f` is
+`1 / 2 • ∑ i, bivector Q (f (b i)) (d i)`.
+
+Indeed, commuting the unscaled sum with a Clifford generator gives two copies of `f x`: one by
+expanding `x` in `b`, and one by skew-adjointness followed by expansion in `d`. -/
+theorem soEquivQuadratic_eq_sum_bivector {ι : Type w} [Fintype ι] [DecidableEq ι]
+    (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) (b : Module.Basis ι K V)
+    (f : skewAdjointLieSubalgebra Q.polarBilin) :
+    (soEquivQuadratic Q hQ f : CliffordAlgebra Q) =
+      (2 : K)⁻¹ • ∑ i, bivector Q ((f : Module.End K V) (b i))
+        (LinearMap.BilinForm.dualBasis Q.polarBilin
+          (QuadraticMap.nondegenerate_polar_iff.mpr hQ) b i) := by
+  let d := LinearMap.BilinForm.dualBasis Q.polarBilin
+    (QuadraticMap.nondegenerate_polar_iff.mpr hQ) b
+  let a : quadraticLieSubalgebra Q :=
+    ⟨(2 : K)⁻¹ • ∑ i, bivector Q ((f : Module.End K V) (b i)) (d i),
+      (quadraticLieSubalgebra Q).smul_mem _ <|
+        (quadraticLieSubalgebra Q).sum_mem fun i _ ↦
+          bivector_mem_quadraticLieSubalgebra Q ((f : Module.End K V) (b i)) (d i)⟩
+  have ha : soEquivQuadratic Q hQ f = a := by
+    apply quadraticLieSubalgebra_ext Q hQ
+    intro x
+    rw [soEquivQuadratic_lie_ι]
+    dsimp only [a]
+    rw [smul_lie, sum_lie]
+    simp_rw [bivector_lie_ι]
+    rw [← map_sum, ← map_smul]
+    congr 1
+    rw [Finset.sum_sub_distrib]
+    have hfirst :
+        ∑ i, Q.polarBilin (d i) x • (f : Module.End K V) (b i) =
+          (f : Module.End K V) x := by
+      calc
+        _ = (f : Module.End K V) (∑ i, Q.polarBilin (d i) x • b i) := by
+          rw [map_sum]
+          simp only [map_smul]
+        _ = (f : Module.End K V) x := by
+          rw [sum_polar_dual_smul_basis Q hQ b x]
+    have hskew (i : ι) :
+        Q.polarBilin ((f : Module.End K V) (b i)) x =
+          -Q.polarBilin (b i) ((f : Module.End K V) x) := by
+      simpa using f.property (b i) x
+    have hsecond :
+        ∑ i, Q.polarBilin ((f : Module.End K V) (b i)) x • d i =
+          -(f : Module.End K V) x := by
+      calc
+        _ = ∑ i, -(Q.polarBilin (b i) ((f : Module.End K V) x) • d i) := by
+          apply Finset.sum_congr rfl
+          intro i _
+          rw [hskew, neg_smul]
+        _ = -(∑ i, Q.polarBilin (b i) ((f : Module.End K V) x) • d i) := by
+          rw [Finset.sum_neg_distrib]
+        _ = -(f : Module.End K V) x := by
+          rw [sum_polar_basis_smul_dual Q hQ b]
+    simp only [QuadraticMap.polarBilin_apply_apply] at hfirst hsecond
+    rw [hfirst, hsecond, sub_neg_eq_add, ← two_smul K, ← mul_smul,
+      inv_mul_cancel₀ (Invertible.ne_zero (2 : K)), one_smul]
+  simpa [a, d] using congrArg Subtype.val ha
+
+/-- The basis dual to `b` for the polar form of the Killing quadratic form is half the
+Killing-dual basis. The factor records that this polar form is `2 • killingForm K L`. -/
+theorem dualBasis_polarBilin_killingQuadraticForm {ι : Type w} [Fintype ι]
+    [DecidableEq ι] {L : Type v} [LieRing L] [LieAlgebra K L]
+    [_root_.LieAlgebra.IsKilling K L]
+    (b : Module.Basis ι K L) (i : ι) :
+    LinearMap.BilinForm.dualBasis
+        (_root_.TauCeti.LieAlgebra.killingQuadraticForm K L).polarBilin
+        (QuadraticMap.nondegenerate_polar_iff.mpr
+          (_root_.TauCeti.LieAlgebra.killingQuadraticForm_nondegenerate K L)) b i =
+      (2 : K)⁻¹ • killingDualBasis b i := by
+  let Q := _root_.TauCeti.LieAlgebra.killingQuadraticForm K L
+  let B := Q.polarBilin
+  let hB : LinearMap.BilinForm.Nondegenerate B :=
+    QuadraticMap.nondegenerate_polar_iff.mpr
+      (_root_.TauCeti.LieAlgebra.killingQuadraticForm_nondegenerate K L)
+  let d := LinearMap.BilinForm.dualBasis B hB b
+  apply LinearMap.ker_eq_bot.mp hB.ker_eq_bot
+  apply b.ext
+  intro j
+  simp only [map_smul]
+  rw [LinearMap.BilinForm.apply_dualBasis_left]
+  simp only [B, Q, _root_.TauCeti.LieAlgebra.polarBilin_killingQuadraticForm,
+    LinearMap.smul_apply, smul_eq_mul]
+  rw [LieModule.traceForm_comm K L L (killingDualBasis b i) (b j),
+    killingForm_killingDualBasis]
+  split_ifs
+  · simp only [mul_one, inv_mul_cancel₀ (Invertible.ne_zero (2 : K))]
+  · simp only [mul_zero]
+
+/-- **The adjoint quadratic lift in Killing-dual coordinates.** For any basis `b` of a
+finite-dimensional Killing-semisimple Lie algebra,
+`adjointCliffordHom K L x` is one quarter of the sum of the bivectors of `[x, b i]` with the
+Killing-dual basis vectors.
+
+The formula is independent of `b`: its sum is the contraction of `adjointBivector Q x` against
+the canonical tensor represented by a basis and its Killing dual. -/
+theorem adjointCliffordHom_eq_sum_bivector {ι : Type w} [Fintype ι]
+    [DecidableEq ι] {L : Type v} [LieRing L] [LieAlgebra K L]
+    [FiniteDimensional K L] [_root_.LieAlgebra.IsKilling K L]
+    (b : Module.Basis ι K L) (x : L) :
+    adjointCliffordHom K L x =
+      (4 : K)⁻¹ • ∑ i, adjointBivector
+        (_root_.TauCeti.LieAlgebra.killingQuadraticForm K L) x
+        (b i) (killingDualBasis b i) := by
+  let Q := _root_.TauCeti.LieAlgebra.killingQuadraticForm K L
+  rw [adjointCliffordHom_apply,
+    soEquivQuadratic_eq_sum_bivector Q
+      (_root_.TauCeti.LieAlgebra.killingQuadraticForm_nondegenerate K L) b]
+  simp only [_root_.TauCeti.LieAlgebra.coe_killingAdjointSO, _root_.LieAlgebra.ad_apply]
+  have hdual (i : ι) :
+      LinearMap.BilinForm.dualBasis Q.polarBilin
+          (QuadraticMap.nondegenerate_polar_iff.mpr
+            (_root_.TauCeti.LieAlgebra.killingQuadraticForm_nondegenerate K L)) b i =
+        (2 : K)⁻¹ • killingDualBasis b i :=
+    dualBasis_polarBilin_killingQuadraticForm b i
+  simp_rw [hdual]
+  have hbiv (y z : L) : bivector Q y ((2 : K)⁻¹ • z) =
+      (2 : K)⁻¹ • bivector Q y z := by
+    simp only [bivector_def, map_smul, smul_mul_assoc, mul_smul_comm]
+    module
+  simp_rw [hbiv, adjointBivector_apply]
+  rw [← Finset.smul_sum, smul_smul]
+  congr 1
+  rw [← mul_inv_rev]
+  norm_num
+
+end CliffordAlgebra

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/Representation.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/Representation.lean
@@ -29,6 +29,8 @@ Clifford action makes the target Clifford module a module for the original Lie a
 * `CliffordAlgebra.cliffordDerivationRep_apply`: its defining commutator equation.
 * `CliffordAlgebra.adjointCliffordHom`: the quadratic lift of the adjoint representation
   for a Killing-semisimple Lie algebra.
+* `CliffordAlgebra.adjointCliffordHom_apply`: the lift as the quadratic realization of the
+  Killing adjoint action.
 * `CliffordAlgebra.adjointCliffordHom_lie_ι`: the lift acts on Clifford generators by the
   original adjoint action.
 * `CliffordAlgebra.adjointCliffordHom_injective`: the lift is injective, since the adjoint action
@@ -151,6 +153,18 @@ noncomputable def adjointCliffordHom (K : Type u) (L : Type v) [Field K]
   quadraticLift (_root_.TauCeti.LieAlgebra.killingQuadraticForm K L)
     (_root_.TauCeti.LieAlgebra.killingQuadraticForm_nondegenerate K L)
     (_root_.TauCeti.LieAlgebra.killingAdjointSO K L)
+
+/-- The adjoint Clifford homomorphism is the quadratic realization of the Killing adjoint
+action. -/
+theorem adjointCliffordHom_apply (K : Type u) (L : Type v) [Field K]
+    [LieRing L] [LieAlgebra K L] [FiniteDimensional K L] [Invertible (2 : K)]
+    [_root_.LieAlgebra.IsKilling K L] (x : L) :
+    adjointCliffordHom K L x =
+      (soEquivQuadratic (_root_.TauCeti.LieAlgebra.killingQuadraticForm K L)
+        (_root_.TauCeti.LieAlgebra.killingQuadraticForm_nondegenerate K L)
+        (_root_.TauCeti.LieAlgebra.killingAdjointSO K L x) :
+          CliffordAlgebra (_root_.TauCeti.LieAlgebra.killingQuadraticForm K L)) := by
+  rfl
 
 /-- The adjoint quadratic lift acts on Clifford generators by the original adjoint action. -/
 @[simp, grind =]

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/Representation.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/Representation.lean
@@ -139,7 +139,7 @@ theorem cliffordDerivationRep_apply {K : Type u} [Field K]
 
 /-- The quadratic lift of the adjoint representation of a Killing-semisimple Lie algebra into the
 Clifford algebra of its Killing quadratic form. -/
-@[expose] noncomputable def adjointCliffordHom (K : Type u) (L : Type v) [Field K]
+noncomputable def adjointCliffordHom (K : Type u) (L : Type v) [Field K]
     [LieRing L] [LieAlgebra K L] [FiniteDimensional K L] [Invertible (2 : K)]
     [_root_.LieAlgebra.IsKilling K L] :
     L →ₗ⁅K⁆ CliffordAlgebra (_root_.TauCeti.LieAlgebra.killingQuadraticForm K L) :=
@@ -147,8 +147,21 @@ Clifford algebra of its Killing quadratic form. -/
     (_root_.TauCeti.LieAlgebra.killingQuadraticForm_nondegenerate K L)
     (_root_.TauCeti.LieAlgebra.killingAdjointSO K L)
 
-/-- The adjoint quadratic lift acts on Clifford generators by the original adjoint action. -/
+/-- The adjoint Clifford homomorphism is the quadratic realization of the Killing adjoint
+action. -/
 @[simp, grind =]
+theorem adjointCliffordHom_apply (K : Type u) (L : Type v) [Field K]
+    [LieRing L] [LieAlgebra K L] [FiniteDimensional K L] [Invertible (2 : K)]
+    [_root_.LieAlgebra.IsKilling K L] (x : L) :
+    adjointCliffordHom K L x =
+      (soEquivQuadratic (_root_.TauCeti.LieAlgebra.killingQuadraticForm K L)
+        (_root_.TauCeti.LieAlgebra.killingQuadraticForm_nondegenerate K L)
+        (_root_.TauCeti.LieAlgebra.killingAdjointSO K L x) :
+          CliffordAlgebra (_root_.TauCeti.LieAlgebra.killingQuadraticForm K L)) := by
+  rfl
+
+/-- The adjoint quadratic lift acts on Clifford generators by the original adjoint action. -/
+@[grind =]
 theorem adjointCliffordHom_lie_ι (K : Type u) (L : Type v) [Field K]
     [LieRing L] [LieAlgebra K L] [FiniteDimensional K L] [Invertible (2 : K)]
     [_root_.LieAlgebra.IsKilling K L] (x y : L) :

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/Representation.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/Representation.lean
@@ -29,8 +29,6 @@ Clifford action makes the target Clifford module a module for the original Lie a
 * `CliffordAlgebra.cliffordDerivationRep_apply`: its defining commutator equation.
 * `CliffordAlgebra.adjointCliffordHom`: the quadratic lift of the adjoint representation
   for a Killing-semisimple Lie algebra.
-* `CliffordAlgebra.adjointCliffordHom_apply`: the lift as the quadratic realization of the
-  Killing adjoint action.
 * `CliffordAlgebra.adjointCliffordHom_lie_ι`: the lift acts on Clifford generators by the
   original adjoint action.
 * `CliffordAlgebra.adjointCliffordHom_injective`: the lift is injective, since the adjoint action
@@ -141,26 +139,13 @@ theorem cliffordDerivationRep_apply {K : Type u} [Field K]
 
 /-- The quadratic lift of the adjoint representation of a Killing-semisimple Lie algebra into the
 Clifford algebra of its Killing quadratic form. -/
-noncomputable def adjointCliffordHom (K : Type u) (L : Type v) [Field K]
+@[expose] noncomputable def adjointCliffordHom (K : Type u) (L : Type v) [Field K]
     [LieRing L] [LieAlgebra K L] [FiniteDimensional K L] [Invertible (2 : K)]
     [_root_.LieAlgebra.IsKilling K L] :
     L →ₗ⁅K⁆ CliffordAlgebra (_root_.TauCeti.LieAlgebra.killingQuadraticForm K L) :=
   quadraticLift (_root_.TauCeti.LieAlgebra.killingQuadraticForm K L)
     (_root_.TauCeti.LieAlgebra.killingQuadraticForm_nondegenerate K L)
     (_root_.TauCeti.LieAlgebra.killingAdjointSO K L)
-
-/-- The adjoint Clifford homomorphism is the quadratic realization of the Killing adjoint
-action. -/
-@[grind =]
-theorem adjointCliffordHom_apply (K : Type u) (L : Type v) [Field K]
-    [LieRing L] [LieAlgebra K L] [FiniteDimensional K L] [Invertible (2 : K)]
-    [_root_.LieAlgebra.IsKilling K L] (x : L) :
-    adjointCliffordHom K L x =
-      (soEquivQuadratic (_root_.TauCeti.LieAlgebra.killingQuadraticForm K L)
-        (_root_.TauCeti.LieAlgebra.killingQuadraticForm_nondegenerate K L)
-        (_root_.TauCeti.LieAlgebra.killingAdjointSO K L x) :
-          CliffordAlgebra (_root_.TauCeti.LieAlgebra.killingQuadraticForm K L)) := by
-  rfl
 
 /-- The adjoint quadratic lift acts on Clifford generators by the original adjoint action. -/
 @[simp, grind =]

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/Representation.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/Representation.lean
@@ -156,6 +156,7 @@ noncomputable def adjointCliffordHom (K : Type u) (L : Type v) [Field K]
 
 /-- The adjoint Clifford homomorphism is the quadratic realization of the Killing adjoint
 action. -/
+@[grind =]
 theorem adjointCliffordHom_apply (K : Type u) (L : Type v) [Field K]
     [LieRing L] [LieAlgebra K L] [FiniteDimensional K L] [Invertible (2 : K)]
     [_root_.LieAlgebra.IsKilling K L] (x : L) :

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/Representation.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/Representation.lean
@@ -35,11 +35,6 @@ Clifford action makes the target Clifford module a module for the original Lie a
   original adjoint action.
 * `CliffordAlgebra.adjointCliffordHom_injective`: the lift is injective, since the adjoint action
   it encodes is faithful.
-
-## References
-
-* [Tau Ceti Roadmap](https://github.com/TauCetiProject/TauCetiRoadmap), Representation Theory / Spin
-  Representations, Layer 9, "Every Clifford module is a `𝔤`-module".
 -/
 
 public section


### PR DESCRIPTION
This PR computes the adjoint Clifford lift in basis coordinates for the SpinRepresentations Layer 9 Killing Cartan/root-weight prerequisite to Kostant isotypy.

Roadmap: RepresentationTheory

## Summary

Express the quadratic realization of a skew-adjoint endomorphism as one half of its bivector contraction against a polar-dual basis. Specialize that formula to the Killing quadratic form, prove that its polar-dual basis is one half of the Killing-dual basis, and obtain the normalized formula

`adjointCliffordHom K L x = (4 : K)⁻¹ • ∑ i, bivector Q [x, b i] (killingDualBasis b i)`.

Package the summand as the bilinear map `adjointBivector Q x`, so the next root calculation can apply the existing basis-independent Killing contraction and opposite-root projection theorems directly. Derive the coordinate reconstructions from Mathlib's dual-basis API and infer finite dimensionality from the supplied finite bases.

Keep `adjointCliffordHom` opaque and provide `adjointCliffordHom_apply` as its characteristic simplification and `grind` equation. The coordinate theorem uses that stable application boundary rather than exposing the composite implementation. Place the generic scalar-multiple dual-basis formula in the bilinear-form infrastructure, the Killing-dual basis and both biorthogonality orientations in `Algebra.Lie.Killing.DualBasis`, and the polar/Killing specialization beside the Killing quadratic-form API. Cite the mathematical source for the quadratic realization and Killing-form construction while keeping roadmap attribution in this PR description rather than Lean documentation.

## Roadmap target

This advances RepresentationTheory/SpinRepresentations Layer 9, specifically the Killing Cartan/root-weight calculation required by the Kostant isotypy summit. It supplies the missing coordinate form of the adjoint quadratic lift, with its sign and `1/4` normalization fixed. After this PR, it remains to split the contraction along opposite root spaces, identify the resulting Cartan weight with the Weyl vector, and prove the isotypy statement.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"adjointcliffordhom-eq-sum-bivector"}-->

## Verification

- Exact head: `8e681eea20dac32deb29197aebfc16fbf68d1bd8`
- Local Lean build: `lake build` — pass (`Build completed successfully (10972 jobs).`)
- Axiom audit: `lake exe axioms` — pass (`axioms: audited 108231 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`)
- Lint: `lake exe module-system`, `bash scripts/lint-env.sh` with GNU `sed`, `python3 scripts/lint-dot-notation.py`, and `bash scripts/lint-style.sh` — pass (4,821 modules; 8,710 documented declarations and no new environment-lint violations; 0 new dot-notation findings; 4,820 conforming headers)
- Proof golf: pinned structural survey and compiled replacement probes — pass; retained the opacity-safe adjoint application boundary, generalized the scalar dual-basis calculation, and removed two redundant imports
- Public CI: pending for the updated head

## Scale and generality

The six-file aggregate adds 485 lines and removes 160 lines relative to its merge base. `adjointBivector` works over any commutative ring in which two is invertible. Both coordinate formulas infer finite dimensionality from their finite-indexed bases rather than exposing an extra typeclass assumption. `Module.Basis.dualBasis_smul_apply` works for any nondegenerate bilinear form over a field and any nonzero scalar, with no symmetry or Lie-algebra hypothesis. The formulas work uniformly for every finite basis, including the zero-dimensional boundary. No Mathlib code or external formalization is vendored.

## Scope

- **Consumes:** `soEquivQuadratic_lie_ι`, `quadraticLieSubalgebra_ext`, Mathlib's dual-basis equations, and Tau Ceti's Killing-form and polar-form APIs.
- **Provides:** `adjointBivector` with its application equation, the generic quadratic coordinate theorem, scalar and Killing dual-basis normalization lemmas, symmetric Killing biorthogonality, the opacity-safe `adjointCliffordHom_apply` boundary, and the `1/4` adjoint coordinate formula.
- **Fits:** turns the merged abstract adjoint quadratic lift into the exact bilinear Killing contraction consumed by the Layer 9 opposite-root projection and Weyl-vector calculation.
- **Boundary:** does not perform the root-space split, calculate the Weyl-vector weight, or claim Kostant isotypy; those are the next milestone steps.

<sub>🤖 GPT-5.6 Sol high · TauCetiWorker @ [910d954fee75dfafda41f98165ce3a9e6676eae1](https://github.com/utensil/TauCetiWorker/commit/910d954fee75dfafda41f98165ce3a9e6676eae1) · rubrics @ [afb424eda89e8ac96d9eb69f6a88972055a4cd1b](https://github.com/utensil/TauCetiReview/commit/afb424eda89e8ac96d9eb69f6a88972055a4cd1b) · local review @ [b533e561b6d44df071c31335ed4a63ae647507d2](https://github.com/utensil/formal-land/commit/b533e561b6d44df071c31335ed4a63ae647507d2) · fixed: api-design, attribution, documentation, generality, naming, placement, reuse</sub>