### PR TITLE
feat: eliminate normal unipotent subgroups of weight Levis

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Weight/Levi/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Weight/Levi/Basic.lean
@@ -72,6 +72,19 @@ noncomputable abbrev weightLeviCoordinateHopfAlgebra (w : Fin N → ℤ) :
   CommHopfAlgCat.quotient (coordinateHopfAlgebra R N)
     (weightLeviDefiningHopfIdeal R w)
 
+/-- The weight-Levi coordinate Hopf algebra with its finite-type property. -/
+noncomputable def weightLeviFiniteTypeCoordinateHopfAlgebra (w : Fin N → ℤ) :
+    FiniteTypeCommHopfAlgCat R :=
+  ⟨weightLeviCoordinateHopfAlgebra R w,
+    inferInstanceAs (Algebra.FiniteType R (weightLeviCoordinateHopfAlgebra R w))⟩
+
+/-- The finite-type package has the weight-Levi coordinate Hopf algebra as its object. -/
+@[simp]
+theorem weightLeviFiniteTypeCoordinateHopfAlgebra_obj (w : Fin N → ℤ) :
+    (weightLeviFiniteTypeCoordinateHopfAlgebra R w).obj =
+      weightLeviCoordinateHopfAlgebra R w :=
+  (rfl)
+
 /-- The affine group scheme represented by the weight-Levi coordinate Hopf algebra. -/
 noncomputable abbrev weightLeviGroupScheme (w : Fin N → ℤ) :=
   CommHopfAlgCat.quotientSpec (coordinateHopfAlgebra R N)

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Weight/Levi/UnipotentRadical.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Weight/Levi/UnipotentRadical.lean
@@ -17,19 +17,11 @@ The statements allow repeated weights, arbitrary characteristic, and rank zero. 
 the normal-subgroup input for reductivity of block-diagonal Levi subgroups and for identifying
 the unipotent radical of their parabolics.
 
-The standard representation is faithful and completely reducible: each weight block is simple,
-and invariant subspaces are sums of blocks. The general normal-invariants criterion therefore
-forces a normal smooth unipotent subgroup to act trivially. Faithfulness identifies its defining
-Hopf ideal with the augmentation ideal.
-
 ## References
 
 * J. S. Milne, *Algebraic Groups* (2017), Chapters 13 and 19.
 * T. A. Springer, *Linear Algebraic Groups*, §§2.2 and 2.4.
-
-The assembly follows `TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Reductive` and uses
-`HopfIdeal.eq_augmentation_of_isNormal_of_smoothUnipotent_of_isFaithful_of_iso` for the
-normal-invariants argument and transport to the finite-type coordinate package.
+* Formal source: `TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Reductive`.
 -/
 
 public section
@@ -46,11 +38,14 @@ variable (k : Type u) [Field k] [IsAlgClosed k] {N : ℕ} (w : Fin N → ℤ)
 
 /-- Every normal smooth unipotent closed subgroup of a weight Levi over an algebraically
 closed field is trivial, including when distinct coordinates have the same weight. -/
-theorem eq_augmentation_of_isNormal_of_smoothUnipotent_weightLevi
+theorem eq_augmentation_weightLevi_of_isNormal_of_smoothUnipotent
     (I : HopfIdeal k (weightLeviFiniteTypeCoordinateHopfAlgebra k w)) (hI : I.IsNormal)
     (hU : smoothUnipotentCommHopfAlgProperty k
       (FiniteTypeCommHopfAlgCat.quotient (weightLeviFiniteTypeCoordinateHopfAlgebra k w) I)) :
     I = HopfIdeal.augmentation k (weightLeviFiniteTypeCoordinateHopfAlgebra k w) := by
+  -- The named finite-type package has an unexposed body. This local presentation has
+  -- the coordinate algebra as its carrier, so its reducedness and comodule instances
+  -- are those of that algebra. The object lemma below supplies the explicit transport.
   let H : FiniteTypeCommHopfAlgCat k :=
     ⟨weightLeviCoordinateHopfAlgebra k w,
       inferInstanceAs (Algebra.FiniteType k (weightLeviCoordinateHopfAlgebra k w))⟩
