### PR TITLE
feat: prove complete reducibility of the CAR module

### DIFF
--- a/TauCeti/Algebra/Lie/GeneralLinear/Basic.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/Basic.lean
@@ -50,6 +50,8 @@ sits *inside* the derived ideal and the two are not complementary.
   `TauCeti.derivedSeries_one_toLieSubalgebra_eq_sl` reads this as `LieAlgebra.SpecialLinear.sl n R`.
 * `TauCeti.isCompl_center_derivedSeries_one_matrix`: when `Fintype.card n` is invertible in `R`,
   the centre and the derived ideal are complementary submodules of `gl n R`.
+* `TauCeti.exists_sl_add_smul_one_eq`: every matrix is a trace-zero matrix plus a scalar matrix
+  when the cardinality is a unit, with the empty case included.
 * `TauCeti.derivedSeries_one_matrix_ne_top`: for nonempty `n` over a nontrivial `R`, `gl n R` is
   not perfect.
 * `TauCeti.not_hasTrivialRadical_matrix`: for nonempty `n` over a nontrivial `R`, `gl n R` is not
@@ -58,8 +60,9 @@ sits *inside* the derived ideal and the two are not complementary.
 ## Implementation notes
 
 Every result about `gl n R` is stated over an arbitrary commutative ring `R`; no field,
-characteristic, or algebraic closure hypothesis is used, and the invertibility of `Fintype.card n`
-is carried as an `Invertible` hypothesis only on the one result that needs it. Two groups of
+characteristic, or algebraic closure hypothesis is used. The bundled complement carries
+invertibility of `Fintype.card n` as an `Invertible` hypothesis, while its elementwise consequence
+asks only that the cardinality be a unit when the index type is nonempty. Two groups of
 declarations ask for less: the matrix-unit bracket identities and the spanning theorem for
 trace-zero matrices need only a ring, and the decomposition of a trace-zero matrix into matrix units
 needs only an additive commutative group, no multiplication at all.
@@ -320,6 +323,28 @@ theorem isCompl_center_derivedSeries_one_matrix [Invertible (Fintype.card n : R)
         ← mul_assoc, invOf_mul_self, one_mul]
     rw [derivedSeries_one_eq_slIdeal R n, LieSubmodule.mem_toSubmodule, mem_slIdeal_iff,
       Matrix.trace_sub, htr, sub_self]
+
+/-- Every square matrix is the sum of a trace-zero matrix and a scalar matrix, as soon as the rank
+is a unit in `R`. This is the elementwise form of
+`TauCeti.isCompl_center_derivedSeries_one_matrix`; the separate rank-zero branch is why the
+hypothesis is an implication rather than a global invertibility assumption. -/
+theorem exists_sl_add_smul_one_eq
+    (hn : Nonempty n → IsUnit (Fintype.card n : R)) (A : Matrix n n R) :
+    ∃ (X : LieAlgebra.SpecialLinear.sl n R) (r : R), (X : Matrix n n R) + r • 1 = A := by
+  cases isEmpty_or_nonempty n with
+  | inl h =>
+      let _ := h
+      exact ⟨0, 0, Subsingleton.elim _ _⟩
+  | inr h =>
+      let _ := h
+      let _ : Invertible (Fintype.card n : R) := (hn h).invertible
+      obtain ⟨Z, X, hZ, hX, hZX⟩ := Submodule.codisjoint_iff_exists_add_eq.mp
+        (isCompl_center_derivedSeries_one_matrix R n).codisjoint A
+      obtain ⟨r, rfl⟩ := mem_center_matrix_iff.mp hZ
+      have hXsl : X ∈ LieAlgebra.SpecialLinear.sl n R := by
+        rw [← derivedSeries_one_toLieSubalgebra_eq_sl R n]
+        exact hX
+      exact ⟨⟨X, hXsl⟩, r, (add_comm X (r • 1)).trans hZX⟩
 
 variable (R n) in
 /-- `gl n R` is not perfect: for nonempty `n` over a nontrivial ring its derived ideal misses the

--- a/TauCeti/Algebra/Lie/GeneralLinear/Clifford.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/Clifford.lean
@@ -96,20 +96,28 @@ theorem glCliffordHom_apply (X : Matrix n n K) :
   change traceQuadraticLift X + scalarTrace X = _
   rfl
 
+/-- On a central matrix the lift is its normal-ordering constant alone: the adjoint action the
+quadratic part lifts already vanishes there. -/
+private theorem glCliffordHom_eq_algebraMap_of_commute {X : Matrix n n K}
+    (hX : ∀ Y : Matrix n n K, Commute Y X) :
+    glCliffordHom (K := K) (n := n) X =
+      algebraMap K (CliffordAlgebra (traceQuadraticForm K n))
+        ((Fintype.card n / 2 : K) * X.trace) := by
+  have hzero : traceAdjointSO K n X = 0 := by
+    refine Subtype.ext (LinearMap.ext fun Y => ?_)
+    rw [coe_traceAdjointSO, _root_.LieAlgebra.ad_apply, Ring.lie_def, (hX Y).eq, sub_self]
+    rfl
+  rw [glCliffordHom_apply, CliffordAlgebra.quadraticLift_apply, hzero, map_zero,
+    ZeroMemClass.coe_zero, zero_add]
+
 /-- The normal-ordered lift sends the identity matrix to the scalar
 `(Fintype.card n : K) ^ 2 / 2`. -/
+@[simp]
 theorem glCliffordHom_one :
     glCliffordHom (K := K) (n := n) 1 =
       algebraMap K (CliffordAlgebra (traceQuadraticForm K n))
         ((Fintype.card n : K) ^ 2 / 2) := by
-  have had : traceAdjointSO K n 1 = 0 := by
-    apply Subtype.ext
-    apply LinearMap.ext
-    intro X
-    rw [coe_traceAdjointSO, _root_.LieAlgebra.ad_apply, Ring.lie_def, one_mul, mul_one, sub_self]
-    rfl
-  rw [glCliffordHom_apply, CliffordAlgebra.quadraticLift_apply, had, map_zero,
-    ZeroMemClass.coe_zero, zero_add, Matrix.trace_one]
+  rw [glCliffordHom_eq_algebraMap_of_commute fun Y ↦ Commute.one_right Y, Matrix.trace_one]
   congr 1
   ring
 
@@ -257,20 +265,6 @@ private theorem commute_of_glCliffordHom_eq_zero {X : Matrix n n K}
   have hXY : ⁅X, Y⁆ = 0 := by rwa [ι_eq_zero_iff] at h
   rw [Ring.lie_def, sub_eq_zero] at hXY
   exact hXY.symm
