### PR TITLE
feat: package a finite separable extension of a DVR with a chosen place

### DIFF
--- a/TauCeti/AlgebraicGeometry/Curves/StableReduction/DVRExtension.lean
+++ b/TauCeti/AlgebraicGeometry/Curves/StableReduction/DVRExtension.lean
@@ -9,7 +9,6 @@ public import Mathlib.RingTheory.DedekindDomain.Dvr
 public import Mathlib.RingTheory.DedekindDomain.Ideal.Lemmas
 public import Mathlib.RingTheory.DedekindDomain.IntegralClosure
 public import Mathlib.RingTheory.Ideal.GoingUp
-public import Mathlib.RingTheory.LocalRing.ResidueField.Basic
 public import Mathlib.RingTheory.Localization.LocalizationLocalization
 
 /-!
@@ -48,12 +47,29 @@ that of `R`.
   discrete valuation ring.
 * `TauCeti.FiniteDVRExtension.isFractionRing_localRing`: its fraction field is the extension field.
 * `TauCeti.FiniteDVRExtension.under_prime`: the chosen place lies over the closed point of `R`.
-* `TauCeti.FiniteDVRExtension.finite_primesOver`: only finitely many places lie over it, so the
+* `TauCeti.FiniteDVRExtension.primesOver_finite`: only finitely many places lie over it, so the
   choice is a choice among finitely many.
 * `TauCeti.FiniteDVRExtension.isLocalHom_algebraMap` and
   `TauCeti.FiniteDVRExtension.under_maximalIdeal_localRing`: the chosen local ring dominates `R`.
 * `TauCeti.FiniteDVRExtension.exists_extensionField_eq`: every finite separable extension of `K`
   underlies such a package, one for each place above the closed point of `R`.
+
+## References
+
+The design of this package is not original to this file: it adapts the interface proposed by the
+stable-reduction roadmap. `TauCetiRoadmap/StableReduction/README.md` states the convention "DVR
+extensions are local data" — choose a maximal ideal of the integral closure above the closed point
+and localize, never pretending the integral closure is itself a discrete valuation ring — and its
+Layer 0 asks for exactly this package; `TauCetiRoadmap/StableReduction/Suggested.lean` pins the
+suggested signature, whose carriers, algebra maps, scalar towers and `prime` field are followed
+here field for field. The two deliberate departures are that the local ring is pinned by
+`IsLocalization.AtPrime` instead of by an explicit `≃ₐ` to `Localization.AtPrime` together with a
+commuting square, and that the sketch's `localRingDomain`, `localRingDVR`, `localRingDominates`
+and `fractionIdentification` assumptions are theorems below rather than fields.
+
+The mathematics itself is standard and is not attributed to any one source; the roadmap's own
+References section collects the literature it works from, of which Q. Liu, *Algebraic Geometry and
+Arithmetic Curves* is the one covering reduction of curves over a discrete valuation ring.
 -/
 
 public section
@@ -118,9 +134,9 @@ instance isDedekindDomain_integralClosure : IsDedekindDomain E.integralClosure :
 instance isIntegral_integralClosure : Algebra.IsIntegral R E.integralClosure :=
   IsIntegralClosure.isIntegral_algebra R E.extensionField
 
-/-- The integral closure is a finite `R`-module, so it is semilocal: the places of `K'` above the
-closed point of `R` are the finitely many maximal ideals of `C`, and there is more than one as soon
-as the place of `R` does not extend uniquely. -/
+/-- The integral closure `C` of `R` in `K'` is a Noetherian `R`-module: it is a finite `R`-module,
+because `K'` is a finite separable extension of the fraction field of the Noetherian integrally
+closed domain `R`. -/
 instance isNoetherian_integralClosure : IsNoetherian R E.integralClosure :=
   IsIntegralClosure.isNoetherian R K E.extensionField _
 
@@ -134,12 +150,13 @@ instance faithfulSMul_integralClosure : FaithfulSMul R E.integralClosure :=
   FaithfulSMul.tower_bot R E.integralClosure E.extensionField
 
 /-- The chosen place lies above the closed point of `R`, spelled as a contraction of ideals. -/
+@[simp]
 theorem under_prime : E.prime.under R = maximalIdeal R :=
   (Ideal.over_def E.prime _).symm
 
 /-- The chosen place is one of finitely many: the places of `K'` above the closed point of `R` are
 the maximal ideals of the Dedekind domain `C` lying over it, and there are finitely many. -/
-theorem finite_primesOver : ((maximalIdeal R).primesOver E.integralClosure).Finite :=
+theorem primesOver_finite : ((maximalIdeal R).primesOver E.integralClosure).Finite :=
   IsDedekindDomain.primesOver_finite _ _
 
 /-- The chosen place is a nonzero prime: it lies over the maximal ideal of `R`, which is nonzero
@@ -172,6 +189,7 @@ instance faithfulSMul_localRing : FaithfulSMul R E.localRing := by
     (FaithfulSMul.algebraMap_injective R E.integralClosure)
 
 /-- The maximal ideal of the local ring of the chosen place contracts to the chosen place. -/
+@[simp]
 theorem under_maximalIdeal_integralClosure :
     (maximalIdeal E.localRing).under E.integralClosure = E.prime :=
   IsLocalization.AtPrime.under_maximalIdeal _ _
@@ -185,6 +203,7 @@ instance isLocalHom_algebraMap : IsLocalHom (algebraMap R E.localRing) := by
 
 /-- Domination spelled as a contraction of ideals: the closed point of `Spec R'` lies over the
 closed point of `Spec R`. -/
+@[simp]
 theorem under_maximalIdeal_localRing : (maximalIdeal E.localRing).under R = maximalIdeal R :=
   IsLocalRing.maximalIdeal_comap _
 
@@ -194,38 +213,25 @@ variable (R K)
 variable (L : Type u) [Field L] [Algebra K L] [FiniteDimensional K L] [Algebra.IsSeparable K L]
   [Algebra R L] [IsScalarTower R K L]
 
-/-- The algebra structure on `Localization.AtPrime P`, for `P` a prime of the integral closure `C`
-of `R` in `L`, given by mapping a fraction of integral elements to the corresponding element of
-`L`. This is legitimate because a prime of a domain misses `0`, so the denominators become units.
-
-This is a reducible non-instance in the sense of the note [reducible non-instances]: which algebra
-structure a localization should carry towards a further ring is context-dependent. It is the value
-taken by the `fractionAlgebra` field of `TauCeti.FiniteDVRExtension.of`. -/
-noncomputable abbrev localizationAlgebra (P : Ideal (_root_.integralClosure R L)) [P.IsPrime] :
-    Algebra (Localization.AtPrime P) L :=
-  RingHom.toAlgebra <| IsLocalization.lift
-    (M := P.primeCompl) (g := algebraMap (_root_.integralClosure R L) L) fun y ↦
-      isUnit_iff_ne_zero.2 fun h ↦ y.2 <| by
-        rw [show (y : _root_.integralClosure R L) = 0 from
-          FaithfulSMul.algebraMap_injective (_root_.integralClosure R L) L (by simpa using h)]
-        exact P.zero_mem
-
-attribute [local instance] localizationAlgebra
-
-instance isScalarTower_localizationAlgebra (P : Ideal (_root_.integralClosure R L)) [P.IsPrime] :
-    IsScalarTower (_root_.integralClosure R L) (Localization.AtPrime P) L :=
-  .of_algebraMap_eq fun x ↦ (IsLocalization.lift_eq _ x).symm
-
 /-- The finite extension of the discrete valuation ring `R` cut out by a maximal ideal `P` of the
-integral closure of `R` in a finite separable extension `L` of `K`, provided `P` lies above the
-maximal ideal of `R`. Its local ring is `Localization.AtPrime P`. -/
+integral closure `C` of `R` in a finite separable extension `L` of `K`, provided `P` lies above the
+maximal ideal of `R`. Its local ring is `Localization.AtPrime P`.
+
+The map from that local ring to `L` is Mathlib's canonical comparison
+`IsLocalization.localizationAlgebraOfSubmonoidLe` between the localizations of `C` at the two
+submonoids `P.primeCompl ≤ nonZeroDivisors C`, the second localization being `L` itself because
+`L` is the fraction field of `C`. -/
 @[expose]
 noncomputable def of (P : Ideal (_root_.integralClosure R L)) [P.IsMaximal]
