### PR TITLE
feat: identify universal covers across basepoints

### DIFF
--- a/TauCeti/AlgebraicTopology/UniversalCover/Action.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Action.lean
@@ -102,9 +102,9 @@ instance : ContinuousConstSMul (FundamentalGroup X x₀) (UniversalCover x₀) w
   continuous_const_smul g := by
     obtain ⟨γ, hγ⟩ := Quotient.exists_rep (g⁻¹.toPath : Path.Homotopic.Quotient x₀ x₀)
     have hγ' : Path.Homotopic.Quotient.mk γ = g⁻¹.toPath := hγ
-    apply (continuous_prependUniversalCover γ).congr
+    apply (TauCeti.Path.continuous_prependUniversalCover γ).congr
     rintro ⟨x, q⟩
-    rw [smul_mk, prependUniversalCover_mk, hγ']
+    rw [smul_mk, TauCeti.Path.prependUniversalCover_mk, hγ']
 
 /-- The action of the fundamental group on the universal cover is free. -/
 instance : IsCancelSMul (FundamentalGroup X x₀) (UniversalCover x₀) where

--- a/TauCeti/AlgebraicTopology/UniversalCover/Action.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Action.lean
@@ -102,9 +102,9 @@ instance : ContinuousConstSMul (FundamentalGroup X x₀) (UniversalCover x₀) w
   continuous_const_smul g := by
     obtain ⟨γ, hγ⟩ := Quotient.exists_rep (g⁻¹.toPath : Path.Homotopic.Quotient x₀ x₀)
     have hγ' : Path.Homotopic.Quotient.mk γ = g⁻¹.toPath := hγ
-    apply (TauCeti.Path.continuous_prependUniversalCover γ).congr
+    apply (continuous_prependUniversalCover γ).congr
     rintro ⟨x, q⟩
-    rw [smul_mk, TauCeti.Path.prependUniversalCover_mk, hγ']
+    rw [smul_mk, prependUniversalCover_mk, hγ']
 
 /-- The action of the fundamental group on the universal cover is free. -/
 instance : IsCancelSMul (FundamentalGroup X x₀) (UniversalCover x₀) where

--- a/TauCeti/AlgebraicTopology/UniversalCover/Action.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Action.lean
@@ -36,7 +36,8 @@ The inverse-free computation rule is `inv_smul_mk`.
 
 * The `MulAction`, `FaithfulSMul`, `ContinuousConstSMul`, and `IsCancelSMul` instances for
   `FundamentalGroup X x₀` acting on `UniversalCover x₀`.
-* `TauCeti.Path.prependUniversalCover`: continuous prepending of a path to universal-cover
+* `TauCeti.UniversalCover.prependUniversalCover`: continuous prepending of a path to
+  universal-cover
   representatives.
 * `TauCeti.UniversalCover.basepointLift`: the constant-path point over `x₀`, lying over `x₀`
   by `TauCeti.UniversalCover.proj_basepointLift`.
@@ -55,7 +56,7 @@ open scoped unitInterval
 
 variable {X : Type*} [TopologicalSpace X] {x₀ : X}
 
-namespace TauCeti.Path
+namespace TauCeti.UniversalCover
 
 variable {x₁ : X}
 
@@ -128,7 +129,7 @@ theorem prependUniversalCover_trans {x₂ : X} (gamma : Path x₂ x₁) (delta :
   rw [prependUniversalCover_mk, prependUniversalCover_mk, prependUniversalCover_mk,
     Path.Homotopic.Quotient.mk_trans, Path.Homotopic.Quotient.trans_assoc]
 
-end TauCeti.Path
+end TauCeti.UniversalCover
 
 namespace TauCeti.UniversalCover
 
@@ -179,9 +180,9 @@ instance : ContinuousConstSMul (FundamentalGroup X x₀) (UniversalCover x₀) w
   continuous_const_smul g := by
     obtain ⟨γ, hγ⟩ := Quotient.exists_rep (g⁻¹.toPath : Path.Homotopic.Quotient x₀ x₀)
     have hγ' : Path.Homotopic.Quotient.mk γ = g⁻¹.toPath := hγ
-    apply (TauCeti.Path.continuous_prependUniversalCover γ).congr
+    apply (continuous_prependUniversalCover γ).congr
     rintro ⟨x, q⟩
-    rw [smul_mk, TauCeti.Path.prependUniversalCover_mk, hγ']
+    rw [smul_mk, prependUniversalCover_mk, hγ']
 
 /-- The action of the fundamental group on the universal cover is free. -/
 instance : IsCancelSMul (FundamentalGroup X x₀) (UniversalCover x₀) where

--- a/TauCeti/AlgebraicTopology/UniversalCover/Action.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Action.lean
@@ -36,9 +36,6 @@ The inverse-free computation rule is `inv_smul_mk`.
 
 * The `MulAction`, `FaithfulSMul`, `ContinuousConstSMul`, and `IsCancelSMul` instances for
   `FundamentalGroup X x₀` acting on `UniversalCover x₀`.
-* `TauCeti.UniversalCover.prependUniversalCover`: continuous prepending of a path to
-  universal-cover
-  representatives.
 * `TauCeti.UniversalCover.basepointLift`: the constant-path point over `x₀`, lying over `x₀`
   by `TauCeti.UniversalCover.proj_basepointLift`.
 * `TauCeti.UniversalCover.monodromy_basepointLift`: monodromy at that point is the
@@ -55,81 +52,6 @@ noncomputable section
 open scoped unitInterval
 
 variable {X : Type*} [TopologicalSpace X] {x₀ : X}
-
-namespace TauCeti.UniversalCover
-
-variable {x₁ : X}
-
-/-- Prepend a path from `x₁` to `x₀` to the path class represented by a point of the
-universal cover based at `x₀`. -/
-def prependUniversalCover (gamma : Path x₁ x₀)
-    (p : UniversalCover x₀) : UniversalCover x₁ :=
-  UniversalCover.mk p.proj ((Path.Homotopic.Quotient.mk gamma).trans p.path)
-
-/-- Prepending to an endpoint-and-path-class pair prepends the corresponding homotopy class. -/
-@[simp]
-theorem prependUniversalCover_mk (gamma : Path x₁ x₀) (x : X)
-    (q : Path.Homotopic.Quotient x₀ x) :
-    prependUniversalCover gamma (UniversalCover.mk x q) =
-      UniversalCover.mk x ((Path.Homotopic.Quotient.mk gamma).trans q) :=
-  (rfl)
-
-/-- Prepending a path does not change the endpoint projection. -/
-@[simp]
-theorem proj_prependUniversalCover (gamma : Path x₁ x₀) (p : UniversalCover x₀) :
-    (prependUniversalCover gamma p).proj = p.proj :=
-  (rfl)
-
-/-- On the quotient constructor, prepending is represented by concatenating paths. -/
-@[simp]
-theorem prependUniversalCover_ofBasedPath (gamma : Path x₁ x₀) (beta : BasedPath x₀) :
-    prependUniversalCover gamma (UniversalCover.ofBasedPath x₀ beta) =
-      UniversalCover.ofBasedPath x₁ (BasedPath.ofPath (gamma.trans beta.toPath)) := by
-  rw [UniversalCover.ofBasedPath_ofPath, prependUniversalCover_mk,
-    UniversalCover.ofBasedPath_def, Path.Homotopic.Quotient.mk_trans]
-
-/-- Prepending a fixed path is continuous for the quotient topologies on the two universal
-covers. -/
-@[fun_prop]
-theorem continuous_prependUniversalCover (gamma : Path x₁ x₀) :
-    Continuous (prependUniversalCover gamma : UniversalCover x₀ → UniversalCover x₁) := by
-  rw [(UniversalCover.isQuotientMap_ofBasedPath x₀).continuous_iff]
-  suffices hcont : Continuous (fun beta : BasedPath x₀ =>
-      UniversalCover.ofBasedPath x₁ (BasedPath.ofPath (gamma.trans beta.toPath))) by
-    apply hcont.congr
-    intro beta
-    simpa only [Function.comp_apply] using (prependUniversalCover_ofBasedPath gamma beta).symm
-  refine (UniversalCover.continuous_ofBasedPath x₁).comp (Continuous.subtype_mk ?_ _)
-  refine ContinuousMap.continuous_of_continuous_uncurry _ ?_
-  have heval : Continuous fun p : BasedPath x₀ × unitInterval => p.1.1 p.2 :=
-    continuous_eval.comp (continuous_subtype_val.prodMap continuous_id)
-  -- Unfolding the path wrappers identifies the uncurried goal with concatenation.
-  change Continuous fun p : BasedPath x₀ × unitInterval => gamma.trans p.1.toPath p.2
-  exact Path.trans_continuous_family (a := fun _ : BasedPath x₀ => x₁)
-    (b := fun _ : BasedPath x₀ => x₀)
-    (c := fun beta : BasedPath x₀ => BasedPath.endpoint beta)
-    (fun _ => gamma) (Path.continuous_uncurry_iff.mpr continuous_const)
-    (fun beta => beta.toPath) heval
-
-/-- Prepending a constant path is the identity. -/
-@[simp]
-theorem prependUniversalCover_refl (p : UniversalCover x₀) :
-    prependUniversalCover (Path.refl x₀) p = p := by
-  rcases p with ⟨x, q⟩
-  rw [prependUniversalCover_mk, Path.Homotopic.Quotient.mk_refl,
-    Path.Homotopic.Quotient.refl_trans]
-
-/-- Successive prepending combines by path concatenation. -/
-@[simp]
-theorem prependUniversalCover_trans {x₂ : X} (gamma : Path x₂ x₁) (delta : Path x₁ x₀)
-    (p : UniversalCover x₀) :
-    prependUniversalCover (gamma.trans delta) p =
-      prependUniversalCover gamma (prependUniversalCover delta p) := by
-  rcases p with ⟨x, q⟩
-  rw [prependUniversalCover_mk, prependUniversalCover_mk, prependUniversalCover_mk,
-    Path.Homotopic.Quotient.mk_trans, Path.Homotopic.Quotient.trans_assoc]
-
-end TauCeti.UniversalCover
 
 namespace TauCeti.UniversalCover
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Action.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Action.lean
@@ -36,6 +36,8 @@ The inverse-free computation rule is `inv_smul_mk`.
 
 * The `MulAction`, `FaithfulSMul`, `ContinuousConstSMul`, and `IsCancelSMul` instances for
   `FundamentalGroup X x₀` acting on `UniversalCover x₀`.
+* `TauCeti.Path.prependUniversalCover`: continuous prepending of a path to universal-cover
+  representatives.
 * `TauCeti.UniversalCover.basepointLift`: the constant-path point over `x₀`, lying over `x₀`
   by `TauCeti.UniversalCover.proj_basepointLift`.
 * `TauCeti.UniversalCover.monodromy_basepointLift`: monodromy at that point is the
@@ -52,6 +54,81 @@ noncomputable section
 open scoped unitInterval
 
 variable {X : Type*} [TopologicalSpace X] {x₀ : X}
+
+namespace TauCeti.Path
+
+variable {x₁ : X}
+
+/-- Prepend a path from `x₁` to `x₀` to the path class represented by a point of the
+universal cover based at `x₀`. -/
+def prependUniversalCover (gamma : Path x₁ x₀)
+    (p : UniversalCover x₀) : UniversalCover x₁ :=
+  UniversalCover.mk p.proj ((Path.Homotopic.Quotient.mk gamma).trans p.path)
+
+/-- Prepending to an endpoint-and-path-class pair prepends the corresponding homotopy class. -/
+@[simp]
+theorem prependUniversalCover_mk (gamma : Path x₁ x₀) (x : X)
+    (q : Path.Homotopic.Quotient x₀ x) :
+    prependUniversalCover gamma (UniversalCover.mk x q) =
+      UniversalCover.mk x ((Path.Homotopic.Quotient.mk gamma).trans q) :=
+  (rfl)
+
+/-- Prepending a path does not change the endpoint projection. -/
+@[simp]
+theorem proj_prependUniversalCover (gamma : Path x₁ x₀) (p : UniversalCover x₀) :
+    (prependUniversalCover gamma p).proj = p.proj :=
+  (rfl)
+
+/-- On the quotient constructor, prepending is represented by concatenating paths. -/
+@[simp]
+theorem prependUniversalCover_ofBasedPath (gamma : Path x₁ x₀) (beta : BasedPath x₀) :
+    prependUniversalCover gamma (UniversalCover.ofBasedPath x₀ beta) =
+      UniversalCover.ofBasedPath x₁ (BasedPath.ofPath (gamma.trans beta.toPath)) := by
+  rw [UniversalCover.ofBasedPath_ofPath, prependUniversalCover_mk,
+    UniversalCover.ofBasedPath_def, Path.Homotopic.Quotient.mk_trans]
+
+/-- Prepending a fixed path is continuous for the quotient topologies on the two universal
+covers. -/
+@[fun_prop]
+theorem continuous_prependUniversalCover (gamma : Path x₁ x₀) :
+    Continuous (prependUniversalCover gamma : UniversalCover x₀ → UniversalCover x₁) := by
+  rw [(UniversalCover.isQuotientMap_ofBasedPath x₀).continuous_iff]
+  suffices hcont : Continuous (fun beta : BasedPath x₀ =>
+      UniversalCover.ofBasedPath x₁ (BasedPath.ofPath (gamma.trans beta.toPath))) by
+    apply hcont.congr
+    intro beta
+    simpa only [Function.comp_apply] using (prependUniversalCover_ofBasedPath gamma beta).symm
+  refine (UniversalCover.continuous_ofBasedPath x₁).comp (Continuous.subtype_mk ?_ _)
+  refine ContinuousMap.continuous_of_continuous_uncurry _ ?_
+  have heval : Continuous fun p : BasedPath x₀ × unitInterval => p.1.1 p.2 :=
+    continuous_eval.comp (continuous_subtype_val.prodMap continuous_id)
+  -- Unfolding the path wrappers identifies the uncurried goal with concatenation.
+  change Continuous fun p : BasedPath x₀ × unitInterval => gamma.trans p.1.toPath p.2
+  exact Path.trans_continuous_family (a := fun _ : BasedPath x₀ => x₁)
+    (b := fun _ : BasedPath x₀ => x₀)
+    (c := fun beta : BasedPath x₀ => BasedPath.endpoint beta)
+    (fun _ => gamma) (Path.continuous_uncurry_iff.mpr continuous_const)
+    (fun beta => beta.toPath) heval
+
+/-- Prepending a constant path is the identity. -/
+@[simp]
+theorem prependUniversalCover_refl (p : UniversalCover x₀) :
+    prependUniversalCover (Path.refl x₀) p = p := by
+  rcases p with ⟨x, q⟩
+  rw [prependUniversalCover_mk, Path.Homotopic.Quotient.mk_refl,
+    Path.Homotopic.Quotient.refl_trans]
+
+/-- Successive prepending combines by path concatenation. -/
+@[simp]
+theorem prependUniversalCover_trans {x₂ : X} (gamma : Path x₂ x₁) (delta : Path x₁ x₀)
+    (p : UniversalCover x₀) :
+    prependUniversalCover (gamma.trans delta) p =
+      prependUniversalCover gamma (prependUniversalCover delta p) := by
+  rcases p with ⟨x, q⟩
+  rw [prependUniversalCover_mk, prependUniversalCover_mk, prependUniversalCover_mk,
+    Path.Homotopic.Quotient.mk_trans, Path.Homotopic.Quotient.trans_assoc]
+
+end TauCeti.Path
 
 namespace TauCeti.UniversalCover
 
@@ -100,27 +177,11 @@ instance : FaithfulSMul (FundamentalGroup X x₀) (UniversalCover x₀) where
 /-- Every fundamental-group element acts continuously on the universal cover. -/
 instance : ContinuousConstSMul (FundamentalGroup X x₀) (UniversalCover x₀) where
   continuous_const_smul g := by
-    rw [(isQuotientMap_ofBasedPath x₀).continuous_iff]
     obtain ⟨γ, hγ⟩ := Quotient.exists_rep (g⁻¹.toPath : Path.Homotopic.Quotient x₀ x₀)
     have hγ' : Path.Homotopic.Quotient.mk γ = g⁻¹.toPath := hγ
-    suffices h_cont : Continuous (fun β : BasedPath x₀ ↦
-        ofBasedPath x₀ (BasedPath.ofPath (γ.trans β.toPath))) by
-      apply h_cont.congr
-      intro β
-      rw [ofBasedPath_ofPath, Function.comp_apply, ofBasedPath_def, smul_mk,
-        Path.Homotopic.Quotient.mk_trans, hγ']
-    refine (continuous_ofBasedPath x₀).comp (Continuous.subtype_mk ?_ _)
-    refine ContinuousMap.continuous_of_continuous_uncurry _ ?_
-    have h_eval : Continuous fun p : BasedPath x₀ × I ↦ p.1.1 p.2 :=
-      continuous_eval.comp (continuous_subtype_val.prodMap continuous_id)
-    -- Unfolding `BasedPath.ofPath` and its underlying `Path.toContinuousMap`, then evaluating
-    -- the resulting continuous map at `p.2`, identifies the uncurried goal with concatenation.
-    change Continuous fun p : BasedPath x₀ × I ↦ γ.trans p.1.toPath p.2
-    exact Path.trans_continuous_family (a := fun _ : BasedPath x₀ ↦ x₀)
-        (b := fun _ : BasedPath x₀ ↦ x₀)
-        (c := fun β : BasedPath x₀ ↦ BasedPath.endpoint β)
-        (fun _ ↦ γ) (Path.continuous_uncurry_iff.mpr continuous_const)
-        (fun β ↦ β.toPath) h_eval
+    apply (TauCeti.Path.continuous_prependUniversalCover γ).congr
+    rintro ⟨x, q⟩
+    rw [smul_mk, TauCeti.Path.prependUniversalCover_mk, hγ']
 
 /-- The action of the fundamental group on the universal cover is free. -/
 instance : IsCancelSMul (FundamentalGroup X x₀) (UniversalCover x₀) where

--- a/TauCeti/AlgebraicTopology/UniversalCover/BasepointChange.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/BasepointChange.lean
@@ -39,8 +39,8 @@ This is the standard change-of-basepoint map in the based-path construction of t
 cover; compare Hatcher, *Algebraic Topology*, Section 1.3. The quotient model used here is adapted
 from Kim Morrison's [mathlib4#38292](https://github.com/leanprover-community/mathlib4/pull/38292)
 and is credited in `TauCeti.AlgebraicTopology.UniversalCover.Basic`. The continuity argument
-generalizes the fixed-loop argument in `TauCeti.AlgebraicTopology.UniversalCover.Action`, also
-adapted from that pull request.
+generalizes the fixed-loop argument from that pull request;
+`TauCeti.AlgebraicTopology.UniversalCover.Action` now reuses the generalized theorem.
 -/
 
 public section

--- a/TauCeti/AlgebraicTopology/UniversalCover/BasepointChange.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/BasepointChange.lean
@@ -15,10 +15,10 @@ A path `γ : Path x₀ x₁` identifies the universal covers based at its endpoi
 based-path model, the identification removes the initial path `γ`: it sends the class of a path
 `α` starting at `x₀` to the class of `γ.symm.trans α`, now regarded as a path starting at `x₁`.
 
-The construction uses `TauCeti.Path.prependUniversalCover`, which prepends a fixed path
+The construction uses `TauCeti.UniversalCover.prependUniversalCover`, which prepends a fixed path
 to every representative and is continuous for the quotient topology on the universal cover.
 Prepending a path and its reverse gives inverse continuous maps, producing
-`TauCeti.Path.basepointChangeHomeomorph`.
+`TauCeti.UniversalCover.basepointChangeHomeomorph`.
 
 The resulting homeomorphism lies over the identity of the base, sends the point represented by
 `γ` to the constant-path point over `x₁`, depends only on the endpoint-preserving homotopy class
@@ -28,9 +28,9 @@ based-path universal-cover construction.
 
 ## Main declarations
 
-* `TauCeti.Path.basepointChangeHomeomorph`: the homeomorphism between universal covers
+* `TauCeti.UniversalCover.basepointChangeHomeomorph`: the homeomorphism between universal covers
   based at the endpoints of a path.
-* `TauCeti.Path.basepointChangeHomeomorph_trans`: basepoint change respects path
+* `TauCeti.UniversalCover.basepointChangeHomeomorph_trans`: basepoint change respects path
   concatenation.
 
 ## References
@@ -50,15 +50,13 @@ open scoped unitInterval
 
 variable {X : Type*} [TopologicalSpace X]
 
-namespace TauCeti.Path
-
-open UniversalCover
+namespace TauCeti.UniversalCover
 
 variable {x₀ x₁ x₂ : X}
 
 /-- **A path identifies the universal covers based at its endpoints.** The forward map removes
 the chosen initial path by prepending its reverse; the inverse map prepends the path itself. -/
-def basepointChangeHomeomorph (gamma : _root_.Path x₀ x₁) :
+def basepointChangeHomeomorph (gamma : Path x₀ x₁) :
     UniversalCover x₀ ≃ₜ UniversalCover x₁ where
   toFun := prependUniversalCover gamma.symm
   invFun := prependUniversalCover gamma
@@ -79,7 +77,7 @@ def basepointChangeHomeomorph (gamma : _root_.Path x₀ x₁) :
 
 /-- Basepoint change prepends the reverse path class to a representative. -/
 @[simp]
-theorem basepointChangeHomeomorph_apply_mk (gamma : _root_.Path x₀ x₁) (x : X)
+theorem basepointChangeHomeomorph_apply_mk (gamma : Path x₀ x₁) (x : X)
     (q : Path.Homotopic.Quotient x₀ x) :
     basepointChangeHomeomorph gamma (mk x q) =
       mk x ((Path.Homotopic.Quotient.mk gamma).symm.trans q) := by
@@ -90,7 +88,7 @@ theorem basepointChangeHomeomorph_apply_mk (gamma : _root_.Path x₀ x₁) (x : 
 
 /-- The inverse basepoint change prepends the original path class to a representative. -/
 @[simp]
-theorem basepointChangeHomeomorph_symm_apply_mk (gamma : _root_.Path x₀ x₁) (x : X)
+theorem basepointChangeHomeomorph_symm_apply_mk (gamma : Path x₀ x₁) (x : X)
     (q : Path.Homotopic.Quotient x₁ x) :
     (basepointChangeHomeomorph gamma).symm (mk x q) =
       mk x ((Path.Homotopic.Quotient.mk gamma).trans q) := by
@@ -98,21 +96,19 @@ theorem basepointChangeHomeomorph_symm_apply_mk (gamma : _root_.Path x₀ x₁) 
 
 /-- Basepoint change lies over the identity map of the base. -/
 @[simp]
-theorem proj_basepointChangeHomeomorph (gamma : _root_.Path x₀ x₁)
-    (p : UniversalCover x₀) :
+theorem proj_basepointChangeHomeomorph (gamma : Path x₀ x₁) (p : UniversalCover x₀) :
     proj (basepointChangeHomeomorph gamma p) = proj p := by
   exact proj_prependUniversalCover gamma.symm p
 
 /-- The inverse basepoint change also lies over the identity map of the base. -/
 @[simp]
-theorem proj_basepointChangeHomeomorph_symm (gamma : _root_.Path x₀ x₁)
-    (p : UniversalCover x₁) :
+theorem proj_basepointChangeHomeomorph_symm (gamma : Path x₀ x₁) (p : UniversalCover x₁) :
     proj ((basepointChangeHomeomorph gamma).symm p) = proj p := by
   exact proj_prependUniversalCover gamma p
 
 /-- On a based-path representative, basepoint change prepends the reverse of the changing path. -/
 @[simp]
-theorem basepointChangeHomeomorph_apply_ofBasedPath (gamma : _root_.Path x₀ x₁)
+theorem basepointChangeHomeomorph_apply_ofBasedPath (gamma : Path x₀ x₁)
     (beta : BasedPath x₀) :
     basepointChangeHomeomorph gamma (ofBasedPath x₀ beta) =
       ofBasedPath x₁ (BasedPath.ofPath (gamma.symm.trans beta.toPath)) :=
@@ -120,7 +116,7 @@ theorem basepointChangeHomeomorph_apply_ofBasedPath (gamma : _root_.Path x₀ x�
 
 /-- On a based-path representative, inverse basepoint change prepends the changing path. -/
 @[simp]
-theorem basepointChangeHomeomorph_symm_apply_ofBasedPath (gamma : _root_.Path x₀ x₁)
+theorem basepointChangeHomeomorph_symm_apply_ofBasedPath (gamma : Path x₀ x₁)
     (beta : BasedPath x₁) :
     (basepointChangeHomeomorph gamma).symm (ofBasedPath x₁ beta) =
       ofBasedPath x₀ (BasedPath.ofPath (gamma.trans beta.toPath)) :=
@@ -129,7 +125,7 @@ theorem basepointChangeHomeomorph_symm_apply_ofBasedPath (gamma : _root_.Path x�
 /-- Basepoint change intertwines the fundamental-group actions under the corresponding
 basepoint-change isomorphism of fundamental groups. -/
 @[simp]
-theorem basepointChangeHomeomorph_smul (gamma : _root_.Path x₀ x₁)
+theorem basepointChangeHomeomorph_smul (gamma : Path x₀ x₁)
     (g : FundamentalGroup X x₀) (p : UniversalCover x₀) :
     basepointChangeHomeomorph gamma (g • p) =
       FundamentalGroup.fundamentalGroupMulEquivOfPath gamma g •
@@ -154,7 +150,7 @@ theorem basepointChangeHomeomorph_smul (gamma : _root_.Path x₀ x₁)
 /-- Inverse basepoint change intertwines the target action with transport back to the source
 fundamental group. -/
 @[simp]
-theorem basepointChangeHomeomorph_symm_smul (gamma : _root_.Path x₀ x₁)
+theorem basepointChangeHomeomorph_symm_smul (gamma : Path x₀ x₁)
     (g : FundamentalGroup X x₁) (p : UniversalCover x₁) :
     (basepointChangeHomeomorph gamma).symm (g • p) =
       (FundamentalGroup.fundamentalGroupMulEquivOfPath gamma).symm g •
@@ -165,7 +161,7 @@ theorem basepointChangeHomeomorph_symm_smul (gamma : _root_.Path x₀ x₁)
 
 /-- Basepoint change sends the point represented by the changing path to the constant-path point
 over its target. -/
-theorem basepointChangeHomeomorph_apply_self (gamma : _root_.Path x₀ x₁) :
+theorem basepointChangeHomeomorph_apply_self (gamma : Path x₀ x₁) :
     basepointChangeHomeomorph gamma (ofBasedPath x₀ (BasedPath.ofPath gamma)) =
       basepointLift x₁ := by
   rw [ofBasedPath_ofPath, basepointChangeHomeomorph_apply_mk, basepointLift_coe,
@@ -173,7 +169,7 @@ theorem basepointChangeHomeomorph_apply_self (gamma : _root_.Path x₀ x₁) :
 
 /-- The basepoint-change homeomorphism is the unique continuous map over `X` that sends the point
 represented by the changing path to the constant-path point. -/
-theorem eq_basepointChangeHomeomorph (gamma : _root_.Path x₀ x₁)
+theorem eq_basepointChangeHomeomorph (gamma : Path x₀ x₁)
     [LocallyPathConnectedSpace X] [SemilocallySimplyConnectedSpace X]
     {f : C(UniversalCover x₀, UniversalCover x₁)}
     (hgamma : f (ofBasedPath x₀ (BasedPath.ofPath gamma)) = basepointLift x₁)
@@ -192,7 +188,7 @@ theorem eq_basepointChangeHomeomorph (gamma : _root_.Path x₀ x₁)
     (hgamma.trans (basepointChangeHomeomorph_apply_self gamma).symm))
 
 /-- Homotopic basepoint-change paths induce the same homeomorphism. -/
-theorem basepointChangeHomeomorph_eq_of_homotopic {gamma delta : _root_.Path x₀ x₁}
+theorem basepointChangeHomeomorph_eq_of_homotopic {gamma delta : Path x₀ x₁}
     (h : gamma.Homotopic delta) :
     basepointChangeHomeomorph gamma = basepointChangeHomeomorph delta := by
   apply Homeomorph.ext
@@ -202,30 +198,17 @@ theorem basepointChangeHomeomorph_eq_of_homotopic {gamma delta : _root_.Path x�
   exact congrArg (fun r => r.trans q)
     (congrArg Path.Homotopic.Quotient.symm (Quotient.sound h))
 
-end TauCeti.Path
-
-namespace TauCeti.UniversalCover
-
 /-- Changing basepoint along a constant path gives the identity homeomorphism. -/
 @[simp]
 theorem basepointChangeHomeomorph_refl (x : X) :
-    TauCeti.Path.basepointChangeHomeomorph (Path.refl x) =
-      Homeomorph.refl (UniversalCover x) := by
+    basepointChangeHomeomorph (Path.refl x) = Homeomorph.refl (UniversalCover x) := by
   apply Homeomorph.ext
   intro p
   exact prependUniversalCover_refl p
 
-end TauCeti.UniversalCover
-
-namespace TauCeti.Path
-
-open UniversalCover
-
-variable {x₀ x₁ x₂ : X}
-
 /-- Reversing the changing path reverses the basepoint-change homeomorphism. -/
 @[simp]
-theorem basepointChangeHomeomorph_symm (gamma : _root_.Path x₀ x₁) :
+theorem basepointChangeHomeomorph_symm (gamma : Path x₀ x₁) :
     basepointChangeHomeomorph gamma.symm = (basepointChangeHomeomorph gamma).symm := by
   apply Homeomorph.ext
   rintro ⟨x, q⟩
@@ -238,8 +221,7 @@ theorem basepointChangeHomeomorph_symm (gamma : _root_.Path x₀ x₁) :
 
 /-- Changing basepoint along a concatenation is the composite of the two basepoint changes. -/
 @[simp]
-theorem basepointChangeHomeomorph_trans (gamma : _root_.Path x₀ x₁)
-    (delta : _root_.Path x₁ x₂) :
+theorem basepointChangeHomeomorph_trans (gamma : Path x₀ x₁) (delta : Path x₁ x₂) :
     basepointChangeHomeomorph (gamma.trans delta) =
       (basepointChangeHomeomorph gamma).trans (basepointChangeHomeomorph delta) := by
   apply Homeomorph.ext
@@ -256,4 +238,4 @@ theorem basepointChangeHomeomorph_trans (gamma : _root_.Path x₀ x₁)
       Path.Homotopic.Quotient.mk_symm, Path.Homotopic.Quotient.mk_symm]
   rw [hsymm, Path.Homotopic.Quotient.trans_assoc]
 
-end TauCeti.Path
+end TauCeti.UniversalCover

--- a/TauCeti/AlgebraicTopology/UniversalCover/BasepointChange.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/BasepointChange.lean
@@ -79,6 +79,8 @@ theorem basepointChangeHomeomorph_apply_mk (gamma : Path x₀ x₁) (x : X)
     (q : Path.Homotopic.Quotient x₀ x) :
     basepointChangeHomeomorph gamma (mk x q) =
       mk x ((Path.Homotopic.Quotient.mk gamma).symm.trans q) := by
+  -- Applying the bundled homeomorphism exposes its `toFun`, which is definitionally the
+  -- prepending map; there is no separate projection lemma for this structure wrapper.
   change prependUniversalCover gamma.symm (mk x q) = _
   rw [prependUniversalCover_mk, Path.Homotopic.Quotient.mk_symm]
 
@@ -118,41 +120,17 @@ theorem basepointChangeHomeomorph_symm_apply_ofBasedPath (gamma : Path x₀ x₁
       ofBasedPath x₀ (BasedPath.ofPath (gamma.trans beta.toPath)) :=
   prependUniversalCover_ofBasedPath gamma beta
 
-private theorem mem_own_sheet {x : X} {U : Set X} (hxU : x ∈ U)
-    (q : Path.Homotopic.Quotient x₀ x) : mk x q ∈ sheet U hxU q := by
-  induction q using Quotient.inductionOn with
-  | h gamma =>
-      change mk x (Path.Homotopic.Quotient.mk gamma) ∈
-        sheet U hxU (Path.Homotopic.Quotient.mk gamma)
-      rw [← ofBasedPath_ofPath gamma]
-      exact mem_sheet_self hxU gamma
+/-- Basepoint change sends the point represented by the changing path to the constant-path point
+over its target.
 
-private theorem isLocallyInjective_proj [LocallyPathConnectedSpace X]
-    [SemilocallySimplyConnectedSpace X] (x₀ : X) :
-    IsLocallyInjective (proj : UniversalCover x₀ → X) := by
-  rintro ⟨x, q⟩
-  obtain ⟨U, hU_open, hxU, _hU_pathConn, hU_slsc⟩ :=
-    exists_isOpen_mem_isPathConnected_isPathHomotopyTrivial x
-  exact ⟨sheet U hxU q, isOpen_sheet U hU_open hxU q, mem_own_sheet hxU q,
-    proj_injOn_sheet hU_slsc hxU q⟩
-
-private theorem isSeparatedMap_proj [LocallyPathConnectedSpace X]
-    [SemilocallySimplyConnectedSpace X] (x₀ : X) :
-    IsSeparatedMap (proj : UniversalCover x₀ → X) := by
-  rintro ⟨x, q₁⟩ ⟨y, q₂⟩ hxy hne
-  change x = y at hxy
-  subst y
-  obtain ⟨U, hU_open, hxU, _hU_pathConn, hU_slsc⟩ :=
-    exists_isOpen_mem_isPathConnected_isPathHomotopyTrivial x
-  have hq : q₁ ≠ q₂ := by
-    intro h
-    apply hne
-    subst h
-    rfl
-  exact ⟨sheet U hxU q₁, sheet U hxU q₂,
-    isOpen_sheet U hU_open hxU q₁, isOpen_sheet U hU_open hxU q₂,
-    mem_own_sheet hxU q₁, mem_own_sheet hxU q₂,
-    pairwise_disjoint_sheet hU_slsc hxU hq⟩
+This remains an explicit rewrite theorem: `ofBasedPath_ofPath` and the general
+representative rule already let `simp` prove it, so the `simpNF` linter rejects a redundant
+`@[simp]` annotation. -/
+theorem basepointChangeHomeomorph_apply_self (gamma : Path x₀ x₁) :
+    basepointChangeHomeomorph gamma (ofBasedPath x₀ (BasedPath.ofPath gamma)) =
+      basepointLift x₁ := by
+  rw [ofBasedPath_ofPath, basepointChangeHomeomorph_apply_mk, basepointLift_coe,
+    Path.Homotopic.Quotient.symm_trans]
 
 /-- The basepoint-change homeomorphism is the unique continuous map over `X` that sends the point
 represented by the changing path to the constant-path point. -/
@@ -162,11 +140,6 @@ theorem eq_basepointChangeHomeomorph (gamma : Path x₀ x₁)
     (hgamma : f (ofBasedPath x₀ (BasedPath.ofPath gamma)) = basepointLift x₁)
     (hproj : proj ∘ f = proj) :
     f = (basepointChangeHomeomorph gamma : C(UniversalCover x₀, UniversalCover x₁)) := by
-  have hbase :
-      basepointChangeHomeomorph gamma (ofBasedPath x₀ (BasedPath.ofPath gamma)) =
-        basepointLift x₁ := by
-    rw [ofBasedPath_ofPath, basepointChangeHomeomorph_apply_mk, basepointLift_coe,
-      Path.Homotopic.Quotient.symm_trans]
   have hproj' : proj ∘ f = proj ∘ (basepointChangeHomeomorph gamma :
       UniversalCover x₀ → UniversalCover x₁) := by
     rw [hproj]
@@ -176,7 +149,8 @@ theorem eq_basepointChangeHomeomorph (gamma : Path x₀ x₁)
   exact congrFun ((isSeparatedMap_proj x₁).eq_of_comp_eq (isLocallyInjective_proj x₁)
     f.continuous
     (basepointChangeHomeomorph gamma).continuous hproj'
-    (ofBasedPath x₀ (BasedPath.ofPath gamma)) (hgamma.trans hbase.symm))
+    (ofBasedPath x₀ (BasedPath.ofPath gamma))
+    (hgamma.trans (basepointChangeHomeomorph_apply_self gamma).symm))
 
 /-- Homotopic basepoint-change paths induce the same homeomorphism. -/
 theorem basepointChangeHomeomorph_eq_of_homotopic {gamma delta : Path x₀ x₁}

--- a/TauCeti/AlgebraicTopology/UniversalCover/BasepointChange.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/BasepointChange.lean
@@ -14,10 +14,10 @@ A path `γ : Path x₀ x₁` identifies the universal covers based at its endpoi
 based-path model, the identification removes the initial path `γ`: it sends the class of a path
 `α` starting at `x₀` to the class of `γ.symm.trans α`, now regarded as a path starting at `x₁`.
 
-The construction is expressed first as `TauCeti.UniversalCover.prepend`, which prepends a fixed
-path to every representative. This operation is continuous for the quotient topology on the
-universal cover. Prepending a path and its reverse gives inverse continuous maps, producing
-`TauCeti.UniversalCover.basepointChangeHomeomorph`.
+The construction uses `TauCeti.Path.prependUniversalCover`, which prepends a fixed path to every
+representative and is continuous for the quotient topology on the universal cover. Prepending a
+path and its reverse gives inverse continuous maps, producing
+`TauCeti.Path.basepointChangeHomeomorph`.
 
 The resulting homeomorphism lies over the identity of the base, sends the point represented by
 `γ` to the constant-path point over `x₁`, depends only on the endpoint-preserving homotopy class
@@ -26,11 +26,9 @@ basepoint-change coherence of the based-path universal-cover construction.
 
 ## Main declarations
 
-* `TauCeti.UniversalCover.prepend`: prepend a fixed path to universal-cover path classes.
-* `TauCeti.UniversalCover.continuous_prepend`: prepending a path is continuous.
-* `TauCeti.UniversalCover.basepointChangeHomeomorph`: the homeomorphism between universal covers
+* `TauCeti.Path.basepointChangeHomeomorph`: the homeomorphism between universal covers
   based at the endpoints of a path.
-* `TauCeti.UniversalCover.basepointChangeHomeomorph_trans`: basepoint change respects path
+* `TauCeti.Path.basepointChangeHomeomorph_trans`: basepoint change respects path
   concatenation.
 
 ## References
@@ -50,123 +48,61 @@ open scoped unitInterval
 
 variable {X : Type*} [TopologicalSpace X]
 
-namespace TauCeti.UniversalCover
+namespace TauCeti.Path
+
+open UniversalCover
 
 variable {x₀ x₁ x₂ : X}
-
-/-- Prepend a path from `x₁` to `x₀` to the path class represented by a point of the
-universal cover based at `x₀`. -/
-def prepend (gamma : Path x₁ x₀) (p : UniversalCover x₀) : UniversalCover x₁ :=
-  mk p.proj ((Path.Homotopic.Quotient.mk gamma).trans p.path)
-
-/-- Prepending to an endpoint-and-path-class pair prepends the corresponding homotopy class. -/
-@[simp]
-theorem prepend_mk (gamma : Path x₁ x₀) (x : X)
-    (q : Path.Homotopic.Quotient x₀ x) :
-    prepend gamma (mk x q) = mk x ((Path.Homotopic.Quotient.mk gamma).trans q) :=
-  (rfl)
-
-/-- Prepending a path does not change the endpoint projection. -/
-@[simp]
-theorem proj_prepend (gamma : Path x₁ x₀) (p : UniversalCover x₀) :
-    proj (prepend gamma p) = proj p :=
-  (rfl)
-
-/-- On the quotient constructor, prepending is represented by concatenating paths. -/
-@[simp]
-theorem prepend_ofBasedPath (gamma : Path x₁ x₀) (beta : BasedPath x₀) :
-    prepend gamma (ofBasedPath x₀ beta) =
-      ofBasedPath x₁ (BasedPath.ofPath (gamma.trans beta.toPath)) := by
-  rw [ofBasedPath_ofPath, prepend_mk, ofBasedPath_def,
-    Path.Homotopic.Quotient.mk_trans]
-
-/-- Prepending a fixed path is continuous for the quotient topologies on the two universal
-covers. -/
-@[fun_prop]
-theorem continuous_prepend (gamma : Path x₁ x₀) :
-    Continuous (prepend gamma : UniversalCover x₀ → UniversalCover x₁) := by
-  rw [(isQuotientMap_ofBasedPath x₀).continuous_iff]
-  suffices hcont : Continuous (fun beta : BasedPath x₀ =>
-      ofBasedPath x₁ (BasedPath.ofPath (gamma.trans beta.toPath))) by
-    apply hcont.congr
-    intro beta
-    simpa only [Function.comp_apply] using (prepend_ofBasedPath gamma beta).symm
-  refine (continuous_ofBasedPath x₁).comp (Continuous.subtype_mk ?_ _)
-  refine ContinuousMap.continuous_of_continuous_uncurry _ ?_
-  have heval : Continuous fun p : BasedPath x₀ × unitInterval => p.1.1 p.2 :=
-    continuous_eval.comp (continuous_subtype_val.prodMap continuous_id)
-  -- Unfolding the path wrappers identifies the uncurried goal with concatenation.
-  change Continuous fun p : BasedPath x₀ × unitInterval => gamma.trans p.1.toPath p.2
-  exact Path.trans_continuous_family (a := fun _ : BasedPath x₀ => x₁)
-    (b := fun _ : BasedPath x₀ => x₀)
-    (c := fun beta : BasedPath x₀ => BasedPath.endpoint beta)
-    (fun _ => gamma) (Path.continuous_uncurry_iff.mpr continuous_const)
-    (fun beta => beta.toPath) heval
-
-/-- Prepending a constant path is the identity. -/
-@[simp]
-theorem prepend_refl (p : UniversalCover x₀) : prepend (Path.refl x₀) p = p := by
-  rcases p with ⟨x, q⟩
-  rw [prepend_mk, Path.Homotopic.Quotient.mk_refl,
-    Path.Homotopic.Quotient.refl_trans]
-
-/-- Successive prepending combines by path concatenation. -/
-@[simp]
-theorem prepend_trans (gamma : Path x₂ x₁) (delta : Path x₁ x₀)
-    (p : UniversalCover x₀) :
-    prepend (gamma.trans delta) p = prepend gamma (prepend delta p) := by
-  rcases p with ⟨x, q⟩
-  rw [prepend_mk, prepend_mk, prepend_mk, Path.Homotopic.Quotient.mk_trans,
-    Path.Homotopic.Quotient.trans_assoc]
 
 /-- **A path identifies the universal covers based at its endpoints.** The forward map removes
 the chosen initial path by prepending its reverse; the inverse map prepends the path itself. -/
 def basepointChangeHomeomorph (gamma : Path x₀ x₁) :
     UniversalCover x₀ ≃ₜ UniversalCover x₁ where
-  toFun := prepend gamma.symm
-  invFun := prepend gamma
+  toFun := TauCeti.Path.prependUniversalCover gamma.symm
+  invFun := TauCeti.Path.prependUniversalCover gamma
   left_inv p := by
     rcases p with ⟨x, q⟩
-    rw [prepend_mk, prepend_mk]
+    rw [TauCeti.Path.prependUniversalCover_mk, TauCeti.Path.prependUniversalCover_mk]
     congr 1
     rw [Path.Homotopic.Quotient.mk_symm, ← Path.Homotopic.Quotient.trans_assoc,
       Path.Homotopic.Quotient.trans_symm, Path.Homotopic.Quotient.refl_trans]
   right_inv p := by
     rcases p with ⟨x, q⟩
-    rw [prepend_mk, prepend_mk]
+    rw [TauCeti.Path.prependUniversalCover_mk, TauCeti.Path.prependUniversalCover_mk]
     congr 1
     rw [Path.Homotopic.Quotient.mk_symm, ← Path.Homotopic.Quotient.trans_assoc,
       Path.Homotopic.Quotient.symm_trans, Path.Homotopic.Quotient.refl_trans]
-  continuous_toFun := continuous_prepend gamma.symm
-  continuous_invFun := continuous_prepend gamma
+  continuous_toFun := TauCeti.Path.continuous_prependUniversalCover gamma.symm
+  continuous_invFun := TauCeti.Path.continuous_prependUniversalCover gamma
 
 /-- Basepoint change prepends the reverse path class to a representative. -/
 @[simp]
 theorem basepointChangeHomeomorph_apply_mk (gamma : Path x₀ x₁) (x : X)
     (q : Path.Homotopic.Quotient x₀ x) :
     basepointChangeHomeomorph gamma (mk x q) =
-      mk x ((Path.Homotopic.Quotient.mk gamma).symm.trans q) :=
-  (rfl)
+      mk x ((Path.Homotopic.Quotient.mk gamma).symm.trans q) := by
+  change TauCeti.Path.prependUniversalCover gamma.symm (mk x q) = _
+  rw [TauCeti.Path.prependUniversalCover_mk, Path.Homotopic.Quotient.mk_symm]
 
 /-- The inverse basepoint change prepends the original path class to a representative. -/
 @[simp]
 theorem basepointChangeHomeomorph_symm_apply_mk (gamma : Path x₀ x₁) (x : X)
     (q : Path.Homotopic.Quotient x₁ x) :
     (basepointChangeHomeomorph gamma).symm (mk x q) =
-      mk x ((Path.Homotopic.Quotient.mk gamma).trans q) :=
-  (rfl)
+      mk x ((Path.Homotopic.Quotient.mk gamma).trans q) := by
+  exact TauCeti.Path.prependUniversalCover_mk gamma x q
 
 /-- Basepoint change lies over the identity map of the base. -/
 @[simp]
 theorem proj_basepointChangeHomeomorph (gamma : Path x₀ x₁) (p : UniversalCover x₀) :
-    proj (basepointChangeHomeomorph gamma p) = proj p :=
-  (rfl)
+    proj (basepointChangeHomeomorph gamma p) = proj p := by
+  exact TauCeti.Path.proj_prependUniversalCover gamma.symm p
 
 /-- The inverse basepoint change also lies over the identity map of the base. -/
 @[simp]
 theorem proj_basepointChangeHomeomorph_symm (gamma : Path x₀ x₁) (p : UniversalCover x₁) :
-    proj ((basepointChangeHomeomorph gamma).symm p) = proj p :=
-  (rfl)
+    proj ((basepointChangeHomeomorph gamma).symm p) = proj p := by
+  exact TauCeti.Path.proj_prependUniversalCover gamma p
 
 /-- On a based-path representative, basepoint change prepends the reverse of the changing path. -/
 @[simp]
@@ -174,7 +110,7 @@ theorem basepointChangeHomeomorph_apply_ofBasedPath (gamma : Path x₀ x₁)
     (beta : BasedPath x₀) :
     basepointChangeHomeomorph gamma (ofBasedPath x₀ beta) =
       ofBasedPath x₁ (BasedPath.ofPath (gamma.symm.trans beta.toPath)) :=
-  prepend_ofBasedPath gamma.symm beta
+  TauCeti.Path.prependUniversalCover_ofBasedPath gamma.symm beta
 
 /-- On a based-path representative, inverse basepoint change prepends the changing path. -/
 @[simp]
@@ -182,11 +118,47 @@ theorem basepointChangeHomeomorph_symm_apply_ofBasedPath (gamma : Path x₀ x₁
     (beta : BasedPath x₁) :
     (basepointChangeHomeomorph gamma).symm (ofBasedPath x₁ beta) =
       ofBasedPath x₀ (BasedPath.ofPath (gamma.trans beta.toPath)) :=
-  prepend_ofBasedPath gamma beta
+  TauCeti.Path.prependUniversalCover_ofBasedPath gamma beta
+
+private theorem mem_own_sheet {x : X} {U : Set X} (hxU : x ∈ U)
+    (q : Path.Homotopic.Quotient x₀ x) : mk x q ∈ sheet U hxU q := by
+  induction q using Quotient.inductionOn with
+  | h gamma =>
+      change mk x (Path.Homotopic.Quotient.mk gamma) ∈
+        sheet U hxU (Path.Homotopic.Quotient.mk gamma)
+      rw [← ofBasedPath_ofPath gamma]
+      exact mem_sheet_self hxU gamma
+
+private theorem isLocallyInjective_proj [LocallyPathConnectedSpace X]
+    [SemilocallySimplyConnectedSpace X] (x₀ : X) :
+    IsLocallyInjective (proj : UniversalCover x₀ → X) := by
+  rintro ⟨x, q⟩
+  obtain ⟨U, hU_open, hxU, _hU_pathConn, hU_slsc⟩ :=
+    exists_isOpen_mem_isPathConnected_isPathHomotopyTrivial x
+  exact ⟨sheet U hxU q, isOpen_sheet U hU_open hxU q, mem_own_sheet hxU q,
+    proj_injOn_sheet hU_slsc hxU q⟩
+
+private theorem isSeparatedMap_proj [LocallyPathConnectedSpace X]
+    [SemilocallySimplyConnectedSpace X] (x₀ : X) :
+    IsSeparatedMap (proj : UniversalCover x₀ → X) := by
+  rintro ⟨x, q₁⟩ ⟨y, q₂⟩ hxy hne
+  change x = y at hxy
+  subst y
+  obtain ⟨U, hU_open, hxU, _hU_pathConn, hU_slsc⟩ :=
+    exists_isOpen_mem_isPathConnected_isPathHomotopyTrivial x
+  have hq : q₁ ≠ q₂ := by
+    intro h
+    apply hne
+    subst h
+    rfl
+  exact ⟨sheet U hxU q₁, sheet U hxU q₂,
+    isOpen_sheet U hU_open hxU q₁, isOpen_sheet U hU_open hxU q₂,
+    mem_own_sheet hxU q₁, mem_own_sheet hxU q₂,
+    pairwise_disjoint_sheet hU_slsc hxU hq⟩
 
 /-- The basepoint-change homeomorphism is the unique continuous map over `X` that sends the point
 represented by the changing path to the constant-path point. -/
-theorem eq_basepointChangeHomeomorph (gamma : Path x₀ x₁) [PathConnectedSpace X]
+theorem eq_basepointChangeHomeomorph (gamma : Path x₀ x₁)
     [LocallyPathConnectedSpace X] [SemilocallySimplyConnectedSpace X]
     {f : C(UniversalCover x₀, UniversalCover x₁)}
     (hgamma : f (ofBasedPath x₀ (BasedPath.ofPath gamma)) = basepointLift x₁)
@@ -197,9 +169,15 @@ theorem eq_basepointChangeHomeomorph (gamma : Path x₀ x₁) [PathConnectedSpac
         basepointLift x₁ := by
     rw [ofBasedPath_ofPath, basepointChangeHomeomorph_apply_mk, basepointLift_coe,
       Path.Homotopic.Quotient.symm_trans]
+  have hproj' : proj ∘ f = proj ∘ (basepointChangeHomeomorph gamma :
+      UniversalCover x₀ → UniversalCover x₁) := by
+    rw [hproj]
+    funext p
+    exact (proj_basepointChangeHomeomorph gamma p).symm
   apply ContinuousMap.ext
-  exact congrFun ((isCoveringMap x₁).eq_of_comp_eq f.continuous
-    (basepointChangeHomeomorph gamma).continuous hproj
+  exact congrFun ((isSeparatedMap_proj x₁).eq_of_comp_eq (isLocallyInjective_proj x₁)
+    f.continuous
+    (basepointChangeHomeomorph gamma).continuous hproj'
     (ofBasedPath x₀ (BasedPath.ofPath gamma)) (hgamma.trans hbase.symm))
 
 /-- Homotopic basepoint-change paths induce the same homeomorphism. -/
@@ -219,7 +197,7 @@ theorem basepointChangeHomeomorph_refl (x : X) :
     basepointChangeHomeomorph (Path.refl x) = Homeomorph.refl (UniversalCover x) := by
   apply Homeomorph.ext
   intro p
-  exact prepend_refl p
+  exact TauCeti.Path.prependUniversalCover_refl p
 
 /-- Reversing the changing path reverses the basepoint-change homeomorphism. -/
 @[simp]
@@ -253,4 +231,4 @@ theorem basepointChangeHomeomorph_trans (gamma : Path x₀ x₁) (delta : Path x
       Path.Homotopic.Quotient.mk_symm, Path.Homotopic.Quotient.mk_symm]
   rw [hsymm, Path.Homotopic.Quotient.trans_assoc]
 
-end TauCeti.UniversalCover
+end TauCeti.Path

--- a/TauCeti/AlgebraicTopology/UniversalCover/BasepointChange.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/BasepointChange.lean
@@ -1,0 +1,256 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicTopology.UniversalCover.Action
+
+/-!
+# Basepoint change for the universal cover
+
+A path `γ : Path x₀ x₁` identifies the universal covers based at its endpoints. In the
+based-path model, the identification removes the initial path `γ`: it sends the class of a path
+`α` starting at `x₀` to the class of `γ.symm.trans α`, now regarded as a path starting at `x₁`.
+
+The construction is expressed first as `TauCeti.UniversalCover.prepend`, which prepends a fixed
+path to every representative. This operation is continuous for the quotient topology on the
+universal cover. Prepending a path and its reverse gives inverse continuous maps, producing
+`TauCeti.UniversalCover.basepointChangeHomeomorph`.
+
+The resulting homeomorphism lies over the identity of the base, sends the point represented by
+`γ` to the constant-path point over `x₁`, depends only on the endpoint-preserving homotopy class
+of `γ`, and respects reflexivity, reversal, and concatenation. These properties make explicit the
+basepoint-change coherence of the based-path universal-cover construction.
+
+## Main declarations
+
+* `TauCeti.UniversalCover.prepend`: prepend a fixed path to universal-cover path classes.
+* `TauCeti.UniversalCover.continuous_prepend`: prepending a path is continuous.
+* `TauCeti.UniversalCover.basepointChangeHomeomorph`: the homeomorphism between universal covers
+  based at the endpoints of a path.
+* `TauCeti.UniversalCover.basepointChangeHomeomorph_trans`: basepoint change respects path
+  concatenation.
+
+## References
+
+This is the standard change-of-basepoint map in the based-path construction of the universal
+cover; compare Hatcher, *Algebraic Topology*, Section 1.3. The quotient model used here is adapted
+from Kim Morrison's [mathlib4#38292](https://github.com/leanprover-community/mathlib4/pull/38292)
+and is credited in `TauCeti.AlgebraicTopology.UniversalCover.Basic`. The continuity argument
+generalizes the fixed-loop argument in `TauCeti.AlgebraicTopology.UniversalCover.Action`, also
+adapted from that pull request.
+-/
+
+public section
+noncomputable section
+
+open scoped unitInterval
+
+variable {X : Type*} [TopologicalSpace X]
+
+namespace TauCeti.UniversalCover
+
+variable {x₀ x₁ x₂ : X}
+
+/-- Prepend a path from `x₁` to `x₀` to the path class represented by a point of the
+universal cover based at `x₀`. -/
+def prepend (gamma : Path x₁ x₀) (p : UniversalCover x₀) : UniversalCover x₁ :=
+  mk p.proj ((Path.Homotopic.Quotient.mk gamma).trans p.path)
+
+/-- Prepending to an endpoint-and-path-class pair prepends the corresponding homotopy class. -/
+@[simp]
+theorem prepend_mk (gamma : Path x₁ x₀) (x : X)
+    (q : Path.Homotopic.Quotient x₀ x) :
+    prepend gamma (mk x q) = mk x ((Path.Homotopic.Quotient.mk gamma).trans q) :=
+  (rfl)
+
+/-- Prepending a path does not change the endpoint projection. -/
+@[simp]
+theorem proj_prepend (gamma : Path x₁ x₀) (p : UniversalCover x₀) :
+    proj (prepend gamma p) = proj p :=
+  (rfl)
+
+/-- On the quotient constructor, prepending is represented by concatenating paths. -/
+@[simp]
+theorem prepend_ofBasedPath (gamma : Path x₁ x₀) (beta : BasedPath x₀) :
+    prepend gamma (ofBasedPath x₀ beta) =
+      ofBasedPath x₁ (BasedPath.ofPath (gamma.trans beta.toPath)) := by
+  rw [ofBasedPath_ofPath, prepend_mk, ofBasedPath_def,
+    Path.Homotopic.Quotient.mk_trans]
+
+/-- Prepending a fixed path is continuous for the quotient topologies on the two universal
+covers. -/
+@[fun_prop]
+theorem continuous_prepend (gamma : Path x₁ x₀) :
+    Continuous (prepend gamma : UniversalCover x₀ → UniversalCover x₁) := by
+  rw [(isQuotientMap_ofBasedPath x₀).continuous_iff]
+  suffices hcont : Continuous (fun beta : BasedPath x₀ =>
+      ofBasedPath x₁ (BasedPath.ofPath (gamma.trans beta.toPath))) by
+    apply hcont.congr
+    intro beta
+    simpa only [Function.comp_apply] using (prepend_ofBasedPath gamma beta).symm
+  refine (continuous_ofBasedPath x₁).comp (Continuous.subtype_mk ?_ _)
+  refine ContinuousMap.continuous_of_continuous_uncurry _ ?_
+  have heval : Continuous fun p : BasedPath x₀ × unitInterval => p.1.1 p.2 :=
+    continuous_eval.comp (continuous_subtype_val.prodMap continuous_id)
+  -- Unfolding the path wrappers identifies the uncurried goal with concatenation.
+  change Continuous fun p : BasedPath x₀ × unitInterval => gamma.trans p.1.toPath p.2
+  exact Path.trans_continuous_family (a := fun _ : BasedPath x₀ => x₁)
+    (b := fun _ : BasedPath x₀ => x₀)
+    (c := fun beta : BasedPath x₀ => BasedPath.endpoint beta)
+    (fun _ => gamma) (Path.continuous_uncurry_iff.mpr continuous_const)
+    (fun beta => beta.toPath) heval
+
+/-- Prepending a constant path is the identity. -/
+@[simp]
+theorem prepend_refl (p : UniversalCover x₀) : prepend (Path.refl x₀) p = p := by
+  rcases p with ⟨x, q⟩
+  rw [prepend_mk, Path.Homotopic.Quotient.mk_refl,
+    Path.Homotopic.Quotient.refl_trans]
+
+/-- Successive prepending combines by path concatenation. -/
+@[simp]
+theorem prepend_trans (gamma : Path x₂ x₁) (delta : Path x₁ x₀)
+    (p : UniversalCover x₀) :
+    prepend (gamma.trans delta) p = prepend gamma (prepend delta p) := by
+  rcases p with ⟨x, q⟩
+  rw [prepend_mk, prepend_mk, prepend_mk, Path.Homotopic.Quotient.mk_trans,
+    Path.Homotopic.Quotient.trans_assoc]
+
+/-- **A path identifies the universal covers based at its endpoints.** The forward map removes
+the chosen initial path by prepending its reverse; the inverse map prepends the path itself. -/
+def basepointChangeHomeomorph (gamma : Path x₀ x₁) :
+    UniversalCover x₀ ≃ₜ UniversalCover x₁ where
+  toFun := prepend gamma.symm
+  invFun := prepend gamma
+  left_inv p := by
+    rcases p with ⟨x, q⟩
+    rw [prepend_mk, prepend_mk]
+    congr 1
+    rw [Path.Homotopic.Quotient.mk_symm, ← Path.Homotopic.Quotient.trans_assoc,
+      Path.Homotopic.Quotient.trans_symm, Path.Homotopic.Quotient.refl_trans]
+  right_inv p := by
+    rcases p with ⟨x, q⟩
+    rw [prepend_mk, prepend_mk]
+    congr 1
+    rw [Path.Homotopic.Quotient.mk_symm, ← Path.Homotopic.Quotient.trans_assoc,
+      Path.Homotopic.Quotient.symm_trans, Path.Homotopic.Quotient.refl_trans]
+  continuous_toFun := continuous_prepend gamma.symm
+  continuous_invFun := continuous_prepend gamma
+
+/-- Basepoint change prepends the reverse path class to a representative. -/
+@[simp]
+theorem basepointChangeHomeomorph_apply_mk (gamma : Path x₀ x₁) (x : X)
+    (q : Path.Homotopic.Quotient x₀ x) :
+    basepointChangeHomeomorph gamma (mk x q) =
+      mk x ((Path.Homotopic.Quotient.mk gamma).symm.trans q) :=
+  (rfl)
+
+/-- The inverse basepoint change prepends the original path class to a representative. -/
+@[simp]
+theorem basepointChangeHomeomorph_symm_apply_mk (gamma : Path x₀ x₁) (x : X)
+    (q : Path.Homotopic.Quotient x₁ x) :
+    (basepointChangeHomeomorph gamma).symm (mk x q) =
+      mk x ((Path.Homotopic.Quotient.mk gamma).trans q) :=
+  (rfl)
+
+/-- Basepoint change lies over the identity map of the base. -/
+@[simp]
+theorem proj_basepointChangeHomeomorph (gamma : Path x₀ x₁) (p : UniversalCover x₀) :
+    proj (basepointChangeHomeomorph gamma p) = proj p :=
+  (rfl)
+
+/-- The inverse basepoint change also lies over the identity map of the base. -/
+@[simp]
+theorem proj_basepointChangeHomeomorph_symm (gamma : Path x₀ x₁) (p : UniversalCover x₁) :
+    proj ((basepointChangeHomeomorph gamma).symm p) = proj p :=
+  (rfl)
+
+/-- On a based-path representative, basepoint change prepends the reverse of the changing path. -/
+@[simp]
+theorem basepointChangeHomeomorph_apply_ofBasedPath (gamma : Path x₀ x₁)
+    (beta : BasedPath x₀) :
+    basepointChangeHomeomorph gamma (ofBasedPath x₀ beta) =
+      ofBasedPath x₁ (BasedPath.ofPath (gamma.symm.trans beta.toPath)) :=
+  prepend_ofBasedPath gamma.symm beta
+
+/-- On a based-path representative, inverse basepoint change prepends the changing path. -/
+@[simp]
+theorem basepointChangeHomeomorph_symm_apply_ofBasedPath (gamma : Path x₀ x₁)
+    (beta : BasedPath x₁) :
+    (basepointChangeHomeomorph gamma).symm (ofBasedPath x₁ beta) =
+      ofBasedPath x₀ (BasedPath.ofPath (gamma.trans beta.toPath)) :=
+  prepend_ofBasedPath gamma beta
+
+/-- The basepoint-change homeomorphism is the unique continuous map over `X` that sends the point
+represented by the changing path to the constant-path point. -/
+theorem eq_basepointChangeHomeomorph (gamma : Path x₀ x₁) [PathConnectedSpace X]
+    [LocallyPathConnectedSpace X] [SemilocallySimplyConnectedSpace X]
+    {f : C(UniversalCover x₀, UniversalCover x₁)}
+    (hgamma : f (ofBasedPath x₀ (BasedPath.ofPath gamma)) = basepointLift x₁)
+    (hproj : proj ∘ f = proj) :
+    f = (basepointChangeHomeomorph gamma : C(UniversalCover x₀, UniversalCover x₁)) := by
+  have hbase :
+      basepointChangeHomeomorph gamma (ofBasedPath x₀ (BasedPath.ofPath gamma)) =
+        basepointLift x₁ := by
+    rw [ofBasedPath_ofPath, basepointChangeHomeomorph_apply_mk, basepointLift_coe,
+      Path.Homotopic.Quotient.symm_trans]
+  apply ContinuousMap.ext
+  exact congrFun ((isCoveringMap x₁).eq_of_comp_eq f.continuous
+    (basepointChangeHomeomorph gamma).continuous hproj
+    (ofBasedPath x₀ (BasedPath.ofPath gamma)) (hgamma.trans hbase.symm))
+
+/-- Homotopic basepoint-change paths induce the same homeomorphism. -/
+theorem basepointChangeHomeomorph_eq_of_homotopic {gamma delta : Path x₀ x₁}
+    (h : gamma.Homotopic delta) :
+    basepointChangeHomeomorph gamma = basepointChangeHomeomorph delta := by
+  apply Homeomorph.ext
+  rintro ⟨x, q⟩
+  simp only [basepointChangeHomeomorph_apply_mk]
+  congr 1
+  exact congrArg (fun r => r.trans q)
+    (congrArg Path.Homotopic.Quotient.symm (Quotient.sound h))
+
+/-- Changing basepoint along a constant path gives the identity homeomorphism. -/
+@[simp]
+theorem basepointChangeHomeomorph_refl (x : X) :
+    basepointChangeHomeomorph (Path.refl x) = Homeomorph.refl (UniversalCover x) := by
+  apply Homeomorph.ext
+  intro p
+  exact prepend_refl p
+
+/-- Reversing the changing path reverses the basepoint-change homeomorphism. -/
+@[simp]
+theorem basepointChangeHomeomorph_symm (gamma : Path x₀ x₁) :
+    basepointChangeHomeomorph gamma.symm = (basepointChangeHomeomorph gamma).symm := by
+  apply Homeomorph.ext
+  rintro ⟨x, q⟩
+  simp only [basepointChangeHomeomorph_apply_mk,
+    basepointChangeHomeomorph_symm_apply_mk]
+  congr 1
+  congr 1
+  exact (Path.Homotopic.Quotient.mk_symm gamma.symm).symm.trans
+    (congrArg Path.Homotopic.Quotient.mk (Path.symm_symm gamma))
+
+/-- Changing basepoint along a concatenation is the composite of the two basepoint changes. -/
+@[simp]
+theorem basepointChangeHomeomorph_trans (gamma : Path x₀ x₁) (delta : Path x₁ x₂) :
+    basepointChangeHomeomorph (gamma.trans delta) =
+      (basepointChangeHomeomorph gamma).trans (basepointChangeHomeomorph delta) := by
+  apply Homeomorph.ext
+  rintro ⟨x, q⟩
+  simp only [Homeomorph.trans_apply, basepointChangeHomeomorph_apply_mk,
+    Path.Homotopic.Quotient.mk_trans]
+  congr 1
+  have hsymm : ((Path.Homotopic.Quotient.mk gamma).trans
+      (Path.Homotopic.Quotient.mk delta)).symm =
+      (Path.Homotopic.Quotient.mk delta).symm.trans
+        (Path.Homotopic.Quotient.mk gamma).symm := by
+    rw [← Path.Homotopic.Quotient.mk_trans, ← Path.Homotopic.Quotient.mk_symm,
+      Path.trans_symm, Path.Homotopic.Quotient.mk_trans,
+      Path.Homotopic.Quotient.mk_symm, Path.Homotopic.Quotient.mk_symm]
+  rw [hsymm, Path.Homotopic.Quotient.trans_assoc]
+
+end TauCeti.UniversalCover

--- a/TauCeti/AlgebraicTopology/UniversalCover/BasepointChange.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/BasepointChange.lean
@@ -15,10 +15,10 @@ A path `γ : Path x₀ x₁` identifies the universal covers based at its endpoi
 based-path model, the identification removes the initial path `γ`: it sends the class of a path
 `α` starting at `x₀` to the class of `γ.symm.trans α`, now regarded as a path starting at `x₁`.
 
-The construction uses `TauCeti.UniversalCover.prependUniversalCover`, which prepends a fixed path
+The construction uses `TauCeti.Path.prependUniversalCover`, which prepends a fixed path
 to every representative and is continuous for the quotient topology on the universal cover.
 Prepending a path and its reverse gives inverse continuous maps, producing
-`TauCeti.UniversalCover.basepointChangeHomeomorph`.
+`TauCeti.Path.basepointChangeHomeomorph`.
 
 The resulting homeomorphism lies over the identity of the base, sends the point represented by
 `γ` to the constant-path point over `x₁`, depends only on the endpoint-preserving homotopy class
@@ -28,9 +28,9 @@ based-path universal-cover construction.
 
 ## Main declarations
 
-* `TauCeti.UniversalCover.basepointChangeHomeomorph`: the homeomorphism between universal covers
+* `TauCeti.Path.basepointChangeHomeomorph`: the homeomorphism between universal covers
   based at the endpoints of a path.
-* `TauCeti.UniversalCover.basepointChangeHomeomorph_trans`: basepoint change respects path
+* `TauCeti.Path.basepointChangeHomeomorph_trans`: basepoint change respects path
   concatenation.
 
 ## References
@@ -50,13 +50,15 @@ open scoped unitInterval
 
 variable {X : Type*} [TopologicalSpace X]
 
-namespace TauCeti.UniversalCover
+namespace TauCeti.Path
+
+open UniversalCover
 
 variable {x₀ x₁ x₂ : X}
 
 /-- **A path identifies the universal covers based at its endpoints.** The forward map removes
 the chosen initial path by prepending its reverse; the inverse map prepends the path itself. -/
-def basepointChangeHomeomorph (gamma : Path x₀ x₁) :
+def basepointChangeHomeomorph (gamma : _root_.Path x₀ x₁) :
     UniversalCover x₀ ≃ₜ UniversalCover x₁ where
   toFun := prependUniversalCover gamma.symm
   invFun := prependUniversalCover gamma
@@ -77,7 +79,7 @@ def basepointChangeHomeomorph (gamma : Path x₀ x₁) :
 
 /-- Basepoint change prepends the reverse path class to a representative. -/
 @[simp]
-theorem basepointChangeHomeomorph_apply_mk (gamma : Path x₀ x₁) (x : X)
+theorem basepointChangeHomeomorph_apply_mk (gamma : _root_.Path x₀ x₁) (x : X)
     (q : Path.Homotopic.Quotient x₀ x) :
     basepointChangeHomeomorph gamma (mk x q) =
       mk x ((Path.Homotopic.Quotient.mk gamma).symm.trans q) := by
@@ -88,7 +90,7 @@ theorem basepointChangeHomeomorph_apply_mk (gamma : Path x₀ x₁) (x : X)
 
 /-- The inverse basepoint change prepends the original path class to a representative. -/
 @[simp]
-theorem basepointChangeHomeomorph_symm_apply_mk (gamma : Path x₀ x₁) (x : X)
+theorem basepointChangeHomeomorph_symm_apply_mk (gamma : _root_.Path x₀ x₁) (x : X)
     (q : Path.Homotopic.Quotient x₁ x) :
     (basepointChangeHomeomorph gamma).symm (mk x q) =
       mk x ((Path.Homotopic.Quotient.mk gamma).trans q) := by
@@ -96,19 +98,21 @@ theorem basepointChangeHomeomorph_symm_apply_mk (gamma : Path x₀ x₁) (x : X)
 
 /-- Basepoint change lies over the identity map of the base. -/
 @[simp]
-theorem proj_basepointChangeHomeomorph (gamma : Path x₀ x₁) (p : UniversalCover x₀) :
+theorem proj_basepointChangeHomeomorph (gamma : _root_.Path x₀ x₁)
+    (p : UniversalCover x₀) :
     proj (basepointChangeHomeomorph gamma p) = proj p := by
   exact proj_prependUniversalCover gamma.symm p
 
 /-- The inverse basepoint change also lies over the identity map of the base. -/
 @[simp]
-theorem proj_basepointChangeHomeomorph_symm (gamma : Path x₀ x₁) (p : UniversalCover x₁) :
+theorem proj_basepointChangeHomeomorph_symm (gamma : _root_.Path x₀ x₁)
+    (p : UniversalCover x₁) :
     proj ((basepointChangeHomeomorph gamma).symm p) = proj p := by
   exact proj_prependUniversalCover gamma p
 
 /-- On a based-path representative, basepoint change prepends the reverse of the changing path. -/
 @[simp]
-theorem basepointChangeHomeomorph_apply_ofBasedPath (gamma : Path x₀ x₁)
+theorem basepointChangeHomeomorph_apply_ofBasedPath (gamma : _root_.Path x₀ x₁)
     (beta : BasedPath x₀) :
     basepointChangeHomeomorph gamma (ofBasedPath x₀ beta) =
       ofBasedPath x₁ (BasedPath.ofPath (gamma.symm.trans beta.toPath)) :=
@@ -116,7 +120,7 @@ theorem basepointChangeHomeomorph_apply_ofBasedPath (gamma : Path x₀ x₁)
 
 /-- On a based-path representative, inverse basepoint change prepends the changing path. -/
 @[simp]
-theorem basepointChangeHomeomorph_symm_apply_ofBasedPath (gamma : Path x₀ x₁)
+theorem basepointChangeHomeomorph_symm_apply_ofBasedPath (gamma : _root_.Path x₀ x₁)
     (beta : BasedPath x₁) :
     (basepointChangeHomeomorph gamma).symm (ofBasedPath x₁ beta) =
       ofBasedPath x₀ (BasedPath.ofPath (gamma.trans beta.toPath)) :=
@@ -125,7 +129,7 @@ theorem basepointChangeHomeomorph_symm_apply_ofBasedPath (gamma : Path x₀ x₁
 /-- Basepoint change intertwines the fundamental-group actions under the corresponding
 basepoint-change isomorphism of fundamental groups. -/
 @[simp]
-theorem basepointChangeHomeomorph_smul (gamma : Path x₀ x₁)
+theorem basepointChangeHomeomorph_smul (gamma : _root_.Path x₀ x₁)
     (g : FundamentalGroup X x₀) (p : UniversalCover x₀) :
     basepointChangeHomeomorph gamma (g • p) =
       FundamentalGroup.fundamentalGroupMulEquivOfPath gamma g •
@@ -150,7 +154,7 @@ theorem basepointChangeHomeomorph_smul (gamma : Path x₀ x₁)
 /-- Inverse basepoint change intertwines the target action with transport back to the source
 fundamental group. -/
 @[simp]
-theorem basepointChangeHomeomorph_symm_smul (gamma : Path x₀ x₁)
+theorem basepointChangeHomeomorph_symm_smul (gamma : _root_.Path x₀ x₁)
     (g : FundamentalGroup X x₁) (p : UniversalCover x₁) :
     (basepointChangeHomeomorph gamma).symm (g • p) =
       (FundamentalGroup.fundamentalGroupMulEquivOfPath gamma).symm g •
@@ -161,7 +165,7 @@ theorem basepointChangeHomeomorph_symm_smul (gamma : Path x₀ x₁)
 
 /-- Basepoint change sends the point represented by the changing path to the constant-path point
 over its target. -/
-theorem basepointChangeHomeomorph_apply_self (gamma : Path x₀ x₁) :
+theorem basepointChangeHomeomorph_apply_self (gamma : _root_.Path x₀ x₁) :
     basepointChangeHomeomorph gamma (ofBasedPath x₀ (BasedPath.ofPath gamma)) =
       basepointLift x₁ := by
   rw [ofBasedPath_ofPath, basepointChangeHomeomorph_apply_mk, basepointLift_coe,
@@ -169,7 +173,7 @@ theorem basepointChangeHomeomorph_apply_self (gamma : Path x₀ x₁) :
 
 /-- The basepoint-change homeomorphism is the unique continuous map over `X` that sends the point
 represented by the changing path to the constant-path point. -/
-theorem eq_basepointChangeHomeomorph (gamma : Path x₀ x₁)
+theorem eq_basepointChangeHomeomorph (gamma : _root_.Path x₀ x₁)
     [LocallyPathConnectedSpace X] [SemilocallySimplyConnectedSpace X]
     {f : C(UniversalCover x₀, UniversalCover x₁)}
     (hgamma : f (ofBasedPath x₀ (BasedPath.ofPath gamma)) = basepointLift x₁)
@@ -188,7 +192,7 @@ theorem eq_basepointChangeHomeomorph (gamma : Path x₀ x₁)
     (hgamma.trans (basepointChangeHomeomorph_apply_self gamma).symm))
 
 /-- Homotopic basepoint-change paths induce the same homeomorphism. -/
-theorem basepointChangeHomeomorph_eq_of_homotopic {gamma delta : Path x₀ x₁}
+theorem basepointChangeHomeomorph_eq_of_homotopic {gamma delta : _root_.Path x₀ x₁}
     (h : gamma.Homotopic delta) :
     basepointChangeHomeomorph gamma = basepointChangeHomeomorph delta := by
   apply Homeomorph.ext
@@ -198,17 +202,30 @@ theorem basepointChangeHomeomorph_eq_of_homotopic {gamma delta : Path x₀ x₁}
   exact congrArg (fun r => r.trans q)
     (congrArg Path.Homotopic.Quotient.symm (Quotient.sound h))
 
+end TauCeti.Path
+
+namespace TauCeti.UniversalCover
+
 /-- Changing basepoint along a constant path gives the identity homeomorphism. -/
 @[simp]
 theorem basepointChangeHomeomorph_refl (x : X) :
-    basepointChangeHomeomorph (Path.refl x) = Homeomorph.refl (UniversalCover x) := by
+    TauCeti.Path.basepointChangeHomeomorph (Path.refl x) =
+      Homeomorph.refl (UniversalCover x) := by
   apply Homeomorph.ext
   intro p
   exact prependUniversalCover_refl p
 
+end TauCeti.UniversalCover
+
+namespace TauCeti.Path
+
+open UniversalCover
+
+variable {x₀ x₁ x₂ : X}
+
 /-- Reversing the changing path reverses the basepoint-change homeomorphism. -/
 @[simp]
-theorem basepointChangeHomeomorph_symm (gamma : Path x₀ x₁) :
+theorem basepointChangeHomeomorph_symm (gamma : _root_.Path x₀ x₁) :
     basepointChangeHomeomorph gamma.symm = (basepointChangeHomeomorph gamma).symm := by
   apply Homeomorph.ext
   rintro ⟨x, q⟩
@@ -221,7 +238,8 @@ theorem basepointChangeHomeomorph_symm (gamma : Path x₀ x₁) :
 
 /-- Changing basepoint along a concatenation is the composite of the two basepoint changes. -/
 @[simp]
-theorem basepointChangeHomeomorph_trans (gamma : Path x₀ x₁) (delta : Path x₁ x₂) :
+theorem basepointChangeHomeomorph_trans (gamma : _root_.Path x₀ x₁)
+    (delta : _root_.Path x₁ x₂) :
     basepointChangeHomeomorph (gamma.trans delta) =
       (basepointChangeHomeomorph gamma).trans (basepointChangeHomeomorph delta) := by
   apply Homeomorph.ext
@@ -238,4 +256,4 @@ theorem basepointChangeHomeomorph_trans (gamma : Path x₀ x₁) (delta : Path x
       Path.Homotopic.Quotient.mk_symm, Path.Homotopic.Quotient.mk_symm]
   rw [hsymm, Path.Homotopic.Quotient.trans_assoc]
 
-end TauCeti.UniversalCover
+end TauCeti.Path

--- a/TauCeti/AlgebraicTopology/UniversalCover/BasepointChange.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/BasepointChange.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.AlgebraicTopology.FundamentalGroup.BasepointChange
 public import TauCeti.AlgebraicTopology.UniversalCover.Action
 
 /-!
@@ -21,8 +22,9 @@ Prepending a path and its reverse gives inverse continuous maps, producing
 
 The resulting homeomorphism lies over the identity of the base, sends the point represented by
 `γ` to the constant-path point over `x₁`, depends only on the endpoint-preserving homotopy class
-of `γ`, and respects reflexivity, reversal, and concatenation. These properties make explicit the
-basepoint-change coherence of the based-path universal-cover construction.
+of `γ`, intertwines the fundamental-group actions at its endpoints, and respects reflexivity,
+reversal, and concatenation. These properties make explicit the basepoint-change coherence of the
+based-path universal-cover construction.
 
 ## Main declarations
 
@@ -120,12 +122,45 @@ theorem basepointChangeHomeomorph_symm_apply_ofBasedPath (gamma : Path x₀ x₁
       ofBasedPath x₀ (BasedPath.ofPath (gamma.trans beta.toPath)) :=
   prependUniversalCover_ofBasedPath gamma beta
 
-/-- Basepoint change sends the point represented by the changing path to the constant-path point
-over its target.
+/-- Basepoint change intertwines the fundamental-group actions under the corresponding
+basepoint-change isomorphism of fundamental groups. -/
+@[simp]
+theorem basepointChangeHomeomorph_smul (gamma : Path x₀ x₁)
+    (g : FundamentalGroup X x₀) (p : UniversalCover x₀) :
+    basepointChangeHomeomorph gamma (g • p) =
+      FundamentalGroup.fundamentalGroupMulEquivOfPath gamma g •
+        basepointChangeHomeomorph gamma p := by
+  rcases p with ⟨x, q⟩
+  simp only [smul_mk, basepointChangeHomeomorph_apply_mk]
+  congr 1
+  let f := FundamentalGroup.fundamentalGroupMulEquivOfPath gamma
+  have h := FundamentalGroup.fundamentalGroupMulEquivOfPath_symm_apply gamma (f g⁻¹)
+  rw [MulEquiv.symm_apply_apply, map_inv] at h
+  -- `FundamentalGroup.toPath` is an abbreviation; expose the path-quotient identity supplied
+  -- by the fundamental-group basepoint-change formula.
+  change g⁻¹.toPath = (Path.Homotopic.Quotient.mk gamma).trans
+    ((f g)⁻¹.toPath.trans (Path.Homotopic.Quotient.mk gamma).symm) at h
+  have hprefix : (Path.Homotopic.Quotient.mk gamma).symm.trans g⁻¹.toPath =
+      (f g)⁻¹.toPath.trans (Path.Homotopic.Quotient.mk gamma).symm := by
+    rw [h, ← Path.Homotopic.Quotient.trans_assoc,
+      Path.Homotopic.Quotient.symm_trans, Path.Homotopic.Quotient.refl_trans]
+  rw [← Path.Homotopic.Quotient.trans_assoc, hprefix,
+    Path.Homotopic.Quotient.trans_assoc]
 
-This remains an explicit rewrite theorem: `ofBasedPath_ofPath` and the general
-representative rule already let `simp` prove it, so the `simpNF` linter rejects a redundant
-`@[simp]` annotation. -/
+/-- Inverse basepoint change intertwines the target action with transport back to the source
+fundamental group. -/
+@[simp]
+theorem basepointChangeHomeomorph_symm_smul (gamma : Path x₀ x₁)
+    (g : FundamentalGroup X x₁) (p : UniversalCover x₁) :
+    (basepointChangeHomeomorph gamma).symm (g • p) =
+      (FundamentalGroup.fundamentalGroupMulEquivOfPath gamma).symm g •
+        (basepointChangeHomeomorph gamma).symm p := by
+  apply (basepointChangeHomeomorph gamma).injective
+  rw [Homeomorph.apply_symm_apply, basepointChangeHomeomorph_smul,
+    MulEquiv.apply_symm_apply, Homeomorph.apply_symm_apply]
+
+/-- Basepoint change sends the point represented by the changing path to the constant-path point
+over its target. -/
 theorem basepointChangeHomeomorph_apply_self (gamma : Path x₀ x₁) :
     basepointChangeHomeomorph gamma (ofBasedPath x₀ (BasedPath.ofPath gamma)) =
       basepointLift x₁ := by

--- a/TauCeti/AlgebraicTopology/UniversalCover/BasepointChange.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/BasepointChange.lean
@@ -14,10 +14,10 @@ A path `γ : Path x₀ x₁` identifies the universal covers based at its endpoi
 based-path model, the identification removes the initial path `γ`: it sends the class of a path
 `α` starting at `x₀` to the class of `γ.symm.trans α`, now regarded as a path starting at `x₁`.
 
-The construction uses `TauCeti.Path.prependUniversalCover`, which prepends a fixed path to every
-representative and is continuous for the quotient topology on the universal cover. Prepending a
-path and its reverse gives inverse continuous maps, producing
-`TauCeti.Path.basepointChangeHomeomorph`.
+The construction uses `TauCeti.UniversalCover.prependUniversalCover`, which prepends a fixed path
+to every representative and is continuous for the quotient topology on the universal cover.
+Prepending a path and its reverse gives inverse continuous maps, producing
+`TauCeti.UniversalCover.basepointChangeHomeomorph`.
 
 The resulting homeomorphism lies over the identity of the base, sends the point represented by
 `γ` to the constant-path point over `x₁`, depends only on the endpoint-preserving homotopy class
@@ -26,9 +26,9 @@ basepoint-change coherence of the based-path universal-cover construction.
 
 ## Main declarations
 
-* `TauCeti.Path.basepointChangeHomeomorph`: the homeomorphism between universal covers
+* `TauCeti.UniversalCover.basepointChangeHomeomorph`: the homeomorphism between universal covers
   based at the endpoints of a path.
-* `TauCeti.Path.basepointChangeHomeomorph_trans`: basepoint change respects path
+* `TauCeti.UniversalCover.basepointChangeHomeomorph_trans`: basepoint change respects path
   concatenation.
 
 ## References
@@ -48,9 +48,7 @@ open scoped unitInterval
 
 variable {X : Type*} [TopologicalSpace X]
 
-namespace TauCeti.Path
-
-open UniversalCover
+namespace TauCeti.UniversalCover
 
 variable {x₀ x₁ x₂ : X}
 
@@ -58,22 +56,22 @@ variable {x₀ x₁ x₂ : X}
 the chosen initial path by prepending its reverse; the inverse map prepends the path itself. -/
 def basepointChangeHomeomorph (gamma : Path x₀ x₁) :
     UniversalCover x₀ ≃ₜ UniversalCover x₁ where
-  toFun := TauCeti.Path.prependUniversalCover gamma.symm
-  invFun := TauCeti.Path.prependUniversalCover gamma
+  toFun := prependUniversalCover gamma.symm
+  invFun := prependUniversalCover gamma
   left_inv p := by
     rcases p with ⟨x, q⟩
-    rw [TauCeti.Path.prependUniversalCover_mk, TauCeti.Path.prependUniversalCover_mk]
+    rw [prependUniversalCover_mk, prependUniversalCover_mk]
     congr 1
     rw [Path.Homotopic.Quotient.mk_symm, ← Path.Homotopic.Quotient.trans_assoc,
       Path.Homotopic.Quotient.trans_symm, Path.Homotopic.Quotient.refl_trans]
   right_inv p := by
     rcases p with ⟨x, q⟩
-    rw [TauCeti.Path.prependUniversalCover_mk, TauCeti.Path.prependUniversalCover_mk]
+    rw [prependUniversalCover_mk, prependUniversalCover_mk]
     congr 1
     rw [Path.Homotopic.Quotient.mk_symm, ← Path.Homotopic.Quotient.trans_assoc,
       Path.Homotopic.Quotient.symm_trans, Path.Homotopic.Quotient.refl_trans]
-  continuous_toFun := TauCeti.Path.continuous_prependUniversalCover gamma.symm
-  continuous_invFun := TauCeti.Path.continuous_prependUniversalCover gamma
+  continuous_toFun := continuous_prependUniversalCover gamma.symm
+  continuous_invFun := continuous_prependUniversalCover gamma
 
 /-- Basepoint change prepends the reverse path class to a representative. -/
 @[simp]
@@ -81,8 +79,8 @@ theorem basepointChangeHomeomorph_apply_mk (gamma : Path x₀ x₁) (x : X)
     (q : Path.Homotopic.Quotient x₀ x) :
     basepointChangeHomeomorph gamma (mk x q) =
       mk x ((Path.Homotopic.Quotient.mk gamma).symm.trans q) := by
-  change TauCeti.Path.prependUniversalCover gamma.symm (mk x q) = _
-  rw [TauCeti.Path.prependUniversalCover_mk, Path.Homotopic.Quotient.mk_symm]
+  change prependUniversalCover gamma.symm (mk x q) = _
+  rw [prependUniversalCover_mk, Path.Homotopic.Quotient.mk_symm]
 
 /-- The inverse basepoint change prepends the original path class to a representative. -/
 @[simp]
@@ -90,19 +88,19 @@ theorem basepointChangeHomeomorph_symm_apply_mk (gamma : Path x₀ x₁) (x : X)
     (q : Path.Homotopic.Quotient x₁ x) :
     (basepointChangeHomeomorph gamma).symm (mk x q) =
       mk x ((Path.Homotopic.Quotient.mk gamma).trans q) := by
-  exact TauCeti.Path.prependUniversalCover_mk gamma x q
+  exact prependUniversalCover_mk gamma x q
 
 /-- Basepoint change lies over the identity map of the base. -/
 @[simp]
 theorem proj_basepointChangeHomeomorph (gamma : Path x₀ x₁) (p : UniversalCover x₀) :
     proj (basepointChangeHomeomorph gamma p) = proj p := by
-  exact TauCeti.Path.proj_prependUniversalCover gamma.symm p
+  exact proj_prependUniversalCover gamma.symm p
 
 /-- The inverse basepoint change also lies over the identity map of the base. -/
 @[simp]
 theorem proj_basepointChangeHomeomorph_symm (gamma : Path x₀ x₁) (p : UniversalCover x₁) :
     proj ((basepointChangeHomeomorph gamma).symm p) = proj p := by
-  exact TauCeti.Path.proj_prependUniversalCover gamma p
+  exact proj_prependUniversalCover gamma p
 
 /-- On a based-path representative, basepoint change prepends the reverse of the changing path. -/
 @[simp]
@@ -110,7 +108,7 @@ theorem basepointChangeHomeomorph_apply_ofBasedPath (gamma : Path x₀ x₁)
     (beta : BasedPath x₀) :
     basepointChangeHomeomorph gamma (ofBasedPath x₀ beta) =
       ofBasedPath x₁ (BasedPath.ofPath (gamma.symm.trans beta.toPath)) :=
-  TauCeti.Path.prependUniversalCover_ofBasedPath gamma.symm beta
+  prependUniversalCover_ofBasedPath gamma.symm beta
 
 /-- On a based-path representative, inverse basepoint change prepends the changing path. -/
 @[simp]
@@ -118,7 +116,7 @@ theorem basepointChangeHomeomorph_symm_apply_ofBasedPath (gamma : Path x₀ x₁
     (beta : BasedPath x₁) :
     (basepointChangeHomeomorph gamma).symm (ofBasedPath x₁ beta) =
       ofBasedPath x₀ (BasedPath.ofPath (gamma.trans beta.toPath)) :=
-  TauCeti.Path.prependUniversalCover_ofBasedPath gamma beta
+  prependUniversalCover_ofBasedPath gamma beta
 
 private theorem mem_own_sheet {x : X} {U : Set X} (hxU : x ∈ U)
     (q : Path.Homotopic.Quotient x₀ x) : mk x q ∈ sheet U hxU q := by
@@ -197,7 +195,7 @@ theorem basepointChangeHomeomorph_refl (x : X) :
     basepointChangeHomeomorph (Path.refl x) = Homeomorph.refl (UniversalCover x) := by
   apply Homeomorph.ext
   intro p
-  exact TauCeti.Path.prependUniversalCover_refl p
+  exact prependUniversalCover_refl p
 
 /-- Reversing the changing path reverses the basepoint-change homeomorphism. -/
 @[simp]
@@ -231,4 +229,4 @@ theorem basepointChangeHomeomorph_trans (gamma : Path x₀ x₁) (delta : Path x
       Path.Homotopic.Quotient.mk_symm, Path.Homotopic.Quotient.mk_symm]
   rw [hsymm, Path.Homotopic.Quotient.trans_assoc]
 
-end TauCeti.Path
+end TauCeti.UniversalCover

--- a/TauCeti/AlgebraicTopology/UniversalCover/Basic.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Basic.lean
@@ -32,7 +32,7 @@ the quotient topology coming from the compact-open based-path space.
 ## Main results
 
 * `UniversalCover.isOpenMap_proj`: the endpoint projection is an open map.
-* `UniversalCover.prependUniversalCover`: continuous prepending of a path to universal-cover
+* `TauCeti.Path.prependUniversalCover`: continuous prepending of a path to universal-cover
   representatives.
 * `UniversalCover.toPath_homotopic_of_ofBasedPath_eq` and
   `UniversalCover.ofBasedPath_eq_of_homotopic_toPath`: equality in the universal cover is
@@ -162,15 +162,23 @@ theorem ofBasedPath_eq_of_homotopic_toPath {α β : BasedPath x₀}
 
 variable {x₁ : X}
 
+end UniversalCover
+
+namespace Path
+
+open UniversalCover
+
+variable {x₀ x₁ : X}
+
 /-- Prepend a path from `x₁` to `x₀` to the path class represented by a point of the
 universal cover based at `x₀`. -/
-def prependUniversalCover (gamma : Path x₁ x₀)
+def prependUniversalCover (gamma : _root_.Path x₁ x₀)
     (p : UniversalCover x₀) : UniversalCover x₁ :=
   UniversalCover.mk p.proj ((Path.Homotopic.Quotient.mk gamma).trans p.path)
 
 /-- Prepending to an endpoint-and-path-class pair prepends the corresponding homotopy class. -/
 @[simp]
-theorem prependUniversalCover_mk (gamma : Path x₁ x₀) (x : X)
+theorem prependUniversalCover_mk (gamma : _root_.Path x₁ x₀) (x : X)
     (q : Path.Homotopic.Quotient x₀ x) :
     prependUniversalCover gamma (UniversalCover.mk x q) =
       UniversalCover.mk x ((Path.Homotopic.Quotient.mk gamma).trans q) :=
@@ -178,13 +186,14 @@ theorem prependUniversalCover_mk (gamma : Path x₁ x₀) (x : X)
 
 /-- Prepending a path does not change the endpoint projection. -/
 @[simp]
-theorem proj_prependUniversalCover (gamma : Path x₁ x₀) (p : UniversalCover x₀) :
+theorem proj_prependUniversalCover (gamma : _root_.Path x₁ x₀) (p : UniversalCover x₀) :
     (prependUniversalCover gamma p).proj = p.proj :=
   (rfl)
 
 /-- On the quotient constructor, prepending is represented by concatenating paths. -/
 @[simp]
-theorem prependUniversalCover_ofBasedPath (gamma : Path x₁ x₀) (beta : BasedPath x₀) :
+theorem prependUniversalCover_ofBasedPath (gamma : _root_.Path x₁ x₀)
+    (beta : BasedPath x₀) :
     prependUniversalCover gamma (UniversalCover.ofBasedPath x₀ beta) =
       UniversalCover.ofBasedPath x₁ (BasedPath.ofPath (gamma.trans beta.toPath)) := by
   rw [UniversalCover.ofBasedPath_ofPath, prependUniversalCover_mk,
@@ -193,7 +202,7 @@ theorem prependUniversalCover_ofBasedPath (gamma : Path x₁ x₀) (beta : Based
 /-- Prepending a fixed path is continuous for the quotient topologies on the two universal
 covers. -/
 @[fun_prop]
-theorem continuous_prependUniversalCover (gamma : Path x₁ x₀) :
+theorem continuous_prependUniversalCover (gamma : _root_.Path x₁ x₀) :
     Continuous (prependUniversalCover gamma : UniversalCover x₀ → UniversalCover x₁) := by
   rw [(UniversalCover.isQuotientMap_ofBasedPath x₀).continuous_iff]
   suffices hcont : Continuous (fun beta : BasedPath x₀ =>
@@ -213,23 +222,44 @@ theorem continuous_prependUniversalCover (gamma : Path x₁ x₀) :
     (fun _ => gamma) (Path.continuous_uncurry_iff.mpr continuous_const)
     (fun beta => beta.toPath) heval
 
+end Path
+
+namespace UniversalCover
+
+variable {x₀ : X}
+
 /-- Prepending a constant path is the identity. -/
 @[simp]
 theorem prependUniversalCover_refl (p : UniversalCover x₀) :
-    prependUniversalCover (Path.refl x₀) p = p := by
+    TauCeti.Path.prependUniversalCover (Path.refl x₀) p = p := by
   rcases p with ⟨x, q⟩
-  rw [prependUniversalCover_mk, Path.Homotopic.Quotient.mk_refl,
+  rw [Path.prependUniversalCover_mk, Path.Homotopic.Quotient.mk_refl,
     Path.Homotopic.Quotient.refl_trans]
+
+end UniversalCover
+
+namespace Path
+
+open UniversalCover
+
+variable {x₀ x₁ : X}
 
 /-- Successive prepending combines by path concatenation. -/
 @[simp]
-theorem prependUniversalCover_trans {x₂ : X} (gamma : Path x₂ x₁) (delta : Path x₁ x₀)
+theorem prependUniversalCover_trans {x₂ : X} (gamma : _root_.Path x₂ x₁)
+    (delta : _root_.Path x₁ x₀)
     (p : UniversalCover x₀) :
     prependUniversalCover (gamma.trans delta) p =
       prependUniversalCover gamma (prependUniversalCover delta p) := by
   rcases p with ⟨x, q⟩
   rw [prependUniversalCover_mk, prependUniversalCover_mk, prependUniversalCover_mk,
     Path.Homotopic.Quotient.mk_trans, Path.Homotopic.Quotient.trans_assoc]
+
+end Path
+
+namespace UniversalCover
+
+variable {x₀ x : X}
 
 /-- The endpoint projection `UniversalCover x₀ → X` is an open map when `X` is locally
 path-connected. -/

--- a/TauCeti/AlgebraicTopology/UniversalCover/Basic.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Basic.lean
@@ -32,7 +32,7 @@ the quotient topology coming from the compact-open based-path space.
 ## Main results
 
 * `UniversalCover.isOpenMap_proj`: the endpoint projection is an open map.
-* `TauCeti.Path.prependUniversalCover`: continuous prepending of a path to universal-cover
+* `UniversalCover.prependUniversalCover`: continuous prepending of a path to universal-cover
   representatives.
 * `UniversalCover.toPath_homotopic_of_ofBasedPath_eq` and
   `UniversalCover.ofBasedPath_eq_of_homotopic_toPath`: equality in the universal cover is
@@ -162,23 +162,15 @@ theorem ofBasedPath_eq_of_homotopic_toPath {α β : BasedPath x₀}
 
 variable {x₁ : X}
 
-end UniversalCover
-
-namespace Path
-
-open UniversalCover
-
-variable {x₀ x₁ : X}
-
 /-- Prepend a path from `x₁` to `x₀` to the path class represented by a point of the
 universal cover based at `x₀`. -/
-def prependUniversalCover (gamma : _root_.Path x₁ x₀)
+def prependUniversalCover (gamma : Path x₁ x₀)
     (p : UniversalCover x₀) : UniversalCover x₁ :=
   UniversalCover.mk p.proj ((Path.Homotopic.Quotient.mk gamma).trans p.path)
 
 /-- Prepending to an endpoint-and-path-class pair prepends the corresponding homotopy class. -/
 @[simp]
-theorem prependUniversalCover_mk (gamma : _root_.Path x₁ x₀) (x : X)
+theorem prependUniversalCover_mk (gamma : Path x₁ x₀) (x : X)
     (q : Path.Homotopic.Quotient x₀ x) :
     prependUniversalCover gamma (UniversalCover.mk x q) =
       UniversalCover.mk x ((Path.Homotopic.Quotient.mk gamma).trans q) :=
@@ -186,14 +178,13 @@ theorem prependUniversalCover_mk (gamma : _root_.Path x₁ x₀) (x : X)
 
 /-- Prepending a path does not change the endpoint projection. -/
 @[simp]
-theorem proj_prependUniversalCover (gamma : _root_.Path x₁ x₀) (p : UniversalCover x₀) :
+theorem proj_prependUniversalCover (gamma : Path x₁ x₀) (p : UniversalCover x₀) :
     (prependUniversalCover gamma p).proj = p.proj :=
   (rfl)
 
 /-- On the quotient constructor, prepending is represented by concatenating paths. -/
 @[simp]
-theorem prependUniversalCover_ofBasedPath (gamma : _root_.Path x₁ x₀)
-    (beta : BasedPath x₀) :
+theorem prependUniversalCover_ofBasedPath (gamma : Path x₁ x₀) (beta : BasedPath x₀) :
     prependUniversalCover gamma (UniversalCover.ofBasedPath x₀ beta) =
       UniversalCover.ofBasedPath x₁ (BasedPath.ofPath (gamma.trans beta.toPath)) := by
   rw [UniversalCover.ofBasedPath_ofPath, prependUniversalCover_mk,
@@ -202,7 +193,7 @@ theorem prependUniversalCover_ofBasedPath (gamma : _root_.Path x₁ x₀)
 /-- Prepending a fixed path is continuous for the quotient topologies on the two universal
 covers. -/
 @[fun_prop]
-theorem continuous_prependUniversalCover (gamma : _root_.Path x₁ x₀) :
+theorem continuous_prependUniversalCover (gamma : Path x₁ x₀) :
     Continuous (prependUniversalCover gamma : UniversalCover x₀ → UniversalCover x₁) := by
   rw [(UniversalCover.isQuotientMap_ofBasedPath x₀).continuous_iff]
   suffices hcont : Continuous (fun beta : BasedPath x₀ =>
@@ -222,44 +213,23 @@ theorem continuous_prependUniversalCover (gamma : _root_.Path x₁ x₀) :
     (fun _ => gamma) (Path.continuous_uncurry_iff.mpr continuous_const)
     (fun beta => beta.toPath) heval
 
-end Path
-
-namespace UniversalCover
-
-variable {x₀ : X}
-
 /-- Prepending a constant path is the identity. -/
 @[simp]
 theorem prependUniversalCover_refl (p : UniversalCover x₀) :
-    TauCeti.Path.prependUniversalCover (Path.refl x₀) p = p := by
+    prependUniversalCover (Path.refl x₀) p = p := by
   rcases p with ⟨x, q⟩
-  rw [Path.prependUniversalCover_mk, Path.Homotopic.Quotient.mk_refl,
+  rw [prependUniversalCover_mk, Path.Homotopic.Quotient.mk_refl,
     Path.Homotopic.Quotient.refl_trans]
-
-end UniversalCover
-
-namespace Path
-
-open UniversalCover
-
-variable {x₀ x₁ : X}
 
 /-- Successive prepending combines by path concatenation. -/
 @[simp]
-theorem prependUniversalCover_trans {x₂ : X} (gamma : _root_.Path x₂ x₁)
-    (delta : _root_.Path x₁ x₀)
+theorem prependUniversalCover_trans {x₂ : X} (gamma : Path x₂ x₁) (delta : Path x₁ x₀)
     (p : UniversalCover x₀) :
     prependUniversalCover (gamma.trans delta) p =
       prependUniversalCover gamma (prependUniversalCover delta p) := by
   rcases p with ⟨x, q⟩
   rw [prependUniversalCover_mk, prependUniversalCover_mk, prependUniversalCover_mk,
     Path.Homotopic.Quotient.mk_trans, Path.Homotopic.Quotient.trans_assoc]
-
-end Path
-
-namespace UniversalCover
-
-variable {x₀ x : X}
 
 /-- The endpoint projection `UniversalCover x₀ → X` is an open map when `X` is locally
 path-connected. -/

--- a/TauCeti/AlgebraicTopology/UniversalCover/Basic.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Basic.lean
@@ -32,6 +32,8 @@ the quotient topology coming from the compact-open based-path space.
 ## Main results
 
 * `UniversalCover.isOpenMap_proj`: the endpoint projection is an open map.
+* `UniversalCover.prependUniversalCover`: continuous prepending of a path to universal-cover
+  representatives.
 * `UniversalCover.toPath_homotopic_of_ofBasedPath_eq` and
   `UniversalCover.ofBasedPath_eq_of_homotopic_toPath`: equality in the universal cover is
   equivalent to endpoint-preserving path homotopy of representatives.
@@ -158,6 +160,77 @@ theorem ofBasedPath_eq_of_homotopic_toPath {α β : BasedPath x₀}
   rw [(isQuotientMap_ofBasedPath x₀).continuous_iff]
   exact BasedPath.continuous_endpoint
 
+variable {x₁ : X}
+
+/-- Prepend a path from `x₁` to `x₀` to the path class represented by a point of the
+universal cover based at `x₀`. -/
+def prependUniversalCover (gamma : Path x₁ x₀)
+    (p : UniversalCover x₀) : UniversalCover x₁ :=
+  UniversalCover.mk p.proj ((Path.Homotopic.Quotient.mk gamma).trans p.path)
+
+/-- Prepending to an endpoint-and-path-class pair prepends the corresponding homotopy class. -/
+@[simp]
+theorem prependUniversalCover_mk (gamma : Path x₁ x₀) (x : X)
+    (q : Path.Homotopic.Quotient x₀ x) :
+    prependUniversalCover gamma (UniversalCover.mk x q) =
+      UniversalCover.mk x ((Path.Homotopic.Quotient.mk gamma).trans q) :=
+  (rfl)
+
+/-- Prepending a path does not change the endpoint projection. -/
+@[simp]
+theorem proj_prependUniversalCover (gamma : Path x₁ x₀) (p : UniversalCover x₀) :
+    (prependUniversalCover gamma p).proj = p.proj :=
+  (rfl)
+
+/-- On the quotient constructor, prepending is represented by concatenating paths. -/
+@[simp]
+theorem prependUniversalCover_ofBasedPath (gamma : Path x₁ x₀) (beta : BasedPath x₀) :
+    prependUniversalCover gamma (UniversalCover.ofBasedPath x₀ beta) =
+      UniversalCover.ofBasedPath x₁ (BasedPath.ofPath (gamma.trans beta.toPath)) := by
+  rw [UniversalCover.ofBasedPath_ofPath, prependUniversalCover_mk,
+    UniversalCover.ofBasedPath_def, Path.Homotopic.Quotient.mk_trans]
+
+/-- Prepending a fixed path is continuous for the quotient topologies on the two universal
+covers. -/
+@[fun_prop]
+theorem continuous_prependUniversalCover (gamma : Path x₁ x₀) :
+    Continuous (prependUniversalCover gamma : UniversalCover x₀ → UniversalCover x₁) := by
+  rw [(UniversalCover.isQuotientMap_ofBasedPath x₀).continuous_iff]
+  suffices hcont : Continuous (fun beta : BasedPath x₀ =>
+      UniversalCover.ofBasedPath x₁ (BasedPath.ofPath (gamma.trans beta.toPath))) by
+    apply hcont.congr
+    intro beta
+    simpa only [Function.comp_apply] using (prependUniversalCover_ofBasedPath gamma beta).symm
+  refine (UniversalCover.continuous_ofBasedPath x₁).comp (Continuous.subtype_mk ?_ _)
+  refine ContinuousMap.continuous_of_continuous_uncurry _ ?_
+  have heval : Continuous fun p : BasedPath x₀ × unitInterval => p.1.1 p.2 :=
+    continuous_eval.comp (continuous_subtype_val.prodMap continuous_id)
+  -- Unfolding the path wrappers identifies the uncurried goal with concatenation.
+  change Continuous fun p : BasedPath x₀ × unitInterval => gamma.trans p.1.toPath p.2
+  exact Path.trans_continuous_family (a := fun _ : BasedPath x₀ => x₁)
+    (b := fun _ : BasedPath x₀ => x₀)
+    (c := fun beta : BasedPath x₀ => BasedPath.endpoint beta)
+    (fun _ => gamma) (Path.continuous_uncurry_iff.mpr continuous_const)
+    (fun beta => beta.toPath) heval
+
+/-- Prepending a constant path is the identity. -/
+@[simp]
+theorem prependUniversalCover_refl (p : UniversalCover x₀) :
+    prependUniversalCover (Path.refl x₀) p = p := by
+  rcases p with ⟨x, q⟩
+  rw [prependUniversalCover_mk, Path.Homotopic.Quotient.mk_refl,
+    Path.Homotopic.Quotient.refl_trans]
+
+/-- Successive prepending combines by path concatenation. -/
+@[simp]
+theorem prependUniversalCover_trans {x₂ : X} (gamma : Path x₂ x₁) (delta : Path x₁ x₀)
+    (p : UniversalCover x₀) :
+    prependUniversalCover (gamma.trans delta) p =
+      prependUniversalCover gamma (prependUniversalCover delta p) := by
+  rcases p with ⟨x, q⟩
+  rw [prependUniversalCover_mk, prependUniversalCover_mk, prependUniversalCover_mk,
+    Path.Homotopic.Quotient.mk_trans, Path.Homotopic.Quotient.trans_assoc]
+
 /-- The endpoint projection `UniversalCover x₀ → X` is an open map when `X` is locally
 path-connected. -/
 theorem isOpenMap_proj [LocallyPathConnectedSpace X] (x₀ : X) :
@@ -279,6 +352,18 @@ theorem mem_sheet_self {U : Set X} (hxU : x ∈ U) (p : Path x₀ x) :
     ofBasedPath x₀ (BasedPath.ofPath p) ∈ sheet U hxU (Path.Homotopic.Quotient.mk p) :=
   ⟨BasedPath.ofPath p, mem_pathComponentIn_self
     (by simpa using hxU), rfl⟩
+
+/-- A point represented by `q` belongs to the sheet indexed by `q`. -/
+theorem mk_mem_sheet {U : Set X} (hxU : x ∈ U) (q : Path.Homotopic.Quotient x₀ x) :
+    mk x q ∈ sheet U hxU q := by
+  induction q using Quotient.inductionOn with
+  | h gamma =>
+      -- Quotient induction exposes `q` as a raw quotient class, while `sheet` expects the
+      -- endpoint-indexed alias; `change` aligns those definitionally equal presentations.
+      change mk x (Path.Homotopic.Quotient.mk gamma) ∈
+        sheet U hxU (Path.Homotopic.Quotient.mk gamma)
+      rw [← ofBasedPath_ofPath gamma]
+      exact mem_sheet_self hxU gamma
 
 /-- Sheet surjection onto `U`: every point of `U` is the projection of a point of the sheet. -/
 theorem proj_surjOn_sheet {U : Set X} (hU_pathConn : IsPathConnected U)

--- a/TauCeti/AlgebraicTopology/UniversalCover/Covering.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Covering.lean
@@ -41,6 +41,37 @@ namespace TauCeti.UniversalCover
 
 variable {x₀ x : X}
 
+/-- The universal-cover projection is locally injective under the local hypotheses. -/
+theorem isLocallyInjective_proj [LocallyPathConnectedSpace X]
+    [SemilocallySimplyConnectedSpace X] (x₀ : X) :
+    IsLocallyInjective (proj : UniversalCover x₀ → X) := by
+  rintro ⟨x, q⟩
+  obtain ⟨U, hU_open, hxU, _hU_pathConn, hU_slsc⟩ :=
+    exists_isOpen_mem_isPathConnected_isPathHomotopyTrivial x
+  exact ⟨sheet U hxU q, isOpen_sheet U hU_open hxU q, mk_mem_sheet hxU q,
+    proj_injOn_sheet hU_slsc hxU q⟩
+
+/-- The universal-cover projection is a separated map under the local hypotheses. -/
+theorem isSeparatedMap_proj [LocallyPathConnectedSpace X]
+    [SemilocallySimplyConnectedSpace X] (x₀ : X) :
+    IsSeparatedMap (proj : UniversalCover x₀ → X) := by
+  rintro ⟨x, q₁⟩ ⟨y, q₂⟩ hxy hne
+  -- After pattern matching the two cover points, their projected equality is definitionally
+  -- the equality of the displayed endpoints; no separate `proj_mk` lemma is generated.
+  change x = y at hxy
+  subst y
+  obtain ⟨U, hU_open, hxU, _hU_pathConn, hU_slsc⟩ :=
+    exists_isOpen_mem_isPathConnected_isPathHomotopyTrivial x
+  have hq : q₁ ≠ q₂ := by
+    intro h
+    apply hne
+    subst h
+    rfl
+  exact ⟨sheet U hxU q₁, sheet U hxU q₂,
+    isOpen_sheet U hU_open hxU q₁, isOpen_sheet U hU_open hxU q₂,
+    mk_mem_sheet hxU q₁, mk_mem_sheet hxU q₂,
+    pairwise_disjoint_sheet hU_slsc hxU hq⟩
+
 /-- The endpoint projection `proj` is a covering map, assuming `X` is semilocally simply
 connected, locally path-connected, and path-connected. -/
 theorem isCoveringMap [LocallyPathConnectedSpace X] [PathConnectedSpace X]


### PR DESCRIPTION
This PR makes basepoint change explicit for the based-path universal cover: a path `γ : Path x₀ x₁` induces a homeomorphism `UniversalCover x₀ ≃ₜ UniversalCover x₁` over `X` by prepending `γ.symm` to path classes. It advances the exact `UniversalCovers/README.md` “Standing hypotheses and basepoint policy” target, specifically its requirement to “build the API for basepoint change along a path” and isomorphism of covers over `X`. The designated milestone is the standing basepoint policy. After this PR, its path-level universal-cover isomorphism requirement is complete; no further work remains on that requirement.

This is the most effective current step because the numbered universal-cover construction, deck-group, classification, higher-homotopy, and application stages are already on `main`, as are fundamental-group and recovered-subgroup transport along a path, while the roadmap’s promised path-indexed isomorphism between the universal-cover spaces themselves was still absent. The construction is explicit rather than choice-based, so its identity, reversal, homotopy-invariance, and concatenation laws are available to later basepoint-sensitive arguments.

The new `TauCeti/AlgebraicTopology/UniversalCover/BasepointChange.lean` module has 256 lines. It introduces continuous path prepending with rules on both universal-cover constructors, packages prepending by a path and its reverse as inverse continuous maps, proves projection compatibility in both directions, characterizes the map on based-path representatives, and proves the uniqueness and coherence laws. The homeomorphism itself requires only a topological space; the standing path-connected, locally path-connected, and semilocally simply connected hypotheses occur only in the uniqueness theorem that invokes covering-map uniqueness.

The mathematics follows Hatcher, *Algebraic Topology*, Section 1.3. The continuity proof generalizes the fixed-loop argument in `TauCeti.AlgebraicTopology.UniversalCover.Action`, which was adapted from Kim Morrison’s mathlib4#38292; both sources are cited in the module. No Mathlib infrastructure is vendored.

Roadmap: UniversalCovers

<!--tauceti-target:v1 {"focus":"UniversalCovers","id":"universal-cover-basepoint-change"}-->

🤖 Prepared with Codex
