### PR TITLE
feat: derive connectedness from a subgroup quotient

### DIFF
--- a/TauCeti/Topology/Algebra/Group/Connected.lean
+++ b/TauCeti/Topology/Algebra/Group/Connected.lean
@@ -6,18 +6,17 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Topology.Algebra.Group.Quotient
-public import Mathlib.Topology.Connected.Clopen
 
 /-!
 # Connectedness of topological groups
 
-This file derives connectedness of a group from connectedness of a subgroup and its coset
+This file derives connectedness of a group from preconnectedness of a subgroup and its coset
 quotient.
 
 ## Main result
 
 * `Subgroup.connectedSpace_of_quotient`: a group with continuous left translations is
-  connected when a subgroup and the corresponding coset quotient are connected.
+  connected when a subgroup and the corresponding coset quotient are preconnected.
 -/
 
 public section
@@ -29,9 +28,9 @@ namespace TauCeti
 variable {G : Type*} [Group G] [TopologicalSpace G] [ContinuousConstSMul G G]
 
 /-- A group with continuous left translations is connected when a subgroup and its coset quotient
-are connected. -/
-theorem _root_.Subgroup.connectedSpace_of_quotient (H : Subgroup G) [ConnectedSpace H]
-    [ConnectedSpace (G ⧸ H)] : ConnectedSpace G := by
+are preconnected. -/
+theorem _root_.Subgroup.connectedSpace_of_quotient (H : Subgroup G) [PreconnectedSpace H]
+    [PreconnectedSpace (G ⧸ H)] : ConnectedSpace G := by
   rw [connectedSpace_iff_univ]
   -- Each fiber of the quotient projection is a left translate of `H`.
   have hfiber : ∀ q : G ⧸ H, IsConnected (QuotientGroup.mk ⁻¹' {q}) := by
@@ -39,7 +38,8 @@ theorem _root_.Subgroup.connectedSpace_of_quotient (H : Subgroup G) [ConnectedSp
     refine QuotientGroup.induction_on q ?_
     intro g
     have hrange : IsConnected (Set.range fun h : H => g * (h : G)) :=
-      isConnected_range ((continuous_const_smul g).comp continuous_subtype_val)
+      ⟨Set.range_nonempty _,
+        isPreconnected_range ((continuous_const_smul g).comp continuous_subtype_val)⟩
     convert hrange using 1
     ext x
     simp only [mem_preimage, mem_singleton_iff, mem_range]
@@ -53,8 +53,10 @@ theorem _root_.Subgroup.connectedSpace_of_quotient (H : Subgroup G) [ConnectedSp
       convert H.inv_mem h.property using 1
       simp
   -- Pull connectedness of the whole quotient back through the quotient projection.
+  have hquot : IsConnected (Set.univ : Set (G ⧸ H)) :=
+    ⟨Set.univ_nonempty, isPreconnected_univ⟩
   have huniv := (QuotientGroup.isQuotientMap_mk H).isCoinducing.isConnected_preimage_of_isClosed
-    hfiber isClosed_univ (isConnected_univ : IsConnected (Set.univ : Set (G ⧸ H)))
+    hfiber isClosed_univ hquot
   simpa using huniv
 
 end TauCeti

--- a/TauCeti/Topology/Algebra/Group/Connected.lean
+++ b/TauCeti/Topology/Algebra/Group/Connected.lean
@@ -1,0 +1,60 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Topology.Algebra.Group.Quotient
+public import Mathlib.Topology.Connected.Clopen
+
+/-!
+# Connectedness of topological groups
+
+This file derives connectedness of a group from connectedness of a subgroup and its coset
+quotient.
+
+## Main result
+
+* `Subgroup.connectedSpace_of_quotient`: a group with continuous left translations is
+  connected when a subgroup and the corresponding coset quotient are connected.
+-/
+
+public section
+
+open Set
+
+namespace TauCeti
+
+variable {G : Type*} [Group G] [TopologicalSpace G] [ContinuousConstSMul G G]
+
+/-- A group with continuous left translations is connected when a subgroup and its coset quotient
+are connected. -/
+theorem _root_.Subgroup.connectedSpace_of_quotient (H : Subgroup G) [ConnectedSpace H]
+    [ConnectedSpace (G ⧸ H)] : ConnectedSpace G := by
+  rw [connectedSpace_iff_univ]
+  -- Each fiber of the quotient projection is a left translate of `H`.
+  have hfiber : ∀ q : G ⧸ H, IsConnected (QuotientGroup.mk ⁻¹' {q}) := by
+    intro q
+    refine QuotientGroup.induction_on q ?_
+    intro g
+    have hrange : IsConnected (Set.range fun h : H => g * (h : G)) :=
+      isConnected_range ((continuous_const_smul g).comp continuous_subtype_val)
+    convert hrange using 1
+    ext x
+    simp only [mem_preimage, mem_singleton_iff, mem_range]
+    constructor
+    · intro hx
+      have hxH : g⁻¹ * x ∈ H := by
+        simpa only [mul_inv_rev, inv_inv] using H.inv_mem (QuotientGroup.eq.mp hx)
+      exact ⟨⟨g⁻¹ * x, hxH⟩, by simp⟩
+    · rintro ⟨h, rfl⟩
+      apply QuotientGroup.eq.mpr
+      convert H.inv_mem h.property using 1
+      simp
+  -- Pull connectedness of the whole quotient back through the quotient projection.
+  have huniv := (QuotientGroup.isQuotientMap_mk H).isCoinducing.isConnected_preimage_of_isClosed
+    hfiber isClosed_univ (isConnected_univ : IsConnected (Set.univ : Set (G ⧸ H)))
+  simpa using huniv
+
+end TauCeti


### PR DESCRIPTION
This PR derives ambient connectedness from a preconnected subgroup and preconnected coset quotient for the RepresentationTheory SpinRepresentations Layer 7 compact-Spin connectivity milestone.

Roadmap: RepresentationTheory

## Summary

Add `Subgroup.connectedSpace_of_quotient`, identifying every fiber of `G → G ⧸ H` with a continuous left translate of `H` and then applying Mathlib's connected-fiber theorem for coinducing maps. Intrinsic nonemptiness of subgroups and group quotients upgrades the preconnected hypotheses to the connected witnesses needed by that theorem. This isolates the exact generic induction step needed once the compact Spin quotient is identified with a sphere.

## Roadmap target

This advances SpinRepresentations Layer 7, “prove `Spin(n)` connected for `n ≥ 2`,” specifically the induction step from connected `Spin(n)` and connected `Spin(n+1) / Spin(n)` to connected `Spin(n+1)`. After this PR, the orbit-map quotient homeomorphism `Spin(n+1) / Spin(n) ≃ₜ S^n`, sphere connectedness, and the resulting compact-Spin induction remain.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"connected-space-of-subgroup-and-quotient"}-->

## Verification

- Exact head: `b28ce884057c4354fff1ca1f6fbe854af82e5da2`
- Local Lean build: `lake exe cache get`, then `lake build` — pass; `Build completed successfully (10982 jobs).` The public-import consumer probe using `H.connectedSpace_of_quotient` also compiles.
- Axiom audit: `lake exe axioms` — `axioms: audited 108557 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`
- Lint: `bash scripts/lint-env.sh` under GNU `sed`, `python3 scripts/lint-dot-notation.py`, `bash scripts/lint-style.sh`, `lake exe module-system`, and `git diff main...HEAD --check` — pass with no new violations; all 4,830 source headers conform and all 4,831 modules use the module system.
- Public CI: sandboxed build and roadmap labeling are in progress on the repaired head.

## Scale and generality

The theorem is stated for an arbitrary group and arbitrary subgroup, with only `PreconnectedSpace` assumptions on the subgroup and quotient and without normality, separation, compactness, or continuity of inversion. Its only algebraic-topological compatibility assumption is `ContinuousConstSMul G G`, exactly the continuous left translations used to make cosets preconnected; ordinary topological groups infer this instance automatically. The change is one 62-line module and one public theorem.

## Scope

- **Consumes:** Mathlib's `QuotientGroup.isQuotientMap_mk`, `QuotientGroup.eq`, `QuotientGroup.induction_on`, `isPreconnected_range`, and `Topology.IsCoinducing.isConnected_preimage_of_isClosed`.
- **Provides:** `Subgroup.connectedSpace_of_quotient`, returning `ConnectedSpace G` from preconnectedness of `H` and `G ⧸ H`.
- **Fits:** supplies the connected-extension step consumed by the Layer 7 compact real Spin sphere-quotient induction, immediately downstream of the quotient–sphere homeomorphism work.
- **Boundary:** does not construct the compact Spin sphere action or quotient homeomorphism, prove sphere connectedness, or carry out the dimension induction.

<sub>🤖 GPT-5.6 Sol high · TauCetiWorker @ [910d954fee75dfafda41f98165ce3a9e6676eae1](https://github.com/utensil/TauCetiWorker/commit/910d954fee75dfafda41f98165ce3a9e6676eae1) · rubrics @ [afb424eda89e8ac96d9eb69f6a88972055a4cd1b](https://github.com/utensil/TauCetiReview/commit/afb424eda89e8ac96d9eb69f6a88972055a4cd1b) · local review @ [b533e561b6d44df071c31335ed4a63ae647507d2](https://github.com/utensil/formal-land/commit/b533e561b6d44df071c31335ed4a63ae647507d2) · fixed: api-design, generality, naming, placement, reuse</sub>