### PR TITLE
feat(RingTheory): a finite product of flat modules is flat, and when it is faithfully flat

### DIFF
--- a/TauCeti/RingTheory/Flat/Pi.lean
+++ b/TauCeti/RingTheory/Flat/Pi.lean
@@ -24,13 +24,13 @@ once**. Individually the factors may all fail to be faithfully flat.
 
 ## Main results
 
-* `Submodule.smul_top_eq_top_of_pi`: `I • ⊤ = ⊤` in a product passes to every factor. No
-  finiteness is needed for this direction.
+* `Ideal.smul_top_eq_top_of_pi`: `I • ⊤ = ⊤` in a product passes to every factor. No finiteness
+  is needed for this direction.
 * `Module.Flat.pi`: a finite product of flat modules is flat.
 * `Module.FaithfullyFlat.pi_of_exists_submodule_ne_top`: a finite product of flat modules is
   faithfully flat as soon as every maximal ideal stays proper in *some* factor.
-* `Module.FaithfullyFlat.pi_of_faithfullyFlat`: the common case — one faithfully flat factor
-  carries the whole product.
+* `Module.FaithfullyFlat.pi_of_faithfullyFlat`: the special case of one distinguished faithfully
+  flat factor.
 * `Module.FaithfullyFlat.pi`: a finite *nonempty* product of faithfully flat modules.
 
 ## Implementation notes
@@ -46,14 +46,13 @@ statement fails outright for a large enough index. Nothing is lost over a noethe
 hypothesis cannot simply be dropped.
 -/
 
-@[expose] public section
+public section
 
-open Module
+variable {R : Type*} {ι : Type*} {M : ι → Type*}
 
-namespace Submodule
+namespace Ideal
 
-variable {R : Type*} [CommRing R] {ι : Type*} {M : ι → Type*} [∀ i, AddCommGroup (M i)]
-    [∀ i, Module R (M i)]
+variable [Semiring R] [∀ i, AddCommMonoid (M i)] [∀ i, Module R (M i)]
 
 /-- If an ideal expands the whole of a product, it expands the whole of every factor. The
 projections are surjective, so this is `Submodule.map_smul''` read along one of them. -/