-    [P.LiesOver (maximalIdeal R)] : FiniteDVRExtension R K where
-  extensionField := L
-  prime := P
-  localRing := Localization.AtPrime P
-  fractionAlgebra := localizationAlgebra R L P
+    [P.LiesOver (maximalIdeal R)] : FiniteDVRExtension R K :=
+  haveI : IsFractionRing (_root_.integralClosure R L) L :=
+    IsIntegralClosure.isFractionRing_of_finite_extension R K L _
+  { extensionField := L
+    prime := P
+    localRing := Localization.AtPrime P
+    fractionAlgebra := IsLocalization.localizationAlgebraOfSubmonoidLe _ _ P.primeCompl
+      (nonZeroDivisors _) P.primeCompl_le_nonZeroDivisors
+    fractionTower := IsLocalization.localization_isScalarTower_of_submonoid_le _ _ _ _ _ }
 
 @[simp]
 theorem of_extensionField (P : Ideal (_root_.integralClosure R L)) [P.IsMaximal]

--- a/TauCeti/AlgebraicGeometry/Curves/StableReduction/DVRExtension.lean
+++ b/TauCeti/AlgebraicGeometry/Curves/StableReduction/DVRExtension.lean
@@ -260,6 +260,16 @@ theorem of_localRingAlgebra (P : Ideal (_root_.integralClosure R L)) [P.IsPrime]
     HEq (of R K L P).localRingAlgebra (inferInstance : Algebra R (Localization.AtPrime P)) := by
   rw [of]
 
+@[simp]
+theorem of_fractionAlgebra (P : Ideal (_root_.integralClosure R L)) [P.IsPrime]
+    [P.LiesOver (maximalIdeal R)] :
+    haveI : IsFractionRing (_root_.integralClosure R L) L :=
+      IsIntegralClosure.isFractionRing_of_finite_extension R K L _
+    HEq (of R K L P).fractionAlgebra
+      (IsLocalization.localizationAlgebraOfSubmonoidLe (Localization.AtPrime P) L P.primeCompl
+        (nonZeroDivisors _) P.primeCompl_le_nonZeroDivisors) := by
+  rw [of]
+
 /-- The algebra-level refinement of `TauCeti.FiniteDVRExtension.of_extensionField`: the extension
 field of the package cut out by `P` is `L` itself as a `K`-algebra, not merely as a type. -/
 theorem nonempty_algEquiv_of_extensionField (P : Ideal (_root_.integralClosure R L)) [P.IsPrime]

--- a/TauCeti/AlgebraicGeometry/Curves/StableReduction/DVRExtension.lean
+++ b/TauCeti/AlgebraicGeometry/Curves/StableReduction/DVRExtension.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.RingTheory.DedekindDomain.Dvr
-public import Mathlib.RingTheory.DedekindDomain.Ideal.Lemmas
 public import Mathlib.RingTheory.DedekindDomain.IntegralClosure
 public import Mathlib.RingTheory.Ideal.GoingUp
 public import Mathlib.RingTheory.Localization.LocalizationLocalization
@@ -47,8 +46,6 @@ that of `R`.
   discrete valuation ring.
 * `TauCeti.FiniteDVRExtension.isFractionRing_localRing`: its fraction field is the extension field.
 * `TauCeti.FiniteDVRExtension.under_prime`: the chosen place lies over the closed point of `R`.
-* `TauCeti.FiniteDVRExtension.primesOver_finite`: only finitely many places lie over it, so the
-  choice is a choice among finitely many.
 * `TauCeti.FiniteDVRExtension.isLocalHom_algebraMap` and
   `TauCeti.FiniteDVRExtension.under_maximalIdeal_localRing`: the chosen local ring dominates `R`.
 * `TauCeti.FiniteDVRExtension.exists_extensionField_eq`: every finite separable extension of `K`
@@ -152,11 +149,6 @@ instance faithfulSMul_integralClosure : FaithfulSMul R E.integralClosure :=
 theorem under_prime : E.prime.under R = maximalIdeal R :=
   (Ideal.over_def E.prime _).symm
 
-/-- The chosen place is one of finitely many: the places of `K'` above the closed point of `R` are
-the maximal ideals of the Dedekind domain `C` lying over it, and there are finitely many. -/
-theorem primesOver_finite : ((maximalIdeal R).primesOver E.integralClosure).Finite :=
-  IsDedekindDomain.primesOver_finite _ _
-
 /-- The chosen place is a nonzero prime: it lies over the maximal ideal of `R`, which is nonzero
 because a discrete valuation ring is not a field. -/
 theorem prime_ne_bot : E.prime ≠ ⊥ :=
@@ -165,6 +157,7 @@ theorem prime_ne_bot : E.prime ≠ ⊥ :=
 instance isDomain_localRing : IsDomain E.localRing :=
   IsLocalization.isDomain_of_le_nonZeroDivisors _ E.prime.primeCompl_le_nonZeroDivisors
 
+/-- The extension field is the fraction field of the chosen localized ring. -/
 instance isFractionRing_localRing : IsFractionRing E.localRing E.extensionField :=
   IsFractionRing.isFractionRing_of_isDomain_of_isLocalization E.prime.primeCompl _ _
 
@@ -211,6 +204,16 @@ variable (R K)
 variable (L : Type u) [Field L] [Algebra K L] [FiniteDimensional K L] [Algebra.IsSeparable K L]
   [Algebra R L] [IsScalarTower R K L]
 
+/-- The canonical algebra structure from the localization at `P` to `L`, obtained by viewing both
+as localizations of the integral closure and using `P.primeCompl ≤ nonZeroDivisors`. -/
+noncomputable abbrev ofFractionAlgebra
+    (P : Ideal (_root_.integralClosure R L)) [P.IsPrime] :
+    Algebra (Localization.AtPrime P) L :=
+  letI : IsFractionRing (_root_.integralClosure R L) L :=
+    IsIntegralClosure.isFractionRing_of_finite_extension R K L _
+  IsLocalization.localizationAlgebraOfSubmonoidLe _ _ P.primeCompl
+    (nonZeroDivisors _) P.primeCompl_le_nonZeroDivisors
+
 /-- The finite extension of the discrete valuation ring `R` cut out by a maximal ideal `P` of the
 integral closure `C` of `R` in a finite separable extension `L` of `K`, provided `P` lies above the
 maximal ideal of `R`. Its local ring is `Localization.AtPrime P`.
@@ -219,29 +222,62 @@ The map from that local ring to `L` is Mathlib's canonical comparison
 `IsLocalization.localizationAlgebraOfSubmonoidLe` between the localizations of `C` at the two
 submonoids `P.primeCompl ≤ nonZeroDivisors C`, the second localization being `L` itself because
 `L` is the fraction field of `C`. -/
-@[expose]
-noncomputable def of (P : Ideal (_root_.integralClosure R L)) [P.IsMaximal]
+noncomputable def of (P : Ideal (_root_.integralClosure R L)) [P.IsPrime]
     [P.LiesOver (maximalIdeal R)] : FiniteDVRExtension R K :=
   haveI : IsFractionRing (_root_.integralClosure R L) L :=
     IsIntegralClosure.isFractionRing_of_finite_extension R K L _
+  letI : P.IsMaximal := .of_liesOver_isMaximal P (maximalIdeal R)
   { extensionField := L
     prime := P
     localRing := Localization.AtPrime P
-    fractionAlgebra := IsLocalization.localizationAlgebraOfSubmonoidLe _ _ P.primeCompl
-      (nonZeroDivisors _) P.primeCompl_le_nonZeroDivisors
+    fractionAlgebra := ofFractionAlgebra R K L P
     fractionTower := IsLocalization.localization_isScalarTower_of_submonoid_le _ _ _ _ _ }
 
 @[simp]
