### PR TITLE
feat: identify bar coderivation squares with Stasheff identities

### DIFF
--- a/TauCeti/Algebra/Homology/AInfinity/Coderivation.lean
+++ b/TauCeti/Algebra/Homology/AInfinity/Coderivation.lean
@@ -1,0 +1,397 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+import Mathlib.LinearAlgebra.PiTensorProduct.Generators
+public import TauCeti.Algebra.Homology.AInfinity.Stasheff
+public import TauCeti.Algebra.Module.GradedModule.Shift
+public import TauCeti.LinearAlgebra.TensorCoalgebra.OddSquare
+public import TauCeti.LinearAlgebra.TensorCoalgebra.TaylorComponent
+
+/-!
+# Stasheff identities from a bar coderivation
+
+This file identifies the Stasheff identities with the Taylor components of the square of the
+corresponding degree-one coderivation of the reduced tensor coalgebra.  The predicate
+`TauCeti.AInfinity.IsSuspension` records the commuting suspension square on homogeneous pure
+tensors.  If `F` is the resulting Taylor map and
+`b = ReducedTensorWords.gradedCoderiv (G.shift 1) F 1`, then the arity-`n` Taylor component of
+`b ∘ b` is exactly the suspended Stasheff sum.  Consequently `b ∘ b = 0` is equivalent to
+all unsuspended Stasheff identities.
+
+The arities one through four are also stated explicitly.  Together they pin the cohomological
+Getzler--Jones/Keller convention: the Leibniz sign in arity two is `(-1)^|a|`, arity three has
+ordinary associativity when the higher operations vanish, and arity four is then zero.
+
+## Main results
+
+* `TauCeti.AInfinity.IsSuspension`: compatibility between a Taylor map and unsuspended operations
+  on homogeneous tensors.
+* `TauCeti.AInfinity.IsSuspension.taylorComponent_comp_self_apply`: the arity component of the
+  coderivation square is the suspended Stasheff sum.
+* `TauCeti.AInfinity.IsSuspension.comp_self_eq_zero_iff_stasheff`: a degree-one bar coderivation
+  squares to zero exactly when all Stasheff identities hold on homogeneous inputs.
+* `TauCeti.AInfinity.IsSuspension.taylorComponent_comp_self_one` through
+  `taylorComponent_comp_self_four`: the first four component formulas verbatim.
+
+## References
+
+* E. Getzler and J. D. S. Jones, *A-infinity algebras and the cyclic bar complex*, Sections 1--2.
+* B. Keller, *Introduction to A-infinity algebras and modules*, Sections 3.1 and 3.6.
+-/
+
+public section
+
+open scoped BigOperators DirectSum TensorProduct
+open _root_.MultilinearMap
+
+universe uR uA
+
+namespace TauCeti
+
+namespace AInfinity
+
+variable {R : Type uR} {A : Type uA} [CommRing R] [AddCommGroup A] [Module R A]
+
+/-- A Taylor map `F : Tᶜ(A) ⟶ A` is the suspension of operations `mₙ` when, on every
+homogeneous pure tensor, it is obtained from `mₙ` by the Koszul sign of the tensor power of the
+degree-`-1` suspension.  The grading is the unsuspended grading; the associated coderivation is
+built using `G.shift 1`.
+
+The relation is required only on homogeneous inputs.  Requiring it on arbitrary inputs with an
+arbitrarily supplied degree family would be inconsistent, since the suspension sign depends on
+those degrees. -/
+def IsSuspension (G : InternalGrading R A) (F : ReducedTensorWords R A →ₗ[R] A)
+    (m : ∀ n : ℕ, MultilinearMap R (fun _ : Fin n ↦ A) A) : Prop :=
+  ∀ (n : ℕ) (hn : 0 < n) (d : ℕ → ℤ) (x : ℕ → A),
+    (∀ i < n, x i ∈ G.piece (d i)) →
+      F (ReducedTensorWords.of R A ⟨n, hn⟩
+          (PiTensorProduct.tprod R fun i : Fin n ↦ x i)) =
+        evalNat (MultilinearMap.suspend d (m n)) x
+
+/-- The defining condition for a Taylor map to be the suspension of a family of operations. -/
+theorem isSuspension_def (G : InternalGrading R A) (F : ReducedTensorWords R A →ₗ[R] A)
+    (m : ∀ n : ℕ, MultilinearMap R (fun _ : Fin n ↦ A) A) :
+    IsSuspension G F m ↔
+      ∀ (n : ℕ) (hn : 0 < n) (d : ℕ → ℤ) (x : ℕ → A),
+        (∀ i < n, x i ∈ G.piece (d i)) →
+          F (ReducedTensorWords.of R A ⟨n, hn⟩
+              (PiTensorProduct.tprod R fun i : Fin n ↦ x i)) =
+            evalNat (MultilinearMap.suspend d (m n)) x :=
+  Iff.rfl
+
+/-- Evaluate a suspended Taylor map on a homogeneous pure tensor. -/
+theorem IsSuspension.apply {G : InternalGrading R A}
+    {F : ReducedTensorWords R A →ₗ[R] A}
+    {m : ∀ n : ℕ, MultilinearMap R (fun _ : Fin n ↦ A) A}
+    (hFm : IsSuspension G F m) (n : ℕ) (hn : 0 < n) (d : ℕ → ℤ) (x : ℕ → A)
+    (hx : ∀ i < n, x i ∈ G.piece (d i)) :
+    F (ReducedTensorWords.of R A ⟨n, hn⟩
+        (PiTensorProduct.tprod R fun i : Fin n ↦ x i)) =
+      evalNat (MultilinearMap.suspend d (m n)) x :=
+  (isSuspension_def G F m).1 hFm n hn d x hx
+
+/-- A Taylor map related by suspension to operations of degree `2 - n` has degree one from tensor
+words in the suspended grading to suspended letters.  This is the homogeneity input that makes the
+square of its bar coderivation an ordinary coderivation. -/
+theorem IsSuspension.isHomogeneous {G : InternalGrading R A}
+    {F : ReducedTensorWords R A →ₗ[R] A}
+    {m : ∀ n : ℕ, MultilinearMap R (fun _ : Fin n ↦ A) A}
+    (hFm : IsSuspension G F m)
+    (hm : ∀ n, MultilinearMap.IsHomogeneous (m n) (fun _ ↦ G.piece) G.piece (2 - n)) :
+    LinearMap.IsHomogeneous F (ReducedTensorWords.gradedPiece (G.shift 1))
+      (G.shift 1).piece 1 := by
+  rw [LinearMap.isHomogeneous_def]
+  intro D z hz
+  refine ReducedTensorWords.gradedPiece_induction
+    (motive := fun w ↦ F w ∈ (G.shift 1).piece (D + 1)) hz ?_ ?_ ?_ ?_
+  · intro n hn e x hx hD
+    let d : ℕ → ℤ := fun i ↦ if h : i < n then e ⟨i, h⟩ + 1 else 0
+    let y : ℕ → A := fun i ↦ if h : i < n then x ⟨i, h⟩ else 0
+    have hy : ∀ i < n, y i ∈ G.piece (d i) := by
+      intro i hi
+      simp only [y, d, hi, dite_true]
+      simpa only [InternalGrading.shift_piece] using hx ⟨i, hi⟩
+    have hyx : (fun i : Fin n ↦ y i) = x := by
+      funext i
+      simp only [y, i.isLt, dite_true]
+    rw [← hyx]
+    rw [hFm.apply n hn d y hy, evalNat_suspend]
+    apply Submodule.smul_mem
+    have hop := (hm n).map_mem (fun i : Fin n ↦ d i) (fun i : Fin n ↦ y i)
+      (fun i ↦ hy i i.isLt)
+    have hsum : (∑ i : Fin n, d i) = D + n := by
+      simp only [d, Fin.isLt, dite_true, Finset.sum_add_distrib, Finset.sum_const,
+        Finset.card_univ, Fintype.card_fin, nsmul_eq_mul, hD, mul_one]
+    rw [hsum] at hop
+    rw [InternalGrading.shift_piece]
+    have hdeg : D + 1 + 1 = (D + (n : ℤ)) + (2 - (n : ℤ)) := by ring
+    rw [hdeg]
+    simpa only [evalNat_def] using hop
+  · rw [_root_.map_zero]
+    exact Submodule.zero_mem _
+  · intro u v _hu _hv ihu ihv
+    rw [map_add]
+    exact Submodule.add_mem _ ihu ihv
+  · intro a u _hu ihu
+    rw [map_smul]
+    exact Submodule.smul_mem _ _ ihu
+
+/-- The arity-`n` Taylor component of the square of the suspended bar coderivation is the
+suspended Stasheff sum.  The input elements are recorded with their unsuspended degrees `d`; they
+therefore have degrees `d i - 1` for the shifted grading used by the coderivation. -/
+theorem IsSuspension.taylorComponent_comp_self_apply {G : InternalGrading R A}
+    {F : ReducedTensorWords R A →ₗ[R] A}
+    {m : ∀ n : ℕ, MultilinearMap R (fun _ : Fin n ↦ A) A}
+    (hFm : IsSuspension G F m)
+    (hm : ∀ n, MultilinearMap.IsHomogeneous (m n) (fun _ ↦ G.piece) G.piece (2 - n))
+    {n : ℕ} (hn : 0 < n) (d : ℕ → ℤ) (x : ℕ → A)
+    (hx : ∀ i < n, x i ∈ G.piece (d i)) :
+    ((ReducedTensorWords.gradedCoderiv (G.shift 1) F 1) ∘ₗ
+        ReducedTensorWords.gradedCoderiv (G.shift 1) F 1).taylorComponent ⟨n, hn⟩
+        (PiTensorProduct.tprod R fun i : Fin n ↦ x i) =
+      suspendedStasheffSum m d x n := by
+  rw [ReducedTensorWords.taylorComponent_comp_gradedCoderiv_of_tprod_of_homogeneous
+    (G.shift 1) (ReducedTensorWords.gradedCoderiv (G.shift 1) F 1) F 1 hn
+    (fun i : Fin n ↦ x i) (fun i : Fin n ↦ d i - 1)]
+  · rw [suspendedStasheffSum_def, Finset.sum_range_succ]
+    have hnot : ¬1 ≤ 0 := by omega
+    simp only [Nat.sub_self, Finset.Icc_eq_empty hnot, Finset.sum_empty,
+      add_zero]
+    refine Finset.sum_congr rfl fun p hp ↦ ?_
+    refine Finset.sum_congr rfl fun s hs ↦ ?_
+    rw [Finset.mem_range] at hp
+    rw [Finset.mem_Icc] at hs
+    have hps : p + s ≤ n := by omega
+    have hspos : 0 < s := hs.1
+    -- The inner Taylor component is the suspended operation on the collapsed block.
+    have hinner : F (ReducedTensorWords.subword R (fun i : Fin n ↦ x i) p s) =
+        evalNat (MultilinearMap.suspend (fun j ↦ d (p + j)) (m s))
+          (fun j ↦ x (p + j)) := by
+      rw [ReducedTensorWords.subword_eq_of_tprod R _ hspos hps]
+      exact hFm.apply s hspos (fun j ↦ d (p + j)) (fun j ↦ x (p + j))
+        (fun i hi ↦ hx (p + i) (by omega))
+    let e := evalNat (MultilinearMap.suspend (fun j ↦ d (p + j)) (m s))
+      (fun j ↦ x (p + j))
+    have he : e ∈ G.piece (blockDeg d p s) := by
+      simp only [e, evalNat_suspend]
+      exact Submodule.smul_mem _ _
+        (evalNat_mem_blockDeg G.piece (m s) (hm s) p (fun j hj ↦ hx (p + j) (by omega)))
+    have hreplace : ∀ i < p + 1 + (n - p - s),
+        replaceBlock x p s e i ∈ G.piece (replaceDeg d p s i) := by
+      intro i hi
+      rcases lt_trichotomy i p with hip | rfl | hip
+      · rw [replaceBlock_of_lt _ _ _ _ hip, replaceDeg_of_lt _ _ _ hip]
+        exact hx i (by omega)
+      · rw [replaceBlock_self, replaceDeg_self]
+        exact he
+      · rw [replaceBlock_of_gt _ _ _ _ hip, replaceDeg_of_gt _ _ _ hip]
+        exact hx _ (by omega)
+    -- Present the spliced word as the pure tensor to which the outer suspension relation applies.
+    have hsplice : ReducedTensorWords.splice R (fun i : Fin n ↦ x i) 0 n p s e =
+        ReducedTensorWords.of R A ⟨p + 1 + (n - p - s), by omega⟩
+          (PiTensorProduct.tprod R fun i : Fin (p + 1 + (n - p - s)) ↦
+            replaceBlock x p s e i) := by
+      rw [ReducedTensorWords.splice_eq_of_tprod R _ e hspos hps (by omega)]
+      apply ReducedTensorWords.of_tprod_congr R A (by omega) (by omega)
+      intro i
+      simp only [Fin.val_cast, Nat.zero_add]
+      split_ifs with hip hi
+      · exact (replaceBlock_of_lt x p s e hip).symm
+      · rw [hi, replaceBlock_self]
+      · exact (replaceBlock_of_gt x p s e (by omega)).symm
+    rw [ReducedTensorWords.letter_comp_gradedCoderiv, hinner]
+    -- `e` names the suspended inner operation so the splice lemma can be reused without
+    -- exposing the implementation of tensor words.
+    change _ • F (ReducedTensorWords.splice R (fun i : Fin n ↦ x i) 0 n p s e) = _
+    rw [suspendedStasheffTerm_def, hsplice]
+    rw [hFm.apply (p + 1 + (n - p - s)) (by omega) (replaceDeg d p s)
+      (replaceBlock x p s e) hreplace]
+    simp only [e]
+    congr 1
+    rw [negOnePowCast_eq_intCast]
+    congr 2
+    simp only [one_mul]
+    congr 1
+    apply Finset.sum_congr rfl
+    intro j hj
+    have hjn : j < n := (Finset.mem_range.mp hj).trans hp
+    simp only [hjn, dite_true]
+  · intro i
+    have hi := hx i i.isLt
+    rw [InternalGrading.shift_piece]
+    simpa only [sub_add_cancel] using hi
+
+/-- The arity component of the bar-coderivation square is the unsuspended Stasheff sum multiplied
+by the single suspension sign of the whole input tuple. -/
+theorem IsSuspension.taylorComponent_comp_self_eq_smul_stasheff {G : InternalGrading R A}
+    {F : ReducedTensorWords R A →ₗ[R] A}
+    {m : ∀ n : ℕ, MultilinearMap R (fun _ : Fin n ↦ A) A}
+    (hFm : IsSuspension G F m)
+    (hm : ∀ n, MultilinearMap.IsHomogeneous (m n) (fun _ ↦ G.piece) G.piece (2 - n))
+    {n : ℕ} (hn : 0 < n) (d : ℕ → ℤ) (x : ℕ → A)
+    (hx : ∀ i < n, x i ∈ G.piece (d i)) :
+    ((ReducedTensorWords.gradedCoderiv (G.shift 1) F 1) ∘ₗ
+        ReducedTensorWords.gradedCoderiv (G.shift 1) F 1).taylorComponent ⟨n, hn⟩
+        (PiTensorProduct.tprod R fun i : Fin n ↦ x i) =
+      negOnePowCast R (suspExp n d) • stasheffSum m d x n := by
+  rw [hFm.taylorComponent_comp_self_apply hm hn d x hx,
+    suspendedStasheffSum_eq_smul]
+
+/-- On homogeneous inputs, an arity component of the bar-coderivation square vanishes exactly
+when the corresponding unsuspended Stasheff sum vanishes. -/
+theorem IsSuspension.taylorComponent_comp_self_eq_zero_iff {G : InternalGrading R A}
+    {F : ReducedTensorWords R A →ₗ[R] A}
+    {m : ∀ n : ℕ, MultilinearMap R (fun _ : Fin n ↦ A) A}
+    (hFm : IsSuspension G F m)
+    (hm : ∀ n, MultilinearMap.IsHomogeneous (m n) (fun _ ↦ G.piece) G.piece (2 - n))
+    {n : ℕ} (hn : 0 < n) (d : ℕ → ℤ) (x : ℕ → A)
+    (hx : ∀ i < n, x i ∈ G.piece (d i)) :
+    ((ReducedTensorWords.gradedCoderiv (G.shift 1) F 1) ∘ₗ
+        ReducedTensorWords.gradedCoderiv (G.shift 1) F 1).taylorComponent ⟨n, hn⟩
+        (PiTensorProduct.tprod R fun i : Fin n ↦ x i) = 0 ↔
+      stasheffSum m d x n = 0 := by
+  rw [hFm.taylorComponent_comp_self_apply hm hn d x hx,
+    suspendedStasheffSum_eq_zero_iff]
+
+/-! ### The first four components -/
+
+/-- The arity-one component of `b ∘ b` vanishes exactly when `m₁ m₁ = 0`. -/
+theorem IsSuspension.taylorComponent_comp_self_one {G : InternalGrading R A}
+    {F : ReducedTensorWords R A →ₗ[R] A}
+    {m : ∀ n : ℕ, MultilinearMap R (fun _ : Fin n ↦ A) A}
+    (hFm : IsSuspension G F m)
+    (hm : ∀ n, MultilinearMap.IsHomogeneous (m n) (fun _ ↦ G.piece) G.piece (2 - n))
+    (d : ℕ → ℤ) (x : ℕ → A) (hx : x 0 ∈ G.piece (d 0)) :
+    ((ReducedTensorWords.gradedCoderiv (G.shift 1) F 1) ∘ₗ
+        ReducedTensorWords.gradedCoderiv (G.shift 1) F 1).taylorComponent ⟨1, by omega⟩
+        (PiTensorProduct.tprod R fun i : Fin 1 ↦ x i) = 0 ↔
+      m 1 ![m 1 ![x 0]] = 0 := by
+  rw [hFm.taylorComponent_comp_self_eq_zero_iff hm (by omega) d x
+    (fun i hi ↦ by
+      have hi0 : i = 0 := by omega
+      subst i
+      exact hx),
+    stasheffSum_one]
+
+/-- The arity-two component of `b ∘ b` is zero exactly when `m₁` obeys the graded Leibniz
+rule for `m₂`, with sign `(-1)^(d 0)` on the second differentiated input. -/
+theorem IsSuspension.taylorComponent_comp_self_two {G : InternalGrading R A}
+    {F : ReducedTensorWords R A →ₗ[R] A}
+    {m : ∀ n : ℕ, MultilinearMap R (fun _ : Fin n ↦ A) A}
+    (hFm : IsSuspension G F m)
+    (hm : ∀ n, MultilinearMap.IsHomogeneous (m n) (fun _ ↦ G.piece) G.piece (2 - n))
+    (d : ℕ → ℤ) (x : ℕ → A) (hx : ∀ i < 2, x i ∈ G.piece (d i)) :
+    ((ReducedTensorWords.gradedCoderiv (G.shift 1) F 1) ∘ₗ
+        ReducedTensorWords.gradedCoderiv (G.shift 1) F 1).taylorComponent ⟨2, by omega⟩
+        (PiTensorProduct.tprod R fun i : Fin 2 ↦ x i) = 0 ↔
+      m 1 ![m 2 ![x 0, x 1]] =
+        m 2 ![m 1 ![x 0], x 1] + negOnePowCast R (d 0) • m 2 ![x 0, m 1 ![x 1]] := by
+  rw [hFm.taylorComponent_comp_self_eq_zero_iff hm (by omega) d x hx,
+    stasheffSum_two_eq_zero_iff]
+
+/-- The arity-three component of `b ∘ b` is zero exactly when the displayed arity-three
+Stasheff expression vanishes, including the two degree-dependent Koszul factors. -/
+theorem IsSuspension.taylorComponent_comp_self_three {G : InternalGrading R A}
+    {F : ReducedTensorWords R A →ₗ[R] A}
+    {m : ∀ n : ℕ, MultilinearMap R (fun _ : Fin n ↦ A) A}
+    (hFm : IsSuspension G F m)
+    (hm : ∀ n, MultilinearMap.IsHomogeneous (m n) (fun _ ↦ G.piece) G.piece (2 - n))
+    (d : ℕ → ℤ) (x : ℕ → A) (hx : ∀ i < 3, x i ∈ G.piece (d i)) :
+    ((ReducedTensorWords.gradedCoderiv (G.shift 1) F 1) ∘ₗ
+        ReducedTensorWords.gradedCoderiv (G.shift 1) F 1).taylorComponent ⟨3, by omega⟩
+        (PiTensorProduct.tprod R fun i : Fin 3 ↦ x i) = 0 ↔
+      m 1 ![m 3 ![x 0, x 1, x 2]]
+        + m 2 ![m 2 ![x 0, x 1], x 2] - m 2 ![x 0, m 2 ![x 1, x 2]]
+        + m 3 ![m 1 ![x 0], x 1, x 2]
+        + negOnePowCast R (d 0) • m 3 ![x 0, m 1 ![x 1], x 2]
+        + negOnePowCast R (d 0 + d 1) • m 3 ![x 0, x 1, m 1 ![x 2]] = 0 := by
+  rw [hFm.taylorComponent_comp_self_eq_zero_iff hm (by omega) d x hx,
+    stasheffSum_three]
+
+/-- The arity-four component of `b ∘ b` is zero exactly when the displayed arity-four
+Stasheff expression vanishes, with all four unary-insertion signs explicit. -/
+theorem IsSuspension.taylorComponent_comp_self_four {G : InternalGrading R A}
+    {F : ReducedTensorWords R A →ₗ[R] A}
+    {m : ∀ n : ℕ, MultilinearMap R (fun _ : Fin n ↦ A) A}
+    (hFm : IsSuspension G F m)
+    (hm : ∀ n, MultilinearMap.IsHomogeneous (m n) (fun _ ↦ G.piece) G.piece (2 - n))
+    (d : ℕ → ℤ) (x : ℕ → A) (hx : ∀ i < 4, x i ∈ G.piece (d i)) :
+    ((ReducedTensorWords.gradedCoderiv (G.shift 1) F 1) ∘ₗ
+        ReducedTensorWords.gradedCoderiv (G.shift 1) F 1).taylorComponent ⟨4, by omega⟩
+        (PiTensorProduct.tprod R fun i : Fin 4 ↦ x i) = 0 ↔
+      m 1 ![m 4 ![x 0, x 1, x 2, x 3]]
+        - m 2 ![m 3 ![x 0, x 1, x 2], x 3]
+        - negOnePowCast R (d 0) • m 2 ![x 0, m 3 ![x 1, x 2, x 3]]
+        + m 3 ![m 2 ![x 0, x 1], x 2, x 3] - m 3 ![x 0, m 2 ![x 1, x 2], x 3]
+        + m 3 ![x 0, x 1, m 2 ![x 2, x 3]]
+        - m 4 ![m 1 ![x 0], x 1, x 2, x 3]
+        - negOnePowCast R (d 0) • m 4 ![x 0, m 1 ![x 1], x 2, x 3]
+        - negOnePowCast R (d 0 + d 1) • m 4 ![x 0, x 1, m 1 ![x 2], x 3]
+        - negOnePowCast R (d 0 + d 1 + d 2) • m 4 ![x 0, x 1, x 2, m 1 ![x 3]] = 0 := by
+  rw [hFm.taylorComponent_comp_self_eq_zero_iff hm (by omega) d x hx,
+    stasheffSum_four]
+
+/-- The suspended bar coderivation squares to zero exactly when the unsuspended operations obey
+every Stasheff identity on homogeneous inputs.  Since an internal grading decomposes every
+element into a finite sum of homogeneous elements, testing those inputs detects the whole linear
+map `b ∘ b`, not merely its restriction to homogeneous words. -/
+theorem IsSuspension.comp_self_eq_zero_iff_stasheff {G : InternalGrading R A}
+    {F : ReducedTensorWords R A →ₗ[R] A}
+    {m : ∀ n : ℕ, MultilinearMap R (fun _ : Fin n ↦ A) A}
+    (hFm : IsSuspension G F m)
+    (hm : ∀ n, MultilinearMap.IsHomogeneous (m n) (fun _ ↦ G.piece) G.piece (2 - n)) :
+    ReducedTensorWords.gradedCoderiv (G.shift 1) F 1 ∘ₗ
+        ReducedTensorWords.gradedCoderiv (G.shift 1) F 1 = 0 ↔
+      ∀ (n : ℕ) (_hn : 0 < n) (d : ℕ → ℤ) (x : ℕ → A),
+        (∀ i < n, x i ∈ G.piece (d i)) → stasheffSum m d x n = 0 := by
+  let b := ReducedTensorWords.gradedCoderiv (G.shift 1) F 1
+  have hb : ReducedTensorWords.IsGradedCoderivation (G.shift 1) 1 b :=
+    ReducedTensorWords.isGradedCoderivation_gradedCoderiv (G.shift 1) F 1
+  have hbHom : LinearMap.IsHomogeneous b (ReducedTensorWords.gradedPiece (G.shift 1))
+      (ReducedTensorWords.gradedPiece (G.shift 1)) 1 :=
+    ReducedTensorWords.isHomogeneous_gradedCoderiv (G.shift 1) F 1 1
+      (hFm.isHomogeneous hm)
+  have hbSquare : ReducedTensorWords.IsCoderivation R (b ∘ₗ b) :=
+    hb.isCoderivation_comp_self_of_isHomogeneous_one hbHom
+  constructor
+  · intro hzero n hn d x hx
+    have hcomponent := hFm.taylorComponent_comp_self_apply hm hn d x hx
+    -- Unfold only the local abbreviation, leaving the coderivation implementation opaque.
+    change b ∘ₗ b = 0 at hzero
+    rw [hzero] at hcomponent
+    simp only [LinearMap.taylorComponent_zero, LinearMap.zero_apply] at hcomponent
+    exact (suspendedStasheffSum_eq_zero_iff m d x n).1 hcomponent.symm
+  · intro hstasheff
+    -- Unfold only the local abbreviation before applying the coderivation Taylor criterion.
+    change b ∘ₗ b = 0
+    rw [hbSquare.eq_zero_iff_taylorComponent_eq_zero]
+    intro n
+    apply PiTensorProduct.ext_of_span_eq_top
+      (g := fun _ (q : Σ d : ℤ, G.piece d) ↦ (q.2 : A))
+    · intro i
+      apply top_unique
+      rw [← G.isInternal.submodule_iSup_eq_top]
+      refine iSup_le fun d ↦ ?_
+      intro a ha
+      exact Submodule.subset_span ⟨⟨d, ⟨a, ha⟩⟩, rfl⟩
+    · intro q
+      let d : ℕ → ℤ := fun i ↦ if h : i < n.1 then (q ⟨i, h⟩).1 else 0
+      let x : ℕ → A := fun i ↦ if h : i < n.1 then (q ⟨i, h⟩).2 else 0
+      have hx : ∀ i < n.1, x i ∈ G.piece (d i) := by
+        intro i hi
+        simp only [x, d, hi, dite_true]
+        exact (q ⟨i, hi⟩).2.property
+      have hcomponent := hFm.taylorComponent_comp_self_apply hm n.2 d x hx
+      have hsuspended : suspendedStasheffSum m d x n.1 = 0 :=
+        (suspendedStasheffSum_eq_zero_iff m d x n.1).2
+          (hstasheff n.1 n.2 d x hx)
+      rw [hsuspended] at hcomponent
+      simpa only [b, LinearMap.zero_apply, x, Fin.isLt, dite_true] using hcomponent
+
+end AInfinity
+
+end TauCeti

