### PR TITLE
feat: compute the D2 half-spin root operators

### DIFF
--- a/TauCeti/LinearAlgebra/Matrix/ToLin.lean
+++ b/TauCeti/LinearAlgebra/Matrix/ToLin.lean
@@ -30,6 +30,8 @@ computation every matrix model of a Lie algebra performs on its root vectors.
   `Module.finBasisOfFinrankEq`.
 * `TauCeti.toLinAlgEquiv_single_apply_basis`: the endomorphism of a matrix unit sends a basis
   vector to a single coordinate.
+* `TauCeti.toMatrixAlgEquiv_eq_single_of_apply_basis`: an endomorphism with one matrix-unit
+  coordinate action has the corresponding single-entry matrix.
 
 The first is used to turn the Azumaya isomorphism of a finite-dimensional central simple algebra
 into a matrix algebra in `TauCeti/Algebra/CentralSimple/Opposite.lean`.
@@ -49,6 +51,21 @@ theorem toLinAlgEquiv_single_apply_basis {R : Type*} [CommRing R] {M : Type*} [A
       (if q = c then v else 0) • bas p := by
   rw [Matrix.toLinAlgEquiv_self]
   simp [Matrix.single_apply, ite_and, ite_smul]
+
+/-- **An endomorphism with a matrix-unit action has a single-entry matrix.** If an endomorphism
+sends the basis vector indexed by `q` to `v • bas p` and every other basis vector to zero, its
+matrix in `bas` is `Matrix.single p q v`. -/
+theorem toMatrixAlgEquiv_eq_single_of_apply_basis {R : Type*} [CommRing R] {M : Type*}
+    [AddCommGroup M] [Module R M] {n : Type*} [Fintype n] [DecidableEq n]
+    (bas : Module.Basis n R M) (f : Module.End R M) (p q : n) (v : R)
+    (h : ∀ c, f (bas c) = (if q = c then v else 0) • bas p) :
+    LinearMap.toMatrixAlgEquiv bas f = Matrix.single p q v := by
+  apply (Matrix.toLinAlgEquiv bas).injective
+  rw [Matrix.toLinAlgEquiv_toMatrixAlgEquiv]
+  apply bas.ext
+  intro c
+  rw [toLinAlgEquiv_single_apply_basis]
+  exact h c
 
 namespace Algebra
 

--- a/TauCeti/RepresentationTheory/Spin/Exceptional/Four/RootOperators.lean
+++ b/TauCeti/RepresentationTheory/Spin/Exceptional/Four/RootOperators.lean
@@ -106,16 +106,39 @@ theorem spinFourExteriorBasis_pair
   have h := TauCeti.ExteriorAlgebra.basis_singleton_mul_basis_erase b 0 {0, 1} (by simp)
   rw [Units.smul_def, ← Int.cast_smul_eq_zsmul K] at h
   rw [Units.smul_def, Units.coe_map]
-  change ((TauCeti.ExteriorAlgebra.basisEraseSign (0 : Fin 2) {0, 1} : ℤ) : K) •
-      b.ExteriorAlgebra {0, 1} = _
-  rw [← h]
-  have herase : ({0, 1} : Finset (Fin 2)).erase 0 = {1} := by decide
-  rw [herase, TauCeti.ExteriorAlgebra.basis_singleton,
-    TauCeti.ExteriorAlgebra.basis_singleton]
+  calc
+    _ = b.ExteriorAlgebra {0} * b.ExteriorAlgebra (({0, 1} : Finset (Fin 2)).erase 0) :=
+      h.symm
+    _ = _ := by
+      have herase : ({0, 1} : Finset (Fin 2)).erase 0 = {1} := by decide
+      rw [herase, TauCeti.ExteriorAlgebra.basis_singleton,
+        TauCeti.ExteriorAlgebra.basis_singleton]
 
 private theorem finsetFinTwo_cases (s : Finset (Fin 2)) :
     s = ∅ ∨ s = {0} ∨ s = {1} ∨ s = {0, 1} := by
   fin_cases s <;> decide
+
+private theorem orderedPair_eq_smul_exteriorBasis
+    (P : SpinPolarizationData Q) (b : Basis (Fin 2) K P.W) :
+    ExteriorAlgebra.ι K (b 0) * ExteriorAlgebra.ι K (b 1) =
+      ((TauCeti.ExteriorAlgebra.basisEraseSign (0 : Fin 2) {0, 1} : ℤ) : K) •
+        b.ExteriorAlgebra {0, 1} := by
+  have h := TauCeti.ExteriorAlgebra.basis_singleton_mul_basis_erase b 0 {0, 1} (by simp)
+  rw [Units.smul_def, ← Int.cast_smul_eq_zsmul K] at h
+  have herase : ({0, 1} : Finset (Fin 2)).erase 0 = {1} := by decide
+  simpa [herase] using h
+
+private theorem toMatrixAlgEquiv_eq_single
+    {M : Type*} [AddCommGroup M] [Module K M] {n : Type*} [Fintype n] [DecidableEq n]
+    (bas : Basis n K M) (f : Module.End K M) (p q : n)
+    (h : ∀ c, f (bas c) = (if q = c then (1 : K) else 0) • bas p) :
+    LinearMap.toMatrixAlgEquiv bas f = Matrix.single p q 1 := by
+  apply (Matrix.toLinAlgEquiv bas).injective
+  rw [Matrix.toLinAlgEquiv_toMatrixAlgEquiv]
+  apply bas.ext
+  intro c
+  rw [toLinAlgEquiv_single_apply_basis]
+  exact h c
 
 private theorem toMatrix_spinAction_typeDSimpleRootBivector_fin_two_zero
     (P : SpinPolarizationData Q) (b : Basis (Fin 2) K P.W) :
@@ -123,14 +146,16 @@ private theorem toMatrix_spinAction_typeDSimpleRootBivector_fin_two_zero
         (spinAction Q P (P.typeDSimpleRootBivector b (by omega) 0)) =
       Matrix.single {0} {1} 1 := by
   rw [P.typeDSimpleRootBivector_def, dite_eq_left (by decide)]
-  apply (Matrix.toLinAlgEquiv (spinFourExteriorBasis P b)).injective
-  rw [Matrix.toLinAlgEquiv_toMatrixAlgEquiv]
-  apply (spinFourExteriorBasis P b).ext
+  apply toMatrixAlgEquiv_eq_single
   intro s
-  rw [toLinAlgEquiv_single_apply_basis]
-  rcases finsetFinTwo_cases s with rfl | rfl | rfl | rfl <;>
+  rcases finsetFinTwo_cases s with rfl | rfl | rfl | rfl
+  · simp [map_mul, Module.End.mul_apply, P.pairingEquiv_dualVector, Finset.ext_iff]
+  · simp [map_mul, Module.End.mul_apply, P.pairingEquiv_dualVector, Finset.ext_iff]
+  · simp [map_mul, Module.End.mul_apply, P.pairingEquiv_dualVector]
+  · rw [spinFourExteriorBasis_pair, orderedPair_eq_smul_exteriorBasis P b]
     simp [map_mul, Module.End.mul_apply, P.pairingEquiv_dualVector,
-      CliffordAlgebra.contractLeft_ι_mul, CliffordAlgebra.contractLeft_ι, Finset.ext_iff]
+      TauCeti.ExteriorAlgebra.ι_mul_basis,
+      TauCeti.ExteriorAlgebra.contractLeft_coord_basis, Finset.ext_iff]
 
 private theorem toMatrix_spinAction_typeDSimpleRootBivector_fin_two_one
     (P : SpinPolarizationData Q) (b : Basis (Fin 2) K P.W) :
