### PR TITLE
refactor(ArithmeticDirichletSeries): name the injectivity behind the prime-to-ideal restriction

### DIFF
--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Analytic.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Analytic.lean
@@ -38,9 +38,6 @@ product of the Dedekind zeta function.
   in the closed geometric form available for a completely multiplicative weight.
 * `TauCeti.MultiplicativeIdealWeight.LSeries_ne_zero_of_summable_idealTerm`: the `L`-series is
   **nonzero** wherever the ideal-indexed series converges absolutely.
-* `TauCeti.MultiplicativeIdealWeight.summable_log_absNorm_mul_norm_div_of_re_lt_re`: the local
-  ratios weighted by `log N(P)` are summable over the primes, strictly to the right of a point of
-  absolute convergence.
 * `TauCeti.dedekindZeta_eulerProduct_hasProd`: the **Euler product of the Dedekind zeta
   function**, valid on `Re s > 1`.
 * `TauCeti.dedekindZeta_ne_zero_of_one_lt_re`: the Dedekind zeta function is **nonzero** on
@@ -311,25 +308,6 @@ theorem summable_div_of_summable_idealTerm
       χ P.asIdeal / (Ideal.absNorm P.asIdeal : ℂ) ^ s :=
   (IdealArithmeticFunction.summable_idealTerm_primeIdealPow_one hs).congr fun P ↦ by
     simp [idealTerm_toIdealArithmeticFunction_primeIdealPow χ P 1 s]
-
-/-- **The log-weighted local ratios are summable over the primes.**  Weighting each local ratio by
-`log N(P)` keeps it summable strictly to the right of a point of absolute convergence.
-
-This is `TauCeti.summable_log_absNorm_mul_norm_idealTerm_of_re_lt_re` restricted to the primes,
-just as `summable_div_of_summable_idealTerm` restricts the unweighted statement; the restriction is
-`HeightOneSpectrum.primeIdealPow_one_injective` in both cases. -/
-theorem summable_log_absNorm_mul_norm_div_of_re_lt_re {s' : ℂ} (h : s.re < s'.re)
-    (hs : Summable (idealTerm K χ.toIdealArithmeticFunction s)) :
-    Summable fun P : HeightOneSpectrum (𝓞 K) ↦
-      Real.log (Ideal.absNorm P.asIdeal)
-        * ‖χ P.asIdeal / (Ideal.absNorm P.asIdeal : ℂ) ^ s'‖ := by
-  refine ((summable_log_absNorm_mul_norm_idealTerm_of_re_lt_re K h hs).comp_injective
-    HeightOneSpectrum.primeIdealPow_one_injective).congr fun P ↦ ?_
-  have hP : 0 < Ideal.absNorm P.asIdeal := by
-    have := NumberField.HeightOneSpectrum.one_lt_absNorm P
-    omega
-  simp only [Function.comp_apply, norm_idealTerm, HeightOneSpectrum.coe_primeIdealPow, pow_one,
-    toIdealArithmeticFunction_apply, norm_div, Complex.norm_natCast_cpow_of_pos hP]
 
 /-- Absolute convergence puts every local ratio `χ(P) N(P)⁻ˢ` strictly inside the unit disc, so no
 local Euler factor has a vanishing denominator. -/

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Analytic.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Analytic.lean
@@ -38,6 +38,9 @@ product of the Dedekind zeta function.
   in the closed geometric form available for a completely multiplicative weight.
 * `TauCeti.MultiplicativeIdealWeight.LSeries_ne_zero_of_summable_idealTerm`: the `L`-series is
   **nonzero** wherever the ideal-indexed series converges absolutely.
+* `TauCeti.MultiplicativeIdealWeight.summable_log_absNorm_mul_norm_div_of_re_lt_re`: the local
+  ratios weighted by `log N(P)` are summable over the primes, strictly to the right of a point of
+  absolute convergence.
 * `TauCeti.dedekindZeta_eulerProduct_hasProd`: the **Euler product of the Dedekind zeta
   function**, valid on `Re s > 1`.
 * `TauCeti.dedekindZeta_ne_zero_of_one_lt_re`: the Dedekind zeta function is **nonzero** on
@@ -156,8 +159,7 @@ own ideal as the `e = 1` member of its power series, and distinct primes give di
 absolute convergence over ideals restricts to the primes. Multiplicativity plays no part. -/
 theorem summable_idealTerm_primeIdealPow_one (hs : Summable (idealTerm K f s)) :
     Summable fun P : HeightOneSpectrum (𝓞 K) ↦ idealTerm K f s (P.primeIdealPow 1) :=
-  hs.comp_injective fun P Q h ↦ HeightOneSpectrum.asIdeal_injective
-    (by simpa only [HeightOneSpectrum.coe_primeIdealPow, pow_one] using congrArg Subtype.val h)
+  hs.comp_injective HeightOneSpectrum.primeIdealPow_one_injective
 
 end IdealArithmeticFunction
 