--- a/TauCeti/Algebra/Homology/AInfinity/Coderivation.lean
+++ b/TauCeti/Algebra/Homology/AInfinity/Coderivation.lean
@@ -34,8 +34,9 @@ ordinary associativity when the higher operations vanish, and arity four is then
   coderivation square is the suspended Stasheff sum.
 * `TauCeti.AInfinity.IsSuspension.comp_self_eq_zero_iff_stasheff`: a degree-one bar coderivation
   squares to zero exactly when all Stasheff identities hold on homogeneous inputs.
-* `TauCeti.AInfinity.IsSuspension.taylorComponent_comp_self_one` through
-  `taylorComponent_comp_self_four`: the first four component formulas verbatim.
+* `TauCeti.AInfinity.IsSuspension.taylorComponent_comp_self_one_eq_zero_iff` through
+  `taylorComponent_comp_self_four_eq_zero_iff`: the vanishing criteria for the first four
+  components, with the Stasheff identities written out verbatim.
 
 ## References
 
@@ -72,7 +73,9 @@ def IsSuspension (G : InternalGrading R A) (F : ReducedTensorWords R A →ₗ[R]
           (PiTensorProduct.tprod R fun i : Fin n ↦ x i)) =
         evalNat (MultilinearMap.suspend d (m n)) x
 
