### PR TITLE
feat: tensorization of the Wasserstein distance

### DIFF
--- a/TauCeti/Analysis/Normed/Lp/MeasurableSpace.lean
+++ b/TauCeti/Analysis/Normed/Lp/MeasurableSpace.lean
@@ -1,0 +1,77 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.Normed.Lp.MeasurableSpace
+public import Mathlib.Analysis.SpecialFunctions.Pow.Continuity
+
+/-!
+# The `ℓ^p` product distance as a measurable function
+
+For a finite exponent `p` the extended distance on `WithLp p (X × Y)` is the `ℓ^p` combination
+`(d₁ ^ p + d₂ ^ p) ^ (1 / p)` of the two factor distances. This file records the two facts that
+make that distance usable as the ground distance of a measure-theoretic construction on the
+product: raising it to the power `p` makes it additive in the two factors, and it is jointly
+measurable as soon as the two factor distances are.
+
+The measurable structure of `WithLp p (X × Y)` is the one pulled back from `X × Y`, so
+measurability is a statement about the product measurable space and only the distance changes
+along the type synonym.
+
+## Main statements
+
+* `TauCeti.edist_toLp_rpow` — the `p`-th power of the `ℓ^p` product distance is the sum of the
+  `p`-th powers of the two factor distances;
+* `TauCeti.measurable_edist_toLp_prod` — joint measurability of the `ℓ^p` product distance.
+-/
+
+public section
+
+noncomputable section
+
+open scoped ENNReal
+
+namespace TauCeti
+
+universe u v
+
+variable {p : ℝ≥0∞} [Fact (1 ≤ p)] {X : Type u} {Y : Type v}
+  [PseudoEMetricSpace X] [PseudoEMetricSpace Y]
+
+/-- Raising the `ℓ^p` product distance to the power `p` makes it additive in the two factors. -/
+theorem edist_toLp_rpow (hp : p ≠ ∞) (z w : X × Y) :
+    edist (WithLp.toLp p z) (WithLp.toLp p w) ^ p.toReal
+      = edist z.1 w.1 ^ p.toReal + edist z.2 w.2 ^ p.toReal := by
+  have hr : 0 < p.toReal := p.toReal_pos_iff_ne_top.mpr hp
+  rw [WithLp.prod_edist_eq_add hr, ← ENNReal.rpow_mul, one_div_mul_cancel hr.ne',
+    ENNReal.rpow_one, WithLp.toLp_fst, WithLp.toLp_fst, WithLp.toLp_snd, WithLp.toLp_snd]
+
+variable [MeasurableSpace X] [MeasurableSpace Y]
+
+/-- The `ℓ^p` product distance is jointly measurable as soon as the two factor distances are. -/
+theorem measurable_edist_toLp_prod (hp : p ≠ ∞)
+    (hdX : Measurable fun z : X × X ↦ edist z.1 z.2)
+    (hdY : Measurable fun z : Y × Y ↦ edist z.1 z.2) :
+    Measurable fun w : WithLp p (X × Y) × WithLp p (X × Y) ↦ edist w.1 w.2 := by
+  have hr : 0 < p.toReal := p.toReal_pos_iff_ne_top.mpr hp
+  have m₁ : Measurable fun w : WithLp p (X × Y) × WithLp p (X × Y) ↦ WithLp.ofLp w.1 :=
+    (WithLp.measurable_ofLp p (X × Y)).comp measurable_fst
+  have m₂ : Measurable fun w : WithLp p (X × Y) × WithLp p (X × Y) ↦ WithLp.ofLp w.2 :=
+    (WithLp.measurable_ofLp p (X × Y)).comp measurable_snd
+  have h₁ : Measurable fun w : WithLp p (X × Y) × WithLp p (X × Y) ↦
+      edist w.1.fst w.2.fst := by
+    simpa [Function.comp_def] using
+      hdX.comp ((measurable_fst.comp m₁).prodMk (measurable_fst.comp m₂))
+  have h₂ : Measurable fun w : WithLp p (X × Y) × WithLp p (X × Y) ↦
+      edist w.1.snd w.2.snd := by
+    simpa [Function.comp_def] using
+      hdY.comp ((measurable_snd.comp m₁).prodMk (measurable_snd.comp m₂))
+  simp only [WithLp.prod_edist_eq_add hr]
+  exact (ENNReal.continuous_rpow_const.measurable).comp
+    ((ENNReal.continuous_rpow_const.measurable.comp h₁).add
+      (ENNReal.continuous_rpow_const.measurable.comp h₂))
+
+end TauCeti

--- a/TauCeti/MeasureTheory/OptimalTransport/Cost/Product.lean
+++ b/TauCeti/MeasureTheory/OptimalTransport/Cost/Product.lean
@@ -24,12 +24,13 @@ soon as one of the two coordinate values is.
 
 The four marginals are probability measures. That normalisation is what makes the coordinate
 pushforwards of a plan of `μ₁ ⊗ μ₂` and `ν₁ ⊗ ν₂` land on `μᵢ` and `νᵢ` rather than on a rescaling
-of them; the rearrangement lemma below carries no such hypothesis.
+of them. The rearrangement of a product of plans that the proofs use is
+`TauCeti.IsCoupling.prodProdProdComm`, which needs no such hypothesis.
 
 ## Main statements
 
-* `TauCeti.IsCoupling.prodProdProdComm` — rearranging the product of two plans gives a plan of the
-  product problem, and `TauCeti.lintegral_map_prodProdProdComm` computes its separable cost;
+* `TauCeti.lintegral_map_prodProdProdComm` — the separable cost of the rearranged product of two
+  plans, `TauCeti.IsCoupling.prodProdProdComm`, is the sum of the two coordinate costs;
 * `TauCeti.transportCost_prod_add` — the value of an additively separable cost on a product of two
   transport problems is the sum of the two values;
 * `TauCeti.IsOptimalCoupling.prod` — rearranging the product of two optimal plans gives an optimal
@@ -58,28 +59,6 @@ variable {X₁ : Type u} {X₂ : Type v} {Y₁ : Type w} {Y₂ : Type*}
   {c₁ : X₁ × Y₁ → ℝ≥0∞} {c₂ : X₂ × Y₂ → ℝ≥0∞}
   {μ₁ : Measure X₁} {μ₂ : Measure X₂} {ν₁ : Measure Y₁} {ν₂ : Measure Y₂}
   {π₁ : Measure (X₁ × Y₁)} {π₂ : Measure (X₂ × Y₂)}
-
-/-- **Rearranging a product of plans.** Exchanging the two middle coordinates of the product of a
-plan of `μ₁, ν₁` and a plan of `μ₂, ν₂` gives a plan of `μ₁ ⊗ μ₂` and `ν₁ ⊗ ν₂`. -/
-protected theorem IsCoupling.prodProdProdComm [SFinite π₁] [SFinite π₂]
-    (h₁ : IsCoupling π₁ μ₁ ν₁) (h₂ : IsCoupling π₂ μ₂ ν₂) :
-    IsCoupling ((π₁.prod π₂).map fun w ↦ ((w.1.1, w.2.1), (w.1.2, w.2.2)))
-      (μ₁.prod μ₂) (ν₁.prod ν₂) := by
-  have hX : Measurable (Prod.map Prod.fst Prod.fst : (X₁ × Y₁) × X₂ × Y₂ → X₁ × X₂) :=
-    measurable_fst.prodMap measurable_fst
-  have hY : Measurable (Prod.map Prod.snd Prod.snd : (X₁ × Y₁) × X₂ × Y₂ → Y₁ × Y₂) :=
-    measurable_snd.prodMap measurable_snd
-  constructor
-  · have h : ((π₁.prod π₂).map fun w ↦ ((w.1.1, w.2.1), (w.1.2, w.2.2))).fst
-        = (π₁.prod π₂).map (Prod.map Prod.fst Prod.fst) :=
-      Measure.fst_map_prodMk hX hY
-    rw [h, ← Measure.map_prod_map π₁ π₂ measurable_fst measurable_fst]
-    exact congrArg₂ Measure.prod h₁.fst_eq h₂.fst_eq
-  · have h : ((π₁.prod π₂).map fun w ↦ ((w.1.1, w.2.1), (w.1.2, w.2.2))).snd
-        = (π₁.prod π₂).map (Prod.map Prod.snd Prod.snd) :=
-      Measure.snd_map_prodMk hX hY
-    rw [h, ← Measure.map_prod_map π₁ π₂ measurable_snd measurable_snd]
-    exact congrArg₂ Measure.prod h₁.snd_eq h₂.snd_eq
 
 /-- The cost of a rearranged product of plans is the sum of the two coordinate costs. -/
 theorem lintegral_map_prodProdProdComm [IsProbabilityMeasure π₁] [IsProbabilityMeasure π₂]