@@ -138,25 +163,22 @@ private theorem toMatrix_spinAction_typeDSimpleRootBivector_fin_two_one
         (spinAction Q P (P.typeDSimpleRootBivector b (by omega) 1)) =
       Matrix.single {0, 1} ∅ 1 := by
   rw [P.typeDSimpleRootBivector_def, dite_eq_right (by decide)]
-  apply (Matrix.toLinAlgEquiv (spinFourExteriorBasis P b)).injective
-  rw [Matrix.toLinAlgEquiv_toMatrixAlgEquiv]
-  apply (spinFourExteriorBasis P b).ext
+  apply toMatrixAlgEquiv_eq_single
   intro s
-  rw [toLinAlgEquiv_single_apply_basis]
-  have hswap : ExteriorAlgebra.ι K (b 1) * ExteriorAlgebra.ι K (b 0) =
-      -(ExteriorAlgebra.ι K (b 0) * ExteriorAlgebra.ι K (b 1)) :=
-    eq_neg_of_add_eq_zero_left
-      (ExteriorAlgebra.ι_add_mul_swap (R := K) (b 1) (b 0))
-  have hleft : ExteriorAlgebra.ι K (b 0) *
-      (ExteriorAlgebra.ι K (b 0) * ExteriorAlgebra.ι K (b 1)) = 0 := by
-    rw [← mul_assoc, ExteriorAlgebra.ι_sq_zero, zero_mul]
-  have hpair : ExteriorAlgebra.ι K (b 0) *
-      (ExteriorAlgebra.ι K (b 1) *
-        (ExteriorAlgebra.ι K (b 0) * ExteriorAlgebra.ι K (b 1))) = 0 := by
-    rw [← mul_assoc (ExteriorAlgebra.ι K (b 1)), hswap]
-    simp only [neg_mul, mul_neg, ← mul_assoc, ExteriorAlgebra.ι_sq_zero, zero_mul, neg_zero]
-  rcases finsetFinTwo_cases s with rfl | rfl | rfl | rfl <;>
-    simp [map_mul, Module.End.mul_apply, Finset.ext_iff, hswap, hleft, hpair]
+  rcases finsetFinTwo_cases s with rfl | rfl | rfl | rfl
+  · simp [map_mul, Module.End.mul_apply]
+  · rw [spinFourExteriorBasis_zero, ← TauCeti.ExteriorAlgebra.basis_singleton]
+    rw [map_mul, Module.End.mul_apply, spinAction_ι_wedge, spinAction_ι_wedge,
+      TauCeti.ExteriorAlgebra.ι_mul_basis, ite_eq_right (by simp), mul_smul_comm,
+      TauCeti.ExteriorAlgebra.ι_mul_basis, ite_eq_left (by simp), smul_zero]
+    simp
+  · rw [spinFourExteriorBasis_one, ← TauCeti.ExteriorAlgebra.basis_singleton]
+    rw [map_mul, Module.End.mul_apply, spinAction_ι_wedge, spinAction_ι_wedge,
+      TauCeti.ExteriorAlgebra.ι_mul_basis, ite_eq_left (by simp), mul_zero]
+    simp
+  · rw [spinFourExteriorBasis_pair, orderedPair_eq_smul_exteriorBasis P b]
+    simp [map_mul, Module.End.mul_apply,
+      TauCeti.ExteriorAlgebra.ι_mul_basis, Finset.ext_iff]
 
 private theorem toMatrix_spinAction_typeDSimpleNegativeRootBivector_fin_two_zero
     (P : SpinPolarizationData Q) (b : Basis (Fin 2) K P.W) :