-/-- The defining condition for a Taylor map to be the suspension of a family of operations. -/
+/-- The defining condition for a Taylor map to be the suspension of a family of operations, as
+a reusable `Iff`: this exposes the body of the predicate to consumers in other modules, for which
+the definition's body is not exposed. -/
 theorem isSuspension_def (G : InternalGrading R A) (F : ReducedTensorWords R A →ₗ[R] A)
     (m : ∀ n : ℕ, MultilinearMap R (fun _ : Fin n ↦ A) A) :
     IsSuspension G F m ↔
@@ -82,17 +85,6 @@ theorem isSuspension_def (G : InternalGrading R A) (F : ReducedTensorWords R A �
               (PiTensorProduct.tprod R fun i : Fin n ↦ x i)) =
             evalNat (MultilinearMap.suspend d (m n)) x :=
   Iff.rfl
-
-/-- Evaluate a suspended Taylor map on a homogeneous pure tensor. -/
-theorem IsSuspension.apply {G : InternalGrading R A}
-    {F : ReducedTensorWords R A →ₗ[R] A}
-    {m : ∀ n : ℕ, MultilinearMap R (fun _ : Fin n ↦ A) A}
-    (hFm : IsSuspension G F m) (n : ℕ) (hn : 0 < n) (d : ℕ → ℤ) (x : ℕ → A)
-    (hx : ∀ i < n, x i ∈ G.piece (d i)) :
-    F (ReducedTensorWords.of R A ⟨n, hn⟩
-        (PiTensorProduct.tprod R fun i : Fin n ↦ x i)) =
-      evalNat (MultilinearMap.suspend d (m n)) x :=
-  (isSuspension_def G F m).1 hFm n hn d x hx
 
 /-- A Taylor map related by suspension to operations of degree `2 - n` has degree one from tensor
 words in the suspended grading to suspended letters.  This is the homogeneity input that makes the