@@ -309,6 +311,25 @@ theorem summable_div_of_summable_idealTerm
       χ P.asIdeal / (Ideal.absNorm P.asIdeal : ℂ) ^ s :=
   (IdealArithmeticFunction.summable_idealTerm_primeIdealPow_one hs).congr fun P ↦ by
     simp [idealTerm_toIdealArithmeticFunction_primeIdealPow χ P 1 s]
+
+/-- **The log-weighted local ratios are summable over the primes.**  Weighting each local ratio by
+`log N(P)` keeps it summable strictly to the right of a point of absolute convergence.
+
+This is `TauCeti.summable_log_absNorm_mul_norm_idealTerm_of_re_lt_re` restricted to the primes,
+just as `summable_div_of_summable_idealTerm` restricts the unweighted statement; the restriction is
+`HeightOneSpectrum.primeIdealPow_one_injective` in both cases. -/
+theorem summable_log_absNorm_mul_norm_div_of_re_lt_re {s' : ℂ} (h : s.re < s'.re)
+    (hs : Summable (idealTerm K χ.toIdealArithmeticFunction s)) :
+    Summable fun P : HeightOneSpectrum (𝓞 K) ↦
+      Real.log (Ideal.absNorm P.asIdeal)
+        * ‖χ P.asIdeal / (Ideal.absNorm P.asIdeal : ℂ) ^ s'‖ := by
+  refine ((summable_log_absNorm_mul_norm_idealTerm_of_re_lt_re K h hs).comp_injective
+    HeightOneSpectrum.primeIdealPow_one_injective).congr fun P ↦ ?_
+  have hP : 0 < Ideal.absNorm P.asIdeal := by
+    have := NumberField.HeightOneSpectrum.one_lt_absNorm P
+    omega
+  simp only [Function.comp_apply, norm_idealTerm, HeightOneSpectrum.coe_primeIdealPow, pow_one,
+    toIdealArithmeticFunction_apply, norm_div, Complex.norm_natCast_cpow_of_pos hP]
 
 /-- Absolute convergence puts every local ratio `χ(P) N(P)⁻ˢ` strictly inside the unit disc, so no
 local Euler factor has a vanishing denominator. -/

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Basic.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Basic.lean
@@ -105,6 +105,15 @@ theorem absNorm_primeIdealPow (P : HeightOneSpectrum (𝓞 K)) (e : ℕ) :
     Ideal.absNorm (primeIdealPow P e : Ideal (𝓞 K)) = Ideal.absNorm P.asIdeal ^ e := by
   rw [coe_primeIdealPow, map_pow]
 
+omit [NumberField K] in
+/-- Distinct primes give distinct first powers, so a family indexed by the primes is a subfamily
+of one indexed by the nonzero ideals. -/
+theorem primeIdealPow_one_injective :
+    Function.Injective fun P : HeightOneSpectrum (𝓞 K) ↦ primeIdealPow P 1 := fun P Q h ↦
+  HeightOneSpectrum.asIdeal_injective
+    (by simpa only [coe_primeIdealPow, pow_one] using
+      congrArg (Subtype.val : (Ideal (𝓞 K))⁰ → Ideal (𝓞 K)) h)
+
 /-- Distinct exponents give distinct prime powers. -/
 theorem primeIdealPow_injective (P : HeightOneSpectrum (𝓞 K)) :
     Function.Injective (primeIdealPow P) := fun m n h ↦


### PR DESCRIPTION
Distinct primes have distinct first powers, so a family indexed by the height-one primes is a
subfamily of one indexed by the nonzero ideals. That fact was written out inline inside
`summable_idealTerm_primeIdealPow_one`. This names it once, beside `primeIdealPow_injective` —
injectivity in the *exponent*, the complementary statement — and the existing proof becomes an
appeal to it.

```lean
theorem TauCeti.IsDedekindDomain.HeightOneSpectrum.primeIdealPow_one_injective :
    Function.Injective fun P : HeightOneSpectrum (𝓞 K) ↦ primeIdealPow P 1
```

It needs no `[NumberField K]`; the unused-section-variable linter pointed that out, and it is
stated with `omit`.

### What changed since round 1

Round 1 also added `summable_log_absNorm_mul_norm_div_of_re_lt_re` to `EulerProduct/Analytic.lean`,
the prime-indexed form of the log-weighted summability bound. The `reuse` rubric asked for it to go,
on the grounds that it is a thin restriction of the ideal-indexed theorem with no in-repository
consumer, and that the eventual derivative proof can apply `.comp_injective` itself. That is right,
and it is now removed — the diff no longer touches `Analytic.lean` except for the one-line proof
above.

That leaves this PR doing one thing: giving the restriction argument a name at the single site that
already uses it. The derivative proof will apply
`summable_log_absNorm_mul_norm_idealTerm_of_re_lt_re K h hs |>.comp_injective
HeightOneSpectrum.primeIdealPow_one_injective` directly, which is the shape the rubric asked for.

Roadmap: ArithmeticDirichletSeries

This PR carries **no `tauceti-target:v1` marker**: naming an argument that already existed inline
authors no roadmap target. The `Roadmap:` line names the roadmap the work serves —
`ArithmeticDirichletSeries` Layer 3.4, whose derivative is the caller that motivated looking here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011dmwkBnj4rJc75STgbwsLF