@@ -164,14 +186,15 @@ private theorem toMatrix_spinAction_typeDSimpleNegativeRootBivector_fin_two_zero
         (spinAction Q P (P.typeDSimpleNegativeRootBivector b (by omega) 0)) =
       Matrix.single {1} {0} 1 := by
   rw [P.typeDSimpleNegativeRootBivector_def, dite_eq_left (by decide)]
-  apply (Matrix.toLinAlgEquiv (spinFourExteriorBasis P b)).injective
-  rw [Matrix.toLinAlgEquiv_toMatrixAlgEquiv]
-  apply (spinFourExteriorBasis P b).ext
+  apply toMatrixAlgEquiv_eq_single
   intro s
-  rw [toLinAlgEquiv_single_apply_basis]
-  rcases finsetFinTwo_cases s with rfl | rfl | rfl | rfl <;>
+  rcases finsetFinTwo_cases s with rfl | rfl | rfl | rfl
+  · simp [map_mul, Module.End.mul_apply, P.pairingEquiv_dualVector, Finset.ext_iff]
+  · simp [map_mul, Module.End.mul_apply, P.pairingEquiv_dualVector]
+  · simp [map_mul, Module.End.mul_apply, P.pairingEquiv_dualVector]
+  · rw [spinFourExteriorBasis_pair, orderedPair_eq_smul_exteriorBasis P b]
     simp [map_mul, Module.End.mul_apply, P.pairingEquiv_dualVector,
-      CliffordAlgebra.contractLeft_ι_mul, CliffordAlgebra.contractLeft_ι, Finset.ext_iff]
+      TauCeti.ExteriorAlgebra.contractLeft_coord_basis, Finset.ext_iff]
 
 private theorem toMatrix_spinAction_typeDSimpleNegativeRootBivector_fin_two_one
     (P : SpinPolarizationData Q) (b : Basis (Fin 2) K P.W) :
@@ -179,17 +202,30 @@ private theorem toMatrix_spinAction_typeDSimpleNegativeRootBivector_fin_two_one
         (spinAction Q P (P.typeDSimpleNegativeRootBivector b (by omega) 1)) =
       Matrix.single ∅ {0, 1} 1 := by
   rw [P.typeDSimpleNegativeRootBivector_def, dite_eq_right (by decide)]
-  apply (Matrix.toLinAlgEquiv (spinFourExteriorBasis P b)).injective
-  rw [Matrix.toLinAlgEquiv_toMatrixAlgEquiv]
-  apply (spinFourExteriorBasis P b).ext
+  apply toMatrixAlgEquiv_eq_single
   intro s
-  rw [toLinAlgEquiv_single_apply_basis]
-  rcases finsetFinTwo_cases s with rfl | rfl | rfl | rfl <;>
-    simp [map_mul, Module.End.mul_apply, P.pairingEquiv_dualVector,
-      CliffordAlgebra.contractLeft_ι_mul, CliffordAlgebra.contractLeft_ι, Finset.ext_iff]
+  rcases finsetFinTwo_cases s with rfl | rfl | rfl | rfl
+  · simp [map_mul, Module.End.mul_apply, P.pairingEquiv_dualVector, Finset.ext_iff]
+  · simp [map_mul, Module.End.mul_apply, P.pairingEquiv_dualVector, Finset.ext_iff]
+  · simp [map_mul, Module.End.mul_apply, P.pairingEquiv_dualVector, Finset.ext_iff]
+  · rw [spinFourExteriorBasis_pair, orderedPair_eq_smul_exteriorBasis P b]
+    simp only [Nat.add_one_sub_one, Fin.mk_one, Fin.isValue, tsub_self, Fin.zero_eta,
+      map_mul, spinAction_ι, SpinPolarizationData.cliffordOperator_coe_W', map_smul,
+      Module.End.mul_apply, SpinPolarizationData.contract_apply,
+      SpinPolarizationData.pairingEquiv_dualVector,
+      TauCeti.ExteriorAlgebra.contractLeft_coord_basis, Finset.mem_insert,
+      Finset.mem_singleton, zero_ne_one, or_false, ↓reduceIte, Finset.erase_insert_eq_erase,
+      not_false_eq_true, Finset.erase_eq_of_notMem, TauCeti.ExteriorAlgebra.basis_singleton,
+      map_zsmul_unit, CliffordAlgebra.contractLeft_ι, Basis.coord_apply, Basis.repr_self,
+      Finsupp.single_eq_same, map_one, spinFourExteriorBasis_empty, one_smul]
+    obtain h | h := Int.units_eq_one_or
+      (TauCeti.ExteriorAlgebra.basisEraseSign (0 : Fin 2) {0, 1})
+    · simp [h]
+    · simp [h]
 
 /-- In the oriented rank-two exterior basis, the two positive type-`D` root bivectors are the
 elementary matrices on the odd and even half-spin blocks, respectively. -/