-theorem of_extensionField (P : Ideal (_root_.integralClosure R L)) [P.IsMaximal]
-    [P.LiesOver (maximalIdeal R)] : (of R K L P).extensionField = L := rfl
+theorem of_extensionField (P : Ideal (_root_.integralClosure R L)) [P.IsPrime]
+    [P.LiesOver (maximalIdeal R)] : (of R K L P).extensionField = L := by
+  rw [of.eq_1]
 
 @[simp]
-theorem of_prime (P : Ideal (_root_.integralClosure R L)) [P.IsMaximal]
-    [P.LiesOver (maximalIdeal R)] : (of R K L P).prime = P := rfl
+theorem of_prime (P : Ideal (_root_.integralClosure R L)) [P.IsPrime]
+    [P.LiesOver (maximalIdeal R)] : HEq (of R K L P).prime P := by
+  rw [of.eq_1]
 
 @[simp]
-theorem of_localRing (P : Ideal (_root_.integralClosure R L)) [P.IsMaximal]
-    [P.LiesOver (maximalIdeal R)] : (of R K L P).localRing = Localization.AtPrime P := rfl
+theorem of_localRing (P : Ideal (_root_.integralClosure R L)) [P.IsPrime]
+    [P.LiesOver (maximalIdeal R)] : (of R K L P).localRing = Localization.AtPrime P := by
+  rw [of.eq_1]
+
+@[simp]
+theorem of_extensionAlgebra (P : Ideal (_root_.integralClosure R L)) [P.IsPrime]
+    [P.LiesOver (maximalIdeal R)] :
+    HEq (of R K L P).extensionAlgebra (inferInstance : Algebra K L) := by
+  rw [of.eq_1]
+
+@[simp]
+theorem of_extensionBaseAlgebra (P : Ideal (_root_.integralClosure R L)) [P.IsPrime]
+    [P.LiesOver (maximalIdeal R)] :
+    HEq (of R K L P).extensionBaseAlgebra (inferInstance : Algebra R L) := by
+  rw [of.eq_1]
+
+@[simp]
+theorem of_localRingClosureAlgebra (P : Ideal (_root_.integralClosure R L)) [P.IsPrime]
+    [P.LiesOver (maximalIdeal R)] :
+    HEq (of R K L P).localRingClosureAlgebra
+      (inferInstance : Algebra (_root_.integralClosure R L) (Localization.AtPrime P)) := by
+  rw [of.eq_1]
+
+@[simp]
+theorem of_localRingAlgebra (P : Ideal (_root_.integralClosure R L)) [P.IsPrime]
+    [P.LiesOver (maximalIdeal R)] :
+    HEq (of R K L P).localRingAlgebra (inferInstance : Algebra R (Localization.AtPrime P)) := by
+  rw [of.eq_1]
+
+@[simp]
+theorem of_fractionAlgebra (P : Ideal (_root_.integralClosure R L)) [P.IsPrime]
+    [P.LiesOver (maximalIdeal R)] :
+    HEq (of R K L P).fractionAlgebra (ofFractionAlgebra R K L P) := by
+  rw [of.eq_1]
 
 /-- Every finite separable extension `L` of `K` underlies a `FiniteDVRExtension R K`: the integral
 closure of `R` in `L` is integral over `R`, so going up produces a maximal ideal above the maximal

--- a/TauCeti/AlgebraicGeometry/Curves/StableReduction/DVRExtension.lean
+++ b/TauCeti/AlgebraicGeometry/Curves/StableReduction/DVRExtension.lean
@@ -49,22 +49,13 @@ that of `R`.
 * `TauCeti.FiniteDVRExtension.isLocalHom_algebraMap` and
   `TauCeti.FiniteDVRExtension.under_maximalIdeal_localRing`: the chosen local ring dominates `R`.
 * `TauCeti.FiniteDVRExtension.exists_extensionField_eq`: every finite separable extension of `K`
-  underlies such a package, one for each place above the closed point of `R`.
+  underlies such a package, for some place above the closed point of `R`; to fix a specified
+  place, use `TauCeti.FiniteDVRExtension.of`.
 
 ## References
 
-The interface here is not original to this file: it adapts the one proposed by the Tau Ceti
-[`StableReduction` roadmap][roadmap], whose `README.md` states the convention "DVR extensions are
-local data" — choose a maximal ideal of the integral closure above the closed point and localize,
-never treating the integral closure itself as a discrete valuation ring — and whose
-[`Suggested.lean`][suggested] writes down the signature followed below: the same carriers, algebra
-maps, scalar towers and chosen prime.
-
 The mathematics is standard; Q. Liu, *Algebraic Geometry and Arithmetic Curves*, covers reduction
 of curves over a discrete valuation ring.
-
-[roadmap]: https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/StableReduction/README.md
-[suggested]: https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/StableReduction/Suggested.lean
 -/
 
 public section
@@ -74,6 +65,10 @@ universe u
 namespace TauCeti
 
 open IsLocalRing
+
+-- Source: this structure adapts the `FiniteDVRExtension` signature (same carriers, algebra maps,
+-- scalar towers and chosen prime) of the Tau Ceti `StableReduction` roadmap's `Suggested.lean`,
+-- https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/StableReduction/Suggested.lean
 
 /-- A finite separable extension of the fraction field `K` of a discrete valuation ring `R`,
 together with a chosen place of that extension above the closed point of `R`.

--- a/TauCeti/AlgebraicGeometry/Curves/StableReduction/DVRExtension.lean
+++ b/TauCeti/AlgebraicGeometry/Curves/StableReduction/DVRExtension.lean
@@ -65,8 +65,13 @@ namespace TauCeti
 
 open IsLocalRing
 
--- Source: this structure adapts the `FiniteDVRExtension` signature (same carriers, algebra maps,
--- scalar towers and chosen prime) of the Tau Ceti `StableReduction` roadmap's `Suggested.lean`,
+-- Source: the chosen-place convention (choose a maximal ideal of the integral closure above the
+-- closed point and localize there, never treating the integral closure itself as a discrete
+-- valuation ring) is the standing convention "DVR extensions are local data" of the Tau Ceti
+-- `StableReduction` roadmap's `README.md`,
+-- https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/StableReduction/README.md
+-- and this structure adapts the `FiniteDVRExtension` signature (same carriers, algebra maps,
+-- scalar towers and chosen prime) of that roadmap's `Suggested.lean`,
 -- https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/StableReduction/Suggested.lean
 
 /-- A finite separable extension of the fraction field `K` of a discrete valuation ring `R`,

--- a/TauCeti/AlgebraicGeometry/Curves/StableReduction/DVRExtension.lean
+++ b/TauCeti/AlgebraicGeometry/Curves/StableReduction/DVRExtension.lean
@@ -56,20 +56,15 @@ that of `R`.
 
 ## References
 
-The design of this package is not original to this file: it adapts the interface proposed by the
-stable-reduction roadmap. `TauCetiRoadmap/StableReduction/README.md` states the convention "DVR
-extensions are local data" — choose a maximal ideal of the integral closure above the closed point
-and localize, never pretending the integral closure is itself a discrete valuation ring — and its
-Layer 0 asks for exactly this package; `TauCetiRoadmap/StableReduction/Suggested.lean` pins the
-suggested signature, whose carriers, algebra maps, scalar towers and `prime` field are followed
-here field for field. The two deliberate departures are that the local ring is pinned by
-`IsLocalization.AtPrime` instead of by an explicit `≃ₐ` to `Localization.AtPrime` together with a
-commuting square, and that the sketch's `localRingDomain`, `localRingDVR`, `localRingDominates`
-and `fractionIdentification` assumptions are theorems below rather than fields.
+The interface here is not original to this file: it adapts the one proposed by the Tau Ceti
+`StableReduction` roadmap, whose `README.md` states the convention "DVR extensions are local
+data" — choose a maximal ideal of the integral closure above the closed point and localize, never
+treating the integral closure itself as a discrete valuation ring — and whose `Suggested.lean`
+writes down the signature followed below: the same carriers, algebra maps, scalar towers and
+chosen prime.
 
