### PR TITLE
feat: characterize Bernstein functions by their completely monotone exponentials

### DIFF
--- a/TauCeti/Analysis/CompletelyMonotone/Basic.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Basic.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Analysis.Calculus.AbsolutelyMonotone
 public import Mathlib.Analysis.Calculus.Deriv.MeanValue
+public import Mathlib.Analysis.Convex.Deriv
 public import Mathlib.Analysis.SpecialFunctions.ExpDeriv
 public import Mathlib.Topology.Order.MonotoneConvergence
 public import TauCeti.Analysis.Calculus.IteratedDerivWithin
@@ -66,6 +67,8 @@ point `0`); on the open half-line it agrees with the ordinary iterated derivativ
   scalar multiples.
 * `TauCeti.IsCompletelyMonotoneOnIoi`: the open-half-line analogue, using ordinary iterated
   derivatives on `(0, ∞)`.
+* `TauCeti.IsCompletelyMonotoneOnIoi.convexOn`: a completely monotone function on `(0, ∞)` is
+  convex there.
 * `TauCeti.isCompletelyMonotoneOnIoi_of_forall_comp_add_const`: complete monotonicity on
   `(0, ∞)` can be checked on the positive translates of a function, the converse of
   `TauCeti.IsCompletelyMonotoneOnIoi.isCompletelyMonotone_comp_add_const`.
@@ -383,6 +386,20 @@ lemma deriv_nonpos (hf : IsCompletelyMonotoneOnIoi f) {t : ℝ} (ht : 0 < t) :
   have h := hf.neg_one_pow_mul_iteratedDeriv_nonneg 1 ht
   rw [pow_one, iteratedDeriv_one] at h
   linarith
+
+/-- A function completely monotone on `(0, ∞)` is convex there: its second derivative is the
+alternating derivative of order `2`, hence nonnegative. -/
+lemma convexOn (hf : IsCompletelyMonotoneOnIoi f) : ConvexOn ℝ (Ioi 0) f := by
+  have hd : DifferentiableOn ℝ f (Ioi 0) := hf.contDiffOn.differentiableOn (by simp)
+  have hderiv : ContDiffOn ℝ ∞ (deriv f) (Ioi 0) :=
+    hf.contDiffOn.deriv_of_isOpen isOpen_Ioi (by simp)
+  have hd' : DifferentiableOn ℝ (deriv f) (Ioi 0) := hderiv.differentiableOn (by simp)
+  refine convexOn_of_deriv2_nonneg (convex_Ioi 0) hf.contDiffOn.continuousOn ?_ ?_ ?_
+  · rwa [interior_Ioi]
+  · rwa [interior_Ioi]
+  · rw [interior_Ioi]
+    intro x hx
+    simpa [iteratedDeriv_eq_iterate] using hf.neg_one_pow_mul_iteratedDeriv_nonneg 2 hx
 
 /-- Complete monotonicity on `(0, ∞)` is preserved by pointwise equality there. -/
 lemma congr (hf : IsCompletelyMonotoneOnIoi f) (h : Set.EqOn g f (Ioi 0)) :

--- a/TauCeti/Analysis/CompletelyMonotone/Basic.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Basic.lean
@@ -66,6 +66,9 @@ point `0`); on the open half-line it agrees with the ordinary iterated derivativ
   scalar multiples.
 * `TauCeti.IsCompletelyMonotoneOnIoi`: the open-half-line analogue, using ordinary iterated
   derivatives on `(0, ∞)`.
+* `TauCeti.isCompletelyMonotoneOnIoi_of_forall_comp_add_const`: complete monotonicity on
+  `(0, ∞)` can be checked on the positive translates of a function, the converse of
+  `TauCeti.IsCompletelyMonotoneOnIoi.isCompletelyMonotone_comp_add_const`.
 * `TauCeti.IsContinuousCompletelyMonotoneOnIoi`: the closed-half-line predicate used by the
   finite-measure Hausdorff--Bernstein--Widder theorem: continuity on `[0, ∞)` plus complete
   monotonicity on `(0, ∞)`.