+@[simp]
 theorem toMatrix_spinAction_typeDSimpleRootBivector_fin_two
     (P : SpinPolarizationData Q)
     (b : Basis (Fin 2) K P.W) (i : Fin 2) :
@@ -202,6 +238,7 @@ theorem toMatrix_spinAction_typeDSimpleRootBivector_fin_two
 
 /-- In the oriented rank-two exterior basis, the two negative type-`D` root bivectors are the
 reverse elementary matrices on the odd and even half-spin blocks, respectively. -/
+@[simp]
 theorem toMatrix_spinAction_typeDSimpleNegativeRootBivector_fin_two
     (P : SpinPolarizationData Q)
     (b : Basis (Fin 2) K P.W) (i : Fin 2) :

--- a/TauCeti/RepresentationTheory/Spin/Exceptional/Four/RootOperators.lean
+++ b/TauCeti/RepresentationTheory/Spin/Exceptional/Four/RootOperators.lean
@@ -128,25 +128,13 @@ private theorem orderedPair_eq_smul_exteriorBasis
   have herase : ({0, 1} : Finset (Fin 2)).erase 0 = {1} := by decide
   simpa [herase] using h
 
-private theorem toMatrixAlgEquiv_eq_single
-    {M : Type*} [AddCommGroup M] [Module K M] {n : Type*} [Fintype n] [DecidableEq n]
-    (bas : Basis n K M) (f : Module.End K M) (p q : n)
-    (h : ∀ c, f (bas c) = (if q = c then (1 : K) else 0) • bas p) :
-    LinearMap.toMatrixAlgEquiv bas f = Matrix.single p q 1 := by
-  apply (Matrix.toLinAlgEquiv bas).injective
-  rw [Matrix.toLinAlgEquiv_toMatrixAlgEquiv]
-  apply bas.ext
-  intro c
-  rw [toLinAlgEquiv_single_apply_basis]
-  exact h c
-
 private theorem toMatrix_spinAction_typeDSimpleRootBivector_fin_two_zero
     (P : SpinPolarizationData Q) (b : Basis (Fin 2) K P.W) :
     LinearMap.toMatrixAlgEquiv (spinFourExteriorBasis P b)
         (spinAction Q P (P.typeDSimpleRootBivector b (by omega) 0)) =
       Matrix.single {0} {1} 1 := by
   rw [P.typeDSimpleRootBivector_def, dite_eq_left (by decide)]
-  apply toMatrixAlgEquiv_eq_single
+  apply toMatrixAlgEquiv_eq_single_of_apply_basis
   intro s
   rcases finsetFinTwo_cases s with rfl | rfl | rfl | rfl
   · simp [map_mul, Module.End.mul_apply, P.pairingEquiv_dualVector, Finset.ext_iff]
@@ -163,7 +151,7 @@ private theorem toMatrix_spinAction_typeDSimpleRootBivector_fin_two_one
         (spinAction Q P (P.typeDSimpleRootBivector b (by omega) 1)) =
       Matrix.single {0, 1} ∅ 1 := by
   rw [P.typeDSimpleRootBivector_def, dite_eq_right (by decide)]
-  apply toMatrixAlgEquiv_eq_single
+  apply toMatrixAlgEquiv_eq_single_of_apply_basis
   intro s
   rcases finsetFinTwo_cases s with rfl | rfl | rfl | rfl
   · simp [map_mul, Module.End.mul_apply]
@@ -186,7 +174,7 @@ private theorem toMatrix_spinAction_typeDSimpleNegativeRootBivector_fin_two_zero
         (spinAction Q P (P.typeDSimpleNegativeRootBivector b (by omega) 0)) =
       Matrix.single {1} {0} 1 := by
   rw [P.typeDSimpleNegativeRootBivector_def, dite_eq_left (by decide)]