-The mathematics itself is standard and is not attributed to any one source; the roadmap's own
-References section collects the literature it works from, of which Q. Liu, *Algebraic Geometry and
-Arithmetic Curves* is the one covering reduction of curves over a discrete valuation ring.
+The mathematics is standard; Q. Liu, *Algebraic Geometry and Arithmetic Curves*, covers reduction
+of curves over a discrete valuation ring.
 -/
 
 public section

--- a/TauCeti/AlgebraicGeometry/Curves/StableReduction/DVRExtension.lean
+++ b/TauCeti/AlgebraicGeometry/Curves/StableReduction/DVRExtension.lean
@@ -170,11 +170,9 @@ instance isScalarTower_localRing : IsScalarTower R E.localRing E.extensionField 
       ← IsScalarTower.algebraMap_apply E.integralClosure E.localRing E.extensionField,
       ← IsScalarTower.algebraMap_apply R E.integralClosure E.extensionField]
 
-instance faithfulSMul_localRing : FaithfulSMul R E.localRing := by
-  rw [faithfulSMul_iff_algebraMap_injective,
-    IsScalarTower.algebraMap_eq R E.integralClosure E.localRing]
-  exact (IsLocalization.injective E.localRing E.prime.primeCompl_le_nonZeroDivisors).comp
-    (FaithfulSMul.algebraMap_injective R E.integralClosure)
+instance faithfulSMul_localRing : FaithfulSMul R E.localRing :=
+  have := IsLocalization.AtPrime.faithfulSMul E.localRing E.integralClosure E.prime
+  FaithfulSMul.trans R E.integralClosure E.localRing
 
 /-- The maximal ideal of the local ring of the chosen place contracts to the chosen place. -/
 @[simp]

--- a/TauCeti/AlgebraicGeometry/Curves/StableReduction/DVRExtension.lean
+++ b/TauCeti/AlgebraicGeometry/Curves/StableReduction/DVRExtension.lean
@@ -220,67 +220,51 @@ noncomputable def of (P : Ideal (_root_.integralClosure R L)) [P.IsPrime]
       (nonZeroDivisors _) P.primeCompl_le_nonZeroDivisors
     fractionTower := IsLocalization.localization_isScalarTower_of_submonoid_le _ _ _ _ _ }
 
-/-- The unfolding equation for `of`, stated once: the characteristic lemmas below are all proved
-from it, so that no public lemma depends on the elaborator-generated equation of `of`. -/
-private theorem of_def (P : Ideal (_root_.integralClosure R L)) [P.IsPrime]
-    [P.LiesOver (maximalIdeal R)] :
-    of R K L P =
-      haveI : IsFractionRing (_root_.integralClosure R L) L :=
-        IsIntegralClosure.isFractionRing_of_finite_extension R K L _
-      letI : P.IsMaximal := .of_liesOver_isMaximal P (maximalIdeal R)
-      { extensionField := L
-        prime := P
-        localRing := Localization.AtPrime P
-        fractionAlgebra := IsLocalization.localizationAlgebraOfSubmonoidLe _ _ P.primeCompl
-          (nonZeroDivisors _) P.primeCompl_le_nonZeroDivisors
-        fractionTower := IsLocalization.localization_isScalarTower_of_submonoid_le _ _ _ _ _ } := by
-  rw [of]
-
 @[simp]
 theorem of_extensionField (P : Ideal (_root_.integralClosure R L)) [P.IsPrime]
     [P.LiesOver (maximalIdeal R)] : (of R K L P).extensionField = L := by
-  rw [of_def]
+  rw [of]
 
 @[simp]
 theorem of_prime (P : Ideal (_root_.integralClosure R L)) [P.IsPrime]
     [P.LiesOver (maximalIdeal R)] : HEq (of R K L P).prime P := by
-  rw [of_def]
+  rw [of]
 
 @[simp]
 theorem of_localRing (P : Ideal (_root_.integralClosure R L)) [P.IsPrime]
     [P.LiesOver (maximalIdeal R)] : (of R K L P).localRing = Localization.AtPrime P := by
-  rw [of_def]
+  rw [of]
 
 @[simp]
 theorem of_extensionAlgebra (P : Ideal (_root_.integralClosure R L)) [P.IsPrime]
     [P.LiesOver (maximalIdeal R)] :
     HEq (of R K L P).extensionAlgebra (inferInstance : Algebra K L) := by
-  rw [of_def]
+  rw [of]
 
 @[simp]
 theorem of_extensionBaseAlgebra (P : Ideal (_root_.integralClosure R L)) [P.IsPrime]
     [P.LiesOver (maximalIdeal R)] :
     HEq (of R K L P).extensionBaseAlgebra (inferInstance : Algebra R L) := by
-  rw [of_def]
+  rw [of]
 
 @[simp]
 theorem of_localRingClosureAlgebra (P : Ideal (_root_.integralClosure R L)) [P.IsPrime]
     [P.LiesOver (maximalIdeal R)] :
     HEq (of R K L P).localRingClosureAlgebra
       (inferInstance : Algebra (_root_.integralClosure R L) (Localization.AtPrime P)) := by
-  rw [of_def]
+  rw [of]
 
 @[simp]
 theorem of_localRingAlgebra (P : Ideal (_root_.integralClosure R L)) [P.IsPrime]
     [P.LiesOver (maximalIdeal R)] :
     HEq (of R K L P).localRingAlgebra (inferInstance : Algebra R (Localization.AtPrime P)) := by
-  rw [of_def]
+  rw [of]
 
 /-- The algebra-level refinement of `TauCeti.FiniteDVRExtension.of_extensionField`: the extension
 field of the package cut out by `P` is `L` itself as a `K`-algebra, not merely as a type. -/
-theorem of_extensionField_algEquiv (P : Ideal (_root_.integralClosure R L)) [P.IsPrime]
+theorem nonempty_algEquiv_of_extensionField (P : Ideal (_root_.integralClosure R L)) [P.IsPrime]
     [P.LiesOver (maximalIdeal R)] : Nonempty ((of R K L P).extensionField ≃ₐ[K] L) := by
-  rw [of_def]
+  rw [of]
   exact ⟨AlgEquiv.refl⟩
 
 /-- Every finite separable extension `L` of `K` underlies a `FiniteDVRExtension R K`: the integral
@@ -297,7 +281,7 @@ theorem exists_algEquiv_extensionField :
   obtain ⟨P, _, _⟩ :=
     Ideal.exists_maximal_ideal_liesOver_of_isIntegral (R := R) (S := _root_.integralClosure R L)
       (maximalIdeal R)
-  exact ⟨of R K L P, of_extensionField_algEquiv R K L P⟩
+  exact ⟨of R K L P, nonempty_algEquiv_of_extensionField R K L P⟩
 
 end Construction
 

