### PR TITLE
feat: compose layer restrictions and restrict layer cohomology

### DIFF
--- a/TauCeti/NumberTheory/ClassFieldTheory/Formation/Restriction.lean
+++ b/TauCeti/NumberTheory/ClassFieldTheory/Formation/Restriction.lean
@@ -6,7 +6,6 @@ Authors: Claude
 module
 
 public import Mathlib.RepresentationTheory.Rep.Res
-public import Mathlib.RepresentationTheory.Homological.GroupCohomology.Functoriality
 public import TauCeti.NumberTheory.ClassFieldTheory.Formation.Basic
 
 /-!
@@ -269,9 +268,9 @@ theorem repIso_inv_apply_coe (T : LayerRestriction small big) (F : Formation G)
 theorem refl (L : NormalLayer G) : LayerRestriction L L :=
   ⟨rfl, le_rfl⟩
 
-/-- The relative degree of the trivial restriction is `1`. `simp` proves this on its own, from
-the `@[simp]` lemmas `relativeDegree_def` and `Subgroup.relIndex_self`, so the statement carries
-no `@[simp]` attribute of its own: tagging it is a `simpNF` error. -/
+-- No `@[simp]` here: `simp` already proves this from the `@[simp]` lemmas `relativeDegree_def`
+-- and `Subgroup.relIndex_self`, so tagging the statement is a `simpNF` error.
+/-- The relative degree of the trivial restriction is `1`. -/
 theorem relativeDegree_self {L : NormalLayer G} (T : LayerRestriction L L) :
     T.relativeDegree = 1 := by
   rw [relativeDegree_def, Subgroup.relIndex_self]
