### PR TITLE
chore: name the empty-index positive-definiteness lemma as a PosDef constructor

### DIFF
--- a/TauCeti/LinearAlgebra/Matrix/PosDef.lean
+++ b/TauCeti/LinearAlgebra/Matrix/PosDef.lean
@@ -33,7 +33,7 @@ Cartan families need.
 
 ## Main results
 
-* `Matrix.posDef_of_isEmpty`: a matrix on an empty index type is positive definite.
+* `Matrix.PosDef.of_isEmpty`: a matrix on an empty index type is positive definite.
 * `TauCeti.Matrix.posDef_map_intCast`: an integer matrix that is positive definite over `ℤ` is
   positive definite over `ℚ`.
 * `TauCeti.Matrix.posDef_conjTranspose_mul_self_of_isUnit`: an invertible rational matrix of the
@@ -72,7 +72,7 @@ private theorem exists_intCast_eq_mul_of_ne_zero [Finite n] {x : n → ℚ} (hx 
 
 /-- **A matrix on an empty index type is vacuously positive definite.** This is what the
 rank-zero members of the classical Cartan families `A 0`, `B 0`, `C 0` and `D 0` need. -/
-theorem _root_.Matrix.posDef_of_isEmpty {R : Type*} [Ring R] [PartialOrder R] [StarRing R]
+theorem _root_.Matrix.PosDef.of_isEmpty {R : Type*} [Ring R] [PartialOrder R] [StarRing R]
     [IsEmpty n] (A : _root_.Matrix n n R) : A.PosDef :=
   ⟨_root_.Matrix.ext fun i _ ↦ isEmptyElim i,
     fun _ hx ↦ (hx (Finsupp.ext fun i ↦ isEmptyElim i)).elim⟩

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/Classical.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/Classical.lean
@@ -378,7 +378,7 @@ empty and positive definiteness is vacuous, and at rank `1` Mathlib's `CartanMat
 identifies the matrix with `A 1`. -/
 theorem posDef_map_intCast_cartanMatrix_D :
     ∀ n : ℕ, ((CartanMatrix.D n).map (Int.cast : ℤ → ℚ)).PosDef
-  | 0 => Matrix.posDef_of_isEmpty _
+  | 0 => Matrix.PosDef.of_isEmpty _
   | 1 => by rw [CartanMatrix.D_one]; exact posDef_map_intCast_cartanMatrix_A 1
   | (k + 2) => by
       rw [← simpleCorootsD_mul_conjTranspose]

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/SimplyLaced.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/SimplyLaced.lean
@@ -41,7 +41,7 @@ namespace TauCeti.DynkinType
 private theorem posDef_map_intCast_cartanMatrix_B_of_le_one {n : ℕ} (hn : n ≤ 1) :
     ((CartanMatrix.B n).map (Int.cast : ℤ → ℚ)).PosDef := by
   interval_cases n
-  · exact Matrix.posDef_of_isEmpty _
+  · exact Matrix.PosDef.of_isEmpty _
   · rw [CartanMatrix.B_one]
     exact posDef_map_intCast_cartanMatrix_A 1
 


### PR DESCRIPTION
This PR renames `Matrix.posDef_of_isEmpty` to `Matrix.PosDef.of_isEmpty`, so that the vacuous
case sits with Mathlib's `Matrix.PosDef.of_*` constructor family rather than under the root
`Matrix.posDef_*` spelling that Mathlib uses for characterisations, and updates its two call sites
and its module-doc entry. This was a review finding on
https://github.com/TauCetiProject/TauCeti/pull/6111 feat: the ADE root lattices are positive
definite against a file owned by
https://github.com/TauCetiProject/TauCeti/pull/6109 feat: the simply-laced Cartan matrices are
positive definite, which had already merged.

Roadmap: IntegralLattices

🤖 Generated with [Claude Code](https://claude.com/claude-code)
