### PR TITLE
feat: aggregate multinomial cells

### DIFF
--- a/TauCeti/Probability/Distributions/Multinomial/Aggregation.lean
+++ b/TauCeti/Probability/Distributions/Multinomial/Aggregation.lean
@@ -6,7 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Probability.Distributions.Multinomial.Transforms
-public import Mathlib.LinearAlgebra.Finsupp.Pi
+public import Mathlib.Topology.Algebra.Monoid.FunOnFinite
 
 /-!
 # Aggregation of multinomial cells
@@ -39,12 +39,6 @@ open Convexity MeasureTheory
 namespace TauCeti.Probability
 
 variable {ι κ : Type*} [Fintype ι] [Fintype κ]
-
-omit [Fintype ι] [Fintype κ] in
-/-- Aggregating count vectors is measurable for the discrete measurable structures. -/
-theorem measurable_funOnFinite_map [Finite ι] [Finite κ] (f : ι → κ) :
-    Measurable (FunOnFinite.map (M := ℕ) f) :=
-  measurable_of_countable _
 
 /-- Pull a Euclidean frequency vector back along a map of cells. -/
 private def pullbackFrequency (f : ι → κ) (t : EuclideanSpace ℝ κ) : EuclideanSpace ℝ ι :=
@@ -105,6 +99,8 @@ theorem map_funOnFinite_map_multinomialMeasure (f : ι → κ) (n : ℕ)
     (multinomialMeasure n p).map (FunOnFinite.map (M := ℕ) f) =
       multinomialMeasure n (p.map f) := by
   apply (measurableEmbedding_multinomialToEuclidean (ι := κ)).map_injective
+  have hmap : Measurable (FunOnFinite.map (M := ℕ) f) :=
+    (FunOnFinite.continuous_map ℕ f).measurable
   let _ := isProbabilityMeasure_multinomialMeasure n p
   let _ := isProbabilityMeasure_multinomialMeasure n (p.map f)
   apply Measure.ext_of_charFun
@@ -115,9 +111,8 @@ theorem map_funOnFinite_map_multinomialMeasure (f : ι → κ) (n : ℕ)
         charFun ((multinomialMeasure n p).map multinomialToEuclidean)
           (pullbackFrequency f t) := by
       rw [charFun_apply, charFun_apply,
-        Measure.map_map measurable_multinomialToEuclidean (measurable_funOnFinite_map f),
-        integral_map (measurable_multinomialToEuclidean.comp
-          (measurable_funOnFinite_map f)).aemeasurable (by fun_prop),
+        Measure.map_map measurable_multinomialToEuclidean hmap,
+        integral_map (measurable_multinomialToEuclidean.comp hmap).aemeasurable (by fun_prop),
         integral_map measurable_multinomialToEuclidean.aemeasurable (by fun_prop)]
       apply integral_congr_ae
       filter_upwards [] with k

--- a/TauCeti/Probability/Distributions/Multinomial/Aggregation.lean
+++ b/TauCeti/Probability/Distributions/Multinomial/Aggregation.lean
@@ -14,8 +14,8 @@ Combining cells of a multinomial count vector again gives a multinomial distribu
 `f : ι → κ`, the count in a target cell `j` is the sum of all source counts over the fibre of
 `j`, while `Convexity.StdSimplex.map f` sums the corresponding cell probabilities.
 
-The proof identifies the Euclidean casts by their characteristic functions. The multinomial
-formula reduces the result to grouping a finite sum by the fibres of `f`.
+This aggregation law supports coarsening a multinomial model by merging categories while
+preserving its multinomial form.
 
 ## Main definitions and results
 
