### PR TITLE
feat: construct Cholesky factors

### DIFF
--- a/TauCeti/Analysis/InnerProductSpace/GramSchmidtOrtho.lean
+++ b/TauCeti/Analysis/InnerProductSpace/GramSchmidtOrtho.lean
@@ -1,0 +1,51 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.InnerProductSpace.GramSchmidtOrtho
+
+/-!
+# The diagonal coefficient of the Gram-Schmidt process
+
+Mathlib's `InnerProductSpace.gramSchmidt_triangular` records that, in the basis `b` it is fed,
+`gramSchmidt 𝕜 b i` has no component along `b j` for `i < j`.  This file supplies the diagonal
+companion: the component along `b i` itself is `1`, because the Gram-Schmidt step subtracts from
+`b i` only vectors spanned by the earlier basis vectors.  Together the two say that the matrix of
+the Gram-Schmidt process is lower unitriangular.
+
+## Main results
+
+* `TauCeti.InnerProductSpace.repr_gramSchmidt_self_eq_one` — the Gram-Schmidt process leaves the
+  coefficient of a basis vector along itself equal to `1`.
+-/
+
+public section
+
+open Finset InnerProductSpace Module
+
+namespace TauCeti
+
+namespace InnerProductSpace
+
+variable {𝕜 E : Type*} [RCLike 𝕜] [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
+variable {ι : Type*} [LinearOrder ι] [LocallyFiniteOrderBot ι] [WellFoundedLT ι]
+
+/-- The Gram-Schmidt process does not change the coefficient of a basis vector along itself:
+`gramSchmidt 𝕜 b i` differs from `b i` by a combination of the strictly earlier `gramSchmidt`
+vectors, each of which has no component along `b i`. -/
+theorem repr_gramSchmidt_self_eq_one (b : Basis ι 𝕜 E) (i : ι) :
+    b.repr (gramSchmidt 𝕜 b i) i = 1 := by
+  have h := congrArg (fun x ↦ b.repr x i) (gramSchmidt_def'' 𝕜 (b : ι → E) i)
+  simp only [Basis.repr_self, Finsupp.single_eq_same, map_add, map_sum, map_smul,
+    Finsupp.add_apply, Finsupp.coe_finsetSum, Finset.sum_apply, Finsupp.smul_apply,
+    smul_eq_mul] at h
+  rw [Finset.sum_eq_zero (fun j hj ↦ ?_), add_zero] at h
+  · exact h.symm
+  · rw [gramSchmidt_triangular (Finset.mem_Iio.mp hj) b, mul_zero]
+
+end InnerProductSpace
+
+end TauCeti

--- a/TauCeti/Analysis/InnerProductSpace/GramSchmidtOrtho.lean
+++ b/TauCeti/Analysis/InnerProductSpace/GramSchmidtOrtho.lean
@@ -36,6 +36,7 @@ variable {ι : Type*} [LinearOrder ι] [LocallyFiniteOrderBot ι] [WellFoundedLT
 /-- The Gram-Schmidt process does not change the coefficient of a basis vector along itself:
 `gramSchmidt 𝕜 b i` differs from `b i` by a combination of the strictly earlier `gramSchmidt`
 vectors, each of which has no component along `b i`. -/
+@[simp]
 theorem repr_gramSchmidt_self_eq_one (b : Basis ι 𝕜 E) (i : ι) :
     b.repr (gramSchmidt 𝕜 b i) i = 1 := by
   have h := congrArg (fun x ↦ b.repr x i) (gramSchmidt_def'' 𝕜 (b : ι → E) i)

--- a/TauCeti/Analysis/InnerProductSpace/GramSchmidtOrtho.lean
+++ b/TauCeti/Analysis/InnerProductSpace/GramSchmidtOrtho.lean
@@ -18,8 +18,8 @@ the Gram-Schmidt process is lower unitriangular.
 
 ## Main results
 
-* `TauCeti.InnerProductSpace.repr_gramSchmidt_self_eq_one` — the Gram-Schmidt process leaves the
-  coefficient of a basis vector along itself equal to `1`.
+* `Module.Basis.repr_gramSchmidt_self_eq_one` — the Gram-Schmidt process leaves the coefficient of a
+  basis vector along itself equal to `1`.
 -/
 
 public section
@@ -28,8 +28,6 @@ open Finset InnerProductSpace Module
 
 namespace TauCeti
 
-namespace InnerProductSpace
-
 variable {𝕜 E : Type*} [RCLike 𝕜] [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
 variable {ι : Type*} [LinearOrder ι] [LocallyFiniteOrderBot ι] [WellFoundedLT ι]
 
@@ -37,7 +35,7 @@ variable {ι : Type*} [LinearOrder ι] [LocallyFiniteOrderBot ι] [WellFoundedLT
 `gramSchmidt 𝕜 b i` differs from `b i` by a combination of the strictly earlier `gramSchmidt`
 vectors, each of which has no component along `b i`. -/
 @[simp]
-theorem repr_gramSchmidt_self_eq_one (b : Basis ι 𝕜 E) (i : ι) :
+theorem _root_.Module.Basis.repr_gramSchmidt_self_eq_one (b : Basis ι 𝕜 E) (i : ι) :
     b.repr (gramSchmidt 𝕜 b i) i = 1 := by
   have h := congrArg (fun x ↦ b.repr x i) (gramSchmidt_def'' 𝕜 (b : ι → E) i)
   simp only [Basis.repr_self, Finsupp.single_eq_same, map_add, map_sum, map_smul,
@@ -46,7 +44,5 @@ theorem repr_gramSchmidt_self_eq_one (b : Basis ι 𝕜 E) (i : ι) :
   rw [Finset.sum_eq_zero (fun j hj ↦ ?_), add_zero] at h
   · exact h.symm
   · rw [gramSchmidt_triangular (Finset.mem_Iio.mp hj) b, mul_zero]
-
-end InnerProductSpace
 
 end TauCeti

--- a/TauCeti/Analysis/Matrix/LDL.lean
+++ b/TauCeti/Analysis/Matrix/LDL.lean
@@ -52,7 +52,7 @@ theorem LDL.lowerInv_apply_diag (i : n) : LDL.lowerInv hS i i = 1 := by
   let := Sᵀ.toInnerProductSpace hS.transpose.posSemidef
   rw [LDL.lowerInv]
   simpa only [Pi.basisFun_repr] using
-    TauCeti.InnerProductSpace.repr_gramSchmidt_self_eq_one (Pi.basisFun 𝕜 n) i
+    (Pi.basisFun 𝕜 n).repr_gramSchmidt_self_eq_one i
 
 /-- The lower factor in Mathlib's LDL decomposition carries `1` on the diagonal, being the
 inverse of a matrix that does. -/

--- a/TauCeti/Analysis/Matrix/LDL.lean
+++ b/TauCeti/Analysis/Matrix/LDL.lean
@@ -19,9 +19,9 @@ on the diagonal, so the lower factor of the decomposition is unitriangular.
 
 ## Main results
 
-* `TauCeti.Matrix.LDL.diagEntries_pos` — the diagonal entries of `D` are positive.
-* `TauCeti.Matrix.LDL.lowerInv_apply_diag` and `TauCeti.Matrix.LDL.lower_apply_diag` — the lower
-  factor of the LDL decomposition and its inverse are unitriangular.
+* `LDL.diagEntries_pos` — the diagonal entries of `D` are positive.
+* `LDL.lowerInv_apply_diag` and `LDL.lower_apply_diag` — the lower factor of the LDL
+  decomposition and its inverse are unitriangular.
 -/
 
 public section
@@ -30,14 +30,12 @@ open scoped ComplexOrder Matrix
 
 namespace TauCeti
 
-namespace Matrix
-
 variable {𝕜 n : Type*} [RCLike 𝕜] [LinearOrder n] [WellFoundedLT n]
   [LocallyFiniteOrderBot n] [Fintype n] {S : Matrix n n 𝕜} (hS : S.PosDef)
 
 /-- The diagonal entries in Mathlib's LDL decomposition of a positive-definite matrix are
 positive. -/
-theorem LDL.diagEntries_pos (i : n) : 0 < LDL.diagEntries hS i := by
+theorem _root_.LDL.diagEntries_pos (i : n) : 0 < LDL.diagEntries hS i := by
   have hdiag : (LDL.diag hS).PosDef := by
     rw [LDL.diag_eq_lowerInv_conj]
     exact hS.mul_mul_conjTranspose_same
@@ -47,7 +45,7 @@ theorem LDL.diagEntries_pos (i : n) : 0 < LDL.diagEntries hS i := by
 /-- The lower factor in Mathlib's LDL decomposition is unitriangular: its inverse is the
 Gram-Schmidt matrix, which carries `1` on the diagonal. -/
 @[simp]
-theorem LDL.lowerInv_apply_diag (i : n) : LDL.lowerInv hS i i = 1 := by
+theorem _root_.LDL.lowerInv_apply_diag (i : n) : LDL.lowerInv hS i i = 1 := by
   let := Sᵀ.toNormedAddCommGroup hS.transpose
   let := Sᵀ.toInnerProductSpace hS.transpose.posSemidef
   rw [LDL.lowerInv]
@@ -57,13 +55,11 @@ theorem LDL.lowerInv_apply_diag (i : n) : LDL.lowerInv hS i i = 1 := by
 /-- The lower factor in Mathlib's LDL decomposition carries `1` on the diagonal, being the
 inverse of a matrix that does. -/
 @[simp]
-theorem LDL.lower_apply_diag (i : n) : LDL.lower hS i i = 1 := by
+theorem _root_.LDL.lower_apply_diag (i : n) : LDL.lower hS i i = 1 := by
   have htri : (LDL.lowerInv hS)ᵀ.IsUpperTriangular :=
     (LDL.isLowerTriangular_lowerInv hS).transpose
   have hinv := Matrix.inv_apply_diag_of_isUpperTriangular htri
     (LDL.lowerInv_apply_diag hS i)
   simpa [LDL.lower, ← Matrix.transpose_nonsing_inv] using hinv
-
-end Matrix
 
 end TauCeti

--- a/TauCeti/Analysis/Matrix/LDL.lean
+++ b/TauCeti/Analysis/Matrix/LDL.lean
@@ -1,0 +1,69 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.Matrix.LDL
+import TauCeti.Analysis.InnerProductSpace.GramSchmidtOrtho
+import TauCeti.LinearAlgebra.Matrix.Triangular
+
+/-!
+# The diagonals of the LDL decomposition
+
+Mathlib's LDL decomposition writes a positive-definite matrix `S` as `L * D * Lᴴ` with `L` lower
+triangular and `D` diagonal, but records nothing about the individual diagonal entries. This file
+supplies them: the diagonal of `D` is positive, and both `LDL.lowerInv` and `LDL.lower` carry `1`
+on the diagonal, so the lower factor of the decomposition is unitriangular.
+
+## Main results
+
+* `TauCeti.Matrix.LDL.diagEntries_pos` — the diagonal entries of `D` are positive.
+* `TauCeti.Matrix.LDL.lowerInv_apply_diag` and `TauCeti.Matrix.LDL.lower_apply_diag` — the lower
+  factor of the LDL decomposition and its inverse are unitriangular.
+-/
+
+public section
+
+open scoped ComplexOrder Matrix
+
+namespace TauCeti
+
+namespace Matrix
+
+variable {𝕜 n : Type*} [RCLike 𝕜] [LinearOrder n] [WellFoundedLT n]
+  [LocallyFiniteOrderBot n] [Fintype n] {S : Matrix n n 𝕜} (hS : S.PosDef)
+
+/-- The diagonal entries in Mathlib's LDL decomposition of a positive-definite matrix are
+positive. -/
+theorem LDL.diagEntries_pos (i : n) : 0 < LDL.diagEntries hS i := by
+  have hdiag : (LDL.diag hS).PosDef := by
+    rw [LDL.diag_eq_lowerInv_conj]
+    exact hS.mul_mul_conjTranspose_same
+      (Matrix.vecMul_injective_of_invertible (LDL.lowerInv hS))
+  simpa [LDL.diag] using hdiag.diag_pos (i := i)
+
+/-- The lower factor in Mathlib's LDL decomposition is unitriangular: its inverse is the
+Gram-Schmidt matrix, which carries `1` on the diagonal. -/
+@[simp]
+theorem LDL.lowerInv_apply_diag (i : n) : LDL.lowerInv hS i i = 1 := by
+  let := Sᵀ.toNormedAddCommGroup hS.transpose
+  let := Sᵀ.toInnerProductSpace hS.transpose.posSemidef
+  rw [LDL.lowerInv]
+  simpa only [Pi.basisFun_repr] using
+    TauCeti.InnerProductSpace.repr_gramSchmidt_self_eq_one (Pi.basisFun 𝕜 n) i
+
+/-- The lower factor in Mathlib's LDL decomposition carries `1` on the diagonal, being the
+inverse of a matrix that does. -/
+@[simp]
+theorem LDL.lower_apply_diag (i : n) : LDL.lower hS i i = 1 := by
+  have htri : (LDL.lowerInv hS)ᵀ.IsUpperTriangular :=
+    (LDL.isLowerTriangular_lowerInv hS).transpose
+  have hinv := Matrix.inv_apply_diag_of_isUpperTriangular htri
+    (LDL.lowerInv_apply_diag hS i)
+  simpa [LDL.lower, ← Matrix.transpose_nonsing_inv] using hinv
+
+end Matrix
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/Matrix/Cholesky/Basic.lean
+++ b/TauCeti/LinearAlgebra/Matrix/Cholesky/Basic.lean
@@ -1,0 +1,173 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.Matrix.LDL
+public import TauCeti.LinearAlgebra.Matrix.Triangular
+public import TauCeti.MeasureTheory.Measure.SymmetricMatrix.PosDef
+import Mathlib.Algebra.Order.Star.Real
+
+/-!
+# Cholesky factors of positive-definite real matrices
+
+This file constructs the lower-triangular Cholesky factor of a positive-definite real matrix
+from Mathlib's LDL decomposition.  The diagonal of the LDL factor is positive, so taking its
+entrywise square root and absorbing it into the lower factor gives `S = L * Lᵀ`, with `L` lower
+triangular and positive on the diagonal.
+
+## Main definitions
+
+* `TauCeti.PosDefMatrix` is the positive-definite cone in the space of real symmetric matrices.
+* `TauCeti.PosDiagLowerTriangular` is the space of lower-triangular real matrices with positive
+  diagonal.
+* `TauCeti.cholesky` constructs the Cholesky factor of a positive-definite matrix.
+* `TauCeti.cholesky_mul_transpose` proves the Cholesky reconstruction identity.
+
+## References
+
+* R. A. Horn and C. R. Johnson, *Matrix Analysis*, second edition, Cambridge University Press,
+  2013, Section 7.2.
+* `TauCetiRoadmap/StandardDistributions/README.md`, Layer 6, item 2, "Cholesky decomposition".
+-/
+
+public section
+
+noncomputable section
+
+open scoped Matrix
+
+namespace TauCeti
+
+/-- The cone of positive-definite real symmetric matrices of size `p`. -/
+abbrev PosDefMatrix (p : ℕ) :=
+  {A : selfAdjoint.submodule ℝ (Matrix (Fin p) (Fin p) ℝ) //
+    (A : Matrix (Fin p) (Fin p) ℝ).PosDef}
+
+/-- Lower-triangular real matrices of size `p` whose diagonal entries are positive. -/
+abbrev PosDiagLowerTriangular (p : ℕ) :=
+  {L : Matrix (Fin p) (Fin p) ℝ // L.IsLowerTriangular ∧ ∀ i, 0 < L i i}
+
+namespace Matrix
+
+variable {p : ℕ} {S : Matrix (Fin p) (Fin p) ℝ} (hS : S.PosDef)
+
+/-- The diagonal entries in Mathlib's LDL decomposition of a positive-definite real matrix are
+positive. -/
+theorem LDL.diagEntries_pos (i : Fin p) : 0 < LDL.diagEntries hS i := by
+  have hdiag : (LDL.diag hS).PosDef := by
+    rw [LDL.diag_eq_lowerInv_conj]
+    exact hS.mul_mul_conjTranspose_same
+      (Matrix.vecMul_injective_of_invertible (LDL.lowerInv hS))
+  simpa [LDL.diag] using hdiag.diag_pos (i := i)
+
+private theorem LDL.lowerInv_apply_diag (i : Fin p) : LDL.lowerInv hS i i = 1 := by
+  let := Sᵀ.toNormedAddCommGroup hS.transpose
+  let := Sᵀ.toInnerProductSpace hS.transpose.posSemidef
+  rw [LDL.lowerInv, InnerProductSpace.gramSchmidt_def]
+  simp only [Pi.basisFun_apply, Pi.sub_apply, Pi.single_eq_same]
+  rw [Finset.sum_apply]
+  rw [sub_eq_self]
+  apply Finset.sum_eq_zero
+  intro j hj
+  rw [Submodule.starProjection_singleton]
+  simp only [Pi.smul_apply, smul_eq_mul]
+  apply mul_eq_zero_of_right
+  simpa only [Pi.basisFun_repr] using
+    InnerProductSpace.gramSchmidt_triangular (Finset.mem_Iio.mp hj)
+      (Pi.basisFun ℝ (Fin p))
+
+private theorem LDL.lower_apply_diag (i : Fin p) : LDL.lower hS i i = 1 := by
+  have htri : (LDL.lowerInv hS)ᵀ.IsUpperTriangular :=
+    (LDL.isLowerTriangular_lowerInv hS).transpose
+  have hinv := Matrix.inv_apply_diag_of_isUpperTriangular htri
+    (LDL.lowerInv_apply_diag hS i)
+  simpa [LDL.lower, ← Matrix.transpose_nonsing_inv] using hinv
+
+private noncomputable def choleskyFactor : Matrix (Fin p) (Fin p) ℝ :=
+  LDL.lower hS * Matrix.diagonal fun i ↦ Real.sqrt (LDL.diagEntries hS i)
+
+private theorem choleskyFactor_isLowerTriangular : (choleskyFactor hS).IsLowerTriangular :=
+  (LDL.isLowerTriangular_lower hS).mul (Matrix.blockTriangular_diagonal _)
+
+private theorem choleskyFactor_diag_pos (i : Fin p) : 0 < choleskyFactor hS i i := by
+  rw [choleskyFactor, Matrix.mul_apply]
+  rw [Finset.sum_eq_single i]
+  · simpa [LDL.lower_apply_diag hS i] using
+      Real.sqrt_pos.2 (LDL.diagEntries_pos hS i)
+  · intro j _ hji
+    rw [Matrix.diagonal_apply_ne _ hji, mul_zero]
+  · simp
+
+private theorem diagonal_sqrt_mul_self :
+    Matrix.diagonal (fun i ↦ Real.sqrt (LDL.diagEntries hS i)) *
+        Matrix.diagonal (fun i ↦ Real.sqrt (LDL.diagEntries hS i)) =
+      LDL.diag hS := by
+  ext i j
+  by_cases hij : i = j
+  · subst j
+    simp only [Matrix.diagonal_mul_diagonal, Matrix.diagonal_apply_eq, LDL.diag]
+    rw [← sq]
+    exact Real.sq_sqrt (LDL.diagEntries_pos hS i).le
+  · simp [LDL.diag, hij]
+
+private theorem choleskyFactor_mul_transpose :
+    choleskyFactor hS * (choleskyFactor hS)ᵀ = S := by
+  rw [choleskyFactor, Matrix.transpose_mul, Matrix.diagonal_transpose]
+  rw [← Matrix.mul_assoc, Matrix.mul_assoc (LDL.lower hS), diagonal_sqrt_mul_self]
+  simpa [Matrix.conjTranspose_eq_transpose_of_trivial] using LDL.lower_conj_diag hS
+
+end Matrix
+
+/-- The lower-triangular Cholesky factor of a positive-definite real symmetric matrix. -/
+noncomputable def cholesky {p : ℕ} (A : PosDefMatrix p) : PosDiagLowerTriangular p :=
+  ⟨Matrix.choleskyFactor A.2,
+    Matrix.choleskyFactor_isLowerTriangular A.2,
+    Matrix.choleskyFactor_diag_pos A.2⟩
+
+/-- A positive-definite matrix is the product of its Cholesky factor and its transpose. -/
+theorem cholesky_mul_transpose {p : ℕ} (A : PosDefMatrix p) :
+    (cholesky A).1 * ((cholesky A).1)ᵀ =
+      (A.1 : Matrix (Fin p) (Fin p) ℝ) :=
+  Matrix.choleskyFactor_mul_transpose A.2
+
+/-- A lower-triangular matrix with positive diagonal has linearly independent rows. -/
+theorem PosDiagLowerTriangular.vecMul_injective {p : ℕ} (L : PosDiagLowerTriangular p) :
+    Function.Injective L.1.vecMul := by
+  apply Matrix.vecMul_injective_of_isUnit
+  rw [Matrix.isUnit_iff_isUnit_det, isUnit_iff_ne_zero,
+    Matrix.det_of_isLowerTriangular L.1 L.2.1]
+  exact Finset.prod_ne_zero_iff.2 fun i _ ↦ (L.2.2 i).ne'
+
+/-- Reconstruct a positive-definite symmetric matrix from a lower-triangular matrix with positive
+diagonal. -/
+noncomputable def choleskyReconstruction {p : ℕ} (L : PosDiagLowerTriangular p) :
+    PosDefMatrix p := by
+  refine ⟨⟨L.1 * L.1ᵀ, ?_⟩, ?_⟩
+  · have h := Matrix.isHermitian_mul_conjTranspose_self L.1
+    rw [Matrix.conjTranspose_eq_transpose_of_trivial] at h
+    exact Matrix.isHermitian_iff_isSelfAdjoint.mp h
+  · have h := Matrix.PosDef.mul_conjTranspose_self L.1 L.vecMul_injective
+    simpa [Matrix.conjTranspose_eq_transpose_of_trivial] using h
+
+/-- The matrix underlying `choleskyReconstruction L` is `L * Lᵀ`. -/
+@[simp]
+theorem choleskyReconstruction_coe {p : ℕ} (L : PosDiagLowerTriangular p) :
+    ((choleskyReconstruction L).1 : Matrix (Fin p) (Fin p) ℝ) = L.1 * L.1ᵀ := by
+  rw [choleskyReconstruction]
+
+/-- Reconstructing a matrix from its Cholesky factor returns the original matrix. -/
+@[simp]
+theorem choleskyReconstruction_cholesky {p : ℕ} (A : PosDefMatrix p) :
+    choleskyReconstruction (cholesky A) = A := by
+  apply Subtype.ext
+  apply Subtype.ext
+  exact cholesky_mul_transpose A
+
+/-- The Cholesky construction is injective. -/
+theorem cholesky_injective {p : ℕ} : Function.Injective (@cholesky p) :=
+  Function.LeftInverse.injective fun A ↦ choleskyReconstruction_cholesky A
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/Matrix/Cholesky/Basic.lean
+++ b/TauCeti/LinearAlgebra/Matrix/Cholesky/Basic.lean
@@ -100,6 +100,7 @@ theorem cholesky_coe {p : ℕ} (A : PosDefMatrix p) :
   (rfl)
 
 /-- A positive-definite matrix is the product of its Cholesky factor and its transpose. -/
+@[simp]
 theorem cholesky_mul_transpose {p : ℕ} (A : PosDefMatrix p) :
     (cholesky A).1 * ((cholesky A).1)ᵀ =
       (A.1 : Matrix (Fin p) (Fin p) ℝ) :=

--- a/TauCeti/LinearAlgebra/Matrix/Cholesky/Basic.lean
+++ b/TauCeti/LinearAlgebra/Matrix/Cholesky/Basic.lean
@@ -8,8 +8,7 @@ module
 public import Mathlib.Analysis.Matrix.LDL
 public import TauCeti.MeasureTheory.Measure.SymmetricMatrix.PosDef
 import Mathlib.Algebra.Order.Star.Real
-import TauCeti.Analysis.InnerProductSpace.GramSchmidtOrtho
-import TauCeti.LinearAlgebra.Matrix.Triangular
+import TauCeti.Analysis.Matrix.LDL
 
 /-!
 # Cholesky factors of positive-definite real matrices
@@ -33,6 +32,9 @@ triangular and positive on the diagonal.
   2013, Section 7.2.
 -/
 
+-- The declaration names and signatures of the Cholesky API below follow the skeleton pinned in
+-- `TauCetiRoadmap/StandardDistributions/Suggested.lean`, section "Cholesky coordinates".
+
 public section
 
 noncomputable section
@@ -47,41 +49,7 @@ abbrev PosDiagLowerTriangular (p : ℕ) :=
 
 namespace Matrix
 
-section General
-
-open scoped ComplexOrder
-
-variable {𝕜 n : Type*} [RCLike 𝕜] [LinearOrder n] [WellFoundedLT n]
-  [LocallyFiniteOrderBot n] [Fintype n] {S : Matrix n n 𝕜} (hS : S.PosDef)
-
-/-- The diagonal entries in Mathlib's LDL decomposition of a positive-definite matrix are
-positive. -/
-theorem LDL.diagEntries_pos (i : n) : 0 < LDL.diagEntries hS i := by
-  have hdiag : (LDL.diag hS).PosDef := by
-    rw [LDL.diag_eq_lowerInv_conj]
-    exact hS.mul_mul_conjTranspose_same
-      (Matrix.vecMul_injective_of_invertible (LDL.lowerInv hS))
-  simpa [LDL.diag] using hdiag.diag_pos (i := i)
-
-/-- The lower factor in Mathlib's LDL decomposition is unitriangular: its inverse is the
-Gram-Schmidt matrix, which carries `1` on the diagonal. -/
-theorem LDL.lowerInv_apply_diag (i : n) : LDL.lowerInv hS i i = 1 := by
-  let := Sᵀ.toNormedAddCommGroup hS.transpose
-  let := Sᵀ.toInnerProductSpace hS.transpose.posSemidef
-  rw [LDL.lowerInv]
-  simpa only [Pi.basisFun_repr] using
-    TauCeti.InnerProductSpace.repr_gramSchmidt_self_eq_one (Pi.basisFun 𝕜 n) i
-
-end General
-
 variable {p : ℕ} {S : Matrix (Fin p) (Fin p) ℝ} (hS : S.PosDef)
-
-private theorem LDL.lower_apply_diag (i : Fin p) : LDL.lower hS i i = 1 := by
-  have htri : (LDL.lowerInv hS)ᵀ.IsUpperTriangular :=
-    (LDL.isLowerTriangular_lowerInv hS).transpose
-  have hinv := Matrix.inv_apply_diag_of_isUpperTriangular htri
-    (LDL.lowerInv_apply_diag hS i)
-  simpa [LDL.lower, ← Matrix.transpose_nonsing_inv] using hinv
 
 private noncomputable def choleskyFactor : Matrix (Fin p) (Fin p) ℝ :=
   LDL.lower hS * Matrix.diagonal fun i ↦ Real.sqrt (LDL.diagEntries hS i)

--- a/TauCeti/LinearAlgebra/Matrix/Cholesky/Basic.lean
+++ b/TauCeti/LinearAlgebra/Matrix/Cholesky/Basic.lean
@@ -6,9 +6,10 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Analysis.Matrix.LDL
-public import TauCeti.LinearAlgebra.Matrix.Triangular
 public import TauCeti.MeasureTheory.Measure.SymmetricMatrix.PosDef
 import Mathlib.Algebra.Order.Star.Real
+import TauCeti.Analysis.InnerProductSpace.GramSchmidtOrtho
+import TauCeti.LinearAlgebra.Matrix.Triangular
 
 /-!
 # Cholesky factors of positive-definite real matrices
@@ -20,17 +21,16 @@ triangular and positive on the diagonal.
 
 ## Main definitions
 
-* `TauCeti.PosDefMatrix` is the positive-definite cone in the space of real symmetric matrices.
 * `TauCeti.PosDiagLowerTriangular` is the space of lower-triangular real matrices with positive
   diagonal.
-* `TauCeti.cholesky` constructs the Cholesky factor of a positive-definite matrix.
+* `TauCeti.cholesky` constructs the Cholesky factor of a positive-definite matrix, and
+  `TauCeti.cholesky_coe` gives its closed form in terms of the LDL decomposition.
 * `TauCeti.cholesky_mul_transpose` proves the Cholesky reconstruction identity.
 
 ## References
 
 * R. A. Horn and C. R. Johnson, *Matrix Analysis*, second edition, Cambridge University Press,
   2013, Section 7.2.
-* `TauCetiRoadmap/StandardDistributions/README.md`, Layer 6, item 2, "Cholesky decomposition".
 -/
 
 public section
@@ -41,43 +41,40 @@ open scoped Matrix
 
 namespace TauCeti
 
-/-- The cone of positive-definite real symmetric matrices of size `p`. -/
-abbrev PosDefMatrix (p : ℕ) :=
-  {A : selfAdjoint.submodule ℝ (Matrix (Fin p) (Fin p) ℝ) //
-    (A : Matrix (Fin p) (Fin p) ℝ).PosDef}
-
 /-- Lower-triangular real matrices of size `p` whose diagonal entries are positive. -/
 abbrev PosDiagLowerTriangular (p : ℕ) :=
   {L : Matrix (Fin p) (Fin p) ℝ // L.IsLowerTriangular ∧ ∀ i, 0 < L i i}
 
 namespace Matrix
 
-variable {p : ℕ} {S : Matrix (Fin p) (Fin p) ℝ} (hS : S.PosDef)
+section General
 
-/-- The diagonal entries in Mathlib's LDL decomposition of a positive-definite real matrix are
+open scoped ComplexOrder
+
+variable {𝕜 n : Type*} [RCLike 𝕜] [LinearOrder n] [WellFoundedLT n]
+  [LocallyFiniteOrderBot n] [Fintype n] {S : Matrix n n 𝕜} (hS : S.PosDef)
+
+/-- The diagonal entries in Mathlib's LDL decomposition of a positive-definite matrix are
 positive. -/
-theorem LDL.diagEntries_pos (i : Fin p) : 0 < LDL.diagEntries hS i := by
+theorem LDL.diagEntries_pos (i : n) : 0 < LDL.diagEntries hS i := by
   have hdiag : (LDL.diag hS).PosDef := by
     rw [LDL.diag_eq_lowerInv_conj]
     exact hS.mul_mul_conjTranspose_same
       (Matrix.vecMul_injective_of_invertible (LDL.lowerInv hS))
   simpa [LDL.diag] using hdiag.diag_pos (i := i)
 
-private theorem LDL.lowerInv_apply_diag (i : Fin p) : LDL.lowerInv hS i i = 1 := by
+/-- The lower factor in Mathlib's LDL decomposition is unitriangular: its inverse is the
+Gram-Schmidt matrix, which carries `1` on the diagonal. -/
+theorem LDL.lowerInv_apply_diag (i : n) : LDL.lowerInv hS i i = 1 := by
   let := Sᵀ.toNormedAddCommGroup hS.transpose
   let := Sᵀ.toInnerProductSpace hS.transpose.posSemidef
-  rw [LDL.lowerInv, InnerProductSpace.gramSchmidt_def]
-  simp only [Pi.basisFun_apply, Pi.sub_apply, Pi.single_eq_same]
-  rw [Finset.sum_apply]
-  rw [sub_eq_self]
-  apply Finset.sum_eq_zero
-  intro j hj
-  rw [Submodule.starProjection_singleton]
-  simp only [Pi.smul_apply, smul_eq_mul]
-  apply mul_eq_zero_of_right
+  rw [LDL.lowerInv]
   simpa only [Pi.basisFun_repr] using
-    InnerProductSpace.gramSchmidt_triangular (Finset.mem_Iio.mp hj)
-      (Pi.basisFun ℝ (Fin p))
+    TauCeti.InnerProductSpace.repr_gramSchmidt_self_eq_one (Pi.basisFun 𝕜 n) i
+
+end General
+
+variable {p : ℕ} {S : Matrix (Fin p) (Fin p) ℝ} (hS : S.PosDef)
 
 private theorem LDL.lower_apply_diag (i : Fin p) : LDL.lower hS i i = 1 := by
   have htri : (LDL.lowerInv hS)ᵀ.IsUpperTriangular :=
@@ -126,6 +123,13 @@ noncomputable def cholesky {p : ℕ} (A : PosDefMatrix p) : PosDiagLowerTriangul
   ⟨Matrix.choleskyFactor A.2,
     Matrix.choleskyFactor_isLowerTriangular A.2,
     Matrix.choleskyFactor_diag_pos A.2⟩
+
+/-- The Cholesky factor of `A` in closed form: Mathlib's LDL lower factor of `A`, with the
+square roots of the LDL diagonal entries absorbed into its columns. -/
+theorem cholesky_coe {p : ℕ} (A : PosDefMatrix p) :
+    (cholesky A).1 =
+      LDL.lower A.2 * Matrix.diagonal fun i ↦ Real.sqrt (LDL.diagEntries A.2 i) :=
+  (rfl)
 
 /-- A positive-definite matrix is the product of its Cholesky factor and its transpose. -/
 theorem cholesky_mul_transpose {p : ℕ} (A : PosDefMatrix p) :

--- a/TauCeti/MeasureTheory/Measure/SymmetricMatrix/PosDef.lean
+++ b/TauCeti/MeasureTheory/Measure/SymmetricMatrix/PosDef.lean
@@ -19,8 +19,12 @@ positive quadratic form, `TauCeti.isOpen_setOfPred_dotProduct_mulVec_pos`.
 The Wishart densities are supported on this cone, so its measurability is part of the
 carrier API.
 
+The cone is also packaged as a subtype, `TauCeti.PosDefMatrix`, which is the carrier the
+Wishart and Cholesky APIs are stated on.
+
 ## Main declarations
 
+* `TauCeti.PosDefMatrix` — the positive-definite cone in the space of real symmetric matrices.
 * `TauCeti.isOpen_setOfPred_posDefMatrix` — the positive-definite cone is open in the symmetric
   subspace.
 * `TauCeti.measurableSet_posDefMatrix` — the positive-definite cone is measurable.
@@ -33,6 +37,11 @@ noncomputable section
 open scoped Matrix
 
 namespace TauCeti
+
+/-- The cone of positive-definite real symmetric matrices of size `p`. -/
+abbrev PosDefMatrix (p : ℕ) :=
+  {A : selfAdjoint.submodule ℝ (Matrix (Fin p) (Fin p) ℝ) //
+    (A : Matrix (Fin p) (Fin p) ℝ).PosDef}
 
 /-- The positive-definite cone is open in the symmetric subspace. -/
 theorem isOpen_setOfPred_posDefMatrix (p : ℕ) :


### PR DESCRIPTION
This PR constructs the positive-diagonal lower-triangular Cholesky factor of every positive-definite real symmetric matrix from Mathlib's LDL decomposition, and packages the reverse reconstruction as a positive-definite symmetric matrix.

This advances `StandardDistributions/README.md`, Layer 6, item 2, “Cholesky decomposition”: it supplies the two roadmap carriers, proves positivity of the LDL diagonal entries, defines `cholesky` and `choleskyReconstruction`, proves `cholesky A * (cholesky A)ᵀ = A`, and records injectivity of the factor map. After this PR, the milestone still needs uniqueness of positive-diagonal lower-triangular factors to form `choleskyEquiv`, followed by continuity, measurability, coordinate topology, and the reconstruction Jacobian.

I fell back from the designated `AdicSpaces` roadmap because its next critical steps are already represented by open PRs: Proposition 8.30's localization/rescaling pieces, Corollary 8.32's faithfully-flat and support inputs, Lemma 8.33's restricted-series prerequisite, and the separated-quotient analytic comparison are all in flight. The remaining completed-localization valuation extension is not presently a coherent small sorry-free step, so the unclaimed Cholesky construction is the most effective available critical-path target.

The three general facts about Mathlib's LDL decomposition — positivity of the diagonal entries and the unit diagonal of `LDL.lowerInv`/`LDL.lower` — live in their own module `TauCeti/Analysis/Matrix/LDL.lean`, mirroring `Mathlib/Analysis/Matrix/LDL.lean`, which the Cholesky module imports privately; they are stated in Mathlib's generic `RCLike`/finite-ordered-index setting.

The construction reuses pinned Mathlib's `LDL.lower`, `LDL.diag`, `LDL.lower_conj_diag`, and `LDL.isLowerTriangular_lower`; no Mathlib implementation is vendored. The only supporting matrix fact used from Tau Ceti is the diagonal-of-inverse API in `TauCeti.LinearAlgebra.Matrix.Triangular`. Both new modules are short and keep all proof-only factor helpers private.

Roadmap: StandardDistributions

<!--tauceti-target:v1 {"focus":"StandardDistributions","id":"cholesky-factor"}-->

🤖 Prepared with Codex

