### PR TITLE
feat: uniqueness of the almost-split sequence at a given end

### DIFF
--- a/TauCeti/CategoryTheory/AlmostSplit/Uniqueness.lean
+++ b/TauCeti/CategoryTheory/AlmostSplit/Uniqueness.lean
@@ -1,0 +1,206 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RingTheory.LocalRing.Basic
+public import TauCeti.CategoryTheory.AlmostSplit.Sequence
+
+/-!
+# Uniqueness of the almost-split sequence at a given end
+
+An almost-split sequence `0 ⟶ A ⟶ B ⟶ C ⟶ 0` is determined by its right-hand end `C`: two
+almost-split sequences with isomorphic right-hand ends are isomorphic as short complexes, so in
+particular their left-hand ends and their middle terms are isomorphic.  This file proves that,
+the uniqueness half of the Auslander-Reiten theorem, and proves it in the sharper form that
+*every* morphism of almost-split sequences invertible at the right-hand end is invertible.
+
+Two inputs beyond the definition are needed, and both are hypotheses rather than ambient
+assumptions.  The category is asked to be preadditive and balanced, which is what makes the
+left-hand end of a short exact sequence a kernel of its second map and lets a morphism that is
+both monic and epic be inverted.  And the endomorphism ring of each left-hand end is asked to be
+**local**, the Krull-Schmidt input: an almost-split sequence has an indecomposable left-hand end
+(`TauCeti.IsLeftAlmostSplit.indecomposable`), and over a finite-dimensional algebra an
+indecomposable module has a local endomorphism ring, but indecomposability by itself is the weaker
+statement that the ring has no idempotents other than `0` and `1`, which does not suffice.
+
+The proof is the classical one, and it turns on a single lemma.  Let `φ` be an endomorphism of an
+almost-split sequence `S` acting as the identity on `S.X₃`.  Then `𝟙 - φ.τ₂` is killed by `S.g`,
+so it factors as `γ ≫ S.f`, and comparing the two ways of composing with the monomorphism `S.f`
+gives `S.f ≫ γ = 𝟙 - φ.τ₁`.  Were `𝟙 - φ.τ₁` invertible, `γ` composed with its inverse would
+retract `S.f`, contradicting that `S.f` is left almost split and so is *not* a split
+monomorphism.  In a local ring one of `a` and `1 - a` is a unit; here it cannot be the second, so
+it is the first, and `φ.τ₁` is an isomorphism.  A morphism between two almost-split sequences
+invertible on the right is then handled by composing it with a comparison morphism running the
+other way, which the right almost split property of the second sequence produces.
+
+## Main results
+
+* `CategoryTheory.ShortComplex.IsAlmostSplit.isIso_τ₁_of_τ₃_eq_id`: **an endomorphism of an
+  almost-split sequence that is the identity on the right-hand end is an isomorphism on the
+  left-hand end**, and `CategoryTheory.ShortComplex.IsAlmostSplit.isIso_of_τ₃_eq_id`: it is then
+  an isomorphism of short complexes.  This is the engine of the file.
+* `CategoryTheory.ShortComplex.IsAlmostSplit.exists_hom_τ₃_eq`: **the comparison morphism.** An
+  isomorphism between the right-hand ends of two almost-split sequences is the third component of
+  a morphism of short complexes between them.
+* `CategoryTheory.ShortComplex.IsAlmostSplit.isIso_of_isIso_τ₃`: **a morphism of almost-split
+  sequences invertible at the right-hand end is invertible**, the sharp form of uniqueness.
+* `CategoryTheory.ShortComplex.IsAlmostSplit.exists_iso_τ₃_eq`: **uniqueness.** An isomorphism
+  between the right-hand ends of two almost-split sequences is realized by an isomorphism of the
+  sequences, so the sequence is unique *under* its right-hand end; the plainer statement is
+  `CategoryTheory.ShortComplex.IsAlmostSplit.nonempty_iso`, with
+  `CategoryTheory.ShortComplex.IsAlmostSplit.nonempty_iso_X₁` and `.nonempty_iso_X₂` the
+  statements about the left-hand ends and the middle terms that the Auslander-Reiten theorem is
+  usually quoted in.
+
+## References
+
+* M. Auslander, I. Reiten, S. Smalø, *Representation Theory of Artin Algebras*, CUP (1995), V.1.
+* I. Assem, D. Simson, A. Skowroński, *Elements of the Representation Theory of Associative
+  Algebras, Vol. 1*, LMS Student Texts 65, CUP (2006), IV.1.13.
+* [Quiver-representation roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md),
+  Layer 6, sublayer 6E, "existence and uniqueness of almost-split sequences", of which this is the
+  uniqueness half.
+-/
+
+public section
+
+open CategoryTheory CategoryTheory.Limits CategoryTheory.Preadditive TauCeti
+
+universe v u
+
+namespace CategoryTheory.ShortComplex
+
+variable {C : Type u} [Category.{v} C] [Preadditive C] [Balanced C] {S S' : ShortComplex C}
+
+namespace IsAlmostSplit
+
+/-! ### Endomorphisms fixing the right-hand end -/
+
+/-- **An endomorphism of an almost-split sequence acting as the identity on the right-hand end is
+an isomorphism on the left-hand end.**
+
+This is the whole content of uniqueness.  The endomorphism `𝟙 - φ` of the sequence vanishes on the
+right-hand end, hence factors through the kernel `S.f` of `S.g`, and monicity of `S.f` transports
+the factorization back to `𝟙 - φ.τ₁ = S.f ≫ γ`.  A factorization of an *isomorphism* through
+`S.f` would retract it, which the left almost split clause forbids; so `𝟙 - φ.τ₁` is not
+invertible, and locality of the endomorphism ring leaves `φ.τ₁` invertible. -/
+theorem isIso_τ₁_of_τ₃_eq_id (hS : S.IsAlmostSplit) [IsLocalRing (End S.X₁)] (φ : S ⟶ S)
+    (hφ : φ.τ₃ = 𝟙 S.X₃) : IsIso φ.τ₁ := by
+  have hmono := hS.shortExact.mono_f
+  -- `𝟙 - φ.τ₂` is killed by `S.g`, because `φ` is the identity on `S.X₃`.
+  have hker : (𝟙 S.X₂ - φ.τ₂) ≫ S.g = 0 := by
+    rw [sub_comp, Category.id_comp, φ.comm₂₃, hφ, Category.comp_id, sub_self]
+  obtain ⟨γ, hγ⟩ := hS.shortExact.exact.lift' (𝟙 S.X₂ - φ.τ₂) hker
+  -- Composing with the monomorphism `S.f` identifies `S.f ≫ γ` with `𝟙 - φ.τ₁`.
+  have hfγ : S.f ≫ γ = 𝟙 S.X₁ - φ.τ₁ := by
+    refine (cancel_mono S.f).mp ?_
+    rw [Category.assoc, hγ, comp_sub, Category.comp_id, sub_comp, Category.id_comp, φ.comm₁₂]
+  -- Were `𝟙 - φ.τ₁` invertible, `S.f` would be a split monomorphism.
+  have hnot : ¬ IsIso (𝟙 S.X₁ - φ.τ₁) := fun h =>
+    hS.isLeftAlmostSplit_f.not_isSplitMono
+      (IsSplitMono.mk' ⟨γ ≫ inv (𝟙 S.X₁ - φ.τ₁), by rw [← Category.assoc, hfγ, IsIso.hom_inv_id]⟩)
+  rcases IsLocalRing.isUnit_or_isUnit_one_sub_self (R := End S.X₁) φ.τ₁ with h | h
+  · exact (isUnit_iff_isIso _).mp h
+  · exact absurd ((isUnit_iff_isIso _).mp h) hnot
+
+/-- **An endomorphism of an almost-split sequence acting as the identity on the right-hand end is
+an isomorphism**, by the five lemma applied to
+`CategoryTheory.ShortComplex.IsAlmostSplit.isIso_τ₁_of_τ₃_eq_id`. -/
+theorem isIso_of_τ₃_eq_id (hS : S.IsAlmostSplit) [IsLocalRing (End S.X₁)] (φ : S ⟶ S)
+    (hφ : φ.τ₃ = 𝟙 S.X₃) : IsIso φ := by
+  have : IsIso φ.τ₁ := hS.isIso_τ₁_of_τ₃_eq_id φ hφ
+  have : IsIso φ.τ₃ := hφ ▸ inferInstanceAs (IsIso (𝟙 S.X₃))
+  have : IsIso φ.τ₂ := isIso₂_of_shortExact_of_isIso₁₃ φ hS.shortExact hS.shortExact
+  exact isIso_of_isIso φ
+
+/-! ### The comparison morphism -/
+
+/-- **An isomorphism between the right-hand ends of two almost-split sequences extends to a
+morphism of short complexes.**
+
+The composite `S.g ≫ e.hom` is not a split epimorphism — a section of it would, read through
+`e`, section `S.g` — so it factors through the right almost split map `S'.g`.  The resulting map
+of middle terms carries `S.f` into the kernel of `S'.g`, which is `S'.f`, and that lift is the
+component on the left-hand ends. -/
+theorem exists_hom_τ₃_eq (hS : S.IsAlmostSplit) (hS' : S'.IsAlmostSplit) (e : S.X₃ ≅ S'.X₃) :
+    ∃ φ : S ⟶ S', φ.τ₃ = e.hom := by
+  have hmono := hS'.shortExact.mono_f
+  have hne : ¬ IsSplitEpi (S.g ≫ e.hom) := by
+    intro h
+    refine hS.isRightAlmostSplit_g.not_isSplitEpi
+      (IsSplitEpi.mk' ⟨e.hom ≫ section_ (S.g ≫ e.hom), ?_⟩)
+    have hsec : section_ (S.g ≫ e.hom) ≫ S.g = e.inv := by
+      rw [← Category.comp_id (section_ (S.g ≫ e.hom) ≫ S.g), ← e.hom_inv_id, ← Category.assoc,
+        Category.assoc (section_ (S.g ≫ e.hom)), IsSplitEpi.id, Category.id_comp]
+    rw [Category.assoc, hsec, e.hom_inv_id]
+  obtain ⟨β, hβ⟩ := hS'.isRightAlmostSplit_g.factors S.X₂ (S.g ≫ e.hom) hne
+  have hzero : (S.f ≫ β) ≫ S'.g = 0 := by
+    rw [Category.assoc, hβ, ← Category.assoc, S.zero, zero_comp]
+  obtain ⟨α, hα⟩ := hS'.shortExact.exact.lift' (S.f ≫ β) hzero
+  exact ⟨⟨α, β, e.hom, hα, hβ⟩, rfl⟩
+
+/-! ### Uniqueness -/
+
+/-- **A morphism of almost-split sequences that is invertible at the right-hand end is
+invertible.**
+
+Compose it with a comparison morphism running the other way, supplied by
+`CategoryTheory.ShortComplex.IsAlmostSplit.exists_hom_τ₃_eq`.  Both composites are the identity on
+the right-hand end, so both are isomorphisms on the left-hand end; the given morphism therefore has
+a left and a right inverse there, hence is monic and epic, hence — the category being balanced —
+invertible on the left-hand ends, and the five lemma finishes. -/
+theorem isIso_of_isIso_τ₃ (hS : S.IsAlmostSplit) (hS' : S'.IsAlmostSplit)
+    [IsLocalRing (End S.X₁)] [IsLocalRing (End S'.X₁)] (φ : S ⟶ S') [IsIso φ.τ₃] : IsIso φ := by
+  obtain ⟨ψ, hψ⟩ := hS'.exists_hom_τ₃_eq hS (asIso φ.τ₃).symm
+  have hcomp : IsIso ((φ ≫ ψ).τ₁) :=
+    hS.isIso_τ₁_of_τ₃_eq_id (φ ≫ ψ) (by simp [hψ])
+  have hcomp' : IsIso ((ψ ≫ φ).τ₁) :=
+    hS'.isIso_τ₁_of_τ₃_eq_id (ψ ≫ φ) (by simp [hψ])
+  rw [comp_τ₁] at hcomp hcomp'
+  have hmf : φ.τ₁ ≫ ψ.τ₁ ≫ inv (φ.τ₁ ≫ ψ.τ₁) = 𝟙 S.X₁ := by
+    rw [← Category.assoc, IsIso.hom_inv_id]
+  have hef : (inv (ψ.τ₁ ≫ φ.τ₁) ≫ ψ.τ₁) ≫ φ.τ₁ = 𝟙 S'.X₁ := by
+    rw [Category.assoc, IsIso.inv_hom_id]
+  have : Mono φ.τ₁ := mono_of_mono_fac hmf
+  have : Epi φ.τ₁ := epi_of_epi_fac hef
+  have : IsIso φ.τ₁ := isIso_of_mono_of_epi φ.τ₁
+  have : IsIso φ.τ₂ := isIso₂_of_shortExact_of_isIso₁₃ φ hS.shortExact hS'.shortExact
+  exact isIso_of_isIso φ
+
+/-- **Uniqueness of the almost-split sequence at a given right-hand end, in its sharp form**: an
+isomorphism between the right-hand ends of two almost-split sequences is realized by an
+isomorphism of the sequences themselves.  The sequence ending at an object is unique not merely up
+to abstract isomorphism but *under* that object, which is what makes the Auslander-Reiten translate
+and the middle term functorial in it. -/
+theorem exists_iso_τ₃_eq (hS : S.IsAlmostSplit) (hS' : S'.IsAlmostSplit) [IsLocalRing (End S.X₁)]
+    [IsLocalRing (End S'.X₁)] (e : S.X₃ ≅ S'.X₃) : ∃ f : S ≅ S', f.hom.τ₃ = e.hom := by
+  obtain ⟨φ, hφ⟩ := hS.exists_hom_τ₃_eq hS' e
+  have : IsIso φ.τ₃ := hφ ▸ inferInstanceAs (IsIso e.hom)
+  have := hS.isIso_of_isIso_τ₃ hS' φ
+  exact ⟨asIso φ, hφ⟩
+
+/-- **Uniqueness of the almost-split sequence at a given right-hand end**: two almost-split
+sequences whose right-hand ends are isomorphic are isomorphic as short complexes. -/
+theorem nonempty_iso (hS : S.IsAlmostSplit) (hS' : S'.IsAlmostSplit) [IsLocalRing (End S.X₁)]
+    [IsLocalRing (End S'.X₁)] (e : S.X₃ ≅ S'.X₃) : Nonempty (S ≅ S') :=
+  (hS.exists_iso_τ₃_eq hS' e).elim fun f _ => ⟨f⟩
+
+/-- **The left-hand ends of two almost-split sequences with isomorphic right-hand ends are
+isomorphic**: the object `τ M` of the Auslander-Reiten theorem is determined by `M`. -/
+theorem nonempty_iso_X₁ (hS : S.IsAlmostSplit) (hS' : S'.IsAlmostSplit) [IsLocalRing (End S.X₁)]
+    [IsLocalRing (End S'.X₁)] (e : S.X₃ ≅ S'.X₃) : Nonempty (S.X₁ ≅ S'.X₁) :=
+  (hS.nonempty_iso hS' e).map fun f => π₁.mapIso f
+
+/-- **The middle terms of two almost-split sequences with isomorphic right-hand ends are
+isomorphic**: the middle term of the Auslander-Reiten sequence ending at `M`, which carries the
+irreducible morphisms into `M`, is determined by `M`. -/
+theorem nonempty_iso_X₂ (hS : S.IsAlmostSplit) (hS' : S'.IsAlmostSplit) [IsLocalRing (End S.X₁)]
+    [IsLocalRing (End S'.X₁)] (e : S.X₃ ≅ S'.X₃) : Nonempty (S.X₂ ≅ S'.X₂) :=
+  (hS.nonempty_iso hS' e).map fun f => π₂.mapIso f
+
+end IsAlmostSplit
+
+end CategoryTheory.ShortComplex

--- a/TauCeti/CategoryTheory/AlmostSplit/Uniqueness.lean
+++ b/TauCeti/CategoryTheory/AlmostSplit/Uniqueness.lean
@@ -27,21 +27,24 @@ Krull-Schmidt input: an almost-split sequence has an indecomposable left-hand en
 indecomposable module has a local endomorphism ring, but indecomposability by itself is the weaker
 statement that the ring has no idempotents other than `0` and `1`, which does not suffice.
 
-The three lemmas the argument runs on need only one half of the almost-split condition — short
-exactness together with `TauCeti.IsLeftAlmostSplit` or `TauCeti.IsRightAlmostSplit` — so they are
-stated in those namespaces; the results about an almost-split sequence are their corollaries.
+The three lemmas the argument runs on need only one half of the almost-split condition —
+exactness, monicity of the first map, and `TauCeti.IsLeftAlmostSplit` or
+`TauCeti.IsRightAlmostSplit` — so they are stated in those namespaces; the results about an
+almost-split sequence are their corollaries.  Only `TauCeti.IsLeftAlmostSplit.isIso_of_τ₃_eq_id`,
+whose five-lemma step needs the second map to be an epimorphism, asks for full short exactness.
 
 ## Main results
 
-* `TauCeti.IsLeftAlmostSplit.isIso_τ₁_of_τ₃_eq_id`: **an endomorphism of a short exact sequence
-  with left almost split first map that is the identity on the right-hand end is an isomorphism on
-  the left-hand end**, and `TauCeti.IsLeftAlmostSplit.isIso_of_τ₃_eq_id`: it is then an
-  isomorphism of short complexes.  This is the engine of the file.
+* `TauCeti.IsLeftAlmostSplit.isIso_τ₁_of_τ₃_eq_id`: **an endomorphism of an exact short complex
+  with monic, left almost split first map that is the identity on the right-hand end is an
+  isomorphism on the left-hand end**, and `TauCeti.IsLeftAlmostSplit.isIso_of_τ₃_eq_id`: it is then
+  an isomorphism of short complexes.  This is the engine of the file.
 * `TauCeti.IsRightAlmostSplit.exists_hom_τ₃_eq_of_not_isSplitEpi`: **the comparison morphism.** A
-  map into the right-hand end of a short exact sequence with right almost split second map, whose
-  composite with the first sequence's `g` is not a split epimorphism, is the third component of a
-  morphism of short complexes; `CategoryTheory.ShortComplex.IsAlmostSplit.exists_hom_τ₃_eq` is the
-  case of an isomorphism between the right-hand ends of two almost-split sequences.
+  map into the right-hand end of an exact short complex with monic first map and right almost split
+  second map, whose composite with the first sequence's `g` is not a split epimorphism, is the third
+  component of a morphism of short complexes;
+  `CategoryTheory.ShortComplex.IsAlmostSplit.exists_hom_τ₃_eq` is the case of an isomorphism
+  between the right-hand ends of two almost-split sequences.
 * `CategoryTheory.ShortComplex.IsAlmostSplit.isIso_of_isIso_τ₃`: **a morphism of almost-split
   sequences invertible at the right-hand end is invertible**, the sharp form of uniqueness.
 * `CategoryTheory.ShortComplex.IsAlmostSplit.exists_iso_τ₃_eq`: **uniqueness.** An isomorphism
@@ -71,16 +74,15 @@ variable {C : Type u} [Category.{v} C] [Preadditive C] [Balanced C] {S S' : Shor
 
 /-! ### Endomorphisms fixing the right-hand end -/
 
-/-- **An endomorphism of a short exact sequence with left almost split first map acting as the
-identity on the right-hand end is an isomorphism on the left-hand end.**  This is the engine of
+/-- **An endomorphism of an exact short complex with monic, left almost split first map acting as
+the identity on the right-hand end is an isomorphism on the left-hand end.**  This is the engine of
 the uniqueness statements below. -/
-theorem IsLeftAlmostSplit.isIso_τ₁_of_τ₃_eq_id (hf : IsLeftAlmostSplit S.f) (hS : S.ShortExact)
-    [IsLocalRing (End S.X₁)] (φ : S ⟶ S) (hφ : φ.τ₃ = 𝟙 S.X₃) : IsIso φ.τ₁ := by
-  have hmono := hS.mono_f
+theorem IsLeftAlmostSplit.isIso_τ₁_of_τ₃_eq_id (hf : IsLeftAlmostSplit S.f) (hS : S.Exact)
+    [Mono S.f] [IsLocalRing (End S.X₁)] (φ : S ⟶ S) (hφ : φ.τ₃ = 𝟙 S.X₃) : IsIso φ.τ₁ := by
   -- `𝟙 - φ.τ₂` is killed by `S.g`, because `φ` is the identity on `S.X₃`.
   have hker : (𝟙 S.X₂ - φ.τ₂) ≫ S.g = 0 := by
     rw [sub_comp, Category.id_comp, φ.comm₂₃, hφ, Category.comp_id, sub_self]
-  obtain ⟨γ, hγ⟩ := hS.exact.lift' (𝟙 S.X₂ - φ.τ₂) hker
+  obtain ⟨γ, hγ⟩ := hS.lift' (𝟙 S.X₂ - φ.τ₂) hker
   -- Composing with the monomorphism `S.f` identifies `S.f ≫ γ` with `𝟙 - φ.τ₁`.
   have hfγ : S.f ≫ γ = 𝟙 S.X₁ - φ.τ₁ := by
     refine (cancel_mono S.f).mp ?_
@@ -98,26 +100,27 @@ theorem IsLeftAlmostSplit.isIso_τ₁_of_τ₃_eq_id (hf : IsLeftAlmostSplit S.f
 identity on the right-hand end is an isomorphism.** -/
 theorem IsLeftAlmostSplit.isIso_of_τ₃_eq_id (hf : IsLeftAlmostSplit S.f) (hS : S.ShortExact)
     [IsLocalRing (End S.X₁)] (φ : S ⟶ S) (hφ : φ.τ₃ = 𝟙 S.X₃) : IsIso φ := by
-  have : IsIso φ.τ₁ := hf.isIso_τ₁_of_τ₃_eq_id hS φ hφ
+  have hmono := hS.mono_f
+  have : IsIso φ.τ₁ := hf.isIso_τ₁_of_τ₃_eq_id hS.exact φ hφ
   have : IsIso φ.τ₃ := hφ ▸ inferInstanceAs (IsIso (𝟙 S.X₃))
   have : IsIso φ.τ₂ := ShortComplex.isIso₂_of_shortExact_of_isIso₁₃ φ hS hS
   exact ShortComplex.isIso_of_isIso φ
 
 /-! ### The comparison morphism -/
 
-/-- **A map `e` into the right-hand end of a short exact sequence `S'` whose second map is right
-almost split extends to a morphism of short complexes `S ⟶ S'`, as soon as `S.g ≫ e` is not a
-split epimorphism.**  No hypothesis on `S` beyond its being a short complex is needed. -/
+/-- **A map `e` into the right-hand end of an exact short complex `S'` with monic first map and
+right almost split second map extends to a morphism of short complexes `S ⟶ S'`, as soon as
+`S.g ≫ e` is not a split epimorphism.**  No hypothesis on `S` beyond its being a short complex is
+needed. -/
 theorem IsRightAlmostSplit.exists_hom_τ₃_eq_of_not_isSplitEpi (hg : IsRightAlmostSplit S'.g)
-    (hS' : S'.ShortExact) (e : S.X₃ ⟶ S'.X₃) (he : ¬ IsSplitEpi (S.g ≫ e)) :
+    (hS' : S'.Exact) [Mono S'.f] (e : S.X₃ ⟶ S'.X₃) (he : ¬ IsSplitEpi (S.g ≫ e)) :
     ∃ φ : S ⟶ S', φ.τ₃ = e := by
-  have hmono := hS'.mono_f
   -- `S.g ≫ e` factors through the right almost split map `S'.g`.
   obtain ⟨β, hβ⟩ := hg.factors S.X₂ (S.g ≫ e) he
   -- The resulting map of middle terms carries `S.f` into the kernel of `S'.g`, which is `S'.f`.
   have hzero : (S.f ≫ β) ≫ S'.g = 0 := by
     rw [Category.assoc, hβ, ← Category.assoc, S.zero, zero_comp]
-  obtain ⟨α, hα⟩ := hS'.exact.lift' (S.f ≫ β) hzero
+  obtain ⟨α, hα⟩ := hS'.lift' (S.f ≫ β) hzero
   exact ⟨⟨α, β, e, hα, hβ⟩, rfl⟩
 
 end TauCeti
@@ -133,8 +136,9 @@ namespace IsAlmostSplit
 /-- **An isomorphism between the right-hand ends of two almost-split sequences is the third
 component of a morphism of short complexes between them.** -/
 theorem exists_hom_τ₃_eq (hS : S.IsAlmostSplit) (hS' : S'.IsAlmostSplit) (e : S.X₃ ≅ S'.X₃) :
-    ∃ φ : S ⟶ S', φ.τ₃ = e.hom :=
-  hS'.isRightAlmostSplit_g.exists_hom_τ₃_eq_of_not_isSplitEpi hS'.shortExact e.hom
+    ∃ φ : S ⟶ S', φ.τ₃ = e.hom := by
+  have hmono := hS'.shortExact.mono_f
+  exact hS'.isRightAlmostSplit_g.exists_hom_τ₃_eq_of_not_isSplitEpi hS'.shortExact.exact e.hom
     (hS.isRightAlmostSplit_g.comp_iso e).not_isSplitEpi
 
 /-- **A morphism of almost-split sequences that is invertible at the right-hand end is
@@ -144,10 +148,12 @@ theorem isIso_of_isIso_τ₃ (hS : S.IsAlmostSplit) (hS' : S'.IsAlmostSplit)
   -- Compose `φ` with a comparison morphism running the other way; both composites are the
   -- identity on the right-hand end, hence isomorphisms on the left-hand ends.
   obtain ⟨ψ, hψ⟩ := hS'.exists_hom_τ₃_eq hS (asIso φ.τ₃).symm
+  have hmono := hS.shortExact.mono_f
+  have hmono' := hS'.shortExact.mono_f
   have hcomp : IsIso ((φ ≫ ψ).τ₁) :=
-    hS.isLeftAlmostSplit_f.isIso_τ₁_of_τ₃_eq_id hS.shortExact (φ ≫ ψ) (by simp [hψ])
+    hS.isLeftAlmostSplit_f.isIso_τ₁_of_τ₃_eq_id hS.shortExact.exact (φ ≫ ψ) (by simp [hψ])
   have hcomp' : IsIso ((ψ ≫ φ).τ₁) :=
-    hS'.isLeftAlmostSplit_f.isIso_τ₁_of_τ₃_eq_id hS'.shortExact (ψ ≫ φ) (by simp [hψ])
+    hS'.isLeftAlmostSplit_f.isIso_τ₁_of_τ₃_eq_id hS'.shortExact.exact (ψ ≫ φ) (by simp [hψ])
   rw [comp_τ₁] at hcomp hcomp'
   -- So `φ.τ₁` has a left and a right inverse, hence is monic and epic, hence invertible.
   have hmf : φ.τ₁ ≫ ψ.τ₁ ≫ inv (φ.τ₁ ≫ ψ.τ₁) = 𝟙 S.X₁ := by

--- a/TauCeti/CategoryTheory/AlmostSplit/Uniqueness.lean
+++ b/TauCeti/CategoryTheory/AlmostSplit/Uniqueness.lean
@@ -19,9 +19,10 @@ the uniqueness half of the Auslander-Reiten theorem, and proves it in the sharpe
 
 Two inputs beyond the definition are needed, and both are hypotheses rather than ambient
 assumptions.  The category is asked to be preadditive and balanced, which is what makes the
-left-hand end of a short exact sequence a kernel of its second map and lets a morphism that is
-both monic and epic be inverted.  And the endomorphism ring of each left-hand end is asked to be
-**local**, the Krull-Schmidt input: an almost-split sequence has an indecomposable left-hand end
+left-hand end of a short exact sequence a kernel of its second map (`ShortComplex.Exact.lift'`
+is stated only for a balanced category) and lets a morphism that is both monic and epic be
+inverted.  And the endomorphism ring of each left-hand end is asked to be **local**, the
+Krull-Schmidt input: an almost-split sequence has an indecomposable left-hand end
 (`TauCeti.IsLeftAlmostSplit.indecomposable`), and over a finite-dimensional algebra an
 indecomposable module has a local endomorphism ring, but indecomposability by itself is the weaker
 statement that the ring has no idempotents other than `0` and `1`, which does not suffice.
@@ -42,9 +43,11 @@ other way, which the right almost split property of the second sequence produces
   almost-split sequence that is the identity on the right-hand end is an isomorphism on the
   left-hand end**, and `CategoryTheory.ShortComplex.IsAlmostSplit.isIso_of_τ₃_eq_id`: it is then
   an isomorphism of short complexes.  This is the engine of the file.
-* `CategoryTheory.ShortComplex.IsAlmostSplit.exists_hom_τ₃_eq`: **the comparison morphism.** An
-  isomorphism between the right-hand ends of two almost-split sequences is the third component of
-  a morphism of short complexes between them.
+* `CategoryTheory.ShortComplex.IsAlmostSplit.exists_hom_τ₃_eq_of_not_isSplitEpi`: **the comparison
+  morphism.** A map into the right-hand end of an almost-split sequence whose composite with the
+  first sequence's `g` is not a split epimorphism is the third component of a morphism of short
+  complexes; `CategoryTheory.ShortComplex.IsAlmostSplit.exists_hom_τ₃_eq` is the case of an
+  isomorphism between the right-hand ends of two almost-split sequences.
 * `CategoryTheory.ShortComplex.IsAlmostSplit.isIso_of_isIso_τ₃`: **a morphism of almost-split
   sequences invertible at the right-hand end is invertible**, the sharp form of uniqueness.
 * `CategoryTheory.ShortComplex.IsAlmostSplit.exists_iso_τ₃_eq`: **uniqueness.** An isomorphism
@@ -60,9 +63,6 @@ other way, which the right almost split property of the second sequence produces
 * M. Auslander, I. Reiten, S. Smalø, *Representation Theory of Artin Algebras*, CUP (1995), V.1.
 * I. Assem, D. Simson, A. Skowroński, *Elements of the Representation Theory of Associative
   Algebras, Vol. 1*, LMS Student Texts 65, CUP (2006), IV.1.13.
-* [Quiver-representation roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md),
-  Layer 6, sublayer 6E, "existence and uniqueness of almost-split sequences", of which this is the
-  uniqueness half.
 -/
 
 public section
@@ -80,13 +80,7 @@ namespace IsAlmostSplit
 /-! ### Endomorphisms fixing the right-hand end -/
 
 /-- **An endomorphism of an almost-split sequence acting as the identity on the right-hand end is
-an isomorphism on the left-hand end.**
-
-This is the whole content of uniqueness.  The endomorphism `𝟙 - φ` of the sequence vanishes on the
-right-hand end, hence factors through the kernel `S.f` of `S.g`, and monicity of `S.f` transports
-the factorization back to `𝟙 - φ.τ₁ = S.f ≫ γ`.  A factorization of an *isomorphism* through
-`S.f` would retract it, which the left almost split clause forbids; so `𝟙 - φ.τ₁` is not
-invertible, and locality of the endomorphism ring leaves `φ.τ₁` invertible. -/
+an isomorphism on the left-hand end.**  This is the engine of the uniqueness statements below. -/
 theorem isIso_τ₁_of_τ₃_eq_id (hS : S.IsAlmostSplit) [IsLocalRing (End S.X₁)] (φ : S ⟶ S)
     (hφ : φ.τ₃ = 𝟙 S.X₃) : IsIso φ.τ₁ := by
   have hmono := hS.shortExact.mono_f
@@ -102,13 +96,13 @@ theorem isIso_τ₁_of_τ₃_eq_id (hS : S.IsAlmostSplit) [IsLocalRing (End S.X�
   have hnot : ¬ IsIso (𝟙 S.X₁ - φ.τ₁) := fun h =>
     hS.isLeftAlmostSplit_f.not_isSplitMono
       (IsSplitMono.mk' ⟨γ ≫ inv (𝟙 S.X₁ - φ.τ₁), by rw [← Category.assoc, hfγ, IsIso.hom_inv_id]⟩)
+  -- In a local ring one of `a` and `1 - a` is a unit, and here it is not the second.
   rcases IsLocalRing.isUnit_or_isUnit_one_sub_self (R := End S.X₁) φ.τ₁ with h | h
   · exact (isUnit_iff_isIso _).mp h
   · exact absurd ((isUnit_iff_isIso _).mp h) hnot
 
 /-- **An endomorphism of an almost-split sequence acting as the identity on the right-hand end is
-an isomorphism**, by the five lemma applied to
-`CategoryTheory.ShortComplex.IsAlmostSplit.isIso_τ₁_of_τ₃_eq_id`. -/
+an isomorphism.** -/
 theorem isIso_of_τ₃_eq_id (hS : S.IsAlmostSplit) [IsLocalRing (End S.X₁)] (φ : S ⟶ S)
     (hφ : φ.τ₃ = 𝟙 S.X₃) : IsIso φ := by
   have : IsIso φ.τ₁ := hS.isIso_τ₁_of_τ₃_eq_id φ hφ
@@ -118,48 +112,42 @@ theorem isIso_of_τ₃_eq_id (hS : S.IsAlmostSplit) [IsLocalRing (End S.X₁)] (
 
 /-! ### The comparison morphism -/
 
-/-- **An isomorphism between the right-hand ends of two almost-split sequences extends to a
-morphism of short complexes.**
-
-The composite `S.g ≫ e.hom` is not a split epimorphism — a section of it would, read through
-`e`, section `S.g` — so it factors through the right almost split map `S'.g`.  The resulting map
-of middle terms carries `S.f` into the kernel of `S'.g`, which is `S'.f`, and that lift is the
-component on the left-hand ends. -/
-theorem exists_hom_τ₃_eq (hS : S.IsAlmostSplit) (hS' : S'.IsAlmostSplit) (e : S.X₃ ≅ S'.X₃) :
-    ∃ φ : S ⟶ S', φ.τ₃ = e.hom := by
+/-- **A map `e` into the right-hand end of an almost-split sequence `S'` extends to a morphism of
+short complexes `S ⟶ S'`, as soon as `S.g ≫ e` is not a split epimorphism.**  No hypothesis on
+`S` beyond its being a short complex is needed. -/
+theorem exists_hom_τ₃_eq_of_not_isSplitEpi (hS' : S'.IsAlmostSplit) (e : S.X₃ ⟶ S'.X₃)
+    (he : ¬ IsSplitEpi (S.g ≫ e)) : ∃ φ : S ⟶ S', φ.τ₃ = e := by
   have hmono := hS'.shortExact.mono_f
-  have hne : ¬ IsSplitEpi (S.g ≫ e.hom) := by
-    intro h
-    refine hS.isRightAlmostSplit_g.not_isSplitEpi
-      (IsSplitEpi.mk' ⟨e.hom ≫ section_ (S.g ≫ e.hom), ?_⟩)
-    have hsec : section_ (S.g ≫ e.hom) ≫ S.g = e.inv := by
-      rw [← Category.comp_id (section_ (S.g ≫ e.hom) ≫ S.g), ← e.hom_inv_id, ← Category.assoc,
-        Category.assoc (section_ (S.g ≫ e.hom)), IsSplitEpi.id, Category.id_comp]
-    rw [Category.assoc, hsec, e.hom_inv_id]
-  obtain ⟨β, hβ⟩ := hS'.isRightAlmostSplit_g.factors S.X₂ (S.g ≫ e.hom) hne
+  -- `S.g ≫ e` factors through the right almost split map `S'.g`.
+  obtain ⟨β, hβ⟩ := hS'.isRightAlmostSplit_g.factors S.X₂ (S.g ≫ e) he
+  -- The resulting map of middle terms carries `S.f` into the kernel of `S'.g`, which is `S'.f`.
   have hzero : (S.f ≫ β) ≫ S'.g = 0 := by
     rw [Category.assoc, hβ, ← Category.assoc, S.zero, zero_comp]
   obtain ⟨α, hα⟩ := hS'.shortExact.exact.lift' (S.f ≫ β) hzero
-  exact ⟨⟨α, β, e.hom, hα, hβ⟩, rfl⟩
+  exact ⟨⟨α, β, e, hα, hβ⟩, rfl⟩
+
+/-- **An isomorphism between the right-hand ends of two almost-split sequences is the third
+component of a morphism of short complexes between them.** -/
+theorem exists_hom_τ₃_eq (hS : S.IsAlmostSplit) (hS' : S'.IsAlmostSplit) (e : S.X₃ ≅ S'.X₃) :
+    ∃ φ : S ⟶ S', φ.τ₃ = e.hom :=
+  hS'.exists_hom_τ₃_eq_of_not_isSplitEpi e.hom
+    (hS.isRightAlmostSplit_g.comp_iso e).not_isSplitEpi
 
 /-! ### Uniqueness -/
 
 /-- **A morphism of almost-split sequences that is invertible at the right-hand end is
-invertible.**
-
-Compose it with a comparison morphism running the other way, supplied by
-`CategoryTheory.ShortComplex.IsAlmostSplit.exists_hom_τ₃_eq`.  Both composites are the identity on
-the right-hand end, so both are isomorphisms on the left-hand end; the given morphism therefore has
-a left and a right inverse there, hence is monic and epic, hence — the category being balanced —
-invertible on the left-hand ends, and the five lemma finishes. -/
+invertible**, the sharp form of uniqueness. -/
 theorem isIso_of_isIso_τ₃ (hS : S.IsAlmostSplit) (hS' : S'.IsAlmostSplit)
     [IsLocalRing (End S.X₁)] [IsLocalRing (End S'.X₁)] (φ : S ⟶ S') [IsIso φ.τ₃] : IsIso φ := by
+  -- Compose `φ` with a comparison morphism running the other way; both composites are the
+  -- identity on the right-hand end, hence isomorphisms on the left-hand ends.
   obtain ⟨ψ, hψ⟩ := hS'.exists_hom_τ₃_eq hS (asIso φ.τ₃).symm
   have hcomp : IsIso ((φ ≫ ψ).τ₁) :=
     hS.isIso_τ₁_of_τ₃_eq_id (φ ≫ ψ) (by simp [hψ])
   have hcomp' : IsIso ((ψ ≫ φ).τ₁) :=
     hS'.isIso_τ₁_of_τ₃_eq_id (ψ ≫ φ) (by simp [hψ])
   rw [comp_τ₁] at hcomp hcomp'
+  -- So `φ.τ₁` has a left and a right inverse, hence is monic and epic, hence invertible.
   have hmf : φ.τ₁ ≫ ψ.τ₁ ≫ inv (φ.τ₁ ≫ ψ.τ₁) = 𝟙 S.X₁ := by
     rw [← Category.assoc, IsIso.hom_inv_id]
   have hef : (inv (ψ.τ₁ ≫ φ.τ₁) ≫ ψ.τ₁) ≫ φ.τ₁ = 𝟙 S'.X₁ := by
@@ -172,9 +160,8 @@ theorem isIso_of_isIso_τ₃ (hS : S.IsAlmostSplit) (hS' : S'.IsAlmostSplit)
 
 /-- **Uniqueness of the almost-split sequence at a given right-hand end, in its sharp form**: an
 isomorphism between the right-hand ends of two almost-split sequences is realized by an
-isomorphism of the sequences themselves.  The sequence ending at an object is unique not merely up
-to abstract isomorphism but *under* that object, which is what makes the Auslander-Reiten translate
-and the middle term functorial in it. -/
+isomorphism of the sequences themselves.  The sequence ending at an object is therefore determined
+up to isomorphism *under* that object, not merely up to abstract isomorphism. -/
 theorem exists_iso_τ₃_eq (hS : S.IsAlmostSplit) (hS' : S'.IsAlmostSplit) [IsLocalRing (End S.X₁)]
     [IsLocalRing (End S'.X₁)] (e : S.X₃ ≅ S'.X₃) : ∃ f : S ≅ S', f.hom.τ₃ = e.hom := by
   obtain ⟨φ, hφ⟩ := hS.exists_hom_τ₃_eq hS' e
@@ -189,14 +176,15 @@ theorem nonempty_iso (hS : S.IsAlmostSplit) (hS' : S'.IsAlmostSplit) [IsLocalRin
   (hS.exists_iso_τ₃_eq hS' e).elim fun f _ => ⟨f⟩
 
 /-- **The left-hand ends of two almost-split sequences with isomorphic right-hand ends are
-isomorphic**: the object `τ M` of the Auslander-Reiten theorem is determined by `M`. -/
+isomorphic**: the object `τ M` of the Auslander-Reiten theorem is determined by `M` up to
+isomorphism. -/
 theorem nonempty_iso_X₁ (hS : S.IsAlmostSplit) (hS' : S'.IsAlmostSplit) [IsLocalRing (End S.X₁)]
     [IsLocalRing (End S'.X₁)] (e : S.X₃ ≅ S'.X₃) : Nonempty (S.X₁ ≅ S'.X₁) :=
   (hS.nonempty_iso hS' e).map fun f => π₁.mapIso f
 
 /-- **The middle terms of two almost-split sequences with isomorphic right-hand ends are
 isomorphic**: the middle term of the Auslander-Reiten sequence ending at `M`, which carries the
-irreducible morphisms into `M`, is determined by `M`. -/
+irreducible morphisms into `M`, is determined by `M` up to isomorphism. -/
 theorem nonempty_iso_X₂ (hS : S.IsAlmostSplit) (hS' : S'.IsAlmostSplit) [IsLocalRing (End S.X₁)]
     [IsLocalRing (End S'.X₁)] (e : S.X₃ ≅ S'.X₃) : Nonempty (S.X₂ ≅ S'.X₂) :=
   (hS.nonempty_iso hS' e).map fun f => π₂.mapIso f

--- a/TauCeti/CategoryTheory/AlmostSplit/Uniqueness.lean
+++ b/TauCeti/CategoryTheory/AlmostSplit/Uniqueness.lean
@@ -11,13 +11,19 @@ public import TauCeti.CategoryTheory.AlmostSplit.Sequence
 /-!
 # Uniqueness of the almost-split sequence at a given end
 
-An almost-split sequence `0 ⟶ A ⟶ B ⟶ C ⟶ 0` is determined by its right-hand end `C`: two
-almost-split sequences with isomorphic right-hand ends are isomorphic as short complexes, so in
-particular their left-hand ends and their middle terms are isomorphic.  This file proves that,
-the uniqueness half of the Auslander-Reiten theorem, and proves it in the sharper form that
-*every* morphism of almost-split sequences invertible at the right-hand end is invertible.
+An almost-split sequence `0 ⟶ A ⟶ B ⟶ C ⟶ 0` whose left-hand end has **local** endomorphism ring
+is determined by its right-hand end `C`: two such almost-split sequences with isomorphic
+right-hand ends are isomorphic as short complexes, so in particular their left-hand ends and their
+middle terms are isomorphic.  This file proves that, the uniqueness half of the Auslander-Reiten
+theorem, and proves it in the sharper form that *every* morphism between two such almost-split
+sequences that is invertible at the right-hand end is invertible.  Concretely, every uniqueness
+statement below carries `[IsLocalRing (End S.X₁)]` together with `[IsLocalRing (End S'.X₁)]` for
+the second sequence, in a preadditive and balanced ambient category; none of these conclusions is
+claimed for an arbitrary almost-split sequence in an arbitrary preadditive category.  Only the
+comparison morphism `CategoryTheory.ShortComplex.IsAlmostSplit.exists_hom_τ₃_eq`, which produces a
+morphism and asserts nothing about its invertibility, is free of the locality hypotheses.
 
-Two inputs beyond the definition are needed, and both are hypotheses rather than ambient
+Two inputs beyond the definition are therefore needed, and both are hypotheses rather than ambient
 assumptions.  The category is asked to be preadditive and balanced, which is what makes the
 left-hand end of a short exact sequence a kernel of its second map (`ShortComplex.Exact.lift'`
 is stated only for a balanced category) and lets a morphism that is both monic and epic be
@@ -52,11 +58,13 @@ whose five-lemma step needs the second map to be an epimorphism, asks for full s
   component of a morphism of short complexes;
   `CategoryTheory.ShortComplex.IsAlmostSplit.exists_hom_τ₃_eq` is the case of an isomorphism
   between the right-hand ends of two almost-split sequences.
-* `CategoryTheory.ShortComplex.IsAlmostSplit.isIso_of_isIso_τ₃`: **a morphism of almost-split
-  sequences invertible at the right-hand end is invertible**, the sharp form of uniqueness.
+* `CategoryTheory.ShortComplex.IsAlmostSplit.isIso_of_isIso_τ₃`: **a morphism between two
+  almost-split sequences with local left-hand endomorphism rings that is invertible at the
+  right-hand end is invertible**, the sharp form of uniqueness.
 * `CategoryTheory.ShortComplex.IsAlmostSplit.exists_iso_τ₃_eq`: **uniqueness.** An isomorphism
-  between the right-hand ends of two almost-split sequences is realized by an isomorphism of the
-  sequences, so the sequence is unique *under* its right-hand end; the plainer statement is
+  between the right-hand ends of two almost-split sequences with local left-hand endomorphism rings
+  is realized by an isomorphism of the sequences, so such a sequence is unique *under* its
+  right-hand end; the plainer statement is
   `CategoryTheory.ShortComplex.IsAlmostSplit.nonempty_iso`, with
   `CategoryTheory.ShortComplex.IsAlmostSplit.nonempty_iso_X₁` and `.nonempty_iso_X₂` the
   statements about the left-hand ends and the middle terms that the Auslander-Reiten theorem is

--- a/TauCeti/CategoryTheory/AlmostSplit/Uniqueness.lean
+++ b/TauCeti/CategoryTheory/AlmostSplit/Uniqueness.lean
@@ -22,10 +22,17 @@ assumptions.  The category is asked to be preadditive and balanced, which is wha
 left-hand end of a short exact sequence a kernel of its second map (`ShortComplex.Exact.lift'`
 is stated only for a balanced category) and lets a morphism that is both monic and epic be
 inverted.  And the endomorphism ring of each left-hand end is asked to be **local**, the
-Krull-Schmidt input: an almost-split sequence has an indecomposable left-hand end
-(`TauCeti.IsLeftAlmostSplit.indecomposable`), and over a finite-dimensional algebra an
-indecomposable module has a local endomorphism ring, but indecomposability by itself is the weaker
-statement that the ring has no idempotents other than `0` and `1`, which does not suffice.
+Krull-Schmidt input.  An almost-split sequence does have an indecomposable left-hand end
+(`TauCeti.IsLeftAlmostSplit.indecomposable`), but indecomposability in a general preadditive
+category does not give locality.  What it gives, once idempotents split — over an
+idempotent-complete category with binary biproducts, for instance any abelian one — is that the
+object is nonzero and has no idempotent endomorphism other than `0` and the identity
+(`TauCeti.indecomposable_iff_idempotent_eq_zero_or_id`), and that is strictly weaker: a ring whose
+only idempotents are `0` and `1` need not be local.  Indecomposability becomes *equivalent* to
+locality of the endomorphism ring for a module of **finite length** — in particular for a
+finite-dimensional module over a finite-dimensional algebra — which is Fitting's lemma, available
+here for objects of `ModuleCat A` as `TauCeti.indecomposable_iff_isLocalRing_end`; that is how a use
+site over such an algebra discharges the hypothesis.
 
 The three lemmas the argument runs on need only one half of the almost-split condition —
 exactness, monicity of the first map, and `TauCeti.IsLeftAlmostSplit` or

--- a/TauCeti/CategoryTheory/AlmostSplit/Uniqueness.lean
+++ b/TauCeti/CategoryTheory/AlmostSplit/Uniqueness.lean
@@ -27,27 +27,21 @@ Krull-Schmidt input: an almost-split sequence has an indecomposable left-hand en
 indecomposable module has a local endomorphism ring, but indecomposability by itself is the weaker
 statement that the ring has no idempotents other than `0` and `1`, which does not suffice.
 
-The proof is the classical one, and it turns on a single lemma.  Let `φ` be an endomorphism of an
-almost-split sequence `S` acting as the identity on `S.X₃`.  Then `𝟙 - φ.τ₂` is killed by `S.g`,
-so it factors as `γ ≫ S.f`, and comparing the two ways of composing with the monomorphism `S.f`
-gives `S.f ≫ γ = 𝟙 - φ.τ₁`.  Were `𝟙 - φ.τ₁` invertible, `γ` composed with its inverse would
-retract `S.f`, contradicting that `S.f` is left almost split and so is *not* a split
-monomorphism.  In a local ring one of `a` and `1 - a` is a unit; here it cannot be the second, so
-it is the first, and `φ.τ₁` is an isomorphism.  A morphism between two almost-split sequences
-invertible on the right is then handled by composing it with a comparison morphism running the
-other way, which the right almost split property of the second sequence produces.
+The three lemmas the argument runs on need only one half of the almost-split condition — short
+exactness together with `TauCeti.IsLeftAlmostSplit` or `TauCeti.IsRightAlmostSplit` — so they are
+stated in those namespaces; the results about an almost-split sequence are their corollaries.
 
 ## Main results
 
-* `CategoryTheory.ShortComplex.IsAlmostSplit.isIso_τ₁_of_τ₃_eq_id`: **an endomorphism of an
-  almost-split sequence that is the identity on the right-hand end is an isomorphism on the
-  left-hand end**, and `CategoryTheory.ShortComplex.IsAlmostSplit.isIso_of_τ₃_eq_id`: it is then
-  an isomorphism of short complexes.  This is the engine of the file.
-* `CategoryTheory.ShortComplex.IsAlmostSplit.exists_hom_τ₃_eq_of_not_isSplitEpi`: **the comparison
-  morphism.** A map into the right-hand end of an almost-split sequence whose composite with the
-  first sequence's `g` is not a split epimorphism is the third component of a morphism of short
-  complexes; `CategoryTheory.ShortComplex.IsAlmostSplit.exists_hom_τ₃_eq` is the case of an
-  isomorphism between the right-hand ends of two almost-split sequences.
+* `TauCeti.IsLeftAlmostSplit.isIso_τ₁_of_τ₃_eq_id`: **an endomorphism of a short exact sequence
+  with left almost split first map that is the identity on the right-hand end is an isomorphism on
+  the left-hand end**, and `TauCeti.IsLeftAlmostSplit.isIso_of_τ₃_eq_id`: it is then an
+  isomorphism of short complexes.  This is the engine of the file.
+* `TauCeti.IsRightAlmostSplit.exists_hom_τ₃_eq_of_not_isSplitEpi`: **the comparison morphism.** A
+  map into the right-hand end of a short exact sequence with right almost split second map, whose
+  composite with the first sequence's `g` is not a split epimorphism, is the third component of a
+  morphism of short complexes; `CategoryTheory.ShortComplex.IsAlmostSplit.exists_hom_τ₃_eq` is the
+  case of an isomorphism between the right-hand ends of two almost-split sequences.
 * `CategoryTheory.ShortComplex.IsAlmostSplit.isIso_of_isIso_τ₃`: **a morphism of almost-split
   sequences invertible at the right-hand end is invertible**, the sharp form of uniqueness.
 * `CategoryTheory.ShortComplex.IsAlmostSplit.exists_iso_τ₃_eq`: **uniqueness.** An isomorphism
@@ -67,9 +61,66 @@ other way, which the right almost split property of the second sequence produces
 
 public section
 
-open CategoryTheory CategoryTheory.Limits CategoryTheory.Preadditive TauCeti
+open CategoryTheory CategoryTheory.Limits CategoryTheory.Preadditive
 
 universe v u
+
+namespace TauCeti
+
+variable {C : Type u} [Category.{v} C] [Preadditive C] [Balanced C] {S S' : ShortComplex C}
+
+/-! ### Endomorphisms fixing the right-hand end -/
+
+/-- **An endomorphism of a short exact sequence with left almost split first map acting as the
+identity on the right-hand end is an isomorphism on the left-hand end.**  This is the engine of
+the uniqueness statements below. -/
+theorem IsLeftAlmostSplit.isIso_τ₁_of_τ₃_eq_id (hf : IsLeftAlmostSplit S.f) (hS : S.ShortExact)
+    [IsLocalRing (End S.X₁)] (φ : S ⟶ S) (hφ : φ.τ₃ = 𝟙 S.X₃) : IsIso φ.τ₁ := by
+  have hmono := hS.mono_f
+  -- `𝟙 - φ.τ₂` is killed by `S.g`, because `φ` is the identity on `S.X₃`.
+  have hker : (𝟙 S.X₂ - φ.τ₂) ≫ S.g = 0 := by
+    rw [sub_comp, Category.id_comp, φ.comm₂₃, hφ, Category.comp_id, sub_self]
+  obtain ⟨γ, hγ⟩ := hS.exact.lift' (𝟙 S.X₂ - φ.τ₂) hker
+  -- Composing with the monomorphism `S.f` identifies `S.f ≫ γ` with `𝟙 - φ.τ₁`.
+  have hfγ : S.f ≫ γ = 𝟙 S.X₁ - φ.τ₁ := by
+    refine (cancel_mono S.f).mp ?_
+    rw [Category.assoc, hγ, comp_sub, Category.comp_id, sub_comp, Category.id_comp, φ.comm₁₂]
+  -- Were `𝟙 - φ.τ₁` invertible, `S.f` would be a split monomorphism.
+  have hnot : ¬ IsIso (𝟙 S.X₁ - φ.τ₁) := fun h =>
+    hf.not_isSplitMono
+      (IsSplitMono.mk' ⟨γ ≫ inv (𝟙 S.X₁ - φ.τ₁), by rw [← Category.assoc, hfγ, IsIso.hom_inv_id]⟩)
+  -- In a local ring one of `a` and `1 - a` is a unit, and here it is not the second.
+  rcases IsLocalRing.isUnit_or_isUnit_one_sub_self (R := End S.X₁) φ.τ₁ with h | h
+  · exact (isUnit_iff_isIso _).mp h
+  · exact absurd ((isUnit_iff_isIso _).mp h) hnot
+
+/-- **An endomorphism of a short exact sequence with left almost split first map acting as the
+identity on the right-hand end is an isomorphism.** -/
+theorem IsLeftAlmostSplit.isIso_of_τ₃_eq_id (hf : IsLeftAlmostSplit S.f) (hS : S.ShortExact)
+    [IsLocalRing (End S.X₁)] (φ : S ⟶ S) (hφ : φ.τ₃ = 𝟙 S.X₃) : IsIso φ := by
+  have : IsIso φ.τ₁ := hf.isIso_τ₁_of_τ₃_eq_id hS φ hφ
+  have : IsIso φ.τ₃ := hφ ▸ inferInstanceAs (IsIso (𝟙 S.X₃))
+  have : IsIso φ.τ₂ := ShortComplex.isIso₂_of_shortExact_of_isIso₁₃ φ hS hS
+  exact ShortComplex.isIso_of_isIso φ
+
+/-! ### The comparison morphism -/
+
+/-- **A map `e` into the right-hand end of a short exact sequence `S'` whose second map is right
+almost split extends to a morphism of short complexes `S ⟶ S'`, as soon as `S.g ≫ e` is not a
+split epimorphism.**  No hypothesis on `S` beyond its being a short complex is needed. -/
+theorem IsRightAlmostSplit.exists_hom_τ₃_eq_of_not_isSplitEpi (hg : IsRightAlmostSplit S'.g)
+    (hS' : S'.ShortExact) (e : S.X₃ ⟶ S'.X₃) (he : ¬ IsSplitEpi (S.g ≫ e)) :
+    ∃ φ : S ⟶ S', φ.τ₃ = e := by
+  have hmono := hS'.mono_f
+  -- `S.g ≫ e` factors through the right almost split map `S'.g`.
+  obtain ⟨β, hβ⟩ := hg.factors S.X₂ (S.g ≫ e) he
+  -- The resulting map of middle terms carries `S.f` into the kernel of `S'.g`, which is `S'.f`.
+  have hzero : (S.f ≫ β) ≫ S'.g = 0 := by
+    rw [Category.assoc, hβ, ← Category.assoc, S.zero, zero_comp]
+  obtain ⟨α, hα⟩ := hS'.exact.lift' (S.f ≫ β) hzero
+  exact ⟨⟨α, β, e, hα, hβ⟩, rfl⟩
+
+end TauCeti
 
 namespace CategoryTheory.ShortComplex
 
@@ -77,63 +128,14 @@ variable {C : Type u} [Category.{v} C] [Preadditive C] [Balanced C] {S S' : Shor
 
 namespace IsAlmostSplit
 
-/-! ### Endomorphisms fixing the right-hand end -/
-
-/-- **An endomorphism of an almost-split sequence acting as the identity on the right-hand end is
-an isomorphism on the left-hand end.**  This is the engine of the uniqueness statements below. -/
-theorem isIso_τ₁_of_τ₃_eq_id (hS : S.IsAlmostSplit) [IsLocalRing (End S.X₁)] (φ : S ⟶ S)
-    (hφ : φ.τ₃ = 𝟙 S.X₃) : IsIso φ.τ₁ := by
-  have hmono := hS.shortExact.mono_f
-  -- `𝟙 - φ.τ₂` is killed by `S.g`, because `φ` is the identity on `S.X₃`.
-  have hker : (𝟙 S.X₂ - φ.τ₂) ≫ S.g = 0 := by
-    rw [sub_comp, Category.id_comp, φ.comm₂₃, hφ, Category.comp_id, sub_self]
-  obtain ⟨γ, hγ⟩ := hS.shortExact.exact.lift' (𝟙 S.X₂ - φ.τ₂) hker
-  -- Composing with the monomorphism `S.f` identifies `S.f ≫ γ` with `𝟙 - φ.τ₁`.
-  have hfγ : S.f ≫ γ = 𝟙 S.X₁ - φ.τ₁ := by
-    refine (cancel_mono S.f).mp ?_
-    rw [Category.assoc, hγ, comp_sub, Category.comp_id, sub_comp, Category.id_comp, φ.comm₁₂]
-  -- Were `𝟙 - φ.τ₁` invertible, `S.f` would be a split monomorphism.
-  have hnot : ¬ IsIso (𝟙 S.X₁ - φ.τ₁) := fun h =>
-    hS.isLeftAlmostSplit_f.not_isSplitMono
-      (IsSplitMono.mk' ⟨γ ≫ inv (𝟙 S.X₁ - φ.τ₁), by rw [← Category.assoc, hfγ, IsIso.hom_inv_id]⟩)
-  -- In a local ring one of `a` and `1 - a` is a unit, and here it is not the second.
-  rcases IsLocalRing.isUnit_or_isUnit_one_sub_self (R := End S.X₁) φ.τ₁ with h | h
-  · exact (isUnit_iff_isIso _).mp h
-  · exact absurd ((isUnit_iff_isIso _).mp h) hnot
-
-/-- **An endomorphism of an almost-split sequence acting as the identity on the right-hand end is
-an isomorphism.** -/
-theorem isIso_of_τ₃_eq_id (hS : S.IsAlmostSplit) [IsLocalRing (End S.X₁)] (φ : S ⟶ S)
-    (hφ : φ.τ₃ = 𝟙 S.X₃) : IsIso φ := by
-  have : IsIso φ.τ₁ := hS.isIso_τ₁_of_τ₃_eq_id φ hφ
-  have : IsIso φ.τ₃ := hφ ▸ inferInstanceAs (IsIso (𝟙 S.X₃))
-  have : IsIso φ.τ₂ := isIso₂_of_shortExact_of_isIso₁₃ φ hS.shortExact hS.shortExact
-  exact isIso_of_isIso φ
-
-/-! ### The comparison morphism -/
-
-/-- **A map `e` into the right-hand end of an almost-split sequence `S'` extends to a morphism of
-short complexes `S ⟶ S'`, as soon as `S.g ≫ e` is not a split epimorphism.**  No hypothesis on
-`S` beyond its being a short complex is needed. -/
-theorem exists_hom_τ₃_eq_of_not_isSplitEpi (hS' : S'.IsAlmostSplit) (e : S.X₃ ⟶ S'.X₃)
-    (he : ¬ IsSplitEpi (S.g ≫ e)) : ∃ φ : S ⟶ S', φ.τ₃ = e := by
-  have hmono := hS'.shortExact.mono_f
-  -- `S.g ≫ e` factors through the right almost split map `S'.g`.
-  obtain ⟨β, hβ⟩ := hS'.isRightAlmostSplit_g.factors S.X₂ (S.g ≫ e) he
-  -- The resulting map of middle terms carries `S.f` into the kernel of `S'.g`, which is `S'.f`.
-  have hzero : (S.f ≫ β) ≫ S'.g = 0 := by
-    rw [Category.assoc, hβ, ← Category.assoc, S.zero, zero_comp]
-  obtain ⟨α, hα⟩ := hS'.shortExact.exact.lift' (S.f ≫ β) hzero
-  exact ⟨⟨α, β, e, hα, hβ⟩, rfl⟩
+/-! ### Uniqueness -/
 
 /-- **An isomorphism between the right-hand ends of two almost-split sequences is the third
 component of a morphism of short complexes between them.** -/
 theorem exists_hom_τ₃_eq (hS : S.IsAlmostSplit) (hS' : S'.IsAlmostSplit) (e : S.X₃ ≅ S'.X₃) :
     ∃ φ : S ⟶ S', φ.τ₃ = e.hom :=
-  hS'.exists_hom_τ₃_eq_of_not_isSplitEpi e.hom
+  hS'.isRightAlmostSplit_g.exists_hom_τ₃_eq_of_not_isSplitEpi hS'.shortExact e.hom
     (hS.isRightAlmostSplit_g.comp_iso e).not_isSplitEpi
-
-/-! ### Uniqueness -/
 
 /-- **A morphism of almost-split sequences that is invertible at the right-hand end is
 invertible**, the sharp form of uniqueness. -/
@@ -143,9 +145,9 @@ theorem isIso_of_isIso_τ₃ (hS : S.IsAlmostSplit) (hS' : S'.IsAlmostSplit)
   -- identity on the right-hand end, hence isomorphisms on the left-hand ends.
   obtain ⟨ψ, hψ⟩ := hS'.exists_hom_τ₃_eq hS (asIso φ.τ₃).symm
   have hcomp : IsIso ((φ ≫ ψ).τ₁) :=
-    hS.isIso_τ₁_of_τ₃_eq_id (φ ≫ ψ) (by simp [hψ])
+    hS.isLeftAlmostSplit_f.isIso_τ₁_of_τ₃_eq_id hS.shortExact (φ ≫ ψ) (by simp [hψ])
   have hcomp' : IsIso ((ψ ≫ φ).τ₁) :=
-    hS'.isIso_τ₁_of_τ₃_eq_id (ψ ≫ φ) (by simp [hψ])
+    hS'.isLeftAlmostSplit_f.isIso_τ₁_of_τ₃_eq_id hS'.shortExact (ψ ≫ φ) (by simp [hψ])
   rw [comp_τ₁] at hcomp hcomp'
   -- So `φ.τ₁` has a left and a right inverse, hence is monic and epic, hence invertible.
   have hmf : φ.τ₁ ≫ ψ.τ₁ ≫ inv (φ.τ₁ ≫ ψ.τ₁) = 𝟙 S.X₁ := by


### PR DESCRIPTION
This PR proves the uniqueness half of the Auslander-Reiten theorem, generically: an almost-split
sequence in a preadditive balanced category is determined by its right-hand end. Two almost-split
sequences whose right-hand ends are isomorphic are isomorphic as short complexes, and the
isomorphism can be chosen to realize the given map on the right-hand ends, so the sequence is
unique *under* the object it ends at.

**Scope: this is a generic prerequisite, not the completion of the pinned roadmap target.** The
motivating target is the "existence and uniqueness of almost-split sequences" bullet of Layer 6
(sublayer 6E) in `TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md`, whose
`Suggested.lean` pins `almostSplitSequence_unique` for `ShortComplex (QuiverRep k Q)`. That pinned
theorem is **not** exported here, and this PR does not claim it: deriving it needs the
Krull-Schmidt transport that turns indecomposability of `S.X₁` into locality of `End S.X₁` for a
quiver representation, which in turn needs the Layer 1 target `quiverRepEquivalence` (still
unbuilt — every mention of it in `TauCeti/` is a docstring pointing at it as future work) together
with the repo's Fitting lemma `indecomposable_iff_isLocalRing_end`, stated for `ModuleCat A`. Both
are separate topics, and the pinned statement also carries no finite-length hypothesis, so
supplying that instance is a further mathematical step. What lands here is the categorical engine
that step will consume; existence remains the deep sublayer the roadmap flags.

The statements are proved for `CategoryTheory.ShortComplex.IsAlmostSplit` in an arbitrary
preadditive balanced category, the setting the existing `TauCeti/CategoryTheory/AlmostSplit/`
layer already works in. The Krull-Schmidt input is carried as the hypothesis
`[IsLocalRing (End S.X₁)]` on each left-hand end rather than as an ambient assumption on the
category. Indecomposability of the left-hand end is already a theorem here
(`TauCeti.IsLeftAlmostSplit.indecomposable`), but by itself it only says that the endomorphism
ring has no idempotents other than `0` and `1`, which is strictly weaker than locality and does
not suffice.

The engine is a single lemma, `isIso_τ₁_of_τ₃_eq_id`: an endomorphism `φ` of an almost-split
sequence that is the identity on the right-hand end is invertible on the left-hand end. The
endomorphism `𝟙 - φ` of the sequence vanishes on the right-hand end, so `𝟙 - φ.τ₂` factors
through the kernel `S.f` of `S.g`, and monicity of `S.f` turns that into `S.f ≫ γ = 𝟙 - φ.τ₁`.
Were `𝟙 - φ.τ₁` invertible, `γ` composed with its inverse would retract `S.f`, contradicting that
`S.f` is left almost split and hence not a split monomorphism; in a local ring one of `a` and
`1 - a` is a unit, so it is `φ.τ₁`. A morphism between two different sequences invertible on the
right is then handled by composing it with a comparison morphism running the other way, built by
`exists_hom_τ₃_eq_of_not_isSplitEpi` — which asks nothing of the source sequence beyond
`¬ IsSplitEpi (S.g ≫ e)`, the isomorphism case `exists_hom_τ₃_eq` being a corollary via
`IsRightAlmostSplit.comp_iso`. The resulting two-sided invertibility of the component on the
left-hand ends is promoted through the balancedness of the category and Mathlib's five lemma
`isIso₂_of_shortExact_of_isIso₁₃`. The sharp form `isIso_of_isIso_τ₃`, that *every* morphism of
almost-split sequences invertible at the right-hand end is invertible, falls out of the same
argument and is what the file states first; `exists_iso_τ₃_eq`, `nonempty_iso`, `nonempty_iso_X₁`
and `nonempty_iso_X₂` are its consequences.

Nothing was vendored from Mathlib; the file consumes `CategoryTheory.ShortComplex.ShortExact`,
`Exact.lift'`, `isIso₂_of_shortExact_of_isIso₁₃` and
`IsLocalRing.isUnit_or_isUnit_one_sub_self` as they stand.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"almostsplitsequence-unique"}-->

🤖 Prepared with Claude Code
