### PR TITLE
feat: proper ideals of a complete Huber pair lie in supports

### DIFF
--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Localization/UniversalProperty.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Localization/UniversalProperty.lean
@@ -6,7 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.AlgebraicGeometry.AdicSpace.Spa.Localization.Basic
-import TauCeti.AlgebraicGeometry.AdicSpace.Spa.Points
+import TauCeti.AlgebraicGeometry.AdicSpace.Spa.Support
 import TauCeti.AlgebraicGeometry.AdicSpace.Spa.Integral
 
 /-!
@@ -17,11 +17,9 @@ continuous `φ : A → B` into a complete `B` extends across `ρ : A → A⟨T/s
 unit and every fraction `φ t / φ s` is power-bounded
 (`TauCeti.Huber.PairOfDefinition.existsUnique_continuous_ringHom_completion_locTopology`).
 Wedhorn's Lemma 8.1 replaces those two algebraic conditions by a single *geometric* one — that
-`Spa(φ)` factors
-through the rational subset `U = R(T/s)`. This file carries that replacement out with the unit
-`φ s` kept as a hypothesis, which asks nothing of the target's maximal ideals; Wedhorn's own
-shape, where the unit is *derived* from the geometric condition, follows as a corollary for
-targets whose maximal ideals are open — see *The hypothesis that is not yet Wedhorn's* below.
+`Spa(φ)` factors through the rational subset `U = R(T/s)`. This file carries that replacement out
+in two shapes: one with the unit `φ s` kept as a hypothesis, for a caller that has it in hand, and
+Wedhorn's own, in which the unit is *derived* from the geometric condition.
 
 Wedhorn's proof has three steps, and all three are discharged here:
 
@@ -30,14 +28,12 @@ Wedhorn's proof has three steps, and all three are discharged here:
 > have `|φ(t)/φ(s)|_w ≤ 1`. This implies `φ(t)/φ(s) ∈ B⁺` by Proposition 7.52. Thus the claim
 > follows from the universal property of `A → A⟨T/s⟩`.
 
-The step `φ s ∈ B^×` is Wedhorn's Proposition 7.52(2), which is on hand as
-`TauCeti.ValuationSpectrum.isUnit_of_forall_not_vle_zero`; the step `|φ(t)/φ(s)|_w ≤ 1` is a
-division by that unit. The step from there to `φ(t)/φ(s) ∈ B⁺` is Proposition 7.52(1), available
-as `TauCeti.ValuationSpectrum.mem_of_forall_vle_one`, which the assembly consumes at its one use
-site. All three steps are therefore proved. Only step 1 asks anything of maximal ideals, so the
-assembly takes the unit as a hypothesis and steps 2 and 3 carry the rest; Wedhorn's own statement,
-which derives the unit, is the corollary obtained by discharging step 1 under `hmax`. See *The
-hypothesis that is not yet Wedhorn's* below for what that costs and what it does not cost.
+The step `φ s ∈ B^×` is Wedhorn's Proposition 7.52(2), which is on hand for a complete Hausdorff
+Huber pair as `TauCeti.ValuationSpectrum.isUnit_iff_forall_mem_spa_notMem_supp`; the step
+`|φ(t)/φ(s)|_w ≤ 1` is a division by that unit. The step from there to `φ(t)/φ(s) ∈ B⁺` is
+Proposition 7.52(1), available as `TauCeti.ValuationSpectrum.mem_of_forall_vle_one`, which the
+assembly consumes at its one use site. All three steps are therefore proved, and each asks of the
+target only what a complete affinoid ring supplies.
 
 The other half of Lemma 8.1, that `Spa ρ : Spa A⟨T/s⟩ → Spa A` factors through `U`, is already
 `TauCeti.ValuationSpectrum.spaComapLoc_mem_rationalSubset`; it is not repeated here.
@@ -52,42 +48,19 @@ All four are in the `TauCeti.ValuationSpectrum` namespace.
   fraction `φ t / φ s` is sub-unit.
 * `existsUnique_continuous_ringHom_of_isUnit_of_forall_comap_mem_rationalSubset` : the geometric
   universal property — a continuous `φ : A → B` whose `Spa(φ)` factors through `R(T/s)` and whose
-  `φ s` is a unit extends across `A → A⟨T/s⟩` in exactly one continuous way. Nothing is asked of
-  the maximal ideals of `B`.
-* `existsUnique_continuous_ringHom_of_forall_comap_mem_rationalSubset` : the same, with the unit
-  obtained from the geometric condition by step 1, for a target whose maximal ideals are open.
+  `φ s` is a unit extends across `A → A⟨T/s⟩` in exactly one continuous way.
+* `existsUnique_continuous_ringHom_of_forall_comap_mem_rationalSubset` : **Wedhorn's Lemma 8.1** —
+  the same, with the unit obtained from the geometric condition by step 1.
 
-## The hypothesis that is not yet Wedhorn's
+## The hypotheses on the target
 
-`hmax`, openness of the target's maximal ideals, is **not** a hypothesis Wedhorn imposes, and it
-is not harmless: by `TauCeti.Huber.IsTateRing.isOpen_iff_eq_top` an ideal of a Tate ring is open
-exactly when it is `⊤`, so a nonzero Tate ring has no open maximal ideal at all. Wedhorn states
-Lemma 8.1 for a complete *affinoid* target, and the affinoid rings §8 works with are Tate in its
-principal case. **So the `hmax` corollary below is vacuous for Tate targets, the principal case
-of §8, and must not be cited as Lemma 8.1 without that restriction.**
-
-The restriction is confined to that corollary. The theorem it comes from takes `φ s` being a unit
-as a hypothesis and asks nothing of maximal ideals, so it applies to Tate targets the moment a
-unit criterion for them exists; what is missing is a form of Wedhorn's Proposition 7.52(2) for
-complete Tate rings, which belongs to `Spa/Points.lean` and not to this file.
-
-It is non-vacuous for *complete* adic Huber targets — `ℤ_p` and its kin — and that is the
-generality in which it is stated. Completeness is doing work in that sentence, not decoration: in
-a complete adic ring the ideal of definition lies in the Jacobson radical, so every maximal ideal
-contains it and is therefore open. Drop completeness and the conclusion fails — `ℤ` with the
-`p`-adic topology is adic Huber, and its maximal ideal `(q)` for a prime `q ≠ p` contains no power
-of `p`, so it is not open. Only this prose was ever at stake: the theorem assumes
-`[CompleteSpace B]`.
-
-The obstruction is inherited, not introduced here. `hmax` is carried by
-`TauCeti.ValuationSpectrum.isUnit_of_forall_not_vle_zero`, this repository's only unit-detection
-lemma over `spa`, which in turn gets it from `exists_mem_spa_supp_eq` — main's Proposition 7.51,
-whose docstring records that it is "weakened from maximal to" open prime. Removing `hmax` needs a
-form of Wedhorn's Proposition 7.52(2) for complete Tate rings that does not route through open
-maximal ideals; that is a change to `Spa/Points.lean` and is tracked separately. Note that 7.52(1)
-already avoids the problem — `mem_of_forall_vle_one` goes through
-`isIntegral_of_forall_continuous_valuation_le_one` and asks nothing of maximal ideals — so the
-asymmetry between the two halves of 7.52 on main is where a fix should start.
+Step 1 asks `(B, B⁺)` to be a complete Hausdorff Huber pair, which is what Wedhorn's *complete
+affinoid ring* is, so it is free at the generality he states. Deriving the unit from an *open*
+maximal ideal of `B` instead — the route of
+`TauCeti.ValuationSpectrum.isUnit_of_forall_not_vle_zero` — is no option for the targets §8 is
+about: by `TauCeti.Huber.IsTateRing.isOpen_iff_eq_top` an ideal of a Tate ring is open exactly
+when it is `⊤`, so a nonzero Tate ring has no open maximal ideal at all, and the affinoid rings
+§8 works with are Tate in its principal case.
 
 ## What this file consumes
 
@@ -107,16 +80,6 @@ hypothesis rather than spelling them out; with `[IsHuberRing B]` they are exactl
 field. `[IsHuberRing B]` is not a restriction added to make the proof go
 through: Wedhorn states Lemma 8.1 for a
 continuous homomorphism into a *complete affinoid ring*, and an affinoid ring is a Huber pair.
-
-Openness of the maximal ideals of `B` is carried separately, as `hmax`, and **is not** derivable
-from `[IsHuberRing B]`. The route through
-`Ideal.isOpen_of_isMaximal_of_isOpen_isTopologicallyNilpotent` needs
-`[IsLinearTopology B B]` — a basis of zero-neighbourhoods by *ideals* — which no Huber instance
-supplies and which would defeat the purpose: by `TauCeti.Huber.IsTateRing.isOpen_iff_eq_top` an
-ideal of a Tate ring is open exactly when it is `⊤`, so a nonzero Tate ring has neither a proper
-open ideal nor a linear topology, and Tate targets are the ones Wedhorn's §8 is about. `hmax`
-therefore stays a hypothesis on `(B, B⁺)`, exactly as it is on
-`TauCeti.ValuationSpectrum.isUnit_of_forall_not_vle_zero`, which is where it is spent.
 
 ## References
 
@@ -140,27 +103,26 @@ variable {A : Type*} [CommRing A] [TopologicalSpace A]
 
 section Steps
 
-variable {B : Type*} [CommRing B] [TopologicalSpace B]
+variable {B : Type*} [CommRing B]
 
 /-- **The denominator becomes a unit.** If every point of `Spa (B, B⁺)` pulls back into the
 rational subset `R(T/s)`, then no point of `Spa (B, B⁺)` vanishes on `φ s`, so `φ s` is a unit
 by Wedhorn's Proposition 7.52(2).
 
-This is the first step of Wedhorn's Lemma 8.1. Openness of the maximal ideals of `B` is the
-hypothesis that 7.52(2) carries; `Ideal.isOpen_of_isMaximal_of_isOpen_isTopologicallyNilpotent`
-supplies it for a complete Hausdorff linearly topologized ring whose topologically nilpotent
-locus is open, as it is for a Huber ring. -/
-theorem isUnit_of_forall_comap_mem_rationalSubset {φ : A →+* B} {Aplus : Subring A}
-    {Bplus : Subring B} (T : Finset A) {s : A}
-    (hmax : ∀ 𝔪 : Ideal B, 𝔪.IsMaximal → IsOpen (𝔪 : Set B))
+This is the first step of Wedhorn's Lemma 8.1. The form of 7.52(2) it uses,
+`isUnit_iff_forall_mem_spa_notMem_supp`, asks the target to be a complete Hausdorff Huber pair,
+which is what Wedhorn's *complete affinoid ring* supplies. -/
+theorem isUnit_of_forall_comap_mem_rationalSubset [UniformSpace B] [IsUniformAddGroup B]
+    [IsTopologicalRing B] [T2Space B] [CompleteSpace B] [Huber.IsHuberRing B] {φ : A →+* B}
+    {Aplus : Subring A} {Bplus : Subring B} (T : Finset A)
+    (hB : Huber.IsRingOfIntegralElements Bplus) {s : A}
     (hfac : ∀ w ∈ spa Bplus, comap φ w ∈ rationalSubset Aplus T s) :
     IsUnit (φ s) := by
-  refine isUnit_of_forall_not_vle_zero Bplus hmax fun w hw hw0 ↦ ?_
+  refine (isUnit_iff_forall_mem_spa_notMem_supp Bplus hB (φ s)).mpr fun w hw hsupp ↦ ?_
   refine ((mem_rationalSubset_iff Aplus T s _).mp (hfac w hw)).2.2 ?_
   rw [comap_vle, map_zero]
-  exact hw0
+  exact (mem_supp_iff w (φ s)).mp hsupp
 
-omit [TopologicalSpace B] in
 /-- **The fractions are sub-unit.** At a point of `Spv B` whose pullback lies in `R(T/s)`, the
 fraction `φ t / φ s` has value at most `1`.
 
@@ -213,10 +175,10 @@ so they are carried by the single hypothesis `hB` rather than spelled out one by
 Asking `B` to be Huber is not a restriction added here: Wedhorn states Lemma 8.1 for a continuous
 homomorphism into a *complete affinoid ring*, and an affinoid ring is a Huber pair.
 
-The unit `φ s` is a hypothesis rather than something derived: deriving it is step 1, which is the
-only step that asks anything of the maximal ideals of `B`. Keeping it here leaves this statement
-usable for Tate targets, for which no maximal ideal is open; the derived form is the corollary
-below.
+The unit `φ s` is a hypothesis rather than something derived, so that a caller already holding it
+— as the presentation-independence results do at a coordinate ring — need not go through step 1;
+`isUnit_of_forall_comap_mem_rationalSubset` is that step, and the corollary below is the two
+together, which is Wedhorn's own statement.
 
 These are properties of the pair `(B, B⁺)` alone: they mention neither `φ` nor `T` nor `s`. The
 per-morphism algebraic conditions of the universal property are replaced by the single geometric
@@ -244,18 +206,13 @@ theorem existsUnique_continuous_ringHom_of_isUnit_of_forall_comap_mem_rationalSu
     (hB.le_powerBoundedSubring (mem_of_forall_vle_one hB.isOpen fun w hw ↦
       vle_one_of_comap_mem_rationalSubset hs (hfac w hw) ht))
 
-/-- **Wedhorn's Lemma 8.1, for a target with open maximal ideals.** The geometric universal
-property in the shape Wedhorn states it: the unit `φ s` is not assumed but derived from the
-factorisation, which is step 1 and is what `hmax` pays for.
-
-`hmax` is vacuous for every nonzero Tate ring, so this corollary is the restricted form; the
-theorem above is the one to reach for otherwise. See the module docstring. -/
+/-- **Wedhorn's Lemma 8.1.** The geometric universal property in the shape Wedhorn states it: the
+unit `φ s` is not assumed but derived from the factorisation, which is step 1. -/
 theorem existsUnique_continuous_ringHom_of_forall_comap_mem_rationalSubset [IsTopologicalRing A]
     (P : PairOfDefinition A) (Aplus : Subring A) (T : Finset A) (s : A) (S : Type*) [CommRing S]
     [Algebra A S] [IsLocalization.Away s S] (hden : HasDenominatorPower P T s S)
     {B : Type*} [CommRing B] [UniformSpace B] [IsUniformAddGroup B] [NonarchimedeanRing B]
     [IsHuberRing B] [CompleteSpace B] [T0Space B] (Bplus : Subring B)
-    (hmax : ∀ 𝔪 : Ideal B, 𝔪.IsMaximal → IsOpen (𝔪 : Set B))
     (hB : IsRingOfIntegralElements Bplus) {φ : A →+* B} (hφ : ContinuousAt φ 0)
     (hfac : ∀ w ∈ spa Bplus, comap φ w ∈ rationalSubset Aplus T s) :
     letI := locUniformSpace P T s S hden
@@ -264,6 +221,6 @@ theorem existsUnique_continuous_ringHom_of_forall_comap_mem_rationalSubset [IsTo
     ∃! g : UniformSpace.Completion S →+* B,
       Continuous g ∧ g.comp (toCompletionLoc P T s S hden) = φ :=
   existsUnique_continuous_ringHom_of_isUnit_of_forall_comap_mem_rationalSubset P Aplus T s S hden
-    Bplus hB hφ (isUnit_of_forall_comap_mem_rationalSubset T hmax hfac) hfac
+    Bplus hB hφ (isUnit_of_forall_comap_mem_rationalSubset T hB hfac) hfac
 
 end TauCeti.ValuationSpectrum

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basic.lean
@@ -93,9 +93,6 @@ layer deferred above.
   Corollary 7.53.
 * `TauCeti.ValuationSpectrum.span_eq_top_iff_forall_mem_spa_exists_not_vle_zero` : Corollary 7.53
   in pointwise form — `T` generates the unit ideal exactly when no point vanishes on all of it.
-* `TauCeti.ValuationSpectrum.span_eq_top_iff_spa_eq_biUnion_rationalSubset` : Corollary 7.53 as
-  the roadmap states it — generating the unit ideal is equivalent to the standard family being a
-  cover. Only the `←` directions need the maximal ideals of `A` to be open.
 
 ## References
 
@@ -383,20 +380,6 @@ theorem span_eq_top_iff_forall_mem_spa_exists_not_vle_zero (Aplus : Subring A)
   refine ⟨fun hT v hv ↦ ?_,
     fun h ↦ span_eq_top_of_forall_mem_spa_exists_not_vle_zero Aplus hmax (T := (T : Set A)) h⟩
   obtain ⟨s, hs, hmem⟩ := mem_rationalSubset_of_span_eq_top_of_mem_spa Aplus hT hv
-  exact ⟨s, hs, ((mem_rationalSubset_iff Aplus T s v).mp hmem).2.2⟩
-
-/-- **Wedhorn Corollary 7.53, in the form the roadmap states it.** A finite set `T` generates the
-unit ideal exactly when the standard family `(R(T/t))_{t ∈ T}` covers `Spa(A, A⁺)`.
-
-The `→` direction is `spa_eq_biUnion_rationalSubset_of_span_eq_top` and needs no hypothesis on
-`A`; only `←` uses `hmax`, so a consumer who already has `Ideal.span T = ⊤` should take the cover
-from that lemma directly rather than through this iff. -/
-theorem span_eq_top_iff_spa_eq_biUnion_rationalSubset (Aplus : Subring A)
-    (hmax : ∀ (𝔪 : Ideal A), 𝔪.IsMaximal → IsOpen (𝔪 : Set A)) {T : Finset A} :
-    Ideal.span (T : Set A) = ⊤ ↔ spa Aplus = ⋃ t ∈ T, rationalSubset Aplus T t := by
-  refine ⟨spa_eq_biUnion_rationalSubset_of_span_eq_top Aplus, fun hcov ↦ ?_⟩
-  refine (span_eq_top_iff_forall_mem_spa_exists_not_vle_zero Aplus hmax).mpr fun v hv ↦ ?_
-  obtain ⟨s, hs, hmem⟩ := Set.mem_iUnion₂.mp (hcov ▸ hv)
   exact ⟨s, hs, ((mem_rationalSubset_iff Aplus T s v).mp hmem).2.2⟩
 
 end TauCeti.ValuationSpectrum

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Cover.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Cover.lean
@@ -1,0 +1,76 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.AdicSpace.Spa.Support
+
+/-!
+# Standard rational families that cover the adic spectrum
+
+**Wedhorn, *Adic Spaces* (arXiv:1910.05934v1), Corollary 7.53.**
+
+For a finite subset `T` of a complete Hausdorff Huber pair `(A, A⁺)`, the standard rational
+family `(R(T/t))_{t ∈ T}` is a covering of `Spa (A, A⁺)` exactly when `T` generates the unit
+ideal:
+
+```text
+Ideal.span T = ⊤  ↔  Spa (A, A⁺) = ⋃ t ∈ T, R(T/t).
+```
+
+The `→` direction holds over an arbitrary commutative ring and is
+`TauCeti.ValuationSpectrum.spa_eq_biUnion_rationalSubset_of_span_eq_top`. The `←` direction is
+the one that needs the pair: a point of the cover is nonzero on some `t ∈ T`, so no point of the
+spectrum kills all of `T`, and the support criterion
+`TauCeti.ValuationSpectrum.span_eq_top_iff_forall_mem_spa_exists_notMem_supp` turns that into the
+spanning statement. Completeness enters only through that criterion.
+
+## Main results
+
+* `TauCeti.ValuationSpectrum.span_eq_top_of_spa_eq_biUnion_rationalSubset` : the `←` direction.
+* `TauCeti.ValuationSpectrum.span_eq_top_iff_spa_eq_biUnion_rationalSubset` : **Wedhorn Corollary
+  7.53**, the two directions together.
+
+## References
+
+* [T. Wedhorn, *Adic Spaces*][wedhorn_adic] (arXiv:1910.05934v1), Corollary 7.53.
+
+## Provenance
+
+Developed here; nothing is ported.
+-/
+
+public section
+
+namespace TauCeti.ValuationSpectrum
+
+open TauCeti.Huber
+
+variable {A : Type*} [CommRing A] [UniformSpace A] [T2Space A] [CompleteSpace A]
+  [IsTopologicalRing A] [IsUniformAddGroup A] [IsHuberRing A]
+
+/-- **The converse half of Wedhorn Corollary 7.53.** If the standard rational family
+`(R(T/t))_{t ∈ T}` covers `Spa (A, A⁺)` for a complete Hausdorff Huber pair, then `T` generates
+the unit ideal. -/
+theorem span_eq_top_of_spa_eq_biUnion_rationalSubset (Aplus : Subring A)
+    (hplus : IsRingOfIntegralElements Aplus) {T : Finset A}
+    (hcov : spa Aplus = ⋃ t ∈ T, rationalSubset Aplus T t) :
+    Ideal.span (T : Set A) = ⊤ := by
+  refine (span_eq_top_iff_forall_mem_spa_exists_notMem_supp Aplus hplus).mpr fun v hv ↦ ?_
+  obtain ⟨t, ht, hmem⟩ := Set.mem_iUnion₂.mp (hcov ▸ hv)
+  exact ⟨t, ht, fun hsupp ↦
+    ((mem_rationalSubset_iff Aplus T t v).mp hmem).2.2 ((mem_supp_iff v t).mp hsupp)⟩
+
+/-- **Wedhorn Corollary 7.53.** A finite set `T` in a complete Hausdorff Huber pair generates the
+unit ideal exactly when the standard family `(R(T/t))_{t ∈ T}` covers `Spa (A, A⁺)`. -/
+theorem span_eq_top_iff_spa_eq_biUnion_rationalSubset (Aplus : Subring A)
+    (hplus : IsRingOfIntegralElements Aplus) {T : Finset A} :
+    Ideal.span (T : Set A) = ⊤ ↔ spa Aplus = ⋃ t ∈ T, rationalSubset Aplus T t :=
+  ⟨spa_eq_biUnion_rationalSubset_of_span_eq_top Aplus,
+    span_eq_top_of_spa_eq_biUnion_rationalSubset Aplus hplus⟩
+
+end TauCeti.ValuationSpectrum
+
+end

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Support.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Support.lean
@@ -1,0 +1,194 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.AdicSpace.Spa.Comap
+public import TauCeti.AlgebraicGeometry.AdicSpace.Spa.Emptiness
+public import TauCeti.RingTheory.Huber.Pair
+public import TauCeti.RingTheory.Huber.UnitGroup
+
+/-!
+# Proper ideals of a complete Huber pair are supports
+
+Over a complete Hausdorff Huber pair `(A, A⁺)` every proper ideal `J` of `A` is contained in the
+support of some point of `Spa (A, A⁺)`:
+
+```text
+J ≠ ⊤  ↔  ∃ v ∈ Spa (A, A⁺), J ⊆ supp v.
+```
+
+This is Wedhorn's Proposition 7.51 in the form his §8 uses. Its two standard consequences follow
+at once: an element on which no point vanishes is a unit (Proposition 7.52(2)), and a finite set
+whose standard rational family covers the spectrum generates the unit ideal (the half of Corollary
+7.53 that the covering direction does not supply).
+
+## Why this is not the statement already on `main`
+
+`TauCeti.ValuationSpectrum.exists_mem_spa_supp_eq` produces a point with prescribed support from an
+*open* prime ideal, using the trivial valuation there, and the derived
+`isUnit_of_forall_not_vle_zero` and `span_eq_top_of_forall_mem_spa_exists_not_vle_zero` inherit an
+openness hypothesis on the maximal ideals of `A`. That hypothesis is **unsatisfiable over a nonzero
+Tate ring**, where an ideal is open exactly when it is `⊤`
+(`TauCeti.Huber.IsTateRing.isOpen_iff_eq_top`), so those statements are vacuous on the affinoid
+rings Wedhorn's §8 is about. The route taken here never mentions an open ideal:
+
+* the quotient Huber pair `(A/J, (A/J)⁺)` is again a Huber pair (`TauCeti.Huber.Pair.quotient`),
+  and its spectrum is empty exactly when `1` lies in the closure of zero
+  (`TauCeti.ValuationSpectrum.spa_eq_empty_iff_one_mem_closure_zero`, Wedhorn Proposition 7.49(1));
+* completeness keeps a proper ideal from being dense, upstairs and downstairs alike
+  (`TauCeti.Huber.one_notMem_closure_zero_quotient_of_ne_top`), because the unit group of a
+  complete Huber ring is open;
+* a point of the quotient spectrum is a point of `Spa (A, A⁺)` whose support contains `J`, which
+  is the range computation `TauCeti.ValuationSpectrum.range_spaComap_quotientMk`.
+
+Completeness replaces openness of the maximal ideals, and is exactly the hypothesis Wedhorn carries.
+
+## Main results
+
+* `TauCeti.ValuationSpectrum.exists_mem_spa_le_supp_of_ne_top` : **Wedhorn Proposition 7.51** — a
+  proper ideal of a complete Hausdorff Huber pair is contained in the support of a point, with
+  `TauCeti.ValuationSpectrum.ne_top_iff_exists_mem_spa_le_supp` the resulting criterion.
+* `TauCeti.ValuationSpectrum.exists_mem_spa_supp_eq_of_isMaximal` : a maximal ideal *is* the
+  support of a point.
+* `TauCeti.ValuationSpectrum.span_eq_top_iff_forall_mem_spa_exists_notMem_supp` : a set generates
+  the unit ideal exactly when no point of the spectrum kills all of it.
+* `TauCeti.ValuationSpectrum.isUnit_iff_forall_mem_spa_notMem_supp` : **Wedhorn Proposition
+  7.52(2)**, as a criterion, together with the packaging
+  `TauCeti.ValuationSpectrum.iUnion_supp_eq_nonunits`.
+* `TauCeti.ValuationSpectrum.span_eq_top_of_spa_eq_biUnion_rationalSubset` : **the converse half of
+  Wedhorn Corollary 7.53** — if the standard family `(R(T/t))_{t ∈ T}` covers the spectrum then `T`
+  generates the unit ideal. The other half is
+  `TauCeti.ValuationSpectrum.spa_eq_biUnion_rationalSubset_of_span_eq_top`, which asks nothing of
+  `A`, so the two together are Corollary 7.53 with no hypothesis on maximal ideals.
+
+## References
+
+* [T. Wedhorn, *Adic Spaces*][wedhorn_adic] (arXiv:1910.05934v1), Propositions 7.49, 7.51, 7.52
+  and Corollary 7.53.
+
+## Provenance
+
+Developed here. AINTLIB reaches Propositions 7.51 and 7.52(2) through an open maximal ideal, which
+is the route `TauCeti/AlgebraicGeometry/AdicSpace/Spa/Points.lean` carries over; the argument
+below shares nothing with it beyond the statements.
+-/
+
+public section
+
+namespace TauCeti.ValuationSpectrum
+
+open TauCeti.Huber
+
+variable {A : Type*} [CommRing A] [UniformSpace A] [T2Space A] [CompleteSpace A]
+  [IsTopologicalRing A] [IsUniformAddGroup A] [IsHuberRing A]
+
+/-- **Wedhorn Proposition 7.51.** Every proper ideal of a complete Hausdorff Huber pair is
+contained in the support of a point of `Spa (A, A⁺)`.
+
+Wedhorn states it for a maximal ideal, where the containment is an equality; that form is
+`exists_mem_spa_supp_eq_of_isMaximal`. The proof runs through the quotient Huber pair: the
+spectrum of `(A/J, (A/J)⁺)` is nonempty because `1` avoids the closure of zero there, and a point
+of it is a point of `Spa (A, A⁺)` whose support contains `J`. -/
+theorem exists_mem_spa_le_supp_of_ne_top (Aplus : Subring A)
+    (hplus : IsRingOfIntegralElements Aplus) {J : Ideal A} (hJ : J ≠ ⊤) :
+    ∃ v ∈ spa Aplus, J ≤ supp v := by
+  have hmapmem : ∀ a ∈ Aplus, Ideal.Quotient.mk J a ∈ Aplus.map (Ideal.Quotient.mk J) :=
+    fun a ha ↦ (Subring.mem_map (f := Ideal.Quotient.mk J)).mpr ⟨a, ha, rfl⟩
+  have hne : (spa (Aplus.map (Ideal.Quotient.mk J))).Nonempty := by
+    rw [Set.nonempty_iff_ne_empty]
+    intro hempty
+    refine one_notMem_closure_zero_quotient_of_ne_top hJ ?_
+    refine (spa_eq_empty_iff_one_mem_closure_zero (Pair.quotient ⟨Aplus, hplus⟩ J).plus
+      (Pair.quotient ⟨Aplus, hplus⟩ J).isRingOfIntegralElements).mp ?_
+    rwa [Pair.quotient_plus, spa_integralClosure]
+  obtain ⟨w, hw⟩ := hne
+  set v := spaComap (Ideal.Quotient.mk J) continuous_quotient_mk' Aplus _ hmapmem ⟨w, hw⟩
+  have hsupp : v ∈ Subtype.val ⁻¹' {u : Spv A | J ≤ u.supp} :=
+    range_spaComap_quotientMk J Aplus ▸ Set.mem_range_self (⟨w, hw⟩ : spa _)
+  exact ⟨v.1, v.2, hsupp⟩
+
+/-- A proper ideal of a complete Hausdorff Huber pair is exactly one that some point of
+`Spa (A, A⁺)` kills. The reverse implication needs nothing: a support is prime, hence proper. -/
+theorem ne_top_iff_exists_mem_spa_le_supp (Aplus : Subring A)
+    (hplus : IsRingOfIntegralElements Aplus) (J : Ideal A) :
+    J ≠ ⊤ ↔ ∃ v ∈ spa Aplus, J ≤ supp v := by
+  refine ⟨exists_mem_spa_le_supp_of_ne_top Aplus hplus, ?_⟩
+  rintro ⟨v, -, hle⟩ rfl
+  exact (Ideal.IsPrime.ne_top inferInstance) (top_le_iff.mp hle)
+
+/-- **Wedhorn Proposition 7.51, for a maximal ideal.** A maximal ideal of a complete Hausdorff
+Huber pair is the support of a point of `Spa (A, A⁺)`: it is contained in one by
+`exists_mem_spa_le_supp_of_ne_top`, and that support is proper because it is prime. -/
+theorem exists_mem_spa_supp_eq_of_isMaximal (Aplus : Subring A)
+    (hplus : IsRingOfIntegralElements Aplus) (𝔪 : Ideal A) [𝔪.IsMaximal] :
+    ∃ v ∈ spa Aplus, supp v = 𝔪 := by
+  obtain ⟨v, hv, hle⟩ :=
+    exists_mem_spa_le_supp_of_ne_top Aplus hplus (Ideal.IsMaximal.ne_top ‹𝔪.IsMaximal›)
+  exact ⟨v, hv, (Ideal.IsMaximal.eq_of_le ‹𝔪.IsMaximal›
+    (Ideal.IsPrime.ne_top inferInstance) hle).symm⟩
+
+/-- A subset of a complete Hausdorff Huber pair generates the unit ideal exactly when no point of
+`Spa (A, A⁺)` kills all of it. The forward implication holds over any commutative ring, since a
+support is a proper ideal; the converse is `exists_mem_spa_le_supp_of_ne_top`. -/
+theorem span_eq_top_iff_forall_mem_spa_exists_notMem_supp (Aplus : Subring A)
+    (hplus : IsRingOfIntegralElements Aplus) {T : Set A} :
+    Ideal.span T = ⊤ ↔ ∀ v ∈ spa Aplus, ∃ t ∈ T, t ∉ supp v := by
+  constructor
+  · intro hT v _
+    by_contra hcon
+    have hle : Ideal.span T ≤ supp v :=
+      Ideal.span_le.mpr fun t ht ↦ by
+        by_contra hts
+        exact hcon ⟨t, ht, hts⟩
+    rw [hT] at hle
+    exact (Ideal.IsPrime.ne_top inferInstance) (top_le_iff.mp hle)
+  · intro h
+    by_contra hne
+    obtain ⟨v, hv, hle⟩ := exists_mem_spa_le_supp_of_ne_top Aplus hplus hne
+    obtain ⟨t, ht, hts⟩ := h v hv
+    exact hts (hle (Ideal.subset_span ht))
+
+/-- **Wedhorn Proposition 7.52(2)**, as a criterion: an element of a complete Hausdorff Huber pair
+is a unit exactly when no point of `Spa (A, A⁺)` vanishes on it.
+
+Unlike `isUnit_of_forall_not_vle_zero`, this asks nothing of the maximal ideals of `A`, so it is
+available over a Tate ring, where that hypothesis cannot be met. -/
+theorem isUnit_iff_forall_mem_spa_notMem_supp (Aplus : Subring A)
+    (hplus : IsRingOfIntegralElements Aplus) (f : A) :
+    IsUnit f ↔ ∀ v ∈ spa Aplus, f ∉ supp v := by
+  rw [← Ideal.span_singleton_eq_top,
+    span_eq_top_iff_forall_mem_spa_exists_notMem_supp Aplus hplus]
+  simp
+
+/-- The supports of the points of `Spa (A, A⁺)` sweep out exactly the nonunits of a complete
+Hausdorff Huber ring. This is `isUnit_iff_forall_mem_spa_notMem_supp` read as a set equality. -/
+theorem iUnion_supp_eq_nonunits (Aplus : Subring A)
+    (hplus : IsRingOfIntegralElements Aplus) :
+    ⋃ v ∈ spa Aplus, (supp v : Set A) = nonunits A := by
+  ext f
+  rw [Set.mem_iUnion₂, mem_nonunits_iff, isUnit_iff_forall_mem_spa_notMem_supp Aplus hplus f]
+  push Not
+  simp only [SetLike.mem_coe, exists_prop]
+
+/-- **The converse half of Wedhorn Corollary 7.53.** If the standard rational family
+`(R(T/t))_{t ∈ T}` covers `Spa (A, A⁺)` for a complete Hausdorff Huber pair, then `T` generates
+the unit ideal.
+
+The other half, `spa_eq_biUnion_rationalSubset_of_span_eq_top`, holds over an arbitrary
+commutative ring, so the two together are Corollary 7.53 with completeness as the only hypothesis
+— in particular with none on the maximal ideals of `A`, which a nonzero Tate ring cannot supply. -/
+theorem span_eq_top_of_spa_eq_biUnion_rationalSubset (Aplus : Subring A)
+    (hplus : IsRingOfIntegralElements Aplus) {T : Finset A}
+    (hcov : spa Aplus = ⋃ t ∈ T, rationalSubset Aplus T t) :
+    Ideal.span (T : Set A) = ⊤ := by
+  refine (span_eq_top_iff_forall_mem_spa_exists_notMem_supp Aplus hplus).mpr fun v hv ↦ ?_
+  obtain ⟨t, ht, hmem⟩ := Set.mem_iUnion₂.mp (hcov ▸ hv)
+  exact ⟨t, ht, fun hsupp ↦
+    ((mem_rationalSubset_iff Aplus T t v).mp hmem).2.2 ((mem_supp_iff v t).mp hsupp)⟩
+
+end TauCeti.ValuationSpectrum
+
+end

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Support.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Support.lean
@@ -20,12 +20,11 @@ support of some point of `Spa (A, A⁺)`:
 J ≠ ⊤  ↔  ∃ v ∈ Spa (A, A⁺), J ⊆ supp v.
 ```
 
