### PR TITLE
feat: identify the finite-cover fibre functor

### DIFF
--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/GaloisCategory.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/GaloisCategory.lean
@@ -243,10 +243,9 @@ theorem fiberActionFintypeCatEquivalence_functor :
     rw [Equivalence.trans_functor, finiteFiberActionEquivalence_functor,
       FiniteAction.equivalenceActionFintypeCat_functor]
 
-/-- The fibre of a finite covering space over `x₀`, as a functor to finite sets.
-
-The body is exposed so that actions transported through the classification equivalence act
-definitionally on the values of this functor. -/
+/-- The fibre of a finite covering space over `x₀`, as a functor to finite sets. -/
+-- Expose the body so actions transported through the classification equivalence act
+-- definitionally on the values of this functor.
 @[expose] def fiberFunctor : FiniteCoveringSpace X ⥤ FintypeCat.{u} :=
   (fiberActionFintypeCatEquivalence x₀).functor ⋙ Action.forget FintypeCat _
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/GaloisCategory.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/GaloisCategory.lean
@@ -243,8 +243,11 @@ theorem fiberActionFintypeCatEquivalence_functor :
     rw [Equivalence.trans_functor, finiteFiberActionEquivalence_functor,
       FiniteAction.equivalenceActionFintypeCat_functor]
 
-/-- The fibre of a finite covering space over `x₀`, as a functor to finite sets. -/
-def fiberFunctor : FiniteCoveringSpace X ⥤ FintypeCat.{u} :=
+/-- The fibre of a finite covering space over `x₀`, as a functor to finite sets.
+
+The body is exposed so that actions transported through the classification equivalence act
+definitionally on the values of this functor. -/
+@[expose] def fiberFunctor : FiniteCoveringSpace X ⥤ FintypeCat.{u} :=
   (fiberActionFintypeCatEquivalence x₀).functor ⋙ Action.forget FintypeCat _
 
 theorem fiberFunctor_eq :

--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/ProfiniteFiberFunctor.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/ProfiniteFiberFunctor.lean
@@ -29,6 +29,8 @@ space.
   completion of `π₁(X, x₀)` is a fundamental group of the finite-cover fibre functor.
 * `TauCeti.FiniteCoveringSpace.profiniteCompletionAutFiberFunctorMulEquiv`: the resulting
   multiplicative equivalence with the automorphism group of the fibre functor.
+* `TauCeti.FiniteCoveringSpace.existsUnique_profiniteCompletion_smul_eq`: every automorphism is
+  induced on every fibre by a unique element of the profinite completion.
 * `TauCeti.FiniteCoveringSpace.profiniteCompletion_etaFn_smul`: the extended action restricts
   along `π₁(X, x₀) → π̂₁(X, x₀)` to the classified monodromy action.
 * `TauCeti.FiniteCoveringSpace.profiniteCompletionAutFiberFunctorMulEquiv_isHomeomorph`: this
@@ -36,8 +38,7 @@ space.
   automorphisms.
 
 The profinite-completion action is constructed in
-`TauCeti.CategoryTheory.Action.ProfiniteCompletion` from Mathlib's universal property. No
-external formalization is copied here.
+`TauCeti.CategoryTheory.Action.ProfiniteCompletion` from Mathlib's universal property.
 -/
 
 public section
@@ -59,7 +60,7 @@ This is the continuous extension of the monodromy action. -/
     MulAction
       (ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of (FundamentalGroup X x₀)))
       ((fiberFunctor x₀).obj p) :=
-  TauCeti.mulActionComp (fiberActionFintypeCatEquivalence x₀).functor
+  CategoryTheory.Functor.mulActionComp (fiberActionFintypeCatEquivalence x₀).functor
     (Action.forget FintypeCat (FundamentalGroup X x₀))
     (ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of (FundamentalGroup X x₀))) p
 
@@ -68,10 +69,10 @@ functor.** -/
 instance instProfiniteCompletionIsFundamentalGroup :
     PreGaloisCategory.IsFundamentalGroup (fiberFunctor x₀)
       (ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of (FundamentalGroup X x₀))) := by
