### PR TITLE
feat: separate closed subgroups along linear complements

### DIFF
--- a/TauCeti/Geometry/Lie/Subgroup/LocalSeparation.lean
+++ b/TauCeti/Geometry/Lie/Subgroup/LocalSeparation.lean
@@ -76,7 +76,7 @@ theorem exists_pos_forall_norm_lt_lieExp_mem_iff_eq_zero_of_disjoint {K : Subgro
   have hZM : Z ∈ M := by
     apply M.closed_of_finiteDimensional.mem_of_tendsto hφ
     filter_upwards with n
-    change ‖X (φ n)‖⁻¹ • X (φ n) ∈ M
+    simp only [Function.comp_apply, Y, NormedSpace.normalize]
     exact M.smul_mem ‖X (φ n)‖⁻¹ (hXM (φ n))
   have hZlie : Z ∈ lieSubalgebraOfSubgroup (I := I) K := by
     apply mem_lieSubalgebraOfSubgroup_of_seq hK

--- a/TauCeti/Geometry/Lie/Subgroup/LocalSeparation.lean
+++ b/TauCeti/Geometry/Lie/Subgroup/LocalSeparation.lean
@@ -21,8 +21,9 @@ This is the local-separation input for the subgroup chart: when `M` is a complem
 
 ## Main result
 
-* `TauCeti.Lie.exists_norm_lt_lieExp_mem_iff_eq_zero_of_disjoint`: exponential membership near
-  zero characterizes the zero vector on any subspace disjoint from the subgroup Lie algebra.
+* `TauCeti.Lie.exists_pos_forall_norm_lt_lieExp_mem_iff_eq_zero_of_disjoint`: exponential
+  membership near zero characterizes the zero vector on any subspace disjoint from the subgroup
+  Lie algebra.
 
 ## References
 
@@ -55,7 +56,7 @@ positive-radius ball about zero, an element of `M` has exponential in `K` exactl
 
 This needs only disjointness; in the closed-subgroup chart construction it applies in particular
 when `M` is chosen as a linear complement of `lieSubalgebraOfSubgroup K`. -/
-theorem exists_norm_lt_lieExp_mem_iff_eq_zero_of_disjoint {K : Subgroup G}
+theorem exists_pos_forall_norm_lt_lieExp_mem_iff_eq_zero_of_disjoint {K : Subgroup G}
     (hK : IsClosed (K : Set G)) (M : Submodule ℝ (LeftInvariantDerivation I G))
     (hM : Disjoint M (lieSubalgebraOfSubgroup (I := I) K).toSubmodule) :
     ∃ ε > 0, ∀ X ∈ M, ‖X‖ < ε → (lieExp (I := I) X ∈ K ↔ X = 0) := by
@@ -75,7 +76,8 @@ theorem exists_norm_lt_lieExp_mem_iff_eq_zero_of_disjoint {K : Subgroup G}
   have hZM : Z ∈ M := by
     apply M.closed_of_finiteDimensional.mem_of_tendsto hφ
     filter_upwards with n
-    exact M.smul_mem _ (hXM (φ n))
+    change ‖X (φ n)‖⁻¹ • X (φ n) ∈ M
+    exact M.smul_mem ‖X (φ n)‖⁻¹ (hXM (φ n))
   have hZlie : Z ∈ lieSubalgebraOfSubgroup (I := I) K := by
     apply mem_lieSubalgebraOfSubgroup_of_seq hK
       (t := fun n => ‖X (φ n)‖) (Xn := Y ∘ φ)

--- a/TauCeti/Geometry/Lie/Subgroup/LocalSeparation.lean
+++ b/TauCeti/Geometry/Lie/Subgroup/LocalSeparation.lean
@@ -16,11 +16,6 @@ Let `K` be a closed subgroup of a finite-dimensional Lie group, and let `M` be a
 of its Lie algebra which is disjoint from `lieSubalgebraOfSubgroup K`. Then the only sufficiently
 small `X ∈ M` whose exponential lies in `K` is `0`.
 
-The proof is the compactness step in the closed-subgroup theorem. If there were arbitrarily small
-nonzero counterexamples, normalize them to the unit sphere and take a convergent subsequence. The
-closed-subgroup limit criterion puts its limit in `lieSubalgebraOfSubgroup K`, while closedness of
-`M` puts the same unit vector in `M`, contradicting disjointness.
-
 This is the local-separation input for the subgroup chart: when `M` is a complement of
 `lieSubalgebraOfSubgroup K`, it forces the transverse coordinate of nearby points of `K` to vanish.
 
@@ -92,9 +87,7 @@ theorem exists_norm_lt_lieExp_mem_iff_eq_zero_of_disjoint {K : Subgroup G}
       simpa only [Function.comp_apply] using (hXnorm (φ n)).le
     · exact hφ
     · filter_upwards with n
-      change lieExp (I := I) (‖X (φ n)‖ • NormedSpace.normalize (X (φ n))) ∈ K
-      rw [NormedSpace.norm_smul_normalize]
-      exact hXexp (φ n)
+      simpa only [Function.comp_apply, Y, NormedSpace.norm_smul_normalize] using hXexp (φ n)
   have hZzero : Z = 0 := Submodule.disjoint_def.mp hM Z hZM hZlie
   have : ‖Z‖ = 1 := by simpa [Metric.mem_sphere, dist_eq_norm] using hZsphere
   simp [hZzero] at this

--- a/TauCeti/Geometry/Lie/Subgroup/LocalSeparation.lean
+++ b/TauCeti/Geometry/Lie/Subgroup/LocalSeparation.lean
@@ -42,14 +42,10 @@ open scoped ContDiff Manifold Topology
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
   {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
   {G : Type*} [TopologicalSpace G] [ChartedSpace H G] [Group G]
-  [FiniteDimensional ℝ E] [LieGroup I ∞ G] [T2Space G]
+  [FiniteDimensional ℝ E] [LieGroup I ∞ G]
 
 attribute [local instance] LieGroup.minSmoothnessThree
 attribute [local instance] ContMDiffMul.boundarylessManifold
-
-local instance finiteDimensionalLeftInvariantDerivationLocalSeparation :
-    FiniteDimensional ℝ (LeftInvariantDerivation I G) :=
-  finiteDimensional_leftInvariantDerivation BoundarylessManifold.isInteriorPoint
 
 /-- Let `K` be a closed subgroup and `M` a linear subspace disjoint from its Lie algebra. In some
 positive-radius ball about zero, an element of `M` has exponential in `K` exactly when it is zero.
@@ -57,9 +53,16 @@ positive-radius ball about zero, an element of `M` has exponential in `K` exactl
 This needs only disjointness; in the closed-subgroup chart construction it applies in particular
 when `M` is chosen as a linear complement of `lieSubalgebraOfSubgroup K`. -/
 theorem exists_pos_forall_norm_lt_lieExp_mem_iff_eq_zero_of_disjoint {K : Subgroup G}
-    (hK : IsClosed (K : Set G)) (M : Submodule ℝ (LeftInvariantDerivation I G))
-    (hM : Disjoint M (lieSubalgebraOfSubgroup (I := I) K).toSubmodule) :
-    ∃ ε > 0, ∀ X ∈ M, ‖X‖ < ε → (lieExp (I := I) X ∈ K ↔ X = 0) := by
+    (hK : IsClosed (K : Set G)) :
+    let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
+    ∀ (M : Submodule ℝ (LeftInvariantDerivation I G)),
+      Disjoint M (lieSubalgebraOfSubgroup (I := I) K).toSubmodule →
+      ∃ ε > 0, ∀ X ∈ M, ‖X‖ < ε → (lieExp (I := I) X ∈ K ↔ X = 0) := by
+  let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
+  dsimp only
+  intro M hM
+  let _ : FiniteDimensional ℝ (LeftInvariantDerivation I G) :=
+    finiteDimensional_leftInvariantDerivation BoundarylessManifold.isInteriorPoint
   suffices ∃ ε > 0, ∀ X ∈ M, ‖X‖ < ε → lieExp (I := I) X ∈ K → X = 0 by
     obtain ⟨ε, hε, h⟩ := this
     refine ⟨ε, hε, fun X hXM hXnorm ↦ ⟨h X hXM hXnorm, ?_⟩⟩

--- a/TauCeti/Geometry/Lie/Subgroup/LocalSeparation.lean
+++ b/TauCeti/Geometry/Lie/Subgroup/LocalSeparation.lean
@@ -1,0 +1,102 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Geometry.Lie.Subgroup.LimitCriterion
+
+import Mathlib.Analysis.Normed.Module.Normalize
+
+/-!
+# Local separation from a closed subgroup
+
+Let `K` be a closed subgroup of a finite-dimensional Lie group, and let `M` be a linear subspace
+of its Lie algebra which is disjoint from `lieSubalgebraOfSubgroup K`. Then the only sufficiently
+small `X ∈ M` whose exponential lies in `K` is `0`.
+
+The proof is the compactness step in the closed-subgroup theorem. If there were arbitrarily small
+nonzero counterexamples, normalize them to the unit sphere and take a convergent subsequence. The
+closed-subgroup limit criterion puts its limit in `lieSubalgebraOfSubgroup K`, while closedness of
+`M` puts the same unit vector in `M`, contradicting disjointness.
+
+This is the local-separation input for the subgroup chart: when `M` is a complement of
+`lieSubalgebraOfSubgroup K`, it forces the transverse coordinate of nearby points of `K` to vanish.
+
+## Main result
+
+* `TauCeti.Lie.exists_norm_lt_lieExp_mem_iff_eq_zero_of_disjoint`: exponential membership near
+  zero characterizes the zero vector on any subspace disjoint from the subgroup Lie algebra.
+
+## References
+
+* J. M. Lee, *Introduction to Smooth Manifolds*, 2nd edition (2013), Theorem 20.12.
+-/
+
+public section
+
+noncomputable section
+
+namespace TauCeti.Lie
+
+open Filter
+open scoped ContDiff Manifold Topology
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+  {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
+  {G : Type*} [TopologicalSpace G] [ChartedSpace H G] [Group G]
+  [FiniteDimensional ℝ E] [LieGroup I ∞ G] [T2Space G]
+
+attribute [local instance] LieGroup.minSmoothnessThree
+attribute [local instance] ContMDiffMul.boundarylessManifold
+
+local instance finiteDimensionalLeftInvariantDerivationLocalSeparation :
+    FiniteDimensional ℝ (LeftInvariantDerivation I G) :=
+  finiteDimensional_leftInvariantDerivation BoundarylessManifold.isInteriorPoint
+
+/-- Let `K` be a closed subgroup and `M` a linear subspace disjoint from its Lie algebra. In some
+positive-radius ball about zero, an element of `M` has exponential in `K` exactly when it is zero.
+
+This needs only disjointness; in the closed-subgroup chart construction it applies in particular
+when `M` is chosen as a linear complement of `lieSubalgebraOfSubgroup K`. -/
+theorem exists_norm_lt_lieExp_mem_iff_eq_zero_of_disjoint {K : Subgroup G}
+    (hK : IsClosed (K : Set G)) (M : Submodule ℝ (LeftInvariantDerivation I G))
+    (hM : Disjoint M (lieSubalgebraOfSubgroup (I := I) K).toSubmodule) :
+    ∃ ε > 0, ∀ X ∈ M, ‖X‖ < ε → (lieExp (I := I) X ∈ K ↔ X = 0) := by
+  suffices ∃ ε > 0, ∀ X ∈ M, ‖X‖ < ε → lieExp (I := I) X ∈ K → X = 0 by
+    obtain ⟨ε, hε, h⟩ := this
+    refine ⟨ε, hε, fun X hXM hXnorm ↦ ⟨h X hXM hXnorm, ?_⟩⟩
+    rintro rfl
+    simpa only [lieExp_zero] using K.one_mem
+  by_contra! h
+  choose X hXM hXnorm hXexp hXne using fun n : ℕ =>
+    h (1 / (n + 1 : ℝ)) (by positivity)
+  let Y : ℕ → LeftInvariantDerivation I G := fun n => NormedSpace.normalize (X n)
+  have hYnorm (n : ℕ) : ‖Y n‖ = 1 := NormedSpace.norm_normalize (hXne n)
+  obtain ⟨Z, hZsphere, φ, hφmono, hφ⟩ :=
+    (isCompact_sphere (0 : LeftInvariantDerivation I G) 1).tendsto_subseq
+      (fun n => by simpa [Metric.mem_sphere, dist_eq_norm] using hYnorm n)
+  have hZM : Z ∈ M := by
+    apply M.closed_of_finiteDimensional.mem_of_tendsto hφ
+    filter_upwards with n
+    exact M.smul_mem _ (hXM (φ n))
+  have hZlie : Z ∈ lieSubalgebraOfSubgroup (I := I) K := by
+    apply mem_lieSubalgebraOfSubgroup_of_seq hK
+      (t := fun n => ‖X (φ n)‖) (Xn := Y ∘ φ)
+    · filter_upwards with n
+      exact norm_pos_iff.mpr (hXne (φ n))
+    · refine squeeze_zero' (Eventually.of_forall fun n => norm_nonneg _) ?_
+        (tendsto_one_div_add_atTop_nhds_zero_nat.comp hφmono.tendsto_atTop)
+      filter_upwards with n
+      simpa only [Function.comp_apply] using (hXnorm (φ n)).le
+    · exact hφ
+    · filter_upwards with n
+      change lieExp (I := I) (‖X (φ n)‖ • NormedSpace.normalize (X (φ n))) ∈ K
+      rw [NormedSpace.norm_smul_normalize]
+      exact hXexp (φ n)
+  have hZzero : Z = 0 := Submodule.disjoint_def.mp hM Z hZM hZlie
+  have : ‖Z‖ = 1 := by simpa [Metric.mem_sphere, dist_eq_norm] using hZsphere
+  simp [hZzero] at this
+
+end TauCeti.Lie


### PR DESCRIPTION
This PR proves local separation of a closed subgroup from any linear subspace transverse to its Lie algebra for the RepresentationTheory/LieGroups Layer 2 closed-subgroup milestone.

Roadmap: RepresentationTheory

## Summary

It shows that if a real submodule `M` is disjoint from `lieSubalgebraOfSubgroup K`, then some positive norm ball in `M` satisfies `lieExp X ∈ K ↔ X = 0`. The proof normalizes hypothetical arbitrarily small counterexamples, extracts a convergent unit direction by finite-dimensional compactness, and applies the merged closed-subgroup limit criterion to contradict transversality. Hausdorffness is derived from the Lie group structure rather than exposed as a separate assumption.

## Roadmap target

This advances RepresentationTheory/LieGroups Layer 2, “the closed-subgroup (Cartan) theorem,” specifically the step where closedness forces the transverse coordinate in a complement chart to vanish. It serves SpinRepresentations Layer 3’s differential of `spinToSpecialOrthogonal`, which needs the resulting Lie structures on Spin and SO. After this PR, the product chart and subgroup atlas, the embedded Lie subgroup structure and automatic-smoothness corollary, and the concrete Spin/SO Lie structures remain.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"closed-subgroup-local-separation"}-->

## Verification

- Exact head: `07c111904a95d1402d72be98b7149367ea5492a3`
- Local Lean build: `lake build` — passed; 11008 jobs
- Axiom audit: `lake exe axioms` — passed; 108774 TauCeti declarations use only `propext`, `Classical.choice`, and `Quot.sound`
- Lint: `bash scripts/lint-style.sh` — passed; all 4856 TauCeti source headers conform
- Public CI: pending for the repaired head

## Scale and generality

The new 100-line module adds one theorem for every finite-dimensional real Lie group, every closed subgroup, and every real submodule disjoint from the subgroup Lie algebra. It derives Hausdorffness from the Lie group structure and assumes only disjointness rather than a chosen direct-sum complement, so any later complement construction can consume it without carrying unnecessary hypotheses.

## Scope

- **Consumes:** `lieSubalgebraOfSubgroup`, `mem_lieSubalgebraOfSubgroup_of_seq`, `t2Space_of_lieGroup`, finite-dimensional compactness of the unit sphere, and Mathlib’s normalized-vector identities.
- **Provides:** `exists_pos_forall_norm_lt_lieExp_mem_iff_eq_zero_of_disjoint`, the complete small-ball characterization of transverse exponential membership.
- **Fits:** It is the compactness/local-separation boundary immediately consumed by the Layer 2 subgroup chart, on the route to automatic smoothness and the Spin/SO differential.
- **Boundary:** It does not construct the complement chart, manifold atlas, embedded Lie subgroup instance, automatic-smoothness theorem, or the concrete Spin/SO Lie structures.

<sub>🤖 GPT-5.6 Sol high · TauCetiWorker @ [7518d4150b846c4524423341570c031027a1d92c](https://github.com/utensil/TauCetiWorker/commit/7518d4150b846c4524423341570c031027a1d92c) · rubrics @ [153ea8a6febe59f492c2f3d48471733e8b550848](https://github.com/utensil/TauCetiReview/commit/153ea8a6febe59f492c2f3d48471733e8b550848) · local review @ [b533e561b6d44df071c31335ed4a63ae647507d2](https://github.com/utensil/formal-land/commit/b533e561b6d44df071c31335ed4a63ae647507d2) · fixed: documentation, generality, naming, proof-quality</sub>