@@ -73,7 +68,7 @@ theorem unipotentRadicalDefiningIdeal_weightLeviFiniteTypeCoordinateHopfAlgebra 
       HopfIdeal.augmentation k (weightLeviFiniteTypeCoordinateHopfAlgebra k w) := by
   rw [FiniteTypeCommHopfAlgCat.unipotentRadicalDefiningIdeal_eq_augmentation_iff]
   intro I hI
-  exact eq_augmentation_of_isNormal_of_smoothUnipotent_weightLevi k w I
+  exact eq_augmentation_weightLevi_of_isNormal_of_smoothUnipotent k w I
     hI.isNormal hI.smoothUnipotent
 
 end

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Weight/Levi/UnipotentRadical.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Weight/Levi/UnipotentRadical.lean
@@ -1,0 +1,81 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Weight.Levi.StandardComodule
+public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Radical.Faithful
+
+/-!
+# Triviality of the unipotent radical of a weight Levi
+
+Over an algebraically closed field, every normal smooth unipotent closed subgroup of a
+general-linear weight Levi is trivial. In particular, the unipotent radical is trivial.
+The statements allow repeated weights, arbitrary characteristic, and rank zero. They provide
+the normal-subgroup input for reductivity of block-diagonal Levi subgroups and for identifying
+the unipotent radical of their parabolics.
+
+The standard representation is faithful and completely reducible: each weight block is simple,
+and invariant subspaces are sums of blocks. The general normal-invariants criterion therefore
+forces a normal smooth unipotent subgroup to act trivially. Faithfulness identifies its defining
+Hopf ideal with the augmentation ideal.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Chapters 13 and 19.
+* T. A. Springer, *Linear Algebraic Groups*, §§2.2 and 2.4.
+
+The assembly follows `TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Reductive` and uses
+`HopfIdeal.eq_augmentation_of_isNormal_of_smoothUnipotent_of_isFaithful_of_iso` for the
+normal-invariants argument and transport to the finite-type coordinate package.
+-/
+
+public section
+
+open CategoryTheory
+
+namespace TauCeti.GeneralLinear
+
+universe u
+
+noncomputable section
+
+variable (k : Type u) [Field k] [IsAlgClosed k] {N : ℕ} (w : Fin N → ℤ)
+
+/-- Every normal smooth unipotent closed subgroup of a weight Levi over an algebraically
+closed field is trivial, including when distinct coordinates have the same weight. -/
+theorem eq_augmentation_of_isNormal_of_smoothUnipotent_weightLevi
+    (I : HopfIdeal k (weightLeviFiniteTypeCoordinateHopfAlgebra k w)) (hI : I.IsNormal)
+    (hU : smoothUnipotentCommHopfAlgProperty k
+      (FiniteTypeCommHopfAlgCat.quotient (weightLeviFiniteTypeCoordinateHopfAlgebra k w) I)) :
+    I = HopfIdeal.augmentation k (weightLeviFiniteTypeCoordinateHopfAlgebra k w) := by
+  let H : FiniteTypeCommHopfAlgCat k :=
+    ⟨weightLeviCoordinateHopfAlgebra k w,
+      inferInstanceAs (Algebra.FiniteType k (weightLeviCoordinateHopfAlgebra k w))⟩
+  let _ : IsReduced H :=
+    inferInstanceAs (IsReduced (weightLeviCoordinateHopfAlgebra k w))
+  let _ : Comodule k (weightLeviCoordinateHopfAlgebra k w) (Fin N → k) :=
+    weightLeviStandardComodule k w
+  exact HopfIdeal.eq_augmentation_of_isNormal_of_smoothUnipotent_of_isFaithful_of_iso
+    k H (Fin N → k) (weightLeviFiniteTypeCoordinateHopfAlgebra k w)
+    (eqToIso (weightLeviFiniteTypeCoordinateHopfAlgebra_obj k w).symm)
+    (isCompletelyReducible_weightLeviStandardComodule w k)
+    (isFaithful_weightLeviStandardComodule k w) I hI hU
+
+/-- The unipotent radical of every weight Levi over an algebraically closed field is trivial.
+Contravariantly, its defining ideal is the augmentation ideal. -/
+@[simp]
+theorem unipotentRadicalDefiningIdeal_weightLeviFiniteTypeCoordinateHopfAlgebra :
+    FiniteTypeCommHopfAlgCat.unipotentRadicalDefiningIdeal
+        (weightLeviFiniteTypeCoordinateHopfAlgebra k w) =
+      HopfIdeal.augmentation k (weightLeviFiniteTypeCoordinateHopfAlgebra k w) := by
+  rw [FiniteTypeCommHopfAlgCat.unipotentRadicalDefiningIdeal_eq_augmentation_iff]
+  intro I hI
+  exact eq_augmentation_of_isNormal_of_smoothUnipotent_weightLevi k w I
+    hI.isNormal hI.smoothUnipotent
+
+end
+
+end TauCeti.GeneralLinear