-  exact TauCeti.isFundamentalGroup_comp_of_equivalence
+  exact CategoryTheory.Functor.isFundamentalGroup_comp
+    (fiberActionFintypeCatEquivalence x₀).functor
     (F := Action.forget FintypeCat (FundamentalGroup X x₀))
     (G := ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of (FundamentalGroup X x₀)))
-    (fiberActionFintypeCatEquivalence x₀)
 
 variable {x₀}
 
@@ -108,6 +109,42 @@ theorem profiniteCompletionAutFiberFunctorMulEquiv_hom_app_apply
   PreGaloisCategory.toAut_hom_app_apply
     (F := fiberFunctor x₀)
     (G := ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of (FundamentalGroup X x₀))) g e
+
+/-- The inverse of the automorphism attached to an element of the profinite completion acts by
+the inverse element on every finite fibre. -/
+@[simp]
+theorem profiniteCompletionAutFiberFunctorMulEquiv_inv_app_apply
+    (g : ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of (FundamentalGroup X x₀)))
+    (p : FiniteCoveringSpace X) (e : (fiberFunctor x₀).obj p) :
+    (profiniteCompletionAutFiberFunctorMulEquiv x₀ g).inv.app p e = g⁻¹ • e := by
+  let η : fiberFunctor x₀ ≅ fiberFunctor x₀ :=
+    profiniteCompletionAutFiberFunctorMulEquiv x₀ g
+  have hg : η.hom.app p (η.inv.app p e) = g • η.inv.app p e := by
+    simpa only [η] using profiniteCompletionAutFiberFunctorMulEquiv_hom_app_apply
+      (x₀ := x₀) g p (η.inv.app p e)
+  have hi : η.hom.app p (η.inv.app p e) = e :=
+    FintypeCat.inv_hom_id_apply (η.app p) e
+  change η.inv.app p e = g⁻¹ • e
+  calc
+    _ = g⁻¹ • (g • η.inv.app p e) := by simp
+    _ = g⁻¹ • η.hom.app p (η.inv.app p e) := congrArg (g⁻¹ • ·) hg.symm
+    _ = g⁻¹ • e := congrArg (g⁻¹ • ·) hi
+
+/-- Every natural automorphism of the finite-cover fibre functor is induced on every fibre by a
+unique element of the profinite completion of `π₁(X, x₀)`. -/
+theorem existsUnique_profiniteCompletion_smul_eq (η : Aut (fiberFunctor x₀)) :
+    ∃! g : ProfiniteGrp.ProfiniteCompletion.completion
+        (GrpCat.of (FundamentalGroup X x₀)),
+      ∀ (p : FiniteCoveringSpace X) (e : (fiberFunctor x₀).obj p),
+        g • e = η.hom.app p e := by
+  refine ⟨(profiniteCompletionAutFiberFunctorMulEquiv x₀).symm η, fun p e => ?_, fun g hg => ?_⟩
+  · rw [← profiniteCompletionAutFiberFunctorMulEquiv_hom_app_apply, MulEquiv.apply_symm_apply]
+  · refine (profiniteCompletionAutFiberFunctorMulEquiv x₀).injective
+      (Aut.ext (NatTrans.ext (funext fun p => ?_)))
+    ext e
+    rw [MulEquiv.apply_symm_apply]
+    exact (profiniteCompletionAutFiberFunctorMulEquiv_hom_app_apply
+      (x₀ := x₀) g p e).trans (hg p e)
 
 variable (x₀)
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/ProfiniteFiberFunctor.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/ProfiniteFiberFunctor.lean
@@ -1,0 +1,121 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicTopology.UniversalCover.Classification.GaloisCategory
+public import TauCeti.CategoryTheory.Action.ProfiniteCompletion
+
+/-!
+# The profinite fundamental group of the finite-cover fibre functor
+
+Let `X` be path connected, locally path connected and semilocally simply connected, and fix a
+basepoint `x₀`. Finite covering spaces of `X` form a Galois category with fibre functor
+`TauCeti.FiniteCoveringSpace.fiberFunctor x₀`. Its fundamental group is the profinite completion
+of `π₁(X, x₀)`.
+
+The result transports the corresponding statement for finite `π₁(X, x₀)`-sets along
+`TauCeti.FiniteCoveringSpace.fiberActionFintypeCatEquivalence`. Thus the action on a finite
+cover's fibre is the unique continuous extension of monodromy from the ordinary fundamental
+group. Mathlib's Galois-category recognition theorem then identifies this profinite completion
+with the natural automorphism group of the fibre functor, as both a group and a topological
+space.
+
+## Main declarations
+
+* `TauCeti.FiniteCoveringSpace.instProfiniteCompletionIsFundamentalGroup`: the profinite
+  completion of `π₁(X, x₀)` is a fundamental group of the finite-cover fibre functor.
+* `TauCeti.FiniteCoveringSpace.profiniteCompletionAutFiberFunctorMulEquiv`: the resulting
+  multiplicative equivalence with the automorphism group of the fibre functor.
+* `TauCeti.FiniteCoveringSpace.profiniteCompletion_etaFn_smul`: the extended action restricts
+  along `π₁(X, x₀) → π̂₁(X, x₀)` to the classified monodromy action.
+* `TauCeti.FiniteCoveringSpace.profiniteCompletionAutFiberFunctorMulEquiv_isHomeomorph`: this
+  equivalence is a homeomorphism for Mathlib's canonical topology on fibre-functor
+  automorphisms.
+
+The profinite-completion action is constructed in
+`TauCeti.CategoryTheory.Action.ProfiniteCompletion` from Mathlib's universal property. No
+external formalization is copied here.
+-/
+
+public section
+noncomputable section
+
+open CategoryTheory Topology
+open scoped CategoryTheory.PreGaloisCategory
+
+universe u
+
+namespace TauCeti.FiniteCoveringSpace
+
+variable {X : TopCat.{u}} (x₀ : X) [PathConnectedSpace X] [LocallyPathConnectedSpace X]
+  [SemilocallySimplyConnectedSpace X]
+
+/-- The profinite completion of `π₁(X, x₀)` acts on the fibre of every finite covering space.
+This is the continuous extension of the monodromy action. -/
+@[instance_reducible] instance instProfiniteCompletionMulAction (p : FiniteCoveringSpace X) :
+    MulAction
+      (ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of (FundamentalGroup X x₀)))
+      ((fiberFunctor x₀).obj p) :=
+  TauCeti.mulActionComp (fiberActionFintypeCatEquivalence x₀).functor
+    (Action.forget FintypeCat (FundamentalGroup X x₀))
+    (ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of (FundamentalGroup X x₀))) p
+
+/-- **The profinite completion of `π₁(X, x₀)` is a fundamental group of the finite-cover fibre
+functor.** -/
+instance instProfiniteCompletionIsFundamentalGroup :
+    PreGaloisCategory.IsFundamentalGroup (fiberFunctor x₀)
+      (ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of (FundamentalGroup X x₀))) := by
+  exact TauCeti.isFundamentalGroup_comp_of_equivalence
+    (F := Action.forget FintypeCat (FundamentalGroup X x₀))
+    (G := ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of (FundamentalGroup X x₀)))
+    (fiberActionFintypeCatEquivalence x₀)
+
+variable {x₀}
+
+/-- The profinite-completion action restricts along the canonical map from `π₁(X, x₀)` to the
+classified finite action. Through `finiteFiberActionFunctor_obj_obj_ρ_apply`, the right-hand side
+is monodromy on the fibre of `p`. -/
+@[simp]
+theorem profiniteCompletion_etaFn_smul (g : FundamentalGroup X x₀)
+    (p : FiniteCoveringSpace X) (e : (fiberFunctor x₀).obj p) :
+    ProfiniteGrp.ProfiniteCompletion.etaFn (GrpCat.of (FundamentalGroup X x₀)) g • e =
+      ConcreteCategory.hom (((fiberActionFintypeCatEquivalence x₀).functor.obj p).ρ g) e :=
+  TauCeti.ProfiniteCompletion.etaFn_smul (FundamentalGroup X x₀)
+    ((fiberActionFintypeCatEquivalence x₀).functor.obj p) g e
+
+variable (x₀)
+
+/-- **The profinite completion of `π₁(X, x₀)` is the automorphism group of the finite-cover fibre
+functor.** -/
+def profiniteCompletionAutFiberFunctorMulEquiv :
+    ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of (FundamentalGroup X x₀)) ≃*
+      Aut (fiberFunctor x₀) :=
+  PreGaloisCategory.toAutMulEquiv (fiberFunctor x₀)
+    (ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of (FundamentalGroup X x₀)))
+
+variable {x₀}
+
+/-- The automorphism attached to an element of the profinite completion acts on every finite
+fibre by the canonical extended action. -/
+@[simp]
+theorem profiniteCompletionAutFiberFunctorMulEquiv_hom_app_apply
+    (g : ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of (FundamentalGroup X x₀)))
+    (p : FiniteCoveringSpace X) (e : (fiberFunctor x₀).obj p) :
+    (profiniteCompletionAutFiberFunctorMulEquiv x₀ g).hom.app p e = g • e :=
+  PreGaloisCategory.toAut_hom_app_apply
+    (F := fiberFunctor x₀)
+    (G := ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of (FundamentalGroup X x₀))) g e
+
+variable (x₀)
+
+/-- The equivalence between the profinite completion and fibre-functor automorphisms is a
+homeomorphism for their canonical topologies. -/
+theorem profiniteCompletionAutFiberFunctorMulEquiv_isHomeomorph :
+    IsHomeomorph (profiniteCompletionAutFiberFunctorMulEquiv x₀) :=
+  PreGaloisCategory.toAutMulEquiv_isHomeomorph (fiberFunctor x₀)
+    (ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of (FundamentalGroup X x₀)))
+
+end TauCeti.FiniteCoveringSpace