@@ -119,7 +111,7 @@ theorem IsSuspension.isHomogeneous {G : InternalGrading R A}
       funext i
       simp only [y, i.isLt, dite_true]
     rw [← hyx]
-    rw [hFm.apply n hn d y hy, evalNat_suspend]
+    rw [(isSuspension_def _ _ _).1 hFm n hn d y hy, evalNat_suspend]
     apply Submodule.smul_mem
     have hop := (hm n hn).map_mem (fun i : Fin n ↦ d i) (fun i : Fin n ↦ y i)
       (fun i ↦ hy i i.isLt)
@@ -147,8 +139,10 @@ theorem IsSuspension.taylorComponent_comp_self_apply {G : InternalGrading R A}
     {F : ReducedTensorWords R A →ₗ[R] A}
     {m : ∀ n : ℕ, MultilinearMap R (fun _ : Fin n ↦ A) A}
     (hFm : IsSuspension G F m)
-    (hm : ∀ n, 0 < n → MultilinearMap.IsHomogeneous (m n) (fun _ ↦ G.piece) G.piece (2 - n))
-    {n : ℕ} (hn : 0 < n) (d : ℕ → ℤ) (x : ℕ → A)
+    {n : ℕ}
+    (hm : ∀ s, 0 < s → s ≤ n →
+      MultilinearMap.IsHomogeneous (m s) (fun _ ↦ G.piece) G.piece (2 - s))
+    (hn : 0 < n) (d : ℕ → ℤ) (x : ℕ → A)
     (hx : ∀ i < n, x i ∈ G.piece (d i)) :
     ((ReducedTensorWords.gradedCoderiv (G.shift 1) F 1) ∘ₗ
         ReducedTensorWords.gradedCoderiv (G.shift 1) F 1).taylorComponent ⟨n, hn⟩
@@ -172,14 +166,15 @@ theorem IsSuspension.taylorComponent_comp_self_apply {G : InternalGrading R A}
         evalNat (MultilinearMap.suspend (fun j ↦ d (p + j)) (m s))
           (fun j ↦ x (p + j)) := by
       rw [ReducedTensorWords.subword_eq_of_tprod R _ hspos hps]
-      exact hFm.apply s hspos (fun j ↦ d (p + j)) (fun j ↦ x (p + j))
+      exact (isSuspension_def _ _ _).1 hFm s hspos (fun j ↦ d (p + j)) (fun j ↦ x (p + j))
         (fun i hi ↦ hx (p + i) (by omega))
     let e := evalNat (MultilinearMap.suspend (fun j ↦ d (p + j)) (m s))
       (fun j ↦ x (p + j))
     have he : e ∈ G.piece (blockDeg d p s) := by
       simp only [e, evalNat_suspend]
       exact Submodule.smul_mem _ _