-
-/-- On a central matrix the lift is its normal-ordering constant alone: the adjoint action the
-quadratic part lifts already vanishes there. -/
-private theorem glCliffordHom_eq_algebraMap_of_commute {X : Matrix n n K}
-    (hX : ∀ Y : Matrix n n K, Commute Y X) :
-    glCliffordHom (K := K) (n := n) X =
-      algebraMap K (CliffordAlgebra (traceQuadraticForm K n))
-        ((Fintype.card n / 2 : K) * X.trace) := by
-  have hzero : traceAdjointSO K n X = 0 := by
-    refine Subtype.ext (LinearMap.ext fun Y => ?_)
-    rw [coe_traceAdjointSO, _root_.LieAlgebra.ad_apply, Ring.lie_def, (hX Y).eq, sub_self]
-    rfl
-  rw [glCliffordHom_apply, CliffordAlgebra.quadraticLift_apply, hzero, map_zero,
-    ZeroMemClass.coe_zero, zero_add]
 
 /-- **The normal-ordered lift is injective as soon as `Fintype.card n` is invertible in `K`.**
 The adjoint action of `gl n K` is not faithful — its kernel is the centre, the scalar matrices

--- a/TauCeti/Algebra/Lie/GeneralLinear/Clifford.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/Clifford.lean
@@ -21,6 +21,7 @@ corresponding Clifford algebra.
 
 * `TauCeti.glCliffordHom`: the normal-ordered Lie homomorphism from matrices to the Clifford
   algebra of their trace quadratic form.
+* `TauCeti.glCliffordHom_one`: its scalar value on the identity matrix.
 * `TauCeti.glCliffordHom_lie_ι`: its commutator action on Clifford generators.
 * `TauCeti.glCliffordHom_single`: its formula on matrix units.
 * `TauCeti.glCliffordHom_normalOrdering`: its decomposition into bivectors and the central
@@ -94,6 +95,23 @@ theorem glCliffordHom_apply (X : Matrix n n K) :
   -- Expose the two private summands used to assemble the public homomorphism.
   change traceQuadraticLift X + scalarTrace X = _
   rfl
+
+/-- The normal-ordered lift sends the identity matrix to the scalar
+`(Fintype.card n : K) ^ 2 / 2`. -/
+theorem glCliffordHom_one :
+    glCliffordHom (K := K) (n := n) 1 =
+      algebraMap K (CliffordAlgebra (traceQuadraticForm K n))
+        ((Fintype.card n : K) ^ 2 / 2) := by
+  have had : traceAdjointSO K n 1 = 0 := by
+    apply Subtype.ext
+    apply LinearMap.ext
+    intro X
+    rw [coe_traceAdjointSO, _root_.LieAlgebra.ad_apply, Ring.lie_def, one_mul, mul_one, sub_self]
+    rfl
+  rw [glCliffordHom_apply, CliffordAlgebra.quadraticLift_apply, had, map_zero,
+    ZeroMemClass.coe_zero, zero_add, Matrix.trace_one]
+  congr 1
+  ring
 
 /-- The normal-ordered lift acts on Clifford generators by the matrix commutator. -/
 @[simp, grind =]