--- a/TauCeti/AlgebraicGeometry/Curves/StableReduction/DVRExtension.lean
+++ b/TauCeti/AlgebraicGeometry/Curves/StableReduction/DVRExtension.lean
@@ -1,0 +1,265 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RingTheory.DedekindDomain.Dvr
+public import Mathlib.RingTheory.DedekindDomain.Ideal.Lemmas
+public import Mathlib.RingTheory.DedekindDomain.IntegralClosure
+public import Mathlib.RingTheory.Ideal.GoingUp
+public import Mathlib.RingTheory.LocalRing.ResidueField.Basic
+public import Mathlib.RingTheory.Localization.LocalizationLocalization
+
+/-!
+# Finite separable extensions of a discrete valuation ring, with a chosen place
+
+Let `R` be a discrete valuation ring with fraction field `K`. A `TauCeti.FiniteDVRExtension R K`
+records a finite separable extension `K'` of `K` together with a *chosen* place of `K'` above the
+closed point of `R`: the integral closure `C` of `R` in `K'`, a maximal ideal `𝔪'` of `C` lying
+over the maximal ideal of `R`, and a ring `R'` presented as the localization of `C` at `𝔪'`.
+
+The choice is genuine data. The integral closure `C` is in general semilocal rather than local, so
+`C` is not itself a discrete valuation ring, and the valuation of `R` extends to `K'` in as many
+ways as `C` has maximal ideals; the package fixes one such extension. Accordingly `R'` is not
+required to be `Localization.AtPrime 𝔪'` on the nose: it is any ring carrying
+`IsLocalization.AtPrime`, so that a package can be assembled from whichever model of the local ring
+is already at hand.
+
+The package carries only what is not forced: the two type-valued carriers, the algebra maps that
+relate them, the chosen ideal, and the `Ideal.LiesOver` witness pinning it above the closed point
+of `R`. That `R'` is a discrete valuation ring with fraction field `K'` dominating `R` is proved
+here rather than assumed. Domination in particular makes `algebraMap R R'` an `IsLocalHom`, which
+is what lets Mathlib's residue-field machinery view the residue field of `R'` as an extension of
+that of `R`.
+
+## Main definitions
+
+* `TauCeti.FiniteDVRExtension`: the package described above.
+* `TauCeti.FiniteDVRExtension.integralClosure`: the integral closure of `R` in the extension field,
+  the ring the chosen place is an ideal of.
+* `TauCeti.FiniteDVRExtension.of`: the package attached to a maximal ideal of that integral closure
+  lying over the maximal ideal of `R`, with `Localization.AtPrime` as its local ring.
+
+## Main results
+
+* `TauCeti.FiniteDVRExtension.isDiscreteValuationRing_localRing`: the chosen local ring is a
+  discrete valuation ring.
+* `TauCeti.FiniteDVRExtension.isFractionRing_localRing`: its fraction field is the extension field.
+* `TauCeti.FiniteDVRExtension.under_prime`: the chosen place lies over the closed point of `R`.
+* `TauCeti.FiniteDVRExtension.finite_primesOver`: only finitely many places lie over it, so the
+  choice is a choice among finitely many.
+* `TauCeti.FiniteDVRExtension.isLocalHom_algebraMap` and
+  `TauCeti.FiniteDVRExtension.under_maximalIdeal_localRing`: the chosen local ring dominates `R`.
+* `TauCeti.FiniteDVRExtension.exists_extensionField_eq`: every finite separable extension of `K`
+  underlies such a package, one for each place above the closed point of `R`.
+-/
+
+public section
+
+universe u
+
+namespace TauCeti
+
+open IsLocalRing
+
+/-- A finite separable extension of the fraction field `K` of a discrete valuation ring `R`,
+together with a chosen place of that extension above the closed point of `R`.
+
+The place is recorded as a maximal ideal `prime` of the integral closure of `R` in the extension
+field, lying over the maximal ideal of `R`, together with a ring `localRing` presented as the
+localization there. See `TauCeti.FiniteDVRExtension.of` for the construction from such an ideal and
+`TauCeti.FiniteDVRExtension.exists_extensionField_eq` for the fact that one always exists. -/
+structure FiniteDVRExtension (R K : Type u) [CommRing R] [IsDomain R] [IsDiscreteValuationRing R]
+    [Field K] [Algebra R K] [IsFractionRing R K] where
+  /-- The extension field `K'` of `K`. -/
+  extensionField : Type u
+  [extensionFieldInst : Field extensionField]
+  [extensionAlgebra : Algebra K extensionField]
+  [extensionFinite : FiniteDimensional K extensionField]
+  [extensionSeparable : Algebra.IsSeparable K extensionField]
+  [extensionBaseAlgebra : Algebra R extensionField]
+  [extensionTower : IsScalarTower R K extensionField]
+  /-- The chosen place of `K'`, as a maximal ideal of the integral closure of `R` in `K'`. -/
+  prime : Ideal (integralClosure R extensionField)
+  [prime_isMaximal : prime.IsMaximal]
+  [prime_liesOver : prime.LiesOver (maximalIdeal R)]
+  /-- The local ring `R'` of the chosen place. -/
+  localRing : Type u
+  [localRingInst : CommRing localRing]
+  [localRingClosureAlgebra : Algebra (integralClosure R extensionField) localRing]
+  [localRingIsLocalization : IsLocalization.AtPrime localRing prime]
+  [localRingAlgebra : Algebra R localRing]
+  [localRingTower : IsScalarTower R (integralClosure R extensionField) localRing]
+  [fractionAlgebra : Algebra localRing extensionField]
+  [fractionTower : IsScalarTower (integralClosure R extensionField) localRing extensionField]
+
+namespace FiniteDVRExtension
+
+attribute [instance] extensionFieldInst extensionAlgebra extensionFinite extensionSeparable
+  extensionBaseAlgebra extensionTower prime_isMaximal prime_liesOver localRingInst
+  localRingClosureAlgebra localRingIsLocalization localRingAlgebra localRingTower
+  fractionAlgebra fractionTower
+
+variable {R K : Type u} [CommRing R] [IsDomain R] [IsDiscreteValuationRing R]
+  [Field K] [Algebra R K] [IsFractionRing R K] (E : FiniteDVRExtension R K)
+
+/-- The integral closure of `R` in the extension field: the ring the chosen place is an ideal
+of. -/
+abbrev integralClosure : Type u := _root_.integralClosure R E.extensionField
+
+instance isFractionRing_integralClosure : IsFractionRing E.integralClosure E.extensionField :=
+  IsIntegralClosure.isFractionRing_of_finite_extension R K E.extensionField _
+
+instance isDedekindDomain_integralClosure : IsDedekindDomain E.integralClosure :=
+  _root_.integralClosure.isDedekindDomain R K E.extensionField
+
+instance isIntegral_integralClosure : Algebra.IsIntegral R E.integralClosure :=
+  IsIntegralClosure.isIntegral_algebra R E.extensionField
+
+/-- The integral closure is a finite `R`-module, so it is semilocal: the places of `K'` above the
+closed point of `R` are the finitely many maximal ideals of `C`, and there is more than one as soon
+as the place of `R` does not extend uniquely. -/
+instance isNoetherian_integralClosure : IsNoetherian R E.integralClosure :=
+  IsIntegralClosure.isNoetherian R K E.extensionField _
+
+instance faithfulSMul_extensionField : FaithfulSMul R E.extensionField :=
+  have : FaithfulSMul K E.extensionField :=
+    (faithfulSMul_iff_algebraMap_injective K E.extensionField).2
+      (algebraMap K E.extensionField).injective
+  FaithfulSMul.trans R K E.extensionField
+
+instance faithfulSMul_integralClosure : FaithfulSMul R E.integralClosure :=
+  FaithfulSMul.tower_bot R E.integralClosure E.extensionField
+
+/-- The chosen place lies above the closed point of `R`, spelled as a contraction of ideals. -/
+theorem under_prime : E.prime.under R = maximalIdeal R :=
+  (Ideal.over_def E.prime _).symm
+
+/-- The chosen place is one of finitely many: the places of `K'` above the closed point of `R` are
+the maximal ideals of the Dedekind domain `C` lying over it, and there are finitely many. -/
+theorem finite_primesOver : ((maximalIdeal R).primesOver E.integralClosure).Finite :=
+  IsDedekindDomain.primesOver_finite _ _
+
+/-- The chosen place is a nonzero prime: it lies over the maximal ideal of `R`, which is nonzero
+because a discrete valuation ring is not a field. -/
+theorem prime_ne_bot : E.prime ≠ ⊥ :=
+  Ideal.ne_bot_of_liesOver_of_ne_bot (IsDiscreteValuationRing.not_a_field R) E.prime
+
+instance isDomain_localRing : IsDomain E.localRing :=
+  IsLocalization.isDomain_of_le_nonZeroDivisors _ E.prime.primeCompl_le_nonZeroDivisors
+
+instance isFractionRing_localRing : IsFractionRing E.localRing E.extensionField :=
+  IsFractionRing.isFractionRing_of_isDomain_of_isLocalization E.prime.primeCompl _ _
+
+/-- The local ring of the chosen place is a discrete valuation ring: it is the localization of the
+Dedekind domain `C` at the nonzero prime `𝔪'`. -/
+instance isDiscreteValuationRing_localRing : IsDiscreteValuationRing E.localRing :=
+  IsLocalization.AtPrime.isDiscreteValuationRing_of_dedekind_domain E.integralClosure
+    E.prime_ne_bot _
+
+instance isScalarTower_localRing : IsScalarTower R E.localRing E.extensionField :=
+  .of_algebraMap_eq fun x ↦ by
+    rw [IsScalarTower.algebraMap_apply R E.integralClosure E.localRing,
+      ← IsScalarTower.algebraMap_apply E.integralClosure E.localRing E.extensionField,
+      ← IsScalarTower.algebraMap_apply R E.integralClosure E.extensionField]
+
+instance faithfulSMul_localRing : FaithfulSMul R E.localRing := by
+  rw [faithfulSMul_iff_algebraMap_injective,
+    IsScalarTower.algebraMap_eq R E.integralClosure E.localRing]
+  exact (IsLocalization.injective E.localRing E.prime.primeCompl_le_nonZeroDivisors).comp
+    (FaithfulSMul.algebraMap_injective R E.integralClosure)
+
+/-- The maximal ideal of the local ring of the chosen place contracts to the chosen place. -/
+theorem under_maximalIdeal_integralClosure :
+    (maximalIdeal E.localRing).under E.integralClosure = E.prime :=
+  IsLocalization.AtPrime.under_maximalIdeal _ _
+
+/-- The local ring of the chosen place dominates `R`. -/
+instance isLocalHom_algebraMap : IsLocalHom (algebraMap R E.localRing) := by
+  refine ((local_hom_TFAE (algebraMap R E.localRing)).out 4 1).1 fun x hx ↦ ?_
+  rw [Ideal.mem_comap, IsScalarTower.algebraMap_apply R E.integralClosure E.localRing]
+  exact (IsLocalization.AtPrime.to_map_mem_maximal_iff _ E.prime _).2
+    ((Ideal.mem_of_liesOver E.prime (maximalIdeal R) x).1 hx)
+
+/-- Domination spelled as a contraction of ideals: the closed point of `Spec R'` lies over the
+closed point of `Spec R`. -/
+theorem under_maximalIdeal_localRing : (maximalIdeal E.localRing).under R = maximalIdeal R :=
+  IsLocalRing.maximalIdeal_comap _
+
+section Construction
+
+variable (R K)
+variable (L : Type u) [Field L] [Algebra K L] [FiniteDimensional K L] [Algebra.IsSeparable K L]
+  [Algebra R L] [IsScalarTower R K L]
+
+/-- The algebra structure on `Localization.AtPrime P`, for `P` a prime of the integral closure `C`
+of `R` in `L`, given by mapping a fraction of integral elements to the corresponding element of
+`L`. This is legitimate because a prime of a domain misses `0`, so the denominators become units.
+
+This is a reducible non-instance in the sense of the note [reducible non-instances]: which algebra
+structure a localization should carry towards a further ring is context-dependent. It is the value
+taken by the `fractionAlgebra` field of `TauCeti.FiniteDVRExtension.of`. -/
+noncomputable abbrev localizationAlgebra (P : Ideal (_root_.integralClosure R L)) [P.IsPrime] :
+    Algebra (Localization.AtPrime P) L :=
+  RingHom.toAlgebra <| IsLocalization.lift
+    (M := P.primeCompl) (g := algebraMap (_root_.integralClosure R L) L) fun y ↦
+      isUnit_iff_ne_zero.2 fun h ↦ y.2 <| by
+        rw [show (y : _root_.integralClosure R L) = 0 from
+          FaithfulSMul.algebraMap_injective (_root_.integralClosure R L) L (by simpa using h)]
+        exact P.zero_mem
+
+attribute [local instance] localizationAlgebra
+
+instance isScalarTower_localizationAlgebra (P : Ideal (_root_.integralClosure R L)) [P.IsPrime] :
+    IsScalarTower (_root_.integralClosure R L) (Localization.AtPrime P) L :=
+  .of_algebraMap_eq fun x ↦ (IsLocalization.lift_eq _ x).symm
+
+/-- The finite extension of the discrete valuation ring `R` cut out by a maximal ideal `P` of the
+integral closure of `R` in a finite separable extension `L` of `K`, provided `P` lies above the
+maximal ideal of `R`. Its local ring is `Localization.AtPrime P`. -/
+@[expose]
+noncomputable def of (P : Ideal (_root_.integralClosure R L)) [P.IsMaximal]
+    [P.LiesOver (maximalIdeal R)] : FiniteDVRExtension R K where
+  extensionField := L
+  prime := P
+  localRing := Localization.AtPrime P
+  fractionAlgebra := localizationAlgebra R L P
+
+@[simp]
+theorem of_extensionField (P : Ideal (_root_.integralClosure R L)) [P.IsMaximal]
+    [P.LiesOver (maximalIdeal R)] : (of R K L P).extensionField = L := rfl
+
+@[simp]
+theorem of_prime (P : Ideal (_root_.integralClosure R L)) [P.IsMaximal]
+    [P.LiesOver (maximalIdeal R)] : (of R K L P).prime = P := rfl
+
+@[simp]
+theorem of_localRing (P : Ideal (_root_.integralClosure R L)) [P.IsMaximal]
+    [P.LiesOver (maximalIdeal R)] : (of R K L P).localRing = Localization.AtPrime P := rfl
+
+/-- Every finite separable extension `L` of `K` underlies a `FiniteDVRExtension R K`: the integral
+closure of `R` in `L` is integral over `R`, so going up produces a maximal ideal above the maximal
+ideal of `R`, and any such ideal cuts out a package with extension field `L`. -/
+theorem exists_extensionField_eq : ∃ E : FiniteDVRExtension R K, E.extensionField = L := by
+  have : FaithfulSMul K L :=
+    (faithfulSMul_iff_algebraMap_injective K L).2 (algebraMap K L).injective
+  have : FaithfulSMul R L := FaithfulSMul.trans R K L
+  have : FaithfulSMul R (_root_.integralClosure R L) :=
+    FaithfulSMul.tower_bot R (_root_.integralClosure R L) L
+  obtain ⟨P, _, _⟩ :=
+    Ideal.exists_maximal_ideal_liesOver_of_isIntegral (R := R) (S := _root_.integralClosure R L)
+      (maximalIdeal R)
+  exact ⟨of R K L P, rfl⟩
+
+end Construction
+
+/-- The trivial extension exists: `K` itself is a finite separable extension of `K`, and `R` is
+already local, so `FiniteDVRExtension R K` is never empty. -/
+instance : Nonempty (FiniteDVRExtension R K) :=
+  ⟨(exists_extensionField_eq R K K).choose⟩
+
+end FiniteDVRExtension
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/Curves/StableReduction/DVRExtension.lean
+++ b/TauCeti/AlgebraicGeometry/Curves/StableReduction/DVRExtension.lean
@@ -126,9 +126,6 @@ instance isFractionRing_integralClosure : IsFractionRing E.integralClosure E.ext
 instance isDedekindDomain_integralClosure : IsDedekindDomain E.integralClosure :=
   _root_.integralClosure.isDedekindDomain R K E.extensionField
 