--- a/TauCeti/MeasureTheory/OptimalTransport/Cost/Product.lean
+++ b/TauCeti/MeasureTheory/OptimalTransport/Cost/Product.lean
@@ -24,8 +24,9 @@ soon as one of the two coordinate values is.
 
 The four marginals are probability measures. That normalisation is what makes the coordinate
 pushforwards of a plan of `μ₁ ⊗ μ₂` and `ν₁ ⊗ ν₂` land on `μᵢ` and `νᵢ` rather than on a rescaling
-of them. The rearrangement of a product of plans that the proofs use is
-`TauCeti.IsCoupling.prodProdProdComm`, which needs no such hypothesis.
+of them. By contrast, `TauCeti.IsCoupling.prodProdProdComm` — rearranging the product of a
+coupling of `μ₁` and `ν₁` with a coupling of `μ₂` and `ν₂` gives a coupling of `μ₁ ⊗ μ₂` and
+`ν₁ ⊗ ν₂` — holds for arbitrary marginals.
 
 ## Main statements
 

--- a/TauCeti/MeasureTheory/OptimalTransport/Cost/Product.lean
+++ b/TauCeti/MeasureTheory/OptimalTransport/Cost/Product.lean
@@ -19,11 +19,8 @@ separable* function
 This file proves that the assembled problem decouples exactly: its value is the sum of the two
 values, and rearranging a pair of optimal plans produces an optimal plan of the product problem.
 
-Neither inequality needs a topology, an attainment theorem or a finiteness hypothesis on the
-values. The upper bound rearranges a pair of feasible plans into a feasible plan of the product
-problem and passes to the infimum through `ENNReal.le_iInf₂_add_iInf₂`; the lower bound pushes a
-feasible plan of the product problem forward to the two coordinate problems, which is where
-measurability of the two costs is used.
+The decoupling is an identity in `ℝ≥0∞`: no value is assumed finite, and both sides are `∞` as
+soon as one of the two coordinate values is.
 
 The four marginals are probability measures. That normalisation is what makes the coordinate
 pushforwards of a plan of `μ₁ ⊗ μ₂` and `ν₁ ⊗ ν₂` land on `μᵢ` and `νᵢ` rather than on a rescaling
@@ -37,13 +34,6 @@ of them; the rearrangement lemma below carries no such hypothesis.
   transport problems is the sum of the two values;
 * `TauCeti.IsOptimalCoupling.prod` — rearranging the product of two optimal plans gives an optimal
   plan for the separable cost.
-
-## Implementation notes
-
-The rearrangement `((x₁, y₁), (x₂, y₂)) ↦ ((x₁, x₂), (y₁, y₂))` that turns a product of plans into
-a plan of the product problem is written out as a lambda. It is `Equiv.prodProdProdComm`, whose
-name the lemmas below reuse, but `Measure.map` consumes a bare function and Mathlib has no
-measurable-equivalence form of that rearrangement to name here.
 
 ## References
 
@@ -75,24 +65,20 @@ protected theorem IsCoupling.prodProdProdComm [SFinite π₁] [SFinite π₂]
     (h₁ : IsCoupling π₁ μ₁ ν₁) (h₂ : IsCoupling π₂ μ₂ ν₂) :
     IsCoupling ((π₁.prod π₂).map fun w ↦ ((w.1.1, w.2.1), (w.1.2, w.2.2)))
       (μ₁.prod μ₂) (ν₁.prod ν₂) := by
-  have hX : Measurable fun w : (X₁ × Y₁) × X₂ × Y₂ ↦ (w.1.1, w.2.1) :=
-    (measurable_fst.comp measurable_fst).prodMk (measurable_fst.comp measurable_snd)
-  have hY : Measurable fun w : (X₁ × Y₁) × X₂ × Y₂ ↦ (w.1.2, w.2.2) :=
-    (measurable_snd.comp measurable_fst).prodMk (measurable_snd.comp measurable_snd)
+  have hX : Measurable (Prod.map Prod.fst Prod.fst : (X₁ × Y₁) × X₂ × Y₂ → X₁ × X₂) :=
+    measurable_fst.prodMap measurable_fst
+  have hY : Measurable (Prod.map Prod.snd Prod.snd : (X₁ × Y₁) × X₂ × Y₂ → Y₁ × Y₂) :=
+    measurable_snd.prodMap measurable_snd
   constructor
   · have h : ((π₁.prod π₂).map fun w ↦ ((w.1.1, w.2.1), (w.1.2, w.2.2))).fst
-        = (π₁.prod π₂).map fun w : (X₁ × Y₁) × X₂ × Y₂ ↦ (w.1.1, w.2.1) :=
+        = (π₁.prod π₂).map (Prod.map Prod.fst Prod.fst) :=
       Measure.fst_map_prodMk hX hY
-    rw [h, show (fun w : (X₁ × Y₁) × X₂ × Y₂ ↦ (w.1.1, w.2.1))
-        = Prod.map Prod.fst Prod.fst from rfl,
-      ← Measure.map_prod_map π₁ π₂ measurable_fst measurable_fst]
+    rw [h, ← Measure.map_prod_map π₁ π₂ measurable_fst measurable_fst]
     exact congrArg₂ Measure.prod h₁.fst_eq h₂.fst_eq
   · have h : ((π₁.prod π₂).map fun w ↦ ((w.1.1, w.2.1), (w.1.2, w.2.2))).snd
-        = (π₁.prod π₂).map fun w : (X₁ × Y₁) × X₂ × Y₂ ↦ (w.1.2, w.2.2) :=
+        = (π₁.prod π₂).map (Prod.map Prod.snd Prod.snd) :=
       Measure.snd_map_prodMk hX hY
-    rw [h, show (fun w : (X₁ × Y₁) × X₂ × Y₂ ↦ (w.1.2, w.2.2))
-        = Prod.map Prod.snd Prod.snd from rfl,
-      ← Measure.map_prod_map π₁ π₂ measurable_snd measurable_snd]
+    rw [h, ← Measure.map_prod_map π₁ π₂ measurable_snd measurable_snd]
     exact congrArg₂ Measure.prod h₁.snd_eq h₂.snd_eq
 
 /-- The cost of a rearranged product of plans is the sum of the two coordinate costs. -/

