### PR TITLE
refactor(ModularForms): expose the lower-right entry of the descent witness

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/Newforms/Descent/Action.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Descent/Action.lean
@@ -39,7 +39,8 @@ representative, `descendExtraGamma`, and the argument is different; that case is
 * `TauCeti.cast_descendShift`: transported to `Fin p`, it is `upperTriShift`.
 * `TauCeti.descendShift_bijective`: it is a bijection of the index set.
 * `TauCeti.exists_mem_Gamma0_descendMatrix_mul`:
-  `descendMatrix p N v * γ = α * descendMatrix p N (shift v)` for some `α ∈ Γ₀(N)`.
+  `descendMatrix p N v * γ = α * descendMatrix p N (shift v)` for some `α ∈ Γ₀(N)` whose
+  lower-right entry is `γ 1 1 - γ 1 0 * shift v`.
 
 ## Scope
 
@@ -103,11 +104,18 @@ product `descendMatrix p N v * γ` is an element of `Γ₀(N)` times the member 
 `descendShift p N hpsq γ v` — and that map is a bijection, by `descendShift_bijective`.
 
 The target index is named rather than existentially quantified, because reindexing the descent's
-slash sum needs the permutation itself, not merely that some member of the family appears. -/
+slash sum needs the permutation itself, not merely that some member of the family appears.
+
+The lower-right entry of `α` is given as an equation, as `exists_mem_Gamma0_upperTriRep_mul`
+gives it, rather than as a congruence: the modulus at which it is useful varies with the caller.
+Transporting a nebentypus through the descent reads off from it that `α` and `γ` agree modulo
+`N / p`, since `N / p ∣ γ 1 0`. -/
 theorem exists_mem_Gamma0_descendMatrix_mul (p N : ℕ) [NeZero p] (hpsq : p ^ 2 ∣ N)
     {γ : SL(2, ℤ)} (hγ : γ ∈ Gamma0 (N / p)) (v : Fin (descendMatrixCount p N)) :
-    ∃ α : SL(2, ℤ), α ∈ Gamma0 N ∧ descendMatrix p N v * mapGL ℝ γ =
-      mapGL ℝ α * descendMatrix p N (descendShift p N hpsq γ v) := by
+    ∃ α : SL(2, ℤ), α ∈ Gamma0 N ∧
+      (α 1 1 : ℤ) = γ 1 1 - γ 1 0 * ((descendShift p N hpsq γ v : ℕ) : ℤ) ∧
+      descendMatrix p N v * mapGL ℝ γ =
+        mapGL ℝ α * descendMatrix p N (descendShift p N hpsq γ v) := by
   have hpN : p ∣ N := dvd_trans (dvd_pow_self p two_ne_zero) hpsq
   have hcount : descendMatrixCount p N = p := descendMatrixCount_of_sq_dvd hpsq
   have hv : v.val < p := lt_of_lt_of_le v.isLt hcount.le
@@ -118,7 +126,7 @@ theorem exists_mem_Gamma0_descendMatrix_mul (p N : ℕ) [NeZero p] (hpsq : p ^ 2
       exact_mod_cast (Nat.mul_div_cancel' hpN).symm
     rw [hpNp]
     exact mul_dvd_mul_left _ ((ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mp (Gamma0_mem.mp hγ))
-  obtain ⟨α, hα, _, hmul⟩ :=
+  obtain ⟨α, hα, hd, hmul⟩ :=
     exists_mem_Gamma0_upperTriRep_mul
       (Gamma0_le_Gamma0_of_dvd (Nat.dvd_div_of_mul_dvd (by rwa [← pow_two])) hγ) hpc ⟨v.val, hv⟩
   have hv' : ((descendShift p N hpsq γ v : Fin (descendMatrixCount p N)) : ℕ) < p :=
@@ -126,9 +134,11 @@ theorem exists_mem_Gamma0_descendMatrix_mul (p N : ℕ) [NeZero p] (hpsq : p ^ 2
   -- the target index, named rather than left to definitional reduction through `finCongr`
   have htgt : (⟨(descendShift p N hpsq γ v : ℕ), hv'⟩ : Fin p) = upperTriShift p γ ⟨v.val, hv⟩ :=
     Fin.ext (descendShift_val hpsq γ v)
-  refine ⟨α, hα, ?_⟩
+  refine ⟨α, hα, ?_, ?_⟩
+  · rw [hd]
+    exact congrArg (fun n : ℕ ↦ (γ 1 1 : ℤ) - γ 1 0 * (n : ℤ)) (congrArg Fin.val htgt).symm
   -- the real identity is the image of the rational one under `GL₂(ℚ) → GL₂(ℝ)`
-  simpa only [descendMatrix_of_lt hv, descendMatrix_of_lt hv', htgt, map_mul, map_mapGL]
-    using congrArg (Matrix.GeneralLinearGroup.map (algebraMap ℚ ℝ)) hmul
+  · simpa only [descendMatrix_of_lt hv, descendMatrix_of_lt hv', htgt, map_mul, map_mapGL]
+      using congrArg (Matrix.GeneralLinearGroup.map (algebraMap ℚ ℝ)) hmul
 
 end TauCeti


### PR DESCRIPTION
Strengthens `TauCeti.exists_mem_Gamma0_descendMatrix_mul` (from #6152) so that the `Γ₀(N)` witness `α` in `descendMatrix p N v * γ = α * descendMatrix p N (descendShift p N hpsq γ v)` comes with its lower-right entry:

```
(α 1 1 : ℤ) = γ 1 1 - γ 1 0 * ((descendShift p N hpsq γ v : ℕ) : ℤ)
```

The proof already had this fact — `HeckeRing.GL2.exists_mem_Gamma0_upperTriRep_mul` returns the entry of its witness as an equation — and discarded it (`obtain ⟨α, hα, _, hmul⟩`). It is now carried through, rewritten along `descendShift_val`, in the same form the upper-triangular factorisation uses ("an equation rather than a congruence, because the modulus at which it is useful varies with the caller").

Why it is needed: transporting a nebentypus through the descent (the `descendCosetList_action` "diamond compatibility" `ZMod.unitsMap (Gamma0MapUnits α_v) = Gamma0MapUnits γ'` that `miyake_hecke_descend_char` consumes) requires that `α` and `γ` agree modulo `N / p`, which follows from this equation and `N / p ∣ γ 1 0`. Without it the descent slash sum (#6242) can only be shown invariant with one scalar for all of `Γ₀(N)`, i.e. for trivial character.

No new declarations; no proof of a new mathematical statement beyond the strengthened conclusion. Module docstring and theorem docstring updated to match.

Roadmap: ModularForms

No `tauceti-target:v1` marker: this modestly strengthens an already-merged lemma, a prerequisite for the Layer 4 Atkin–Lehner Main Lemma node (the per-character route `mainLemma_charSpace_routeB`, which the roadmap records as "Miyake's sieve/conductor descent") rather than the node itself, and the contract asks for a deterministic target identifier, not an invented one.

Provenance: github.com/CBirkbeck/AINTLIB @ `2baa76f742bdb4fb8ee323fabba41203bd390e08` (Apache-2.0, Chris Birkbeck), `projects/LeanModularForms/LeanModularForms/StrongMultiplicityOne/DescentCosets.lean` — the second conjunct of `descendCosetList_action` (the `Gamma0MapUnits` compatibility), specialised to `p² ∣ N` and stated as the integer entry equation rather than as an equality of units.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQieFQn95rzgvYRvNdX3hR
