### PR TITLE
feat: a multiquadratic field lies in a cyclotomic field

### DIFF
--- a/TauCeti/NumberTheory/Multiquadratic/Cyclotomic/Embedding.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Cyclotomic/Embedding.lean
@@ -1,0 +1,240 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.NumberTheory.Multiquadratic.Cyclotomic.GaussSum
+public import Mathlib.RingTheory.RootsOfUnity.Complex
+
+/-!
+# A multiquadratic field lies in a cyclotomic field
+
+This file proves the explicit Kronecker–Weber theorem for multiquadratic fields: the field
+generated over `ℚ` by square roots of rational numbers `d₁, …, dₙ` is contained in a cyclotomic
+field. Concretely, inside any field `L` of characteristic zero holding a primitive `N`-th root of
+unity `ζ`, every square root of a nonzero integer `m` with `4 |m| ∣ N` already lies in `ℚ(ζ)`.
+
+The engine is the prime case: a square root of a prime `p` is assembled from a root of unity of
+order `4p`. For odd `p` the quadratic Gauss sum supplies a square root of the prime discriminant
+`p* = ±p` (`exists_mem_sq_eq_oddPrimeDiscriminant`), and the fourth root of unity corrects its sign
+when `p ≡ 3 (mod 4)`; for `p = 2` the eighth root of unity supplies `√2` directly
+(`exists_mem_sq_eq_two`). Multiplying square roots along a prime factorization reaches every
+positive integer, the fourth root of unity reaches the negative ones, and clearing denominators
+reaches every rational number. Since the two square roots of an element differ by a sign, *every*
+square root of such an `m` lies in the field, not just the constructed one.
+
+Taking `L = ℂ` makes the statement unconditional: with `N = 4 ∏ᵢ |dᵢ|` one may use
+`ζ = exp (2 π i / N)`, so `ℚ(√d₁, …, √dₙ) ⊆ ℚ(ζ_N)` for any choice of square roots. The target
+`ℚ(ζ_N)` is the `N`-th cyclotomic field: `IsPrimitiveRoot.adjoin_isCyclotomicExtension` identifies
+it as a cyclotomic extension of `ℚ`.
+
+This is the multiquadratic case of the Kronecker–Weber theorem, which it makes explicit: the
+cyclotomic field is named, not merely asserted to exist. The general theorem, for every abelian
+extension of `ℚ`, is not proved here. For the classical account see K. Ireland and M. Rosen, *A
+Classical Introduction to Modern Number Theory*, Chapter 6.
+
+## Main results
+
+* `TauCeti.Multiquadratic.mem_of_sq_eq_intCast`: every square root of a nonzero integer `m` lies in
+  an intermediate field holding a primitive `N`-th root of unity, provided `4 |m| ∣ N`.
+* `TauCeti.Multiquadratic.mem_of_sq_eq_ratCast`: the same for a nonzero rational number.
+* `TauCeti.Multiquadratic.adjoin_range_le_of_sq_eq_ratCast`: a multiquadratic field with rational
+  radicands is contained in any such intermediate field.
+* `TauCeti.Multiquadratic.adjoin_range_le_adjoin_exp`: over `ℂ`, with integer radicands,
+  `ℚ(√d₁, …, √dₙ) ⊆ ℚ(ζ_N)` for `N = 4 ∏ᵢ |dᵢ|`.
+* `TauCeti.Multiquadratic.exists_isPrimitiveRoot_adjoin_range_le_adjoin`: every multiquadratic
+  field with rational radicands lies in a cyclotomic field.
+-/
+
+public section
+
+open IntermediateField
+
+namespace TauCeti.Multiquadratic
+
+variable {L : Type*} [Field L] [CharZero L] {F : IntermediateField ℚ L} {ζ : L} {N : ℕ}
+
+/-- **A root of unity of order `4p` carries a square root of the prime `p`.** For an odd prime the
+Gauss sum gives a square root of `p* = ±p`, and a primitive fourth root of unity repairs the sign;
+for `p = 2` a primitive eighth root of unity gives `√2`. -/
+theorem exists_mem_sq_eq_prime (hN : 0 < N) (hζ : IsPrimitiveRoot ζ N) (hmem : ζ ∈ F) {p : ℕ}
+    (hp : p.Prime) (hdvd : 4 * p ∣ N) :
+    ∃ x ∈ F, x ^ 2 = (p : L) := by
+  rcases eq_or_ne p 2 with rfl | hp2
+  · have h8 : 8 ∣ N := by norm_num at hdvd; exact hdvd
+    obtain ⟨x, hxF, hx⟩ := exists_mem_sq_eq_two (hζ.pow hN (Nat.div_mul_cancel h8).symm)
+      (pow_mem hmem _)
+    exact ⟨x, hxF, by rw [hx]; norm_num⟩
+  · have hpN : p ∣ N := (dvd_mul_left p 4).trans hdvd
+    have h4N : 4 ∣ N := (dvd_mul_right 4 p).trans hdvd
+    obtain ⟨w, hwF, hw⟩ := exists_mem_sq_eq_oddPrimeDiscriminant hp hp2
+      (hζ.pow hN (Nat.div_mul_cancel hpN).symm) (pow_mem hmem _)
+    by_cases hp4 : p % 4 = 1
+    · rw [oddPrimeDiscriminant_of_mod_four_eq_one hp4] at hw
+      exact ⟨w, hwF, by rw [hw]; push_cast; ring⟩
+    · rw [oddPrimeDiscriminant_of_mod_four_ne_one hp4] at hw
+      obtain ⟨i, hiF, hi⟩ := exists_mem_sq_eq_neg_one (hζ.pow hN (Nat.div_mul_cancel h4N).symm)
+        (pow_mem hmem _)
+      refine ⟨i * w, mul_mem hiF hwF, ?_⟩
+      rw [mul_pow, hi, hw]
+      push_cast
+      ring
+
+/-- **A root of unity of order divisible by `4n` carries a square root of `n`.** The square roots
+of the prime factors of `n` multiply together. -/
+theorem exists_mem_sq_eq_natCast (hN : 0 < N) (hζ : IsPrimitiveRoot ζ N) (hmem : ζ ∈ F) {n : ℕ}
+    (hn : 0 < n) (hdvd : 4 * n ∣ N) :
+    ∃ x ∈ F, x ^ 2 = (n : L) := by
+  induction n using Nat.strong_induction_on with
+  | _ n ih =>
+    rcases eq_or_ne n 1 with rfl | hn1
+    · exact ⟨1, one_mem F, by norm_num⟩
+    · obtain ⟨p, k, hpp, hk⟩ : ∃ p k, Nat.Prime p ∧ n = p * k :=
+        ⟨n.minFac, n / n.minFac, Nat.minFac_prime hn1,
+          (Nat.mul_div_cancel' n.minFac_dvd).symm⟩
+      have hk0 : 0 < k := by
+        rcases Nat.eq_zero_or_pos k with rfl | h
+        · simp only [Nat.mul_zero] at hk; omega
+        · exact h
+      have h2k : 2 * k ≤ n := hk ▸ Nat.mul_le_mul_right k hpp.two_le
+      obtain ⟨y, hyF, hy⟩ := ih k (by omega) hk0
+        (dvd_trans ⟨p, by rw [hk]; ring⟩ hdvd)
+      obtain ⟨z, hzF, hz⟩ := exists_mem_sq_eq_prime hN hζ hmem hpp
+        (dvd_trans ⟨k, by rw [hk]; ring⟩ hdvd)
+      refine ⟨y * z, mul_mem hyF hzF, ?_⟩
+      rw [mul_pow, hy, hz, hk]
+      push_cast
+      ring
+
+/-- **A root of unity of order divisible by `4 |m| ` carries a square root of the integer `m`.**
+A primitive fourth root of unity turns the square root of `|m|` into one of `m`. -/
+theorem exists_mem_sq_eq_intCast (hN : 0 < N) (hζ : IsPrimitiveRoot ζ N) (hmem : ζ ∈ F) {m : ℤ}
+    (hm : m ≠ 0) (hdvd : 4 * m.natAbs ∣ N) :
+    ∃ x ∈ F, x ^ 2 = (m : L) := by
+  obtain ⟨x, hxF, hx⟩ := exists_mem_sq_eq_natCast hN hζ hmem (Int.natAbs_pos.mpr hm) hdvd
+  rcases m.natAbs_eq with hm' | hm'
+  · have hcast : ((m : L)) = ((m.natAbs : ℕ) : L) := by rw [hm']; simp
+    exact ⟨x, hxF, by rw [hx, hcast]⟩
+  · have h4N : 4 ∣ N := (dvd_mul_right 4 m.natAbs).trans hdvd
+    obtain ⟨i, hiF, hi⟩ := exists_mem_sq_eq_neg_one (hζ.pow hN (Nat.div_mul_cancel h4N).symm)
+      (pow_mem hmem _)
+    have hcast : ((m : L)) = -((m.natAbs : ℕ) : L) := by
+      rw [hm']
+      simp
+    refine ⟨i * x, mul_mem hiF hxF, ?_⟩
+    rw [mul_pow, hi, hx, hcast]
+    ring
+
+/-- **Every square root of an integer lies in a field of roots of unity of matching order.** If the
+intermediate field `F` contains a primitive `N`-th root of unity and `4 |m| ∣ N` for a nonzero
+integer `m`, then both square roots of `m` lie in `F`: the constructed one does, and the two differ
+by a sign. -/
+theorem mem_of_sq_eq_intCast (hN : 0 < N) (hζ : IsPrimitiveRoot ζ N) (hmem : ζ ∈ F) {m : ℤ}
+    (hm : m ≠ 0) (hdvd : 4 * m.natAbs ∣ N) {x : L} (hx : x ^ 2 = (m : L)) : x ∈ F := by
+  obtain ⟨y, hyF, hy⟩ := exists_mem_sq_eq_intCast hN hζ hmem hm hdvd
+  have hfac : (x - y) * (x + y) = 0 := by linear_combination hx - hy
+  rcases mul_eq_zero.mp hfac with h | h
+  · rw [sub_eq_zero] at h
+    exact h ▸ hyF
+  · rw [add_eq_zero_iff_eq_neg] at h
+    exact h ▸ neg_mem hyF
+
+/-- **Every square root of a rational number lies in a field of roots of unity of matching
+order.** Clearing the denominator of `q` turns it into the integer `q.num * q.den`, whose square
+class it shares. -/
+theorem mem_of_sq_eq_ratCast (hN : 0 < N) (hζ : IsPrimitiveRoot ζ N) (hmem : ζ ∈ F) {q : ℚ}
+    (hq : q ≠ 0) (hdvd : 4 * (q.num * q.den).natAbs ∣ N) {x : L}
+    (hx : x ^ 2 = (q : L)) : x ∈ F := by
+  have hden : ((q.den : L)) ≠ 0 := Nat.cast_ne_zero.mpr q.den_nz
+  have hnum : q.num * q.den ≠ 0 := mul_ne_zero (Rat.num_ne_zero.mpr hq) (by exact_mod_cast q.den_nz)
+  have hq' : (q : L) * q.den = q.num := by
+    rw [Rat.cast_def]
+    field_simp
+  have hxd : (x * q.den) ^ 2 = ((q.num * q.den : ℤ) : L) := by
+    rw [mul_pow, hx, show ((q : L)) * (q.den : L) ^ 2 = ((q : L) * q.den) * q.den by ring, hq']
+    push_cast
+    ring
+  have hmemxd : x * q.den ∈ F := mem_of_sq_eq_intCast hN hζ hmem hnum hdvd hxd
+  have hxeq : x = (x * q.den) / (q.den : L) := by field_simp
+  rw [hxeq]
+  exact div_mem hmemxd (IntermediateField.natCast_mem F _)
+
+/-- **A multiquadratic field lies in any field of roots of unity of matching order.** If the
+intermediate field `F` of `L / ℚ` contains a primitive `N`-th root of unity and, for each nonzero
+rational radicand `d i`, the order `N` is divisible by `4 |num (d i) · den (d i)|`, then every
+field generated over `ℚ` by square roots `r i` of the `d i` is contained in `F`. -/
+theorem adjoin_range_le_of_sq_eq_ratCast {ι : Type*} (hN : 0 < N) (hζ : IsPrimitiveRoot ζ N)
+    (hmem : ζ ∈ F) {d : ι → ℚ} {r : ι → L} (hd : ∀ i, d i ≠ 0)
+    (hr : ∀ i, r i ^ 2 = (d i : L)) (hdvd : ∀ i, 4 * ((d i).num * (d i).den).natAbs ∣ N) :
+    adjoin ℚ (Set.range r) ≤ F := by
+  rw [adjoin_le_iff]
+  rintro x ⟨i, rfl⟩
+  exact mem_of_sq_eq_ratCast hN hζ hmem (hd i) (hdvd i) (hr i)
+
+/-- **A multiquadratic field with integer radicands lies in any field of roots of unity of matching
+order.** The integer analogue of `adjoin_range_le_of_sq_eq_ratCast`: the divisibility condition
+reads `4 |d i| ∣ N`. -/
+theorem adjoin_range_le_of_sq_eq_intCast {ι : Type*} (hN : 0 < N) (hζ : IsPrimitiveRoot ζ N)
+    (hmem : ζ ∈ F) {d : ι → ℤ} {r : ι → L} (hd : ∀ i, d i ≠ 0)
+    (hr : ∀ i, r i ^ 2 = (d i : L)) (hdvd : ∀ i, 4 * (d i).natAbs ∣ N) :
+    adjoin ℚ (Set.range r) ≤ F := by
+  rw [adjoin_le_iff]
+  rintro x ⟨i, rfl⟩
+  exact mem_of_sq_eq_intCast hN hζ hmem (hd i) (hdvd i) (hr i)
+
+/-- **A multiquadratic field with integer radicands lies in the cyclotomic field `ℚ(ζ_N)`.** The
+`F = ℚ(ζ)` case of `adjoin_range_le_of_sq_eq_intCast`. -/
+theorem adjoin_range_le_adjoin_of_sq_eq_intCast {ι : Type*} (hN : 0 < N)
+    (hζ : IsPrimitiveRoot ζ N) {d : ι → ℤ} {r : ι → L} (hd : ∀ i, d i ≠ 0)
+    (hr : ∀ i, r i ^ 2 = (d i : L)) (hdvd : ∀ i, 4 * (d i).natAbs ∣ N) :
+    adjoin ℚ (Set.range r) ≤ adjoin ℚ {ζ} :=
+  adjoin_range_le_of_sq_eq_intCast hN hζ (mem_adjoin_simple_self ℚ ζ) hd hr hdvd
+
+/-! ### Over `ℂ` no root of unity need be assumed -/
+
+/-- **Every multiquadratic field lies in a cyclotomic field.** For a finite family of nonzero
+rational radicands `d i` and any choice of complex square roots `r i`, the field `ℚ(√d₁, …, √dₙ)`
+is contained in a cyclotomic extension of `ℚ`; the order exhibited is
+`N = 4 ∏ᵢ |num (dᵢ) · den (dᵢ)|`.
+
+This is the explicit Kronecker–Weber theorem for multiquadratic fields; for integer radicands the
+order is `N = 4 ∏ᵢ |dᵢ|`. -/
+theorem exists_isCyclotomicExtension_adjoin_range_le {ι : Type*} [Finite ι] {d : ι → ℚ}
+    {r : ι → ℂ} (hd : ∀ i, d i ≠ 0) (hr : ∀ i, r i ^ 2 = (d i : ℂ)) :
+    ∃ N : ℕ, 0 < N ∧ ∃ G : IntermediateField ℚ ℂ,
+      IsCyclotomicExtension {N} ℚ G ∧ adjoin ℚ (Set.range r) ≤ G := by
+  classical
+  let _ : Fintype ι := Fintype.ofFinite ι
+  have hfac : ∀ i, ((d i).num * (d i).den) ≠ 0 := fun i =>
+    mul_ne_zero (Rat.num_ne_zero.mpr (hd i)) (by exact_mod_cast (d i).den_nz)
+  have hprod : 0 < ∏ i, ((d i).num * (d i).den).natAbs :=
+    Finset.prod_pos fun i _ => Int.natAbs_pos.mpr (hfac i)
+  set N := 4 * ∏ i, ((d i).num * (d i).den).natAbs with hNdef
+  have hpos : 0 < N := by rw [hNdef]; omega
+  set ζ₀ := Complex.exp (2 * Real.pi * Complex.I / N)
+  have hζ : IsPrimitiveRoot ζ₀ N := Complex.isPrimitiveRoot_exp N hpos.ne'
+  have : NeZero N := ⟨hpos.ne'⟩
+  have hcyc : IsCyclotomicExtension {N} ℚ (adjoin ℚ {ζ₀}) :=
+    (IntermediateField.isCyclotomicExtension_singleton_iff_eq_adjoin
+      (F := adjoin ℚ {ζ₀}) (hζ := hζ)).mpr rfl
+  exact ⟨N, hpos, adjoin ℚ {ζ₀}, hcyc,
+    adjoin_range_le_of_sq_eq_ratCast hpos hζ (mem_adjoin_simple_self ℚ _) hd hr
+      fun i => Nat.mul_dvd_mul_left 4 (Finset.dvd_prod_of_mem _ (Finset.mem_univ i))⟩
+
+/-- **Worked example: `ℚ(√2, √3) ⊆ ℚ(ζ₂₄)`.** The smallest nontrivial multiquadratic field lies in
+the `24`-th cyclotomic field, for either choice of the two square roots. The order `24` is what the
+construction uses: `√2` is built from an eighth root of unity and `√3` from a twelfth. -/
+theorem adjoin_pair_le_adjoin_of_sq_eq_two_of_sq_eq_three {ζ x y : ℂ} (hζ : IsPrimitiveRoot ζ 24)
+    (hx : x ^ 2 = 2) (hy : y ^ 2 = 3) :
+    adjoin ℚ {x, y} ≤ adjoin ℚ {ζ} := by
+  have hmem : ∀ {m : ℤ} {z : ℂ}, m ≠ 0 → 4 * m.natAbs ∣ 24 → z ^ 2 = (m : ℂ) →
+      z ∈ adjoin ℚ {ζ} := fun hm hdvd hz =>
+    mem_of_sq_eq_intCast (by norm_num) hζ (mem_adjoin_simple_self ℚ ζ) hm hdvd hz
+  rw [adjoin_le_iff]
+  rintro z (rfl | rfl)
+  · exact hmem (m := 2) (by norm_num) (by norm_num) (by rw [hx]; norm_num)
+  · exact hmem (m := 3) (by norm_num) (by norm_num) (by rw [hy]; norm_num)
+
+end TauCeti.Multiquadratic

--- a/TauCeti/NumberTheory/Multiquadratic/Cyclotomic/Embedding.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Cyclotomic/Embedding.lean
@@ -14,7 +14,8 @@ public import Mathlib.RingTheory.RootsOfUnity.Complex
 This file proves the explicit Kronecker–Weber theorem for multiquadratic fields: the field
 generated over `ℚ` by square roots of rational numbers `d₁, …, dₙ` is contained in a cyclotomic
 field. Concretely, inside any field `L` of characteristic zero holding a primitive `N`-th root of
-unity `ζ`, every square root of a nonzero integer `m` with `4 |m| ∣ N` already lies in `ℚ(ζ)`.
+unity `ζ` with `0 < N`, every square root of an integer `m` with `4 |m| ∣ N` already lies in
+`ℚ(ζ)`.
 
 The engine is the prime case: a square root of a prime `p` is assembled from a root of unity of
 order `4p`. For odd `p` the quadratic Gauss sum supplies a square root of the prime discriminant
@@ -23,9 +24,10 @@ when `p ≡ 3 (mod 4)`; for `p = 2` the eighth root of unity supplies `√2` dir
 (`exists_mem_sq_eq_two`). Multiplying square roots along a prime factorization reaches every
 positive integer, the fourth root of unity reaches the negative ones, and clearing denominators
 reaches every rational number. Since the two square roots of an element differ by a sign, *every*
-square root of such an `m` lies in the field, not just the constructed one.
+square root of such an `m` lies in the field, not just the constructed one. A zero radicand is
+excluded automatically: `4 · 0 ∣ N` forces `N = 0`.
 
-Taking `L = ℂ` makes the statement unconditional: with `N = 4 ∏ᵢ |dᵢ|` one may use
+Taking `L = ℂ` makes the statement unconditional: with `N = 4 ∏ᵢ |num dᵢ · den dᵢ|` one may use
 `ζ = exp (2 π i / N)`, so `ℚ(√d₁, …, √dₙ) ⊆ ℚ(ζ_N)` for any choice of square roots. The target
 `ℚ(ζ_N)` is the `N`-th cyclotomic field: `IsPrimitiveRoot.adjoin_isCyclotomicExtension` identifies
 it as a cyclotomic extension of `ℚ`.
@@ -37,15 +39,15 @@ Classical Introduction to Modern Number Theory*, Chapter 6.
 
 ## Main results
 
-* `TauCeti.Multiquadratic.mem_of_sq_eq_intCast`: every square root of a nonzero integer `m` lies in
-  an intermediate field holding a primitive `N`-th root of unity, provided `4 |m| ∣ N`.
-* `TauCeti.Multiquadratic.mem_of_sq_eq_ratCast`: the same for a nonzero rational number.
+* `TauCeti.Multiquadratic.mem_of_sq_eq_intCast`: every square root of an integer `m` lies in an
+  intermediate field holding a primitive `N`-th root of unity, provided `0 < N` and `4 |m| ∣ N`.
+* `TauCeti.Multiquadratic.mem_of_sq_eq_ratCast`: the same for a rational number.
 * `TauCeti.Multiquadratic.adjoin_range_le_of_sq_eq_ratCast`: a multiquadratic field with rational
   radicands is contained in any such intermediate field.
-* `TauCeti.Multiquadratic.adjoin_range_le_adjoin_exp`: over `ℂ`, with integer radicands,
-  `ℚ(√d₁, …, √dₙ) ⊆ ℚ(ζ_N)` for `N = 4 ∏ᵢ |dᵢ|`.
-* `TauCeti.Multiquadratic.exists_isPrimitiveRoot_adjoin_range_le_adjoin`: every multiquadratic
-  field with rational radicands lies in a cyclotomic field.
+* `TauCeti.Multiquadratic.adjoin_range_le_adjoin_exp`: over `ℂ`, `ℚ(√d₁, …, √dₙ) ⊆ ℚ(ζ_N)` for the
+  root of unity `ζ_N = exp (2 π i / N)` and the order `N = 4 ∏ᵢ |num dᵢ · den dᵢ|`.
+* `TauCeti.Multiquadratic.exists_isCyclotomicExtension_adjoin_range_le`: every multiquadratic field
+  with rational radicands lies in a cyclotomic field.
 -/
 
 public section
@@ -85,35 +87,26 @@ theorem exists_mem_sq_eq_prime (hN : 0 < N) (hζ : IsPrimitiveRoot ζ N) (hmem :
 /-- **A root of unity of order divisible by `4n` carries a square root of `n`.** The square roots
 of the prime factors of `n` multiply together. -/
 theorem exists_mem_sq_eq_natCast (hN : 0 < N) (hζ : IsPrimitiveRoot ζ N) (hmem : ζ ∈ F) {n : ℕ}
-    (hn : 0 < n) (hdvd : 4 * n ∣ N) :
+    (hdvd : 4 * n ∣ N) :
     ∃ x ∈ F, x ^ 2 = (n : L) := by
-  induction n using Nat.strong_induction_on with
-  | _ n ih =>
-    rcases eq_or_ne n 1 with rfl | hn1
-    · exact ⟨1, one_mem F, by norm_num⟩
-    · obtain ⟨p, k, hpp, hk⟩ : ∃ p k, Nat.Prime p ∧ n = p * k :=
-        ⟨n.minFac, n / n.minFac, Nat.minFac_prime hn1,
-          (Nat.mul_div_cancel' n.minFac_dvd).symm⟩
-      have hk0 : 0 < k := by
-        rcases Nat.eq_zero_or_pos k with rfl | h
-        · simp only [Nat.mul_zero] at hk; omega
-        · exact h
-      have h2k : 2 * k ≤ n := hk ▸ Nat.mul_le_mul_right k hpp.two_le
-      obtain ⟨y, hyF, hy⟩ := ih k (by omega) hk0
-        (dvd_trans ⟨p, by rw [hk]; ring⟩ hdvd)
-      obtain ⟨z, hzF, hz⟩ := exists_mem_sq_eq_prime hN hζ hmem hpp
-        (dvd_trans ⟨k, by rw [hk]; ring⟩ hdvd)
-      refine ⟨y * z, mul_mem hyF hzF, ?_⟩
-      rw [mul_pow, hy, hz, hk]
-      push_cast
-      ring
+  induction n using induction_on_primes with
+  | zero => simp only [Nat.mul_zero, zero_dvd_iff] at hdvd; omega
+  | one => exact ⟨1, one_mem F, by norm_num⟩
+  | prime_mul p n hp ih =>
+    obtain ⟨y, hyF, hy⟩ := ih ((mul_dvd_mul_left 4 ⟨p, mul_comm p n⟩).trans hdvd)
+    obtain ⟨z, hzF, hz⟩ := exists_mem_sq_eq_prime hN hζ hmem hp
+      ((mul_dvd_mul_left 4 (Dvd.intro n rfl)).trans hdvd)
+    refine ⟨y * z, mul_mem hyF hzF, ?_⟩
+    rw [mul_pow, hy, hz]
+    push_cast
+    ring
 
 /-- **A root of unity of order divisible by `4 |m| ` carries a square root of the integer `m`.**
 A primitive fourth root of unity turns the square root of `|m|` into one of `m`. -/
 theorem exists_mem_sq_eq_intCast (hN : 0 < N) (hζ : IsPrimitiveRoot ζ N) (hmem : ζ ∈ F) {m : ℤ}
-    (hm : m ≠ 0) (hdvd : 4 * m.natAbs ∣ N) :
+    (hdvd : 4 * m.natAbs ∣ N) :
     ∃ x ∈ F, x ^ 2 = (m : L) := by
-  obtain ⟨x, hxF, hx⟩ := exists_mem_sq_eq_natCast hN hζ hmem (Int.natAbs_pos.mpr hm) hdvd
+  obtain ⟨x, hxF, hx⟩ := exists_mem_sq_eq_natCast hN hζ hmem hdvd
   rcases m.natAbs_eq with hm' | hm'
   · have hcast : ((m : L)) = ((m.natAbs : ℕ) : L) := by rw [hm']; simp
     exact ⟨x, hxF, by rw [hx, hcast]⟩
@@ -128,113 +121,130 @@ theorem exists_mem_sq_eq_intCast (hN : 0 < N) (hζ : IsPrimitiveRoot ζ N) (hmem
     ring
 
 /-- **Every square root of an integer lies in a field of roots of unity of matching order.** If the
-intermediate field `F` contains a primitive `N`-th root of unity and `4 |m| ∣ N` for a nonzero
-integer `m`, then both square roots of `m` lie in `F`: the constructed one does, and the two differ
-by a sign. -/
+intermediate field `F` contains a primitive `N`-th root of unity of positive order `N` and
+`4 |m| ∣ N`, then both square roots of the integer `m` lie in `F`: the constructed one does, and
+the two differ by a sign. -/
 theorem mem_of_sq_eq_intCast (hN : 0 < N) (hζ : IsPrimitiveRoot ζ N) (hmem : ζ ∈ F) {m : ℤ}
-    (hm : m ≠ 0) (hdvd : 4 * m.natAbs ∣ N) {x : L} (hx : x ^ 2 = (m : L)) : x ∈ F := by
-  obtain ⟨y, hyF, hy⟩ := exists_mem_sq_eq_intCast hN hζ hmem hm hdvd
-  have hfac : (x - y) * (x + y) = 0 := by linear_combination hx - hy
-  rcases mul_eq_zero.mp hfac with h | h
-  · rw [sub_eq_zero] at h
-    exact h ▸ hyF
-  · rw [add_eq_zero_iff_eq_neg] at h
-    exact h ▸ neg_mem hyF
+    (hdvd : 4 * m.natAbs ∣ N) {x : L} (hx : x ^ 2 = (m : L)) : x ∈ F := by
+  obtain ⟨y, hyF, hy⟩ := exists_mem_sq_eq_intCast hN hζ hmem hdvd
+  rcases eq_or_eq_neg_of_sq_eq_sq x y (hx.trans hy.symm) with h | h
+  · exact h ▸ hyF
+  · exact h ▸ neg_mem hyF
 
 /-- **Every square root of a rational number lies in a field of roots of unity of matching
 order.** Clearing the denominator of `q` turns it into the integer `q.num * q.den`, whose square
 class it shares. -/
 theorem mem_of_sq_eq_ratCast (hN : 0 < N) (hζ : IsPrimitiveRoot ζ N) (hmem : ζ ∈ F) {q : ℚ}
-    (hq : q ≠ 0) (hdvd : 4 * (q.num * q.den).natAbs ∣ N) {x : L}
-    (hx : x ^ 2 = (q : L)) : x ∈ F := by
+    (hdvd : 4 * (q.num * q.den).natAbs ∣ N) {x : L} (hx : x ^ 2 = (q : L)) : x ∈ F := by
   have hden : ((q.den : L)) ≠ 0 := Nat.cast_ne_zero.mpr q.den_nz
-  have hnum : q.num * q.den ≠ 0 := mul_ne_zero (Rat.num_ne_zero.mpr hq) (by exact_mod_cast q.den_nz)
-  have hq' : (q : L) * q.den = q.num := by
-    rw [Rat.cast_def]
-    field_simp
-  have hxd : (x * q.den) ^ 2 = ((q.num * q.den : ℤ) : L) := by
-    rw [mul_pow, hx, show ((q : L)) * (q.den : L) ^ 2 = ((q : L) * q.den) * q.den by ring, hq']
-    push_cast
-    ring
-  have hmemxd : x * q.den ∈ F := mem_of_sq_eq_intCast hN hζ hmem hnum hdvd hxd
+  have hq' : (q : L) * q.den = ((q.num : ℤ) : L) := by
+    exact_mod_cast congrArg (fun t : ℚ => (t : L)) q.mul_den_eq_num
+  have hxd : (x * q.den) ^ 2 = ((q.num * q.den : ℤ) : L) :=
+    calc (x * q.den) ^ 2 = x ^ 2 * q.den * q.den := by ring
+      _ = (q : L) * q.den * q.den := by rw [hx]
+      _ = ((q.num : ℤ) : L) * q.den := by rw [hq']
+      _ = ((q.num * q.den : ℤ) : L) := by push_cast; ring
+  have hmemxd : x * q.den ∈ F := mem_of_sq_eq_intCast hN hζ hmem hdvd hxd
   have hxeq : x = (x * q.den) / (q.den : L) := by field_simp
   rw [hxeq]
   exact div_mem hmemxd (IntermediateField.natCast_mem F _)
 
 /-- **A multiquadratic field lies in any field of roots of unity of matching order.** If the
-intermediate field `F` of `L / ℚ` contains a primitive `N`-th root of unity and, for each nonzero
-rational radicand `d i`, the order `N` is divisible by `4 |num (d i) · den (d i)|`, then every
+intermediate field `F` of `L / ℚ` contains a primitive `N`-th root of unity of positive order `N`
+and, for each radicand `d i`, the order `N` is divisible by `4 |num (d i) · den (d i)|`, then every
 field generated over `ℚ` by square roots `r i` of the `d i` is contained in `F`. -/
 theorem adjoin_range_le_of_sq_eq_ratCast {ι : Type*} (hN : 0 < N) (hζ : IsPrimitiveRoot ζ N)
-    (hmem : ζ ∈ F) {d : ι → ℚ} {r : ι → L} (hd : ∀ i, d i ≠ 0)
-    (hr : ∀ i, r i ^ 2 = (d i : L)) (hdvd : ∀ i, 4 * ((d i).num * (d i).den).natAbs ∣ N) :
+    (hmem : ζ ∈ F) {d : ι → ℚ} {r : ι → L} (hr : ∀ i, r i ^ 2 = (d i : L))
+    (hdvd : ∀ i, 4 * ((d i).num * (d i).den).natAbs ∣ N) :
     adjoin ℚ (Set.range r) ≤ F := by
   rw [adjoin_le_iff]
   rintro x ⟨i, rfl⟩
-  exact mem_of_sq_eq_ratCast hN hζ hmem (hd i) (hdvd i) (hr i)
+  exact mem_of_sq_eq_ratCast hN hζ hmem (hdvd i) (hr i)
 
 /-- **A multiquadratic field with integer radicands lies in any field of roots of unity of matching
 order.** The integer analogue of `adjoin_range_le_of_sq_eq_ratCast`: the divisibility condition
 reads `4 |d i| ∣ N`. -/
 theorem adjoin_range_le_of_sq_eq_intCast {ι : Type*} (hN : 0 < N) (hζ : IsPrimitiveRoot ζ N)
-    (hmem : ζ ∈ F) {d : ι → ℤ} {r : ι → L} (hd : ∀ i, d i ≠ 0)
-    (hr : ∀ i, r i ^ 2 = (d i : L)) (hdvd : ∀ i, 4 * (d i).natAbs ∣ N) :
+    (hmem : ζ ∈ F) {d : ι → ℤ} {r : ι → L} (hr : ∀ i, r i ^ 2 = (d i : L))
+    (hdvd : ∀ i, 4 * (d i).natAbs ∣ N) :
     adjoin ℚ (Set.range r) ≤ F := by
   rw [adjoin_le_iff]
   rintro x ⟨i, rfl⟩
-  exact mem_of_sq_eq_intCast hN hζ hmem (hd i) (hdvd i) (hr i)
+  exact mem_of_sq_eq_intCast hN hζ hmem (hdvd i) (hr i)
 
 /-- **A multiquadratic field with integer radicands lies in the cyclotomic field `ℚ(ζ_N)`.** The
 `F = ℚ(ζ)` case of `adjoin_range_le_of_sq_eq_intCast`. -/
 theorem adjoin_range_le_adjoin_of_sq_eq_intCast {ι : Type*} (hN : 0 < N)
-    (hζ : IsPrimitiveRoot ζ N) {d : ι → ℤ} {r : ι → L} (hd : ∀ i, d i ≠ 0)
-    (hr : ∀ i, r i ^ 2 = (d i : L)) (hdvd : ∀ i, 4 * (d i).natAbs ∣ N) :
+    (hζ : IsPrimitiveRoot ζ N) {d : ι → ℤ} {r : ι → L} (hr : ∀ i, r i ^ 2 = (d i : L))
+    (hdvd : ∀ i, 4 * (d i).natAbs ∣ N) :
     adjoin ℚ (Set.range r) ≤ adjoin ℚ {ζ} :=
-  adjoin_range_le_of_sq_eq_intCast hN hζ (mem_adjoin_simple_self ℚ ζ) hd hr hdvd
+  adjoin_range_le_of_sq_eq_intCast hN hζ (mem_adjoin_simple_self ℚ ζ) hr hdvd
 
 /-! ### Over `ℂ` no root of unity need be assumed -/
 
-/-- **Every multiquadratic field lies in a cyclotomic field.** For a finite family of nonzero
-rational radicands `d i` and any choice of complex square roots `r i`, the field `ℚ(√d₁, …, √dₙ)`
-is contained in a cyclotomic extension of `ℚ`; the order exhibited is
-`N = 4 ∏ᵢ |num (dᵢ) · den (dᵢ)|`.
+/-- **A multiquadratic field lies in the explicitly named cyclotomic field.** For a finite family
+of nonzero rational radicands `d i` and any choice of complex square roots `r i`, the field
+`ℚ(√d₁, …, √dₙ)` is contained in `ℚ(exp (2 π i / N))` for `N = 4 ∏ᵢ |num (dᵢ) · den (dᵢ)|`. -/
+theorem adjoin_range_le_adjoin_exp {ι : Type*} [Fintype ι] {d : ι → ℚ} {r : ι → ℂ}
+    (hd : ∀ i, d i ≠ 0) (hr : ∀ i, r i ^ 2 = (d i : ℂ)) :
+    adjoin ℚ (Set.range r) ≤ adjoin ℚ {Complex.exp (2 * Real.pi * Complex.I /
+      ((4 * ∏ i, ((d i).num * (d i).den).natAbs : ℕ) : ℂ))} := by
+  have hprod : 0 < ∏ i, ((d i).num * (d i).den).natAbs :=
+    Finset.prod_pos fun i _ => Int.natAbs_pos.mpr
+      (mul_ne_zero (Rat.num_ne_zero.mpr (hd i)) (by exact_mod_cast (d i).den_nz))
+  have hpos : 0 < 4 * ∏ i, ((d i).num * (d i).den).natAbs := by omega
+  exact adjoin_range_le_of_sq_eq_ratCast hpos (Complex.isPrimitiveRoot_exp _ hpos.ne')
+    (mem_adjoin_simple_self ℚ _) hr
+    fun i => Nat.mul_dvd_mul_left 4 (Finset.dvd_prod_of_mem _ (Finset.mem_univ i))
 
-This is the explicit Kronecker–Weber theorem for multiquadratic fields; for integer radicands the
-order is `N = 4 ∏ᵢ |dᵢ|`. -/
+/-- **Every multiquadratic field lies in a cyclotomic field.** For a finite family of rational
+radicands `d i` and any choice of complex square roots `r i`, the field `ℚ(√d₁, …, √dₙ)` is
+contained in a cyclotomic extension of `ℚ`. The order and the field are named explicitly in
+`adjoin_range_le_adjoin_exp`, from which this existential form is deduced after discarding the
+zero radicands, whose square roots are `0`.
+
+This is the explicit Kronecker–Weber theorem for multiquadratic fields. -/
 theorem exists_isCyclotomicExtension_adjoin_range_le {ι : Type*} [Finite ι] {d : ι → ℚ}
-    {r : ι → ℂ} (hd : ∀ i, d i ≠ 0) (hr : ∀ i, r i ^ 2 = (d i : ℂ)) :
+    {r : ι → ℂ} (hr : ∀ i, r i ^ 2 = (d i : ℂ)) :
     ∃ N : ℕ, 0 < N ∧ ∃ G : IntermediateField ℚ ℂ,
       IsCyclotomicExtension {N} ℚ G ∧ adjoin ℚ (Set.range r) ≤ G := by
   classical
-  let _ : Fintype ι := Fintype.ofFinite ι
-  have hfac : ∀ i, ((d i).num * (d i).den) ≠ 0 := fun i =>
-    mul_ne_zero (Rat.num_ne_zero.mpr (hd i)) (by exact_mod_cast (d i).den_nz)
-  have hprod : 0 < ∏ i, ((d i).num * (d i).den).natAbs :=
-    Finset.prod_pos fun i _ => Int.natAbs_pos.mpr (hfac i)
-  set N := 4 * ∏ i, ((d i).num * (d i).den).natAbs with hNdef
-  have hpos : 0 < N := by rw [hNdef]; omega
-  set ζ₀ := Complex.exp (2 * Real.pi * Complex.I / N)
-  have hζ : IsPrimitiveRoot ζ₀ N := Complex.isPrimitiveRoot_exp N hpos.ne'
+  obtain ⟨N, hpos, hle⟩ : ∃ N : ℕ, 0 < N ∧ adjoin ℚ (Set.range r) ≤
+      adjoin ℚ {Complex.exp (2 * Real.pi * Complex.I / (N : ℂ))} := by
+    have : Fintype {i : ι // d i ≠ 0} := Fintype.ofFinite _
+    have hprod : 0 < ∏ i : {i : ι // d i ≠ 0}, ((d i.1).num * (d i.1).den).natAbs :=
+      Finset.prod_pos fun i _ => Int.natAbs_pos.mpr
+        (mul_ne_zero (Rat.num_ne_zero.mpr i.2) (by exact_mod_cast (d i.1).den_nz))
+    refine ⟨_, ?_, le_trans ?_
+      (adjoin_range_le_adjoin_exp (fun i : {i : ι // d i ≠ 0} => i.2) fun i => hr i.1)⟩
+    · omega
+    · rw [adjoin_le_iff]
+      rintro x ⟨i, rfl⟩
+      by_cases hi : d i = 0
+      · have hr0 : r i = 0 := by
+          have h := hr i
+          rw [hi, Rat.cast_zero] at h
+          exact sq_eq_zero_iff.mp h
+        exact hr0 ▸ zero_mem _
+      · exact subset_adjoin ℚ _ ⟨⟨i, hi⟩, rfl⟩
+  have hζ : IsPrimitiveRoot (Complex.exp (2 * Real.pi * Complex.I / (N : ℂ))) N :=
+    Complex.isPrimitiveRoot_exp N hpos.ne'
   have : NeZero N := ⟨hpos.ne'⟩
-  have hcyc : IsCyclotomicExtension {N} ℚ (adjoin ℚ {ζ₀}) :=
-    (IntermediateField.isCyclotomicExtension_singleton_iff_eq_adjoin
-      (F := adjoin ℚ {ζ₀}) (hζ := hζ)).mpr rfl
-  exact ⟨N, hpos, adjoin ℚ {ζ₀}, hcyc,
-    adjoin_range_le_of_sq_eq_ratCast hpos hζ (mem_adjoin_simple_self ℚ _) hd hr
-      fun i => Nat.mul_dvd_mul_left 4 (Finset.dvd_prod_of_mem _ (Finset.mem_univ i))⟩
+  exact ⟨N, hpos, _, (IntermediateField.isCyclotomicExtension_singleton_iff_eq_adjoin
+    (F := adjoin ℚ {Complex.exp (2 * Real.pi * Complex.I / (N : ℂ))}) (hζ := hζ)).mpr rfl, hle⟩
 
-/-- **Worked example: `ℚ(√2, √3) ⊆ ℚ(ζ₂₄)`.** The smallest nontrivial multiquadratic field lies in
-the `24`-th cyclotomic field, for either choice of the two square roots. The order `24` is what the
-construction uses: `√2` is built from an eighth root of unity and `√3` from a twelfth. -/
+/-- **Worked example: `ℚ(√2, √3) ⊆ ℚ(ζ₂₄)`.** A biquadratic field lies in the `24`-th cyclotomic
+field, for either choice of the two square roots. The order `24` is what the construction uses:
+`√2` is built from an eighth root of unity and `√3` from a twelfth. -/
 theorem adjoin_pair_le_adjoin_of_sq_eq_two_of_sq_eq_three {ζ x y : ℂ} (hζ : IsPrimitiveRoot ζ 24)
     (hx : x ^ 2 = 2) (hy : y ^ 2 = 3) :
     adjoin ℚ {x, y} ≤ adjoin ℚ {ζ} := by
-  have hmem : ∀ {m : ℤ} {z : ℂ}, m ≠ 0 → 4 * m.natAbs ∣ 24 → z ^ 2 = (m : ℂ) →
-      z ∈ adjoin ℚ {ζ} := fun hm hdvd hz =>
-    mem_of_sq_eq_intCast (by norm_num) hζ (mem_adjoin_simple_self ℚ ζ) hm hdvd hz
+  have hmem : ∀ {m : ℤ} {z : ℂ}, 4 * m.natAbs ∣ 24 → z ^ 2 = (m : ℂ) →
+      z ∈ adjoin ℚ {ζ} := fun hdvd hz =>
+    mem_of_sq_eq_intCast (by norm_num) hζ (mem_adjoin_simple_self ℚ ζ) hdvd hz
   rw [adjoin_le_iff]
   rintro z (rfl | rfl)
-  · exact hmem (m := 2) (by norm_num) (by norm_num) (by rw [hx]; norm_num)
-  · exact hmem (m := 3) (by norm_num) (by norm_num) (by rw [hy]; norm_num)
+  · exact hmem (m := 2) (by norm_num) (by rw [hx]; norm_num)
+  · exact hmem (m := 3) (by norm_num) (by rw [hy]; norm_num)
 
 end TauCeti.Multiquadratic

--- a/TauCeti/NumberTheory/Multiquadratic/Cyclotomic/Embedding.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Cyclotomic/Embedding.lean
@@ -182,14 +182,6 @@ theorem adjoin_range_le_of_sq_eq_intCast {ι : Type*} (hN : 0 < N) (hζ : IsPrim
   rintro x ⟨i, rfl⟩
   exact mem_of_sq_eq_intCast hN hζ hmem (hdvd i) (hr i)
 
-/-- **A multiquadratic field with integer radicands lies in the cyclotomic field `ℚ(ζ_N)`.** The
-`F = ℚ(ζ)` case of `adjoin_range_le_of_sq_eq_intCast`. -/
-theorem adjoin_range_le_adjoin_of_sq_eq_intCast {ι : Type*} (hN : 0 < N)
-    (hζ : IsPrimitiveRoot ζ N) {d : ι → ℤ} {r : ι → L} (hr : ∀ i, r i ^ 2 = (d i : L))
-    (hdvd : ∀ i, 4 * (d i).natAbs ∣ N) :
-    adjoin ℚ (Set.range r) ≤ adjoin ℚ {ζ} :=
-  adjoin_range_le_of_sq_eq_intCast hN hζ (mem_adjoin_simple_self ℚ ζ) hr hdvd
-
 /-! ### Over `ℂ` no root of unity need be assumed -/
 
 /-- **A multiquadratic field lies in the explicitly named cyclotomic field.** For a finite family

--- a/TauCeti/NumberTheory/Multiquadratic/Cyclotomic/Embedding.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Cyclotomic/Embedding.lean
@@ -6,8 +6,9 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.NumberTheory.Multiquadratic.Cyclotomic.GaussSum
-public import TauCeti.NumberTheory.Multiquadratic.Galois.Kummer
-public import Mathlib.RingTheory.RootsOfUnity.Complex
+public import Mathlib.NumberTheory.Cyclotomic.Basic
+import Mathlib.RingTheory.RootsOfUnity.Complex
+import TauCeti.NumberTheory.Multiquadratic.Galois.Kummer
 import Mathlib.Analysis.Complex.Polynomial.Basic
 
 /-!
@@ -19,10 +20,10 @@ field. Concretely, inside any field `L` of characteristic zero holding a primiti
 unity `ζ` with `0 < N`, every square root of an integer `m` with `4 |m| ∣ N` already lies in
 `ℚ(ζ)`.
 
-The engine is the prime case: a square root of a prime `p` is assembled from a root of unity of
-order `4p`. For odd `p` the quadratic Gauss sum supplies a square root of the prime discriminant
-`p* = ±p` (`exists_mem_sq_eq_oddPrimeDiscriminant`), and the fourth root of unity corrects its sign
-when `p ≡ 3 (mod 4)`; for `p = 2` the eighth root of unity supplies `√2` directly
+The engine is the prime case: a square root of a prime `p` is assembled from a root of unity whose
+order is divisible by `4p`. For odd `p` the quadratic Gauss sum supplies a square root of the prime
+discriminant `p* = ±p` (`exists_mem_sq_eq_oddPrimeDiscriminant`), and the fourth root of unity
+corrects its sign when `p ≡ 3 (mod 4)`; for `p = 2` the eighth root of unity supplies `√2` directly
 (`exists_mem_sq_eq_two`). Multiplying square roots along a prime factorization reaches every
 positive integer, the fourth root of unity reaches the negative ones, and clearing denominators
 reaches every rational number. Since the two square roots of an element differ by a sign, *every*
@@ -53,9 +54,9 @@ Classical Introduction to Modern Number Theory*, Chapter 6.
   radicands is contained in any such intermediate field.
 * `TauCeti.Multiquadratic.adjoin_range_le_adjoin_exp`: over `ℂ`, `ℚ(√d₁, …, √dₙ) ⊆ ℚ(ζ_N)` for the
   root of unity `ζ_N = exp (2 π i / N)` and the order `N = 4 ∏ᵢ |num dᵢ · den dᵢ|`.
-* `TauCeti.Multiquadratic.exists_isCyclotomicExtension_adjoin_range_le`: every multiquadratic field
-  with rational radicands lies in a cyclotomic field.
-* `TauCeti.Multiquadratic.exists_isCyclotomicExtension_nonempty_algHom`: the abstract form — a
+* `TauCeti.Multiquadratic.exists_isCyclotomicExtension_and_adjoin_range_le`: every
+  multiquadratic field with rational radicands lies in a cyclotomic field.
+* `TauCeti.Multiquadratic.exists_isCyclotomicExtension_and_nonempty_algHom`: the abstract form — a
   finite Galois extension of `ℚ` whose Galois group has exponent dividing two admits a
   `ℚ`-algebra embedding into a cyclotomic extension of `ℚ`.
 -/
@@ -68,9 +69,11 @@ namespace TauCeti.Multiquadratic
 
 variable {L : Type*} [Field L] [CharZero L] {F : IntermediateField ℚ L} {ζ : L} {N : ℕ}
 
-/-- **A root of unity of order `4p` carries a square root of the prime `p`.** For an odd prime the
-Gauss sum gives a square root of `p* = ±p`, and a primitive fourth root of unity repairs the sign;
-for `p = 2` a primitive eighth root of unity gives `√2`. -/
+/-- **A root of unity of order divisible by `4p` carries a square root of the prime `p`.** The
+primitive `N`-th root of unity `ζ` is powered down to the roots of unity the construction needs,
+which `4 * p ∣ N` makes available. For an odd prime the Gauss sum gives a square root of
+`p* = ±p`, and a primitive fourth root of unity repairs the sign; for `p = 2` a primitive eighth
+root of unity gives `√2`. -/
 theorem exists_mem_sq_eq_prime (hN : 0 < N) (hζ : IsPrimitiveRoot ζ N) (hmem : ζ ∈ F) {p : ℕ}
     (hp : p.Prime) (hdvd : 4 * p ∣ N) :
     ∃ x ∈ F, x ^ 2 = (p : L) := by
@@ -177,10 +180,9 @@ reads `4 |d i| ∣ N`. -/
 theorem adjoin_range_le_of_sq_eq_intCast {ι : Type*} (hN : 0 < N) (hζ : IsPrimitiveRoot ζ N)
     (hmem : ζ ∈ F) {d : ι → ℤ} {r : ι → L} (hr : ∀ i, r i ^ 2 = (d i : L))
     (hdvd : ∀ i, 4 * (d i).natAbs ∣ N) :
-    adjoin ℚ (Set.range r) ≤ F := by
-  rw [adjoin_le_iff]
-  rintro x ⟨i, rfl⟩
-  exact mem_of_sq_eq_intCast hN hζ hmem (hdvd i) (hr i)
+    adjoin ℚ (Set.range r) ≤ F :=
+  adjoin_range_le_of_sq_eq_ratCast hN hζ hmem (d := fun i => ((d i : ℚ)))
+    (fun i => by rw [hr i]; push_cast; ring) fun i => by simpa using hdvd i
 
 /-! ### Over `ℂ` no root of unity need be assumed -/
 
@@ -206,7 +208,7 @@ contained in a cyclotomic extension of `ℚ`. The order and the field are named 
 zero radicands, whose square roots are `0`.
 
 This is the explicit Kronecker–Weber theorem for multiquadratic fields. -/
-theorem exists_isCyclotomicExtension_adjoin_range_le {ι : Type*} [Finite ι] {d : ι → ℚ}
+theorem exists_isCyclotomicExtension_and_adjoin_range_le {ι : Type*} [Finite ι] {d : ι → ℚ}
     {r : ι → ℂ} (hr : ∀ i, r i ^ 2 = (d i : ℂ)) :
     ∃ N : ℕ, 0 < N ∧ ∃ G : IntermediateField ℚ ℂ,
       IsCyclotomicExtension {N} ℚ G ∧ adjoin ℚ (Set.range r) ≤ G := by
@@ -243,15 +245,15 @@ This is the abstract form of the containment above: nothing is assumed about how
 only about the shape of its Galois group. Exponent-two Kummer theory
 (`exists_root_adjoin_range_eq_top`) supplies rational radicands and square roots generating `E`,
 a complex embedding carries them into `ℂ`, and
-`exists_isCyclotomicExtension_adjoin_range_le` places the image in a cyclotomic field. -/
-theorem exists_isCyclotomicExtension_nonempty_algHom (E : Type*) [Field E] [Algebra ℚ E]
+`exists_isCyclotomicExtension_and_adjoin_range_le` places the image in a cyclotomic field. -/
+theorem exists_isCyclotomicExtension_and_nonempty_algHom (E : Type*) [Field E] [Algebra ℚ E]
     [FiniteDimensional ℚ E] [IsGalois ℚ E] (hexp : Monoid.exponent (E ≃ₐ[ℚ] E) ∣ 2) :
     ∃ N : ℕ, 0 < N ∧ ∃ G : IntermediateField ℚ ℂ,
       IsCyclotomicExtension {N} ℚ G ∧ Nonempty (E →ₐ[ℚ] G) := by
   obtain ⟨n, d, root, hroot, -, hadjoin, -⟩ :=
     exists_root_adjoin_range_eq_top (K := ℚ) (L := E) hexp
   let φ : E →ₐ[ℚ] ℂ := IsAlgClosed.lift
-  obtain ⟨N, hN, G, hG, hle⟩ := exists_isCyclotomicExtension_adjoin_range_le (d := d)
+  obtain ⟨N, hN, G, hG, hle⟩ := exists_isCyclotomicExtension_and_adjoin_range_le (d := d)
     (r := fun i => φ (root i)) fun i => by rw [← map_pow, hroot i, AlgHom.commutes, eq_ratCast]
   refine ⟨N, hN, G, hG, ⟨(IntermediateField.inclusion ?_).comp φ.equivFieldRange.toAlgHom⟩⟩
   rintro _ ⟨x, rfl⟩
@@ -262,8 +264,7 @@ theorem exists_isCyclotomicExtension_nonempty_algHom (E : Type*) [Field E] [Alge
 /-- **Worked example: `ℚ(√2, √3) ⊆ ℚ(ζ₂₄)`.** A biquadratic field lies in the `24`-th cyclotomic
 field, for either choice of the two square roots. The order `24` is what the construction uses:
 `√2` is built from an eighth root of unity and `√3` from a twelfth. -/
-theorem adjoin_pair_le_adjoin_of_sq_eq_two_of_sq_eq_three {ζ x y : ℂ} (hζ : IsPrimitiveRoot ζ 24)
-    (hx : x ^ 2 = 2) (hy : y ^ 2 = 3) :
+example {ζ x y : ℂ} (hζ : IsPrimitiveRoot ζ 24) (hx : x ^ 2 = 2) (hy : y ^ 2 = 3) :
     adjoin ℚ {x, y} ≤ adjoin ℚ {ζ} := by
   have hmem : ∀ {m : ℤ} {z : ℂ}, 4 * m.natAbs ∣ 24 → z ^ 2 = (m : ℂ) →
       z ∈ adjoin ℚ {ζ} := fun hdvd hz =>

--- a/TauCeti/NumberTheory/Multiquadratic/Cyclotomic/Embedding.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Cyclotomic/Embedding.lean
@@ -6,7 +6,9 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.NumberTheory.Multiquadratic.Cyclotomic.GaussSum
+public import TauCeti.NumberTheory.Multiquadratic.Galois.Kummer
 public import Mathlib.RingTheory.RootsOfUnity.Complex
+import Mathlib.Analysis.Complex.Polynomial.Basic
 
 /-!
 # A multiquadratic field lies in a cyclotomic field
@@ -32,6 +34,11 @@ Taking `L = ℂ` makes the statement unconditional: with `N = 4 ∏ᵢ |num dᵢ
 `ℚ(ζ_N)` is the `N`-th cyclotomic field: `IsPrimitiveRoot.adjoin_isCyclotomicExtension` identifies
 it as a cyclotomic extension of `ℚ`.
 
+No presentation by radicals need be assumed of the input field: exponent-two Kummer theory
+(`TauCeti.Multiquadratic.exists_root_adjoin_range_eq_top`) writes any finite Galois extension of
+`ℚ` whose Galois group has exponent dividing two as `ℚ(√d₁, …, √dₙ)` for rational `dᵢ`, so such a
+field admits a `ℚ`-algebra embedding into a cyclotomic field.
+
 This is the multiquadratic case of the Kronecker–Weber theorem, which it makes explicit: the
 cyclotomic field is named, not merely asserted to exist. The general theorem, for every abelian
 extension of `ℚ`, is not proved here. For the classical account see K. Ireland and M. Rosen, *A
@@ -48,6 +55,9 @@ Classical Introduction to Modern Number Theory*, Chapter 6.
   root of unity `ζ_N = exp (2 π i / N)` and the order `N = 4 ∏ᵢ |num dᵢ · den dᵢ|`.
 * `TauCeti.Multiquadratic.exists_isCyclotomicExtension_adjoin_range_le`: every multiquadratic field
   with rational radicands lies in a cyclotomic field.
+* `TauCeti.Multiquadratic.exists_isCyclotomicExtension_nonempty_algHom`: the abstract form — a
+  finite Galois extension of `ℚ` whose Galois group has exponent dividing two admits a
+  `ℚ`-algebra embedding into a cyclotomic extension of `ℚ`.
 -/
 
 public section
@@ -232,6 +242,30 @@ theorem exists_isCyclotomicExtension_adjoin_range_le {ι : Type*} [Finite ι] {d
   have : NeZero N := ⟨hpos.ne'⟩
   exact ⟨N, hpos, _, (IntermediateField.isCyclotomicExtension_singleton_iff_eq_adjoin
     (F := adjoin ℚ {Complex.exp (2 * Real.pi * Complex.I / (N : ℂ))}) (hζ := hζ)).mpr rfl, hle⟩
+
+/-- **Every multiquadratic field embeds in a cyclotomic field.** Let `E / ℚ` be a finite Galois
+extension whose Galois group has exponent dividing two. Then there is a cyclotomic extension `G`
+of `ℚ` inside `ℂ` and a `ℚ`-algebra embedding of `E` into `G`.
+
+This is the abstract form of the containment above: nothing is assumed about how `E` is presented,
+only about the shape of its Galois group. Exponent-two Kummer theory
+(`exists_root_adjoin_range_eq_top`) supplies rational radicands and square roots generating `E`,
+a complex embedding carries them into `ℂ`, and
+`exists_isCyclotomicExtension_adjoin_range_le` places the image in a cyclotomic field. -/
+theorem exists_isCyclotomicExtension_nonempty_algHom (E : Type*) [Field E] [Algebra ℚ E]
+    [FiniteDimensional ℚ E] [IsGalois ℚ E] (hexp : Monoid.exponent (E ≃ₐ[ℚ] E) ∣ 2) :
+    ∃ N : ℕ, 0 < N ∧ ∃ G : IntermediateField ℚ ℂ,
+      IsCyclotomicExtension {N} ℚ G ∧ Nonempty (E →ₐ[ℚ] G) := by
+  obtain ⟨n, d, root, hroot, -, hadjoin, -⟩ :=
+    exists_root_adjoin_range_eq_top (K := ℚ) (L := E) hexp
+  let φ : E →ₐ[ℚ] ℂ := IsAlgClosed.lift
+  obtain ⟨N, hN, G, hG, hle⟩ := exists_isCyclotomicExtension_adjoin_range_le (d := d)
+    (r := fun i => φ (root i)) fun i => by rw [← map_pow, hroot i, AlgHom.commutes, eq_ratCast]
+  refine ⟨N, hN, G, hG, ⟨(IntermediateField.inclusion ?_).comp φ.equivFieldRange.toAlgHom⟩⟩
+  rintro _ ⟨x, rfl⟩
+  have hx : φ x ∈ (adjoin ℚ (Set.range root)).map φ := ⟨x, hadjoin ▸ mem_top, rfl⟩
+  rw [adjoin_map, ← Set.range_comp] at hx
+  exact hle hx
 
 /-- **Worked example: `ℚ(√2, √3) ⊆ ℚ(ζ₂₄)`.** A biquadratic field lies in the `24`-th cyclotomic
 field, for either choice of the two square roots. The order `24` is what the construction uses:

--- a/TauCeti/NumberTheory/Multiquadratic/Cyclotomic/Embedding.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Cyclotomic/Embedding.lean
@@ -30,10 +30,14 @@ reaches every rational number. Since the two square roots of an element differ b
 square root of such an `m` lies in the field, not just the constructed one. A zero radicand is
 excluded automatically: `4 · 0 ∣ N` forces `N = 0`.
 
-Taking `L = ℂ` makes the statement unconditional: with `N = 4 ∏ᵢ |num dᵢ · den dᵢ|` one may use
-`ζ = exp (2 π i / N)`, so `ℚ(√d₁, …, √dₙ) ⊆ ℚ(ζ_N)` for any choice of square roots. The target
-`ℚ(ζ_N)` is the `N`-th cyclotomic field: `IsPrimitiveRoot.adjoin_isCyclotomicExtension` identifies
-it as a cyclotomic extension of `ℚ`.
+Taking `L = ℂ` makes the statement unconditional, provided every radicand is nonzero: for
+`d i ≠ 0` and `N = 4 ∏ᵢ |num dᵢ · den dᵢ|` one may use `ζ = exp (2 π i / N)`, so
+`ℚ(√d₁, …, √dₙ) ⊆ ℚ(ζ_N)` for any choice of square roots. Nonvanishing of the radicands is what
+makes this `N` positive. The existential form below needs no such hypothesis: a zero radicand has
+only the square root `0`, so those indices are discarded before the order is formed. The target
+`ℚ(ζ_N)` is the `N`-th cyclotomic field:
+`IntermediateField.isCyclotomicExtension_singleton_iff_eq_adjoin` identifies it as a cyclotomic
+extension of `ℚ`.
 
 No presentation by radicals need be assumed of the input field: exponent-two Kummer theory
 (`TauCeti.Multiquadratic.exists_root_adjoin_range_eq_top`) writes any finite Galois extension of
@@ -52,8 +56,9 @@ Classical Introduction to Modern Number Theory*, Chapter 6.
 * `TauCeti.Multiquadratic.mem_of_sq_eq_ratCast`: the same for a rational number.
 * `TauCeti.Multiquadratic.adjoin_range_le_of_sq_eq_ratCast`: a multiquadratic field with rational
   radicands is contained in any such intermediate field.
-* `TauCeti.Multiquadratic.adjoin_range_le_adjoin_exp`: over `ℂ`, `ℚ(√d₁, …, √dₙ) ⊆ ℚ(ζ_N)` for the
-  root of unity `ζ_N = exp (2 π i / N)` and the order `N = 4 ∏ᵢ |num dᵢ · den dᵢ|`.
+* `TauCeti.Multiquadratic.adjoin_range_le_adjoin_exp`: over `ℂ`, for nonzero radicands,
+  `ℚ(√d₁, …, √dₙ) ⊆ ℚ(ζ_N)` for the root of unity `ζ_N = exp (2 π i / N)` and the order
+  `N = 4 ∏ᵢ |num dᵢ · den dᵢ|`.
 * `TauCeti.Multiquadratic.exists_isCyclotomicExtension_and_adjoin_range_le`: every
   multiquadratic field with rational radicands lies in a cyclotomic field.
 * `TauCeti.Multiquadratic.exists_isCyclotomicExtension_and_nonempty_algHom`: the abstract form — a

--- a/TauCeti/NumberTheory/Multiquadratic/Cyclotomic/GaussSum.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Cyclotomic/GaussSum.lean
@@ -7,7 +7,8 @@ module
 
 public import TauCeti.NumberTheory.Multiquadratic.Prime.Discriminant.Basic
 public import Mathlib.FieldTheory.IntermediateField.Adjoin.Basic
-public import Mathlib.NumberTheory.LegendreSymbol.QuadraticChar.GaussSum
+public import Mathlib.RingTheory.RootsOfUnity.PrimitiveRoots
+import Mathlib.NumberTheory.LegendreSymbol.QuadraticChar.GaussSum
 
 /-!
 # Square roots of prime discriminants in a field of roots of unity

--- a/TauCeti/NumberTheory/Multiquadratic/Cyclotomic/GaussSum.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Cyclotomic/GaussSum.lean
@@ -87,7 +87,7 @@ theorem exists_mem_sq_eq_oddPrimeDiscriminant {p : ℕ} (hp : p.Prime) (hp2 : p 
       simp [hχ, MulChar.ringHomComp_apply]
     rw [hval]
     exact intCast_mem F _
-  · have hval : ψ a = ζ ^ a.val := rfl
+  · have hval : ψ a = ζ ^ a.val := by rw [hψdef, AddChar.zmodChar_apply]
     rw [hval]
     exact pow_mem hmem _
   · rw [gaussSum_sq hχ₁ hχ₂ hψ]

--- a/TauCeti/NumberTheory/Multiquadratic/Cyclotomic/GaussSum.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Cyclotomic/GaussSum.lean
@@ -1,0 +1,119 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.NumberTheory.Multiquadratic.Prime.Discriminant.Basic
+public import Mathlib.FieldTheory.IntermediateField.Adjoin.Basic
+public import Mathlib.NumberTheory.LegendreSymbol.AddCharacter
+public import Mathlib.NumberTheory.LegendreSymbol.QuadraticChar.GaussSum
+
+/-!
+# Square roots of prime discriminants in a field of roots of unity
+
+This file extracts the square roots of the prime discriminants from roots of unity. Let `L` be a
+field of characteristic zero and let `F` be an intermediate field of `L / ℚ`.
+
+* if `F` contains a primitive `p`-th root of unity for an odd prime `p`, it contains a square root
+  of the odd prime discriminant `p* = (-1)^((p-1)/2) p`;
+* if `F` contains a primitive fourth root of unity, it contains a square root of `-1`;
+* if `F` contains a primitive eighth root of unity, it contains a square root of `2`.
+
+Up to rational squares these are all the prime discriminants, since `-4 = -1 · 2²` and
+`±8 = ±2 · 2²`, and they are the arithmetic input to the containment of a multiquadratic field in a
+cyclotomic field.
+
+The odd case is the classical quadratic Gauss sum `g = ∑_{a} (a/p) ζ^a`, whose square is `p*`.
+Mathlib's `gaussSum_sq` already computes `g²` as `χ(-1)` times the cardinality of the source, for
+any nontrivial quadratic character `χ` and primitive additive character `ψ` valued in a domain;
+specialising `χ` to the quadratic
+character of `ZMod p` pushed into `L` and `ψ` to the additive character attached to `ζ`
+(`AddChar.zmodChar`) turns that computation into the statement above, since
+`(-1/p) = (-1)^((p-1)/2)`. Mathlib uses this only in positive characteristic, where the Gauss sum
+produces the quadratic reciprocity law; here the target is characteristic zero, where it produces
+a square root.
+
+The two even cases are direct computations: a primitive fourth root of unity squares to `-1`
+(its square is a primitive square root of unity), and for a primitive eighth root of unity `ζ`
+the element `ζ + ζ⁷` squares to `2`, because `ζ⁴ = -1`.
+
+For the classical account of the quadratic Gauss sum see K. Ireland and M. Rosen, *A Classical
+Introduction to Modern Number Theory*, Chapter 6.
+
+## Main results
+
+* `TauCeti.Multiquadratic.exists_mem_sq_eq_oddPrimeDiscriminant`: a primitive `p`-th root of unity
+  carries a square root of `p*`.
+* `TauCeti.Multiquadratic.exists_mem_sq_eq_neg_one`: a primitive fourth root of unity is a square
+  root of `-1`.
+* `TauCeti.Multiquadratic.exists_mem_sq_eq_two`: a primitive eighth root of unity carries a square
+  root of `2`.
+-/
+
+public section
+
+open IntermediateField
+
+namespace TauCeti.Multiquadratic
+
+variable {L : Type*} [Field L] [CharZero L] {F : IntermediateField ℚ L} {ζ : L}
+
+/-- **The quadratic Gauss sum is a square root of the prime discriminant.** If an intermediate
+field `F` of `L / ℚ` contains a primitive `p`-th root of unity for an odd prime `p`, then it
+contains a square root of the odd prime discriminant `p*`.
+
+The witness is the Gauss sum `∑_{a : ZMod p} (a/p) ζ^a`, a `ℤ`-linear combination of powers of
+`ζ`; `gaussSum_sq` evaluates its square as `(-1/p) · p`, which is `p*`. -/
+theorem exists_mem_sq_eq_oddPrimeDiscriminant {p : ℕ} (hp : p.Prime) (hp2 : p ≠ 2)
+    (hζ : IsPrimitiveRoot ζ p) (hmem : ζ ∈ F) :
+    ∃ x ∈ F, x ^ 2 = ((oddPrimeDiscriminant p : ℤ) : L) := by
+  classical
+  have : Fact p.Prime := ⟨hp⟩
+  have : NeZero p := ⟨hp.ne_zero⟩
+  set χ : MulChar (ZMod p) L := (quadraticChar (ZMod p)).ringHomComp (Int.castRingHom L) with hχ
+  set ψ : AddChar (ZMod p) L := AddChar.zmodChar p ((IsPrimitiveRoot.iff_def ζ p).mp hζ).left
+    with hψdef
+  have hψ : ψ.IsPrimitive := AddChar.zmodChar_primitive_of_primitive_root p hζ
+  have hχ₂ : χ.IsQuadratic := (quadraticChar_isQuadratic (ZMod p)).comp _
+  have hrc : ringChar (ZMod p) ≠ 2 := by rw [ZMod.ringChar_zmod_n]; exact hp2
+  have hχ₁ : χ ≠ 1 := by
+    obtain ⟨a, ha⟩ := quadraticChar_exists_neg_one' hrc
+    refine MulChar.ne_one_iff.mpr ⟨a, ?_⟩
+    simp only [hχ, MulChar.ringHomComp_apply, ha, eq_intCast, Int.cast_neg, Int.cast_one]
+    exact Ring.neg_one_ne_one_of_char_ne_two (by simp [ringChar.eq_zero])
+  refine ⟨gaussSum χ ψ, sum_mem fun a _ => mul_mem ?_ ?_, ?_⟩
+  · have hval : χ a = ((quadraticChar (ZMod p) a : ℤ) : L) := by
+      simp [hχ, MulChar.ringHomComp_apply]
+    rw [hval]
+    exact intCast_mem F _
+  · have hval : ψ a = ζ ^ a.val := rfl
+    rw [hval]
+    exact pow_mem hmem _
+  · rw [gaussSum_sq hχ₁ hχ₂ hψ]
+    have hval : χ (-1) = ((quadraticChar (ZMod p) (-1) : ℤ) : L) := by
+      simp [hχ, MulChar.ringHomComp_apply]
+    rw [hval, quadraticChar_neg_one hrc, ZMod.card p,
+      ZMod.χ₄_eq_neg_one_pow (Nat.odd_iff.mp (hp.odd_of_ne_two hp2)),
+      oddPrimeDiscriminant_eq_neg_one_pow_div_two_mul (hp.odd_of_ne_two hp2)]
+    push_cast
+    ring
+
+/-- **A primitive fourth root of unity is a square root of `-1`.** -/
+theorem exists_mem_sq_eq_neg_one (hζ : IsPrimitiveRoot ζ 4) (hmem : ζ ∈ F) :
+    ∃ x ∈ F, x ^ 2 = (-1 : L) :=
+  ⟨ζ, hmem, (hζ.pow (by norm_num) (by norm_num : 4 = 2 * 2)).eq_neg_one_of_two_right⟩
+
+/-- **A primitive eighth root of unity carries a square root of `2`.** The witness is
+`ζ + ζ⁷ = ζ + ζ⁻¹`, whose square is `ζ² + 2 + ζ⁻²`, and `ζ⁻² = -ζ²` because `ζ⁴ = -1`. -/
+theorem exists_mem_sq_eq_two (hζ : IsPrimitiveRoot ζ 8) (hmem : ζ ∈ F) :
+    ∃ x ∈ F, x ^ 2 = (2 : L) := by
+  have h4 : ζ ^ 4 = -1 := (hζ.pow (by norm_num) (by norm_num : 8 = 4 * 2)).eq_neg_one_of_two_right
+  have h8 : ζ ^ 8 = 1 := hζ.pow_eq_one
+  refine ⟨ζ + ζ ^ 7, add_mem hmem (pow_mem hmem 7), ?_⟩
+  have expand : (ζ + ζ ^ 7) ^ 2 = ζ ^ 2 + 2 * ζ ^ 8 + ζ ^ 8 * (ζ ^ 4 * ζ ^ 2) := by ring
+  rw [expand, h8, h4]
+  ring
+
+end TauCeti.Multiquadratic

--- a/TauCeti/NumberTheory/Multiquadratic/Cyclotomic/GaussSum.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Cyclotomic/GaussSum.lean
@@ -7,7 +7,6 @@ module
 
 public import TauCeti.NumberTheory.Multiquadratic.Prime.Discriminant.Basic
 public import Mathlib.FieldTheory.IntermediateField.Adjoin.Basic
-public import Mathlib.NumberTheory.LegendreSymbol.AddCharacter
 public import Mathlib.NumberTheory.LegendreSymbol.QuadraticChar.GaussSum
 
 /-!


### PR DESCRIPTION
This PR proves that a multiquadratic field lies in a cyclotomic field, with the cyclotomic field named explicitly. Inside a field `L` of characteristic zero, let `F` be an intermediate field of `L / ℚ` containing a primitive `N`-th root of unity. The quadratic Gauss sum `g = ∑_a (a/p) ζ^a` puts a square root of the odd prime discriminant `p* = (-1)^((p-1)/2) p` into `F` whenever `F` holds a primitive `p`-th root of unity; a primitive fourth root of unity is a square root of `-1`, and `ζ + ζ⁷` is a square root of `2` for a primitive eighth root `ζ`. Multiplying these along a prime factorization, correcting signs with the fourth root of unity, and clearing denominators gives: every square root of a nonzero rational `q` with `4 |num q · den q| ∣ N` already lies in `F`. Hence for any family of nonzero rational radicands `d i` and any choice of square roots `r i`, `ℚ(√d₁, …, √dₙ) ≤ F`; over `ℂ` no root of unity need be assumed, and the witness is the cyclotomic extension of order `N = 4 ∏ᵢ |num dᵢ · den dᵢ|`. The smallest case is discharged as a worked example: `ℚ(√2, √3) ⊆ ℚ(ζ₂₄)`, for either choice of the two square roots.

Exponent-two Kummer theory, already in the repository as `exists_root_adjoin_range_eq_top`, removes the presentation by radicals from the hypothesis: any finite Galois extension of `ℚ` whose Galois group has exponent dividing two is generated by square roots of rationals, so `exists_isCyclotomicExtension_nonempty_algHom` gives it a `ℚ`-algebra embedding into a cyclotomic extension of `ℚ` inside `ℂ`.

The exact roadmap target is the `Multiquadratic/README.md` node "Long horizon", at its first item: "Explicit Kronecker–Weber for the abelian-over-`ℚ` case (every multiquadratic field embeds in a cyclotomic field, via Gauss sums)". That node is the roadmap's remaining named direction: Layers 0–3 are closed on `main` — the degree theorem and the explicit Galois group, the general subfield lattice, the Frobenius/splitting law, `Cl/Cl²` with the exact unit-square index, the genus field (`isGenusField_candidateGenusField`) and the narrow genus field, the isomorphism `Gal(K_gen/K) ≅ Cl⁺(K)/Cl⁺(K)²` together with its ordinary form for `d < 0` (`autCandidateGenusFieldEquivElementaryTwoQuotient`), the imaginary and narrow `2`-rank formulas `rank₂ = t - 1`, the ambiguous class number formula, and every worked example including `[ℚ(√2, √3) : ℚ] = 4` and the degree `2^(g+1)` of the Erdős CM family. Layer 0's degree theorem is the prerequisite this node builds on, and it supplies the generators: the genus field is the compositum of the `ℚ(√P)` for prime discriminants `P`, so the prime-discriminant square roots built here are exactly the elements it is generated by. What remains of the node after this PR is the rest of the long horizon: the conductor-exponent sharpness of the order `N`, the Hilbert class field, and ring class fields; the general Kronecker–Weber theorem for all abelian extensions of `ℚ` is untouched.

Two files are added, `TauCeti/NumberTheory/Multiquadratic/Cyclotomic/GaussSum.lean` (the three square-root constructions from roots of unity) and `TauCeti/NumberTheory/Multiquadratic/Cyclotomic/Embedding.lean` (the prime factorization induction, the rational case, and the containments). They reuse the existing `oddPrimeDiscriminant` normalization and Mathlib's `gaussSum_sq`, `AddChar.zmodChar`, `quadraticChar_neg_one`, `IsPrimitiveRoot.pow`, `Complex.isPrimitiveRoot_exp` and `IntermediateField.isCyclotomicExtension_singleton_iff_eq_adjoin`; Mathlib instantiates the Gauss sum only in positive characteristic, where it yields quadratic reciprocity rather than a square root, and has no statement placing a square root inside a field of roots of unity. No Mathlib source was vendored.

Roadmap: Multiquadratic

<!--tauceti-target:v1 {"focus":"Multiquadratic","id":"multiquadratic-field-embeds-in-cyclotomic-field"}-->

🤖 Prepared with Claude Code