### PR TITLE
feat: the unblocked grid differential squares to zero

### DIFF
--- a/TauCeti/KnotTheory/Grid/CyclicInterval.lean
+++ b/TauCeti/KnotTheory/Grid/CyclicInterval.lean
@@ -34,6 +34,8 @@ directions before taking products.
 * `TauCeti.Grid.mem_cIoo_or_mem_cIoo_swap_iff`: a point lies in one opposite arc exactly when
   it is not an endpoint.
 * `TauCeti.Grid.cIoo_union_swap`: the two opposite arcs cover the endpoint complement.
+* `TauCeti.Grid.mem_cIoo_cyclic_left`, `TauCeti.Grid.mem_cIoo_cyclic_right`: the two rotations
+  of a cyclic order of three points.
 * `TauCeti.Grid.mem_cIoo_swap_of_notMem`: a point off both endpoints that misses one arc lies on
   the opposite arc.
 * `TauCeti.Grid.mem_cIoo_of_mem_cIoo_of_mem_cIoo_swap`: if `a` and `b` lie on opposite arcs from
@@ -461,6 +463,18 @@ theorem not_mem_cIoo_iff {a b x : Fin n} (h : a ≠ b) :
       exact right_notMem_cIoo a b
     · intro hxab
       exact not_mem_cIoo_and_cIoo_swap a b x ⟨hxab, hx⟩
+
+/-- Rotating a cyclic order: if `b` lies on the clockwise arc from `a` to `c`, then `c` lies on
+the clockwise arc from `b` to `a`. -/
+theorem mem_cIoo_cyclic_left {a b c : Fin n} (h : b ∈ cIoo a c) : c ∈ cIoo b a := by
+  simp only [cIoo, Set.Finite.mem_toFinset, Set.mem_cIoo] at h ⊢
+  exact sbtw_cyclic_left h
+
+/-- Rotating a cyclic order the other way: if `b` lies on the clockwise arc from `a` to `c`, then
+`a` lies on the clockwise arc from `c` to `b`. -/
+theorem mem_cIoo_cyclic_right {a b c : Fin n} (h : b ∈ cIoo a c) : a ∈ cIoo c b := by
+  simp only [cIoo, Set.Finite.mem_toFinset, Set.mem_cIoo] at h ⊢
+  exact sbtw_cyclic_right h
 
 /-- A point off both endpoints and outside one cyclic arc lies on the opposite arc. -/
 theorem mem_cIoo_swap_of_notMem {a b u : Fin n} (hab : a ≠ b)

--- a/TauCeti/KnotTheory/Grid/Diagram/Basic.lean
+++ b/TauCeti/KnotTheory/Grid/Diagram/Basic.lean
@@ -357,6 +357,20 @@ theorem swapColumns_comm (a b : Fin n) (x : GridState n) :
   ext c
   simp [swapColumns_apply, Equiv.swap_comm]
 
+/-- Swapping two columns of a grid state is the same as swapping the two rows they occupy: the
+state is a bijection between columns and rows, and either operation exchanges exactly the two
+grid points in those columns. -/
+theorem swapColumns_eq_swapRows (a b : Fin n) (x : GridState n) :
+    x.swapColumns a b = x.swapRows (x a) (x b) := by
+  ext c
+  rw [swapColumns_apply, swapRows_apply]
+  rcases eq_or_ne c a with rfl | hca
+  · simp
+  rcases eq_or_ne c b with rfl | hcb
+  · simp
+  rw [Equiv.swap_apply_of_ne_of_ne hca hcb,
+    Equiv.swap_apply_of_ne_of_ne (x.toPerm.injective.ne hca) (x.toPerm.injective.ne hcb)]
+
 /-- Swapping the same pair of columns twice is the identity on grid states. -/
 @[simp]
 theorem swapColumns_swapColumns (a b : Fin n) (x : GridState n) :

--- a/TauCeti/KnotTheory/Grid/Differential/Square/OverlapOrder.lean
+++ b/TauCeti/KnotTheory/Grid/Differential/Square/OverlapOrder.lean
@@ -55,19 +55,6 @@ namespace GridRectangleDecomposition
 
 variable {n : ℕ} {x z : GridState n}
 
-private theorem mem_cIoo_cyclic_left {a b c : Fin n} (h : b ∈ Grid.cIoo a c) :
-    c ∈ Grid.cIoo b a := by
-  rw [Grid.mem_cIoo] at h ⊢
-  constructor
-  · intro hba
-    subst b
-    split_ifs at h <;> omega
-  · split_ifs at h ⊢ <;> omega
-
-private theorem mem_cIoo_cyclic_right {a b c : Fin n} (h : b ∈ Grid.cIoo a c) :
-    a ∈ Grid.cIoo c b := by
-  exact mem_cIoo_cyclic_left (mem_cIoo_cyclic_left h)
-
 /-- Suppose the two empty rectangles in a decomposition share their initial side column and no
 other side. Then their two terminal sides occur in one of the two possible cyclic orders around
 the common side, while the row of the common corner lies strictly between the other two corner
@@ -119,9 +106,9 @@ theorem cyclicOrder_of_isEmpty_of_left_eq_left (D : GridRectangleDecomposition x
       (by simpa only [hbottom] using D.first.bottom_ne_top)
       (by simpa only [hbottom] using htop_ne_firstBottom.symm) (by simpa only [hbottom] using hnot)
     exact ⟨Or.inl hfirstRight, by
-      simpa only [hbottom] using mem_cIoo_cyclic_left hrow⟩
+      simpa only [hbottom] using Grid.mem_cIoo_cyclic_left hrow⟩
   · have hsecondRight : D.second.right ∈ Grid.cIoo D.first.left D.first.right :=
-      mem_cIoo_cyclic_right hfirstRight
+      Grid.mem_cIoo_cyclic_right hfirstRight
     have hnot : D.second.top ∉ Grid.cIoo D.first.bottom D.first.top := by
       intro hrow
       exact D.first.not_mem_interior_target_of_isEmpty hfirst
@@ -137,7 +124,7 @@ theorem cyclicOrder_of_isEmpty_of_left_eq_left (D : GridRectangleDecomposition x
               GridRectangleBetween.toGridRectangle_top] using hrow)
     have hrow := Grid.mem_cIoo_swap_of_notMem D.first.bottom_ne_top
       htop_ne_firstBottom htop_ne_firstTop hnot
-    exact ⟨Or.inr hsecondRight, mem_cIoo_cyclic_right hrow⟩
+    exact ⟨Or.inr hsecondRight, Grid.mem_cIoo_cyclic_right hrow⟩
 
 /-- Suppose the two empty rectangles share their terminal side column and no other side. Then
 their two initial sides occur in one of the two possible cyclic orders around the common side,
@@ -185,9 +172,9 @@ theorem cyclicOrder_of_isEmpty_of_right_eq_right (D : GridRectangleDecomposition
       hbottom_ne_firstTop.symm (by simpa only [htop] using D.first.bottom_ne_top.symm)
       (by simpa only [htop] using hnot)
     exact ⟨Or.inl hfirstLeft,
-      mem_cIoo_cyclic_right (by simpa only [htop] using hrow)⟩
+      Grid.mem_cIoo_cyclic_right (by simpa only [htop] using hrow)⟩
   · have hsecondLeft : D.second.left ∈ Grid.cIoo D.first.left D.first.right :=
-      mem_cIoo_cyclic_left hfirstLeft
+      Grid.mem_cIoo_cyclic_left hfirstLeft
     have hnot : D.second.bottom ∉ Grid.cIoo D.first.bottom D.first.top := by
       intro hrow
       exact D.first.not_mem_interior_target_of_isEmpty hfirst
@@ -203,7 +190,7 @@ theorem cyclicOrder_of_isEmpty_of_right_eq_right (D : GridRectangleDecomposition
               GridRectangleBetween.toGridRectangle_top] using hrow)
     have hrow := Grid.mem_cIoo_swap_of_notMem D.first.bottom_ne_top
       hbottom_ne_firstBottom hbottom_ne_firstTop hnot
-    exact ⟨Or.inr hsecondLeft, mem_cIoo_cyclic_left hrow⟩
+    exact ⟨Or.inr hsecondLeft, Grid.mem_cIoo_cyclic_left hrow⟩
 
 /-- Suppose the first empty rectangle's initial side is the second one's terminal side, with no
 other common side. The other side columns have a fixed cyclic order, while the three corner rows
