### PR TITLE
refactor(RingTheory): state the rename-associativity transport with pairSubstitution

### DIFF
--- a/TauCeti/RingTheory/MvPowerSeries/Rename.lean
+++ b/TauCeti/RingTheory/MvPowerSeries/Rename.lean
@@ -8,7 +8,7 @@ module
 public import TauCeti.Data.Fin.Sum
 public import Mathlib.RingTheory.MvPowerSeries.Rename
 public import Mathlib.RingTheory.MvPowerSeries.Substitution
-import TauCeti.RingTheory.MvPowerSeries.Substitution
+public import TauCeti.RingTheory.MvPowerSeries.Substitution
 
 /-!
 # Renaming the variables of a multivariate power series
@@ -28,9 +28,9 @@ likewise available only through `coeff_embDomain_rename`, which speaks about `Fi
 at one variable raised to an arbitrary power the `single (e i) n` spelling is the more usable one.
 
 Associativity is where the two spellings of a two-variable series genuinely diverge: the named
-form substitutes an already-substituted series through `Sum.elim`, the `Fin 2` form through a
-`Matrix.cons` family over `Fin 3`. Transporting the identity therefore means reindexing the
-three-variable ambient ring as well, along `unitSumUnitSumUnitEquivFinThree`.
+form substitutes an already-substituted series through `pairSubstitution`, the `Fin 2` form
+through a `Matrix.cons` family over `Fin 3`. Transporting the identity therefore means
+reindexing the three-variable ambient ring as well, along `unitSumUnitSumUnitEquivFinThree`.
 
 ## Main results
 
@@ -82,13 +82,12 @@ private theorem rename_unitSumUnitEquivFinTwo_assoc_left_family
     (![subst (![X 0, X 1] ∘ unitSumUnitEquivFinTwo) p, X 2] ∘
         unitSumUnitEquivFinTwo) =
       (fun s ↦ subst (X (R := R) ∘ unitSumUnitSumUnitEquivFinThree)
-        (Sum.elim (fun _ ↦ subst
-            (Sum.elim (fun _ ↦ (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R))
-              (fun _ ↦ X (Sum.inr (Sum.inl ())))) p)
-          (fun _ ↦ X (Sum.inr (Sum.inr ()))) s)) := by
+        (pairSubstitution (subst
+            (pairSubstitution (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R)
+              (X (Sum.inr (Sum.inl ())))) p) (X (Sum.inr (Sum.inr ()))) s)) := by
   have h₀₁ : HasSubst
-      (Sum.elim (fun _ ↦ (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R))
-        (fun _ ↦ X (Sum.inr (Sum.inl ())))) := hasSubst_pair (by simp) (by simp)
+      (pairSubstitution (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R)
+        (X (Sum.inr (Sum.inl ())))) := hasSubst_pair (by simp) (by simp)
   have hrename : HasSubst
       (X (R := R) ∘ unitSumUnitSumUnitEquivFinThree) := HasSubst.X_comp _
   funext s
@@ -108,13 +107,11 @@ private theorem rename_unitSumUnitEquivFinTwo_assoc_right_family
     (![X 0, subst (![X 1, X 2] ∘ unitSumUnitEquivFinTwo) p] ∘
         unitSumUnitEquivFinTwo) =
       (fun s ↦ subst (X (R := R) ∘ unitSumUnitSumUnitEquivFinThree)
-        (Sum.elim (fun _ ↦ (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R))
-          (fun _ ↦ subst
-            (Sum.elim (fun _ ↦ X (Sum.inr (Sum.inl ())))
-              (fun _ ↦ X (Sum.inr (Sum.inr ())))) p) s)) := by
+        (pairSubstitution (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R) (subst
+            (pairSubstitution (X (Sum.inr (Sum.inl ()))) (X (Sum.inr (Sum.inr ())))) p) s)) := by
   have h₁₂ : HasSubst
-      (Sum.elim (fun _ ↦ (X (Sum.inr (Sum.inl ())) :
-        MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R)) (fun _ ↦ X (Sum.inr (Sum.inr ())))) :=
+      (pairSubstitution (X (Sum.inr (Sum.inl ())) :
+        MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R) (X (Sum.inr (Sum.inr ())))) :=
     hasSubst_pair (by simp) (by simp)
   have hrename : HasSubst
       (X (R := R) ∘ unitSumUnitSumUnitEquivFinThree) := HasSubst.X_comp _
@@ -151,16 +148,13 @@ the target is exactly the identity expected by `FormalGroup.assoc`. -/
 theorem rename_unitSumUnitEquivFinTwo_assoc (p : MvPowerSeries (Unit ⊕ Unit) R)
     (hp : constantCoeff p = 0)
     (hassoc :
-      subst (Sum.elim
-          (fun _ ↦ subst (Sum.elim
-              (fun _ ↦ (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R))
-              (fun _ ↦ X (Sum.inr (Sum.inl ())))) p)
-          (fun _ ↦ X (Sum.inr (Sum.inr ())))) p =
-        subst (Sum.elim
-          (fun _ ↦ (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R))
-          (fun _ ↦ subst
-            (Sum.elim (fun _ ↦ X (Sum.inr (Sum.inl ())))
-              (fun _ ↦ X (Sum.inr (Sum.inr ())))) p)) p) :
+      subst (pairSubstitution
+          (subst (pairSubstitution (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R)
+            (X (Sum.inr (Sum.inl ())))) p)
+          (X (Sum.inr (Sum.inr ())))) p =
+        subst (pairSubstitution (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R)
+          (subst (pairSubstitution (X (Sum.inr (Sum.inl ())))
+            (X (Sum.inr (Sum.inr ())))) p)) p) :
     subst ![subst ![(X 0 : MvPowerSeries (Fin 3) R), X 1]
         (rename unitSumUnitEquivFinTwo p), X 2]
         (rename unitSumUnitEquivFinTwo p) =
@@ -175,30 +169,29 @@ theorem rename_unitSumUnitEquivFinTwo_assoc (p : MvPowerSeries (Unit ⊕ Unit) R
   rw [subst_rename unitSumUnitEquivFinTwo _ HasSubst.X_X,
     subst_rename unitSumUnitEquivFinTwo _ HasSubst.X_X]
   have h₀₁ : HasSubst
-      (Sum.elim (fun _ ↦ (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R))
-        (fun _ ↦ X (Sum.inr (Sum.inl ())))) := hasSubst_pair (by simp) (by simp)
+      (pairSubstitution (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R)
+        (X (Sum.inr (Sum.inl ())))) := hasSubst_pair (by simp) (by simp)
   have h₁₂ : HasSubst
-      (Sum.elim (fun _ ↦ (X (Sum.inr (Sum.inl ())) :
-        MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R)) (fun _ ↦ X (Sum.inr (Sum.inr ())))) :=
+      (pairSubstitution (X (Sum.inr (Sum.inl ())) :
+        MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R) (X (Sum.inr (Sum.inr ())))) :=
     hasSubst_pair (by simp) (by simp)
   have hz₀₁ : constantCoeff (subst
-      (Sum.elim (fun _ ↦ (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R))
-        (fun _ ↦ X (Sum.inr (Sum.inl ())))) p) = 0 :=
+      (pairSubstitution (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R)
+        (X (Sum.inr (Sum.inl ())))) p) = 0 :=
     constantCoeff_subst_eq_zero h₀₁ (by rintro (u | u) <;> simp) hp
   have hz₁₂ : constantCoeff (subst
-      (Sum.elim (fun _ ↦ (X (Sum.inr (Sum.inl ())) :
-        MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R)) (fun _ ↦ X (Sum.inr (Sum.inr ())))) p) = 0 :=
+      (pairSubstitution (X (Sum.inr (Sum.inl ())) :
+        MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R) (X (Sum.inr (Sum.inr ())))) p) = 0 :=
     constantCoeff_subst_eq_zero h₁₂ (by rintro (u | u) <;> simp) hp
   have hsourceLeft : HasSubst
-      (Sum.elim (fun _ ↦ subst
-          (Sum.elim (fun _ ↦ (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R))
-            (fun _ ↦ X (Sum.inr (Sum.inl ())))) p)
-        (fun _ ↦ X (Sum.inr (Sum.inr ())))) := hasSubst_pair hz₀₁ (by simp)
+      (pairSubstitution (subst
+          (pairSubstitution (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R)
+            (X (Sum.inr (Sum.inl ())))) p) (X (Sum.inr (Sum.inr ())))) :=
+              hasSubst_pair hz₀₁ (by simp)
   have hsourceRight : HasSubst
-      (Sum.elim (fun _ ↦ (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R))
-        (fun _ ↦ subst
-          (Sum.elim (fun _ ↦ X (Sum.inr (Sum.inl ())))
-            (fun _ ↦ X (Sum.inr (Sum.inr ())))) p)) := hasSubst_pair (by simp) hz₁₂
+      (pairSubstitution (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R) (subst
+          (pairSubstitution (X (Sum.inr (Sum.inl ()))) (X (Sum.inr (Sum.inr ())))) p)) :=
+            hasSubst_pair (by simp) hz₁₂
   have hrename : HasSubst
       (X (R := R) ∘ unitSumUnitSumUnitEquivFinThree) := HasSubst.X_comp _
   have h := congrArg (rename unitSumUnitSumUnitEquivFinThree) hassoc


### PR DESCRIPTION
`pairSubstitution` (#6172) names the two-variable substitution family indexed by `Unit ⊕ Unit`.
`Rename.lean` was not migrated with the rest and still spelled it out in full at all **18** sites:
the two private index-family helpers, and the `hassoc` hypothesis of the public
`rename_unitSumUnitEquivFinTwo_assoc`.

```lean
-- before
Sum.elim (fun _ ↦ (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R))
  (fun _ ↦ X (Sum.inr (Sum.inl ())))