-This is Wedhorn's Proposition 7.51 in the form his §8 uses. Its two standard consequences follow
-at once: an element on which no point vanishes is a unit (Proposition 7.52(2)), and a finite set
-whose standard rational family covers the spectrum generates the unit ideal (the half of Corollary
-7.53 that the covering direction does not supply).
+This is Wedhorn's Proposition 7.51 in the form his §8 uses. Its two standard consequences are the
+unit criterion of Proposition 7.52(2) and Corollary 7.53, which characterizes when a finite set's
+standard rational family covers the spectrum.
 
-## Why this is not the statement already on `main`
+## Comparison with the open-prime approach
 
 `TauCeti.ValuationSpectrum.exists_mem_spa_supp_eq` produces a point with prescribed support from an
 *open* prime ideal, using the trivial valuation there, and the derived
@@ -33,7 +32,7 @@ whose standard rational family covers the spectrum generates the unit ideal (the
 openness hypothesis on the maximal ideals of `A`. That hypothesis is **unsatisfiable over a nonzero
 Tate ring**, where an ideal is open exactly when it is `⊤`
 (`TauCeti.Huber.IsTateRing.isOpen_iff_eq_top`), so those statements are vacuous on the affinoid
-rings Wedhorn's §8 is about. The route taken here never mentions an open ideal:
+rings Wedhorn's §8 is about. The quotient-spectrum approach instead uses the following facts:
 
 * the quotient Huber pair `(A/J, (A/J)⁺)` is again a Huber pair (`TauCeti.Huber.Pair.quotient`),
   and its spectrum is empty exactly when `1` lies in the closure of zero
@@ -56,13 +55,10 @@ Completeness replaces openness of the maximal ideals, and is exactly the hypothe
 * `TauCeti.ValuationSpectrum.span_eq_top_iff_forall_mem_spa_exists_notMem_supp` : a set generates
   the unit ideal exactly when no point of the spectrum kills all of it.
 * `TauCeti.ValuationSpectrum.isUnit_iff_forall_mem_spa_notMem_supp` : **Wedhorn Proposition
-  7.52(2)**, as a criterion, together with the packaging
-  `TauCeti.ValuationSpectrum.iUnion_supp_eq_nonunits`.
-* `TauCeti.ValuationSpectrum.span_eq_top_of_spa_eq_biUnion_rationalSubset` : **the converse half of
-  Wedhorn Corollary 7.53** — if the standard family `(R(T/t))_{t ∈ T}` covers the spectrum then `T`
-  generates the unit ideal. The other half is
-  `TauCeti.ValuationSpectrum.spa_eq_biUnion_rationalSubset_of_span_eq_top`, which asks nothing of
-  `A`, so the two together are Corollary 7.53 with no hypothesis on maximal ideals.
+  7.52(2)**, as a criterion.
+* `TauCeti.ValuationSpectrum.span_eq_top_iff_spa_eq_biUnion_rationalSubset` : **Wedhorn Corollary
+  7.53** — the standard family `(R(T/t))_{t ∈ T}` covers the spectrum exactly when `T` generates
+  the unit ideal.
 
 ## References
 
@@ -86,12 +82,8 @@ variable {A : Type*} [CommRing A] [UniformSpace A] [T2Space A] [CompleteSpace A]
   [IsTopologicalRing A] [IsUniformAddGroup A] [IsHuberRing A]
 
 /-- **Wedhorn Proposition 7.51.** Every proper ideal of a complete Hausdorff Huber pair is
-contained in the support of a point of `Spa (A, A⁺)`.
-
-Wedhorn states it for a maximal ideal, where the containment is an equality; that form is
-`exists_mem_spa_supp_eq_of_isMaximal`. The proof runs through the quotient Huber pair: the
-spectrum of `(A/J, (A/J)⁺)` is nonempty because `1` avoids the closure of zero there, and a point
-of it is a point of `Spa (A, A⁺)` whose support contains `J`. -/
+contained in the support of a point of `Spa (A, A⁺)`. Wedhorn states the maximal-ideal case, where
+the containment is an equality. -/
 theorem exists_mem_spa_le_supp_of_ne_top (Aplus : Subring A)
     (hplus : IsRingOfIntegralElements Aplus) {J : Ideal A} (hJ : J ≠ ⊤) :
     ∃ v ∈ spa Aplus, J ≤ supp v := by
@@ -110,8 +102,8 @@ theorem exists_mem_spa_le_supp_of_ne_top (Aplus : Subring A)
     range_spaComap_quotientMk J Aplus ▸ Set.mem_range_self (⟨w, hw⟩ : spa _)
   exact ⟨v.1, v.2, hsupp⟩
 
-/-- A proper ideal of a complete Hausdorff Huber pair is exactly one that some point of
-`Spa (A, A⁺)` kills. The reverse implication needs nothing: a support is prime, hence proper. -/
+/-- A proper ideal of a complete Hausdorff Huber pair is exactly one contained in the support of
+some point of `Spa (A, A⁺)`. -/
 theorem ne_top_iff_exists_mem_spa_le_supp (Aplus : Subring A)
     (hplus : IsRingOfIntegralElements Aplus) (J : Ideal A) :
     J ≠ ⊤ ↔ ∃ v ∈ spa Aplus, J ≤ supp v := by
@@ -120,8 +112,7 @@ theorem ne_top_iff_exists_mem_spa_le_supp (Aplus : Subring A)
   exact (Ideal.IsPrime.ne_top inferInstance) (top_le_iff.mp hle)
 
 /-- **Wedhorn Proposition 7.51, for a maximal ideal.** A maximal ideal of a complete Hausdorff
-Huber pair is the support of a point of `Spa (A, A⁺)`: it is contained in one by
-`exists_mem_spa_le_supp_of_ne_top`, and that support is proper because it is prime. -/
+Huber pair is the support of a point of `Spa (A, A⁺)`. -/
 theorem exists_mem_spa_supp_eq_of_isMaximal (Aplus : Subring A)
     (hplus : IsRingOfIntegralElements Aplus) (𝔪 : Ideal A) [𝔪.IsMaximal] :
     ∃ v ∈ spa Aplus, supp v = 𝔪 := by
@@ -131,8 +122,7 @@ theorem exists_mem_spa_supp_eq_of_isMaximal (Aplus : Subring A)
     (Ideal.IsPrime.ne_top inferInstance) hle).symm⟩
 
 /-- A subset of a complete Hausdorff Huber pair generates the unit ideal exactly when no point of