@@ -306,7 +305,7 @@ theorem galHom_trans (T : LayerRestriction a b) (T' : LayerRestriction b c) :
 /-- **The identifications of coefficient modules compose along a tower of restrictions.** All
 three are the identity on the ambient module, so this is an equation between three inclusions of
 one and the same level. -/
-theorem repIso_inv_hom_trans (T : LayerRestriction a b) (T' : LayerRestriction b c)
+theorem repIso_inv_hom_trans_apply (T : LayerRestriction a b) (T' : LayerRestriction b c)
     (F : Formation G) (x : F.level c.top) :
     ((T.trans T').repIso F).inv.hom x = (T.repIso F).inv.hom ((T'.repIso F).inv.hom x) :=
   Subtype.ext <| ((T.trans T').repIso_inv_apply_coe F x).trans
@@ -343,7 +342,7 @@ theorem cohomologyRes_trans (T : LayerRestriction a b) (T' : LayerRestriction b 
   rw [cohomologyRes, cohomologyRes, cohomologyRes,
     ← groupCohomology.map_comp T'.galHom T.galHom (T'.repIso F).inv (T.repIso F).inv n]
   exact groupCohomology.map_congr (galHom_trans T T')
-    (by ext x; exact congrArg Subtype.val (T.repIso_inv_hom_trans T' F x)) n
+    (by ext x; exact congrArg Subtype.val (T.repIso_inv_hom_trans_apply T' F x)) n
 
 /-- The **ground-level inclusion** of a restriction: raising the ground field from `F` to `E`
 enlarges the ground level, `A^U ⊆ A^{U'}`. It is the degree-zero shadow of `cohomologyRes`. -/
@@ -396,6 +395,20 @@ theorem mem_subgroupGround {g : G} :
     exact ⟨hu, hmem⟩
   · rintro ⟨hg, hmem⟩
     exact ⟨⟨g, hg⟩, hmem, rfl⟩
+
+/-- The intermediate subgroup of `H`, written without the correspondence theorem: it is the
+preimage of `H` under the quotient map `U → U ⧸ V`, pushed into `G`. This is the form in which
+relative indices transport along `subgroupGround`. -/
+theorem subgroupGround_eq_map_comap :
+    L.subgroupGround H =
+      (Subgroup.comap (QuotientGroup.mk' L.relativeTop) H).map L.ground.toSubgroup.subtype := by
+  ext g
+  rw [mem_subgroupGround, Subgroup.mem_map]
+  constructor
+  · rintro ⟨hg, hmem⟩
+    exact ⟨⟨g, hg⟩, Subgroup.mem_comap.2 hmem, rfl⟩
+  · rintro ⟨⟨u, hu⟩, hmem, rfl⟩
+    exact ⟨hu, Subgroup.mem_comap.1 hmem⟩
 
 /-- The intermediate subgroup lies in the ground subgroup. -/
 theorem subgroupGround_le_ground : L.subgroupGround H ≤ L.ground.toSubgroup :=
@@ -532,10 +545,8 @@ theorem subgroupGalEquiv_galHom_subgroupLayerRestriction (h : K ≤ H)
 the two subgroups.** -/
 theorem relativeDegree_subgroupLayerRestriction (h : K ≤ H) :
     (L.subgroupLayerRestriction h).relativeDegree = K.relIndex H := by
-  have hcoe (X : Subgroup L.Gal) : ((QuotientGroup.comapMk'OrderIso L.relativeTop X).1 :
-      Subgroup L.ground) = Subgroup.comap (QuotientGroup.mk' L.relativeTop) X := rfl
   rw [LayerRestriction.relativeDegree_def, ground_subgroupLayer, ground_subgroupLayer,
-    subgroupGround, subgroupGround, hcoe, hcoe,
+    subgroupGround_eq_map_comap, subgroupGround_eq_map_comap,
     Subgroup.relIndex_map_map_of_injective _ _ (Subgroup.subtype_injective _),
     Subgroup.relIndex_comap,
     Subgroup.map_comap_eq_self_of_surjective (QuotientGroup.mk'_surjective L.relativeTop)]

--- a/TauCeti/NumberTheory/ClassFieldTheory/Formation/Restriction.lean
+++ b/TauCeti/NumberTheory/ClassFieldTheory/Formation/Restriction.lean
@@ -40,7 +40,7 @@ layer be restricted to a subgroup of its Galois group at all, and it is what
 `H^n(U/V, A^V) ⟶ H^n(U'/V, A^V)`.
 
 In degree zero this map is the inclusion `A^U ⊆ A^{U'}` of ground levels
-(`LayerRestriction.groundLevelEquiv_cohomologyRes_zero`), which is what fixes its direction.
+(`LayerRestriction.groundLevelEquiv_cohomologyRes_zero_apply`), which is what fixes its direction.
 
 Restrictions compose (`LayerRestriction.trans`), and along a tower `F ⊆ E ⊆ E' ⊆ K` the relative
 degree is multiplicative, the homomorphisms of Galois groups compose, and restriction of
@@ -89,8 +89,8 @@ how Tate's theorem is used downstream.
   and the homomorphisms of Galois groups compose along a tower of restrictions.
 * `TauCeti.ClassFieldTheory.LayerRestriction.cohomologyRes_trans`: restriction of cohomology is
   functorial along a tower of restrictions.
-* `TauCeti.ClassFieldTheory.LayerRestriction.groundLevelEquiv_cohomologyRes_zero`: in degree zero,
-  restriction of cohomology is the ground-level inclusion.
+* `TauCeti.ClassFieldTheory.LayerRestriction.groundLevelEquiv_cohomologyRes_zero_apply`: in degree
+  zero, restriction of cohomology is the ground-level inclusion.
 * `TauCeti.ClassFieldTheory.NormalLayer.relativeDegree_subgroupLayerRestriction`: the relative
   degree of a tower `K ≤ H` inside the finite quotient system is the relative index of `K` in `H`.
 * `TauCeti.ClassFieldTheory.NormalLayer.subgroupLayer_subgroupLayer`: the layer of a subgroup of
@@ -274,7 +274,9 @@ theorem galHom_self {L : NormalLayer G} (T : LayerRestriction L L) :
     T.galHom = MonoidHom.id L.Gal :=
   MonoidHom.ext fun γ ↦ by
     induction γ using QuotientGroup.induction_on with
-    | H w => rw [galHom_mk, MonoidHom.id_apply]; rfl
+    | H w =>
+      rw [galHom_mk, MonoidHom.id_apply]
+      exact congrArg QuotientGroup.mk (Subtype.ext (Subgroup.coe_inclusion _ w))
 
 variable {a b c : NormalLayer G}
 
@@ -293,7 +295,9 @@ theorem galHom_trans (T : LayerRestriction a b) (T' : LayerRestriction b c) :
     (T.trans T').galHom = T'.galHom.comp T.galHom :=
   MonoidHom.ext fun γ ↦ by
     induction γ using QuotientGroup.induction_on with
-    | H w => rw [galHom_mk, MonoidHom.comp_apply, galHom_mk, galHom_mk]; rfl
+    | H w =>
+      rw [galHom_mk, MonoidHom.comp_apply, galHom_mk, galHom_mk]
+      exact congrArg QuotientGroup.mk (Subtype.ext (by simp only [Subgroup.coe_inclusion]))
 
 /-- **The identifications of coefficient modules compose along a tower of restrictions.** All
 three are the identity on the ambient module, so this is an equation between three inclusions of
@@ -353,8 +357,8 @@ theorem groundInclusion_apply_coe (T : LayerRestriction small big) (F : Formatio
 identification of `H⁰(U/V, A^V)` with the ground level `A^U`, restricting a class from the layer
 `K/F` to the layer `K/E` is the inclusion `A^U ⊆ A^{U'}`. This is what fixes the direction of
 `cohomologyRes`. -/
-theorem groundLevelEquiv_cohomologyRes_zero (T : LayerRestriction small big) (F : Formation G)
-    (x : big.H F 0) :
+theorem groundLevelEquiv_cohomologyRes_zero_apply (T : LayerRestriction small big)
+    (F : Formation G) (x : big.H F 0) :
     small.groundLevelEquiv F
         ((groupCohomology.H0Iso (small.rep F)).hom.hom (T.cohomologyRes F 0 x)) =
       T.groundInclusion F (big.groundLevelEquiv F
@@ -525,7 +529,7 @@ theorem subgroupLayerRestriction (h : K ≤ H) :
 
 /-- **The homomorphism of Galois groups of a tower inside the finite quotient system is the
 inclusion of subgroups**, read through `subgroupGalEquiv`. -/
-theorem subgroupGalEquiv_galHom_subgroupLayerRestriction (h : K ≤ H)
+theorem subgroupGalEquiv_galHom_subgroupLayerRestriction_apply (h : K ≤ H)
     (γ : (L.subgroupLayer K).Gal) :
     L.subgroupGalEquiv H ((L.subgroupLayerRestriction h).galHom γ) =
       Subgroup.inclusion h (L.subgroupGalEquiv K γ) := by
@@ -559,7 +563,7 @@ theorem subgroupLayer_subgroupLayer (H' : Subgroup (L.subgroupLayer H).Gal) :
   · rintro ⟨hg, hmem⟩
     refine ⟨L.subgroupGround_le_ground H hg, QuotientGroup.mk ⟨g, hg⟩, hmem, ?_⟩
     rw [LayerRestriction.galHom_mk]
-    rfl
+    exact congrArg QuotientGroup.mk (Subtype.ext (Subgroup.coe_inclusion _ _))
   · rintro ⟨hg, δ, hδ, hδg⟩
     induction δ using QuotientGroup.induction_on with
     | H w =>
@@ -594,7 +598,8 @@ theorem subgroupLayer_range_galHom {small : NormalLayer G} (T : LayerRestriction
       rwa [mul_inv_cancel_left] at hmul
   · intro hg
     exact ⟨T.ground_toSubgroup_le hg, QuotientGroup.mk ⟨g, hg⟩, by
-      rw [LayerRestriction.galHom_mk]; rfl⟩
+      rw [LayerRestriction.galHom_mk]
+      exact congrArg QuotientGroup.mk (Subtype.ext (Subgroup.coe_inclusion _ _))⟩
 
 end NormalLayer
 

--- a/TauCeti/NumberTheory/ClassFieldTheory/Formation/Restriction.lean
+++ b/TauCeti/NumberTheory/ClassFieldTheory/Formation/Restriction.lean
@@ -109,10 +109,6 @@ the relative degree cannot be read off the datum itself: `relativeDegree` is a f
 layers, and takes the restriction proof to make that dependency explicit and support the notation
 `T.relativeDegree`.
 
-Corestriction is deliberately absent. Mathlib's change-of-group maps supply the map induced by a
-homomorphism of groups, which is restriction on cohomology; the transfer in the other direction is
-not yet available in any degree, and belongs to the generic cohomology supplier rather than here.
-
 `NormalLayer.subgroupGround` is the correspondence-theorem preimage of `H` — the subgroup
 `QuotientGroup.comapMk'OrderIso` attaches to `H` — pushed from `U` into the ambient group `G`, so
 that it can be an `OpenSubgroup G` and be compared with the other subgroups of a formation.
@@ -273,7 +269,9 @@ theorem repIso_inv_apply_coe (T : LayerRestriction small big) (F : Formation G)
 theorem refl (L : NormalLayer G) : LayerRestriction L L :=
   ⟨rfl, le_rfl⟩
 
-/-- The relative degree of the trivial restriction is `1`. -/
+/-- The relative degree of the trivial restriction is `1`. `simp` proves this on its own, from
+the `@[simp]` lemmas `relativeDegree_def` and `Subgroup.relIndex_self`, so the statement carries
+no `@[simp]` attribute of its own: tagging it is a `simpNF` error. -/
 theorem relativeDegree_self {L : NormalLayer G} (T : LayerRestriction L L) :
     T.relativeDegree = 1 := by
   rw [relativeDegree_def, Subgroup.relIndex_self]
@@ -338,7 +336,7 @@ theorem cohomologyRes_self {L : NormalLayer G} (T : LayerRestriction L L) (F : F
   rw [cohomologyRes, groupCohomology.map_congr T.galHom_self h n, groupCohomology.map_id]
 
 /-- **Restriction of cohomology is functorial along a tower of restrictions.** Restricting from
-`K/F` to `K/E'` and then to `K/E` is restricting from `K/F` to `K/E`. -/
+`K/F` to `K/E` and then to `K/E'` is restricting from `K/F` to `K/E'`. -/
 theorem cohomologyRes_trans (T : LayerRestriction a b) (T' : LayerRestriction b c)
     (F : Formation G) (n : ℕ) :
     (T.trans T').cohomologyRes F n = T'.cohomologyRes F n ≫ T.cohomologyRes F n := by
@@ -507,10 +505,8 @@ theorem subgroupLayer_top : L.subgroupLayer ⊤ = L :=
 /-! ### Towers inside the finite quotient system -/
 
 /-- The intermediate subgroup attached to a subgroup of the Galois group grows with it. -/
-theorem subgroupGround_mono : Monotone L.subgroupGround := by
-  intro K K' hK g hg
-  obtain ⟨hgU, hmem⟩ := (L.mem_subgroupGround K).1 hg
-  exact (L.mem_subgroupGround K').2 ⟨hgU, hK hmem⟩
+theorem subgroupGround_mono : Monotone L.subgroupGround := fun _ _ hK ↦
+  Subgroup.map_mono ((QuotientGroup.comapMk'OrderIso L.relativeTop).monotone hK)
 
 variable {H} {K : Subgroup L.Gal}
 
@@ -521,13 +517,6 @@ theorem subgroupLayerRestriction (h : K ≤ H) :
     LayerRestriction (L.subgroupLayer K) (L.subgroupLayer H) :=
   ⟨rfl, OpenSubgroup.toSubgroup_le.1 (L.subgroupGround_mono h)⟩
 
-/-- **The restriction to a subgroup factors through the restriction to any bigger subgroup**, at
-the level of Galois groups. -/
-theorem galHom_subgroupRestriction_comp (h : K ≤ H) :
-    (L.subgroupRestriction H).galHom.comp (L.subgroupLayerRestriction h).galHom =
-      (L.subgroupRestriction K).galHom :=
-  (LayerRestriction.galHom_trans _ _).symm
-
 /-- **The homomorphism of Galois groups of a tower inside the finite quotient system is the
 inclusion of subgroups**, read through `subgroupGalEquiv`. -/
 theorem subgroupGalEquiv_galHom_subgroupLayerRestriction (h : K ≤ H)
@@ -536,28 +525,20 @@ theorem subgroupGalEquiv_galHom_subgroupLayerRestriction (h : K ≤ H)
       Subgroup.inclusion h (L.subgroupGalEquiv K γ) := by
   refine Subtype.ext ?_
   rw [subgroupGalEquiv_apply_coe, Subgroup.coe_inclusion, subgroupGalEquiv_apply_coe,
-    ← galHom_subgroupRestriction_comp L h, MonoidHom.comp_apply]
+    ← MonoidHom.comp_apply, ← LayerRestriction.galHom_trans (L.subgroupLayerRestriction h)
+      (L.subgroupRestriction H)]
 
 /-- **The relative degree of a tower inside the finite quotient system is the relative index of
 the two subgroups.** -/
 theorem relativeDegree_subgroupLayerRestriction (h : K ≤ H) :
     (L.subgroupLayerRestriction h).relativeDegree = K.relIndex H := by
-  have hd := (L.subgroupLayerRestriction h).degree_mul_relativeDegree
-  rw [degree_subgroupLayer, degree_subgroupLayer] at hd
-  have hcard : Nat.card (K.subgroupOf H) = Nat.card K :=
-    Nat.card_congr (Subgroup.subgroupOfEquivOfLe h).toEquiv
-  have hK : Nat.card K * K.relIndex H = Nat.card H := by
-    rw [← hcard]
-    exact Subgroup.card_mul_index (K.subgroupOf H)
-  exact Nat.eq_of_mul_eq_mul_left Nat.card_pos (hd.trans hK.symm)
-
-/-- **Restriction of cohomology is functorial along a tower inside the finite quotient system.**
-Restricting to `H` and then to `K` is restricting to `K`. -/
-theorem cohomologyRes_subgroupRestriction (h : K ≤ H) (F : Formation G) (n : ℕ) :
-    (L.subgroupRestriction K).cohomologyRes F n =
-      (L.subgroupRestriction H).cohomologyRes F n ≫
-        (L.subgroupLayerRestriction h).cohomologyRes F n :=
-  LayerRestriction.cohomologyRes_trans _ _ F n
+  have hcoe (X : Subgroup L.Gal) : ((QuotientGroup.comapMk'OrderIso L.relativeTop X).1 :
+      Subgroup L.ground) = Subgroup.comap (QuotientGroup.mk' L.relativeTop) X := rfl
+  rw [LayerRestriction.relativeDegree_def, ground_subgroupLayer, ground_subgroupLayer,
+    subgroupGround, subgroupGround, hcoe, hcoe,
+    Subgroup.relIndex_map_map_of_injective _ _ (Subgroup.subtype_injective _),
+    Subgroup.relIndex_comap,
+    Subgroup.map_comap_eq_self_of_surjective (QuotientGroup.mk'_surjective L.relativeTop)]
 
 /-- **The finite quotient system is closed under passing to a sublayer.** The layer of a subgroup
 `H'` of the Galois group of the layer of `H` is the layer of the image of `H'` in `U/V`. This is

--- a/TauCeti/NumberTheory/ClassFieldTheory/Formation/Restriction.lean
+++ b/TauCeti/NumberTheory/ClassFieldTheory/Formation/Restriction.lean
@@ -268,13 +268,6 @@ theorem repIso_inv_apply_coe (T : LayerRestriction small big) (F : Formation G)
 theorem refl (L : NormalLayer G) : LayerRestriction L L :=
   ⟨rfl, le_rfl⟩
 
--- No `@[simp]` here: `simp` already proves this from the `@[simp]` lemmas `relativeDegree_def`
--- and `Subgroup.relIndex_self`, so tagging the statement is a `simpNF` error.
-/-- The relative degree of the trivial restriction is `1`. -/
-theorem relativeDegree_self {L : NormalLayer G} (T : LayerRestriction L L) :
-    T.relativeDegree = 1 := by
-  rw [relativeDegree_def, Subgroup.relIndex_self]
-
 /-- The homomorphism of Galois groups attached to the trivial restriction is the identity. -/
 @[simp]
 theorem galHom_self {L : NormalLayer G} (T : LayerRestriction L L) :

--- a/TauCeti/NumberTheory/ClassFieldTheory/Formation/Restriction.lean
+++ b/TauCeti/NumberTheory/ClassFieldTheory/Formation/Restriction.lean
@@ -6,6 +6,7 @@ Authors: Claude
 module
 
 public import Mathlib.RepresentationTheory.Rep.Res
+public import Mathlib.RepresentationTheory.Homological.GroupCohomology.Functoriality
 public import TauCeti.NumberTheory.ClassFieldTheory.Formation.Basic
 
 /-!
@@ -34,7 +35,21 @@ so injectively; the degrees multiply along the restriction
 subgroup, hence the same coefficient module `A^V` — the coefficient module of the smaller layer
 *is* the coefficient module of the bigger one, restricted along `galHom`
 (`LayerRestriction.repIso`). It is that last identification which lets a cohomology class of the
-layer be restricted to a subgroup of its Galois group at all.
+layer be restricted to a subgroup of its Galois group at all, and it is what
+`LayerRestriction.cohomologyRes` feeds to Mathlib's change-of-group map to obtain
+
+`H^n(U/V, A^V) ⟶ H^n(U'/V, A^V)`.
+
+In degree zero this map is the inclusion `A^U ⊆ A^{U'}` of ground levels
+(`LayerRestriction.groundLevelEquiv_cohomologyRes_zero`), which is what fixes its direction.
+
+Restrictions compose (`LayerRestriction.trans`), and along a tower `F ⊆ E ⊆ E' ⊆ K` the relative
+degree is multiplicative, the homomorphisms of Galois groups compose, and restriction of
+cohomology is functorial. Inside the finite quotient system the same tower structure is indexed by
+an inclusion `K ≤ H` of subgroups of `Γ`, and a subgroup of the Galois group of the layer of `H`
+gives back a layer of the system (`NormalLayer.subgroupLayer_subgroupLayer`), so a statement
+quantified over all subgroups of `Γ` can be applied inside the layer of any one of them — which is
+how Tate's theorem is used downstream.
 
 ## Main definitions
 
@@ -44,6 +59,11 @@ layer be restricted to a subgroup of its Galois group at all.
 * `TauCeti.ClassFieldTheory.LayerRestriction.galHom`: the induced homomorphism `U'/V → U/V`.
 * `TauCeti.ClassFieldTheory.LayerRestriction.repIso`: the coefficient module of the smaller layer
   is the coefficient module of the bigger layer, restricted along `galHom`.
+* `TauCeti.ClassFieldTheory.LayerRestriction.trans`: the composite of two restrictions.
+* `TauCeti.ClassFieldTheory.LayerRestriction.cohomologyRes`: restriction of the cohomology of a
+  layer along a restriction of layers.
+* `TauCeti.ClassFieldTheory.LayerRestriction.groundInclusion`: the inclusion `A^U ⊆ A^{U'}` of
+  ground levels, the degree-zero shadow of `cohomologyRes`.
 * `TauCeti.ClassFieldTheory.NormalLayer.subgroupGround`: the intermediate open subgroup attached
   to a subgroup of the Galois group.
 * `TauCeti.ClassFieldTheory.NormalLayer.subgroupLayer`: the layer of a subgroup of the Galois
@@ -65,6 +85,19 @@ layer be restricted to a subgroup of its Galois group at all.
   groups it induces is the inclusion of `H`.
 * `TauCeti.ClassFieldTheory.NormalLayer.subgroupLayer_top`: the layer of the whole Galois group is
   the layer itself.
+* `TauCeti.ClassFieldTheory.LayerRestriction.relativeDegree_trans` and
+  `TauCeti.ClassFieldTheory.LayerRestriction.galHom_trans`: the relative degree is multiplicative
+  and the homomorphisms of Galois groups compose along a tower of restrictions.
+* `TauCeti.ClassFieldTheory.LayerRestriction.cohomologyRes_trans`: restriction of cohomology is
+  functorial along a tower of restrictions.
+* `TauCeti.ClassFieldTheory.LayerRestriction.groundLevelEquiv_cohomologyRes_zero`: in degree zero,
+  restriction of cohomology is the ground-level inclusion.
+* `TauCeti.ClassFieldTheory.NormalLayer.relativeDegree_subgroupLayerRestriction`: the relative
+  degree of a tower `K ≤ H` inside the finite quotient system is the relative index of `K` in `H`.
+* `TauCeti.ClassFieldTheory.NormalLayer.subgroupLayer_subgroupLayer`: the layer of a subgroup of
+  the Galois group of the layer of `H` is again a layer of the system.
+* `TauCeti.ClassFieldTheory.NormalLayer.subgroupLayer_range_galHom`: conversely, every restriction
+  of `L` is the layer of a subgroup of its Galois group.
 
 ## Implementation notes
 
@@ -75,6 +108,10 @@ of restrictions compose without transporting a layer along an equality. Because 
 the relative degree cannot be read off the datum itself: `relativeDegree` is a function of the two
 layers, and takes the restriction proof to make that dependency explicit and support the notation
 `T.relativeDegree`.
+
+Corestriction is deliberately absent. Mathlib's change-of-group maps supply the map induced by a
+homomorphism of groups, which is restriction on cohomology; the transfer in the other direction is
+not yet available in any degree, and belongs to the generic cohomology supplier rather than here.
 
 `NormalLayer.subgroupGround` is the correspondence-theorem preimage of `H` — the subgroup
 `QuotientGroup.comapMk'OrderIso` attaches to `H` — pushed from `U` into the ambient group `G`, so
@@ -94,6 +131,8 @@ that it can be an `OpenSubgroup G` and be compared with the other subgroups of a
 -- of intermediate layers formalised here.
 
 public noncomputable section
+
+open CategoryTheory
 
 namespace TauCeti.ClassFieldTheory
 
@@ -228,6 +267,114 @@ theorem repIso_inv_apply_coe (T : LayerRestriction small big) (F : Formation G)
     (((T.repIso F).inv.hom x : F.level small.top) : F.toRep.V) = (x : F.toRep.V) :=
   LinearEquiv.coe_ofEq_apply (congrArg F.level T.same_top).symm x
 
+/-! ### Towers of restrictions -/
+
+/-- **Every layer is a restriction of itself.** -/
+theorem refl (L : NormalLayer G) : LayerRestriction L L :=
+  ⟨rfl, le_rfl⟩
+
+/-- The relative degree of the trivial restriction is `1`. -/
+theorem relativeDegree_self {L : NormalLayer G} (T : LayerRestriction L L) :
+    T.relativeDegree = 1 := by
+  rw [relativeDegree_def, Subgroup.relIndex_self]
+
+/-- The homomorphism of Galois groups attached to the trivial restriction is the identity. -/
+@[simp]
+theorem galHom_self {L : NormalLayer G} (T : LayerRestriction L L) :
+    T.galHom = MonoidHom.id L.Gal :=
+  MonoidHom.ext fun γ ↦ by
+    induction γ using QuotientGroup.induction_on with
+    | H w => rw [galHom_mk, MonoidHom.id_apply]; rfl
+
+variable {a b c : NormalLayer G}
+
+/-- **Restrictions compose:** raising the ground field twice is one restriction. In field notation
+this is the tower `F ⊆ E ⊆ E' ⊆ K`. -/
+theorem trans (T : LayerRestriction a b) (T' : LayerRestriction b c) : LayerRestriction a c :=
+  ⟨T.same_top.trans T'.same_top, T.ground_le.trans T'.ground_le⟩
+
+/-- **The relative degree is multiplicative along a tower of restrictions.** -/
+theorem relativeDegree_trans (T : LayerRestriction a b) (T' : LayerRestriction b c) :
+    (T.trans T').relativeDegree = T.relativeDegree * T'.relativeDegree :=
+  (Subgroup.relIndex_mul_relIndex _ _ _ T.ground_toSubgroup_le T'.ground_toSubgroup_le).symm
+
+/-- **The homomorphisms of Galois groups compose along a tower of restrictions.** -/
+theorem galHom_trans (T : LayerRestriction a b) (T' : LayerRestriction b c) :
+    (T.trans T').galHom = T'.galHom.comp T.galHom :=
+  MonoidHom.ext fun γ ↦ by
+    induction γ using QuotientGroup.induction_on with
+    | H w => rw [galHom_mk, MonoidHom.comp_apply, galHom_mk, galHom_mk]; rfl
+
+/-- **The identifications of coefficient modules compose along a tower of restrictions.** All
+three are the identity on the ambient module, so this is an equation between three inclusions of
+one and the same level. -/
+theorem repIso_inv_hom_trans (T : LayerRestriction a b) (T' : LayerRestriction b c)
+    (F : Formation G) (x : F.level c.top) :
+    ((T.trans T').repIso F).inv.hom x = (T.repIso F).inv.hom ((T'.repIso F).inv.hom x) :=
+  Subtype.ext <| ((T.trans T').repIso_inv_apply_coe F x).trans
+    (((T.repIso_inv_apply_coe F _).trans (T'.repIso_inv_apply_coe F x)).symm)
+
+/-! ### Restriction of layer cohomology -/
+
+/-- **Restriction of cohomology along a restriction of layers**, the map
+
+`H^n(U/V, A^V) ⟶ H^n(U'/V, A^V)`
+
+induced by the inclusion `U'/V ↪ U/V` of Galois groups and the identification of the two
+coefficient modules. Both layers have the same top subgroup, so no coefficient actually moves:
+the map is Mathlib's change-of-group map for the inclusion. -/
+def cohomologyRes (T : LayerRestriction small big) (F : Formation G) (n : ℕ) :
+    big.H F n ⟶ small.H F n :=
+  groupCohomology.map T.galHom (T.repIso F).inv n
+
+/-- **Restricting along the trivial restriction does nothing.** -/
+@[simp]
+theorem cohomologyRes_self {L : NormalLayer G} (T : LayerRestriction L L) (F : Formation G)
+    (n : ℕ) : T.cohomologyRes F n = 𝟙 (L.H F n) := by
+  have h : ((T.repIso F).inv).hom.toLinearMap =
+      (𝟙 (L.rep F) : L.rep F ⟶ L.rep F).hom.toLinearMap := by
+    ext x
+    exact T.repIso_inv_apply_coe F x
+  rw [cohomologyRes, groupCohomology.map_congr T.galHom_self h n, groupCohomology.map_id]
+
+/-- **Restriction of cohomology is functorial along a tower of restrictions.** Restricting from
+`K/F` to `K/E'` and then to `K/E` is restricting from `K/F` to `K/E`. -/
+theorem cohomologyRes_trans (T : LayerRestriction a b) (T' : LayerRestriction b c)
+    (F : Formation G) (n : ℕ) :
+    (T.trans T').cohomologyRes F n = T'.cohomologyRes F n ≫ T.cohomologyRes F n := by
+  rw [cohomologyRes, cohomologyRes, cohomologyRes,
+    ← groupCohomology.map_comp T'.galHom T.galHom (T'.repIso F).inv (T.repIso F).inv n]
+  exact groupCohomology.map_congr (galHom_trans T T')
+    (by ext x; exact congrArg Subtype.val (T.repIso_inv_hom_trans T' F x)) n
+
+/-- The **ground-level inclusion** of a restriction: raising the ground field from `F` to `E`
+enlarges the ground level, `A^U ⊆ A^{U'}`. It is the degree-zero shadow of `cohomologyRes`. -/
+def groundInclusion (T : LayerRestriction small big) (F : Formation G) :
+    F.level big.ground →ₗ[ℤ] F.level small.ground :=
+  Submodule.inclusion (F.level_antitone T.ground_le)
+
+@[simp]
+theorem groundInclusion_apply_coe (T : LayerRestriction small big) (F : Formation G)
+    (x : F.level big.ground) : ((T.groundInclusion F x : F.level small.ground) : F.toRep.V) =
+      (x : F.toRep.V) :=
+  Submodule.coe_inclusion _ x
+
+/-- **In degree zero, restriction of cohomology is the ground-level inclusion.** Read through the
+identification of `H⁰(U/V, A^V)` with the ground level `A^U`, restricting a class from the layer
+`K/F` to the layer `K/E` is the inclusion `A^U ⊆ A^{U'}`. This is what fixes the direction of
+`cohomologyRes`. -/
+theorem groundLevelEquiv_cohomologyRes_zero (T : LayerRestriction small big) (F : Formation G)
+    (x : big.H F 0) :
+    small.groundLevelEquiv F
+        ((groupCohomology.H0Iso (small.rep F)).hom.hom (T.cohomologyRes F 0 x)) =
+      T.groundInclusion F (big.groundLevelEquiv F
+        ((groupCohomology.H0Iso (big.rep F)).hom.hom x)) := by
+  refine Subtype.ext ?_
+  rw [NormalLayer.groundLevelEquiv_apply_coe, groundInclusion_apply_coe,
+    NormalLayer.groundLevelEquiv_apply_coe]
+  have h := groupCohomology.map_H0Iso_hom_f_apply T.galHom (T.repIso F).inv x
+  exact (congrArg Subtype.val h).trans (T.repIso_inv_apply_coe F _)
+
 end LayerRestriction
 
 /-! ### The finite quotient system -/
@@ -356,6 +503,113 @@ theorem subgroupLayer_top : L.subgroupLayer ⊤ = L :=
   NormalLayer.ext
     (OpenSubgroup.toSubgroup_injective (by rw [ground_subgroupLayer, subgroupGround_top]))
     (L.top_subgroupLayer ⊤)
+
+/-! ### Towers inside the finite quotient system -/
+
+/-- The intermediate subgroup attached to a subgroup of the Galois group grows with it. -/
+theorem subgroupGround_mono : Monotone L.subgroupGround := by
+  intro K K' hK g hg
+  obtain ⟨hgU, hmem⟩ := (L.mem_subgroupGround K).1 hg
+  exact (L.mem_subgroupGround K').2 ⟨hgU, hK hmem⟩
+
+variable {H} {K : Subgroup L.Gal}
+
+/-- **The layer of a smaller subgroup is a restriction of the layer of a bigger one.** Together
+with `NormalLayer.subgroupRestriction` this makes the finite quotient system a system of towers:
+`K ≤ H ≤ U/V` is the tower of ground fields `F ⊆ E ⊆ E' ⊆ K`. -/
+theorem subgroupLayerRestriction (h : K ≤ H) :
+    LayerRestriction (L.subgroupLayer K) (L.subgroupLayer H) :=
+  ⟨rfl, OpenSubgroup.toSubgroup_le.1 (L.subgroupGround_mono h)⟩
+
+/-- **The restriction to a subgroup factors through the restriction to any bigger subgroup**, at
+the level of Galois groups. -/
+theorem galHom_subgroupRestriction_comp (h : K ≤ H) :
+    (L.subgroupRestriction H).galHom.comp (L.subgroupLayerRestriction h).galHom =
+      (L.subgroupRestriction K).galHom :=
+  (LayerRestriction.galHom_trans _ _).symm
+
+/-- **The homomorphism of Galois groups of a tower inside the finite quotient system is the
+inclusion of subgroups**, read through `subgroupGalEquiv`. -/
+theorem subgroupGalEquiv_galHom_subgroupLayerRestriction (h : K ≤ H)
+    (γ : (L.subgroupLayer K).Gal) :
+    L.subgroupGalEquiv H ((L.subgroupLayerRestriction h).galHom γ) =
+      Subgroup.inclusion h (L.subgroupGalEquiv K γ) := by
+  refine Subtype.ext ?_
+  rw [subgroupGalEquiv_apply_coe, Subgroup.coe_inclusion, subgroupGalEquiv_apply_coe,
+    ← galHom_subgroupRestriction_comp L h, MonoidHom.comp_apply]
+
+/-- **The relative degree of a tower inside the finite quotient system is the relative index of
+the two subgroups.** -/
+theorem relativeDegree_subgroupLayerRestriction (h : K ≤ H) :
+    (L.subgroupLayerRestriction h).relativeDegree = K.relIndex H := by
+  have hd := (L.subgroupLayerRestriction h).degree_mul_relativeDegree
+  rw [degree_subgroupLayer, degree_subgroupLayer] at hd
+  have hcard : Nat.card (K.subgroupOf H) = Nat.card K :=
+    Nat.card_congr (Subgroup.subgroupOfEquivOfLe h).toEquiv
+  have hK : Nat.card K * K.relIndex H = Nat.card H := by
+    rw [← hcard]
+    exact Subgroup.card_mul_index (K.subgroupOf H)
+  exact Nat.eq_of_mul_eq_mul_left Nat.card_pos (hd.trans hK.symm)
+
+/-- **Restriction of cohomology is functorial along a tower inside the finite quotient system.**
+Restricting to `H` and then to `K` is restricting to `K`. -/
+theorem cohomologyRes_subgroupRestriction (h : K ≤ H) (F : Formation G) (n : ℕ) :
+    (L.subgroupRestriction K).cohomologyRes F n =
+      (L.subgroupRestriction H).cohomologyRes F n ≫
+        (L.subgroupLayerRestriction h).cohomologyRes F n :=
+  LayerRestriction.cohomologyRes_trans _ _ F n
+
+/-- **The finite quotient system is closed under passing to a sublayer.** The layer of a subgroup
+`H'` of the Galois group of the layer of `H` is the layer of the image of `H'` in `U/V`. This is
+what lets a statement quantified over all subgroups of `U/V` be applied inside the layer of one of
+them. -/
+theorem subgroupLayer_subgroupLayer (H' : Subgroup (L.subgroupLayer H).Gal) :
+    (L.subgroupLayer H).subgroupLayer H' =
+      L.subgroupLayer (H'.map (L.subgroupRestriction H).galHom) := by
+  refine NormalLayer.ext (OpenSubgroup.toSubgroup_injective ?_) (by simp)
+  rw [ground_subgroupLayer, ground_subgroupLayer]
+  ext g
+  simp only [mem_subgroupGround, Subgroup.mem_map]
+  constructor
+  · rintro ⟨hg, hmem⟩
+    refine ⟨L.subgroupGround_le_ground H hg, QuotientGroup.mk ⟨g, hg⟩, hmem, ?_⟩
+    rw [LayerRestriction.galHom_mk]
+    rfl
+  · rintro ⟨hg, δ, hδ, hδg⟩
+    induction δ using QuotientGroup.induction_on with
+    | H w =>
+      rw [LayerRestriction.galHom_mk, QuotientGroup.eq] at hδg
+      have hw : (w : G)⁻¹ * g ∈ L.top := Subgroup.mem_subgroupOf.1 hδg
+      have hgmem : g ∈ L.subgroupGround H := by
+        have hmul := mul_mem w.2 (L.top_le_subgroupGround H hw)
+        rwa [mul_inv_cancel_left] at hmul
+      refine ⟨hgmem, ?_⟩
+      have hEq : (QuotientGroup.mk w : (L.subgroupLayer H).Gal) =
+          QuotientGroup.mk ⟨g, hgmem⟩ :=
+        (QuotientGroup.eq (s := (L.subgroupLayer H).relativeTop)).2
+          (Subgroup.mem_subgroupOf.2 hw)
+      rwa [← hEq]
+
+/-- **Every restriction of a layer is the layer of a subgroup of its Galois group.** Together with
+`NormalLayer.subgroupRestriction` and `NormalLayer.range_galHom_subgroupRestriction` this is the
+correspondence between restrictions of `L` and subgroups of `U ⧸ V`. -/
+theorem subgroupLayer_range_galHom {small : NormalLayer G} (T : LayerRestriction small L) :
+    L.subgroupLayer T.galHom.range = small := by
+  refine NormalLayer.ext (OpenSubgroup.toSubgroup_injective ?_) T.same_top.symm
+  rw [ground_subgroupLayer]
+  ext g
+  simp only [mem_subgroupGround, MonoidHom.mem_range]
+  constructor
+  · rintro ⟨hg, δ, hδ⟩
+    induction δ using QuotientGroup.induction_on with
+    | H w =>
+      rw [LayerRestriction.galHom_mk, QuotientGroup.eq] at hδ
+      have hw : (w : G)⁻¹ * g ∈ L.top := Subgroup.mem_subgroupOf.1 hδ
+      have hmul := mul_mem w.2 (small.top_le_ground (T.same_top ▸ hw))
+      rwa [mul_inv_cancel_left] at hmul
+  · intro hg
+    exact ⟨T.ground_toSubgroup_le hg, QuotientGroup.mk ⟨g, hg⟩, by
+      rw [LayerRestriction.galHom_mk]; rfl⟩
 
 end NormalLayer
 


### PR DESCRIPTION
This PR gives restrictions of a finite normal layer their tower structure, builds the restriction map on the cohomology of a layer, and completes the correspondence between restrictions of a layer and subgroups of its Galois group. Restrictions compose (`LayerRestriction.trans`), and along a tower `F ⊆ E ⊆ E' ⊆ K` the relative degree is multiplicative (`relativeDegree_trans`), the homomorphisms of Galois groups compose (`galHom_trans`), and the three identifications of coefficient modules agree (`repIso_inv_hom_trans`). `LayerRestriction.cohomologyRes` is the resulting map `H^n(U/V, A^V) ⟶ H^n(U'/V, A^V)`; it is the identity for the trivial restriction and functorial along a tower (`cohomologyRes_self`, `cohomologyRes_trans`). Its direction is pinned in degree zero: read through the identification of `H⁰(U/V, A^V)` with the ground level, it is the ground-level inclusion `A^U ⊆ A^{U'}` (`groundInclusion`, `groundLevelEquiv_cohomologyRes_zero_apply`). Inside the finite quotient system the same tower is indexed by an inclusion `K ≤ H` of subgroups of `Γ`, whose relative degree is the relative index (`relativeDegree_subgroupLayerRestriction`) and whose homomorphism of Galois groups is `Subgroup.inclusion` (`subgroupGalEquiv_galHom_subgroupLayerRestriction_apply`); and the system is closed both ways — a subgroup of the Galois group of the layer of `H` gives back a layer of the system (`subgroupLayer_subgroupLayer`), and conversely every restriction of `L` is the layer of a subgroup of `Γ` (`subgroupLayer_range_galHom`).

The target is `TauCetiRoadmap/ClassFieldTheory/README.md` §4, Layer 1 ("formations and finite normal layers"), whose required API asks for "restriction and corestriction as separate named maps in every degree (`LayerRestriction.cohomologyRes`, `cohomologyCor`, …)" and for "tower compatibility: restrictions and refinements compose (`LayerRestriction.trans`, …), the relative degree is multiplicative along a tower (`relativeDegree_trans`), and every one of the maps above is functorial along a composite (`cohomologyRes_trans`, …)". Layer 1's exit criterion is that the layer's cohomology, its ground level and its towers each have a name; this PR supplies the restriction half of that. The declarations are consumed by Layer 2's `fundamentalClass_restrict` and `h1_subgroupLayer`/`card_H2_subgroupLayer`/`fundamentalClass_restrict_generates`, which are stated over the finite quotient system `H ↦ subgroupLayer H` and therefore need exactly the tower laws proved here, and by Layer 3's `tateIso_res_trans`.

After this PR, Layer 1 still owes corestriction and the `cor ∘ res = [E : F]` normalization, the Tate-degree versions `tateRes`/`tateCor`/`trivialTateRes`/`trivialTateCor` in all integer degrees, layer refinements (`LayerRefinement`, `cohomologyInfl_trans`) and the conjugation adapters. Corestriction is deliberately not attempted here: the pinned Mathlib supplies only the change-of-group map induced by a homomorphism of groups, which is restriction, while the transfer in the other direction exists in no degree, and per Layer 0 item 4 it belongs in the generic Tate-cohomology supplier rather than in the formation files. The same goes for `tateRes`/`tateCor`, which wait on that Layer 0 bullet. Layer 0 itself is on `main`, under `TauCeti/RepresentationTheory/Homological/TateCohomology/` (`LowDegree.lean`, `Inflation.lean`, `Periodic.lean`, `HerbrandQuotient.lean`, landed by #5639, #5642, #5809, #5764 and #5997), with Herbrand multiplicativity open as #5923; `Formation/Basic.lean` already imports `TateCohomology.LowDegree`, so this file sits on top of the prerequisite layer rather than ahead of it.

No Mathlib infrastructure is vendored. The construction reuses `groupCohomology.map` and its `map_id`/`map_comp`/`map_congr`/`map_H0Iso_hom_f` API, `Subgroup.relIndex_mul_relIndex`, the relative-index transport lemmas `Subgroup.relIndex_map_map_of_injective`, `Subgroup.relIndex_comap` and `Subgroup.map_comap_eq_self_of_surjective`, the correspondence theorem `QuotientGroup.comapMk'OrderIso` with its monotonicity, and `Submodule.inclusion`. The mathematical organization is that of Artin–Tate, *Class Field Theory*, Chapter XIV, §§1–2 and Neukirch, *Class Field Theory*, Chapter III, §1, as already credited in the file's references.

All changes are in the existing `TauCeti/NumberTheory/ClassFieldTheory/Formation/Restriction.lean`, which grows by 236 lines (about 165 of them declarations, the rest module documentation).

**Review rounds.** The reuse, documentation, placement, naming and proof-quality findings of the earlier rounds are fixed: the direct `GroupCohomology.Functoriality` import is dropped, `repIso_inv_hom_trans` is renamed `repIso_inv_hom_trans_apply`, `relativeDegree_subgroupLayerRestriction` goes through the named `NormalLayer.subgroupGround_eq_map_comap`, and the unused `relativeDegree_self` is deleted as reuse required (`simp` closes `T.relativeDegree = 1` through the `@[simp]` lemmas `relativeDegree_def` and `Subgroup.relIndex_self`). In the latest round the two pointwise lemmas gained their `_apply` suffix, and the `rfl` steps closing quotient-class equalities in `galHom_self`, `galHom_trans`, `subgroupLayer_subgroupLayer` and `subgroupLayer_range_galHom` are replaced by `Subgroup.coe_inclusion`. The api-design request to re-add `@[simp] relativeDegree_self` is contested because it reverses the reuse deletion, and plain `simp` already proves the identity law. The reuse request to build `groundInclusion` out of `TauCeti.invariantsInclusion` is contested because `Formation.level` is a sealed `def`, so the suggestion does not typecheck. The earlier `@[simp]` requests on the `_trans` laws are contested because `LayerRestriction` is a `Prop`, so their left-hand sides cannot fire (`simpNF`).

Roadmap: ClassFieldTheory

<!--tauceti-target:v1 {"focus":"ClassFieldTheory","id":"layerrestriction-trans-cohomologyres"}-->

🤖 Prepared with Claude Code