-instance isIntegral_integralClosure : Algebra.IsIntegral R E.integralClosure :=
-  IsIntegralClosure.isIntegral_algebra R E.extensionField
-
 /-- The integral closure `C` of `R` in `K'` is a Noetherian `R`-module: it is a finite `R`-module,
 because `K'` is a finite separable extension of the fraction field of the Noetherian integrally
 closed domain `R`. -/

--- a/TauCeti/AlgebraicGeometry/Curves/StableReduction/DVRExtension.lean
+++ b/TauCeti/AlgebraicGeometry/Curves/StableReduction/DVRExtension.lean
@@ -57,14 +57,17 @@ that of `R`.
 ## References
 
 The interface here is not original to this file: it adapts the one proposed by the Tau Ceti
-`StableReduction` roadmap, whose `README.md` states the convention "DVR extensions are local
-data" — choose a maximal ideal of the integral closure above the closed point and localize, never
-treating the integral closure itself as a discrete valuation ring — and whose `Suggested.lean`
-writes down the signature followed below: the same carriers, algebra maps, scalar towers and
-chosen prime.
+[`StableReduction` roadmap][roadmap], whose `README.md` states the convention "DVR extensions are
+local data" — choose a maximal ideal of the integral closure above the closed point and localize,
+never treating the integral closure itself as a discrete valuation ring — and whose
+[`Suggested.lean`][suggested] writes down the signature followed below: the same carriers, algebra
+maps, scalar towers and chosen prime.
 
 The mathematics is standard; Q. Liu, *Algebraic Geometry and Arithmetic Curves*, covers reduction
 of curves over a discrete valuation ring.
