### PR TITLE
feat(RingTheory): scaling numerator and denominator by the same element leaves the fraction alone

### DIFF
--- a/TauCeti/RingTheory/Localization/Away.lean
+++ b/TauCeti/RingTheory/Localization/Away.lean
@@ -144,9 +144,9 @@ theorem divBy_mul_algebraMap :
 
 That extra instance is what the hypothesis really is: for a unit `u` it comes for free, since
 `u * s` and `s` are then associated and `IsLocalization.Away.of_associated` transports the
-localisation. Rescaling a denominator *alone* need not preserve the fraction, so a construction
-indexed by a presentation is preserved only when the numerators are rescaled by the same
-factor. -/
+localisation. Rescaling a denominator *alone* need not preserve the fraction; rescaling numerator
+and denominator together always does, which is what a construction indexed by a presentation
+needs. -/
 @[simp]
 theorem divBy_mul_mul_left {u : A} [IsLocalization.Away (u * s) S] :
     (divBy (u * t) (u * s) : S) = divBy t s := by

--- a/TauCeti/RingTheory/Localization/Away.lean
+++ b/TauCeti/RingTheory/Localization/Away.lean
@@ -35,6 +35,9 @@ Huber namespace, alongside `TauCeti/RingTheory/Localization/DenIdeal.lean`.
   numerator.
 * `TauCeti.Localization.divBy_mul_cancel_left` and
   `TauCeti.Localization.divBy_mul_cancel_right`: `(s · t)/s = t` and `(t · s)/s = t`.
+* `TauCeti.Localization.divBy_mul_mul_left` and
+  `TauCeti.Localization.divBy_mul_mul_right`: `(u · t)/(u · s) = t/s` and `(t · u)/(s · u) = t/s`,
+  given that `S` is a localisation away from the rescaled denominator as well.
 * `TauCeti.Localization.divBy_self`: `s/s = 1`.
 * `TauCeti.Localization.adjoin_invSelf_eq_top`: `S` is generated over `A` by `1/s`.
 * `TauCeti.Localization.adjoin_divBy_eq_top`: as soon as the numerators `T` together with the
@@ -141,14 +144,23 @@ theorem divBy_mul_algebraMap :
 
 That extra instance is what the hypothesis really is: for a unit `u` it comes for free, since
 `u * s` and `s` are then associated and `IsLocalization.Away.of_associated` transports the
