### PR TITLE
feat: compute the symplectic diagonal torus centralizer

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Symplectic/DiagonalTorus/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Symplectic/DiagonalTorus/Basic.lean
@@ -8,7 +8,7 @@ module
 public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Weight.Torus
 public import TauCeti.Algebra.AlgebraicGroup.Symplectic.BaseChange
 public import TauCeti.Algebra.AlgebraicGroup.Symplectic.RootSubgroup
-public import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Symplectic.Diagonal
+public import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Symplectic.Diagonal.Basic
 
 /-!
 # The diagonal torus of the symplectic group scheme

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic/Diagonal/Basic.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic/Diagonal/Basic.lean
@@ -147,6 +147,28 @@ theorem mem_diagonalTorus_iff_exists_diagonal {g : GLSymplecticFin m R} :
 instance instIsMulCommutativeDiagonalTorus : IsMulCommutative (diagonalTorus R m) :=
   inferInstanceAs (IsMulCommutative (diagonal (m := m) (R := R)).range)
 
+/-- The paired diagonal torus is the group of coordinatewise units. -/
+noncomputable def diagonalTorusEquiv (R : Type u) [CommRing R] (m : ℕ) :
+    (Fin m → Rˣ) ≃* diagonalTorus R m :=
+  MonoidHom.ofInjective diagonal_injective
+
+/-- The torus element attached to a family of units is its paired diagonal matrix. -/
+@[simp]
+theorem coe_diagonalTorusEquiv_apply (t : Fin m → Rˣ) :
+    ((diagonalTorusEquiv R m t : diagonalTorus R m) : GLSymplecticFin m R) = diagonal t :=
+  MonoidHom.ofInjective_apply diagonal_injective
+
+/-- The `i`-th coordinate of a torus element is its `i`-th diagonal entry in the first block. -/
+@[simp]
+theorem coe_diagonalTorusEquiv_symm_apply (g : diagonalTorus R m) (i : Fin m) :
+    (((diagonalTorusEquiv R m).symm g i : Rˣ) : R) =
+      (((g : GLSymplecticFin m R) : GL (Fin (m + m)) R) :
+        Matrix (Fin (m + m)) (Fin (m + m)) R) (Fin.castAdd m i) (Fin.castAdd m i) := by
+  have h : diagonal ((diagonalTorusEquiv R m).symm g) = (g : GLSymplecticFin m R) :=
+    MonoidHom.apply_ofInjective_symm diagonal_injective g
+  conv_rhs => rw [← h, coe_diagonal, diagGL_coe]
+  simp
+
 /-- A symplectic matrix belongs to the paired diagonal torus exactly when it is diagonal. -/
 @[simp]
 theorem mem_diagonalTorus_iff {g : GLSymplecticFin m R} :

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic/Diagonal/Basic.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic/Diagonal/Basic.lean
@@ -19,7 +19,8 @@ diag(t₀, …, tₘ₋₁, t₀⁻¹, …, tₘ₋₁⁻¹)
 
 preserves the standard alternating form. This file packages these matrices as the homomorphism
 `TauCeti.GLSymplecticFin.diagonal` into `Sp₂ₘ(R)` and computes conjugation on every standard
-symplectic root subgroup.
+symplectic root subgroup. A symplectic matrix belongs to this image exactly when its underlying
+matrix is diagonal.
 
 The five root characters are `tᵢ²`, `tᵢ⁻²`, `tᵢtⱼ⁻¹`, `tᵢtⱼ`, and
 `(tᵢtⱼ)⁻¹` for the roots `2eᵢ`, `-2eᵢ`, `eᵢ-eⱼ`, `eᵢ+eⱼ`, and
@@ -128,6 +129,39 @@ theorem coe_diagonal (t : Fin m → Rˣ) :
 /-- The symplectic diagonal homomorphism is injective. -/
 theorem diagonal_injective : Function.Injective (diagonal (m := m) (R := R)) := by
   exact leviHom_injective.comp diagGL_injective
