### PR TITLE
feat: expose the rational-to-complex base-change tower

### DIFF
--- a/TauCeti/Geometry/Hodge/BaseChange.lean
+++ b/TauCeti/Geometry/Hodge/BaseChange.lean
@@ -184,8 +184,8 @@ theorem isBaseChange_rationalToComplexMap (hℚ : IsBaseChange ℚ ιℚ)
 /-- The two abstract legs `Vℤ → Vℚ → Vℂ` compose to a base change from `ℤ` to `ℂ`. -/
 theorem isBaseChange_rationalToComplexMap_comp (hℚ : IsBaseChange ℚ ιℚ)
     (hℂ : IsBaseChange ℂ ιℂ) :
-    IsBaseChange ℂ ((rationalToComplexMap hℚ ιℂ).restrictScalars ℤ ∘ₗ ιℚ) :=
-  hℚ.comp (isBaseChange_rationalToComplexMap hℚ hℂ)
+    IsBaseChange ℂ ((rationalToComplexMap hℚ ιℂ).restrictScalars ℤ ∘ₗ ιℚ) := by
+  simpa only [rationalToComplexMap_restrictScalars_comp] using hℂ
 
 /-- On a purely rational vector the tower equivalence agrees with the rational-to-complex
 structure map. -/

--- a/TauCeti/Geometry/Hodge/BaseChange.lean
+++ b/TauCeti/Geometry/Hodge/BaseChange.lean
@@ -33,8 +33,12 @@ imposed later as structure data.
 
 ## Main declarations
 
-* `TauCeti.Hodge.rationalToComplexLinearEquiv`: the canonical tower equivalence from an abstract
+* `TauCeti.Hodge.rationalToComplexMap`: the canonical structure map from an abstract
   rationalification to an abstract complexification.
+* `TauCeti.Hodge.isBaseChange_rationalToComplexMap`: the complex space is the base change of the
+  rational space along this structure map.
+* `TauCeti.Hodge.rationalToComplexLinearEquiv`: the canonical tower equivalence between the
+  concrete rational base change and the abstract complexification.
 * `TauCeti.Hodge.rationalToComplexSubmodule`: the complexification of a rational subspace inside
   the chosen ambient complexification.
 * `TauCeti.Hodge.rationalToComplexSubmoduleEquiv`: the canonical identification of the concrete
@@ -54,10 +58,11 @@ imposed later as structure data.
 * `TauCeti.Hodge.rationalToComplexSubmodule_le_iff`: an inclusion of rational subspaces can be
   tested on their complexifications.
 
-The design follows the base-change interface specified in the Hodge structures roadmap. Its only
-nontrivial comparison map is Mathlib's
-`TensorProduct.AlgebraTensorModule.cancelBaseChange`, which cancels the middle `ℚ` in the concrete
-tower before the result is transported to the two abstract models.
+The design follows the base-change interface specified in the Hodge structures roadmap. The
+`ℚ → ℂ` structure map is obtained from the universal property of the first leg, and Mathlib's
+`IsBaseChange.comp` and `IsBaseChange.of_comp` show that it is the second leg of a base-change
+tower. Consumers needing only this property can therefore use it directly; the concrete tower
+equivalence remains available for constructions which need an equivalence as data.
 
 ## References
 