--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/ProfiniteFiberFunctor.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/ProfiniteFiberFunctor.lean
@@ -117,17 +117,16 @@ theorem profiniteCompletionAutFiberFunctorMulEquiv_inv_app_apply
     (g : ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of (FundamentalGroup X x₀)))
     (p : FiniteCoveringSpace X) (e : (fiberFunctor x₀).obj p) :
     (profiniteCompletionAutFiberFunctorMulEquiv x₀ g).inv.app p e = g⁻¹ • e := by
-  let η : fiberFunctor x₀ ≅ fiberFunctor x₀ :=
-    profiniteCompletionAutFiberFunctorMulEquiv x₀ g
-  have hg : η.hom.app p (η.inv.app p e) = g • η.inv.app p e := by
-    simpa only [η] using profiniteCompletionAutFiberFunctorMulEquiv_hom_app_apply
-      (x₀ := x₀) g p (η.inv.app p e)
-  have hi : η.hom.app p (η.inv.app p e) = e :=
-    FintypeCat.inv_hom_id_apply (η.app p) e
-  change η.inv.app p e = g⁻¹ • e
+  have hg := profiniteCompletionAutFiberFunctorMulEquiv_hom_app_apply
+    (x₀ := x₀) g p ((profiniteCompletionAutFiberFunctorMulEquiv x₀ g).inv.app p e)
+  have hi := FintypeCat.inv_hom_id_apply
+    ((profiniteCompletionAutFiberFunctorMulEquiv x₀ g).app p) e
   calc
