### PR TITLE
refactor(EllipticCurve): state the associativity theorems with pairSubstitution

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Assoc.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Assoc.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.Add.Series
+public import TauCeti.RingTheory.MvPowerSeries.Substitution
 import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.Add.PairSubst
 import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.Add.Unit
 import TauCeti.AlgebraicGeometry.EllipticCurve.Universal
@@ -165,10 +166,9 @@ private theorem subst_formalW_subst_formalInverse {q : MvPowerSeries σ O}
 are fixed by `MvPowerSeries.map`, so only `map_formalAdd` is doing any work. -/
 private theorem map_subst_pair_X_formalAdd {σ' S : Type*} [CommRing S] (φ : O →+* S)
     (s₁ s₂ : σ') :
-    MvPowerSeries.map φ (subst (Sum.elim (fun _ ↦ (X s₁ : MvPowerSeries σ' O)) (fun _ ↦ X s₂) :
-        Unit ⊕ Unit → MvPowerSeries σ' O) (formalAdd W)) =
-      subst (Sum.elim (fun _ ↦ (X s₁ : MvPowerSeries σ' S)) (fun _ ↦ X s₂) :
-        Unit ⊕ Unit → MvPowerSeries σ' S) (formalAdd (W.map φ)) := by
+    MvPowerSeries.map φ (subst (pairSubstitution (X s₁ : MvPowerSeries σ' O) (X s₂))
+        (formalAdd W)) =
+      subst (pairSubstitution (X s₁ : MvPowerSeries σ' S) (X s₂)) (formalAdd (W.map φ)) := by
   rw [MvPowerSeries.map_subst (hasSubst_pair (constantCoeff_X _) (constantCoeff_X _)),
     map_formalAdd]
   congr 1
@@ -553,26 +553,16 @@ honest elliptic curve `fracCurve Universal.curve` over that ring's fraction fiel
 bracketing into a sum of three points, `thetaPoint_add_of_ne` computes both, associativity of the
 curve's group law identifies them, and `thetaPoint_inj` brings the equality back to the series. -/
 private theorem assoc_formalAdd_universal :
-    subst (Sum.elim
-        (fun _ ↦ subst (Sum.elim
-            (fun _ ↦ (X (Sum.inl ()) :
-              MvPowerSeries (Unit ⊕ Unit ⊕ Unit) (MvPolynomial Coeff ℤ)))
-            (fun _ ↦ X (Sum.inr (Sum.inl ()))) :
-              Unit ⊕ Unit → MvPowerSeries (Unit ⊕ Unit ⊕ Unit) (MvPolynomial Coeff ℤ))
-          (formalAdd Universal.curve))
-        (fun _ ↦ X (Sum.inr (Sum.inr ()))) :
-          Unit ⊕ Unit → MvPowerSeries (Unit ⊕ Unit ⊕ Unit) (MvPolynomial Coeff ℤ))
+    subst (pairSubstitution
+        (subst (pairSubstitution (X (Sum.inl ()) :
+            MvPowerSeries (Unit ⊕ Unit ⊕ Unit) (MvPolynomial Coeff ℤ))
+          (X (Sum.inr (Sum.inl ())))) (formalAdd Universal.curve))
+        (X (Sum.inr (Sum.inr ()))))
       (formalAdd Universal.curve) =
-    subst (Sum.elim
-        (fun _ ↦ (X (Sum.inl ()) :
-          MvPowerSeries (Unit ⊕ Unit ⊕ Unit) (MvPolynomial Coeff ℤ)))
-        (fun _ ↦ subst (Sum.elim
-            (fun _ ↦ (X (Sum.inr (Sum.inl ())) :
-              MvPowerSeries (Unit ⊕ Unit ⊕ Unit) (MvPolynomial Coeff ℤ)))
-            (fun _ ↦ X (Sum.inr (Sum.inr ()))) :
-              Unit ⊕ Unit → MvPowerSeries (Unit ⊕ Unit ⊕ Unit) (MvPolynomial Coeff ℤ))
-          (formalAdd Universal.curve)) :
-          Unit ⊕ Unit → MvPowerSeries (Unit ⊕ Unit ⊕ Unit) (MvPolynomial Coeff ℤ))
+    subst (pairSubstitution (X (Sum.inl ()) :
+        MvPowerSeries (Unit ⊕ Unit ⊕ Unit) (MvPolynomial Coeff ℤ))
+        (subst (pairSubstitution (X (Sum.inr (Sum.inl ()))) (X (Sum.inr (Sum.inr ()))))
+          (formalAdd Universal.curve)))
       (formalAdd Universal.curve) := by
   classical
   set R := MvPolynomial Coeff ℤ with hR
@@ -608,13 +598,11 @@ private theorem assoc_formalAdd_universal :
   have hχ'3 := subst_coordSpecialize_X_of_ne (O := R)
     (i := (Sum.inr (Sum.inl ()) : Unit ⊕ Unit ⊕ Unit)) (j := Sum.inr (Sum.inr ())) (by simp)
   -- the two inner sums
-  set F₁₂ := subst (Sum.elim (fun _ ↦ (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R))
-    (fun _ ↦ X (Sum.inr (Sum.inl ()))) : Unit ⊕ Unit → MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R)
-    (formalAdd Universal.curve) with hF₁₂def
-  set F₂₃ := subst (Sum.elim
-    (fun _ ↦ (X (Sum.inr (Sum.inl ())) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R))
-    (fun _ ↦ X (Sum.inr (Sum.inr ()))) : Unit ⊕ Unit → MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R)
-    (formalAdd Universal.curve) with hF₂₃def
+  set F₁₂ := subst (pairSubstitution (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R)
+    (X (Sum.inr (Sum.inl ())))) (formalAdd Universal.curve) with hF₁₂def
+  set F₂₃ := subst (pairSubstitution
+    (X (Sum.inr (Sum.inl ())) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R)
+    (X (Sum.inr (Sum.inr ())))) (formalAdd Universal.curve) with hF₂₃def
   have hF₁₂c : constantCoeff F₁₂ = 0 :=
     constantCoeff_subst_pair_formalAdd Universal.curve (constantCoeff_X _)
         (constantCoeff_X _)
@@ -666,23 +654,14 @@ series ring therefore has a fraction field — and `map_specialize` carries it t
 The three variables are indexed by `Unit ⊕ Unit ⊕ Unit`, with the two bracketings written as
 nested substitutions of `formalAdd` into itself. -/
 theorem formalAdd_assoc :
-    subst (Sum.elim
-        (fun _ ↦ subst (Sum.elim
-            (fun _ ↦ (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) O))
-            (fun _ ↦ X (Sum.inr (Sum.inl ()))) :
-              Unit ⊕ Unit → MvPowerSeries (Unit ⊕ Unit ⊕ Unit) O)
-          (formalAdd W))
-        (fun _ ↦ X (Sum.inr (Sum.inr ()))) :
-          Unit ⊕ Unit → MvPowerSeries (Unit ⊕ Unit ⊕ Unit) O)
+    subst (pairSubstitution
+        (subst (pairSubstitution (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) O)
+          (X (Sum.inr (Sum.inl ())))) (formalAdd W))
+        (X (Sum.inr (Sum.inr ()))))
       (formalAdd W) =
-    subst (Sum.elim
-        (fun _ ↦ (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) O))
-        (fun _ ↦ subst (Sum.elim
-            (fun _ ↦ (X (Sum.inr (Sum.inl ())) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) O))
-            (fun _ ↦ X (Sum.inr (Sum.inr ()))) :
-              Unit ⊕ Unit → MvPowerSeries (Unit ⊕ Unit ⊕ Unit) O)
-          (formalAdd W)) :
-          Unit ⊕ Unit → MvPowerSeries (Unit ⊕ Unit ⊕ Unit) O)
+    subst (pairSubstitution (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) O)
+        (subst (pairSubstitution (X (Sum.inr (Sum.inl ()))) (X (Sum.inr (Sum.inr ()))))
+          (formalAdd W)))
       (formalAdd W) := by
   have h := congrArg (MvPowerSeries.map W.specialize) assoc_formalAdd_universal
   rw [MvPowerSeries.map_subst (hasSubst_pair


### PR DESCRIPTION
#6172 named the two-variable substitution family as `pairSubstitution` and migrated 15 sites in
this file. It left the ones in the two big **statements**, which kept the spelled-out form. This
finishes the job: 8 sites across `assoc_formalAdd_universal`, the public `formalAdd_assoc`, the
two `set` bindings for the inner sums, and `map_subst_pair_X_formalAdd`.

Each bracketing goes from ten lines to five:

```lean
-- before
subst (Sum.elim
    (fun _ ↦ subst (Sum.elim
        (fun _ ↦ (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) O))
        (fun _ ↦ X (Sum.inr (Sum.inl ()))) :
          Unit ⊕ Unit → MvPowerSeries (Unit ⊕ Unit ⊕ Unit) O)
      (formalAdd W))
    (fun _ ↦ X (Sum.inr (Sum.inr ()))) :
      Unit ⊕ Unit → MvPowerSeries (Unit ⊕ Unit ⊕ Unit) O)
  (formalAdd W)

-- after
subst (pairSubstitution
    (subst (pairSubstitution (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) O)
      (X (Sum.inr (Sum.inl ())))) (formalAdd W))
    (X (Sum.inr (Sum.inr ()))))
  (formalAdd W)
```

**This needs one new `public import`, and that is the substantive part of the diff.**
`formalAdd_assoc` is public and its statement now mentions `pairSubstitution`, which lives in
`TauCeti/RingTheory/MvPowerSeries/Substitution.lean` — reached here through a plain `import`. A
plain-imported declaration cannot appear in a public statement, so the module errors with
`Unknown identifier 'pairSubstitution'` until the import is public. That is the module system
working as intended rather than an obstacle to route around: the public statement genuinely
exposes `pairSubstitution`, so the import that supplies it belongs in the public group. It is
also why #6172 could not simply have included these sites.

**Two sites are deliberately left on `Sum.elim`**, both inside
`subst_subst_pair_formalAdd_eq_X`/`_eq_zero`:

```lean
show (fun s : Unit ⊕ Unit ↦ subst g (Sum.elim (fun _ ↦ a) (fun _ ↦ b) s)) =
  (Sum.elim X (fun _ ↦ 0) : Unit ⊕ Unit → MvPowerSeries Unit O) from …
```

These are not a pair of parameters — they are the *composite* family produced by
`subst_comp_subst_apply` and the target family `subst_unitR_formalAdd` is stated against, which
`rw` has to match syntactically. The existing comment above them says so, and it stays true.

**Measured.** The file goes 705 → 683 lines (25 insertions, 46 deletions). No proof body changes
behaviour; `assoc_formalAdd_universal`'s body drops 91 → 89 purely from the two compacted `set`
bindings.

**Relation to #6191**, which also touches this file: the two diffs are disjoint (#6191 adds a
private lemma and edits the nonvanishing `have`s; this one edits statements, `set` bindings and
imports). I verified they merge cleanly and that the *merged* file compiles, so neither ordering
breaks `main`.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"EllipticCurves/README.md:Layer-6-formal-group:pairsubstitution-statements"}-->

Provenance: no port and no new declaration — this restates existing declarations using
`pairSubstitution`, which was added to
`TauCeti/RingTheory/MvPowerSeries/Substitution.lean` by #6172. The module's own upstream source
is Michael Stoll's `EllipticCurves` (`github.com/MichaelStollBayreuth/EllipticCurves`,
Apache-2.0) @ `66889eada51a74c2f5dfb7fb5909b0b5a0a2d96e`; it has no such abbreviation, writing
`Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂)` inline at every site, so there is nothing upstream this
could have been taken from.
