### PR TITLE
feat: attach Schwarz-Christoffel edges to their vertices

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/SchwarzChristoffel/Boundary.lean
+++ b/TauCeti/Analysis/Complex/Conformal/SchwarzChristoffel/Boundary.lean
@@ -17,9 +17,10 @@ the prevertices it continues holomorphically across a neighbourhood, while at a 
 has a finite limit when the total exponent there is greater than `-1`.  This file packages both
 cases in a single boundary map.
 
-The canonical value `schwarzChristoffelBoundary a e z₀ x` is the limit of the primitive from the
-upper half-plane.  Its defining limit exists whenever the total exponent at `x` is greater than
-`-1`; this includes every point which is not a prevertex.  On a prevertex it agrees with
+The canonical value `schwarzChristoffelBoundary a e z₀ x` is Mathlib's `extendFrom` extension of
+the primitive from the upper half-plane.  That extension is a genuine limit of the primitive
+wherever such a limit exists, which is the case whenever the total exponent at `x` is greater
+than `-1`; this includes every point which is not a prevertex.  On a prevertex it agrees with
 `schwarzChristoffelVertex`, and on an interval free of nonzero prevertices it is continuous,
 injective, and has the explicit straight-edge increment formula from the boundary continuation.
 Thus the boundary map is the common object in which the vertices and the open edges of the
@@ -36,14 +37,14 @@ eventual polygon meet.
   value wherever the total exponent is greater than `-1`.
 * `TauCeti.schwarzChristoffelBoundary_apply_prevertex` -- the boundary value at a prevertex is
   the previously constructed Schwarz--Christoffel vertex.
-* `TauCeti.schwarzChristoffelBoundary_sub_eq` -- an open edge has the expected fixed direction
-  and positive real parametrization.
+* `TauCeti.schwarzChristoffelBoundary_change_base` -- changing the normalization point of the
+  primitive subtracts a constant from the boundary map.
+* `TauCeti.schwarzChristoffelBoundary_sub_eq` -- an increment of the boundary map along an open
+  edge is a real integral times the fixed edge direction.
 * `TauCeti.schwarzChristoffelBoundary_injOn` and
   `TauCeti.collinear_schwarzChristoffelBoundary_image` -- an open edge is embedded in a line.
 * `TauCeti.schwarzChristoffelBoundary_image_Icc_eq_closure_image_Ioo` -- the closed boundary arc
   is the closure of its open edge.
-* `TauCeti.schwarzChristoffelEdgeAngle_sub_eq_exponent_sum_of_adjacent` -- crossing an adjacent
-  prevertex changes the edge angle by its total turning exponent.
 
 ## References
 
@@ -61,9 +62,11 @@ namespace TauCeti
 
 variable {ι : Type*} [Fintype ι]
 
-/-- The **boundary value of the Schwarz--Christoffel map** at a real point, defined as the limit
-of its normalized primitive from the upper half-plane.  The limit exists when the total exponent
-at the point is greater than `-1`; see `tendsto_schwarzChristoffelPrimitive_boundary`. -/
+/-- The **boundary value of the Schwarz--Christoffel map** at a real point: the value at that
+point of Mathlib's `extendFrom` extension of the normalized primitive from the upper half-plane.
+The extension is total, so this is a limit of the primitive only where such a limit exists; that
+happens whenever the total exponent at the point is greater than `-1`, by
+`tendsto_schwarzChristoffelPrimitive_boundary`, and the value is unspecified elsewhere. -/
 def schwarzChristoffelBoundary (a e : ι → ℝ) (z₀ : UpperHalfPlane) (x : ℝ) : ℂ :=
   extendFrom upperHalfPlaneSet (schwarzChristoffelPrimitive a e z₀) (x : ℂ)
 
@@ -126,6 +129,19 @@ theorem tendsto_schwarzChristoffelPrimitive_boundary (a e : ι → ℝ)
   rw [schwarzChristoffelBoundary]
   exact tendsto_extendFrom (exists_tendsto_schwarzChristoffelPrimitive_boundary a e z₀ x he)
 
+/-- Changing the base point of the normalized primitive subtracts, from the canonical
+Schwarz--Christoffel boundary map, the value of the primitive at the old base point.  This is the
+boundary counterpart of `schwarzChristoffelPrimitive_change_base`, and holds wherever the total
+exponent is greater than `-1`. -/
+theorem schwarzChristoffelBoundary_change_base (a e : ι → ℝ) (b c : UpperHalfPlane) (x : ℝ)
+    (he : -1 < ∑ i with a i = x, e i) :
+    schwarzChristoffelBoundary a e b x =
+      schwarzChristoffelBoundary a e c x - schwarzChristoffelPrimitive a e c b := by
+  refine schwarzChristoffelBoundary_eq_of_tendsto a e b x (Tendsto.congr' ?_
+    ((tendsto_schwarzChristoffelPrimitive_boundary a e c x he).sub tendsto_const_nhds))
+  filter_upwards [self_mem_nhdsWithin] with z hz
+  exact (schwarzChristoffelPrimitive_change_base a e b c hz).symm
+
 /-- The canonical Schwarz--Christoffel boundary map is continuous on any set of real points at
 which the total exponent is greater than `-1`.  This simultaneously gives continuity along open
 edges and attachment of those edges to every integrable prevertex. -/