### PR DESCRIPTION
This PR proves that every normal smooth unipotent closed subgroup of a general-linear weight Levi over an algebraically closed field is trivial, and identifies its unipotent radical with the augmentation ideal. Allow repeated weights, arbitrary characteristic, and rank zero; package the coordinate Hopf algebra as finite type beside its existing definition.

It advances [ReductiveGroups/README.md, Layer 7, “Structure theory”](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/ReductiveGroups/README.md#layer-7-structure-theory), specifically “parabolic subgroups and Levi decomposition” via the dynamic approach. The immediate consumer is reductivity of arbitrary-weight Levis: the new normal-subgroup elimination theorem supplies the final hypothesis of `reductiveCommHopfAlgProperty_of_geometricFiber_iso` once the geometric-fibre comparison in #6169 is available. That reductivity then feeds removal of the injective-weight hypothesis from `unipotentRadicalDefiningIdeal_weightParabolicFiniteTypeCoordinateHopfAlgebra`.

The faithful, completely reducible standard comodule landed in #6160, and smoothness and geometric connectedness are already on main. Applying the shared normal-invariants criterion is therefore the next available step on this path, distinct from #6169's base-change comparison. After this PR, this part of the Layer 7 milestone still needs the geometric-fibre comparison and reductivity assembly, followed by the arbitrary-weight parabolic radical identification; general conjugacy, root-data extraction, and Bruhat theory remain in the broader milestone.

Add `TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Weight/Levi/UnipotentRadical.lean` (81 lines) and extend `Weight/Levi/Basic.lean` by 13 lines, for 94 added lines and four public declarations. The proof reuses `HopfIdeal.eq_augmentation_of_isNormal_of_smoothUnipotent_of_isFaithful_of_iso`, the weight-Levi standard-comodule theorems, and the unipotent-radical characterization. Its assembly follows `GeneralLinear.Reductive`; the module credits that formal source and Milne, *Algebraic Groups*, Chapters 13 and 19, and Springer, *Linear Algebraic Groups*, §§2.2 and 2.4. No Mathlib infrastructure is vendored.

Self-review against api-design, reuse, and generality found no duplicated result or unnecessary hypothesis and required no substantive change. The finite-type package has a characteristic simp lemma and sits in its canonical earlier module. The build required one explicit finite-type typeclass annotation in a local package. All ten review rubrics were read: scope, correctness, reuse, attribution, api-design, generality, placement, naming, documentation, and proof-quality.

Validation: the targeted build passes for the new module and the downstream `GeneralLinear.Dynamic.Weight.Unipotent.Radical` module, including the changed basic module. `tauceti-axioms --changed-since-merge-base origin/main` accepts all 20 declarations in the two changed modules. `git diff --check` passes. The prescribed environment-lint wrapper stops at its freshness guard because its fixed list omits the newly default `tacticAlt`; a temporary copy adding exactly that linter passes the full current default set on both changed modules, with zero violations and zero grandfathered findings. No repository script or linter configuration is changed.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"weight-levi-normal-unipotent-trivial"}-->

🤖 Prepared with Codex
