### PR TITLE
feat: make the symplectic diagonal torus a closed subgroup

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Symplectic/DiagonalTorus/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Symplectic/DiagonalTorus/Basic.lean
@@ -24,8 +24,9 @@ ring. The construction is made simultaneously in the functor-of-points, coordina
 and affine-group-scheme models. On algebra-valued points it is injective, natural in the value
 algebra, and conjugates each symplectic root subgroup through its standard root character.
 
-This is the torus and pinning-equation part of the standard type-`C` pinning. It does not claim that
-the morphism is a closed immersion or that its image is maximal.
+This is the torus and pinning-equation part of the standard type-`C` pinning. The coordinate
+morphism is surjective; its closed-subgroup interpretation is developed in
+`TauCeti.Algebra.AlgebraicGroup.Symplectic.DiagonalTorus.ClosedImmersion`.
 
 ## Main definitions
 
@@ -236,9 +237,11 @@ theorem mapPointsFunctor_diagonalTorusCoordinateMap_app
         (diagonalTorusCoordinateMap (R := R) (m := m)).hom t.ofConv) p
   rw [← htp, ← hnat, hp, mapValue_diagonalTorusPoints]
 
+/-- The Laurent coordinate ring in which the generic diagonal symplectic matrix is evaluated. -/
 private abbrev diagonalTorusCoordinateRing :=
   MonoidAlgebra R (Multiplicative (ULift.{u} (Fin m) →₀ ℤ))
 