-`Spa (A, A⁺)` kills all of it. The forward implication holds over any commutative ring, since a
-support is a proper ideal; the converse is `exists_mem_spa_le_supp_of_ne_top`. -/
+`Spa (A, A⁺)` kills all of it. -/
 theorem span_eq_top_iff_forall_mem_spa_exists_notMem_supp (Aplus : Subring A)
     (hplus : IsRingOfIntegralElements Aplus) {T : Set A} :
     Ideal.span T = ⊤ ↔ ∀ v ∈ spa Aplus, ∃ t ∈ T, t ∉ supp v := by
@@ -151,11 +141,8 @@ theorem span_eq_top_iff_forall_mem_spa_exists_notMem_supp (Aplus : Subring A)
     obtain ⟨t, ht, hts⟩ := h v hv
     exact hts (hle (Ideal.subset_span ht))
 
-/-- **Wedhorn Proposition 7.52(2)**, as a criterion: an element of a complete Hausdorff Huber pair
-is a unit exactly when no point of `Spa (A, A⁺)` vanishes on it.
-
-Unlike `isUnit_of_forall_not_vle_zero`, this asks nothing of the maximal ideals of `A`, so it is
-available over a Tate ring, where that hypothesis cannot be met. -/
+/-- **Wedhorn Proposition 7.52(2).** An element of a complete Hausdorff Huber pair is a unit
+exactly when no point of `Spa (A, A⁺)` vanishes on it. -/
 theorem isUnit_iff_forall_mem_spa_notMem_supp (Aplus : Subring A)
     (hplus : IsRingOfIntegralElements Aplus) (f : A) :
     IsUnit f ↔ ∀ v ∈ spa Aplus, f ∉ supp v := by
