### PR TITLE
feat: add the normalized local-field absolute value

### DIFF
--- a/TauCeti/Data/Int/WithZero.lean
+++ b/TauCeti/Data/Int/WithZero.lean
@@ -1,0 +1,95 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Order.Field.Rat
+public import Mathlib.Data.Int.WithZero
+
+/-!
+# Rational realizations of `ℤᵐ⁰`
+
+This file constructs the monoid-with-zero homomorphism from `ℤᵐ⁰` to the nonnegative rationals
+that sends an integer exponent `n` to `e ^ n`. It is the rational-valued counterpart of
+Mathlib's `WithZeroMulInt.toNNReal` and is useful when a discretely valued field has an
+integer-valued normalization whose associated absolute value is rational.
+
+## Main definitions
+
+* `WithZeroMulInt.toNNRat`: sends `0` to `0` and a nonzero exponent `n` to `e ^ n`.
+
+## Main results
+
+* `WithZeroMulInt.toNNRat_strictMono`: the map is strictly increasing when `1 < e`.
+
+The construction and proofs follow Mathlib's `WithZeroMulInt.toNNReal`, with codomain `ℚ≥0`
+instead of `ℝ≥0`.
+-/
+
+public section
+noncomputable section
+
+open Multiplicative WithZero
+open scoped NNRat
+
+namespace WithZeroMulInt
+
+/-- The monoid-with-zero homomorphism `ℤᵐ⁰ → ℚ≥0` sending a nonzero exponent `n` to `e ^ n`.
+
+This is the nonnegative-rational counterpart of Mathlib's `WithZeroMulInt.toNNReal`. -/
+def toNNRat {e : ℚ≥0} (he : e ≠ 0) : ℤᵐ⁰ →*₀ ℚ≥0 where
+  __ := WithZero.lift' <|
+    (Units.coeHom ℚ≥0).comp <| zpowersHom ℚ≥0ˣ (Units.mk0 e he)
+
+/-- On a finite exponent, `toNNRat` is the corresponding integer power of its base. -/
+@[simp]
+theorem toNNRat_coe {e : ℚ≥0} (he : e ≠ 0) (n : Multiplicative ℤ) :
+    toNNRat he (n : ℤᵐ⁰) = e ^ n.toAdd := by
+  simp [toNNRat]
+
+/-- The value of `toNNRat` at a nonzero exponent is the corresponding integer power. -/
+theorem toNNRat_apply_of_ne_zero {e : ℚ≥0} (he : e ≠ 0) {x : ℤᵐ⁰} (hx : x ≠ 0) :
+    toNNRat he x = e ^ (WithZero.unzero hx).toAdd := by
+  simpa only [WithZero.coe_unzero] using toNNRat_coe he (WithZero.unzero hx)
+
+/-- `toNNRat` sends nonzero exponents to nonzero values. -/
+theorem toNNRat_ne_zero {e : ℚ≥0} {x : ℤᵐ⁰} (he : e ≠ 0) (hx : x ≠ 0) :
+    toNNRat he x ≠ 0 := by
+  simp only [ne_eq, map_eq_zero, hx, not_false_eq_true]
+
+/-- `toNNRat` sends nonzero exponents to positive values. -/
+theorem toNNRat_pos {e : ℚ≥0} {x : ℤᵐ⁰} (he : e ≠ 0) (hx : x ≠ 0) :
+    0 < toNNRat he x :=
+  (toNNRat_ne_zero he hx).pos
+
+/-- The map `toNNRat` is strictly increasing when its base is greater than one. -/
+theorem toNNRat_strictMono {e : ℚ≥0} (he : 1 < e) :
+    StrictMono (toNNRat he.ne_zero) := by
+  intro x y hxy
+  cases y
+  · exact (not_lt_of_ge bot_le hxy).elim
+  cases x
+  · simpa using zpow_pos he.pos _
+  · rw [toNNRat_coe, toNNRat_coe]
+    exact (zpow_right_strictMono₀ he) <|
+      Multiplicative.toAdd_lt.mpr (WithZero.coe_lt_coe.mp hxy)
+
+/-- For a base different from zero and one, `toNNRat` takes the value one only at exponent
+one, which represents the integer exponent zero in `ℤᵐ⁰`. -/
+theorem toNNRat_eq_one_iff {e : ℚ≥0} (x : ℤᵐ⁰) (he0 : e ≠ 0) (he1 : e ≠ 1) :
+    toNNRat he0 x = 1 ↔ x = 1 := by
+  by_cases hx : x = 0
+  · simp only [hx, map_zero, zero_ne_one]
+  · refine ⟨fun h ↦ ?_, fun h ↦ h ▸ map_one _⟩
+    rw [toNNRat_apply_of_ne_zero he0 hx, zpow_eq_one_iff_right₀ bot_le he1, toAdd_eq_zero] at h
+    rw [← WithZero.coe_unzero hx, h, coe_one]
+
+/-- For a base greater than one, comparison with one in `ℚ≥0` is comparison with one in
+`ℤᵐ⁰`. -/
+theorem toNNRat_le_one_iff {e : ℚ≥0} {x : ℤᵐ⁰} (he : 1 < e) :
+    toNNRat he.ne_zero x ≤ 1 ↔ x ≤ 1 := by
+  rw [← (toNNRat_strictMono he).le_iff_le, map_one]
+
+end WithZeroMulInt