-  apply toMatrixAlgEquiv_eq_single
+  apply toMatrixAlgEquiv_eq_single_of_apply_basis
   intro s
   rcases finsetFinTwo_cases s with rfl | rfl | rfl | rfl
   · simp [map_mul, Module.End.mul_apply, P.pairingEquiv_dualVector, Finset.ext_iff]
@@ -202,7 +190,7 @@ private theorem toMatrix_spinAction_typeDSimpleNegativeRootBivector_fin_two_one
         (spinAction Q P (P.typeDSimpleNegativeRootBivector b (by omega) 1)) =
       Matrix.single ∅ {0, 1} 1 := by
   rw [P.typeDSimpleNegativeRootBivector_def, dite_eq_right (by decide)]
-  apply toMatrixAlgEquiv_eq_single
+  apply toMatrixAlgEquiv_eq_single_of_apply_basis
   intro s
   rcases finsetFinTwo_cases s with rfl | rfl | rfl | rfl
   · simp [map_mul, Module.End.mul_apply, P.pairingEquiv_dualVector, Finset.ext_iff]

--- a/TauCeti/RepresentationTheory/Spin/Exceptional/Four/RootOperators.lean
+++ b/TauCeti/RepresentationTheory/Spin/Exceptional/Four/RootOperators.lean
@@ -1,0 +1,215 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.RepresentationTheory.Spin.Polarization.TypeD.RootBivectors
+
+import TauCeti.LinearAlgebra.Matrix.ToLin
+
+/-!
+# Root operators on the four-dimensional spinor model
+
+For an isotropic summand with basis indexed by `Fin 2`, the spinor module has exterior basis
+indexed by the four subsets of `Fin 2`. Its even half has coordinates `empty` and `{0, 1}`, while
+its odd half has coordinates `{0}` and `{1}`. The two simple-root pairs of type `D2` act on these
+two halves independently.
+
+The exterior basis records its top wedge only up to the shuffle unit used by its construction.
+`TauCeti.spinFourExteriorBasis` absorbs that unit once, so its top coordinate is literally the
+ordered product of the two exterior generators. In this basis the positive and negative root
+bivectors are literal matrix units: the chain root moves `{1}` to `{0}`, and the fork root moves
+the vacuum to `{0, 1}`; the negative roots reverse those moves. Thus one root pair occupies the
+odd block and the other occupies the even block.
+
+These formulas isolate the two elementary `sl2` actions inside the spinor model. In particular,
+adding scalar multiples of the root operators to the identity produces the elementary matrix
+directions needed to identify the two half-spin factors.
+
+## Main definitions and results
+
+* `TauCeti.spinFourExteriorBasis`: the oriented exterior basis in isotropic rank two.
+* `TauCeti.toMatrix_spinAction_typeDSimpleRootBivector_fin_two`: the two positive root matrices.
+* `TauCeti.toMatrix_spinAction_typeDSimpleNegativeRootBivector_fin_two`: the two negative root
+  matrices.
+
+## References
+
+* W. Fulton and J. Harris, *Representation Theory: A First Course*, Lecture 20.
+-/
+
+public section
+
+open CliffordAlgebra Module QuadraticMap
+
+namespace TauCeti
+
+universe u v
+
+variable {K : Type u} [CommRing K] {V : Type v} [AddCommGroup V] [Module K V]
+  {Q : QuadraticForm K V}
+
+/-- The scalar unit that orients the top exterior-basis vector as the ordered product of the two
+generators. All other exterior-basis vectors retain their original normalization. -/
+private noncomputable def spinFourBasisUnit (s : Finset (Fin 2)) : Kˣ :=
+  if s = {0, 1} then
+    Units.map (Int.castRingHom K).toMonoidHom
+      (TauCeti.ExteriorAlgebra.basisEraseSign (0 : Fin 2) {0, 1})
+  else 1
+
+/-- The exterior basis in isotropic rank two, oriented so that its top vector is
+`ExteriorAlgebra.ι K (b 0) * ExteriorAlgebra.ι K (b 1)`.
+
+The even half-spin coordinates are `empty` and `{0, 1}`; the odd half-spin coordinates are `{0}`
+and `{1}`. -/
+noncomputable def spinFourExteriorBasis (P : SpinPolarizationData Q)
+    (b : Basis (Fin 2) K P.W) :
+    Basis (Finset (Fin 2)) K (ExteriorAlgebra K P.W) :=
+  b.ExteriorAlgebra.unitsSMul spinFourBasisUnit
+
+/-- The vacuum vector in the oriented rank-two exterior basis. -/
+@[simp]
+theorem spinFourExteriorBasis_empty
+    (P : SpinPolarizationData Q) (b : Basis (Fin 2) K P.W) :
+    spinFourExteriorBasis P b ∅ = 1 := by
+  rw [spinFourExteriorBasis, Basis.unitsSMul_apply, spinFourBasisUnit,
+    ite_eq_right (by decide), one_smul, ExteriorAlgebra.basis_apply]
+  simp
+
+/-- The first singleton vector in the oriented rank-two exterior basis. -/
+@[simp]
+theorem spinFourExteriorBasis_zero
+    (P : SpinPolarizationData Q) (b : Basis (Fin 2) K P.W) :
+    spinFourExteriorBasis P b {0} = ExteriorAlgebra.ι K (b 0) := by
+  rw [spinFourExteriorBasis, Basis.unitsSMul_apply, spinFourBasisUnit,
+    ite_eq_right (by decide), one_smul, TauCeti.ExteriorAlgebra.basis_singleton]
+
+/-- The second singleton vector in the oriented rank-two exterior basis. -/
+@[simp]
+theorem spinFourExteriorBasis_one
+    (P : SpinPolarizationData Q) (b : Basis (Fin 2) K P.W) :
+    spinFourExteriorBasis P b {1} = ExteriorAlgebra.ι K (b 1) := by
+  rw [spinFourExteriorBasis, Basis.unitsSMul_apply, spinFourBasisUnit,
+    ite_eq_right (by decide), one_smul, TauCeti.ExteriorAlgebra.basis_singleton]
+
+/-- The top vector in the oriented rank-two exterior basis is the ordered product of its two
+generators. -/
+@[simp]
+theorem spinFourExteriorBasis_pair
+    (P : SpinPolarizationData Q) (b : Basis (Fin 2) K P.W) :
+    spinFourExteriorBasis P b {0, 1} =
+      ExteriorAlgebra.ι K (b 0) * ExteriorAlgebra.ι K (b 1) := by
+  rw [spinFourExteriorBasis, Basis.unitsSMul_apply, spinFourBasisUnit,
+    ite_eq_left rfl]
+  have h := TauCeti.ExteriorAlgebra.basis_singleton_mul_basis_erase b 0 {0, 1} (by simp)
+  rw [Units.smul_def, ← Int.cast_smul_eq_zsmul K] at h
+  rw [Units.smul_def, Units.coe_map]
+  change ((TauCeti.ExteriorAlgebra.basisEraseSign (0 : Fin 2) {0, 1} : ℤ) : K) •
+      b.ExteriorAlgebra {0, 1} = _
+  rw [← h]
+  have herase : ({0, 1} : Finset (Fin 2)).erase 0 = {1} := by decide
+  rw [herase, TauCeti.ExteriorAlgebra.basis_singleton,
+    TauCeti.ExteriorAlgebra.basis_singleton]
+
+private theorem finsetFinTwo_cases (s : Finset (Fin 2)) :
+    s = ∅ ∨ s = {0} ∨ s = {1} ∨ s = {0, 1} := by
+  fin_cases s <;> decide
+
+private theorem toMatrix_spinAction_typeDSimpleRootBivector_fin_two_zero
+    (P : SpinPolarizationData Q) (b : Basis (Fin 2) K P.W) :
+    LinearMap.toMatrixAlgEquiv (spinFourExteriorBasis P b)
+        (spinAction Q P (P.typeDSimpleRootBivector b (by omega) 0)) =
+      Matrix.single {0} {1} 1 := by
+  rw [P.typeDSimpleRootBivector_def, dite_eq_left (by decide)]
+  apply (Matrix.toLinAlgEquiv (spinFourExteriorBasis P b)).injective
+  rw [Matrix.toLinAlgEquiv_toMatrixAlgEquiv]
+  apply (spinFourExteriorBasis P b).ext
+  intro s
+  rw [toLinAlgEquiv_single_apply_basis]
+  rcases finsetFinTwo_cases s with rfl | rfl | rfl | rfl <;>
+    simp [map_mul, Module.End.mul_apply, P.pairingEquiv_dualVector,
+      CliffordAlgebra.contractLeft_ι_mul, CliffordAlgebra.contractLeft_ι, Finset.ext_iff]
+
+private theorem toMatrix_spinAction_typeDSimpleRootBivector_fin_two_one
+    (P : SpinPolarizationData Q) (b : Basis (Fin 2) K P.W) :
+    LinearMap.toMatrixAlgEquiv (spinFourExteriorBasis P b)
+        (spinAction Q P (P.typeDSimpleRootBivector b (by omega) 1)) =
+      Matrix.single {0, 1} ∅ 1 := by
+  rw [P.typeDSimpleRootBivector_def, dite_eq_right (by decide)]
+  apply (Matrix.toLinAlgEquiv (spinFourExteriorBasis P b)).injective
+  rw [Matrix.toLinAlgEquiv_toMatrixAlgEquiv]
+  apply (spinFourExteriorBasis P b).ext
+  intro s
+  rw [toLinAlgEquiv_single_apply_basis]
+  have hswap : ExteriorAlgebra.ι K (b 1) * ExteriorAlgebra.ι K (b 0) =
+      -(ExteriorAlgebra.ι K (b 0) * ExteriorAlgebra.ι K (b 1)) :=
+    eq_neg_of_add_eq_zero_left
+      (ExteriorAlgebra.ι_add_mul_swap (R := K) (b 1) (b 0))
+  have hleft : ExteriorAlgebra.ι K (b 0) *
+      (ExteriorAlgebra.ι K (b 0) * ExteriorAlgebra.ι K (b 1)) = 0 := by
+    rw [← mul_assoc, ExteriorAlgebra.ι_sq_zero, zero_mul]
+  have hpair : ExteriorAlgebra.ι K (b 0) *
+      (ExteriorAlgebra.ι K (b 1) *
+        (ExteriorAlgebra.ι K (b 0) * ExteriorAlgebra.ι K (b 1))) = 0 := by
+    rw [← mul_assoc (ExteriorAlgebra.ι K (b 1)), hswap]
+    simp only [neg_mul, mul_neg, ← mul_assoc, ExteriorAlgebra.ι_sq_zero, zero_mul, neg_zero]
+  rcases finsetFinTwo_cases s with rfl | rfl | rfl | rfl <;>
+    simp [map_mul, Module.End.mul_apply, Finset.ext_iff, hswap, hleft, hpair]
+
+private theorem toMatrix_spinAction_typeDSimpleNegativeRootBivector_fin_two_zero
+    (P : SpinPolarizationData Q) (b : Basis (Fin 2) K P.W) :
+    LinearMap.toMatrixAlgEquiv (spinFourExteriorBasis P b)
+        (spinAction Q P (P.typeDSimpleNegativeRootBivector b (by omega) 0)) =
+      Matrix.single {1} {0} 1 := by
+  rw [P.typeDSimpleNegativeRootBivector_def, dite_eq_left (by decide)]
+  apply (Matrix.toLinAlgEquiv (spinFourExteriorBasis P b)).injective
+  rw [Matrix.toLinAlgEquiv_toMatrixAlgEquiv]
+  apply (spinFourExteriorBasis P b).ext
+  intro s
+  rw [toLinAlgEquiv_single_apply_basis]
+  rcases finsetFinTwo_cases s with rfl | rfl | rfl | rfl <;>
+    simp [map_mul, Module.End.mul_apply, P.pairingEquiv_dualVector,
+      CliffordAlgebra.contractLeft_ι_mul, CliffordAlgebra.contractLeft_ι, Finset.ext_iff]
+
+private theorem toMatrix_spinAction_typeDSimpleNegativeRootBivector_fin_two_one
+    (P : SpinPolarizationData Q) (b : Basis (Fin 2) K P.W) :
+    LinearMap.toMatrixAlgEquiv (spinFourExteriorBasis P b)
+        (spinAction Q P (P.typeDSimpleNegativeRootBivector b (by omega) 1)) =
+      Matrix.single ∅ {0, 1} 1 := by
+  rw [P.typeDSimpleNegativeRootBivector_def, dite_eq_right (by decide)]
+  apply (Matrix.toLinAlgEquiv (spinFourExteriorBasis P b)).injective
+  rw [Matrix.toLinAlgEquiv_toMatrixAlgEquiv]
+  apply (spinFourExteriorBasis P b).ext
+  intro s
+  rw [toLinAlgEquiv_single_apply_basis]
+  rcases finsetFinTwo_cases s with rfl | rfl | rfl | rfl <;>
+    simp [map_mul, Module.End.mul_apply, P.pairingEquiv_dualVector,
+      CliffordAlgebra.contractLeft_ι_mul, CliffordAlgebra.contractLeft_ι, Finset.ext_iff]
+
+/-- In the oriented rank-two exterior basis, the two positive type-`D` root bivectors are the
+elementary matrices on the odd and even half-spin blocks, respectively. -/
+theorem toMatrix_spinAction_typeDSimpleRootBivector_fin_two
+    (P : SpinPolarizationData Q)
+    (b : Basis (Fin 2) K P.W) (i : Fin 2) :
+    LinearMap.toMatrixAlgEquiv (spinFourExteriorBasis P b)
+        (spinAction Q P (P.typeDSimpleRootBivector b (by omega) i)) =
+      if i = 0 then Matrix.single {0} {1} 1 else Matrix.single {0, 1} ∅ 1 := by
+  fin_cases i
+  · simpa using toMatrix_spinAction_typeDSimpleRootBivector_fin_two_zero P b
+  · simpa using toMatrix_spinAction_typeDSimpleRootBivector_fin_two_one P b
+
+/-- In the oriented rank-two exterior basis, the two negative type-`D` root bivectors are the
+reverse elementary matrices on the odd and even half-spin blocks, respectively. -/
+theorem toMatrix_spinAction_typeDSimpleNegativeRootBivector_fin_two
+    (P : SpinPolarizationData Q)
+    (b : Basis (Fin 2) K P.W) (i : Fin 2) :
+    LinearMap.toMatrixAlgEquiv (spinFourExteriorBasis P b)
+        (spinAction Q P (P.typeDSimpleNegativeRootBivector b (by omega) i)) =
+      if i = 0 then Matrix.single {1} {0} 1 else Matrix.single ∅ {0, 1} 1 := by
+  fin_cases i
+  · simpa using toMatrix_spinAction_typeDSimpleNegativeRootBivector_fin_two_zero P b
+  · simpa using toMatrix_spinAction_typeDSimpleNegativeRootBivector_fin_two_one P b
+
+end TauCeti