@@ -163,23 +150,9 @@ theorem isUnit_iff_forall_mem_spa_notMem_supp (Aplus : Subring A)
     span_eq_top_iff_forall_mem_spa_exists_notMem_supp Aplus hplus]
   simp
 
-/-- The supports of the points of `Spa (A, A⁺)` sweep out exactly the nonunits of a complete
-Hausdorff Huber ring. This is `isUnit_iff_forall_mem_spa_notMem_supp` read as a set equality. -/
-theorem iUnion_supp_eq_nonunits (Aplus : Subring A)
-    (hplus : IsRingOfIntegralElements Aplus) :
-    ⋃ v ∈ spa Aplus, (supp v : Set A) = nonunits A := by
-  ext f
-  rw [Set.mem_iUnion₂, mem_nonunits_iff, isUnit_iff_forall_mem_spa_notMem_supp Aplus hplus f]
-  push Not
-  simp only [SetLike.mem_coe, exists_prop]
-
 /-- **The converse half of Wedhorn Corollary 7.53.** If the standard rational family
 `(R(T/t))_{t ∈ T}` covers `Spa (A, A⁺)` for a complete Hausdorff Huber pair, then `T` generates
-the unit ideal.
-
-The other half, `spa_eq_biUnion_rationalSubset_of_span_eq_top`, holds over an arbitrary
-commutative ring, so the two together are Corollary 7.53 with completeness as the only hypothesis
-— in particular with none on the maximal ideals of `A`, which a nonzero Tate ring cannot supply. -/
+the unit ideal. -/
 theorem span_eq_top_of_spa_eq_biUnion_rationalSubset (Aplus : Subring A)
     (hplus : IsRingOfIntegralElements Aplus) {T : Finset A}
     (hcov : spa Aplus = ⋃ t ∈ T, rationalSubset Aplus T t) :
