### PR TITLE
feat(ModularForms): bundled good Hecke eigenforms and newforms

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/DiamondOperators.lean
+++ b/TauCeti/NumberTheory/ModularForms/DiamondOperators.lean
@@ -57,6 +57,7 @@ re-founded slash action with built-in character) and their names. The Hecke pair
 * `diamondOp_coe_cuspForm`, `coe_mem_modFormCharSpace_iff`: the diamond operators, and hence the
   character spaces, commute with the coercion `S_k(Γ₁(N)) → M_k(Γ₁(N))`; a cusp form is a
   `χ`-form exactly when the modular form underlying it is.
+* `eq_of_mem_cuspFormCharSpace_of_ne_zero`: a nonzero cusp form determines its nebentypus.
 
 ## References
 
@@ -293,6 +294,15 @@ theorem diamondOpCusp_apply_of_mem_cuspFormCharSpace (k : ℤ) (χ : (ZMod N)ˣ 
     (hf : f ∈ cuspFormCharSpace k χ) :
     diamondOpCusp k d f = (↑(χ d) : ℂ) • f :=
   (mem_cuspFormCharSpace_iff k χ f).mp hf d
+
+/-- **A nonzero cusp form determines its nebentypus**: the character spaces of two distinct
+characters meet only in `0`, since `⟨d⟩ f = χ(d) • f = χ'(d) • f` forces `χ(d) = χ'(d)`. -/
+theorem eq_of_mem_cuspFormCharSpace_of_ne_zero {k : ℤ} {χ χ' : (ZMod N)ˣ →* ℂˣ}
+    {f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k} (hf : f ∈ cuspFormCharSpace k χ)
+    (hf' : f ∈ cuspFormCharSpace k χ') (h0 : f ≠ 0) : χ = χ' :=
+  MonoidHom.ext fun d ↦ Units.ext <| smul_left_injective ℂ h0 <|
+    (diamondOpCusp_apply_of_mem_cuspFormCharSpace k χ d hf).symm.trans
+      (diamondOpCusp_apply_of_mem_cuspFormCharSpace k χ' d hf')
 
 /-- The modular-form nebentypus character space `M_k(Γ₁(N), χ)`. -/
 noncomputable def modFormCharSpace (k : ℤ) (χ : (ZMod N)ˣ →* ℂˣ) :

--- a/TauCeti/NumberTheory/ModularForms/Newforms/Newform.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Newform.lean
@@ -44,6 +44,7 @@ that the character, the eigenvalue system and the analytic invariants travel wit
 
 * `HeckeRing.GL2.EigenformAwayFromLevel.ext`, `HeckeRing.GL2.Newform.ext`: the bundled data is
   determined by the underlying cusp form.
+* `HeckeRing.GL2.Newform.qExpansion_coeff_one`: the normalisation `a₁ = 1` as a simp lemma.
 
 ## Provenance
 
@@ -125,6 +126,12 @@ theorem ext {f g : EigenformAwayFromLevel N k} (h : f.toCuspForm = g.toCuspForm)
 end EigenformAwayFromLevel
 
 namespace Newform
+
+/-- The normalisation `a₁ = 1`, as a simp lemma. The eigenvector equation `isEigen` has no simp
+form: its right-hand side depends on the coprimality proof, so no rewrite rule can produce it. -/
+@[simp]
+theorem qExpansion_coeff_one (f : Newform N k) : (qExpansion 1 f.toCuspForm).coeff 1 = 1 :=
+  f.isNorm
 
 /-- **Extensionality**: two newforms with the same underlying cusp form are equal. -/
 @[ext]

--- a/TauCeti/NumberTheory/ModularForms/Newforms/Newform.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Newform.lean
@@ -21,41 +21,42 @@ that the character, the eigenvalue system and the analytic invariants travel wit
 
 ## Design
 
-* Eigen-ness is demanded only at indices coprime to `N`: the ring element at a bad index lies in
-  another double coset and is not packaged. The eigenvalue slot at a bad index carries no
-  arithmetic and is normalised to `0`, which is what makes an eigenform determined by its
-  underlying cusp form and character (`EigenformAwayFromLevel.ext_of_toCuspForm`). It is not a
-  claim about `U_p`.
-* The public eigenvalue interface is `EigenformAwayFromLevel.eigenvalue`, guarded by
-  `Nat.Coprime n N`; the total `ringEigenvalue` is a representation detail.
+* Eigen-ness is demanded only at indices coprime to `N`, and the eigenvalues are stored only
+  there: `eigenvalue n hn` takes the coprimality proof `hn` as an argument, and `isEigen n hn`
+  is its characteristic equation, `heckeTCompositeGamma0 N n` acting on the form by
+  `eigenvalue n hn`. No value and no eigencondition is packaged at an index not coprime to
+  `N`; the ring element exists there, but its action on a good eigenform is not part of this
+  notion (and is not a claim about `U_n`).
+* A good eigenform is determined by its underlying cusp form: the character by
+  `eq_of_mem_cuspFormCharSpace_of_ne_zero`, the eigenvalues by cancelling the nonzero form in
+  the eigenvector equations (`EigenformAwayFromLevel.ext_of_toCuspForm`).
 * That a newform is an eigenvector of every `T_n` is a theorem (Atkin–Lehner–Li; Miyake
-  Theorem 4.6.13), not a field. The comparison of the ring eigenvalue with the classical
-  operator `heckeTCuspNat` is likewise a theorem, and is not proved here.
+  Theorem 4.6.13), not a field, and so is the comparison of the ring eigenvalues with the
+  classical operator `heckeTCuspNat`; neither is proved here.
 
 ## Main definitions
 
-* `HeckeRing.GL2.EigenformAwayFromLevel`: the bundled good Hecke eigenform.
+* `HeckeRing.GL2.EigenformAwayFromLevel`: the bundled good Hecke eigenform, with its
+  eigenvalue system `EigenformAwayFromLevel.eigenvalue` at the indices coprime to the level.
 * `HeckeRing.GL2.Newform`: the bundled newform.
-* `HeckeRing.GL2.EigenformAwayFromLevel.eigenvalue`: the eigenvalue at an index coprime to the
-  level.
 
 ## Main results
 
 * `HeckeRing.GL2.EigenformAwayFromLevel.ext_of_toCuspForm`,
   `HeckeRing.GL2.Newform.ext_of_toCuspForm`: the bundled data is determined by the underlying
-  cusp form and the character.
+  cusp form.
 
 ## Provenance
 
 Follows the shapes of `structure Eigenform` and `structure Newform` of the AINTLIB
 `LeanModularForms` project (`LeanModularForms/HeckeRIngs/GL2/Newforms/{Basic,MainLemma}.lean`,
 Chris Birkbeck, commit `2baa76f742bdb4fb8ee323fabba41203bd390e08`, Apache-2.0,
-<https://github.com/CBirkbeck/AINTLIB/tree/main/projects/LeanModularForms>), with the porting
-decisions the roadmap pins: the structure is named for the qualified notion, the nonzeroness
-field is added, the character space is the cusp-form one, and the bad-index slots are
-normalised to `0`. The source's `Eigenform.eigenvalue`/`isEigen` (the classical eigenvalue,
-which in its convention carries a diamond factor `χ(n)`) rest on its
-`heckeT_n_cusp_eq_heckeRingHom`, which has no counterpart here yet.
+<https://github.com/CBirkbeck/AINTLIB/tree/main/projects/LeanModularForms>), with these
+differences: the structure is named for the qualified notion, nonzeroness is a field, the
+character space is the cusp-form one, and the eigenvalues are stored at the good indices only
+rather than as a total function with unconstrained values at the bad ones. The source's
+classical eigenvalue `Eigenform.eigenvalue` (which in its convention carries a diamond factor
+`χ(n)`) is not reproduced.
 
 ## References
 
@@ -76,27 +77,22 @@ variable {N : ℕ} [NeZero N] {k : ℤ}
 /-- **A good Hecke eigenform, bundled.** A nonzero cusp form of level `Γ₁(N)` with a nebentypus
 `χ`, together with an eigenvalue system for the `Γ₀(N)` Hecke ring acting on
 `cuspFormCharSpace k χ`: at every index `n` coprime to `N`, the ring element
-`heckeTCompositeGamma0 N n` acts by the scalar `ringEigenvalue n`. Eigen-ness is demanded only
-away from the level; the slots at indices not coprime to `N` carry no arithmetic and are
-normalised to `0`, so that an eigenform is determined by its underlying cusp form and character.
--/
+`heckeTCompositeGamma0 N n` acts by the scalar `eigenvalue n hn`. Eigen-ness is demanded, and an
+eigenvalue stored, only away from the level. -/
 structure EigenformAwayFromLevel (N : ℕ) [NeZero N] (k : ℤ)
     extends CuspForm ((Gamma1 N).map (mapGL ℝ)) k where
   /-- The nebentypus character. -/
   χ : (ZMod N)ˣ →* ℂˣ
   /-- The form transforms under the diamond operators by `χ`. -/
   mem_charSpace : toCuspForm ∈ cuspFormCharSpace k χ
-  /-- The eigenvalue system for the `Γ₀(N)` Hecke ring; only the values at indices coprime to
-  `N` carry meaning. -/
-  ringEigenvalue : ℕ+ → ℂ
-  /-- At an index coprime to `N`, the Hecke ring element `heckeTCompositeGamma0 N n` acts on the
-  form by `ringEigenvalue n`. -/
-  isRingEigen : ∀ n : ℕ+, Nat.Coprime n.val N →
+  /-- The eigenvalue at an index coprime to the level. -/
+  eigenvalue : ∀ n : ℕ+, Nat.Coprime n.val N → ℂ
+  /-- At an index `n` coprime to `N`, the Hecke ring element `heckeTCompositeGamma0 N n` acts on
+  the form by `eigenvalue n hn`. -/
+  isEigen : ∀ (n : ℕ+) (hn : Nat.Coprime n.val N),
     heckeRingHomCuspCharSpace (k := k) (χ := χ) (heckeTCompositeGamma0 N n.val)
         ⟨toCuspForm, mem_charSpace⟩
-      = ringEigenvalue n • (⟨toCuspForm, mem_charSpace⟩ : cuspFormCharSpace k χ)
-  /-- The slots at indices not coprime to `N` are normalised to `0`. -/
-  ringEigen_bad : ∀ n : ℕ+, ¬ Nat.Coprime n.val N → ringEigenvalue n = 0
+      = eigenvalue n hn • (⟨toCuspForm, mem_charSpace⟩ : cuspFormCharSpace k χ)
   /-- An eigenform is nonzero. -/
   ne_zero : toCuspForm ≠ 0
 
@@ -111,24 +107,18 @@ structure Newform (N : ℕ) [NeZero N] (k : ℤ) extends EigenformAwayFromLevel 
 
 namespace EigenformAwayFromLevel
 
-variable (f : EigenformAwayFromLevel N k)
-
-/-- The eigenvalue at an index coprime to the level: the public face of `ringEigenvalue`. -/
-def eigenvalue (n : ℕ+) (_hn : Nat.Coprime n.val N) : ℂ := f.ringEigenvalue n
-
-/-- Two good Hecke eigenforms with the same underlying cusp form and character are equal: the
-eigenvalues at good indices are determined by the form, and the bad slots are normalised. -/
-theorem ext_of_toCuspForm {f g : EigenformAwayFromLevel N k} (hχ : f.χ = g.χ)
-    (h : f.toCuspForm = g.toCuspForm) : f = g := by
-  obtain ⟨F, χf, memf, af, eigf, badf, nzf⟩ := f
-  obtain ⟨G, χg, memg, ag, eigg, badg, nzg⟩ := g
-  simp only at hχ h
-  subst hχ h
+/-- Two good Hecke eigenforms with the same underlying cusp form are equal: the form determines
+its nebentypus, and the eigenvalues at good indices are read off the eigenvector equations. -/
+theorem ext_of_toCuspForm {f g : EigenformAwayFromLevel N k} (h : f.toCuspForm = g.toCuspForm) :
+    f = g := by
+  obtain ⟨F, χf, memf, af, eigf, nzf⟩ := f
+  obtain ⟨G, χg, memg, ag, eigg, nzg⟩ := g
+  simp only at h
+  subst h
+  obtain rfl : χf = χg := eq_of_mem_cuspFormCharSpace_of_ne_zero memf memg nzf
   have hx : (⟨F, memf⟩ : cuspFormCharSpace k χf) ≠ 0 := fun hx ↦ nzf (congrArg Subtype.val hx)
-  have hae : af = ag := funext fun n ↦ by
-    by_cases hn : Nat.Coprime n.val N
-    · exact smul_left_injective ℂ hx ((eigf n hn).symm.trans (eigg n hn))
-    · rw [badf n hn, badg n hn]
+  have hae : af = ag := funext fun n ↦ funext fun hn ↦
+    smul_left_injective ℂ hx ((eigf n hn).symm.trans (eigg n hn))
   subst hae
   rfl
 
@@ -136,12 +126,11 @@ end EigenformAwayFromLevel
 
 namespace Newform
 
-/-- Two newforms with the same underlying cusp form and character are equal. -/
-theorem ext_of_toCuspForm {f g : Newform N k} (hχ : f.χ = g.χ)
-    (h : f.toCuspForm = g.toCuspForm) : f = g := by
+/-- Two newforms with the same underlying cusp form are equal. -/
+theorem ext_of_toCuspForm {f g : Newform N k} (h : f.toCuspForm = g.toCuspForm) : f = g := by
   obtain ⟨f, hfn, hf1⟩ := f
   obtain ⟨g, hgn, hg1⟩ := g
-  have : f = g := EigenformAwayFromLevel.ext_of_toCuspForm hχ h
+  have : f = g := EigenformAwayFromLevel.ext_of_toCuspForm h
   subst this
   rfl
 

--- a/TauCeti/NumberTheory/ModularForms/Newforms/Newform.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Newform.lean
@@ -29,7 +29,7 @@ that the character, the eigenvalue system and the analytic invariants travel wit
   notion (and is not a claim about `U_n`).
 * A good eigenform is determined by its underlying cusp form: the character by
   `eq_of_mem_cuspFormCharSpace_of_ne_zero`, the eigenvalues by cancelling the nonzero form in
-  the eigenvector equations (`EigenformAwayFromLevel.ext_of_toCuspForm`).
+  the eigenvector equations (`EigenformAwayFromLevel.ext`).
 * That a newform is an eigenvector of every `T_n` is a theorem (Atkin–Lehner–Li; Miyake
   Theorem 4.6.13), not a field, and so is the comparison of the ring eigenvalues with the
   classical operator `heckeTCuspNat`; neither is proved here.
@@ -42,9 +42,8 @@ that the character, the eigenvalue system and the analytic invariants travel wit
 
 ## Main results
 
-* `HeckeRing.GL2.EigenformAwayFromLevel.ext_of_toCuspForm`,
-  `HeckeRing.GL2.Newform.ext_of_toCuspForm`: the bundled data is determined by the underlying
-  cusp form.
+* `HeckeRing.GL2.EigenformAwayFromLevel.ext`, `HeckeRing.GL2.Newform.ext`: the bundled data is
+  determined by the underlying cusp form.
 
 ## Provenance
 
@@ -107,10 +106,11 @@ structure Newform (N : ℕ) [NeZero N] (k : ℤ) extends EigenformAwayFromLevel 
 
 namespace EigenformAwayFromLevel
 
-/-- Two good Hecke eigenforms with the same underlying cusp form are equal: the form determines
-its nebentypus, and the eigenvalues at good indices are read off the eigenvector equations. -/
-theorem ext_of_toCuspForm {f g : EigenformAwayFromLevel N k} (h : f.toCuspForm = g.toCuspForm) :
-    f = g := by
+/-- **Extensionality**: two good Hecke eigenforms with the same underlying cusp form are equal.
+The form determines its nebentypus, and the eigenvalues at good indices are read off the
+eigenvector equations. -/
+@[ext]
+theorem ext {f g : EigenformAwayFromLevel N k} (h : f.toCuspForm = g.toCuspForm) : f = g := by
   obtain ⟨F, χf, memf, af, eigf, nzf⟩ := f
   obtain ⟨G, χg, memg, ag, eigg, nzg⟩ := g
   simp only at h
@@ -126,11 +126,12 @@ end EigenformAwayFromLevel
 
 namespace Newform
 
-/-- Two newforms with the same underlying cusp form are equal. -/
-theorem ext_of_toCuspForm {f g : Newform N k} (h : f.toCuspForm = g.toCuspForm) : f = g := by
+/-- **Extensionality**: two newforms with the same underlying cusp form are equal. -/
+@[ext]
+theorem ext {f g : Newform N k} (h : f.toCuspForm = g.toCuspForm) : f = g := by
   obtain ⟨f, hfn, hf1⟩ := f
   obtain ⟨g, hgn, hg1⟩ := g
-  have : f = g := EigenformAwayFromLevel.ext_of_toCuspForm h
+  have : f = g := EigenformAwayFromLevel.ext h
   subst this
   rfl
 

--- a/TauCeti/NumberTheory/ModularForms/Newforms/Newform.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Newform.lean
@@ -30,8 +30,7 @@ that the character, the eigenvalue system and the analytic invariants travel wit
   `Nat.Coprime n N`; the total `ringEigenvalue` is a representation detail.
 * That a newform is an eigenvector of every `T_n` is a theorem (Atkin–Lehner–Li; Miyake
   Theorem 4.6.13), not a field. The comparison of the ring eigenvalue with the classical
-  operator `heckeTCuspNat` — through the diamond factor `χ(n)` — is likewise a theorem, and is
-  not proved here.
+  operator `heckeTCuspNat` is likewise a theorem, and is not proved here.
 
 ## Main definitions
 
@@ -54,8 +53,9 @@ Chris Birkbeck, commit `2baa76f742bdb4fb8ee323fabba41203bd390e08`, Apache-2.0,
 <https://github.com/CBirkbeck/AINTLIB/tree/main/projects/LeanModularForms>), with the porting
 decisions the roadmap pins: the structure is named for the qualified notion, the nonzeroness
 field is added, the character space is the cusp-form one, and the bad-index slots are
-normalised to `0`. The source's `Eigenform.eigenvalue`/`isEigen` (the classical eigenvalue) rest
-on its `heckeT_n_cusp_eq_heckeRingHom`, which has no counterpart here yet.
+normalised to `0`. The source's `Eigenform.eigenvalue`/`isEigen` (the classical eigenvalue,
+which in its convention carries a diamond factor `χ(n)`) rest on its
+`heckeT_n_cusp_eq_heckeRingHom`, which has no counterpart here yet.
 
 ## References
 