### PR DESCRIPTION
This PR computes the positive and negative type-`D₂` simple-root operators as literal matrix units on the two half-spin blocks for the low-dimensional exceptional-isomorphism milestone.

Roadmap: RepresentationTheory

## Summary

Add an oriented exterior basis for an isotropic summand of rank two, with coordinates `∅`, `{0}`, `{1}`, and `{0, 1}`. Compute the two positive and two negative root actions in that basis: the chain-root pair is the pair of off-diagonal units on the odd block, while the fork-root pair is the corresponding pair on the even block. This supplies the elementary transvection directions needed for the exact-image argument, rather than merely showing that the spin action lands in two rank-two blocks.

The implementation reuses Mathlib's `Module.Basis.ExteriorAlgebra`, `Basis.unitsSMul`, `LinearMap.toMatrixAlgEquiv`, and `Matrix.single`, together with Tau Ceti's exterior-basis multiplication and contraction formulas, generic type-`D` root bivectors, and Fock action. The generic converse from basis-vector action to a single-entry matrix is exposed beside Tau Ceti's existing forward matrix-unit theorem and reused by all four root calculations; no upstream code is vendored.

## Roadmap target

This advances `RepresentationTheory/SpinRepresentations/README.md`, Layer 6, **`Spin₄ ≅ SL₂ × SL₂`**, specifically the requirement that `S⁺` and `S⁻` be the standard representations of the two factors and that the image be proved exact. The live route orders the split-Cartan/Borel highest-weight identification in Layer 5 before `Spin₄`; this candidate therefore remains staged until that prerequisite lands. Afterward, the even-Clifford-algebra/reversal identification and the group-level generation and exact-image proof still remain.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"d2-half-spin-root-operators"}-->