--- a/TauCeti/Algebra/Lie/GeneralLinear/CompleteReducibility.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/CompleteReducibility.lean
@@ -1,0 +1,198 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Lie.GeneralLinear.Fock
+public import TauCeti.Algebra.Lie.GeneralLinear.Restriction
+import TauCeti.Algebra.Lie.GeneralLinear.Radical
+import TauCeti.Algebra.Lie.HighestWeight.CompleteReducibility
+import Mathlib.Algebra.Lie.CartanCriterion
+import TauCeti.LinearAlgebra.CliffordAlgebra.Dimension
+
+/-!
+# Complete reducibility for the general linear Lie algebra and its CAR module
+
+The Killing form of `gl n` is degenerate on the scalar matrices, so Weyl's complete-reducibility
+theorem does not apply to it directly. It does apply to `sl n`. This file proves that `sl n` has
+trivial radical in characteristic zero, restricts a `gl n`-module to `sl n`, and then promotes an
+`sl n`-stable complement back to `gl n` whenever the identity matrix acts by a scalar.
+
+The final section applies this transfer to the left-regular CAR module. The normal-ordered lift
+sends the identity matrix to the scalar `(card n) ^ 2 / 2`; hence the centre preserves every
+`sl n`-submodule, and the CAR module is completely reducible.
+
+## Main results
+
+* `TauCeti.hasTrivialRadical_specialLinear`: `sl n` has zero solvable radical over a
+  characteristic-zero field.
+* `TauCeti.exists_isCompl_gl_of_forall_one_lie_eq_smul`: a finite-dimensional `gl n`-module on
+  which the identity acts by a scalar has a complement to every Lie submodule.
+* `TauCeti.complementedLattice_lieSubmodule_gl_of_forall_one_lie_eq_smul`: the corresponding
+  complemented-lattice statement.
+* `TauCeti.complementedLattice_lieSubmodule_car`: complete reducibility of the CAR module.
+
+## References
+
+* J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, GTM 9, §6.3, for
+  Weyl's complete-reducibility theorem.
+* B. Kostant, *Clifford algebra analogue of the Hopf--Koszul--Samelson theorem*, Adv. Math. 125
+  (1997), 275--350, for the left-regular Clifford module.
+-/
+
+public section
+
+namespace TauCeti
+
+open _root_.LieAlgebra
+
+attribute [local instance 100] LieRing.ofAssociativeRing
+
+universe u v w
+
+/-! ### Semisimplicity of the special linear Lie algebra -/
+
+section SpecialLinear
+
+variable (K : Type u) [Field K] [CharZero K]
+variable (n : Type v) [Fintype n] [DecidableEq n]
+
+/-- The inclusion of an ideal of `sl n` into `gl n` has ideal range. Scalar matrices commute with
+the image, while the `sl n` summand preserves the ideal. -/
+private theorem slIncl_isIdealMorphism (J : LieIdeal K (SpecialLinear.sl n K)) :
+    ((SpecialLinear.sl n K).incl.comp J.incl).IsIdealMorphism := by
+  rw [LieHom.isIdealMorphism_iff]
+  intro A y
+  cases isEmpty_or_nonempty n with
+  | inl hn =>
+      let _ := hn
+      exact ⟨0, Subsingleton.elim _ _⟩
+  | inr hn =>
+      let _ := hn
+      let _ : Invertible (Fintype.card n : K) :=
+        invertibleOfNonzero (Nat.cast_ne_zero.mpr Fintype.card_ne_zero)
+      obtain ⟨X, Z, hX, hZ, hXZ⟩ := Submodule.codisjoint_iff_exists_add_eq.mp
+        (isCompl_center_derivedSeries_one_matrix K n).codisjoint A
+      have hZsl : Z ∈ SpecialLinear.sl n K := by
+        rw [← derivedSeries_one_toLieSubalgebra_eq_sl K n]
+        exact hZ
+      have hXzero : ⁅X, ((SpecialLinear.sl n K).incl.comp J.incl) y⁆ = 0 := by
+        rw [← lie_skew, (LieModule.mem_maxTrivSubmodule K _ _ X).1 hX, neg_zero]
+      let z : J := ⟨⁅⟨Z, hZsl⟩, (y : SpecialLinear.sl n K)⁆, J.lie_mem y.property⟩
+      refine ⟨z, ?_⟩
+      rw [← hXZ, add_lie, hXzero, zero_add]
+      rfl
+
+/-- **The special linear Lie algebra has trivial radical in characteristic zero.** A solvable
+ideal of `sl n` maps to a solvable ideal of `gl n`, hence lies in the scalar matrices because the
+radical of `gl n` is its centre. Its image also lies in the derived ideal `sl n`; the centre and
+derived ideal are complementary, so the original ideal vanishes. -/
+theorem hasTrivialRadical_specialLinear :
+    LieAlgebra.HasTrivialRadical K (SpecialLinear.sl n K) := by
+  rw [LieAlgebra.hasTrivialRadical_iff_no_solvable_ideals]
+  intro J hJ
+  rw [eq_bot_iff]
+  intro x hx
+  let f : J →ₗ⁅K⁆ Matrix n n K := (SpecialLinear.sl n K).incl.comp J.incl
+  have hf : f.IsIdealMorphism := slIncl_isIdealMorphism K n J
+  have hsolvRange : LieAlgebra.IsSolvable f.range := by
+    let _ : LieAlgebra.IsSolvable J := hJ
+    infer_instance
+  have hsolv : LieAlgebra.IsSolvable f.idealRange := by
+    let e : (f.idealRange : LieSubalgebra K (Matrix n n K)) ≃ₗ⁅K⁆ f.range :=
+      LieEquiv.ofEq _ _ (congrArg (fun S : LieSubalgebra K (Matrix n n K) ↦
+        (S : Set (Matrix n n K))) hf.eq)
+    exact (LieAlgebra.solvable_iff_equiv_solvable e).mpr hsolvRange
+  have hcenter : f ⟨x, hx⟩ ∈ LieAlgebra.center K (Matrix n n K) := by
+    rw [← radical_eq_center]
+    exact (LieIdeal.solvable_iff_le_radical K _ f.idealRange).mp hsolv
+      (f.mem_idealRange ⟨x, hx⟩)
+  cases isEmpty_or_nonempty n with
+  | inl hn =>
+      let _ := hn
+      exact Subsingleton.elim _ _
+  | inr hn =>
+      let _ := hn
+      let _ : Invertible (Fintype.card n : K) :=
+        invertibleOfNonzero (Nat.cast_ne_zero.mpr Fintype.card_ne_zero)
+      have hderived : f ⟨x, hx⟩ ∈ (derivedSeries K (Matrix n n K) 1).toSubmodule := by
+        rw [derivedSeries_one_eq_slIdeal K n, LieSubmodule.mem_toSubmodule, mem_slIdeal_iff]
+        exact x.property
+      have hzero : f ⟨x, hx⟩ = 0 :=
+        (isCompl_center_derivedSeries_one_matrix K n).disjoint.le_bot ⟨hcenter, hderived⟩
+      exact Subtype.ext (by simpa [f] using hzero)
+
+end SpecialLinear
+
+/-! ### Complete reducibility for scalar-centre `gl n` modules -/
+
+section GeneralLinear
+
+variable {K : Type u} [Field K] [CharZero K] [IsAlgClosed K]
+variable {n : Type v} [Fintype n] [DecidableEq n]
+variable {M : Type w} [AddCommGroup M] [Module K M]
+variable [LieRingModule (Matrix n n K) M] [LieModule K (Matrix n n K) M]
+
+/-- Extend an `sl n`-submodule to `gl n` when the identity acts by a scalar. -/
+private def extendSl (c : K) (hc : ∀ m : M, ⁅(1 : Matrix n n K), m⁆ = c • m)
+    (N : LieSubmodule K (SpecialLinear.sl n K) M) : LieSubmodule K (Matrix n n K) M where
+  __ := N.toSubmodule
+  lie_mem {A m} hm := by
+    obtain ⟨X, r, rfl⟩ := exists_sl_add_smul_one_eq
+      (fun h ↦ by let _ := h; exact Nat.cast_ne_zero.mpr Fintype.card_ne_zero) A
+    rw [add_lie, smul_lie, hc, smul_smul]
+    exact N.add_mem (N.lie_mem hm) (N.smul_mem _ hm)
+
+/-- **Complete reducibility for a general-linear module with scalar centre.** Every Lie submodule
+has a complement when the identity matrix acts by a scalar. Restriction to `sl n` supplies a
+complement by Weyl's theorem, and the scalar action makes that complement stable under all of
+`gl n`. -/
+theorem exists_isCompl_gl_of_forall_one_lie_eq_smul [FiniteDimensional K M] {c : K}
+    (hc : ∀ m : M, ⁅(1 : Matrix n n K), m⁆ = c • m)
+    (N : LieSubmodule K (Matrix n n K) M) :
+    ∃ N' : LieSubmodule K (Matrix n n K) M, IsCompl N N' := by
+  let _ : LieAlgebra.HasTrivialRadical K (SpecialLinear.sl n K) :=
+    hasTrivialRadical_specialLinear K n
+  obtain ⟨P, hP⟩ := exists_isCompl_of_isKilling (K := K)
+    (L := SpecialLinear.sl n K) (N.restr (SpecialLinear.sl n K))
+  refine ⟨extendSl c hc P, IsCompl.of_eq ?_ ?_⟩
+  · apply LieSubmodule.toSubmodule_injective
+    simpa [extendSl] using congrArg LieSubmodule.toSubmodule hP.inf_eq_bot
+  · apply LieSubmodule.toSubmodule_injective
+    simpa [extendSl] using congrArg LieSubmodule.toSubmodule hP.sup_eq_top
+
+variable (K n M) in
+/-- The Lie-submodule lattice of a finite-dimensional `gl n`-module is complemented when the
+identity matrix acts by a scalar. -/
+theorem complementedLattice_lieSubmodule_gl_of_forall_one_lie_eq_smul
+    [FiniteDimensional K M] {c : K}
+    (hc : ∀ m : M, ⁅(1 : Matrix n n K), m⁆ = c • m) :
+    ComplementedLattice (LieSubmodule K (Matrix n n K) M) :=
+  ⟨exists_isCompl_gl_of_forall_one_lie_eq_smul hc⟩
+
+end GeneralLinear
+
+/-! ### The CAR module -/
+
+section CAR
+
+attribute [local instance] Classical.decEq
+open scoped TauCeti
+
+variable {K n : Type*} [Field K] [Fintype n] [Invertible (2 : K)]
+
+variable [CharZero K] [IsAlgClosed K]
+
+variable (K n) in
+/-- **The CAR module is completely reducible.** Its Lie-submodule lattice is complemented because
+the normal-ordered action of the identity matrix is scalar. -/
+theorem complementedLattice_lieSubmodule_car :
+    ComplementedLattice
+      (LieSubmodule K (Matrix n n K) (CliffordAlgebra (traceQuadraticForm K n))) :=
+  complementedLattice_lieSubmodule_gl_of_forall_one_lie_eq_smul K n _ car_one_lie_eq_smul
+
+end CAR
+
+end TauCeti

--- a/TauCeti/Algebra/Lie/GeneralLinear/CompleteReducibility.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/CompleteReducibility.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.Lie.GeneralLinear.Fock
-public import TauCeti.Algebra.Lie.GeneralLinear.Restriction
 import TauCeti.Algebra.Lie.GeneralLinear.Radical
 import TauCeti.Algebra.Lie.HighestWeight.CompleteReducibility
 import Mathlib.Algebra.Lie.CartanCriterion