@@ -105,6 +110,62 @@ theorem integralMapToComplex_ratTensorMap {U U' : Type*} [AddCommGroup U] [Modul
   (isBaseChange_ratTensorMap ℂ U).algHom_ext _ _ fun u ↦ by
     rw [integralMapToComplex_apply_ι, ratTensorMap_apply, ratTensorMap_apply,
       LinearMap.restrictScalars_apply, LinearMap.baseChange_tmul]
+
+noncomputable section RationalComplexMap
+
+local instance : Module ℚ Vℂ := Module.restrictScalars ℚ ℂ Vℂ
+local instance : IsScalarTower ℚ ℂ Vℂ := IsScalarTower.restrictScalars ℚ ℂ Vℂ
+local instance : IsScalarTower ℤ ℚ ℂ where
+  smul_assoc z q w := by
+    norm_num [Algebra.smul_def, smul_eq_mul]
+    ring
+local instance : IsScalarTower ℤ ℚ Vℂ := IsScalarTower.to₁₂₄ ℤ ℚ ℂ Vℂ
+
+/-- The canonical `ℚ`-linear structure map from an abstract rationalification to an abstract
+complexification of the same integral module.
+
+It is the unique map whose composite with the integral structure map `ιℚ` is `ιℂ`. -/
+noncomputable def rationalToComplexMap (hℚ : IsBaseChange ℚ ιℚ) (ιℂ : Vℤ →ₗ[ℤ] Vℂ) :
+    Vℚ →ₗ[ℚ] Vℂ :=
+  hℚ.lift ιℂ
+
+/-- The rational-to-complex structure map carries an integral vector to the corresponding vector
+in the complexification. -/
+@[simp]
+theorem rationalToComplexMap_apply_ι (hℚ : IsBaseChange ℚ ιℚ) (ιℂ : Vℤ →ₗ[ℤ] Vℂ) (x : Vℤ) :
+    rationalToComplexMap hℚ ιℂ (ιℚ x) = ιℂ x := by
+  exact LinearMap.congr_fun (hℚ.lift_comp ιℂ) x
+
+/-- Composing the rational-to-complex structure map with rationalification recovers the given
+integral-to-complex structure map. -/
+@[simp]
+theorem rationalToComplexMap_restrictScalars_comp (hℚ : IsBaseChange ℚ ιℚ)
+    (ιℂ : Vℤ →ₗ[ℤ] Vℂ) :
+    (rationalToComplexMap hℚ ιℂ).restrictScalars ℤ ∘ₗ ιℚ = ιℂ :=
+  hℚ.lift_comp ιℂ
+
+/-- The rational-to-complex structure map is the unique `ℚ`-linear map extending `ιℂ` along
+`ιℚ`. -/
+theorem rationalToComplexMap_eq_of_restrictScalars_comp_eq (hℚ : IsBaseChange ℚ ιℚ)
+    (ιℂ : Vℤ →ₗ[ℤ] Vℂ) (f : Vℚ →ₗ[ℚ] Vℂ)
+    (hf : f.restrictScalars ℤ ∘ₗ ιℚ = ιℂ) : f = rationalToComplexMap hℚ ιℂ := by
+  apply hℚ.algHom_ext'
+  rw [hf, rationalToComplexMap_restrictScalars_comp]
+
+/-- The abstract complexification is the base change of the abstract rationalification along the
+canonical rational-to-complex structure map. -/
+theorem isBaseChange_rationalToComplexMap (hℚ : IsBaseChange ℚ ιℚ)
+    (hℂ : IsBaseChange ℂ ιℂ) : IsBaseChange ℂ (rationalToComplexMap hℚ ιℂ) := by
+  apply IsBaseChange.of_comp hℚ
+  simpa only [rationalToComplexMap_restrictScalars_comp] using hℂ
+
+/-- The two abstract legs `Vℤ → Vℚ → Vℂ` compose to a base change from `ℤ` to `ℂ`. -/
+theorem isBaseChange_rationalToComplexMap_comp (hℚ : IsBaseChange ℚ ιℚ)
+    (hℂ : IsBaseChange ℂ ιℂ) :
+    IsBaseChange ℂ ((rationalToComplexMap hℚ ιℂ).restrictScalars ℤ ∘ₗ ιℚ) :=
+  hℚ.comp (isBaseChange_rationalToComplexMap hℚ hℂ)
+
+end RationalComplexMap
 
 /-- The canonical tower equivalence from an abstract rational base change to an abstract complex
 base change of the same integral module. -/

--- a/TauCeti/Geometry/Hodge/BaseChange.lean
+++ b/TauCeti/Geometry/Hodge/BaseChange.lean
@@ -181,12 +181,6 @@ theorem isBaseChange_rationalToComplexMap (hℚ : IsBaseChange ℚ ιℚ)
   apply IsBaseChange.of_comp hℚ
   simpa only [rationalToComplexMap_restrictScalars_comp] using hℂ
 
-/-- The two abstract legs `Vℤ → Vℚ → Vℂ` compose to a base change from `ℤ` to `ℂ`. -/
-theorem isBaseChange_rationalToComplexMap_comp (hℚ : IsBaseChange ℚ ιℚ)
-    (hℂ : IsBaseChange ℂ ιℂ) :
-    IsBaseChange ℂ ((rationalToComplexMap hℚ ιℂ).restrictScalars ℤ ∘ₗ ιℚ) := by
-  simpa only [rationalToComplexMap_restrictScalars_comp] using hℂ
-
 /-- On a purely rational vector the tower equivalence agrees with the rational-to-complex
 structure map. -/
 theorem rationalToComplexLinearEquiv_one_tmul (hℚ : IsBaseChange ℚ ιℚ)

--- a/TauCeti/Geometry/Hodge/BaseChange.lean
+++ b/TauCeti/Geometry/Hodge/BaseChange.lean
@@ -133,14 +133,20 @@ noncomputable def rationalToComplexMap (hℚ : IsBaseChange ℚ ιℚ) (ιℂ : 
   hℚ.lift ιℂ
 
 /-- The rational-to-complex structure map carries an integral vector to the corresponding vector
-in the complexification. -/
+in the complexification.
+
+This is the elementwise characterization of `rationalToComplexMap`, whose body is not exposed, so
+Mathlib's `IsBaseChange.lift_eq` does not apply to such a goal outside this module. -/
 @[simp]
 theorem rationalToComplexMap_apply_ι (hℚ : IsBaseChange ℚ ιℚ) (ιℂ : Vℤ →ₗ[ℤ] Vℂ) (x : Vℤ) :
-    rationalToComplexMap hℚ ιℂ (ιℚ x) = ιℂ x := by
-  exact LinearMap.congr_fun (hℚ.lift_comp ιℂ) x
+    rationalToComplexMap hℚ ιℂ (ιℚ x) = ιℂ x :=
+  hℚ.lift_eq ιℂ x
 
 /-- Composing the rational-to-complex structure map with rationalification recovers the given
-integral-to-complex structure map. -/
+integral-to-complex structure map.
+
+This is the composite characterization of `rationalToComplexMap`, whose body is not exposed, so
+Mathlib's `IsBaseChange.lift_comp` does not apply to such a goal outside this module. -/
 @[simp]
 theorem rationalToComplexMap_restrictScalars_comp (hℚ : IsBaseChange ℚ ιℚ)
     (ιℂ : Vℤ →ₗ[ℤ] Vℂ) :

--- a/TauCeti/Geometry/Hodge/BaseChange.lean
+++ b/TauCeti/Geometry/Hodge/BaseChange.lean
@@ -373,6 +373,19 @@ theorem rationalMapToComplex_rationalToComplexLinearEquiv_tmul
       rationalToComplexLinearEquiv h'ℚ h'ℂ (z ⊗ₜ[ℚ] f x) := by
   simp [rationalMapToComplex]
 
+/-- Complexification of a rational map is natural for the rational-to-complex structure maps:
+it carries the image of a rational vector to the image of its value under the map. -/
+@[simp]
+theorem rationalMapToComplex_rationalToComplexMap
+    (hℚ : IsBaseChange ℚ ιℚ) (hℂ : IsBaseChange ℂ ιℂ)
+    (h'ℚ : IsBaseChange ℚ ι'ℚ) (h'ℂ : IsBaseChange ℂ ι'ℂ)
+    (f : Vℚ →ₗ[ℚ] V'ℚ) (x : Vℚ) :
+    rationalMapToComplex hℚ hℂ h'ℚ h'ℂ f (rationalToComplexMap hℚ ιℂ x) =
+      rationalToComplexMap h'ℚ ι'ℂ (f x) := by
+  rw [← rationalToComplexLinearEquiv_one_tmul hℚ hℂ,
+    ← rationalToComplexLinearEquiv_one_tmul h'ℚ h'ℂ,
+    rationalMapToComplex_rationalToComplexLinearEquiv_tmul]
+
 /-- Complexification sends the identity rational map to the identity complex map. -/
 @[simp]
 theorem rationalMapToComplex_id (hℚ : IsBaseChange ℚ ιℚ)

--- a/TauCeti/Geometry/Hodge/BaseChange.lean
+++ b/TauCeti/Geometry/Hodge/BaseChange.lean
@@ -58,11 +58,13 @@ imposed later as structure data.
 * `TauCeti.Hodge.rationalToComplexSubmodule_le_iff`: an inclusion of rational subspaces can be
   tested on their complexifications.
 
-The design follows the base-change interface specified in the Hodge structures roadmap. The
-`ℚ → ℂ` structure map is obtained from the universal property of the first leg, and Mathlib's
-`IsBaseChange.comp` and `IsBaseChange.of_comp` show that it is the second leg of a base-change
-tower. Consumers needing only this property can therefore use it directly; the concrete tower
-equivalence remains available for constructions which need an equivalence as data.
+The tower is available in two presentations. The structure map `rationalToComplexMap` and the
+witness `isBaseChange_rationalToComplexMap` describe `Vℂ` as the complex scalar extension of `Vℚ`;
+that is what a construction needs when it extends a `ℚ`-linear datum to a `ℂ`-linear one and is
+therefore determined by its values on rational vectors. The equivalence
+`rationalToComplexLinearEquiv` is needed instead when a construction manipulates the concrete
+tensor product `ℂ ⊗[ℚ] Vℚ` as data, as the complexification of a rational subspace does. On purely
+rational vectors the two agree, by `rationalToComplexLinearEquiv_one_tmul`.
 
 ## References
 
@@ -111,12 +113,29 @@ theorem integralMapToComplex_ratTensorMap {U U' : Type*} [AddCommGroup U] [Modul
     rw [integralMapToComplex_apply_ι, ratTensorMap_apply, ratTensorMap_apply,
       LinearMap.restrictScalars_apply, LinearMap.baseChange_tmul]
 
+/-- The canonical tower equivalence from an abstract rational base change to an abstract complex
+base change of the same integral module. -/
+noncomputable def rationalToComplexLinearEquiv (hℚ : IsBaseChange ℚ ιℚ)
+    (hℂ : IsBaseChange ℂ ιℂ) : ℂ ⊗[ℚ] Vℚ ≃ₗ[ℂ] Vℂ :=
+  (TensorProduct.AlgebraTensorModule.congr (LinearEquiv.refl ℂ ℂ) hℚ.equiv.symm).trans
+    ((TensorProduct.AlgebraTensorModule.cancelBaseChange ℤ ℚ ℂ ℂ Vℤ).trans hℂ.equiv)
+
+/-- The tower equivalence carries an integral vector through the rationalification to the same
+integral vector in the complexification. -/
+@[simp]
+theorem rationalToComplexLinearEquiv_one_tmul_ι (hℚ : IsBaseChange ℚ ιℚ)
+    (hℂ : IsBaseChange ℂ ιℂ) (x : Vℤ) :
+    rationalToComplexLinearEquiv hℚ hℂ (1 ⊗ₜ[ℚ] ιℚ x) = ιℂ x := by
+  simp [rationalToComplexLinearEquiv]
+
 noncomputable section RationalComplexMap
 
 /-- The `ℚ`-module structure on an abstract complexification, obtained by restricting its
 `ℂ`-module structure along `ℚ → ℂ`. It is local to this section, where it is needed to state that
-the rational-to-complex structure map is `ℚ`-linear. -/
-local instance moduleRatOfComplex : Module ℚ Vℂ := Module.restrictScalars ℚ ℂ Vℂ
+the rational-to-complex structure map is `ℚ`-linear, and has low priority so that `ℂ` itself keeps
+its `Algebra`-derived `ℚ`-module structure. -/
+local instance (priority := low) moduleRatOfComplex : Module ℚ Vℂ :=
+  Module.restrictScalars ℚ ℂ Vℂ
 local instance : IsScalarTower ℚ ℂ Vℂ := IsScalarTower.restrictScalars ℚ ℂ Vℂ
 local instance : IsScalarTower ℤ ℚ ℂ where
   smul_assoc z q w := by
@@ -133,20 +152,14 @@ noncomputable def rationalToComplexMap (hℚ : IsBaseChange ℚ ιℚ) (ιℂ : 
   hℚ.lift ιℂ
 
 /-- The rational-to-complex structure map carries an integral vector to the corresponding vector
-in the complexification.
-
-This is the elementwise characterization of `rationalToComplexMap`, whose body is not exposed, so
-Mathlib's `IsBaseChange.lift_eq` does not apply to such a goal outside this module. -/
+in the complexification. -/
 @[simp]
 theorem rationalToComplexMap_apply_ι (hℚ : IsBaseChange ℚ ιℚ) (ιℂ : Vℤ →ₗ[ℤ] Vℂ) (x : Vℤ) :
     rationalToComplexMap hℚ ιℂ (ιℚ x) = ιℂ x :=
   hℚ.lift_eq ιℂ x
 
 /-- Composing the rational-to-complex structure map with rationalification recovers the given
-integral-to-complex structure map.
-
-This is the composite characterization of `rationalToComplexMap`, whose body is not exposed, so
-Mathlib's `IsBaseChange.lift_comp` does not apply to such a goal outside this module. -/
+integral-to-complex structure map. -/
 @[simp]
 theorem rationalToComplexMap_restrictScalars_comp (hℚ : IsBaseChange ℚ ιℚ)
     (ιℂ : Vℤ →ₗ[ℤ] Vℂ) :
@@ -155,7 +168,7 @@ theorem rationalToComplexMap_restrictScalars_comp (hℚ : IsBaseChange ℚ ιℚ
 
 /-- The rational-to-complex structure map is the unique `ℚ`-linear map extending `ιℂ` along
 `ιℚ`. -/
-theorem rationalToComplexMap_eq_of_restrictScalars_comp_eq (hℚ : IsBaseChange ℚ ιℚ)
+theorem eq_rationalToComplexMap_of_restrictScalars_comp_eq (hℚ : IsBaseChange ℚ ιℚ)
     (ιℂ : Vℤ →ₗ[ℤ] Vℂ) (f : Vℚ →ₗ[ℚ] Vℂ)
     (hf : f.restrictScalars ℤ ∘ₗ ιℚ = ιℂ) : f = rationalToComplexMap hℚ ιℂ := by
   apply hℚ.algHom_ext'
@@ -174,22 +187,17 @@ theorem isBaseChange_rationalToComplexMap_comp (hℚ : IsBaseChange ℚ ιℚ)
     IsBaseChange ℂ ((rationalToComplexMap hℚ ιℂ).restrictScalars ℤ ∘ₗ ιℚ) :=
   hℚ.comp (isBaseChange_rationalToComplexMap hℚ hℂ)
 
+/-- On a purely rational vector the tower equivalence agrees with the rational-to-complex
+structure map. -/
+theorem rationalToComplexLinearEquiv_one_tmul (hℚ : IsBaseChange ℚ ιℚ)
+    (hℂ : IsBaseChange ℂ ιℂ) (x : Vℚ) :
+    rationalToComplexLinearEquiv hℚ hℂ (1 ⊗ₜ[ℚ] x) = rationalToComplexMap hℚ ιℂ x := by
+  have h := eq_rationalToComplexMap_of_restrictScalars_comp_eq hℚ ιℂ
+    ((rationalToComplexLinearEquiv hℚ hℂ).toLinearMap.restrictScalars ℚ ∘ₗ
+      TensorProduct.mk ℚ ℂ Vℚ 1) (by ext y; simp)
+  exact LinearMap.congr_fun h x
+
 end RationalComplexMap
-
-/-- The canonical tower equivalence from an abstract rational base change to an abstract complex
-base change of the same integral module. -/
-noncomputable def rationalToComplexLinearEquiv (hℚ : IsBaseChange ℚ ιℚ)
-    (hℂ : IsBaseChange ℂ ιℂ) : ℂ ⊗[ℚ] Vℚ ≃ₗ[ℂ] Vℂ :=
-  (TensorProduct.AlgebraTensorModule.congr (LinearEquiv.refl ℂ ℂ) hℚ.equiv.symm).trans
-    ((TensorProduct.AlgebraTensorModule.cancelBaseChange ℤ ℚ ℂ ℂ Vℤ).trans hℂ.equiv)
-
-/-- The tower equivalence carries an integral vector through the rationalification to the same
-integral vector in the complexification. -/
-@[simp]
-theorem rationalToComplexLinearEquiv_one_tmul_ι (hℚ : IsBaseChange ℚ ιℚ)
-    (hℂ : IsBaseChange ℂ ιℂ) (x : Vℤ) :
-    rationalToComplexLinearEquiv hℚ hℂ (1 ⊗ₜ[ℚ] ιℚ x) = ιℂ x := by
-  simp [rationalToComplexLinearEquiv]
 
 /-- The complexification of a rational subspace, realized inside the chosen ambient
 complexification. -/

--- a/TauCeti/Geometry/Hodge/BaseChange.lean
+++ b/TauCeti/Geometry/Hodge/BaseChange.lean
@@ -113,7 +113,10 @@ theorem integralMapToComplex_ratTensorMap {U U' : Type*} [AddCommGroup U] [Modul
 
 noncomputable section RationalComplexMap
 
-local instance : Module ℚ Vℂ := Module.restrictScalars ℚ ℂ Vℂ
+/-- The `ℚ`-module structure on an abstract complexification, obtained by restricting its
+`ℂ`-module structure along `ℚ → ℂ`. It is local to this section, where it is needed to state that
+the rational-to-complex structure map is `ℚ`-linear. -/
+local instance moduleRatOfComplex : Module ℚ Vℂ := Module.restrictScalars ℚ ℂ Vℂ
 local instance : IsScalarTower ℚ ℂ Vℂ := IsScalarTower.restrictScalars ℚ ℂ Vℂ
 local instance : IsScalarTower ℤ ℚ ℂ where
   smul_assoc z q w := by


### PR DESCRIPTION
This PR exposes the canonical `ℚ`-linear structure map from an abstract rationalification to an abstract complexification and proves that it is itself a base change, so the abstract `ℤ → ℚ → ℂ` tower is available as a base-change tower rather than merely asserted.

It advances the exact HodgeStructures README “Core definitions” target under *Rational substructures*: the composed `ℤ → ℂ` witness for the two-leg tower, so that constructions no longer transport along `cancelBaseChange` by hand. The missing ingredient was the middle leg: `rationalToComplexMap` is the `ℚ → ℂ` structure map `ι_{ℚℂ}`, and `isBaseChange_rationalToComplexMap` is its base-change witness. Given those, the composite is available directly — `IsBaseChange.comp hℚ (isBaseChange_rationalToComplexMap hℚ hℂ)` — and `rationalToComplexMap_restrictScalars_comp` identifies that composite with `ιℂ`. An earlier revision also carried a named `isBaseChange_rationalToComplexMap_comp`; it has been removed, because after the composition lemma its statement is the hypothesis `hℂ` restated and it therefore carried no content of its own.

The designated consumer milestone is L2 — “Mixed Hodge structures; strictness (Deligne)” — whose rational subspaces, complex weight filtration, and complexified morphisms use the abstract `ℤ → ℚ → ℂ` tower. All four headline milestones are already landed; after this PR, the roadmap frontier still includes the fine conjugation relation on Deligne’s bigrading, kernels and cokernels for the abelian mixed category, and the effective weight-one construction from a lattice, complex structure, and Riemann form.

The API defines `rationalToComplexMap` by the universal property of the rational base change, characterizes its action and its composite with `ιℚ`, proves its uniqueness, proves the second leg is a base change, and compares it with the existing tower equivalence on purely rational vectors. Local restriction-of-scalars instances keep the construction canonical without perturbing the existing tensor-product instance graph.

Mathlib infrastructure reused directly: `IsBaseChange.lift`, `IsBaseChange.lift_eq`, `IsBaseChange.lift_comp`, `IsBaseChange.algHom_ext'`, `IsBaseChange.of_comp`, and `Module.restrictScalars`. No Mathlib code or external formalization is vendored.

Roadmap: HodgeStructures

<!--tauceti-target:v1 {"focus":"HodgeStructures","id":"composed-base-change-witness"}-->

🤖 Prepared with Codex