@@ -188,6 +161,14 @@ theorem span_eq_top_of_spa_eq_biUnion_rationalSubset (Aplus : Subring A)
   obtain ⟨t, ht, hmem⟩ := Set.mem_iUnion₂.mp (hcov ▸ hv)
   exact ⟨t, ht, fun hsupp ↦
     ((mem_rationalSubset_iff Aplus T t v).mp hmem).2.2 ((mem_supp_iff v t).mp hsupp)⟩
+
+/-- **Wedhorn Corollary 7.53.** A finite set `T` in a complete Hausdorff Huber pair generates the
+unit ideal exactly when the standard family `(R(T/t))_{t ∈ T}` covers `Spa (A, A⁺)`. -/
+theorem span_eq_top_iff_spa_eq_biUnion_rationalSubset (Aplus : Subring A)
+    (hplus : IsRingOfIntegralElements Aplus) {T : Finset A} :
+    Ideal.span (T : Set A) = ⊤ ↔ spa Aplus = ⋃ t ∈ T, rationalSubset Aplus T t :=
+  ⟨spa_eq_biUnion_rationalSubset_of_span_eq_top Aplus,
+    span_eq_top_of_spa_eq_biUnion_rationalSubset Aplus hplus⟩
 
 end TauCeti.ValuationSpectrum
 

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Support.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Support.lean
@@ -7,11 +7,10 @@ module
 
 public import TauCeti.AlgebraicGeometry.AdicSpace.Spa.Comap
 public import TauCeti.AlgebraicGeometry.AdicSpace.Spa.Emptiness