-- after
pairSubstitution (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R)
  (X (Sum.inr (Sum.inl ())))
```

**One import becomes public, and that is the substantive part of the diff.**
`rename_unitSumUnitEquivFinTwo_assoc` is public and its hypothesis now mentions
`pairSubstitution`, which lives in `TauCeti/RingTheory/MvPowerSeries/Substitution.lean` — imported
here plainly. A plain-imported declaration cannot appear in a public statement, so without this
the module fails to elaborate. The public statement genuinely exposes `pairSubstitution`, so the
public import is the correct form rather than a way around the error.

**Two `Sum.elim` references are deliberately kept**, both as `simp` arguments:
`Sum.elim_inl` and `Sum.elim_inr`. Those are the family's *characteristic equations* — the API
`pairSubstitution` is evaluated through, since it deliberately carries no projection lemmas of its
own — not a spelling of the family. Keeping them is the point of that design, not an oversight.

The module docstring said the named form "substitutes an already-substituted series through
`Sum.elim`"; it now says `pairSubstitution`, so the prose still describes the code.

**Measured.** File 250 → 243 lines (35 insertions, 42 deletions). No proof changes behaviour:
`rename_unitSumUnitEquivFinTwo_assoc`'s body goes 61 → 60 lines, so the one over-convention proof
in this file is pre-existing and marginally shorter here, not longer. `lake build` is green on the
module and on its full reverse-dependency closure — `PairEval`, `Basic`, `Add/Unit` and
`Add/Fin2`, the last of which consumes the public theorem whose statement changed.

Roadmap: none

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"EllipticCurves/README.md:Layer-6-formal-group:rename-pairsubstitution"}-->

Provenance: no port and no new declaration — this restates existing declarations using
`pairSubstitution`, which was added to `TauCeti/RingTheory/MvPowerSeries/Substitution.lean` by
#6172. Swept Michael Stoll's `EllipticCurves`
(`github.com/MichaelStollBayreuth/EllipticCurves`, Apache-2.0) @
`66889eada51a74c2f5dfb7fb5909b0b5a0a2d96e` for the thing this PR is about — a pair-substitution
family abbreviation — and it has none: the `Unit ⊕ Unit`-indexed declarations there are series
(`slopeSeries`, `interceptSeries`, `thirdRootSeries`, `addSeries`), and `GroupLaw.lean` writes the
`Sum.elim` pair spelling inline 52 times. So there is nothing upstream this restatement could have
been taken from.

That source does carry its own `rename` lemmas (`decay_rename`, `coeff_rename_equiv`,
`rename_pderiv`, `subst_pair_rename`, `coeff_rename_single`), so it is not true that it lacks a
reindexing layer; what it lacks is a counterpart to *this* module's results — no `subst_rename`
and no rename-associativity transport.