-        (evalNat_mem_blockDeg G.piece (m s) (hm s hspos) p (fun j hj ↦ hx (p + j) (by omega)))
+        (evalNat_mem_blockDeg G.piece (m s) (hm s hspos (by omega)) p
+          (fun j hj ↦ hx (p + j) (by omega)))
     have hreplace : ∀ i < p + 1 + (n - p - s),
         replaceBlock x p s e i ∈ G.piece (replaceDeg d p s i) := by
       intro i hi
@@ -208,18 +203,18 @@ theorem IsSuspension.taylorComponent_comp_self_apply {G : InternalGrading R A}
     -- exposing the implementation of tensor words.
     change _ • F (ReducedTensorWords.splice R (fun i : Fin n ↦ x i) 0 n p s e) = _
     rw [suspendedStasheffTerm_def, hsplice]
-    rw [hFm.apply (p + 1 + (n - p - s)) (by omega) (replaceDeg d p s)
+    rw [(isSuspension_def _ _ _).1 hFm (p + 1 + (n - p - s)) (by omega) (replaceDeg d p s)
       (replaceBlock x p s e) hreplace]
     simp only [e]
-    congr 1
-    rw [negOnePowCast_eq_intCast]
-    congr 2
-    simp only [one_mul]
-    congr 1
-    apply Finset.sum_congr rfl
-    intro j hj
-    have hjn : j < n := (Finset.mem_range.mp hj).trans hp
-    simp only [hjn, dite_true]
+    -- The two prefix signs agree: every index below `p` lies below `n`, so the guarded degrees
+    -- are the shifted degrees `d i - 1`.
+    have hexp : (1 : ℤ) * ∑ j ∈ Finset.range p, (if h : j < n then d j - 1 else 0) =
+        ∑ i ∈ Finset.range p, (d i - 1) := by
+      rw [one_mul]
+      refine Finset.sum_congr rfl fun j hj ↦ ?_
+      have hjn : j < n := (Finset.mem_range.mp hj).trans hp
+      simp only [hjn, dite_true]
+    rw [← negOnePowCast_eq_intCast, hexp]
   · intro i
     have hi := hx i i.isLt
     rw [InternalGrading.shift_piece]
@@ -231,8 +226,10 @@ theorem IsSuspension.taylorComponent_comp_self_eq_smul_stasheff {G : InternalGra
     {F : ReducedTensorWords R A →ₗ[R] A}
     {m : ∀ n : ℕ, MultilinearMap R (fun _ : Fin n ↦ A) A}
     (hFm : IsSuspension G F m)
-    (hm : ∀ n, 0 < n → MultilinearMap.IsHomogeneous (m n) (fun _ ↦ G.piece) G.piece (2 - n))
-    {n : ℕ} (hn : 0 < n) (d : ℕ → ℤ) (x : ℕ → A)
+    {n : ℕ}
+    (hm : ∀ s, 0 < s → s ≤ n →
+      MultilinearMap.IsHomogeneous (m s) (fun _ ↦ G.piece) G.piece (2 - s))
+    (hn : 0 < n) (d : ℕ → ℤ) (x : ℕ → A)
     (hx : ∀ i < n, x i ∈ G.piece (d i)) :
     ((ReducedTensorWords.gradedCoderiv (G.shift 1) F 1) ∘ₗ
         ReducedTensorWords.gradedCoderiv (G.shift 1) F 1).taylorComponent ⟨n, hn⟩
@@ -247,8 +244,10 @@ theorem IsSuspension.taylorComponent_comp_self_eq_zero_iff {G : InternalGrading 
     {F : ReducedTensorWords R A →ₗ[R] A}
     {m : ∀ n : ℕ, MultilinearMap R (fun _ : Fin n ↦ A) A}
     (hFm : IsSuspension G F m)
-    (hm : ∀ n, 0 < n → MultilinearMap.IsHomogeneous (m n) (fun _ ↦ G.piece) G.piece (2 - n))
-    {n : ℕ} (hn : 0 < n) (d : ℕ → ℤ) (x : ℕ → A)
+    {n : ℕ}
+    (hm : ∀ s, 0 < s → s ≤ n →
+      MultilinearMap.IsHomogeneous (m s) (fun _ ↦ G.piece) G.piece (2 - s))
+    (hn : 0 < n) (d : ℕ → ℤ) (x : ℕ → A)
     (hx : ∀ i < n, x i ∈ G.piece (d i)) :
     ((ReducedTensorWords.gradedCoderiv (G.shift 1) F 1) ∘ₗ
         ReducedTensorWords.gradedCoderiv (G.shift 1) F 1).taylorComponent ⟨n, hn⟩
@@ -260,11 +259,12 @@ theorem IsSuspension.taylorComponent_comp_self_eq_zero_iff {G : InternalGrading 
 /-! ### The first four components -/
 
 /-- The arity-one component of `b ∘ b` vanishes exactly when `m₁ m₁ = 0`. -/
-theorem IsSuspension.taylorComponent_comp_self_one {G : InternalGrading R A}
+theorem IsSuspension.taylorComponent_comp_self_one_eq_zero_iff {G : InternalGrading R A}
     {F : ReducedTensorWords R A →ₗ[R] A}
     {m : ∀ n : ℕ, MultilinearMap R (fun _ : Fin n ↦ A) A}
     (hFm : IsSuspension G F m)
-    (hm : ∀ n, 0 < n → MultilinearMap.IsHomogeneous (m n) (fun _ ↦ G.piece) G.piece (2 - n))
+    (hm : ∀ s, 0 < s → s ≤ 1 →
+      MultilinearMap.IsHomogeneous (m s) (fun _ ↦ G.piece) G.piece (2 - s))
     (d : ℕ → ℤ) (x : ℕ → A) (hx : x 0 ∈ G.piece (d 0)) :
     ((ReducedTensorWords.gradedCoderiv (G.shift 1) F 1) ∘ₗ
         ReducedTensorWords.gradedCoderiv (G.shift 1) F 1).taylorComponent ⟨1, by omega⟩
@@ -279,11 +279,12 @@ theorem IsSuspension.taylorComponent_comp_self_one {G : InternalGrading R A}
 
 /-- The arity-two component of `b ∘ b` is zero exactly when `m₁` obeys the graded Leibniz
 rule for `m₂`, with sign `(-1)^(d 0)` on the second differentiated input. -/
-theorem IsSuspension.taylorComponent_comp_self_two {G : InternalGrading R A}
+theorem IsSuspension.taylorComponent_comp_self_two_eq_zero_iff {G : InternalGrading R A}
     {F : ReducedTensorWords R A →ₗ[R] A}
     {m : ∀ n : ℕ, MultilinearMap R (fun _ : Fin n ↦ A) A}
     (hFm : IsSuspension G F m)
-    (hm : ∀ n, 0 < n → MultilinearMap.IsHomogeneous (m n) (fun _ ↦ G.piece) G.piece (2 - n))
+    (hm : ∀ s, 0 < s → s ≤ 2 →
+      MultilinearMap.IsHomogeneous (m s) (fun _ ↦ G.piece) G.piece (2 - s))
     (d : ℕ → ℤ) (x : ℕ → A) (hx : ∀ i < 2, x i ∈ G.piece (d i)) :
     ((ReducedTensorWords.gradedCoderiv (G.shift 1) F 1) ∘ₗ
         ReducedTensorWords.gradedCoderiv (G.shift 1) F 1).taylorComponent ⟨2, by omega⟩
@@ -295,11 +296,12 @@ theorem IsSuspension.taylorComponent_comp_self_two {G : InternalGrading R A}
 
 /-- The arity-three component of `b ∘ b` is zero exactly when the displayed arity-three
 Stasheff expression vanishes, including the two degree-dependent Koszul factors. -/
-theorem IsSuspension.taylorComponent_comp_self_three {G : InternalGrading R A}
+theorem IsSuspension.taylorComponent_comp_self_three_eq_zero_iff {G : InternalGrading R A}
     {F : ReducedTensorWords R A →ₗ[R] A}
     {m : ∀ n : ℕ, MultilinearMap R (fun _ : Fin n ↦ A) A}
     (hFm : IsSuspension G F m)
-    (hm : ∀ n, 0 < n → MultilinearMap.IsHomogeneous (m n) (fun _ ↦ G.piece) G.piece (2 - n))
+    (hm : ∀ s, 0 < s → s ≤ 3 →
+      MultilinearMap.IsHomogeneous (m s) (fun _ ↦ G.piece) G.piece (2 - s))
     (d : ℕ → ℤ) (x : ℕ → A) (hx : ∀ i < 3, x i ∈ G.piece (d i)) :
     ((ReducedTensorWords.gradedCoderiv (G.shift 1) F 1) ∘ₗ
         ReducedTensorWords.gradedCoderiv (G.shift 1) F 1).taylorComponent ⟨3, by omega⟩
@@ -314,11 +316,12 @@ theorem IsSuspension.taylorComponent_comp_self_three {G : InternalGrading R A}
 
 /-- The arity-four component of `b ∘ b` is zero exactly when the displayed arity-four
 Stasheff expression vanishes, with all four unary-insertion signs explicit. -/
-theorem IsSuspension.taylorComponent_comp_self_four {G : InternalGrading R A}
+theorem IsSuspension.taylorComponent_comp_self_four_eq_zero_iff {G : InternalGrading R A}
     {F : ReducedTensorWords R A →ₗ[R] A}
     {m : ∀ n : ℕ, MultilinearMap R (fun _ : Fin n ↦ A) A}
     (hFm : IsSuspension G F m)
-    (hm : ∀ n, 0 < n → MultilinearMap.IsHomogeneous (m n) (fun _ ↦ G.piece) G.piece (2 - n))
+    (hm : ∀ s, 0 < s → s ≤ 4 →
+      MultilinearMap.IsHomogeneous (m s) (fun _ ↦ G.piece) G.piece (2 - s))
     (d : ℕ → ℤ) (x : ℕ → A) (hx : ∀ i < 4, x i ∈ G.piece (d i)) :
     ((ReducedTensorWords.gradedCoderiv (G.shift 1) F 1) ∘ₗ
         ReducedTensorWords.gradedCoderiv (G.shift 1) F 1).taylorComponent ⟨4, by omega⟩
@@ -359,7 +362,7 @@ theorem IsSuspension.comp_self_eq_zero_iff_stasheff {G : InternalGrading R A}
     hb.isCoderivation_comp_self_of_isHomogeneous_one hbHom
   constructor
   · intro hzero n hn d x hx
-    have hcomponent := hFm.taylorComponent_comp_self_apply hm hn d x hx
+    have hcomponent := hFm.taylorComponent_comp_self_apply (fun s hs _ ↦ hm s hs) hn d x hx
     -- Unfold only the local abbreviation, leaving the coderivation implementation opaque.
     change b ∘ₗ b = 0 at hzero
     rw [hzero] at hcomponent
@@ -385,7 +388,7 @@ theorem IsSuspension.comp_self_eq_zero_iff_stasheff {G : InternalGrading R A}
         intro i hi
         simp only [x, d, hi, dite_true]
         exact (q ⟨i, hi⟩).2.property
-      have hcomponent := hFm.taylorComponent_comp_self_apply hm n.2 d x hx
+      have hcomponent := hFm.taylorComponent_comp_self_apply (fun s hs _ ↦ hm s hs) n.2 d x hx
       have hsuspended : suspendedStasheffSum m d x n.1 = 0 :=
         (suspendedStasheffSum_eq_zero_iff m d x n.1).2
           (hstasheff n.1 n.2 d x hx)

--- a/TauCeti/Algebra/Homology/AInfinity/Coderivation.lean
+++ b/TauCeti/Algebra/Homology/AInfinity/Coderivation.lean
@@ -101,7 +101,7 @@ theorem IsSuspension.isHomogeneous {G : InternalGrading R A}
     {F : ReducedTensorWords R A →ₗ[R] A}
     {m : ∀ n : ℕ, MultilinearMap R (fun _ : Fin n ↦ A) A}
     (hFm : IsSuspension G F m)
-    (hm : ∀ n, MultilinearMap.IsHomogeneous (m n) (fun _ ↦ G.piece) G.piece (2 - n)) :
+    (hm : ∀ n, 0 < n → MultilinearMap.IsHomogeneous (m n) (fun _ ↦ G.piece) G.piece (2 - n)) :
     LinearMap.IsHomogeneous F (ReducedTensorWords.gradedPiece (G.shift 1))
       (G.shift 1).piece 1 := by
   rw [LinearMap.isHomogeneous_def]
@@ -121,7 +121,7 @@ theorem IsSuspension.isHomogeneous {G : InternalGrading R A}
     rw [← hyx]
     rw [hFm.apply n hn d y hy, evalNat_suspend]
     apply Submodule.smul_mem
-    have hop := (hm n).map_mem (fun i : Fin n ↦ d i) (fun i : Fin n ↦ y i)
+    have hop := (hm n hn).map_mem (fun i : Fin n ↦ d i) (fun i : Fin n ↦ y i)
       (fun i ↦ hy i i.isLt)
     have hsum : (∑ i : Fin n, d i) = D + n := by
       simp only [d, Fin.isLt, dite_true, Finset.sum_add_distrib, Finset.sum_const,
@@ -147,7 +147,7 @@ theorem IsSuspension.taylorComponent_comp_self_apply {G : InternalGrading R A}
     {F : ReducedTensorWords R A →ₗ[R] A}
     {m : ∀ n : ℕ, MultilinearMap R (fun _ : Fin n ↦ A) A}
     (hFm : IsSuspension G F m)
-    (hm : ∀ n, MultilinearMap.IsHomogeneous (m n) (fun _ ↦ G.piece) G.piece (2 - n))
+    (hm : ∀ n, 0 < n → MultilinearMap.IsHomogeneous (m n) (fun _ ↦ G.piece) G.piece (2 - n))
     {n : ℕ} (hn : 0 < n) (d : ℕ → ℤ) (x : ℕ → A)
     (hx : ∀ i < n, x i ∈ G.piece (d i)) :
     ((ReducedTensorWords.gradedCoderiv (G.shift 1) F 1) ∘ₗ
@@ -179,7 +179,7 @@ theorem IsSuspension.taylorComponent_comp_self_apply {G : InternalGrading R A}
     have he : e ∈ G.piece (blockDeg d p s) := by
       simp only [e, evalNat_suspend]
       exact Submodule.smul_mem _ _
-        (evalNat_mem_blockDeg G.piece (m s) (hm s) p (fun j hj ↦ hx (p + j) (by omega)))
+        (evalNat_mem_blockDeg G.piece (m s) (hm s hspos) p (fun j hj ↦ hx (p + j) (by omega)))
     have hreplace : ∀ i < p + 1 + (n - p - s),
         replaceBlock x p s e i ∈ G.piece (replaceDeg d p s i) := by
       intro i hi
@@ -231,7 +231,7 @@ theorem IsSuspension.taylorComponent_comp_self_eq_smul_stasheff {G : InternalGra
     {F : ReducedTensorWords R A →ₗ[R] A}
     {m : ∀ n : ℕ, MultilinearMap R (fun _ : Fin n ↦ A) A}
     (hFm : IsSuspension G F m)
-    (hm : ∀ n, MultilinearMap.IsHomogeneous (m n) (fun _ ↦ G.piece) G.piece (2 - n))
+    (hm : ∀ n, 0 < n → MultilinearMap.IsHomogeneous (m n) (fun _ ↦ G.piece) G.piece (2 - n))
     {n : ℕ} (hn : 0 < n) (d : ℕ → ℤ) (x : ℕ → A)
     (hx : ∀ i < n, x i ∈ G.piece (d i)) :
     ((ReducedTensorWords.gradedCoderiv (G.shift 1) F 1) ∘ₗ
@@ -247,7 +247,7 @@ theorem IsSuspension.taylorComponent_comp_self_eq_zero_iff {G : InternalGrading 
     {F : ReducedTensorWords R A →ₗ[R] A}
     {m : ∀ n : ℕ, MultilinearMap R (fun _ : Fin n ↦ A) A}
     (hFm : IsSuspension G F m)
-    (hm : ∀ n, MultilinearMap.IsHomogeneous (m n) (fun _ ↦ G.piece) G.piece (2 - n))
+    (hm : ∀ n, 0 < n → MultilinearMap.IsHomogeneous (m n) (fun _ ↦ G.piece) G.piece (2 - n))
     {n : ℕ} (hn : 0 < n) (d : ℕ → ℤ) (x : ℕ → A)
     (hx : ∀ i < n, x i ∈ G.piece (d i)) :
     ((ReducedTensorWords.gradedCoderiv (G.shift 1) F 1) ∘ₗ
@@ -264,7 +264,7 @@ theorem IsSuspension.taylorComponent_comp_self_one {G : InternalGrading R A}
     {F : ReducedTensorWords R A →ₗ[R] A}
     {m : ∀ n : ℕ, MultilinearMap R (fun _ : Fin n ↦ A) A}
     (hFm : IsSuspension G F m)
-    (hm : ∀ n, MultilinearMap.IsHomogeneous (m n) (fun _ ↦ G.piece) G.piece (2 - n))
+    (hm : ∀ n, 0 < n → MultilinearMap.IsHomogeneous (m n) (fun _ ↦ G.piece) G.piece (2 - n))
     (d : ℕ → ℤ) (x : ℕ → A) (hx : x 0 ∈ G.piece (d 0)) :
     ((ReducedTensorWords.gradedCoderiv (G.shift 1) F 1) ∘ₗ
         ReducedTensorWords.gradedCoderiv (G.shift 1) F 1).taylorComponent ⟨1, by omega⟩
@@ -283,7 +283,7 @@ theorem IsSuspension.taylorComponent_comp_self_two {G : InternalGrading R A}
     {F : ReducedTensorWords R A →ₗ[R] A}
     {m : ∀ n : ℕ, MultilinearMap R (fun _ : Fin n ↦ A) A}
     (hFm : IsSuspension G F m)
-    (hm : ∀ n, MultilinearMap.IsHomogeneous (m n) (fun _ ↦ G.piece) G.piece (2 - n))
+    (hm : ∀ n, 0 < n → MultilinearMap.IsHomogeneous (m n) (fun _ ↦ G.piece) G.piece (2 - n))
     (d : ℕ → ℤ) (x : ℕ → A) (hx : ∀ i < 2, x i ∈ G.piece (d i)) :
     ((ReducedTensorWords.gradedCoderiv (G.shift 1) F 1) ∘ₗ
         ReducedTensorWords.gradedCoderiv (G.shift 1) F 1).taylorComponent ⟨2, by omega⟩
@@ -299,7 +299,7 @@ theorem IsSuspension.taylorComponent_comp_self_three {G : InternalGrading R A}
     {F : ReducedTensorWords R A →ₗ[R] A}
     {m : ∀ n : ℕ, MultilinearMap R (fun _ : Fin n ↦ A) A}
     (hFm : IsSuspension G F m)
-    (hm : ∀ n, MultilinearMap.IsHomogeneous (m n) (fun _ ↦ G.piece) G.piece (2 - n))
+    (hm : ∀ n, 0 < n → MultilinearMap.IsHomogeneous (m n) (fun _ ↦ G.piece) G.piece (2 - n))
     (d : ℕ → ℤ) (x : ℕ → A) (hx : ∀ i < 3, x i ∈ G.piece (d i)) :
     ((ReducedTensorWords.gradedCoderiv (G.shift 1) F 1) ∘ₗ
         ReducedTensorWords.gradedCoderiv (G.shift 1) F 1).taylorComponent ⟨3, by omega⟩
@@ -318,7 +318,7 @@ theorem IsSuspension.taylorComponent_comp_self_four {G : InternalGrading R A}
     {F : ReducedTensorWords R A →ₗ[R] A}
     {m : ∀ n : ℕ, MultilinearMap R (fun _ : Fin n ↦ A) A}
     (hFm : IsSuspension G F m)
-    (hm : ∀ n, MultilinearMap.IsHomogeneous (m n) (fun _ ↦ G.piece) G.piece (2 - n))
+    (hm : ∀ n, 0 < n → MultilinearMap.IsHomogeneous (m n) (fun _ ↦ G.piece) G.piece (2 - n))
     (d : ℕ → ℤ) (x : ℕ → A) (hx : ∀ i < 4, x i ∈ G.piece (d i)) :
     ((ReducedTensorWords.gradedCoderiv (G.shift 1) F 1) ∘ₗ
         ReducedTensorWords.gradedCoderiv (G.shift 1) F 1).taylorComponent ⟨4, by omega⟩
@@ -343,7 +343,7 @@ theorem IsSuspension.comp_self_eq_zero_iff_stasheff {G : InternalGrading R A}
     {F : ReducedTensorWords R A →ₗ[R] A}
     {m : ∀ n : ℕ, MultilinearMap R (fun _ : Fin n ↦ A) A}
     (hFm : IsSuspension G F m)
-    (hm : ∀ n, MultilinearMap.IsHomogeneous (m n) (fun _ ↦ G.piece) G.piece (2 - n)) :
+    (hm : ∀ n, 0 < n → MultilinearMap.IsHomogeneous (m n) (fun _ ↦ G.piece) G.piece (2 - n)) :
     ReducedTensorWords.gradedCoderiv (G.shift 1) F 1 ∘ₗ
         ReducedTensorWords.gradedCoderiv (G.shift 1) F 1 = 0 ↔
       ∀ (n : ℕ) (_hn : 0 < n) (d : ℕ → ℤ) (x : ℕ → A),

--- a/TauCeti/Algebra/Homology/AInfinity/Coderivation.lean
+++ b/TauCeti/Algebra/Homology/AInfinity/Coderivation.lean
@@ -32,8 +32,9 @@ ordinary associativity when the higher operations vanish, and arity four is then
   on homogeneous tensors.
 * `TauCeti.AInfinity.IsSuspension.taylorComponent_comp_self_apply`: the arity component of the
   coderivation square is the suspended Stasheff sum.
-* `TauCeti.AInfinity.IsSuspension.comp_self_eq_zero_iff_stasheff`: a degree-one bar coderivation
-  squares to zero exactly when all Stasheff identities hold on homogeneous inputs.
+* `TauCeti.AInfinity.IsSuspension.comp_self_eq_zero_iff_forall_stasheffSum_eq_zero`:
+  a degree-one bar coderivation squares to zero exactly when all Stasheff identities hold on
+  homogeneous inputs.
 * `TauCeti.AInfinity.IsSuspension.taylorComponent_comp_self_one_eq_zero_iff` through
   `taylorComponent_comp_self_four_eq_zero_iff`: the vanishing criteria for the first four
   components, with the Stasheff identities written out verbatim.
@@ -176,15 +177,8 @@ theorem IsSuspension.taylorComponent_comp_self_apply {G : InternalGrading R A}
         (evalNat_mem_blockDeg G.piece (m s) (hm s hspos (by omega)) p
           (fun j hj ↦ hx (p + j) (by omega)))
     have hreplace : ∀ i < p + 1 + (n - p - s),
-        replaceBlock x p s e i ∈ G.piece (replaceDeg d p s i) := by
-      intro i hi
-      rcases lt_trichotomy i p with hip | rfl | hip
-      · rw [replaceBlock_of_lt _ _ _ _ hip, replaceDeg_of_lt _ _ _ hip]
-        exact hx i (by omega)
-      · rw [replaceBlock_self, replaceDeg_self]
-        exact he
-      · rw [replaceBlock_of_gt _ _ _ _ hip, replaceDeg_of_gt _ _ _ hip]
-        exact hx _ (by omega)
+        replaceBlock x p s e i ∈ G.piece (replaceDeg d p s i) := fun _ hi ↦
+      replaceBlock_mem_replaceDeg_of_mem_blockDeg G.piece hx he hps hi
     -- Present the spliced word as the pure tensor to which the outer suspension relation applies.
     have hsplice : ReducedTensorWords.splice R (fun i : Fin n ↦ x i) 0 n p s e =
         ReducedTensorWords.of R A ⟨p + 1 + (n - p - s), by omega⟩
@@ -222,7 +216,7 @@ theorem IsSuspension.taylorComponent_comp_self_apply {G : InternalGrading R A}
 
 /-- The arity component of the bar-coderivation square is the unsuspended Stasheff sum multiplied
 by the single suspension sign of the whole input tuple. -/
-theorem IsSuspension.taylorComponent_comp_self_eq_smul_stasheff {G : InternalGrading R A}
+theorem IsSuspension.taylorComponent_comp_self_eq_smul_stasheffSum {G : InternalGrading R A}
     {F : ReducedTensorWords R A →ₗ[R] A}
     {m : ∀ n : ℕ, MultilinearMap R (fun _ : Fin n ↦ A) A}
     (hFm : IsSuspension G F m)
@@ -342,7 +336,7 @@ theorem IsSuspension.taylorComponent_comp_self_four_eq_zero_iff {G : InternalGra
 every Stasheff identity on homogeneous inputs.  Since an internal grading decomposes every
 element into a finite sum of homogeneous elements, testing those inputs detects the whole linear
 map `b ∘ b`, not merely its restriction to homogeneous words. -/
-theorem IsSuspension.comp_self_eq_zero_iff_stasheff {G : InternalGrading R A}
+theorem IsSuspension.comp_self_eq_zero_iff_forall_stasheffSum_eq_zero {G : InternalGrading R A}
     {F : ReducedTensorWords R A →ₗ[R] A}
     {m : ∀ n : ℕ, MultilinearMap R (fun _ : Fin n ↦ A) A}
     (hFm : IsSuspension G F m)

--- a/TauCeti/Algebra/Homology/AInfinity/Stasheff.lean
+++ b/TauCeti/Algebra/Homology/AInfinity/Stasheff.lean
@@ -43,13 +43,14 @@ inputs, `(-1) ^ ((2 - s) * (d 0 + ⋯ + d (r - 1)))` before suspension and
 `MultilinearMap.koszulSign`. As in
 `TauCeti/LinearAlgebra/Graded/Insertion.lean`, the degrees of the inputs are supplied as an
 explicit parameter rather than read off a direct-sum decomposition; on the intended component the
-sign is a scalar, and `TauCeti.AInfinity.replaceBlock_mem_replaceDeg` proves that the supplied
-degrees are the actual ones once every operation is homogeneous of degree `2 - k`.
+sign is a scalar, and `TauCeti.AInfinity.replaceBlock_mem_replaceDeg_of_mem_blockDeg` proves that
+the supplied degrees are the actual ones once the inputs and the inserted value are homogeneous of
+the recorded degrees.
 
 The arities one to four are written out on the nose using the supplied degree family `d`; these
 formulas themselves make no homogeneity assumption. Homogeneity enters only in
-`evalNat_mem_blockDeg` and `replaceBlock_mem_replaceDeg`. The degeneration to a differential
-graded algebra is also checked.
+`evalNat_mem_blockDeg` and `replaceBlock_mem_replaceDeg_of_mem_blockDeg`.
+The degeneration to a differential graded algebra is also checked.
 
 Inputs are indexed by `ℕ` rather than by `Fin n` throughout; only the first `n` entries of an input
 family are read, and this keeps the reindexing of the Stasheff sums free of transports between
@@ -686,17 +687,6 @@ theorem replaceBlock_mem_replaceDeg_of_mem_blockDeg {n p s : ℕ} {d : ℕ → �
     exact he
   · rw [replaceBlock_of_gt _ _ _ _ h, replaceDeg_of_gt _ _ _ h]
     exact hx _ (by omega)
-
-/-- **The supplied degrees of a Stasheff term are the actual ones.** If an arity-`s` operation is
-homogeneous of degree `2 - s` and the inputs are homogeneous of degrees `d`, then `replaceDeg`
-records the degrees of the inputs of the outer operation after inserting its value. -/
-theorem replaceBlock_mem_replaceDeg {s : ℕ}
-    (f : MultilinearMap R (fun _ : Fin s ↦ A) A) {d : ℕ → ℤ} {x : ℕ → A}
-    (hf : MultilinearMap.IsHomogeneous f (fun _ ↦ 𝒜) 𝒜 (2 - s))
-    (hx : ∀ i, x i ∈ 𝒜 (d i)) (p i : ℕ) :
-    replaceBlock x p s (evalNat f fun j ↦ x (p + j)) i ∈ 𝒜 (replaceDeg d p s i) :=
-  replaceBlock_mem_replaceDeg_of_mem_blockDeg (n := p + s + i) 𝒜 (fun j _ ↦ hx j)
-    (evalNat_mem_blockDeg 𝒜 f hf p fun j _ ↦ hx (p + j)) (by omega) (by omega)
 
 end Comparison
 

--- a/TauCeti/Algebra/Homology/AInfinity/Stasheff.lean
+++ b/TauCeti/Algebra/Homology/AInfinity/Stasheff.lean
@@ -669,6 +669,24 @@ theorem evalNat_mem_blockDeg {s : ℕ} (f : MultilinearMap R (fun _ : Fin s ↦ 
     evalNat_def]
   exact hf.map_mem _ _ fun j ↦ hx j j.isLt
 
+omit [AddCommMonoid A] in
+/-- **The supplied degrees of a Stasheff term are the actual ones**, for an arbitrary inserted
+element.  If the inputs occurring in an arity-`n` word are homogeneous of degrees `d` and the
+element `e` replacing the block of length `s` at position `p` is homogeneous of degree
+`blockDeg d p s`, then `replaceDeg` records the degrees of the inputs of the outer operation.
+Only the inputs actually read, namely those below `n`, need be homogeneous. -/
+theorem replaceBlock_mem_replaceDeg_of_mem_blockDeg {n p s : ℕ} {d : ℕ → ℤ} {x : ℕ → A} {e : A}
+    (hx : ∀ i < n, x i ∈ 𝒜 (d i)) (he : e ∈ 𝒜 (blockDeg d p s)) (hps : p + s ≤ n)
+    {i : ℕ} (hi : i < p + 1 + (n - p - s)) :
+    replaceBlock x p s e i ∈ 𝒜 (replaceDeg d p s i) := by
+  rcases lt_trichotomy i p with h | rfl | h
+  · rw [replaceBlock_of_lt _ _ _ _ h, replaceDeg_of_lt _ _ _ h]
+    exact hx i (by omega)
+  · rw [replaceBlock_self, replaceDeg_self]
+    exact he
+  · rw [replaceBlock_of_gt _ _ _ _ h, replaceDeg_of_gt _ _ _ h]
+    exact hx _ (by omega)
+
 /-- **The supplied degrees of a Stasheff term are the actual ones.** If an arity-`s` operation is
 homogeneous of degree `2 - s` and the inputs are homogeneous of degrees `d`, then `replaceDeg`
 records the degrees of the inputs of the outer operation after inserting its value. -/
@@ -676,14 +694,9 @@ theorem replaceBlock_mem_replaceDeg {s : ℕ}
     (f : MultilinearMap R (fun _ : Fin s ↦ A) A) {d : ℕ → ℤ} {x : ℕ → A}
     (hf : MultilinearMap.IsHomogeneous f (fun _ ↦ 𝒜) 𝒜 (2 - s))
     (hx : ∀ i, x i ∈ 𝒜 (d i)) (p i : ℕ) :
-    replaceBlock x p s (evalNat f fun j ↦ x (p + j)) i ∈ 𝒜 (replaceDeg d p s i) := by
-  rcases lt_trichotomy i p with h | rfl | h
-  · rw [replaceBlock_of_lt _ _ _ _ h, replaceDeg_of_lt _ _ _ h]
-    exact hx i
-  · rw [replaceBlock_self, replaceDeg_self]
-    exact evalNat_mem_blockDeg 𝒜 f hf i (fun j _ ↦ hx (i + j))
-  · rw [replaceBlock_of_gt _ _ _ _ h, replaceDeg_of_gt _ _ _ h]
-    exact hx _
+    replaceBlock x p s (evalNat f fun j ↦ x (p + j)) i ∈ 𝒜 (replaceDeg d p s i) :=
+  replaceBlock_mem_replaceDeg_of_mem_blockDeg (n := p + s + i) 𝒜 (fun j _ ↦ hx j)
+    (evalNat_mem_blockDeg 𝒜 f hf p fun j _ ↦ hx (p + j)) (by omega) (by omega)
 
 end Comparison
 


### PR DESCRIPTION
This PR identifies every positive-arity Taylor component of the square of a suspended degree-one bar coderivation with the corresponding unsuspended Stasheff sum. It supplies the general component theorem, its zero-equivalence, the arity 1--4 equations with the roadmap's exact signs, and the global equivalence between square-zero and the homogeneous Stasheff identities.

This completes the DGAInfinity Layer 0 milestone “Implement the suspension/unsuspension equivalence fixed above. Prove the general Stasheff component formula and the arity 1--4 equations verbatim,” building directly on the landed Taylor-component, odd-square, suspension, and Stasheff-sign infrastructure. It is the most effective current step toward Layer 2's first milestone because it is the final algebraic bridge needed to define a nonunital A∞ algebra interchangeably by a square-zero bar coderivation or by its operations.

After this PR, Layer 2 still needs to package nonunital A∞ algebras and expose the canonical conversion between their coderivation and operation presentations before adding units, morphisms, and categories.

The implementation reuses Mathlib's `PiTensorProduct.ext_of_span_eq_top` to pass from homogeneous pure-tensor generators to equality of coderivations, and the existing TauCeti sign infrastructure throughout. The module documentation records the Getzler--Jones and Keller conventions used by the roadmap.

Roadmap: DGAInfinity

<!--tauceti-target:v1 {"focus":"DGAInfinity","id":"arity-one-four-coderivation-stasheff"}-->

🤖 Prepared with Codex