-    _ = g⁻¹ • (g • η.inv.app p e) := by simp
-    _ = g⁻¹ • η.hom.app p (η.inv.app p e) := congrArg (g⁻¹ • ·) hg.symm
+    (profiniteCompletionAutFiberFunctorMulEquiv x₀ g).inv.app p e =
+        g⁻¹ • (g • (profiniteCompletionAutFiberFunctorMulEquiv x₀ g).inv.app p e) := by simp
+    _ = g⁻¹ • (profiniteCompletionAutFiberFunctorMulEquiv x₀ g).hom.app p
+        ((profiniteCompletionAutFiberFunctorMulEquiv x₀ g).inv.app p e) :=
+      congrArg (g⁻¹ • ·) hg.symm
     _ = g⁻¹ • e := congrArg (g⁻¹ • ·) hi
 
 /-- Every natural automorphism of the finite-cover fibre functor is induced on every fibre by a

--- a/TauCeti/CategoryTheory/Galois/Transport.lean
+++ b/TauCeti/CategoryTheory/Galois/Transport.lean
@@ -37,7 +37,7 @@ preimage under `e.functor` of `e.counit.app Z ≫ u`; taking the preimage rather
   composes with an equivalence `C ≌ D` to a fibre functor on `C`.
 * `TauCeti.galoisCategory_of_equivalence`: a category equivalent to a Galois category is a
   Galois category.