+
+[roadmap]: https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/StableReduction/README.md
+[suggested]: https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/StableReduction/Suggested.lean
 -/
 
 public section

--- a/TauCeti/AlgebraicGeometry/Curves/StableReduction/DVRExtension.lean
+++ b/TauCeti/AlgebraicGeometry/Curves/StableReduction/DVRExtension.lean
@@ -7,7 +7,6 @@ module
 
 public import Mathlib.RingTheory.DedekindDomain.Dvr
 public import Mathlib.RingTheory.DedekindDomain.IntegralClosure
-public import Mathlib.RingTheory.Ideal.GoingUp
 public import Mathlib.RingTheory.Localization.LocalizationLocalization
 
 /-!
@@ -233,6 +232,18 @@ theorem of_prime (P : Ideal (_root_.integralClosure R L)) [P.IsPrime]
 @[simp]
 theorem of_localRing (P : Ideal (_root_.integralClosure R L)) [P.IsPrime]
     [P.LiesOver (maximalIdeal R)] : (of R K L P).localRing = Localization.AtPrime P := by
+  rw [of]
+
+@[simp]
+theorem of_extensionFieldInst (P : Ideal (_root_.integralClosure R L)) [P.IsPrime]
+    [P.LiesOver (maximalIdeal R)] :
+    HEq (of R K L P).extensionFieldInst (inferInstance : Field L) := by
+  rw [of]
+
+@[simp]
+theorem of_localRingInst (P : Ideal (_root_.integralClosure R L)) [P.IsPrime]
+    [P.LiesOver (maximalIdeal R)] :
+    HEq (of R K L P).localRingInst (inferInstance : CommRing (Localization.AtPrime P)) := by
   rw [of]
 
 @[simp]

--- a/TauCeti/AlgebraicGeometry/Curves/StableReduction/DVRExtension.lean
+++ b/TauCeti/AlgebraicGeometry/Curves/StableReduction/DVRExtension.lean
@@ -48,9 +48,9 @@ that of `R`.
 * `TauCeti.FiniteDVRExtension.under_prime`: the chosen place lies over the closed point of `R`.
 * `TauCeti.FiniteDVRExtension.isLocalHom_algebraMap` and
   `TauCeti.FiniteDVRExtension.under_maximalIdeal_localRing`: the chosen local ring dominates `R`.
-* `TauCeti.FiniteDVRExtension.exists_extensionField_eq`: every finite separable extension of `K`
-  underlies such a package, for some place above the closed point of `R`; to fix a specified
-  place, use `TauCeti.FiniteDVRExtension.of`.
+* `TauCeti.FiniteDVRExtension.exists_algEquiv_extensionField`: every finite separable extension of
+  `K` is, as a `K`-algebra, the extension field of such a package, for some place above the closed
+  point of `R`; to fix a specified place, use `TauCeti.FiniteDVRExtension.of`.
 
 ## References
 
@@ -76,7 +76,8 @@ together with a chosen place of that extension above the closed point of `R`.
 The place is recorded as a maximal ideal `prime` of the integral closure of `R` in the extension
 field, lying over the maximal ideal of `R`, together with a ring `localRing` presented as the
 localization there. See `TauCeti.FiniteDVRExtension.of` for the construction from such an ideal and
-`TauCeti.FiniteDVRExtension.exists_extensionField_eq` for the fact that one always exists. -/
+`TauCeti.FiniteDVRExtension.exists_algEquiv_extensionField` for the fact that one always
+exists. -/
 structure FiniteDVRExtension (R K : Type u) [CommRing R] [IsDomain R] [IsDiscreteValuationRing R]
     [Field K] [Algebra R K] [IsFractionRing R K] where
   /-- The extension field `K'` of `K`. -/
@@ -199,16 +200,6 @@ variable (R K)
 variable (L : Type u) [Field L] [Algebra K L] [FiniteDimensional K L] [Algebra.IsSeparable K L]
   [Algebra R L] [IsScalarTower R K L]
 
-/-- The canonical algebra structure from the localization at `P` to `L`, obtained by viewing both
-as localizations of the integral closure and using `P.primeCompl ≤ nonZeroDivisors`. -/
-noncomputable abbrev ofFractionAlgebra
-    (P : Ideal (_root_.integralClosure R L)) [P.IsPrime] :
-    Algebra (Localization.AtPrime P) L :=
-  letI : IsFractionRing (_root_.integralClosure R L) L :=
-    IsIntegralClosure.isFractionRing_of_finite_extension R K L _
-  IsLocalization.localizationAlgebraOfSubmonoidLe _ _ P.primeCompl
-    (nonZeroDivisors _) P.primeCompl_le_nonZeroDivisors
-
 /-- The finite extension of the discrete valuation ring `R` cut out by a maximal ideal `P` of the
 integral closure `C` of `R` in a finite separable extension `L` of `K`, provided `P` lies above the
 maximal ideal of `R`. Its local ring is `Localization.AtPrime P`.
@@ -225,59 +216,79 @@ noncomputable def of (P : Ideal (_root_.integralClosure R L)) [P.IsPrime]
   { extensionField := L
     prime := P
     localRing := Localization.AtPrime P
-    fractionAlgebra := ofFractionAlgebra R K L P
+    fractionAlgebra := IsLocalization.localizationAlgebraOfSubmonoidLe _ _ P.primeCompl
+      (nonZeroDivisors _) P.primeCompl_le_nonZeroDivisors
     fractionTower := IsLocalization.localization_isScalarTower_of_submonoid_le _ _ _ _ _ }
+
+/-- The unfolding equation for `of`, stated once: the characteristic lemmas below are all proved
+from it, so that no public lemma depends on the elaborator-generated equation of `of`. -/
+private theorem of_def (P : Ideal (_root_.integralClosure R L)) [P.IsPrime]
+    [P.LiesOver (maximalIdeal R)] :
+    of R K L P =
+      haveI : IsFractionRing (_root_.integralClosure R L) L :=
+        IsIntegralClosure.isFractionRing_of_finite_extension R K L _
+      letI : P.IsMaximal := .of_liesOver_isMaximal P (maximalIdeal R)
+      { extensionField := L
+        prime := P
+        localRing := Localization.AtPrime P
+        fractionAlgebra := IsLocalization.localizationAlgebraOfSubmonoidLe _ _ P.primeCompl
+          (nonZeroDivisors _) P.primeCompl_le_nonZeroDivisors
+        fractionTower := IsLocalization.localization_isScalarTower_of_submonoid_le _ _ _ _ _ } := by
+  rw [of]
 
 @[simp]
 theorem of_extensionField (P : Ideal (_root_.integralClosure R L)) [P.IsPrime]
     [P.LiesOver (maximalIdeal R)] : (of R K L P).extensionField = L := by
-  rw [of.eq_1]
+  rw [of_def]
 
 @[simp]
 theorem of_prime (P : Ideal (_root_.integralClosure R L)) [P.IsPrime]
     [P.LiesOver (maximalIdeal R)] : HEq (of R K L P).prime P := by