@@ -63,17 +62,24 @@ theorem smul_top_eq_top_of_pi (I : Ideal R) (h : I • (⊤ : Submodule R (∀ i
   rwa [Submodule.map_smul'', Submodule.map_top,
     LinearMap.range_eq_top.mpr (Function.surjective_eval i)] at this
 
-end Submodule
+end Ideal
 
 namespace Module
 
-variable {R : Type*} [CommRing R] {ι : Type*} {M : ι → Type*} [∀ i, AddCommGroup (M i)]
-    [∀ i, Module R (M i)]
+section Flat
+
+variable [CommSemiring R] [∀ i, AddCommMonoid (M i)] [∀ i, Module R (M i)]
 
 /-- **A finite product of flat modules is flat**, by comparison with the direct sum. -/
 instance Flat.pi [Finite ι] [∀ i, Flat R (M i)] : Flat R (∀ i, M i) := by
   have := Fintype.ofFinite ι
   exact Flat.of_linearEquiv (DirectSum.linearEquivFunOnFintype R ι M).symm
+
+end Flat
+
+section FaithfullyFlat
+
+variable [CommRing R] [∀ i, AddCommGroup (M i)] [∀ i, Module R (M i)]
 
 /-- **A finite product of flat modules is faithfully flat as soon as no maximal ideal expands
 every factor at once.** Each individual factor may fail to be faithfully flat; what is needed is
@@ -81,12 +87,11 @@ that the failures are not simultaneous. -/
 theorem FaithfullyFlat.pi_of_exists_submodule_ne_top [Finite ι] [∀ i, Flat R (M i)]
     (h : ∀ m : Ideal R, m.IsMaximal → ∃ i, m • (⊤ : Submodule R (M i)) ≠ ⊤) :
     FaithfullyFlat R (∀ i, M i) where
-  submodule_ne_top m hm htop :=
-    (h m hm).elim fun i hi ↦ hi (Submodule.smul_top_eq_top_of_pi m htop i)
+  submodule_ne_top m hm htop := (h m hm).elim fun i hi ↦ hi (m.smul_top_eq_top_of_pi htop i)
 
-/-- **One faithfully flat factor carries a finite product of flat modules.** This is how the
-criterion is usually met: a rational cover contributes one distinguished piece, and the rest need
-only be flat. -/
+/-- **One faithfully flat factor carries a finite product of flat modules.** This is the special
+case of `FaithfullyFlat.pi_of_exists_submodule_ne_top` where one fixed index works for every
+maximal ideal; when no single factor does, that criterion is the one to use. -/
 theorem FaithfullyFlat.pi_of_faithfullyFlat [Finite ι] [∀ i, Flat R (M i)] (j : ι)
     [FaithfullyFlat R (M j)] : FaithfullyFlat R (∀ i, M i) :=
   FaithfullyFlat.pi_of_exists_submodule_ne_top fun _ hm ↦
@@ -98,4 +103,8 @@ instance FaithfullyFlat.pi [Nonempty ι] [Finite ι] [∀ i, FaithfullyFlat R (M
     FaithfullyFlat R (∀ i, M i) :=
   FaithfullyFlat.pi_of_faithfullyFlat (Classical.arbitrary ι)
 
+end FaithfullyFlat
+
 end Module
+
+end

--- a/TauCeti/RingTheory/Flat/Pi.lean
+++ b/TauCeti/RingTheory/Flat/Pi.lean
@@ -1,0 +1,101 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.DirectSum.Module
+public import Mathlib.RingTheory.Flat.FaithfullyFlat.Basic
+public import Mathlib.RingTheory.Ideal.Operations
+
+/-!
+# A finite product of flat modules is flat, and when it is faithfully flat
+
+Mathlib knows that an arbitrary direct sum of flat modules is flat (`Module.Flat.directSum`), but
+`∀ i, M i` is not definitionally a direct sum, so nothing fires for a product. Over a finite index
+the two agree, and this file records the resulting instance together with the criterion that
+upgrades it to faithful flatness.
+
+Mathlib defines `Module.FaithfullyFlat` as flatness plus `m • ⊤ ≠ ⊤` for every maximal ideal `m`,
+so the criterion is about locating a single component that keeps `m` proper: a product is
+faithfully flat as soon as each factor is flat and **no maximal ideal expands in every factor at
+once**. Individually the factors may all fail to be faithfully flat.
+
+## Main results
+
+* `Submodule.smul_top_eq_top_of_pi`: `I • ⊤ = ⊤` in a product passes to every factor. No
+  finiteness is needed for this direction.
+* `Module.Flat.pi`: a finite product of flat modules is flat.
+* `Module.FaithfullyFlat.pi_of_exists_submodule_ne_top`: a finite product of flat modules is
+  faithfully flat as soon as every maximal ideal stays proper in *some* factor.
+* `Module.FaithfullyFlat.pi_of_faithfullyFlat`: the common case — one faithfully flat factor
+  carries the whole product.
+* `Module.FaithfullyFlat.pi`: a finite *nonempty* product of faithfully flat modules.
+
+## Implementation notes
+
+`Module.FaithfullyFlat.pi` asks `[Nonempty ι]`, and that is not slack: for `ι` empty the product
+is the trivial module, in which `m • ⊤ = ⊤ = ⊥` for every `m`, so it is faithfully flat over no
+nonzero ring at all — while `∀ i, FaithfullyFlat R (M i)` holds vacuously. Dropping the hypothesis
+would make the instance false. Flatness has no such caveat: the trivial module is flat.
+
+The finiteness is not an artefact of the comparison used here: by Chase's theorem a ring is
+coherent exactly when every product of flat modules is flat, so over a non-coherent ring the
+statement fails outright for a large enough index. Nothing is lost over a noetherian base, but the
+hypothesis cannot simply be dropped.
+-/
+
+@[expose] public section
+
+open Module
+
+namespace Submodule
+
+variable {R : Type*} [CommRing R] {ι : Type*} {M : ι → Type*} [∀ i, AddCommGroup (M i)]
+    [∀ i, Module R (M i)]
+
+/-- If an ideal expands the whole of a product, it expands the whole of every factor. The
+projections are surjective, so this is `Submodule.map_smul''` read along one of them. -/
+theorem smul_top_eq_top_of_pi (I : Ideal R) (h : I • (⊤ : Submodule R (∀ i, M i)) = ⊤) (i : ι) :
+    I • (⊤ : Submodule R (M i)) = ⊤ := by
+  have := congrArg (Submodule.map (LinearMap.proj (R := R) (φ := M) i)) h
+  rwa [Submodule.map_smul'', Submodule.map_top,
+    LinearMap.range_eq_top.mpr (Function.surjective_eval i)] at this
+
+end Submodule
+
+namespace Module
+
+variable {R : Type*} [CommRing R] {ι : Type*} {M : ι → Type*} [∀ i, AddCommGroup (M i)]
+    [∀ i, Module R (M i)]
+
+/-- **A finite product of flat modules is flat**, by comparison with the direct sum. -/
+instance Flat.pi [Finite ι] [∀ i, Flat R (M i)] : Flat R (∀ i, M i) := by
+  have := Fintype.ofFinite ι
+  exact Flat.of_linearEquiv (DirectSum.linearEquivFunOnFintype R ι M).symm
+
+/-- **A finite product of flat modules is faithfully flat as soon as no maximal ideal expands
+every factor at once.** Each individual factor may fail to be faithfully flat; what is needed is
+that the failures are not simultaneous. -/
+theorem FaithfullyFlat.pi_of_exists_submodule_ne_top [Finite ι] [∀ i, Flat R (M i)]
+    (h : ∀ m : Ideal R, m.IsMaximal → ∃ i, m • (⊤ : Submodule R (M i)) ≠ ⊤) :
+    FaithfullyFlat R (∀ i, M i) where
+  submodule_ne_top m hm htop :=
+    (h m hm).elim fun i hi ↦ hi (Submodule.smul_top_eq_top_of_pi m htop i)
+
+/-- **One faithfully flat factor carries a finite product of flat modules.** This is how the
+criterion is usually met: a rational cover contributes one distinguished piece, and the rest need
+only be flat. -/
+theorem FaithfullyFlat.pi_of_faithfullyFlat [Finite ι] [∀ i, Flat R (M i)] (j : ι)
+    [FaithfullyFlat R (M j)] : FaithfullyFlat R (∀ i, M i) :=
+  FaithfullyFlat.pi_of_exists_submodule_ne_top fun _ hm ↦
+    ⟨j, FaithfullyFlat.submodule_ne_top hm⟩
+
+/-- A finite **nonempty** product of faithfully flat modules is faithfully flat. The emptiness
+hypothesis is essential; see the module docstring. -/
+instance FaithfullyFlat.pi [Nonempty ι] [Finite ι] [∀ i, FaithfullyFlat R (M i)] :
+    FaithfullyFlat R (∀ i, M i) :=
+  FaithfullyFlat.pi_of_faithfullyFlat (Classical.arbitrary ι)
+
+end Module

--- a/TauCeti/RingTheory/Flat/Pi.lean
+++ b/TauCeti/RingTheory/Flat/Pi.lean
@@ -21,7 +21,7 @@ upgrades it to faithful flatness.
 
 Mathlib defines `Module.FaithfullyFlat` as flatness plus `m • ⊤ ≠ ⊤` for every maximal ideal `m`,
 so the criterion is about locating a single component that keeps `m` proper — the factorwise half
-of that is `TauCeti.Ideal.smul_top_eq_top_of_pi`, a general ideal-action fact with no flatness or
+of that is `Ideal.smul_top_eq_top_of_pi`, a general ideal-action fact with no flatness or
 finiteness in it, which lives in `TauCeti/RingTheory/Ideal/Operations.lean`: a product is
 faithfully flat as soon as each factor is flat and **no maximal ideal expands in every factor at
 once**. Individually the factors may all fail to be faithfully flat.

--- a/TauCeti/RingTheory/Flat/Pi.lean
+++ b/TauCeti/RingTheory/Flat/Pi.lean
@@ -5,10 +5,9 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Algebra.DirectSum.Module
 public import Mathlib.RingTheory.Flat.FaithfullyFlat.Basic
-public import Mathlib.RingTheory.Ideal.Operations
 
+import Mathlib.Algebra.DirectSum.Module
 import TauCeti.RingTheory.Ideal.Operations
 
 /-!

--- a/TauCeti/RingTheory/Flat/Pi.lean
+++ b/TauCeti/RingTheory/Flat/Pi.lean
@@ -9,6 +9,8 @@ public import Mathlib.Algebra.DirectSum.Module
 public import Mathlib.RingTheory.Flat.FaithfullyFlat.Basic
 public import Mathlib.RingTheory.Ideal.Operations
 
+import TauCeti.RingTheory.Ideal.Operations
+
 /-!
 # A finite product of flat modules is flat, and when it is faithfully flat
 
@@ -18,14 +20,14 @@ the two agree, and this file records the resulting instance together with the cr
 upgrades it to faithful flatness.
 
 Mathlib defines `Module.FaithfullyFlat` as flatness plus `m • ⊤ ≠ ⊤` for every maximal ideal `m`,
-so the criterion is about locating a single component that keeps `m` proper: a product is
+so the criterion is about locating a single component that keeps `m` proper — the factorwise half
+of that is `TauCeti.Ideal.smul_top_eq_top_of_pi`, a general ideal-action fact with no flatness or
+finiteness in it, which lives in `TauCeti/RingTheory/Ideal/Operations.lean`: a product is
 faithfully flat as soon as each factor is flat and **no maximal ideal expands in every factor at
 once**. Individually the factors may all fail to be faithfully flat.
 
 ## Main results
 
-* `Ideal.smul_top_eq_top_of_pi`: `I • ⊤ = ⊤` in a product passes to every factor. No finiteness
-  is needed for this direction.
 * `Module.Flat.pi`: a finite product of flat modules is flat.
 * `Module.FaithfullyFlat.pi_of_exists_submodule_ne_top`: a finite product of flat modules is
   faithfully flat as soon as every maximal ideal stays proper in *some* factor.
@@ -50,27 +52,14 @@ public section
 
 variable {R : Type*} {ι : Type*} {M : ι → Type*}
 
-namespace Ideal
-
-variable [Semiring R] [∀ i, AddCommMonoid (M i)] [∀ i, Module R (M i)]
-
-/-- If an ideal expands the whole of a product, it expands the whole of every factor. The
-projections are surjective, so this is `Submodule.map_smul''` read along one of them. -/
-theorem smul_top_eq_top_of_pi (I : Ideal R) (h : I • (⊤ : Submodule R (∀ i, M i)) = ⊤) (i : ι) :
-    I • (⊤ : Submodule R (M i)) = ⊤ := by
-  have := congrArg (Submodule.map (LinearMap.proj (R := R) (φ := M) i)) h
-  rwa [Submodule.map_smul'', Submodule.map_top,
-    LinearMap.range_eq_top.mpr (Function.surjective_eval i)] at this
-
-end Ideal
-
 namespace Module
 
 section Flat
 
 variable [CommSemiring R] [∀ i, AddCommMonoid (M i)] [∀ i, Module R (M i)]
 
-/-- **A finite product of flat modules is flat**, by comparison with the direct sum. -/
+/-- **A finite product of flat modules is flat.** The finiteness is essential; see the module
+docstring. -/
 instance Flat.pi [Finite ι] [∀ i, Flat R (M i)] : Flat R (∀ i, M i) := by
   have := Fintype.ofFinite ι
   exact Flat.of_linearEquiv (DirectSum.linearEquivFunOnFintype R ι M).symm

--- a/TauCeti/RingTheory/Ideal/Operations.lean
+++ b/TauCeti/RingTheory/Ideal/Operations.lean
@@ -7,22 +7,28 @@ module
 
 public import Mathlib.RingTheory.Ideal.Operations
 
+import Mathlib.LinearAlgebra.Pi
+
 /-!
-# Complements on the multiplicative monoid of ideals
+# Complements on ideal multiplication and the ideal action
 
-This file collects general facts about the multiplication of ideals of a commutative semiring,
-complementing `Mathlib/RingTheory/Ideal/Operations.lean`.
+This file collects general facts about the multiplication of ideals and about the action `I • N`
+of an ideal on a module, complementing `Mathlib/RingTheory/Ideal/Operations.lean`.
 
-## Main result
+## Main results
 
 * `Ideal.eq_one_of_mul_eq_one`: the only factorization of the unit ideal is the trivial one, so a
   factor of `1` is `1`. This is the ideal-theoretic cancellation step behind the fact that the
   divisor antidiagonal of the unit ideal is a singleton.
+* `Ideal.smul_top_eq_top_of_pi`: an ideal that expands the whole of a product of modules expands
+  the whole of every factor.
 -/
 
 public section
 
 namespace Ideal
+
+section Mul
 
 variable {R : Type*} [CommSemiring R] {I J : Ideal R}
 
@@ -33,6 +39,24 @@ theorem eq_one_of_mul_eq_one (h : I * J = 1) : I = 1 := by
     exact Ideal.mul_le_left
   rw [Ideal.one_eq_top, eq_top_iff]
   simpa [Ideal.one_eq_top] using hle
+
+end Mul
+
+section Pi
+
+variable {R : Type*} [Semiring R] {ι : Type*} {M : ι → Type*} [∀ i, AddCommMonoid (M i)]
+    [∀ i, Module R (M i)]
+
+/-- **Expanding a product expands every factor**: if `I • ⊤ = ⊤` in `∀ i, M i` then `I • ⊤ = ⊤` in
+each `M i`. Faithful flatness of a product is decided factorwise through this, since
+`Module.FaithfullyFlat` is flatness together with `m • ⊤ ≠ ⊤` at every maximal ideal. -/
+theorem smul_top_eq_top_of_pi (I : Ideal R) (h : I • (⊤ : Submodule R (∀ i, M i)) = ⊤) (i : ι) :
+    I • (⊤ : Submodule R (M i)) = ⊤ := by
+  have := congrArg (Submodule.map (LinearMap.proj (R := R) (φ := M) i)) h
+  rwa [Submodule.map_smul'', Submodule.map_top,
+    LinearMap.range_eq_top.mpr (Function.surjective_eval i)] at this
+
+end Pi
 
 end Ideal
 


### PR DESCRIPTION
Mathlib knows that an arbitrary direct sum of flat modules is flat (`Module.Flat.directSum`), but
`∀ i, M i` is not definitionally a direct sum and nothing fires for a product. Today neither of
these is synthesisable, for a `Finite` index:

```lean
example (R : Type) [CommRing R] (ι : Type) [Finite ι] (M : ι → Type)
    [∀ i, AddCommGroup (M i)] [∀ i, Module R (M i)] [∀ i, Module.Flat R (M i)] :
    Module.Flat R (∀ i, M i) := by infer_instance          -- fails

example (R : Type) [CommRing R] (ι : Type) [Finite ι] (M : ι → Type)
    [∀ i, AddCommGroup (M i)] [∀ i, Module R (M i)] [∀ i, Module.FaithfullyFlat R (M i)] :
    Module.FaithfullyFlat R (∀ i, M i) := by infer_instance -- fails
```

## What is added

* `Ideal.smul_top_eq_top_of_pi` — `I • ⊤ = ⊤` in a product passes to every factor. No finiteness
  needed, and stated at `[Semiring R]` with `[AddCommMonoid (M i)]`. It carries no flatness at all,
  so it lives in **`TauCeti/RingTheory/Ideal/Operations.lean`** beside the rest of the ideal-action
  material, and `Flat/Pi.lean` imports it.
* `Module.Flat.pi` — instance; over a finite index the product is the direct sum. Stated at
  `[CommSemiring R]`; the ring and group assumptions enter only for the faithfully flat results,
  whose class demands them.
* `Module.FaithfullyFlat.pi_of_exists_submodule_ne_top` — the criterion. `Module.FaithfullyFlat`
  is *defined* as flatness plus `m • ⊤ ≠ ⊤` at every maximal ideal, so what a product needs is a
  witnessing factor for each `m`. The factors may individually all fail to be faithfully flat;
  what matters is that they do not fail simultaneously.
* `Module.FaithfullyFlat.pi_of_faithfullyFlat` — the special case where one fixed index works
  for every maximal ideal, the rest merely flat. (A rational cover does **not** generally meet
  this: covers are only jointly faithful, so no individual member need be faithfully flat. That
  is what the `∃`-criterion above is for.)
* `Module.FaithfullyFlat.pi` — instance for a finite **nonempty** product of faithfully flat
  modules.

## `Nonempty` is load-bearing

For an empty index the product is the trivial module, where `m • ⊤ = ⊤ = ⊥` for every `m`. So it
is faithfully flat over **no** nonzero ring — while `∀ i, FaithfullyFlat R (M i)` holds vacuously.
Without `[Nonempty ι]` the instance would be false, not merely weak:

```lean
example (R : Type) [CommRing R] [Nontrivial R] (M : Empty → Type)
    [∀ i, AddCommGroup (M i)] [∀ i, Module R (M i)] :
    ¬ Module.FaithfullyFlat R (∀ i, M i) := by
  intro h
  obtain ⟨m, hm⟩ := Ideal.exists_maximal R
  exact h.submodule_ne_top hm (Subsingleton.elim _ _)
```

Flatness has no such caveat — the trivial module is flat — so `Module.Flat.pi` needs no
nonemptiness.

Finiteness is also not an artefact of the direct-sum comparison: by Chase's theorem a ring is
coherent exactly when every product of flat modules is flat, so over a non-coherent ring the
statement fails outright for a large enough index.

## Why this, now

`AdicSpaces/README.md` line 574 makes step 4 of Layer 4.1 **"Corollary 8.32: obtain the
faithful-flatness and injectivity statements for rational covers"** — that is, `∏ᵢ 𝒪(Uᵢ)`
faithfully flat over `𝒪(U₀)`, with each restriction flat by step 3 (Proposition 8.30). Deciding
when a finite product of flat modules is faithfully flat is the algebraic content that statement
rests on, and it is missing from mathlib. Nothing here is adic: it is `Module.Flat` and
`Module.FaithfullyFlat` over an arbitrary commutative ring, which is why it goes in
`TauCeti/RingTheory/Flat/` beside `QuotientRegular.lean` rather than under `Huber/`.

The *injectivity* half of that roadmap line needs nothing new: once the product is known
faithfully flat, `FaithfulSMul.algebraMap_injective` gives injectivity of the structure map
straight from Mathlib. Faithful flatness of the product is the only missing input, which is what
this PR supplies.

Step 4 is also what `scope` on #5559 is waiting for, having narrowed to it once Proposition 8.30
appeared.

## Notes

* No `sorry`, no `native_decide`, no `maxHeartbeats`. `runLinter` and `scripts/HeaderStyle.lean`
  both clean; every declaration checks out on `propext`, `Classical.choice`, `Quot.sound` alone.
* No `tauceti-target` marker: this supplies a prerequisite, it does not author the target itself.

Provenance: none copied. Swept against AINTLIB (`github.com/CBirkbeck/AINTLIB`, Apache-2.0) at
revision `4c04933eb7b686b01031d775541533c492131be6`, queries `cor_8_32`, `8.32`, `FaithfullyFlat`.
AINTLIB reaches Corollary 8.32 via `cor_8_32_productRestriction_faithfullyFlat` in
`Adic spaces/RelativePieceKeystone.lean`, resting on `cor_8_32_spaExtendsAlongRestriction`
(`Adic spaces/Cor832.lean`:1658), which its own docstring records as the open lemma everything
downstream is sorry-free *given*. That route is bound to its `RationalCoveringData`; the general
product criterion contributed here is not stated there.

Roadmap: AdicSpaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kb8uv44XKmG5Mw9BvLjsb1