-public import TauCeti.RingTheory.Huber.Pair
 public import TauCeti.RingTheory.Huber.UnitGroup
 
 /-!
-# Proper ideals of a complete Huber pair are supports
+# Proper ideals of a complete Huber pair are contained in supports
 
 Over a complete Hausdorff Huber pair `(A, A⁺)` every proper ideal `J` of `A` is contained in the
 support of some point of `Spa (A, A⁺)`:
@@ -20,9 +19,11 @@ support of some point of `Spa (A, A⁺)`:
 J ≠ ⊤  ↔  ∃ v ∈ Spa (A, A⁺), J ⊆ supp v.
 ```
 
-This is Wedhorn's Proposition 7.51 in the form his §8 uses. Its two standard consequences are the
-unit criterion of Proposition 7.52(2) and Corollary 7.53, which characterizes when a finite set's
-standard rational family covers the spectrum.
+This is Wedhorn's Proposition 7.51 in the form his §8 uses; for a maximal ideal the containment is
+an equality. Its standard consequence proved here is the unit criterion of Proposition 7.52(2).
+Corollary 7.53, which characterizes when a finite set's standard rational family covers the
+spectrum, is read off from it in
+`TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Cover.lean`.
 
 ## Comparison with the open-prime approach
 
@@ -56,14 +57,11 @@ Completeness replaces openness of the maximal ideals, and is exactly the hypothe
   the unit ideal exactly when no point of the spectrum kills all of it.
 * `TauCeti.ValuationSpectrum.isUnit_iff_forall_mem_spa_notMem_supp` : **Wedhorn Proposition
   7.52(2)**, as a criterion.
-* `TauCeti.ValuationSpectrum.span_eq_top_iff_spa_eq_biUnion_rationalSubset` : **Wedhorn Corollary
-  7.53** — the standard family `(R(T/t))_{t ∈ T}` covers the spectrum exactly when `T` generates
-  the unit ideal.
 
 ## References
 
-* [T. Wedhorn, *Adic Spaces*][wedhorn_adic] (arXiv:1910.05934v1), Propositions 7.49, 7.51, 7.52
-  and Corollary 7.53.
+* [T. Wedhorn, *Adic Spaces*][wedhorn_adic] (arXiv:1910.05934v1), Propositions 7.49, 7.51
+  and 7.52.
 
 ## Provenance
 
@@ -149,26 +147,6 @@ theorem isUnit_iff_forall_mem_spa_notMem_supp (Aplus : Subring A)
   rw [← Ideal.span_singleton_eq_top,
     span_eq_top_iff_forall_mem_spa_exists_notMem_supp Aplus hplus]
   simp
-
-/-- **The converse half of Wedhorn Corollary 7.53.** If the standard rational family
-`(R(T/t))_{t ∈ T}` covers `Spa (A, A⁺)` for a complete Hausdorff Huber pair, then `T` generates
-the unit ideal. -/
-theorem span_eq_top_of_spa_eq_biUnion_rationalSubset (Aplus : Subring A)
-    (hplus : IsRingOfIntegralElements Aplus) {T : Finset A}
-    (hcov : spa Aplus = ⋃ t ∈ T, rationalSubset Aplus T t) :
-    Ideal.span (T : Set A) = ⊤ := by
-  refine (span_eq_top_iff_forall_mem_spa_exists_notMem_supp Aplus hplus).mpr fun v hv ↦ ?_
-  obtain ⟨t, ht, hmem⟩ := Set.mem_iUnion₂.mp (hcov ▸ hv)
-  exact ⟨t, ht, fun hsupp ↦
-    ((mem_rationalSubset_iff Aplus T t v).mp hmem).2.2 ((mem_supp_iff v t).mp hsupp)⟩
-
-/-- **Wedhorn Corollary 7.53.** A finite set `T` in a complete Hausdorff Huber pair generates the
-unit ideal exactly when the standard family `(R(T/t))_{t ∈ T}` covers `Spa (A, A⁺)`. -/
-theorem span_eq_top_iff_spa_eq_biUnion_rationalSubset (Aplus : Subring A)
-    (hplus : IsRingOfIntegralElements Aplus) {T : Finset A} :
-    Ideal.span (T : Set A) = ⊤ ↔ spa Aplus = ⋃ t ∈ T, rationalSubset Aplus T t :=
-  ⟨spa_eq_biUnion_rationalSubset_of_span_eq_top Aplus,
-    span_eq_top_of_spa_eq_biUnion_rationalSubset Aplus hplus⟩
 
 end TauCeti.ValuationSpectrum
 

--- a/TauCeti/RingTheory/Huber/LocalizationTopology/Pi.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/Pi.lean
@@ -19,12 +19,11 @@ arbitrary finite `T`.
 The family `(R(T/t))_{t ∈ T}` is a cover of `Spa(A,A⁺)` — a *standard rational cover* — **when**
 `T` generates the unit ideal, by
 `TauCeti.ValuationSpectrum.spa_eq_biUnion_rationalSubset_of_span_eq_top`, which needs nothing of
-`A`. The converse holds as well, but only once every maximal ideal of `A` is open
-(`TauCeti.ValuationSpectrum.span_eq_top_iff_spa_eq_biUnion_rationalSubset`, Corollary 7.53), and
-that hypothesis is not carried here. Under the spanning hypothesis
-this map is the comparison whose faithful flatness and injectivity Wedhorn's Corollary 8.32
-asserts. Neither the hypothesis nor those conclusions appear below; this is the map they are
-about.
+`A`. For a complete Hausdorff Huber pair the converse holds as well
+(`TauCeti.ValuationSpectrum.span_eq_top_iff_spa_eq_biUnion_rationalSubset`, Corollary 7.53).
+Under the spanning hypothesis this map is the comparison whose faithful flatness and injectivity
+Wedhorn's Corollary 8.32 asserts. Neither the hypothesis nor those conclusions appear below; this
+is the map they are about.
 
 ## Implementation notes
 

--- a/TauCeti/RingTheory/Huber/UnitGroup.lean
+++ b/TauCeti/RingTheory/Huber/UnitGroup.lean
@@ -46,9 +46,8 @@ form of Proposition 7.51 that survives the Tate case.
 * `TauCeti.Huber.isOpen_setOf_isUnit` : the unit group of a complete Huber ring is open.
 * `TauCeti.Huber.isClosed_of_isMaximal` : **Wedhorn Proposition 7.51, closedness half** — every
   maximal ideal of a complete Huber ring is closed.
-* `TauCeti.Huber.one_notMem_closure_of_ne_top` : no proper ideal of a complete Huber ring is
-  dense, and `TauCeti.Huber.one_notMem_closure_zero_quotient_of_ne_top` says the same downstairs:
-  the separated quotient of `A ⧸ J` is nonzero for every proper `J`.
+* `TauCeti.Huber.one_notMem_closure_zero_quotient_of_ne_top` : the separated quotient of `A ⧸ J`
+  is nonzero for every proper `J`.
 
 ## Provenance
 
@@ -87,11 +86,7 @@ namespace TauCeti.Huber
 variable {A : Type*} [CommRing A] [UniformSpace A] [T2Space A] [CompleteSpace A]
   [IsTopologicalRing A] [IsUniformAddGroup A] [IsHuberRing A]
 
-/-- **The unit group of a complete Huber ring is open.** Around a unit `u` the set of `x` with
-`u⁻¹x - 1` topologically nilpotent is an open neighbourhood of `u` consisting of units: it is open
-because `A°°` is and `x ↦ u⁻¹x - 1` is continuous, it contains `u` because `u⁻¹u - 1 = 0`, and each
-of its points is a unit because `u⁻¹x = 1 + (u⁻¹x - 1)` is one by the geometric series
-(Proposition 5.38) and `x = u * (u⁻¹x)`. -/
+/-- **The unit group of a complete Huber ring is open.** -/
 theorem isOpen_setOf_isUnit : IsOpen {a : A | IsUnit a} := by
   rw [isOpen_iff_forall_mem_open]
   rintro u hu
@@ -112,23 +107,15 @@ argument, so the plus subring is absent here. -/
 theorem isClosed_of_isMaximal (𝔪 : Ideal A) [𝔪.IsMaximal] : IsClosed (𝔪 : Set A) :=
   Ideal.isClosed_of_isMaximal_of_isOpen_isUnit isOpen_setOf_isUnit 𝔪
 
-/-- **No proper ideal of a complete Huber ring is dense.** The unit group is open and a proper
-ideal misses it, so the closure of the ideal misses it too, and in particular misses `1`. -/
-theorem one_notMem_closure_of_ne_top {J : Ideal A} (hJ : J ≠ ⊤) :
-    (1 : A) ∉ closure (J : Set A) := by
-  have h := Ideal.closure_ne_top_of_isOpen_isUnit (A := A) isOpen_setOf_isUnit hJ
-  rwa [Ideal.ne_top_iff_one, ← SetLike.mem_coe, Ideal.coe_closure] at h
-
 /-- **The separated quotient of `A ⧸ J` is nonzero for every proper ideal `J` of a complete Huber
-ring.** The quotient map is open, so the closure of `{0}` in `A ⧸ J` pulls back to the closure of
-`J` in `A`, which misses `1` by `one_notMem_closure_of_ne_top`.
-
-Together with Wedhorn's Proposition 7.49(1) this is what makes the adic spectrum of the quotient
-Huber pair nonempty. -/
+ring.** -/
 theorem one_notMem_closure_zero_quotient_of_ne_top {J : Ideal A} (hJ : J ≠ ⊤) :
     (1 : A ⧸ J) ∉ closure ({0} : Set (A ⧸ J)) := by
   intro hmem
-  refine one_notMem_closure_of_ne_top hJ ?_
+  have hclosure :=
+    Ideal.closure_ne_top_of_isOpen_isUnit (A := A) isOpen_setOf_isUnit hJ
+  rw [Ideal.ne_top_iff_one, ← SetLike.mem_coe, Ideal.coe_closure] at hclosure
+  refine hclosure ?_
   have hpre : (Ideal.Quotient.mk J) ⁻¹' ({0} : Set (A ⧸ J)) = (J : Set A) := by
     ext a
     simp [Ideal.Quotient.eq_zero_iff_mem]

--- a/TauCeti/RingTheory/Huber/UnitGroup.lean
+++ b/TauCeti/RingTheory/Huber/UnitGroup.lean
@@ -10,19 +10,22 @@ public import TauCeti.Topology.Algebra.Nonarchimedean.GeometricSeries
 public import TauCeti.Topology.Algebra.Ring.MaximalIdeals
 
 /-!
-# The unit group of a complete Huber ring is open, and maximal ideals are closed
+# The unit group of a complete Huber ring is open, and proper ideals stay proper
 
 This is the first half of Wedhorn's Proposition 7.51, whose statement is "*then `𝔪` is closed
 and there exists `v ∈ Spa A` with `supp v = 𝔪`*". Only the closedness conjunct is proved here;
-the existence conjunct needs nonemptiness of the adic spectrum (Wedhorn Proposition 7.49), which
-is a separate development.
+the existence conjunct needs nonemptiness of the adic spectrum (Wedhorn Proposition 7.49) and is
+carried out in `TauCeti/AlgebraicGeometry/AdicSpace/Spa/Support.lean`, which consumes the density
+statements below.
 
 The argument is Wedhorn's. The topologically nilpotent elements of a Huber ring form an open set
 (`TauCeti.Huber.isOpen_setOf_isTopologicallyNilpotent`), and completeness makes `1 + A°°` consist
 of units (`IsTopologicallyNilpotent.isUnit_one_add`). Around a unit `u` the set of `x` with
 `u⁻¹x - 1` topologically nilpotent is then an open neighbourhood of `u` made of units, so the unit
 group is open. Closedness of maximal ideals is then immediate from
-`Ideal.isClosed_of_isMaximal_of_isOpen_isUnit`, which holds over any topological ring.
+`Ideal.isClosed_of_isMaximal_of_isOpen_isUnit`, which holds over any topological ring, and so is
+the fact that a proper ideal is never dense — a statement that survives the passage to `A ⧸ J`,
+where it says that the separated quotient of `A ⧸ J` is nonzero.
 
 ## Why this does not assume a linear topology
 
@@ -43,6 +46,9 @@ form of Proposition 7.51 that survives the Tate case.
 * `TauCeti.Huber.isOpen_setOf_isUnit` : the unit group of a complete Huber ring is open.
 * `TauCeti.Huber.isClosed_of_isMaximal` : **Wedhorn Proposition 7.51, closedness half** — every
   maximal ideal of a complete Huber ring is closed.
+* `TauCeti.Huber.one_notMem_closure_of_ne_top` : no proper ideal of a complete Huber ring is
+  dense, and `TauCeti.Huber.one_notMem_closure_zero_quotient_of_ne_top` says the same downstairs:
+  the separated quotient of `A ⧸ J` is nonzero for every proper `J`.
 
 ## Provenance
 
@@ -105,6 +111,32 @@ is closed. Wedhorn states it for a complete affinoid ring; the affinoid `A⁺` p
 argument, so the plus subring is absent here. -/
 theorem isClosed_of_isMaximal (𝔪 : Ideal A) [𝔪.IsMaximal] : IsClosed (𝔪 : Set A) :=
   Ideal.isClosed_of_isMaximal_of_isOpen_isUnit isOpen_setOf_isUnit 𝔪
+
+/-- **No proper ideal of a complete Huber ring is dense.** The unit group is open and a proper
+ideal misses it, so the closure of the ideal misses it too, and in particular misses `1`. -/
+theorem one_notMem_closure_of_ne_top {J : Ideal A} (hJ : J ≠ ⊤) :
+    (1 : A) ∉ closure (J : Set A) := by
+  have h := Ideal.closure_ne_top_of_isOpen_isUnit (A := A) isOpen_setOf_isUnit hJ
+  rwa [Ideal.ne_top_iff_one, ← SetLike.mem_coe, Ideal.coe_closure] at h
+
+/-- **The separated quotient of `A ⧸ J` is nonzero for every proper ideal `J` of a complete Huber
+ring.** The quotient map is open, so the closure of `{0}` in `A ⧸ J` pulls back to the closure of
+`J` in `A`, which misses `1` by `one_notMem_closure_of_ne_top`.
+
+Together with Wedhorn's Proposition 7.49(1) this is what makes the adic spectrum of the quotient
+Huber pair nonempty. -/
+theorem one_notMem_closure_zero_quotient_of_ne_top {J : Ideal A} (hJ : J ≠ ⊤) :
+    (1 : A ⧸ J) ∉ closure ({0} : Set (A ⧸ J)) := by
+  intro hmem
+  refine one_notMem_closure_of_ne_top hJ ?_
+  have hpre : (Ideal.Quotient.mk J) ⁻¹' ({0} : Set (A ⧸ J)) = (J : Set A) := by
+    ext a
+    simp [Ideal.Quotient.eq_zero_iff_mem]
+  have hopen := (QuotientRing.isOpenMap_coe J).preimage_closure_eq_closure_preimage
+    continuous_quotient_mk' ({0} : Set (A ⧸ J))
+  rw [hpre] at hopen
+  rw [← hopen]
+  simpa using hmem
 
 end TauCeti.Huber
 

--- a/TauCeti/Topology/Algebra/Ring/MaximalIdeals.lean
+++ b/TauCeti/Topology/Algebra/Ring/MaximalIdeals.lean
@@ -9,11 +9,12 @@ public import Mathlib.RingTheory.Ideal.Maximal
 public import Mathlib.Topology.Algebra.Ring.Ideal
 
 /-!
-# Maximal ideals of a topological ring with open unit group
+# Ideals of a topological ring with open unit group
 
-A maximal ideal of a topological ring is closed as soon as the unit group is open. The closure of
-`𝔪` is again an ideal, and it is proper because the units are open, so their complement is a closed
-set containing `𝔪` and hence containing its closure; maximality then forces that closure to be `𝔪`.
+Openness of the unit group makes the closure of a proper ideal proper again: the units are open, so
+their complement is a closed set containing the ideal, hence containing its closure. For a maximal
+ideal `𝔪` that closure is an ideal squeezed between `𝔪` and the unit ideal, so it is `𝔪` itself and
+`𝔪` is closed.
 
 Openness of the unit group is the only topological input, and it stays a hypothesis so that any
 route to it can consume this lemma. `TauCeti.RingTheory.Huber.UnitGroup` supplies one for complete
@@ -27,14 +28,17 @@ is open; closedness is the form that survives.
 
 ## Main results
 
+* `Ideal.closure_ne_top_of_isOpen_isUnit` : the closure of a proper ideal of a topological ring is
+  again proper once the unit group is open.
 * `Ideal.isClosed_of_isMaximal_of_isOpen_isUnit` : a maximal ideal of a topological ring is closed
   once the unit group is open.
 
 ## Provenance
 
 Adapted from AINTLIB (see References), section `MaximalIdealClosed` of the source file, where the
-statement is `isClosed_of_isMaximal_of_isOpen_units`. The argument is that file's, essentially
-verbatim; only the commutativity hypothesis is dropped.
+statement is `isClosed_of_isMaximal_of_isOpen_units`. The argument is that file's; the
+commutativity hypothesis is dropped, and the properness step, which uses nothing about maximality,
+is separated out as `Ideal.closure_ne_top_of_isOpen_isUnit`.
 
 ## References
 
@@ -45,19 +49,26 @@ verbatim; only the commutativity hypothesis is dropped.
 
 public section
 
+/-- **The closure of a proper ideal of a topological ring is proper once the unit group is
+open.** A proper ideal contains no unit, so it lies in the complement of the unit group; that
+complement is closed, hence contains the closure too, which therefore misses `1`. -/
+theorem Ideal.closure_ne_top_of_isOpen_isUnit {A : Type*} [Ring A] [TopologicalSpace A]
+    [IsTopologicalRing A] (hU : IsOpen {a : A | IsUnit a}) {J : Ideal A} (hJ : J ≠ ⊤) :
+    J.closure ≠ ⊤ := by
+  rw [Ideal.ne_top_iff_one]
+  exact fun h1 ↦ (closure_minimal (fun x hx ↦ mt (Ideal.eq_top_of_isUnit_mem J hx) hJ)
+    hU.isClosed_compl h1) isUnit_one
+
 /-- **A maximal ideal of a topological ring is closed once the unit group is open.** The closure
-of `𝔪` is an ideal containing `𝔪`, and it is proper because it avoids the units — the units are
-open, so their complement is a closed set containing `𝔪` and hence its closure. Maximality then
-forces the closure to be `𝔪` itself. -/
+of `𝔪` is an ideal containing `𝔪`, and `Ideal.closure_ne_top_of_isOpen_isUnit` makes it proper, so
+maximality forces it to be `𝔪` itself. -/
 theorem Ideal.isClosed_of_isMaximal_of_isOpen_isUnit {A : Type*} [Ring A] [TopologicalSpace A]
     [IsTopologicalRing A] (hU : IsOpen {a : A | IsUnit a}) (𝔪 : Ideal A) [𝔪.IsMaximal] :
     IsClosed (𝔪 : Set A) := by
   rw [← closure_eq_iff_isClosed, ← Ideal.coe_closure]
   congr 1
-  have hne : 𝔪.closure ≠ ⊤ := by
-    rw [Ideal.ne_top_iff_one]
-    exact fun h1 ↦ (closure_minimal (fun x hx ↦ mt (Ideal.eq_top_of_isUnit_mem 𝔪 hx)
-      (Ideal.IsMaximal.ne_top ‹_›)) hU.isClosed_compl h1) isUnit_one
-  exact (Ideal.IsMaximal.eq_of_le ‹_› hne fun x hx ↦ subset_closure hx).symm
+  exact (Ideal.IsMaximal.eq_of_le ‹_›
+    (Ideal.closure_ne_top_of_isOpen_isUnit hU (Ideal.IsMaximal.ne_top ‹_›))
+    fun x hx ↦ subset_closure hx).symm
 
 end

--- a/TauCeti/Topology/Algebra/Ring/MaximalIdeals.lean
+++ b/TauCeti/Topology/Algebra/Ring/MaximalIdeals.lean
@@ -50,8 +50,7 @@ is separated out as `Ideal.closure_ne_top_of_isOpen_isUnit`.
 public section
 
 /-- **The closure of a proper ideal of a topological ring is proper once the unit group is
-open.** A proper ideal contains no unit, so it lies in the complement of the unit group; that
-complement is closed, hence contains the closure too, which therefore misses `1`. -/
+open.** -/
 theorem Ideal.closure_ne_top_of_isOpen_isUnit {A : Type*} [Ring A] [TopologicalSpace A]
     [IsTopologicalRing A] (hU : IsOpen {a : A | IsUnit a}) {J : Ideal A} (hJ : J ≠ ⊤) :
     J.closure ≠ ⊤ := by
@@ -59,9 +58,7 @@ theorem Ideal.closure_ne_top_of_isOpen_isUnit {A : Type*} [Ring A] [TopologicalS
   exact fun h1 ↦ (closure_minimal (fun x hx ↦ mt (Ideal.eq_top_of_isUnit_mem J hx) hJ)
     hU.isClosed_compl h1) isUnit_one
 
-/-- **A maximal ideal of a topological ring is closed once the unit group is open.** The closure
-of `𝔪` is an ideal containing `𝔪`, and `Ideal.closure_ne_top_of_isOpen_isUnit` makes it proper, so
-maximality forces it to be `𝔪` itself. -/
+/-- **A maximal ideal of a topological ring is closed once the unit group is open.** -/
 theorem Ideal.isClosed_of_isMaximal_of_isOpen_isUnit {A : Type*} [Ring A] [TopologicalSpace A]
     [IsTopologicalRing A] (hU : IsOpen {a : A | IsUnit a}) (𝔪 : Ideal A) [𝔪.IsMaximal] :
     IsClosed (𝔪 : Set A) := by


### PR DESCRIPTION
This PR proves that over a complete Hausdorff Huber pair `(A, A⁺)` every proper ideal of `A` is contained in the support of a point of `Spa (A, A⁺)`, and reads off the two consequences Wedhorn's §8 uses: an element on which no point vanishes is a unit, and a finite set whose standard rational family covers the spectrum generates the unit ideal. This is Wedhorn, *Adic Spaces* (arXiv:1910.05934v1), Proposition 7.51 together with Proposition 7.52(2) and the converse half of Corollary 7.53.

The roadmap target is `TauCetiRoadmap/AdicSpaces/README.md`, Layer 2.2, which asks for "Corollary 7.53: if `T` is a finite subset of a complete Hausdorff affinoid ring, then `T` generates the unit ideal if and only if the standard family `(R(T/t))_{t ∈ T}` covers `Spa(A,A⁺)`". `STATUS.md` records Corollary 7.53 as not established; what was on `main` is `span_eq_top_iff_spa_eq_biUnion_rationalSubset`, whose `←` direction carried an openness hypothesis on the maximal ideals of `A`. That hypothesis is unsatisfiable over a nonzero Tate ring — an ideal of a Tate ring is open exactly when it is `⊤`, by `TauCeti.Huber.IsTateRing.isOpen_iff_eq_top` — so the statement is vacuous on exactly the affinoid rings the roadmap's §8 material is about. The forward direction, `spa_eq_biUnion_rationalSubset_of_span_eq_top`, already holds over an arbitrary commutative ring, so the missing direction proved here completes Corollary 7.53 with completeness as the only hypothesis, and the obsolete `hmax` form is removed. What remains on that milestone is Lemma 7.54, the standard rational refinement of an open cover, which consumes Corollary 7.53 and additionally needs Huber's [Hu2] Lemma 2.6.

The named consumer inside this repository is explicit. `TauCeti/AlgebraicGeometry/AdicSpace/Spa/Localization/UniversalProperty.lean` states, of its Lemma 8.1 corollary `existsUnique_continuous_ringHom_of_forall_comap_mem_rationalSubset`, that "what is missing is a form of Wedhorn's Proposition 7.52(2) for complete Tate rings, which belongs to `Spa/Points.lean` and not to this file", and that removing the openness hypothesis there "needs a form of Wedhorn's Proposition 7.52(2) for complete Tate rings that does not route through open maximal ideals". `isUnit_iff_forall_mem_spa_notMem_supp` is that form: the corollary already assumes `[CompleteSpace B]`, `[T0Space B]` and `[IsHuberRing B]`, which is precisely what the new criterion asks for. `hmax` is therefore dropped from `isUnit_of_forall_comap_mem_rationalSubset` and from `existsUnique_continuous_ringHom_of_forall_comap_mem_rationalSubset`, so the exposed Lemma 8.1 interface is no longer vacuous on Tate targets.

The proof avoids open ideals entirely. The quotient Huber pair `(A/J, (A/J)⁺)` is a Huber pair by `TauCeti.Huber.Pair.quotient`; its adic spectrum is empty exactly when `1` lies in the closure of zero, which is Wedhorn Proposition 7.49(1), already on `main` as `spa_eq_empty_iff_one_mem_closure_zero`; and completeness stops a proper ideal from being dense, because the unit group of a complete Huber ring is open. A point of the quotient spectrum is then a point of `Spa (A, A⁺)` whose support contains `J`, by the range computation `range_spaComap_quotientMk`. Completeness is what replaces openness of the maximal ideals, and it is the hypothesis Wedhorn himself carries.

New module `TauCeti/AlgebraicGeometry/AdicSpace/Spa/Support.lean`:

- `exists_mem_spa_le_supp_of_ne_top` and `ne_top_iff_exists_mem_spa_le_supp`, the engine and its criterion form;
- `exists_mem_spa_supp_eq_of_isMaximal`, Proposition 7.51 for a maximal ideal, which is the existence conjunct that `TauCeti/RingTheory/Huber/UnitGroup.lean` recorded as a separate development;
- `span_eq_top_iff_forall_mem_spa_exists_notMem_supp`, for an arbitrary subset;
- `isUnit_iff_forall_mem_spa_notMem_supp`, Proposition 7.52(2) as a criterion.

New module `TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Cover.lean`, which is where the rational-subset half lives: `span_eq_top_of_spa_eq_biUnion_rationalSubset`, the converse half of Corollary 7.53, and `span_eq_top_iff_spa_eq_biUnion_rationalSubset`, Corollary 7.53 itself, replacing the `hmax` form deleted from `Spa/RationalSubset/Basic.lean`.

Existing files change as follows. `TauCeti/AlgebraicGeometry/AdicSpace/Spa/Localization/UniversalProperty.lean` loses `hmax` from the two declarations named above, deriving the unit from the new criterion instead. `TauCeti/Topology/Algebra/Ring/MaximalIdeals.lean` gains `Ideal.closure_ne_top_of_isOpen_isUnit`, which is the properness step that was an inline `have` in `Ideal.isClosed_of_isMaximal_of_isOpen_isUnit`; that theorem now calls it, so the argument is written once. `TauCeti/RingTheory/Huber/UnitGroup.lean` gains its two Huber specializations, `one_notMem_closure_of_ne_top` and `one_notMem_closure_zero_quotient_of_ne_top`, next to `isOpen_setOf_isUnit` from which they follow. Neither statement mentions the adic spectrum, so neither belongs in the new module.

The statements are stated with `[T2Space A]`, which a caller carrying only `[T0Space A]` obtains from instance search for a topological group, so the `[T0Space B]` targets of Lemma 8.1 are covered.

No Mathlib infrastructure is vendored, and nothing is ported: AINTLIB reaches Propositions 7.51 and 7.52(2) through an open maximal ideal, which is the route `Spa/Points.lean` already carries over, and the argument here shares nothing with it beyond the statements.

Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"exists-mem-spa-le-supp-of-ne-top"}-->

🤖 Prepared with Claude Code