--- a/TauCeti/Data/Int/WithZero.lean
+++ b/TauCeti/Data/Int/WithZero.lean
@@ -86,6 +86,12 @@ theorem toNNRat_eq_one_iff {e : ℚ≥0} (x : ℤᵐ⁰) (he0 : e ≠ 0) (he1 : 
     rw [toNNRat_apply_of_ne_zero he0 hx, zpow_eq_one_iff_right₀ bot_le he1, toAdd_eq_zero] at h
     rw [← WithZero.coe_unzero hx, h, coe_one]
 
+/-- For a base greater than one, strict comparison with one in `ℚ≥0` is strict comparison with
+one in `ℤᵐ⁰`. -/
+theorem toNNRat_lt_one_iff {e : ℚ≥0} {x : ℤᵐ⁰} (he : 1 < e) :
+    toNNRat he.ne_zero x < 1 ↔ x < 1 := by
+  rw [← (toNNRat_strictMono he).lt_iff_lt, map_one]
+
 /-- For a base greater than one, comparison with one in `ℚ≥0` is comparison with one in
 `ℤᵐ⁰`. -/
 theorem toNNRat_le_one_iff {e : ℚ≥0} {x : ℤᵐ⁰} (he : 1 < e) :

--- a/TauCeti/NumberTheory/LocalField/NormalizedValuation.lean
+++ b/TauCeti/NumberTheory/LocalField/NormalizedValuation.lean
@@ -10,6 +10,7 @@ public import Mathlib.RingTheory.OrderOfVanishing.Noetherian
 public import Mathlib.Algebra.Order.AbsoluteValue.Basic
 public import Mathlib.Algebra.Order.Ring.IsNonarchimedean
 public import TauCeti.Data.Int.WithZero
+public import TauCeti.RingTheory.Valuation.Discrete.AbsoluteValue
 public import TauCeti.RingTheory.Valuation.Discrete.Order
 
 /-!
@@ -383,26 +384,7 @@ theorem normalizedAbsoluteValue_irreducible {π : 𝒪[K]} (hπ : Irreducible π
 /-- The normalized absolute value satisfies the strong triangle inequality. -/
 theorem isNonarchimedean_normalizedAbsoluteValue :
     IsNonarchimedean (normalizedAbsoluteValue K) := by
-  intro x y
-  rcases le_total (intValuation (K := K) x) (intValuation (K := K) y) with h | h
-  · have hxy : normalizedAbsoluteValue K x ≤ normalizedAbsoluteValue K y := by
-      simp only [normalizedAbsoluteValue, Valuation.toAbsoluteValue_apply]
-      exact (WithZeroMulInt.toNNRat_strictMono
-        (one_lt_residueFieldCard (K := K))).monotone h
-    rw [max_eq_right hxy]
-    apply Valuation.toAbsoluteValue_add_le_right
-      (v := intValuation (K := K))
-      (f := WithZeroMulInt.toNNRat (one_lt_residueFieldCard (K := K)).ne_zero)
-    exact h
-  · have hyx : normalizedAbsoluteValue K y ≤ normalizedAbsoluteValue K x := by
-      simp only [normalizedAbsoluteValue, Valuation.toAbsoluteValue_apply]
-      exact (WithZeroMulInt.toNNRat_strictMono
-        (one_lt_residueFieldCard (K := K))).monotone h
-    rw [max_eq_left hyx, add_comm]
-    apply Valuation.toAbsoluteValue_add_le_right
-      (v := intValuation (K := K))
-      (f := WithZeroMulInt.toNNRat (one_lt_residueFieldCard (K := K)).ne_zero)
-    exact h
+  apply Valuation.toAbsoluteValue_isNonarchimedean
 
 /-- The normalized absolute value takes the value one exactly on the elements of valuation one,
 that is, on the units of the ring of integers. -/

--- a/TauCeti/NumberTheory/LocalField/NormalizedValuation.lean
+++ b/TauCeti/NumberTheory/LocalField/NormalizedValuation.lean
@@ -7,6 +7,9 @@ module
 
 public import Mathlib.NumberTheory.LocalField.Basic
 public import Mathlib.RingTheory.OrderOfVanishing.Noetherian
+public import Mathlib.Algebra.Order.AbsoluteValue.Basic
+public import Mathlib.Algebra.Order.Ring.IsNonarchimedean
+public import TauCeti.Data.Int.WithZero
 public import TauCeti.RingTheory.Valuation.Discrete.Order
 
 /-!
@@ -22,13 +25,19 @@ homomorphism
 
 whose value at a uniformizer is `Multiplicative.ofAdd 1`, and its zero-preserving extension
 `normalizedValuationWithZero K : K →*₀ ℤᵐ⁰`. An integer is recovered from a nonzero value by
-decoding with `Multiplicative.toAdd`.
+decoding with `Multiplicative.toAdd`. The associated rational-valued absolute value is
+
+`normalizedAbsoluteValue K : AbsoluteValue K ℚ≥0`.
+
+Its value at a nonzero `x` is `q ^ (-v_K(x))`, where `q` is the cardinality of the residue field.
 
 ## Main definitions
 
 * `TauCeti.normalizedValuation`: the normalized valuation `v_K^×` of a nonarchimedean local
   field, as a homomorphism from the unit group to `Multiplicative ℤ`.
 * `TauCeti.normalizedValuationWithZero`: its zero-preserving extension to all of the field.
+* `TauCeti.normalizedAbsoluteValue`: the normalized `ℚ≥0`-valued absolute value associated to
+  `normalizedValuation`.
 
 ## Main results
 
@@ -42,6 +51,9 @@ decoding with `Multiplicative.toAdd`.
   API for it comes from.
 * `TauCeti.normalizedValuation_eq_one_of_isOfFinOrder`: the normalized valuation vanishes on the
   roots of unity of `K`.
+* `TauCeti.normalizedAbsoluteValue_apply_ne_zero`: the formula `|x|_K = q ^ (-v_K(x))`.
+* `TauCeti.isNonarchimedean_normalizedAbsoluteValue`: the normalized absolute value satisfies the
+  strong triangle inequality.
 * `TauCeti.eq_normalizedValuation`: the kernel condition together with the uniformizer equation
   characterizes the normalized valuation among homomorphisms `Kˣ →* Multiplicative ℤ`.
 * `TauCeti.isUnit_iff_normalizedValuationWithZero_eq_one`,
@@ -318,5 +330,105 @@ theorem exists_eq_valuation_zpow_of_irreducible {π : 𝒪[K]} (hπ : Irreducibl
   obtain ⟨n, hn⟩ := Subgroup.mem_zpowers_iff.mp hγ
   refine ⟨n, ?_⟩
   simpa using congrArg Units.val hn.symm
+
+section NormalizedAbsoluteValue
+
+open scoped NNRat
+
+private theorem one_lt_residueFieldCard :
+    (1 : ℚ≥0) < Nat.card 𝓀[K] := by
+  exact_mod_cast (Finite.one_lt_card : 1 < Nat.card 𝓀[K])
+
+private noncomputable def normalizedAbsoluteValueHom : K →*₀ ℚ≥0 :=
+  (WithZeroMulInt.toNNRat (one_lt_residueFieldCard (K := K)).ne_zero).comp
+    (intValuation (K := K)).toMonoidWithZeroHom
+
+private theorem normalizedAbsoluteValueHom_apply (x : K) :
+    normalizedAbsoluteValueHom (K := K) x =
+      WithZeroMulInt.toNNRat (one_lt_residueFieldCard (K := K)).ne_zero
+        (intValuation (K := K) x) :=
+  rfl
+
+private theorem isNonarchimedean_normalizedAbsoluteValueHom :
+    IsNonarchimedean (normalizedAbsoluteValueHom (K := K)) := by
+  intro x y
+  rw [normalizedAbsoluteValueHom_apply, normalizedAbsoluteValueHom_apply,
+    normalizedAbsoluteValueHom_apply,
+    ← (WithZeroMulInt.toNNRat_strictMono (one_lt_residueFieldCard (K := K))).monotone.map_max]
+  exact (WithZeroMulInt.toNNRat_strictMono (one_lt_residueFieldCard (K := K))).monotone
+    ((intValuation (K := K)).map_add x y)
+
+variable (K) in
+/-- The normalized absolute value of a nonarchimedean local field, with values in `ℚ≥0`.
+For a nonzero element `x`, its value is `q ^ (-v_K(x))`, where
+`q = Nat.card 𝓀[K]` is the cardinality of the residue field. -/
+noncomputable def normalizedAbsoluteValue : AbsoluteValue K ℚ≥0 where
+  toFun := normalizedAbsoluteValueHom (K := K)
+  map_mul' := map_mul (normalizedAbsoluteValueHom (K := K))
+  nonneg' _ := bot_le
+  eq_zero' x := by
+    simp [normalizedAbsoluteValueHom, intValuation]
+  add_le' x y := IsNonarchimedean.add_le (fun _ ↦ bot_le)
+    isNonarchimedean_normalizedAbsoluteValueHom
+
+private theorem normalizedAbsoluteValue_apply (x : K) :
+    normalizedAbsoluteValue K x = normalizedAbsoluteValueHom (K := K) x :=
+  rfl
+
+/-- The normalized absolute value is the rational power `q ^ (-v_K(x))` at every nonzero
+element, where `q` is the cardinality of the residue field. -/
+theorem normalizedAbsoluteValue_apply_ne_zero (x : K) (hx : x ≠ 0) :
+    normalizedAbsoluteValue K x =
+      (Nat.card 𝓀[K] : ℚ≥0) ^
+        (-(normalizedValuation K (Units.mk0 x hx)).toAdd) := by
+  rw [normalizedAbsoluteValue_apply, normalizedAbsoluteValueHom_apply,
+    WithZeroMulInt.toNNRat_apply_of_ne_zero]
+  · rw [toAdd_normalizedValuation_eq_ord, Valuation.ord_def, neg_neg,
+      WithZero.toAdd_unzero_eq_log]
+    rfl
+  · simp [intValuation, hx]
+
+/-- The normalized absolute value on `Kˣ` is the rational power `q ^ (-v_K(x))`. -/
+theorem normalizedAbsoluteValue_coe (x : Kˣ) :
+    normalizedAbsoluteValue K (x : K) =
+      (Nat.card 𝓀[K] : ℚ≥0) ^ (-(normalizedValuation K x).toAdd) := by
+  simpa using normalizedAbsoluteValue_apply_ne_zero (x : K) x.ne_zero
+
+/-- The normalized absolute value satisfies the strong triangle inequality. -/
+theorem isNonarchimedean_normalizedAbsoluteValue :
+    IsNonarchimedean (normalizedAbsoluteValue K) :=
+  isNonarchimedean_normalizedAbsoluteValueHom
+
+/-- The normalized absolute value takes the value one exactly on the elements of valuation one,
+that is, on the units of the ring of integers. -/
+@[simp]
+theorem normalizedAbsoluteValue_eq_one_iff (x : K) :
+    normalizedAbsoluteValue K x = 1 ↔ valuation K x = 1 := by
+  rw [normalizedAbsoluteValue_apply, normalizedAbsoluteValueHom_apply,
+    WithZeroMulInt.toNNRat_eq_one_iff]
+  · change valueGroupWithZeroIsoInt K (valuation K x) = 1 ↔ valuation K x = 1
+    simp
+  · exact (one_lt_residueFieldCard (K := K)).ne'
+
+/-- An element belongs to the ring of integers exactly when its normalized absolute value is at
+most one. -/
+theorem mem_integer_iff_normalizedAbsoluteValue_le_one (x : K) :
+    x ∈ 𝒪[K] ↔ normalizedAbsoluteValue K x ≤ 1 := by
+  rw [Valuation.mem_integer_iff, normalizedAbsoluteValue_apply, normalizedAbsoluteValueHom_apply,
+    WithZeroMulInt.toNNRat_le_one_iff]
+  · change valuation K x ≤ 1 ↔ valueGroupWithZeroIsoInt K (valuation K x) ≤ 1
+    simpa only [map_one] using
+      (OrderIsoClass.map_le_map_iff (valueGroupWithZeroIsoInt K)
+        (a := valuation K x) (b := 1)).symm
+  · exact one_lt_residueFieldCard (K := K)
+
+/-- The normalized absolute value is one on every root of unity. -/
+theorem normalizedAbsoluteValue_eq_one_of_isOfFinOrder {x : Kˣ} (hx : IsOfFinOrder x) :
+    normalizedAbsoluteValue K (x : K) = 1 := by
+  rw [normalizedAbsoluteValue_eq_one_iff]
+  exact (normalizedValuation_eq_one_iff x).1
+    (normalizedValuation_eq_one_of_isOfFinOrder hx)
+
+end NormalizedAbsoluteValue
 
 end TauCeti

--- a/TauCeti/NumberTheory/LocalField/NormalizedValuation.lean
+++ b/TauCeti/NumberTheory/LocalField/NormalizedValuation.lean
@@ -115,10 +115,6 @@ private noncomputable def intValuation : Valuation K ℤᵐ⁰ :=
   (valuation K).map (valueGroupWithZeroIsoInt K).toMonoidWithZeroHom
     (valueGroupWithZeroIsoInt K).toOrderIso.monotone
 
-private theorem intValuation_apply (x : K) :
-    intValuation (K := K) x = valueGroupWithZeroIsoInt K (valuation K x) :=
-  rfl
-
 private theorem intValuation_surjective : Function.Surjective (intValuation (K := K)) := by
   intro z
   obtain ⟨x, hx⟩ := ValuativeRel.valuation_surjective ((valueGroupWithZeroIsoInt K).symm z)
@@ -343,41 +339,16 @@ private theorem one_lt_residueFieldCard :
     (1 : ℚ≥0) < Nat.card 𝓀[K] := by
   exact_mod_cast (Finite.one_lt_card : 1 < Nat.card 𝓀[K])
 
-private noncomputable def normalizedAbsoluteValueHom : K →*₀ ℚ≥0 :=
-  (WithZeroMulInt.toNNRat (one_lt_residueFieldCard (K := K)).ne_zero).comp
-    (intValuation (K := K)).toMonoidWithZeroHom
-
-private theorem normalizedAbsoluteValueHom_apply (x : K) :
-    normalizedAbsoluteValueHom (K := K) x =
-      WithZeroMulInt.toNNRat (one_lt_residueFieldCard (K := K)).ne_zero
-        (intValuation (K := K) x) :=
-  rfl
-
-private theorem isNonarchimedean_normalizedAbsoluteValueHom :
-    IsNonarchimedean (normalizedAbsoluteValueHom (K := K)) := by
-  intro x y
-  rw [normalizedAbsoluteValueHom_apply, normalizedAbsoluteValueHom_apply,
-    normalizedAbsoluteValueHom_apply,
-    ← (WithZeroMulInt.toNNRat_strictMono (one_lt_residueFieldCard (K := K))).monotone.map_max]
-  exact (WithZeroMulInt.toNNRat_strictMono (one_lt_residueFieldCard (K := K))).monotone
-    ((intValuation (K := K)).map_add x y)
-
 variable (K) in
 /-- The normalized absolute value of a nonarchimedean local field, with values in `ℚ≥0`.
 For a nonzero element `x`, its value is `q ^ (-v_K(x))`, where
 `q = Nat.card 𝓀[K]` is the cardinality of the residue field. -/
-noncomputable def normalizedAbsoluteValue : AbsoluteValue K ℚ≥0 where
-  toFun := normalizedAbsoluteValueHom (K := K)
-  map_mul' := map_mul (normalizedAbsoluteValueHom (K := K))
-  nonneg' _ := bot_le
-  eq_zero' x := by
-    simp [normalizedAbsoluteValueHom, intValuation]
-  add_le' x y := IsNonarchimedean.add_le (fun _ ↦ bot_le)
-    isNonarchimedean_normalizedAbsoluteValueHom
-
-private theorem normalizedAbsoluteValue_apply (x : K) :
-    normalizedAbsoluteValue K x = normalizedAbsoluteValueHom (K := K) x :=
-  rfl
+noncomputable def normalizedAbsoluteValue : AbsoluteValue K ℚ≥0 :=
+  (intValuation (K := K)).toAbsoluteValue
+    (WithZeroMulInt.toNNRat (one_lt_residueFieldCard (K := K)).ne_zero)
+    (fun _ _ h ↦
+      (WithZeroMulInt.toNNRat_strictMono (one_lt_residueFieldCard (K := K))).monotone h)
+    (WithZeroMulInt.toNNRat_strictMono (one_lt_residueFieldCard (K := K))).injective
 
 /-- The normalized absolute value is the rational power `q ^ (-v_K(x))` at every nonzero
 element, where `q` is the cardinality of the residue field. -/
@@ -385,14 +356,15 @@ theorem normalizedAbsoluteValue_apply_ne_zero (x : K) (hx : x ≠ 0) :
     normalizedAbsoluteValue K x =
       (Nat.card 𝓀[K] : ℚ≥0) ^
         (-(normalizedValuation K (Units.mk0 x hx)).toAdd) := by
-  rw [normalizedAbsoluteValue_apply, normalizedAbsoluteValueHom_apply,
+  rw [normalizedAbsoluteValue, Valuation.toAbsoluteValue_apply,
     WithZeroMulInt.toNNRat_apply_of_ne_zero]
   · rw [toAdd_normalizedValuation_eq_ord, Valuation.ord_def, neg_neg,
       WithZero.toAdd_unzero_eq_log]
-    simp only [intValuation_apply, Units.val_mk0]
-  · simp [intValuation_apply, hx]
+    simp only [Units.val_mk0]
+  · simp [intValuation, hx]
 
 /-- The normalized absolute value on `Kˣ` is the rational power `q ^ (-v_K(x))`. -/
+@[simp]
 theorem normalizedAbsoluteValue_coe (x : Kˣ) :
     normalizedAbsoluteValue K (x : K) =
       (Nat.card 𝓀[K] : ℚ≥0) ^ (-(normalizedValuation K x).toAdd) := by
@@ -403,24 +375,43 @@ of `K`, is the inverse of the residue-field cardinality. -/
 @[simp]
 theorem normalizedAbsoluteValue_irreducible {π : 𝒪[K]} (hπ : Irreducible π) :
     normalizedAbsoluteValue K (π : K) = (Nat.card 𝓀[K] : ℚ≥0)⁻¹ := by
-  rw [show (π : K) =
-      ((Units.mk0 (π : K) (fun h => hπ.ne_zero (Subtype.ext h)) : Kˣ) : K) from rfl,
-    normalizedAbsoluteValue_coe, normalizedValuation_irreducible hπ]
+  rw [normalizedAbsoluteValue_apply_ne_zero (π : K)
+      (fun h ↦ hπ.ne_zero (Subtype.ext h)),
+    normalizedValuation_irreducible hπ]
   simp
 
 /-- The normalized absolute value satisfies the strong triangle inequality. -/
 theorem isNonarchimedean_normalizedAbsoluteValue :
-    IsNonarchimedean (normalizedAbsoluteValue K) :=
-  isNonarchimedean_normalizedAbsoluteValueHom
+    IsNonarchimedean (normalizedAbsoluteValue K) := by
+  intro x y
+  rcases le_total (intValuation (K := K) x) (intValuation (K := K) y) with h | h
+  · have hxy : normalizedAbsoluteValue K x ≤ normalizedAbsoluteValue K y := by
+      simp only [normalizedAbsoluteValue, Valuation.toAbsoluteValue_apply]
+      exact (WithZeroMulInt.toNNRat_strictMono
+        (one_lt_residueFieldCard (K := K))).monotone h
+    rw [max_eq_right hxy]
+    apply Valuation.toAbsoluteValue_add_le_right
+      (v := intValuation (K := K))
+      (f := WithZeroMulInt.toNNRat (one_lt_residueFieldCard (K := K)).ne_zero)
+    exact h
+  · have hyx : normalizedAbsoluteValue K y ≤ normalizedAbsoluteValue K x := by
+      simp only [normalizedAbsoluteValue, Valuation.toAbsoluteValue_apply]
+      exact (WithZeroMulInt.toNNRat_strictMono
+        (one_lt_residueFieldCard (K := K))).monotone h
+    rw [max_eq_left hyx]
+    apply Valuation.toAbsoluteValue_add_le_left
+      (v := intValuation (K := K))
+      (f := WithZeroMulInt.toNNRat (one_lt_residueFieldCard (K := K)).ne_zero)
+    exact h
 
 /-- The normalized absolute value takes the value one exactly on the elements of valuation one,
 that is, on the units of the ring of integers. -/
 @[simp]
 theorem normalizedAbsoluteValue_eq_one_iff (x : K) :
     normalizedAbsoluteValue K x = 1 ↔ valuation K x = 1 := by
-  rw [normalizedAbsoluteValue_apply, normalizedAbsoluteValueHom_apply,
+  rw [normalizedAbsoluteValue, Valuation.toAbsoluteValue_apply,
     WithZeroMulInt.toNNRat_eq_one_iff]
-  · rw [intValuation_apply]
+  · change valueGroupWithZeroIsoInt K (valuation K x) = 1 ↔ valuation K x = 1
     have hone : valueGroupWithZeroIsoInt K (1 : ValueGroupWithZero K) = 1 := map_one _
     rw [← hone]
     exact (valueGroupWithZeroIsoInt K).injective.eq_iff
@@ -430,13 +421,21 @@ theorem normalizedAbsoluteValue_eq_one_iff (x : K) :
 most one. -/
 theorem mem_integer_iff_normalizedAbsoluteValue_le_one (x : K) :
     x ∈ 𝒪[K] ↔ normalizedAbsoluteValue K x ≤ 1 := by
-  rw [Valuation.mem_integer_iff, normalizedAbsoluteValue_apply, normalizedAbsoluteValueHom_apply,
+  rw [Valuation.mem_integer_iff, normalizedAbsoluteValue, Valuation.toAbsoluteValue_apply,
     WithZeroMulInt.toNNRat_le_one_iff]
-  · rw [intValuation_apply]
+  · change valuation K x ≤ 1 ↔ valueGroupWithZeroIsoInt K (valuation K x) ≤ 1
     simpa only [map_one] using
       (OrderIsoClass.map_le_map_iff (valueGroupWithZeroIsoInt K)
         (a := valuation K x) (b := 1)).symm
   · exact one_lt_residueFieldCard (K := K)
+
+/-- The normalized absolute value is one on every unit of the ring of integers. -/
+@[simp]
+theorem normalizedAbsoluteValue_integerRingUnit (u : 𝒪[K]ˣ) :
+    normalizedAbsoluteValue K ((u : 𝒪[K]) : K) = 1 := by
+  rw [normalizedAbsoluteValue_eq_one_iff]
+  exact (Valuation.Integers.isUnit_iff_valuation_eq_one
+    (Valuation.integer.integers (valuation K))).mp u.isUnit
 
 /-- The normalized absolute value is one on every root of unity. -/
 theorem normalizedAbsoluteValue_eq_one_of_isOfFinOrder {x : Kˣ} (hx : IsOfFinOrder x) :

--- a/TauCeti/NumberTheory/LocalField/NormalizedValuation.lean
+++ b/TauCeti/NumberTheory/LocalField/NormalizedValuation.lean
@@ -348,7 +348,7 @@ noncomputable def normalizedAbsoluteValue : AbsoluteValue K ℚ≥0 :=
     (WithZeroMulInt.toNNRat (one_lt_residueFieldCard (K := K)).ne_zero)
     (fun _ _ h ↦
       (WithZeroMulInt.toNNRat_strictMono (one_lt_residueFieldCard (K := K))).monotone h)
-    (WithZeroMulInt.toNNRat_strictMono (one_lt_residueFieldCard (K := K))).injective
+    (fun _ ↦ map_eq_zero _)
 
 /-- The normalized absolute value is the rational power `q ^ (-v_K(x))` at every nonzero
 element, where `q` is the cardinality of the residue field. -/

--- a/TauCeti/NumberTheory/LocalField/NormalizedValuation.lean
+++ b/TauCeti/NumberTheory/LocalField/NormalizedValuation.lean
@@ -115,6 +115,11 @@ private noncomputable def intValuation : Valuation K ℤᵐ⁰ :=
   (valuation K).map (valueGroupWithZeroIsoInt K).toMonoidWithZeroHom
     (valueGroupWithZeroIsoInt K).toOrderIso.monotone
 
+@[simp]
+private theorem intValuation_apply (x : K) :
+    intValuation (K := K) x = valueGroupWithZeroIsoInt K (valuation K x) := by
+  rfl
+
 private theorem intValuation_surjective : Function.Surjective (intValuation (K := K)) := by
   intro z
   obtain ⟨x, hx⟩ := ValuativeRel.valuation_surjective ((valueGroupWithZeroIsoInt K).symm z)
@@ -398,8 +403,8 @@ theorem isNonarchimedean_normalizedAbsoluteValue :
       simp only [normalizedAbsoluteValue, Valuation.toAbsoluteValue_apply]
       exact (WithZeroMulInt.toNNRat_strictMono
         (one_lt_residueFieldCard (K := K))).monotone h
-    rw [max_eq_left hyx]
-    apply Valuation.toAbsoluteValue_add_le_left
+    rw [max_eq_left hyx, add_comm]
+    apply Valuation.toAbsoluteValue_add_le_right
       (v := intValuation (K := K))
       (f := WithZeroMulInt.toNNRat (one_lt_residueFieldCard (K := K)).ne_zero)
     exact h
@@ -411,7 +416,7 @@ theorem normalizedAbsoluteValue_eq_one_iff (x : K) :
     normalizedAbsoluteValue K x = 1 ↔ valuation K x = 1 := by
   rw [normalizedAbsoluteValue, Valuation.toAbsoluteValue_apply,
     WithZeroMulInt.toNNRat_eq_one_iff]
-  · change valueGroupWithZeroIsoInt K (valuation K x) = 1 ↔ valuation K x = 1
+  · rw [intValuation_apply]
     have hone : valueGroupWithZeroIsoInt K (1 : ValueGroupWithZero K) = 1 := map_one _
     rw [← hone]
     exact (valueGroupWithZeroIsoInt K).injective.eq_iff
@@ -419,11 +424,12 @@ theorem normalizedAbsoluteValue_eq_one_iff (x : K) :
 
 /-- An element belongs to the ring of integers exactly when its normalized absolute value is at
 most one. -/
+@[simp]
 theorem mem_integer_iff_normalizedAbsoluteValue_le_one (x : K) :
     x ∈ 𝒪[K] ↔ normalizedAbsoluteValue K x ≤ 1 := by
   rw [Valuation.mem_integer_iff, normalizedAbsoluteValue, Valuation.toAbsoluteValue_apply,
     WithZeroMulInt.toNNRat_le_one_iff]
-  · change valuation K x ≤ 1 ↔ valueGroupWithZeroIsoInt K (valuation K x) ≤ 1
+  · rw [intValuation_apply]
     simpa only [map_one] using
       (OrderIsoClass.map_le_map_iff (valueGroupWithZeroIsoInt K)
         (a := valuation K x) (b := 1)).symm

--- a/TauCeti/NumberTheory/LocalField/NormalizedValuation.lean
+++ b/TauCeti/NumberTheory/LocalField/NormalizedValuation.lean
@@ -115,11 +115,6 @@ private noncomputable def intValuation : Valuation K ℤᵐ⁰ :=
   (valuation K).map (valueGroupWithZeroIsoInt K).toMonoidWithZeroHom
     (valueGroupWithZeroIsoInt K).toOrderIso.monotone
 
-@[simp]
-private theorem intValuation_apply (x : K) :
-    intValuation (K := K) x = valueGroupWithZeroIsoInt K (valuation K x) := by
-  rfl
-
 private theorem intValuation_surjective : Function.Surjective (intValuation (K := K)) := by
   intro z
   obtain ⟨x, hx⟩ := ValuativeRel.valuation_surjective ((valueGroupWithZeroIsoInt K).symm z)
@@ -416,7 +411,7 @@ theorem normalizedAbsoluteValue_eq_one_iff (x : K) :
     normalizedAbsoluteValue K x = 1 ↔ valuation K x = 1 := by
   rw [normalizedAbsoluteValue, Valuation.toAbsoluteValue_apply,
     WithZeroMulInt.toNNRat_eq_one_iff]
-  · rw [intValuation_apply]
+  · simp only [intValuation]
     have hone : valueGroupWithZeroIsoInt K (1 : ValueGroupWithZero K) = 1 := map_one _
     rw [← hone]
     exact (valueGroupWithZeroIsoInt K).injective.eq_iff
@@ -429,7 +424,9 @@ theorem mem_integer_iff_normalizedAbsoluteValue_le_one (x : K) :
     x ∈ 𝒪[K] ↔ normalizedAbsoluteValue K x ≤ 1 := by
   rw [Valuation.mem_integer_iff, normalizedAbsoluteValue, Valuation.toAbsoluteValue_apply,
     WithZeroMulInt.toNNRat_le_one_iff]
-  · rw [intValuation_apply]
+  · -- `Valuation.map_apply` encounters the two propositionally equal preorder instances on
+    -- `ℤᵐ⁰` under `≤`; expose the mapped value before transporting the comparison.
+    change valuation K x ≤ 1 ↔ valueGroupWithZeroIsoInt K (valuation K x) ≤ 1
     simpa only [map_one] using
       (OrderIsoClass.map_le_map_iff (valueGroupWithZeroIsoInt K)
         (a := valuation K x) (b := 1)).symm

--- a/TauCeti/NumberTheory/LocalField/NormalizedValuation.lean
+++ b/TauCeti/NumberTheory/LocalField/NormalizedValuation.lean
@@ -10,7 +10,7 @@ public import Mathlib.RingTheory.OrderOfVanishing.Noetherian
 public import Mathlib.Algebra.Order.AbsoluteValue.Basic
 public import Mathlib.Algebra.Order.Ring.IsNonarchimedean
 public import TauCeti.Data.Int.WithZero
-public import TauCeti.RingTheory.Valuation.Discrete.AbsoluteValue
+public import TauCeti.RingTheory.Valuation.AbsoluteValue
 public import TauCeti.RingTheory.Valuation.Discrete.Order
 
 /-!
@@ -384,7 +384,7 @@ theorem normalizedAbsoluteValue_irreducible {π : 𝒪[K]} (hπ : Irreducible π
 /-- The normalized absolute value satisfies the strong triangle inequality. -/
 theorem isNonarchimedean_normalizedAbsoluteValue :
     IsNonarchimedean (normalizedAbsoluteValue K) := by
-  apply Valuation.toAbsoluteValue_isNonarchimedean
+  apply Valuation.isNonarchimedean_toAbsoluteValue
 
 /-- The normalized absolute value takes the value one exactly on the elements of valuation one,
 that is, on the units of the ring of integers. -/
@@ -416,7 +416,7 @@ theorem mem_integer_iff_normalizedAbsoluteValue_le_one (x : K) :
 
 /-- The normalized absolute value is one on every unit of the ring of integers. -/
 @[simp]
-theorem normalizedAbsoluteValue_integerRingUnit (u : 𝒪[K]ˣ) :
+theorem normalizedAbsoluteValue_coe_unit (u : 𝒪[K]ˣ) :
     normalizedAbsoluteValue K ((u : 𝒪[K]) : K) = 1 := by
   rw [normalizedAbsoluteValue_eq_one_iff]
   exact (Valuation.Integers.isUnit_iff_valuation_eq_one

--- a/TauCeti/NumberTheory/LocalField/NormalizedValuation.lean
+++ b/TauCeti/NumberTheory/LocalField/NormalizedValuation.lean
@@ -115,6 +115,10 @@ private noncomputable def intValuation : Valuation K ℤᵐ⁰ :=
   (valuation K).map (valueGroupWithZeroIsoInt K).toMonoidWithZeroHom
     (valueGroupWithZeroIsoInt K).toOrderIso.monotone
 
+private theorem intValuation_apply (x : K) :
+    intValuation (K := K) x = valueGroupWithZeroIsoInt K (valuation K x) :=
+  rfl
+
 private theorem intValuation_surjective : Function.Surjective (intValuation (K := K)) := by
   intro z
   obtain ⟨x, hx⟩ := ValuativeRel.valuation_surjective ((valueGroupWithZeroIsoInt K).symm z)
@@ -385,14 +389,24 @@ theorem normalizedAbsoluteValue_apply_ne_zero (x : K) (hx : x ≠ 0) :
     WithZeroMulInt.toNNRat_apply_of_ne_zero]
   · rw [toAdd_normalizedValuation_eq_ord, Valuation.ord_def, neg_neg,
       WithZero.toAdd_unzero_eq_log]
-    rfl
-  · simp [intValuation, hx]
+    simp only [intValuation_apply, Units.val_mk0]
+  · simp [intValuation_apply, hx]
 
 /-- The normalized absolute value on `Kˣ` is the rational power `q ^ (-v_K(x))`. -/
 theorem normalizedAbsoluteValue_coe (x : Kˣ) :
     normalizedAbsoluteValue K (x : K) =
       (Nat.card 𝓀[K] : ℚ≥0) ^ (-(normalizedValuation K x).toAdd) := by
   simpa using normalizedAbsoluteValue_apply_ne_zero (x : K) x.ne_zero
+
+/-- The normalized absolute value of an irreducible element of `𝒪[K]`, that is of a uniformizer
+of `K`, is the inverse of the residue-field cardinality. -/
+@[simp]
+theorem normalizedAbsoluteValue_irreducible {π : 𝒪[K]} (hπ : Irreducible π) :
+    normalizedAbsoluteValue K (π : K) = (Nat.card 𝓀[K] : ℚ≥0)⁻¹ := by
+  rw [show (π : K) =
+      ((Units.mk0 (π : K) (fun h => hπ.ne_zero (Subtype.ext h)) : Kˣ) : K) from rfl,
+    normalizedAbsoluteValue_coe, normalizedValuation_irreducible hπ]
+  simp
 
 /-- The normalized absolute value satisfies the strong triangle inequality. -/
 theorem isNonarchimedean_normalizedAbsoluteValue :
@@ -406,8 +420,10 @@ theorem normalizedAbsoluteValue_eq_one_iff (x : K) :
     normalizedAbsoluteValue K x = 1 ↔ valuation K x = 1 := by
   rw [normalizedAbsoluteValue_apply, normalizedAbsoluteValueHom_apply,
     WithZeroMulInt.toNNRat_eq_one_iff]
-  · change valueGroupWithZeroIsoInt K (valuation K x) = 1 ↔ valuation K x = 1
-    simp
+  · rw [intValuation_apply]
+    have hone : valueGroupWithZeroIsoInt K (1 : ValueGroupWithZero K) = 1 := map_one _
+    rw [← hone]
+    exact (valueGroupWithZeroIsoInt K).injective.eq_iff
   · exact (one_lt_residueFieldCard (K := K)).ne'
 
 /-- An element belongs to the ring of integers exactly when its normalized absolute value is at
@@ -416,7 +432,7 @@ theorem mem_integer_iff_normalizedAbsoluteValue_le_one (x : K) :
     x ∈ 𝒪[K] ↔ normalizedAbsoluteValue K x ≤ 1 := by
   rw [Valuation.mem_integer_iff, normalizedAbsoluteValue_apply, normalizedAbsoluteValueHom_apply,
     WithZeroMulInt.toNNRat_le_one_iff]
-  · change valuation K x ≤ 1 ↔ valueGroupWithZeroIsoInt K (valuation K x) ≤ 1
+  · rw [intValuation_apply]
     simpa only [map_one] using
       (OrderIsoClass.map_le_map_iff (valueGroupWithZeroIsoInt K)
         (a := valuation K x) (b := 1)).symm

--- a/TauCeti/RingTheory/Valuation/AbsoluteValue.lean
+++ b/TauCeti/RingTheory/Valuation/AbsoluteValue.lean
@@ -82,15 +82,16 @@ variable {K S Γ₀ : Type*} [DivisionRing K] [LinearOrderedCommMonoidWithZero �
 
 /-- An absolute value obtained from a valuation through a monotone realization is
 nonarchimedean. -/
-theorem toAbsoluteValue_isNonarchimedean (v : _root_.Valuation K Γ₀) (f : Γ₀ →*₀ S)
+theorem isNonarchimedean_toAbsoluteValue (v : _root_.Valuation K Γ₀) (f : Γ₀ →*₀ S)
     (hf : ∀ ⦃a b⦄, a ≤ b → f a ≤ f b) (hf_zero : ∀ a, f a = 0 ↔ a = 0) :
     IsNonarchimedean (v.toAbsoluteValue f hf hf_zero) := by
   intro x y
-  simp only [toAbsoluteValue_apply]
-  refine (hf (v.map_add x y)).trans ?_
   rcases le_total (v x) (v y) with h | h
-  · rw [max_eq_right h, max_eq_right (hf h)]
-  · rw [max_eq_left h, max_eq_left (hf h)]
+  · rw [max_eq_right (by simpa only [toAbsoluteValue_apply] using hf h)]
+    exact v.toAbsoluteValue_add_le_right f hf hf_zero h
+  · rw [max_eq_left (by simpa only [toAbsoluteValue_apply] using hf h)]
+    simpa only [add_comm] using
+      v.toAbsoluteValue_add_le_right f hf hf_zero (x := y) (y := x) h
 
 end IsNonarchimedean
 

--- a/TauCeti/RingTheory/Valuation/Approximation.lean
+++ b/TauCeti/RingTheory/Valuation/Approximation.lean
@@ -7,7 +7,7 @@ module
 
 public import Mathlib.Analysis.AbsoluteValue.Equivalence
 public import Mathlib.Data.Int.WithZero
-public import TauCeti.RingTheory.Valuation.Discrete.AbsoluteValue
+public import TauCeti.RingTheory.Valuation.AbsoluteValue
 
 /-!
 # Weak approximation for discrete valuations

--- a/TauCeti/RingTheory/Valuation/Approximation.lean
+++ b/TauCeti/RingTheory/Valuation/Approximation.lean
@@ -61,11 +61,6 @@ private theorem withZeroMulIntToReal_monotone {m n : ℤᵐ⁰}
   exact_mod_cast
     WithZeroMulInt.toNNReal_strictMono (by norm_num : (1 : ℝ≥0) < 2) |>.monotone hmn
 
-private theorem withZeroMulIntToReal_injective : Function.Injective withZeroMulIntToReal := by
-  intro m n h
-  exact WithZeroMulInt.toNNReal_strictMono
-    (by norm_num : (1 : ℝ≥0) < 2) |>.injective (NNReal.coe_injective h)
-
 section DivisionRing
 
 variable {K : Type*} [DivisionRing K]
@@ -79,7 +74,7 @@ noncomputable def toRealAbsoluteValue (v : Valuation K ℤᵐ⁰) : AbsoluteValu
   @toAbsoluteValue K ℝ _ _ Real.partialOrder (by infer_instance) (by infer_instance) v
     withZeroMulIntToReal
     (fun {_ _} h ↦ withZeroMulIntToReal_monotone h)
-    withZeroMulIntToReal_injective
+    (fun _ ↦ map_eq_zero _)
 
 @[simp]
 theorem toRealAbsoluteValue_apply (v : Valuation K ℤᵐ⁰) (x : K) :

--- a/TauCeti/RingTheory/Valuation/Approximation.lean
+++ b/TauCeti/RingTheory/Valuation/Approximation.lean
@@ -7,7 +7,7 @@ module
 
 public import Mathlib.Analysis.AbsoluteValue.Equivalence
 public import Mathlib.Data.Int.WithZero
-public import Mathlib.RingTheory.Valuation.Basic
+public import TauCeti.RingTheory.Valuation.Discrete.Order
 
 /-!
 # Weak approximation for discrete valuations
@@ -40,12 +40,31 @@ open scoped NNReal WithZero
 
 namespace Valuation
 
+private noncomputable def withZeroMulIntToReal : ℤᵐ⁰ →*₀ ℝ :=
+  NNReal.toRealHom.toMonoidWithZeroHom.comp
+    (WithZeroMulInt.toNNReal (by norm_num : (2 : ℝ≥0) ≠ 0))
+
 private theorem withZeroMulIntToReal_strictMono :
-    StrictMono (fun n : ℤᵐ⁰ ↦
-      (WithZeroMulInt.toNNReal (by norm_num : (2 : ℝ≥0) ≠ 0) n : ℝ)) := by
+    StrictMono withZeroMulIntToReal := by
   intro m n hmn
   exact_mod_cast
     WithZeroMulInt.toNNReal_strictMono (by norm_num : (1 : ℝ≥0) < 2) hmn
+
+-- `AbsoluteValue K ℝ` uses `Real.partialOrder`, while the bundled strict-monotonicity theorem
+-- infers `Real.instPreorder`; spell out the propositionally identical comparison needed by the
+-- generic constructor to avoid an order-instance diamond.
+private theorem withZeroMulIntToReal_monotone {m n : ℤᵐ⁰}
+    (hmn : @LE.le ℤᵐ⁰ (@Preorder.toLE ℤᵐ⁰
+      (@WithZero.instPreorder (Multiplicative ℤ)
+        (@Multiplicative.preorder ℤ Int.instPreorder))) m n) :
+    @LE.le ℝ Real.partialOrder.toLE (withZeroMulIntToReal m) (withZeroMulIntToReal n) := by
+  exact_mod_cast
+    WithZeroMulInt.toNNReal_strictMono (by norm_num : (1 : ℝ≥0) < 2) |>.monotone hmn
+
+private theorem withZeroMulIntToReal_injective : Function.Injective withZeroMulIntToReal := by
+  intro m n h
+  exact WithZeroMulInt.toNNReal_strictMono
+    (by norm_num : (1 : ℝ≥0) < 2) |>.injective (NNReal.coe_injective h)
 
 section DivisionRing
 
@@ -57,32 +76,16 @@ its value group. This changes neither comparisons nor equivalence of valuations.
 A division ring is needed already here: an `AbsoluteValue` vanishes only at `0`, whereas a
 valuation on a general ring may have nontrivial support. -/
 noncomputable def toRealAbsoluteValue (v : Valuation K ℤᵐ⁰) : AbsoluteValue K ℝ :=
-  AbsoluteValue.mk
-    (NNReal.toRealHom.toMonoidWithZeroHom.comp
-      ((WithZeroMulInt.toNNReal (by norm_num : (2 : ℝ≥0) ≠ 0)).comp
-        v.toMonoidWithZeroHom))
-    (fun _ ↦ NNReal.coe_nonneg _)
-    (fun x ↦ by simp)
-    fun x y ↦ calc
-      (WithZeroMulInt.toNNReal (by norm_num : (2 : ℝ≥0) ≠ 0) (v (x + y)) : ℝ)
-          ≤ (WithZeroMulInt.toNNReal (by norm_num : (2 : ℝ≥0) ≠ 0)
-            (max (v x) (v y)) : ℝ) :=
-        withZeroMulIntToReal_strictMono.monotone (v.map_add x y)
-      _ = max
-          (WithZeroMulInt.toNNReal (by norm_num : (2 : ℝ≥0) ≠ 0) (v x) : ℝ)
-          (WithZeroMulInt.toNNReal (by norm_num : (2 : ℝ≥0) ≠ 0) (v y) : ℝ) :=
-        withZeroMulIntToReal_strictMono.monotone.map_max
-      _ ≤ (WithZeroMulInt.toNNReal (by norm_num : (2 : ℝ≥0) ≠ 0) (v x) : ℝ) +
-          (WithZeroMulInt.toNNReal (by norm_num : (2 : ℝ≥0) ≠ 0) (v y) : ℝ) :=
-        max_le_add_of_nonneg (NNReal.coe_nonneg _) (NNReal.coe_nonneg _)
+  @toAbsoluteValue K ℝ _ _ Real.partialOrder (by infer_instance) (by infer_instance) v
+    withZeroMulIntToReal
+    (fun {_ _} h ↦ withZeroMulIntToReal_monotone h)
+    withZeroMulIntToReal_injective
 
 @[simp]
 theorem toRealAbsoluteValue_apply (v : Valuation K ℤᵐ⁰) (x : K) :
     v.toRealAbsoluteValue x =
       (WithZeroMulInt.toNNReal (by norm_num : (2 : ℝ≥0) ≠ 0) (v x) : ℝ) :=
-  -- The parentheses keep the module system's `rfl`-theorem check from demanding that
-  -- `toRealAbsoluteValue` be `@[expose]`d; the two sides are definitionally equal.
-  (rfl)
+  by simp [toRealAbsoluteValue, withZeroMulIntToReal]
 
 /-- Passing a discrete valuation to its real absolute value preserves and reflects inequalities. -/
 theorem toRealAbsoluteValue_le_iff (v : Valuation K ℤᵐ⁰) {x y : K} :
@@ -108,7 +111,7 @@ theorem toRealAbsoluteValue_isNontrivial_iff (v : Valuation K ℤᵐ⁰) :
     refine ⟨x, v.ne_zero_iff.mp hx0, fun hx ↦ hx1 ?_⟩
     rw [toRealAbsoluteValue_apply] at hx
     refine withZeroMulIntToReal_strictMono.injective ?_
-    simpa using hx
+    simpa [withZeroMulIntToReal] using hx
 
 end DivisionRing
 

--- a/TauCeti/RingTheory/Valuation/Approximation.lean
+++ b/TauCeti/RingTheory/Valuation/Approximation.lean
@@ -7,7 +7,7 @@ module
 
 public import Mathlib.Analysis.AbsoluteValue.Equivalence
 public import Mathlib.Data.Int.WithZero
-public import TauCeti.RingTheory.Valuation.Discrete.Order
+public import TauCeti.RingTheory.Valuation.Discrete.AbsoluteValue
 
 /-!
 # Weak approximation for discrete valuations
@@ -71,7 +71,7 @@ its value group. This changes neither comparisons nor equivalence of valuations.
 A division ring is needed already here: an `AbsoluteValue` vanishes only at `0`, whereas a
 valuation on a general ring may have nontrivial support. -/
 noncomputable def toRealAbsoluteValue (v : Valuation K ℤᵐ⁰) : AbsoluteValue K ℝ :=
-  @toAbsoluteValue K ℝ _ _ Real.partialOrder (by infer_instance) (by infer_instance) v
+  @toAbsoluteValue K ℝ ℤᵐ⁰ _ _ _ _ Real.partialOrder (by infer_instance) (by infer_instance) v
     withZeroMulIntToReal
     (fun {_ _} h ↦ withZeroMulIntToReal_monotone h)
     (fun _ ↦ map_eq_zero _)

--- a/TauCeti/RingTheory/Valuation/Discrete/AbsoluteValue.lean
+++ b/TauCeti/RingTheory/Valuation/Discrete/AbsoluteValue.lean
@@ -1,0 +1,97 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Order.AbsoluteValue.Basic
+public import Mathlib.Algebra.Order.Ring.IsNonarchimedean
+public import Mathlib.RingTheory.Valuation.Basic
+
+/-!
+# Absolute values from valuations
+
+This file constructs an absolute value by composing a valuation with a monotone, zero-reflecting
+monoid-with-zero homomorphism.
+-/
+
+public section
+
+open MonoidWithZeroHom
+
+namespace Valuation
+
+section AbsoluteValue
+
+variable {K S Γ₀ : Type*} [DivisionRing K] [LinearOrderedCommMonoidWithZero Γ₀] [Nontrivial Γ₀]
+  [Semiring S] [PartialOrder S] [addLeftMono : AddLeftMono S] [addRightMono : AddRightMono S]
+
+omit [Nontrivial Γ₀] in
+private theorem comp_apply_add_le_add_of_monotone (v : _root_.Valuation K Γ₀)
+    (f : Γ₀ →*₀ S) (hf : ∀ ⦃a b⦄, a ≤ b → f a ≤ f b) (x y : K) :
+    f (v (x + y)) ≤ f (v x) + f (v y) := by
+  refine (hf (v.map_add x y)).trans ?_
+  rcases le_total (v x) (v y) with h | h
+  · rw [max_eq_right h]
+    exact le_add_of_nonneg_left <| by rw [← map_zero f]; exact hf zero_le
+  · rw [max_eq_left h]
+    exact le_add_of_nonneg_right <| by rw [← map_zero f]; exact hf zero_le
+
+/-- Compose a valuation with a monotone, zero-reflecting monoid-with-zero homomorphism to obtain
+an absolute value. -/
+noncomputable def toAbsoluteValue (v : _root_.Valuation K Γ₀) (f : Γ₀ →*₀ S)
+    (hf : ∀ ⦃a b⦄, a ≤ b → f a ≤ f b) (hf_zero : ∀ a, f a = 0 ↔ a = 0) :
+    AbsoluteValue K S :=
+  AbsoluteValue.mk (f.comp v.toMonoidWithZeroHom)
+    (fun x ↦ by rw [← map_zero f]; exact hf zero_le)
+    (fun x ↦ by
+      -- `AbsoluteValue.mk` has no evaluation lemma available while constructing the value.
+      change f (v x) = 0 ↔ x = 0
+      rw [hf_zero]
+      exact v.zero_iff)
+    (comp_apply_add_le_add_of_monotone v f hf)
+
+include addLeftMono addRightMono in
+/-- Evaluation of the absolute value obtained by composing a valuation with a monotone,
+zero-reflecting monoid-with-zero homomorphism. -/
+@[simp]
+theorem toAbsoluteValue_apply (v : _root_.Valuation K Γ₀) (f : Γ₀ →*₀ S)
+    (hf : ∀ ⦃a b⦄, a ≤ b → f a ≤ f b) (hf_zero : ∀ a, f a = 0 ↔ a = 0) (x : K) :
+    v.toAbsoluteValue f hf hf_zero x = f (v x) := by
+  -- Unfold the constructor once to establish the public evaluation lemma used below.
+  change (f.comp v.toMonoidWithZeroHom) x = f (v x)
+  rfl
+
+include addLeftMono addRightMono in
+/-- If one input has no larger valuation than another, their sum has absolute value at most that
+of the latter. -/
+theorem toAbsoluteValue_add_le_right (v : _root_.Valuation K Γ₀) (f : Γ₀ →*₀ S)
+    (hf : ∀ ⦃a b⦄, a ≤ b → f a ≤ f b) (hf_zero : ∀ a, f a = 0 ↔ a = 0)
+    {x y : K} (h : v x ≤ v y) :
+    v.toAbsoluteValue f hf hf_zero (x + y) ≤ v.toAbsoluteValue f hf hf_zero y := by
+  rw [toAbsoluteValue_apply, toAbsoluteValue_apply]
+  exact hf ((v.map_add x y).trans_eq (max_eq_right h))
+
+end AbsoluteValue
+
+section IsNonarchimedean
+
+variable {K S Γ₀ : Type*} [DivisionRing K] [LinearOrderedCommMonoidWithZero Γ₀] [Nontrivial Γ₀]
+  [Semiring S] [LinearOrder S] [addLeftMono : AddLeftMono S] [addRightMono : AddRightMono S]
+
+/-- An absolute value obtained from a valuation through a monotone realization is
+nonarchimedean. -/
+theorem toAbsoluteValue_isNonarchimedean (v : _root_.Valuation K Γ₀) (f : Γ₀ →*₀ S)
+    (hf : ∀ ⦃a b⦄, a ≤ b → f a ≤ f b) (hf_zero : ∀ a, f a = 0 ↔ a = 0) :
+    IsNonarchimedean (v.toAbsoluteValue f hf hf_zero) := by
+  intro x y
+  simp only [toAbsoluteValue_apply]
+  refine (hf (v.map_add x y)).trans ?_
+  rcases le_total (v x) (v y) with h | h
+  · rw [max_eq_right h, max_eq_right (hf h)]
+  · rw [max_eq_left h, max_eq_left (hf h)]
+
+end IsNonarchimedean
+
+end Valuation

--- a/TauCeti/RingTheory/Valuation/Discrete/Order.lean
+++ b/TauCeti/RingTheory/Valuation/Discrete/Order.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import Mathlib.Algebra.Order.AbsoluteValue.Basic
 public import Mathlib.RingTheory.Valuation.Discrete.Basic
 
 /-!
@@ -14,6 +15,9 @@ This file packages the additive order attached to a `ℤᵐ⁰`-valued valuation
 facts that do not depend on a choice of constant field.  The convention is
 `ord_v f = -log (v f)`, so a uniformizer has order one.  As `WithZero.log 0 = 0`, the order
 has the junk value `ord_v 0 = 0`; hypotheses excluding zero are included where necessary.
+
+It also constructs an absolute value by composing a `ℤᵐ⁰`-valued valuation with an ordered
+zero-preserving monoid embedding.
 -/
 
 public section
@@ -23,6 +27,67 @@ open scoped WithZero
 open MonoidWithZeroHom
 
 namespace Valuation
+
+section AbsoluteValue
+
+variable {K S : Type*} [DivisionRing K] [Semiring S] [PartialOrder S]
+  [addLeftMono : AddLeftMono S] [addRightMono : AddRightMono S]
+
+private theorem comp_apply_add_le_add_of_monotone (v : _root_.Valuation K ℤᵐ⁰)
+    (f : ℤᵐ⁰ →*₀ S) (hf : ∀ ⦃a b⦄, a ≤ b → f a ≤ f b) (x y : K) :
+    f (v (x + y)) ≤ f (v x) + f (v y) := by
+  refine (hf (v.map_add x y)).trans ?_
+  rcases le_total (v x) (v y) with h | h
+  · rw [max_eq_right h]
+    exact le_add_of_nonneg_left <| by rw [← map_zero f]; exact hf bot_le
+  · rw [max_eq_left h]
+    exact le_add_of_nonneg_right <| by rw [← map_zero f]; exact hf bot_le
+
+/-- Compose a `ℤᵐ⁰`-valued valuation with an order-embedding zero-preserving monoid homomorphism
+to obtain an absolute value. -/
+noncomputable def toAbsoluteValue (v : _root_.Valuation K ℤᵐ⁰) (f : ℤᵐ⁰ →*₀ S)
+    (hf : ∀ ⦃a b⦄, a ≤ b → f a ≤ f b) (hf_injective : Function.Injective f) :
+    AbsoluteValue K S :=
+  AbsoluteValue.mk (f.comp v.toMonoidWithZeroHom)
+    (fun x ↦ by rw [← map_zero f]; exact hf bot_le)
+    (fun x ↦ by
+      change f (v x) = 0 ↔ x = 0
+      rw [← map_zero f]
+      rw [hf_injective.eq_iff]
+      simp)
+    (comp_apply_add_le_add_of_monotone v f hf)
+
+include addLeftMono addRightMono in
+/-- Evaluation of the absolute value obtained by composing a valuation with a strictly monotone
+zero-preserving monoid homomorphism. -/
+@[simp]
+theorem toAbsoluteValue_apply (v : _root_.Valuation K ℤᵐ⁰) (f : ℤᵐ⁰ →*₀ S)
+    (hf : ∀ ⦃a b⦄, a ≤ b → f a ≤ f b) (hf_injective : Function.Injective f) (x : K) :
+    v.toAbsoluteValue f hf hf_injective x = f (v x) := by
+  change (f.comp v.toMonoidWithZeroHom) x = f (v x)
+  rfl
+
+include addLeftMono addRightMono in
+/-- If one input has no larger valuation than another, their sum has absolute value at most that
+of the latter. -/
+theorem toAbsoluteValue_add_le_right (v : _root_.Valuation K ℤᵐ⁰) (f : ℤᵐ⁰ →*₀ S)
+    (hf : ∀ ⦃a b⦄, a ≤ b → f a ≤ f b) (hf_injective : Function.Injective f)
+    {x y : K} (h : v x ≤ v y) :
+    v.toAbsoluteValue f hf hf_injective (x + y) ≤ v.toAbsoluteValue f hf hf_injective y := by
+  change f (v (x + y)) ≤ f (v y)
+  exact hf ((v.map_add x y).trans_eq (max_eq_right h))
+
+include addLeftMono addRightMono in
+/-- If one input has no smaller valuation than another, their sum has absolute value at most that
+of the former. -/
+theorem toAbsoluteValue_add_le_left (v : _root_.Valuation K ℤᵐ⁰) (f : ℤᵐ⁰ →*₀ S)
+    (hf : ∀ ⦃a b⦄, a ≤ b → f a ≤ f b) (hf_injective : Function.Injective f)
+    {x y : K} (h : v y ≤ v x) :
+    v.toAbsoluteValue f hf hf_injective (x + y) ≤ v.toAbsoluteValue f hf hf_injective x := by
+  change f (v (x + y)) ≤ f (v x)
+  exact hf ((v.map_add x y).trans_eq (max_eq_left h))
+
+end AbsoluteValue
 
 variable {F : Type*} [Field F]
 

--- a/TauCeti/RingTheory/Valuation/Discrete/Order.lean
+++ b/TauCeti/RingTheory/Valuation/Discrete/Order.lean
@@ -16,8 +16,8 @@ facts that do not depend on a choice of constant field.  The convention is
 `ord_v f = -log (v f)`, so a uniformizer has order one.  As `WithZero.log 0 = 0`, the order
 has the junk value `ord_v 0 = 0`; hypotheses excluding zero are included where necessary.
 
-It also constructs an absolute value by composing a `ℤᵐ⁰`-valued valuation with an ordered
-zero-preserving monoid embedding.
+It also constructs an absolute value by composing a `ℤᵐ⁰`-valued valuation with a monotone,
+zero-reflecting monoid-with-zero homomorphism.
 -/
 
 public section
@@ -43,28 +43,27 @@ private theorem comp_apply_add_le_add_of_monotone (v : _root_.Valuation K ℤᵐ
   · rw [max_eq_left h]
     exact le_add_of_nonneg_right <| by rw [← map_zero f]; exact hf bot_le
 
-/-- Compose a `ℤᵐ⁰`-valued valuation with an order-embedding zero-preserving monoid homomorphism
+/-- Compose a `ℤᵐ⁰`-valued valuation with a monotone, zero-reflecting monoid-with-zero homomorphism
 to obtain an absolute value. -/
 noncomputable def toAbsoluteValue (v : _root_.Valuation K ℤᵐ⁰) (f : ℤᵐ⁰ →*₀ S)
-    (hf : ∀ ⦃a b⦄, a ≤ b → f a ≤ f b) (hf_injective : Function.Injective f) :
+    (hf : ∀ ⦃a b⦄, a ≤ b → f a ≤ f b) (hf_zero : ∀ a, f a = 0 ↔ a = 0) :
     AbsoluteValue K S :=
   AbsoluteValue.mk (f.comp v.toMonoidWithZeroHom)
     (fun x ↦ by rw [← map_zero f]; exact hf bot_le)
     (fun x ↦ by
       -- `AbsoluteValue.mk` has no evaluation lemma available while constructing the value.
       change f (v x) = 0 ↔ x = 0
-      rw [← map_zero f]
-      rw [hf_injective.eq_iff]
+      rw [hf_zero]
       simp)
     (comp_apply_add_le_add_of_monotone v f hf)
 
 include addLeftMono addRightMono in
-/-- Evaluation of the absolute value obtained by composing a valuation with a strictly monotone
-zero-preserving monoid homomorphism. -/
+/-- Evaluation of the absolute value obtained by composing a valuation with a monotone,
+zero-reflecting monoid-with-zero homomorphism. -/
 @[simp]
 theorem toAbsoluteValue_apply (v : _root_.Valuation K ℤᵐ⁰) (f : ℤᵐ⁰ →*₀ S)
-    (hf : ∀ ⦃a b⦄, a ≤ b → f a ≤ f b) (hf_injective : Function.Injective f) (x : K) :
-    v.toAbsoluteValue f hf hf_injective x = f (v x) := by
+    (hf : ∀ ⦃a b⦄, a ≤ b → f a ≤ f b) (hf_zero : ∀ a, f a = 0 ↔ a = 0) (x : K) :
+    v.toAbsoluteValue f hf hf_zero x = f (v x) := by
   -- Unfold the constructor once to establish the public evaluation lemma used below.
   change (f.comp v.toMonoidWithZeroHom) x = f (v x)
   rfl
@@ -73,9 +72,9 @@ include addLeftMono addRightMono in
 /-- If one input has no larger valuation than another, their sum has absolute value at most that
 of the latter. -/
 theorem toAbsoluteValue_add_le_right (v : _root_.Valuation K ℤᵐ⁰) (f : ℤᵐ⁰ →*₀ S)
-    (hf : ∀ ⦃a b⦄, a ≤ b → f a ≤ f b) (hf_injective : Function.Injective f)
+    (hf : ∀ ⦃a b⦄, a ≤ b → f a ≤ f b) (hf_zero : ∀ a, f a = 0 ↔ a = 0)
     {x y : K} (h : v x ≤ v y) :
-    v.toAbsoluteValue f hf hf_injective (x + y) ≤ v.toAbsoluteValue f hf hf_injective y := by
+    v.toAbsoluteValue f hf hf_zero (x + y) ≤ v.toAbsoluteValue f hf hf_zero y := by
   rw [toAbsoluteValue_apply, toAbsoluteValue_apply]
   exact hf ((v.map_add x y).trans_eq (max_eq_right h))
 

--- a/TauCeti/RingTheory/Valuation/Discrete/Order.lean
+++ b/TauCeti/RingTheory/Valuation/Discrete/Order.lean
@@ -51,6 +51,7 @@ noncomputable def toAbsoluteValue (v : _root_.Valuation K ℤᵐ⁰) (f : ℤᵐ
   AbsoluteValue.mk (f.comp v.toMonoidWithZeroHom)
     (fun x ↦ by rw [← map_zero f]; exact hf bot_le)
     (fun x ↦ by
+      -- `AbsoluteValue.mk` has no evaluation lemma available while constructing the value.
       change f (v x) = 0 ↔ x = 0
       rw [← map_zero f]
       rw [hf_injective.eq_iff]
@@ -64,6 +65,7 @@ zero-preserving monoid homomorphism. -/
 theorem toAbsoluteValue_apply (v : _root_.Valuation K ℤᵐ⁰) (f : ℤᵐ⁰ →*₀ S)
     (hf : ∀ ⦃a b⦄, a ≤ b → f a ≤ f b) (hf_injective : Function.Injective f) (x : K) :
     v.toAbsoluteValue f hf hf_injective x = f (v x) := by
+  -- Unfold the constructor once to establish the public evaluation lemma used below.
   change (f.comp v.toMonoidWithZeroHom) x = f (v x)
   rfl
 
@@ -74,18 +76,8 @@ theorem toAbsoluteValue_add_le_right (v : _root_.Valuation K ℤᵐ⁰) (f : ℤ
     (hf : ∀ ⦃a b⦄, a ≤ b → f a ≤ f b) (hf_injective : Function.Injective f)
     {x y : K} (h : v x ≤ v y) :
     v.toAbsoluteValue f hf hf_injective (x + y) ≤ v.toAbsoluteValue f hf hf_injective y := by
-  change f (v (x + y)) ≤ f (v y)
+  rw [toAbsoluteValue_apply, toAbsoluteValue_apply]
   exact hf ((v.map_add x y).trans_eq (max_eq_right h))
-
-include addLeftMono addRightMono in
-/-- If one input has no smaller valuation than another, their sum has absolute value at most that
-of the former. -/
-theorem toAbsoluteValue_add_le_left (v : _root_.Valuation K ℤᵐ⁰) (f : ℤᵐ⁰ →*₀ S)
-    (hf : ∀ ⦃a b⦄, a ≤ b → f a ≤ f b) (hf_injective : Function.Injective f)
-    {x y : K} (h : v y ≤ v x) :
-    v.toAbsoluteValue f hf hf_injective (x + y) ≤ v.toAbsoluteValue f hf hf_injective x := by
-  change f (v (x + y)) ≤ f (v x)
-  exact hf ((v.map_add x y).trans_eq (max_eq_left h))
 
 end AbsoluteValue
 

--- a/TauCeti/RingTheory/Valuation/Discrete/Order.lean
+++ b/TauCeti/RingTheory/Valuation/Discrete/Order.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Algebra.Order.AbsoluteValue.Basic
 public import Mathlib.RingTheory.Valuation.Discrete.Basic
 
 /-!
@@ -16,8 +15,6 @@ facts that do not depend on a choice of constant field.  The convention is
 `ord_v f = -log (v f)`, so a uniformizer has order one.  As `WithZero.log 0 = 0`, the order
 has the junk value `ord_v 0 = 0`; hypotheses excluding zero are included where necessary.
 
-It also constructs an absolute value by composing a `ℤᵐ⁰`-valued valuation with a monotone,
-zero-reflecting monoid-with-zero homomorphism.
 -/
 
 public section
@@ -27,58 +24,6 @@ open scoped WithZero
 open MonoidWithZeroHom
 
 namespace Valuation
-
-section AbsoluteValue
-
-variable {K S : Type*} [DivisionRing K] [Semiring S] [PartialOrder S]
-  [addLeftMono : AddLeftMono S] [addRightMono : AddRightMono S]
-
-private theorem comp_apply_add_le_add_of_monotone (v : _root_.Valuation K ℤᵐ⁰)
-    (f : ℤᵐ⁰ →*₀ S) (hf : ∀ ⦃a b⦄, a ≤ b → f a ≤ f b) (x y : K) :
-    f (v (x + y)) ≤ f (v x) + f (v y) := by
-  refine (hf (v.map_add x y)).trans ?_
-  rcases le_total (v x) (v y) with h | h
-  · rw [max_eq_right h]
-    exact le_add_of_nonneg_left <| by rw [← map_zero f]; exact hf bot_le
-  · rw [max_eq_left h]
-    exact le_add_of_nonneg_right <| by rw [← map_zero f]; exact hf bot_le
-
-/-- Compose a `ℤᵐ⁰`-valued valuation with a monotone, zero-reflecting monoid-with-zero homomorphism
-to obtain an absolute value. -/
-noncomputable def toAbsoluteValue (v : _root_.Valuation K ℤᵐ⁰) (f : ℤᵐ⁰ →*₀ S)
-    (hf : ∀ ⦃a b⦄, a ≤ b → f a ≤ f b) (hf_zero : ∀ a, f a = 0 ↔ a = 0) :
-    AbsoluteValue K S :=
-  AbsoluteValue.mk (f.comp v.toMonoidWithZeroHom)
-    (fun x ↦ by rw [← map_zero f]; exact hf bot_le)
-    (fun x ↦ by
-      -- `AbsoluteValue.mk` has no evaluation lemma available while constructing the value.
-      change f (v x) = 0 ↔ x = 0
-      rw [hf_zero]
-      simp)
-    (comp_apply_add_le_add_of_monotone v f hf)
-
-include addLeftMono addRightMono in
-/-- Evaluation of the absolute value obtained by composing a valuation with a monotone,
-zero-reflecting monoid-with-zero homomorphism. -/
-@[simp]
-theorem toAbsoluteValue_apply (v : _root_.Valuation K ℤᵐ⁰) (f : ℤᵐ⁰ →*₀ S)
-    (hf : ∀ ⦃a b⦄, a ≤ b → f a ≤ f b) (hf_zero : ∀ a, f a = 0 ↔ a = 0) (x : K) :
-    v.toAbsoluteValue f hf hf_zero x = f (v x) := by
-  -- Unfold the constructor once to establish the public evaluation lemma used below.
-  change (f.comp v.toMonoidWithZeroHom) x = f (v x)
-  rfl
-
-include addLeftMono addRightMono in
-/-- If one input has no larger valuation than another, their sum has absolute value at most that
-of the latter. -/
-theorem toAbsoluteValue_add_le_right (v : _root_.Valuation K ℤᵐ⁰) (f : ℤᵐ⁰ →*₀ S)
-    (hf : ∀ ⦃a b⦄, a ≤ b → f a ≤ f b) (hf_zero : ∀ a, f a = 0 ↔ a = 0)
-    {x y : K} (h : v x ≤ v y) :
-    v.toAbsoluteValue f hf hf_zero (x + y) ≤ v.toAbsoluteValue f hf hf_zero y := by
-  rw [toAbsoluteValue_apply, toAbsoluteValue_apply]
-  exact hf ((v.map_add x y).trans_eq (max_eq_right h))
-
-end AbsoluteValue
 
 variable {F : Type*} [Field F]
 


### PR DESCRIPTION
This PR defines the rational-valued normalized absolute value of a nonarchimedean local field and completes the second constructor in the `LocalFieldsRamification/README.md` Layer 0 milestone **The normalized valuation**: `‖x‖_K = q ^ (-v_K(x))` with `q = Nat.card 𝓀[K]` and codomain `ℚ≥0`.

It adds `WithZeroMulInt.toNNRat`, the ordered monoid-with-zero realization of `ℤᵐ⁰` needed to transport the existing normalized valuation, together with its power formula, nonvanishing, strict monotonicity, and comparisons with one. It then bundles `normalizedAbsoluteValue K : AbsoluteValue K ℚ≥0`, proves the exact formula on nonzero elements and units, proves ultrametricity, characterizes the ring of integers by `|x| ≤ 1`, characterizes absolute value one by valuation one, and gives the root-of-unity value.

This is the most direct remaining critical-path step because the first constructor `v_K^×` and its uniformizer, surjectivity, unit, and divisibility API are already present, while the roadmap explicitly requires the absolute-value constructor before its norm comparison and point-set applications. After this PR, the milestone still needs agreement with the `Padic` norm on `ℚ_[p]`, the stated point-set consequences, finite-extension naturality, and the worked `ℚ_2` values.

No Mathlib source is vendored. The generic rational realization follows Mathlib's `WithZeroMulInt.toNNReal` in `Mathlib/Data/Int/WithZero.lean` and reuses `WithZero.lift'` and `zpowersHom`.

Roadmap: LocalFieldsRamification

<!--tauceti-target:v1 {"focus":"LocalFieldsRamification","id":"normalized-absolute-value"}-->

🤖 Prepared with Codex
