### PR TITLE
feat: prove the special orthogonal groups connected and reductive

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Hopf/Translation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Hopf/Translation.lean
@@ -29,6 +29,8 @@ action laws, and identifies its action on the prime spectrum.
 * `TauCeti.HopfAlgebra.rightTranslationAlgEquiv_mul` and
   `TauCeti.HopfAlgebra.rightTranslationAlgHom_mul`: right translation respects the convolution
   product of points.
+* `TauCeti.HopfAlgebra.rightTranslationStabilizer`: the subgroup of points whose right
+  translation fixes a given function.
 * `TauCeti.HopfAlgebra.comap_rightTranslationAlgEquiv_augmentationPoint`: the translated counit
   point is the given point.
 * `TauCeti.HopfAlgebra.rightTranslationHomeomorph`: right translation on the prime spectrum.
@@ -226,6 +228,25 @@ theorem rightTranslationAlgHom_mul (g h : WithConv (H →ₐ[k] k)) :
 theorem rightTranslationAlgEquiv_inv (g : WithConv (H →ₐ[k] k)) :
     rightTranslationAlgEquiv g⁻¹ = (rightTranslationAlgEquiv g)⁻¹ := by
   exact map_inv (MonoidHom.mk' rightTranslationAlgEquiv rightTranslationAlgEquiv_mul) g
+
+/-- The points whose right translation fixes a given function form a subgroup. -/
+noncomputable def rightTranslationStabilizer (x : H) : Subgroup (WithConv (H →ₐ[k] k)) where
+  carrier := {g | rightTranslationAlgHom g x = x}
+  one_mem' := by simp
+  mul_mem' {g h} hg hh := by
+    simp only [Set.mem_ofPred_eq] at hg hh ⊢
+    rw [rightTranslationAlgHom_mul, AlgHom.comp_apply, hh, hg]
+  inv_mem' {g} hg := by
+    simp only [Set.mem_ofPred_eq] at hg ⊢
+    have h := DFunLike.congr_fun (rightTranslationAlgHom_mul g⁻¹ g) x
+    rw [inv_mul_cancel, rightTranslationAlgHom_one, AlgHom.id_apply, AlgHom.comp_apply, hg] at h
+    exact h.symm
+
+/-- A point lies in the stabilizer of a function exactly when its right translation fixes it. -/
+@[simp]
+theorem mem_rightTranslationStabilizer {x : H} {g : WithConv (H →ₐ[k] k)} :
+    g ∈ rightTranslationStabilizer x ↔ rightTranslationAlgHom g x = x :=
+  Iff.rfl
 
 /-- Right translation as an algebra equivalence has the expected evaluation formula. -/
 theorem rightTranslationAlgEquiv_apply (g : WithConv (H →ₐ[k] k)) (x : H) :

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialOrthogonal/Connected.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialOrthogonal/Connected.lean
@@ -291,28 +291,10 @@ private theorem rightTranslationAlgHom_eq_self_of_invertibleTwo
     (g : WithConv (K ⊗[k] coordinateHopfAlgebra k n →ₐ[K] K)) :
     HopfAlgebra.rightTranslationAlgHom g e = e := by
   let E := baseChangePointsMulEquiv (k := k) (K := K) n K
-  let fixes (x : Matrix.specialOrthogonalGroup (Fin n) K) : Prop :=
-    HopfAlgebra.rightTranslationAlgHom (E.symm x) e = e
-  have fixes_one : fixes 1 := by
-    dsimp only [fixes]
-    rw [map_one, HopfAlgebra.rightTranslationAlgHom_one, AlgHom.id_apply]
-  have fixes_mul {x y : Matrix.specialOrthogonalGroup (Fin n) K} (hx : fixes x) (hy : fixes y) :
-      fixes (x * y) := by
-    dsimp only [fixes] at hx hy ⊢
-    rw [map_mul, HopfAlgebra.rightTranslationAlgHom_mul, AlgHom.comp_apply, hy, hx]
-  have fixes_inv {x : Matrix.specialOrthogonalGroup (Fin n) K} (hx : fixes x) : fixes x⁻¹ := by
-    dsimp only [fixes] at hx ⊢
-    have h := DFunLike.congr_fun
-      (HopfAlgebra.rightTranslationAlgHom_mul (E.symm x⁻¹) (E.symm x)) e
-    rw [← map_mul E.symm, inv_mul_cancel x, map_one,
-      HopfAlgebra.rightTranslationAlgHom_one, AlgHom.id_apply, AlgHom.comp_apply, hx] at h
-    exact h.symm
-  let P : Subgroup (Matrix.specialOrthogonalGroup (Fin n) K) :=
-    { carrier := fixes
-      one_mem' := fixes_one
-      mul_mem' := fixes_mul
-      inv_mem' := fixes_inv }
-  have mem_P (x : Matrix.specialOrthogonalGroup (Fin n) K) : x ∈ P ↔ fixes x := Iff.rfl
+  let P := (HopfAlgebra.rightTranslationStabilizer e).comap E.symm.toMonoidHom
+  have mem_P (x : Matrix.specialOrthogonalGroup (Fin n) K) :
+      x ∈ P ↔ HopfAlgebra.rightTranslationAlgHom (E.symm x) e = e :=
+    Subgroup.mem_comap.trans HopfAlgebra.mem_rightTranslationStabilizer
   -- By Cartan-Dieudonné, the special orthogonal matrices form the monoid closure of the products
   -- of two reflections, and every such product lies in `P`.
   let Q := Matrix.toQuadraticForm' (1 : Matrix (Fin n) (Fin n) K)
@@ -340,7 +322,7 @@ private theorem rightTranslationAlgHom_eq_self_of_invertibleTwo
   have hg : E g ∈ P := by
     rw [hP]
     exact Subgroup.mem_top _
-  simpa only [fixes, MulEquiv.symm_apply_apply] using (mem_P _).mp hg
+  simpa only [MulEquiv.symm_apply_apply] using (mem_P _).mp hg
 
 /-- **The coordinate Hopf algebra of `SOₙ` is geometrically connected over every field of
 characteristic different from two**, in every dimension. -/

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialOrthogonal/Connected.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialOrthogonal/Connected.lean
@@ -7,7 +7,7 @@ module
 
 public import TauCeti.Algebra.AlgebraicGroup.Connected.CommHopfAlgCat
 public import TauCeti.Algebra.AlgebraicGroup.SpecialOrthogonal.Basic
-public import TauCeti.LinearAlgebra.Matrix.SpecialOrthogonalGroup.Reflection
+import TauCeti.LinearAlgebra.Matrix.SpecialOrthogonalGroup.Reflection
 import TauCeti.Algebra.AlgebraicGroup.BaseChange.Naturality
 import TauCeti.Algebra.AlgebraicGroup.Connected.AlgebraicallyClosed
 import TauCeti.Algebra.AlgebraicGroup.MultiplicativeGroup.Basic

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialOrthogonal/Connected.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialOrthogonal/Connected.lean
@@ -16,14 +16,15 @@ import TauCeti.LinearAlgebra.Matrix.SpecialOrthogonalGroup.FinTwo
 /-!
 # Geometric connectedness of the special orthogonal groups
 
-The coordinate Hopf algebra of the standard group `SOₙ` is geometrically connected in every rank
-away from characteristic two, and in rank two over every field. Connectedness is tested by
+The coordinate Hopf algebra of the standard group `SOₙ` is geometrically connected in every
+dimension away from characteristic two, and in dimension two over every field. Connectedness is
+tested by
 idempotents: over an algebraically closed extension an idempotent regular function is constant
 once right translation by every rational point fixes it, and a rational point which is joined to
 the identity by a path (a point over a domain specializing to it at one parameter and to the
 identity at another) translates every idempotent to itself.
 
-In every rank, away from characteristic two, the paths come from reflections. Cartan-Dieudonné
+In every dimension, away from characteristic two, the paths come from reflections. Cartan-Dieudonné
 writes a special orthogonal matrix as a product of pairs of reflections, and the points fixing a
 given idempotent form a subgroup, so it is enough to join each product of two reflections to the
 identity. Reflecting in a fixed anisotropic vector `v` and then in a vector moving along a
@@ -43,8 +44,8 @@ space is still connected.
 * `TauCeti.SpecialOrthogonal.geometricallyConnectedCommHopfAlgProperty_coordinateHopfAlgebra_two`:
   `SO₂` is geometrically connected over every field.
 * `TauCeti.SpecialOrthogonal.geometricallyConnectedCommHopfAlgProperty_coordinateHopfAlgebra`:
-  `SOₙ` is geometrically connected in every rank over a field of characteristic different from
-  two.
+  `SOₙ` is geometrically connected in every dimension over a field of characteristic different
+  from two.
 
 ## References
 
@@ -249,7 +250,7 @@ theorem geometricallyConnectedCommHopfAlgProperty_coordinateHopfAlgebra_two
     (Algebra.TensorProduct.comm k H K).toRingEquiv
   exact (PrimeSpectrum.homeomorphOfRingEquiv equiv).connectedSpace_iff.mpr hconnected
 
-/-! ### Every rank, away from characteristic two -/
+/-! ### Every dimension, away from characteristic two -/
 
 section CharNeTwo
 
@@ -321,7 +322,7 @@ private theorem rightTranslationAlgHom_eq_self_of_invertibleTwo
   simpa only [fixes, MulEquiv.symm_apply_apply] using (mem_P _).mp hg
 
 /-- **The coordinate Hopf algebra of `SOₙ` is geometrically connected over every field of
-characteristic different from two**, in every rank. -/
+characteristic different from two**, in every dimension. -/
 theorem geometricallyConnectedCommHopfAlgProperty_coordinateHopfAlgebra
     (k : Type u) [Field k] [NeZero (2 : k)] (n : ℕ) :
     geometricallyConnectedCommHopfAlgProperty k (coordinateHopfAlgebra k n) := by

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialOrthogonal/Connected.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialOrthogonal/Connected.lean
@@ -12,6 +12,7 @@ import TauCeti.Algebra.AlgebraicGroup.BaseChange.Naturality
 import TauCeti.Algebra.AlgebraicGroup.Connected.AlgebraicallyClosed
 import TauCeti.Algebra.AlgebraicGroup.MultiplicativeGroup.Basic
 import TauCeti.LinearAlgebra.Matrix.SpecialOrthogonalGroup.FinTwo
+import TauCeti.LinearAlgebra.Matrix.SpecialOrthogonalGroup.Generation
 
 /-!
 # Geometric connectedness of the special orthogonal groups
@@ -312,10 +313,30 @@ private theorem rightTranslationAlgHom_eq_self_of_invertibleTwo
       mul_mem' := fixes_mul
       inv_mem' := fixes_inv }
   have mem_P (x : Matrix.specialOrthogonalGroup (Fin n) K) : x ∈ P ↔ fixes x := Iff.rfl
+  -- By Cartan-Dieudonné, the special orthogonal matrices form the monoid closure of the products
+  -- of two reflections, and every such product lies in `P`.
+  let Q := Matrix.toQuadraticForm' (1 : Matrix (Fin n) (Fin n) K)
+  have hle : Submonoid.closure {A : Matrix (Fin n) (Fin n) K |
+      ∃ (v w : Fin n → K) (_ : Invertible (Q v)) (_ : Invertible (Q w)),
+        LinearMap.toMatrix' (QuadraticMap.reflection Q v).toLinearMap *
+          LinearMap.toMatrix' (QuadraticMap.reflection Q w).toLinearMap = A} ≤
+      P.toSubmonoid.map (Matrix.specialOrthogonalGroup (Fin n) K).subtype := by
+    refine Submonoid.closure_le.mpr ?_
+    rintro _ ⟨v, w, hv, hw, rfl⟩
+    have hcv : 2 * ⅟(Q v) * (v ⬝ᵥ v) = 2 := by
+      rw [← toQuadraticForm'_one_apply v, mul_assoc, invOf_mul_self, mul_one]
+    have hcw : 2 * ⅟(Q w) * (w ⬝ᵥ w) = 2 := by
+      rw [← toQuadraticForm'_one_apply w, mul_assoc, invOf_mul_self, mul_one]
+    refine ⟨reflectionPair v w _ _ hcv hcw,
+      (mem_P _).mpr (rightTranslationAlgHom_eq_self_of_reflectionPair n e he hcv hcw), ?_⟩
+    -- The mapped subgroup witness coerces definitionally to its underlying matrix equality.
+    change (reflectionPair v w _ _ hcv hcw : Matrix (Fin n) (Fin n) K) = _
+    rw [coe_reflectionPair, toMatrix'_reflection, toMatrix'_reflection]
   have hP : P = ⊤ := by
-    apply eq_top_of_forall_reflectionPair_mem P
-    intro v w c d hc hd
-    exact (mem_P _).mpr (rightTranslationAlgHom_eq_self_of_reflectionPair n e he hc hd)
+    refine eq_top_iff.mpr fun x _ => ?_
+    obtain ⟨y, hy, hyx⟩ :=
+      hle ((closure_reflection_mul_eq_matrixSpecialOrthogonalGroup (n := Fin n) (K := K)).ge x.2)
+    exact Subtype.ext hyx ▸ hy
   have hg : E g ∈ P := by
     rw [hP]
     exact Subgroup.mem_top _

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialOrthogonal/Connected.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialOrthogonal/Connected.lean
@@ -7,35 +7,49 @@ module
 
 public import TauCeti.Algebra.AlgebraicGroup.Connected.CommHopfAlgCat
 public import TauCeti.Algebra.AlgebraicGroup.SpecialOrthogonal.Basic
+public import TauCeti.LinearAlgebra.Matrix.SpecialOrthogonalGroup.Reflection
 import TauCeti.Algebra.AlgebraicGroup.BaseChange.Naturality
 import TauCeti.Algebra.AlgebraicGroup.Connected.AlgebraicallyClosed
 import TauCeti.Algebra.AlgebraicGroup.MultiplicativeGroup.Basic
 import TauCeti.LinearAlgebra.Matrix.SpecialOrthogonalGroup.FinTwo
 
 /-!
-# Geometric connectedness of the two-dimensional special orthogonal group
+# Geometric connectedness of the special orthogonal groups
 
-The coordinate Hopf algebra of the standard group `SO₂` is geometrically connected over every
-field. Away from characteristic two, after extending to an algebraically closed field, choose a
-square root `i` of `-1`. The explicit equivalence `SO₂(K) ≃* Kˣ` writes every rational point on a
-Laurent-polynomial path from the identity. In characteristic two, every rational point lies on an
-affine-line path of matrices `!![1 + tb, tb; -tb, 1 + tb]`. An idempotent regular function is
-constant on either kind of path, so all right translations fix it; the standard Hopf-algebra
-criterion then proves connectedness.
+The coordinate Hopf algebra of the standard group `SOₙ` is geometrically connected in every rank
+away from characteristic two, and in rank two over every field. Connectedness is tested by
+idempotents: over an algebraically closed extension an idempotent regular function is constant
+once right translation by every rational point fixes it, and a rational point which is joined to
+the identity by a path (a point over a domain specializing to it at one parameter and to the
+identity at another) translates every idempotent to itself.
 
-The argument away from characteristic two uses Laurent rather than ordinary polynomial paths
-because the parameter is a unit. It treats the standard symmetric form used by
-`TauCeti.SpecialOrthogonal`; in characteristic two this determinant-one model is nonreduced but
-has connected underlying space.
+In every rank, away from characteristic two, the paths come from reflections. Cartan-Dieudonné
+writes a special orthogonal matrix as a product of pairs of reflections, and the points fixing a
+given idempotent form a subgroup, so it is enough to join each product of two reflections to the
+identity. Reflecting in a fixed anisotropic vector `v` and then in a vector moving along a
+Laurent-polynomial family through the plane spanned by `v` and `w` does exactly that, by
+`TauCeti.exists_laurentPath_reflectionMatrix_mul`.
 
-## Main declaration
+Rank two is treated separately because that argument needs an invertible two, while the
+determinant-one model of `SO₂` is geometrically connected over every field. Away from
+characteristic two, after extending to an algebraically closed field, the explicit equivalence
+`SO₂(K) ≃* Kˣ` writes every rational point on a Laurent-polynomial path from the identity; in
+characteristic two, every rational point lies on the affine-line path of matrices
+`!![1 + tb, tb; -tb, 1 + tb]`. That model is nonreduced in characteristic two, but its underlying
+space is still connected.
+
+## Main declarations
 
 * `TauCeti.SpecialOrthogonal.geometricallyConnectedCommHopfAlgProperty_coordinateHopfAlgebra_two`:
   `SO₂` is geometrically connected over every field.
+* `TauCeti.SpecialOrthogonal.geometricallyConnectedCommHopfAlgProperty_coordinateHopfAlgebra`:
+  `SOₙ` is geometrically connected in every rank over a field of characteristic different from
+  two.
 
 ## References
 
-* J. S. Milne, *Algebraic Groups* (2017), §§2.3 and 18.c.
+* J. S. Milne, *Algebraic Groups* (2017), §§2.3, 2.a and 18.c.
+* T. A. Springer, *Linear Algebraic Groups*, §2.2.
 -/
 
 public section
@@ -54,33 +68,33 @@ variable {k K : Type u} [Field k] [Field K] [Algebra k K]
 local instance : IsScalarTower k K (LaurentPolynomial K) :=
   IsScalarTower.of_algebraMap_eq (by simp)
 
-/-- Base-changed `SO₂` points identified with special orthogonal matrices. -/
-private def baseChangePointsMulEquiv
+/-- Base-changed `SOₙ` points identified with special orthogonal matrices. -/
+private def baseChangePointsMulEquiv (n : ℕ)
     (A : Type u) [CommRing A] [Algebra k A] [Algebra K A] [IsScalarTower k K A] :
-    WithConv (K ⊗[k] coordinateHopfAlgebra k 2 →ₐ[K] A) ≃*
-      Matrix.specialOrthogonalGroup (Fin 2) A :=
+    WithConv (K ⊗[k] coordinateHopfAlgebra k n →ₐ[K] A) ≃*
+      Matrix.specialOrthogonalGroup (Fin n) A :=
   (AlgHom.baseChangePointsMulEquiv (k := k) (K := K)
-    (A := coordinateHopfAlgebra k 2) (R := A)).symm.trans
-      (pointsMulEquiv k 2 (A := A))
+    (A := coordinateHopfAlgebra k n) (R := A)).symm.trans
+      (pointsMulEquiv k n (A := A))
 
-private theorem baseChangePointsMulEquiv_mapValue
+private theorem baseChangePointsMulEquiv_mapValue (n : ℕ)
     {A B : Type u} [CommRing A] [CommRing B]
     [Algebra k A] [Algebra K A] [IsScalarTower k K A]
     [Algebra k B] [Algebra K B] [IsScalarTower k K B]
-    (phi : A →ₐ[K] B) (f : WithConv (K ⊗[k] coordinateHopfAlgebra k 2 →ₐ[K] A)) :
-    baseChangePointsMulEquiv (k := k) (K := K) B
-        (AlgHom.mapValue (H := K ⊗[k] coordinateHopfAlgebra k 2) phi f) =
+    (phi : A →ₐ[K] B) (f : WithConv (K ⊗[k] coordinateHopfAlgebra k n →ₐ[K] A)) :
+    baseChangePointsMulEquiv (k := k) (K := K) n B
+        (AlgHom.mapValue (H := K ⊗[k] coordinateHopfAlgebra k n) phi f) =
       Matrix.SpecialOrthogonalGroup.map phi.toRingHom
-        (baseChangePointsMulEquiv (k := k) (K := K) A f) := by
+        (baseChangePointsMulEquiv (k := k) (K := K) n A f) := by
   rw [baseChangePointsMulEquiv, MulEquiv.trans_apply,
     AlgHom.baseChangePointsMulEquiv_symm_mapValue,
     baseChangePointsMulEquiv, MulEquiv.trans_apply]
-  exact pointsMulEquiv_mapValue (R := k) (n := 2) (phi.restrictScalars k) _
+  exact pointsMulEquiv_mapValue (R := k) (n := n) (phi.restrictScalars k) _
 
 /-- The Laurent-polynomial path in `SO₂` attached to the generic unit. -/
 private def laurentPath (i half : K) (hi : i ^ 2 = -1) (hhalf : 2 * half = 1) :
     WithConv (K ⊗[k] coordinateHopfAlgebra k 2 →ₐ[K] LaurentPolynomial K) :=
-  (baseChangePointsMulEquiv (k := k) (K := K) (LaurentPolynomial K)).symm
+  (baseChangePointsMulEquiv (k := k) (K := K) 2 (LaurentPolynomial K)).symm
     (Matrix.SpecialOrthogonalGroup.finTwoOfUnit
       (LaurentPolynomial.C i) (LaurentPolynomial.C half)
       (by simpa only [map_pow, map_neg, map_one] using
@@ -93,9 +107,9 @@ private theorem mapValue_laurentPath
     (i half : K) (hi : i ^ 2 = -1) (hhalf : 2 * half = 1) (u : Kˣ) :
     AlgHom.mapValue (H := K ⊗[k] coordinateHopfAlgebra k 2)
         (MultiplicativeGroup.point u) (laurentPath (k := k) i half hi hhalf) =
-      (baseChangePointsMulEquiv (k := k) (K := K) K).symm
+      (baseChangePointsMulEquiv (k := k) (K := K) 2 K).symm
         (Matrix.SpecialOrthogonalGroup.finTwoOfUnit i half hi hhalf u) := by
-  apply (baseChangePointsMulEquiv (k := k) (K := K) K).injective
+  apply (baseChangePointsMulEquiv (k := k) (K := K) 2 K).injective
   rw [baseChangePointsMulEquiv_mapValue]
   simp only [laurentPath, MulEquiv.apply_symm_apply]
   rw [Matrix.SpecialOrthogonalGroup.map_finTwoOfUnit]
@@ -136,11 +150,11 @@ private theorem rightTranslationAlgHom_eq_self_of_char_two
     (g : WithConv (K ⊗[k] coordinateHopfAlgebra k 2 →ₐ[K] K)) :
     HopfAlgebra.rightTranslationAlgHom g e = e := by
   let _ : CharP K 2 := CharTwo.of_one_ne_zero_of_two_eq_zero one_ne_zero h2
-  let E := baseChangePointsMulEquiv (k := k) (K := K) K
+  let E := baseChangePointsMulEquiv (k := k) (K := K) 2 K
   let M := E g
   let b : K := M.val 0 1
   let xX : WithConv (K ⊗[k] coordinateHopfAlgebra k 2 →ₐ[K] Polynomial K) :=
-    (baseChangePointsMulEquiv (k := k) (K := K) (Polynomial K)).symm
+    (baseChangePointsMulEquiv (k := k) (K := K) 2 (Polynomial K)).symm
       (charTwoMatrixPath b h2)
   let eval (c : K) : Polynomial K →ₐ[K] K :=
     Polynomial.aevalTower (AlgHom.id K K) c
@@ -192,7 +206,7 @@ private theorem rightTranslationAlgHom_eq_self_of_two_ne_zero
   let half : K := (2 : K)⁻¹
   have hhalf : 2 * half = 1 := by
     exact mul_inv_cancel₀ h2
-  let E := baseChangePointsMulEquiv (k := k) (K := K) K
+  let E := baseChangePointsMulEquiv (k := k) (K := K) 2 K
   let u : Kˣ := Matrix.SpecialOrthogonalGroup.finTwoToUnit i hi (E g)
   let eval (v : Kˣ) : LaurentPolynomial K →ₐ[K] K := MultiplicativeGroup.point v
   apply HopfAlgebra.rightTranslationAlgHom_eq_self_of_path e he g
@@ -234,6 +248,101 @@ theorem geometricallyConnectedCommHopfAlgProperty_coordinateHopfAlgebra_two
   let equiv : (H : Type u) ⊗[k] K ≃+* K ⊗[k] H :=
     (Algebra.TensorProduct.comm k H K).toRingEquiv
   exact (PrimeSpectrum.homeomorphOfRingEquiv equiv).connectedSpace_iff.mpr hconnected
+
+/-! ### Every rank, away from characteristic two -/
+
+section CharNeTwo
+
+variable (n : ℕ)
+
+/-- **Right translation by a product of two reflections fixes every idempotent.** The
+Laurent-polynomial family joining that point to the identity is a path in the sense of
+`TauCeti.HopfAlgebra.rightTranslationAlgHom_eq_self_of_path`, evaluated at the two units the
+family singles out. -/
+private theorem rightTranslationAlgHom_eq_self_of_reflectionPair
+    [Invertible (2 : K)] [IsAlgClosed K]
+    (e : K ⊗[k] coordinateHopfAlgebra k n) (he : IsIdempotentElem e)
+    {v w : Fin n → K} {c d : K} (hc : c * (v ⬝ᵥ v) = 2) (hd : d * (w ⬝ᵥ w) = 2) :
+    HopfAlgebra.rightTranslationAlgHom
+        ((baseChangePointsMulEquiv (k := k) (K := K) n K).symm
+          (reflectionPair v w c d hc hd)) e = e := by
+  obtain ⟨M, a, b, hM⟩ := exists_laurentPath_reflectionMatrix_mul (n := Fin n) hc hd
+  apply HopfAlgebra.rightTranslationAlgHom_eq_self_of_path e he _
+    ((baseChangePointsMulEquiv (k := k) (K := K) n (LaurentPolynomial K)).symm M)
+    (MultiplicativeGroup.point b) (MultiplicativeGroup.point a)
+  · apply (baseChangePointsMulEquiv (k := k) (K := K) n K).injective
+    rw [baseChangePointsMulEquiv_mapValue, MulEquiv.apply_symm_apply, MulEquiv.apply_symm_apply]
+    refine Subtype.ext ?_
+    rw [Matrix.SpecialOrthogonalGroup.coe_map, coe_reflectionPair]
+    exact (hM (MultiplicativeGroup.point b)).2 (by simp)
+  · apply (baseChangePointsMulEquiv (k := k) (K := K) n K).injective
+    rw [baseChangePointsMulEquiv_mapValue, MulEquiv.apply_symm_apply, map_one]
+    refine Subtype.ext ?_
+    rw [Matrix.SpecialOrthogonalGroup.coe_map, Submonoid.coe_one]
+    exact (hM (MultiplicativeGroup.point a)).1 (by simp)
+
+/-- Right translation by any rational point of `SOₙ` fixes every idempotent: the points fixing a
+given idempotent form a subgroup, and products of two reflections generate. -/
+private theorem rightTranslationAlgHom_eq_self_of_invertibleTwo
+    [Invertible (2 : K)] [IsAlgClosed K]
+    (e : K ⊗[k] coordinateHopfAlgebra k n) (he : IsIdempotentElem e)
+    (g : WithConv (K ⊗[k] coordinateHopfAlgebra k n →ₐ[K] K)) :
+    HopfAlgebra.rightTranslationAlgHom g e = e := by
+  let E := baseChangePointsMulEquiv (k := k) (K := K) n K
+  let fixes (x : Matrix.specialOrthogonalGroup (Fin n) K) : Prop :=
+    HopfAlgebra.rightTranslationAlgHom (E.symm x) e = e
+  have fixes_one : fixes 1 := by
+    dsimp only [fixes]
+    rw [map_one, HopfAlgebra.rightTranslationAlgHom_one, AlgHom.id_apply]
+  have fixes_mul {x y : Matrix.specialOrthogonalGroup (Fin n) K} (hx : fixes x) (hy : fixes y) :
+      fixes (x * y) := by
+    dsimp only [fixes] at hx hy ⊢
+    rw [map_mul, HopfAlgebra.rightTranslationAlgHom_mul, AlgHom.comp_apply, hy, hx]
+  have fixes_inv {x : Matrix.specialOrthogonalGroup (Fin n) K} (hx : fixes x) : fixes x⁻¹ := by
+    dsimp only [fixes] at hx ⊢
+    have h := DFunLike.congr_fun
+      (HopfAlgebra.rightTranslationAlgHom_mul (E.symm x⁻¹) (E.symm x)) e
+    rw [← map_mul E.symm, inv_mul_cancel x, map_one,
+      HopfAlgebra.rightTranslationAlgHom_one, AlgHom.id_apply, AlgHom.comp_apply, hx] at h
+    exact h.symm
+  let P : Subgroup (Matrix.specialOrthogonalGroup (Fin n) K) :=
+    { carrier := fixes
+      one_mem' := fixes_one
+      mul_mem' := fixes_mul
+      inv_mem' := fixes_inv }
+  have mem_P (x : Matrix.specialOrthogonalGroup (Fin n) K) : x ∈ P ↔ fixes x := Iff.rfl
+  have hP : P = ⊤ := by
+    apply eq_top_of_forall_reflectionPair_mem P
+    intro v w c d hc hd
+    exact (mem_P _).mpr (rightTranslationAlgHom_eq_self_of_reflectionPair n e he hc hd)
+  have hg : E g ∈ P := by
+    rw [hP]
+    exact Subgroup.mem_top _
+  simpa only [fixes, MulEquiv.symm_apply_apply] using (mem_P _).mp hg
+
+/-- **The coordinate Hopf algebra of `SOₙ` is geometrically connected over every field of
+characteristic different from two**, in every rank. -/
+theorem geometricallyConnectedCommHopfAlgProperty_coordinateHopfAlgebra
+    (k : Type u) [Field k] [NeZero (2 : k)] (n : ℕ) :
+    geometricallyConnectedCommHopfAlgProperty k (coordinateHopfAlgebra k n) := by
+  rw [geometricallyConnectedCommHopfAlgProperty_iff_connectedSpace_of_isAlgClosed]
+  intro K _ _ _
+  have h2 : (2 : K) ≠ 0 := by
+    simpa only [map_ofNat] using (map_ne_zero (algebraMap k K)).2 (NeZero.ne (2 : k))
+  let _ : Invertible (2 : K) := invertibleOfNonzero h2
+  let H := coordinateHopfAlgebra k n
+  let _ : Nontrivial H := Bialgebra.nontrivial (A := H) k
+  let _ : Nontrivial (K ⊗[k] H) :=
+    Algebra.TensorProduct.nontrivial_of_algebraMap_injective_of_flat_left k K H
+      (RingHom.injective (algebraMap k H))
+  have hconnected : ConnectedSpace (PrimeSpectrum (K ⊗[k] H)) :=
+    HopfAlgebra.connectedSpace_primeSpectrum_of_forall_rightTranslationAlgHom_eq_self
+      fun e he g ↦ rightTranslationAlgHom_eq_self_of_invertibleTwo (k := k) (K := K) n e he g
+  let equiv : (H : Type u) ⊗[k] K ≃+* K ⊗[k] H :=
+    (Algebra.TensorProduct.comm k H K).toRingEquiv
+  exact (PrimeSpectrum.homeomorphOfRingEquiv equiv).connectedSpace_iff.mpr hconnected
+
+end CharNeTwo
 
 end
 

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialOrthogonal/Reductive.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialOrthogonal/Reductive.lean
@@ -140,14 +140,6 @@ theorem reductiveCommHopfAlgProperty_iff_geometricallyConnected_of_three_le
     exact eq_augmentation_of_isNormal_of_smoothUnipotent_of_three_le
       (AlgebraicClosure k) n hn I hI hU
 
-/-- **`SOₙ` is reductive in dimension at least three**, over every field of characteristic
-different from two. -/
-theorem reductiveCommHopfAlgProperty_finiteTypeCoordinateHopfAlgebra_of_three_le
-    (k : Type u) [Field k] [NeZero (2 : k)] (n : Nat) (hn : 3 ≤ n) :
-    reductiveCommHopfAlgProperty k (finiteTypeCoordinateHopfAlgebra k n) :=
-  (reductiveCommHopfAlgProperty_iff_geometricallyConnected_of_three_le k n hn).mpr
-    (geometricallyConnectedCommHopfAlgProperty_coordinateHopfAlgebra k n)
-
 /-- **Every standard special orthogonal group is reductive**, over every field of characteristic
 different from two.
 
@@ -162,8 +154,9 @@ theorem reductiveCommHopfAlgProperty_finiteTypeCoordinateHopfAlgebra
   | 1 => reductiveCommHopfAlgProperty_finiteTypeCoordinateHopfAlgebra_one k
   | 2 => reductiveCommHopfAlgProperty_finiteTypeCoordinateHopfAlgebra_two k
   | (m + 3) =>
-    reductiveCommHopfAlgProperty_finiteTypeCoordinateHopfAlgebra_of_three_le k (m + 3)
-      (by omega)
+    (reductiveCommHopfAlgProperty_iff_geometricallyConnected_of_three_le k (m + 3)
+        (by omega)).mpr
+      (geometricallyConnectedCommHopfAlgProperty_coordinateHopfAlgebra k (m + 3))
 
 end
 

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialOrthogonal/Reductive.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialOrthogonal/Reductive.lean
@@ -6,10 +6,10 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.Reductive.Basic
-public import TauCeti.Algebra.AlgebraicGroup.SpecialOrthogonal.Connected
+import TauCeti.Algebra.AlgebraicGroup.SpecialOrthogonal.Connected
 public import TauCeti.Algebra.AlgebraicGroup.SpecialOrthogonal.Irreducible
-public import TauCeti.Algebra.AlgebraicGroup.SpecialOrthogonal.LowRank
-public import TauCeti.Algebra.AlgebraicGroup.SpecialOrthogonal.Torus
+import TauCeti.Algebra.AlgebraicGroup.SpecialOrthogonal.LowRank
+import TauCeti.Algebra.AlgebraicGroup.SpecialOrthogonal.Torus
 public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Radical.Faithful
 import TauCeti.Algebra.AlgebraicGroup.SpecialOrthogonal.BaseChange
 import TauCeti.Algebra.AlgebraicGroup.SpecialOrthogonal.Smooth

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialOrthogonal/Reductive.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialOrthogonal/Reductive.lean
@@ -27,9 +27,9 @@ theorem then forces a normal smooth unipotent subgroup to act trivially, and fai
 identifies its defining Hopf ideal with the augmentation ideal.
 
 Smoothness is already known away from characteristic two, and so is geometric connectedness, so
-reductivity follows in dimension at least three. Together with the rank-zero and rank-one cases,
-where the group is special linear, and the rank-two case, where it is a torus, this makes every
-standard special orthogonal group reductive away from characteristic two.
+reductivity follows in dimension at least three. Together with the dimension-zero and
+dimension-one cases, where the group is special linear, and the dimension-two case, where it is a
+torus, this makes every standard special orthogonal group reductive away from characteristic two.
 
 ## Main declarations
 
@@ -41,7 +41,7 @@ standard special orthogonal group reductive away from characteristic two.
   in these dimensions and characteristics, `SOₙ` is reductive exactly when it is geometrically
   connected.
 * `TauCeti.SpecialOrthogonal.reductiveCommHopfAlgProperty_finiteTypeCoordinateHopfAlgebra`: `SOₙ`
-  is reductive in every rank, over every field of characteristic different from two.
+  is reductive in every dimension, over every field of characteristic different from two.
 
 ## References
 
@@ -151,9 +151,9 @@ theorem reductiveCommHopfAlgProperty_finiteTypeCoordinateHopfAlgebra_of_three_le
 /-- **Every standard special orthogonal group is reductive**, over every field of characteristic
 different from two.
 
-The rank-zero and rank-one groups are special linear, the rank-two group is a torus, and from
-rank three on the standard representation is simple, which is what makes the unipotent radical
-trivial. -/
+The dimension-zero and dimension-one groups are special linear, the dimension-two group is a
+torus, and from dimension three on the standard representation is simple, which makes the
+unipotent radical trivial. -/
 theorem reductiveCommHopfAlgProperty_finiteTypeCoordinateHopfAlgebra
     (k : Type u) [Field k] [NeZero (2 : k)] (n : Nat) :
     reductiveCommHopfAlgProperty k (finiteTypeCoordinateHopfAlgebra k n) :=

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialOrthogonal/Reductive.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialOrthogonal/Reductive.lean
@@ -6,13 +6,16 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.Reductive.Basic
+public import TauCeti.Algebra.AlgebraicGroup.SpecialOrthogonal.Connected
 public import TauCeti.Algebra.AlgebraicGroup.SpecialOrthogonal.Irreducible
+public import TauCeti.Algebra.AlgebraicGroup.SpecialOrthogonal.LowRank
+public import TauCeti.Algebra.AlgebraicGroup.SpecialOrthogonal.Torus
 public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Radical.Faithful
 import TauCeti.Algebra.AlgebraicGroup.SpecialOrthogonal.BaseChange
 import TauCeti.Algebra.AlgebraicGroup.SpecialOrthogonal.Smooth
 
 /-!
-# The unipotent radical obstruction for higher-dimensional special orthogonal groups
+# Reductivity of the special orthogonal groups
 
 Let `SOₙ` be the special orthogonal group of the standard symmetric form over a field of
 characteristic different from two. In dimension at least three, every normal smooth unipotent
@@ -23,10 +26,10 @@ simple in dimension at least three, hence completely reducible. The general norm
 theorem then forces a normal smooth unipotent subgroup to act trivially, and faithfulness
 identifies its defining Hopf ideal with the augmentation ideal.
 
-Smoothness is already known away from characteristic two. Consequently reductivity of `SOₙ`
-in dimension at least three is equivalent to the one remaining geometric condition,
-connectedness. This isolates exactly what is still needed for the dimension-at-least-three
-standard special-orthogonal groups.
+Smoothness is already known away from characteristic two, and so is geometric connectedness, so
+reductivity follows in dimension at least three. Together with the rank-zero and rank-one cases,
+where the group is special linear, and the rank-two case, where it is a torus, this makes every
+standard special orthogonal group reductive away from characteristic two.
 
 ## Main declarations
 
@@ -37,6 +40,8 @@ standard special-orthogonal groups.
 * `TauCeti.SpecialOrthogonal.reductiveCommHopfAlgProperty_iff_geometricallyConnected_of_three_le`:
   in these dimensions and characteristics, `SOₙ` is reductive exactly when it is geometrically
   connected.
+* `TauCeti.SpecialOrthogonal.reductiveCommHopfAlgProperty_finiteTypeCoordinateHopfAlgebra`: `SOₙ`
+  is reductive in every rank, over every field of characteristic different from two.
 
 ## References
 
@@ -134,6 +139,31 @@ theorem reductiveCommHopfAlgProperty_iff_geometricallyConnected_of_three_le
     intro I hI hU
     exact eq_augmentation_of_isNormal_of_smoothUnipotent_of_three_le
       (AlgebraicClosure k) n hn I hI hU
+
+/-- **`SOₙ` is reductive in dimension at least three**, over every field of characteristic
+different from two. -/
+theorem reductiveCommHopfAlgProperty_finiteTypeCoordinateHopfAlgebra_of_three_le
+    (k : Type u) [Field k] [NeZero (2 : k)] (n : Nat) (hn : 3 ≤ n) :
+    reductiveCommHopfAlgProperty k (finiteTypeCoordinateHopfAlgebra k n) :=
+  (reductiveCommHopfAlgProperty_iff_geometricallyConnected_of_three_le k n hn).mpr
+    (geometricallyConnectedCommHopfAlgProperty_coordinateHopfAlgebra k n)
+
+/-- **Every standard special orthogonal group is reductive**, over every field of characteristic
+different from two.
+
+The rank-zero and rank-one groups are special linear, the rank-two group is a torus, and from
+rank three on the standard representation is simple, which is what makes the unipotent radical
+trivial. -/
+theorem reductiveCommHopfAlgProperty_finiteTypeCoordinateHopfAlgebra
+    (k : Type u) [Field k] [NeZero (2 : k)] (n : Nat) :
+    reductiveCommHopfAlgProperty k (finiteTypeCoordinateHopfAlgebra k n) :=
+  match n with
+  | 0 => reductiveCommHopfAlgProperty_finiteTypeCoordinateHopfAlgebra_zero k
+  | 1 => reductiveCommHopfAlgProperty_finiteTypeCoordinateHopfAlgebra_one k
+  | 2 => reductiveCommHopfAlgProperty_finiteTypeCoordinateHopfAlgebra_two k
+  | (m + 3) =>
+    reductiveCommHopfAlgProperty_finiteTypeCoordinateHopfAlgebra_of_three_le k (m + 3)
+      (by omega)
 
 end
 

--- a/TauCeti/Algebra/AlgebraicGroup/Symplectic/Connected.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Symplectic/Connected.lean
@@ -108,36 +108,17 @@ private theorem rightTranslationAlgHom_eq_self
     (g : WithConv (K ⊗[k] coordinateHopfAlgebra k m →ₐ[K] K)) :
     HopfAlgebra.rightTranslationAlgHom g e = e := by
   let E := baseChangeSymplecticPointsMulEquiv (k := k) (K := K) m K
-  let fixes (x : GLSymplecticFin m K) : Prop :=
-    HopfAlgebra.rightTranslationAlgHom (E.symm x) e = e
-  have fixes_one : fixes 1 := by
-    dsimp only [fixes]
-    rw [map_one, HopfAlgebra.rightTranslationAlgHom_one, AlgHom.id_apply]
-  have fixes_mul {x y : GLSymplecticFin m K} (hx : fixes x) (hy : fixes y) :
-      fixes (x * y) := by
-    dsimp only [fixes] at hx hy ⊢
-    rw [map_mul, HopfAlgebra.rightTranslationAlgHom_mul, AlgHom.comp_apply, hy, hx]
-  have fixes_inv {x : GLSymplecticFin m K} (hx : fixes x) : fixes x⁻¹ := by
-    dsimp only [fixes] at hx ⊢
-    have h := DFunLike.congr_fun
-      (HopfAlgebra.rightTranslationAlgHom_mul (E.symm x⁻¹) (E.symm x)) e
-    rw [← map_mul E.symm, inv_mul_cancel x, map_one,
-      HopfAlgebra.rightTranslationAlgHom_one,
-      AlgHom.id_apply, AlgHom.comp_apply, hx] at h
-    exact h.symm
-  let P : Subgroup (GLSymplecticFin m K) :=
-    { carrier := fixes
-      one_mem' := fixes_one
-      mul_mem' := fixes_mul
-      inv_mem' := fixes_inv }
-  have mem_P (x : GLSymplecticFin m K) : x ∈ P ↔ fixes x := Iff.rfl
+  let P := (HopfAlgebra.rightTranslationStabilizer e).comap E.symm.toMonoidHom
+  have mem_P (x : GLSymplecticFin m K) :
+      x ∈ P ↔ HopfAlgebra.rightTranslationAlgHom (E.symm x) e = e :=
+    Subgroup.mem_comap.trans HopfAlgebra.mem_rightTranslationStabilizer
   have hP : P = ⊤ := by
     apply GLSymplecticFin.eq_top_of_root_subgroups P
     intro root c
     exact (mem_P _).mpr
       (rightTranslationAlgHom_eq_self_of_root (k := k) (K := K) m e he root c.toAdd)
   have hg : E g ∈ P := by rw [hP]; exact Subgroup.mem_top _
-  simpa only [fixes, MulEquiv.symm_apply_apply] using (mem_P _).mp hg
+  simpa only [MulEquiv.symm_apply_apply] using (mem_P _).mp hg
 
 /-- The coordinate Hopf algebra of `Sp_{2m}` is geometrically connected over every field. -/
 theorem geometricallyConnectedCommHopfAlgProperty_coordinateHopfAlgebra

--- a/TauCeti/LinearAlgebra/Matrix/OrthogonalGroup/QuadraticForm.lean
+++ b/TauCeti/LinearAlgebra/Matrix/OrthogonalGroup/QuadraticForm.lean
@@ -65,9 +65,8 @@ theorem toMatrix_mem_orthogonalGroup_iff (R : Type u) [CommRing R]
   have hpolar (x y : n → R) :
       QuadraticMap.polar (Matrix.toQuadraticForm' (1 : Matrix n n R)) x y =
         (2 : R) • B x y := by
-    simp only [Matrix.toQuadraticForm', LinearMap.BilinMap.polar_toQuadraticMap,
-      Matrix.toLinearMap₂'_apply', Matrix.one_mulVec, B, two_smul,
-      dotProduct_comm y x]
+    simp only [polar_toQuadraticForm'_one, B, Matrix.toLinearMap₂'_apply', Matrix.one_mulVec,
+      smul_eq_mul]
   simp only [hpolar, h2.eq_iff, BilinForm.isIsometry_iff, LinearEquiv.coe_coe]
 
 /-- The coordinate matrix is special orthogonal exactly when the linear automorphism is

--- a/TauCeti/LinearAlgebra/Matrix/OrthogonalGroup/QuadraticForm.lean
+++ b/TauCeti/LinearAlgebra/Matrix/OrthogonalGroup/QuadraticForm.lean
@@ -30,8 +30,10 @@ universe u v
 
 variable {R : Type u} [CommRing R] {n : Type v} [Fintype n] [DecidableEq n]
 
-/-- The standard quadratic form is the square of the Euclidean norm. -/
-@[simp]
+/-- The quadratic form of the identity matrix sends a vector to its dot product with itself.
+
+This is not a `simp` lemma: `TauCeti.PDE.toQuadraticForm'_one` already normalises the same
+left-hand side to `‖ξ‖ ^ 2` on `EuclideanSpace ℝ n`, and the two cannot both be simp-normal. -/
 theorem toQuadraticForm'_one_apply (x : n → R) :
     Matrix.toQuadraticForm' (1 : Matrix n n R) x = x ⬝ᵥ x := by
   simp [Matrix.toQuadraticForm', Matrix.toLinearMap₂'_apply']

--- a/TauCeti/LinearAlgebra/Matrix/OrthogonalGroup/QuadraticForm.lean
+++ b/TauCeti/LinearAlgebra/Matrix/OrthogonalGroup/QuadraticForm.lean
@@ -28,6 +28,21 @@ open Matrix
 
 universe u v
 
+variable {R : Type u} [CommRing R] {n : Type v} [Fintype n] [DecidableEq n]
+
+/-- The standard quadratic form is the square of the Euclidean norm. -/
+@[simp]
+theorem toQuadraticForm'_one_apply (x : n → R) :
+    Matrix.toQuadraticForm' (1 : Matrix n n R) x = x ⬝ᵥ x := by
+  simp [Matrix.toQuadraticForm', Matrix.toLinearMap₂'_apply']
+
+/-- The polar form of the standard quadratic form is twice the dot product. -/
+@[simp]
+theorem polar_toQuadraticForm'_one (x y : n → R) :
+    QuadraticMap.polar (Matrix.toQuadraticForm' (1 : Matrix n n R)) x y = 2 * (x ⬝ᵥ y) := by
+  simp only [Matrix.toQuadraticForm', LinearMap.BilinMap.polar_toQuadraticMap,
+    Matrix.toLinearMap₂'_apply', Matrix.one_mulVec, two_mul, dotProduct_comm y x]
+
 /-- The coordinate matrix of a linear automorphism is orthogonal exactly when the
 automorphism preserves the standard quadratic form. -/
 @[simp]

--- a/TauCeti/LinearAlgebra/Matrix/SpecialOrthogonalGroup/Reflection.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SpecialOrthogonalGroup/Reflection.lean
@@ -184,6 +184,24 @@ theorem coe_reflectionPair {v w : n → R} {c d : R} (hc : c * (v ⬝ᵥ v) = 2)
       reflectionMatrix v c * reflectionMatrix w d :=
   (rfl)
 
+omit [DecidableEq n] in
+/-- A ring homomorphism carries the normalizing equation of a reflection to the normalizing
+equation of the reflection in the mapped vector with the mapped scalar. -/
+theorem map_mul_dotProduct_eq_two (f : R →+* S) {v : n → R} {c : R} (hc : c * (v ⬝ᵥ v) = 2) :
+    f c * ((f ∘ v) ⬝ᵥ (f ∘ v)) = 2 := by
+  rw [← RingHom.map_dotProduct, ← map_mul, hc, map_ofNat]
+
+/-- Products of two reflections are natural in the coefficient ring. -/
+@[simp]
+theorem map_reflectionPair (f : R →+* S) {v w : n → R} {c d : R} (hc : c * (v ⬝ᵥ v) = 2)
+    (hd : d * (w ⬝ᵥ w) = 2) :
+    Matrix.SpecialOrthogonalGroup.map f (reflectionPair v w c d hc hd) =
+      reflectionPair (f ∘ v) (f ∘ w) (f c) (f d) (map_mul_dotProduct_eq_two f hc)
+        (map_mul_dotProduct_eq_two f hd) :=
+  Subtype.ext <| by
+    rw [Matrix.SpecialOrthogonalGroup.coe_map, coe_reflectionPair, coe_reflectionPair,
+      Matrix.map_mul, map_reflectionMatrix, map_reflectionMatrix]
+
 end Pair
 
 /-! ### Generation of the special orthogonal group -/

--- a/TauCeti/LinearAlgebra/Matrix/SpecialOrthogonalGroup/Reflection.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SpecialOrthogonalGroup/Reflection.lean
@@ -1,0 +1,481 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Polynomial.Laurent
+public import Mathlib.FieldTheory.IsAlgClosed.Basic
+public import TauCeti.LinearAlgebra.Matrix.OneSubVecMulVec
+public import TauCeti.LinearAlgebra.Matrix.SpecialOrthogonalGroup.Basic
+public import TauCeti.LinearAlgebra.Matrix.SpecialOrthogonalGroup.Generation
+
+/-!
+# Reflection matrices for the standard symmetric form
+
+The reflection of `Rⁿ` in the hyperplane orthogonal to a vector `v` has the matrix
+`1 - c • vecMulVec v v`, where the scalar `c` satisfies `c * (v ⬝ᵥ v) = 2`. Carrying the scalar
+as data rather than as `2 * ⅟(v ⬝ᵥ v)` makes the construction available over any commutative
+ring in which the norm of `v` happens to be invertible, makes it visibly natural in the
+coefficient ring, and makes the invariance of a reflection under rescaling its vector a
+one-line computation: rescaling `v` by `μ` rescales `c` by `μ⁻²`.
+
+Products of two such matrices are exactly the generators of the special orthogonal group
+supplied by `TauCeti.closure_reflection_mul_eq_matrixSpecialOrthogonalGroup`. They are packaged
+here as `TauCeti.reflectionPair`, and the generation theorem is restated as a criterion for a
+subgroup of `Matrix.specialOrthogonalGroup n K` to be the whole group.
+
+## Main declarations
+
+* `TauCeti.reflectionMatrix`: the matrix of a reflection, with its normalizing scalar as data.
+* `TauCeti.reflectionPair`: the product of two reflections, as a special orthogonal matrix.
+* `TauCeti.eq_top_of_forall_reflectionPair_mem`: a subgroup of the matrix special orthogonal
+  group containing every product of two reflections is the whole group.
+
+## References
+
+* H. B. Lawson and M.-L. Michelsohn, *Spin Geometry* (1989), Chapter I, §2.
+* J. S. Milne, *Algebraic Groups* (2017), §2.3.
+-/
+
+public section
+
+namespace TauCeti
+
+open Matrix
+
+universe u v w
+
+variable {n : Type v} [DecidableEq n]
+variable {R : Type u} [CommRing R] {S : Type w} [CommRing S]
+
+attribute [local instance] starRingOfComm
+
+/-- The matrix of the reflection of `Rⁿ` in the hyperplane orthogonal to `v`, for a scalar `c`
+playing the role of `2 / (v ⬝ᵥ v)`. It is a reflection precisely when `c * (v ⬝ᵥ v) = 2`, which
+is not part of the definition. -/
+def reflectionMatrix (v : n → R) (c : R) : Matrix n n R := 1 - c • vecMulVec v v
+
+theorem reflectionMatrix_apply (v : n → R) (c : R) (i j : n) :
+    reflectionMatrix v c i j = (if i = j then 1 else 0) - c * (v i * v j) := by
+  simp [reflectionMatrix, Matrix.one_apply, vecMulVec_apply]
+
+@[simp]
+theorem transpose_reflectionMatrix (v : n → R) (c : R) :
+    (reflectionMatrix v c)ᵀ = reflectionMatrix v c := by
+  simp [reflectionMatrix, Matrix.transpose_sub, Matrix.transpose_smul, transpose_vecMulVec]
+
+/-- Reflection matrices are natural in the coefficient ring. -/
+theorem reflectionMatrix_map (f : R →+* S) (v : n → R) (c : R) :
+    (reflectionMatrix v c).map f = reflectionMatrix (f ∘ v) (f c) := by
+  ext i j
+  simp [reflectionMatrix_apply, apply_ite f]
+
+/-- Rescaling the vector of a reflection by `μ` rescales its normalizing scalar by `μ⁻²`. -/
+theorem reflectionMatrix_smul (v : n → R) (c μ : R) :
+    reflectionMatrix (fun i => μ * v i) c = reflectionMatrix v (μ * μ * c) := by
+  ext i j
+  simp only [reflectionMatrix_apply]
+  ring_nf
+
+/-- A reflection matrix is a rank-one perturbation of the identity, so the calculus of
+`TauCeti.LinearAlgebra.Matrix.OneSubVecMulVec` applies to it. -/
+theorem reflectionMatrix_eq_one_sub_vecMulVec (v : n → R) (c : R) :
+    reflectionMatrix v c = 1 - vecMulVec (c • v) v := by
+  rw [reflectionMatrix, smul_vecMulVec]
+
+omit [DecidableEq n] in
+private theorem dotProduct_smul_self [Fintype n] {v : n → R} {c : R} (hc : c * (v ⬝ᵥ v) = 2) :
+    v ⬝ᵥ (c • v) = 2 := by
+  rw [dotProduct_smul, smul_eq_mul, ← hc, mul_comm]
+
+/-- A reflection matrix is an involution. -/
+theorem reflectionMatrix_mul_self [Fintype n] {v : n → R} {c : R} (hc : c * (v ⬝ᵥ v) = 2) :
+    reflectionMatrix v c * reflectionMatrix v c = 1 := by
+  rw [reflectionMatrix_eq_one_sub_vecMulVec,
+    one_sub_vecMulVec_mul_self 1 (by rw [dotProduct_smul_self hc]; norm_num)]
+  module
+
+/-- A reflection matrix is orthogonal. -/
+theorem reflectionMatrix_mem_orthogonalGroup [Fintype n] {v : n → R} {c : R}
+    (hc : c * (v ⬝ᵥ v) = 2) :
+    reflectionMatrix v c ∈ Matrix.orthogonalGroup n R := by
+  rw [Matrix.mem_orthogonalGroup_iff, transpose_reflectionMatrix]
+  exact reflectionMatrix_mul_self hc
+
+/-- **A reflection matrix has determinant `-1`.** -/
+theorem det_reflectionMatrix [Fintype n] {v : n → R} {c : R} (hc : c * (v ⬝ᵥ v) = 2) :
+    (reflectionMatrix v c).det = -1 := by
+  rw [reflectionMatrix_eq_one_sub_vecMulVec, det_one_sub_vecMulVec, dotProduct_smul_self hc]
+  norm_num
+
+/-! ### Comparison with the reflection of the standard quadratic form -/
+
+section QuadraticForm
+
+variable [Fintype n]
+
+/-- The standard quadratic form is the square of the euclidean norm. -/
+theorem toQuadraticForm'_one_apply (x : n → R) :
+    Matrix.toQuadraticForm' (1 : Matrix n n R) x = x ⬝ᵥ x := by
+  simp [Matrix.toQuadraticForm', Matrix.toLinearMap₂'_apply']
+
+/-- The polar form of the standard quadratic form is twice the dot product. -/
+theorem polar_toQuadraticForm'_one (x y : n → R) :
+    QuadraticMap.polar (Matrix.toQuadraticForm' (1 : Matrix n n R)) x y = 2 * (x ⬝ᵥ y) := by
+  simp only [Matrix.toQuadraticForm', LinearMap.BilinMap.polar_toQuadraticMap,
+    Matrix.toLinearMap₂'_apply', Matrix.one_mulVec, two_mul, dotProduct_comm y x]
+
+/-- The reflection of the standard quadratic form in a vector of invertible norm has
+`reflectionMatrix` as its coordinate matrix. -/
+theorem toMatrix'_reflection (v : n → R)
+    [Invertible (Matrix.toQuadraticForm' (1 : Matrix n n R) v)] :
+    LinearMap.toMatrix'
+        (QuadraticMap.reflection (Matrix.toQuadraticForm' (1 : Matrix n n R)) v).toLinearMap =
+      reflectionMatrix v (2 * ⅟(Matrix.toQuadraticForm' (1 : Matrix n n R) v)) := by
+  ext i j
+  rw [LinearMap.toMatrix'_apply, LinearEquiv.coe_coe, QuadraticMap.reflection_apply,
+    reflectionMatrix_apply]
+  simp only [Pi.sub_apply, Pi.smul_apply, smul_eq_mul, polar_toQuadraticForm'_one,
+    Pi.single_apply, dotProduct_single, mul_one]
+  ring_nf
+
+end QuadraticForm
+
+/-! ### Products of two reflections -/
+
+section Pair
+
+variable [Fintype n]
+
+/-- The product of two reflection matrices is special orthogonal. -/
+theorem reflectionMatrix_mul_mem_specialOrthogonalGroup {v w : n → R} {c d : R}
+    (hc : c * (v ⬝ᵥ v) = 2) (hd : d * (w ⬝ᵥ w) = 2) :
+    reflectionMatrix v c * reflectionMatrix w d ∈ Matrix.specialOrthogonalGroup n R :=
+  Matrix.mem_specialOrthogonalGroup_iff.mpr
+    ⟨Submonoid.mul_mem _ (reflectionMatrix_mem_orthogonalGroup hc)
+        (reflectionMatrix_mem_orthogonalGroup hd),
+      by rw [Matrix.det_mul, det_reflectionMatrix hc, det_reflectionMatrix hd]; ring⟩
+
+/-- **The product of the reflections in two vectors of invertible norm**, as an element of the
+matrix special orthogonal group of the standard symmetric form. -/
+def reflectionPair (v w : n → R) (c d : R) (hc : c * (v ⬝ᵥ v) = 2) (hd : d * (w ⬝ᵥ w) = 2) :
+    Matrix.specialOrthogonalGroup n R :=
+  ⟨reflectionMatrix v c * reflectionMatrix w d,
+    reflectionMatrix_mul_mem_specialOrthogonalGroup hc hd⟩
+
+@[simp]
+theorem coe_reflectionPair {v w : n → R} {c d : R} (hc : c * (v ⬝ᵥ v) = 2)
+    (hd : d * (w ⬝ᵥ w) = 2) :
+    (reflectionPair v w c d hc hd : Matrix n n R) =
+      reflectionMatrix v c * reflectionMatrix w d :=
+  (rfl)
+
+end Pair
+
+/-! ### Generation of the special orthogonal group -/
+
+/-- **A subgroup of the matrix special orthogonal group which contains every product of two
+reflections is the whole group.**
+
+This is the Cartan-Dieudonné generation theorem
+`TauCeti.closure_reflection_mul_eq_matrixSpecialOrthogonalGroup`, restated for the reflection
+matrices of this file. -/
+theorem eq_top_of_forall_reflectionPair_mem {K : Type u} [Field K] [Fintype n]
+    [NeZero (2 : K)] (P : Subgroup (Matrix.specialOrthogonalGroup n K))
+    (hP : ∀ (v w : n → K) (c d : K) (hc : c * (v ⬝ᵥ v) = 2) (hd : d * (w ⬝ᵥ w) = 2),
+      reflectionPair v w c d hc hd ∈ P) :
+    P = ⊤ := by
+  refine eq_top_iff.mpr fun x _ => ?_
+  have hclosure := closure_reflection_mul_eq_matrixSpecialOrthogonalGroup (n := n) (K := K)
+  have hle : Submonoid.closure {A : Matrix n n K |
+      ∃ (v w : n → K) (_ : Invertible (Matrix.toQuadraticForm' (1 : Matrix n n K) v))
+        (_ : Invertible (Matrix.toQuadraticForm' (1 : Matrix n n K) w)),
+        LinearMap.toMatrix'
+            (QuadraticMap.reflection (Matrix.toQuadraticForm' (1 : Matrix n n K)) v).toLinearMap *
+          LinearMap.toMatrix'
+            (QuadraticMap.reflection
+              (Matrix.toQuadraticForm' (1 : Matrix n n K)) w).toLinearMap = A} ≤
+      P.toSubmonoid.map (Matrix.specialOrthogonalGroup n K).subtype := by
+    refine Submonoid.closure_le.mpr ?_
+    rintro _ ⟨v, w, hv, hw, rfl⟩
+    have hcv : 2 * ⅟(Matrix.toQuadraticForm' (1 : Matrix n n K) v) * (v ⬝ᵥ v) = 2 := by
+      rw [← toQuadraticForm'_one_apply v, mul_assoc, invOf_mul_self, mul_one]
+    have hcw : 2 * ⅟(Matrix.toQuadraticForm' (1 : Matrix n n K) w) * (w ⬝ᵥ w) = 2 := by
+      rw [← toQuadraticForm'_one_apply w, mul_assoc, invOf_mul_self, mul_one]
+    refine ⟨reflectionPair v w _ _ hcv hcw, hP _ _ _ _ hcv hcw, ?_⟩
+    change (reflectionPair v w _ _ hcv hcw : Matrix n n K) = _
+    rw [coe_reflectionPair, toMatrix'_reflection, toMatrix'_reflection]
+  obtain ⟨y, hy, hyx⟩ := hle (hclosure.ge x.2)
+  have hxy : y = x := Subtype.ext hyx
+  exact hxy ▸ hy
+
+/-! ### One-parameter families through a product of two reflections -/
+
+section Path
+
+open scoped LaurentPolynomial
+
+open LaurentPolynomial
+
+variable {K : Type u} [Field K]
+
+/-- The constant Laurent-polynomial vector attached to a vector over the coefficient field. -/
+private noncomputable def constVector (v : n → K) : n → K[T;T⁻¹] := fun i => C (v i)
+
+/-- The Laurent-polynomial vector `X • v + Y • w`. Its two coefficients travel along the
+family, and each endpoint of the family is a parameter at which one of them vanishes. -/
+private noncomputable def pathVector (v w : n → K) (X Y : K[T;T⁻¹]) : n → K[T;T⁻¹] :=
+  fun i => X * C (v i) + Y * C (w i)
+
+omit [DecidableEq n] in
+private theorem sum_C_mul_C [Fintype n] (u₁ u₂ : n → K) :
+    ∑ i, (C (u₁ i) : K[T;T⁻¹]) * C (u₂ i) = C (u₁ ⬝ᵥ u₂) := by
+  rw [dotProduct, map_sum]
+  exact Finset.sum_congr rfl fun i _ => (map_mul C _ _).symm
+
+omit [DecidableEq n] in
+private theorem constVector_dotProduct [Fintype n] (v w : n → K) :
+    constVector v ⬝ᵥ constVector w = C (v ⬝ᵥ w) :=
+  sum_C_mul_C v w
+
+omit [DecidableEq n] in
+private theorem pathVector_dotProduct [Fintype n] (v w : n → K) (X Y X' Y' : K[T;T⁻¹]) :
+    pathVector v w X Y ⬝ᵥ pathVector v w X' Y' =
+      X * X' * C (v ⬝ᵥ v) + (X * Y' + Y * X') * C (v ⬝ᵥ w) + Y * Y' * C (w ⬝ᵥ w) := by
+  rw [dotProduct]
+  rw [Finset.sum_congr rfl fun i _ =>
+    show pathVector v w X Y i * pathVector v w X' Y' i =
+        X * X' * (C (v i) * C (v i)) + X * Y' * (C (v i) * C (w i)) +
+          Y * X' * (C (w i) * C (v i)) + Y * Y' * (C (w i) * C (w i)) by
+      simp only [pathVector]; ring]
+  simp only [Finset.sum_add_distrib, ← Finset.mul_sum, sum_C_mul_C]
+  rw [dotProduct_comm w v]
+  ring
+
+omit [DecidableEq n] in
+private theorem algHom_C (φ : K[T;T⁻¹] →ₐ[K] K) (x : K) : φ (C x) = x := by
+  rw [C_eq_algebraMap, AlgHom.commutes]
+  simp
+
+omit [DecidableEq n] in
+private theorem algHom_T_neg_one (φ : K[T;T⁻¹] →ₐ[K] K) {a : Kˣ} (ha : φ (T 1) = (a : K)) :
+    φ (T (-1)) = ((a⁻¹ : Kˣ) : K) := by
+  have h : (a : K) * φ (T (-1)) = 1 := by
+    rw [← ha, ← map_mul, ← T_add]
+    norm_num
+  rw [Units.val_inv_eq_inv_val, ← inv_eq_of_mul_eq_one_right h]
+
+/-- Away from the endpoints only the coefficients of the path vector move, so a coefficient-field
+point of the family is the product of the reflection in `v` and the reflection in the
+specialized path vector. -/
+private theorem map_reflectionMatrix_mul [Fintype n] (φ : K[T;T⁻¹] →ₐ[K] K) (v w : n → K) (c : K)
+    (X Y E : K[T;T⁻¹]) :
+    (reflectionMatrix (constVector v) (C c) *
+        reflectionMatrix (pathVector v w X Y) E).map (φ : K[T;T⁻¹] →+* K) =
+      reflectionMatrix v c *
+        reflectionMatrix ((φ : K[T;T⁻¹] →+* K) ∘ pathVector v w X Y) (φ E) := by
+  rw [Matrix.map_mul, reflectionMatrix_map, reflectionMatrix_map]
+  congr 1
+  have h : (φ : K[T;T⁻¹] →+* K) ∘ constVector v = v := by
+    funext i
+    exact algHom_C φ (v i)
+  have hc : (φ : K[T;T⁻¹] →+* K) (C c) = c := algHom_C φ c
+  rw [h, hc]
+
+private theorem reflectionMatrix_comp_pathVector_left (φ : K[T;T⁻¹] →ₐ[K] K) {v w : n → K}
+    {X Y E : K[T;T⁻¹]} {c : K} (hY : φ Y = 0) (hc : φ X * φ X * φ E = c) :
+    reflectionMatrix ((φ : K[T;T⁻¹] →+* K) ∘ pathVector v w X Y) (φ E) =
+      reflectionMatrix v c := by
+  have h : (φ : K[T;T⁻¹] →+* K) ∘ pathVector v w X Y = fun i => φ X * v i := by
+    funext i
+    simp only [Function.comp_apply, RingHom.coe_coe, pathVector, map_add, map_mul, algHom_C, hY,
+      zero_mul, add_zero]
+  rw [h, reflectionMatrix_smul, hc]
+
+private theorem reflectionMatrix_comp_pathVector_right (φ : K[T;T⁻¹] →ₐ[K] K) {v w : n → K}
+    {X Y E : K[T;T⁻¹]} {d : K} (hX : φ X = 0) (hd : φ Y * φ Y * φ E = d) :
+    reflectionMatrix ((φ : K[T;T⁻¹] →+* K) ∘ pathVector v w X Y) (φ E) =
+      reflectionMatrix w d := by
+  have h : (φ : K[T;T⁻¹] →+* K) ∘ pathVector v w X Y = fun i => φ Y * w i := by
+    funext i
+    simp only [Function.comp_apply, RingHom.coe_coe, pathVector, map_add, map_mul, algHom_C, hX,
+      zero_mul, zero_add]
+  rw [h, reflectionMatrix_smul, hd]
+
+/-- Assembling a one-parameter family from path data: a coefficient pair `(X, Y)` for the
+moving vector, a normalizing scalar `E`, and two parameters at which one of the coefficients
+vanishes and the surviving reflection is the reflection in `v`, respectively in `w`. -/
+private theorem exists_laurentPath_of_pathData [Fintype n] {v w : n → K}
+    {c d : K} (hc : c * (v ⬝ᵥ v) = 2) (X Y E : K[T;T⁻¹]) (a b : Kˣ)
+    (hE : E * (pathVector v w X Y ⬝ᵥ pathVector v w X Y) = 2)
+    (ha : ∀ φ : K[T;T⁻¹] →ₐ[K] K, φ (T 1) = (a : K) → φ Y = 0 ∧ φ X * φ X * φ E = c)
+    (hb : ∀ φ : K[T;T⁻¹] →ₐ[K] K, φ (T 1) = (b : K) → φ X = 0 ∧ φ Y * φ Y * φ E = d) :
+    ∃ (M : Matrix.specialOrthogonalGroup n K[T;T⁻¹]) (a b : Kˣ),
+      ∀ φ : K[T;T⁻¹] →ₐ[K] K,
+        (φ (T 1) = (a : K) → (M : Matrix n n K[T;T⁻¹]).map (φ : K[T;T⁻¹] →+* K) = 1) ∧
+        (φ (T 1) = (b : K) → (M : Matrix n n K[T;T⁻¹]).map (φ : K[T;T⁻¹] →+* K) =
+          reflectionMatrix v c * reflectionMatrix w d) := by
+  have hCc : (C c : K[T;T⁻¹]) * (constVector v ⬝ᵥ constVector v) = 2 := by
+    rw [constVector_dotProduct, ← map_mul, hc, map_ofNat]
+  refine ⟨⟨reflectionMatrix (constVector v) (C c) * reflectionMatrix (pathVector v w X Y) E,
+    reflectionMatrix_mul_mem_specialOrthogonalGroup hCc hE⟩, a, b, fun φ => ⟨?_, ?_⟩⟩
+  · intro hφ
+    obtain ⟨hY, hX⟩ := ha φ hφ
+    change (reflectionMatrix (constVector v) (C c) *
+      reflectionMatrix (pathVector v w X Y) E).map (φ : K[T;T⁻¹] →+* K) = 1
+    rw [map_reflectionMatrix_mul, reflectionMatrix_comp_pathVector_left φ hY hX,
+      reflectionMatrix_mul_self hc]
+  · intro hφ
+    obtain ⟨hX, hY⟩ := hb φ hφ
+    change (reflectionMatrix (constVector v) (C c) *
+      reflectionMatrix (pathVector v w X Y) E).map (φ : K[T;T⁻¹] →+* K) = _
+    rw [map_reflectionMatrix_mul, reflectionMatrix_comp_pathVector_right φ hX hY]
+
+/-- **Every product of two reflections is joined to the identity by a one-parameter family of
+special orthogonal matrices over the Laurent polynomials.**
+
+Both reflection vectors are anisotropic, so they span either a degenerate or a nondegenerate
+plane. In the degenerate case the two vectors are joined, up to scaling, by an affine line of
+vectors of constant norm. In the nondegenerate case the plane has, over an algebraically closed
+field, a basis of two isotropic vectors `e` and `f`, and `e + t • f` runs through every
+anisotropic line of the plane as `t` runs through the units. Reflecting first in `v` and then in
+the moving vector gives the family, and its two endpoints are the parameters at which the moving
+vector is proportional to `v`, respectively to `w`. -/
+theorem exists_laurentPath_reflectionMatrix_mul [Fintype n] [Invertible (2 : K)] [IsAlgClosed K]
+    {v w : n → K} {c d : K} (hc : c * (v ⬝ᵥ v) = 2) (hd : d * (w ⬝ᵥ w) = 2) :
+    ∃ (M : Matrix.specialOrthogonalGroup n K[T;T⁻¹]) (a b : Kˣ),
+      ∀ φ : K[T;T⁻¹] →ₐ[K] K,
+        (φ (T 1) = (a : K) → (M : Matrix n n K[T;T⁻¹]).map (φ : K[T;T⁻¹] →+* K) = 1) ∧
+        (φ (T 1) = (b : K) → (M : Matrix n n K[T;T⁻¹]).map (φ : K[T;T⁻¹] →+* K) =
+          reflectionMatrix v c * reflectionMatrix w d) := by
+  have h2 : (2 : K) ≠ 0 := Invertible.ne_zero 2
+  have hqv : v ⬝ᵥ v ≠ 0 := fun h => h2 (by rw [← hc, h, mul_zero])
+  have hqw : w ⬝ᵥ w ≠ 0 := fun h => h2 (by rw [← hd, h, mul_zero])
+  have hcv : c = 2 / (v ⬝ᵥ v) := (eq_div_iff hqv).mpr hc
+  have hdw : d = 2 / (w ⬝ᵥ w) := (eq_div_iff hqw).mpr hd
+  have hT : (T (-1) : K[T;T⁻¹]) * T 1 = 1 := by
+    rw [← T_add]
+    norm_num
+  by_cases hdeg : (v ⬝ᵥ w) * (v ⬝ᵥ w) - (v ⬝ᵥ v) * (w ⬝ᵥ w) = 0
+  · -- The plane spanned by `v` and `w` is degenerate: an affine line of vectors of constant
+    -- norm joins a multiple of `v` to a multiple of `w`.
+    have hbb : (v ⬝ᵥ w) * (v ⬝ᵥ w) = (v ⬝ᵥ v) * (w ⬝ᵥ w) := sub_eq_zero.mp hdeg
+    have hC : (C (v ⬝ᵥ w) : K[T;T⁻¹]) * C (v ⬝ᵥ w) = C (v ⬝ᵥ v) * C (w ⬝ᵥ w) := by
+      rw [← map_mul, ← map_mul, hbb]
+    have hκ : (v ⬝ᵥ v) * (v ⬝ᵥ v) * (w ⬝ᵥ w) ≠ 0 := mul_ne_zero (mul_ne_zero hqv hqv) hqw
+    have hu : pathVector v w ((2 - T 1) * C (v ⬝ᵥ w)) ((T 1 - 1) * C (v ⬝ᵥ v)) ⬝ᵥ
+        pathVector v w ((2 - T 1) * C (v ⬝ᵥ w)) ((T 1 - 1) * C (v ⬝ᵥ v)) =
+          C ((v ⬝ᵥ v) * (v ⬝ᵥ v) * (w ⬝ᵥ w)) := by
+      rw [pathVector_dotProduct, map_mul, map_mul]
+      linear_combination ((2 * T 1 - T 1 * T 1) * C (v ⬝ᵥ v)) * hC
+    refine exists_laurentPath_of_pathData hc ((2 - T 1) * C (v ⬝ᵥ w))
+      ((T 1 - 1) * C (v ⬝ᵥ v)) (C (2 / ((v ⬝ᵥ v) * (v ⬝ᵥ v) * (w ⬝ᵥ w)))) 1
+      (unitOfInvertible (2 : K)) ?_ ?_ ?_
+    · rw [hu, ← map_mul, div_mul_cancel₀ _ hκ, map_ofNat]
+    · intro φ hφ
+      have hφ1 : φ (T 1) = 1 := by rw [hφ, Units.val_one]
+      have hX : φ ((2 - T 1) * C (v ⬝ᵥ w)) = v ⬝ᵥ w := by
+        rw [map_mul, map_sub, map_ofNat, hφ1, algHom_C]
+        ring
+      have hY : φ ((T 1 - 1) * C (v ⬝ᵥ v)) = 0 := by
+        rw [map_mul, map_sub, map_one, hφ1, algHom_C]
+        ring
+      refine ⟨hY, ?_⟩
+      rw [hX, algHom_C, hbb, hcv]
+      field_simp
+    · intro φ hφ
+      have hφ2 : φ (T 1) = 2 := by rw [hφ, val_unitOfInvertible]
+      have hX : φ ((2 - T 1) * C (v ⬝ᵥ w)) = 0 := by
+        rw [map_mul, map_sub, map_ofNat, hφ2, sub_self, zero_mul]
+      have hY : φ ((T 1 - 1) * C (v ⬝ᵥ v)) = v ⬝ᵥ v := by
+        rw [map_mul, map_sub, map_one, hφ2, algHom_C]
+        ring
+      refine ⟨hX, ?_⟩
+      rw [hY, algHom_C, hdw]
+      field_simp
+  · -- The plane spanned by `v` and `w` is nondegenerate: it has an isotropic basis `e`, `f`,
+    -- and `e + t • f` sweeps out its anisotropic lines as `t` runs through the units.
+    obtain ⟨s, hs⟩ := IsAlgClosed.exists_pow_nat_eq
+      ((v ⬝ᵥ w) * (v ⬝ᵥ w) - (v ⬝ᵥ v) * (w ⬝ᵥ w)) (n := 2) (by norm_num)
+    rw [pow_two] at hs
+    have hs0 : s ≠ 0 := fun h => hdeg (by rw [← hs, h, mul_zero])
+    have hfac : ((v ⬝ᵥ w) + s) * ((v ⬝ᵥ w) - s) = (v ⬝ᵥ v) * (w ⬝ᵥ w) := by
+      linear_combination -hs
+    have hqvw : (v ⬝ᵥ v) * (w ⬝ᵥ w) ≠ 0 := mul_ne_zero hqv hqw
+    have hbps : (v ⬝ᵥ w) + s ≠ 0 := fun h => hqvw (by rw [← hfac, h, zero_mul])
+    have hbms : (v ⬝ᵥ w) - s ≠ 0 := fun h => hqvw (by rw [← hfac, h, mul_zero])
+    have hC : (C s : K[T;T⁻¹]) * C s = C (v ⬝ᵥ w) * C (v ⬝ᵥ w) - C (v ⬝ᵥ v) * C (w ⬝ᵥ w) := by
+      rw [← map_mul, ← map_mul, ← map_mul, ← map_sub, hs]
+    have hu : pathVector v w (-C (v ⬝ᵥ w) + C s + T 1 * (-C (v ⬝ᵥ w) - C s))
+        (C (v ⬝ᵥ v) + T 1 * C (v ⬝ᵥ v)) ⬝ᵥ
+          pathVector v w (-C (v ⬝ᵥ w) + C s + T 1 * (-C (v ⬝ᵥ w) - C s))
+            (C (v ⬝ᵥ v) + T 1 * C (v ⬝ᵥ v)) =
+          C (-(4 * (v ⬝ᵥ v) * (s * s))) * T 1 := by
+      rw [pathVector_dotProduct]
+      have hRHS : (C (-(4 * (v ⬝ᵥ v) * (s * s))) : K[T;T⁻¹]) =
+          -(4 * C (v ⬝ᵥ v) * (C s * C s)) := by
+        rw [map_neg, map_mul, map_mul, map_mul, map_ofNat]
+      rw [hRHS]
+      linear_combination (C (v ⬝ᵥ v) * (1 + T 1) * (1 + T 1)) * hC
+    refine exists_laurentPath_of_pathData hc (-C (v ⬝ᵥ w) + C s + T 1 * (-C (v ⬝ᵥ w) - C s))
+      (C (v ⬝ᵥ v) + T 1 * C (v ⬝ᵥ v)) (C (-(2 * (v ⬝ᵥ v) * (s * s))⁻¹) * T (-1)) (-1)
+      (Units.mk0 (-(((v ⬝ᵥ w) - s) / ((v ⬝ᵥ w) + s))) (by
+        simp only [ne_eq, neg_eq_zero, div_eq_zero_iff, not_or]
+        exact ⟨hbms, hbps⟩)) ?_ ?_ ?_
+    · rw [hu]
+      calc C (-(2 * (v ⬝ᵥ v) * (s * s))⁻¹) * T (-1) * (C (-(4 * (v ⬝ᵥ v) * (s * s))) * T 1)
+          = C (-(2 * (v ⬝ᵥ v) * (s * s))⁻¹) * C (-(4 * (v ⬝ᵥ v) * (s * s))) *
+              ((T (-1) : K[T;T⁻¹]) * T 1) := by ring
+        _ = C (-(2 * (v ⬝ᵥ v) * (s * s))⁻¹ * -(4 * (v ⬝ᵥ v) * (s * s))) := by
+              rw [hT, mul_one, ← map_mul]
+        _ = 2 := by
+              rw [show -(2 * (v ⬝ᵥ v) * (s * s))⁻¹ * -(4 * (v ⬝ᵥ v) * (s * s)) = 2 by
+                field_simp
+                ring]
+              exact map_ofNat C 2
+    · intro φ hφ
+      have hφ1 : φ (T 1) = -1 := by rw [hφ, Units.val_neg, Units.val_one]
+      have hφ2 : φ (T (-1)) = -1 := by
+        rw [algHom_T_neg_one φ hφ, Units.val_inv_eq_inv_val, Units.val_neg, Units.val_one]
+        norm_num
+      have hX : φ (-C (v ⬝ᵥ w) + C s + T 1 * (-C (v ⬝ᵥ w) - C s)) = 2 * s := by
+        rw [map_add, map_add, map_neg, map_mul, map_sub, map_neg, algHom_C, algHom_C, hφ1]
+        ring
+      have hY : φ (C (v ⬝ᵥ v) + T 1 * C (v ⬝ᵥ v)) = 0 := by
+        rw [map_add, map_mul, algHom_C, hφ1]
+        ring
+      have hEv : φ (C (-(2 * (v ⬝ᵥ v) * (s * s))⁻¹) * T (-1)) = (2 * (v ⬝ᵥ v) * (s * s))⁻¹ := by
+        rw [map_mul, algHom_C, hφ2]
+        ring
+      refine ⟨hY, ?_⟩
+      rw [hX, hEv, hcv]
+      field_simp
+    · intro φ hφ
+      have hφ1 : φ (T 1) = -(((v ⬝ᵥ w) - s) / ((v ⬝ᵥ w) + s)) := by rw [hφ, Units.val_mk0]
+      have hφ2 : φ (T (-1)) = -(((v ⬝ᵥ w) + s) / ((v ⬝ᵥ w) - s)) := by
+        rw [algHom_T_neg_one φ hφ, Units.val_inv_eq_inv_val, Units.val_mk0, ← neg_inv, inv_div]
+      have hX : φ (-C (v ⬝ᵥ w) + C s + T 1 * (-C (v ⬝ᵥ w) - C s)) = 0 := by
+        rw [map_add, map_add, map_neg, map_mul, map_sub, map_neg, algHom_C, algHom_C, hφ1]
+        field_simp
+        ring
+      have hY : φ (C (v ⬝ᵥ v) + T 1 * C (v ⬝ᵥ v)) =
+          (v ⬝ᵥ v) * (2 * s) / ((v ⬝ᵥ w) + s) := by
+        rw [map_add, map_mul, algHom_C, hφ1]
+        field_simp
+        ring
+      have hEv : φ (C (-(2 * (v ⬝ᵥ v) * (s * s))⁻¹) * T (-1)) =
+          ((v ⬝ᵥ w) + s) / (((v ⬝ᵥ w) - s) * (2 * (v ⬝ᵥ v) * (s * s))) := by
+        rw [map_mul, algHom_C, hφ2]
+        field_simp
+      have hms : (v ⬝ᵥ w) - s = (v ⬝ᵥ v) * (w ⬝ᵥ w) / ((v ⬝ᵥ w) + s) := by
+        field_simp
+        linear_combination hfac
+      refine ⟨hX, ?_⟩
+      rw [hY, hEv, hms, hdw]
+      field_simp
+
+end Path
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/Matrix/SpecialOrthogonalGroup/Reflection.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SpecialOrthogonalGroup/Reflection.lean
@@ -71,7 +71,7 @@ theorem transpose_reflectionMatrix (v : n → R) (c : R) :
 
 /-- Reflection matrices are natural in the coefficient ring. -/
 @[simp]
-theorem reflectionMatrix_map (f : R →+* S) (v : n → R) (c : R) :
+theorem map_reflectionMatrix (f : R →+* S) (v : n → R) (c : R) :
     (reflectionMatrix v c).map f = reflectionMatrix (f ∘ v) (f c) := by
   ext i j
   simp [reflectionMatrix_apply, apply_ite f]
@@ -257,7 +257,7 @@ private theorem map_reflectionMatrix_mul [Fintype n] (φ : K[T;T⁻¹] →ₐ[K]
         reflectionMatrix (pathVector v w X Y) E).map (φ : K[T;T⁻¹] →+* K) =
       reflectionMatrix v c *
         reflectionMatrix ((φ : K[T;T⁻¹] →+* K) ∘ pathVector v w X Y) (φ E) := by
-  rw [Matrix.map_mul, reflectionMatrix_map, reflectionMatrix_map]
+  rw [Matrix.map_mul, map_reflectionMatrix, map_reflectionMatrix]
   congr 1
   have h : (φ : K[T;T⁻¹] →+* K) ∘ constVector v = v := by
     funext i

--- a/TauCeti/LinearAlgebra/Matrix/SpecialOrthogonalGroup/Reflection.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SpecialOrthogonalGroup/Reflection.lean
@@ -7,10 +7,10 @@ module
 
 public import Mathlib.FieldTheory.IsAlgClosed.Basic
 public import TauCeti.Algebra.Polynomial.Laurent
-public import TauCeti.LinearAlgebra.Matrix.OneSubVecMulVec
+import TauCeti.LinearAlgebra.Matrix.OneSubVecMulVec
 public import TauCeti.LinearAlgebra.Matrix.OrthogonalGroup.QuadraticForm
 public import TauCeti.LinearAlgebra.Matrix.SpecialOrthogonalGroup.Basic
-public import TauCeti.LinearAlgebra.Matrix.SpecialOrthogonalGroup.Generation
+import TauCeti.LinearAlgebra.Matrix.SpecialOrthogonalGroup.Generation
 
 /-!
 # Reflection matrices for the standard symmetric form
@@ -91,6 +91,7 @@ theorem reflectionMatrix_eq_one_sub_vecMulVec (v : n → R) (c : R) :
   rw [reflectionMatrix, smul_vecMulVec]
 
 /-- A reflection matrix is an involution. -/
+@[simp]
 theorem reflectionMatrix_mul_self [Fintype n] {v : n → R} {c : R} (hc : c * (v ⬝ᵥ v) = 2) :
     reflectionMatrix v c * reflectionMatrix v c = 1 := by
   rw [reflectionMatrix_eq_one_sub_vecMulVec,
@@ -105,6 +106,7 @@ theorem reflectionMatrix_mem_orthogonalGroup [Fintype n] {v : n → R} {c : R}
   exact reflectionMatrix_mul_self hc
 
 /-- **A reflection matrix has determinant `-1`.** -/
+@[simp]
 theorem det_reflectionMatrix [Fintype n] {v : n → R} {c : R} (hc : c * (v ⬝ᵥ v) = 2) :
     (reflectionMatrix v c).det = -1 := by
   rw [reflectionMatrix_eq_one_sub_vecMulVec, det_one_sub_vecMulVec, dotProduct_smul,
@@ -148,8 +150,9 @@ theorem reflectionMatrix_mul_mem_specialOrthogonalGroup {v w : n → R} {c d : R
         (reflectionMatrix_mem_orthogonalGroup hd),
       by rw [Matrix.det_mul, det_reflectionMatrix hc, det_reflectionMatrix hd]; ring⟩
 
-/-- **The product of the reflections in two vectors of invertible norm**, as an element of the
-matrix special orthogonal group of the standard symmetric form. -/
+/-- **The product of the reflections in two vectors with supplied normalizing scalars**, as an
+element of the matrix special orthogonal group of the standard symmetric form. The scalars satisfy
+the displayed equations with the respective norms. -/
 def reflectionPair (v w : n → R) (c d : R) (hc : c * (v ⬝ᵥ v) = 2) (hd : d * (w ⬝ᵥ w) = 2) :
     Matrix.specialOrthogonalGroup n R :=
   ⟨reflectionMatrix v c * reflectionMatrix w d,

--- a/TauCeti/LinearAlgebra/Matrix/SpecialOrthogonalGroup/Reflection.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SpecialOrthogonalGroup/Reflection.lean
@@ -24,12 +24,12 @@ one-line computation: putting `μ²c` on the unscaled-vector side gives the same
 putting `c` on the side whose vector is scaled by `μ`.
 
 Products of two such matrices are exactly the generators of the special orthogonal group
-supplied by `TauCeti.closure_reflection_mul_eq_matrixSpecialOrthogonalGroup`. They are packaged
-here as `TauCeti.reflectionPair`, and the generation theorem is restated as a criterion for a
-subgroup of `Matrix.specialOrthogonalGroup n K` to be the whole group.
+supplied by `TauCeti.closure_reflection_mul_eq_matrixSpecialOrthogonalGroup`, once
+`toMatrix'_reflection` identifies the coordinate matrix of the reflection of the standard
+quadratic form with `reflectionMatrix`. They are packaged here as `TauCeti.reflectionPair`.
 
-The last and largest section of the file, occupying everything after that criterion, builds
-one-parameter families joining such a product to the identity. Over an algebraically closed
+The last and largest section of the file builds one-parameter families joining such a product to
+the identity. Over an algebraically closed
 field of characteristic different from two, `exists_laurentPath_reflectionMatrix_mul` produces
 for every product of two reflections a single special orthogonal matrix over the Laurent
 polynomials `K[T;T⁻¹]` together with two units `a` and `b` of `K`, such that specializing the
@@ -41,15 +41,15 @@ throughout, and the two parameters are those at which the moving vector becomes 
 `v`, respectively to `w`. Consuming these families is what proves the special orthogonal group
 geometrically connected: an idempotent regular function on the group is constant once right
 translation by every rational point fixes it, a point joined to the identity by such a family
-fixes every idempotent, and the generation criterion above reduces the rational points to be
-handled to the products of two reflections.
+fixes every idempotent, and the generation theorem reduces the rational points to be handled to
+the products of two reflections.
 
 ## Main declarations
 
 * `TauCeti.reflectionMatrix`: the matrix of a reflection, with its normalizing scalar as data.
 * `TauCeti.reflectionPair`: the product of two reflections, as a special orthogonal matrix.
-* `TauCeti.eq_top_of_forall_reflectionPair_mem`: a subgroup of the matrix special orthogonal
-  group containing every product of two reflections is the whole group.
+* `TauCeti.toMatrix'_reflection`: `reflectionMatrix` is the coordinate matrix of the reflection
+  of the standard quadratic form.
 * `TauCeti.exists_laurentPath_reflectionMatrix_mul`: over an algebraically closed field of
   characteristic different from two, every product of two reflections is joined to the identity
   by a one-parameter family of special orthogonal matrices over the Laurent polynomials.
@@ -184,63 +184,19 @@ theorem coe_reflectionPair {v w : n → R} {c d : R} (hc : c * (v ⬝ᵥ v) = 2)
       reflectionMatrix v c * reflectionMatrix w d :=
   (rfl)
 
-omit [DecidableEq n] in
-/-- A ring homomorphism carries the normalizing equation of a reflection to the normalizing
-equation of the reflection in the mapped vector with the mapped scalar. -/
-theorem map_mul_dotProduct_eq_two (f : R →+* S) {v : n → R} {c : R} (hc : c * (v ⬝ᵥ v) = 2) :
-    f c * ((f ∘ v) ⬝ᵥ (f ∘ v)) = 2 := by
-  rw [← RingHom.map_dotProduct, ← map_mul, hc, map_ofNat]
-
 /-- Products of two reflections are natural in the coefficient ring. -/
 @[simp]
 theorem map_reflectionPair (f : R →+* S) {v w : n → R} {c d : R} (hc : c * (v ⬝ᵥ v) = 2)
     (hd : d * (w ⬝ᵥ w) = 2) :
     Matrix.SpecialOrthogonalGroup.map f (reflectionPair v w c d hc hd) =
-      reflectionPair (f ∘ v) (f ∘ w) (f c) (f d) (map_mul_dotProduct_eq_two f hc)
-        (map_mul_dotProduct_eq_two f hd) :=
+      reflectionPair (f ∘ v) (f ∘ w) (f c) (f d)
+        (by rw [← RingHom.map_dotProduct, ← map_mul, hc, map_ofNat])
+        (by rw [← RingHom.map_dotProduct, ← map_mul, hd, map_ofNat]) :=
   Subtype.ext <| by
     rw [Matrix.SpecialOrthogonalGroup.coe_map, coe_reflectionPair, coe_reflectionPair,
       Matrix.map_mul, map_reflectionMatrix, map_reflectionMatrix]
 
 end Pair
-
-/-! ### Generation of the special orthogonal group -/
-
-/-- **A subgroup of the matrix special orthogonal group which contains every product of two
-reflections is the whole group.**
-
-This is the Cartan-Dieudonné generation theorem
-`TauCeti.closure_reflection_mul_eq_matrixSpecialOrthogonalGroup`, restated for the reflection
-matrices of this file. -/
-theorem eq_top_of_forall_reflectionPair_mem {K : Type u} [Field K] [Fintype n]
-    [NeZero (2 : K)] (P : Subgroup (Matrix.specialOrthogonalGroup n K))
-    (hP : ∀ (v w : n → K) (c d : K) (hc : c * (v ⬝ᵥ v) = 2) (hd : d * (w ⬝ᵥ w) = 2),
-      reflectionPair v w c d hc hd ∈ P) :
-    P = ⊤ := by
-  refine eq_top_iff.mpr fun x _ => ?_
-  have hclosure := closure_reflection_mul_eq_matrixSpecialOrthogonalGroup (n := n) (K := K)
-  have hle : Submonoid.closure {A : Matrix n n K |
-      ∃ (v w : n → K) (_ : Invertible (Matrix.toQuadraticForm' (1 : Matrix n n K) v))
-        (_ : Invertible (Matrix.toQuadraticForm' (1 : Matrix n n K) w)),
-        LinearMap.toMatrix'
-            (QuadraticMap.reflection (Matrix.toQuadraticForm' (1 : Matrix n n K)) v).toLinearMap *
-          LinearMap.toMatrix'
-            (QuadraticMap.reflection
-              (Matrix.toQuadraticForm' (1 : Matrix n n K)) w).toLinearMap = A} ≤
-      P.toSubmonoid.map (Matrix.specialOrthogonalGroup n K).subtype := by
-    refine Submonoid.closure_le.mpr ?_
-    rintro _ ⟨v, w, hv, hw, rfl⟩
-    have hcv : 2 * ⅟(Matrix.toQuadraticForm' (1 : Matrix n n K) v) * (v ⬝ᵥ v) = 2 := by
-      rw [← toQuadraticForm'_one_apply v, mul_assoc, invOf_mul_self, mul_one]
-    have hcw : 2 * ⅟(Matrix.toQuadraticForm' (1 : Matrix n n K) w) * (w ⬝ᵥ w) = 2 := by
-      rw [← toQuadraticForm'_one_apply w, mul_assoc, invOf_mul_self, mul_one]
-    refine ⟨reflectionPair v w _ _ hcv hcw, hP _ _ _ _ hcv hcw, ?_⟩
-    -- The mapped subgroup witness coerces definitionally to its underlying matrix equality.
-    change (reflectionPair v w _ _ hcv hcw : Matrix n n K) = _
-    rw [coe_reflectionPair, toMatrix'_reflection, toMatrix'_reflection]
-  obtain ⟨y, hy, hyx⟩ := hle (hclosure.ge x.2)
-  have hxy : y = x := Subtype.ext hyx
-  exact hxy ▸ hy
 
 /-! ### One-parameter families through a product of two reflections -/
 

--- a/TauCeti/LinearAlgebra/Matrix/SpecialOrthogonalGroup/Reflection.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SpecialOrthogonalGroup/Reflection.lean
@@ -28,12 +28,31 @@ supplied by `TauCeti.closure_reflection_mul_eq_matrixSpecialOrthogonalGroup`. Th
 here as `TauCeti.reflectionPair`, and the generation theorem is restated as a criterion for a
 subgroup of `Matrix.specialOrthogonalGroup n K` to be the whole group.
 
+The last and largest section of the file, occupying everything after that criterion, builds
+one-parameter families joining such a product to the identity. Over an algebraically closed
+field of characteristic different from two, `exists_laurentPath_reflectionMatrix_mul` produces
+for every product of two reflections a single special orthogonal matrix over the Laurent
+polynomials `K[T;T⁻¹]` together with two units `a` and `b` of `K`, such that specializing the
+parameter `T` to `a` gives the identity and specializing it to `b` gives the given product; a
+specialization is any `K`-algebra map `K[T;T⁻¹] →ₐ[K] K`, so the units are exactly the
+admissible parameter values. The family reflects first in `v` and then in a vector moving
+through the plane spanned by `v` and `w`, chosen so that the moving vector has invertible norm
+throughout, and the two parameters are those at which the moving vector becomes proportional to
+`v`, respectively to `w`. Consuming these families is what proves the special orthogonal group
+geometrically connected: an idempotent regular function on the group is constant once right
+translation by every rational point fixes it, a point joined to the identity by such a family
+fixes every idempotent, and the generation criterion above reduces the rational points to be
+handled to the products of two reflections.
+
 ## Main declarations
 
 * `TauCeti.reflectionMatrix`: the matrix of a reflection, with its normalizing scalar as data.
 * `TauCeti.reflectionPair`: the product of two reflections, as a special orthogonal matrix.
 * `TauCeti.eq_top_of_forall_reflectionPair_mem`: a subgroup of the matrix special orthogonal
   group containing every product of two reflections is the whole group.
+* `TauCeti.exists_laurentPath_reflectionMatrix_mul`: over an algebraically closed field of
+  characteristic different from two, every product of two reflections is joined to the identity
+  by a one-parameter family of special orthogonal matrices over the Laurent polynomials.
 
 ## References
 

--- a/TauCeti/LinearAlgebra/Matrix/SpecialOrthogonalGroup/Reflection.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SpecialOrthogonalGroup/Reflection.lean
@@ -5,9 +5,10 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Algebra.Polynomial.Laurent
 public import Mathlib.FieldTheory.IsAlgClosed.Basic
+public import TauCeti.Algebra.Polynomial.Laurent
 public import TauCeti.LinearAlgebra.Matrix.OneSubVecMulVec
+public import TauCeti.LinearAlgebra.Matrix.OrthogonalGroup.QuadraticForm
 public import TauCeti.LinearAlgebra.Matrix.SpecialOrthogonalGroup.Basic
 public import TauCeti.LinearAlgebra.Matrix.SpecialOrthogonalGroup.Generation
 
@@ -19,7 +20,8 @@ The reflection of `Rⁿ` in the hyperplane orthogonal to a vector `v` has the ma
 as data rather than as `2 * ⅟(v ⬝ᵥ v)` makes the construction available over any commutative
 ring in which the norm of `v` happens to be invertible, makes it visibly natural in the
 coefficient ring, and makes the invariance of a reflection under rescaling its vector a
-one-line computation: rescaling `v` by `μ` rescales `c` by `μ⁻²`.
+one-line computation: putting `μ²c` on the unscaled-vector side gives the same matrix as
+putting `c` on the side whose vector is scaled by `μ`.
 
 Products of two such matrices are exactly the generators of the special orthogonal group
 supplied by `TauCeti.closure_reflection_mul_eq_matrixSpecialOrthogonalGroup`. They are packaged
@@ -57,6 +59,7 @@ playing the role of `2 / (v ⬝ᵥ v)`. It is a reflection precisely when `c * (
 is not part of the definition. -/
 def reflectionMatrix (v : n → R) (c : R) : Matrix n n R := 1 - c • vecMulVec v v
 
+@[simp]
 theorem reflectionMatrix_apply (v : n → R) (c : R) (i j : n) :
     reflectionMatrix v c i j = (if i = j then 1 else 0) - c * (v i * v j) := by
   simp [reflectionMatrix, Matrix.one_apply, vecMulVec_apply]
@@ -67,12 +70,14 @@ theorem transpose_reflectionMatrix (v : n → R) (c : R) :
   simp [reflectionMatrix, Matrix.transpose_sub, Matrix.transpose_smul, transpose_vecMulVec]
 
 /-- Reflection matrices are natural in the coefficient ring. -/
+@[simp]
 theorem reflectionMatrix_map (f : R →+* S) (v : n → R) (c : R) :
     (reflectionMatrix v c).map f = reflectionMatrix (f ∘ v) (f c) := by
   ext i j
   simp [reflectionMatrix_apply, apply_ite f]
 
-/-- Rescaling the vector of a reflection by `μ` rescales its normalizing scalar by `μ⁻²`. -/
+/-- Scaling the vector by `μ` with scalar `c` gives the same matrix as keeping the vector
+unchanged and using scalar `μ²c`. -/
 theorem reflectionMatrix_smul (v : n → R) (c μ : R) :
     reflectionMatrix (fun i => μ * v i) c = reflectionMatrix v (μ * μ * c) := by
   ext i j
@@ -85,16 +90,11 @@ theorem reflectionMatrix_eq_one_sub_vecMulVec (v : n → R) (c : R) :
     reflectionMatrix v c = 1 - vecMulVec (c • v) v := by
   rw [reflectionMatrix, smul_vecMulVec]
 
-omit [DecidableEq n] in
-private theorem dotProduct_smul_self [Fintype n] {v : n → R} {c : R} (hc : c * (v ⬝ᵥ v) = 2) :
-    v ⬝ᵥ (c • v) = 2 := by
-  rw [dotProduct_smul, smul_eq_mul, ← hc, mul_comm]
-
 /-- A reflection matrix is an involution. -/
 theorem reflectionMatrix_mul_self [Fintype n] {v : n → R} {c : R} (hc : c * (v ⬝ᵥ v) = 2) :
     reflectionMatrix v c * reflectionMatrix v c = 1 := by
   rw [reflectionMatrix_eq_one_sub_vecMulVec,
-    one_sub_vecMulVec_mul_self 1 (by rw [dotProduct_smul_self hc]; norm_num)]
+    one_sub_vecMulVec_mul_self 1 (by rw [dotProduct_smul, smul_eq_mul, hc]; norm_num)]
   module
 
 /-- A reflection matrix is orthogonal. -/
@@ -107,7 +107,8 @@ theorem reflectionMatrix_mem_orthogonalGroup [Fintype n] {v : n → R} {c : R}
 /-- **A reflection matrix has determinant `-1`.** -/
 theorem det_reflectionMatrix [Fintype n] {v : n → R} {c : R} (hc : c * (v ⬝ᵥ v) = 2) :
     (reflectionMatrix v c).det = -1 := by
-  rw [reflectionMatrix_eq_one_sub_vecMulVec, det_one_sub_vecMulVec, dotProduct_smul_self hc]
+  rw [reflectionMatrix_eq_one_sub_vecMulVec, det_one_sub_vecMulVec, dotProduct_smul,
+    smul_eq_mul, hc]
   norm_num
 
 /-! ### Comparison with the reflection of the standard quadratic form -/
@@ -115,17 +116,6 @@ theorem det_reflectionMatrix [Fintype n] {v : n → R} {c : R} (hc : c * (v ⬝�
 section QuadraticForm
 
 variable [Fintype n]
-
-/-- The standard quadratic form is the square of the euclidean norm. -/
-theorem toQuadraticForm'_one_apply (x : n → R) :
-    Matrix.toQuadraticForm' (1 : Matrix n n R) x = x ⬝ᵥ x := by
-  simp [Matrix.toQuadraticForm', Matrix.toLinearMap₂'_apply']
-
-/-- The polar form of the standard quadratic form is twice the dot product. -/
-theorem polar_toQuadraticForm'_one (x y : n → R) :
-    QuadraticMap.polar (Matrix.toQuadraticForm' (1 : Matrix n n R)) x y = 2 * (x ⬝ᵥ y) := by
-  simp only [Matrix.toQuadraticForm', LinearMap.BilinMap.polar_toQuadraticMap,
-    Matrix.toLinearMap₂'_apply', Matrix.one_mulVec, two_mul, dotProduct_comm y x]
 
 /-- The reflection of the standard quadratic form in a vector of invertible norm has
 `reflectionMatrix` as its coordinate matrix. -/
@@ -205,6 +195,7 @@ theorem eq_top_of_forall_reflectionPair_mem {K : Type u} [Field K] [Fintype n]
     have hcw : 2 * ⅟(Matrix.toQuadraticForm' (1 : Matrix n n K) w) * (w ⬝ᵥ w) = 2 := by
       rw [← toQuadraticForm'_one_apply w, mul_assoc, invOf_mul_self, mul_one]
     refine ⟨reflectionPair v w _ _ hcv hcw, hP _ _ _ _ hcv hcw, ?_⟩
+    -- The mapped subgroup witness coerces definitionally to its underlying matrix equality.
     change (reflectionPair v w _ _ hcv hcw : Matrix n n K) = _
     rw [coe_reflectionPair, toMatrix'_reflection, toMatrix'_reflection]
   obtain ⟨y, hy, hyx⟩ := hle (hclosure.ge x.2)
@@ -230,42 +221,29 @@ private noncomputable def pathVector (v w : n → K) (X Y : K[T;T⁻¹]) : n →
   fun i => X * C (v i) + Y * C (w i)
 
 omit [DecidableEq n] in
-private theorem sum_C_mul_C [Fintype n] (u₁ u₂ : n → K) :
-    ∑ i, (C (u₁ i) : K[T;T⁻¹]) * C (u₂ i) = C (u₁ ⬝ᵥ u₂) := by
-  rw [dotProduct, map_sum]
-  exact Finset.sum_congr rfl fun i _ => (map_mul C _ _).symm
-
-omit [DecidableEq n] in
 private theorem constVector_dotProduct [Fintype n] (v w : n → K) :
-    constVector v ⬝ᵥ constVector w = C (v ⬝ᵥ w) :=
-  sum_C_mul_C v w
+    constVector v ⬝ᵥ constVector w = C (v ⬝ᵥ w) := by
+  simp only [constVector, dotProduct]
+  rw [map_sum]
+  exact Finset.sum_congr rfl fun i _ => (map_mul C _ _).symm
 
 omit [DecidableEq n] in
 private theorem pathVector_dotProduct [Fintype n] (v w : n → K) (X Y X' Y' : K[T;T⁻¹]) :
     pathVector v w X Y ⬝ᵥ pathVector v w X' Y' =
       X * X' * C (v ⬝ᵥ v) + (X * Y' + Y * X') * C (v ⬝ᵥ w) + Y * Y' * C (w ⬝ᵥ w) := by
+  have hC (u₁ u₂ : n → K) :
+      ∑ i, (C (u₁ i) : K[T;T⁻¹]) * C (u₂ i) = C (u₁ ⬝ᵥ u₂) := by
+    simpa only [constVector, dotProduct] using constVector_dotProduct u₁ u₂
   rw [dotProduct]
+  -- `Finset.sum_congr` asks for the pointwise product obtained by unfolding `pathVector`.
   rw [Finset.sum_congr rfl fun i _ =>
     show pathVector v w X Y i * pathVector v w X' Y' i =
         X * X' * (C (v i) * C (v i)) + X * Y' * (C (v i) * C (w i)) +
           Y * X' * (C (w i) * C (v i)) + Y * Y' * (C (w i) * C (w i)) by
       simp only [pathVector]; ring]
-  simp only [Finset.sum_add_distrib, ← Finset.mul_sum, sum_C_mul_C]
+  simp only [Finset.sum_add_distrib, ← Finset.mul_sum, hC]
   rw [dotProduct_comm w v]
   ring
-
-omit [DecidableEq n] in
-private theorem algHom_C (φ : K[T;T⁻¹] →ₐ[K] K) (x : K) : φ (C x) = x := by
-  rw [C_eq_algebraMap, AlgHom.commutes]
-  simp
-
-omit [DecidableEq n] in
-private theorem algHom_T_neg_one (φ : K[T;T⁻¹] →ₐ[K] K) {a : Kˣ} (ha : φ (T 1) = (a : K)) :
-    φ (T (-1)) = ((a⁻¹ : Kˣ) : K) := by
-  have h : (a : K) * φ (T (-1)) = 1 := by
-    rw [← ha, ← map_mul, ← T_add]
-    norm_num
-  rw [Units.val_inv_eq_inv_val, ← inv_eq_of_mul_eq_one_right h]
 
 /-- Away from the endpoints only the coefficients of the path vector move, so a coefficient-field
 point of the family is the product of the reflection in `v` and the reflection in the
@@ -280,8 +258,11 @@ private theorem map_reflectionMatrix_mul [Fintype n] (φ : K[T;T⁻¹] →ₐ[K]
   congr 1
   have h : (φ : K[T;T⁻¹] →+* K) ∘ constVector v = v := by
     funext i
-    exact algHom_C φ (v i)
-  have hc : (φ : K[T;T⁻¹] →+* K) (C c) = c := algHom_C φ c
+    simp only [Function.comp_apply, RingHom.coe_coe, constVector, C_eq_algebraMap,
+      AlgHom.commutes, Algebra.algebraMap_self_apply]
+  have hc : (φ : K[T;T⁻¹] →+* K) (C c) = c := by
+    simp only [RingHom.coe_coe, C_eq_algebraMap, AlgHom.commutes,
+      Algebra.algebraMap_self_apply]
   rw [h, hc]
 
 private theorem reflectionMatrix_comp_pathVector_left (φ : K[T;T⁻¹] →ₐ[K] K) {v w : n → K}
@@ -290,8 +271,8 @@ private theorem reflectionMatrix_comp_pathVector_left (φ : K[T;T⁻¹] →ₐ[K
       reflectionMatrix v c := by
   have h : (φ : K[T;T⁻¹] →+* K) ∘ pathVector v w X Y = fun i => φ X * v i := by
     funext i
-    simp only [Function.comp_apply, RingHom.coe_coe, pathVector, map_add, map_mul, algHom_C, hY,
-      zero_mul, add_zero]
+    simp only [Function.comp_apply, RingHom.coe_coe, pathVector, map_add, map_mul,
+      C_eq_algebraMap, AlgHom.commutes, Algebra.algebraMap_self_apply, hY, zero_mul, add_zero]
   rw [h, reflectionMatrix_smul, hc]
 
 private theorem reflectionMatrix_comp_pathVector_right (φ : K[T;T⁻¹] →ₐ[K] K) {v w : n → K}
@@ -300,8 +281,8 @@ private theorem reflectionMatrix_comp_pathVector_right (φ : K[T;T⁻¹] →ₐ[
       reflectionMatrix w d := by
   have h : (φ : K[T;T⁻¹] →+* K) ∘ pathVector v w X Y = fun i => φ Y * w i := by
     funext i
-    simp only [Function.comp_apply, RingHom.coe_coe, pathVector, map_add, map_mul, algHom_C, hX,
-      zero_mul, zero_add]
+    simp only [Function.comp_apply, RingHom.coe_coe, pathVector, map_add, map_mul,
+      C_eq_algebraMap, AlgHom.commutes, Algebra.algebraMap_self_apply, hX, zero_mul, zero_add]
   rw [h, reflectionMatrix_smul, hd]
 
 /-- Assembling a one-parameter family from path data: a coefficient pair `(X, Y)` for the
@@ -323,12 +304,14 @@ private theorem exists_laurentPath_of_pathData [Fintype n] {v w : n → K}
     reflectionMatrix_mul_mem_specialOrthogonalGroup hCc hE⟩, a, b, fun φ => ⟨?_, ?_⟩⟩
   · intro hφ
     obtain ⟨hY, hX⟩ := ha φ hφ
+    -- Coercing the inline subtype defining `M` exposes its underlying matrix definitionally.
     change (reflectionMatrix (constVector v) (C c) *
       reflectionMatrix (pathVector v w X Y) E).map (φ : K[T;T⁻¹] →+* K) = 1
     rw [map_reflectionMatrix_mul, reflectionMatrix_comp_pathVector_left φ hY hX,
       reflectionMatrix_mul_self hc]
   · intro hφ
     obtain ⟨hX, hY⟩ := hb φ hφ
+    -- Coercing the inline subtype defining `M` exposes its underlying matrix definitionally.
     change (reflectionMatrix (constVector v) (C c) *
       reflectionMatrix (pathVector v w X Y) E).map (φ : K[T;T⁻¹] →+* K) = _
     rw [map_reflectionMatrix_mul, reflectionMatrix_comp_pathVector_right φ hX hY]
@@ -343,14 +326,15 @@ field, a basis of two isotropic vectors `e` and `f`, and `e + t • f` runs thro
 anisotropic line of the plane as `t` runs through the units. Reflecting first in `v` and then in
 the moving vector gives the family, and its two endpoints are the parameters at which the moving
 vector is proportional to `v`, respectively to `w`. -/
-theorem exists_laurentPath_reflectionMatrix_mul [Fintype n] [Invertible (2 : K)] [IsAlgClosed K]
+theorem exists_laurentPath_reflectionMatrix_mul [Fintype n] [NeZero (2 : K)] [IsAlgClosed K]
     {v w : n → K} {c d : K} (hc : c * (v ⬝ᵥ v) = 2) (hd : d * (w ⬝ᵥ w) = 2) :
     ∃ (M : Matrix.specialOrthogonalGroup n K[T;T⁻¹]) (a b : Kˣ),
       ∀ φ : K[T;T⁻¹] →ₐ[K] K,
         (φ (T 1) = (a : K) → (M : Matrix n n K[T;T⁻¹]).map (φ : K[T;T⁻¹] →+* K) = 1) ∧
         (φ (T 1) = (b : K) → (M : Matrix n n K[T;T⁻¹]).map (φ : K[T;T⁻¹] →+* K) =
           reflectionMatrix v c * reflectionMatrix w d) := by
-  have h2 : (2 : K) ≠ 0 := Invertible.ne_zero 2
+  let _ : Invertible (2 : K) := invertibleOfNonzero (NeZero.ne _)
+  have h2 : (2 : K) ≠ 0 := NeZero.ne (2 : K)
   have hqv : v ⬝ᵥ v ≠ 0 := fun h => h2 (by rw [← hc, h, mul_zero])
   have hqw : w ⬝ᵥ w ≠ 0 := fun h => h2 (by rw [← hd, h, mul_zero])
   have hcv : c = 2 / (v ⬝ᵥ v) := (eq_div_iff hqv).mpr hc
@@ -377,23 +361,26 @@ theorem exists_laurentPath_reflectionMatrix_mul [Fintype n] [Invertible (2 : K)]
     · intro φ hφ
       have hφ1 : φ (T 1) = 1 := by rw [hφ, Units.val_one]
       have hX : φ ((2 - T 1) * C (v ⬝ᵥ w)) = v ⬝ᵥ w := by
-        rw [map_mul, map_sub, map_ofNat, hφ1, algHom_C]
+        rw [map_mul, map_sub, map_ofNat, hφ1, C_eq_algebraMap, AlgHom.commutes,
+          Algebra.algebraMap_self_apply]
         ring
       have hY : φ ((T 1 - 1) * C (v ⬝ᵥ v)) = 0 := by
-        rw [map_mul, map_sub, map_one, hφ1, algHom_C]
+        rw [map_mul, map_sub, map_one, hφ1, C_eq_algebraMap, AlgHom.commutes,
+          Algebra.algebraMap_self_apply]
         ring
       refine ⟨hY, ?_⟩
-      rw [hX, algHom_C, hbb, hcv]
+      rw [hX, C_eq_algebraMap, AlgHom.commutes, Algebra.algebraMap_self_apply, hbb, hcv]
       field_simp
     · intro φ hφ
       have hφ2 : φ (T 1) = 2 := by rw [hφ, val_unitOfInvertible]
       have hX : φ ((2 - T 1) * C (v ⬝ᵥ w)) = 0 := by
         rw [map_mul, map_sub, map_ofNat, hφ2, sub_self, zero_mul]
       have hY : φ ((T 1 - 1) * C (v ⬝ᵥ v)) = v ⬝ᵥ v := by
-        rw [map_mul, map_sub, map_one, hφ2, algHom_C]
+        rw [map_mul, map_sub, map_one, hφ2, C_eq_algebraMap, AlgHom.commutes,
+          Algebra.algebraMap_self_apply]
         ring
       refine ⟨hX, ?_⟩
-      rw [hY, algHom_C, hdw]
+      rw [hY, C_eq_algebraMap, AlgHom.commutes, Algebra.algebraMap_self_apply, hdw]
       field_simp
   · -- The plane spanned by `v` and `w` is nondegenerate: it has an isotropic basis `e`, `f`,
     -- and `e + t • f` sweeps out its anisotropic lines as `t` runs through the units.
@@ -431,6 +418,7 @@ theorem exists_laurentPath_reflectionMatrix_mul [Fintype n] [Invertible (2 : K)]
         _ = C (-(2 * (v ⬝ᵥ v) * (s * s))⁻¹ * -(4 * (v ⬝ᵥ v) * (s * s))) := by
               rw [hT, mul_one, ← map_mul]
         _ = 2 := by
+              -- Isolate the coefficient-field identity so `rw` can rewrite beneath `C`.
               rw [show -(2 * (v ⬝ᵥ v) * (s * s))⁻¹ * -(4 * (v ⬝ᵥ v) * (s * s)) = 2 by
                 field_simp
                 ring]
@@ -438,16 +426,19 @@ theorem exists_laurentPath_reflectionMatrix_mul [Fintype n] [Invertible (2 : K)]
     · intro φ hφ
       have hφ1 : φ (T 1) = -1 := by rw [hφ, Units.val_neg, Units.val_one]
       have hφ2 : φ (T (-1)) = -1 := by
-        rw [algHom_T_neg_one φ hφ, Units.val_inv_eq_inv_val, Units.val_neg, Units.val_one]
+        rw [laurentEval_unique _ φ hφ, laurentEval_T, zpow_neg, zpow_one,
+          Units.val_inv_eq_inv_val, Units.val_neg, Units.val_one]
         norm_num
       have hX : φ (-C (v ⬝ᵥ w) + C s + T 1 * (-C (v ⬝ᵥ w) - C s)) = 2 * s := by
-        rw [map_add, map_add, map_neg, map_mul, map_sub, map_neg, algHom_C, algHom_C, hφ1]
+        simp only [map_add, map_neg, map_mul, map_sub, C_eq_algebraMap, AlgHom.commutes,
+          Algebra.algebraMap_self_apply, hφ1]
         ring
       have hY : φ (C (v ⬝ᵥ v) + T 1 * C (v ⬝ᵥ v)) = 0 := by
-        rw [map_add, map_mul, algHom_C, hφ1]
+        simp only [map_add, map_mul, C_eq_algebraMap, AlgHom.commutes,
+          Algebra.algebraMap_self_apply, hφ1]
         ring
       have hEv : φ (C (-(2 * (v ⬝ᵥ v) * (s * s))⁻¹) * T (-1)) = (2 * (v ⬝ᵥ v) * (s * s))⁻¹ := by
-        rw [map_mul, algHom_C, hφ2]
+        rw [map_mul, C_eq_algebraMap, AlgHom.commutes, Algebra.algebraMap_self_apply, hφ2]
         ring
       refine ⟨hY, ?_⟩
       rw [hX, hEv, hcv]
@@ -455,19 +446,22 @@ theorem exists_laurentPath_reflectionMatrix_mul [Fintype n] [Invertible (2 : K)]
     · intro φ hφ
       have hφ1 : φ (T 1) = -(((v ⬝ᵥ w) - s) / ((v ⬝ᵥ w) + s)) := by rw [hφ, Units.val_mk0]
       have hφ2 : φ (T (-1)) = -(((v ⬝ᵥ w) + s) / ((v ⬝ᵥ w) - s)) := by
-        rw [algHom_T_neg_one φ hφ, Units.val_inv_eq_inv_val, Units.val_mk0, ← neg_inv, inv_div]
+        rw [laurentEval_unique _ φ hφ, laurentEval_T, zpow_neg, zpow_one,
+          Units.val_inv_eq_inv_val, Units.val_mk0, ← neg_inv, inv_div]
       have hX : φ (-C (v ⬝ᵥ w) + C s + T 1 * (-C (v ⬝ᵥ w) - C s)) = 0 := by
-        rw [map_add, map_add, map_neg, map_mul, map_sub, map_neg, algHom_C, algHom_C, hφ1]
+        simp only [map_add, map_neg, map_mul, map_sub, C_eq_algebraMap, AlgHom.commutes,
+          Algebra.algebraMap_self_apply, hφ1]
         field_simp
         ring
       have hY : φ (C (v ⬝ᵥ v) + T 1 * C (v ⬝ᵥ v)) =
           (v ⬝ᵥ v) * (2 * s) / ((v ⬝ᵥ w) + s) := by
-        rw [map_add, map_mul, algHom_C, hφ1]
+        simp only [map_add, map_mul, C_eq_algebraMap, AlgHom.commutes,
+          Algebra.algebraMap_self_apply, hφ1]
         field_simp
         ring
       have hEv : φ (C (-(2 * (v ⬝ᵥ v) * (s * s))⁻¹) * T (-1)) =
           ((v ⬝ᵥ w) + s) / (((v ⬝ᵥ w) - s) * (2 * (v ⬝ᵥ v) * (s * s))) := by
-        rw [map_mul, algHom_C, hφ2]
+        rw [map_mul, C_eq_algebraMap, AlgHom.commutes, Algebra.algebraMap_self_apply, hφ2]
         field_simp
       have hms : (v ⬝ᵥ w) - s = (v ⬝ᵥ v) * (w ⬝ᵥ w) / ((v ⬝ᵥ w) + s) := by
         field_simp

--- a/TauCeti/LinearAlgebra/Matrix/SpecialOrthogonalGroup/Reflection.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SpecialOrthogonalGroup/Reflection.lean
@@ -217,17 +217,12 @@ private noncomputable def pathVector (v w : n → K) (X Y : K[T;T⁻¹]) : n →
   fun i => X * C (v i) + Y * C (w i)
 
 omit [DecidableEq n] in
-private theorem constVector_dotProduct [Fintype n] (v w : n → K) :
-    constVector v ⬝ᵥ constVector w = C (v ⬝ᵥ w) :=
-  (RingHom.map_dotProduct C v w).symm
-
-omit [DecidableEq n] in
 private theorem pathVector_dotProduct [Fintype n] (v w : n → K) (X Y X' Y' : K[T;T⁻¹]) :
     pathVector v w X Y ⬝ᵥ pathVector v w X' Y' =
       X * X' * C (v ⬝ᵥ v) + (X * Y' + Y * X') * C (v ⬝ᵥ w) + Y * Y' * C (w ⬝ᵥ w) := by
   have hC (u₁ u₂ : n → K) :
       ∑ i, (C (u₁ i) : K[T;T⁻¹]) * C (u₂ i) = C (u₁ ⬝ᵥ u₂) := by
-    simpa only [constVector, dotProduct] using constVector_dotProduct u₁ u₂
+    simpa only [dotProduct, Function.comp_apply] using (RingHom.map_dotProduct C u₁ u₂).symm
   rw [dotProduct]
   -- `Finset.sum_congr` asks for the pointwise product obtained by unfolding `pathVector`.
   rw [Finset.sum_congr rfl fun i _ =>
@@ -293,7 +288,9 @@ private theorem exists_laurentPath_of_pathData [Fintype n] {v w : n → K}
         (φ (T 1) = (b : K) → (M : Matrix n n K[T;T⁻¹]).map (φ : K[T;T⁻¹] →+* K) =
           reflectionMatrix v c * reflectionMatrix w d) := by
   have hCc : (C c : K[T;T⁻¹]) * (constVector v ⬝ᵥ constVector v) = 2 := by
-    rw [constVector_dotProduct, ← map_mul, hc, map_ofNat]
+    -- `constVector v` is `C ∘ v` by definition, the form `RingHom.map_dotProduct` rewrites.
+    change (C c : K[T;T⁻¹]) * ((C ∘ v) ⬝ᵥ (C ∘ v)) = 2
+    rw [← RingHom.map_dotProduct, ← map_mul, hc, map_ofNat]
   refine ⟨⟨reflectionMatrix (constVector v) (C c) * reflectionMatrix (pathVector v w X Y) E,
     reflectionMatrix_mul_mem_specialOrthogonalGroup hCc hE⟩, a, b, fun φ => ⟨?_, ?_⟩⟩
   · intro hφ

--- a/TauCeti/LinearAlgebra/Matrix/SpecialOrthogonalGroup/Reflection.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SpecialOrthogonalGroup/Reflection.lean
@@ -218,10 +218,8 @@ private noncomputable def pathVector (v w : n → K) (X Y : K[T;T⁻¹]) : n →
 
 omit [DecidableEq n] in
 private theorem constVector_dotProduct [Fintype n] (v w : n → K) :
-    constVector v ⬝ᵥ constVector w = C (v ⬝ᵥ w) := by
-  simp only [constVector, dotProduct]
-  rw [map_sum]
-  exact Finset.sum_congr rfl fun i _ => (map_mul C _ _).symm
+    constVector v ⬝ᵥ constVector w = C (v ⬝ᵥ w) :=
+  (RingHom.map_dotProduct C v w).symm
 
 omit [DecidableEq n] in
 private theorem pathVector_dotProduct [Fintype n] (v w : n → K) (X Y X' Y' : K[T;T⁻¹]) :

--- a/TauCeti/LinearAlgebra/Matrix/SpecialOrthogonalGroup/Reflection.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SpecialOrthogonalGroup/Reflection.lean
@@ -10,7 +10,6 @@ public import TauCeti.Algebra.Polynomial.Laurent
 import TauCeti.LinearAlgebra.Matrix.OneSubVecMulVec
 public import TauCeti.LinearAlgebra.Matrix.OrthogonalGroup.QuadraticForm
 public import TauCeti.LinearAlgebra.Matrix.SpecialOrthogonalGroup.Basic
-import TauCeti.LinearAlgebra.Matrix.SpecialOrthogonalGroup.Generation
 
 /-!
 # Reflection matrices for the standard symmetric form


### PR DESCRIPTION
This PR proves that the standard special orthogonal group `SOₙ` is geometrically connected in
every rank over a field of characteristic different from two, and deduces that `SOₙ` is
reductive in every such rank. It closes the `SOₙ` entry of the "Worked examples" list of
`TauCetiRoadmap/ReductiveGroups/README.md`, which asks that the standard groups be proved
"reductive where applicable via `R_u = 1` / root data (the definition that works in all
characteristics)", and so serves the Layer 6 milestone "Reductive and semisimple groups"
(`Reductive: smooth, connected, with R_u(G_k̄) trivial`). On `main` the unipotent-radical half
was already done: `reductiveCommHopfAlgProperty_iff_geometricallyConnected_of_three_le` reduces
reductivity of `SOₙ` for `3 ≤ n` to geometric connectedness, the Layer 3 notion where
"connected always means the geometric notion", and connectedness itself was known only in rank
two. This PR supplies that missing input in every rank, and assembles the four rank cases into
`reductiveCommHopfAlgProperty_finiteTypeCoordinateHopfAlgebra`.

Connectedness is tested on idempotents: over an algebraically closed extension an idempotent
regular function is constant once right translation by every rational point fixes it, and a
rational point joined to the identity by a path fixes every idempotent. The points fixing a
given idempotent form a subgroup, so by the Cartan-Dieudonné generation theorem merged in #6132
it is enough to join each product of two reflections to the identity. That is what the new
one-parameter family does. Write `q(v)` for `v ⬝ᵥ v` and `b` for `v ⬝ᵥ w`, and reflect first in
`v` and then in a vector moving through the plane spanned by `v` and `w`. When the plane is
degenerate, `b * b = q(v) * q(w)`, the affine line `t ↦ (2 - t) • (b • v) + (t - 1) • (q(v) • w)`
has constant norm `q(v)² q(w)`, and its values at `t = 1` and `t = 2` are multiples of `v` and of
`w`. When the plane is nondegenerate, a square root `s` of `b * b - q(v) * q(w)` exists over an
algebraically closed field and makes `e = (s - b) • v + q(v) • w` and `f = (-s - b) • v + q(v) • w`
isotropic, so `e + t • f` has norm `-4 q(v) s² t`, a unit in the Laurent polynomials, and its
values at `t = -1` and `t = -(b - s)/(b + s)` are multiples of `v` and of `w`. Reflecting in a
vector is invariant under rescaling it, so both endpoints of the family are the reflection in
`v`, respectively in `w`, and the family joins `1` to the given product of two reflections.

The new file `TauCeti/LinearAlgebra/Matrix/SpecialOrthogonalGroup/Reflection.lean` (471 lines)
carries the matrix side: `TauCeti.reflectionMatrix v c = 1 - c • vecMulVec v v`, with the
normalizing scalar `c` as data subject to `c * (v ⬝ᵥ v) = 2` rather than as `2 * ⅟(v ⬝ᵥ v)`,
which is what makes rescaling invariance and naturality in the coefficient ring one-liners and
keeps the construction available over any commutative ring. Its involutivity and its determinant
`-1` are read off from the existing rank-one perturbation calculus of
`TauCeti/LinearAlgebra/Matrix/OneSubVecMulVec.lean` (`one_sub_vecMulVec_mul_self`,
`det_one_sub_vecMulVec`); `toMatrix'_reflection` identifies it with the coordinate matrix of the
existing `TauCeti.QuadraticMap.reflection`, which is what lets the connectedness proof
apply the generation theorem to these matrices; and `exists_laurentPath_reflectionMatrix_mul`
is the family above. Nothing was vendored from Mathlib.

`TauCeti/Algebra/AlgebraicGroup/SpecialOrthogonal/Connected.lean` generalizes its private
base-change points equivalence from rank two to rank `n` (imports and rank arguments only; the
existing rank-two proof, which also covers characteristic two, is untouched) and adds
`geometricallyConnectedCommHopfAlgProperty_coordinateHopfAlgebra`.
`TauCeti/Algebra/AlgebraicGroup/SpecialOrthogonal/Reductive.lean` adds the all-rank corollary and
retitles its module docstring, since the file no longer isolates an obstruction.

The subgroup of points whose right translation fixes a given function, which the connectedness
proof needs, is now the shared `TauCeti.HopfAlgebra.rightTranslationStabilizer` in
`TauCeti/Algebra/AlgebraicGroup/Hopf/Translation.lean`, next to `rightTranslationAlgHom_mul`.
`TauCeti/Algebra/AlgebraicGroup/Symplectic/Connected.lean`, which built the same subgroup by
hand, now pulls it back from there too.

After this PR the worked-examples list still owes `PGLₙ` and the root data of `SOₙ`, and
reductivity of a *general* group still waits on conjugacy of maximal tori and Borel subgroups,
which is the roadmap's Layer 7 frontier.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"special-orthogonal-geometrically-connected"}-->

🤖 Prepared with Claude Code