--- a/TauCeti/NumberTheory/ModularForms/Newforms/Newform.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Newform.lean
@@ -1,0 +1,150 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.NumberTheory.HeckeRing.GL2.Gamma0.Diagonal.Composite
+public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Nebentypus.Action
+public import TauCeti.NumberTheory.ModularForms.Newforms.Basic
+
+/-!
+# Good Hecke eigenforms and newforms, as bundled forms
+
+A **good Hecke eigenform** of level `Γ₁(N)` and weight `k` is a nonzero cusp form with a
+nebentypus `χ` that is a simultaneous eigenvector of the `Γ₀(N)` Hecke ring acting on
+`cuspFormCharSpace k χ` (`heckeRingHomCuspCharSpace`), at every index coprime to the level.
+A **newform** is a good Hecke eigenform lying in the new subspace and normalised by `a₁ = 1`:
+Miyake's *primitive form* (§4.6). Both are bundled here as structures extending `CuspForm`, so
+that the character, the eigenvalue system and the analytic invariants travel with the form.
+
+## Design
+
+* Eigen-ness is demanded only at indices coprime to `N`: the ring element at a bad index lies in
+  another double coset and is not packaged. The eigenvalue slot at a bad index carries no
+  arithmetic and is normalised to `0`, which is what makes an eigenform determined by its
+  underlying cusp form and character (`EigenformAwayFromLevel.ext_of_toCuspForm`). It is not a
+  claim about `U_p`.
+* The public eigenvalue interface is `EigenformAwayFromLevel.eigenvalue`, guarded by
+  `Nat.Coprime n N`; the total `ringEigenvalue` is a representation detail.
+* That a newform is an eigenvector of every `T_n` is a theorem (Atkin–Lehner–Li; Miyake
+  Theorem 4.6.13), not a field. The comparison of the ring eigenvalue with the classical
+  operator `heckeTCuspNat` — through the diamond factor `χ(n)` — is likewise a theorem, and is
+  not proved here.
+
+## Main definitions
+
+* `HeckeRing.GL2.EigenformAwayFromLevel`: the bundled good Hecke eigenform.
+* `HeckeRing.GL2.Newform`: the bundled newform.
+* `HeckeRing.GL2.EigenformAwayFromLevel.eigenvalue`: the eigenvalue at an index coprime to the
+  level.
+
+## Main results
+
+* `HeckeRing.GL2.EigenformAwayFromLevel.ext_of_toCuspForm`,
+  `HeckeRing.GL2.Newform.ext_of_toCuspForm`: the bundled data is determined by the underlying
+  cusp form and the character.
+
+## Provenance
+
+Follows the shapes of `structure Eigenform` and `structure Newform` of the AINTLIB
+`LeanModularForms` project (`LeanModularForms/HeckeRIngs/GL2/Newforms/{Basic,MainLemma}.lean`,
+Chris Birkbeck, commit `2baa76f742bdb4fb8ee323fabba41203bd390e08`, Apache-2.0,
+<https://github.com/CBirkbeck/AINTLIB/tree/main/projects/LeanModularForms>), with the porting
+decisions the roadmap pins: the structure is named for the qualified notion, the nonzeroness
+field is added, the character space is the cusp-form one, and the bad-index slots are
+normalised to `0`. The source's `Eigenform.eigenvalue`/`isEigen` (the classical eigenvalue) rest
+on its `heckeT_n_cusp_eq_heckeRingHom`, which has no counterpart here yet.
+
+## References
+
+* [F. Diamond and J. Shurman, *A first course in modular forms*][diamondshurman2005], §5.8.
+* [T. Miyake, *Modular forms*][miyake1989], §4.6.
+-/
+
+public section
+
+open Matrix Matrix.SpecialLinearGroup UpperHalfPlane CongruenceSubgroup HeckeRing.GLn
+
+open scoped MatrixGroups ModularForm HeckeCosetModule
+
+namespace HeckeRing.GL2
+
+variable {N : ℕ} [NeZero N] {k : ℤ}
+
+/-- **A good Hecke eigenform, bundled.** A nonzero cusp form of level `Γ₁(N)` with a nebentypus
+`χ`, together with an eigenvalue system for the `Γ₀(N)` Hecke ring acting on
+`cuspFormCharSpace k χ`: at every index `n` coprime to `N`, the ring element
+`heckeTCompositeGamma0 N n` acts by the scalar `ringEigenvalue n`. Eigen-ness is demanded only
+away from the level; the slots at indices not coprime to `N` carry no arithmetic and are
+normalised to `0`, so that an eigenform is determined by its underlying cusp form and character.
+-/
+structure EigenformAwayFromLevel (N : ℕ) [NeZero N] (k : ℤ)
+    extends CuspForm ((Gamma1 N).map (mapGL ℝ)) k where
+  /-- The nebentypus character. -/
+  χ : (ZMod N)ˣ →* ℂˣ
+  /-- The form transforms under the diamond operators by `χ`. -/
+  mem_charSpace : toCuspForm ∈ cuspFormCharSpace k χ
+  /-- The eigenvalue system for the `Γ₀(N)` Hecke ring; only the values at indices coprime to
+  `N` carry meaning. -/
+  ringEigenvalue : ℕ+ → ℂ
+  /-- At an index coprime to `N`, the Hecke ring element `heckeTCompositeGamma0 N n` acts on the
+  form by `ringEigenvalue n`. -/
+  isRingEigen : ∀ n : ℕ+, Nat.Coprime n.val N →
+    heckeRingHomCuspCharSpace (k := k) (χ := χ) (heckeTCompositeGamma0 N n.val)
+        ⟨toCuspForm, mem_charSpace⟩
+      = ringEigenvalue n • (⟨toCuspForm, mem_charSpace⟩ : cuspFormCharSpace k χ)
+  /-- The slots at indices not coprime to `N` are normalised to `0`. -/
+  ringEigen_bad : ∀ n : ℕ+, ¬ Nat.Coprime n.val N → ringEigenvalue n = 0
+  /-- An eigenform is nonzero. -/
+  ne_zero : toCuspForm ≠ 0
+
+/-- **A newform**: a good Hecke eigenform lying in the new subspace and normalised by `a₁ = 1`
+(Miyake's *primitive form*). That a newform is an eigenform for every `T_n` is a theorem, not
+part of the definition. -/
+structure Newform (N : ℕ) [NeZero N] (k : ℤ) extends EigenformAwayFromLevel N k where
+  /-- The form lies in the new subspace `S_k(Γ₁(N))ⁿᵉʷ`. -/
+  isNew : toCuspForm ∈ TauCeti.cuspFormsNew N k
+  /-- The form is normalised: its first Fourier coefficient is `1`. -/
+  isNorm : (qExpansion 1 toCuspForm).coeff 1 = 1
+
+namespace EigenformAwayFromLevel
+
+variable (f : EigenformAwayFromLevel N k)
+
+/-- The eigenvalue at an index coprime to the level: the public face of `ringEigenvalue`. -/
+def eigenvalue (n : ℕ+) (_hn : Nat.Coprime n.val N) : ℂ := f.ringEigenvalue n
+
+/-- Two good Hecke eigenforms with the same underlying cusp form and character are equal: the
+eigenvalues at good indices are determined by the form, and the bad slots are normalised. -/
+theorem ext_of_toCuspForm {f g : EigenformAwayFromLevel N k} (hχ : f.χ = g.χ)
+    (h : f.toCuspForm = g.toCuspForm) : f = g := by
+  obtain ⟨F, χf, memf, af, eigf, badf, nzf⟩ := f
+  obtain ⟨G, χg, memg, ag, eigg, badg, nzg⟩ := g
+  simp only at hχ h
+  subst hχ h
+  have hx : (⟨F, memf⟩ : cuspFormCharSpace k χf) ≠ 0 := fun hx ↦ nzf (congrArg Subtype.val hx)
+  have hae : af = ag := funext fun n ↦ by
+    by_cases hn : Nat.Coprime n.val N
+    · exact smul_left_injective ℂ hx ((eigf n hn).symm.trans (eigg n hn))
+    · rw [badf n hn, badg n hn]
+  subst hae
+  rfl
+
+end EigenformAwayFromLevel
+
+namespace Newform
+
+/-- Two newforms with the same underlying cusp form and character are equal. -/
+theorem ext_of_toCuspForm {f g : Newform N k} (hχ : f.χ = g.χ)
+    (h : f.toCuspForm = g.toCuspForm) : f = g := by
+  obtain ⟨f, hfn, hf1⟩ := f
+  obtain ⟨g, hgn, hg1⟩ := g
+  have : f = g := EigenformAwayFromLevel.ext_of_toCuspForm hχ h
+  subst this
+  rfl
+
+end Newform
+
+end HeckeRing.GL2


### PR DESCRIPTION
Adds the roadmap's Layer-4 bundled shapes for good Hecke eigenforms and newforms, in `Newforms/Newform.lean`:

- `HeckeRing.GL2.EigenformAwayFromLevel N k`, extending `CuspForm ((Gamma1 N).map (mapGL ℝ)) k` with the nebentypus `χ`, `mem_charSpace : toCuspForm ∈ cuspFormCharSpace k χ`, the eigenvalue system `eigenvalue : ∀ n : ℕ+, Nat.Coprime n N → ℂ` stored at the good indices only, its characteristic equation `isEigen n hn` for the `Γ₀(N)` Hecke ring acting through `heckeRingHomCuspCharSpace` (the ring element being `heckeTCompositeGamma0 N n`), and `ne_zero`.
- `HeckeRing.GL2.Newform N k`, extending it with `isNew : toCuspForm ∈ cuspFormsNew N k` and `isNorm : a₁ = 1` — Miyake's primitive form: new, normalised, eigen away from the level.
- The two `@[ext]` lemmas `EigenformAwayFromLevel.ext` and `Newform.ext`: the bundled data is determined by the underlying cusp form alone — the character by the new `TauCeti.eq_of_mem_cuspFormCharSpace_of_ne_zero` (`DiamondOperators.lean`: a nonzero cusp form determines its nebentypus), the eigenvalues by `smul_left_injective` on the nonzero form.

These are the definitions the roadmap lists under "Definitions — AINTLIB's actual shapes" in Layer 4. Differences from the source: the structure is named for the qualified notion (`EigenformAwayFromLevel`, next to the existing predicate `IsEigenformAwayFromLevel`), nonzeroness is a field, and the eigenvalues are stored at the good indices only, guarded by `Nat.Coprime n N`, instead of as a total function with conventional values at bad indices — so no bad-index value exists to be consumed. The all-`Tₙ` upgrade and the comparison with the classical `heckeTCuspNat` stay theorems and are not claimed here.

Roadmap: ModularForms
<!--tauceti-target:v1 {"focus":"ModularForms","id":"ModularForms/README.md:Layer-4:EigenformAwayFromLevel-Newform-structures"}-->

Provenance: github.com/CBirkbeck/AINTLIB @ `2baa76f742bdb4fb8ee323fabba41203bd390e08` (Apache-2.0, Chris Birkbeck), `projects/LeanModularForms/LeanModularForms/HeckeRIngs/GL2/Newforms/Basic.lean` (`structure Eigenform`, `Eigenform.eigenvalue`) and `Newforms/MainLemma.lean` (`structure Newform`). Fields restated over `cuspFormCharSpace` and this repository's `heckeRingHomCuspCharSpace`/`heckeTCompositeGamma0`; `ne_zero` and the guarded eigenvalue storage are this port's; the `ext` lemmas and the nebentypus-uniqueness lemma are new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQieFQn95rzgvYRvNdX3hR