## Verification

- Exact head: `ce1bb3a168b1049b9e0365384364850db86d43b6`
- Local Lean build: `lake build` — pass; `Build completed successfully (11011 jobs).`
- Axiom audit: `lake exe axioms` — pass; `axioms: audited 108904 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`
- Lint: `lake exe module-system && env PATH="/opt/homebrew/opt/gnu-sed/libexec/gnubin:$PATH" bash scripts/lint-env.sh && python3 scripts/lint-dot-notation.py && bash scripts/lint-style.sh && git diff --check 9c9db2d4832788850bdbfa72b1129b2c899d8883...HEAD` — pass; no new violations, 8,753 declarations documented, all 4,859 source headers conform, and all 4,860 modules use the module system
- Proof golf: pinned exact-conclusion search plus `ProbeMatrix.lean` and `Consumer.lean` — pass; relocate the repeated generic matrix-unit criterion, generalize its coefficient, and preserve both indexed formulas under bare `simp`
- Public CI: pending for this updated head

## Scale and generality

The aggregate adds 257 lines across two modules: a 240-line rank-two root-operator module and a 17-line documented addition to the existing matrix conversion API. The root formulas hold over an arbitrary commutative ring, for an arbitrary quadratic module and polarization admitting a `Fin 2` basis of its isotropic summand. The generic matrix criterion works for an arbitrary coefficient, basis, and finite index type. Neither boundary requires invertibility of two, ambient nondegeneracy, finite dimensionality, or algebraic closure beyond the finite index used for matrices.