+
+/-- A symplectic matrix belongs to the paired diagonal torus exactly when it is diagonal. -/
+@[simp]
+theorem exists_diagonal_eq_iff {g : GLSymplecticFin m R} :
+    (∃ t : Fin m → Rˣ, diagonal t = g) ↔
+      ((g : GL (Fin (m + m)) R) : Matrix (Fin (m + m)) (Fin (m + m)) R).IsDiag := by
+  constructor
+  · rintro ⟨t, rfl⟩
+    rw [coe_diagonal, diagGL_coe]
+    exact Matrix.isDiag_diagonal _
+  · intro hg
+    obtain ⟨t, ht⟩ := mem_diagonalTorus_iff_exists_diagGL.mp (mem_diagonalTorus_iff.mpr hg)
+    have hform := mem_iff.mp g.property
+    rw [← ht, diagGL_coe, Matrix.diagonal_transpose] at hform
+    have hpair (i : Fin m) : t (i.addNat m) = (t (Fin.castAdd m i))⁻¹ := by
+      have hentry := congrArg (fun M => M (Fin.castAdd m i) (i.addNat m)) hform
+      simp only [Matrix.mul_diagonal, Matrix.diagonal_mul] at hentry
+      have hJ : JFin m R (Fin.castAdd m i) (i.addNat m) = -1 := by
+        have h := congrArg (fun M => M (Sum.inl i) (Sum.inr i))
+          (JFin_submatrix m (R := R))
+        simpa [Matrix.submatrix_apply, Fin.natAdd_eq_addNat, Matrix.J] using h
+      rw [hJ, mul_neg_one, neg_mul, neg_inj] at hentry
+      apply eq_inv_iff_mul_eq_one.mpr
+      apply Units.ext
+      simpa [mul_comm] using hentry
+    refine ⟨fun i => t (Fin.castAdd m i), ?_⟩
+    apply Subtype.ext
+    rw [coe_diagonal, ← ht]
+    congr 1
+    funext i
+    obtain ⟨i | i, rfl⟩ := finSumFinEquiv.surjective i
+    · simp
+    · simpa [Fin.natAdd_eq_addNat] using (hpair i).symm
 
 /-- The diagonal symplectic matrix commutes with change of coefficient ring. -/
 @[simp]

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic/Diagonal/Basic.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic/Diagonal/Basic.lean
@@ -32,6 +32,8 @@ equation.
 
 * `TauCeti.GLSymplecticFin.diagonal`: the diagonal split-torus homomorphism into the symplectic
   matrix group.
+* `TauCeti.GLSymplecticFin.diagonalTorus`: the subgroup of paired diagonal matrices, with
+  membership characterized by `TauCeti.GLSymplecticFin.mem_diagonalTorus_iff`.
 * `TauCeti.GLSymplecticFin.RootSubgroupIndex.character`: the character of the diagonal torus
   belonging to a root.
 * `TauCeti.GLSymplecticFin.diagonal_mul_rootSubgroup_mul_inv`: conjugation scales a root parameter
@@ -130,17 +132,33 @@ theorem coe_diagonal (t : Fin m → Rˣ) :
 theorem diagonal_injective : Function.Injective (diagonal (m := m) (R := R)) := by
   exact leviHom_injective.comp diagGL_injective
 