-  rw [of.eq_1]
+  rw [of_def]
 
 @[simp]
 theorem of_localRing (P : Ideal (_root_.integralClosure R L)) [P.IsPrime]
     [P.LiesOver (maximalIdeal R)] : (of R K L P).localRing = Localization.AtPrime P := by
-  rw [of.eq_1]
+  rw [of_def]
 
 @[simp]
 theorem of_extensionAlgebra (P : Ideal (_root_.integralClosure R L)) [P.IsPrime]
     [P.LiesOver (maximalIdeal R)] :
     HEq (of R K L P).extensionAlgebra (inferInstance : Algebra K L) := by
-  rw [of.eq_1]
+  rw [of_def]
 
 @[simp]
 theorem of_extensionBaseAlgebra (P : Ideal (_root_.integralClosure R L)) [P.IsPrime]
     [P.LiesOver (maximalIdeal R)] :
     HEq (of R K L P).extensionBaseAlgebra (inferInstance : Algebra R L) := by
-  rw [of.eq_1]
+  rw [of_def]
 
 @[simp]
 theorem of_localRingClosureAlgebra (P : Ideal (_root_.integralClosure R L)) [P.IsPrime]
     [P.LiesOver (maximalIdeal R)] :
     HEq (of R K L P).localRingClosureAlgebra
       (inferInstance : Algebra (_root_.integralClosure R L) (Localization.AtPrime P)) := by
-  rw [of.eq_1]
+  rw [of_def]
 
 @[simp]
 theorem of_localRingAlgebra (P : Ideal (_root_.integralClosure R L)) [P.IsPrime]
     [P.LiesOver (maximalIdeal R)] :
     HEq (of R K L P).localRingAlgebra (inferInstance : Algebra R (Localization.AtPrime P)) := by
-  rw [of.eq_1]
+  rw [of_def]
 
-@[simp]
-theorem of_fractionAlgebra (P : Ideal (_root_.integralClosure R L)) [P.IsPrime]
-    [P.LiesOver (maximalIdeal R)] :
-    HEq (of R K L P).fractionAlgebra (ofFractionAlgebra R K L P) := by
-  rw [of.eq_1]
+/-- The algebra-level refinement of `TauCeti.FiniteDVRExtension.of_extensionField`: the extension
+field of the package cut out by `P` is `L` itself as a `K`-algebra, not merely as a type. -/
+theorem of_extensionField_algEquiv (P : Ideal (_root_.integralClosure R L)) [P.IsPrime]
+    [P.LiesOver (maximalIdeal R)] : Nonempty ((of R K L P).extensionField ≃ₐ[K] L) := by
+  rw [of_def]
+  exact ⟨AlgEquiv.refl⟩
 
 /-- Every finite separable extension `L` of `K` underlies a `FiniteDVRExtension R K`: the integral
 closure of `R` in `L` is integral over `R`, so going up produces a maximal ideal above the maximal
-ideal of `R`, and any such ideal cuts out a package with extension field `L`. -/
-theorem exists_extensionField_eq : ∃ E : FiniteDVRExtension R K, E.extensionField = L := by
+ideal of `R`, and any such ideal cuts out a package whose extension field is `L` as a
+`K`-algebra. -/
+theorem exists_algEquiv_extensionField :
+    ∃ E : FiniteDVRExtension R K, Nonempty (E.extensionField ≃ₐ[K] L) := by
   have : FaithfulSMul K L :=
     (faithfulSMul_iff_algebraMap_injective K L).2 (algebraMap K L).injective
   have : FaithfulSMul R L := FaithfulSMul.trans R K L
@@ -286,14 +297,14 @@ theorem exists_extensionField_eq : ∃ E : FiniteDVRExtension R K, E.extensionFi
   obtain ⟨P, _, _⟩ :=
     Ideal.exists_maximal_ideal_liesOver_of_isIntegral (R := R) (S := _root_.integralClosure R L)
       (maximalIdeal R)
-  exact ⟨of R K L P, rfl⟩
+  exact ⟨of R K L P, of_extensionField_algEquiv R K L P⟩
 
 end Construction
 
 /-- The trivial extension exists: `K` itself is a finite separable extension of `K`, and `R` is
 already local, so `FiniteDVRExtension R K` is never empty. -/
 instance : Nonempty (FiniteDVRExtension R K) :=
-  ⟨(exists_extensionField_eq R K K).choose⟩
+  ⟨(exists_algEquiv_extensionField R K K).choose⟩
 
 end FiniteDVRExtension
 


### PR DESCRIPTION
This PR builds the `FiniteDVRExtension R K` package that the stable-reduction roadmap's Layer 0 ("relative curves and extensions of DVRs") calls for: for a discrete valuation ring `R` with fraction field `K`, it records a finite separable extension `K'` of `K` together with a *chosen* place of `K'` above the closed point of `R` — the integral closure `C` of `R` in `K'`, a maximal ideal `𝔪'` of `C` lying over the maximal ideal of `R`, and a ring `R'` presented as the localization of `C` at `𝔪'`. The roadmap's standing convention on DVR extensions is explicit that this choice must be recorded and that the integral closure must not be passed off as a DVR: `C` is only semilocal, so the valuation of `R` extends to `K'` in as many ways as `C` has maximal ideals. The package therefore stores the two carriers, the algebra maps relating them, the ideal and an `Ideal.LiesOver` witness, and everything else is proved: `R'` is a discrete valuation ring, its fraction field is `K'`, `R → R'` is injective and an `IsLocalHom`, and the closed point of `Spec R'` contracts to the closed point of `Spec R`. `FiniteDVRExtension.of` builds the package from any maximal ideal of `C` lying over the maximal ideal of `R`, and `exists_algEquiv_extensionField` produces one over every finite separable `L/K`, with `L` recovered as the extension field up to a `K`-algebra equivalence. That the choice of place is a choice among finitely many is Mathlib's `IsDedekindDomain.primesOver_finite`, which applies to `E.integralClosure` through the instances this module supplies; it is not restated here.

The milestone served is the roadmap's first summit, existence of stable reduction (`TauCetiRoadmap/StableReduction/README.md`, "The summit", item 1: for a smooth projective geometrically connected curve of genus `g ≥ 2` over `K` there are a finite separable `K'/K`, a maximal ideal `m'` of the integral closure of `R` in `K'`, and a stable family over `Spec(R̃_{m'})` with the prescribed generic fibre). `FiniteDVRExtension` is exactly the data that statement quantifies over, and it is the Layer 0 bullet "Define the `FiniteDVRExtension R K` package described above"; the signature follows `TauCetiRoadmap/StableReduction/Suggested.lean`'s `FiniteDVRExtension` field-for-field, except that the abstract `localRing` is pinned by the standard `IsLocalization.AtPrime` predicate rather than by an explicit `≃ₐ` to `Localization.AtPrime` plus a commuting square, and the fields the roadmap sketch lists as assumptions (`localRingDomain`, `localRingDVR`, `localRingDominates`, `fractionIdentification`) are theorems here instead. After this PR that Layer 0 bullet still owes the finite and separable towers and the common-refinement lemmas embedding two packages compatibly into a third; the rest of Layer 0 — relative dimension, `FamilyOfCurves`, generic and special fibres, and models with their category — is untouched, and no scheme-level work is claimed here.

Placement follows the roadmap's suggested home for its own reduction theory, `TauCeti/AlgebraicGeometry/Curves/StableReduction/`, which is new in this PR; the file is ring theory because that is what a DVR extension is, but the package is roadmap-specific bundling rather than general commutative algebra, so it does not belong in the shared `TauCeti/RingTheory/` tree. No Mathlib code is vendored: the discrete-valuation-ring, Dedekind-domain, integral-closure, localization and `Ideal.LiesOver` inputs are all consumed from the pinned Mathlib, and the `IsLocalHom` instance proved here is what makes Mathlib's residue-field extension `ResidueField R → ResidueField R'` available downstream for free.

Roadmap: StableReduction

<!--tauceti-target:v1 {"focus":"StableReduction","id":"finitedvrextension"}-->

🤖 Prepared with Claude Code