+/-- The diagonal symplectic matrix evaluated at the universal point of the split torus. -/
 private noncomputable def diagonalTorusGenericMatrix :
     Matrix (Fin (m + m)) (Fin (m + m)) (diagonalTorusCoordinateRing (R := R) (m := m)) :=
   ((GLSymplecticFin.diagonal
@@ -349,6 +352,23 @@ private theorem coordinateMap_comp_diagonalTorusCoordinateMap :
       simp [pairedWeight, ← Fin.natAdd_eq_addNat, finSumFinEquiv_symm_apply_natAdd]
   · rw [coordinateMap_comp_diagonalTorusCoordinateMap_X_of_ne _ _ hij]
     simp [hij]
+
+/-- The coordinate restriction from `Sp₂ₘ` to its diagonal torus is surjective over every
+commutative base ring. -/
+theorem diagonalTorusCoordinateMap_surjective :
+    Function.Surjective (diagonalTorusCoordinateMap (R := R) (m := m)).hom := by
+  have hspan : Submodule.span ℤ (Set.range (pairedWeight (m := m))) = ⊤ := by
+    apply top_unique
+    rw [← (Pi.basisFun ℤ (ULift.{u} (Fin m))).span_eq]
+    apply Submodule.span_mono
+    rintro _ ⟨i, rfl⟩
+    refine ⟨Fin.castAdd m i.down, ?_⟩
+    simp [pairedWeight, Pi.basisFun_apply]
+  have hsurj := GeneralLinear.weightTorusCoordinateMap_surjective
+    (R := R) (pairedWeight (m := m)) hspan
+  rw [← coordinateMap_comp_diagonalTorusCoordinateMap] at hsurj
+  simp only [_root_.CommHopfAlgCat.hom_comp, BialgHom.coe_comp] at hsurj
+  exact hsurj.of_comp
 
 /-- **The symplectic diagonal-torus coordinate morphism commutes with base change.** -/
 theorem diagonalTorusCoordinateMap_baseChange

--- a/TauCeti/Algebra/AlgebraicGroup/Symplectic/DiagonalTorus/ClosedImmersion.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Symplectic/DiagonalTorus/ClosedImmersion.lean
@@ -7,7 +7,7 @@ module
 
 public import TauCeti.Algebra.AlgebraicGroup.Symplectic.DiagonalTorus.Basic
 public import TauCeti.Algebra.AlgebraicGroup.Torus.Basic
-public import TauCeti.AlgebraicGeometry.AffineGroupScheme.ClosedImmersion
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Scheme.Classification
 import TauCeti.CategoryTheory.Comma.Over
 
 /-!
@@ -64,6 +64,20 @@ theorem mem_diagonalTorusDefiningIdeal (x : coordinateHopfAlgebra R m) :
       (diagonalTorusCoordinateMap (R := R) (m := m)).hom x = 0 := by
   rw [diagonalTorusDefiningIdeal, HopfIdeal.comapOfSurjective_bot,
     HopfIdeal.mem_kerOfSurjective]
+
+/-- The closed-subgroup classification recovers the diagonal torus's defining Hopf ideal. -/
+@[simp↓]
+theorem hopfIdealOrderIsoClosedSubgroup_symm_apply_diagonalTorusClosedSubgroup :
+    (CommHopfAlgCat.hopfIdealOrderIsoClosedSubgroup (coordinateHopfAlgebra R m)).symm
+        (diagonalTorusClosedSubgroup R m) =
+      OrderDual.toDual (diagonalTorusDefiningIdeal R m) := by
+  rw [diagonalTorusDefiningIdeal, HopfIdeal.comapOfSurjective_bot]
+  apply CommHopfAlgCat.hopfIdealOrderIsoClosedSubgroup_symm_apply_eq_ker
+    (coordinateHopfAlgebra R m) _ (diagonalTorusClosedSubgroup R m)
+    ((eqToIso (DiagonalizableGroup.groupScheme_def R
+        (SplitTorus.characterGroup (ULift.{u} (Fin m))))).symm ≪≫
+      (ClosedSubgroupScheme.mkIso (diagonalTorus (R := R) (m := m))).symm)
+  simp [diagonalTorusClosedSubgroup, diagonalTorus_def]
 
 /-- The quotient by the diagonal-torus ideal is the rank-`m` split-torus coordinate algebra. -/
 noncomputable def diagonalTorusCoordinateIso :

--- a/TauCeti/Algebra/AlgebraicGroup/Symplectic/DiagonalTorus/ClosedImmersion.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Symplectic/DiagonalTorus/ClosedImmersion.lean
@@ -1,0 +1,108 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Symplectic.DiagonalTorus.Basic
+public import TauCeti.Algebra.AlgebraicGroup.Torus.Basic
+public import TauCeti.AlgebraicGeometry.AffineGroupScheme.ClosedImmersion
+import TauCeti.CategoryTheory.Comma.Over
+
+/-!
+# The diagonal torus as a closed subgroup of the symplectic group
+
+Over every commutative ring, the diagonal map from the rank-`m` split torus to `Sp₂ₘ` is a
+closed immersion. Its defining Hopf ideal is the kernel of restriction to diagonal coordinates,
+and the quotient is isomorphic to the split-torus coordinate Hopf algebra. These constructions
+make the diagonal torus available as a closed subgroup when studying maximal tori and pinnings.
+
+The coordinate surjectivity proved in `Symplectic.DiagonalTorus.Basic` uses
+`GeneralLinear.weightTorusCoordinateMap_surjective`: the weights of the standard symplectic
+representation include a basis of the character lattice. The quotient identification uses
+`HopfIdeal.kerLiftBialgEquiv`, the existing first isomorphism theorem for Hopf algebras.
+The scheme packaging follows `GeneralLinear.DiagonalTorus.ClosedImmersion`.
+-/
+
+public section
+
+open AlgebraicGeometry CategoryTheory
+
+namespace TauCeti.Symplectic
+
+universe u
+
+variable (R : Type u) [CommRing R] (m : ℕ)
+
+/-- The diagonal split torus is a closed subgroup of `Sp₂ₘ` over every commutative ring. -/
+instance isClosedImmersion_diagonalTorus :
+    IsClosedImmersion (diagonalTorus (R := R) (m := m)).hom.hom.left := by
+  rw [diagonalTorus_def]
+  simp only [Grp.comp', Mon.comp_hom', Over.comp_left]
+  rw [MorphismProperty.cancel_left_of_respectsIso (P := @IsClosedImmersion),
+    MorphismProperty.cancel_right_of_respectsIso (P := @IsClosedImmersion)]
+  exact (CommHopfAlgCat.isClosedImmersion_hopfSpec_map_iff _).2
+    diagonalTorusCoordinateMap_surjective
+
+/-- The diagonal split torus, bundled as a closed subgroup scheme of `Sp₂ₘ`. -/
+noncomputable def diagonalTorusClosedSubgroup : ClosedSubgroupScheme (groupScheme R m) :=
+  ClosedSubgroupScheme.mk (diagonalTorus (R := R) (m := m))
+
+/-- The closed diagonal torus has the subobject represented by the diagonal morphism. -/
+@[simp]
+theorem coe_diagonalTorusClosedSubgroup :
+    (diagonalTorusClosedSubgroup R m).1 =
+      Subobject.mk (diagonalTorus (R := R) (m := m)) :=
+  ClosedSubgroupScheme.coe_mk _
+
+/-- The defining Hopf ideal of the diagonal torus is the kernel of coordinate restriction. -/
+noncomputable def diagonalTorusDefiningIdeal : HopfIdeal R (coordinateHopfAlgebra R m) :=
+  HopfIdeal.kerOfSurjective (diagonalTorusCoordinateMap (R := R) (m := m)).hom
+    diagonalTorusCoordinateMap_surjective
+
+/-- A function belongs to the diagonal-torus ideal precisely when its restriction vanishes. -/
+@[simp]
+theorem mem_diagonalTorusDefiningIdeal (x : coordinateHopfAlgebra R m) :
+    x ∈ diagonalTorusDefiningIdeal R m ↔
+      (diagonalTorusCoordinateMap (R := R) (m := m)).hom x = 0 :=
+  HopfIdeal.mem_kerOfSurjective _ _
+
+/-- The quotient by the diagonal-torus ideal is the rank-`m` split-torus coordinate algebra. -/
+noncomputable def diagonalTorusCoordinateIso :
+    FiniteTypeCommHopfAlgCat.quotient ⟨coordinateHopfAlgebra R m,
+        (finiteTypeCommHopfAlgProperty_iff _).2 inferInstance⟩
+        (diagonalTorusDefiningIdeal R m) ≅
+      DiagonalizableGroup.coordinateRing R
+        (SplitTorus.characterGroup (ULift.{u} (Fin m))) :=
+  ObjectProperty.isoMk _ <|
+    _root_.CommHopfAlgCat.isoMk
+      (HopfIdeal.kerLiftBialgEquiv (diagonalTorusCoordinateMap (R := R) (m := m)).hom
+        diagonalTorusCoordinateMap_surjective)
+
+/-- The quotient isomorphism identifies the quotient map with restriction to the torus. -/
+@[simp]
+theorem mkQuotient_comp_diagonalTorusCoordinateIso_hom :
+    FiniteTypeCommHopfAlgCat.mkQuotient ⟨coordinateHopfAlgebra R m,
+        (finiteTypeCommHopfAlgProperty_iff _).2 inferInstance⟩
+          (diagonalTorusDefiningIdeal R m) ≫
+        (diagonalTorusCoordinateIso R m).hom =
+      ObjectProperty.homMk (diagonalTorusCoordinateMap (R := R) (m := m)) := by
+  apply ObjectProperty.hom_ext
+  apply _root_.CommHopfAlgCat.hom_ext
+  apply DFunLike.ext
+  intro x
+  exact HopfIdeal.kerLiftBialgHom_mk
+    (diagonalTorusCoordinateMap (R := R) (m := m)).hom
+    diagonalTorusCoordinateMap_surjective x
+
+/-- The coordinate quotient defining the symplectic diagonal torus is a split torus. -/
+theorem splitTorusCommHopfAlgProperty_quotient_diagonalTorusDefiningIdeal :
+    splitTorusCommHopfAlgProperty R
+      (FiniteTypeCommHopfAlgCat.quotient ⟨coordinateHopfAlgebra R m,
+        (finiteTypeCommHopfAlgProperty_iff _).2 inferInstance⟩
+        (diagonalTorusDefiningIdeal R m)) := by
+  rw [splitTorusCommHopfAlgProperty_iff]
+  exact ⟨m, ⟨(diagonalTorusCoordinateIso R m).symm⟩⟩
+
+end TauCeti.Symplectic

--- a/TauCeti/Algebra/AlgebraicGroup/Symplectic/DiagonalTorus/ClosedImmersion.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Symplectic/DiagonalTorus/ClosedImmersion.lean
@@ -17,12 +17,6 @@ Over every commutative ring, the diagonal map from the rank-`m` split torus to `
 closed immersion. Its defining Hopf ideal is the kernel of restriction to diagonal coordinates,
 and the quotient is isomorphic to the split-torus coordinate Hopf algebra. These constructions
 make the diagonal torus available as a closed subgroup when studying maximal tori and pinnings.
-
-The coordinate surjectivity proved in `Symplectic.DiagonalTorus.Basic` uses
-`GeneralLinear.weightTorusCoordinateMap_surjective`: the weights of the standard symplectic
-representation include a basis of the character lattice. The quotient identification uses
-`HopfIdeal.kerLiftBialgEquiv`, the existing first isomorphism theorem for Hopf algebras.
-The scheme packaging follows `GeneralLinear.DiagonalTorus.ClosedImmersion`.
 -/
 
 public section
@@ -38,6 +32,7 @@ variable (R : Type u) [CommRing R] (m : ℕ)
 /-- The diagonal split torus is a closed subgroup of `Sp₂ₘ` over every commutative ring. -/
 instance isClosedImmersion_diagonalTorus :
     IsClosedImmersion (diagonalTorus (R := R) (m := m)).hom.hom.left := by
+  -- Scheme packaging follows `GeneralLinear.DiagonalTorus.ClosedImmersion`.
   rw [diagonalTorus_def]
   simp only [Grp.comp', Mon.comp_hom', Over.comp_left]
   rw [MorphismProperty.cancel_left_of_respectsIso (P := @IsClosedImmersion),
@@ -58,15 +53,17 @@ theorem coe_diagonalTorusClosedSubgroup :
 
 /-- The defining Hopf ideal of the diagonal torus is the kernel of coordinate restriction. -/
 noncomputable def diagonalTorusDefiningIdeal : HopfIdeal R (coordinateHopfAlgebra R m) :=
-  HopfIdeal.kerOfSurjective (diagonalTorusCoordinateMap (R := R) (m := m)).hom
+  (⊥ : HopfIdeal R _).comapOfSurjective
+    (diagonalTorusCoordinateMap (R := R) (m := m)).hom
     diagonalTorusCoordinateMap_surjective
 
 /-- A function belongs to the diagonal-torus ideal precisely when its restriction vanishes. -/
 @[simp]
 theorem mem_diagonalTorusDefiningIdeal (x : coordinateHopfAlgebra R m) :
     x ∈ diagonalTorusDefiningIdeal R m ↔
-      (diagonalTorusCoordinateMap (R := R) (m := m)).hom x = 0 :=
-  HopfIdeal.mem_kerOfSurjective _ _
+      (diagonalTorusCoordinateMap (R := R) (m := m)).hom x = 0 := by
+  rw [diagonalTorusDefiningIdeal, HopfIdeal.comapOfSurjective_bot,
+    HopfIdeal.mem_kerOfSurjective]
 
 /-- The quotient by the diagonal-torus ideal is the rank-`m` split-torus coordinate algebra. -/
 noncomputable def diagonalTorusCoordinateIso :
@@ -76,9 +73,11 @@ noncomputable def diagonalTorusCoordinateIso :
       DiagonalizableGroup.coordinateRing R
         (SplitTorus.characterGroup (ULift.{u} (Fin m))) :=
   ObjectProperty.isoMk _ <|
-    _root_.CommHopfAlgCat.isoMk
-      (HopfIdeal.kerLiftBialgEquiv (diagonalTorusCoordinateMap (R := R) (m := m)).hom
-        diagonalTorusCoordinateMap_surjective)
+    -- Quotient comparison follows `GeneralLinear.DiagonalTorus.Maximal`.
+    CommHopfAlgCat.quotientIsoOfSurjective
+      (diagonalTorusCoordinateMap (R := R) (m := m))
+      diagonalTorusCoordinateMap_surjective ⊥ ≪≫
+    CommHopfAlgCat.quotientBotIso _
 
 /-- The quotient isomorphism identifies the quotient map with restriction to the torus. -/
 @[simp]
@@ -89,12 +88,12 @@ theorem mkQuotient_comp_diagonalTorusCoordinateIso_hom :
         (diagonalTorusCoordinateIso R m).hom =
       ObjectProperty.homMk (diagonalTorusCoordinateMap (R := R) (m := m)) := by
   apply ObjectProperty.hom_ext
-  apply _root_.CommHopfAlgCat.hom_ext
-  apply DFunLike.ext
-  intro x
-  exact HopfIdeal.kerLiftBialgHom_mk
-    (diagonalTorusCoordinateMap (R := R) (m := m)).hom
-    diagonalTorusCoordinateMap_surjective x
+  simp only [ObjectProperty.FullSubcategory.comp_hom, diagonalTorusCoordinateIso,
+    ObjectProperty.isoMk_hom, ObjectProperty.homMk_hom, diagonalTorusDefiningIdeal,
+    Iso.trans_hom]
+  rw [← Category.assoc, CommHopfAlgCat.mkQuotient_comp_quotientIsoOfSurjective_hom
+      (diagonalTorusCoordinateMap (R := R) (m := m)) diagonalTorusCoordinateMap_surjective,
+    ← CommHopfAlgCat.quotientBotIso_inv, Category.assoc, Iso.inv_hom_id, Category.comp_id]
 
 /-- The coordinate quotient defining the symplectic diagonal torus is a split torus. -/
 theorem splitTorusCommHopfAlgProperty_quotient_diagonalTorusDefiningIdeal :
@@ -104,5 +103,20 @@ theorem splitTorusCommHopfAlgProperty_quotient_diagonalTorusDefiningIdeal :
         (diagonalTorusDefiningIdeal R m)) := by
   rw [splitTorusCommHopfAlgProperty_iff]
   exact ⟨m, ⟨(diagonalTorusCoordinateIso R m).symm⟩⟩
+
+grind_pattern splitTorusCommHopfAlgProperty_quotient_diagonalTorusDefiningIdeal =>
+  diagonalTorusDefiningIdeal R m
+
+/-- Over a field, the coordinate quotient defining the symplectic diagonal torus is a torus. -/
+theorem torusCommHopfAlgProperty_quotient_diagonalTorusDefiningIdeal
+    (k : Type u) [Field k] (m : ℕ) :
+    torusCommHopfAlgProperty k
+      (FiniteTypeCommHopfAlgCat.quotient ⟨coordinateHopfAlgebra k m,
+        (finiteTypeCommHopfAlgProperty_iff _).2 inferInstance⟩
+        (diagonalTorusDefiningIdeal k m)) :=
+  (splitTorusCommHopfAlgProperty_quotient_diagonalTorusDefiningIdeal k m).torus k _
+
+grind_pattern torusCommHopfAlgProperty_quotient_diagonalTorusDefiningIdeal =>
+  diagonalTorusDefiningIdeal k m
 
 end TauCeti.Symplectic


### PR DESCRIPTION
This PR proves that the standard diagonal split torus is a closed subgroup scheme of `Sp₂ₘ` over every commutative base ring. Identify its defining Hopf ideal as the kernel of coordinate restriction and its quotient coordinate Hopf algebra with the rank-`m` split torus.

It advances [ReductiveGroups/README.md, Layer 9, “Pinnings”](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/ReductiveGroups/README.md#layer-9-pinned-chevalleydemazure-group-schemes-over-ℤ), specifically the split maximal torus required as data in the type-C pinning, through Layer 7’s “Borel subgroups, maximal tori” target. The immediate consumer is the missing maximality statement `HopfIdeal.IsMaximalTorus R (Symplectic.coordinateHopfAlgebra R m) (Symplectic.diagonalTorusDefiningIdeal R m)` over a field: this PR supplies the defining closed-subgroup ideal and its split-torus property. The existing morphism and conjugation equations landed in #5000, whose description explicitly leaves coordinate surjectivity and closed immersion next; no open or merged PR found in the duplicate scan supplies them. After this PR, the type-C pinning still needs maximality, compatible Borel and root-datum packaging, and identification with the pinned simply connected Chevalley–Demazure carrier.

The proof reuses `GeneralLinear.weightTorusCoordinateMap_surjective`: the paired symplectic weights contain the standard basis, so their coordinate map from the general linear group is surjective, and hence its factor through the symplectic coordinate algebra is surjective. The quotient comparison uses `CommHopfAlgCat.quotientIsoOfSurjective` and `CommHopfAlgCat.quotientBotIso`, following `GeneralLinear.DiagonalTorus.Maximal`; the scheme packaging follows `GeneralLinear.DiagonalTorus.ClosedImmersion`. Local proof comments credit these formal sources. The quotient has split-torus and field-specialized torus property lemmas, both registered with `grind` patterns. No Mathlib infrastructure is vendored. There are no characteristic, nontriviality, or positive-rank assumptions.

Add `TauCeti/Algebra/AlgebraicGroup/Symplectic/DiagonalTorus/ClosedImmersion.lean` (122 lines). The basic module gains the coordinate-surjectivity theorem and updated documentation, for 144 added and two removed lines overall. The required directory normalization preserves all existing declaration names, removes the obsolete module path, and has no existing importers to update:

| Old module | New module |
| --- | --- |
| `TauCeti.Algebra.AlgebraicGroup.Symplectic.DiagonalTorus` | `TauCeti.Algebra.AlgebraicGroup.Symplectic.DiagonalTorus.Basic` |

Self-review against api-design, reuse, and generality confirmed the arbitrary-ring statement, kept characteristic membership and quotient-map lemmas, reused the categorical quotient API, and removed a redundant import. Environment lint also caught two undocumented helpers in the relocated original module; both now have docstrings. All ten rubrics were read: scope, correctness, reuse, attribution, api-design, generality, placement, naming, documentation, and proof-quality.

Validation: the targeted `lake build TauCeti.Algebra.AlgebraicGroup.Symplectic.DiagonalTorus.ClosedImmersion` passes, including the moved basic module. `tauceti-axioms --changed-since-merge-base origin/main` accepts all 58 declarations in the two changed modules, and `git diff --check` passes. Separate importing examples prove both quotient-property goals with plain `grind`. The prescribed `tauceti-lint-env --changed-since-merge-base origin/main` stops at its freshness guard because the downloaded checker omits the newly default `tacticAlt`; a temporary copy adding exactly that linter passes the full current default set on both changed modules, with zero violations and zero grandfathered findings. No repository script, linter setting, or Lake pin is changed.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"symplectic-diagonal-torus-closed-immersion"}-->

🤖 Prepared with Codex