+/-- The paired diagonal torus in the symplectic group: the image of the diagonal homomorphism. -/
+noncomputable def diagonalTorus (R : Type u) [CommRing R] (m : ℕ) :
+    Subgroup (GLSymplecticFin m R) :=
+  (diagonal (m := m) (R := R)).range
+
+/-- A symplectic matrix belongs to the diagonal torus exactly when it is a paired diagonal
+matrix for some family of units. -/
+theorem mem_diagonalTorus_iff_exists_diagonal {g : GLSymplecticFin m R} :
+    g ∈ diagonalTorus R m ↔ ∃ t : Fin m → Rˣ, diagonal t = g :=
+  MonoidHom.mem_range
+
+/-- The paired diagonal torus is commutative, as the image of the coordinatewise units. -/
+instance instIsMulCommutativeDiagonalTorus : IsMulCommutative (diagonalTorus R m) :=
+  inferInstanceAs (IsMulCommutative (diagonal (m := m) (R := R)).range)
+
 /-- A symplectic matrix belongs to the paired diagonal torus exactly when it is diagonal. -/
 @[simp]
-theorem exists_diagonal_eq_iff {g : GLSymplecticFin m R} :
-    (∃ t : Fin m → Rˣ, diagonal t = g) ↔
+theorem mem_diagonalTorus_iff {g : GLSymplecticFin m R} :
+    g ∈ diagonalTorus R m ↔
       ((g : GL (Fin (m + m)) R) : Matrix (Fin (m + m)) (Fin (m + m)) R).IsDiag := by
   constructor
   · rintro ⟨t, rfl⟩
     rw [coe_diagonal, diagGL_coe]
     exact Matrix.isDiag_diagonal _
   · intro hg
-    obtain ⟨t, ht⟩ := mem_diagonalTorus_iff_exists_diagGL.mp (mem_diagonalTorus_iff.mpr hg)
+    obtain ⟨t, ht⟩ := mem_diagonalTorus_iff_exists_diagGL.mp
+      (TauCeti.mem_diagonalTorus_iff.mpr hg)
     have hform := mem_iff.mp g.property
     rw [← ht, diagGL_coe, Matrix.diagonal_transpose] at hform
     have hpair (i : Fin m) : t (i.addNat m) = (t (Fin.castAdd m i))⁻¹ := by

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic/Diagonal/Centralizer.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic/Diagonal/Centralizer.lean
@@ -61,19 +61,27 @@ variable [CommRing R] [IsCancelMulZero R]
 
 /-- The paired diagonal torus is its own centralizer whenever the domain has a unit different
 from its inverse. -/
-theorem centralizer_range_diagonal (u : Rˣ) (hu : u ≠ u⁻¹) :
-    Subgroup.centralizer ((diagonal (m := m) (R := R)).range : Set (GLSymplecticFin m R)) =
-      (diagonal (m := m) (R := R)).range := by
-  refine le_antisymm (fun g hg => MonoidHom.mem_range.mpr <|
-    exists_diagonal_eq_iff.mpr fun i j hij => ?_)
+theorem centralizer_diagonalTorus (u : Rˣ) (hu : u ≠ u⁻¹) :
+    Subgroup.centralizer (diagonalTorus R m : Set (GLSymplecticFin m R)) =
+      diagonalTorus R m := by
+  refine le_antisymm (fun g hg => mem_diagonalTorus_iff.mpr fun i j hij => ?_)
     (Subgroup.le_centralizer _)
   obtain ⟨t, ht⟩ := exists_diagonalCoordinates_ne u hu hij
-  have hcomm := Subgroup.mem_centralizer_iff.mp hg (diagonal t) ⟨t, rfl⟩
+  have hcomm := Subgroup.mem_centralizer_iff.mp hg (diagonal t)
+    (mem_diagonalTorus_iff_exists_diagonal.mpr ⟨t, rfl⟩)
   have hmatrix := congrArg
     (fun g : GLSymplecticFin m R =>
       ((g : GL (Fin (m + m)) R) : Matrix (Fin (m + m)) (Fin (m + m)) R)) hcomm
   simp only [Subgroup.coe_mul, Units.val_mul, coe_diagonal, diagGL_coe] at hmatrix
   exact apply_eq_zero_of_commute_diagonal hmatrix (fun h => ht (Units.ext h))