@@ -154,9 +170,9 @@ theorem continuousOn_schwarzChristoffelBoundary (a e : ι → ℝ) (z₀ : Upper
   exact schwarzChristoffelBoundary_eq_of_tendsto a e z₀ x (hL x hx)
 
 /-- Along a real interval free of prevertices with nonzero exponent, the increment of the
-canonical Schwarz--Christoffel boundary map is a real integral times the fixed edge direction.
-In particular, all its increments have argument
-`schwarzChristoffelEdgeAngle a e p` up to reversal. -/
+canonical Schwarz--Christoffel boundary map between two points is the real integral of
+`∏ i, |t - a i| ^ e i` between them, times the fixed unimodular direction with argument
+`schwarzChristoffelEdgeAngle a e p`. -/
 theorem schwarzChristoffelBoundary_sub_eq (a e : ι → ℝ) (z₀ : UpperHalfPlane)
     {p q : ℝ} (ha : ∀ i, e i ≠ 0 → a i ∉ Ioo p q) {x y : ℝ}
     (hx : x ∈ Ioo p q) (hy : y ∈ Ioo p q) :
@@ -196,12 +212,12 @@ theorem collinear_schwarzChristoffelBoundary_image (a e : ι → ℝ)
   · rintro ⟨x, hx, rfl⟩
     exact ⟨x, hx, schwarzChristoffelBoundary_eq_of_tendsto a e z₀ x (hL x hx)⟩
 
-/-- Between adjacent real prevertices with integrable endpoint exponents, the canonical
-Schwarz--Christoffel boundary map is continuous on the closed interval.  Hence the open straight
-edge supplied by `schwarzChristoffelBoundary_sub_eq` attaches continuously to its two vertices. -/
+/-- Between real prevertices with integrable endpoint exponents and no prevertex of nonzero
+exponent strictly between them, the canonical Schwarz--Christoffel boundary map is continuous on
+the closed interval.  Hence the open straight edge supplied by
+`schwarzChristoffelBoundary_sub_eq` attaches continuously to its two vertices. -/
 theorem continuousOn_schwarzChristoffelBoundary_Icc (a e : ι → ℝ)
-    (z₀ : UpperHalfPlane) {p q : ℝ} (hpq : p < q)
-    (ha : ∀ i, e i ≠ 0 → a i ∉ Ioo p q)
+    (z₀ : UpperHalfPlane) {p q : ℝ} (ha : ∀ i, e i ≠ 0 → a i ∉ Ioo p q)
     (hp : -1 < ∑ i with a i = p, e i) (hq : -1 < ∑ i with a i = q, e i) :
     ContinuousOn (schwarzChristoffelBoundary a e z₀) (Icc p q) := by
   classical
@@ -229,14 +245,10 @@ theorem schwarzChristoffelBoundary_image_Icc_eq_closure_image_Ioo (a e : ι → 
     (hp : -1 < ∑ i with a i = p, e i) (hq : -1 < ∑ i with a i = q, e i) :
     schwarzChristoffelBoundary a e z₀ '' Icc p q =
       closure (schwarzChristoffelBoundary a e z₀ '' Ioo p q) := by
-  apply Subset.antisymm
-  · have hcont : ContinuousOn (schwarzChristoffelBoundary a e z₀) (closure (Ioo p q)) := by
-      simpa only [closure_Ioo hpq.ne] using
-        continuousOn_schwarzChristoffelBoundary_Icc a e z₀ hpq ha hp hq
-    simpa only [closure_Ioo hpq.ne] using hcont.image_closure
-  · apply closure_minimal (image_mono Ioo_subset_Icc_self)
-    exact (isCompact_Icc.image_of_continuousOn
-      (continuousOn_schwarzChristoffelBoundary_Icc a e z₀ hpq ha hp hq)).isClosed
+  rw [← closure_Ioo hpq.ne]
+  refine image_closure_of_isCompact ?_ ?_ <;> rw [closure_Ioo hpq.ne]
+  · exact isCompact_Icc
+  · exact continuousOn_schwarzChristoffelBoundary_Icc a e z₀ ha hp hq
 
 /-- The two Schwarz--Christoffel vertices belonging to adjacent prevertices lie in the closure of
 the open straight edge between them.  This is the endpoint form of the local polygon gluing: the
@@ -255,25 +267,5 @@ theorem schwarzChristoffelVertices_mem_closure_boundary_image_Ioo (a e : ι → 
       schwarzChristoffelBoundary_apply_prevertex a e z₀ j hj⟩
   · exact ⟨a k, right_mem_Icc.mpr hjk.le,
       schwarzChristoffelBoundary_apply_prevertex a e z₀ k hk⟩
-
-/-- Across two adjacent real boundary points, the change in Schwarz--Christoffel edge angle is
-exactly `π` times the total exponent at the right endpoint.  Equivalently, moving from left to
-right turns the edge direction by the exterior angle given by the negative of this quantity. -/
-theorem schwarzChristoffelEdgeAngle_sub_eq_exponent_sum_of_adjacent (a e : ι → ℝ)
-    {p q : ℝ} (hpq : p < q) (ha : ∀ i, e i ≠ 0 → a i ∉ Ioo p q) :
-    schwarzChristoffelEdgeAngle a e p - schwarzChristoffelEdgeAngle a e q =
-      Real.pi * ∑ i with a i = q, e i := by
-  rw [schwarzChristoffelEdgeAngle_sub a e hpq.le]
-  congr 1
-  symm
-  apply Finset.sum_subset
-  · intro i hi
-    simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hi ⊢
-    rw [hi]
-    exact ⟨hpq, le_rfl⟩
-  · intro i hi hiq
-    simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hi hiq
-    by_contra hei
-    exact ha i hei ⟨hi.1, hi.2.lt_of_ne hiq⟩
 
 end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/SchwarzChristoffel/Boundary.lean
+++ b/TauCeti/Analysis/Complex/Conformal/SchwarzChristoffel/Boundary.lean
@@ -72,13 +72,6 @@ happens whenever the total exponent at the point is greater than `-1`, by
 def schwarzChristoffelBoundary (a e : ι → ℝ) (z₀ : UpperHalfPlane) (x : ℝ) : ℂ :=
   extendFrom upperHalfPlaneSet (schwarzChristoffelPrimitive a e z₀) (x : ℂ)
 
-/-- The Schwarz--Christoffel boundary map is Mathlib's canonical extension-by-limits of the
-primitive from the upper half-plane, restricted to the real axis. -/
-theorem schwarzChristoffelBoundary_def (a e : ι → ℝ) (z₀ : UpperHalfPlane) (x : ℝ) :
-    schwarzChristoffelBoundary a e z₀ x =
-      extendFrom upperHalfPlaneSet (schwarzChristoffelPrimitive a e z₀) (x : ℂ) := by
-  rfl
-
 /-- A limit of the Schwarz--Christoffel primitive from the upper half-plane is its canonical
 boundary value. -/
 theorem schwarzChristoffelBoundary_eq_of_tendsto (a e : ι → ℝ) (z₀ : UpperHalfPlane)

--- a/TauCeti/Analysis/Complex/Conformal/SchwarzChristoffel/Boundary.lean
+++ b/TauCeti/Analysis/Complex/Conformal/SchwarzChristoffel/Boundary.lean
@@ -20,8 +20,9 @@ cases in a single boundary map.
 The canonical value `schwarzChristoffelBoundary a e z₀ x` is Mathlib's `extendFrom` extension of
 the primitive from the upper half-plane.  That extension is a genuine limit of the primitive
 wherever such a limit exists, which is the case whenever the total exponent at `x` is greater
-than `-1`; this includes every point which is not a prevertex.  On a prevertex it agrees with
-`schwarzChristoffelVertex`, and on an interval free of nonzero prevertices it is continuous,
+than `-1`; this includes every point which is not a prevertex.  On a prevertex whose total
+exponent is greater than `-1` it agrees with `schwarzChristoffelVertex`, and on an interval free
+of nonzero prevertices it is continuous,
 injective, and has the explicit straight-edge increment formula from the boundary continuation.
 Thus the boundary map is the common object in which the vertices and the open edges of the
 eventual polygon meet.
@@ -35,8 +36,9 @@ eventual polygon meet.
 
 * `TauCeti.tendsto_schwarzChristoffelPrimitive_boundary` -- the primitive tends to the boundary
   value wherever the total exponent is greater than `-1`.
-* `TauCeti.schwarzChristoffelBoundary_apply_prevertex` -- the boundary value at a prevertex is
-  the previously constructed Schwarz--Christoffel vertex.
+* `TauCeti.schwarzChristoffelBoundary_apply_prevertex` -- at a prevertex whose total exponent is
+  greater than `-1`, the boundary value is the previously constructed Schwarz--Christoffel
+  vertex.
 * `TauCeti.schwarzChristoffelBoundary_change_base` -- changing the normalization point of the
   primitive subtracts a constant from the boundary map.
 * `TauCeti.schwarzChristoffelBoundary_sub_eq` -- an increment of the boundary map along an open
@@ -86,8 +88,8 @@ theorem schwarzChristoffelBoundary_eq_of_tendsto (a e : ι → ℝ) (z₀ : Uppe
   rw [schwarzChristoffelBoundary]
   exact extendFrom_eq (by rw [Complex.closure_setOfPred_lt_im]; simp) h
 
-/-- At a prevertex, the canonical Schwarz--Christoffel boundary value is the
-Schwarz--Christoffel vertex. -/
+/-- At a prevertex whose total exponent is greater than `-1`, the canonical
+Schwarz--Christoffel boundary value is the Schwarz--Christoffel vertex. -/
 @[simp]
 theorem schwarzChristoffelBoundary_apply_prevertex (a e : ι → ℝ) (z₀ : UpperHalfPlane)
     (j : ι) (he : -1 < ∑ i with a i = a j, e i) :
@@ -212,10 +214,11 @@ theorem collinear_schwarzChristoffelBoundary_image (a e : ι → ℝ)
   · rintro ⟨x, hx, rfl⟩
     exact ⟨x, hx, schwarzChristoffelBoundary_eq_of_tendsto a e z₀ x (hL x hx)⟩
 
-/-- Between real prevertices with integrable endpoint exponents and no prevertex of nonzero
-exponent strictly between them, the canonical Schwarz--Christoffel boundary map is continuous on
-the closed interval.  Hence the open straight edge supplied by
-`schwarzChristoffelBoundary_sub_eq` attaches continuously to its two vertices. -/
+/-- Between two real endpoints whose total exponents are greater than `-1`, with no prevertex of
+nonzero exponent strictly between them, the canonical Schwarz--Christoffel boundary map is
+continuous on the closed interval.  When the endpoints are prevertices, this says that the open
+straight edge supplied by `schwarzChristoffelBoundary_sub_eq` attaches continuously to its two
+vertices. -/
 theorem continuousOn_schwarzChristoffelBoundary_Icc (a e : ι → ℝ)
     (z₀ : UpperHalfPlane) {p q : ℝ} (ha : ∀ i, e i ≠ 0 → a i ∉ Ioo p q)
     (hp : -1 < ∑ i with a i = p, e i) (hq : -1 < ∑ i with a i = q, e i) :
@@ -236,9 +239,11 @@ theorem continuousOn_schwarzChristoffelBoundary_Icc (a e : ι → ℝ)
   rw [hzero]
   norm_num
 
-/-- The closed boundary arc between adjacent integrable prevertices is exactly the closure of its
-open straight edge.  In particular, both endpoint vertices belong to the closure of that edge,
-which is the local gluing statement needed to assemble the Schwarz--Christoffel polygon. -/
+/-- The closed boundary arc between two real endpoints whose total exponents are greater than
+`-1`, with no prevertex of nonzero exponent strictly between them, is exactly the closure of its
+open straight edge.  When the endpoints are prevertices, this places both endpoint vertices --
+rewriting with `schwarzChristoffelBoundary_apply_prevertex` -- in the closure of that edge, which
+is the local gluing statement needed to assemble the Schwarz--Christoffel polygon. -/
 theorem schwarzChristoffelBoundary_image_Icc_eq_closure_image_Ioo (a e : ι → ℝ)
     (z₀ : UpperHalfPlane) {p q : ℝ} (hpq : p < q)
     (ha : ∀ i, e i ≠ 0 → a i ∉ Ioo p q)
@@ -249,23 +254,5 @@ theorem schwarzChristoffelBoundary_image_Icc_eq_closure_image_Ioo (a e : ι → 
   refine image_closure_of_isCompact ?_ ?_ <;> rw [closure_Ioo hpq.ne]
   · exact isCompact_Icc
   · exact continuousOn_schwarzChristoffelBoundary_Icc a e z₀ ha hp hq
-
-/-- The two Schwarz--Christoffel vertices belonging to adjacent prevertices lie in the closure of
-the open straight edge between them.  This is the endpoint form of the local polygon gluing: the
-closed boundary arc is not merely collinear but attaches to the previously defined vertex values. -/
-theorem schwarzChristoffelVertices_mem_closure_boundary_image_Ioo (a e : ι → ℝ)
-    (z₀ : UpperHalfPlane) {j k : ι} (hjk : a j < a k)
-    (ha : ∀ i, e i ≠ 0 → a i ∉ Ioo (a j) (a k))
-    (hj : -1 < ∑ i with a i = a j, e i) (hk : -1 < ∑ i with a i = a k, e i) :
-    schwarzChristoffelVertex a e z₀ j ∈
-        closure (schwarzChristoffelBoundary a e z₀ '' Ioo (a j) (a k)) ∧
-      schwarzChristoffelVertex a e z₀ k ∈
-        closure (schwarzChristoffelBoundary a e z₀ '' Ioo (a j) (a k)) := by
-  rw [← schwarzChristoffelBoundary_image_Icc_eq_closure_image_Ioo a e z₀ hjk ha hj hk]
-  constructor
-  · exact ⟨a j, left_mem_Icc.mpr hjk.le,
-      schwarzChristoffelBoundary_apply_prevertex a e z₀ j hj⟩
-  · exact ⟨a k, right_mem_Icc.mpr hjk.le,
-      schwarzChristoffelBoundary_apply_prevertex a e z₀ k hk⟩
 
 end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/SchwarzChristoffel/Boundary.lean
+++ b/TauCeti/Analysis/Complex/Conformal/SchwarzChristoffel/Boundary.lean
@@ -1,0 +1,279 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Topology.ExtendFrom
+public import TauCeti.Analysis.Complex.Conformal.SchwarzChristoffel.Edge
+public import TauCeti.Analysis.Complex.Conformal.SchwarzChristoffel.Vertex
+
+/-!
+# Boundary values of the Schwarz--Christoffel map
+
+The Schwarz--Christoffel primitive has two kinds of boundary point on the real axis.  Away from
+the prevertices it continues holomorphically across a neighbourhood, while at a prevertex it still
+has a finite limit when the total exponent there is greater than `-1`.  This file packages both
+cases in a single boundary map.
+
+The canonical value `schwarzChristoffelBoundary a e z₀ x` is the limit of the primitive from the
+upper half-plane.  Its defining limit exists whenever the total exponent at `x` is greater than
+`-1`; this includes every point which is not a prevertex.  On a prevertex it agrees with
+`schwarzChristoffelVertex`, and on an interval free of nonzero prevertices it is continuous,
+injective, and has the explicit straight-edge increment formula from the boundary continuation.
+Thus the boundary map is the common object in which the vertices and the open edges of the
+eventual polygon meet.
+
+## Main definitions
+
+* `TauCeti.schwarzChristoffelBoundary` -- the boundary value of the Schwarz--Christoffel
+  primitive at a real point.
+
+## Main results
+
+* `TauCeti.tendsto_schwarzChristoffelPrimitive_boundary` -- the primitive tends to the boundary
+  value wherever the total exponent is greater than `-1`.
+* `TauCeti.schwarzChristoffelBoundary_apply_prevertex` -- the boundary value at a prevertex is
+  the previously constructed Schwarz--Christoffel vertex.
+* `TauCeti.schwarzChristoffelBoundary_sub_eq` -- an open edge has the expected fixed direction
+  and positive real parametrization.
+* `TauCeti.schwarzChristoffelBoundary_injOn` and
+  `TauCeti.collinear_schwarzChristoffelBoundary_image` -- an open edge is embedded in a line.
+* `TauCeti.schwarzChristoffelBoundary_image_Icc_eq_closure_image_Ioo` -- the closed boundary arc
+  is the closure of its open edge.
+* `TauCeti.schwarzChristoffelEdgeAngle_sub_eq_exponent_sum_of_adjacent` -- crossing an adjacent
+  prevertex changes the edge angle by its total turning exponent.
+
+## References
+
+* L. Ahlfors, *Complex Analysis*, Ch. 6, Section 2.
+* T. Driscoll and L. Trefethen, *Schwarz--Christoffel Mapping*, Ch. 2.
+-/
+
+public section
+
+noncomputable section
+
+open Complex Filter Set Topology UpperHalfPlane
+
+namespace TauCeti
+
+variable {ι : Type*} [Fintype ι]
+
+/-- The **boundary value of the Schwarz--Christoffel map** at a real point, defined as the limit
+of its normalized primitive from the upper half-plane.  The limit exists when the total exponent
+at the point is greater than `-1`; see `tendsto_schwarzChristoffelPrimitive_boundary`. -/
+def schwarzChristoffelBoundary (a e : ι → ℝ) (z₀ : UpperHalfPlane) (x : ℝ) : ℂ :=
+  extendFrom upperHalfPlaneSet (schwarzChristoffelPrimitive a e z₀) (x : ℂ)
+
+/-- The Schwarz--Christoffel boundary map is Mathlib's canonical extension-by-limits of the
+primitive from the upper half-plane, restricted to the real axis. -/
+theorem schwarzChristoffelBoundary_def (a e : ι → ℝ) (z₀ : UpperHalfPlane) (x : ℝ) :
+    schwarzChristoffelBoundary a e z₀ x =
+      extendFrom upperHalfPlaneSet (schwarzChristoffelPrimitive a e z₀) (x : ℂ) := by
+  rfl
+
+/-- A limit of the Schwarz--Christoffel primitive from the upper half-plane is its canonical
+boundary value. -/
+theorem schwarzChristoffelBoundary_eq_of_tendsto (a e : ι → ℝ) (z₀ : UpperHalfPlane)
+    (x : ℝ) {v : ℂ} (h : Tendsto (schwarzChristoffelPrimitive a e z₀)
+      (𝓝[upperHalfPlaneSet] (x : ℂ)) (𝓝 v)) :
+    schwarzChristoffelBoundary a e z₀ x = v := by
+  rw [schwarzChristoffelBoundary]
+  exact extendFrom_eq (by rw [Complex.closure_setOfPred_lt_im]; simp) h
+
+/-- At a prevertex, the canonical Schwarz--Christoffel boundary value is the
+Schwarz--Christoffel vertex. -/
+@[simp]
+theorem schwarzChristoffelBoundary_apply_prevertex (a e : ι → ℝ) (z₀ : UpperHalfPlane)
+    (j : ι) (he : -1 < ∑ i with a i = a j, e i) :
+    schwarzChristoffelBoundary a e z₀ (a j) = schwarzChristoffelVertex a e z₀ j := by
+  exact schwarzChristoffelBoundary_eq_of_tendsto a e z₀ (a j)
+    (tendsto_schwarzChristoffelPrimitive a e z₀ j he)
+
+private theorem exists_tendsto_schwarzChristoffelPrimitive_boundary (a e : ι → ℝ)
+    (z₀ : UpperHalfPlane) (x : ℝ) (he : -1 < ∑ i with a i = x, e i) :
+    ∃ v, Tendsto (schwarzChristoffelPrimitive a e z₀)
+      (𝓝[upperHalfPlaneSet] (x : ℂ)) (𝓝 v) := by
+  classical
+  by_cases hx : x ∈ Set.range a
+  · obtain ⟨j, hj⟩ := hx
+    subst x
+    exact ⟨_, tendsto_schwarzChristoffelPrimitive a e z₀ j he⟩
+  · have hopen : IsOpen ((Set.range a)ᶜ : Set ℝ) :=
+      Set.Finite.isClosed (Set.finite_range a) |>.isOpen_compl
+    obtain ⟨ε, hε, hball⟩ := Metric.isOpen_iff.mp hopen x hx
+    have hxIoo : x ∈ Ioo (x - ε) (x + ε) := by constructor <;> linarith
+    have ha : ∀ i, e i ≠ 0 → a i ∉ Ioo (x - ε) (x + ε) := by
+      intro i _ hi
+      have hai : a i ∈ Metric.ball x ε := by
+        rw [Metric.mem_ball, Real.dist_eq, abs_lt]
+        constructor <;> linarith [hi.1, hi.2]
+      exact (hball hai) ⟨i, rfl⟩
+    obtain ⟨L, hL, -, -⟩ :=
+      exists_tendsto_schwarzChristoffelPrimitive_sub_eq a e z₀ ha
+    exact ⟨L x, hL x hxIoo⟩
+
+/-- The Schwarz--Christoffel primitive tends to its canonical boundary value at every real point
+where the total exponent is greater than `-1`.  At a prevertex this is the integrable-singularity
+estimate; away from all prevertices the integrand continues holomorphically across a real
+neighbourhood. -/
+theorem tendsto_schwarzChristoffelPrimitive_boundary (a e : ι → ℝ)
+    (z₀ : UpperHalfPlane) (x : ℝ) (he : -1 < ∑ i with a i = x, e i) :
+    Tendsto (schwarzChristoffelPrimitive a e z₀)
+      (𝓝[upperHalfPlaneSet] (x : ℂ)) (𝓝 (schwarzChristoffelBoundary a e z₀ x)) := by
+  rw [schwarzChristoffelBoundary]
+  exact tendsto_extendFrom (exists_tendsto_schwarzChristoffelPrimitive_boundary a e z₀ x he)
+
+/-- The canonical Schwarz--Christoffel boundary map is continuous on any set of real points at
+which the total exponent is greater than `-1`.  This simultaneously gives continuity along open
+edges and attachment of those edges to every integrable prevertex. -/
+theorem continuousOn_schwarzChristoffelBoundary_of_exponent_sum_gt_neg_one (a e : ι → ℝ)
+    (z₀ : UpperHalfPlane) {s : Set ℝ} (he : ∀ x ∈ s, -1 < ∑ i with a i = x, e i) :
+    ContinuousOn (schwarzChristoffelBoundary a e z₀) s := by
+  let F : ℂ → ℂ := schwarzChristoffelPrimitive a e z₀
+  have hcont : ContinuousOn (extendFrom upperHalfPlaneSet F) (Complex.ofReal '' s) := by
+    apply continuousOn_extendFrom
+    · intro z hz
+      rw [Complex.closure_setOfPred_lt_im]
+      obtain ⟨x, -, rfl⟩ := hz
+      simp
+    · rintro z ⟨x, hx, rfl⟩
+      exact exists_tendsto_schwarzChristoffelPrimitive_boundary a e z₀ x (he x hx)
+  exact hcont.comp Complex.continuous_ofReal.continuousOn fun x hx => ⟨x, hx, rfl⟩
+
+/-- On a real interval free of prevertices with nonzero exponent, the canonical boundary map is
+continuous. -/
+theorem continuousOn_schwarzChristoffelBoundary (a e : ι → ℝ) (z₀ : UpperHalfPlane)
+    {p q : ℝ} (ha : ∀ i, e i ≠ 0 → a i ∉ Ioo p q) :
+    ContinuousOn (schwarzChristoffelBoundary a e z₀) (Ioo p q) := by
+  obtain ⟨L, hL, hLcont, -⟩ :=
+    exists_tendsto_schwarzChristoffelPrimitive_sub_eq a e z₀ ha
+  refine hLcont.congr fun x hx => ?_
+  exact schwarzChristoffelBoundary_eq_of_tendsto a e z₀ x (hL x hx)
+
+/-- Along a real interval free of prevertices with nonzero exponent, the increment of the
+canonical Schwarz--Christoffel boundary map is a real integral times the fixed edge direction.
+In particular, all its increments have argument
+`schwarzChristoffelEdgeAngle a e p` up to reversal. -/
+theorem schwarzChristoffelBoundary_sub_eq (a e : ι → ℝ) (z₀ : UpperHalfPlane)
+    {p q : ℝ} (ha : ∀ i, e i ≠ 0 → a i ∉ Ioo p q) {x y : ℝ}
+    (hx : x ∈ Ioo p q) (hy : y ∈ Ioo p q) :
+    schwarzChristoffelBoundary a e z₀ x - schwarzChristoffelBoundary a e z₀ y =
+      ((∫ t in y..x, ∏ i, |t - a i| ^ e i : ℝ) : ℂ) *
+        Complex.exp (schwarzChristoffelEdgeAngle a e p * Complex.I) := by
+  obtain ⟨L, hL, -, hsub⟩ :=
+    exists_tendsto_schwarzChristoffelPrimitive_sub_eq a e z₀ ha
+  rw [schwarzChristoffelBoundary_eq_of_tendsto a e z₀ x (hL x hx),
+    schwarzChristoffelBoundary_eq_of_tendsto a e z₀ y (hL y hy)]
+  exact hsub x hx y hy
+
+/-- The canonical Schwarz--Christoffel boundary map is injective on every real interval free of
+prevertices with nonzero exponent. -/
+theorem schwarzChristoffelBoundary_injOn (a e : ι → ℝ) (z₀ : UpperHalfPlane)
+    {p q : ℝ} (ha : ∀ i, e i ≠ 0 → a i ∉ Ioo p q) :
+    InjOn (schwarzChristoffelBoundary a e z₀) (Ioo p q) := by
+  obtain ⟨L, hL, -, hLinj, -⟩ :=
+    exists_tendsto_schwarzChristoffelPrimitive_injOn_collinear a e z₀ ha
+  intro x hx y hy hxy
+  apply hLinj hx hy
+  rwa [schwarzChristoffelBoundary_eq_of_tendsto a e z₀ x (hL x hx),
+    schwarzChristoffelBoundary_eq_of_tendsto a e z₀ y (hL y hy)] at hxy
+
+/-- The image of a prevertex-free real interval under the canonical Schwarz--Christoffel boundary
+map is collinear. -/
+theorem collinear_schwarzChristoffelBoundary_image (a e : ι → ℝ)
+    (z₀ : UpperHalfPlane) {p q : ℝ} (ha : ∀ i, e i ≠ 0 → a i ∉ Ioo p q) :
+    Collinear ℝ (schwarzChristoffelBoundary a e z₀ '' Ioo p q) := by
+  obtain ⟨L, hL, -, -, hLcol⟩ :=
+    exists_tendsto_schwarzChristoffelPrimitive_injOn_collinear a e z₀ ha
+  convert hLcol using 1
+  ext z
+  constructor
+  · rintro ⟨x, hx, rfl⟩
+    exact ⟨x, hx, (schwarzChristoffelBoundary_eq_of_tendsto a e z₀ x (hL x hx)).symm⟩
+  · rintro ⟨x, hx, rfl⟩
+    exact ⟨x, hx, schwarzChristoffelBoundary_eq_of_tendsto a e z₀ x (hL x hx)⟩
+
+/-- Between adjacent real prevertices with integrable endpoint exponents, the canonical
+Schwarz--Christoffel boundary map is continuous on the closed interval.  Hence the open straight
+edge supplied by `schwarzChristoffelBoundary_sub_eq` attaches continuously to its two vertices. -/
+theorem continuousOn_schwarzChristoffelBoundary_Icc (a e : ι → ℝ)
+    (z₀ : UpperHalfPlane) {p q : ℝ} (hpq : p < q)
+    (ha : ∀ i, e i ≠ 0 → a i ∉ Ioo p q)
+    (hp : -1 < ∑ i with a i = p, e i) (hq : -1 < ∑ i with a i = q, e i) :
+    ContinuousOn (schwarzChristoffelBoundary a e z₀) (Icc p q) := by
+  classical
+  apply continuousOn_schwarzChristoffelBoundary_of_exponent_sum_gt_neg_one
+  intro x hx
+  rcases eq_or_lt_of_le hx.1 with rfl | hpx
+  · exact hp
+  rcases eq_or_lt_of_le hx.2 with rfl | hxq
+  · exact hq
+  have hzero : ∑ i with a i = x, e i = 0 := by
+    apply Finset.sum_eq_zero
+    intro i hi
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hi
+    by_contra hei
+    exact ha i hei ⟨hi ▸ hpx, hi ▸ hxq⟩
+  rw [hzero]
+  norm_num
+
+/-- The closed boundary arc between adjacent integrable prevertices is exactly the closure of its
+open straight edge.  In particular, both endpoint vertices belong to the closure of that edge,
+which is the local gluing statement needed to assemble the Schwarz--Christoffel polygon. -/
+theorem schwarzChristoffelBoundary_image_Icc_eq_closure_image_Ioo (a e : ι → ℝ)
+    (z₀ : UpperHalfPlane) {p q : ℝ} (hpq : p < q)
+    (ha : ∀ i, e i ≠ 0 → a i ∉ Ioo p q)
+    (hp : -1 < ∑ i with a i = p, e i) (hq : -1 < ∑ i with a i = q, e i) :
+    schwarzChristoffelBoundary a e z₀ '' Icc p q =
+      closure (schwarzChristoffelBoundary a e z₀ '' Ioo p q) := by
+  apply Subset.antisymm
+  · have hcont : ContinuousOn (schwarzChristoffelBoundary a e z₀) (closure (Ioo p q)) := by
+      simpa only [closure_Ioo hpq.ne] using
+        continuousOn_schwarzChristoffelBoundary_Icc a e z₀ hpq ha hp hq
+    simpa only [closure_Ioo hpq.ne] using hcont.image_closure
+  · apply closure_minimal (image_mono Ioo_subset_Icc_self)
+    exact (isCompact_Icc.image_of_continuousOn
+      (continuousOn_schwarzChristoffelBoundary_Icc a e z₀ hpq ha hp hq)).isClosed
+
+/-- The two Schwarz--Christoffel vertices belonging to adjacent prevertices lie in the closure of
+the open straight edge between them.  This is the endpoint form of the local polygon gluing: the
+closed boundary arc is not merely collinear but attaches to the previously defined vertex values. -/
+theorem schwarzChristoffelVertices_mem_closure_boundary_image_Ioo (a e : ι → ℝ)
+    (z₀ : UpperHalfPlane) {j k : ι} (hjk : a j < a k)
+    (ha : ∀ i, e i ≠ 0 → a i ∉ Ioo (a j) (a k))
+    (hj : -1 < ∑ i with a i = a j, e i) (hk : -1 < ∑ i with a i = a k, e i) :
+    schwarzChristoffelVertex a e z₀ j ∈
+        closure (schwarzChristoffelBoundary a e z₀ '' Ioo (a j) (a k)) ∧
+      schwarzChristoffelVertex a e z₀ k ∈
+        closure (schwarzChristoffelBoundary a e z₀ '' Ioo (a j) (a k)) := by
+  rw [← schwarzChristoffelBoundary_image_Icc_eq_closure_image_Ioo a e z₀ hjk ha hj hk]
+  constructor
+  · exact ⟨a j, left_mem_Icc.mpr hjk.le,
+      schwarzChristoffelBoundary_apply_prevertex a e z₀ j hj⟩
+  · exact ⟨a k, right_mem_Icc.mpr hjk.le,
+      schwarzChristoffelBoundary_apply_prevertex a e z₀ k hk⟩
+
+/-- Across two adjacent real boundary points, the change in Schwarz--Christoffel edge angle is
+exactly `π` times the total exponent at the right endpoint.  Equivalently, moving from left to
+right turns the edge direction by the exterior angle given by the negative of this quantity. -/
+theorem schwarzChristoffelEdgeAngle_sub_eq_exponent_sum_of_adjacent (a e : ι → ℝ)
+    {p q : ℝ} (hpq : p < q) (ha : ∀ i, e i ≠ 0 → a i ∉ Ioo p q) :
+    schwarzChristoffelEdgeAngle a e p - schwarzChristoffelEdgeAngle a e q =
+      Real.pi * ∑ i with a i = q, e i := by
+  rw [schwarzChristoffelEdgeAngle_sub a e hpq.le]
+  congr 1
+  symm
+  apply Finset.sum_subset
+  · intro i hi
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hi ⊢
+    rw [hi]
+    exact ⟨hpq, le_rfl⟩
+  · intro i hi hiq
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hi hiq
+    by_contra hei
+    exact ha i hei ⟨hi.1, hi.2.lt_of_ne hiq⟩
+
+end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/SchwarzChristoffel/Edge.lean
+++ b/TauCeti/Analysis/Complex/Conformal/SchwarzChristoffel/Edge.lean
@@ -49,8 +49,10 @@ prevertex `a i` rotates the edge direction by `-π · e i`, which for the classi
 
 ## Main results
 
-* `TauCeti.schwarzChristoffelEdgeAngle_sub_eq_pi_mul_exponent_sum_of_adjacent` -- crossing an
-  adjacent prevertex changes the edge angle by `π` times its total turning exponent.
+* `TauCeti.schwarzChristoffelEdgeAngle_sub_eq_pi_mul_exponent_sum_of_adjacent` -- across
+  adjacent reference points `p < q`, the edge angle at `p` minus the edge angle at `q` is `π`
+  times the total exponent carried by `q`; moving from left to right therefore changes the edge
+  angle by `-π` times that total.
 * `TauCeti.schwarzChristoffelIntegrand_eq_exp_mul_continued` -- on the upper half-plane the
   integrand is the continued integrand times the unimodular edge-direction constant.
 * `TauCeti.schwarzChristoffelContinuedIntegrand_ofReal` -- on a prevertex-free real interval the
@@ -129,11 +131,12 @@ theorem schwarzChristoffelEdgeAngle_sub (a e : ι → ℝ) {c d : ℝ} (hcd : c 
     · simp [h₁, not_lt.mpr h₂, Set.mem_Ioc, h₂]
     · simp [h₁, h₂, Set.mem_Ioc, not_le.mpr h₂]
 
-/-- Across two adjacent real reference points -- that is, with no prevertex of nonzero exponent
-strictly between them -- the change in Schwarz--Christoffel edge angle is exactly `π` times the
-total exponent carried by the right endpoint.  For the classical choice `e i = α i / π - 1`
-attached to a polygon with interior angle `α i`, moving from left to right therefore turns the
-edge direction by the exterior angle which is the negative of that quantity. -/
+/-- Across two adjacent real reference points `p < q` -- that is, with no prevertex of nonzero
+exponent strictly between them -- the Schwarz--Christoffel edge angle at `p` minus the edge angle
+at `q` is exactly `π` times the total exponent carried by `q`; equivalently, moving from left to
+right changes the edge angle by `-π` times that total.  For the classical choice
+`e i = α i / π - 1` attached to a polygon with interior angle `α i`, that left-to-right change is
+the exterior angle `π - α i` at the vertex. -/
 theorem schwarzChristoffelEdgeAngle_sub_eq_pi_mul_exponent_sum_of_adjacent (a e : ι → ℝ)
     {p q : ℝ} (hpq : p < q) (ha : ∀ i, e i ≠ 0 → a i ∉ Ioo p q) :
     schwarzChristoffelEdgeAngle a e p - schwarzChristoffelEdgeAngle a e q =

--- a/TauCeti/Analysis/Complex/Conformal/SchwarzChristoffel/Edge.lean
+++ b/TauCeti/Analysis/Complex/Conformal/SchwarzChristoffel/Edge.lean
@@ -135,8 +135,9 @@ theorem schwarzChristoffelEdgeAngle_sub (a e : ι → ℝ) {c d : ℝ} (hcd : c 
 exponent strictly between them -- the Schwarz--Christoffel edge angle at `p` minus the edge angle
 at `q` is exactly `π` times the total exponent carried by `q`; equivalently, moving from left to
 right changes the edge angle by `-π` times that total.  For the classical choice
-`e i = α i / π - 1`, each index at `q` contributes the exterior angle `π - α i` to that
-left-to-right change, so the total is the sum of those contributions. -/
+`e i = α i / π - 1`, every index `i` with `a i = q` contributes the exterior angle `π - α i` to
+that left-to-right change, which is therefore the sum of those contributions and equals a single
+exterior angle exactly when one index sits at `q`. -/
 theorem schwarzChristoffelEdgeAngle_sub_eq_pi_mul_exponent_sum_of_adjacent (a e : ι → ℝ)
     {p q : ℝ} (hpq : p < q) (ha : ∀ i, e i ≠ 0 → a i ∉ Ioo p q) :
     schwarzChristoffelEdgeAngle a e p - schwarzChristoffelEdgeAngle a e q =

--- a/TauCeti/Analysis/Complex/Conformal/SchwarzChristoffel/Edge.lean
+++ b/TauCeti/Analysis/Complex/Conformal/SchwarzChristoffel/Edge.lean
@@ -135,8 +135,8 @@ theorem schwarzChristoffelEdgeAngle_sub (a e : ι → ℝ) {c d : ℝ} (hcd : c 
 exponent strictly between them -- the Schwarz--Christoffel edge angle at `p` minus the edge angle
 at `q` is exactly `π` times the total exponent carried by `q`; equivalently, moving from left to
 right changes the edge angle by `-π` times that total.  For the classical choice
-`e i = α i / π - 1` attached to a polygon with interior angle `α i`, that left-to-right change is
-the exterior angle `π - α i` at the vertex. -/
+`e i = α i / π - 1`, each index at `q` contributes the exterior angle `π - α i` to that
+left-to-right change, so the total is the sum of those contributions. -/
 theorem schwarzChristoffelEdgeAngle_sub_eq_pi_mul_exponent_sum_of_adjacent (a e : ι → ℝ)
     {p q : ℝ} (hpq : p < q) (ha : ∀ i, e i ≠ 0 → a i ∉ Ioo p q) :
     schwarzChristoffelEdgeAngle a e p - schwarzChristoffelEdgeAngle a e q =

--- a/TauCeti/Analysis/Complex/Conformal/SchwarzChristoffel/Edge.lean
+++ b/TauCeti/Analysis/Complex/Conformal/SchwarzChristoffel/Edge.lean
@@ -49,6 +49,8 @@ prevertex `a i` rotates the edge direction by `-π · e i`, which for the classi
 
 ## Main results
 
+* `TauCeti.schwarzChristoffelEdgeAngle_sub_eq_pi_mul_exponent_sum_of_adjacent` -- crossing an
+  adjacent prevertex changes the edge angle by `π` times its total turning exponent.
 * `TauCeti.schwarzChristoffelIntegrand_eq_exp_mul_continued` -- on the upper half-plane the
   integrand is the continued integrand times the unimodular edge-direction constant.
 * `TauCeti.schwarzChristoffelContinuedIntegrand_ofReal` -- on a prevertex-free real interval the
@@ -126,6 +128,28 @@ theorem schwarzChristoffelEdgeAngle_sub (a e : ι → ℝ) {c d : ℝ} (hcd : c 
   · rcases le_or_gt (a i) d with h₂ | h₂
     · simp [h₁, not_lt.mpr h₂, Set.mem_Ioc, h₂]
     · simp [h₁, h₂, Set.mem_Ioc, not_le.mpr h₂]
+
+/-- Across two adjacent real reference points -- that is, with no prevertex of nonzero exponent
+strictly between them -- the change in Schwarz--Christoffel edge angle is exactly `π` times the
+total exponent carried by the right endpoint.  For the classical choice `e i = α i / π - 1`
+attached to a polygon with interior angle `α i`, moving from left to right therefore turns the
+edge direction by the exterior angle which is the negative of that quantity. -/
+theorem schwarzChristoffelEdgeAngle_sub_eq_pi_mul_exponent_sum_of_adjacent (a e : ι → ℝ)
+    {p q : ℝ} (hpq : p < q) (ha : ∀ i, e i ≠ 0 → a i ∉ Ioo p q) :
+    schwarzChristoffelEdgeAngle a e p - schwarzChristoffelEdgeAngle a e q =
+      Real.pi * ∑ i with a i = q, e i := by
+  rw [schwarzChristoffelEdgeAngle_sub a e hpq.le]
+  congr 1
+  symm
+  apply Finset.sum_subset
+  · intro i hi
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hi ⊢
+    rw [hi]
+    exact ⟨hpq, le_rfl⟩
+  · intro i hi hiq
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hi hiq
+    by_contra hei
+    exact ha i hei ⟨hi.1, hi.2.lt_of_ne hiq⟩
 
 /-- On the upper half-plane the Schwarz--Christoffel integrand is its continuation across any real
 reference point, times the unimodular constant with argument the edge angle there. -/


### PR DESCRIPTION
This PR defines the canonical real-axis boundary map of the Schwarz--Christoffel primitive and proves that its open straight edges attach continuously to their endpoint vertices, with the change between adjacent edge directions equal to the total turning exponent at the intervening prevertex.

It advances the exact `ConformalMapping/README.md` L6 target “Schwarz--Christoffel: explicit conformal maps onto polygons, built on L4 + L5.” The milestone already has the integrand, primitive, straight open edges, and individual vertex limits; this PR is the next critical step because `schwarzChristoffelBoundary` makes those separate limits one continuous boundary object, proves that the closed arc between adjacent integrable prevertices is exactly the closure of its open edge, and places both named vertices in that closure. After this PR, L6 still needs the sharper leading-order turning asymptotic at a prevertex, global cyclic closure (including the point at infinity), and identification of the primitive's image with the prescribed polygonal domain.

The limit theorem is stated at its natural condition: the sum of all exponents carried by a real point is greater than `-1`, so coincident prevertices are handled without a distinctness assumption and ordinary non-prevertices are included automatically. On any locus satisfying that condition, Mathlib's `extendFrom` and `continuousOn_extendFrom` turn the pointwise upper-half-plane limits into a continuous boundary map. The adjacent-edge results then reuse the landed straight-edge continuation and vertex estimates, while `schwarzChristoffelEdgeAngle_sub_eq_exponent_sum_of_adjacent` records the exact corner rotation.

The construction follows L. Ahlfors, *Complex Analysis*, Chapter 6 §2, and T. Driscoll and L. Trefethen, *Schwarz--Christoffel Mapping*, Chapter 2, as cited in the module documentation. It reuses Mathlib's `extendFrom`, `continuousOn_extendFrom`, `extendFrom_eq`, and `Complex.closure_setOfPred_lt_im`; no Mathlib infrastructure or external formalization is vendored.

The new `TauCeti/Analysis/Complex/Conformal/SchwarzChristoffel/Boundary.lean` module contains 279 lines.

Roadmap: ConformalMapping

<!--tauceti-target:v1 {"focus":"ConformalMapping","id":"schwarz-christoffel-adjacent-vertex-edges"}-->

🤖 Prepared with Codex