-* `TauCeti.isFundamentalGroup_comp_of_equivalence`: a fundamental group of a fibre functor
+* `CategoryTheory.Functor.isFundamentalGroup_comp`: a fundamental group of a fibre functor
   remains one after the functor is transported along an equivalence.
 
 ## References
@@ -101,25 +101,24 @@ theorem galoisCategory_of_equivalence {D : Type u₂} [Category.{v₁} D] (e : C
 variable (K : C ⥤ D) (F : D ⥤ FintypeCat.{w})
   (G : Type*) [Group G] [∀ Y, MulAction G (F.obj Y)]
 
-/-- The action on a fibre functor, pulled back along a functor on its source category.
-
-The body is exposed so that later fundamental-group instances use definitionally the same action
-as the original fibre functor. -/
-@[expose, instance_reducible] def mulActionComp (X : C) : MulAction G ((K ⋙ F).obj X) := by
+/-- The action on a fibre functor, pulled back along a functor on its source category. -/
+-- Expose the body so transported fundamental-group instances use the original action
+-- definitionally.
+@[expose, instance_reducible] def _root_.CategoryTheory.Functor.mulActionComp
+    (X : C) : MulAction G ((K ⋙ F).obj X) := by
   -- Functor composition does not reduce while typeclass inference searches for the source action.
   change MulAction G (F.obj (K.obj X))
   infer_instance
 
-attribute [local instance] mulActionComp
+attribute [local instance] CategoryTheory.Functor.mulActionComp
 
 /-- A natural action on a fibre functor remains natural after precomposition. -/
-theorem isNaturalSMul_comp [IsNaturalSMul F G] : IsNaturalSMul (K ⋙ F) G where
+theorem _root_.CategoryTheory.Functor.isNaturalSMul_comp
+    [IsNaturalSMul F G] : IsNaturalSMul (K ⋙ F) G where
   naturality g {X Y} f x := by
     -- Reveal the composite map so that the original naturality field applies.
     change F.map (K.map f) (g • x) = g • F.map (K.map f) x
     exact IsNaturalSMul.naturality g (K.map f) x
-
-variable (e : C ≌ D)
 
 /-- **A fundamental group of a fibre functor remains a fundamental group after transport along
 an equivalence of its source category.**
@@ -127,26 +126,28 @@ an equivalence of its source category.**
 The action on each transported fibre is the original action on the corresponding object.
 Connectedness transports along the equivalence, while faithfulness is reflected using essential
 surjectivity and naturality along a chosen isomorphism. -/
-theorem isFundamentalGroup_comp_of_equivalence [GaloisCategory C] [GaloisCategory D]
-    [FiberFunctor F] [TopologicalSpace G] [IsTopologicalGroup G] [CompactSpace G]
-    [IsFundamentalGroup F G] : IsFundamentalGroup (e.functor ⋙ F) G := by
+theorem _root_.CategoryTheory.Functor.isFundamentalGroup_comp [K.IsEquivalence]
+    [GaloisCategory C] [GaloisCategory D] [FiberFunctor F] [TopologicalSpace G]
+    [IsTopologicalGroup G] [CompactSpace G] [IsFundamentalGroup F G] :
+    IsFundamentalGroup (K ⋙ F) G := by
   refine
-    { toIsNaturalSMul := isNaturalSMul_comp e.functor F G
+    { toIsNaturalSMul := K.isNaturalSMul_comp F G
       transitive_of_isGalois := fun X _ => ?_
       continuous_smul := fun X =>
-        IsFundamentalGroup.continuous_smul (F := F) (G := G) (e.functor.obj X)
+        IsFundamentalGroup.continuous_smul (F := F) (G := G) (K.obj X)
       non_trivial' := fun g h => ?_ }
   · let : IsConnected X := IsGalois.toIsConnected
-    let : IsConnected (e.functor.obj X) := isConnected_map e.functor X
-    change MulAction.IsPretransitive G (F.obj (e.functor.obj X))
+    let : IsConnected (K.obj X) := isConnected_map K X
+    change MulAction.IsPretransitive G (F.obj (K.obj X))
     exact inferInstance
   · apply IsFundamentalGroup.non_trivial (F := F) g
     intro Y y
-    let X := e.functor.objPreimage Y
-    let i := e.functor.objObjPreimageIso Y
+    let X := K.objPreimage Y
+    let i := K.objObjPreimageIso Y
     have hg := h X (F.map i.inv y)
     have hn := IsNaturalSMul.naturality g i.hom (F.map i.inv y)
-    rw [hg, ← F.map_comp_apply, i.inv_hom_id, F.map_id, FintypeCat.id_apply] at hn
-    exact hn.symm
+    have hi : F.map i.hom (F.map i.inv y) = y :=
+      FintypeCat.inv_hom_id_apply (F.mapIso i) y
+    simpa only [hg, hi] using hn.symm
 
 end TauCeti

--- a/TauCeti/CategoryTheory/Galois/Transport.lean
+++ b/TauCeti/CategoryTheory/Galois/Transport.lean
@@ -127,7 +127,7 @@ The action on each transported fibre is the original action on the corresponding
 Connectedness transports along the equivalence, while faithfulness is reflected using essential
 surjectivity and naturality along a chosen isomorphism. -/
 theorem _root_.CategoryTheory.Functor.isFundamentalGroup_comp [K.IsEquivalence]
-    [GaloisCategory C] [GaloisCategory D] [FiberFunctor F] [TopologicalSpace G]
+    [GaloisCategory C] [GaloisCategory D] [TopologicalSpace G]
     [IsTopologicalGroup G] [CompactSpace G] [IsFundamentalGroup F G] :
     IsFundamentalGroup (K ⋙ F) G := by
   refine
@@ -138,8 +138,21 @@ theorem _root_.CategoryTheory.Functor.isFundamentalGroup_comp [K.IsEquivalence]
       non_trivial' := fun g h => ?_ }
   · let : IsConnected X := IsGalois.toIsConnected
     let : IsConnected (K.obj X) := isConnected_map K X
-    change MulAction.IsPretransitive G (F.obj (K.obj X))
-    exact inferInstance
+    let : IsGalois (K.obj X) := by
+      obtain ⟨H, hH⟩ := GaloisCategory.hasFiberFunctor D
+      let : FiberFunctor H := hH
+      let : FiberFunctor (K ⋙ H) := fiberFunctor_comp_of_equivalence K.asEquivalence H
+      apply (isGalois_iff_pretransitive H (K.obj X)).2
+      refine ⟨fun y z => ?_⟩
+      let : MulAction (Aut X) (H.obj (K.obj X)) := by
+        change MulAction (Aut X) ((K ⋙ H).obj X)
+        infer_instance
+      let : MulAction.IsPretransitive (Aut X) (H.obj (K.obj X)) := by
+        change MulAction.IsPretransitive (Aut X) ((K ⋙ H).obj X)
+        infer_instance
+      obtain ⟨φ, hφ⟩ := MulAction.exists_smul_eq (Aut X) y z
+      exact ⟨K.mapIso φ, hφ⟩
+    exact IsFundamentalGroup.transitive_of_isGalois (F := F) (G := G) (K.obj X)
   · apply IsFundamentalGroup.non_trivial (F := F) g
     intro Y y
     let X := K.objPreimage Y

--- a/TauCeti/CategoryTheory/Galois/Transport.lean
+++ b/TauCeti/CategoryTheory/Galois/Transport.lean
@@ -5,7 +5,8 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.CategoryTheory.Galois.Basic
+public import Mathlib.CategoryTheory.Galois.IsFundamentalgroup
+public import TauCeti.CategoryTheory.Galois.Connected
 
 /-!
 # Transporting the Galois-category axioms along an equivalence
@@ -36,6 +37,8 @@ preimage under `e.functor` of `e.counit.app Z ≫ u`; taking the preimage rather
   composes with an equivalence `C ≌ D` to a fibre functor on `C`.
 * `TauCeti.galoisCategory_of_equivalence`: a category equivalent to a Galois category is a
   Galois category.
+* `TauCeti.isFundamentalGroup_comp_of_equivalence`: a fundamental group of a fibre functor
+  remains one after the functor is transported along an equivalence.
 
 ## References
 
@@ -94,5 +97,56 @@ theorem galoisCategory_of_equivalence {D : Type u₂} [Category.{v₁} D] (e : C
     have := preGaloisCategory_of_equivalence e
     obtain ⟨F, hF⟩ := GaloisCategory.hasFiberFunctor D
     exact ⟨e.functor ⋙ F, fiberFunctor_comp_of_equivalence e F⟩
+
+variable (K : C ⥤ D) (F : D ⥤ FintypeCat.{w})
+  (G : Type*) [Group G] [∀ Y, MulAction G (F.obj Y)]
+
+/-- The action on a fibre functor, pulled back along a functor on its source category.
+
+The body is exposed so that later fundamental-group instances use definitionally the same action
+as the original fibre functor. -/
+@[expose, instance_reducible] def mulActionComp (X : C) : MulAction G ((K ⋙ F).obj X) := by
+  -- Functor composition does not reduce while typeclass inference searches for the source action.
+  change MulAction G (F.obj (K.obj X))
+  infer_instance
+
+attribute [local instance] mulActionComp
+
+/-- A natural action on a fibre functor remains natural after precomposition. -/
+theorem isNaturalSMul_comp [IsNaturalSMul F G] : IsNaturalSMul (K ⋙ F) G where
+  naturality g {X Y} f x := by
+    -- Reveal the composite map so that the original naturality field applies.
+    change F.map (K.map f) (g • x) = g • F.map (K.map f) x
+    exact IsNaturalSMul.naturality g (K.map f) x
+
+variable (e : C ≌ D)
+
+/-- **A fundamental group of a fibre functor remains a fundamental group after transport along
+an equivalence of its source category.**
+
+The action on each transported fibre is the original action on the corresponding object.
+Connectedness transports along the equivalence, while faithfulness is reflected using essential
+surjectivity and naturality along a chosen isomorphism. -/
+theorem isFundamentalGroup_comp_of_equivalence [GaloisCategory C] [GaloisCategory D]
+    [FiberFunctor F] [TopologicalSpace G] [IsTopologicalGroup G] [CompactSpace G]
+    [IsFundamentalGroup F G] : IsFundamentalGroup (e.functor ⋙ F) G := by
+  refine
+    { toIsNaturalSMul := isNaturalSMul_comp e.functor F G
+      transitive_of_isGalois := fun X _ => ?_
+      continuous_smul := fun X =>
+        IsFundamentalGroup.continuous_smul (F := F) (G := G) (e.functor.obj X)
+      non_trivial' := fun g h => ?_ }
+  · let : IsConnected X := IsGalois.toIsConnected
+    let : IsConnected (e.functor.obj X) := isConnected_map e.functor X
+    change MulAction.IsPretransitive G (F.obj (e.functor.obj X))
+    exact inferInstance
+  · apply IsFundamentalGroup.non_trivial (F := F) g
+    intro Y y
+    let X := e.functor.objPreimage Y
+    let i := e.functor.objObjPreimageIso Y
+    have hg := h X (F.map i.inv y)
+    have hn := IsNaturalSMul.naturality g i.hom (F.map i.inv y)
+    rw [hg, ← F.map_comp_apply, i.inv_hom_id, F.map_id, FintypeCat.id_apply] at hn
+    exact hn.symm
 
 end TauCeti

--- a/TauCeti/CategoryTheory/Galois/Transport.lean
+++ b/TauCeti/CategoryTheory/Galois/Transport.lean
@@ -123,9 +123,7 @@ theorem _root_.CategoryTheory.Functor.isNaturalSMul_comp
 /-- **A fundamental group of a fibre functor remains a fundamental group after transport along
 an equivalence of its source category.**
 
-The action on each transported fibre is the original action on the corresponding object.
-Connectedness transports along the equivalence, while faithfulness is reflected using essential
-surjectivity and naturality along a chosen isomorphism. -/
+The action on each transported fibre is the original action on the corresponding object. -/
 theorem _root_.CategoryTheory.Functor.isFundamentalGroup_comp [K.IsEquivalence]
     [GaloisCategory C] [GaloisCategory D] [TopologicalSpace G]
     [IsTopologicalGroup G] [CompactSpace G] [IsFundamentalGroup F G] :
@@ -144,6 +142,8 @@ theorem _root_.CategoryTheory.Functor.isFundamentalGroup_comp [K.IsEquivalence]
       let : FiberFunctor (K ⋙ H) := fiberFunctor_comp_of_equivalence K.asEquivalence H
       apply (isGalois_iff_pretransitive H (K.obj X)).2
       refine ⟨fun y z => ?_⟩
+      -- Typeclass inference does not unfold functor composition here, so expose the definitional
+      -- equality between `H.obj (K.obj X)` and `(K ⋙ H).obj X` before synthesizing both instances.
       let : MulAction (Aut X) (H.obj (K.obj X)) := by
         change MulAction (Aut X) ((K ⋙ H).obj X)
         infer_instance


### PR DESCRIPTION
This PR identifies the profinite completion of `π₁(X, x₀)` with the automorphism group of the fibre functor on finite covering spaces. It advances `TauCetiRoadmap/UniversalCovers/README.md`, Stage 2, item 8, specifically the alternative Galois-category lens through `IsFundamentalGroup` and `toAutMulEquiv`: the explicit dependency edge is `FiniteCoveringSpace.fiberFunctor` automorphisms ← the profinite-completion fundamental group of finite `π₁(X, x₀)`-sets transported along `FiniteCoveringSpace.fiberActionFintypeCatEquivalence`.

This is the most effective current step because the finite-cover Galois category and its equivalence with finite fundamental-group actions are already on `main`, and the immediately preceding profinite-action work explicitly left this transport to the concrete finite-cover fibre functor. The PR adds the transported profinite action, the `IsFundamentalGroup` instance, the canonical multiplicative equivalence with fibre-functor automorphisms, its action formula on every fibre, its restriction along `π₁(X, x₀) → π̂₁(X, x₀)`, and the homeomorphism theorem. After this PR, the Stage 2 item 8 automorphism-group identification is complete in both forms: `π₁(X, x₀)` for all covers and its profinite completion for finite covers; the broader roadmap frontier still includes constructing a `K(G, 1)` for an arbitrary group.

The reusable prerequisite `TauCeti.isFundamentalGroup_comp_of_equivalence` transports Mathlib's `PreGaloisCategory.IsFundamentalGroup` structure along an equivalence, using categorical connectedness transport and essential surjectivity. Its action and naturality helpers are stated for arbitrary precomposition, the natural level used by the proof. `FiniteCoveringSpace.fiberFunctor` is exposed consistently with the all-cover fibre functor so that the transported action computes definitionally on its values.

The new `TauCeti/AlgebraicTopology/UniversalCover/Classification/ProfiniteFiberFunctor.lean` module has 121 lines; `CategoryTheory/Galois/Transport.lean` gains 55 net lines and `Classification/GaloisCategory.lean` gains 5 net lines. No Mathlib infrastructure is vendored and no external formalization is copied. The construction reuses Mathlib's `PreGaloisCategory.IsFundamentalGroup`, `toAutMulEquiv`, and `toAutMulEquiv_isHomeomorph`, together with Tau Ceti's profinite-completion action and finite-cover classification equivalence.

Roadmap: UniversalCovers

<!--tauceti-target:v1 {"focus":"UniversalCovers","id":"finite-cover-fiber-functor-profinite-completion"}-->

🤖 Prepared with Codex