--- a/TauCeti/MeasureTheory/OptimalTransport/Cost/Product.lean
+++ b/TauCeti/MeasureTheory/OptimalTransport/Cost/Product.lean
@@ -1,0 +1,172 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.MeasureTheory.OptimalTransport.Cost.Basic
+
+/-!
+# Transport costs of a product problem
+
+Two transport problems, one from `μ₁` to `ν₁` with cost `c₁` and one from `μ₂` to `ν₂` with cost
+`c₂`, assemble into a single problem from `μ₁ ⊗ μ₂` to `ν₁ ⊗ ν₂` whose cost is the *additively
+separable* function
+
+`c ((x₁, x₂), (y₁, y₂)) = c₁ (x₁, y₁) + c₂ (x₂, y₂)`.
+
+This file proves that the assembled problem decouples exactly: its value is the sum of the two
+values, and rearranging a pair of optimal plans produces an optimal plan of the product problem.
+
+Neither inequality needs a topology, an attainment theorem or a finiteness hypothesis on the
+values. The upper bound rearranges a pair of feasible plans into a feasible plan of the product
+problem and passes to the infimum through `ENNReal.le_iInf₂_add_iInf₂`; the lower bound pushes a
+feasible plan of the product problem forward to the two coordinate problems, which is where
+measurability of the two costs is used.
+
+The four marginals are probability measures. That normalisation is what makes the coordinate
+pushforwards of a plan of `μ₁ ⊗ μ₂` and `ν₁ ⊗ ν₂` land on `μᵢ` and `νᵢ` rather than on a rescaling
+of them; the rearrangement lemma below carries no such hypothesis.
+
+## Main statements
+
+* `TauCeti.IsCoupling.prodProdProdComm` — rearranging the product of two plans gives a plan of the
+  product problem, and `TauCeti.lintegral_map_prodProdProdComm` computes its separable cost;
+* `TauCeti.transportCost_prod_add` — the value of an additively separable cost on a product of two
+  transport problems is the sum of the two values;
+* `TauCeti.IsOptimalCoupling.prod` — rearranging the product of two optimal plans gives an optimal
+  plan for the separable cost.
+
+## Implementation notes
+
+The rearrangement `((x₁, y₁), (x₂, y₂)) ↦ ((x₁, x₂), (y₁, y₂))` that turns a product of plans into
+a plan of the product problem is written out as a lambda. It is `Equiv.prodProdProdComm`, whose
+name the lemmas below reuse, but `Measure.map` consumes a bare function and Mathlib has no
+measurable-equivalence form of that rearrangement to name here.
+
+## References
+
+* C. Villani, *Optimal Transport: Old and New*, Grundlehren 338, Springer 2009, Chapter 6, where
+  the tensorization of the Wasserstein distance is the special case `cᵢ = dᵢ ^ p` of the identity
+  proved here.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory
+open scoped ENNReal
+
+namespace TauCeti
+
+universe u v w
+
+variable {X₁ : Type u} {X₂ : Type v} {Y₁ : Type w} {Y₂ : Type*}
+  [MeasurableSpace X₁] [MeasurableSpace X₂] [MeasurableSpace Y₁] [MeasurableSpace Y₂]
+  {c₁ : X₁ × Y₁ → ℝ≥0∞} {c₂ : X₂ × Y₂ → ℝ≥0∞}
+  {μ₁ : Measure X₁} {μ₂ : Measure X₂} {ν₁ : Measure Y₁} {ν₂ : Measure Y₂}
+  {π₁ : Measure (X₁ × Y₁)} {π₂ : Measure (X₂ × Y₂)}
+
+/-- **Rearranging a product of plans.** Exchanging the two middle coordinates of the product of a
+plan of `μ₁, ν₁` and a plan of `μ₂, ν₂` gives a plan of `μ₁ ⊗ μ₂` and `ν₁ ⊗ ν₂`. -/
+protected theorem IsCoupling.prodProdProdComm [SFinite π₁] [SFinite π₂]
+    (h₁ : IsCoupling π₁ μ₁ ν₁) (h₂ : IsCoupling π₂ μ₂ ν₂) :
+    IsCoupling ((π₁.prod π₂).map fun w ↦ ((w.1.1, w.2.1), (w.1.2, w.2.2)))
+      (μ₁.prod μ₂) (ν₁.prod ν₂) := by
+  have hX : Measurable fun w : (X₁ × Y₁) × X₂ × Y₂ ↦ (w.1.1, w.2.1) :=
+    (measurable_fst.comp measurable_fst).prodMk (measurable_fst.comp measurable_snd)
+  have hY : Measurable fun w : (X₁ × Y₁) × X₂ × Y₂ ↦ (w.1.2, w.2.2) :=
+    (measurable_snd.comp measurable_fst).prodMk (measurable_snd.comp measurable_snd)
+  constructor
+  · have h : ((π₁.prod π₂).map fun w ↦ ((w.1.1, w.2.1), (w.1.2, w.2.2))).fst
+        = (π₁.prod π₂).map fun w : (X₁ × Y₁) × X₂ × Y₂ ↦ (w.1.1, w.2.1) :=
+      Measure.fst_map_prodMk hX hY
+    rw [h, show (fun w : (X₁ × Y₁) × X₂ × Y₂ ↦ (w.1.1, w.2.1))
+        = Prod.map Prod.fst Prod.fst from rfl,
+      ← Measure.map_prod_map π₁ π₂ measurable_fst measurable_fst]
+    exact congrArg₂ Measure.prod h₁.fst_eq h₂.fst_eq
+  · have h : ((π₁.prod π₂).map fun w ↦ ((w.1.1, w.2.1), (w.1.2, w.2.2))).snd
+        = (π₁.prod π₂).map fun w : (X₁ × Y₁) × X₂ × Y₂ ↦ (w.1.2, w.2.2) :=
+      Measure.snd_map_prodMk hX hY
+    rw [h, show (fun w : (X₁ × Y₁) × X₂ × Y₂ ↦ (w.1.2, w.2.2))
+        = Prod.map Prod.snd Prod.snd from rfl,
+      ← Measure.map_prod_map π₁ π₂ measurable_snd measurable_snd]
+    exact congrArg₂ Measure.prod h₁.snd_eq h₂.snd_eq
+
+/-- The cost of a rearranged product of plans is the sum of the two coordinate costs. -/
+theorem lintegral_map_prodProdProdComm [IsProbabilityMeasure π₁] [IsProbabilityMeasure π₂]
+    (hc₁ : Measurable c₁) (hc₂ : Measurable c₂) :
+    ∫⁻ z : (X₁ × X₂) × Y₁ × Y₂, (c₁ (z.1.1, z.2.1) + c₂ (z.1.2, z.2.2))
+        ∂((π₁.prod π₂).map fun w ↦ ((w.1.1, w.2.1), (w.1.2, w.2.2)))
+      = ∫⁻ u, c₁ u ∂π₁ + ∫⁻ v, c₂ v ∂π₂ := by
+  have hm : Measurable fun z : (X₁ × X₂) × Y₁ × Y₂ ↦ c₁ (z.1.1, z.2.1) + c₂ (z.1.2, z.2.2) :=
+    (hc₁.comp ((measurable_fst.comp measurable_fst).prodMk
+        (measurable_fst.comp measurable_snd))).add
+      (hc₂.comp ((measurable_snd.comp measurable_fst).prodMk
+        (measurable_snd.comp measurable_snd)))
+  have hg : Measurable fun w : (X₁ × Y₁) × X₂ × Y₂ ↦ ((w.1.1, w.2.1), (w.1.2, w.2.2)) :=
+    (((measurable_fst.comp measurable_fst).prodMk
+        (measurable_fst.comp measurable_snd)).prodMk
+      ((measurable_snd.comp measurable_fst).prodMk (measurable_snd.comp measurable_snd)))
+  rw [lintegral_map (f := fun z : (X₁ × X₂) × Y₁ × Y₂ ↦ c₁ (z.1.1, z.2.1) + c₂ (z.1.2, z.2.2))
+    (g := fun w : (X₁ × Y₁) × X₂ × Y₂ ↦ ((w.1.1, w.2.1), (w.1.2, w.2.2))) hm hg]
+  simpa using (isCoupling_prod π₁ π₂).lintegral_add_split hc₁ hc₂ 0
+
+section Separable
+
+variable [IsProbabilityMeasure μ₁] [IsProbabilityMeasure μ₂]
+  [IsProbabilityMeasure ν₁] [IsProbabilityMeasure ν₂]
+
+/-- **The transport cost of a product problem splits.** For an additively separable cost on a
+product of two transport problems between probability measures, the value of the assembled problem
+is the sum of the two coordinate values.
+
+No coordinate value is assumed finite: both sides are `∞` as soon as one of them is. -/
+theorem transportCost_prod_add (hc₁ : Measurable c₁) (hc₂ : Measurable c₂) :
+    transportCost (fun z : (X₁ × X₂) × Y₁ × Y₂ ↦ c₁ (z.1.1, z.2.1) + c₂ (z.1.2, z.2.2))
+        (μ₁.prod μ₂) (ν₁.prod ν₂)
+      = transportCost c₁ μ₁ ν₁ + transportCost c₂ μ₂ ν₂ := by
+  have hm₁ : Measurable fun z : (X₁ × X₂) × Y₁ × Y₂ ↦ c₁ (z.1.1, z.2.1) :=
+    hc₁.comp ((measurable_fst.comp measurable_fst).prodMk (measurable_fst.comp measurable_snd))
+  refine le_antisymm ?_ (le_transportCost fun π hπ ↦ ?_)
+  · rw [transportCost_def (c := c₁) (μ := μ₁) (ν := ν₁),
+      transportCost_def (c := c₂) (μ := μ₂) (ν := ν₂)]
+    refine ENNReal.le_iInf₂_add_iInf₂ fun σ₁ hσ₁ σ₂ hσ₂ ↦ ?_
+    have : IsProbabilityMeasure σ₁ := hσ₁.isProbabilityMeasure
+    have : IsProbabilityMeasure σ₂ := hσ₂.isProbabilityMeasure
+    exact (transportCost_le_lintegral (hσ₁.prodProdProdComm hσ₂) _).trans_eq
+      (lintegral_map_prodProdProdComm hc₁ hc₂)
+  · have eμ₁ : Measure.map Prod.fst (μ₁.prod μ₂) = μ₁ := Measure.fst_prod
+    have eν₁ : Measure.map Prod.fst (ν₁.prod ν₂) = ν₁ := Measure.fst_prod
+    have eμ₂ : Measure.map Prod.snd (μ₁.prod μ₂) = μ₂ := Measure.snd_prod
+    have eν₂ : Measure.map Prod.snd (ν₁.prod ν₂) = ν₂ := Measure.snd_prod
+    have hπ₁ : IsCoupling (π.map (Prod.map Prod.fst Prod.fst)) μ₁ ν₁ := by
+      simpa only [eμ₁, eν₁] using hπ.map measurable_fst measurable_fst
+    have hπ₂ : IsCoupling (π.map (Prod.map Prod.snd Prod.snd)) μ₂ ν₂ := by
+      simpa only [eμ₂, eν₂] using hπ.map measurable_snd measurable_snd
+    calc transportCost c₁ μ₁ ν₁ + transportCost c₂ μ₂ ν₂
+        ≤ (∫⁻ u, c₁ u ∂π.map (Prod.map Prod.fst Prod.fst))
+            + ∫⁻ v, c₂ v ∂π.map (Prod.map Prod.snd Prod.snd) :=
+          add_le_add (transportCost_le_lintegral hπ₁ c₁) (transportCost_le_lintegral hπ₂ c₂)
+      _ = ∫⁻ z, (c₁ (z.1.1, z.2.1) + c₂ (z.1.2, z.2.2)) ∂π := by
+          rw [lintegral_map hc₁ (measurable_fst.prodMap measurable_fst),
+            lintegral_map hc₂ (measurable_snd.prodMap measurable_snd)]
+          exact (lintegral_add_left hm₁ _).symm
+
+/-- Rearranging the product of two optimal plans gives an optimal plan for the additively
+separable cost on the product problem. -/
+protected theorem IsOptimalCoupling.prod (hc₁ : Measurable c₁) (hc₂ : Measurable c₂)
+    (h₁ : IsOptimalCoupling c₁ π₁ μ₁ ν₁) (h₂ : IsOptimalCoupling c₂ π₂ μ₂ ν₂) :
+    IsOptimalCoupling (fun z : (X₁ × X₂) × Y₁ × Y₂ ↦ c₁ (z.1.1, z.2.1) + c₂ (z.1.2, z.2.2))
+      ((π₁.prod π₂).map fun w ↦ ((w.1.1, w.2.1), (w.1.2, w.2.2))) (μ₁.prod μ₂) (ν₁.prod ν₂) := by
+  have : IsProbabilityMeasure π₁ := h₁.toIsCoupling.isProbabilityMeasure
+  have : IsProbabilityMeasure π₂ := h₂.toIsCoupling.isProbabilityMeasure
+  refine ⟨h₁.toIsCoupling.prodProdProdComm h₂.toIsCoupling, ?_⟩
+  rw [lintegral_map_prodProdProdComm hc₁ hc₂, h₁.lintegral_eq, h₂.lintegral_eq,
+    transportCost_prod_add hc₁ hc₂]
+
+end Separable
+
+end TauCeti