+
+/-- If the domain has a unit different from its inverse, every commutative subgroup containing
+the paired diagonal torus is that torus. -/
+theorem eq_diagonalTorus_of_le_of_isMulCommutative (u : Rˣ) (hu : u ≠ u⁻¹)
+    (H : Subgroup (GLSymplecticFin m R)) [IsMulCommutative H]
+    (hH : diagonalTorus R m ≤ H) : H = diagonalTorus R m :=
+  Subgroup.eq_of_centralizer_eq_self_of_le_of_isMulCommutative
+    (centralizer_diagonalTorus u hu) hH
 
 end Domain
 
@@ -83,13 +91,13 @@ variable [Field R] [Infinite R]
 
 /-- Over an infinite field, the paired diagonal torus in the symplectic group is its own
 centralizer. -/
-theorem centralizer_range_diagonal_of_infinite :
-    Subgroup.centralizer ((diagonal (m := m) (R := R)).range : Set (GLSymplecticFin m R)) =
-      (diagonal (m := m) (R := R)).range := by
+theorem centralizer_diagonalTorus_of_infinite :
+    Subgroup.centralizer (diagonalTorus R m : Set (GLSymplecticFin m R)) =
+      diagonalTorus R m := by
   classical
   obtain ⟨a, ha⟩ := Infinite.exists_notMem_finset ({0, 1, -1} : Finset R)
   simp only [Finset.mem_insert, Finset.mem_singleton, not_or] at ha
-  apply centralizer_range_diagonal (Units.mk0 a ha.1)
+  apply centralizer_diagonalTorus (Units.mk0 a ha.1)
   intro h
   have heq : a = a⁻¹ := congrArg Units.val h
   have hsq : a ^ 2 = 1 := by
@@ -100,12 +108,11 @@ theorem centralizer_range_diagonal_of_infinite :
 
 /-- Over an infinite field, every commutative subgroup containing the paired diagonal torus
 is that torus. -/
-theorem eq_range_diagonal_of_le_of_isMulCommutative
+theorem eq_diagonalTorus_of_le_of_isMulCommutative_of_infinite
     (H : Subgroup (GLSymplecticFin m R)) [IsMulCommutative H]
-    (hH : (diagonal (m := m) (R := R)).range ≤ H) :
-    H = (diagonal (m := m) (R := R)).range :=
+    (hH : diagonalTorus R m ≤ H) : H = diagonalTorus R m :=
   Subgroup.eq_of_centralizer_eq_self_of_le_of_isMulCommutative
-    centralizer_range_diagonal_of_infinite hH
+    centralizer_diagonalTorus_of_infinite hH
 
 end InfiniteField
 

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic/Diagonal/Centralizer.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic/Diagonal/Centralizer.lean
@@ -19,11 +19,10 @@ This pointwise centralizer calculation supplies the matrix comparison used to pr
 of the diagonal torus as a closed subgroup scheme. The unit hypothesis distinguishes the two
 weights on each symplectic plane; it cannot simply be omitted over small finite fields.
 
-The proof uses `TauCeti.apply_eq_zero_of_commute_diagonal` and follows the centralizer argument
-for general linear groups in `TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Diagonal.Basic`.
-
 ## References
 