## Scope

- **Consumes:** `SpinPolarizationData.typeDSimpleRootBivector`, `typeDSimpleNegativeRootBivector`, `spinAction`, the exterior basis multiplication/contraction formulas, and matrix/linear-map equivalences
- **Provides:** the generic `toMatrixAlgEquiv_eq_single_of_apply_basis`, `spinFourExteriorBasis` and its four coordinate simplifiers, plus indexed positive- and negative-root matrix formulas separating the even and odd half-spin blocks
- **Fits:** the formulas turn the two `D₂ = A₁ × A₁` root pairs into the elementary generators used to identify the two half-spin standard representations and prove the `Spin₄` image is all of `SL₂ × SL₂`
- **Boundary:** the required Layer 5 highest-weight identification, duplicate `D₂` roots, Spin-group definition, reversal/determinant characterization, product homomorphism, and surjectivity theorem are not introduced here

<sub>🤖 GPT-5.6 Sol high · TauCetiWorker @ [910d954fee75dfafda41f98165ce3a9e6676eae1](https://github.com/utensil/TauCetiWorker/commit/910d954fee75dfafda41f98165ce3a9e6676eae1) · rubrics @ [afb424eda89e8ac96d9eb69f6a88972055a4cd1b](https://github.com/utensil/TauCetiReview/commit/afb424eda89e8ac96d9eb69f6a88972055a4cd1b) · local review @ [b533e561b6d44df071c31335ed4a63ae647507d2](https://github.com/utensil/formal-land/commit/b533e561b6d44df071c31335ed4a63ae647507d2) · fixed: reuse, api-design, proof-quality</sub>