@@ -91,28 +91,22 @@ private theorem sum_map_weights_mul_cexp (f : ι → κ) (p : StdSimplex NNReal 
     ∑ j, (((p.map f).weights j : NNReal) : ℂ) * Complex.exp (Complex.I * (t j : ℂ)) =
       ∑ i, (p.weights i : ℂ) * Complex.exp (Complex.I * (t (f i) : ℂ)) := by
   classical
-  have hweights (j : κ) : (p.map f).weights j = ∑ i with f i = j, p.weights i := by
-    rw [StdSimplex.weights_map, Finsupp.mapDomain_fintype, Finsupp.coe_finsetSum,
-      Finset.sum_apply,
-      ← Finset.sum_eq_of_subset (s₁ := {i | f i = j}) (by simp) _
-        (fun i _ hi ↦ Finsupp.single_eq_of_ne' (by simpa using hi))]
-    refine Finset.sum_congr rfl fun i hi ↦ ?_
-    obtain rfl : f i = j := by simpa using hi
-    simp
-  simp_rw [hweights]
-  push_cast
-  simp_rw [Finset.sum_mul]
+  rw [StdSimplex.weights_map]
   calc
-    _ = ∑ j, ∑ i with f i = j,
-        (p.weights i : ℂ) * Complex.exp (Complex.I * (t (f i) : ℂ)) := by
-      apply Finset.sum_congr rfl
-      intro j hj
-      apply Finset.sum_congr rfl
-      intro i hi
-      rw [(Finset.mem_filter.mp hi).2]
+    _ = (p.weights.mapDomain f).sum fun j x ↦
+        (x : ℂ) * Complex.exp (Complex.I * (t j : ℂ)) := by
+      rw [Finsupp.sum_fintype]
+      simp
+    _ = p.weights.sum fun i x ↦
+        (x : ℂ) * Complex.exp (Complex.I * (t (f i) : ℂ)) := by
+      apply Finsupp.sum_mapDomain_index
+      · simp
+      · intro j x y
+        push_cast
+        ring
     _ = _ := by
-      simpa using Finset.sum_fiberwise Finset.univ f
-        (fun i ↦ (p.weights i : ℂ) * Complex.exp (Complex.I * (t (f i) : ℂ)))
+      rw [Finsupp.sum_fintype]
+      simp
 
 /-- **Aggregation law for the multinomial distribution.** Combining cells along `f` gives the
 multinomial law whose target-cell probabilities are the sums of the source probabilities over
@@ -140,12 +134,12 @@ theorem map_multinomialAggregate_multinomialMeasure (f : ι → κ) (n : ℕ)
       rw [Function.comp_apply, inner_multinomialAggregate]
     _ = (∑ i, (p.weights i : ℂ) *
           Complex.exp (Complex.I * (t (f i) : ℂ))) ^ n := by
-      rw [charFun_multinomial]
+      rw [charFun_map_multinomialToEuclidean_multinomialMeasure]
       simp only [pullbackFrequency_apply]
     _ = (∑ j, ((p.map f).weights j : ℂ) *
           Complex.exp (Complex.I * (t j : ℂ))) ^ n := by
       rw [sum_map_weights_mul_cexp]
     _ = charFun ((multinomialMeasure n (p.map f)).map multinomialToEuclidean) t :=
-      (charFun_multinomial n (p.map f) t).symm
+      (charFun_map_multinomialToEuclidean_multinomialMeasure n (p.map f) t).symm
 
 end TauCeti.Probability

--- a/TauCeti/Probability/Distributions/Multinomial/Aggregation.lean
+++ b/TauCeti/Probability/Distributions/Multinomial/Aggregation.lean
@@ -94,6 +94,7 @@ private theorem sum_map_weights_mul_cexp (f : ι → κ) (p : StdSimplex NNReal 
 /-- **Aggregation law for the multinomial distribution.** Combining cells along `f` gives the
 multinomial law whose target-cell probabilities are the sums of the source probabilities over
 the fibres of `f`. -/
+@[simp]
 theorem map_funOnFinite_map_multinomialMeasure (f : ι → κ) (n : ℕ)
     (p : StdSimplex NNReal ι) :
     (multinomialMeasure n p).map (FunOnFinite.map (M := ℕ) f) =

--- a/TauCeti/Probability/Distributions/Multinomial/Aggregation.lean
+++ b/TauCeti/Probability/Distributions/Multinomial/Aggregation.lean
@@ -52,6 +52,28 @@ theorem multinomialAggregate_apply (f : ι → κ) (k : ι → ℕ) (j : κ) :
     multinomialAggregate f k j = ∑ i with f i = j, k i := (rfl)
 
 omit [Fintype κ] in
+/-- Aggregating along the identity map leaves a count vector unchanged. -/
+@[simp]
+theorem multinomialAggregate_id (k : ι → ℕ) :
+    multinomialAggregate id k = k := by
+  classical
+  funext i
+  rw [multinomialAggregate_apply, Finset.sum_eq_single i]
+  · simp
+  · simp
+
+/-- Successive aggregations agree with aggregation along the composite map. -/
+@[simp]
+theorem multinomialAggregate_comp {υ : Type*} (f : ι → κ) (g : κ → υ) (k : ι → ℕ) :
+    multinomialAggregate g (multinomialAggregate f k) =
+      multinomialAggregate (g ∘ f) k := by
+  classical
+  funext j
+  simp only [multinomialAggregate_apply, Function.comp_apply]
+  simpa using
+    Finset.sum_fiberwise_eq_sum_filter Finset.univ {x | g x = j} f k
+
+omit [Fintype κ] in
 /-- Aggregating count vectors is measurable for the discrete measurable structures. -/
 theorem measurable_multinomialAggregate (f : ι → κ) :
     Measurable (multinomialAggregate f) :=

--- a/TauCeti/Probability/Distributions/Multinomial/Aggregation.lean
+++ b/TauCeti/Probability/Distributions/Multinomial/Aggregation.lean
@@ -6,21 +6,22 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Probability.Distributions.Multinomial.Transforms
+public import Mathlib.LinearAlgebra.Finsupp.Pi
 
 /-!
 # Aggregation of multinomial cells
 
 Combining cells of a multinomial count vector again gives a multinomial distribution. For a map
 `f : ι → κ`, the count in a target cell `j` is the sum of all source counts over the fibre of
-`j`, while `Convexity.StdSimplex.map f` sums the corresponding cell probabilities.
+`j`, which is Mathlib's `FunOnFinite.map f`, while `Convexity.StdSimplex.map f` sums the
+corresponding cell probabilities.
 
 This aggregation law supports coarsening a multinomial model by merging categories while
 preserving its multinomial form.
 
-## Main definitions and results
+## Main results
 
-* `TauCeti.Probability.multinomialAggregate`: aggregate a count vector along a map of cells.
-* `TauCeti.Probability.map_multinomialAggregate_multinomialMeasure`: aggregation sends a
+* `TauCeti.Probability.map_funOnFinite_map_multinomialMeasure`: aggregation sends a
   multinomial law to the multinomial law with aggregated probabilities.
 
 ## References
@@ -39,44 +40,10 @@ namespace TauCeti.Probability
 
 variable {ι κ : Type*} [Fintype ι] [Fintype κ]
 
-open Classical in
-/-- Aggregate a count vector by summing the counts in every fibre of a map of cells. -/
-def multinomialAggregate (f : ι → κ) (k : ι → ℕ) (j : κ) : ℕ :=
-  ∑ i with f i = j, k i
-
-open Classical in
-omit [Fintype κ] in
-/-- The count in an aggregated cell is the sum of the counts in its fibre. -/
-@[simp]
-theorem multinomialAggregate_apply (f : ι → κ) (k : ι → ℕ) (j : κ) :
-    multinomialAggregate f k j = ∑ i with f i = j, k i := (rfl)
-
-omit [Fintype κ] in
-/-- Aggregating along the identity map leaves a count vector unchanged. -/
-@[simp]
-theorem multinomialAggregate_id (k : ι → ℕ) :
-    multinomialAggregate id k = k := by
-  classical
-  funext i
-  rw [multinomialAggregate_apply, Finset.sum_eq_single i]
-  · simp
-  · simp
-
-/-- Successive aggregations agree with aggregation along the composite map. -/
-@[simp]
-theorem multinomialAggregate_comp {υ : Type*} (f : ι → κ) (g : κ → υ) (k : ι → ℕ) :
-    multinomialAggregate g (multinomialAggregate f k) =
-      multinomialAggregate (g ∘ f) k := by
-  classical
-  funext j
-  simp only [multinomialAggregate_apply, Function.comp_apply]
-  simpa using
-    Finset.sum_fiberwise_eq_sum_filter Finset.univ {x | g x = j} f k
-
-omit [Fintype κ] in
+omit [Fintype ι] [Fintype κ] in
 /-- Aggregating count vectors is measurable for the discrete measurable structures. -/
-theorem measurable_multinomialAggregate (f : ι → κ) :
-    Measurable (multinomialAggregate f) :=
+theorem measurable_funOnFinite_map [Finite ι] [Finite κ] (f : ι → κ) :
+    Measurable (FunOnFinite.map (M := ℕ) f) :=
   measurable_of_countable _
 
 /-- Pull a Euclidean frequency vector back along a map of cells. -/
@@ -88,13 +55,13 @@ omit [Fintype ι] [Fintype κ] in
 private theorem pullbackFrequency_apply (f : ι → κ) (t : EuclideanSpace ℝ κ) (i : ι) :
     pullbackFrequency f t i = t (f i) := (rfl)
 
-private theorem inner_multinomialAggregate (f : ι → κ) (k : ι → ℕ)
+private theorem inner_multinomialToEuclidean_funOnFinite_map (f : ι → κ) (k : ι → ℕ)
     (t : EuclideanSpace ℝ κ) :
-    inner ℝ (multinomialToEuclidean (multinomialAggregate f k)) t =
+    inner ℝ (multinomialToEuclidean (FunOnFinite.map f k)) t =
       inner ℝ (multinomialToEuclidean k) (pullbackFrequency f t) := by
   classical
   simp only [EuclideanSpace.inner_eq_star_dotProduct, dotProduct, star_trivial,
-    multinomialToEuclidean_apply, multinomialAggregate_apply, pullbackFrequency_apply]
+    multinomialToEuclidean_apply, FunOnFinite.map_apply_apply, pullbackFrequency_apply]
   push_cast
   simp_rw [Finset.mul_sum]
   calc
@@ -133,27 +100,28 @@ private theorem sum_map_weights_mul_cexp (f : ι → κ) (p : StdSimplex NNReal 
 /-- **Aggregation law for the multinomial distribution.** Combining cells along `f` gives the
 multinomial law whose target-cell probabilities are the sums of the source probabilities over
 the fibres of `f`. -/
-theorem map_multinomialAggregate_multinomialMeasure (f : ι → κ) (n : ℕ)
+theorem map_funOnFinite_map_multinomialMeasure (f : ι → κ) (n : ℕ)
     (p : StdSimplex NNReal ι) :
-    (multinomialMeasure n p).map (multinomialAggregate f) = multinomialMeasure n (p.map f) := by
+    (multinomialMeasure n p).map (FunOnFinite.map (M := ℕ) f) =
+      multinomialMeasure n (p.map f) := by
   apply (measurableEmbedding_multinomialToEuclidean (ι := κ)).map_injective
   let _ := isProbabilityMeasure_multinomialMeasure n p
   let _ := isProbabilityMeasure_multinomialMeasure n (p.map f)
   apply Measure.ext_of_charFun
   funext t
   calc
-    charFun (((multinomialMeasure n p).map (multinomialAggregate f)).map
+    charFun (((multinomialMeasure n p).map (FunOnFinite.map (M := ℕ) f)).map
         multinomialToEuclidean) t =
         charFun ((multinomialMeasure n p).map multinomialToEuclidean)
           (pullbackFrequency f t) := by
       rw [charFun_apply, charFun_apply,
-        Measure.map_map measurable_multinomialToEuclidean (measurable_multinomialAggregate f),
+        Measure.map_map measurable_multinomialToEuclidean (measurable_funOnFinite_map f),
         integral_map (measurable_multinomialToEuclidean.comp
-          (measurable_multinomialAggregate f)).aemeasurable (by fun_prop),
+          (measurable_funOnFinite_map f)).aemeasurable (by fun_prop),
         integral_map measurable_multinomialToEuclidean.aemeasurable (by fun_prop)]
       apply integral_congr_ae
       filter_upwards [] with k
-      rw [Function.comp_apply, inner_multinomialAggregate]
+      rw [Function.comp_apply, inner_multinomialToEuclidean_funOnFinite_map]
     _ = (∑ i, (p.weights i : ℂ) *
           Complex.exp (Complex.I * (t (f i) : ℂ))) ^ n := by
       rw [charFun_map_multinomialToEuclidean_multinomialMeasure]

--- a/TauCeti/Probability/Distributions/Multinomial/Aggregation.lean
+++ b/TauCeti/Probability/Distributions/Multinomial/Aggregation.lean
@@ -1,0 +1,151 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Probability.Distributions.Multinomial.Transforms
+
+/-!
+# Aggregation of multinomial cells
+
+Combining cells of a multinomial count vector again gives a multinomial distribution. For a map
+`f : ι → κ`, the count in a target cell `j` is the sum of all source counts over the fibre of
+`j`, while `Convexity.StdSimplex.map f` sums the corresponding cell probabilities.
+
+The proof identifies the Euclidean casts by their characteristic functions. The multinomial
+formula reduces the result to grouping a finite sum by the fibres of `f`.
+
+## Main definitions and results
+
+* `TauCeti.Probability.multinomialAggregate`: aggregate a count vector along a map of cells.
+* `TauCeti.Probability.map_multinomialAggregate_multinomialMeasure`: aggregation sends a
+  multinomial law to the multinomial law with aggregated probabilities.
+
+## References
+
+* N. L. Johnson, S. Kotz, N. Balakrishnan, *Discrete Multivariate Distributions*, Wiley, 1997,
+  Chapter 35.
+-/
+
+public section
+
+noncomputable section
+
+open Convexity MeasureTheory
+
+namespace TauCeti.Probability
+
+variable {ι κ : Type*} [Fintype ι] [Fintype κ]
+
+open Classical in
+/-- Aggregate a count vector by summing the counts in every fibre of a map of cells. -/
+def multinomialAggregate (f : ι → κ) (k : ι → ℕ) (j : κ) : ℕ :=
+  ∑ i with f i = j, k i
+
+open Classical in
+omit [Fintype κ] in
+/-- The count in an aggregated cell is the sum of the counts in its fibre. -/
+@[simp]
+theorem multinomialAggregate_apply (f : ι → κ) (k : ι → ℕ) (j : κ) :
+    multinomialAggregate f k j = ∑ i with f i = j, k i := (rfl)
+
+omit [Fintype κ] in
+/-- Aggregating count vectors is measurable for the discrete measurable structures. -/
+theorem measurable_multinomialAggregate (f : ι → κ) :
+    Measurable (multinomialAggregate f) :=
+  measurable_of_countable _
+
+/-- Pull a Euclidean frequency vector back along a map of cells. -/
+private def pullbackFrequency (f : ι → κ) (t : EuclideanSpace ℝ κ) : EuclideanSpace ℝ ι :=
+  (EuclideanSpace.equiv ι ℝ).symm fun i ↦ t (f i)
+
+omit [Fintype ι] [Fintype κ] in
+@[simp]
+private theorem pullbackFrequency_apply (f : ι → κ) (t : EuclideanSpace ℝ κ) (i : ι) :
+    pullbackFrequency f t i = t (f i) := (rfl)
+
+private theorem inner_multinomialAggregate (f : ι → κ) (k : ι → ℕ)
+    (t : EuclideanSpace ℝ κ) :
+    inner ℝ (multinomialToEuclidean (multinomialAggregate f k)) t =
+      inner ℝ (multinomialToEuclidean k) (pullbackFrequency f t) := by
+  classical
+  simp only [EuclideanSpace.inner_eq_star_dotProduct, dotProduct, star_trivial,
+    multinomialToEuclidean_apply, multinomialAggregate_apply, pullbackFrequency_apply]
+  push_cast
+  simp_rw [Finset.mul_sum]
+  calc
+    _ = ∑ j, ∑ i with f i = j, (k i : ℝ) * t (f i) := by
+      apply Finset.sum_congr rfl
+      intro j hj
+      apply Finset.sum_congr rfl
+      intro i hi
+      rw [(Finset.mem_filter.mp hi).2, mul_comm]
+    _ = _ := by
+      simpa [mul_comm] using
+        Finset.sum_fiberwise Finset.univ f (fun i ↦ (k i : ℝ) * t (f i))
+
+private theorem sum_map_weights_mul_cexp (f : ι → κ) (p : StdSimplex NNReal ι)
+    (t : EuclideanSpace ℝ κ) :
+    ∑ j, (((p.map f).weights j : NNReal) : ℂ) * Complex.exp (Complex.I * (t j : ℂ)) =
+      ∑ i, (p.weights i : ℂ) * Complex.exp (Complex.I * (t (f i) : ℂ)) := by
+  classical
+  have hweights (j : κ) : (p.map f).weights j = ∑ i with f i = j, p.weights i := by
+    rw [StdSimplex.weights_map, Finsupp.mapDomain_fintype, Finsupp.coe_finsetSum,
+      Finset.sum_apply,
+      ← Finset.sum_eq_of_subset (s₁ := {i | f i = j}) (by simp) _
+        (fun i _ hi ↦ Finsupp.single_eq_of_ne' (by simpa using hi))]
+    refine Finset.sum_congr rfl fun i hi ↦ ?_
+    obtain rfl : f i = j := by simpa using hi
+    simp
+  simp_rw [hweights]
+  push_cast
+  simp_rw [Finset.sum_mul]
+  calc
+    _ = ∑ j, ∑ i with f i = j,
+        (p.weights i : ℂ) * Complex.exp (Complex.I * (t (f i) : ℂ)) := by
+      apply Finset.sum_congr rfl
+      intro j hj
+      apply Finset.sum_congr rfl
+      intro i hi
+      rw [(Finset.mem_filter.mp hi).2]
+    _ = _ := by
+      simpa using Finset.sum_fiberwise Finset.univ f
+        (fun i ↦ (p.weights i : ℂ) * Complex.exp (Complex.I * (t (f i) : ℂ)))
+
+/-- **Aggregation law for the multinomial distribution.** Combining cells along `f` gives the
+multinomial law whose target-cell probabilities are the sums of the source probabilities over
+the fibres of `f`. -/
+theorem map_multinomialAggregate_multinomialMeasure (f : ι → κ) (n : ℕ)
+    (p : StdSimplex NNReal ι) :
+    (multinomialMeasure n p).map (multinomialAggregate f) = multinomialMeasure n (p.map f) := by
+  apply (measurableEmbedding_multinomialToEuclidean (ι := κ)).map_injective
+  let _ := isProbabilityMeasure_multinomialMeasure n p
+  let _ := isProbabilityMeasure_multinomialMeasure n (p.map f)
+  apply Measure.ext_of_charFun
+  funext t
+  calc
+    charFun (((multinomialMeasure n p).map (multinomialAggregate f)).map
+        multinomialToEuclidean) t =
+        charFun ((multinomialMeasure n p).map multinomialToEuclidean)
+          (pullbackFrequency f t) := by
+      rw [charFun_apply, charFun_apply,
+        Measure.map_map measurable_multinomialToEuclidean (measurable_multinomialAggregate f),
+        integral_map (measurable_multinomialToEuclidean.comp
+          (measurable_multinomialAggregate f)).aemeasurable (by fun_prop),
+        integral_map measurable_multinomialToEuclidean.aemeasurable (by fun_prop)]
+      apply integral_congr_ae
+      filter_upwards [] with k
+      rw [Function.comp_apply, inner_multinomialAggregate]
+    _ = (∑ i, (p.weights i : ℂ) *
+          Complex.exp (Complex.I * (t (f i) : ℂ))) ^ n := by
+      rw [charFun_multinomial]
+      simp only [pullbackFrequency_apply]
+    _ = (∑ j, ((p.map f).weights j : ℂ) *
+          Complex.exp (Complex.I * (t j : ℂ))) ^ n := by
+      rw [sum_map_weights_mul_cexp]
+    _ = charFun ((multinomialMeasure n (p.map f)).map multinomialToEuclidean) t :=
+      (charFun_multinomial n (p.map f) t).symm
+
+end TauCeti.Probability

--- a/TauCeti/Probability/Distributions/Multinomial/Basic.lean
+++ b/TauCeti/Probability/Distributions/Multinomial/Basic.lean
@@ -292,15 +292,13 @@ theorem measurable_multinomialToEuclidean [Finite ι] :
 omit [Fintype ι] in
 /-- Casting count vectors into Euclidean space is a measurable embedding. -/
 theorem measurableEmbedding_multinomialToEuclidean [Finite ι] :
-    MeasurableEmbedding (multinomialToEuclidean (ι := ι)) where
-  injective k l h := by
-    ext i
-    exact Nat.cast_injective (by
-      simpa only [multinomialToEuclidean_apply] using
-        congr_arg (fun x : EuclideanSpace ℝ ι ↦ x i) h : (k i : ℝ) = l i)
-  measurable := measurable_multinomialToEuclidean
-  measurableSet_image' s _ :=
-    ((Set.to_countable s).image (multinomialToEuclidean (ι := ι))).measurableSet
+    MeasurableEmbedding (multinomialToEuclidean (ι := ι)) := by
+  apply measurable_multinomialToEuclidean.measurableEmbedding
+  intro k l h
+  ext i
+  exact Nat.cast_injective (by
+    simpa only [multinomialToEuclidean_apply] using
+      congr_arg (fun x : EuclideanSpace ℝ ι ↦ x i) h : (k i : ℝ) = l i)
 
 end Probability
 

--- a/TauCeti/Probability/Distributions/Multinomial/Basic.lean
+++ b/TauCeti/Probability/Distributions/Multinomial/Basic.lean
@@ -289,6 +289,19 @@ theorem measurable_multinomialToEuclidean [Finite ι] :
   refine (EuclideanSpace.equiv ι ℝ).symm.continuous.measurable.comp ?_
   exact Measurable.of_eval fun i => measurable_from_nat.comp (measurable_pi_apply i)
 
+omit [Fintype ι] in
+/-- Casting count vectors into Euclidean space is a measurable embedding. -/
+theorem measurableEmbedding_multinomialToEuclidean [Finite ι] :
+    MeasurableEmbedding (multinomialToEuclidean (ι := ι)) where
+  injective k l h := by
+    ext i
+    exact Nat.cast_injective (by
+      simpa only [multinomialToEuclidean_apply] using
+        congr_arg (fun x : EuclideanSpace ℝ ι ↦ x i) h : (k i : ℝ) = l i)
+  measurable := measurable_multinomialToEuclidean
+  measurableSet_image' s _ :=
+    ((Set.to_countable s).image (multinomialToEuclidean (ι := ι))).measurableSet
+
 end Probability
 
 end TauCeti

--- a/TauCeti/Probability/Distributions/Multinomial/Transforms.lean
+++ b/TauCeti/Probability/Distributions/Multinomial/Transforms.lean
@@ -8,15 +8,19 @@ module
 public import TauCeti.Probability.Distributions.Multinomial.Basic
 public import Mathlib.Probability.Moments.Basic
 public import Mathlib.Probability.Moments.IntegrableExpMul
+public import Mathlib.MeasureTheory.Measure.CharacteristicFunction.Basic
 
 /-!
-# Directional exponential transforms of the multinomial distribution
+# Transforms of the multinomial distribution
 
 For the pushforward of `multinomialMeasure n p` into `EuclideanSpace ℝ ι` along
 `multinomialToEuclidean` and a direction `θ`, the directional moment generating function is
 finite everywhere and equals
 `(∑ i, p i * exp (t * θ i)) ^ n`: the multinomial theorem, with the cell weights tilted by
 `exp (t * θ i)`. The cumulant generating function is its real logarithm.
+
+The characteristic function of the Euclidean cast is the corresponding complex multinomial
+polynomial, `(∑ i, p i * exp (I * t i)) ^ n`.
 
 A probability vector on `ι` forces `ι` to be nonempty, so the statements need no separate
 hypothesis for it beyond the parameter `p`. Every statement holds for `n = 0`
@@ -30,6 +34,7 @@ cells, which contribute nothing to the tilted sum.
   for every direction of the Euclidean pushforward;
 * `TauCeti.Probability.mgf_inner_multinomial` — the directional moment generating function;
 * `TauCeti.Probability.cgf_inner_multinomial` — the directional cumulant generating function.
+* `TauCeti.Probability.charFun_multinomial` — the characteristic function of the Euclidean cast.
 
 ## References
 
@@ -114,6 +119,31 @@ theorem cgf_inner_multinomial (n : ℕ) (p : StdSimplex NNReal ι)
     cgf (fun x => inner ℝ θ x) ((multinomialMeasure n p).map multinomialToEuclidean) t =
       Real.log ((∑ i, (p.weights i : ℝ) * exp (t * θ i)) ^ n) := by
   rw [cgf, mgf_inner_multinomial]
+
+/-- **Characteristic function of the multinomial law**: for a frequency vector `t`, it is the
+`n`th power of the probability-weighted sum of the coordinate characters. -/
+theorem charFun_multinomial (n : ℕ) (p : StdSimplex NNReal ι) (t : EuclideanSpace ℝ ι) :
+    charFun ((multinomialMeasure n p).map multinomialToEuclidean) t =
+      (∑ i, (p.weights i : ℂ) * Complex.exp (Complex.I * (t i : ℂ))) ^ n := by
+  classical
+  rw [charFun_apply, integral_map measurable_multinomialToEuclidean.aemeasurable
+    (by fun_prop : AEStronglyMeasurable
+      (fun x : EuclideanSpace ℝ ι => Complex.exp ((inner ℝ x t : ℂ) * Complex.I)) _),
+    integral_multinomialMeasure]
+  simp only [EuclideanSpace.inner_eq_star_dotProduct, dotProduct, star_trivial,
+    multinomialToEuclidean_apply, Complex.real_smul]
+  simp_rw [multinomialWeightReal_def]
+  push_cast
+  rw [Finset.sum_pow_eq_sum_piAntidiag]
+  apply Finset.sum_congr rfl
+  intro k hk
+  rw [Finset.sum_mul, Complex.exp_sum, mul_assoc, ← Finset.prod_mul_distrib]
+  congr 1
+  apply Finset.prod_congr rfl
+  intro i hi
+  rw [mul_pow, ← Complex.exp_nat_mul]
+  congr 1
+  ring_nf
 
 end Probability
 

--- a/TauCeti/Probability/Distributions/Multinomial/Transforms.lean
+++ b/TauCeti/Probability/Distributions/Multinomial/Transforms.lean
@@ -34,7 +34,8 @@ cells, which contribute nothing to the tilted sum.
   for every direction of the Euclidean pushforward;
 * `TauCeti.Probability.mgf_inner_multinomial` — the directional moment generating function;
 * `TauCeti.Probability.cgf_inner_multinomial` — the directional cumulant generating function.
-* `TauCeti.Probability.charFun_multinomial` — the characteristic function of the Euclidean cast.
+* `TauCeti.Probability.charFun_map_multinomialToEuclidean_multinomialMeasure` — the
+  characteristic function of the Euclidean cast.
 
 ## References
 
@@ -122,7 +123,8 @@ theorem cgf_inner_multinomial (n : ℕ) (p : StdSimplex NNReal ι)
 
 /-- **Characteristic function of the multinomial law**: for a frequency vector `t`, it is the
 `n`th power of the probability-weighted sum of the coordinate characters. -/
-theorem charFun_multinomial (n : ℕ) (p : StdSimplex NNReal ι) (t : EuclideanSpace ℝ ι) :
+theorem charFun_map_multinomialToEuclidean_multinomialMeasure (n : ℕ)
+    (p : StdSimplex NNReal ι) (t : EuclideanSpace ℝ ι) :
     charFun ((multinomialMeasure n p).map multinomialToEuclidean) t =
       (∑ i, (p.weights i : ℂ) * Complex.exp (Complex.I * (t i : ℂ))) ^ n := by
   classical


### PR DESCRIPTION
This PR aggregates multinomial cells along an arbitrary map of finite index types and identifies the resulting pushforward with the multinomial law whose probabilities are aggregated by `Convexity.StdSimplex.map`. It also supplies the roadmap's characteristic-function formula for the Euclidean cast, which gives a clean uniqueness proof of the aggregation law.

This advances `StandardDistributions/README.md`, Layer 5, item 5, “Multinomial distribution,” specifically the target “aggregation along any map `f : ι → κ`” and the listed characteristic function. The Layer 5 multinomial milestone still needs the Euclidean mean and covariance formulas, their `covMatrix`/`covarianceBilin` packaging, and parameter measurability.

Aggregation itself is Mathlib's `FunOnFinite.map`, whose application, identity and composition laws the module reuses rather than restating; this PR adds only its measurability and the multinomial pushforward law. The proof covers zero trials, zero-weight cells, and non-surjective aggregation maps without extra hypotheses. It also reuses Mathlib's `StdSimplex.map`, `Finset.sum_fiberwise`, `Measure.ext_of_charFun`, and measurable-map injectivity; no Mathlib infrastructure is vendored. The mathematical formula follows Johnson, Kotz, and Balakrishnan, *Discrete Multivariate Distributions*, Chapter 35, as cited in the module documentation.

The new `TauCeti/Probability/Distributions/Multinomial/Aggregation.lean` module contains 135 lines. Small additions to `Multinomial/Basic.lean` and `Multinomial/Transforms.lean` expose the measurable embedding of the Euclidean cast and the characteristic function.

Roadmap: StandardDistributions

<!--tauceti-target:v1 {"focus":"StandardDistributions","id":"multinomial-aggregation"}-->

🤖 Prepared with Codex