@@ -429,6 +432,29 @@ lemma isCompletelyMonotone_comp_add_const (hf : IsCompletelyMonotoneOnIoi f) {a 
     exact hf.neg_one_pow_mul_iteratedDeriv_nonneg n htpa
 
 end IsCompletelyMonotoneOnIoi
+
+/-- Complete monotonicity on `(0, ∞)` is detected by the positive translates of a function: if
+`t ↦ f (t + a)` is completely monotone on `(0, ∞)` for every `a > 0`, then so is `f`.  This is the
+converse of `TauCeti.IsCompletelyMonotoneOnIoi.isCompletelyMonotone_comp_add_const`, and it is how
+a statement proved after moving the boundary into the open half-line is transported back. -/
+theorem isCompletelyMonotoneOnIoi_of_forall_comp_add_const {f : ℝ → ℝ}
+    (h : ∀ a : ℝ, 0 < a → IsCompletelyMonotoneOnIoi fun s => f (s + a)) :
+    IsCompletelyMonotoneOnIoi f := by
+  have hsmooth : ContDiffOn ℝ ∞ f (Ioi 0) := by
+    intro u hu
+    have ha : (0 : ℝ) < u / 2 := by linarith [mem_Ioi.mp hu]
+    have hhalf : u - u / 2 = u / 2 := by ring
+    have hshift : ContDiffAt ℝ ∞ (fun s : ℝ => f (s + u / 2)) ((fun s : ℝ => s - u / 2) u) := by
+      have := ((h (u / 2) ha).contDiffOn).contDiffAt (isOpen_Ioi.mem_nhds (mem_Ioi.mpr ha))
+      simpa [hhalf] using this
+    have hcomp := hshift.comp u (by fun_prop : ContDiffAt ℝ ∞ (fun s : ℝ => s - u / 2) u)
+    exact (by simpa [Function.comp_def] using hcomp : ContDiffAt ℝ ∞ f u).contDiffWithinAt
+  refine ⟨hsmooth, fun n u hu => ?_⟩
+  have ha : (0 : ℝ) < u / 2 := by linarith
+  have hhalves : u / 2 + u / 2 = u := by ring
+  have hsign := (h (u / 2) ha).neg_one_pow_mul_iteratedDeriv_nonneg n ha
+  rw [iteratedDeriv_comp_add_const] at hsign
+  simpa [hhalves] using hsign
 
 /-! ## Closed-half-line complete monotonicity -/
 

--- a/TauCeti/Analysis/CompletelyMonotone/Bernstein/Exponential.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Bernstein/Exponential.lean
@@ -47,7 +47,7 @@ completely monotone.
   `t ↦ f'(t) · e^{-x f(t)}` is completely monotone on `(0, ∞)` whenever `e^{-x f}` is.
 * `TauCeti.isBernsteinFunction_of_forall_isCompletelyMonotoneOnIoi_exp_neg_mul`: the converse
   direction, that the family of exponentials forces `f` to be a Bernstein function.
-* `TauCeti.isBernsteinFunction_iff_forall_isContinuousCompletelyMonotoneOnIoi_exp_neg_mul`: the
+* `isBernsteinFunction_iff_nonneg_and_forall_isContinuousCompletelyMonotoneOnIoi_exp_neg_mul`: the
   resulting characterization of Bernstein functions.
 
 ## References
@@ -65,28 +65,25 @@ namespace TauCeti
 
 variable {f : ℝ → ℝ}
 
-/-- The function is recovered from one of its exponentials as `f = -x⁻¹ log (e^{-x f})`, on the
-nose and not just up to a null set, so any pointwise-stated regularity transfers. -/
-private lemma eq_neg_inv_mul_log_exp {x : ℝ} (hx : x ≠ 0) (t : ℝ) :
-    f t = -x⁻¹ * Real.log (Real.exp (-x * f t)) := by
-  rw [Real.log_exp]
-  field_simp
-
 /-- Smoothness of `f` on `(0, ∞)` is inherited from a single exponential `e^{-x f}`: the
 exponential is positive, so composing with the logarithm stays inside the domain of smoothness of
-`Real.log`. -/
+`Real.log`, and `Real.log_exp` recovers `f` from `e^{-x f}` on the nose. -/
 lemma contDiffOn_of_contDiffOn_exp_neg_mul {x : ℝ} (hx : x ≠ 0) {s : Set ℝ}
     (h : ContDiffOn ℝ ∞ (fun t => Real.exp (-x * f t)) s) : ContDiffOn ℝ ∞ f s := by
   have hlog : ContDiffOn ℝ ∞ (fun t => -x⁻¹ * Real.log (Real.exp (-x * f t))) s :=
     (h.log fun t _ => (Real.exp_pos _).ne').const_smul (-x⁻¹)
-  exact hlog.congr fun t _ => eq_neg_inv_mul_log_exp hx t
+  refine hlog.congr fun t _ => ?_
+  simp only [Real.log_exp]
+  field_simp
 
 /-- Continuity of `f` on a set is inherited from a single exponential `e^{-x f}`. -/
 lemma continuousOn_of_continuousOn_exp_neg_mul {x : ℝ} (hx : x ≠ 0) {s : Set ℝ}
     (h : ContinuousOn (fun t => Real.exp (-x * f t)) s) : ContinuousOn f s := by
   have hlog : ContinuousOn (fun t => -x⁻¹ * Real.log (Real.exp (-x * f t))) s :=
     continuousOn_const.mul (h.log fun t _ => (Real.exp_pos _).ne')
-  exact hlog.congr fun t _ => eq_neg_inv_mul_log_exp hx t
+  refine hlog.congr fun t _ => ?_
+  simp only [Real.log_exp]
+  field_simp
 
 /-- The derivative of `f` weighted by an exponential.  If `e^{-x f}` is completely monotone on
 `(0, ∞)` for some `x > 0`, then so is `t ↦ f'(t) · e^{-x f(t)}`, because that function is
@@ -120,7 +117,7 @@ theorem isBernsteinFunction_of_forall_isCompletelyMonotoneOnIoi_exp_neg_mul
   refine isBernsteinFunction_iff.mpr ⟨hcont, hsmooth, hnonneg, ?_⟩
   refine isCompletelyMonotoneOnIoi_of_tendsto (L := atTop)
     (F := fun n : ℕ => fun t => deriv f t * Real.exp (-(1 / ((n : ℝ) + 1)) * f t))
-    (fun n => isCompletelyMonotoneOnIoi_deriv_mul_exp_neg_mul (by positivity)
+    (.of_forall fun n => isCompletelyMonotoneOnIoi_deriv_mul_exp_neg_mul (by positivity)
       (h _ (by positivity))) fun u _ => ?_
   have hc : Continuous fun y : ℝ => deriv f u * Real.exp (-y * f u) := by fun_prop
   simpa [Function.comp_def] using (hc.tendsto 0).comp tendsto_one_div_add_atTop_nhds_zero_nat
@@ -131,7 +128,7 @@ each `e^{-x f}`, `x > 0`, is completely monotone on `(0, ∞)` and continuous on
 
 Continuity of `f` itself is not part of the right-hand side: it is recovered from continuity of
 one exponential.  Nonnegativity is not: the constant `-1` satisfies every other clause. -/
-theorem isBernsteinFunction_iff_forall_isContinuousCompletelyMonotoneOnIoi_exp_neg_mul :
+theorem isBernsteinFunction_iff_nonneg_and_forall_isContinuousCompletelyMonotoneOnIoi_exp_neg_mul :
     IsBernsteinFunction f ↔
       (∀ t : ℝ, 0 ≤ t → 0 ≤ f t) ∧
         ∀ x : ℝ, 0 < x → IsContinuousCompletelyMonotoneOnIoi fun t => Real.exp (-x * f t) := by

--- a/TauCeti/Analysis/CompletelyMonotone/Bernstein/Exponential.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Bernstein/Exponential.lean
@@ -1,0 +1,144 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.CompletelyMonotone.Composition
+public import TauCeti.Analysis.CompletelyMonotone.Limits
+public import Mathlib.Analysis.SpecialFunctions.Log.Deriv
+
+/-!
+# Bernstein functions are the exponents of completely monotone semigroups
+
+`TauCeti.IsBernsteinFunction.isContinuousCompletelyMonotoneOnIoi_exp_neg_mul` produces, from a
+Bernstein function `f`, the completely monotone functions `t ↦ e^{-x f(t)}` for every `x ≥ 0` —
+the Laplace transforms of the convolution semigroup subordinate to `f`.  This file proves the
+converse, so that the two classes determine each other:
+
+**`f` is a Bernstein function if and only if `f` is nonnegative on `[0, ∞)` and `e^{-x f}` is
+completely monotone for every `x > 0`.**
+
+This is the standard correspondence between the two classes, and the form in which Bernstein
+functions enter probability theory: `e^{-x f}` completely monotone for all `x > 0` says exactly
+that `f` is the Laplace exponent of a subordinator.
+
+Quantifying over *all* `x > 0` is essential, and the proof shows why: differentiating
+`t ↦ e^{-x f(t)}` gives the exact identity
+
+`- x⁻¹ · (e^{-x f})'(t) = f'(t) · e^{-x f(t)}`,
+
+so the left-hand side is completely monotone by
+`TauCeti.IsCompletelyMonotoneOnIoi.neg_deriv`, and letting `x ↓ 0` along `x = 1 / (n + 1)` makes
+the right-hand side converge pointwise to `f'`.  Complete monotonicity survives that limit by
+`TauCeti.isCompletelyMonotoneOnIoi_of_tendsto`, which is the whole content: a single `x` says far
+less, since it constrains only one member of the family.
+
+The remaining hypotheses of `TauCeti.IsBernsteinFunction` are recovered from the exponentials
+rather than assumed: `f = -x⁻¹ log (e^{-x f})` inherits smoothness on `(0, ∞)` from `e^{-x f}`,
+and continuity on `[0, ∞)` as soon as one exponential is continuous there.  Nonnegativity of `f`
+is genuinely independent — the constant `-1` has `e^{x}` for its exponentials, and constants are
+completely monotone.
+
+## Main declarations
+
+* `TauCeti.isCompletelyMonotoneOnIoi_deriv_mul_exp_neg_mul`: for `x > 0`, the function
+  `t ↦ f'(t) · e^{-x f(t)}` is completely monotone on `(0, ∞)` whenever `e^{-x f}` is.
+* `TauCeti.isBernsteinFunction_of_forall_isCompletelyMonotoneOnIoi_exp_neg_mul`: the converse
+  direction, that the family of exponentials forces `f` to be a Bernstein function.
+* `TauCeti.isBernsteinFunction_iff_forall_isContinuousCompletelyMonotoneOnIoi_exp_neg_mul`: the
+  resulting characterization of Bernstein functions.
+
+## References
+
+* R. Schilling, R. Song, Z. Vondraček, *Bernstein Functions: Theory and Applications*
+  (de Gruyter, 2nd ed. 2012), Theorem 3.7.
+-/
+
+public section
+
+open Filter Set
+open scoped ContDiff Topology
+
+namespace TauCeti
+
+variable {f : ℝ → ℝ}
+
+/-- The function is recovered from one of its exponentials as `f = -x⁻¹ log (e^{-x f})`, on the
+nose and not just up to a null set, so any pointwise-stated regularity transfers. -/
+private lemma eq_neg_inv_mul_log_exp {x : ℝ} (hx : x ≠ 0) (t : ℝ) :
+    f t = -x⁻¹ * Real.log (Real.exp (-x * f t)) := by
+  rw [Real.log_exp]
+  field_simp
+
+/-- Smoothness of `f` on `(0, ∞)` is inherited from a single exponential `e^{-x f}`: the
+exponential is positive, so composing with the logarithm stays inside the domain of smoothness of
+`Real.log`. -/
+private lemma contDiffOn_of_contDiffOn_exp_neg_mul {x : ℝ} (hx : x ≠ 0) {s : Set ℝ}
+    (h : ContDiffOn ℝ ∞ (fun t => Real.exp (-x * f t)) s) : ContDiffOn ℝ ∞ f s := by
+  have hlog : ContDiffOn ℝ ∞ (fun t => -x⁻¹ * Real.log (Real.exp (-x * f t))) s :=
+    (h.log fun t _ => (Real.exp_pos _).ne').const_smul (-x⁻¹)
+  exact hlog.congr fun t _ => eq_neg_inv_mul_log_exp hx t
+
+/-- Continuity of `f` on a set is inherited from a single exponential `e^{-x f}`. -/
+private lemma continuousOn_of_continuousOn_exp_neg_mul {x : ℝ} (hx : x ≠ 0) {s : Set ℝ}
+    (h : ContinuousOn (fun t => Real.exp (-x * f t)) s) : ContinuousOn f s := by
+  have hlog : ContinuousOn (fun t => -x⁻¹ * Real.log (Real.exp (-x * f t))) s :=
+    continuousOn_const.mul (h.log fun t _ => (Real.exp_pos _).ne')
+  exact hlog.congr fun t _ => eq_neg_inv_mul_log_exp hx t
+
+/-- The derivative of `f` weighted by an exponential.  If `e^{-x f}` is completely monotone on
+`(0, ∞)` for some `x > 0`, then so is `t ↦ f'(t) · e^{-x f(t)}`, because that function is
+`-x⁻¹` times the derivative of `e^{-x f}`. -/
+theorem isCompletelyMonotoneOnIoi_deriv_mul_exp_neg_mul {x : ℝ} (hx : 0 < x)
+    (h : IsCompletelyMonotoneOnIoi fun t => Real.exp (-x * f t)) :
+    IsCompletelyMonotoneOnIoi fun t => deriv f t * Real.exp (-x * f t) := by
+  have hsmooth : ContDiffOn ℝ ∞ f (Ioi 0) :=
+    contDiffOn_of_contDiffOn_exp_neg_mul hx.ne' h.contDiffOn
+  refine (h.neg_deriv.smul (c := x⁻¹) (by positivity)).congr fun t ht => ?_
+  have hdf : HasDerivAt f (deriv f t) t :=
+    (hsmooth.differentiableOn (by simp)).differentiableAt (isOpen_Ioi.mem_nhds ht) |>.hasDerivAt
+  have hexp : HasDerivAt (fun t => Real.exp (-x * f t))
+      (Real.exp (-x * f t) * (-x * deriv f t)) t := ((hdf.const_mul (-x)).exp)
+  rw [Pi.smul_apply, smul_eq_mul, hexp.deriv]
+  field_simp
+
+/-- **The exponentials of a Bernstein function determine it.**  If `f` is nonnegative on `[0, ∞)`,
+continuous there, and `e^{-x f}` is completely monotone on `(0, ∞)` for every `x > 0`, then `f` is
+a Bernstein function.
+
+This is the converse of
+`TauCeti.IsBernsteinFunction.isContinuousCompletelyMonotoneOnIoi_exp_neg_mul`; smoothness of `f`
+on `(0, ∞)` is not assumed, but deduced from the exponential at `x = 1`. -/
+theorem isBernsteinFunction_of_forall_isCompletelyMonotoneOnIoi_exp_neg_mul
+    (hcont : ContinuousOn f (Ici 0)) (hnonneg : ∀ t : ℝ, 0 ≤ t → 0 ≤ f t)
+    (h : ∀ x : ℝ, 0 < x → IsCompletelyMonotoneOnIoi fun t => Real.exp (-x * f t)) :
+    IsBernsteinFunction f := by
+  have hsmooth : ContDiffOn ℝ ∞ f (Ioi 0) :=
+    contDiffOn_of_contDiffOn_exp_neg_mul one_ne_zero (h 1 one_pos).contDiffOn
+  refine isBernsteinFunction_iff.mpr ⟨hcont, hsmooth, hnonneg, ?_⟩
+  refine isCompletelyMonotoneOnIoi_of_tendsto (L := atTop)
+    (F := fun n : ℕ => fun t => deriv f t * Real.exp (-(1 / ((n : ℝ) + 1)) * f t))
+    (fun n => isCompletelyMonotoneOnIoi_deriv_mul_exp_neg_mul (by positivity)
+      (h _ (by positivity))) fun u _ => ?_
+  have hc : Continuous fun y : ℝ => deriv f u * Real.exp (-y * f u) := by fun_prop
+  simpa [Function.comp_def] using (hc.tendsto 0).comp tendsto_one_div_add_atTop_nhds_zero_nat
+
+/-- **The characterization of Bernstein functions by complete monotonicity of their
+exponentials.**  A function is a Bernstein function exactly when it is nonnegative on `[0, ∞)` and
+each `e^{-x f}`, `x > 0`, is completely monotone on `(0, ∞)` and continuous on `[0, ∞)`.
+
+Continuity of `f` itself is not part of the right-hand side: it is recovered from continuity of
+one exponential.  Nonnegativity is not: the constant `-1` satisfies every other clause. -/
+theorem isBernsteinFunction_iff_forall_isContinuousCompletelyMonotoneOnIoi_exp_neg_mul :
+    IsBernsteinFunction f ↔
+      (∀ t : ℝ, 0 ≤ t → 0 ≤ f t) ∧
+        ∀ x : ℝ, 0 < x → IsContinuousCompletelyMonotoneOnIoi fun t => Real.exp (-x * f t) := by
+  refine ⟨fun hf => ⟨fun t ht => hf.nonneg ht, fun x hx =>
+    hf.isContinuousCompletelyMonotoneOnIoi_exp_neg_mul hx.le⟩, fun ⟨hnonneg, h⟩ => ?_⟩
+  refine isBernsteinFunction_of_forall_isCompletelyMonotoneOnIoi_exp_neg_mul ?_ hnonneg
+    fun x hx => (h x hx).isCompletelyMonotoneOnIoi
+  exact continuousOn_of_continuousOn_exp_neg_mul one_ne_zero (h 1 one_pos).continuousOn
+
+end TauCeti

--- a/TauCeti/Analysis/CompletelyMonotone/Bernstein/Exponential.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Bernstein/Exponential.lean
@@ -7,22 +7,23 @@ module
 
 public import TauCeti.Analysis.CompletelyMonotone.Composition
 public import TauCeti.Analysis.CompletelyMonotone.Limits
-public import Mathlib.Analysis.SpecialFunctions.Log.Deriv
+public import TauCeti.Analysis.SpecialFunctions.ExpRecovery
 
 /-!
 # Bernstein functions are the exponents of completely monotone semigroups
 
 `TauCeti.IsBernsteinFunction.isContinuousCompletelyMonotoneOnIoi_exp_neg_mul` produces, from a
 Bernstein function `f`, the completely monotone functions `t ↦ e^{-x f(t)}` for every `x ≥ 0` —
-the Laplace transforms of the convolution semigroup subordinate to `f`.  This file proves the
-converse, so that the two classes determine each other:
+the Laplace transforms of the subprobability convolution semigroup subordinate to `f`.  This
+file proves the converse, so that the two classes determine each other:
 
 **`f` is a Bernstein function if and only if `f` is nonnegative on `[0, ∞)` and, for every
 `x > 0`, `e^{-x f}` is continuous on `[0, ∞)` and completely monotone on `(0, ∞)`.**
 
 This is the standard correspondence between the two classes, and the form in which Bernstein
 functions enter probability theory: `e^{-x f}` completely monotone for all `x > 0` says exactly
-that `f` is the Laplace exponent of a subordinator.
+that `f` is the Laplace exponent of a possibly killed subordinator, the killing rate being
+`f 0`, which this library allows to be positive.
 
 Quantifying over *all* `x > 0` is essential, and the proof shows why: differentiating
 `t ↦ e^{-x f(t)}` gives the exact identity
@@ -36,10 +37,11 @@ the right-hand side converge pointwise to `f'`.  Complete monotonicity survives 
 less, since it constrains only one member of the family.
 
 The remaining hypotheses of `TauCeti.IsBernsteinFunction` are recovered from the exponentials
-rather than assumed: `f = -x⁻¹ log (e^{-x f})` inherits smoothness on `(0, ∞)` from `e^{-x f}`,
-and continuity on `[0, ∞)` as soon as one exponential is continuous there.  Nonnegativity of `f`
-is genuinely independent — the constant `-1` has `e^{x}` for its exponentials, and constants are
-completely monotone.
+rather than assumed, through `TauCeti.contDiffOn_of_contDiffOn_exp_const_mul`: smoothness of `f`
+on `(0, ∞)` comes from that of `e^{-x f}`, and only right-continuity of `f` at `0` is left to
+hypothesize, the rest of its continuity on `[0, ∞)` following from the smoothness.
+Nonnegativity of `f` is genuinely independent — the constant `-1` has `e^{x}` for its
+exponentials, and constants are completely monotone.
 
 ## Main declarations
 
@@ -65,26 +67,6 @@ namespace TauCeti
 
 variable {f : ℝ → ℝ}
 
-/-- Smoothness of `f` on `(0, ∞)` is inherited from a single exponential `e^{-x f}`: the
-exponential is positive, so composing with the logarithm stays inside the domain of smoothness of
-`Real.log`, and `Real.log_exp` recovers `f` from `e^{-x f}` on the nose. -/
-lemma contDiffOn_of_contDiffOn_exp_neg_mul {x : ℝ} (hx : x ≠ 0) {s : Set ℝ}
-    (h : ContDiffOn ℝ ∞ (fun t => Real.exp (-x * f t)) s) : ContDiffOn ℝ ∞ f s := by
-  have hlog : ContDiffOn ℝ ∞ (fun t => -x⁻¹ * Real.log (Real.exp (-x * f t))) s :=
-    (h.log fun t _ => (Real.exp_pos _).ne').const_smul (-x⁻¹)
-  refine hlog.congr fun t _ => ?_
-  simp only [Real.log_exp]
-  field_simp
-
-/-- Continuity of `f` on a set is inherited from a single exponential `e^{-x f}`. -/
-lemma continuousOn_of_continuousOn_exp_neg_mul {x : ℝ} (hx : x ≠ 0) {s : Set ℝ}
-    (h : ContinuousOn (fun t => Real.exp (-x * f t)) s) : ContinuousOn f s := by
-  have hlog : ContinuousOn (fun t => -x⁻¹ * Real.log (Real.exp (-x * f t))) s :=
-    continuousOn_const.mul (h.log fun t _ => (Real.exp_pos _).ne')
-  refine hlog.congr fun t _ => ?_
-  simp only [Real.log_exp]
-  field_simp
-
 /-- The derivative of `f` weighted by an exponential.  If `e^{-x f}` is completely monotone on
 `(0, ∞)` for some `x > 0`, then so is `t ↦ f'(t) · e^{-x f(t)}`, because that function is
 `-x⁻¹` times the derivative of `e^{-x f}`. -/
@@ -92,7 +74,7 @@ theorem isCompletelyMonotoneOnIoi_deriv_mul_exp_neg_mul {x : ℝ} (hx : 0 < x)
     (h : IsCompletelyMonotoneOnIoi fun t => Real.exp (-x * f t)) :
     IsCompletelyMonotoneOnIoi fun t => deriv f t * Real.exp (-x * f t) := by
   have hsmooth : ContDiffOn ℝ ∞ f (Ioi 0) :=
-    contDiffOn_of_contDiffOn_exp_neg_mul hx.ne' h.contDiffOn
+    contDiffOn_of_contDiffOn_exp_const_mul (neg_ne_zero.mpr hx.ne') h.contDiffOn
   refine (h.neg_deriv.smul (c := x⁻¹) (by positivity)).congr fun t ht => ?_
   have hdf : HasDerivAt f (deriv f t) t :=
     (hsmooth.differentiableOn (by simp)).differentiableAt (isOpen_Ioi.mem_nhds ht) |>.hasDerivAt
@@ -102,18 +84,25 @@ theorem isCompletelyMonotoneOnIoi_deriv_mul_exp_neg_mul {x : ℝ} (hx : 0 < x)
   field_simp
 
 /-- **The exponentials of a Bernstein function determine it.**  If `f` is nonnegative on `[0, ∞)`,
-continuous there, and `e^{-x f}` is completely monotone on `(0, ∞)` for every `x > 0`, then `f` is
-a Bernstein function.
+right-continuous at `0`, and `e^{-x f}` is completely monotone on `(0, ∞)` for every `x > 0`,
+then `f` is a Bernstein function.
 
 This is the converse of
 `TauCeti.IsBernsteinFunction.isContinuousCompletelyMonotoneOnIoi_exp_neg_mul`; smoothness of `f`
-on `(0, ∞)` is not assumed, but deduced from the exponential at `x = 1`. -/
+on `(0, ∞)` is not assumed, but deduced from the exponential at `x = 1`, and with it continuity
+of `f` away from the endpoint. -/
 theorem isBernsteinFunction_of_forall_isCompletelyMonotoneOnIoi_exp_neg_mul
-    (hcont : ContinuousOn f (Ici 0)) (hnonneg : ∀ t : ℝ, 0 ≤ t → 0 ≤ f t)
+    (hzero : ContinuousWithinAt f (Ici 0) 0) (hnonneg : ∀ t : ℝ, 0 ≤ t → 0 ≤ f t)
     (h : ∀ x : ℝ, 0 < x → IsCompletelyMonotoneOnIoi fun t => Real.exp (-x * f t)) :
     IsBernsteinFunction f := by
   have hsmooth : ContDiffOn ℝ ∞ f (Ioi 0) :=
-    contDiffOn_of_contDiffOn_exp_neg_mul one_ne_zero (h 1 one_pos).contDiffOn
+    contDiffOn_of_contDiffOn_exp_const_mul (neg_ne_zero.mpr one_ne_zero) (h 1 one_pos).contDiffOn
+  have hcont : ContinuousOn f (Ici 0) := by
+    intro u hu
+    rcases (mem_Ici.mp hu).lt_or_eq with hupos | hu0
+    · exact (hsmooth.continuousOn.continuousAt
+        (isOpen_Ioi.mem_nhds (mem_Ioi.mpr hupos))).continuousWithinAt
+    · exact hu0 ▸ hzero
   refine isBernsteinFunction_iff.mpr ⟨hcont, hsmooth, hnonneg, ?_⟩
   refine isCompletelyMonotoneOnIoi_of_tendsto (L := atTop)
     (F := fun n : ℕ => fun t => deriv f t * Real.exp (-(1 / ((n : ℝ) + 1)) * f t))
@@ -136,6 +125,7 @@ theorem isBernsteinFunction_iff_nonneg_and_forall_isContinuousCompletelyMonotone
     hf.isContinuousCompletelyMonotoneOnIoi_exp_neg_mul hx.le⟩, fun ⟨hnonneg, h⟩ => ?_⟩
   refine isBernsteinFunction_of_forall_isCompletelyMonotoneOnIoi_exp_neg_mul ?_ hnonneg
     fun x hx => (h x hx).isCompletelyMonotoneOnIoi
-  exact continuousOn_of_continuousOn_exp_neg_mul one_ne_zero (h 1 one_pos).continuousOn
+  exact continuousOn_of_continuousOn_exp_const_mul (neg_ne_zero.mpr one_ne_zero)
+    (h 1 one_pos).continuousOn 0 (mem_Ici.mpr le_rfl)
 
 end TauCeti

--- a/TauCeti/Analysis/CompletelyMonotone/Bernstein/Exponential.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Bernstein/Exponential.lean
@@ -17,8 +17,8 @@ Bernstein function `f`, the completely monotone functions `t ↦ e^{-x f(t)}` fo
 the Laplace transforms of the convolution semigroup subordinate to `f`.  This file proves the
 converse, so that the two classes determine each other:
 
-**`f` is a Bernstein function if and only if `f` is nonnegative on `[0, ∞)` and `e^{-x f}` is
-completely monotone for every `x > 0`.**
+**`f` is a Bernstein function if and only if `f` is nonnegative on `[0, ∞)` and, for every
+`x > 0`, `e^{-x f}` is continuous on `[0, ∞)` and completely monotone on `(0, ∞)`.**
 
 This is the standard correspondence between the two classes, and the form in which Bernstein
 functions enter probability theory: `e^{-x f}` completely monotone for all `x > 0` says exactly
@@ -75,14 +75,14 @@ private lemma eq_neg_inv_mul_log_exp {x : ℝ} (hx : x ≠ 0) (t : ℝ) :
 /-- Smoothness of `f` on `(0, ∞)` is inherited from a single exponential `e^{-x f}`: the
 exponential is positive, so composing with the logarithm stays inside the domain of smoothness of
 `Real.log`. -/
-private lemma contDiffOn_of_contDiffOn_exp_neg_mul {x : ℝ} (hx : x ≠ 0) {s : Set ℝ}
+lemma contDiffOn_of_contDiffOn_exp_neg_mul {x : ℝ} (hx : x ≠ 0) {s : Set ℝ}
     (h : ContDiffOn ℝ ∞ (fun t => Real.exp (-x * f t)) s) : ContDiffOn ℝ ∞ f s := by
   have hlog : ContDiffOn ℝ ∞ (fun t => -x⁻¹ * Real.log (Real.exp (-x * f t))) s :=
     (h.log fun t _ => (Real.exp_pos _).ne').const_smul (-x⁻¹)
   exact hlog.congr fun t _ => eq_neg_inv_mul_log_exp hx t
 
 /-- Continuity of `f` on a set is inherited from a single exponential `e^{-x f}`. -/
-private lemma continuousOn_of_continuousOn_exp_neg_mul {x : ℝ} (hx : x ≠ 0) {s : Set ℝ}
+lemma continuousOn_of_continuousOn_exp_neg_mul {x : ℝ} (hx : x ≠ 0) {s : Set ℝ}
     (h : ContinuousOn (fun t => Real.exp (-x * f t)) s) : ContinuousOn f s := by
   have hlog : ContinuousOn (fun t => -x⁻¹ * Real.log (Real.exp (-x * f t))) s :=
     continuousOn_const.mul (h.log fun t _ => (Real.exp_pos _).ne')

--- a/TauCeti/Analysis/CompletelyMonotone/FiniteDifference/Basic.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/FiniteDifference/Basic.lean
@@ -274,11 +274,11 @@ theorem tendsto_fwdDiffList {ι : Type*} {L : Filter ι} {F : ι → ℝ → ℝ
 finite-difference formulation: the derivative form is not visibly stable under pointwise
 convergence. -/
 theorem isDifferenceCompletelyMonotone_of_tendsto {ι : Type*} {L : Filter ι} [L.NeBot]
-    {F : ι → ℝ → ℝ} (hF : ∀ i, IsDifferenceCompletelyMonotone (F i))
+    {F : ι → ℝ → ℝ} (hF : ∀ᶠ i in L, IsDifferenceCompletelyMonotone (F i))
     (hlim : ∀ u : ℝ, 0 ≤ u → Tendsto (fun i => F i u) L (𝓝 (f u))) :
     IsDifferenceCompletelyMonotone f := fun l hl t ht =>
   ge_of_tendsto (tendsto_const_nhds.mul (tendsto_fwdDiffList hl hlim ht))
-    (Eventually.of_forall fun i => hF i l hl t ht)
+    (hF.mono fun _ hi => hi l hl t ht)
 
 namespace IsDifferenceCompletelyMonotone
 

--- a/TauCeti/Analysis/CompletelyMonotone/FiniteDifference/Laplace.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/FiniteDifference/Laplace.lean
@@ -119,7 +119,7 @@ finite-difference predicate passes to their pointwise limit. -/
 theorem IsContinuousCompletelyMonotoneOnIoi.isDifferenceCompletelyMonotone
     (hf : IsContinuousCompletelyMonotoneOnIoi f) : IsDifferenceCompletelyMonotone f := by
   refine isDifferenceCompletelyMonotone_of_tendsto (L := atTop)
-    (F := fun (n : ℕ) t => f (t + 1 / ((n : ℝ) + 1))) (fun n => ?_) ?_
+    (F := fun (n : ℕ) t => f (t + 1 / ((n : ℝ) + 1))) (.of_forall fun n => ?_) ?_
   · have hshift : 0 < 1 / ((n : ℝ) + 1) := by positivity
     exact IsCompletelyMonotone.isDifferenceCompletelyMonotone
       (hf.isCompletelyMonotoneOnIoi.isCompletelyMonotone_comp_add_const hshift)

--- a/TauCeti/Analysis/CompletelyMonotone/Limits.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Limits.lean
@@ -7,7 +7,6 @@ module
 
 public import TauCeti.Analysis.CompletelyMonotone.FiniteDifference.Laplace
 public import Mathlib.Analysis.Convex.Continuous
-public import Mathlib.Analysis.Convex.Deriv
 
 /-!
 # Pointwise limits of completely monotone functions
@@ -25,7 +24,8 @@ theorem of `TauCeti.Analysis.CompletelyMonotone.FiniteDifference.Laplace`.  That
 the limit to be right-continuous at the left endpoint of the half-line it is stated on, and this
 is where the convexity of a completely monotone function is used: a pointwise limit of convex
 functions is convex, hence continuous on the *open* half-line, so every positive translate of the
-limit is right-continuous at `0`.
+limit is right-continuous at `0`.  That convexity is
+`TauCeti.IsCompletelyMonotoneOnIoi.convexOn`.
 
 The open half-line is not a defect of the proof.  Complete monotonicity on the closed half-line is
 genuinely *not* closed under pointwise limits: the functions `t ↦ (1 + n t)⁻¹` are completely
@@ -36,8 +36,6 @@ too.
 
 ## Main declarations
 
-* `TauCeti.IsCompletelyMonotoneOnIoi.convexOn`: a completely monotone function on `(0, ∞)` is
-  convex there.
 * `TauCeti.isCompletelyMonotoneOnIoi_of_tendsto`: **complete monotonicity on `(0, ∞)` is closed
   under pointwise limits.**
 * `TauCeti.isContinuousCompletelyMonotoneOnIoi_of_tendsto`: the closed-half-line predicate is
@@ -59,21 +57,6 @@ open scoped ContDiff Topology
 namespace TauCeti
 
 variable {f : ℝ → ℝ}
-
-/-- A function completely monotone on `(0, ∞)` is convex there: its second derivative is the
-alternating derivative of order `2`, hence nonnegative. -/
-lemma IsCompletelyMonotoneOnIoi.convexOn (hf : IsCompletelyMonotoneOnIoi f) :
-    ConvexOn ℝ (Ioi 0) f := by
-  have hd : DifferentiableOn ℝ f (Ioi 0) := hf.contDiffOn.differentiableOn (by simp)
-  have hderiv : ContDiffOn ℝ ∞ (deriv f) (Ioi 0) :=
-    hf.contDiffOn.deriv_of_isOpen isOpen_Ioi (by simp)
-  have hd' : DifferentiableOn ℝ (deriv f) (Ioi 0) := hderiv.differentiableOn (by simp)
-  refine convexOn_of_deriv2_nonneg (convex_Ioi 0) hf.contDiffOn.continuousOn ?_ ?_ ?_
-  · rwa [interior_Ioi]
-  · rwa [interior_Ioi]
-  · rw [interior_Ioi]
-    intro x hx
-    simpa [iteratedDeriv_eq_iterate] using hf.neg_one_pow_mul_iteratedDeriv_nonneg 2 hx
 
 /-- **Complete monotonicity on `(0, ∞)` is closed under pointwise limits.**  A pointwise limit of
 functions completely monotone on `(0, ∞)` is completely monotone on `(0, ∞)`; in particular it is

--- a/TauCeti/Analysis/CompletelyMonotone/Limits.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Limits.lean
@@ -1,0 +1,148 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.CompletelyMonotone.FiniteDifference.Laplace
+public import Mathlib.Analysis.Convex.Continuous
+public import Mathlib.Analysis.Convex.Deriv
+
+/-!
+# Pointwise limits of completely monotone functions
+
+Complete monotonicity on `(0, ∞)` is stable under pointwise convergence: no uniformity, no
+equicontinuity, and no smoothness of the limit need be assumed.  This file proves that closure
+property, completing the algebraic ones of
+`TauCeti.Analysis.CompletelyMonotone.OpenClosure`.
+
+The derivative form of the predicate is not visibly stable under pointwise limits — nothing says
+that the derivatives converge — so the proof passes through the finite-difference form
+`TauCeti.IsDifferenceCompletelyMonotone`, which is manifestly stable
+(`TauCeti.isDifferenceCompletelyMonotone_of_tendsto`), and comes back through the representation
+theorem of `TauCeti.Analysis.CompletelyMonotone.FiniteDifference.Laplace`.  That return trip needs
+the limit to be right-continuous at the left endpoint of the half-line it is stated on, and this
+is where the convexity of a completely monotone function is used: a pointwise limit of convex
+functions is convex, hence continuous on the *open* half-line, so every positive translate of the
+limit is right-continuous at `0`.
+
+The open half-line is not a defect of the proof.  Complete monotonicity on the closed half-line is
+genuinely *not* closed under pointwise limits: the functions `t ↦ (1 + n t)⁻¹` are completely
+monotone on `[0, ∞)` and converge pointwise to the indicator of `{0}`, which is not even
+continuous.  What survives at the endpoint is exactly one extra hypothesis, right-continuity at
+`0`, and with it `TauCeti.IsContinuousCompletelyMonotoneOnIoi` is closed under pointwise limits
+too.
+
+## Main declarations
+
+* `TauCeti.IsCompletelyMonotoneOnIoi.convexOn`: a completely monotone function on `(0, ∞)` is
+  convex there.
+* `TauCeti.isCompletelyMonotoneOnIoi_of_forall_comp_add_const`: complete monotonicity on `(0, ∞)`
+  can be checked on positive translates, the converse of
+  `TauCeti.IsCompletelyMonotoneOnIoi.isCompletelyMonotone_comp_add_const`.
+* `TauCeti.isCompletelyMonotoneOnIoi_of_tendsto`: **complete monotonicity on `(0, ∞)` is closed
+  under pointwise limits.**
+* `TauCeti.isContinuousCompletelyMonotoneOnIoi_of_tendsto`: the closed-half-line predicate is
+  closed under pointwise limits of functions completely monotone on `(0, ∞)`, given
+  right-continuity of the limit at `0`.
+
+## References
+
+* R. Schilling, R. Song, Z. Vondraček, *Bernstein Functions: Theory and Applications*
+  (de Gruyter, 2nd ed. 2012), Corollary 1.7.
+* D. V. Widder, *The Laplace Transform* (Princeton, 1941), Chapter IV.
+-/
+
+public section
+
+open Filter Set
+open scoped ContDiff Topology
+
+namespace TauCeti
+
+variable {f : ℝ → ℝ}
+
+/-- A function completely monotone on `(0, ∞)` is convex there: its second derivative is the
+alternating derivative of order `2`, hence nonnegative. -/
+lemma IsCompletelyMonotoneOnIoi.convexOn (hf : IsCompletelyMonotoneOnIoi f) :
+    ConvexOn ℝ (Ioi 0) f := by
+  have hd : DifferentiableOn ℝ f (Ioi 0) := hf.contDiffOn.differentiableOn (by simp)
+  have hderiv : ContDiffOn ℝ ∞ (deriv f) (Ioi 0) :=
+    hf.contDiffOn.deriv_of_isOpen isOpen_Ioi (by simp)
+  have hd' : DifferentiableOn ℝ (deriv f) (Ioi 0) := hderiv.differentiableOn (by simp)
+  refine convexOn_of_deriv2_nonneg (convex_Ioi 0) hf.contDiffOn.continuousOn ?_ ?_ ?_
+  · rwa [interior_Ioi]
+  · rwa [interior_Ioi]
+  · rw [interior_Ioi]
+    intro x hx
+    simpa [iteratedDeriv_eq_iterate] using hf.neg_one_pow_mul_iteratedDeriv_nonneg 2 hx
+
+/-- Complete monotonicity on `(0, ∞)` is detected by the positive translates of a function: if
+`t ↦ f (t + a)` is completely monotone on `(0, ∞)` for every `a > 0`, then so is `f`.  This is the
+converse of `TauCeti.IsCompletelyMonotoneOnIoi.isCompletelyMonotone_comp_add_const`, and it is how
+a statement proved after moving the boundary into the open half-line is transported back. -/
+theorem isCompletelyMonotoneOnIoi_of_forall_comp_add_const
+    (h : ∀ a : ℝ, 0 < a → IsCompletelyMonotoneOnIoi fun s => f (s + a)) :
+    IsCompletelyMonotoneOnIoi f := by
+  have hsmooth : ContDiffOn ℝ ∞ f (Ioi 0) := by
+    intro u hu
+    have ha : (0 : ℝ) < u / 2 := by linarith [mem_Ioi.mp hu]
+    have hshift : ContDiffAt ℝ ∞ (fun s : ℝ => f (s + u / 2)) ((fun s : ℝ => s - u / 2) u) := by
+      have := ((h (u / 2) ha).contDiffOn).contDiffAt (isOpen_Ioi.mem_nhds (mem_Ioi.mpr ha))
+      simpa [show u - u / 2 = u / 2 by ring] using this
+    have hcomp := hshift.comp u (by fun_prop : ContDiffAt ℝ ∞ (fun s : ℝ => s - u / 2) u)
+    exact (by simpa [Function.comp_def] using hcomp : ContDiffAt ℝ ∞ f u).contDiffWithinAt
+  refine ⟨hsmooth, fun n u hu => ?_⟩
+  have ha : (0 : ℝ) < u / 2 := by linarith
+  have hsign := (h (u / 2) ha).neg_one_pow_mul_iteratedDeriv_nonneg n ha
+  rw [iteratedDeriv_comp_add_const] at hsign
+  simpa [show u / 2 + u / 2 = u by ring] using hsign
+
+/-- **Complete monotonicity on `(0, ∞)` is closed under pointwise limits.**  A pointwise limit of
+functions completely monotone on `(0, ∞)` is completely monotone on `(0, ∞)`; in particular it is
+automatically `C^∞` there.
+
+Nothing is assumed about the limit, and no uniformity is assumed about the convergence.  The
+closed half-line version is false, see the module docstring, and
+`TauCeti.isContinuousCompletelyMonotoneOnIoi_of_tendsto` for what replaces it. -/
+theorem isCompletelyMonotoneOnIoi_of_tendsto {ι : Type*} {L : Filter ι} [L.NeBot]
+    {F : ι → ℝ → ℝ} (hF : ∀ i, IsCompletelyMonotoneOnIoi (F i))
+    (hlim : ∀ u : ℝ, 0 < u → Tendsto (fun i => F i u) L (𝓝 (f u))) :
+    IsCompletelyMonotoneOnIoi f := by
+  have hconv : ConvexOn ℝ (Ioi 0) f := by
+    refine ⟨convex_Ioi 0, fun x hx y hy a b ha hb hab => ?_⟩
+    have hmem : a • x + b • y ∈ Ioi (0 : ℝ) := convex_Ioi 0 hx hy ha hb hab
+    refine le_of_tendsto_of_tendsto' (hlim _ hmem)
+      (((hlim x hx).const_smul a).add ((hlim y hy).const_smul b)) fun i => ?_
+    exact (hF i).convexOn.2 hx hy ha hb hab
+  have hcont : ContinuousOn f (Ioi 0) := hconv.continuousOn isOpen_Ioi
+  refine isCompletelyMonotoneOnIoi_of_forall_comp_add_const fun a ha => ?_
+  have hdiff : IsDifferenceCompletelyMonotone fun s => f (s + a) :=
+    isDifferenceCompletelyMonotone_of_tendsto
+      (fun i => ((hF i).isCompletelyMonotone_comp_add_const ha).isDifferenceCompletelyMonotone)
+      fun u hu => hlim (u + a) (by linarith)
+  have hzero : ContinuousWithinAt (fun s => f (s + a)) (Ici 0) 0 := by
+    have hfa : ContinuousAt f a := hcont.continuousAt (isOpen_Ioi.mem_nhds (mem_Ioi.mpr ha))
+    have hcomp : ContinuousAt (f ∘ fun s : ℝ => s + a) 0 :=
+      hfa.comp_of_eq (by fun_prop) (zero_add a)
+    simpa [Function.comp_def] using hcomp.continuousWithinAt (s := Ici 0)
+  exact (hdiff.isContinuousCompletelyMonotoneOnIoi hzero).isCompletelyMonotoneOnIoi
+
+/-- Complete monotonicity in the closed-half-line sense of
+`TauCeti.IsContinuousCompletelyMonotoneOnIoi` is closed under pointwise limits on `(0, ∞)`, once
+the limit is known to be right-continuous at the endpoint.  That extra hypothesis cannot be
+dropped: see the module docstring. -/
+theorem isContinuousCompletelyMonotoneOnIoi_of_tendsto {ι : Type*} {L : Filter ι} [L.NeBot]
+    {F : ι → ℝ → ℝ} (hF : ∀ i, IsCompletelyMonotoneOnIoi (F i))
+    (hlim : ∀ u : ℝ, 0 < u → Tendsto (fun i => F i u) L (𝓝 (f u)))
+    (hzero : ContinuousWithinAt f (Ici 0) 0) :
+    IsContinuousCompletelyMonotoneOnIoi f := by
+  have hcm : IsCompletelyMonotoneOnIoi f := isCompletelyMonotoneOnIoi_of_tendsto hF hlim
+  refine isContinuousCompletelyMonotoneOnIoi_iff.mpr ⟨fun u hu => ?_, hcm⟩
+  rcases (mem_Ici.mp hu).lt_or_eq with h | h
+  · exact (hcm.contDiffOn.continuousOn.continuousAt
+      (isOpen_Ioi.mem_nhds (mem_Ioi.mpr h))).continuousWithinAt
+  · exact h ▸ hzero
+
+end TauCeti

--- a/TauCeti/Analysis/CompletelyMonotone/Limits.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Limits.lean
@@ -38,9 +38,6 @@ too.
 
 * `TauCeti.IsCompletelyMonotoneOnIoi.convexOn`: a completely monotone function on `(0, ∞)` is
   convex there.
-* `TauCeti.isCompletelyMonotoneOnIoi_of_forall_comp_add_const`: complete monotonicity on `(0, ∞)`
-  can be checked on positive translates, the converse of
-  `TauCeti.IsCompletelyMonotoneOnIoi.isCompletelyMonotone_comp_add_const`.
 * `TauCeti.isCompletelyMonotoneOnIoi_of_tendsto`: **complete monotonicity on `(0, ∞)` is closed
   under pointwise limits.**
 * `TauCeti.isContinuousCompletelyMonotoneOnIoi_of_tendsto`: the closed-half-line predicate is
@@ -77,27 +74,6 @@ lemma IsCompletelyMonotoneOnIoi.convexOn (hf : IsCompletelyMonotoneOnIoi f) :
   · rw [interior_Ioi]
     intro x hx
     simpa [iteratedDeriv_eq_iterate] using hf.neg_one_pow_mul_iteratedDeriv_nonneg 2 hx
-
-/-- Complete monotonicity on `(0, ∞)` is detected by the positive translates of a function: if
-`t ↦ f (t + a)` is completely monotone on `(0, ∞)` for every `a > 0`, then so is `f`.  This is the
-converse of `TauCeti.IsCompletelyMonotoneOnIoi.isCompletelyMonotone_comp_add_const`, and it is how
-a statement proved after moving the boundary into the open half-line is transported back. -/
-theorem isCompletelyMonotoneOnIoi_of_forall_comp_add_const
-    (h : ∀ a : ℝ, 0 < a → IsCompletelyMonotoneOnIoi fun s => f (s + a)) :
-    IsCompletelyMonotoneOnIoi f := by
-  have hsmooth : ContDiffOn ℝ ∞ f (Ioi 0) := by
-    intro u hu
-    have ha : (0 : ℝ) < u / 2 := by linarith [mem_Ioi.mp hu]
-    have hshift : ContDiffAt ℝ ∞ (fun s : ℝ => f (s + u / 2)) ((fun s : ℝ => s - u / 2) u) := by
-      have := ((h (u / 2) ha).contDiffOn).contDiffAt (isOpen_Ioi.mem_nhds (mem_Ioi.mpr ha))
-      simpa [show u - u / 2 = u / 2 by ring] using this
-    have hcomp := hshift.comp u (by fun_prop : ContDiffAt ℝ ∞ (fun s : ℝ => s - u / 2) u)
-    exact (by simpa [Function.comp_def] using hcomp : ContDiffAt ℝ ∞ f u).contDiffWithinAt
-  refine ⟨hsmooth, fun n u hu => ?_⟩
-  have ha : (0 : ℝ) < u / 2 := by linarith
-  have hsign := (h (u / 2) ha).neg_one_pow_mul_iteratedDeriv_nonneg n ha
-  rw [iteratedDeriv_comp_add_const] at hsign
-  simpa [show u / 2 + u / 2 = u by ring] using hsign
 
 /-- **Complete monotonicity on `(0, ∞)` is closed under pointwise limits.**  A pointwise limit of
 functions completely monotone on `(0, ∞)` is completely monotone on `(0, ∞)`; in particular it is

--- a/TauCeti/Analysis/CompletelyMonotone/Limits.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Limits.lean
@@ -107,20 +107,21 @@ Nothing is assumed about the limit, and no uniformity is assumed about the conve
 closed half-line version is false, see the module docstring, and
 `TauCeti.isContinuousCompletelyMonotoneOnIoi_of_tendsto` for what replaces it. -/
 theorem isCompletelyMonotoneOnIoi_of_tendsto {ι : Type*} {L : Filter ι} [L.NeBot]
-    {F : ι → ℝ → ℝ} (hF : ∀ i, IsCompletelyMonotoneOnIoi (F i))
+    {F : ι → ℝ → ℝ} (hF : ∀ᶠ i in L, IsCompletelyMonotoneOnIoi (F i))
     (hlim : ∀ u : ℝ, 0 < u → Tendsto (fun i => F i u) L (𝓝 (f u))) :
     IsCompletelyMonotoneOnIoi f := by
   have hconv : ConvexOn ℝ (Ioi 0) f := by
     refine ⟨convex_Ioi 0, fun x hx y hy a b ha hb hab => ?_⟩
     have hmem : a • x + b • y ∈ Ioi (0 : ℝ) := convex_Ioi 0 hx hy ha hb hab
-    refine le_of_tendsto_of_tendsto' (hlim _ hmem)
-      (((hlim x hx).const_smul a).add ((hlim y hy).const_smul b)) fun i => ?_
-    exact (hF i).convexOn.2 hx hy ha hb hab
+    refine le_of_tendsto_of_tendsto (hlim _ hmem)
+      (((hlim x hx).const_smul a).add ((hlim y hy).const_smul b)) (hF.mono fun i hi => ?_)
+    exact hi.convexOn.2 hx hy ha hb hab
   have hcont : ContinuousOn f (Ioi 0) := hconv.continuousOn isOpen_Ioi
   refine isCompletelyMonotoneOnIoi_of_forall_comp_add_const fun a ha => ?_
   have hdiff : IsDifferenceCompletelyMonotone fun s => f (s + a) :=
     isDifferenceCompletelyMonotone_of_tendsto
-      (fun i => ((hF i).isCompletelyMonotone_comp_add_const ha).isDifferenceCompletelyMonotone)
+      (hF.mono fun i hi =>
+        (hi.isCompletelyMonotone_comp_add_const ha).isDifferenceCompletelyMonotone)
       fun u hu => hlim (u + a) (by linarith)
   have hzero : ContinuousWithinAt (fun s => f (s + a)) (Ici 0) 0 := by
     have hfa : ContinuousAt f a := hcont.continuousAt (isOpen_Ioi.mem_nhds (mem_Ioi.mpr ha))
@@ -134,7 +135,7 @@ theorem isCompletelyMonotoneOnIoi_of_tendsto {ι : Type*} {L : Filter ι} [L.NeB
 the limit is known to be right-continuous at the endpoint.  That extra hypothesis cannot be
 dropped: see the module docstring. -/
 theorem isContinuousCompletelyMonotoneOnIoi_of_tendsto {ι : Type*} {L : Filter ι} [L.NeBot]
-    {F : ι → ℝ → ℝ} (hF : ∀ i, IsCompletelyMonotoneOnIoi (F i))
+    {F : ι → ℝ → ℝ} (hF : ∀ᶠ i in L, IsCompletelyMonotoneOnIoi (F i))
     (hlim : ∀ u : ℝ, 0 < u → Tendsto (fun i => F i u) L (𝓝 (f u)))
     (hzero : ContinuousWithinAt f (Ici 0) 0) :
     IsContinuousCompletelyMonotoneOnIoi f := by

--- a/TauCeti/Analysis/SpecialFunctions/ExpRecovery.lean
+++ b/TauCeti/Analysis/SpecialFunctions/ExpRecovery.lean
@@ -1,0 +1,52 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.SpecialFunctions.Log.Deriv
+
+/-!
+# Recovering a function from one of its exponentials
+
+`Real.exp` is a smooth bijection onto `(0, ∞)` whose inverse `Real.log` is smooth there, so a
+real-valued function `g` is exactly as regular as any single exponential `t ↦ e^{c g(t)}` built
+from it with `c ≠ 0`.  Mathlib supplies the easy direction (`ContDiffOn.exp`, `Continuous.exp`);
+this file records the converse, which recovers `g` as `c⁻¹ log (e^{c g})`.
+
+## Main declarations
+
+* `TauCeti.contDiffOn_of_contDiffOn_exp_const_mul`: smoothness of `g` on a set follows from
+  smoothness of `t ↦ e^{c g(t)}` there, for a single `c ≠ 0`.
+* `TauCeti.continuousOn_of_continuousOn_exp_const_mul`: the same for continuity.
+-/
+
+public section
+
+namespace TauCeti
+
+/-- A real-valued function is smooth on a set as soon as one of its exponentials
+`t ↦ e^{c g(t)}`, `c ≠ 0`, is: the exponential is positive, so composing with `Real.log` stays
+inside the domain of smoothness of the logarithm, and `Real.log_exp` recovers `g` on the nose. -/
+theorem contDiffOn_of_contDiffOn_exp_const_mul {E : Type*} [NormedAddCommGroup E]
+    [NormedSpace ℝ E] {n : WithTop ℕ∞} {c : ℝ} (hc : c ≠ 0) {g : E → ℝ} {s : Set E}
+    (h : ContDiffOn ℝ n (fun t => Real.exp (c * g t)) s) : ContDiffOn ℝ n g s := by
+  have hlog : ContDiffOn ℝ n (fun t => c⁻¹ * Real.log (Real.exp (c * g t))) s :=
+    (h.log fun t _ => (Real.exp_pos _).ne').const_smul c⁻¹
+  refine hlog.congr fun t _ => ?_
+  simp only [Real.log_exp]
+  field_simp
+
+/-- A real-valued function is continuous on a set as soon as one of its exponentials
+`t ↦ e^{c g(t)}`, `c ≠ 0`, is. -/
+theorem continuousOn_of_continuousOn_exp_const_mul {α : Type*} [TopologicalSpace α] {c : ℝ}
+    (hc : c ≠ 0) {g : α → ℝ} {s : Set α}
+    (h : ContinuousOn (fun t => Real.exp (c * g t)) s) : ContinuousOn g s := by
+  have hlog : ContinuousOn (fun t => c⁻¹ * Real.log (Real.exp (c * g t))) s :=
+    continuousOn_const.mul (h.log fun t _ => (Real.exp_pos _).ne')
+  refine hlog.congr fun t _ => ?_
+  simp only [Real.log_exp]
+  field_simp
+
+end TauCeti


### PR DESCRIPTION
This PR characterizes Bernstein functions by the complete monotonicity of their exponentials, and supplies the pointwise-limit closure property the proof needs. `TauCeti.IsBernsteinFunction.isContinuousCompletelyMonotoneOnIoi_exp_neg_mul` already sends a Bernstein function `f` to the completely monotone functions `t ↦ e^{-x f(t)}`; the converse direction, `TauCeti.isBernsteinFunction_of_forall_isCompletelyMonotoneOnIoi_exp_neg_mul`, is new here, and `TauCeti.isBernsteinFunction_iff_nonneg_and_forall_isContinuousCompletelyMonotoneOnIoi_exp_neg_mul` turns the pair into an equivalence: `f` is a Bernstein function exactly when it is nonnegative on `[0, ∞)` and every `e^{-x f}`, `x > 0`, is continuous on `[0, ∞)` and completely monotone on `(0, ∞)`. Neither continuity nor smoothness of `f` is assumed — both are recovered from a single exponential through `f = -x⁻¹ log (e^{-x f})` — while nonnegativity is genuinely independent, since the constant `-1` has the completely monotone constants `e^{x}` for its exponentials.

The target is `OneParameterSemigroups/README.md`, Part B, in its "API to develop" list: the closure clause "completely monotone functions are closed under sums, nonnegative scalar multiples, products, and pointwise limits", and "the Stieltjes / Bernstein-function relationships (completely monotone ↔ Bernstein via the standard correspondences)". Sums, scalar multiples and products are on `main`; pointwise limits were the one missing closure property, and the exponential characterization (Schilling–Song–Vondraček, Theorem 3.7) is the standard correspondence carrying complete monotonicity back to the Bernstein class. The milestone these serve is Part B's Bernstein-function theory around Bernstein's theorem; what remains of Part B after this PR is the Stieltjes side, where the transforms currently run only from a Stieltjes representation outwards.

`TauCeti.isCompletelyMonotoneOnIoi_of_tendsto` states that a pointwise limit of functions completely monotone on `(0, ∞)` is completely monotone there, with no uniformity and no regularity assumed of the limit. The derivative form of the predicate is not visibly stable under such limits, so the proof routes through the finite-difference form already in the repository — `TauCeti.isDifferenceCompletelyMonotone_of_tendsto` is manifestly stable — and returns through `TauCeti.IsDifferenceCompletelyMonotone.isContinuousCompletelyMonotoneOnIoi`. That return trip needs right-continuity of the limit at the endpoint of the half-line it is stated on, which is where the new `TauCeti.IsCompletelyMonotoneOnIoi.convexOn` is used: convexity passes to pointwise limits and gives continuity on the open half-line, so every positive translate is right-continuous at `0`. Translating back is `TauCeti.isCompletelyMonotoneOnIoi_of_forall_comp_add_const`, the converse of the existing `TauCeti.IsCompletelyMonotoneOnIoi.isCompletelyMonotone_comp_add_const`. The closed-half-line predicate is not closed under pointwise limits — `t ↦ (1 + n t)⁻¹` converges to the indicator of `{0}` — so `TauCeti.isContinuousCompletelyMonotoneOnIoi_of_tendsto` carries the one extra hypothesis that survives.

The exponential converse then needs only an exact identity rather than any interchange of limits: differentiating gives `-x⁻¹ · (e^{-x f})'(t) = f'(t) · e^{-x f(t)}`, whose left-hand side is completely monotone by `TauCeti.IsCompletelyMonotoneOnIoi.neg_deriv`, and letting `x ↓ 0` along `x = 1/(n+1)` makes the right-hand side converge pointwise to `f'`. Quantifying over all `x > 0` is what makes this work; one exponential constrains a single member of the family and does not suffice.

Three files are added: `TauCeti/Analysis/CompletelyMonotone/Limits.lean`, `TauCeti/Analysis/CompletelyMonotone/Bernstein/Exponential.lean`, and `TauCeti/Analysis/SpecialFunctions/ExpRecovery.lean`, the last holding the two general regularity transfers `TauCeti.contDiffOn_of_contDiffOn_exp_const_mul` and `TauCeti.continuousOn_of_continuousOn_exp_const_mul`, which recover a function from a single exponential and mention neither complete monotonicity nor Bernstein functions. `TauCeti.isCompletelyMonotoneOnIoi_of_forall_comp_add_const` lives in the existing `TauCeti/Analysis/CompletelyMonotone/Basic.lean`, beside the translation lemma it converses. No Mathlib code is vendored; the argument follows Schilling–Song–Vondraček, *Bernstein Functions: Theory and Applications*, 2nd ed., Corollary 1.7 and Theorem 3.7, cited in the module documentation.

Roadmap: OneParameterSemigroups

<!--tauceti-target:v1 {"focus":"OneParameterSemigroups","id":"bernstein-iff-exp-neg-completely-monotone"}-->

🤖 Prepared with Claude Code