--- a/TauCeti/MeasureTheory/OptimalTransport/Coupling.lean
+++ b/TauCeti/MeasureTheory/OptimalTransport/Coupling.lean
@@ -38,6 +38,8 @@ measures, and the probability case is packaged separately as a subtype of
 * `TauCeti.IsCoupling.measurePreserving_fst`, `TauCeti.IsCoupling.measurePreserving_snd`,
   `TauCeti.IsCoupling.integral_comp_fst`, and `TauCeti.IsCoupling.integral_comp_snd` — projection
   and integral-transfer forms of the marginal conditions;
+* `TauCeti.IsCoupling.prodProdProdComm` — exchanging the two middle coordinates of a product of
+  two couplings couples the two product measures;
 * `TauCeti.exists_isCoupling_iff` — a finite measure and any other measure admit a coupling
   exactly when they have the same total mass, the witness being their normalised product;
 * `TauCeti.isCoupling_map_swap_iff` and `TauCeti.isCoupling_map_prodMap_iff` —
@@ -232,6 +234,28 @@ protected theorem map_left (hπ : IsCoupling π μ ν) {f : X → X'} (hf : Meas
 protected theorem map_right (hπ : IsCoupling π μ ν) {g : Y → Y'} (hg : Measurable g) :
     IsCoupling (π.map (Prod.map id g)) μ (ν.map g) := by
   simpa only [Measure.map_id] using hπ.map measurable_id hg
+
+/-- **Rearranging a product of plans.** Exchanging the two middle coordinates of the product of a
+coupling of `μ, ν` and a coupling of `μ', ν'` gives a coupling of `μ ⊗ μ'` and `ν ⊗ ν'`. -/
+protected theorem prodProdProdComm {π' : Measure (X' × Y')} {μ' : Measure X'} {ν' : Measure Y'}
+    [SFinite π] [SFinite π'] (hπ : IsCoupling π μ ν) (hπ' : IsCoupling π' μ' ν') :
+    IsCoupling ((π.prod π').map fun w ↦ ((w.1.1, w.2.1), (w.1.2, w.2.2)))
+      (μ.prod μ') (ν.prod ν') := by
+  have hX : Measurable (Prod.map Prod.fst Prod.fst : (X × Y) × X' × Y' → X × X') :=
+    measurable_fst.prodMap measurable_fst
+  have hY : Measurable (Prod.map Prod.snd Prod.snd : (X × Y) × X' × Y' → Y × Y') :=
+    measurable_snd.prodMap measurable_snd
+  constructor
+  · have h : ((π.prod π').map fun w ↦ ((w.1.1, w.2.1), (w.1.2, w.2.2))).fst
+        = (π.prod π').map (Prod.map Prod.fst Prod.fst) :=
+      Measure.fst_map_prodMk hX hY
+    rw [h, ← Measure.map_prod_map π π' measurable_fst measurable_fst]
+    exact congrArg₂ Measure.prod hπ.fst_eq hπ'.fst_eq
+  · have h : ((π.prod π').map fun w ↦ ((w.1.1, w.2.1), (w.1.2, w.2.2))).snd
+        = (π.prod π').map (Prod.map Prod.snd Prod.snd) :=
+      Measure.snd_map_prodMk hX hY
+    rw [h, ← Measure.map_prod_map π π' measurable_snd measurable_snd]
+    exact congrArg₂ Measure.prod hπ.snd_eq hπ'.snd_eq
 
 end IsCoupling
 

--- a/TauCeti/MeasureTheory/OptimalTransport/Wasserstein/Product.lean
+++ b/TauCeti/MeasureTheory/OptimalTransport/Wasserstein/Product.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Analysis.Normed.Lp.MeasurableSpace
-public import Mathlib.Analysis.Normed.Lp.ProdLp
 public import TauCeti.MeasureTheory.OptimalTransport.Cost.Product
 public import TauCeti.MeasureTheory.OptimalTransport.Wasserstein.Basic
 
@@ -24,10 +23,10 @@ supremum distance that `X × Y` carries by default. Accordingly the product law 
 measurable structure of `WithLp p (X × Y)` is the one pulled back from `X × Y`, so this pushforward
 changes nothing but the distance.
 
-The proof is the `cᵢ = edist ^ p` case of `TauCeti.transportCost_prod_add`: raising the `ℓ^p`
-product distance to the power `p` makes the cost additively separable, and the transport cost of a
-separable cost on a product problem splits. In particular no attainment theorem and no topological
-hypothesis are needed, and the identity is an identity in `ℝ≥0∞` with no finiteness assumption.
+Tensorization holds because raising the `ℓ^p` product distance to the power `p` makes the ground
+cost additively separable across the two factors, so the two coordinates of a transport problem on
+the product never interact. The identity holds in `ℝ≥0∞`, with no finiteness assumption on either
+factor distance.
 
 The exponent is finite throughout. At `p = ∞` the `ℓ^p` product distance is the maximum of the two
 factor distances rather than an `ℓ^p` sum, so tensorization there is a maximum formula and a
@@ -41,8 +40,9 @@ separate statement; it is not obtained from the identity below.
   the hypothesis that the two-variable Wasserstein API asks for;
 * `TauCeti.wassersteinEDist_map_toLp_prod_rpow` and `TauCeti.wassersteinEDist_map_toLp_prod` — the
   tensorization identity, in its `p`-th power form and its root form;
-* `TauCeti.wassersteinEDist_map_toLp_prod_right` — tensorizing two laws with a common second
-  factor leaves their Wasserstein distance unchanged;
+* `TauCeti.wassersteinEDist_map_toLp_prod_left` and
+  `TauCeti.wassersteinEDist_map_toLp_prod_right` — tensorizing two laws with a common first, resp.
+  second, factor leaves their Wasserstein distance unchanged;
 * `TauCeti.hasFiniteMoment_map_toLp_prod` — a product law has finite `p`-moment exactly when both
   factors do.
 
@@ -142,12 +142,13 @@ theorem wassersteinEDist_map_toLp_prod_rpow (hp : p ≠ ∞)
     wassersteinEDist_rpow_eq_transportCost hp0 hp, ← MeasurableEquiv.coe_toLp p (X × Y),
     ← transportCost_comp_prodMap (MeasurableEquiv.toLp p (X × Y))
       (MeasurableEquiv.toLp p (X × Y)) hcZ]
-  rw [show (fun z : (X × Y) × X × Y ↦
+  have hsep : (fun z : (X × Y) × X × Y ↦
         edist (MeasurableEquiv.toLp p (X × Y) z.1) (MeasurableEquiv.toLp p (X × Y) z.2)
           ^ p.toReal)
       = fun z : (X × Y) × X × Y ↦
-        edist z.1.1 z.2.1 ^ p.toReal + edist z.1.2 z.2.2 ^ p.toReal from
-      funext fun z ↦ edist_toLp_rpow hp z.1 z.2]
+        edist z.1.1 z.2.1 ^ p.toReal + edist z.1.2 z.2.2 ^ p.toReal :=
+    funext fun z ↦ edist_toLp_rpow hp z.1 z.2
+  rw [hsep]
   exact transportCost_prod_add hcX hcY
 
 /-- **Tensorization of the Wasserstein distance**, in root form. -/
@@ -160,6 +161,20 @@ theorem wassersteinEDist_map_toLp_prod (hp : p ≠ ∞)
   have hr : 0 < p.toReal := toReal_exponent_pos hp
   rw [← wassersteinEDist_map_toLp_prod_rpow hp hdX hdY, ← ENNReal.rpow_mul,
     mul_one_div_cancel hr.ne', ENNReal.rpow_one]
+
+omit [IsProbabilityMeasure ν₁] in
+/-- Tensorizing two laws with a common first factor leaves their `p`-Wasserstein distance
+unchanged: the common factor contributes a vanishing term to the tensorization identity. -/
+theorem wassersteinEDist_map_toLp_prod_left (hp : p ≠ ∞)
+    (hdX : Measurable fun z : X × X ↦ edist z.1 z.2)
+    (hdY : Measurable fun z : Y × Y ↦ edist z.1 z.2) :
+    wassersteinEDist p ((μ₁.prod μ₂).map (WithLp.toLp p)) ((μ₁.prod ν₂).map (WithLp.toLp p))
+      = wassersteinEDist p μ₂ ν₂ := by
+  have hr : 0 < p.toReal := toReal_exponent_pos hp
+  have h := wassersteinEDist_map_toLp_prod_rpow (μ₁ := μ₁) (ν₁ := μ₁) (μ₂ := μ₂) (ν₂ := ν₂)
+    hp hdX hdY
+  rw [wassersteinEDist_self_of_measurable_edist hdX, ENNReal.zero_rpow_of_pos hr, zero_add] at h
+  exact ENNReal.rpow_left_injective hr.ne' h
 
 omit [IsProbabilityMeasure ν₂] in
 /-- Tensorizing two laws with a common second factor leaves their `p`-Wasserstein distance

--- a/TauCeti/MeasureTheory/OptimalTransport/Wasserstein/Product.lean
+++ b/TauCeti/MeasureTheory/OptimalTransport/Wasserstein/Product.lean
@@ -5,7 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Analysis.Normed.Lp.MeasurableSpace
+public import TauCeti.Analysis.Normed.Lp.MeasurableSpace
 public import TauCeti.MeasureTheory.OptimalTransport.Cost.Product
 public import TauCeti.MeasureTheory.OptimalTransport.Wasserstein.Basic
 
@@ -34,17 +34,13 @@ separate statement; it is not obtained from the identity below.
 
 ## Main statements
 
-* `TauCeti.edist_toLp_rpow` — the defining additivity of the `ℓ^p` product distance after raising
-  to the power `p`;
-* `TauCeti.measurable_edist_toLp_prod` — joint measurability of the `ℓ^p` product ground distance,
-  the hypothesis that the two-variable Wasserstein API asks for;
 * `TauCeti.wassersteinEDist_map_toLp_prod_rpow` and `TauCeti.wassersteinEDist_map_toLp_prod` — the
   tensorization identity, in its `p`-th power form and its root form;
 * `TauCeti.wassersteinEDist_map_toLp_prod_left` and
   `TauCeti.wassersteinEDist_map_toLp_prod_right` — tensorizing two laws with a common first, resp.
   second, factor leaves their Wasserstein distance unchanged;
-* `TauCeti.hasFiniteMoment_map_toLp_prod` — a product law has finite `p`-moment exactly when both
-  factors do.
+* `TauCeti.hasFiniteMoment_map_toLp_prod_iff` — a product law has finite `p`-moment exactly when
+  both factors do.
 
 ## References
 
@@ -64,54 +60,8 @@ namespace TauCeti
 
 universe u v
 
-variable {p : ℝ≥0∞} [Fact (1 ≤ p)]
-
-/-- An exponent carrying the `Fact (1 ≤ p)` instance that the `ℓ^p` product distance needs is
-nonzero. -/
-private theorem exponent_ne_zero : p ≠ 0 :=
-  (zero_lt_one.trans_le (Fact.out : (1 : ℝ≥0∞) ≤ p)).ne'
-
-/-- A finite exponent carrying the `Fact (1 ≤ p)` instance has positive real part. -/
-private theorem toReal_exponent_pos (hp : p ≠ ∞) : 0 < p.toReal :=
-  ENNReal.toReal_pos exponent_ne_zero hp
-
-variable {X : Type u} {Y : Type v} [MeasurableSpace X] [MeasurableSpace Y]
-  [PseudoEMetricSpace X] [PseudoEMetricSpace Y]
-
-omit [MeasurableSpace X] [MeasurableSpace Y] in
-/-- Raising the `ℓ^p` product distance to the power `p` makes it additive in the two factors.
-This is the reason the tensorization identity below is an identity of `p`-th powers. -/
-theorem edist_toLp_rpow (hp : p ≠ ∞) (z w : X × Y) :
-    edist (WithLp.toLp p z) (WithLp.toLp p w) ^ p.toReal
-      = edist z.1 w.1 ^ p.toReal + edist z.2 w.2 ^ p.toReal := by
-  have hr : 0 < p.toReal := toReal_exponent_pos hp
-  rw [WithLp.prod_edist_eq_add hr, ← ENNReal.rpow_mul, one_div_mul_cancel hr.ne',
-    ENNReal.rpow_one, WithLp.toLp_fst, WithLp.toLp_fst, WithLp.toLp_snd, WithLp.toLp_snd]
-
-/-- The `ℓ^p` product ground distance is jointly measurable as soon as the two factor distances
-are. This is the hypothesis under which the two-variable Wasserstein API applies on
-`WithLp p (X × Y)`. -/
-theorem measurable_edist_toLp_prod (hp : p ≠ ∞)
-    (hdX : Measurable fun z : X × X ↦ edist z.1 z.2)
-    (hdY : Measurable fun z : Y × Y ↦ edist z.1 z.2) :
-    Measurable fun w : WithLp p (X × Y) × WithLp p (X × Y) ↦ edist w.1 w.2 := by
-  have hr : 0 < p.toReal := toReal_exponent_pos hp
-  have m₁ : Measurable fun w : WithLp p (X × Y) × WithLp p (X × Y) ↦ WithLp.ofLp w.1 :=
-    (WithLp.measurable_ofLp p (X × Y)).comp measurable_fst
-  have m₂ : Measurable fun w : WithLp p (X × Y) × WithLp p (X × Y) ↦ WithLp.ofLp w.2 :=
-    (WithLp.measurable_ofLp p (X × Y)).comp measurable_snd
-  have h₁ : Measurable fun w : WithLp p (X × Y) × WithLp p (X × Y) ↦
-      edist w.1.fst w.2.fst := by
-    simpa [Function.comp_def] using
-      hdX.comp ((measurable_fst.comp m₁).prodMk (measurable_fst.comp m₂))
-  have h₂ : Measurable fun w : WithLp p (X × Y) × WithLp p (X × Y) ↦
-      edist w.1.snd w.2.snd := by
-    simpa [Function.comp_def] using
-      hdY.comp ((measurable_snd.comp m₁).prodMk (measurable_snd.comp m₂))
-  simp only [WithLp.prod_edist_eq_add hr]
-  exact (ENNReal.continuous_rpow_const.measurable).comp
-    ((ENNReal.continuous_rpow_const.measurable.comp h₁).add
-      (ENNReal.continuous_rpow_const.measurable.comp h₂))
+variable {p : ℝ≥0∞} [Fact (1 ≤ p)] {X : Type u} {Y : Type v}
+  [MeasurableSpace X] [MeasurableSpace Y] [PseudoEMetricSpace X] [PseudoEMetricSpace Y]
 
 section Tensorization
 
@@ -130,7 +80,7 @@ theorem wassersteinEDist_map_toLp_prod_rpow (hp : p ≠ ∞)
     wassersteinEDist p ((μ₁.prod μ₂).map (WithLp.toLp p)) ((ν₁.prod ν₂).map (WithLp.toLp p))
         ^ p.toReal
       = wassersteinEDist p μ₁ ν₁ ^ p.toReal + wassersteinEDist p μ₂ ν₂ ^ p.toReal := by
-  have hp0 : p ≠ 0 := exponent_ne_zero
+  have hp0 : p ≠ 0 := (zero_lt_one.trans_le (Fact.out : (1 : ℝ≥0∞) ≤ p)).ne'
   have hcZ : Measurable fun w : WithLp p (X × Y) × WithLp p (X × Y) ↦
       edist w.1 w.2 ^ p.toReal :=
     ENNReal.continuous_rpow_const.measurable.comp (measurable_edist_toLp_prod hp hdX hdY)
@@ -158,7 +108,7 @@ theorem wassersteinEDist_map_toLp_prod (hp : p ≠ ∞)
     wassersteinEDist p ((μ₁.prod μ₂).map (WithLp.toLp p)) ((ν₁.prod ν₂).map (WithLp.toLp p))
       = (wassersteinEDist p μ₁ ν₁ ^ p.toReal + wassersteinEDist p μ₂ ν₂ ^ p.toReal)
           ^ (1 / p.toReal) := by
-  have hr : 0 < p.toReal := toReal_exponent_pos hp
+  have hr : 0 < p.toReal := p.toReal_pos_iff_ne_top.mpr hp
   rw [← wassersteinEDist_map_toLp_prod_rpow hp hdX hdY, ← ENNReal.rpow_mul,
     mul_one_div_cancel hr.ne', ENNReal.rpow_one]
 
@@ -170,7 +120,7 @@ theorem wassersteinEDist_map_toLp_prod_left (hp : p ≠ ∞)
     (hdY : Measurable fun z : Y × Y ↦ edist z.1 z.2) :
     wassersteinEDist p ((μ₁.prod μ₂).map (WithLp.toLp p)) ((μ₁.prod ν₂).map (WithLp.toLp p))
       = wassersteinEDist p μ₂ ν₂ := by
-  have hr : 0 < p.toReal := toReal_exponent_pos hp
+  have hr : 0 < p.toReal := p.toReal_pos_iff_ne_top.mpr hp
   have h := wassersteinEDist_map_toLp_prod_rpow (μ₁ := μ₁) (ν₁ := μ₁) (μ₂ := μ₂) (ν₂ := ν₂)
     hp hdX hdY
   rw [wassersteinEDist_self_of_measurable_edist hdX, ENNReal.zero_rpow_of_pos hr, zero_add] at h
@@ -184,7 +134,7 @@ theorem wassersteinEDist_map_toLp_prod_right (hp : p ≠ ∞)
     (hdY : Measurable fun z : Y × Y ↦ edist z.1 z.2) :
     wassersteinEDist p ((μ₁.prod μ₂).map (WithLp.toLp p)) ((ν₁.prod μ₂).map (WithLp.toLp p))
       = wassersteinEDist p μ₁ ν₁ := by
-  have hr : 0 < p.toReal := toReal_exponent_pos hp
+  have hr : 0 < p.toReal := p.toReal_pos_iff_ne_top.mpr hp
   have h := wassersteinEDist_map_toLp_prod_rpow (μ₁ := μ₁) (ν₁ := ν₁) (μ₂ := μ₂) (ν₂ := μ₂)
     hp hdX hdY
   rw [wassersteinEDist_self_of_measurable_edist hdY, ENNReal.zero_rpow_of_pos hr, add_zero] at h
@@ -192,12 +142,12 @@ theorem wassersteinEDist_map_toLp_prod_right (hp : p ≠ ∞)
 
 /-- A product law has finite `p`-moment for the `ℓ^p` product distance exactly when both of its
 factors do. -/
-theorem hasFiniteMoment_map_toLp_prod (hp : p ≠ ∞)
+theorem hasFiniteMoment_map_toLp_prod_iff (hp : p ≠ ∞)
     (hdX : Measurable fun z : X × X ↦ edist z.1 z.2)
     (hdY : Measurable fun z : Y × Y ↦ edist z.1 z.2) :
     HasFiniteMoment p ((μ₁.prod μ₂).map (WithLp.toLp p)) ↔
       HasFiniteMoment p μ₁ ∧ HasFiniteMoment p μ₂ := by
-  have hr : 0 < p.toReal := toReal_exponent_pos hp
+  have hr : 0 < p.toReal := p.toReal_pos_iff_ne_top.mpr hp
   have hd : Measurable fun w : WithLp p (X × Y) × WithLp p (X × Y) ↦ edist w.1 w.2 :=
     measurable_edist_toLp_prod hp hdX hdY
   have key : ∀ x₀ : X, ∀ y₀ : Y,

--- a/TauCeti/MeasureTheory/OptimalTransport/Wasserstein/Product.lean
+++ b/TauCeti/MeasureTheory/OptimalTransport/Wasserstein/Product.lean
@@ -1,0 +1,229 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.Normed.Lp.MeasurableSpace
+public import Mathlib.Analysis.Normed.Lp.ProdLp
+public import TauCeti.MeasureTheory.OptimalTransport.Cost.Product
+public import TauCeti.MeasureTheory.OptimalTransport.Wasserstein.Basic
+
+/-!
+# Tensorization of the Wasserstein distance
+
+The `p`-Wasserstein distance of two product laws is computed by the two factors:
+
+`W_p (μ₁ ⊗ μ₂, ν₁ ⊗ ν₂) ^ p = W_p (μ₁, ν₁) ^ p + W_p (μ₂, ν₂) ^ p`.
+
+The identity is a statement about a *specific* ground distance on the product: the `ℓ^p` product
+of the two ground distances, which in Lean is the one carried by `WithLp p (X × Y)` and not the
+supremum distance that `X × Y` carries by default. Accordingly the product law appears here as
+`(μ₁.prod μ₂).map (WithLp.toLp p)`, the product measure read on the `ℓ^p` type synonym; the
+measurable structure of `WithLp p (X × Y)` is the one pulled back from `X × Y`, so this pushforward
+changes nothing but the distance.
+
+The proof is the `cᵢ = edist ^ p` case of `TauCeti.transportCost_prod_add`: raising the `ℓ^p`
+product distance to the power `p` makes the cost additively separable, and the transport cost of a
+separable cost on a product problem splits. In particular no attainment theorem and no topological
+hypothesis are needed, and the identity is an identity in `ℝ≥0∞` with no finiteness assumption.
+
+The exponent is finite throughout. At `p = ∞` the `ℓ^p` product distance is the maximum of the two
+factor distances rather than an `ℓ^p` sum, so tensorization there is a maximum formula and a
+separate statement; it is not obtained from the identity below.
+
+## Main statements
+
+* `TauCeti.edist_toLp_rpow` — the defining additivity of the `ℓ^p` product distance after raising
+  to the power `p`;
+* `TauCeti.measurable_edist_toLp_prod` — joint measurability of the `ℓ^p` product ground distance,
+  the hypothesis that the two-variable Wasserstein API asks for;
+* `TauCeti.wassersteinEDist_map_toLp_prod_rpow` and `TauCeti.wassersteinEDist_map_toLp_prod` — the
+  tensorization identity, in its `p`-th power form and its root form;
+* `TauCeti.wassersteinEDist_map_toLp_prod_right` — tensorizing two laws with a common second
+  factor leaves their Wasserstein distance unchanged;
+* `TauCeti.hasFiniteMoment_map_toLp_prod` — a product law has finite `p`-moment exactly when both
+  factors do.
+
+## References
+
+* C. Villani, *Optimal Transport: Old and New*, Grundlehren 338, Springer 2009, Chapter 6, where
+  tensorization of `W_p` is recorded for the `ℓ^p` product distance.
+* F. Santambrogio, *Optimal Transport for Applied Mathematicians*, Birkhäuser 2015, Chapter 5.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory
+open scoped ENNReal
+
+namespace TauCeti
+
+universe u v
+
+variable {p : ℝ≥0∞} [Fact (1 ≤ p)]
+
+/-- An exponent carrying the `Fact (1 ≤ p)` instance that the `ℓ^p` product distance needs is
+nonzero. -/
+private theorem exponent_ne_zero : p ≠ 0 :=
+  (zero_lt_one.trans_le (Fact.out : (1 : ℝ≥0∞) ≤ p)).ne'
+
+/-- A finite exponent carrying the `Fact (1 ≤ p)` instance has positive real part. -/
+private theorem toReal_exponent_pos (hp : p ≠ ∞) : 0 < p.toReal :=
+  ENNReal.toReal_pos exponent_ne_zero hp
+
+variable {X : Type u} {Y : Type v} [MeasurableSpace X] [MeasurableSpace Y]
+  [PseudoEMetricSpace X] [PseudoEMetricSpace Y]
+
+omit [MeasurableSpace X] [MeasurableSpace Y] in
+/-- Raising the `ℓ^p` product distance to the power `p` makes it additive in the two factors.
+This is the reason the tensorization identity below is an identity of `p`-th powers. -/
+theorem edist_toLp_rpow (hp : p ≠ ∞) (z w : X × Y) :
+    edist (WithLp.toLp p z) (WithLp.toLp p w) ^ p.toReal
+      = edist z.1 w.1 ^ p.toReal + edist z.2 w.2 ^ p.toReal := by
+  have hr : 0 < p.toReal := toReal_exponent_pos hp
+  rw [WithLp.prod_edist_eq_add hr, ← ENNReal.rpow_mul, one_div_mul_cancel hr.ne',
+    ENNReal.rpow_one, WithLp.toLp_fst, WithLp.toLp_fst, WithLp.toLp_snd, WithLp.toLp_snd]
+
+/-- The `ℓ^p` product ground distance is jointly measurable as soon as the two factor distances
+are. This is the hypothesis under which the two-variable Wasserstein API applies on
+`WithLp p (X × Y)`. -/
+theorem measurable_edist_toLp_prod (hp : p ≠ ∞)
+    (hdX : Measurable fun z : X × X ↦ edist z.1 z.2)
+    (hdY : Measurable fun z : Y × Y ↦ edist z.1 z.2) :
+    Measurable fun w : WithLp p (X × Y) × WithLp p (X × Y) ↦ edist w.1 w.2 := by
+  have hr : 0 < p.toReal := toReal_exponent_pos hp
+  have m₁ : Measurable fun w : WithLp p (X × Y) × WithLp p (X × Y) ↦ WithLp.ofLp w.1 :=
+    (WithLp.measurable_ofLp p (X × Y)).comp measurable_fst
+  have m₂ : Measurable fun w : WithLp p (X × Y) × WithLp p (X × Y) ↦ WithLp.ofLp w.2 :=
+    (WithLp.measurable_ofLp p (X × Y)).comp measurable_snd
+  have h₁ : Measurable fun w : WithLp p (X × Y) × WithLp p (X × Y) ↦
+      edist w.1.fst w.2.fst := by
+    simpa [Function.comp_def] using
+      hdX.comp ((measurable_fst.comp m₁).prodMk (measurable_fst.comp m₂))
+  have h₂ : Measurable fun w : WithLp p (X × Y) × WithLp p (X × Y) ↦
+      edist w.1.snd w.2.snd := by
+    simpa [Function.comp_def] using
+      hdY.comp ((measurable_snd.comp m₁).prodMk (measurable_snd.comp m₂))
+  simp only [WithLp.prod_edist_eq_add hr]
+  exact (ENNReal.continuous_rpow_const.measurable).comp
+    ((ENNReal.continuous_rpow_const.measurable.comp h₁).add
+      (ENNReal.continuous_rpow_const.measurable.comp h₂))
+
+section Tensorization
+
+variable {μ₁ ν₁ : Measure X} {μ₂ ν₂ : Measure Y}
+  [IsProbabilityMeasure μ₁] [IsProbabilityMeasure ν₁]
+  [IsProbabilityMeasure μ₂] [IsProbabilityMeasure ν₂]
+
+/-- **Tensorization of the Wasserstein distance.** For the `ℓ^p` product distance and a finite
+exponent, the `p`-th power of the `p`-Wasserstein distance of two product laws is the sum of the
+`p`-th powers of the two factor distances.
+
+Both sides are `∞` as soon as one factor distance is, so no finiteness hypothesis is needed. -/
+theorem wassersteinEDist_map_toLp_prod_rpow (hp : p ≠ ∞)
+    (hdX : Measurable fun z : X × X ↦ edist z.1 z.2)
+    (hdY : Measurable fun z : Y × Y ↦ edist z.1 z.2) :
+    wassersteinEDist p ((μ₁.prod μ₂).map (WithLp.toLp p)) ((ν₁.prod ν₂).map (WithLp.toLp p))
+        ^ p.toReal
+      = wassersteinEDist p μ₁ ν₁ ^ p.toReal + wassersteinEDist p μ₂ ν₂ ^ p.toReal := by
+  have hp0 : p ≠ 0 := exponent_ne_zero
+  have hcZ : Measurable fun w : WithLp p (X × Y) × WithLp p (X × Y) ↦
+      edist w.1 w.2 ^ p.toReal :=
+    ENNReal.continuous_rpow_const.measurable.comp (measurable_edist_toLp_prod hp hdX hdY)
+  have hcX : Measurable fun z : X × X ↦ edist z.1 z.2 ^ p.toReal :=
+    ENNReal.continuous_rpow_const.measurable.comp hdX
+  have hcY : Measurable fun z : Y × Y ↦ edist z.1 z.2 ^ p.toReal :=
+    ENNReal.continuous_rpow_const.measurable.comp hdY
+  rw [wassersteinEDist_rpow_eq_transportCost hp0 hp, wassersteinEDist_rpow_eq_transportCost hp0 hp,
+    wassersteinEDist_rpow_eq_transportCost hp0 hp, ← MeasurableEquiv.coe_toLp p (X × Y),
+    ← transportCost_comp_prodMap (MeasurableEquiv.toLp p (X × Y))
+      (MeasurableEquiv.toLp p (X × Y)) hcZ]
+  rw [show (fun z : (X × Y) × X × Y ↦
+        edist (MeasurableEquiv.toLp p (X × Y) z.1) (MeasurableEquiv.toLp p (X × Y) z.2)
+          ^ p.toReal)
+      = fun z : (X × Y) × X × Y ↦
+        edist z.1.1 z.2.1 ^ p.toReal + edist z.1.2 z.2.2 ^ p.toReal from
+      funext fun z ↦ edist_toLp_rpow hp z.1 z.2]
+  exact transportCost_prod_add hcX hcY
+
+/-- **Tensorization of the Wasserstein distance**, in root form. -/
+theorem wassersteinEDist_map_toLp_prod (hp : p ≠ ∞)
+    (hdX : Measurable fun z : X × X ↦ edist z.1 z.2)
+    (hdY : Measurable fun z : Y × Y ↦ edist z.1 z.2) :
+    wassersteinEDist p ((μ₁.prod μ₂).map (WithLp.toLp p)) ((ν₁.prod ν₂).map (WithLp.toLp p))
+      = (wassersteinEDist p μ₁ ν₁ ^ p.toReal + wassersteinEDist p μ₂ ν₂ ^ p.toReal)
+          ^ (1 / p.toReal) := by
+  have hr : 0 < p.toReal := toReal_exponent_pos hp
+  rw [← wassersteinEDist_map_toLp_prod_rpow hp hdX hdY, ← ENNReal.rpow_mul,
+    mul_one_div_cancel hr.ne', ENNReal.rpow_one]
+
+omit [IsProbabilityMeasure ν₂] in
+/-- Tensorizing two laws with a common second factor leaves their `p`-Wasserstein distance
+unchanged: the common factor contributes a vanishing term to the tensorization identity. -/
+theorem wassersteinEDist_map_toLp_prod_right (hp : p ≠ ∞)
+    (hdX : Measurable fun z : X × X ↦ edist z.1 z.2)
+    (hdY : Measurable fun z : Y × Y ↦ edist z.1 z.2) :
+    wassersteinEDist p ((μ₁.prod μ₂).map (WithLp.toLp p)) ((ν₁.prod μ₂).map (WithLp.toLp p))
+      = wassersteinEDist p μ₁ ν₁ := by
+  have hr : 0 < p.toReal := toReal_exponent_pos hp
+  have h := wassersteinEDist_map_toLp_prod_rpow (μ₁ := μ₁) (ν₁ := ν₁) (μ₂ := μ₂) (ν₂ := μ₂)
+    hp hdX hdY
+  rw [wassersteinEDist_self_of_measurable_edist hdY, ENNReal.zero_rpow_of_pos hr, add_zero] at h
+  exact ENNReal.rpow_left_injective hr.ne' h
+
+/-- A product law has finite `p`-moment for the `ℓ^p` product distance exactly when both of its
+factors do. -/
+theorem hasFiniteMoment_map_toLp_prod (hp : p ≠ ∞)
+    (hdX : Measurable fun z : X × X ↦ edist z.1 z.2)
+    (hdY : Measurable fun z : Y × Y ↦ edist z.1 z.2) :
+    HasFiniteMoment p ((μ₁.prod μ₂).map (WithLp.toLp p)) ↔
+      HasFiniteMoment p μ₁ ∧ HasFiniteMoment p μ₂ := by
+  have hr : 0 < p.toReal := toReal_exponent_pos hp
+  have hd : Measurable fun w : WithLp p (X × Y) × WithLp p (X × Y) ↦ edist w.1 w.2 :=
+    measurable_edist_toLp_prod hp hdX hdY
+  have key : ∀ x₀ : X, ∀ y₀ : Y,
+      wassersteinEDist p (Measure.dirac (WithLp.toLp p (x₀, y₀)))
+          ((μ₁.prod μ₂).map (WithLp.toLp p)) ≠ ∞ ↔
+        wassersteinEDist p (Measure.dirac x₀) μ₁ ≠ ∞ ∧
+          wassersteinEDist p (Measure.dirac y₀) μ₂ ≠ ∞ := fun x₀ y₀ ↦ by
+    have hdir : (Measure.dirac (WithLp.toLp p (x₀, y₀)) : Measure (WithLp p (X × Y)))
+        = ((Measure.dirac x₀).prod (Measure.dirac y₀)).map (WithLp.toLp p) := by
+      rw [Measure.dirac_prod_dirac, Measure.map_dirac' (WithLp.measurable_toLp p (X × Y))]
+    have hsum := wassersteinEDist_map_toLp_prod_rpow (μ₁ := Measure.dirac x₀)
+      (μ₂ := Measure.dirac y₀) (ν₁ := μ₁) (ν₂ := μ₂) hp hdX hdY
+    rw [hdir, ← not_or, not_iff_not]
+    calc wassersteinEDist p (((Measure.dirac x₀).prod (Measure.dirac y₀)).map (WithLp.toLp p))
+            ((μ₁.prod μ₂).map (WithLp.toLp p)) = ∞
+        ↔ wassersteinEDist p (((Measure.dirac x₀).prod (Measure.dirac y₀)).map (WithLp.toLp p))
+            ((μ₁.prod μ₂).map (WithLp.toLp p)) ^ p.toReal = ∞ :=
+          (ENNReal.rpow_eq_top_iff_of_pos hr).symm
+      _ ↔ wassersteinEDist p (Measure.dirac x₀) μ₁ ^ p.toReal
+            + wassersteinEDist p (Measure.dirac y₀) μ₂ ^ p.toReal = ∞ := by rw [hsum]
+      _ ↔ wassersteinEDist p (Measure.dirac x₀) μ₁ ^ p.toReal = ∞ ∨
+            wassersteinEDist p (Measure.dirac y₀) μ₂ ^ p.toReal = ∞ := ENNReal.add_eq_top
+      _ ↔ wassersteinEDist p (Measure.dirac x₀) μ₁ = ∞ ∨
+            wassersteinEDist p (Measure.dirac y₀) μ₂ = ∞ := by
+          rw [ENNReal.rpow_eq_top_iff_of_pos hr, ENNReal.rpow_eq_top_iff_of_pos hr]
+  constructor
+  · intro h
+    obtain ⟨⟨⟨x₀, y₀⟩⟩, hz₀⟩ := hasFiniteMoment_def.mp h
+    have hk := (key x₀ y₀).mp ((memLp_edist_iff_wassersteinEDist_dirac_ne_top hd _ _).mp hz₀)
+    exact ⟨hasFiniteMoment_def.mpr
+        ⟨x₀, (memLp_edist_iff_wassersteinEDist_dirac_ne_top hdX x₀ μ₁).mpr hk.1⟩,
+      hasFiniteMoment_def.mpr
+        ⟨y₀, (memLp_edist_iff_wassersteinEDist_dirac_ne_top hdY y₀ μ₂).mpr hk.2⟩⟩
+  · rintro ⟨h₁, h₂⟩
+    obtain ⟨x₀, hx₀⟩ := hasFiniteMoment_def.mp h₁
+    obtain ⟨y₀, hy₀⟩ := hasFiniteMoment_def.mp h₂
+    exact hasFiniteMoment_def.mpr ⟨WithLp.toLp p (x₀, y₀),
+      (memLp_edist_iff_wassersteinEDist_dirac_ne_top hd _ _).mpr ((key x₀ y₀).mpr
+        ⟨(memLp_edist_iff_wassersteinEDist_dirac_ne_top hdX x₀ μ₁).mp hx₀,
+          (memLp_edist_iff_wassersteinEDist_dirac_ne_top hdY y₀ μ₂).mp hy₀⟩)⟩
+
+end Tensorization
+
+end TauCeti

--- a/TauCeti/MeasureTheory/OptimalTransport/Wasserstein/Product.lean
+++ b/TauCeti/MeasureTheory/OptimalTransport/Wasserstein/Product.lean
@@ -142,6 +142,7 @@ theorem wassersteinEDist_map_toLp_prod_right (hp : p ≠ ∞)
 
 /-- A product law has finite `p`-moment for the `ℓ^p` product distance exactly when both of its
 factors do. -/
+@[simp]
 theorem hasFiniteMoment_map_toLp_prod_iff (hp : p ≠ ∞)
     (hdX : Measurable fun z : X × X ↦ edist z.1 z.2)
     (hdY : Measurable fun z : Y × Y ↦ edist z.1 z.2) :


### PR DESCRIPTION
This PR proves tensorization of the Wasserstein distance: for a finite exponent `1 ≤ p < ∞` and the `ℓ^p` product ground distance, `W_p (μ₁ ⊗ μ₂, ν₁ ⊗ ν₂) ^ p = W_p (μ₁, ν₁) ^ p + W_p (μ₂, ν₂) ^ p`. This is the product estimate named in Layer 3, item 5 of the OptimalTransport roadmap ("For products, fix the `ℓᵖ` product metric — in Lean the metric carried by `WithLp p (X × Y)`, not Mathlib's default sup metric on `X × Y` — and prove the equality"), whose milestone is Layer 3's functorial estimates for `W_p`. After this PR, item 5 still needs the mixture bound, the convolution and translation estimates on a normed additive group, and the Markov-kernel contraction with its measurable-selection hypotheses; the maximum forms at `p = ∞` belong to item 6.

The product law is written `(μ₁.prod μ₂).map (WithLp.toLp p)`: the roadmap pins the ground metric to `WithLp p (X × Y)` rather than the sup metric that `X × Y` carries by default, and `WithLp.measurableSpace` is the pullback of the product measurable structure, so the pushforward changes the distance and nothing else.

`TauCeti/MeasureTheory/OptimalTransport/Cost/Product.lean` (172 lines) supplies the engine at the level of Layer 1's transport cost, where the statement is cleaner and carries no metric: for an additively separable cost `c ((x₁, x₂), (y₁, y₂)) = c₁ (x₁, y₁) + c₂ (x₂, y₂)` on a product of two transport problems between probability measures, `transportCost` splits as a sum. Both inequalities are elementary and neither needs a topology, an attainment theorem or a finiteness hypothesis. The upper bound rearranges a product of feasible plans by `Equiv.prodProdProdComm` and passes to the infimum through `ENNReal.le_iInf₂_add_iInf₂`; the lower bound pushes a feasible plan of the product problem forward to the two coordinate problems. The file also records that the rearranged product of two optimal plans is optimal for the separable cost.

`TauCeti/MeasureTheory/OptimalTransport/Wasserstein/Product.lean` (229 lines) is the `cᵢ = edist ^ p` specialization: raising the `ℓ^p` product distance to the power `p` is exactly what makes the cost separable, and `TauCeti.wassersteinEDist_rpow_eq_transportCost` together with `TauCeti.transportCost_comp_prodMap` transports the identity across the `WithLp` type synonym. Besides the identity in its power and root forms, the file proves joint measurability of the `ℓ^p` product ground distance — the hypothesis the two-variable Wasserstein API asks for, so that the rest of that API is usable on `WithLp p (X × Y)` — that tensorizing with a common second factor leaves the distance unchanged, and that a product law has finite `p`-moment exactly when both of its factors do.

No Mathlib source was vendored. The proofs consume Mathlib's `WithLp.prod_edist_eq_add`, `WithLp.measurableSpace` and `MeasurableEquiv.toLp` from `Mathlib.Analysis.Normed.Lp`, together with `Measure.map_prod_map` and `Measure.fst_map_prodMk`.

Roadmap: OptimalTransport

<!--tauceti-target:v1 {"focus":"OptimalTransport","id":"wasserstein-distance-of-product-measures"}-->

🤖 Prepared with Claude Code