+* The general-linear centralizer formalization in
+  `TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Diagonal.Basic`.
 * J. E. Humphreys, *Linear Algebraic Groups*, §16.1 and §26.3.
 -/
 

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic/Diagonal/Centralizer.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic/Diagonal/Centralizer.lean
@@ -1,0 +1,112 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Symplectic.Diagonal.Basic
+
+/-!
+# The centralizer of the symplectic diagonal torus
+
+The diagonal symplectic matrices are exactly the image of the paired diagonal homomorphism.
+Over a domain with a unit different from its inverse, this image is its own centralizer, hence
+maximal among commutative subgroups. In particular these conclusions hold over every infinite
+field, in all characteristics and in every rank.
+
+This pointwise centralizer calculation supplies the matrix comparison used to prove maximality
+of the diagonal torus as a closed subgroup scheme. The unit hypothesis distinguishes the two
+weights on each symplectic plane; it cannot simply be omitted over small finite fields.
+
+The proof uses `TauCeti.apply_eq_zero_of_commute_diagonal` and follows the centralizer argument
+for general linear groups in `TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Diagonal.Basic`.
+
+## References
+
+* J. E. Humphreys, *Linear Algebraic Groups*, §16.1 and §26.3.
+-/
+
+public section
+
+open Matrix
+
+namespace TauCeti.GLSymplecticFin
+
+variable {m : ℕ} {R : Type*}
+
+/-- A unit different from its inverse lets paired diagonal coordinates separate any two
+positions. -/
+theorem exists_diagonalCoordinates_ne [Monoid R] (u : Rˣ) (hu : u ≠ u⁻¹)
+    {i j : Fin (m + m)} (hij : i ≠ j) :
+    ∃ t : Fin m → Rˣ, diagonalCoordinates t i ≠ diagonalCoordinates t j := by
+  have hu1 : u ≠ 1 := by
+    rintro rfl
+    exact hu (inv_one.symm)
+  obtain ⟨i | i, rfl⟩ := finSumFinEquiv.surjective i <;>
+    obtain ⟨j | j, rfl⟩ := finSumFinEquiv.surjective j
+  · have h : i ≠ j := fun h => hij (by simp [h])
+    exact ⟨fun k => if k = i then u else 1, by simp [Ne.symm h, hu1]⟩
+  · refine ⟨fun k => if k = i then u else 1, ?_⟩
+    by_cases h : j = i <;> simp [Fin.natAdd_eq_addNat, h, hu, hu1]
+  · refine ⟨fun k => if k = j then u else 1, ?_⟩
+    by_cases h : i = j <;> simp [Fin.natAdd_eq_addNat, h, Ne.symm hu, Ne.symm hu1]
+  · have h : i ≠ j := fun h => hij (by simp [h])
+    exact ⟨fun k => if k = i then u else 1, by
+      simp [Fin.natAdd_eq_addNat, Ne.symm h, hu1]⟩
+
+section Domain
+
+variable [CommRing R] [IsCancelMulZero R]
+
+/-- The paired diagonal torus is its own centralizer whenever the domain has a unit different
+from its inverse. -/
+theorem centralizer_range_diagonal (u : Rˣ) (hu : u ≠ u⁻¹) :
+    Subgroup.centralizer ((diagonal (m := m) (R := R)).range : Set (GLSymplecticFin m R)) =
+      (diagonal (m := m) (R := R)).range := by
+  refine le_antisymm (fun g hg => MonoidHom.mem_range.mpr <|
+    exists_diagonal_eq_iff.mpr fun i j hij => ?_)
+    (Subgroup.le_centralizer _)
+  obtain ⟨t, ht⟩ := exists_diagonalCoordinates_ne u hu hij
+  have hcomm := Subgroup.mem_centralizer_iff.mp hg (diagonal t) ⟨t, rfl⟩
+  have hmatrix := congrArg
+    (fun g : GLSymplecticFin m R =>
+      ((g : GL (Fin (m + m)) R) : Matrix (Fin (m + m)) (Fin (m + m)) R)) hcomm
+  simp only [Subgroup.coe_mul, Units.val_mul, coe_diagonal, diagGL_coe] at hmatrix
+  exact apply_eq_zero_of_commute_diagonal hmatrix (fun h => ht (Units.ext h))
+
+end Domain
+
+section InfiniteField
+
+variable [Field R] [Infinite R]
+
+/-- Over an infinite field, the paired diagonal torus in the symplectic group is its own
+centralizer. -/
+theorem centralizer_range_diagonal_of_infinite :
+    Subgroup.centralizer ((diagonal (m := m) (R := R)).range : Set (GLSymplecticFin m R)) =
+      (diagonal (m := m) (R := R)).range := by
+  classical
+  obtain ⟨a, ha⟩ := Infinite.exists_notMem_finset ({0, 1, -1} : Finset R)
+  simp only [Finset.mem_insert, Finset.mem_singleton, not_or] at ha
+  apply centralizer_range_diagonal (Units.mk0 a ha.1)
+  intro h
+  have heq : a = a⁻¹ := congrArg Units.val h
+  have hsq : a ^ 2 = 1 := by
+    calc
+      a ^ 2 = a * a⁻¹ := by rw [pow_two, ← heq]
+      _ = 1 := mul_inv_cancel₀ ha.1
+  exact (sq_eq_one_iff.mp hsq).elim ha.2.1 ha.2.2
+
+/-- Over an infinite field, every commutative subgroup containing the paired diagonal torus
+is that torus. -/
+theorem eq_range_diagonal_of_le_of_isMulCommutative
+    (H : Subgroup (GLSymplecticFin m R)) [IsMulCommutative H]
+    (hH : (diagonal (m := m) (R := R)).range ≤ H) :
+    H = (diagonal (m := m) (R := R)).range :=
+  Subgroup.eq_of_centralizer_eq_self_of_le_of_isMulCommutative
+    centralizer_range_diagonal_of_infinite hH
+
+end InfiniteField
+
+end TauCeti.GLSymplecticFin