@@ -16,9 +15,9 @@ import TauCeti.LinearAlgebra.CliffordAlgebra.Dimension
 # Complete reducibility for the general linear Lie algebra and its CAR module
 
 The Killing form of `gl n` is degenerate on the scalar matrices, so Weyl's complete-reducibility
-theorem does not apply to it directly. It does apply to `sl n`. This file proves that `sl n` has
-trivial radical in characteristic zero, restricts a `gl n`-module to `sl n`, and then promotes an
-`sl n`-stable complement back to `gl n` whenever the identity matrix acts by a scalar.
+theorem does not apply to it directly. It does apply to `sl n`. This file restricts a `gl n`-module
+to `sl n`, and then promotes an `sl n`-stable complement back to `gl n` whenever the identity
+matrix acts by a scalar.
 
 The final section applies this transfer to the left-regular CAR module. The normal-ordered lift
 sends the identity matrix to the scalar `(card n) ^ 2 / 2`; hence the centre preserves every
@@ -26,8 +25,6 @@ sends the identity matrix to the scalar `(card n) ^ 2 / 2`; hence the centre pre
 
 ## Main results
 
-* `TauCeti.hasTrivialRadical_specialLinear`: `sl n` has zero solvable radical over a
-  characteristic-zero field.
 * `TauCeti.exists_isCompl_gl_of_forall_one_lie_eq_smul`: a finite-dimensional `gl n`-module on
   which the identity acts by a scalar has a complement to every Lie submodule.
 * `TauCeti.complementedLattice_lieSubmodule_gl_of_forall_one_lie_eq_smul`: the corresponding
@@ -52,80 +49,6 @@ attribute [local instance 100] LieRing.ofAssociativeRing
 
 universe u v w
 
-/-! ### Semisimplicity of the special linear Lie algebra -/
-
-section SpecialLinear
-
-variable (K : Type u) [Field K] [CharZero K]
-variable (n : Type v) [Fintype n] [DecidableEq n]
-
-/-- The inclusion of an ideal of `sl n` into `gl n` has ideal range. Scalar matrices commute with
-the image, while the `sl n` summand preserves the ideal. -/
-private theorem slIncl_isIdealMorphism (J : LieIdeal K (SpecialLinear.sl n K)) :
-    ((SpecialLinear.sl n K).incl.comp J.incl).IsIdealMorphism := by
-  rw [LieHom.isIdealMorphism_iff]
-  intro A y
-  cases isEmpty_or_nonempty n with
-  | inl hn =>
-      let _ := hn
-      exact ⟨0, Subsingleton.elim _ _⟩
-  | inr hn =>
-      let _ := hn
-      let _ : Invertible (Fintype.card n : K) :=
-        invertibleOfNonzero (Nat.cast_ne_zero.mpr Fintype.card_ne_zero)
-      obtain ⟨X, Z, hX, hZ, hXZ⟩ := Submodule.codisjoint_iff_exists_add_eq.mp
-        (isCompl_center_derivedSeries_one_matrix K n).codisjoint A
-      have hZsl : Z ∈ SpecialLinear.sl n K := by
-        rw [← derivedSeries_one_toLieSubalgebra_eq_sl K n]
-        exact hZ
-      have hXzero : ⁅X, ((SpecialLinear.sl n K).incl.comp J.incl) y⁆ = 0 := by
-        rw [← lie_skew, (LieModule.mem_maxTrivSubmodule K _ _ X).1 hX, neg_zero]
-      let z : J := ⟨⁅⟨Z, hZsl⟩, (y : SpecialLinear.sl n K)⁆, J.lie_mem y.property⟩
-      refine ⟨z, ?_⟩
-      rw [← hXZ, add_lie, hXzero, zero_add]
-      rfl
-
-/-- **The special linear Lie algebra has trivial radical in characteristic zero.** A solvable
-ideal of `sl n` maps to a solvable ideal of `gl n`, hence lies in the scalar matrices because the
-radical of `gl n` is its centre. Its image also lies in the derived ideal `sl n`; the centre and
-derived ideal are complementary, so the original ideal vanishes. -/
-theorem hasTrivialRadical_specialLinear :
-    LieAlgebra.HasTrivialRadical K (SpecialLinear.sl n K) := by
-  rw [LieAlgebra.hasTrivialRadical_iff_no_solvable_ideals]
-  intro J hJ
-  rw [eq_bot_iff]
-  intro x hx
-  let f : J →ₗ⁅K⁆ Matrix n n K := (SpecialLinear.sl n K).incl.comp J.incl
-  have hf : f.IsIdealMorphism := slIncl_isIdealMorphism K n J
-  have hsolvRange : LieAlgebra.IsSolvable f.range := by
-    let _ : LieAlgebra.IsSolvable J := hJ
-    infer_instance
-  have hsolv : LieAlgebra.IsSolvable f.idealRange := by
-    let e : (f.idealRange : LieSubalgebra K (Matrix n n K)) ≃ₗ⁅K⁆ f.range :=
-      LieEquiv.ofEq _ _ (congrArg (fun S : LieSubalgebra K (Matrix n n K) ↦
-        (S : Set (Matrix n n K))) hf.eq)
-    exact (LieAlgebra.solvable_iff_equiv_solvable e).mpr hsolvRange
-  have hcenter : f ⟨x, hx⟩ ∈ LieAlgebra.center K (Matrix n n K) := by
-    rw [← radical_eq_center]
-    exact (LieIdeal.solvable_iff_le_radical K _ f.idealRange).mp hsolv
-      (f.mem_idealRange ⟨x, hx⟩)
-  cases isEmpty_or_nonempty n with
-  | inl hn =>
-      let _ := hn
-      exact Subsingleton.elim _ _
-  | inr hn =>
-      let _ := hn
-      let _ : Invertible (Fintype.card n : K) :=
-        invertibleOfNonzero (Nat.cast_ne_zero.mpr Fintype.card_ne_zero)
-      have hderived : f ⟨x, hx⟩ ∈ (derivedSeries K (Matrix n n K) 1).toSubmodule := by
-        rw [derivedSeries_one_eq_slIdeal K n, LieSubmodule.mem_toSubmodule, mem_slIdeal_iff]
-        exact x.property
-      have hzero : f ⟨x, hx⟩ = 0 :=
-        (isCompl_center_derivedSeries_one_matrix K n).disjoint.le_bot ⟨hcenter, hderived⟩
-      exact Subtype.ext (by simpa [f] using hzero)
-
-end SpecialLinear
-
 /-! ### Complete reducibility for scalar-centre `gl n` modules -/
 
 section GeneralLinear
