### PR TITLE
feat: relate Stieltjes and complete Bernstein functions

### DIFF
--- a/TauCeti/Analysis/CompletelyMonotone/Stieltjes/Bernstein.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Stieltjes/Bernstein.lean
@@ -36,8 +36,8 @@ the normalization `μ {0} = 0` removes the only point where `t / (t + x)` does n
   continuous extension of `t * f(t)` written directly from Stieltjes representing data and its
   defining equation.
 * `TauCeti.stieltjesBernsteinTransform_zero`: the transform takes the value `a` at zero.
-* `TauCeti.stieltjesBernsteinIntegral_eq_mul_integral_inv_add`: the integral term is the
-  parameter times the corresponding Stieltjes integral.
+* `TauCeti.integral_div_add_eq_mul_integral_inv_add`: the integral term is the parameter times
+  the corresponding Stieltjes integral.
 * `TauCeti.integrable_mul_zpow_neg_two_sub_add`: the derivative kernels of the integral term are
   integrable at positive parameters.
 * `TauCeti.iteratedDeriv_integral_div_add`: the iterated derivatives of the integral
@@ -51,8 +51,6 @@ the normalization `μ {0} = 0` removes the only point where `t / (t + x)` does n
   transform of a Stieltjes representation of `f` is `t * f(t)`.
 * `TauCeti.RepresentsStieltjes.isBernsteinFunction_stieltjesBernsteinTransform`: the transform of
   a Stieltjes representation is Bernstein.
-* `TauCeti.IsStieltjesFunction.exists_isBernsteinFunction_eqOn_mul`: every Stieltjes function has
-  a Bernstein extension of its product with the parameter on `(0, ∞)`.
 
 ## References
 
@@ -90,7 +88,7 @@ theorem stieltjesBernsteinTransform_zero (μ : Measure ℝ≥0) (a b : ℝ≥0) 
 
 /-- The integral term in the Stieltjes--Bernstein transform is the parameter times the
 corresponding Stieltjes integral. -/
-theorem stieltjesBernsteinIntegral_eq_mul_integral_inv_add (μ : Measure ℝ≥0)
+theorem integral_div_add_eq_mul_integral_inv_add (μ : Measure ℝ≥0)
     (t : ℝ) :
     (∫ x : ℝ≥0, t / (t + x) ∂μ) =
       t * ∫ x : ℝ≥0, (t + x)⁻¹ ∂μ := by
@@ -135,7 +133,7 @@ private lemma contDiffOn_stieltjesBernsteinIntegral {μ : Measure ℝ≥0}
     ContDiffOn ℝ ∞ (fun t : ℝ => ∫ x : ℝ≥0, t / (t + x) ∂μ) (Ioi 0) := by
   refine (contDiffOn_id.mul
     (isCompletelyMonotoneOnIoi_integral_inv_add hμ).contDiffOn).congr fun t _ => ?_
-  simpa only [id_eq] using stieltjesBernsteinIntegral_eq_mul_integral_inv_add μ t
+  simpa only [id_eq] using integral_div_add_eq_mul_integral_inv_add μ t
 
 /-- The Leibniz expansion of `t * F t` collapses to two terms, because every derivative of the
 identity beyond the first vanishes. -/
@@ -175,7 +173,7 @@ theorem iteratedDeriv_integral_div_add {μ : Measure ℝ≥0}
   have hjumpEq : (fun u : ℝ => ∫ x : ℝ≥0, u / (u + x) ∂μ) =
       fun u => u * F u := by
     funext u
-    exact stieltjesBernsteinIntegral_eq_mul_integral_inv_add μ u
+    exact integral_div_add_eq_mul_integral_inv_add μ u
   rw [hjumpEq, iteratedDeriv_succ_id_mul hFdiff]
   have hn := iteratedDeriv_integral_inv_add hμ n ht
   have hn1 := iteratedDeriv_integral_inv_add hμ (n + 1) ht
@@ -301,7 +299,7 @@ transform on the open half-line. -/
 theorem stieltjesBernsteinTransform_eq_mul (h : RepresentsStieltjes μ a b f) {t : ℝ}
     (ht : 0 < t) : stieltjesBernsteinTransform μ a b t = t * f t := by
   rw [h.eq_div_add_add_integral_inv_add ht, stieltjesBernsteinTransform_apply]