@@ -227,7 +214,7 @@ theorem cyclicOrder_of_isEmpty_of_left_eq_right (D : GridRectangleDecomposition 
   have h := D.transpose.cyclicOrder_of_isEmpty_of_right_eq_right htransRight htransLeft
     (D.isEmpty_transpose_first.mpr hfirst) (D.isEmpty_transpose_second.mpr hsecond)
   rcases h with ⟨hrows, hcolumns⟩
-  exact ⟨mem_cIoo_cyclic_left (by
+  exact ⟨Grid.mem_cIoo_cyclic_left (by
       simpa only [transpose_first_bottom, transpose_second_bottom, transpose_first_top] using
         hcolumns), by
     simpa only [transpose_first_left, transpose_second_left, transpose_first_right] using hrows⟩

--- a/TauCeti/KnotTheory/Grid/Differential/Square/Recut/Pairing.lean
+++ b/TauCeti/KnotTheory/Grid/Differential/Square/Recut/Pairing.lean
@@ -24,10 +24,12 @@ A decomposition has at most one orientation of its common column, so exactly one
 hold and the relation has a unique solution. Recutting twice returns the original decomposition:
 a common initial or terminal column recuts to a mixed common column and conversely, and in each of
 the eight resulting configurations the original decomposition satisfies precisely the side data
-that describes the recut of the recut. The relation is therefore symmetric, and uniqueness turns
-it into an involution `GridRectangleDecomposition.recut`. It has no fixed point, since the
-intermediate state changes, and it preserves the covered-square domain, hence the weight
-`V^{O(r₁)} · V^{O(r₂)}` that the square of the differential attaches to a two-step term.
+that describes the recut of the recut. On the decompositions the unblocked differential counts
+whose two rectangles share exactly one side column -- the only ones for which a recut is
+constructed -- the relation is therefore symmetric, and uniqueness turns it into an involution
+`GridRectangleDecomposition.recut` of that set. It has no fixed point, since the intermediate state
+changes, and it preserves the covered-square domain, hence the weight `V^{O(r₁)} · V^{O(r₂)}` that
+the square of the differential attaches to a two-step term.
 
 The geometric input is the cyclic order forced by emptiness of both rectangles: for a common
 initial or terminal column the corner row of the common side lies strictly between the other two
@@ -52,7 +54,8 @@ the recut's own side data holds.
 
 * `TauCeti.GridRectangleDecomposition.existsUnique_isRecut`: a counted decomposition sharing
   exactly one side column has exactly one recut.
-* `TauCeti.GridRectangleDecomposition.IsRecut.symm`: a decomposition is a recut of its own recut.
+* `TauCeti.GridRectangleDecomposition.IsRecut.symm`: a counted decomposition sharing exactly one
+  side column is a recut of its own recut.
 * `TauCeti.GridRectangleDecomposition.recut_recut`: recutting is an involution.
 * `TauCeti.GridRectangleDecomposition.recut_ne`: it has no fixed point.
 * `TauCeti.GridRectangleDecomposition.hasOneCommonSide_recut`: the recut again shares exactly one
@@ -183,25 +186,274 @@ theorem existsUnique_isRecut (G : GridDiagram n) (D : GridRectangleDecomposition
 
 /-! ### The recut of the recut -/
 
-/-- A decomposition sharing exactly one side column does not use the same unordered pair of side
-columns twice. -/
-private theorem sideColumns_ne_of_hasOneCommonSide (D : GridRectangleDecomposition x z)
-    (hone : D.HasOneCommonSide) : D.first.sideColumns ≠ D.second.sideColumns := fun h =>
-  D.target_ne_source_of_hasOneCommonSide hone (D.target_eq_source_iff_sideColumns_eq.mpr h)
-
-/-- The intermediate state of a decomposition swaps the two rows occupied by the side columns of
-its first rectangle. -/
-private theorem middle_eq_swapRows (D : GridRectangleDecomposition x z) :
-    D.middle = x.swapRows (x D.first.left) (x D.first.right) :=
-  D.first.target_eq_swapColumns.trans (GridState.swapColumns_eq_swapRows _ _ _)
-
 /-- A column read off the row it occupies after a column swap. -/
 private theorem eq_swap_of_swapColumns_apply_eq {a b c d : Fin n}
     (h : x.swapColumns a b c = x d) : c = Equiv.swap a b d :=
   Equiv.swap_apply_eq_iff.mp (x.toPerm.injective (by rwa [GridState.swapColumns_apply] at h))
 
+/-- The recut of a counted decomposition whose two rectangles share their initial side column
+carries the side data describing the original decomposition as its own recut. The common column
+of the recut is mixed, so which of the two mixed alternatives holds is decided by the cyclic
+order of the three corner rows that emptiness forces. -/
+private theorem isRecut_symm_of_left_eq_left {D E : GridRectangleDecomposition x z}
+    (hdata : D.IsRecutOfLeftEqLeft E) (hone : D.HasOneCommonSide)
+    (hDempty₁ : D.first.IsEmpty) (hDempty₂ : D.second.IsEmpty) :
+    E.IsRecutOfLeftEqLeft D ∨ E.IsRecutOfRightEqRight D ∨
+      E.IsRecutOfLeftEqRight D ∨ E.IsRecutOfRightEqLeft D := by
+  obtain ⟨hcommon, hE₁, hE₂, hbranch⟩ := hdata
+  have hDmid := D.first.target_eq_swapRows
+  have hother : D.first.right ≠ D.second.right := fun hr =>
+    D.sideColumns_ne_of_hasOneCommonSide hone
+      (by rw [GridRectangleBetween.sideColumns, GridRectangleBetween.sideColumns, hcommon, hr])
+  have hvm : D.second.right ≠ D.first.left := by
+    rw [hcommon]
+    exact D.second.left_ne_right.symm
+  have hrow := (D.cyclicOrder_of_isEmpty_of_left_eq_left hcommon hother hDempty₁ hDempty₂).2
+  have hDbot₂ : D.second.bottom = x D.first.right := by
+    rw [GridRectangleBetween.bottom_def, ← hcommon, D.first.target_apply, Equiv.swap_apply_left]
+  have hDtop₂ : D.second.top = x D.second.right := by
+    rw [GridRectangleBetween.top_def, D.first.target_apply,
+      Equiv.swap_apply_of_ne_of_ne hvm hother.symm]
+  rw [hDtop₂] at hrow
+  rcases hbranch with ⟨-, hEmid, hEl₁, hEl₂⟩ | ⟨-, hEmid, hEl₁, hEl₂⟩
+  · -- the recut has its common column initial for the first and terminal for the second
+    have hEbot₁ : E.first.bottom = x D.first.right := by
+      rw [GridRectangleBetween.bottom_def, hEl₁]
+    have hEtop₁ : E.first.top = x D.second.right := by
+      rw [GridRectangleBetween.top_def, hE₁]
+    have hEbot₂ : E.second.bottom = x D.first.left := by
+      rw [GridRectangleBetween.bottom_def, hEl₂, hEmid, GridState.swapColumns_apply,
+        Equiv.swap_apply_of_ne_of_ne D.first.left_ne_right hvm.symm]
+    refine Or.inr (Or.inr (Or.inl ⟨hEl₁.trans hE₂.symm, ?_, ?_, Or.inl ⟨?_, ?_, ?_, ?_⟩⟩))
+    · rw [hEbot₂, GridRectangleBetween.bottom_def]
+    · rw [hEbot₁, hDbot₂]
+    · rw [hEbot₁, hEbot₂, hEtop₁]
+      exact hrow
+    · rw [hEbot₁, hEbot₂]
+      exact hDmid
+    · rw [hEbot₁, GridRectangleBetween.top_def]
+    · rw [hEtop₁, hDtop₂]
+  · -- the recut has its common column terminal for the first and initial for the second
+    have hEbot₁ : E.first.bottom = x D.first.left := by
+      rw [GridRectangleBetween.bottom_def, hEl₁]
+    have hEtop₁ : E.first.top = x D.second.right := by
+      rw [GridRectangleBetween.top_def, hE₁]
+    have hEtop₂ : E.second.top = x D.first.right := by
+      rw [GridRectangleBetween.top_def, hE₂, hEmid, GridState.swapColumns_apply,
+        Equiv.swap_apply_of_ne_of_ne D.first.left_ne_right.symm hother]
+    refine Or.inr (Or.inr (Or.inr ⟨hE₁.trans hEl₂.symm, ?_, ?_, Or.inr ⟨?_, ?_, ?_, ?_⟩⟩))
+    · rw [hEtop₂, GridRectangleBetween.top_def]
+    · rw [hEtop₁, hDtop₂]
+    · rw [hEtop₂, hEbot₁, hEtop₁]
+      exact hrow
+    · rw [hEbot₁, hEtop₂]
+      exact hDmid
+    · rw [hEbot₁, GridRectangleBetween.bottom_def]
+    · rw [hEtop₂, hDbot₂]
+
+/-- The recut of a counted decomposition whose two rectangles share their terminal side column
+carries the side data describing the original decomposition as its own recut. As in the initial
+case the common column of the recut is mixed, and the cyclic order of the corner rows decides
+which mixed alternative holds. -/
+private theorem isRecut_symm_of_right_eq_right {D E : GridRectangleDecomposition x z}
+    (hdata : D.IsRecutOfRightEqRight E) (hone : D.HasOneCommonSide)
+    (hDempty₁ : D.first.IsEmpty) (hDempty₂ : D.second.IsEmpty) :
+    E.IsRecutOfLeftEqLeft D ∨ E.IsRecutOfRightEqRight D ∨
+      E.IsRecutOfLeftEqRight D ∨ E.IsRecutOfRightEqLeft D := by
+  obtain ⟨hcommon, hE₁, hE₂, hbranch⟩ := hdata
+  have hDmid := D.first.target_eq_swapRows
+  have hother : D.first.left ≠ D.second.left := fun hl =>
+    D.sideColumns_ne_of_hasOneCommonSide hone
+      (by rw [GridRectangleBetween.sideColumns, GridRectangleBetween.sideColumns, hcommon, hl])
+  have hvm : D.second.left ≠ D.first.right := by
+    rw [hcommon]
+    exact D.second.left_ne_right
+  have hrow := (D.cyclicOrder_of_isEmpty_of_right_eq_right hcommon hother hDempty₁ hDempty₂).2
+  have hDbot₂ : D.second.bottom = x D.second.left := by
+    rw [GridRectangleBetween.bottom_def, D.first.target_apply,
+      Equiv.swap_apply_of_ne_of_ne hother.symm hvm]
+  have hDtop₂ : D.second.top = x D.first.left := by
+    rw [GridRectangleBetween.top_def, ← hcommon, D.first.target_apply, Equiv.swap_apply_right]
+  rw [hDbot₂] at hrow
+  rcases hbranch with ⟨-, hEmid, hEr₁, hEr₂⟩ | ⟨-, hEmid, hEr₁, hEr₂⟩
+  · -- the recut has its common column terminal for the first and initial for the second
+    have hEbot₁ : E.first.bottom = x D.second.left := by
+      rw [GridRectangleBetween.bottom_def, hE₁]
+    have hEtop₁ : E.first.top = x D.first.left := by
+      rw [GridRectangleBetween.top_def, hEr₁]
+    have hEtop₂ : E.second.top = x D.first.right := by
+      rw [GridRectangleBetween.top_def, hEr₂, hEmid, GridState.swapColumns_apply,
+        Equiv.swap_apply_of_ne_of_ne hvm.symm D.first.left_ne_right.symm]
+    refine Or.inr (Or.inr (Or.inr ⟨hEr₁.trans hE₂.symm, ?_, ?_, Or.inl ⟨?_, ?_, ?_, ?_⟩⟩))
+    · rw [hEtop₂, GridRectangleBetween.top_def]
+    · rw [hEtop₁, hDtop₂]
+    · rw [hEtop₁, hEbot₁, hEtop₂]
+      exact hrow
+    · rw [hEtop₁, hEtop₂]
+      exact hDmid
+    · rw [hEtop₁, GridRectangleBetween.bottom_def]
+    · rw [hEbot₁, hDbot₂]
+  · -- the recut has its common column initial for the first and terminal for the second
+    have hEbot₁ : E.first.bottom = x D.second.left := by
+      rw [GridRectangleBetween.bottom_def, hE₁]
+    have hEtop₁ : E.first.top = x D.first.right := by
+      rw [GridRectangleBetween.top_def, hEr₁]
+    have hEbot₂ : E.second.bottom = x D.first.left := by
+      rw [GridRectangleBetween.bottom_def, hE₂, hEmid, GridState.swapColumns_apply,
+        Equiv.swap_apply_of_ne_of_ne hother D.first.left_ne_right]
+    refine Or.inr (Or.inr (Or.inl ⟨hE₁.trans hEr₂.symm, ?_, ?_, Or.inr ⟨?_, ?_, ?_, ?_⟩⟩))
+    · rw [hEbot₂, GridRectangleBetween.bottom_def]
+    · rw [hEbot₁, hDbot₂]
+    · rw [hEbot₂, hEbot₁, hEtop₁]
+      exact hrow
+    · rw [hEbot₂, hEtop₁]
+      exact hDmid
+    · rw [hEtop₁, GridRectangleBetween.top_def]
+    · rw [hEbot₂, hDtop₂]
+
+/-- The recut of a counted decomposition whose common column is initial for its first rectangle
+and terminal for its second carries the side data describing the original decomposition as its
+own recut. Here the recut has both its rectangles on one side column, so the intermediate state
+is a column swap and the side columns are read off the rows they occupy. -/
+private theorem isRecut_symm_of_left_eq_right {D E : GridRectangleDecomposition x z}
+    (hdata : D.IsRecutOfLeftEqRight E) (hone : D.HasOneCommonSide)
+    (hDempty₁ : D.first.IsEmpty) (hDempty₂ : D.second.IsEmpty) :
+    E.IsRecutOfLeftEqLeft D ∨ E.IsRecutOfRightEqRight D ∨
+      E.IsRecutOfLeftEqRight D ∨ E.IsRecutOfRightEqLeft D := by
+  obtain ⟨hcommon, hE₁, hE₂, hbranch⟩ := hdata
+  have hother : D.first.right ≠ D.second.left := fun hr =>
+    D.sideColumns_ne_of_hasOneCommonSide hone
+      (by rw [GridRectangleBetween.sideColumns, GridRectangleBetween.sideColumns, hcommon, hr,
+        Finset.pair_comm])
+  have hvm : D.second.left ≠ D.first.left := by
+    rw [hcommon]
+    exact D.second.left_ne_right
+  have hcol := (D.cyclicOrder_of_isEmpty_of_left_eq_right hcommon hother hDempty₁ hDempty₂).1
+  have hrot : D.first.left ∈ Grid.cIoo D.second.left D.first.right :=
+    Grid.mem_cIoo_cyclic_right hcol
+  have hDbot₂ : D.second.bottom = x D.second.left := by
+    rw [GridRectangleBetween.bottom_def, D.first.target_apply,
+      Equiv.swap_apply_of_ne_of_ne hvm hother.symm]
+  have hDtop₂ : D.second.top = x D.first.right := by
+    rw [GridRectangleBetween.top_def, ← hcommon, D.first.target_apply, Equiv.swap_apply_left]
+  rcases hbranch with ⟨-, hEmid, hEt₁, hEt₂⟩ | ⟨-, hEmid, hEt₁, hEt₂⟩
+  · -- the recut has both its rectangles on the same initial side column
+    have hEmid' : E.middle = x.swapColumns D.second.left D.first.left := by
+      rw [hEmid, hDbot₂, GridRectangleBetween.bottom_def, GridState.swapColumns_eq_swapRows]
+    have hxEl₁ : x E.first.left = x D.second.left := by exact hE₁.trans hDbot₂
+    have hEl₁ : E.first.left = D.second.left := x.toPerm.injective hxEl₁
+    have hxEr₁ : x E.first.right = x D.first.left := by exact hEt₁
+    have hEr₁ : E.first.right = D.first.left := x.toPerm.injective hxEr₁
+    have hEl₂ : E.second.left = Equiv.swap D.second.left D.first.left D.first.left :=
+      eq_swap_of_swapColumns_apply_eq (by rw [← hEmid']; exact hE₂)
+    have hEr₂ : E.second.right = Equiv.swap D.second.left D.first.left D.first.right :=
+      eq_swap_of_swapColumns_apply_eq (by rw [← hEmid']; exact hEt₂)
+    rw [Equiv.swap_apply_right] at hEl₂
+    rw [Equiv.swap_apply_of_ne_of_ne hother D.first.left_ne_right.symm] at hEr₂
+    refine Or.inl ⟨hEl₁.trans hEl₂.symm, hEr₂.symm, ?_, Or.inl ⟨?_, ?_, ?_, ?_⟩⟩
+    · rw [hEr₁]
+      exact hcommon.symm
+    · rw [hEr₁, hEl₁, hEr₂]
+      exact hrot
+    · rw [hEr₁, hEr₂]
+      exact D.first.target_eq_swapColumns
+    · rw [hEr₁]
+    · rw [hEl₁]
+  · -- the recut has both its rectangles on the same terminal side column
+    have hEmid' : E.middle = x.swapColumns D.second.left D.first.right := by
+      rw [hEmid, hDbot₂, GridRectangleBetween.top_def, GridState.swapColumns_eq_swapRows]
+    have hxEl₁ : x E.first.left = x D.second.left := by exact hE₁.trans hDbot₂
+    have hEl₁ : E.first.left = D.second.left := x.toPerm.injective hxEl₁
+    have hxEr₁ : x E.first.right = x D.first.right := by exact hEt₁
+    have hEr₁ : E.first.right = D.first.right := x.toPerm.injective hxEr₁
+    have hEl₂ : E.second.left = Equiv.swap D.second.left D.first.right D.first.left :=
+      eq_swap_of_swapColumns_apply_eq (by rw [← hEmid']; exact hE₂)
+    have hEr₂ : E.second.right = Equiv.swap D.second.left D.first.right D.second.left :=
+      eq_swap_of_swapColumns_apply_eq (by rw [← hEmid']; exact hEt₂.trans hDbot₂)
+    rw [Equiv.swap_apply_of_ne_of_ne hvm.symm D.first.left_ne_right] at hEl₂
+    rw [Equiv.swap_apply_left] at hEr₂
+    refine Or.inr (Or.inl ⟨hEr₁.trans hEr₂.symm, hEl₂.symm, ?_, Or.inr ⟨?_, ?_, ?_, ?_⟩⟩)
+    · rw [hEl₁]
+    · rw [hEl₂, hEl₁, hEr₁]
+      exact hrot
+    · rw [hEl₂, hEr₁]
+      exact D.first.target_eq_swapColumns
+    · rw [hEr₁]
+    · rw [hEl₂]
+      exact hcommon.symm
+
+/-- The recut of a counted decomposition whose common column is terminal for its first rectangle
+and initial for its second carries the side data describing the original decomposition as its own
+recut. As in the previous case the recut shares a side column and its side columns are read off
+the rows they occupy. -/
+private theorem isRecut_symm_of_right_eq_left {D E : GridRectangleDecomposition x z}
+    (hdata : D.IsRecutOfRightEqLeft E) (hone : D.HasOneCommonSide)
+    (hDempty₁ : D.first.IsEmpty) (hDempty₂ : D.second.IsEmpty) :
+    E.IsRecutOfLeftEqLeft D ∨ E.IsRecutOfRightEqRight D ∨
+      E.IsRecutOfLeftEqRight D ∨ E.IsRecutOfRightEqLeft D := by
+  obtain ⟨hcommon, hE₁, hE₂, hbranch⟩ := hdata
+  have hother : D.first.left ≠ D.second.right := fun hl =>
+    D.sideColumns_ne_of_hasOneCommonSide hone
+      (by rw [GridRectangleBetween.sideColumns, GridRectangleBetween.sideColumns, hcommon, hl,
+        Finset.pair_comm])
+  have hvm : D.second.right ≠ D.first.right := by
+    rw [hcommon]
+    exact D.second.left_ne_right.symm
+  have hcol := (D.cyclicOrder_of_isEmpty_of_right_eq_left hcommon hother hDempty₁ hDempty₂).1
+  have hDbot₂ : D.second.bottom = x D.first.left := by
+    rw [GridRectangleBetween.bottom_def, ← hcommon, D.first.target_apply,
+      Equiv.swap_apply_right]
+  have hDtop₂ : D.second.top = x D.second.right := by
+    rw [GridRectangleBetween.top_def, D.first.target_apply,
+      Equiv.swap_apply_of_ne_of_ne hother.symm hvm]
+  rcases hbranch with ⟨-, hEmid, hEb₁, hEb₂⟩ | ⟨-, hEmid, hEb₁, hEb₂⟩
+  · -- the recut has both its rectangles on the same terminal side column
+    have hEmid' : E.middle = x.swapColumns D.first.right D.second.right := by
+      rw [hEmid, hDtop₂, GridRectangleBetween.top_def, GridState.swapColumns_eq_swapRows]
+    have hxEl₁ : x E.first.left = x D.first.right := by exact hEb₁
+    have hEl₁ : E.first.left = D.first.right := x.toPerm.injective hxEl₁
+    have hxEr₁ : x E.first.right = x D.second.right := by exact hE₁.trans hDtop₂
+    have hEr₁ : E.first.right = D.second.right := x.toPerm.injective hxEr₁
+    have hEl₂ : E.second.left = Equiv.swap D.first.right D.second.right D.first.left :=
+      eq_swap_of_swapColumns_apply_eq (by rw [← hEmid']; exact hEb₂)
+    have hEr₂ : E.second.right = Equiv.swap D.first.right D.second.right D.first.right :=
+      eq_swap_of_swapColumns_apply_eq (by rw [← hEmid']; exact hE₂)
+    rw [Equiv.swap_apply_of_ne_of_ne D.first.left_ne_right hother] at hEl₂
+    rw [Equiv.swap_apply_left] at hEr₂
+    refine Or.inr (Or.inl ⟨hEr₁.trans hEr₂.symm, hEl₂.symm, ?_, Or.inl ⟨?_, ?_, ?_, ?_⟩⟩)
+    · rw [hEl₁]
+      exact hcommon.symm
+    · rw [hEl₁, hEl₂, hEr₁]
+      exact hcol
+    · rw [hEl₂, hEl₁]
+      exact D.first.target_eq_swapColumns
+    · rw [hEl₁]
+    · rw [hEr₁]
+  · -- the recut has both its rectangles on the same initial side column
+    have hEmid' : E.middle = x.swapColumns D.first.left D.second.right := by
+      rw [hEmid, hDtop₂, GridRectangleBetween.bottom_def, GridState.swapColumns_eq_swapRows]
+    have hxEl₁ : x E.first.left = x D.first.left := by exact hEb₁
+    have hEl₁ : E.first.left = D.first.left := x.toPerm.injective hxEl₁
+    have hxEr₁ : x E.first.right = x D.second.right := by exact hE₁.trans hDtop₂
+    have hEr₁ : E.first.right = D.second.right := x.toPerm.injective hxEr₁
+    have hEl₂ : E.second.left = Equiv.swap D.first.left D.second.right D.second.right :=
+      eq_swap_of_swapColumns_apply_eq (by rw [← hEmid']; exact hEb₂.trans hDtop₂)
+    have hEr₂ : E.second.right = Equiv.swap D.first.left D.second.right D.first.right :=
+      eq_swap_of_swapColumns_apply_eq (by rw [← hEmid']; exact hE₂)
+    rw [Equiv.swap_apply_right] at hEl₂
+    rw [Equiv.swap_apply_of_ne_of_ne D.first.left_ne_right.symm hvm.symm] at hEr₂
+    refine Or.inl ⟨hEl₁.trans hEl₂.symm, hEr₂.symm, hEr₁.symm, Or.inr ⟨?_, ?_, ?_, ?_⟩⟩
+    · rw [hEr₂, hEl₁, hEr₁]
+      exact hcol
+    · rw [hEl₁, hEr₂]
+      exact D.first.target_eq_swapColumns
+    · rw [hEl₁]
+    · rw [hEr₂]
+      exact hcommon.symm
+
 /-- If `E` is a recut of a counted two-step decomposition `D` whose rectangles share exactly one
-side column, then `D` is a recut of `E`. -/
+side column, then `D` is a recut of `E`: in each of the four orientations of the common column of
+`D`, the recut carries precisely the side data that describes `D` as its recut. -/
 theorem IsRecut.symm {G : GridDiagram n} {D E : GridRectangleDecomposition x z}
     (h : D.IsRecut G E) (hone : D.HasOneCommonSide)
     (hfirst : D.first ∈ G.unblockedRectangles x D.middle)
@@ -210,228 +462,12 @@ theorem IsRecut.symm {G : GridDiagram n} {D E : GridRectangleDecomposition x z}
   obtain ⟨hrep, hmid, hEf, hEs, hdata⟩ := h
   have hDempty₁ := G.isEmpty_of_mem_unblockedRectangles hfirst
   have hDempty₂ := G.isEmpty_of_mem_unblockedRectangles hsecond
-  have hDmid := D.middle_eq_swapRows
   refine ⟨hrep.symm, hmid.symm, hfirst, hsecond, ?_⟩
-  rcases hdata with ⟨hcommon, hE₁, hE₂, hbranch⟩ | ⟨hcommon, hE₁, hE₂, hbranch⟩ |
-      ⟨hcommon, hE₁, hE₂, hbranch⟩ | ⟨hcommon, hE₁, hE₂, hbranch⟩
-  · -- the two rectangles of `D` share their initial side column
-    have hother : D.first.right ≠ D.second.right := fun hr =>
-      D.sideColumns_ne_of_hasOneCommonSide hone
-        (by rw [GridRectangleBetween.sideColumns, GridRectangleBetween.sideColumns, hcommon, hr])
-    have hvm : D.second.right ≠ D.first.left := by
-      rw [hcommon]
-      exact D.second.left_ne_right.symm
-    have hrow := (D.cyclicOrder_of_isEmpty_of_left_eq_left hcommon hother hDempty₁ hDempty₂).2
-    have hDbot₂ : D.second.bottom = x D.first.right := by
-      rw [GridRectangleBetween.bottom_def, ← hcommon, D.first.target_apply, Equiv.swap_apply_left]
-    have hDtop₂ : D.second.top = x D.second.right := by
-      rw [GridRectangleBetween.top_def, D.first.target_apply,
-        Equiv.swap_apply_of_ne_of_ne hvm hother.symm]
-    rw [hDtop₂] at hrow
-    rcases hbranch with ⟨-, hEmid, hEl₁, hEl₂⟩ | ⟨-, hEmid, hEl₁, hEl₂⟩
-    · -- the recut has its common column initial for the first and terminal for the second
-      have hEbot₁ : E.first.bottom = x D.first.right := by
-        rw [GridRectangleBetween.bottom_def, hEl₁]
-      have hEtop₁ : E.first.top = x D.second.right := by
-        rw [GridRectangleBetween.top_def, hE₁]
-      have hEbot₂ : E.second.bottom = x D.first.left := by
-        rw [GridRectangleBetween.bottom_def, hEl₂, hEmid, GridState.swapColumns_apply,
-          Equiv.swap_apply_of_ne_of_ne D.first.left_ne_right hvm.symm]
-      refine Or.inr (Or.inr (Or.inl ⟨hEl₁.trans hE₂.symm, ?_, ?_, Or.inl ⟨?_, ?_, ?_, ?_⟩⟩))
-      · rw [hEbot₂, GridRectangleBetween.bottom_def]
-      · rw [hEbot₁, hDbot₂]
-      · rw [hEbot₁, hEbot₂, hEtop₁]
-        exact hrow
-      · rw [hEbot₁, hEbot₂]
-        exact hDmid
-      · rw [hEbot₁, GridRectangleBetween.top_def]
-      · rw [hEtop₁, hDtop₂]
-    · -- the recut has its common column terminal for the first and initial for the second
-      have hEbot₁ : E.first.bottom = x D.first.left := by
-        rw [GridRectangleBetween.bottom_def, hEl₁]
-      have hEtop₁ : E.first.top = x D.second.right := by
-        rw [GridRectangleBetween.top_def, hE₁]
-      have hEtop₂ : E.second.top = x D.first.right := by
-        rw [GridRectangleBetween.top_def, hE₂, hEmid, GridState.swapColumns_apply,
-          Equiv.swap_apply_of_ne_of_ne D.first.left_ne_right.symm hother]
-      refine Or.inr (Or.inr (Or.inr ⟨hE₁.trans hEl₂.symm, ?_, ?_, Or.inr ⟨?_, ?_, ?_, ?_⟩⟩))
-      · rw [hEtop₂, GridRectangleBetween.top_def]
-      · rw [hEtop₁, hDtop₂]
-      · rw [hEtop₂, hEbot₁, hEtop₁]
-        exact hrow
-      · rw [hEbot₁, hEtop₂]
-        exact hDmid
-      · rw [hEbot₁, GridRectangleBetween.bottom_def]
-      · rw [hEtop₂, hDbot₂]
-  · -- the two rectangles of `D` share their terminal side column
-    have hother : D.first.left ≠ D.second.left := fun hl =>
-      D.sideColumns_ne_of_hasOneCommonSide hone
-        (by rw [GridRectangleBetween.sideColumns, GridRectangleBetween.sideColumns, hcommon, hl])
-    have hvm : D.second.left ≠ D.first.right := by
-      rw [hcommon]
-      exact D.second.left_ne_right
-    have hrow := (D.cyclicOrder_of_isEmpty_of_right_eq_right hcommon hother hDempty₁ hDempty₂).2
-    have hDbot₂ : D.second.bottom = x D.second.left := by
-      rw [GridRectangleBetween.bottom_def, D.first.target_apply,
-        Equiv.swap_apply_of_ne_of_ne hother.symm hvm]
-    have hDtop₂ : D.second.top = x D.first.left := by
-      rw [GridRectangleBetween.top_def, ← hcommon, D.first.target_apply, Equiv.swap_apply_right]
-    rw [hDbot₂] at hrow
-    rcases hbranch with ⟨-, hEmid, hEr₁, hEr₂⟩ | ⟨-, hEmid, hEr₁, hEr₂⟩
-    · -- the recut has its common column terminal for the first and initial for the second
-      have hEbot₁ : E.first.bottom = x D.second.left := by
-        rw [GridRectangleBetween.bottom_def, hE₁]
-      have hEtop₁ : E.first.top = x D.first.left := by
-        rw [GridRectangleBetween.top_def, hEr₁]
-      have hEtop₂ : E.second.top = x D.first.right := by
-        rw [GridRectangleBetween.top_def, hEr₂, hEmid, GridState.swapColumns_apply,
-          Equiv.swap_apply_of_ne_of_ne hvm.symm D.first.left_ne_right.symm]
-      refine Or.inr (Or.inr (Or.inr ⟨hEr₁.trans hE₂.symm, ?_, ?_, Or.inl ⟨?_, ?_, ?_, ?_⟩⟩))
-      · rw [hEtop₂, GridRectangleBetween.top_def]
-      · rw [hEtop₁, hDtop₂]
-      · rw [hEtop₁, hEbot₁, hEtop₂]
-        exact hrow
-      · rw [hEtop₁, hEtop₂]
-        exact hDmid
-      · rw [hEtop₁, GridRectangleBetween.bottom_def]
-      · rw [hEbot₁, hDbot₂]
-    · -- the recut has its common column initial for the first and terminal for the second
-      have hEbot₁ : E.first.bottom = x D.second.left := by
-        rw [GridRectangleBetween.bottom_def, hE₁]
-      have hEtop₁ : E.first.top = x D.first.right := by
-        rw [GridRectangleBetween.top_def, hEr₁]
-      have hEbot₂ : E.second.bottom = x D.first.left := by
-        rw [GridRectangleBetween.bottom_def, hE₂, hEmid, GridState.swapColumns_apply,
-          Equiv.swap_apply_of_ne_of_ne hother D.first.left_ne_right]
-      refine Or.inr (Or.inr (Or.inl ⟨hE₁.trans hEr₂.symm, ?_, ?_, Or.inr ⟨?_, ?_, ?_, ?_⟩⟩))
-      · rw [hEbot₂, GridRectangleBetween.bottom_def]
-      · rw [hEbot₁, hDbot₂]
-      · rw [hEbot₂, hEbot₁, hEtop₁]
-        exact hrow
-      · rw [hEbot₂, hEtop₁]
-        exact hDmid
-      · rw [hEtop₁, GridRectangleBetween.top_def]
-      · rw [hEbot₂, hDtop₂]
-  · -- the common column of `D` is initial for the first rectangle and terminal for the second
-    have hother : D.first.right ≠ D.second.left := fun hr =>
-      D.sideColumns_ne_of_hasOneCommonSide hone
-        (by rw [GridRectangleBetween.sideColumns, GridRectangleBetween.sideColumns, hcommon, hr,
-          Finset.pair_comm])
-    have hvm : D.second.left ≠ D.first.left := by
-      rw [hcommon]
-      exact D.second.left_ne_right
-    have hcol := (D.cyclicOrder_of_isEmpty_of_left_eq_right hcommon hother hDempty₁ hDempty₂).1
-    have hrot : D.first.left ∈ Grid.cIoo D.second.left D.first.right :=
-      Grid.mem_cIoo_cyclic_right hcol
-    have hDbot₂ : D.second.bottom = x D.second.left := by
-      rw [GridRectangleBetween.bottom_def, D.first.target_apply,
-        Equiv.swap_apply_of_ne_of_ne hvm hother.symm]
-    have hDtop₂ : D.second.top = x D.first.right := by
-      rw [GridRectangleBetween.top_def, ← hcommon, D.first.target_apply, Equiv.swap_apply_left]
-    rcases hbranch with ⟨-, hEmid, hEt₁, hEt₂⟩ | ⟨-, hEmid, hEt₁, hEt₂⟩
-    · -- the recut has both its rectangles on the same initial side column
-      have hEmid' : E.middle = x.swapColumns D.second.left D.first.left := by
-        rw [hEmid, hDbot₂, GridRectangleBetween.bottom_def, GridState.swapColumns_eq_swapRows]
-      have hxEl₁ : x E.first.left = x D.second.left := by exact hE₁.trans hDbot₂
-      have hEl₁ : E.first.left = D.second.left := x.toPerm.injective hxEl₁
-      have hxEr₁ : x E.first.right = x D.first.left := by exact hEt₁
-      have hEr₁ : E.first.right = D.first.left := x.toPerm.injective hxEr₁
-      have hEl₂ : E.second.left = Equiv.swap D.second.left D.first.left D.first.left :=
-        eq_swap_of_swapColumns_apply_eq (by rw [← hEmid']; exact hE₂)
-      have hEr₂ : E.second.right = Equiv.swap D.second.left D.first.left D.first.right :=
-        eq_swap_of_swapColumns_apply_eq (by rw [← hEmid']; exact hEt₂)
-      rw [Equiv.swap_apply_right] at hEl₂
-      rw [Equiv.swap_apply_of_ne_of_ne hother D.first.left_ne_right.symm] at hEr₂
-      refine Or.inl ⟨hEl₁.trans hEl₂.symm, hEr₂.symm, ?_, Or.inl ⟨?_, ?_, ?_, ?_⟩⟩
-      · rw [hEr₁]
-        exact hcommon.symm
-      · rw [hEr₁, hEl₁, hEr₂]
-        exact hrot
-      · rw [hEr₁, hEr₂]
-        exact D.first.target_eq_swapColumns
-      · rw [hEr₁]
-      · rw [hEl₁]
-    · -- the recut has both its rectangles on the same terminal side column
-      have hEmid' : E.middle = x.swapColumns D.second.left D.first.right := by
-        rw [hEmid, hDbot₂, GridRectangleBetween.top_def, GridState.swapColumns_eq_swapRows]
-      have hxEl₁ : x E.first.left = x D.second.left := by exact hE₁.trans hDbot₂
-      have hEl₁ : E.first.left = D.second.left := x.toPerm.injective hxEl₁
-      have hxEr₁ : x E.first.right = x D.first.right := by exact hEt₁
-      have hEr₁ : E.first.right = D.first.right := x.toPerm.injective hxEr₁
-      have hEl₂ : E.second.left = Equiv.swap D.second.left D.first.right D.first.left :=
-        eq_swap_of_swapColumns_apply_eq (by rw [← hEmid']; exact hE₂)
-      have hEr₂ : E.second.right = Equiv.swap D.second.left D.first.right D.second.left :=
-        eq_swap_of_swapColumns_apply_eq (by rw [← hEmid']; exact hEt₂.trans hDbot₂)
-      rw [Equiv.swap_apply_of_ne_of_ne hvm.symm D.first.left_ne_right] at hEl₂
-      rw [Equiv.swap_apply_left] at hEr₂
-      refine Or.inr (Or.inl ⟨hEr₁.trans hEr₂.symm, hEl₂.symm, ?_, Or.inr ⟨?_, ?_, ?_, ?_⟩⟩)
-      · rw [hEl₁]
-      · rw [hEl₂, hEl₁, hEr₁]
-        exact hrot
-      · rw [hEl₂, hEr₁]
-        exact D.first.target_eq_swapColumns
-      · rw [hEr₁]
-      · rw [hEl₂]
-        exact hcommon.symm
-  · -- the common column of `D` is terminal for the first rectangle and initial for the second
-    have hother : D.first.left ≠ D.second.right := fun hl =>
-      D.sideColumns_ne_of_hasOneCommonSide hone
-        (by rw [GridRectangleBetween.sideColumns, GridRectangleBetween.sideColumns, hcommon, hl,
-          Finset.pair_comm])
-    have hvm : D.second.right ≠ D.first.right := by
-      rw [hcommon]
-      exact D.second.left_ne_right.symm
-    have hcol := (D.cyclicOrder_of_isEmpty_of_right_eq_left hcommon hother hDempty₁ hDempty₂).1
-    have hDbot₂ : D.second.bottom = x D.first.left := by
-      rw [GridRectangleBetween.bottom_def, ← hcommon, D.first.target_apply,
-        Equiv.swap_apply_right]
-    have hDtop₂ : D.second.top = x D.second.right := by
-      rw [GridRectangleBetween.top_def, D.first.target_apply,
-        Equiv.swap_apply_of_ne_of_ne hother.symm hvm]
-    rcases hbranch with ⟨-, hEmid, hEb₁, hEb₂⟩ | ⟨-, hEmid, hEb₁, hEb₂⟩
-    · -- the recut has both its rectangles on the same terminal side column
-      have hEmid' : E.middle = x.swapColumns D.first.right D.second.right := by
-        rw [hEmid, hDtop₂, GridRectangleBetween.top_def, GridState.swapColumns_eq_swapRows]
-      have hxEl₁ : x E.first.left = x D.first.right := by exact hEb₁
-      have hEl₁ : E.first.left = D.first.right := x.toPerm.injective hxEl₁
-      have hxEr₁ : x E.first.right = x D.second.right := by exact hE₁.trans hDtop₂
-      have hEr₁ : E.first.right = D.second.right := x.toPerm.injective hxEr₁
-      have hEl₂ : E.second.left = Equiv.swap D.first.right D.second.right D.first.left :=
-        eq_swap_of_swapColumns_apply_eq (by rw [← hEmid']; exact hEb₂)
-      have hEr₂ : E.second.right = Equiv.swap D.first.right D.second.right D.first.right :=
-        eq_swap_of_swapColumns_apply_eq (by rw [← hEmid']; exact hE₂)
-      rw [Equiv.swap_apply_of_ne_of_ne D.first.left_ne_right hother] at hEl₂
-      rw [Equiv.swap_apply_left] at hEr₂
-      refine Or.inr (Or.inl ⟨hEr₁.trans hEr₂.symm, hEl₂.symm, ?_, Or.inl ⟨?_, ?_, ?_, ?_⟩⟩)
-      · rw [hEl₁]
-        exact hcommon.symm
-      · rw [hEl₁, hEl₂, hEr₁]
-        exact hcol
-      · rw [hEl₂, hEl₁]
-        exact D.first.target_eq_swapColumns
-      · rw [hEl₁]
-      · rw [hEr₁]
-    · -- the recut has both its rectangles on the same initial side column
-      have hEmid' : E.middle = x.swapColumns D.first.left D.second.right := by
-        rw [hEmid, hDtop₂, GridRectangleBetween.bottom_def, GridState.swapColumns_eq_swapRows]
-      have hxEl₁ : x E.first.left = x D.first.left := by exact hEb₁
-      have hEl₁ : E.first.left = D.first.left := x.toPerm.injective hxEl₁
-      have hxEr₁ : x E.first.right = x D.second.right := by exact hE₁.trans hDtop₂
-      have hEr₁ : E.first.right = D.second.right := x.toPerm.injective hxEr₁
-      have hEl₂ : E.second.left = Equiv.swap D.first.left D.second.right D.second.right :=
-        eq_swap_of_swapColumns_apply_eq (by rw [← hEmid']; exact hEb₂.trans hDtop₂)
-      have hEr₂ : E.second.right = Equiv.swap D.first.left D.second.right D.first.right :=
-        eq_swap_of_swapColumns_apply_eq (by rw [← hEmid']; exact hE₂)
-      rw [Equiv.swap_apply_right] at hEl₂
-      rw [Equiv.swap_apply_of_ne_of_ne D.first.left_ne_right.symm hvm.symm] at hEr₂
-      refine Or.inl ⟨hEl₁.trans hEl₂.symm, hEr₂.symm, hEr₁.symm, Or.inr ⟨?_, ?_, ?_, ?_⟩⟩
-      · rw [hEr₂, hEl₁, hEr₁]
-        exact hcol
-      · rw [hEl₁, hEr₂]
-        exact D.first.target_eq_swapColumns
-      · rw [hEl₁]
-      · rw [hEr₂]
-        exact hcommon.symm
+  rcases hdata with hdata | hdata | hdata | hdata
+  · exact isRecut_symm_of_left_eq_left hdata hone hDempty₁ hDempty₂
+  · exact isRecut_symm_of_right_eq_right hdata hone hDempty₁ hDempty₂
+  · exact isRecut_symm_of_left_eq_right hdata hone hDempty₁ hDempty₂
+  · exact isRecut_symm_of_right_eq_left hdata hone hDempty₁ hDempty₂
 
 /-! ### The recut as an involution -/
 
@@ -460,8 +496,9 @@ theorem hasOneCommonSide_of_mem_commonSideColumns (D : GridRectangleDecompositio
   (D.hasDisjointSides_or_hasOneCommonSide_of_ne hzx).resolve_left fun hdisjoint =>
     Finset.eq_empty_iff_forall_notMem.mp (D.commonSideColumns_eq_empty_iff.mpr hdisjoint) c hc
 
-/-- The recut of a decomposition again has exactly one common side column: its side data records
-which of the four orientations its own common column has. -/
+/-- A nondiagonal decomposition admitting a recut has exactly one common side column: the side
+data of that recut records which of the four orientations the decomposition's own common column
+has. -/
 theorem hasOneCommonSide_of_isRecut {G : GridDiagram n} {D E : GridRectangleDecomposition x z}
     (h : E.IsRecut G D) (hzx : z ≠ x) : E.HasOneCommonSide := by
   obtain ⟨-, -, -, -, hdata⟩ := h

--- a/TauCeti/KnotTheory/Grid/Differential/Square/Recut/Pairing.lean
+++ b/TauCeti/KnotTheory/Grid/Differential/Square/Recut/Pairing.lean
@@ -1,0 +1,534 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.KnotTheory.Grid.Differential.Square.Recut.Mixed
+
+/-!
+# The recut pairing on two-step grid rectangle decompositions
+
+A nondiagonal term in the square of the unblocked grid differential `∂⁻` is a pair of composable
+empty rectangles whose two pairs of side columns are disjoint or share exactly one column. In the
+second case the two rectangles meet at a corner, their union is an L-shaped hexagon, and cutting
+that hexagon the other way gives a second such pair through a different intermediate grid state.
+The four orientations of the common column are constructed in `Recut/Initial.lean`,
+`Recut/Terminal.lean` and `Recut/Mixed.lean`, each as the unique decomposition carrying the side
+data computed there. This file assembles those four constructions into a single involution, the
+pairing that cancels the one-common-side terms of `∂⁻ ∘ ∂⁻` in characteristic two.
+
+`GridRectangleDecomposition.IsRecut` collects the four side-data alternatives into one relation.
+A decomposition has at most one orientation of its common column, so exactly one alternative can
+hold and the relation has a unique solution. Recutting twice returns the original decomposition:
+a common initial or terminal column recuts to a mixed common column and conversely, and in each of
+the eight resulting configurations the original decomposition satisfies precisely the side data
+that describes the recut of the recut. The relation is therefore symmetric, and uniqueness turns
+it into an involution `GridRectangleDecomposition.recut`. It has no fixed point, since the
+intermediate state changes, and it preserves the covered-square domain, hence the weight
+`V^{O(r₁)} · V^{O(r₂)}` that the square of the differential attaches to a two-step term.
+
+The geometric input is the cyclic order forced by emptiness of both rectangles: for a common
+initial or terminal column the corner row of the common side lies strictly between the other two
+corner rows, and for a mixed common column the terminal side of the first rectangle lies strictly
+between the other two side columns. That one order fact decides which of the two alternatives of
+the recut's own side data holds.
+
+## Main definitions
+
+* `TauCeti.GridRectangleDecomposition.IsRecutOfLeftEqLeft`,
+  `TauCeti.GridRectangleDecomposition.IsRecutOfRightEqRight`,
+  `TauCeti.GridRectangleDecomposition.IsRecutOfLeftEqRight` and
+  `TauCeti.GridRectangleDecomposition.IsRecutOfRightEqLeft`: the side data computed for the recut
+  in each of the four orientations of the common side column.
+* `TauCeti.GridRectangleDecomposition.IsRecut`: a second two-step decomposition repartitioning the
+  same domain into rectangles the unblocked differential counts, through a different intermediate
+  state, with the side data of the matching orientation.
+* `TauCeti.GridRectangleDecomposition.recut`: the recut of a decomposition sharing exactly one
+  side column.
+
+## Main results
+
+* `TauCeti.GridRectangleDecomposition.existsUnique_isRecut`: a counted decomposition sharing
+  exactly one side column has exactly one recut.
+* `TauCeti.GridRectangleDecomposition.IsRecut.symm`: a decomposition is a recut of its own recut.
+* `TauCeti.GridRectangleDecomposition.recut_recut`: recutting is an involution.
+* `TauCeti.GridRectangleDecomposition.recut_ne`: it has no fixed point.
+* `TauCeti.GridRectangleDecomposition.hasOneCommonSide_recut`: the recut again shares exactly one
+  side column, so the involution stays inside the one-common-side terms.
+
+## References
+
+The recut of an L-shaped juxtaposition follows Ozsváth--Stipsicz--Szabó, *Grid Homology for Knots
+and Links*, Chapter 4.6.
+-/
+public section
+
+namespace TauCeti
+
+namespace GridRectangleDecomposition
+
+variable {n : ℕ} {x z : GridState n}
+
+/-- The side data of the recut of a decomposition whose two rectangles share their initial side
+column. -/
+def IsRecutOfLeftEqLeft (D E : GridRectangleDecomposition x z) : Prop :=
+  D.first.left = D.second.left ∧
+    E.first.right = D.second.right ∧ E.second.right = D.first.right ∧
+      ((D.first.right ∈ Grid.cIoo D.first.left D.second.right ∧
+          E.middle = x.swapColumns D.first.right D.second.right ∧
+            E.first.left = D.first.right ∧ E.second.left = D.first.left) ∨
+        (D.second.right ∈ Grid.cIoo D.first.left D.first.right ∧
+          E.middle = x.swapColumns D.first.left D.second.right ∧
+            E.first.left = D.first.left ∧ E.second.left = D.second.right))
+
+/-- The side data of the recut of a decomposition whose two rectangles share their terminal side
+column. -/
+def IsRecutOfRightEqRight (D E : GridRectangleDecomposition x z) : Prop :=
+  D.first.right = D.second.right ∧
+    E.first.left = D.second.left ∧ E.second.left = D.first.left ∧
+      ((D.first.left ∈ Grid.cIoo D.second.left D.first.right ∧
+          E.middle = x.swapColumns D.second.left D.first.left ∧
+            E.first.right = D.first.left ∧ E.second.right = D.first.right) ∨
+        (D.second.left ∈ Grid.cIoo D.first.left D.first.right ∧
+          E.middle = x.swapColumns D.second.left D.first.right ∧
+            E.first.right = D.first.right ∧ E.second.right = D.second.left))
+
+/-- The side data of the recut of a decomposition whose common column is the initial side of its
+first rectangle and the terminal side of its second. -/
+def IsRecutOfLeftEqRight (D E : GridRectangleDecomposition x z) : Prop :=
+  D.first.left = D.second.right ∧
+    E.first.bottom = D.second.bottom ∧ E.second.bottom = D.first.bottom ∧
+      ((D.first.bottom ∈ Grid.cIoo D.second.bottom D.first.top ∧
+          E.middle = x.swapRows D.second.bottom D.first.bottom ∧
+            E.first.top = D.first.bottom ∧ E.second.top = D.first.top) ∨
+        (D.second.bottom ∈ Grid.cIoo D.first.bottom D.first.top ∧
+          E.middle = x.swapRows D.second.bottom D.first.top ∧
+            E.first.top = D.first.top ∧ E.second.top = D.second.bottom))
+
+/-- The side data of the recut of a decomposition whose common column is the terminal side of its
+first rectangle and the initial side of its second. -/
+def IsRecutOfRightEqLeft (D E : GridRectangleDecomposition x z) : Prop :=
+  D.first.right = D.second.left ∧
+    E.first.top = D.second.top ∧ E.second.top = D.first.top ∧
+      ((D.first.top ∈ Grid.cIoo D.first.bottom D.second.top ∧
+          E.middle = x.swapRows D.first.top D.second.top ∧
+            E.first.bottom = D.first.top ∧ E.second.bottom = D.first.bottom) ∨
+        (D.second.top ∈ Grid.cIoo D.first.bottom D.first.top ∧
+          E.middle = x.swapRows D.first.bottom D.second.top ∧
+            E.first.bottom = D.first.bottom ∧ E.second.bottom = D.second.top))
+
+/-- `E` is the recut of the two-step decomposition `D`: it repartitions the same domain into two
+rectangles the unblocked differential counts, passes through a different intermediate state, and
+carries the side data computed for the orientation of the common side column of `D`. -/
+def IsRecut (G : GridDiagram n) (D E : GridRectangleDecomposition x z) : Prop :=
+  D.IsRepartition E ∧ E.middle ≠ D.middle ∧
+    E.first ∈ G.unblockedRectangles x E.middle ∧
+      E.second ∈ G.unblockedRectangles E.middle z ∧
+        (D.IsRecutOfLeftEqLeft E ∨ D.IsRecutOfRightEqRight E ∨
+          D.IsRecutOfLeftEqRight E ∨ D.IsRecutOfRightEqLeft E)
+
+/-! ### Existence and uniqueness of the recut -/
+
+/-- A two-step decomposition counted by the unblocked differential whose two rectangles share
+exactly one side column has exactly one recut.
+
+Existence is the recut construction in each of the four orientations of the common column;
+uniqueness holds because the orientation of the common column of `D` is unique, so only the
+matching one of the four side-data alternatives can occur. -/
+theorem existsUnique_isRecut (G : GridDiagram n) (D : GridRectangleDecomposition x z)
+    (hone : D.HasOneCommonSide)
+    (hfirst : D.first ∈ G.unblockedRectangles x D.middle)
+    (hsecond : D.second ∈ G.unblockedRectangles D.middle z) :
+    ∃! E : GridRectangleDecomposition x z, D.IsRecut G E := by
+  rcases D.side_eq_cases_of_hasOneCommonSide hone with
+      ⟨hcommon, hother⟩ | ⟨hcommon, hother⟩ | ⟨hcommon, hother⟩ | ⟨hcommon, hother⟩
+  · obtain ⟨E, ⟨hrep, hmid, hEf, hEs, hE₁, hE₂, hbranch⟩, hunique⟩ :=
+      D.exists_isRepartition_of_mem_unblockedRectangles_of_left_eq_left G hcommon hother hfirst
+        hsecond
+    refine ⟨E, ⟨hrep, hmid, hEf, hEs, Or.inl ⟨hcommon, hE₁, hE₂, hbranch⟩⟩, ?_⟩
+    rintro E' ⟨hrep', hmid', hEf', hEs', hdata'⟩
+    rcases hdata' with ⟨-, h⟩ | ⟨h, -⟩ | ⟨h, -⟩ | ⟨h, -⟩
+    · exact hunique E' ⟨hrep', hmid', hEf', hEs', h⟩
+    · exact absurd h hother
+    · exact absurd (hcommon.symm.trans h) D.second.left_ne_right
+    · exact absurd (h.trans hcommon.symm) D.first.left_ne_right.symm
+  · obtain ⟨E, ⟨hrep, hmid, hEf, hEs, hE₁, hE₂, hbranch⟩, hunique⟩ :=
+      D.exists_isRepartition_of_mem_unblockedRectangles_of_left_eq_right G hcommon hother hfirst
+        hsecond
+    refine ⟨E, ⟨hrep, hmid, hEf, hEs, Or.inr (Or.inr (Or.inl ⟨hcommon, hE₁, hE₂, hbranch⟩))⟩, ?_⟩
+    rintro E' ⟨hrep', hmid', hEf', hEs', hdata'⟩
+    rcases hdata' with ⟨h, -⟩ | ⟨h, -⟩ | ⟨-, h⟩ | ⟨h, -⟩
+    · exact absurd (hcommon.symm.trans h) D.second.left_ne_right.symm
+    · exact absurd (hcommon.trans h.symm) D.first.left_ne_right
+    · exact hunique E' ⟨hrep', hmid', hEf', hEs', h⟩
+    · exact absurd h hother
+  · obtain ⟨E, ⟨hrep, hmid, hEf, hEs, hE₁, hE₂, hbranch⟩, hunique⟩ :=
+      D.exists_isRepartition_of_mem_unblockedRectangles_of_right_eq_left G hcommon hother hfirst
+        hsecond
+    refine ⟨E, ⟨hrep, hmid, hEf, hEs, Or.inr (Or.inr (Or.inr ⟨hcommon, hE₁, hE₂, hbranch⟩))⟩, ?_⟩
+    rintro E' ⟨hrep', hmid', hEf', hEs', hdata'⟩
+    rcases hdata' with ⟨h, -⟩ | ⟨h, -⟩ | ⟨h, -⟩ | ⟨-, h⟩
+    · exact absurd (h.trans hcommon.symm) D.first.left_ne_right
+    · exact absurd (hcommon.symm.trans h) D.second.left_ne_right
+    · exact absurd h hother
+    · exact hunique E' ⟨hrep', hmid', hEf', hEs', h⟩
+  · obtain ⟨E, ⟨hrep, hmid, hEf, hEs, hE₁, hE₂, hbranch⟩, hunique⟩ :=
+      D.exists_isRepartition_of_mem_unblockedRectangles_of_right_eq_right G hcommon hother hfirst
+        hsecond
+    refine ⟨E, ⟨hrep, hmid, hEf, hEs, Or.inr (Or.inl ⟨hcommon, hE₁, hE₂, hbranch⟩)⟩, ?_⟩
+    rintro E' ⟨hrep', hmid', hEf', hEs', hdata'⟩
+    rcases hdata' with ⟨h, -⟩ | ⟨-, h⟩ | ⟨h, -⟩ | ⟨h, -⟩
+    · exact absurd h hother
+    · exact hunique E' ⟨hrep', hmid', hEf', hEs', h⟩
+    · exact absurd (h.trans hcommon.symm) D.first.left_ne_right
+    · exact absurd (hcommon.symm.trans h) D.second.left_ne_right.symm
+
+/-! ### The recut of the recut -/
+
+/-- A decomposition sharing exactly one side column does not use the same unordered pair of side
+columns twice. -/
+private theorem sideColumns_ne_of_hasOneCommonSide (D : GridRectangleDecomposition x z)
+    (hone : D.HasOneCommonSide) : D.first.sideColumns ≠ D.second.sideColumns := fun h =>
+  D.target_ne_source_of_hasOneCommonSide hone (D.target_eq_source_iff_sideColumns_eq.mpr h)
+
+/-- The intermediate state of a decomposition swaps the two rows occupied by the side columns of
+its first rectangle. -/
+private theorem middle_eq_swapRows (D : GridRectangleDecomposition x z) :
+    D.middle = x.swapRows (x D.first.left) (x D.first.right) :=
+  D.first.target_eq_swapColumns.trans (GridState.swapColumns_eq_swapRows _ _ _)
+
+/-- A column read off the row it occupies after a column swap. -/
+private theorem eq_swap_of_swapColumns_apply_eq {a b c d : Fin n}
+    (h : x.swapColumns a b c = x d) : c = Equiv.swap a b d :=
+  Equiv.swap_apply_eq_iff.mp (x.toPerm.injective (by rwa [GridState.swapColumns_apply] at h))
+
+/-- The recut of the recut of a two-step decomposition is the decomposition itself.
+
+The recut of a decomposition whose common column is initial or terminal for both rectangles has
+a mixed common column, and conversely; in each of the eight configurations the original
+decomposition carries exactly the side data computed for the recut, so it is the recut of the
+recut. The geometric input is the same cyclic order used to build the recut: for a common initial
+or terminal column, the corner row of the common side lies between the other two corner rows,
+and for a mixed common column the terminal side of the first rectangle lies between the other two
+side columns. -/
+theorem IsRecut.symm {G : GridDiagram n} {D E : GridRectangleDecomposition x z}
+    (h : D.IsRecut G E) (hone : D.HasOneCommonSide)
+    (hfirst : D.first ∈ G.unblockedRectangles x D.middle)
+    (hsecond : D.second ∈ G.unblockedRectangles D.middle z) :
+    E.IsRecut G D := by
+  obtain ⟨hrep, hmid, hEf, hEs, hdata⟩ := h
+  have hDempty₁ := G.isEmpty_of_mem_unblockedRectangles hfirst
+  have hDempty₂ := G.isEmpty_of_mem_unblockedRectangles hsecond
+  have hDmid := D.middle_eq_swapRows
+  refine ⟨hrep.symm, hmid.symm, hfirst, hsecond, ?_⟩
+  rcases hdata with ⟨hcommon, hE₁, hE₂, hbranch⟩ | ⟨hcommon, hE₁, hE₂, hbranch⟩ |
+      ⟨hcommon, hE₁, hE₂, hbranch⟩ | ⟨hcommon, hE₁, hE₂, hbranch⟩
+  · -- the two rectangles of `D` share their initial side column
+    have hother : D.first.right ≠ D.second.right := fun hr =>
+      D.sideColumns_ne_of_hasOneCommonSide hone
+        (by rw [GridRectangleBetween.sideColumns, GridRectangleBetween.sideColumns, hcommon, hr])
+    have hvm : D.second.right ≠ D.first.left := by
+      rw [hcommon]
+      exact D.second.left_ne_right.symm
+    have hrow := (D.cyclicOrder_of_isEmpty_of_left_eq_left hcommon hother hDempty₁ hDempty₂).2
+    have hDbot₂ : D.second.bottom = x D.first.right := by
+      rw [GridRectangleBetween.bottom_def, ← hcommon, D.first.target_apply, Equiv.swap_apply_left]
+    have hDtop₂ : D.second.top = x D.second.right := by
+      rw [GridRectangleBetween.top_def, D.first.target_apply,
+        Equiv.swap_apply_of_ne_of_ne hvm hother.symm]
+    rw [hDtop₂] at hrow
+    rcases hbranch with ⟨-, hEmid, hEl₁, hEl₂⟩ | ⟨-, hEmid, hEl₁, hEl₂⟩
+    · -- the recut has its common column initial for the first and terminal for the second
+      have hEbot₁ : E.first.bottom = x D.first.right := by
+        rw [GridRectangleBetween.bottom_def, hEl₁]
+      have hEtop₁ : E.first.top = x D.second.right := by
+        rw [GridRectangleBetween.top_def, hE₁]
+      have hEbot₂ : E.second.bottom = x D.first.left := by
+        rw [GridRectangleBetween.bottom_def, hEl₂, hEmid, GridState.swapColumns_apply,
+          Equiv.swap_apply_of_ne_of_ne D.first.left_ne_right hvm.symm]
+      refine Or.inr (Or.inr (Or.inl ⟨hEl₁.trans hE₂.symm, ?_, ?_, Or.inl ⟨?_, ?_, ?_, ?_⟩⟩))
+      · rw [hEbot₂, GridRectangleBetween.bottom_def]
+      · rw [hEbot₁, hDbot₂]
+      · rw [hEbot₁, hEbot₂, hEtop₁]
+        exact hrow
+      · rw [hEbot₁, hEbot₂]
+        exact hDmid
+      · rw [hEbot₁, GridRectangleBetween.top_def]
+      · rw [hEtop₁, hDtop₂]
+    · -- the recut has its common column terminal for the first and initial for the second
+      have hEbot₁ : E.first.bottom = x D.first.left := by
+        rw [GridRectangleBetween.bottom_def, hEl₁]
+      have hEtop₁ : E.first.top = x D.second.right := by
+        rw [GridRectangleBetween.top_def, hE₁]
+      have hEtop₂ : E.second.top = x D.first.right := by
+        rw [GridRectangleBetween.top_def, hE₂, hEmid, GridState.swapColumns_apply,
+          Equiv.swap_apply_of_ne_of_ne D.first.left_ne_right.symm hother]
+      refine Or.inr (Or.inr (Or.inr ⟨hE₁.trans hEl₂.symm, ?_, ?_, Or.inr ⟨?_, ?_, ?_, ?_⟩⟩))
+      · rw [hEtop₂, GridRectangleBetween.top_def]
+      · rw [hEtop₁, hDtop₂]
+      · rw [hEtop₂, hEbot₁, hEtop₁]
+        exact hrow
+      · rw [hEbot₁, hEtop₂]
+        exact hDmid
+      · rw [hEbot₁, GridRectangleBetween.bottom_def]
+      · rw [hEtop₂, hDbot₂]
+  · -- the two rectangles of `D` share their terminal side column
+    have hother : D.first.left ≠ D.second.left := fun hl =>
+      D.sideColumns_ne_of_hasOneCommonSide hone
+        (by rw [GridRectangleBetween.sideColumns, GridRectangleBetween.sideColumns, hcommon, hl])
+    have hvm : D.second.left ≠ D.first.right := by
+      rw [hcommon]
+      exact D.second.left_ne_right
+    have hrow := (D.cyclicOrder_of_isEmpty_of_right_eq_right hcommon hother hDempty₁ hDempty₂).2
+    have hDbot₂ : D.second.bottom = x D.second.left := by
+      rw [GridRectangleBetween.bottom_def, D.first.target_apply,
+        Equiv.swap_apply_of_ne_of_ne hother.symm hvm]
+    have hDtop₂ : D.second.top = x D.first.left := by
+      rw [GridRectangleBetween.top_def, ← hcommon, D.first.target_apply, Equiv.swap_apply_right]
+    rw [hDbot₂] at hrow
+    rcases hbranch with ⟨-, hEmid, hEr₁, hEr₂⟩ | ⟨-, hEmid, hEr₁, hEr₂⟩
+    · -- the recut has its common column terminal for the first and initial for the second
+      have hEbot₁ : E.first.bottom = x D.second.left := by
+        rw [GridRectangleBetween.bottom_def, hE₁]
+      have hEtop₁ : E.first.top = x D.first.left := by
+        rw [GridRectangleBetween.top_def, hEr₁]
+      have hEtop₂ : E.second.top = x D.first.right := by
+        rw [GridRectangleBetween.top_def, hEr₂, hEmid, GridState.swapColumns_apply,
+          Equiv.swap_apply_of_ne_of_ne hvm.symm D.first.left_ne_right.symm]
+      refine Or.inr (Or.inr (Or.inr ⟨hEr₁.trans hE₂.symm, ?_, ?_, Or.inl ⟨?_, ?_, ?_, ?_⟩⟩))
+      · rw [hEtop₂, GridRectangleBetween.top_def]
+      · rw [hEtop₁, hDtop₂]
+      · rw [hEtop₁, hEbot₁, hEtop₂]
+        exact hrow
+      · rw [hEtop₁, hEtop₂]
+        exact hDmid
+      · rw [hEtop₁, GridRectangleBetween.bottom_def]
+      · rw [hEbot₁, hDbot₂]
+    · -- the recut has its common column initial for the first and terminal for the second
+      have hEbot₁ : E.first.bottom = x D.second.left := by
+        rw [GridRectangleBetween.bottom_def, hE₁]
+      have hEtop₁ : E.first.top = x D.first.right := by
+        rw [GridRectangleBetween.top_def, hEr₁]
+      have hEbot₂ : E.second.bottom = x D.first.left := by
+        rw [GridRectangleBetween.bottom_def, hE₂, hEmid, GridState.swapColumns_apply,
+          Equiv.swap_apply_of_ne_of_ne hother D.first.left_ne_right]
+      refine Or.inr (Or.inr (Or.inl ⟨hE₁.trans hEr₂.symm, ?_, ?_, Or.inr ⟨?_, ?_, ?_, ?_⟩⟩))
+      · rw [hEbot₂, GridRectangleBetween.bottom_def]
+      · rw [hEbot₁, hDbot₂]
+      · rw [hEbot₂, hEbot₁, hEtop₁]
+        exact hrow
+      · rw [hEbot₂, hEtop₁]
+        exact hDmid
+      · rw [hEtop₁, GridRectangleBetween.top_def]
+      · rw [hEbot₂, hDtop₂]
+  · -- the common column of `D` is initial for the first rectangle and terminal for the second
+    have hother : D.first.right ≠ D.second.left := fun hr =>
+      D.sideColumns_ne_of_hasOneCommonSide hone
+        (by rw [GridRectangleBetween.sideColumns, GridRectangleBetween.sideColumns, hcommon, hr,
+          Finset.pair_comm])
+    have hvm : D.second.left ≠ D.first.left := by
+      rw [hcommon]
+      exact D.second.left_ne_right
+    have hcol := (D.cyclicOrder_of_isEmpty_of_left_eq_right hcommon hother hDempty₁ hDempty₂).1
+    have hrot : D.first.left ∈ Grid.cIoo D.second.left D.first.right :=
+      Grid.mem_cIoo_cyclic_right hcol
+    have hDbot₂ : D.second.bottom = x D.second.left := by
+      rw [GridRectangleBetween.bottom_def, D.first.target_apply,
+        Equiv.swap_apply_of_ne_of_ne hvm hother.symm]
+    have hDtop₂ : D.second.top = x D.first.right := by
+      rw [GridRectangleBetween.top_def, ← hcommon, D.first.target_apply, Equiv.swap_apply_left]
+    rcases hbranch with ⟨-, hEmid, hEt₁, hEt₂⟩ | ⟨-, hEmid, hEt₁, hEt₂⟩
+    · -- the recut has both its rectangles on the same initial side column
+      have hEmid' : E.middle = x.swapColumns D.second.left D.first.left := by
+        rw [hEmid, hDbot₂, GridRectangleBetween.bottom_def, GridState.swapColumns_eq_swapRows]
+      have hEl₁ : E.first.left = D.second.left :=
+        x.toPerm.injective (show x E.first.left = x D.second.left from hE₁.trans hDbot₂)
+      have hEr₁ : E.first.right = D.first.left :=
+        x.toPerm.injective (show x E.first.right = x D.first.left from hEt₁)
+      have hEl₂ : E.second.left = Equiv.swap D.second.left D.first.left D.first.left :=
+        eq_swap_of_swapColumns_apply_eq (by rw [← hEmid']; exact hE₂)
+      have hEr₂ : E.second.right = Equiv.swap D.second.left D.first.left D.first.right :=
+        eq_swap_of_swapColumns_apply_eq (by rw [← hEmid']; exact hEt₂)
+      rw [Equiv.swap_apply_right] at hEl₂
+      rw [Equiv.swap_apply_of_ne_of_ne hother D.first.left_ne_right.symm] at hEr₂
+      refine Or.inl ⟨hEl₁.trans hEl₂.symm, hEr₂.symm, ?_, Or.inl ⟨?_, ?_, ?_, ?_⟩⟩
+      · rw [hEr₁]
+        exact hcommon.symm
+      · rw [hEr₁, hEl₁, hEr₂]
+        exact hrot
+      · rw [hEr₁, hEr₂]
+        exact D.first.target_eq_swapColumns
+      · rw [hEr₁]
+      · rw [hEl₁]
+    · -- the recut has both its rectangles on the same terminal side column
+      have hEmid' : E.middle = x.swapColumns D.second.left D.first.right := by
+        rw [hEmid, hDbot₂, GridRectangleBetween.top_def, GridState.swapColumns_eq_swapRows]
+      have hEl₁ : E.first.left = D.second.left :=
+        x.toPerm.injective (show x E.first.left = x D.second.left from hE₁.trans hDbot₂)
+      have hEr₁ : E.first.right = D.first.right :=
+        x.toPerm.injective (show x E.first.right = x D.first.right from hEt₁)
+      have hEl₂ : E.second.left = Equiv.swap D.second.left D.first.right D.first.left :=
+        eq_swap_of_swapColumns_apply_eq (by rw [← hEmid']; exact hE₂)
+      have hEr₂ : E.second.right = Equiv.swap D.second.left D.first.right D.second.left :=
+        eq_swap_of_swapColumns_apply_eq (by rw [← hEmid']; exact hEt₂.trans hDbot₂)
+      rw [Equiv.swap_apply_of_ne_of_ne hvm.symm D.first.left_ne_right] at hEl₂
+      rw [Equiv.swap_apply_left] at hEr₂
+      refine Or.inr (Or.inl ⟨hEr₁.trans hEr₂.symm, hEl₂.symm, ?_, Or.inr ⟨?_, ?_, ?_, ?_⟩⟩)
+      · rw [hEl₁]
+      · rw [hEl₂, hEl₁, hEr₁]
+        exact hrot
+      · rw [hEl₂, hEr₁]
+        exact D.first.target_eq_swapColumns
+      · rw [hEr₁]
+      · rw [hEl₂]
+        exact hcommon.symm
+  · -- the common column of `D` is terminal for the first rectangle and initial for the second
+    have hother : D.first.left ≠ D.second.right := fun hl =>
+      D.sideColumns_ne_of_hasOneCommonSide hone
+        (by rw [GridRectangleBetween.sideColumns, GridRectangleBetween.sideColumns, hcommon, hl,
+          Finset.pair_comm])
+    have hvm : D.second.right ≠ D.first.right := by
+      rw [hcommon]
+      exact D.second.left_ne_right.symm
+    have hcol := (D.cyclicOrder_of_isEmpty_of_right_eq_left hcommon hother hDempty₁ hDempty₂).1
+    have hDbot₂ : D.second.bottom = x D.first.left := by
+      rw [GridRectangleBetween.bottom_def, ← hcommon, D.first.target_apply,
+        Equiv.swap_apply_right]
+    have hDtop₂ : D.second.top = x D.second.right := by
+      rw [GridRectangleBetween.top_def, D.first.target_apply,
+        Equiv.swap_apply_of_ne_of_ne hother.symm hvm]
+    rcases hbranch with ⟨-, hEmid, hEb₁, hEb₂⟩ | ⟨-, hEmid, hEb₁, hEb₂⟩
+    · -- the recut has both its rectangles on the same terminal side column
+      have hEmid' : E.middle = x.swapColumns D.first.right D.second.right := by
+        rw [hEmid, hDtop₂, GridRectangleBetween.top_def, GridState.swapColumns_eq_swapRows]
+      have hEl₁ : E.first.left = D.first.right :=
+        x.toPerm.injective (show x E.first.left = x D.first.right from hEb₁)
+      have hEr₁ : E.first.right = D.second.right :=
+        x.toPerm.injective (show x E.first.right = x D.second.right from hE₁.trans hDtop₂)
+      have hEl₂ : E.second.left = Equiv.swap D.first.right D.second.right D.first.left :=
+        eq_swap_of_swapColumns_apply_eq (by rw [← hEmid']; exact hEb₂)
+      have hEr₂ : E.second.right = Equiv.swap D.first.right D.second.right D.first.right :=
+        eq_swap_of_swapColumns_apply_eq (by rw [← hEmid']; exact hE₂)
+      rw [Equiv.swap_apply_of_ne_of_ne D.first.left_ne_right hother] at hEl₂
+      rw [Equiv.swap_apply_left] at hEr₂
+      refine Or.inr (Or.inl ⟨hEr₁.trans hEr₂.symm, hEl₂.symm, ?_, Or.inl ⟨?_, ?_, ?_, ?_⟩⟩)
+      · rw [hEl₁]
+        exact hcommon.symm
+      · rw [hEl₁, hEl₂, hEr₁]
+        exact hcol
+      · rw [hEl₂, hEl₁]
+        exact D.first.target_eq_swapColumns
+      · rw [hEl₁]
+      · rw [hEr₁]
+    · -- the recut has both its rectangles on the same initial side column
+      have hEmid' : E.middle = x.swapColumns D.first.left D.second.right := by
+        rw [hEmid, hDtop₂, GridRectangleBetween.bottom_def, GridState.swapColumns_eq_swapRows]
+      have hEl₁ : E.first.left = D.first.left :=
+        x.toPerm.injective (show x E.first.left = x D.first.left from hEb₁)
+      have hEr₁ : E.first.right = D.second.right :=
+        x.toPerm.injective (show x E.first.right = x D.second.right from hE₁.trans hDtop₂)
+      have hEl₂ : E.second.left = Equiv.swap D.first.left D.second.right D.second.right :=
+        eq_swap_of_swapColumns_apply_eq (by rw [← hEmid']; exact hEb₂.trans hDtop₂)
+      have hEr₂ : E.second.right = Equiv.swap D.first.left D.second.right D.first.right :=
+        eq_swap_of_swapColumns_apply_eq (by rw [← hEmid']; exact hE₂)
+      rw [Equiv.swap_apply_right] at hEl₂
+      rw [Equiv.swap_apply_of_ne_of_ne D.first.left_ne_right.symm hvm.symm] at hEr₂
+      refine Or.inl ⟨hEl₁.trans hEl₂.symm, hEr₂.symm, hEr₁.symm, Or.inr ⟨?_, ?_, ?_, ?_⟩⟩
+      · rw [hEr₂, hEl₁, hEr₁]
+        exact hcol
+      · rw [hEl₁, hEr₂]
+        exact D.first.target_eq_swapColumns
+      · rw [hEl₁]
+      · rw [hEr₂]
+        exact hcommon.symm
+
+/-! ### The recut as an involution -/
+
+/-- The two decompositions of a recut pair repartition the same domain. -/
+theorem IsRecut.isRepartition {G : GridDiagram n} {D E : GridRectangleDecomposition x z}
+    (h : D.IsRecut G E) : D.IsRepartition E := h.1
+
+/-- A recut passes through a different intermediate grid state. -/
+theorem IsRecut.middle_ne {G : GridDiagram n} {D E : GridRectangleDecomposition x z}
+    (h : D.IsRecut G E) : E.middle ≠ D.middle := h.2.1
+
+/-- The unblocked differential counts the first rectangle of a recut. -/
+theorem IsRecut.mem_unblockedRectangles_first {G : GridDiagram n}
+    {D E : GridRectangleDecomposition x z} (h : D.IsRecut G E) :
+    E.first ∈ G.unblockedRectangles x E.middle := h.2.2.1
+
+/-- The unblocked differential counts the second rectangle of a recut. -/
+theorem IsRecut.mem_unblockedRectangles_second {G : GridDiagram n}
+    {D E : GridRectangleDecomposition x z} (h : D.IsRecut G E) :
+    E.second ∈ G.unblockedRectangles E.middle z := h.2.2.2.1
+
+/-- A nondiagonal decomposition whose two rectangles have a common side column has exactly one
+common side column. -/
+theorem hasOneCommonSide_of_mem_commonSideColumns (D : GridRectangleDecomposition x z)
+    {c : Fin n} (hc : c ∈ D.commonSideColumns) (hzx : z ≠ x) : D.HasOneCommonSide :=
+  (D.hasDisjointSides_or_hasOneCommonSide_of_ne hzx).resolve_left fun hdisjoint =>
+    Finset.eq_empty_iff_forall_notMem.mp (D.commonSideColumns_eq_empty_iff.mpr hdisjoint) c hc
+
+/-- The recut of a decomposition again has exactly one common side column: its side data records
+which of the four orientations its own common column has. -/
+theorem hasOneCommonSide_of_isRecut {G : GridDiagram n} {D E : GridRectangleDecomposition x z}
+    (h : E.IsRecut G D) (hzx : z ≠ x) : E.HasOneCommonSide := by
+  obtain ⟨-, -, -, -, hdata⟩ := h
+  rcases hdata with ⟨hc, -⟩ | ⟨hc, -⟩ | ⟨hc, -⟩ | ⟨hc, -⟩
+  · exact E.hasOneCommonSide_of_mem_commonSideColumns (c := E.first.left) (by simp [hc]) hzx
+  · exact E.hasOneCommonSide_of_mem_commonSideColumns (c := E.first.right) (by simp [hc]) hzx
+  · exact E.hasOneCommonSide_of_mem_commonSideColumns (c := E.first.left) (by simp [hc]) hzx
+  · exact E.hasOneCommonSide_of_mem_commonSideColumns (c := E.first.right) (by simp [hc]) hzx
+
+/-- The recut of a two-step decomposition counted by the unblocked differential whose two
+rectangles share exactly one side column. -/
+noncomputable def recut (G : GridDiagram n) (D : GridRectangleDecomposition x z)
+    (hone : D.HasOneCommonSide) (hfirst : D.first ∈ G.unblockedRectangles x D.middle)
+    (hsecond : D.second ∈ G.unblockedRectangles D.middle z) :
+    GridRectangleDecomposition x z :=
+  (D.existsUnique_isRecut G hone hfirst hsecond).choose
+
+/-- The recut of a decomposition is a recut of it. -/
+theorem isRecut_recut (G : GridDiagram n) (D : GridRectangleDecomposition x z)
+    (hone : D.HasOneCommonSide) (hfirst : D.first ∈ G.unblockedRectangles x D.middle)
+    (hsecond : D.second ∈ G.unblockedRectangles D.middle z) :
+    D.IsRecut G (D.recut G hone hfirst hsecond) :=
+  (D.existsUnique_isRecut G hone hfirst hsecond).choose_spec.1
+
+/-- The recut of a decomposition again shares exactly one side column. -/
+theorem hasOneCommonSide_recut (G : GridDiagram n) (D : GridRectangleDecomposition x z)
+    (hone : D.HasOneCommonSide) (hfirst : D.first ∈ G.unblockedRectangles x D.middle)
+    (hsecond : D.second ∈ G.unblockedRectangles D.middle z) :
+    (D.recut G hone hfirst hsecond).HasOneCommonSide :=
+  hasOneCommonSide_of_isRecut
+    ((D.isRecut_recut G hone hfirst hsecond).symm hone hfirst hsecond)
+    (D.target_ne_source_of_hasOneCommonSide hone)
+
+/-- The recut of a decomposition is different from it: the two pass through different
+intermediate grid states. -/
+theorem recut_ne (G : GridDiagram n) (D : GridRectangleDecomposition x z)
+    (hone : D.HasOneCommonSide) (hfirst : D.first ∈ G.unblockedRectangles x D.middle)
+    (hsecond : D.second ∈ G.unblockedRectangles D.middle z) :
+    D.recut G hone hfirst hsecond ≠ D := fun h =>
+  (D.isRecut_recut G hone hfirst hsecond).middle_ne (congrArg GridRectangleDecomposition.middle h)
+
+/-- Recutting is an involution on the two-step decompositions counted by the unblocked
+differential whose two rectangles share exactly one side column. -/
+theorem recut_recut (G : GridDiagram n) (D : GridRectangleDecomposition x z)
+    (hone : D.HasOneCommonSide) (hfirst : D.first ∈ G.unblockedRectangles x D.middle)
+    (hsecond : D.second ∈ G.unblockedRectangles D.middle z)
+    (hone' : (D.recut G hone hfirst hsecond).HasOneCommonSide)
+    (hfirst' : (D.recut G hone hfirst hsecond).first ∈
+      G.unblockedRectangles x (D.recut G hone hfirst hsecond).middle)
+    (hsecond' : (D.recut G hone hfirst hsecond).second ∈
+      G.unblockedRectangles (D.recut G hone hfirst hsecond).middle z) :
+    (D.recut G hone hfirst hsecond).recut G hone' hfirst' hsecond' = D :=
+  ((D.recut G hone hfirst hsecond).existsUnique_isRecut G hone' hfirst' hsecond').unique
+    ((D.recut G hone hfirst hsecond).isRecut_recut G hone' hfirst' hsecond')
+    ((D.isRecut_recut G hone hfirst hsecond).symm hone hfirst hsecond)
+
+end GridRectangleDecomposition
+
+end TauCeti

--- a/TauCeti/KnotTheory/Grid/Differential/Square/Recut/Pairing.lean
+++ b/TauCeti/KnotTheory/Grid/Differential/Square/Recut/Pairing.lean
@@ -489,13 +489,6 @@ theorem IsRecut.mem_unblockedRectangles_second {G : GridDiagram n}
     {D E : GridRectangleDecomposition x z} (h : D.IsRecut G E) :
     E.second ∈ G.unblockedRectangles E.middle z := h.2.2.2.1
 
-/-- A nondiagonal decomposition whose two rectangles have a common side column has exactly one
-common side column. -/
-theorem hasOneCommonSide_of_mem_commonSideColumns (D : GridRectangleDecomposition x z)
-    {c : Fin n} (hc : c ∈ D.commonSideColumns) (hzx : z ≠ x) : D.HasOneCommonSide :=
-  (D.hasDisjointSides_or_hasOneCommonSide_of_ne hzx).resolve_left fun hdisjoint =>
-    Finset.eq_empty_iff_forall_notMem.mp (D.commonSideColumns_eq_empty_iff.mpr hdisjoint) c hc
-
 /-- A nondiagonal decomposition admitting a recut has exactly one common side column: the side
 data of that recut records which of the four orientations the decomposition's own common column
 has. -/

--- a/TauCeti/KnotTheory/Grid/Differential/Square/Recut/Pairing.lean
+++ b/TauCeti/KnotTheory/Grid/Differential/Square/Recut/Pairing.lean
@@ -132,11 +132,7 @@ def IsRecut (G : GridDiagram n) (D E : GridRectangleDecomposition x z) : Prop :=
 /-! ### Existence and uniqueness of the recut -/
 
 /-- A two-step decomposition counted by the unblocked differential whose two rectangles share
-exactly one side column has exactly one recut.
-
-Existence is the recut construction in each of the four orientations of the common column;
-uniqueness holds because the orientation of the common column of `D` is unique, so only the
-matching one of the four side-data alternatives can occur. -/
+exactly one side column has exactly one recut. -/
 theorem existsUnique_isRecut (G : GridDiagram n) (D : GridRectangleDecomposition x z)
     (hone : D.HasOneCommonSide)
     (hfirst : D.first ∈ G.unblockedRectangles x D.middle)
@@ -204,15 +200,8 @@ private theorem eq_swap_of_swapColumns_apply_eq {a b c d : Fin n}
     (h : x.swapColumns a b c = x d) : c = Equiv.swap a b d :=
   Equiv.swap_apply_eq_iff.mp (x.toPerm.injective (by rwa [GridState.swapColumns_apply] at h))
 
-/-- The recut of the recut of a two-step decomposition is the decomposition itself.
-
-The recut of a decomposition whose common column is initial or terminal for both rectangles has
-a mixed common column, and conversely; in each of the eight configurations the original
-decomposition carries exactly the side data computed for the recut, so it is the recut of the
-recut. The geometric input is the same cyclic order used to build the recut: for a common initial
-or terminal column, the corner row of the common side lies between the other two corner rows,
-and for a mixed common column the terminal side of the first rectangle lies between the other two
-side columns. -/
+/-- If `E` is a recut of a counted two-step decomposition `D` whose rectangles share exactly one
+side column, then `D` is a recut of `E`. -/
 theorem IsRecut.symm {G : GridDiagram n} {D E : GridRectangleDecomposition x z}
     (h : D.IsRecut G E) (hone : D.HasOneCommonSide)
     (hfirst : D.first ∈ G.unblockedRectangles x D.middle)
@@ -343,10 +332,10 @@ theorem IsRecut.symm {G : GridDiagram n} {D E : GridRectangleDecomposition x z}
     · -- the recut has both its rectangles on the same initial side column
       have hEmid' : E.middle = x.swapColumns D.second.left D.first.left := by
         rw [hEmid, hDbot₂, GridRectangleBetween.bottom_def, GridState.swapColumns_eq_swapRows]
-      have hEl₁ : E.first.left = D.second.left :=
-        x.toPerm.injective (show x E.first.left = x D.second.left from hE₁.trans hDbot₂)
-      have hEr₁ : E.first.right = D.first.left :=
-        x.toPerm.injective (show x E.first.right = x D.first.left from hEt₁)
+      have hxEl₁ : x E.first.left = x D.second.left := by exact hE₁.trans hDbot₂
+      have hEl₁ : E.first.left = D.second.left := x.toPerm.injective hxEl₁
+      have hxEr₁ : x E.first.right = x D.first.left := by exact hEt₁
+      have hEr₁ : E.first.right = D.first.left := x.toPerm.injective hxEr₁
       have hEl₂ : E.second.left = Equiv.swap D.second.left D.first.left D.first.left :=
         eq_swap_of_swapColumns_apply_eq (by rw [← hEmid']; exact hE₂)
       have hEr₂ : E.second.right = Equiv.swap D.second.left D.first.left D.first.right :=
@@ -365,10 +354,10 @@ theorem IsRecut.symm {G : GridDiagram n} {D E : GridRectangleDecomposition x z}
     · -- the recut has both its rectangles on the same terminal side column
       have hEmid' : E.middle = x.swapColumns D.second.left D.first.right := by
         rw [hEmid, hDbot₂, GridRectangleBetween.top_def, GridState.swapColumns_eq_swapRows]
-      have hEl₁ : E.first.left = D.second.left :=
-        x.toPerm.injective (show x E.first.left = x D.second.left from hE₁.trans hDbot₂)
-      have hEr₁ : E.first.right = D.first.right :=
-        x.toPerm.injective (show x E.first.right = x D.first.right from hEt₁)
+      have hxEl₁ : x E.first.left = x D.second.left := by exact hE₁.trans hDbot₂
+      have hEl₁ : E.first.left = D.second.left := x.toPerm.injective hxEl₁
+      have hxEr₁ : x E.first.right = x D.first.right := by exact hEt₁
+      have hEr₁ : E.first.right = D.first.right := x.toPerm.injective hxEr₁
       have hEl₂ : E.second.left = Equiv.swap D.second.left D.first.right D.first.left :=
         eq_swap_of_swapColumns_apply_eq (by rw [← hEmid']; exact hE₂)
       have hEr₂ : E.second.right = Equiv.swap D.second.left D.first.right D.second.left :=
@@ -403,10 +392,10 @@ theorem IsRecut.symm {G : GridDiagram n} {D E : GridRectangleDecomposition x z}
     · -- the recut has both its rectangles on the same terminal side column
       have hEmid' : E.middle = x.swapColumns D.first.right D.second.right := by
         rw [hEmid, hDtop₂, GridRectangleBetween.top_def, GridState.swapColumns_eq_swapRows]
-      have hEl₁ : E.first.left = D.first.right :=
-        x.toPerm.injective (show x E.first.left = x D.first.right from hEb₁)
-      have hEr₁ : E.first.right = D.second.right :=
-        x.toPerm.injective (show x E.first.right = x D.second.right from hE₁.trans hDtop₂)
+      have hxEl₁ : x E.first.left = x D.first.right := by exact hEb₁
+      have hEl₁ : E.first.left = D.first.right := x.toPerm.injective hxEl₁
+      have hxEr₁ : x E.first.right = x D.second.right := by exact hE₁.trans hDtop₂
+      have hEr₁ : E.first.right = D.second.right := x.toPerm.injective hxEr₁
       have hEl₂ : E.second.left = Equiv.swap D.first.right D.second.right D.first.left :=
         eq_swap_of_swapColumns_apply_eq (by rw [← hEmid']; exact hEb₂)
       have hEr₂ : E.second.right = Equiv.swap D.first.right D.second.right D.first.right :=
@@ -425,10 +414,10 @@ theorem IsRecut.symm {G : GridDiagram n} {D E : GridRectangleDecomposition x z}
     · -- the recut has both its rectangles on the same initial side column
       have hEmid' : E.middle = x.swapColumns D.first.left D.second.right := by
         rw [hEmid, hDtop₂, GridRectangleBetween.bottom_def, GridState.swapColumns_eq_swapRows]
-      have hEl₁ : E.first.left = D.first.left :=
-        x.toPerm.injective (show x E.first.left = x D.first.left from hEb₁)
-      have hEr₁ : E.first.right = D.second.right :=
-        x.toPerm.injective (show x E.first.right = x D.second.right from hE₁.trans hDtop₂)
+      have hxEl₁ : x E.first.left = x D.first.left := by exact hEb₁
+      have hEl₁ : E.first.left = D.first.left := x.toPerm.injective hxEl₁
+      have hxEr₁ : x E.first.right = x D.second.right := by exact hE₁.trans hDtop₂
+      have hEr₁ : E.first.right = D.second.right := x.toPerm.injective hxEr₁
       have hEl₂ : E.second.left = Equiv.swap D.first.left D.second.right D.second.right :=
         eq_swap_of_swapColumns_apply_eq (by rw [← hEmid']; exact hEb₂.trans hDtop₂)
       have hEr₂ : E.second.right = Equiv.swap D.first.left D.second.right D.first.right :=
@@ -516,17 +505,21 @@ theorem recut_ne (G : GridDiagram n) (D : GridRectangleDecomposition x z)
 
 /-- Recutting is an involution on the two-step decompositions counted by the unblocked
 differential whose two rectangles share exactly one side column. -/
-theorem recut_recut (G : GridDiagram n) (D : GridRectangleDecomposition x z)
+@[simp] theorem recut_recut (G : GridDiagram n) (D : GridRectangleDecomposition x z)
     (hone : D.HasOneCommonSide) (hfirst : D.first ∈ G.unblockedRectangles x D.middle)
-    (hsecond : D.second ∈ G.unblockedRectangles D.middle z)
-    (hone' : (D.recut G hone hfirst hsecond).HasOneCommonSide)
-    (hfirst' : (D.recut G hone hfirst hsecond).first ∈
-      G.unblockedRectangles x (D.recut G hone hfirst hsecond).middle)
-    (hsecond' : (D.recut G hone hfirst hsecond).second ∈
-      G.unblockedRectangles (D.recut G hone hfirst hsecond).middle z) :
-    (D.recut G hone hfirst hsecond).recut G hone' hfirst' hsecond' = D :=
-  ((D.recut G hone hfirst hsecond).existsUnique_isRecut G hone' hfirst' hsecond').unique
-    ((D.recut G hone hfirst hsecond).isRecut_recut G hone' hfirst' hsecond')
+    (hsecond : D.second ∈ G.unblockedRectangles D.middle z) :
+    (D.recut G hone hfirst hsecond).recut G
+      (D.hasOneCommonSide_recut G hone hfirst hsecond)
+      ((D.isRecut_recut G hone hfirst hsecond).mem_unblockedRectangles_first)
+      ((D.isRecut_recut G hone hfirst hsecond).mem_unblockedRectangles_second) = D :=
+  ((D.recut G hone hfirst hsecond).existsUnique_isRecut G
+      (D.hasOneCommonSide_recut G hone hfirst hsecond)
+      ((D.isRecut_recut G hone hfirst hsecond).mem_unblockedRectangles_first)
+      ((D.isRecut_recut G hone hfirst hsecond).mem_unblockedRectangles_second)).unique
+    ((D.recut G hone hfirst hsecond).isRecut_recut G
+      (D.hasOneCommonSide_recut G hone hfirst hsecond)
+      ((D.isRecut_recut G hone hfirst hsecond).mem_unblockedRectangles_first)
+      ((D.isRecut_recut G hone hfirst hsecond).mem_unblockedRectangles_second))
     ((D.isRecut_recut G hone hfirst hsecond).symm hone hfirst hsecond)
 
 end GridRectangleDecomposition

--- a/TauCeti/KnotTheory/Grid/Differential/Square/SideOverlap.lean
+++ b/TauCeti/KnotTheory/Grid/Differential/Square/SideOverlap.lean
@@ -41,6 +41,8 @@ disjoint rectangles or rectangles sharing exactly one side column.
   applies two disjoint column transpositions has disjoint side pairs.
 * `TauCeti.GridRectangleDecomposition.target_ne_source_iff`: a decomposition is nondiagonal
   exactly when its sides are disjoint or have exactly one column in common.
+* `TauCeti.GridRectangleDecomposition.sideColumns_ne_of_hasOneCommonSide`: sharing exactly one
+  side column means the two side pairs differ.
 
 ## References
 
@@ -282,6 +284,12 @@ theorem target_ne_source_of_hasDisjointSides (D : GridRectangleDecomposition x z
 theorem target_ne_source_of_hasOneCommonSide (D : GridRectangleDecomposition x z)
     (h : D.HasOneCommonSide) : z ≠ x :=
   D.target_ne_source_iff.mpr (Or.inr h)
+
+/-- A decomposition sharing exactly one side column does not use the same unordered pair of side
+columns twice: coinciding side pairs are the diagonal case. -/
+theorem sideColumns_ne_of_hasOneCommonSide (D : GridRectangleDecomposition x z)
+    (hone : D.HasOneCommonSide) : D.first.sideColumns ≠ D.second.sideColumns := fun h =>
+  D.target_ne_source_of_hasOneCommonSide hone (D.target_eq_source_iff_sideColumns_eq.mpr h)
 
 /-- The disjoint-side and one-common-side cases are mutually exclusive. -/
 theorem not_hasDisjointSides_of_hasOneCommonSide (D : GridRectangleDecomposition x z)

--- a/TauCeti/KnotTheory/Grid/Differential/Square/SideOverlap.lean
+++ b/TauCeti/KnotTheory/Grid/Differential/Square/SideOverlap.lean
@@ -43,6 +43,8 @@ disjoint rectangles or rectangles sharing exactly one side column.
   exactly when its sides are disjoint or have exactly one column in common.
 * `TauCeti.GridRectangleDecomposition.sideColumns_ne_of_hasOneCommonSide`: sharing exactly one
   side column means the two side pairs differ.
+* `TauCeti.GridRectangleDecomposition.hasOneCommonSide_of_mem_commonSideColumns`: a nondiagonal
+  decomposition with a common side column has exactly one.
 
 ## References
 
@@ -260,6 +262,13 @@ theorem hasDisjointSides_or_hasOneCommonSide_of_ne
   · exact Or.inl h
   · exact Or.inr h
   · exact (hzx h).elim
+
+/-- A nondiagonal decomposition whose two rectangles have a common side column has exactly one
+common side column. -/
+theorem hasOneCommonSide_of_mem_commonSideColumns (D : GridRectangleDecomposition x z)
+    {c : Fin n} (hc : c ∈ D.commonSideColumns) (hzx : z ≠ x) : D.HasOneCommonSide :=
+  (D.hasDisjointSides_or_hasOneCommonSide_of_ne hzx).resolve_left fun hdisjoint =>
+    Finset.eq_empty_iff_forall_notMem.mp (D.commonSideColumns_eq_empty_iff.mpr hdisjoint) c hc
 
 /-- A two-step rectangle decomposition is nondiagonal exactly when its side pairs are disjoint or
 share exactly one column. -/

--- a/TauCeti/KnotTheory/Grid/Differential/Square/Zero.lean
+++ b/TauCeti/KnotTheory/Grid/Differential/Square/Zero.lean
@@ -1,0 +1,150 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+import Mathlib.RingTheory.MvPolynomial.Basic
+public import TauCeti.KnotTheory.Grid.Differential.Square.Annulus
+public import TauCeti.KnotTheory.Grid.Differential.Square.DoubleTransposition
+public import TauCeti.KnotTheory.Grid.Differential.Square.Recut.Pairing
+public import TauCeti.KnotTheory.Grid.SimplyBlocked
+
+/-!
+# The unblocked and simply blocked grid differentials square to zero
+
+The square of the unblocked grid differential `∂⁻` of `Unblocked.lean` is a sum over pairs of
+composable rectangles which are empty and cover no `X`-marking. This file completes the
+juxtaposition argument that the sum vanishes in characteristic two, so that `GC⁻` is a chain
+complex.
+
+The two side-column pairs of such a two-step term are equal, disjoint, or meet in exactly one
+column. Equal pairs mean the second rectangle returns to the source of the first; those terms
+cover a full toroidal annulus, hence an `X`-marking, and vanish over every coefficient ring. The
+other two cases pair the terms off two by two, by a weight-preserving involution without fixed
+points: rectangles with disjoint side columns are applied in the opposite order, and rectangles
+sharing one side column bound an L-shaped hexagon which is cut the other way. Each pairing changes
+the intermediate grid state and preserves the covered-square domain, hence the monomial weight, so
+in characteristic two the two terms of a pair cancel.
+
+Specializing at `V_i = 0` carries the theorem to the simply blocked map, so the simply blocked
+complex is a chain complex too. The fully blocked complex is not treated here: its rectangles must
+avoid the `O`-markings as well, so it needs a recut of its own.
+
+## Main results
+
+* `TauCeti.GridDiagram.sum_unblockedCoefficient_mul_unblockedCoefficient_eq_zero`: every matrix
+  entry of the square of `∂⁻` vanishes.
+* `TauCeti.GridDiagram.unblockedDifferential_comp_self_eq_zero`: `∂⁻ ∘ ∂⁻ = 0`.
+* `TauCeti.GridDiagram.simplyBlockedDifferential_comp_self_eq_zero`: the same for the
+  specialization at `V_i = 0`.
+
+## References
+
+The juxtaposition proof follows Ozsváth--Stipsicz--Szabó, *Grid Homology for Knots and Links*,
+Chapter 4.6.
+-/
+public section
+
+namespace TauCeti
+
+namespace GridDiagram
+
+variable {n : ℕ} (G : GridDiagram n) (R : Type*) [CommSemiring R] [CharP R 2]
+
+/-- In characteristic two every matrix entry of the square of the unblocked grid differential
+vanishes. -/
+theorem sum_unblockedCoefficient_mul_unblockedCoefficient_eq_zero (x z : GridState n) :
+    ∑ y : GridState n, G.unblockedCoefficient R x y * G.unblockedCoefficient R y z = 0 := by
+  classical
+  rcases eq_or_ne z x with rfl | hzx
+  · exact Finset.sum_eq_zero fun y _ =>
+      G.unblockedCoefficient_mul_unblockedCoefficient_eq_zero R z y
+  rw [G.sum_unblockedCoefficient_mul_unblockedCoefficient R x z,
+    ← Finset.sum_filter_add_sum_filter_not (G.unblockedDecompositions x z)
+      (fun D => D.HasDisjointSides) (G.unblockedDecompositionWeight R)]
+  have hdisjoint : ∑ D ∈ (G.unblockedDecompositions x z).filter
+      (fun D => D.HasDisjointSides), G.unblockedDecompositionWeight R D = 0 := by
+    refine Finset.sum_involution
+      (fun D hD => D.commute (Finset.mem_filter.mp hD).2) (fun D hD => ?_) (fun D hD _ => ?_)
+      (fun D hD => ?_) (fun D hD => ?_)
+    · rw [G.unblockedDecompositionWeight_commute R D]
+      exact CharTwo.add_self_eq_zero _
+    · exact D.commute_ne _
+    · exact Finset.mem_filter.mpr ⟨(G.commute_mem_unblockedDecompositions_iff D _).mpr
+        (Finset.mem_filter.mp hD).1, D.hasDisjointSides_commute _⟩
+    · exact D.commute_commute _
+  have hone : ∀ D ∈ (G.unblockedDecompositions x z).filter
+      (fun D => ¬D.HasDisjointSides), D.HasOneCommonSide := fun D hD =>
+    (D.hasDisjointSides_or_hasOneCommonSide_of_ne hzx).resolve_left (Finset.mem_filter.mp hD).2
+  have hfirst : ∀ D ∈ (G.unblockedDecompositions x z).filter
+      (fun D => ¬D.HasDisjointSides), D.first ∈ G.unblockedRectangles x D.middle := fun D hD =>
+    ((G.mem_unblockedDecompositions x z D).mp (Finset.mem_filter.mp hD).1).1
+  have hsecond : ∀ D ∈ (G.unblockedDecompositions x z).filter
+      (fun D => ¬D.HasDisjointSides), D.second ∈ G.unblockedRectangles D.middle z := fun D hD =>
+    ((G.mem_unblockedDecompositions x z D).mp (Finset.mem_filter.mp hD).1).2
+  have hcommon : ∑ D ∈ (G.unblockedDecompositions x z).filter
+      (fun D => ¬D.HasDisjointSides), G.unblockedDecompositionWeight R D = 0 := by
+    refine Finset.sum_involution
+      (fun D hD => D.recut G (hone D hD) (hfirst D hD) (hsecond D hD)) (fun D hD => ?_)
+      (fun D hD _ => ?_) (fun D hD => ?_) (fun D hD => ?_)
+    · have hweight : G.unblockedDecompositionWeight R
+          (D.recut G (hone D hD) (hfirst D hD) (hsecond D hD)) =
+            G.unblockedDecompositionWeight R D := by
+        rw [G.unblockedDecompositionWeight_def R, G.unblockedDecompositionWeight_def R]
+        exact (D.isRecut_recut G (hone D hD) (hfirst D hD)
+          (hsecond D hD)).isRepartition.OMonomial_mul_OMonomial G R
+      rw [hweight]
+      exact CharTwo.add_self_eq_zero _
+    · exact D.recut_ne G _ _ _
+    · refine Finset.mem_filter.mpr ⟨(G.mem_unblockedDecompositions x z _).mpr ⟨?_, ?_⟩, ?_⟩
+      · exact (D.isRecut_recut G _ _ _).mem_unblockedRectangles_first
+      · exact (D.isRecut_recut G _ _ _).mem_unblockedRectangles_second
+      · exact GridRectangleDecomposition.not_hasDisjointSides_of_hasOneCommonSide _
+          (D.hasOneCommonSide_recut G _ _ _)
+    · exact D.recut_recut G _ _ _ _ _ _
+  rw [hdisjoint, hcommon, add_zero]
+
+/-- In characteristic two the square of the unblocked grid differential vanishes on a
+generator. -/
+theorem unblockedDifferential_sq_single_apply_eq_zero (x z : GridState n) :
+    G.unblockedDifferential R (G.unblockedDifferential R (Finsupp.single x 1)) z = 0 := by
+  rw [G.unblockedDifferential_sq_single_apply R x z]
+  exact G.sum_unblockedCoefficient_mul_unblockedCoefficient_eq_zero R x z
+
+/-- In characteristic two the square of the unblocked grid differential kills every
+generator. -/
+theorem unblockedDifferential_sq_single_eq_zero (x : GridState n) :
+    G.unblockedDifferential R (G.unblockedDifferential R (Finsupp.single x 1)) = 0 := by
+  refine Finsupp.ext fun z => ?_
+  rw [Finsupp.coe_zero, Pi.zero_apply]
+  exact G.unblockedDifferential_sq_single_apply_eq_zero R x z
+
+/-- The unblocked grid differential squares to zero in characteristic two. -/
+theorem unblockedDifferential_comp_self_eq_zero :
+    G.unblockedDifferential R ∘ₗ G.unblockedDifferential R =
+      (0 : GridChainMinus R n →ₗ[MvPolynomial (Fin n) R] GridChainMinus R n) := by
+  refine Finsupp.lhom_ext' fun x => LinearMap.ext_ring ?_
+  simp only [LinearMap.comp_apply, Finsupp.lsingle_apply, LinearMap.zero_comp,
+    LinearMap.zero_apply]
+  exact G.unblockedDifferential_sq_single_eq_zero R x
+
+/-- The simply blocked grid map squares to zero in characteristic two: it is the specialization
+of `∂⁻` at `V_i = 0`, and specialization intertwines the two maps. -/
+theorem simplyBlockedDifferential_comp_self_eq_zero (i : Fin n) :
+    G.simplyBlockedDifferential R i ∘ₗ G.simplyBlockedDifferential R i =
+      (0 : GridChainHat R n i →ₗ[MvPolynomial {c : Fin n // c ≠ i} R] GridChainHat R n i) := by
+  refine Finsupp.lhom_ext' fun x => LinearMap.ext_ring ?_
+  simp only [LinearMap.comp_apply, Finsupp.lsingle_apply, LinearMap.zero_comp,
+    LinearMap.zero_apply]
+  have hsingle : (Finsupp.single x 1 : GridChainHat R n i) =
+      simplyBlockedSpecialization R i (Finsupp.single x 1) := by
+    rw [simplyBlockedSpecialization_single, map_one]
+  rw [hsingle, ← G.simplyBlockedSpecialization_unblockedDifferential R i,
+    ← G.simplyBlockedSpecialization_unblockedDifferential R i]
+  rw [G.unblockedDifferential_sq_single_eq_zero R x, map_zero]
+
+end GridDiagram
+
+end TauCeti

--- a/TauCeti/KnotTheory/Grid/Differential/Square/Zero.lean
+++ b/TauCeti/KnotTheory/Grid/Differential/Square/Zero.lean
@@ -103,7 +103,7 @@ theorem sum_unblockedCoefficient_mul_unblockedCoefficient_eq_zero (x z : GridSta
       · exact (D.isRecut_recut G _ _ _).mem_unblockedRectangles_second
       · exact GridRectangleDecomposition.not_hasDisjointSides_of_hasOneCommonSide _
           (D.hasOneCommonSide_recut G _ _ _)
-    · exact D.recut_recut G _ _ _ _ _ _
+    · exact D.recut_recut G _ _ _
   rw [hdisjoint, hcommon, add_zero]
 
 /-- In characteristic two the square of the unblocked grid differential vanishes on a

--- a/TauCeti/KnotTheory/Grid/Differential/Square/Zero.lean
+++ b/TauCeti/KnotTheory/Grid/Differential/Square/Zero.lean
@@ -12,7 +12,7 @@ public import TauCeti.KnotTheory.Grid.Differential.Square.Recut.Pairing
 public import TauCeti.KnotTheory.Grid.SimplyBlocked
 
 /-!
-# The unblocked and simply blocked grid differentials square to zero
+# The grid differentials square to zero
 
 The square of the unblocked grid differential `∂⁻` of `Unblocked.lean` is a sum over pairs of
 composable rectangles which are empty and cover no `X`-marking. This file completes the
@@ -28,9 +28,12 @@ sharing one side column bound an L-shaped hexagon which is cut the other way. Ea
 the intermediate grid state and preserves the covered-square domain, hence the monomial weight, so
 in characteristic two the two terms of a pair cancel.
 
-Specializing at `V_i = 0` carries the theorem to the simply blocked map, so the simply blocked
-complex is a chain complex too. The fully blocked complex is not treated here: its rectangles must
-avoid the `O`-markings as well, so it needs a recut of its own.
+Specializing carries the theorem to the two blocked theories, so their complexes are chain
+complexes too. Setting one `V_i` to zero gives the simply blocked map, and specialization
+intertwines the two differentials. Setting every `V_i` to zero — that is, taking constant terms —
+gives the fully blocked differential of `Complex.lean`, whose rectangles must avoid the
+`O`-markings as well: `GridDiagram.fullyBlockedRectangleCount_eq_constantCoeff` identifies its
+matrix coefficients with the constant terms of `∂⁻` over `ZMod 2`.
 
 ## Main results
 
@@ -39,6 +42,9 @@ avoid the `O`-markings as well, so it needs a recut of its own.
 * `TauCeti.GridDiagram.unblockedDifferential_comp_self_eq_zero`: `∂⁻ ∘ ∂⁻ = 0`.
 * `TauCeti.GridDiagram.simplyBlockedDifferential_comp_self_eq_zero`: the same for the
   specialization at `V_i = 0`.
+* `TauCeti.GridDiagram.fullyBlockedDecompositionCount_eq_zero`,
+  `TauCeti.GridDiagram.fullyBlockedDifferential_comp_self_eq_zero`: the same for the fully blocked
+  differential, the specialization at every `V_i = 0`.
 
 ## References
 
@@ -144,6 +150,30 @@ theorem simplyBlockedDifferential_comp_self_eq_zero (i : Fin n) :
   rw [hsingle, ← G.simplyBlockedSpecialization_unblockedDifferential R i,
     ← G.simplyBlockedSpecialization_unblockedDifferential R i]
   rw [G.unblockedDifferential_sq_single_eq_zero R x, map_zero]
+
+/-- Every fully blocked two-step decomposition count is even.
+
+The fully blocked matrix coefficients are the constant terms of the unblocked ones over `ZMod 2`,
+and taking constant terms is a ring homomorphism, so this entry of the fully blocked square is the
+constant term of the corresponding entry of `∂⁻ ∘ ∂⁻`. -/
+theorem fullyBlockedDecompositionCount_eq_zero (x z : GridState n) :
+    G.fullyBlockedDecompositionCount x z = 0 := by
+  have hterm : ∀ y : GridState n,
+      G.fullyBlockedRectangleCount x y * G.fullyBlockedRectangleCount y z =
+        MvPolynomial.constantCoeff
+          (G.unblockedCoefficient (ZMod 2) x y * G.unblockedCoefficient (ZMod 2) y z) :=
+    fun y => by
+      rw [map_mul, G.fullyBlockedRectangleCount_eq_constantCoeff x y,
+        G.fullyBlockedRectangleCount_eq_constantCoeff y z]
+  rw [G.fullyBlockedDecompositionCount_eq_sum x z, Finset.sum_congr rfl fun y _ => hterm y,
+    ← map_sum, G.sum_unblockedCoefficient_mul_unblockedCoefficient_eq_zero (ZMod 2) x z, map_zero]
+
+/-- The fully blocked grid differential squares to zero, so the fully blocked grid complex of
+`Complex.lean` is a chain complex. -/
+theorem fullyBlockedDifferential_comp_self_eq_zero :
+    G.fullyBlockedDifferential.comp G.fullyBlockedDifferential = 0 :=
+  G.fullyBlockedDifferential_comp_self_eq_zero_iff_decompositionCount.mpr
+    G.fullyBlockedDecompositionCount_eq_zero
 
 end GridDiagram
 

--- a/TauCeti/KnotTheory/Grid/Differential/Square/Zero.lean
+++ b/TauCeti/KnotTheory/Grid/Differential/Square/Zero.lean
@@ -16,8 +16,8 @@ public import TauCeti.KnotTheory.Grid.SimplyBlocked
 
 The square of the unblocked grid differential `∂⁻` of `Unblocked.lean` is a sum over pairs of
 composable rectangles which are empty and cover no `X`-marking. This file completes the
-juxtaposition argument that the sum vanishes in characteristic two, so that `GC⁻` is a chain
-complex.
+juxtaposition argument that the sum vanishes in characteristic two. That is the square-zero
+condition a chain complex structure on `GC⁻` needs; the structure itself is not built here.
 
 The two side-column pairs of such a two-step term are equal, disjoint, or meet in exactly one
 column. Equal pairs mean the second rectangle returns to the source of the first; those terms
@@ -28,12 +28,12 @@ sharing one side column bound an L-shaped hexagon which is cut the other way. Ea
 the intermediate grid state and preserves the covered-square domain, hence the monomial weight, so
 in characteristic two the two terms of a pair cancel.
 
-Specializing carries the theorem to the two blocked theories, so their complexes are chain
-complexes too. Setting one `V_i` to zero gives the simply blocked map, and specialization
-intertwines the two differentials. Setting every `V_i` to zero — that is, taking constant terms —
-gives the fully blocked differential of `Complex.lean`, whose rectangles must avoid the
-`O`-markings as well: `GridDiagram.fullyBlockedRectangleCount_eq_constantCoeff` identifies its
-matrix coefficients with the constant terms of `∂⁻` over `ZMod 2`.
+Specializing carries the square-zero identity to the two blocked theories as well. Setting one
+`V_i` to zero gives the simply blocked map, and specialization intertwines the two differentials.
+Setting every `V_i` to zero — that is, taking constant terms — gives the fully blocked
+differential of `Complex.lean`, whose rectangles must avoid the `O`-markings as well:
+`GridDiagram.fullyBlockedRectangleCount_eq_constantCoeff` identifies its matrix coefficients with
+the constant terms of `∂⁻` over `ZMod 2`.
 
 ## Main results
 
@@ -168,8 +168,7 @@ theorem fullyBlockedDecompositionCount_eq_zero (x z : GridState n) :
   rw [G.fullyBlockedDecompositionCount_eq_sum x z, Finset.sum_congr rfl fun y _ => hterm y,
     ← map_sum, G.sum_unblockedCoefficient_mul_unblockedCoefficient_eq_zero (ZMod 2) x z, map_zero]
 
-/-- The fully blocked grid differential squares to zero, so the fully blocked grid complex of
-`Complex.lean` is a chain complex. -/
+/-- The fully blocked grid differential of `Complex.lean` squares to zero. -/
 theorem fullyBlockedDifferential_comp_self_eq_zero :
     G.fullyBlockedDifferential.comp G.fullyBlockedDifferential = 0 :=
   G.fullyBlockedDifferential_comp_self_eq_zero_iff_decompositionCount.mpr

--- a/TauCeti/KnotTheory/Grid/JFunction/Center.lean
+++ b/TauCeti/KnotTheory/Grid/JFunction/Center.lean
@@ -28,9 +28,9 @@ argument holds grid points and the right argument names squares, so there is no 
 since shifting *both* point sets by `(1/2, 1/2)` preserves every strict comparison; those keep
 using `GridPoint.J`.
 
-This file corrects the grading pairing only. The older `GridRectangle.AvoidsMarkings` predicate
-still interprets marking indices using the open grid-line interior; aligning that Lane G.3
-differential convention with square-centered markings is a separate rectangle correction.
+The grid differential reads marking indices the same way: its marking-avoidance predicate
+`GridRectangle.AvoidsMarkings` tests the squares a rectangle covers, so a marking index names a
+square there too.
 
 ## Main definitions
 

--- a/TauCeti/KnotTheory/Grid/Rectangle/Annulus.lean
+++ b/TauCeti/KnotTheory/Grid/Rectangle/Annulus.lean
@@ -35,11 +35,10 @@ and by the unblocked complex `GC⁻`. Applied to the `O`- or the `X`-markings of
 of which are grid states, the last lemma therefore says that a returning pair of rectangles can
 never consist of two rectangles disjoint from the markings' squares, so the annular terms vanish
 for any grid differential whose marking-free test is that disjointness — in particular for the
-`X`-test of the unblocked differential `∂⁻`. It does not apply as it stands to the fully blocked
-differential of `Complex.lean`, whose `GridRectangle.AvoidsMarkings` predicate still tests the open
-grid-line interior, treating markings as lattice points rather than as square centres; that is the
-acknowledged convention error whose correction is the open TauCeti#3135, and against the corrected
-square-centred predicate this lemma will serve the fully blocked case unchanged.
+`X`-test of the unblocked differential `∂⁻`. The marking-avoidance predicate
+`GridRectangle.AvoidsMarkings` tests that same region under its other name `GridRectangle.squares`,
+which `GridRectangle.squares_eq_coveredSquares` identifies with `coveredSquares`, so the lemma
+serves the fully blocked differential of `Complex.lean` unchanged.
 
 ## Main results
 
@@ -199,8 +198,9 @@ Applied to the `O`- or `X`-markings of a grid diagram, this is the vanishing of 
 in the square of a grid differential that tests markings by disjointness from
 `GridRectangle.coveredSquares`, such as the unblocked differential `∂⁻`: two rectangles that return
 to their source can never both avoid the markings in that sense. The fully blocked differential of
-`Complex.lean` is not yet such a differential, since `GridRectangle.AvoidsMarkings` still tests the
-open grid-line interior; see the module docstring. -/
+`Complex.lean` is such a differential too: its `GridRectangle.AvoidsMarkings` predicate tests
+`GridRectangle.squares`, which `GridRectangle.squares_eq_coveredSquares` identifies with
+`coveredSquares`. -/
 theorem not_disjoint_coveredSquares_or_not_disjoint_coveredSquares (M : GridState n) :
     ¬Disjoint R.toGridRectangle.coveredSquares M.pointSet ∨
       ¬Disjoint S.toGridRectangle.coveredSquares M.pointSet := by

--- a/TauCeti/KnotTheory/Grid/Rectangle/Basic.lean
+++ b/TauCeti/KnotTheory/Grid/Rectangle/Basic.lean
@@ -28,10 +28,10 @@ where the states exchange rows, and agreement everywhere else. This is the shape
 the grid differential; the `IsEmptyFor` and `AvoidsMarkings` predicates record the two
 finite-set disjointness conditions used for empty rectangles and marking-avoiding rectangles.
 
-`AvoidsMarkings` currently uses the same open grid-line interior as `IsEmptyFor`. Thus it treats
-marking indices as lattice points, not as the southwest corners of square-centred markings. The
-Lane G.2 grading correction does not silently change this Lane G.3 differential convention;
-changing it requires a separate update of the blocked-rectangle and small-grid differential API.
+`AvoidsMarkings` tests `squares`, so a marking counts as covered exactly when its square lies
+under the rectangle: marking indices are the southwest corners of square-centred markings, the
+convention the Lane G.2 gradings use. `GridRectangle.squares_eq_coveredSquares` in
+`Rectangle/Squares.lean` identifies `squares` with the grading side's name for that region.
 
 ## Main definitions
 

--- a/TauCeti/KnotTheory/Grid/Rectangle/Basic.lean
+++ b/TauCeti/KnotTheory/Grid/Rectangle/Basic.lean
@@ -30,7 +30,7 @@ finite-set disjointness conditions used for empty rectangles and marking-avoidin
 
 `AvoidsMarkings` tests `squares`, so a marking counts as covered exactly when its square lies
 under the rectangle: marking indices are the southwest corners of square-centred markings, the
-convention the Lane G.2 gradings use. `GridRectangle.squares_eq_coveredSquares` in
+convention the Maslov and Alexander gradings use. `GridRectangle.squares_eq_coveredSquares` in
 `Rectangle/Squares.lean` identifies `squares` with the grading side's name for that region.
 
 ## Main definitions

--- a/TauCeti/KnotTheory/Grid/Rectangle/Squares.lean
+++ b/TauCeti/KnotTheory/Grid/Rectangle/Squares.lean
@@ -28,9 +28,8 @@ The convention that markings sit at the centres of their squares is the one the 
 Alexander gradings already use (`JFunction/Center.lean`); this file supplies the matching
 rectangle domain, which `Grading/MarkingCount.lean` then uses to turn the Maslov and Alexander
 grading changes across a rectangle move into marking counts. The Lane G.3 differential predicate
-`GridRectangle.AvoidsMarkings` still tests the grid-line interior and is left untouched here;
-aligning it with the square-centred convention is a separate correction to that predicate and to
-everything it feeds.
+`GridRectangle.AvoidsMarkings` tests the same square-centred region under its other name
+`GridRectangle.squares`; `GridRectangle.squares_eq_coveredSquares` identifies the two.
 
 ## Main definitions
 
@@ -46,6 +45,8 @@ everything it feeds.
   exactly when their covered columns or their covered rows are disjoint.
 * `TauCeti.GridRectangle.card_coveredSquares`: the number of covered squares is the product of the
   two arc lengths.
+* `TauCeti.GridRectangle.squares_eq_coveredSquares`: the covered squares are the region
+  `GridRectangle.squares` that the marking-avoidance predicate tests.
 
 ## References
 
@@ -151,6 +152,12 @@ theorem disjoint_coveredSquares_iff (R S : GridRectangle n) :
 theorem interior_subset_coveredSquares : R.interior ⊆ R.coveredSquares :=
   Finset.product_subset_product R.columnInterior_subset_coveredColumns
     R.rowInterior_subset_coveredRows
+
+/-- The squares a rectangle covers are the region the marking-avoidance predicate tests: both
+`GridRectangle.squares` and `coveredSquares` are the product of the two half-open arcs. -/
+theorem squares_eq_coveredSquares : R.squares = R.coveredSquares := by
+  ext p
+  simp [mem_coveredSquares]
 
 /-- The number of covered squares is the product of the numbers of covered columns and covered
 rows. -/

--- a/TauCeti/KnotTheory/Grid/Rectangle/Squares.lean
+++ b/TauCeti/KnotTheory/Grid/Rectangle/Squares.lean
@@ -27,9 +27,10 @@ without a nondegeneracy hypothesis.
 The convention that markings sit at the centres of their squares is the one the Maslov and
 Alexander gradings already use (`JFunction/Center.lean`); this file supplies the matching
 rectangle domain, which `Grading/MarkingCount.lean` then uses to turn the Maslov and Alexander
-grading changes across a rectangle move into marking counts. The Lane G.3 differential predicate
-`GridRectangle.AvoidsMarkings` tests the same square-centred region under its other name
-`GridRectangle.squares`; `GridRectangle.squares_eq_coveredSquares` identifies the two.
+grading changes across a rectangle move into marking counts. The marking-avoidance predicate of
+the grid differential, `GridRectangle.AvoidsMarkings`, tests that same square-centred region under
+its other name `GridRectangle.squares`; `GridRectangle.squares_eq_coveredSquares` identifies the
+two.
 
 ## Main definitions
 

--- a/TauCeti/KnotTheory/Grid/Rectangle/Swap.lean
+++ b/TauCeti/KnotTheory/Grid/Rectangle/Swap.lean
@@ -27,6 +27,8 @@ a Maslov or Alexander grading-change computation across a rectangle rests on, an
 
 * `TauCeti.GridRectangleBetween.target_eq_swapColumns`: the target state of a rectangle is the
   source state with the two side columns swapped.
+* `TauCeti.GridRectangleBetween.target_eq_swapRows`: equivalently, the source state with the two
+  rows those columns occupy swapped.
 * `TauCeti.GridRectangleBetween.nonempty_all_iff`: oriented rectangles between `x` and `y` exist
   exactly when `y` is a column transposition of `x`.
 * `TauCeti.GridRectangleBetween.source_eq_swapColumns`: the symmetric statement recovering the
@@ -77,6 +79,12 @@ theorem target_eq_swapColumns : y = x.swapColumns R.left R.right := by
   refine GridState.ext fun c => ?_
   rw [GridState.swapColumns_apply]
   exact target_apply R c
+
+/-- The target state of an oriented rectangle is also the source state with the two rows occupied
+by its side columns swapped: a grid state is a bijection from columns to rows, so exchanging the
+two side columns exchanges exactly the two rows they occupy. -/
+theorem target_eq_swapRows : y = x.swapRows (x R.left) (x R.right) :=
+  R.target_eq_swapColumns.trans (GridState.swapColumns_eq_swapRows _ _ _)
 
 /-- The oriented rectangle associated to an equality expressing the target as a nontrivial
 column swap of the source. -/

--- a/TauCeti/KnotTheory/Grid/SmallGrid/Differential.lean
+++ b/TauCeti/KnotTheory/Grid/SmallGrid/Differential.lean
@@ -140,8 +140,10 @@ At most two grid states are available. If the source and the target of a two-ste
 distinct they exhaust those states, so every intermediate state coincides with the source or with
 the target and its term is killed by the vanishing of the diagonal matrix coefficient. If instead
 the source and the target coincide, the term returns to its source and the annular argument
-applies. This is the first instance of the roadmap's square-zero milestone for `GC⁻`; the general
-case still needs the disjoint and overlapping juxtaposition cases. -/
+applies. Unlike the general square-zero theorem
+`GridDiagram.unblockedDifferential_comp_self_eq_zero`, which pairs juxtaposed rectangles and so
+needs characteristic two, this small-grid instance holds over every commutative coefficient
+semiring. -/
 theorem unblockedDifferential_comp_self_eq_zero_of_le_two (hn : n ≤ 2) :
     G.unblockedDifferential R ∘ₗ G.unblockedDifferential R =
       (0 : GridChainMinus R n →ₗ[MvPolynomial (Fin n) R] GridChainMinus R n) := by

--- a/TauCeti/KnotTheory/Grid/Unblocked.lean
+++ b/TauCeti/KnotTheory/Grid/Unblocked.lean
@@ -35,9 +35,10 @@ Two conventions are fixed here.
 carries the markings of the squares it covers, `GridRectangle.coveredSquares`, not those of the
 grid points in its open interior. That is the region the Maslov and Alexander grading changes are
 computed against in `Grading/MarkingCount.lean`, and it is the region used throughout this file.
-It is also the region the Lane G.3 predicate `GridRectangle.AvoidsMarkings` tests, under its other
-name `GridRectangle.squares`; `GridRectangle.squares_eq_coveredSquares` identifies the two, which
-is what makes the fully blocked count a specialization of a matrix coefficient here.
+It is also the region the marking-avoidance predicate `GridRectangle.AvoidsMarkings` of the grid
+differential tests, under its other name `GridRectangle.squares`;
+`GridRectangle.squares_eq_coveredSquares` identifies the two, which is what makes the fully blocked
+count a specialization of a matrix coefficient here.
 
 *Which grading the variables carry.* Giving `V_c` bidegree `(-2, -1)` makes the differential
 homogeneous of bidegree `(-1, 0)`: `maslovO_sub_two_mul_card_OColumns_eq_maslovO_sub_one` and

--- a/TauCeti/KnotTheory/Grid/Unblocked.lean
+++ b/TauCeti/KnotTheory/Grid/Unblocked.lean
@@ -26,8 +26,8 @@ runs over the empty rectangles `r` from `x` to `y` carrying no `X`-marking, each
 monomial `V^{O(r)} = ∏ V_c` over the columns whose `O`-marking the rectangle covers. This is the
 theory that survives (de)stabilization and whose homology is a module over `R[U]`. The simply
 blocked theory is obtained by setting one selected variable, conventionally `V₀`, to zero; setting
-every variable to zero gives the square-centred fully blocked count once the canonical
-`GridRectangle.AvoidsMarkings` predicate uses that same marking region.
+every variable to zero gives the fully blocked count of `BlockedRectangle.lean`, which is
+`fullyBlockedRectangleCount_eq_constantCoeff`.
 
 Two conventions are fixed here.
 
@@ -35,9 +35,9 @@ Two conventions are fixed here.
 carries the markings of the squares it covers, `GridRectangle.coveredSquares`, not those of the
 grid points in its open interior. That is the region the Maslov and Alexander grading changes are
 computed against in `Grading/MarkingCount.lean`, and it is the region used throughout this file.
-The Lane G.3 predicate `GridRectangle.AvoidsMarkings` still tests the open interior; aligning it
-with the square-centred convention is a separate correction to that predicate, so no result here
-is phrased in terms of it.
+It is also the region the Lane G.3 predicate `GridRectangle.AvoidsMarkings` tests, under its other
+name `GridRectangle.squares`; `GridRectangle.squares_eq_coveredSquares` identifies the two, which
+is what makes the fully blocked count a specialization of a matrix coefficient here.
 
 *Which grading the variables carry.* Giving `V_c` bidegree `(-2, -1)` makes the differential
 homogeneous of bidegree `(-1, 0)`: `maslovO_sub_two_mul_card_OColumns_eq_maslovO_sub_one` and
@@ -76,6 +76,9 @@ assignment, a later stage of the roadmap.
   of bidegree `(-1, 0)` once `V_c` is given bidegree `(-2, -1)`.
 * `TauCeti.GridDiagram.constantCoeff_unblockedCoefficient`: the constant term of a matrix
   coefficient counts the contributing rectangles that carry no `O`-marking either.
+* `TauCeti.GridDiagram.fullyBlockedRectangles_eq_filter`,
+  `TauCeti.GridDiagram.fullyBlockedRectangleCount_eq_constantCoeff`: those rectangles are the
+  fully blocked ones, so the fully blocked matrix coefficient is the constant term of `∂⁻`.
 * `TauCeti.GridDiagram.exists_mem_unblockedRectangles_of_mem_support_unblockedCoefficient`: every
   monomial of a matrix coefficient is the weight of a contributing rectangle.
 
@@ -269,9 +272,9 @@ theorem unblockedCoefficient_self (x : GridState n) : G.unblockedCoefficient R x
 /-- The constant term of a matrix coefficient of the unblocked differential counts those
 contributing rectangles that carry no `O`-marking either.
 
-This is the square-centred count obtained by setting every variable to zero. It is not identified
-here with the current canonical fully blocked coefficient, whose `GridRectangle.AvoidsMarkings`
-predicate still uses the smaller open interior. -/
+This is the count obtained by setting every variable to zero;
+`fullyBlockedRectangles_eq_filter` identifies the rectangles it counts with the fully blocked
+ones. -/
 theorem constantCoeff_unblockedCoefficient (x y : GridState n) :
     constantCoeff (G.unblockedCoefficient R x y) =
       (((G.unblockedRectangles x y).filter fun r =>
@@ -291,6 +294,34 @@ theorem constantCoeff_unblockedCoefficient (x y : GridState n) :
     exact Finset.prod_eq_zero hc (by simp)
   rw [Finset.sum_congr rfl h₁, Finset.sum_congr rfl h₂, Finset.sum_const, Finset.sum_const_zero,
     nsmul_eq_mul, mul_one, add_zero]
+
+/-- The rectangles the unblocked differential counts with trivial weight are exactly the fully
+blocked ones: both sets consist of the empty rectangles covering no `X`-marking, and covering no
+`O`-marking is the remaining fully blocked condition. -/
+theorem fullyBlockedRectangles_eq_filter (x y : GridState n) :
+    G.fullyBlockedRectangles x y =
+      (G.unblockedRectangles x y).filter fun r => G.OColumns r.toGridRectangle = ∅ := by
+  classical
+  ext r
+  simp only [Finset.mem_filter, mem_fullyBlockedRectangles, mem_unblockedRectangles,
+    GridRectangleBetween.avoidsMarkings_iff, GridRectangle.squares_eq_coveredSquares,
+    G.OColumns_eq_empty_iff]
+  tauto
+
+/-- The constant term of a matrix coefficient of the unblocked differential is the number of
+fully blocked rectangles it counts. -/
+theorem constantCoeff_unblockedCoefficient_eq_card_fullyBlockedRectangles (x y : GridState n) :
+    constantCoeff (G.unblockedCoefficient R x y) =
+      ((G.fullyBlockedRectangles x y).card : R) := by
+  rw [G.constantCoeff_unblockedCoefficient R x y, G.fullyBlockedRectangles_eq_filter x y]
+
+/-- The fully blocked matrix coefficient is the constant term of the unblocked one: blocking every
+`O`-marking is setting every variable to zero. -/
+theorem fullyBlockedRectangleCount_eq_constantCoeff (x y : GridState n) :
+    G.fullyBlockedRectangleCount x y =
+      constantCoeff (G.unblockedCoefficient (ZMod 2) x y) := by
+  rw [G.constantCoeff_unblockedCoefficient_eq_card_fullyBlockedRectangles (ZMod 2) x y,
+    fullyBlockedRectangleCount_def]
 
 /-- Every monomial occurring in a matrix coefficient of the unblocked differential is the weight of
 one of the rectangles that coefficient counts. -/


### PR DESCRIPTION
This PR closes the square-zero theorem for the grid complexes of Lane G.3: `∂⁻ ∘ ∂⁻ = 0` for the
unblocked differential over every commutative coefficient semiring of characteristic two, and, by
specialization, for the simply blocked map at `V_i = 0` and for the fully blocked differential of
`Complex.lean` at every `V_i = 0`. The target is milestone 3 of Lane G, "The complexes and
`∂² = 0`", in `CombinatorialHeegaardFloer/README.md`, whose juxtaposition case analysis already had
its annular case (#4507), its disjoint case (#4670) and all four orientations of the overlapping
case (#5374, #5989, #6067) on `main`; what was missing was the pairing of the overlapping terms and
the assembly, which is what this PR supplies. After this PR the milestone still owes an actual
`HomologicalComplex` structure on the three complexes.

Two composable empty `X`-avoiding rectangles sharing exactly one side column bound an L-shaped
hexagon, and the four merged constructions cut that hexagon the other way, each producing the
unique decomposition carrying the side data it computes.
`GridRectangleDecomposition.IsRecut` collects the four alternatives into a single relation, which
has a unique solution because a decomposition has only one orientation of its common column. The
new geometric content is that this relation is symmetric on the counted decompositions sharing
exactly one side column: recutting a common initial or terminal column produces a mixed common
column and conversely, and in each of the eight resulting configurations the original decomposition
satisfies exactly the side data that describes the recut of its recut. The four orientations are
`isRecut_symm_of_left_eq_left` and its three companions, which
`GridRectangleDecomposition.IsRecut.symm` dispatches to. The only geometric input is the cyclic
order that emptiness of both rectangles already forces
(`cyclicOrder_of_isEmpty_of_left_eq_left` and its three companions); the rest is bookkeeping of
corner rows against side columns, for which a grid state's column swap is rewritten as the swap of
the two rows those columns occupy. Symmetry together with uniqueness makes
`GridRectangleDecomposition.recut` an involution; it has no fixed point because the intermediate
state changes, and it preserves the covered-square domain and hence the monomial weight, so the
one-common-side terms cancel in pairs in characteristic two.

The assembly is then the merged trichotomy: a two-step term whose target is its source covers a
toroidal annulus and vanishes over any ring, and otherwise its two side pairs are disjoint or meet
in exactly one column, so the counted decompositions split into the part reordered by
`GridRectangleDecomposition.commute` and the part paired by `recut`, each summing to zero.
Specializing at `V_i = 0` transports the theorem to the simply blocked map along the intertwining
of the two differentials. Setting *every* variable to zero is taking constant terms, and
`fullyBlockedRectangleCount_eq_constantCoeff` identifies the fully blocked matrix coefficients with
the constant terms of `∂⁻` over `ZMod 2`; since `MvPolynomial.constantCoeff` is a ring
homomorphism, the fully blocked square-zero theorem is the constant term of the unblocked one, and
no second recut is needed. That identification rests on `GridRectangle.squares_eq_coveredSquares`:
`GridRectangle.squares`, the region `AvoidsMarkings` tests, and `GridRectangle.coveredSquares`, the
region the gradings and `OMonomial` count in, are both the product of the two half-open arcs. Three
module docstrings still announced that alignment as an outstanding correction and are updated.

Supporting changes outside the new files. The two cyclic rotations of an arc, which were private in
`Differential/Square/OverlapOrder.lean`, move to `Grid/CyclicInterval.lean` where the rest of the
arc API lives, and are now proved from Mathlib's `sbtw_cyclic_left`/`sbtw_cyclic_right` rather than
by case analysis on representatives; the eight call sites are updated.
`GridState.swapColumns_eq_swapRows` joins the swap API in `Grid/Diagram/Basic.lean` and
`GridRectangleBetween.target_eq_swapRows` joins `target_eq_swapColumns` in `Grid/Rectangle/Swap.lean`.
`GridRectangleDecomposition.sideColumns_ne_of_hasOneCommonSide` is stated in
`Differential/Square/SideOverlap.lean` next to the rest of the side-overlap API. A stale sentence in
`SmallGrid/Differential.lean` announcing that the general case is still open is replaced by the
difference that survives: the small-grid instance needs no assumption on the characteristic.

Files added: `TauCeti/KnotTheory/Grid/Differential/Square/Recut/Pairing.lean` (564 lines) and
`TauCeti/KnotTheory/Grid/Differential/Square/Zero.lean` (180 lines).

The juxtaposition argument, the recut of an L-shaped pair of rectangles and the trichotomy it
rests on all follow Ozsváth–Stipsicz–Szabó, *Grid Homology for Knots and Links*, AMS 2015,
Chapter 4.6.

Roadmap: CombinatorialHeegaardFloer

<!--tauceti-target:v1 {"focus":"CombinatorialHeegaardFloer","id":"unblockeddifferential-comp-self-eq-zero"}-->

🤖 Prepared with Claude Code