### PR DESCRIPTION
The paired diagonal torus is its own centralizer in the symplectic matrix group over a commutative ring with cancellation of nonzero factors and a unit different from its inverse. It is therefore maximal among commutative subgroups. Infinite-field corollaries discharge the unit hypothesis, including in characteristic two; every statement includes rank zero.

The canonical subgroup `GLSymplecticFin.diagonalTorus R m` has an existential membership lemma, a commutativity instance, and a simp characterization of membership as diagonality of the underlying matrix. The centralizer and maximality theorems use this subgroup. The proof reuses the existing general-linear diagonal API, `apply_eq_zero_of_commute_diagonal`, `JFin_submatrix`, and Tau Ceti's general maximal-commutative-subgroup criterion. The module credits the general-linear argument and Humphreys, *Linear Algebraic Groups*, §§16.1 and 26.3.

This advances [TauCetiRoadmap/ReductiveGroups/README.md, Layer 7, “Borel subgroups, maximal tori, and their conjugacy”](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/ReductiveGroups/README.md#layer-7-structure-theory). The immediate consumer is the scheme-level statement `HopfIdeal.IsMaximalTorus k (Symplectic.coordinateHopfAlgebra k m) (Symplectic.diagonalTorusDefiningIdeal k m)`: over the algebraic closure, `GLSymplecticFin.eq_diagonalTorus_of_le_of_isMulCommutative_of_infinite` supplies the pointwise maximality comparison. Combining it with the closed-subgroup construction and reduced finite-type point separation is the next step toward the split maximal torus required by Layer 9's pinnings target.

The new centralizer module sits beside the diagonal API in `Symplectic/Diagonal/`. The former `Symplectic/Diagonal.lean` moves to `Symplectic/Diagonal/Basic.lean`, and its importer in `Symplectic/DiagonalTorus/Basic.lean` is updated. Obsolete theorem names and the old module path are removed.

Validation: targeted `lake build` passes for both diagonal modules and the affected scheme-level `Symplectic.DiagonalTorus.Basic` module. `lake exe cache get` succeeds. `tauceti-axioms --changed-since-merge-base origin/main` accepts all 96 declarations in the three changed modules. The prescribed lint wrapper fails its freshness guard because its downloaded list omits Mathlib's default `tacticAlt`; a temporary copy adding exactly that linter passes the full current default set, with 11 documented declarations scanned, zero violations, and zero grandfathered findings. No repository scripts, linter settings, or Lake pins are changed. `git diff --check` passes.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"symplectic-diagonal-centralizer"}-->