-  rw [stieltjesBernsteinIntegral_eq_mul_integral_inv_add]
+  rw [integral_div_add_eq_mul_integral_inv_add]
   field_simp [ht.ne']
 
 /-- The transform attached to a Stieltjes representation is a Bernstein function.  Its agreement
@@ -313,22 +311,6 @@ theorem isBernsteinFunction_stieltjesBernsteinTransform (h : RepresentsStieltjes
     h.measure_singleton_zero h.integrable_weight
 
 end RepresentsStieltjes
-
-namespace IsStieltjesFunction
-
-variable {f : ℝ → ℝ}
-
-/-- Every Stieltjes function has a Bernstein extension of its product with the parameter on the
-open positive half-line. -/
-theorem exists_isBernsteinFunction_eqOn_mul (h : IsStieltjesFunction f) :
-    ∃ g : ℝ → ℝ, IsBernsteinFunction g ∧ EqOn g (fun t => t * f t) (Ioi 0) := by
-  rw [isStieltjesFunction_iff] at h
-  obtain ⟨a, b, μ, hrep⟩ := h
-  exact ⟨stieltjesBernsteinTransform μ a b,
-    hrep.isBernsteinFunction_stieltjesBernsteinTransform,
-    fun _ ht => hrep.stieltjesBernsteinTransform_eq_mul ht⟩
-
-end IsStieltjesFunction
 
 end TauCeti
 

--- a/TauCeti/Analysis/CompletelyMonotone/Stieltjes/Bernstein.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Stieltjes/Bernstein.lean
@@ -36,6 +36,8 @@ the normalization `μ {0} = 0` removes the only point where `t / (t + x)` does n
   continuous extension of `t * f(t)` written directly from Stieltjes representing data and its
   defining equation.
 * `TauCeti.stieltjesBernsteinTransform_zero`: the transform takes the value `a` at zero.
+* `TauCeti.stieltjesBernsteinIntegral_eq_mul_integral_inv_add`: the integral term is the
+  parameter times the corresponding Stieltjes integral.
 * `TauCeti.integrable_mul_zpow_neg_two_sub_add`: the derivative kernels of the integral term are
   integrable at positive parameters.
 * `TauCeti.iteratedDeriv_integral_div_add`: the iterated derivatives of the integral
@@ -86,7 +88,9 @@ theorem stieltjesBernsteinTransform_zero (μ : Measure ℝ≥0) (a b : ℝ≥0) 
     stieltjesBernsteinTransform μ a b 0 = a := by
   simp [stieltjesBernsteinTransform_apply]
 
-private lemma stieltjesBernsteinIntegral_eq_mul_integral_inv_add (μ : Measure ℝ≥0)
+/-- The integral term in the Stieltjes--Bernstein transform is the parameter times the
+corresponding Stieltjes integral. -/
+theorem stieltjesBernsteinIntegral_eq_mul_integral_inv_add (μ : Measure ℝ≥0)
     (t : ℝ) :
     (∫ x : ℝ≥0, t / (t + x) ∂μ) =
       t * ∫ x : ℝ≥0, (t + x)⁻¹ ∂μ := by

--- a/TauCeti/Analysis/CompletelyMonotone/Stieltjes/CompleteBernstein.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Stieltjes/CompleteBernstein.lean
@@ -65,7 +65,7 @@ theorem representsCompleteBernstein_iff {μ : Measure ℝ≥0} {a b : ℝ≥0} {
 
 namespace RepresentsCompleteBernstein
 
-variable {μ : Measure ℝ≥0} {a b : ℝ≥0} {f g : ℝ → ℝ}
+variable {μ ν : Measure ℝ≥0} {a b c d : ℝ≥0} {f g : ℝ → ℝ}
 
 /-- A complete-Bernstein representing measure has no atom at zero. -/
 lemma measure_singleton_zero (h : RepresentsCompleteBernstein μ a b f) : μ {0} = 0 :=
@@ -86,6 +86,44 @@ lemma eq_stieltjesBernsteinTransform (h : RepresentsCompleteBernstein μ a b f)
 lemma congr (h : RepresentsCompleteBernstein μ a b f) (hgf : EqOn g f (Ici 0)) :
     RepresentsCompleteBernstein μ a b g :=
   ⟨h.measure_singleton_zero, h.integrable_weight, hgf.trans h.2.2⟩
+
+private lemma integrable_div_add (hμ : Integrable stieltjesWeight μ) {t : ℝ} (ht : 0 ≤ t) :
+    Integrable (fun x : ℝ≥0 => t / (t + x)) μ := by
+  rcases ht.eq_or_lt with rfl | ht
+  · have hz : Integrable (fun _ : ℝ≥0 => (0 : ℝ)) μ := integrable_zero ℝ≥0 ℝ μ
+    simpa only [zero_div] using hz
+  · simpa only [div_eq_mul_inv] using (integrable_inv_add hμ ht).const_mul t
+
+/-- The sum of two complete-Bernstein representations is represented by the sum of their
+coefficients and measures. -/
+lemma add (hf : RepresentsCompleteBernstein μ a b f)
+    (hg : RepresentsCompleteBernstein ν c d g) :
+    RepresentsCompleteBernstein (μ + ν) (a + c) (b + d) (f + g) := by
+  refine ⟨by simp [hf.measure_singleton_zero, hg.measure_singleton_zero],
+    hf.integrable_weight.add_measure hg.integrable_weight, fun t ht => ?_⟩
+  rw [Pi.add_apply, hf.eq_stieltjesBernsteinTransform ht,
+    hg.eq_stieltjesBernsteinTransform ht]
+  simp only [stieltjesBernsteinTransform_apply]
+  rw [integral_add_measure
+      (integrable_div_add hf.integrable_weight ht)
+      (integrable_div_add hg.integrable_weight ht)]
+  push_cast
+  ring
+
+/-- A nonnegative scalar multiple of a complete-Bernstein representation is represented by
+scaling its coefficients and measure. -/
+lemma smul (h : RepresentsCompleteBernstein μ a b f) {r : ℝ} (hr : 0 ≤ r) :
+    RepresentsCompleteBernstein ((ENNReal.ofReal r) • μ)
+      (r.toNNReal * a) (r.toNNReal * b) (r • f) := by
+  refine ⟨by simp [h.measure_singleton_zero],
+    h.integrable_weight.smul_measure ENNReal.ofReal_ne_top, fun t ht => ?_⟩
+  rw [Pi.smul_apply, smul_eq_mul, h.eq_stieltjesBernsteinTransform ht]
+  simp only [stieltjesBernsteinTransform_apply]
+  rw [integral_smul_measure]
+  · simp only [ENNReal.toReal_ofReal hr, smul_eq_mul]
+    push_cast
+    rw [Real.coe_toNNReal r hr]
+    ring
 
 /-- A function with a complete-Bernstein representation is a Bernstein function. -/
 theorem isBernsteinFunction (h : RepresentsCompleteBernstein μ a b f) :
@@ -121,6 +159,7 @@ namespace IsCompleteBernsteinFunction
 variable {f g : ℝ → ℝ}
 
 /-- Every complete Bernstein function is a Bernstein function. -/
+@[grind =>]
 theorem isBernsteinFunction (hf : IsCompleteBernsteinFunction f) : IsBernsteinFunction f := by
   obtain ⟨a, b, μ, hμ⟩ := hf
   exact hμ.isBernsteinFunction
@@ -131,6 +170,19 @@ theorem congr (hf : IsCompleteBernsteinFunction f) (hgf : EqOn g f (Ici 0)) :
   obtain ⟨a, b, μ, hμ⟩ := hf
   exact ⟨a, b, μ, hμ.congr hgf⟩
 
+/-- Complete Bernstein functions are closed under addition. -/
+lemma add (hf : IsCompleteBernsteinFunction f) (hg : IsCompleteBernsteinFunction g) :
+    IsCompleteBernsteinFunction (f + g) := by
+  obtain ⟨a, b, μ, hμ⟩ := hf
+  obtain ⟨c, d, ν, hν⟩ := hg
+  exact ⟨a + c, b + d, μ + ν, hμ.add hν⟩
+
+/-- Complete Bernstein functions are closed under multiplication by a nonnegative scalar. -/
+lemma smul (hf : IsCompleteBernsteinFunction f) {r : ℝ} (hr : 0 ≤ r) :
+    IsCompleteBernsteinFunction (r • f) := by
+  obtain ⟨a, b, μ, hμ⟩ := hf
+  exact ⟨r.toNNReal * a, r.toNNReal * b, ENNReal.ofReal r • μ, hμ.smul hr⟩
+
 /-- Dividing a complete Bernstein function by its parameter gives a Stieltjes function. -/
 theorem isStieltjesFunction_div (hf : IsCompleteBernsteinFunction f) :
     IsStieltjesFunction (fun t => f t / t) := by
@@ -139,6 +191,22 @@ theorem isStieltjesFunction_div (hf : IsCompleteBernsteinFunction f) :
   exact ⟨a, b, μ, hμ.representsStieltjes_div⟩
 
 end IsCompleteBernsteinFunction
+
+/-- The Stieltjes--Bernstein transform of normalized, integrable measure data has a complete
+Bernstein representation with the given measure and coefficients. -/
+theorem representsCompleteBernstein_stieltjesBernsteinTransform
+    {μ : Measure ℝ≥0} {a b : ℝ≥0} (hzero : μ {0} = 0)
+    (hμ : Integrable stieltjesWeight μ) :
+    RepresentsCompleteBernstein μ a b (stieltjesBernsteinTransform μ a b) :=
+  ⟨hzero, hμ, fun _ _ => rfl⟩
+
+/-- The Stieltjes--Bernstein transform of normalized, integrable measure data is a complete
+Bernstein function. -/
+theorem isCompleteBernsteinFunction_stieltjesBernsteinTransform
+    {μ : Measure ℝ≥0} {a b : ℝ≥0} (hzero : μ {0} = 0)
+    (hμ : Integrable stieltjesWeight μ) :
+    IsCompleteBernsteinFunction (stieltjesBernsteinTransform μ a b) :=
+  ⟨a, b, μ, representsCompleteBernstein_stieltjesBernsteinTransform hzero hμ⟩
 
 namespace RepresentsStieltjes
 
@@ -149,14 +217,16 @@ complete Bernstein function by the same measure and coefficients. -/
 theorem representsCompleteBernstein_stieltjesBernsteinTransform
     (h : RepresentsStieltjes μ a b f) :
     RepresentsCompleteBernstein μ a b (stieltjesBernsteinTransform μ a b) :=
-  ⟨h.measure_singleton_zero, h.integrable_weight, fun _ _ => rfl⟩
+  TauCeti.representsCompleteBernstein_stieltjesBernsteinTransform
+    h.measure_singleton_zero h.integrable_weight
 
 /-- The Stieltjes--Bernstein transform of Stieltjes representing data is a complete Bernstein
 function. -/
 theorem isCompleteBernsteinFunction_stieltjesBernsteinTransform
     (h : RepresentsStieltjes μ a b f) :
     IsCompleteBernsteinFunction (stieltjesBernsteinTransform μ a b) :=
-  ⟨a, b, μ, h.representsCompleteBernstein_stieltjesBernsteinTransform⟩
+  TauCeti.isCompleteBernsteinFunction_stieltjesBernsteinTransform
+    h.measure_singleton_zero h.integrable_weight
 
 end RepresentsStieltjes
 

--- a/TauCeti/Analysis/CompletelyMonotone/Stieltjes/CompleteBernstein.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Stieltjes/CompleteBernstein.lean
@@ -1,0 +1,219 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.CompletelyMonotone.Stieltjes.Bernstein
+
+/-!
+# Complete Bernstein functions and Stieltjes functions
+
+A complete Bernstein function has a representation
+
+`g(t) = a + b t + ∫ x, t / (t + x) ∂μ`,
+
+where `a, b ≥ 0`, the positive measure `μ` has no atom at zero, and
+`∫ (1 + x)⁻¹ ∂μ < ∞`.  The normalization at zero makes the constant coefficient canonical.
+This file packages that standard representation and proves the first fundamental correspondence:
+`f` is Stieltjes exactly when `t ↦ t f(t)` on `(0, ∞)` has a complete Bernstein extension to
+`[0, ∞)`.
+
+The extension is necessary when the Stieltjes representation has a nonzero `a / t` term: its
+value at zero must be `a`, whereas the literal product `0 * f(0)` is zero.  Values of a Stieltjes
+function outside `(0, ∞)` remain irrelevant, and values of a complete Bernstein function outside
+`[0, ∞)` remain irrelevant.
+
+## Main declarations
+
+* `TauCeti.RepresentsCompleteBernstein`: complete-Bernstein representing data.
+* `TauCeti.IsCompleteBernsteinFunction`: the representation-based predicate.
+* `TauCeti.IsCompleteBernsteinFunction.isBernsteinFunction`: a complete Bernstein function is a
+  Bernstein function.
+* `TauCeti.isStieltjesFunction_iff_exists_isCompleteBernsteinFunction_eqOn_mul`: the
+  Stieltjes--complete-Bernstein correspondence.
+
+## References
+
+* R. Schilling, R. Song, Z. Vondraček, *Bernstein Functions: Theory and Applications*,
+  2nd ed., Theorems 6.2 and 7.3.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory Set
+open scoped ENNReal NNReal
+
+namespace TauCeti
+
+/-- A measure `μ` and coefficients `a, b ≥ 0` represent a complete Bernstein function when
+`μ` satisfies the standard Stieltjes integrability condition and the function agrees on
+`[0, ∞)` with `a + b t + ∫ x, t / (t + x) ∂μ`.  Requiring `μ {0} = 0` makes `a` canonical. -/
+def RepresentsCompleteBernstein (μ : Measure ℝ≥0) (a b : ℝ≥0) (f : ℝ → ℝ) : Prop :=
+  μ {0} = 0 ∧ Integrable stieltjesWeight μ ∧
+    EqOn f (stieltjesBernsteinTransform μ a b) (Ici 0)
+
+/-- Characterization of complete-Bernstein representing data without unfolding the predicate. -/
+theorem representsCompleteBernstein_iff {μ : Measure ℝ≥0} {a b : ℝ≥0} {f : ℝ → ℝ} :
+    RepresentsCompleteBernstein μ a b f ↔
+      μ {0} = 0 ∧ Integrable stieltjesWeight μ ∧
+        EqOn f (stieltjesBernsteinTransform μ a b) (Ici 0) :=
+  Iff.rfl
+
+namespace RepresentsCompleteBernstein
+
+variable {μ : Measure ℝ≥0} {a b : ℝ≥0} {f g : ℝ → ℝ}
+
+/-- A complete-Bernstein representing measure has no atom at zero. -/
+lemma measure_singleton_zero (h : RepresentsCompleteBernstein μ a b f) : μ {0} = 0 :=
+  h.1
+
+/-- A complete-Bernstein representing measure satisfies the Stieltjes weight condition. -/
+lemma integrable_weight (h : RepresentsCompleteBernstein μ a b f) :
+    Integrable stieltjesWeight μ :=
+  h.2.1
+
+/-- Evaluation of a complete-Bernstein representation at a nonnegative parameter. -/
+lemma eq_stieltjesBernsteinTransform (h : RepresentsCompleteBernstein μ a b f)
+    {t : ℝ} (ht : 0 ≤ t) : f t = stieltjesBernsteinTransform μ a b t :=
+  h.2.2 ht
+
+/-- A complete-Bernstein representation depends only on the represented function's values on
+`[0, ∞)`. -/
+lemma congr (h : RepresentsCompleteBernstein μ a b f) (hgf : EqOn g f (Ici 0)) :
+    RepresentsCompleteBernstein μ a b g :=
+  ⟨h.measure_singleton_zero, h.integrable_weight, hgf.trans h.2.2⟩
+
+/-- A function with a complete-Bernstein representation is a Bernstein function. -/
+theorem isBernsteinFunction (h : RepresentsCompleteBernstein μ a b f) :
+    IsBernsteinFunction f :=
+  (isBernsteinFunction_stieltjesBernsteinTransform h.measure_singleton_zero
+    h.integrable_weight).congr h.2.2
+
+/-- Dividing a complete Bernstein function by its parameter on `(0, ∞)` gives the Stieltjes
+function with the same representing data. -/
+theorem representsStieltjes_div (h : RepresentsCompleteBernstein μ a b f) :
+    RepresentsStieltjes μ a b (fun t => f t / t) := by
+  rw [representsStieltjes_iff]
+  refine ⟨h.measure_singleton_zero, h.integrable_weight, fun t ht => ?_⟩
+  rw [h.eq_stieltjesBernsteinTransform ht.le, stieltjesBernsteinTransform_apply,
+    stieltjesBernsteinIntegral_eq_mul_integral_inv_add]
+  field_simp
+
+end RepresentsCompleteBernstein
+
+/-- A real function is a complete Bernstein function if it has the standard Stieltjes-type
+representation on `[0, ∞)`. -/
+def IsCompleteBernsteinFunction (f : ℝ → ℝ) : Prop :=
+  ∃ a b : ℝ≥0, ∃ μ : Measure ℝ≥0, RepresentsCompleteBernstein μ a b f
+
+/-- Characterization of a complete Bernstein function by its representing data. -/
+theorem isCompleteBernsteinFunction_iff {f : ℝ → ℝ} :
+    IsCompleteBernsteinFunction f ↔
+      ∃ a b : ℝ≥0, ∃ μ : Measure ℝ≥0, RepresentsCompleteBernstein μ a b f :=
+  Iff.rfl
+
+namespace IsCompleteBernsteinFunction
+
+variable {f g : ℝ → ℝ}
+
+/-- Every complete Bernstein function is a Bernstein function. -/
+theorem isBernsteinFunction (hf : IsCompleteBernsteinFunction f) : IsBernsteinFunction f := by
+  obtain ⟨a, b, μ, hμ⟩ := hf
+  exact hμ.isBernsteinFunction
+
+/-- The complete Bernstein property depends only on values on `[0, ∞)`. -/
+theorem congr (hf : IsCompleteBernsteinFunction f) (hgf : EqOn g f (Ici 0)) :
+    IsCompleteBernsteinFunction g := by
+  obtain ⟨a, b, μ, hμ⟩ := hf
+  exact ⟨a, b, μ, hμ.congr hgf⟩
+
+/-- Dividing a complete Bernstein function by its parameter gives a Stieltjes function. -/
+theorem isStieltjesFunction_div (hf : IsCompleteBernsteinFunction f) :
+    IsStieltjesFunction (fun t => f t / t) := by
+  obtain ⟨a, b, μ, hμ⟩ := hf
+  rw [isStieltjesFunction_iff]
+  exact ⟨a, b, μ, hμ.representsStieltjes_div⟩
+
+end IsCompleteBernsteinFunction
+
+namespace RepresentsStieltjes
+
+variable {μ : Measure ℝ≥0} {a b : ℝ≥0} {f : ℝ → ℝ}
+
+/-- The Stieltjes--Bernstein transform of Stieltjes representing data is represented as a
+complete Bernstein function by the same measure and coefficients. -/
+theorem representsCompleteBernstein_stieltjesBernsteinTransform
+    (h : RepresentsStieltjes μ a b f) :
+    RepresentsCompleteBernstein μ a b (stieltjesBernsteinTransform μ a b) :=
+  ⟨h.measure_singleton_zero, h.integrable_weight, fun _ _ => rfl⟩
+
+/-- The Stieltjes--Bernstein transform of Stieltjes representing data is a complete Bernstein
+function. -/
+theorem isCompleteBernsteinFunction_stieltjesBernsteinTransform
+    (h : RepresentsStieltjes μ a b f) :
+    IsCompleteBernsteinFunction (stieltjesBernsteinTransform μ a b) :=
+  ⟨a, b, μ, h.representsCompleteBernstein_stieltjesBernsteinTransform⟩
+
+end RepresentsStieltjes
+
+/-- **Stieltjes--complete-Bernstein correspondence.** A function `f` is Stieltjes exactly when
+its product `t ↦ t * f t` on `(0, ∞)` extends to a complete Bernstein function on `[0, ∞)`.
+The extension's value at zero records the coefficient of the possible `t⁻¹` singularity. -/
+theorem isStieltjesFunction_iff_exists_isCompleteBernsteinFunction_eqOn_mul
+    {f : ℝ → ℝ} :
+    IsStieltjesFunction f ↔
+      ∃ g : ℝ → ℝ, IsCompleteBernsteinFunction g ∧
+        EqOn g (fun t => t * f t) (Ioi 0) := by
+  constructor
+  · intro hf
+    rw [isStieltjesFunction_iff] at hf
+    obtain ⟨a, b, μ, hμ⟩ := hf
+    exact ⟨stieltjesBernsteinTransform μ a b,
+      hμ.isCompleteBernsteinFunction_stieltjesBernsteinTransform,
+      fun _ ht => hμ.stieltjesBernsteinTransform_eq_mul ht⟩
+  · rintro ⟨g, ⟨a, b, μ, hμ⟩, hgf⟩
+    rw [isStieltjesFunction_iff]
+    refine ⟨a, b, μ, hμ.representsStieltjes_div.congr fun t ht => ?_⟩
+    calc
+      f t = t * f t / t := (mul_div_cancel_left₀ (f t) (ne_of_gt ht)).symm
+      _ = g t / t := congrArg (fun y : ℝ => y / t) (hgf ht).symm
+
+/-- Nonnegative constant functions are complete Bernstein functions. -/
+theorem isCompleteBernsteinFunction_const {c : ℝ} (hc : 0 ≤ c) :
+    IsCompleteBernsteinFunction (fun _ : ℝ => c) := by
+  rw [isCompleteBernsteinFunction_iff]
+  refine ⟨c.toNNReal, 0, 0, ?_⟩
+  rw [representsCompleteBernstein_iff]
+  refine ⟨by simp, integrable_zero_measure, fun t _ => ?_⟩
+  simp [stieltjesBernsteinTransform_apply, Real.coe_toNNReal c hc]
+
+/-- The identity function is a complete Bernstein function. -/
+theorem isCompleteBernsteinFunction_id : IsCompleteBernsteinFunction id := by
+  rw [isCompleteBernsteinFunction_iff]
+  refine ⟨0, 1, 0, ?_⟩
+  rw [representsCompleteBernstein_iff]
+  refine ⟨by simp, integrable_zero_measure, fun t _ => ?_⟩
+  simp [stieltjesBernsteinTransform_apply]
+
+/-- For `x > 0`, the basic function `t ↦ t / (t + x)` is complete Bernstein, represented by
+the unit point mass at `x`. -/
+theorem isCompleteBernsteinFunction_div_add {x : ℝ} (hx : 0 < x) :
+    IsCompleteBernsteinFunction (fun t : ℝ => t / (t + x)) := by
+  let xₙ := x.toNNReal
+  have hxₙ : xₙ ≠ 0 := ne_of_gt (Real.toNNReal_pos.mpr hx)
+  rw [isCompleteBernsteinFunction_iff]
+  refine ⟨0, 0, Measure.dirac xₙ, ?_⟩
+  rw [representsCompleteBernstein_iff]
+  refine ⟨by simp [hxₙ], integrable_dirac (by simp), fun t _ => ?_⟩
+  rw [stieltjesBernsteinTransform_apply, integral_dirac]
+  simp [xₙ, Real.coe_toNNReal x hx.le]
+
+end TauCeti
+
+end
+
+end

--- a/TauCeti/Analysis/CompletelyMonotone/Stieltjes/CompleteBernstein.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Stieltjes/CompleteBernstein.lean
@@ -15,7 +15,9 @@ A complete Bernstein function has a representation
 `g(t) = a + b t + ∫ x, t / (t + x) ∂μ`,
 
 where `a, b ≥ 0`, the positive measure `μ` has no atom at zero, and
-`∫ (1 + x)⁻¹ ∂μ < ∞`.  The normalization at zero makes the constant coefficient canonical.
+`∫ (1 + x)⁻¹ ∂μ < ∞`.  The normalization `μ {0} = 0` stops an atom at zero from making the
+integral term jump — such an atom contributes `1` at every positive parameter and `0` at zero —
+so the integral term vanishes at zero and the representation is the intended continuous extension.
 This file packages that standard representation and proves the first fundamental correspondence:
 `f` is Stieltjes exactly when `t ↦ t f(t)` on `(0, ∞)` has a complete Bernstein extension to
 `[0, ∞)`.
@@ -51,7 +53,8 @@ namespace TauCeti
 
 /-- A measure `μ` and coefficients `a, b ≥ 0` represent a complete Bernstein function when
 `μ` satisfies the standard Stieltjes integrability condition and the function agrees on
-`[0, ∞)` with `a + b t + ∫ x, t / (t + x) ∂μ`.  Requiring `μ {0} = 0` makes `a` canonical. -/
+`[0, ∞)` with `a + b t + ∫ x, t / (t + x) ∂μ`.  Requiring `μ {0} = 0` stops an atom at zero from
+making the integral term jump between zero and the positive parameters. -/
 def RepresentsCompleteBernstein (μ : Measure ℝ≥0) (a b : ℝ≥0) (f : ℝ → ℝ) : Prop :=
   μ {0} = 0 ∧ Integrable stieltjesWeight μ ∧
     EqOn f (stieltjesBernsteinTransform μ a b) (Ici 0)
@@ -208,28 +211,6 @@ theorem isCompleteBernsteinFunction_stieltjesBernsteinTransform
     IsCompleteBernsteinFunction (stieltjesBernsteinTransform μ a b) :=
   ⟨a, b, μ, representsCompleteBernstein_stieltjesBernsteinTransform hzero hμ⟩
 
-namespace RepresentsStieltjes
-
-variable {μ : Measure ℝ≥0} {a b : ℝ≥0} {f : ℝ → ℝ}
-
-/-- The Stieltjes--Bernstein transform of Stieltjes representing data is represented as a
-complete Bernstein function by the same measure and coefficients. -/
-theorem representsCompleteBernstein_stieltjesBernsteinTransform
-    (h : RepresentsStieltjes μ a b f) :
-    RepresentsCompleteBernstein μ a b (stieltjesBernsteinTransform μ a b) :=
-  TauCeti.representsCompleteBernstein_stieltjesBernsteinTransform
-    h.measure_singleton_zero h.integrable_weight
-
-/-- The Stieltjes--Bernstein transform of Stieltjes representing data is a complete Bernstein
-function. -/
-theorem isCompleteBernsteinFunction_stieltjesBernsteinTransform
-    (h : RepresentsStieltjes μ a b f) :
-    IsCompleteBernsteinFunction (stieltjesBernsteinTransform μ a b) :=
-  TauCeti.isCompleteBernsteinFunction_stieltjesBernsteinTransform
-    h.measure_singleton_zero h.integrable_weight
-
-end RepresentsStieltjes
-
 /-- **Stieltjes--complete-Bernstein correspondence.** A function `f` is Stieltjes exactly when
 its product `t ↦ t * f t` on `(0, ∞)` extends to a complete Bernstein function on `[0, ∞)`.
 The extension's value at zero records the coefficient of the possible `t⁻¹` singularity. -/
@@ -243,7 +224,8 @@ theorem isStieltjesFunction_iff_exists_isCompleteBernsteinFunction_eqOn_mul
     rw [isStieltjesFunction_iff] at hf
     obtain ⟨a, b, μ, hμ⟩ := hf
     exact ⟨stieltjesBernsteinTransform μ a b,
-      hμ.isCompleteBernsteinFunction_stieltjesBernsteinTransform,
+      isCompleteBernsteinFunction_stieltjesBernsteinTransform hμ.measure_singleton_zero
+        hμ.integrable_weight,
       fun _ ht => hμ.stieltjesBernsteinTransform_eq_mul ht⟩
   · rintro ⟨g, ⟨a, b, μ, hμ⟩, hgf⟩
     rw [isStieltjesFunction_iff]

--- a/TauCeti/Analysis/CompletelyMonotone/Stieltjes/CompleteBernstein.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Stieltjes/CompleteBernstein.lean
@@ -22,6 +22,13 @@ This file packages that standard representation and proves the first fundamental
 `f` is Stieltjes exactly when `t ↦ t f(t)` on `(0, ∞)` has a complete Bernstein extension to
 `[0, ∞)`.
 
+The predicate defined here *is* the integral representation, that is, the representing clause of
+the cited theorem, and it carries exactly the data `μ, a, b` of `TauCeti.RepresentsStieltjes`.
+The correspondence below is therefore the change of normalization `f ↦ t f(t)` performed on that
+shared data.  The equivalence of the representation with the analytic characterizations of a
+complete Bernstein function — extension to a Pick function on `ℂ ∖ (-∞, 0]`, or operator
+monotonicity — is not formalized here.
+
 The extension is necessary when the Stieltjes representation has a nonzero `a / t` term: its
 value at zero must be `a`, whereas the literal product `0 * f(0)` is zero.  Values of a Stieltjes
 function outside `(0, ∞)` remain irrelevant, and values of a complete Bernstein function outside
@@ -29,12 +36,26 @@ function outside `(0, ∞)` remain irrelevant, and values of a complete Bernstei
 
 ## Main declarations
 
-* `TauCeti.RepresentsCompleteBernstein`: complete-Bernstein representing data.
+* `TauCeti.RepresentsCompleteBernstein`: complete-Bernstein representing data, with the accessors
+  `measure_singleton_zero`, `integrable_weight`, `eq_stieltjesBernsteinTransform`, `apply_zero`
+  and `congr`.
 * `TauCeti.IsCompleteBernsteinFunction`: the representation-based predicate.
+* `TauCeti.representsCompleteBernstein_stieltjesBernsteinTransform` and
+  `TauCeti.isCompleteBernsteinFunction_stieltjesBernsteinTransform`: the transform of normalized,
+  integrable representing data carries the representation.
+* `TauCeti.RepresentsCompleteBernstein.add`, `TauCeti.RepresentsCompleteBernstein.smul`,
+  `TauCeti.IsCompleteBernsteinFunction.add` and `TauCeti.IsCompleteBernsteinFunction.smul`:
+  complete Bernstein functions are closed under sums and nonnegative scalar multiples.
 * `TauCeti.IsCompleteBernsteinFunction.isBernsteinFunction`: a complete Bernstein function is a
   Bernstein function.
+* `TauCeti.RepresentsCompleteBernstein.representsStieltjes_div` and
+  `TauCeti.IsCompleteBernsteinFunction.isStieltjesFunction_div`: dividing a complete Bernstein
+  function by its parameter gives a Stieltjes function.
 * `TauCeti.isStieltjesFunction_iff_exists_isCompleteBernsteinFunction_eqOn_mul`: the
   Stieltjes--complete-Bernstein correspondence.
+* `TauCeti.isCompleteBernsteinFunction_affine`, `TauCeti.isCompleteBernsteinFunction_const`,
+  `TauCeti.isCompleteBernsteinFunction_id` and `TauCeti.isCompleteBernsteinFunction_div_add`:
+  the affine, constant, identity and point-mass witnesses.
 
 ## References
 
@@ -84,18 +105,28 @@ lemma eq_stieltjesBernsteinTransform (h : RepresentsCompleteBernstein μ a b f)
     {t : ℝ} (ht : 0 ≤ t) : f t = stieltjesBernsteinTransform μ a b t :=
   h.2.2 ht
 
+/-- A represented complete Bernstein function takes the value `a` at zero: the boundary value
+records the coefficient of the `a / t` term of the associated Stieltjes function. -/
+lemma apply_zero (h : RepresentsCompleteBernstein μ a b f) : f 0 = a := by
+  simp [h.eq_stieltjesBernsteinTransform le_rfl]
+
 /-- A complete-Bernstein representation depends only on the represented function's values on
 `[0, ∞)`. -/
 lemma congr (h : RepresentsCompleteBernstein μ a b f) (hgf : EqOn g f (Ici 0)) :
     RepresentsCompleteBernstein μ a b g :=
   ⟨h.measure_singleton_zero, h.integrable_weight, hgf.trans h.2.2⟩
 
-private lemma integrable_div_add (hμ : Integrable stieltjesWeight μ) {t : ℝ} (ht : 0 ≤ t) :
-    Integrable (fun x : ℝ≥0 => t / (t + x)) μ := by
-  rcases ht.eq_or_lt with rfl | ht
-  · have hz : Integrable (fun _ : ℝ≥0 => (0 : ℝ)) μ := integrable_zero ℝ≥0 ℝ μ
-    simpa only [zero_div] using hz
-  · simpa only [div_eq_mul_inv] using (integrable_inv_add hμ ht).const_mul t
+/-- Dividing a complete Bernstein function by its parameter on `(0, ∞)` gives the Stieltjes
+function with the same representing data. -/
+theorem representsStieltjes_div (h : RepresentsCompleteBernstein μ a b f) :
+    RepresentsStieltjes μ a b (fun t => f t / t) := by
+  have hcanon : RepresentsStieltjes μ a b
+      (fun t => (a : ℝ) / t + (b : ℝ) + ∫ x : ℝ≥0, (t + (x : ℝ))⁻¹ ∂μ) :=
+    representsStieltjes_iff.mpr ⟨h.measure_singleton_zero, h.integrable_weight, fun _ _ => rfl⟩
+  refine hcanon.congr fun t ht => ?_
+  rw [h.eq_stieltjesBernsteinTransform (mem_Ioi.mp ht).le,
+    hcanon.stieltjesBernsteinTransform_eq_mul (mem_Ioi.mp ht),
+    mul_div_cancel_left₀ _ (mem_Ioi.mp ht).ne']
 
 /-- The sum of two complete-Bernstein representations is represented by the sum of their
 coefficients and measures. -/
@@ -104,14 +135,12 @@ lemma add (hf : RepresentsCompleteBernstein μ a b f)
     RepresentsCompleteBernstein (μ + ν) (a + c) (b + d) (f + g) := by
   refine ⟨by simp [hf.measure_singleton_zero, hg.measure_singleton_zero],
     hf.integrable_weight.add_measure hg.integrable_weight, fun t ht => ?_⟩
-  rw [Pi.add_apply, hf.eq_stieltjesBernsteinTransform ht,
-    hg.eq_stieltjesBernsteinTransform ht]
-  simp only [stieltjesBernsteinTransform_apply]
-  rw [integral_add_measure
-      (integrable_div_add hf.integrable_weight ht)
-      (integrable_div_add hg.integrable_weight ht)]
-  push_cast
-  ring
+  rcases (mem_Ici.mp ht).eq_or_lt with rfl | htpos
+  · simp [hf.apply_zero, hg.apply_zero]
+  · rw [(hf.representsStieltjes_div.add
+      hg.representsStieltjes_div).stieltjesBernsteinTransform_eq_mul htpos]
+    simp only [Pi.add_apply]
+    field_simp [htpos.ne']
 
 /-- A nonnegative scalar multiple of a complete-Bernstein representation is represented by
 scaling its coefficients and measure. -/
@@ -120,29 +149,17 @@ lemma smul (h : RepresentsCompleteBernstein μ a b f) {r : ℝ} (hr : 0 ≤ r) :
       (r.toNNReal * a) (r.toNNReal * b) (r • f) := by
   refine ⟨by simp [h.measure_singleton_zero],
     h.integrable_weight.smul_measure ENNReal.ofReal_ne_top, fun t ht => ?_⟩
-  rw [Pi.smul_apply, smul_eq_mul, h.eq_stieltjesBernsteinTransform ht]
-  simp only [stieltjesBernsteinTransform_apply]
-  rw [integral_smul_measure]
-  · simp only [ENNReal.toReal_ofReal hr, smul_eq_mul]
-    push_cast
-    rw [Real.coe_toNNReal r hr]
-    ring
+  rcases (mem_Ici.mp ht).eq_or_lt with rfl | htpos
+  · simp [h.apply_zero, Real.coe_toNNReal r hr]
+  · rw [(h.representsStieltjes_div.smul hr).stieltjesBernsteinTransform_eq_mul htpos]
+    simp only [Pi.smul_apply, smul_eq_mul]
+    field_simp [htpos.ne']
 
 /-- A function with a complete-Bernstein representation is a Bernstein function. -/
 theorem isBernsteinFunction (h : RepresentsCompleteBernstein μ a b f) :
     IsBernsteinFunction f :=
   (isBernsteinFunction_stieltjesBernsteinTransform h.measure_singleton_zero
     h.integrable_weight).congr h.2.2
-
-/-- Dividing a complete Bernstein function by its parameter on `(0, ∞)` gives the Stieltjes
-function with the same representing data. -/
-theorem representsStieltjes_div (h : RepresentsCompleteBernstein μ a b f) :
-    RepresentsStieltjes μ a b (fun t => f t / t) := by
-  rw [representsStieltjes_iff]
-  refine ⟨h.measure_singleton_zero, h.integrable_weight, fun t ht => ?_⟩
-  rw [h.eq_stieltjesBernsteinTransform ht.le, stieltjesBernsteinTransform_apply,
-    stieltjesBernsteinIntegral_eq_mul_integral_inv_add]
-  field_simp
 
 end RepresentsCompleteBernstein
 
@@ -213,7 +230,9 @@ theorem isCompleteBernsteinFunction_stieltjesBernsteinTransform
 
 /-- **Stieltjes--complete-Bernstein correspondence.** A function `f` is Stieltjes exactly when
 its product `t ↦ t * f t` on `(0, ∞)` extends to a complete Bernstein function on `[0, ∞)`.
-The extension's value at zero records the coefficient of the possible `t⁻¹` singularity. -/
+The extension's value at zero records the coefficient of the possible `t⁻¹` singularity.  Both
+sides are the same representing data `μ, a, b`, so the content is the change of normalization
+`f ↦ t f(t)` and the continuous extension of the product across zero. -/
 theorem isStieltjesFunction_iff_exists_isCompleteBernsteinFunction_eqOn_mul
     {f : ℝ → ℝ} :
     IsStieltjesFunction f ↔
@@ -234,22 +253,23 @@ theorem isStieltjesFunction_iff_exists_isCompleteBernsteinFunction_eqOn_mul
       f t = t * f t / t := (mul_div_cancel_left₀ (f t) (ne_of_gt ht)).symm
       _ = g t / t := congrArg (fun y : ℝ => y / t) (hgf ht).symm
 
+/-- Nonnegative affine functions are complete Bernstein functions. -/
+theorem isCompleteBernsteinFunction_affine {c d : ℝ} (hc : 0 ≤ c) (hd : 0 ≤ d) :
+    IsCompleteBernsteinFunction (fun t : ℝ => c + d * t) := by
+  rw [isCompleteBernsteinFunction_iff]
+  refine ⟨c.toNNReal, d.toNNReal, 0, ?_⟩
+  rw [representsCompleteBernstein_iff]
+  refine ⟨by simp, integrable_zero_measure, fun t _ => ?_⟩
+  simp [stieltjesBernsteinTransform_apply, Real.coe_toNNReal c hc, Real.coe_toNNReal d hd]
+
 /-- Nonnegative constant functions are complete Bernstein functions. -/
 theorem isCompleteBernsteinFunction_const {c : ℝ} (hc : 0 ≤ c) :
-    IsCompleteBernsteinFunction (fun _ : ℝ => c) := by
-  rw [isCompleteBernsteinFunction_iff]
-  refine ⟨c.toNNReal, 0, 0, ?_⟩
-  rw [representsCompleteBernstein_iff]
-  refine ⟨by simp, integrable_zero_measure, fun t _ => ?_⟩
-  simp [stieltjesBernsteinTransform_apply, Real.coe_toNNReal c hc]
+    IsCompleteBernsteinFunction (fun _ : ℝ => c) :=
+  (isCompleteBernsteinFunction_affine hc le_rfl).congr fun t _ => by simp
 
 /-- The identity function is a complete Bernstein function. -/
-theorem isCompleteBernsteinFunction_id : IsCompleteBernsteinFunction id := by
-  rw [isCompleteBernsteinFunction_iff]
-  refine ⟨0, 1, 0, ?_⟩
-  rw [representsCompleteBernstein_iff]
-  refine ⟨by simp, integrable_zero_measure, fun t _ => ?_⟩
-  simp [stieltjesBernsteinTransform_apply]
+theorem isCompleteBernsteinFunction_id : IsCompleteBernsteinFunction (fun t : ℝ => t) :=
+  (isCompleteBernsteinFunction_affine le_rfl zero_le_one).congr fun t _ => by simp
 
 /-- For `x > 0`, the basic function `t ↦ t / (t + x)` is complete Bernstein, represented by
 the unit point mass at `x`. -/


### PR DESCRIPTION
This PR introduces complete Bernstein functions by their standard normalized Stieltjes-type representation and proves the two-way correspondence that a function `f` is Stieltjes exactly when `t ↦ t * f t` on `(0, ∞)` extends to a complete Bernstein function on `[0, ∞)`. It advances `OneParameterSemigroups/README.md`, Part B, API target “the Stieltjes / Bernstein-function relationships (completely monotone ↔ Bernstein via the standard correspondences),” in the developed theory surrounding the Bernstein’s theorem milestone.

Define `RepresentsCompleteBernstein` and `IsCompleteBernsteinFunction`, expose the representation accessors and congruence principle, prove that every represented function is Bernstein, and prove that division by the parameter recovers a Stieltjes function. The converse construction reuses the existing `stieltjesBernsteinTransform`; its integral factorization is promoted from a private helper because it is the canonical bridge between the two representations. The 219-line module also supplies nontrivial constant, identity, and point-mass witnesses.

The definitions and theorem follow Schilling–Song–Vondraček, *Bernstein Functions: Theory and Applications*, 2nd edition, Theorems 6.2 and 7.3, cited in the module. No Mathlib infrastructure is vendored; searches of pinned Mathlib and Tau Ceti found no complete-Bernstein predicate or equivalent correspondence.

After this PR, the Part B correspondence frontier still needs the reciprocal characterization that a nonzero function is Stieltjes exactly when its reciprocal is complete Bernstein; the separate Part A complex-resolvent frontier still needs a normed complexification of real generators after the scalar-generic analyticity work in #6156.

Roadmap: OneParameterSemigroups

<!--tauceti-target:v1 {"focus":"OneParameterSemigroups","id":"isstieltjesfunction-iff-exists-iscompletebernsteinfunction-eqon-mul"}-->

🤖 Prepared with Codex