@@ -141,9 +64,20 @@ private def extendSl (c : K) (hc : ∀ m : M, ⁅(1 : Matrix n n K), m⁆ = c �
   __ := N.toSubmodule
   lie_mem {A m} hm := by
     obtain ⟨X, r, rfl⟩ := exists_sl_add_smul_one_eq
-      (fun h ↦ by let _ := h; exact Nat.cast_ne_zero.mpr Fintype.card_ne_zero) A
+      (fun h ↦ by
+        let _ := h
+        exact isUnit_iff_ne_zero.mpr (Nat.cast_ne_zero.mpr Fintype.card_ne_zero)) A
     rw [add_lie, smul_lie, hc, smul_smul]
     exact N.add_mem (N.lie_mem hm) (N.smul_mem _ hm)
+
+omit [IsAlgClosed K] in
+/-- The scalar-centre extension preserves the underlying submodule. -/
+@[simp]
+private theorem extendSl_toSubmodule (c : K)
+    (hc : ∀ m : M, ⁅(1 : Matrix n n K), m⁆ = c • m)
+    (N : LieSubmodule K (SpecialLinear.sl n K) M) :
+    (extendSl c hc N).toSubmodule = N.toSubmodule :=
+  rfl
 
 /-- **Complete reducibility for a general-linear module with scalar centre.** Every Lie submodule
 has a complement when the identity matrix acts by a scalar. Restriction to `sl n` supplies a
@@ -153,15 +87,17 @@ theorem exists_isCompl_gl_of_forall_one_lie_eq_smul [FiniteDimensional K M] {c :
     (hc : ∀ m : M, ⁅(1 : Matrix n n K), m⁆ = c • m)
     (N : LieSubmodule K (Matrix n n K) M) :
     ∃ N' : LieSubmodule K (Matrix n n K) M, IsCompl N N' := by
-  let _ : LieAlgebra.HasTrivialRadical K (SpecialLinear.sl n K) :=
-    hasTrivialRadical_specialLinear K n
   obtain ⟨P, hP⟩ := exists_isCompl_of_isKilling (K := K)
     (L := SpecialLinear.sl n K) (N.restr (SpecialLinear.sl n K))
   refine ⟨extendSl c hc P, IsCompl.of_eq ?_ ?_⟩
   · apply LieSubmodule.toSubmodule_injective
-    simpa [extendSl] using congrArg LieSubmodule.toSubmodule hP.inf_eq_bot
+    simpa only [LieSubmodule.inf_toSubmodule, extendSl_toSubmodule,
+      LieSubmodule.restr_toSubmodule, LieSubmodule.bot_toSubmodule] using
+      congrArg LieSubmodule.toSubmodule hP.inf_eq_bot
   · apply LieSubmodule.toSubmodule_injective
-    simpa [extendSl] using congrArg LieSubmodule.toSubmodule hP.sup_eq_top
+    simpa only [LieSubmodule.sup_toSubmodule, extendSl_toSubmodule,
+      LieSubmodule.restr_toSubmodule, LieSubmodule.top_toSubmodule] using
+      congrArg LieSubmodule.toSubmodule hP.sup_eq_top
 
 variable (K n M) in
 /-- The Lie-submodule lattice of a finite-dimensional `gl n`-module is complemented when the
@@ -181,9 +117,7 @@ section CAR
 attribute [local instance] Classical.decEq
 open scoped TauCeti
 
-variable {K n : Type*} [Field K] [Fintype n] [Invertible (2 : K)]
-
-variable [CharZero K] [IsAlgClosed K]
+variable {K n : Type*} [Field K] [Fintype n] [CharZero K] [IsAlgClosed K]
 
 variable (K n) in
 /-- **The CAR module is completely reducible.** Its Lie-submodule lattice is complemented because
@@ -191,7 +125,8 @@ the normal-ordered action of the identity matrix is scalar. -/
 theorem complementedLattice_lieSubmodule_car :
     ComplementedLattice
       (LieSubmodule K (Matrix n n K) (CliffordAlgebra (traceQuadraticForm K n))) :=
-  complementedLattice_lieSubmodule_gl_of_forall_one_lie_eq_smul K n _ car_one_lie_eq_smul
+  complementedLattice_lieSubmodule_gl_of_forall_one_lie_eq_smul K n _
+    CliffordAlgebra.car_one_lie_eq_smul
 
 end CAR
 

--- a/TauCeti/Algebra/Lie/GeneralLinear/Fock.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/Fock.lean
@@ -51,6 +51,7 @@ one by a right multiplication (`TauCeti.car_lie_sub_mul`) and is not the isotypi
 ## Main results
 
 * `TauCeti.car_lie_def`: the defining equation of the action.
+* `TauCeti.car_one_lie_eq_smul`: the scalar by which the identity matrix acts.
 * `TauCeti.car_lie_ι`: its value on a Clifford generator, where the matrix commutator reappears
   together with a right-multiplication term.
 * `TauCeti.car_lie_sub_mul`: the comparison with the inner derivation action.
@@ -101,6 +102,12 @@ normal-ordered quadratic lift. -/
 theorem car_lie_def (X : Matrix n n K) (c : CliffordAlgebra (traceQuadraticForm K n)) :
     ⁅X, c⁆ = glCliffordHom X * c :=
   LieHom.leftRegularRep_apply _ X c
+
+/-- The identity matrix acts on the CAR module by the scalar
+`(Fintype.card n : K) ^ 2 / 2`. -/
+theorem car_one_lie_eq_smul (c : CliffordAlgebra (traceQuadraticForm K n)) :
+    ⁅(1 : Matrix n n K), c⁆ = ((Fintype.card n : K) ^ 2 / 2) • c := by
+  rw [car_lie_def, glCliffordHom_one, Algebra.smul_def]
 
 /-- **The action on a Clifford generator.** The matrix commutator is visible in the CAR module, but
 only up to a right-multiplication term: left multiplication is not the derivation action. Not a

--- a/TauCeti/Algebra/Lie/GeneralLinear/Fock.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/Fock.lean
@@ -51,7 +51,7 @@ one by a right multiplication (`TauCeti.car_lie_sub_mul`) and is not the isotypi
 ## Main results
 
 * `TauCeti.car_lie_def`: the defining equation of the action.
-* `TauCeti.car_one_lie_eq_smul`: the scalar by which the identity matrix acts.
+* `CliffordAlgebra.car_one_lie_eq_smul`: the scalar by which the identity matrix acts.
 * `TauCeti.car_lie_ι`: its value on a Clifford generator, where the matrix commutator reappears
   together with a right-multiplication term.
 * `TauCeti.car_lie_sub_mul`: the comparison with the inner derivation action.
@@ -105,7 +105,9 @@ theorem car_lie_def (X : Matrix n n K) (c : CliffordAlgebra (traceQuadraticForm 
 
 /-- The identity matrix acts on the CAR module by the scalar
 `(Fintype.card n : K) ^ 2 / 2`. -/
-theorem car_one_lie_eq_smul (c : CliffordAlgebra (traceQuadraticForm K n)) :
+@[grind =]
+theorem _root_.CliffordAlgebra.car_one_lie_eq_smul
+    (c : CliffordAlgebra (traceQuadraticForm K n)) :
     ⁅(1 : Matrix n n K), c⁆ = ((Fintype.card n : K) ^ 2 / 2) • c := by
   rw [car_lie_def, glCliffordHom_one, Algebra.smul_def]
 

--- a/TauCeti/Algebra/Lie/GeneralLinear/Radical.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/Radical.lean
@@ -10,7 +10,7 @@ import TauCeti.Algebra.Lie.GeneralLinear.DiagonalCartan
 import Mathlib.Tactic.NoncommRing
 
 /-!
-# `gl n K` is reductive: its radical is its centre
+# The radicals of `gl n K` and `sl n K`
 
 `TauCeti/Algebra/Lie/GeneralLinear/Basic.lean` identifies the centre of `gl n R` (the scalar
 matrices) and its derived ideal (`sl n R`), and shows that the two are complementary submodules as
@@ -19,6 +19,10 @@ Mathlib's `LieAlgebra.HasCentralRadical`: over a field in which `2 ≠ 0`, the s
 `gl n K` **is** its centre. That is the third clause of the concrete `gl n` structure statement of
 the highest-weight roadmap, and it is what makes the reductive vocabulary applicable to `gl n`,
 whose Killing form is degenerate.
+
+The same structure shows that `sl n K` has trivial radical when `2` and the nonempty matrix size
+are nonzero. In characteristic zero this is registered as an instance, so Cartan's criterion makes
+the Killing-form API available by typeclass synthesis.
 
 The proof is the structure of the Lie ideals of `gl n K`. The centre is always an abelian, hence
 solvable, ideal, so it is contained in the radical. For the other inclusion, every solvable ideal
@@ -52,6 +56,8 @@ bracket again, all the remaining units.
   nontrivial and there are at least two indices.
 * `TauCeti.radical_matrix_eq_center` and `TauCeti.hasCentralRadical_matrix`: **`gl n K` is
   reductive**, its radical being its centre.
+* `TauCeti.hasTrivialRadical_sl`: **`sl n K` has trivial radical** when `2` and the nonempty
+  matrix size are nonzero; the characteristic-zero case is a named instance.
 
 ## Implementation notes
 
@@ -406,5 +412,89 @@ instance [CharZero K] : LieAlgebra.HasCentralRadical K (Matrix n n K) :=
   hasCentralRadical_matrix two_ne_zero
 
 end Radical
+
+/-! ### Semisimplicity of the special linear Lie algebra -/
+
+section SpecialLinear
+
+variable (K : Type*) [Field K]
+variable (n : Type*) [Fintype n] [DecidableEq n]
+
+/-- The inclusion of an ideal of `sl n` into `gl n` has ideal range. Scalar matrices commute with
+the image, while the `sl n` summand preserves the ideal. -/
+private theorem slIncl_isIdealMorphism
+    (hn : Nonempty n → (Fintype.card n : K) ≠ 0) (J : LieIdeal K (SpecialLinear.sl n K)) :
+    ((SpecialLinear.sl n K).incl.comp J.incl).IsIdealMorphism := by
+  rw [LieHom.isIdealMorphism_iff]
+  intro A y
+  cases isEmpty_or_nonempty n with
+  | inl hn' =>
+      let _ := hn'
+      exact ⟨0, Subsingleton.elim _ _⟩
+  | inr hn' =>
+      let _ := hn'
+      let _ : Invertible (Fintype.card n : K) := invertibleOfNonzero (hn hn')
+      obtain ⟨X, Z, hX, hZ, hXZ⟩ := Submodule.codisjoint_iff_exists_add_eq.mp
+        (isCompl_center_derivedSeries_one_matrix K n).codisjoint A
+      have hZsl : Z ∈ SpecialLinear.sl n K := by
+        rw [← derivedSeries_one_toLieSubalgebra_eq_sl K n]
+        exact hZ
+      have hXzero : ⁅X, ((SpecialLinear.sl n K).incl.comp J.incl) y⁆ = 0 := by
+        rw [← lie_skew, (LieModule.mem_maxTrivSubmodule K _ _ X).1 hX, neg_zero]
+      let z : J := ⟨⁅⟨Z, hZsl⟩, (y : SpecialLinear.sl n K)⁆, J.lie_mem y.property⟩
+      refine ⟨z, ?_⟩
+      rw [← hXZ, add_lie, hXzero, zero_add]
+      simp only [z, LieHom.coe_comp, Function.comp_apply, LieSubalgebra.coe_incl,
+        LieIdeal.incl_apply, LieSubalgebra.coe_bracket]
+
+/-- **The special linear Lie algebra has trivial radical.** If `2` and, for nonempty `n`, the
+cardinality of `n` are nonzero, a solvable ideal of `sl n` maps to a solvable ideal of `gl n`,
+hence lies in the scalar matrices. Its image also lies in the complementary derived ideal `sl n`,
+so the original ideal vanishes. -/
+theorem hasTrivialRadical_sl (htwo : (2 : K) ≠ 0)
+    (hn : Nonempty n → (Fintype.card n : K) ≠ 0) :
+    LieAlgebra.HasTrivialRadical K (SpecialLinear.sl n K) := by
+  rw [LieAlgebra.hasTrivialRadical_iff_no_solvable_ideals]
+  intro J hJ
+  rw [eq_bot_iff]
+  intro x hx
+  let f : J →ₗ⁅K⁆ Matrix n n K := (SpecialLinear.sl n K).incl.comp J.incl
+  have hf : f.IsIdealMorphism := slIncl_isIdealMorphism K n hn J
+  have hsolvRange : LieAlgebra.IsSolvable f.range := by
+    let _ : LieAlgebra.IsSolvable J := hJ
+    infer_instance
+  have hsolv : LieAlgebra.IsSolvable f.idealRange := by
+    let e : (f.idealRange : LieSubalgebra K (Matrix n n K)) ≃ₗ⁅K⁆ f.range :=
+      LieEquiv.ofEq _ _ (congrArg (fun S : LieSubalgebra K (Matrix n n K) ↦
+        (S : Set (Matrix n n K))) hf.eq)
+    exact (LieAlgebra.solvable_iff_equiv_solvable e).mpr hsolvRange
+  have hcenter : f ⟨x, hx⟩ ∈ LieAlgebra.center K (Matrix n n K) := by
+    rw [← radical_matrix_eq_center htwo]
+    exact (LieIdeal.solvable_iff_le_radical K _ f.idealRange).mp hsolv
+      (f.mem_idealRange ⟨x, hx⟩)
+  cases isEmpty_or_nonempty n with
+  | inl hn' =>
+      let _ := hn'
+      exact Subsingleton.elim _ _
+  | inr hn' =>
+      let _ := hn'
+      let _ : Invertible (Fintype.card n : K) := invertibleOfNonzero (hn hn')
+      have hderived : f ⟨x, hx⟩ ∈ (derivedSeries K (Matrix n n K) 1).toSubmodule := by
+        rw [derivedSeries_one_eq_slIdeal K n, LieSubmodule.mem_toSubmodule, mem_slIdeal_iff]
+        exact x.property
+      have hzero : f ⟨x, hx⟩ = 0 :=
+        (isCompl_center_derivedSeries_one_matrix K n).disjoint.le_bot ⟨hcenter, hderived⟩
+      apply Subtype.ext
+      simpa only [f, LieHom.coe_comp, Function.comp_apply, LieSubalgebra.coe_incl,
+        LieIdeal.incl_apply, ZeroMemClass.coe_zero] using hzero
+
+/-- In characteristic zero, `sl n` has trivial radical. -/
+instance instHasTrivialRadicalSl [CharZero K] :
+    LieAlgebra.HasTrivialRadical K (SpecialLinear.sl n K) :=
+  hasTrivialRadical_sl K n two_ne_zero fun h ↦ by
+    let _ := h
+    exact Nat.cast_ne_zero.mpr Fintype.card_ne_zero
+
+end SpecialLinear
 
 end TauCeti

--- a/TauCeti/Algebra/Lie/GeneralLinear/Restriction.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/Restriction.lean
@@ -27,6 +27,8 @@ field discharge it themselves.
 
 ## Main results
 
+* `TauCeti.exists_sl_add_smul_one_eq`: every matrix is a trace-zero matrix plus a scalar matrix
+  when the cardinality is invertible, with the empty case included.
 * `TauCeti.isIrreducible_restrict_sl_of_forall_one_lie_eq_smul`: restriction of an irreducible
   `gl n` module to `sl n` is irreducible as soon as the identity matrix acts by a scalar, and
   `TauCeti.isIrreducible_restrict_sl_of_isGlHighestWeightVector` reads that scalar off a highest
@@ -54,30 +56,27 @@ universe u
 
 section Decomposition
 
-variable {K : Type*} [Field K]
+variable {K n : Type*} [Field K] [Fintype n] [DecidableEq n]
 
 /-- Every square matrix is the sum of a trace-zero matrix and a scalar matrix, as soon as the rank
 is invertible in `K`. This is the elementwise form of the existing centre/derived-ideal complement;
 the separate rank-zero branch is why the hypothesis is an implication rather than invertibility of
 the cardinality of an empty index type. -/
-private theorem exists_sl_add_smul_one_eq {n : ℕ} (hn : n ≠ 0 → (n : K) ≠ 0)
-    (A : Matrix (Fin n) (Fin n) K) :
-    ∃ (X : LieAlgebra.SpecialLinear.sl (Fin n) K) (r : K),
-      (X : Matrix (Fin n) (Fin n) K) + r • 1 = A := by
-  cases n with
-  | zero =>
+theorem exists_sl_add_smul_one_eq (hn : Nonempty n → (Fintype.card n : K) ≠ 0)
+    (A : Matrix n n K) :
+    ∃ (X : LieAlgebra.SpecialLinear.sl n K) (r : K), (X : Matrix n n K) + r • 1 = A := by
+  cases isEmpty_or_nonempty n with
+  | inl h =>
+      let _ := h
       exact ⟨0, 0, Subsingleton.elim _ _⟩
-  | succ n =>
-      have hcard : (Fintype.card (Fin (n + 1)) : K) ≠ 0 := by
-        rw [Fintype.card_fin]
-        exact hn (Nat.succ_ne_zero n)
-      let _ : Invertible (Fintype.card (Fin (n + 1)) : K) :=
-        invertibleOfNonzero hcard
+  | inr h =>
+      let _ := h
+      let _ : Invertible (Fintype.card n : K) := invertibleOfNonzero (hn h)
       obtain ⟨Z, X, hZ, hX, hZX⟩ := Submodule.codisjoint_iff_exists_add_eq.mp
-        (isCompl_center_derivedSeries_one_matrix K (Fin (n + 1))).codisjoint A
+        (isCompl_center_derivedSeries_one_matrix K n).codisjoint A
       obtain ⟨r, rfl⟩ := mem_center_matrix_iff.mp hZ
-      have hXsl : X ∈ LieAlgebra.SpecialLinear.sl (Fin (n + 1)) K := by
-        rw [← derivedSeries_one_toLieSubalgebra_eq_sl K (Fin (n + 1))]
+      have hXsl : X ∈ LieAlgebra.SpecialLinear.sl n K := by
+        rw [← derivedSeries_one_toLieSubalgebra_eq_sl K n]
         exact hX
       exact ⟨⟨X, hXsl⟩, r, (add_comm X (r • 1)).trans hZX⟩
 
@@ -96,7 +95,12 @@ private theorem sup_center_eq_top (hn : n ≠ 0 → (n : K) ≠ 0) :
       (LieAlgebra.center K (Matrix (Fin n) (Fin n) K)).toSubmodule = ⊤ := by
   apply top_unique
   intro A _
-  obtain ⟨X, r, hA⟩ := exists_sl_add_smul_one_eq hn A
+  obtain ⟨X, r, hA⟩ := exists_sl_add_smul_one_eq (n := Fin n)
+    (fun (h : Nonempty (Fin n)) ↦ by
+      let _ := h
+      rw [Fintype.card_fin]
+      exact hn (by simpa only [Fintype.card_fin] using
+        (Fintype.card_ne_zero : Fintype.card (Fin n) ≠ 0))) A
   refine Submodule.mem_sup.mpr ⟨X, X.property, r • 1, ?_, hA⟩
   rw [LieSubmodule.mem_toSubmodule]
   exact mem_center_matrix_iff.mpr ⟨r, rfl⟩
@@ -166,7 +170,8 @@ theorem gl_equiv_of_sl_equiv_of_central_scalar (c : K)
   -- The anonymous constructor exposes its `toFun` only after the bundled linear equivalence is
   -- unfolded; the restricted `sl n` action is then definitionally the ambient matrix action.
   change e ⁅A, m⁆ = ⁅A, e m⁆
-  obtain ⟨X, r, hA⟩ := exists_sl_add_smul_one_eq (fun hn => Nat.cast_ne_zero.mpr hn) A
+  obtain ⟨X, r, hA⟩ := exists_sl_add_smul_one_eq (n := Fin n)
+    (fun _ => Nat.cast_ne_zero.mpr Fintype.card_ne_zero) A
   have hXaction :
       e ⁅(X : Matrix (Fin n) (Fin n) K), m⁆ = ⁅(X : Matrix (Fin n) (Fin n) K), e m⁆ := by
     simpa only [LieSubalgebra.coe_bracket_of_module, LieModuleEquiv.coe_toLieModuleHom]

--- a/TauCeti/Algebra/Lie/GeneralLinear/Restriction.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/Restriction.lean
@@ -27,8 +27,6 @@ field discharge it themselves.
 
 ## Main results
 
-* `TauCeti.exists_sl_add_smul_one_eq`: every matrix is a trace-zero matrix plus a scalar matrix
-  when the cardinality is invertible, with the empty case included.
 * `TauCeti.isIrreducible_restrict_sl_of_forall_one_lie_eq_smul`: restriction of an irreducible
   `gl n` module to `sl n` is irreducible as soon as the identity matrix acts by a scalar, and
   `TauCeti.isIrreducible_restrict_sl_of_isGlHighestWeightVector` reads that scalar off a highest
@@ -54,34 +52,6 @@ attribute [local instance 100] LieRing.ofAssociativeRing
 
 universe u
 
-section Decomposition
-
-variable {K n : Type*} [Field K] [Fintype n] [DecidableEq n]
-
-/-- Every square matrix is the sum of a trace-zero matrix and a scalar matrix, as soon as the rank
-is invertible in `K`. This is the elementwise form of the existing centre/derived-ideal complement;
-the separate rank-zero branch is why the hypothesis is an implication rather than invertibility of
-the cardinality of an empty index type. -/
-theorem exists_sl_add_smul_one_eq (hn : Nonempty n → (Fintype.card n : K) ≠ 0)
-    (A : Matrix n n K) :
-    ∃ (X : LieAlgebra.SpecialLinear.sl n K) (r : K), (X : Matrix n n K) + r • 1 = A := by
-  cases isEmpty_or_nonempty n with
-  | inl h =>
-      let _ := h
-      exact ⟨0, 0, Subsingleton.elim _ _⟩
-  | inr h =>
-      let _ := h
-      let _ : Invertible (Fintype.card n : K) := invertibleOfNonzero (hn h)
-      obtain ⟨Z, X, hZ, hX, hZX⟩ := Submodule.codisjoint_iff_exists_add_eq.mp
-        (isCompl_center_derivedSeries_one_matrix K n).codisjoint A
-      obtain ⟨r, rfl⟩ := mem_center_matrix_iff.mp hZ
-      have hXsl : X ∈ LieAlgebra.SpecialLinear.sl n K := by
-        rw [← derivedSeries_one_toLieSubalgebra_eq_sl K n]
-        exact hX
-      exact ⟨⟨X, hXsl⟩, r, (add_comm X (r • 1)).trans hZX⟩
-
-end Decomposition
-
 section Restriction
 
 variable {K : Type*} [Field K]
@@ -98,7 +68,7 @@ private theorem sup_center_eq_top (hn : n ≠ 0 → (n : K) ≠ 0) :
   obtain ⟨X, r, hA⟩ := exists_sl_add_smul_one_eq (n := Fin n)
     (fun (h : Nonempty (Fin n)) ↦ by
       let _ := h
-      rw [Fintype.card_fin]
+      rw [Fintype.card_fin, isUnit_iff_ne_zero]
       exact hn (by simpa only [Fintype.card_fin] using
         (Fintype.card_ne_zero : Fintype.card (Fin n) ≠ 0))) A
   refine Submodule.mem_sup.mpr ⟨X, X.property, r • 1, ?_, hA⟩
@@ -171,7 +141,7 @@ theorem gl_equiv_of_sl_equiv_of_central_scalar (c : K)
   -- unfolded; the restricted `sl n` action is then definitionally the ambient matrix action.
   change e ⁅A, m⁆ = ⁅A, e m⁆
   obtain ⟨X, r, hA⟩ := exists_sl_add_smul_one_eq (n := Fin n)
-    (fun _ => Nat.cast_ne_zero.mpr Fintype.card_ne_zero) A
+    (fun _ => isUnit_iff_ne_zero.mpr (Nat.cast_ne_zero.mpr Fintype.card_ne_zero)) A
   have hXaction :
       e ⁅(X : Matrix (Fin n) (Fin n) K), m⁆ = ⁅(X : Matrix (Fin n) (Fin n) K), e m⁆ := by
     simpa only [LieSubalgebra.coe_bracket_of_module, LieModuleEquiv.coe_toLieModuleHom]


### PR DESCRIPTION
This PR proves complete reducibility of the left-regular CAR module for the RepresentationTheory SpinRepresentations Layer 9 CAR isotypy milestone.

Roadmap: RepresentationTheory

## Summary

The special linear algebra `sl n` has trivial radical whenever `2` and the nonempty matrix size are nonzero; the characteristic-zero case is registered as an instance. Weyl's theorem therefore supplies complements after restriction to `sl n`, and the decomposition `gl n = sl n + K·1` promotes them back whenever the identity acts by a scalar. The normal-ordered Clifford lift sends `1` to `(card n)^2/2`, so this transfer gives the CAR module the `ComplementedLattice` structure required by the existing isotypy API.

## Roadmap target

This advances RepresentationTheory/SpinRepresentations Layer 9, target `car_isotypic`, by discharging the complete-reducibility premise of `nonempty_lieModuleEquiv_directSum_glIrreducible_of_forall_isGlHighestWeightVector`. After this PR, it remains to locate a vector of the staircase weight inside every simple CAR submodule; the single-weight criterion can then prove `car_isotypic`, after which the multiplicity calculation remains.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"car-complete-reducibility"}-->

## Verification

- Exact head: `ba21de712505d442c1e56c27c4803fd212283508`
- Local Lean build: `lake build` — pass (`Build completed successfully (11016 jobs).`)
- Axiom audit: `lake exe axioms` — pass (`axioms: audited 108981 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`)
- Lint: `env PATH=/opt/homebrew/opt/gnu-sed/libexec/gnubin:$PATH bash scripts/lint-env.sh && python3 scripts/lint-dot-notation.py && bash scripts/lint-style.sh && lake exe module-system` — pass (no new environment or dot-notation violations; `4864` headers and `4865` modules checked)
- Proof golf: `ut-lean-golf` — pass (`glCliffordHom_one` now specializes the existing commuting-matrix formula; one private `extendSl_toSubmodule` lemma serves both lattice proofs; bundled inclusion coercions use named equations)
- Public CI: pending for this head

## Scale and generality

The aggregate change adds 294 lines and removes 50 across six focused general-linear modules, with `CompleteReducibility.lean` reduced to 133 lines. The matrix decomposition now holds over an arbitrary commutative ring under the precise unit hypothesis, while the special-linear radical theorem exposes only nonvanishing of `2` and the nonempty matrix size. Algebraic closedness and finite-dimensionality occur only where Weyl's theorem needs them; the CAR theorem no longer carries a redundant explicit `Invertible (2 : K)` parameter.

## Scope

- **Consumes:** `radical_matrix_eq_center`, `isCompl_center_derivedSeries_one_matrix`, `LieSubmodule.restr`, `exists_isCompl_of_isKilling`, `glCliffordHom_eq_algebraMap_of_commute`, and `car_lie_def`.
- **Provides:** the ring-general `exists_sl_add_smul_one_eq`, `hasTrivialRadical_sl` and its characteristic-zero instance, scalar-centre `gl n` complement and lattice theorems, the namespaced identity action `CliffordAlgebra.car_one_lie_eq_smul`, and `complementedLattice_lieSubmodule_car`.
- **Fits:** supplies the complete-reducibility hypothesis consumed by the merged single-weight `gl n` isotypy criterion on the CAR branch.
- **Boundary:** does not assert that every simple CAR submodule contains the target staircase weight; that live highest-weight existence step remains separate, followed by the isotypy and multiplicity conclusions.

<sub>🤖 GPT-5.6 Sol high · TauCetiWorker @ [7659e031566725114c800be803907b56646b51c6](https://github.com/utensil/TauCetiWorker/commit/7659e031566725114c800be803907b56646b51c6) · rubrics @ [153ea8a6febe59f492c2f3d48471733e8b550848](https://github.com/utensil/TauCetiReview/commit/153ea8a6febe59f492c2f3d48471733e8b550848) · local review @ [b533e561b6d44df071c31335ed4a63ae647507d2](https://github.com/utensil/formal-land/commit/b533e561b6d44df071c31335ed4a63ae647507d2) · fixed: reuse, api-design, generality, placement, naming, proof-quality</sub>