### PR TITLE
feat: recognize symmetric groups in prime degree

### DIFF
--- a/TauCeti/GroupTheory/Perm/Recognition.lean
+++ b/TauCeti/GroupTheory/Perm/Recognition.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.GroupTheory.GroupAction.Quotient
 public import Mathlib.GroupTheory.GroupAction.Transitive
 public import Mathlib.GroupTheory.Perm.Cycle.Type
+import Mathlib.GroupTheory.GroupAction.Jordan
 
 /-!
 # Recognizing cycles and transpositions in a permutation group
@@ -28,6 +29,8 @@ through the Frobenius element.
 
 * `TauCeti.exists_isCycle_mem_of_isPretransitive_of_prime_card`: a transitive permutation group
   of prime degree contains a full cycle.
+* `TauCeti.subgroup_eq_top_of_isPretransitive_of_prime_card_of_isSwap_mem`: a transitive
+  permutation group of prime degree that contains a transposition is the full symmetric group.
 * `Equiv.Perm.isSwap_pow_prod_erase_two_cycleType_and_odd`: if a permutation has exactly one
   2-cycle and all its other cycles have odd length, an explicit odd power is a transposition.
 * `Equiv.Perm.exists_odd_isSwap_pow`: the corresponding existential form.
@@ -69,6 +72,21 @@ theorem exists_isCycle_mem_of_isPretransitive_of_prime_card
   have hsupport : (g : Equiv.Perm α).support = Finset.univ :=
     Finset.eq_univ_of_card (g : Equiv.Perm α).support (hcycle.orderOf.symm.trans horder)
   exact ⟨g, g.property, hcycle, hsupport⟩
+
+/-- A transitive subgroup of a symmetric group of prime degree that contains a transposition is
+the full symmetric group.
+
+Prime degree promotes transitivity to primitivity, after which Jordan's transposition criterion
+applies. This is the prime-degree recognition step used to identify Galois groups from an
+irreducible polynomial and a factorization pattern exhibiting a transposition. -/
+theorem subgroup_eq_top_of_isPretransitive_of_prime_card_of_isSwap_mem
+    {β : Type*} [Finite β] [DecidableEq β] {G : Subgroup (Equiv.Perm β)}
+    (hG : IsPretransitive G β)
+    (hp : Nat.Prime (Nat.card β)) (g : Equiv.Perm β) (hgSwap : g.IsSwap) (hg : g ∈ G) :
+    G = ⊤ := by
+  let _ : IsPretransitive G β := hG
+  exact Equiv.Perm.subgroup_eq_top_of_isPreprimitive_of_isSwap_mem
+    (IsPreprimitive.of_prime_card hp) g hgSwap hg
 
 /-- If a permutation has exactly one cycle of length two and every other cycle has odd length,
 then raising it to the product of those other cycle lengths gives a transposition.

--- a/TauCeti/GroupTheory/Perm/Recognition.lean
+++ b/TauCeti/GroupTheory/Perm/Recognition.lean
@@ -79,10 +79,10 @@ the full symmetric group, the prime-degree form of Jordan's transposition recogn
 This recognition result identifies Galois groups from an irreducible polynomial and a
 factorization pattern exhibiting a transposition. -/
 theorem subgroup_eq_top_of_isPretransitive_of_prime_card_of_isSwap_mem
-    {β : Type*} [Finite β] [DecidableEq β] {G : Subgroup (Equiv.Perm β)}
-    (hG : IsPretransitive G β)
+    {β : Type*} [DecidableEq β] {G : Subgroup (Equiv.Perm β)} (hG : IsPretransitive G β)
     (hp : Nat.Prime (Nat.card β)) (g : Equiv.Perm β) (hgSwap : g.IsSwap) (hg : g ∈ G) :
     G = ⊤ := by
+  have : Finite β := Nat.finite_of_card_ne_zero hp.ne_zero
   let _ : IsPretransitive G β := hG
   exact Equiv.Perm.subgroup_eq_top_of_isPreprimitive_of_isSwap_mem
     (IsPreprimitive.of_prime_card hp) g hgSwap hg

--- a/TauCeti/GroupTheory/Perm/Recognition.lean
+++ b/TauCeti/GroupTheory/Perm/Recognition.lean
@@ -74,11 +74,10 @@ theorem exists_isCycle_mem_of_isPretransitive_of_prime_card
   exact ⟨g, g.property, hcycle, hsupport⟩
 
 /-- A transitive subgroup of a symmetric group of prime degree that contains a transposition is
-the full symmetric group.
+the full symmetric group, the prime-degree form of Jordan's transposition recognition theorem.
 
-Prime degree promotes transitivity to primitivity, after which Jordan's transposition criterion
-applies. This is the prime-degree recognition step used to identify Galois groups from an
-irreducible polynomial and a factorization pattern exhibiting a transposition. -/
+This recognition result identifies Galois groups from an irreducible polynomial and a
+factorization pattern exhibiting a transposition. -/
 theorem subgroup_eq_top_of_isPretransitive_of_prime_card_of_isSwap_mem
     {β : Type*} [Finite β] [DecidableEq β] {G : Subgroup (Equiv.Perm β)}
     (hG : IsPretransitive G β)


### PR DESCRIPTION
This PR proves that a transitive subgroup of a finite symmetric group of prime degree which contains a transposition is the full symmetric group. It advances `PolynomialGaloisGroups/README.md`, Layer 1, milestone “The recognition theorems,” at the exact target “A transitive subgroup of `S_p` of prime degree that contains a transposition is `S_p`.”

This is the most effective distinct current step after falling back from the designated Multiquadratic roadmap: all four frontier items recorded in its status and both remaining worked examples are already on `main`, while the remaining genus-field Artin-map refinement is in flight in #6215. The prime-degree recognition result is unclaimed, and Layer 9’s three-prime realization of `S_n` consumes it in its group-theoretic final step.

The proof keeps the statement at the natural `Finite` level. It promotes the supplied transitive action to a primitive action with Mathlib’s `MulAction.IsPreprimitive.of_prime_card`, then applies Mathlib’s `Equiv.Perm.subgroup_eq_top_of_isPreprimitive_of_isSwap_mem`. No Mathlib infrastructure or external formalization is vendored.

After this PR, the Layer 1 recognition-theorems milestone is complete using the existing Tau Ceti long-cycle and odd-power results together with Mathlib’s primitive transposition and three-cycle criteria; Layer 1 still needs Jordan’s `p`-cycle theorem and the block and wreath-product milestones.

The existing `TauCeti/GroupTheory/Perm/Recognition.lean` gains 18 lines: one documented public theorem, its module-summary entry, and the proof-only Jordan import.

Roadmap: PolynomialGaloisGroups

<!--tauceti-target:v1 {"focus":"PolynomialGaloisGroups","id":"transitive-prime-degree-transposition"}-->

🤖 Prepared with Codex