-localisation. Rescaling a denominator *alone* is not such a move — `t/s` and `t/(u · s)` are
-different fractions — so a construction indexed by a presentation is preserved only when the
-numerators are rescaled by the same factor. -/
+localisation. Rescaling a denominator *alone* need not preserve the fraction, so a construction
+indexed by a presentation is preserved only when the numerators are rescaled by the same
+factor. -/
+@[simp]
 theorem divBy_mul_mul_left {u : A} [IsLocalization.Away (u * s) S] :
     (divBy (u * t) (u * s) : S) = divBy t s := by
   rw [divBy_def (u * t) (u * s)]
   refine (IsLocalization.eq_mk'_iff_mul_eq.mpr ?_).symm
   rw [map_mul, ← mul_assoc, mul_right_comm, divBy_mul_algebraMap, ← map_mul, mul_comm t u]
+
+/-- The same on the other side: `(t · u)/(s · u) = t/s`. -/
+@[simp]
+theorem divBy_mul_mul_right {u : A} [IsLocalization.Away (s * u) S] :
+    (divBy (t * u) (s * u) : S) = divBy t s := by
+  rw [divBy_def (t * u) (s * u)]
+  refine (IsLocalization.eq_mk'_iff_mul_eq.mpr ?_).symm
+  rw [map_mul, ← mul_assoc, divBy_mul_algebraMap, ← map_mul]
 
 /-- The mirror of `invSelf_mul_algebraMap`, for the same reason. -/
 @[simp]

--- a/TauCeti/RingTheory/Localization/Away.lean
+++ b/TauCeti/RingTheory/Localization/Away.lean
@@ -136,6 +136,20 @@ theorem divBy_mul_algebraMap :
   rw [divBy_def]
   exact IsLocalization.mk'_spec S t (⟨s, Submonoid.mem_powers s⟩ : Submonoid.powers s)
 
+/-- **Scaling numerator and denominator by the same element leaves the fraction alone**:
+`(u · t)/(u · s) = t/s`, whenever `S` is also a localisation away from `u · s`.
+
+That extra instance is what the hypothesis really is: for a unit `u` it comes for free, since
+`u * s` and `s` are then associated and `IsLocalization.Away.of_associated` transports the
+localisation. Rescaling a denominator *alone* is not such a move — `t/s` and `t/(u · s)` are
+different fractions — so a construction indexed by a presentation is preserved only when the
+numerators are rescaled by the same factor. -/
+theorem divBy_mul_mul_left {u : A} [IsLocalization.Away (u * s) S] :
+    (divBy (u * t) (u * s) : S) = divBy t s := by
+  rw [divBy_def (u * t) (u * s)]
+  refine (IsLocalization.eq_mk'_iff_mul_eq.mpr ?_).symm
+  rw [map_mul, ← mul_assoc, mul_right_comm, divBy_mul_algebraMap, ← map_mul, mul_comm t u]
+
 /-- The mirror of `invSelf_mul_algebraMap`, for the same reason. -/
 @[simp]
 theorem algebraMap_mul_invSelf :


### PR DESCRIPTION
Completes the `divBy` cancellation family with the one case it was missing.

```lean
@[simp] theorem divBy_mul_mul_left {u : A} [IsLocalization.Away (u * s) S] :
    (divBy (u * t) (u * s) : S) = divBy t s

@[simp] theorem divBy_mul_mul_right {u : A} [IsLocalization.Away (s * u) S] :
    (divBy (t * u) (s * u) : S) = divBy t s
```

They sit beside the existing `divBy_mul_cancel_left`, `divBy_mul_cancel_right` and
`divBy_mul_algebraMap`, and are proved from the last of those in four lines each. The left/right
pair matches how the file already states every parallel cancellation, so a syntactically
right-scaled fraction needs no manual `mul_comm`.

## What the hypothesis is

`S` must also be a localisation away from `u * s`. For a **unit** `u` that comes for free: `u * s`
and `s` are then associated, and mathlib's `IsLocalization.Away.of_associated` transports the
instance. Stating it as an instance argument rather than as `IsUnit u` keeps the lemma at the
generality its proof actually has.

## Why it is wanted

A rational localisation `A⟨T/s⟩` is indexed by a presentation `(T, s)`, and the chain results in
`LocalizationTopology/Laurent/Flat.lean` carry a topological-nilpotence hypothesis on the
denominator that Wedhorn's Proposition 8.30 does not assume. Removing it means rescaling the
presentation by a pseudouniformiser, and this lemma is what makes such a rescaling harmless.

The asymmetry is the point, and the docstring records it: rescaling the denominator **alone** does
move the fraction — `t/s ≠ t/(u · s)` — so a presentation is preserved only when the numerators
are rescaled by the same factor. I had that wrong in an earlier docstring and review caught it.

## Notes

* No `sorry`, no `native_decide`, no `maxHeartbeats`. Header audit and width check clean.
* This improves code that already exists, so it claims no roadmap target; `AdicSpaces` is the
  roadmap motivating the work.

Provenance: none — proved from the file's own `divBy_mul_algebraMap`. Swept against mathlib at
`2b1308ee396f215169fdaa6807ea1d0f91d0001f` for `mk'_cancel`, `mk'_mul_cancel_left`,
`mk'_mul_cancel_right` and `eq_mk'_iff_mul_eq`: the general `mk'` cancellations are present, this
`divBy`-level statement is not.

Roadmap: AdicSpaces

