### PR TITLE
feat: define numerical types and their signed genus

### DIFF
--- a/TauCeti/Algebra/BigOperators/Finset/OffDiagonal.lean
+++ b/TauCeti/Algebra/BigOperators/Finset/OffDiagonal.lean
@@ -27,9 +27,10 @@ public section
 namespace TauCeti
 
 /-- **The off-diagonal sum of a symmetric function is even.** The ordered pairs of distinct
-elements of `s` come in transposed couples contributing equal terms. -/
+elements of `s` come in transposed couples contributing equal terms, so `f` need only be
+symmetric on `s`. -/
 theorem even_sum_sum_erase {α M : Type*} [DecidableEq α] [AddCommMonoid M] {f : α → α → M}
-    (hf : ∀ i j, f i j = f j i) (s : Finset α) :
+    (s : Finset α) (hf : ∀ i ∈ s, ∀ j ∈ s, f i j = f j i) :
     Even (∑ i ∈ s, ∑ j ∈ s.erase i, f i j) := by
   induction s using Finset.induction with
   | empty => simp
@@ -41,8 +42,10 @@ theorem even_sum_sum_erase {α M : Type*} [DecidableEq α] [AddCommMonoid M] {f 
         Finset.sum_insert (fun h ↦ ha (Finset.mem_of_mem_erase h))]
     rw [Finset.sum_insert ha, Finset.erase_insert ha, Finset.sum_congr rfl hstep,
       Finset.sum_add_distrib, ← add_assoc]
-    refine Even.add ?_ ih
-    rw [Finset.sum_congr rfl fun i (_ : i ∈ s) ↦ hf i a]
+    refine Even.add ?_ (ih fun i hi j hj ↦
+      hf i (Finset.mem_insert_of_mem hi) j (Finset.mem_insert_of_mem hj))
+    rw [Finset.sum_congr rfl fun i hi ↦
+      hf i (Finset.mem_insert_of_mem hi) a (Finset.mem_insert_self a s)]
     exact ⟨_, rfl⟩
 
 end TauCeti

--- a/TauCeti/Algebra/BigOperators/Finset/OffDiagonal.lean
+++ b/TauCeti/Algebra/BigOperators/Finset/OffDiagonal.lean
@@ -1,0 +1,48 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.BigOperators.Group.Finset.Basic
+public import Mathlib.Algebra.Group.Even
+
+/-!
+# Off-diagonal sums of a symmetric function
+
+The off-diagonal sum of `f : α → α → M` over a finite set `s` is
+`∑ i ∈ s, ∑ j ∈ s.erase i, f i j`: every ordered pair of distinct elements of `s` contributes
+once. When `f` is symmetric the two members of each unordered pair contribute equal terms, so the
+whole sum is even; this is `TauCeti.even_sum_sum_erase`, proved by induction on `s`.
+
+## Main results
+
+* `TauCeti.even_sum_sum_erase`: the off-diagonal sum of a symmetric function over a finite set is
+  even.
+-/
+
+public section
+
+namespace TauCeti
+
+/-- **The off-diagonal sum of a symmetric function is even.** The ordered pairs of distinct
+elements of `s` come in transposed couples contributing equal terms. -/
+theorem even_sum_sum_erase {α M : Type*} [DecidableEq α] [AddCommMonoid M] {f : α → α → M}
+    (hf : ∀ i j, f i j = f j i) (s : Finset α) :
+    Even (∑ i ∈ s, ∑ j ∈ s.erase i, f i j) := by
+  induction s using Finset.induction with
+  | empty => simp
+  | insert a s ha ih =>
+    have hstep : ∀ i ∈ s, ∑ j ∈ (insert a s).erase i, f i j = f i a + ∑ j ∈ s.erase i, f i j := by
+      intro i hi
+      have hai : a ≠ i := fun h ↦ ha (h ▸ hi)
+      rw [Finset.erase_insert_of_ne hai,
+        Finset.sum_insert (fun h ↦ ha (Finset.mem_of_mem_erase h))]
+    rw [Finset.sum_insert ha, Finset.erase_insert ha, Finset.sum_congr rfl hstep,
+      Finset.sum_add_distrib, ← add_assoc]
+    refine Even.add ?_ ih
+    rw [Finset.sum_congr rfl fun i (_ : i ∈ s) ↦ hf i a]
+    exact ⟨_, rfl⟩
+
+end TauCeti

--- a/TauCeti/Algebra/BigOperators/Finset/OffDiagonal.lean
+++ b/TauCeti/Algebra/BigOperators/Finset/OffDiagonal.lean
@@ -14,17 +14,17 @@ public import Mathlib.Algebra.Group.Even
 The off-diagonal sum of `f : α → α → M` over a finite set `s` is
 `∑ i ∈ s, ∑ j ∈ s.erase i, f i j`: every ordered pair of distinct elements of `s` contributes
 once. When `f` is symmetric the two members of each unordered pair contribute equal terms, so the
-whole sum is even; this is `TauCeti.even_sum_sum_erase`, proved by induction on `s`.
+whole sum is even; this is `Finset.even_sum_sum_erase`, proved by induction on `s`.
 
 ## Main results
 
-* `TauCeti.even_sum_sum_erase`: the off-diagonal sum of a symmetric function over a finite set is
+* `Finset.even_sum_sum_erase`: the off-diagonal sum of a symmetric function over a finite set is
   even.
 -/
 
 public section
 
-namespace TauCeti
+namespace Finset
 
 /-- **The off-diagonal sum of a symmetric function is even.** The ordered pairs of distinct
 elements of `s` come in transposed couples contributing equal terms, so `f` need only be
@@ -48,4 +48,4 @@ theorem even_sum_sum_erase {α M : Type*} [DecidableEq α] [AddCommMonoid M] {f 
       hf i (Finset.mem_insert_of_mem hi) a (Finset.mem_insert_self a s)]
     exact ⟨_, rfl⟩
 
-end TauCeti
+end Finset

--- a/TauCeti/AlgebraicGeometry/Curves/StableReduction/NumericalType.lean
+++ b/TauCeti/AlgebraicGeometry/Curves/StableReduction/NumericalType.lean
@@ -81,7 +81,7 @@ namespace TauCeti
 
 open Finset
 
-universe u v
+universe u v w
 
 /-- A numerical type, in the sense of
 [Stacks, Tag 0C6Z](https://stacks.math.columbia.edu/tag/0C6Z).
@@ -333,6 +333,30 @@ def reindex {C : Type v} (e : T.Component ≃ C) : NumericalType.{v} :=
     weight_dvd _ _ := T.weight_dvd _ _
     genus c := T.genus (e.symm c) }
 
+/-- Numerical types are determined by their multiplicity, weight, intersection and genus data:
+an equivalence of component sets matching all four identifies the two types. As the component set
+is a field rather than a parameter, this is the extensionality principle for numerical types; the
+instance fields are subsingletons and the remaining fields are proofs. -/
+lemma reindex_eq {T' : NumericalType.{v}} (e : T.Component ≃ T'.Component)
+    (hm : ∀ i, T'.multiplicity (e i) = T.multiplicity i)
+    (hw : ∀ i, T'.weight (e i) = T.weight i)
+    (hA : ∀ i j, T'.intersection (e i) (e j) = T.intersection i j)
+    (hg : ∀ i, T'.genus (e i) = T.genus i) :
+    T.reindex e = T' := by
+  cases T' with
+  | mk C' m' w' A' hs ho hc hf hd g' =>
+    unfold reindex
+    -- `congr 1` leaves the four data fields, the transported `Fintype` and `DecidableEq`
+    -- instances, which are subsingletons, and the proof fields, which are irrelevant
+    congr 1 <;>
+      first
+        | exact Subsingleton.elim _ _
+        | exact proof_irrel_heq _ _
+        | (funext c; simpa using (hm (e.symm c)).symm)
+        | (funext c; simpa using (hw (e.symm c)).symm)
+        | (funext c; simpa using (hg (e.symm c)).symm)
+        | (funext c d; simpa using (hA (e.symm c) (e.symm d)).symm)
+
 variable {C : Type v} (e : T.Component ≃ C)
 
 /-- Multiplicities of a reindexed numerical type. -/
@@ -352,6 +376,21 @@ lemma reindex_genus (c : C) : (T.reindex e).genus c = T.genus (e.symm c) := rfl
 @[simp]
 lemma reindex_intersection (c d : C) :
     (T.reindex e).intersection c d = T.intersection (e.symm c) (e.symm d) := rfl
+
+/-- Reindexing along the identity equivalence changes nothing. -/
+@[simp]
+lemma reindex_refl : T.reindex (Equiv.refl T.Component) = T :=
+  T.reindex_eq _ (fun _ ↦ rfl) (fun _ ↦ rfl) (fun _ _ ↦ rfl) fun _ ↦ rfl
+
+/-- Reindexing twice is reindexing along the composite equivalence. -/
+@[simp]
+lemma reindex_reindex {D : Type w} (f : C ≃ D) :
+    (T.reindex e).reindex f = T.reindex (e.trans f) := by
+  -- `reindex_eq` does not apply directly, since `f` has the type it asks for only after
+  -- unfolding `reindex`; both sides are the same data on the same component set anyway
+  cases T
+  unfold reindex
+  congr 1 <;> first | exact Subsingleton.elim _ _ | exact proof_irrel_heq _ _
 
 /-- The signed genus does not depend on the chosen indexing of the components. -/
 @[simp]

--- a/TauCeti/AlgebraicGeometry/Curves/StableReduction/NumericalType.lean
+++ b/TauCeti/AlgebraicGeometry/Curves/StableReduction/NumericalType.lean
@@ -1,0 +1,456 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Order.BigOperators.Group.Finset
+public import Mathlib.LinearAlgebra.Matrix.Notation
+public import Mathlib.LinearAlgebra.Matrix.Symmetric
+public import Mathlib.Tactic.FinCases
+public import Mathlib.Tactic.Linarith
+public import Mathlib.Tactic.LinearCombination
+public import Mathlib.Tactic.Ring
+
+/-!
+# Numerical types and their signed genus
+
+A **numerical type** is the combinatorial shadow of the special fibre of a proper regular model
+of a curve over a discrete valuation ring: a finite nonempty set of components carrying
+multiplicities `mᵢ`, weights `wᵢ` (the degrees of the constant fields of the components over the
+residue field) and genera `gᵢ`, together with a symmetric matrix of intersection numbers
+`A = (aᵢⱼ)` whose off-diagonal entries are nonnegative, whose associated graph is connected,
+which is killed by the multiplicity vector, and whose `i`-th row is divisible by `wᵢ`.
+
+This file introduces that structure, its positivity and connectedness API, its reindexing along
+an equivalence of component sets, and its signed genus
+
+`g(T) = 1 + ∑ᵢ mᵢ (wᵢ (gᵢ - 1) - aᵢᵢ / 2)`.
+
+The arithmetic subtlety in the genus formula is that the individual half-diagonals `aᵢᵢ / 2` need
+not be integers, so the halving may only be performed once, on the whole sum. That this is
+legitimate is `TauCeti.NumericalType.even_sum_multiplicity_mul_diagonal`: pairing the fibre
+relation against the multiplicity vector gives `∑ᵢⱼ mᵢ mⱼ aᵢⱼ = 0`, whose off-diagonal part is
+even by symmetry, so `∑ᵢ mᵢ² aᵢᵢ` is even; and `mᵢ² ≡ mᵢ` modulo two.
+
+## Main definitions
+
+* `TauCeti.NumericalType`: the structure described above, following
+  [Stacks, Tag 0C6Z](https://stacks.math.columbia.edu/tag/0C6Z).
+* `TauCeti.NumericalType.Adj`: the adjacency relation `i ≠ j ∧ 0 < aᵢⱼ` whose reflexive
+  transitive closure the connectedness axiom requires to be total.
+* `TauCeti.NumericalType.reindex`: the numerical type obtained by transporting the component set
+  along an equivalence.
+* `TauCeti.NumericalType.arithmeticGenus`: the signed genus, valued in `ℤ`.
+
+## Main results
+
+* `TauCeti.NumericalType.even_sum_multiplicity_mul_diagonal`: `∑ᵢ mᵢ aᵢᵢ` is even, which is what
+  makes the halving in the genus formula exact, and
+  `TauCeti.NumericalType.two_mul_arithmeticGenus`, the resulting division-free form of that
+  formula.
+* `TauCeti.NumericalType.intersection_self_nonpos` and
+  `TauCeti.NumericalType.intersection_self_neg`: self-intersections are nonpositive, and are
+  negative as soon as there is more than one component.
+* `TauCeti.NumericalType.reflTransGen_adj_iff` and
+  `TauCeti.NumericalType.exists_mem_notMem_adj`: connectedness of the intersection graph is the
+  same as the absence of a disconnecting cut, the form in which
+  [Stacks, Tag 0C6Z](https://stacks.math.columbia.edu/tag/0C6Z) states the condition.
+* `TauCeti.NumericalType.arithmeticGenus_reindex`: the signed genus does not depend on the chosen
+  indexing of the components.
+
+## Implementation notes
+
+Abstract numerical types can have negative genus, so `arithmeticGenus` lands in `ℤ` rather than
+`ℕ`; the genus-zero variant of `weightedExample` at the end of the file has genus `-1`. Nor may
+the halving be distributed over the sum: `oddDiagonalExample` has odd diagonal entries.
+
+Symmetry of the intersection matrix is recorded through Mathlib's `Matrix.IsSymm` rather than as
+a bare pointwise equation, so that a reindexed matrix inherits it from `Matrix.IsSymm.submatrix`.
+-/
+
+public section
+
+namespace TauCeti
+
+open Finset
+
+universe u
+
+/-- A numerical type, in the sense of
+[Stacks, Tag 0C6Z](https://stacks.math.columbia.edu/tag/0C6Z).
+
+`multiplicity i` and `weight i` are the multiplicity of the `i`-th component of the special fibre
+of a proper regular model and the degree of its constant field over the residue field, and
+`genus i` is its arithmetic genus over that constant field, not the genus of its normalization.
+The matrix `intersection` records the intersection numbers of the components. -/
+structure NumericalType where
+  /-- The finite nonempty index set of components. -/
+  Component : Type u
+  [componentFintype : Fintype Component]
+  [componentDecidableEq : DecidableEq Component]
+  [componentNonempty : Nonempty Component]
+  /-- The multiplicity of a component in the special fibre. -/
+  multiplicity : Component → ℕ+
+  /-- The degree of the constant field of a component over the residue field. -/
+  weight : Component → ℕ+
+  /-- The matrix of intersection numbers of the components. -/
+  intersection : Matrix Component Component ℤ
+  /-- Intersection numbers are symmetric. -/
+  intersection_isSymm : intersection.IsSymm
+  /-- Distinct components meet nonnegatively. -/
+  offDiagonal_nonneg : ∀ i j, i ≠ j → 0 ≤ intersection i j
+  /-- The graph joining components that meet is connected. -/
+  connected : ∀ i j, Relation.ReflTransGen
+    (fun i j ↦ i ≠ j ∧ 0 < intersection i j) i j
+  /-- The whole special fibre meets every component in degree zero. -/
+  fiber_relation : ∀ i, ∑ j, (multiplicity j : ℤ) * intersection i j = 0
+  /-- The `i`-th row of the intersection matrix is divisible by the weight of the `i`-th
+  component. -/
+  weight_dvd : ∀ i j, (weight i : ℤ) ∣ intersection i j
+  /-- The arithmetic genus of a component over its own constant field. -/
+  genus : Component → ℕ
+
+namespace NumericalType
+
+attribute [instance] componentFintype componentDecidableEq componentNonempty
+
+variable (T : NumericalType.{u})
+
+/-- Intersection numbers of a numerical type commute. -/
+lemma intersection_comm (i j : T.Component) : T.intersection i j = T.intersection j i :=
+  (T.intersection_isSymm.apply i j).symm
+
+/-! ### Connectedness of the intersection graph -/
+
+/-- Two components of a numerical type are adjacent when they are distinct and meet. -/
+def Adj (i j : T.Component) : Prop := i ≠ j ∧ 0 < T.intersection i j
+
+/-- Unfolding of `TauCeti.NumericalType.Adj`. -/
+lemma adj_iff {i j : T.Component} : T.Adj i j ↔ i ≠ j ∧ 0 < T.intersection i j := Iff.rfl
+
+/-- The connectedness axiom, phrased with `TauCeti.NumericalType.Adj`. -/
+lemma reflTransGen_adj (i j : T.Component) : Relation.ReflTransGen T.Adj i j := T.connected i j
+
+variable {T} in
+/-- Adjacency is a symmetric relation. -/
+lemma Adj.symm {i j : T.Component} (h : T.Adj i j) : T.Adj j i :=
+  ⟨h.1.symm, T.intersection_comm i j ▸ h.2⟩
+
+/-- Totality of the reflexive transitive closure of a relation is exactly the absence of a
+nonempty proper subset with no outgoing edge. -/
+private lemma forall_reflTransGen_iff {α : Type*} (r : α → α → Prop) :
+    (∀ i j, Relation.ReflTransGen r i j) ↔
+      ∀ s : Set α, s.Nonempty → s ≠ Set.univ → ∃ i ∈ s, ∃ j ∉ s, r i j := by
+  constructor
+  · rintro h s ⟨a, ha⟩ hs
+    obtain ⟨b, hb⟩ : ∃ b, b ∉ s := by
+      by_contra hcon
+      exact hs (Set.eq_univ_of_forall fun x ↦ by
+        by_contra hx
+        exact hcon ⟨x, hx⟩)
+    have key : ∀ x y, Relation.ReflTransGen r x y → x ∈ s → y ∉ s → ∃ i ∈ s, ∃ j ∉ s, r i j := by
+      intro x y hxy
+      induction hxy with
+      | refl => exact fun hx hy ↦ absurd hx hy
+      | @tail c d _ hcd ih =>
+        intro hx hd
+        by_cases hc : c ∈ s
+        · exact ⟨c, hc, d, hd, hcd⟩
+        · exact ih hx hc
+    exact key a b (h a b) ha hb
+  · intro h i j
+    by_contra hij
+    have hs : {k | Relation.ReflTransGen r i k} ≠ Set.univ := by
+      intro hs
+      have hj : j ∈ {k | Relation.ReflTransGen r i k} := by rw [hs]; trivial
+      exact hij hj
+    obtain ⟨a, ha, b, hb, hab⟩ := h _ ⟨i, Relation.ReflTransGen.refl⟩ hs
+    exact hb (Relation.ReflTransGen.tail ha hab)
+
+/-- Every nonempty proper set of components of a numerical type meets its complement: this is the
+no-disconnected-cut form of the connectedness axiom. -/
+lemma exists_mem_notMem_adj (s : Set T.Component) (hne : s.Nonempty) (hs : s ≠ Set.univ) :
+    ∃ i ∈ s, ∃ j ∉ s, T.Adj i j :=
+  (forall_reflTransGen_iff T.Adj).1 T.reflTransGen_adj s hne hs
+
+/-- The connectedness axiom of a numerical type, for a symmetric matrix `A` of intersection
+numbers, is equivalent to the absence of a disconnecting cut; the right-hand side is the form in
+which [Stacks, Tag 0C6Z](https://stacks.math.columbia.edu/tag/0C6Z) states the condition, so this
+is what supplies the `connected` field when a numerical type is constructed. -/
+lemma reflTransGen_adj_iff {C : Type*} (A : Matrix C C ℤ) :
+    (∀ i j, Relation.ReflTransGen (fun i j ↦ i ≠ j ∧ 0 < A i j) i j) ↔
+      ∀ s : Set C, s.Nonempty → s ≠ Set.univ → ∃ i ∈ s, ∃ j ∉ s, i ≠ j ∧ 0 < A i j :=
+  forall_reflTransGen_iff _
+
+/-! ### Self-intersections -/
+
+private lemma multiplicity_pos (i : T.Component) : (0 : ℤ) < (T.multiplicity i : ℤ) :=
+  Int.natCast_pos.mpr (T.multiplicity i).pos
+
+/-- Off the diagonal, multiplicity-weighted intersection numbers are nonnegative. -/
+lemma multiplicity_mul_intersection_nonneg {i j : T.Component} (h : i ≠ j) :
+    0 ≤ (T.multiplicity j : ℤ) * T.intersection i j :=
+  mul_nonneg (T.multiplicity_pos j).le (T.offDiagonal_nonneg i j h)
+
+/-- The fibre relation with the diagonal term isolated. -/
+lemma multiplicity_mul_intersection_self (i : T.Component) :
+    (T.multiplicity i : ℤ) * T.intersection i i =
+      -∑ j ∈ univ.erase i, (T.multiplicity j : ℤ) * T.intersection i j := by
+  have h := T.fiber_relation i
+  rw [← Finset.add_sum_erase _ _ (mem_univ i)] at h
+  linarith
+
+/-- Self-intersections in a numerical type are nonpositive. -/
+lemma intersection_self_nonpos (i : T.Component) : T.intersection i i ≤ 0 := by
+  have hle : (T.multiplicity i : ℤ) * T.intersection i i ≤ 0 := by
+    rw [T.multiplicity_mul_intersection_self i, neg_nonpos]
+    exact Finset.sum_nonneg fun _ hj ↦
+      T.multiplicity_mul_intersection_nonneg (Finset.ne_of_mem_erase hj).symm
+  by_contra hgt
+  rw [not_le] at hgt
+  exact absurd hle (not_le.2 (mul_pos (T.multiplicity_pos i) hgt))
+
+/-- In a numerical type with more than one component, every component meets some other one. -/
+lemma exists_adj (h : 1 < Fintype.card T.Component) (i : T.Component) : ∃ j, T.Adj i j := by
+  obtain ⟨j, hj⟩ := Fintype.exists_ne_of_one_lt_card h i
+  rcases (T.reflTransGen_adj i j).cases_head with rfl | ⟨k, hk, -⟩
+  · exact absurd rfl hj
+  · exact ⟨k, hk⟩
+
+/-- In a numerical type with more than one component, self-intersections are negative. -/
+lemma intersection_self_neg (h : 1 < Fintype.card T.Component) (i : T.Component) :
+    T.intersection i i < 0 := by
+  obtain ⟨j, hij, hpos⟩ := T.exists_adj h i
+  have hmem : j ∈ univ.erase i := mem_erase.2 ⟨hij.symm, mem_univ j⟩
+  have hsum : 0 < ∑ k ∈ univ.erase i, (T.multiplicity k : ℤ) * T.intersection i k :=
+    lt_of_lt_of_le (mul_pos (T.multiplicity_pos j) hpos)
+      (Finset.single_le_sum (fun k hk ↦
+        T.multiplicity_mul_intersection_nonneg (Finset.ne_of_mem_erase hk).symm) hmem)
+  have hneg : (T.multiplicity i : ℤ) * T.intersection i i < 0 := by
+    rw [T.multiplicity_mul_intersection_self i]
+    linarith
+  by_contra hge
+  rw [not_lt] at hge
+  exact absurd hneg (not_lt.2 (mul_nonneg (T.multiplicity_pos i).le hge))
+
+/-! ### Integrality of the signed genus -/
+
+/-- The sum of a symmetric function over the off-diagonal of a finite set is even. -/
+private lemma two_dvd_sum_sum_erase {α : Type*} [DecidableEq α] {f : α → α → ℤ}
+    (hf : ∀ i j, f i j = f j i) (s : Finset α) :
+    (2 : ℤ) ∣ ∑ i ∈ s, ∑ j ∈ s.erase i, f i j := by
+  induction s using Finset.induction with
+  | empty => simp
+  | insert a s ha ih =>
+    have hstep : ∀ i ∈ s, ∑ j ∈ (insert a s).erase i, f i j = f i a + ∑ j ∈ s.erase i, f i j := by
+      intro i hi
+      have hai : a ≠ i := fun h ↦ ha (h ▸ hi)
+      rw [Finset.erase_insert_of_ne hai,
+        Finset.sum_insert (fun h ↦ ha (Finset.mem_of_mem_erase h))]
+    rw [Finset.sum_insert ha, Finset.erase_insert ha, Finset.sum_congr rfl hstep,
+      Finset.sum_add_distrib, ← add_assoc]
+    refine dvd_add ?_ ih
+    rw [Finset.sum_congr rfl fun i (_ : i ∈ s) ↦ hf i a, ← two_mul]
+    exact dvd_mul_right 2 _
+
+/-- `m² ≡ m` modulo two. -/
+private lemma two_dvd_self_mul_sub (m : ℤ) : (2 : ℤ) ∣ m * m - m := by
+  rcases Int.even_or_odd m with ⟨k, hk⟩ | ⟨k, hk⟩ <;> subst hk
+  · exact ⟨2 * k * k - k, by ring⟩
+  · exact ⟨2 * k * k + k, by ring⟩
+
+/-- The multiplicity-weighted sum of the self-intersections of a numerical type is even.
+
+This is what makes the halving in the genus formula exact; the individual terms `mᵢ aᵢᵢ` need not
+be even, as `oddDiagonalExample` shows. -/
+lemma even_sum_multiplicity_mul_diagonal :
+    Even (∑ i, (T.multiplicity i : ℤ) * T.intersection i i) := by
+  have hoff : (2 : ℤ) ∣ ∑ i, ∑ j ∈ univ.erase i,
+      (T.multiplicity i : ℤ) * (T.multiplicity j : ℤ) * T.intersection i j :=
+    two_dvd_sum_sum_erase (s := univ)
+      (f := fun i j ↦ (T.multiplicity i : ℤ) * (T.multiplicity j : ℤ) * T.intersection i j)
+      (fun i j ↦ by rw [T.intersection_comm i j]; ring)
+  have htotal : ∑ i, ∑ j,
+      (T.multiplicity i : ℤ) * (T.multiplicity j : ℤ) * T.intersection i j = 0 := by
+    refine Finset.sum_eq_zero fun i _ ↦ ?_
+    have hrow : ∑ j, (T.multiplicity i : ℤ) * (T.multiplicity j : ℤ) * T.intersection i j
+        = (T.multiplicity i : ℤ) * ∑ j, (T.multiplicity j : ℤ) * T.intersection i j := by
+      rw [Finset.mul_sum]
+      exact Finset.sum_congr rfl fun j _ ↦ by ring
+    rw [hrow, T.fiber_relation i, mul_zero]
+  have hdiag : (2 : ℤ) ∣
+      ∑ i, (T.multiplicity i : ℤ) * (T.multiplicity i : ℤ) * T.intersection i i := by
+    have hsplit : ∑ i, (T.multiplicity i : ℤ) * (T.multiplicity i : ℤ) * T.intersection i i
+        = -∑ i, ∑ j ∈ univ.erase i,
+            (T.multiplicity i : ℤ) * (T.multiplicity j : ℤ) * T.intersection i j := by
+      rw [eq_neg_iff_add_eq_zero, ← Finset.sum_add_distrib, ← htotal]
+      exact Finset.sum_congr rfl fun i _ ↦ Finset.add_sum_erase univ
+        (fun j ↦ (T.multiplicity i : ℤ) * (T.multiplicity j : ℤ) * T.intersection i j)
+        (mem_univ i)
+    rw [hsplit]
+    exact dvd_neg.2 hoff
+  have hcorr : (2 : ℤ) ∣ ∑ i, ((T.multiplicity i : ℤ) * (T.multiplicity i : ℤ) *
+      T.intersection i i - (T.multiplicity i : ℤ) * T.intersection i i) := by
+    refine Finset.dvd_sum fun i _ ↦ ?_
+    obtain ⟨c, hc⟩ := two_dvd_self_mul_sub (T.multiplicity i : ℤ)
+    exact ⟨c * T.intersection i i, by linear_combination T.intersection i i * hc⟩
+  have key : ∑ i, (T.multiplicity i : ℤ) * T.intersection i i =
+      (∑ i, (T.multiplicity i : ℤ) * (T.multiplicity i : ℤ) * T.intersection i i) -
+        ∑ i, ((T.multiplicity i : ℤ) * (T.multiplicity i : ℤ) * T.intersection i i -
+          (T.multiplicity i : ℤ) * T.intersection i i) := by
+    rw [Finset.sum_sub_distrib]
+    ring
+  rw [even_iff_two_dvd, key]
+  exact dvd_sub hdiag hcorr
+
+/-! ### The signed genus -/
+
+/-- The signed genus of a numerical type,
+`g(T) = 1 + ∑ᵢ mᵢ (wᵢ (gᵢ - 1) - aᵢᵢ / 2)`
+(compare [Stacks, Tag 0C71](https://stacks.math.columbia.edu/tag/0C71)).
+
+The halving is performed once, on the whole sum `∑ᵢ mᵢ aᵢᵢ`, which is even by
+`even_sum_multiplicity_mul_diagonal`; the individual half-diagonals need not be integers.
+Abstract numerical types can have negative genus, so the value is an integer, not a natural
+number. -/
+def arithmeticGenus : ℤ :=
+  1 + (∑ i, (T.multiplicity i : ℤ) * (T.weight i : ℤ) * ((T.genus i : ℤ) - 1)) -
+    (∑ i, (T.multiplicity i : ℤ) * T.intersection i i) / 2
+
+/-- The genus formula with the halving cleared, which is the shape in which it is used. -/
+lemma two_mul_arithmeticGenus :
+    2 * T.arithmeticGenus =
+      2 + 2 * (∑ i, (T.multiplicity i : ℤ) * (T.weight i : ℤ) * ((T.genus i : ℤ) - 1)) -
+        ∑ i, (T.multiplicity i : ℤ) * T.intersection i i := by
+  have h : (2 : ℤ) * ((∑ i, (T.multiplicity i : ℤ) * T.intersection i i) / 2)
+      = ∑ i, (T.multiplicity i : ℤ) * T.intersection i i :=
+    Int.mul_ediv_cancel' T.even_sum_multiplicity_mul_diagonal.two_dvd
+  rw [arithmeticGenus]
+  linarith
+
+/-! ### Reindexing -/
+
+/-- The numerical type obtained by transporting the component set along an equivalence. -/
+@[expose]
+def reindex {C : Type u} [Fintype C] [DecidableEq C] (e : T.Component ≃ C) :
+    NumericalType.{u} where
+  Component := C
+  componentNonempty := T.componentNonempty.map e
+  multiplicity c := T.multiplicity (e.symm c)
+  weight c := T.weight (e.symm c)
+  intersection := T.intersection.submatrix e.symm e.symm
+  intersection_isSymm := T.intersection_isSymm.submatrix _
+  offDiagonal_nonneg _ _ h := T.offDiagonal_nonneg _ _ fun hh ↦ h (e.symm.injective hh)
+  connected i j := by
+    have key : ∀ a b : T.Component,
+        Relation.ReflTransGen (fun x y ↦ x ≠ y ∧ 0 < T.intersection x y) a b →
+        Relation.ReflTransGen
+          (fun x y : C ↦ x ≠ y ∧ 0 < T.intersection.submatrix e.symm e.symm x y) (e a) (e b) := by
+      intro a b hab
+      induction hab with
+      | refl => exact Relation.ReflTransGen.refl
+      | @tail c d _ hcd ih =>
+        refine ih.tail ⟨fun hh ↦ hcd.1 (e.injective hh), ?_⟩
+        simpa using hcd.2
+    simpa using key (e.symm i) (e.symm j) (T.connected _ _)
+  fiber_relation i :=
+    (Fintype.sum_equiv e.symm _
+      (fun k ↦ (T.multiplicity k : ℤ) * T.intersection (e.symm i) k) fun _ ↦ rfl).trans
+      (T.fiber_relation (e.symm i))
+  weight_dvd _ _ := T.weight_dvd _ _
+  genus c := T.genus (e.symm c)
+
+variable {C : Type u} [Fintype C] [DecidableEq C] (e : T.Component ≃ C)
+
+/-- Multiplicities of a reindexed numerical type. -/
+@[simp]
+lemma reindex_multiplicity (c : C) :
+    (T.reindex e).multiplicity c = T.multiplicity (e.symm c) := rfl
+
+/-- Weights of a reindexed numerical type. -/
+@[simp]
+lemma reindex_weight (c : C) : (T.reindex e).weight c = T.weight (e.symm c) := rfl
+
+/-- Component genera of a reindexed numerical type. -/
+@[simp]
+lemma reindex_genus (c : C) : (T.reindex e).genus c = T.genus (e.symm c) := rfl
+
+/-- Intersection numbers of a reindexed numerical type. -/
+@[simp]
+lemma reindex_intersection (c d : C) :
+    (T.reindex e).intersection c d = T.intersection (e.symm c) (e.symm d) := rfl
+
+/-- The signed genus does not depend on the chosen indexing of the components. -/
+@[simp]
+lemma arithmeticGenus_reindex : (T.reindex e).arithmeticGenus = T.arithmeticGenus := by
+  refine mul_left_cancel₀ (a := (2 : ℤ)) two_ne_zero ?_
+  have h1 : ∑ i, ((T.reindex e).multiplicity i : ℤ) * ((T.reindex e).weight i : ℤ) *
+      (((T.reindex e).genus i : ℤ) - 1)
+      = ∑ k, (T.multiplicity k : ℤ) * (T.weight k : ℤ) * ((T.genus k : ℤ) - 1) :=
+    Fintype.sum_equiv e.symm _ _ fun _ ↦ rfl
+  have h2 : ∑ i, ((T.reindex e).multiplicity i : ℤ) * (T.reindex e).intersection i i
+      = ∑ k, (T.multiplicity k : ℤ) * T.intersection k k :=
+    Fintype.sum_equiv e.symm _ _ fun _ ↦ rfl
+  rw [(T.reindex e).two_mul_arithmeticGenus, T.two_mul_arithmeticGenus, h1, h2]
+
+/-! ### Worked examples -/
+
+/-- Two components of multiplicity one, weight two and genus one, meeting doubly: a numerical
+type of signed genus three. -/
+private noncomputable abbrev weightedExample : NumericalType.{0} where
+  Component := Fin 2
+  multiplicity _ := 1
+  weight _ := 2
+  intersection := !![-2, 2; 2, -2]
+  intersection_isSymm := Matrix.IsSymm.ext fun i j ↦ by fin_cases i <;> fin_cases j <;> rfl
+  offDiagonal_nonneg i j h := by
+    fin_cases i <;> fin_cases j <;> first | exact absurd rfl h | decide
+  connected := by
+    have key : ∀ i j : Fin 2, i ≠ j → (0 : ℤ) < !![(-2 : ℤ), 2; 2, -2] i j := by
+      intro i j h
+      fin_cases i <;> fin_cases j <;> first | exact absurd rfl h | decide
+    intro i j
+    rcases eq_or_ne i j with rfl | h
+    · exact Relation.ReflTransGen.refl
+    · exact Relation.ReflTransGen.single ⟨h, key i j h⟩
+  fiber_relation i := by fin_cases i <;> decide
+  weight_dvd i j := by fin_cases i <;> fin_cases j <;> decide
+  genus _ := 1
+
+example : weightedExample.arithmeticGenus = 3 := by decide
+
+example : ({ weightedExample with genus := fun _ ↦ 0 } : NumericalType).arithmeticGenus = -1 := by
+  decide
+
+/-- Two components of multiplicity and weight one and genus one, meeting transversally. Both
+diagonal entries are odd, so the halving in the genus formula cannot be distributed over the
+sum. -/
+private noncomputable abbrev oddDiagonalExample : NumericalType.{0} where
+  Component := Fin 2
+  multiplicity _ := 1
+  weight _ := 1
+  intersection := !![-1, 1; 1, -1]
+  intersection_isSymm := Matrix.IsSymm.ext fun i j ↦ by fin_cases i <;> fin_cases j <;> rfl
+  offDiagonal_nonneg i j h := by
+    fin_cases i <;> fin_cases j <;> first | exact absurd rfl h | decide
+  connected := by
+    have key : ∀ i j : Fin 2, i ≠ j → (0 : ℤ) < !![(-1 : ℤ), 1; 1, -1] i j := by
+      intro i j h
+      fin_cases i <;> fin_cases j <;> first | exact absurd rfl h | decide
+    intro i j
+    rcases eq_or_ne i j with rfl | h
+    · exact Relation.ReflTransGen.refl
+    · exact Relation.ReflTransGen.single ⟨h, key i j h⟩
+  fiber_relation i := by fin_cases i <;> decide
+  weight_dvd _ _ := one_dvd _
+  genus _ := 1
+
+example : oddDiagonalExample.intersection 0 0 = -1 := by decide
+
+example : oddDiagonalExample.arithmeticGenus = 2 := by decide
+
+end NumericalType
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/Curves/StableReduction/NumericalType.lean
+++ b/TauCeti/AlgebraicGeometry/Curves/StableReduction/NumericalType.lean
@@ -55,7 +55,7 @@ even by symmetry, so `∑ᵢ mᵢ² aᵢᵢ` is even; and `mᵢ² ≡ mᵢ` modu
 * `TauCeti.NumericalType.intersection_self_nonpos` and
   `TauCeti.NumericalType.intersection_self_neg`: self-intersections are nonpositive, and are
   negative as soon as there is more than one component.
-* `TauCeti.NumericalType.reflTransGen_adj_iff` and
+* `Matrix.forall_reflTransGen_ne_and_pos_iff` and
   `TauCeti.NumericalType.exists_mem_notMem_adj`: connectedness of the intersection graph is the
   same as the absence of a disconnecting cut, the form in which
   [Stacks, Tag 0C6Z](https://stacks.math.columbia.edu/tag/0C6Z) states the condition.
@@ -70,12 +70,46 @@ the halving be distributed over the sum: `oddDiagonalExample` has odd diagonal e
 
 Symmetry of the intersection matrix is recorded through Mathlib's `Matrix.IsSymm` rather than as
 a bare pointwise equation, so that a reindexed matrix inherits it from `Matrix.IsSymm.submatrix`.
+
+The no-disconnected-cut criterion is stated for a bare matrix, in the `Matrix` namespace, because
+it has to be available before a numerical type exists: it is what discharges the `connected` field
+when one is built.
 -/
 
 -- The `NumericalType` structure, the signed genus and the two worked examples follow the
 -- signatures written down in `StableReduction/Suggested.lean` of the Tau Ceti roadmap.
 
 public section
+
+namespace Matrix
+
+/-- For a matrix `A` whose off-diagonal entries are nonnegative, connectedness of the graph
+joining distinct indices `i`, `j` with `0 < A i j` is equivalent to the absence of a disconnecting
+cut: no nonempty proper set of indices `s` has all its cross-entries zero. The right-hand side is
+the form in which [Stacks, Tag 0C6Z](https://stacks.math.columbia.edu/tag/0C6Z) states the
+connectedness condition on a numerical type, so this is what supplies the `connected` field of
+`TauCeti.NumericalType` when one is constructed.
+
+The nonnegativity hypothesis is what turns a nonzero cross-entry into a positive one, and so
+cannot be dropped. -/
+lemma forall_reflTransGen_ne_and_pos_iff {C : Type*} (A : Matrix C C ℤ)
+    (hA : ∀ i j, i ≠ j → 0 ≤ A i j) :
+    (∀ i j, Relation.ReflTransGen (fun i j ↦ i ≠ j ∧ 0 < A i j) i j) ↔
+      ∀ s : Set C, s.Nonempty → s ≠ Set.univ → ¬ ∀ i ∈ s, ∀ j ∉ s, A i j = 0 := by
+  rw [TauCeti.forall_reflTransGen_iff]
+  refine forall_congr' fun s ↦ imp_congr_right fun _ ↦ imp_congr_right fun _ ↦ ?_
+  constructor
+  · rintro ⟨i, hi, j, hj, -, hpos⟩ hcut
+    exact hpos.ne' (hcut i hi j hj)
+  · intro hcut
+    by_contra hcon
+    refine hcut fun i hi j hj ↦ ?_
+    have hij : i ≠ j := fun h ↦ hj (h ▸ hi)
+    refine le_antisymm ?_ (hA i j hij)
+    by_contra hle
+    exact hcon ⟨i, hi, j, hj, hij, not_le.1 hle⟩
+
+end Matrix
 
 namespace TauCeti
 
@@ -149,30 +183,6 @@ no-disconnected-cut form of the connectedness axiom. -/
 lemma exists_mem_notMem_adj (s : Set T.Component) (hne : s.Nonempty) (hs : s ≠ Set.univ) :
     ∃ i ∈ s, ∃ j ∉ s, T.Adj i j :=
   (TauCeti.forall_reflTransGen_iff T.Adj).1 T.reflTransGen_adj s hne hs
-
-/-- For a matrix `A` of intersection numbers whose off-diagonal entries are nonnegative, the
-connectedness axiom of a numerical type is equivalent to the absence of a disconnecting cut: no
-nonempty proper set of indices `s` has all its cross-intersections zero. The right-hand side is
-the form in which [Stacks, Tag 0C6Z](https://stacks.math.columbia.edu/tag/0C6Z) states the
-condition, so this is what supplies the `connected` field when a numerical type is constructed.
-
-The nonnegativity hypothesis is what turns a nonzero cross-intersection into a positive one, and
-so cannot be dropped. -/
-lemma reflTransGen_adj_iff {C : Type*} (A : Matrix C C ℤ) (hA : ∀ i j, i ≠ j → 0 ≤ A i j) :
-    (∀ i j, Relation.ReflTransGen (fun i j ↦ i ≠ j ∧ 0 < A i j) i j) ↔
-      ∀ s : Set C, s.Nonempty → s ≠ Set.univ → ¬ ∀ i ∈ s, ∀ j ∉ s, A i j = 0 := by
-  rw [TauCeti.forall_reflTransGen_iff]
-  refine forall_congr' fun s ↦ imp_congr_right fun _ ↦ imp_congr_right fun _ ↦ ?_
-  constructor
-  · rintro ⟨i, hi, j, hj, -, hpos⟩ hcut
-    exact hpos.ne' (hcut i hi j hj)
-  · intro hcut
-    by_contra hcon
-    refine hcut fun i hi j hj ↦ ?_
-    have hij : i ≠ j := fun h ↦ hj (h ▸ hi)
-    refine le_antisymm ?_ (hA i j hij)
-    by_contra hle
-    exact hcon ⟨i, hi, j, hj, hij, not_le.1 hle⟩
 
 /-! ### Self-intersections -/
 

--- a/TauCeti/AlgebraicGeometry/Curves/StableReduction/NumericalType.lean
+++ b/TauCeti/AlgebraicGeometry/Curves/StableReduction/NumericalType.lean
@@ -6,12 +6,14 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Algebra.Order.BigOperators.Group.Finset
-public import Mathlib.LinearAlgebra.Matrix.Notation
 public import Mathlib.LinearAlgebra.Matrix.Symmetric
-public import Mathlib.Tactic.FinCases
-public import Mathlib.Tactic.Linarith
-public import Mathlib.Tactic.LinearCombination
-public import Mathlib.Tactic.Ring
+import Mathlib.LinearAlgebra.Matrix.Notation
+import Mathlib.Tactic.FinCases
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.LinearCombination
+import Mathlib.Tactic.Ring
+import TauCeti.Algebra.BigOperators.Finset.OffDiagonal
+import TauCeti.Logic.Relation
 
 /-!
 # Numerical types and their signed genus
@@ -70,13 +72,16 @@ Symmetry of the intersection matrix is recorded through Mathlib's `Matrix.IsSymm
 a bare pointwise equation, so that a reindexed matrix inherits it from `Matrix.IsSymm.submatrix`.
 -/
 
+-- The `NumericalType` structure, the signed genus and the two worked examples follow the
+-- signatures written down in `StableReduction/Suggested.lean` of the Tau Ceti roadmap.
+
 public section
 
 namespace TauCeti
 
 open Finset
 
-universe u
+universe u v
 
 /-- A numerical type, in the sense of
 [Stacks, Tag 0C6Z](https://stacks.math.columbia.edu/tag/0C6Z).
@@ -128,6 +133,7 @@ lemma intersection_comm (i j : T.Component) : T.intersection i j = T.intersectio
 def Adj (i j : T.Component) : Prop := i ≠ j ∧ 0 < T.intersection i j
 
 /-- Unfolding of `TauCeti.NumericalType.Adj`. -/
+@[simp]
 lemma adj_iff {i j : T.Component} : T.Adj i j ↔ i ≠ j ∧ 0 < T.intersection i j := Iff.rfl
 
 /-- The connectedness axiom, phrased with `TauCeti.NumericalType.Adj`. -/
@@ -138,42 +144,11 @@ variable {T} in
 lemma Adj.symm {i j : T.Component} (h : T.Adj i j) : T.Adj j i :=
   ⟨h.1.symm, T.intersection_comm i j ▸ h.2⟩
 
-/-- Totality of the reflexive transitive closure of a relation is exactly the absence of a
-nonempty proper subset with no outgoing edge. -/
-private lemma forall_reflTransGen_iff {α : Type*} (r : α → α → Prop) :
-    (∀ i j, Relation.ReflTransGen r i j) ↔
-      ∀ s : Set α, s.Nonempty → s ≠ Set.univ → ∃ i ∈ s, ∃ j ∉ s, r i j := by
-  constructor
-  · rintro h s ⟨a, ha⟩ hs
-    obtain ⟨b, hb⟩ : ∃ b, b ∉ s := by
-      by_contra hcon
-      exact hs (Set.eq_univ_of_forall fun x ↦ by
-        by_contra hx
-        exact hcon ⟨x, hx⟩)
-    have key : ∀ x y, Relation.ReflTransGen r x y → x ∈ s → y ∉ s → ∃ i ∈ s, ∃ j ∉ s, r i j := by
-      intro x y hxy
-      induction hxy with
-      | refl => exact fun hx hy ↦ absurd hx hy
-      | @tail c d _ hcd ih =>
-        intro hx hd
-        by_cases hc : c ∈ s
-        · exact ⟨c, hc, d, hd, hcd⟩
-        · exact ih hx hc
-    exact key a b (h a b) ha hb
-  · intro h i j
-    by_contra hij
-    have hs : {k | Relation.ReflTransGen r i k} ≠ Set.univ := by
-      intro hs
-      have hj : j ∈ {k | Relation.ReflTransGen r i k} := by rw [hs]; trivial
-      exact hij hj
-    obtain ⟨a, ha, b, hb, hab⟩ := h _ ⟨i, Relation.ReflTransGen.refl⟩ hs
-    exact hb (Relation.ReflTransGen.tail ha hab)
-
 /-- Every nonempty proper set of components of a numerical type meets its complement: this is the
 no-disconnected-cut form of the connectedness axiom. -/
 lemma exists_mem_notMem_adj (s : Set T.Component) (hne : s.Nonempty) (hs : s ≠ Set.univ) :
     ∃ i ∈ s, ∃ j ∉ s, T.Adj i j :=
-  (forall_reflTransGen_iff T.Adj).1 T.reflTransGen_adj s hne hs
+  (TauCeti.forall_reflTransGen_iff T.Adj).1 T.reflTransGen_adj s hne hs
 
 /-- For a matrix `A` of intersection numbers whose off-diagonal entries are nonnegative, the
 connectedness axiom of a numerical type is equivalent to the absence of a disconnecting cut: no
@@ -186,7 +161,7 @@ so cannot be dropped. -/
 lemma reflTransGen_adj_iff {C : Type*} (A : Matrix C C ℤ) (hA : ∀ i j, i ≠ j → 0 ≤ A i j) :
     (∀ i j, Relation.ReflTransGen (fun i j ↦ i ≠ j ∧ 0 < A i j) i j) ↔
       ∀ s : Set C, s.Nonempty → s ≠ Set.univ → ¬ ∀ i ∈ s, ∀ j ∉ s, A i j = 0 := by
-  rw [forall_reflTransGen_iff]
+  rw [TauCeti.forall_reflTransGen_iff]
   refine forall_congr' fun s ↦ imp_congr_right fun _ ↦ imp_congr_right fun _ ↦ ?_
   constructor
   · rintro ⟨i, hi, j, hj, -, hpos⟩ hcut
@@ -252,33 +227,15 @@ lemma intersection_self_neg (h : 1 < Fintype.card T.Component) (i : T.Component)
 
 /-! ### Integrality of the signed genus -/
 
-/-- The sum of a symmetric function over the off-diagonal of a finite set is even. -/
-private lemma two_dvd_sum_sum_erase {α : Type*} [DecidableEq α] {f : α → α → ℤ}
-    (hf : ∀ i j, f i j = f j i) (s : Finset α) :
-    (2 : ℤ) ∣ ∑ i ∈ s, ∑ j ∈ s.erase i, f i j := by
-  induction s using Finset.induction with
-  | empty => simp
-  | insert a s ha ih =>
-    have hstep : ∀ i ∈ s, ∑ j ∈ (insert a s).erase i, f i j = f i a + ∑ j ∈ s.erase i, f i j := by
-      intro i hi
-      have hai : a ≠ i := fun h ↦ ha (h ▸ hi)
-      rw [Finset.erase_insert_of_ne hai,
-        Finset.sum_insert (fun h ↦ ha (Finset.mem_of_mem_erase h))]
-    rw [Finset.sum_insert ha, Finset.erase_insert ha, Finset.sum_congr rfl hstep,
-      Finset.sum_add_distrib, ← add_assoc]
-    refine dvd_add ?_ ih
-    rw [Finset.sum_congr rfl fun i (_ : i ∈ s) ↦ hf i a, ← two_mul]
-    exact dvd_mul_right 2 _
-
 /-- The multiplicity-weighted sum of the self-intersections of a numerical type is even.
 
 This is what makes the halving in the genus formula exact; the individual terms `mᵢ aᵢᵢ` need not
 be even, as `oddDiagonalExample` shows. -/
 lemma even_sum_multiplicity_mul_diagonal :
     Even (∑ i, (T.multiplicity i : ℤ) * T.intersection i i) := by
-  have hoff : (2 : ℤ) ∣ ∑ i, ∑ j ∈ univ.erase i,
-      (T.multiplicity i : ℤ) * (T.multiplicity j : ℤ) * T.intersection i j :=
-    two_dvd_sum_sum_erase (s := univ)
+  have hoff : Even (∑ i, ∑ j ∈ univ.erase i,
+      (T.multiplicity i : ℤ) * (T.multiplicity j : ℤ) * T.intersection i j) :=
+    TauCeti.even_sum_sum_erase (s := univ)
       (f := fun i j ↦ (T.multiplicity i : ℤ) * (T.multiplicity j : ℤ) * T.intersection i j)
       (fun i j ↦ by rw [T.intersection_comm i j]; ring)
   have htotal : ∑ i, ∑ j,
@@ -299,7 +256,7 @@ lemma even_sum_multiplicity_mul_diagonal :
         (fun j ↦ (T.multiplicity i : ℤ) * (T.multiplicity j : ℤ) * T.intersection i j)
         (mem_univ i)
     rw [hsplit]
-    exact dvd_neg.2 hoff
+    exact dvd_neg.2 hoff.two_dvd
   have hcorr : (2 : ℤ) ∣ ∑ i, ((T.multiplicity i : ℤ) * (T.multiplicity i : ℤ) *
       T.intersection i i - (T.multiplicity i : ℤ) * T.intersection i i) := by
     refine Finset.dvd_sum fun i _ ↦ ?_
@@ -342,37 +299,41 @@ lemma two_mul_arithmeticGenus :
 
 /-! ### Reindexing -/
 
-/-- The numerical type obtained by transporting the component set along an equivalence. -/
-@[expose]
-def reindex {C : Type u} [Fintype C] [DecidableEq C] (e : T.Component ≃ C) :
-    NumericalType.{u} where
-  Component := C
-  componentNonempty := T.componentNonempty.map e
-  multiplicity c := T.multiplicity (e.symm c)
-  weight c := T.weight (e.symm c)
-  intersection := T.intersection.submatrix e.symm e.symm
-  intersection_isSymm := T.intersection_isSymm.submatrix _
-  offDiagonal_nonneg _ _ h := T.offDiagonal_nonneg _ _ fun hh ↦ h (e.symm.injective hh)
-  connected i j := by
-    have key : ∀ a b : T.Component,
-        Relation.ReflTransGen (fun x y ↦ x ≠ y ∧ 0 < T.intersection x y) a b →
-        Relation.ReflTransGen
-          (fun x y : C ↦ x ≠ y ∧ 0 < T.intersection.submatrix e.symm e.symm x y) (e a) (e b) := by
-      intro a b hab
-      induction hab with
-      | refl => exact Relation.ReflTransGen.refl
-      | @tail c d _ hcd ih =>
-        refine ih.tail ⟨fun hh ↦ hcd.1 (e.injective hh), ?_⟩
-        simpa using hcd.2
-    simpa using key (e.symm i) (e.symm j) (T.connected _ _)
-  fiber_relation i :=
-    (Fintype.sum_equiv e.symm _
-      (fun k ↦ (T.multiplicity k : ℤ) * T.intersection (e.symm i) k) fun _ ↦ rfl).trans
-      (T.fiber_relation (e.symm i))
-  weight_dvd _ _ := T.weight_dvd _ _
-  genus c := T.genus (e.symm c)
+/-- The numerical type obtained by transporting the component set along an equivalence.
 
-variable {C : Type u} [Fintype C] [DecidableEq C] (e : T.Component ≃ C)
+The finiteness and decidable equality of the new component set are transported along the
+equivalence, so the target needs no instances of its own and may live in any universe. -/
+@[expose]
+def reindex {C : Type v} (e : T.Component ≃ C) : NumericalType.{v} :=
+  letI : Fintype C := Fintype.ofEquiv _ e
+  letI : DecidableEq C := e.symm.decidableEq
+  { Component := C
+    componentNonempty := T.componentNonempty.map e
+    multiplicity c := T.multiplicity (e.symm c)
+    weight c := T.weight (e.symm c)
+    intersection := T.intersection.submatrix e.symm e.symm
+    intersection_isSymm := T.intersection_isSymm.submatrix _
+    offDiagonal_nonneg _ _ h := T.offDiagonal_nonneg _ _ fun hh ↦ h (e.symm.injective hh)
+    connected i j := by
+      have key : ∀ a b : T.Component,
+          Relation.ReflTransGen (fun x y ↦ x ≠ y ∧ 0 < T.intersection x y) a b →
+          Relation.ReflTransGen
+            (fun x y : C ↦ x ≠ y ∧ 0 < T.intersection.submatrix e.symm e.symm x y) (e a) (e b) := by
+        intro a b hab
+        induction hab with
+        | refl => exact Relation.ReflTransGen.refl
+        | @tail c d _ hcd ih =>
+          refine ih.tail ⟨fun hh ↦ hcd.1 (e.injective hh), ?_⟩
+          simpa using hcd.2
+      simpa using key (e.symm i) (e.symm j) (T.connected _ _)
+    fiber_relation i :=
+      (Fintype.sum_equiv e.symm _
+        (fun k ↦ (T.multiplicity k : ℤ) * T.intersection (e.symm i) k) fun _ ↦ rfl).trans
+        (T.fiber_relation (e.symm i))
+    weight_dvd _ _ := T.weight_dvd _ _
+    genus c := T.genus (e.symm c) }
+
+variable {C : Type v} (e : T.Component ≃ C)
 
 /-- Multiplicities of a reindexed numerical type. -/
 @[simp]
@@ -395,6 +356,9 @@ lemma reindex_intersection (c d : C) :
 /-- The signed genus does not depend on the chosen indexing of the components. -/
 @[simp]
 lemma arithmeticGenus_reindex : (T.reindex e).arithmeticGenus = T.arithmeticGenus := by
+  -- name the `Fintype C` that `reindex` transported along `e`, so that the two sums below can
+  -- be compared with `Fintype.sum_equiv`
+  let _ : Fintype C := (T.reindex e).componentFintype
   refine mul_left_cancel₀ (a := (2 : ℤ)) two_ne_zero ?_
   have h1 : ∑ i, ((T.reindex e).multiplicity i : ℤ) * ((T.reindex e).weight i : ℤ) *
       (((T.reindex e).genus i : ℤ) - 1)

--- a/TauCeti/AlgebraicGeometry/Curves/StableReduction/NumericalType.lean
+++ b/TauCeti/AlgebraicGeometry/Curves/StableReduction/NumericalType.lean
@@ -270,12 +270,6 @@ private lemma two_dvd_sum_sum_erase {α : Type*} [DecidableEq α] {f : α → α
     rw [Finset.sum_congr rfl fun i (_ : i ∈ s) ↦ hf i a, ← two_mul]
     exact dvd_mul_right 2 _
 
-/-- `m² ≡ m` modulo two. -/
-private lemma two_dvd_self_mul_sub (m : ℤ) : (2 : ℤ) ∣ m * m - m := by
-  rcases Int.even_or_odd m with ⟨k, hk⟩ | ⟨k, hk⟩ <;> subst hk
-  · exact ⟨2 * k * k - k, by ring⟩
-  · exact ⟨2 * k * k + k, by ring⟩
-
 /-- The multiplicity-weighted sum of the self-intersections of a numerical type is even.
 
 This is what makes the halving in the genus formula exact; the individual terms `mᵢ aᵢᵢ` need not
@@ -309,7 +303,8 @@ lemma even_sum_multiplicity_mul_diagonal :
   have hcorr : (2 : ℤ) ∣ ∑ i, ((T.multiplicity i : ℤ) * (T.multiplicity i : ℤ) *
       T.intersection i i - (T.multiplicity i : ℤ) * T.intersection i i) := by
     refine Finset.dvd_sum fun i _ ↦ ?_
-    obtain ⟨c, hc⟩ := two_dvd_self_mul_sub (T.multiplicity i : ℤ)
+    obtain ⟨c, hc⟩ := by
+      simpa [mul_sub] using (Int.even_mul_pred_self (T.multiplicity i : ℤ)).two_dvd
     exact ⟨c * T.intersection i i, by linear_combination T.intersection i i * hc⟩
   have key : ∑ i, (T.multiplicity i : ℤ) * T.intersection i i =
       (∑ i, (T.multiplicity i : ℤ) * (T.multiplicity i : ℤ) * T.intersection i i) -

--- a/TauCeti/AlgebraicGeometry/Curves/StableReduction/NumericalType.lean
+++ b/TauCeti/AlgebraicGeometry/Curves/StableReduction/NumericalType.lean
@@ -389,12 +389,14 @@ structure Equiv (T' : NumericalType.{v}) where
   /-- The bijection preserves the genera of the components. -/
   genus_apply : ∀ i, T'.genus (toEquiv i) = T.genus i
 
+attribute [simp] Equiv.multiplicity_apply Equiv.weight_apply Equiv.intersection_apply
+  Equiv.genus_apply
+
 namespace Equiv
 
 variable {T} {T' : NumericalType.{v}} {T'' : NumericalType.{w}}
 
 /-- The identity equivalence of a numerical type. -/
-@[expose, simps toEquiv]
 def refl : T.Equiv T where
   toEquiv := _root_.Equiv.refl T.Component
   multiplicity_apply _ := rfl
@@ -402,8 +404,11 @@ def refl : T.Equiv T where
   intersection_apply _ _ := rfl
   genus_apply _ := rfl
 
+/-- The bijection underlying `TauCeti.NumericalType.Equiv.refl` is the identity. -/
+@[simp]
+lemma refl_toEquiv : (refl : T.Equiv T).toEquiv = _root_.Equiv.refl T.Component := (rfl)
+
 /-- The inverse of an equivalence of numerical types. -/
-@[expose, simps toEquiv]
 def symm (f : T.Equiv T') : T'.Equiv T where
   toEquiv := f.toEquiv.symm
   multiplicity_apply j := by simpa using (f.multiplicity_apply (f.toEquiv.symm j)).symm
@@ -412,14 +417,22 @@ def symm (f : T.Equiv T') : T'.Equiv T where
     simpa using (f.intersection_apply (f.toEquiv.symm j) (f.toEquiv.symm k)).symm
   genus_apply j := by simpa using (f.genus_apply (f.toEquiv.symm j)).symm
 
+/-- The bijection underlying the inverse is the inverse bijection. -/
+@[simp]
+lemma symm_toEquiv (f : T.Equiv T') : f.symm.toEquiv = f.toEquiv.symm := (rfl)
+
 /-- The composite of two equivalences of numerical types. -/
-@[expose, simps toEquiv]
 def trans (f : T.Equiv T') (g : T'.Equiv T'') : T.Equiv T'' where
   toEquiv := f.toEquiv.trans g.toEquiv
   multiplicity_apply i := (g.multiplicity_apply _).trans (f.multiplicity_apply i)
   weight_apply i := (g.weight_apply _).trans (f.weight_apply i)
   intersection_apply i j := (g.intersection_apply _ _).trans (f.intersection_apply i j)
   genus_apply i := (g.genus_apply _).trans (f.genus_apply i)
+
+/-- The bijection underlying a composite is the composite bijection. -/
+@[simp]
+lemma trans_toEquiv (f : T.Equiv T') (g : T'.Equiv T'') :
+    (f.trans g).toEquiv = f.toEquiv.trans g.toEquiv := (rfl)
 
 /-- An equivalence of numerical types identifies the target with the reindexed source. -/
 lemma reindex_eq (f : T.Equiv T') : T.reindex f.toEquiv = T' :=
@@ -433,7 +446,6 @@ end Equiv
 
 /-- A numerical type is equivalent to each of its reindexings, along the reindexing
 equivalence. -/
-@[expose]
 def equivReindex : T.Equiv (T.reindex e) where
   toEquiv := e
   multiplicity_apply i := congrArg T.multiplicity (e.symm_apply_apply i)
@@ -443,7 +455,7 @@ def equivReindex : T.Equiv (T.reindex e) where
 
 /-- The bijection underlying `TauCeti.NumericalType.equivReindex` is the reindexing equivalence. -/
 @[simp]
-lemma equivReindex_toEquiv : (T.equivReindex e).toEquiv = e := rfl
+lemma equivReindex_toEquiv : (T.equivReindex e).toEquiv = e := (rfl)
 
 /-- Two numerical types are equivalent exactly when one is a reindexing of the other. -/
 lemma nonempty_equiv_iff {T' : NumericalType.{v}} :

--- a/TauCeti/AlgebraicGeometry/Curves/StableReduction/NumericalType.lean
+++ b/TauCeti/AlgebraicGeometry/Curves/StableReduction/NumericalType.lean
@@ -92,8 +92,8 @@ connectedness condition on a numerical type, so this is what supplies the `conne
 
 The nonnegativity hypothesis is what turns a nonzero cross-entry into a positive one, and so
 cannot be dropped. -/
-lemma forall_reflTransGen_ne_and_pos_iff {C : Type*} (A : Matrix C C ℤ)
-    (hA : ∀ i j, i ≠ j → 0 ≤ A i j) :
+lemma forall_reflTransGen_ne_and_pos_iff {C R : Type*} [PartialOrder R] [Zero R]
+    (A : Matrix C C R) (hA : ∀ i j, i ≠ j → 0 ≤ A i j) :
     (∀ i j, Relation.ReflTransGen (fun i j ↦ i ≠ j ∧ 0 < A i j) i j) ↔
       ∀ s : Set C, s.Nonempty → s ≠ Set.univ → ¬ ∀ i ∈ s, ∀ j ∉ s, A i j = 0 := by
   rw [TauCeti.forall_reflTransGen_iff]
@@ -105,9 +105,8 @@ lemma forall_reflTransGen_ne_and_pos_iff {C : Type*} (A : Matrix C C ℤ)
     by_contra hcon
     refine hcut fun i hi j hj ↦ ?_
     have hij : i ≠ j := fun h ↦ hj (h ▸ hi)
-    refine le_antisymm ?_ (hA i j hij)
-    by_contra hle
-    exact hcon ⟨i, hi, j, hj, hij, not_le.1 hle⟩
+    by_contra hne
+    exact hcon ⟨i, hi, j, hj, hij, lt_of_le_of_ne (hA i j hij) (Ne.symm hne)⟩
 
 end Matrix
 

--- a/TauCeti/AlgebraicGeometry/Curves/StableReduction/NumericalType.lean
+++ b/TauCeti/AlgebraicGeometry/Curves/StableReduction/NumericalType.lean
@@ -247,7 +247,7 @@ lemma even_sum_multiplicity_mul_diagonal :
       (T.multiplicity i : ℤ) * (T.multiplicity j : ℤ) * T.intersection i j) :=
     TauCeti.even_sum_sum_erase (s := univ)
       (f := fun i j ↦ (T.multiplicity i : ℤ) * (T.multiplicity j : ℤ) * T.intersection i j)
-      (fun i j ↦ by rw [T.intersection_comm i j]; ring)
+      (fun i _ j _ ↦ by rw [T.intersection_comm i j]; ring)
   have htotal : ∑ i, ∑ j,
       (T.multiplicity i : ℤ) * (T.multiplicity j : ℤ) * T.intersection i j = 0 := by
     refine Finset.sum_eq_zero fun i _ ↦ ?_

--- a/TauCeti/AlgebraicGeometry/Curves/StableReduction/NumericalType.lean
+++ b/TauCeti/AlgebraicGeometry/Curves/StableReduction/NumericalType.lean
@@ -13,7 +13,6 @@ import Mathlib.LinearAlgebra.Matrix.Notation
 import Mathlib.Tactic.FinCases
 import Mathlib.Tactic.Linarith
 import TauCeti.LinearAlgebra.Matrix.Symmetric
-import TauCeti.Logic.Relation
 
 /-!
 # Numerical types and their signed genus
@@ -26,7 +25,7 @@ residue field) and genera `gᵢ`, together with a symmetric matrix of intersecti
 which is killed by the multiplicity vector, and whose `i`-th row is divisible by `wᵢ`.
 
 This file introduces that structure, its positivity and connectedness API, its reindexing along
-an equivalence of component sets, and its signed genus
+an equivalence of component sets, equivalences of numerical types, and its signed genus
 
 `g(T) = 1 + ∑ᵢ mᵢ (wᵢ (gᵢ - 1) - aᵢᵢ / 2)`.
 
@@ -45,6 +44,8 @@ matrix that forces `∑ᵢ mᵢ aᵢᵢ` to be even
   transitive closure the connectedness axiom requires to be total.
 * `TauCeti.NumericalType.reindex`: the numerical type obtained by transporting the component set
   along an equivalence.
+* `TauCeti.NumericalType.Equiv`: an equivalence of numerical types, a bijection of component sets
+  matching all of their data, with its identity, inverse and composite.
 * `TauCeti.NumericalType.arithmeticGenus`: the signed genus, valued in `ℤ`.
 
 ## Main results
@@ -62,6 +63,9 @@ matrix that forces `∑ᵢ mᵢ aᵢᵢ` to be even
   condition.
 * `TauCeti.NumericalType.arithmeticGenus_reindex`: the signed genus does not depend on the chosen
   indexing of the components.
+* `TauCeti.NumericalType.nonempty_equiv_iff`: two numerical types are equivalent exactly when
+  one is a reindexing of the other, and `TauCeti.NumericalType.Equiv.arithmeticGenus_eq`:
+  equivalent numerical types have the same signed genus.
 
 ## Implementation notes
 
@@ -366,6 +370,85 @@ lemma arithmeticGenus_reindex : (T.reindex e).arithmeticGenus = T.arithmeticGenu
       = ∑ k, (T.multiplicity k : ℤ) * T.intersection k k :=
     Fintype.sum_equiv e.symm _ _ fun _ ↦ rfl
   rw [(T.reindex e).two_mul_arithmeticGenus, T.two_mul_arithmeticGenus, h1, h2]
+
+/-! ### Equivalence of numerical types -/
+
+/-- An equivalence of numerical types, in the sense of
+[Stacks, Tag 0C6Z](https://stacks.math.columbia.edu/tag/0C6Z): a bijection of component sets
+matching multiplicities, weights, intersection numbers and genera. Two numerical types are
+equivalent when `Nonempty (T.Equiv T')`. -/
+structure Equiv (T' : NumericalType.{v}) where
+  /-- The underlying bijection of component sets. -/
+  toEquiv : T.Component ≃ T'.Component
+  /-- The bijection preserves multiplicities. -/
+  multiplicity_apply : ∀ i, T'.multiplicity (toEquiv i) = T.multiplicity i
+  /-- The bijection preserves weights. -/
+  weight_apply : ∀ i, T'.weight (toEquiv i) = T.weight i
+  /-- The bijection preserves intersection numbers. -/
+  intersection_apply : ∀ i j, T'.intersection (toEquiv i) (toEquiv j) = T.intersection i j
+  /-- The bijection preserves the genera of the components. -/
+  genus_apply : ∀ i, T'.genus (toEquiv i) = T.genus i
+
+namespace Equiv
+
+variable {T} {T' : NumericalType.{v}} {T'' : NumericalType.{w}}
+
+/-- The identity equivalence of a numerical type. -/
+@[expose, simps toEquiv]
+def refl : T.Equiv T where
+  toEquiv := _root_.Equiv.refl T.Component
+  multiplicity_apply _ := rfl
+  weight_apply _ := rfl
+  intersection_apply _ _ := rfl
+  genus_apply _ := rfl
+
+/-- The inverse of an equivalence of numerical types. -/
+@[expose, simps toEquiv]
+def symm (f : T.Equiv T') : T'.Equiv T where
+  toEquiv := f.toEquiv.symm
+  multiplicity_apply j := by simpa using (f.multiplicity_apply (f.toEquiv.symm j)).symm
+  weight_apply j := by simpa using (f.weight_apply (f.toEquiv.symm j)).symm
+  intersection_apply j k := by
+    simpa using (f.intersection_apply (f.toEquiv.symm j) (f.toEquiv.symm k)).symm
+  genus_apply j := by simpa using (f.genus_apply (f.toEquiv.symm j)).symm
+
+/-- The composite of two equivalences of numerical types. -/
+@[expose, simps toEquiv]
+def trans (f : T.Equiv T') (g : T'.Equiv T'') : T.Equiv T'' where
+  toEquiv := f.toEquiv.trans g.toEquiv
+  multiplicity_apply i := (g.multiplicity_apply _).trans (f.multiplicity_apply i)
+  weight_apply i := (g.weight_apply _).trans (f.weight_apply i)
+  intersection_apply i j := (g.intersection_apply _ _).trans (f.intersection_apply i j)
+  genus_apply i := (g.genus_apply _).trans (f.genus_apply i)
+
+/-- An equivalence of numerical types identifies the target with the reindexed source. -/
+lemma reindex_eq (f : T.Equiv T') : T.reindex f.toEquiv = T' :=
+  T.reindex_eq f.toEquiv f.multiplicity_apply f.weight_apply f.intersection_apply f.genus_apply
+
+/-- Equivalent numerical types have the same signed genus. -/
+lemma arithmeticGenus_eq (f : T.Equiv T') : T'.arithmeticGenus = T.arithmeticGenus := by
+  rw [← f.reindex_eq, arithmeticGenus_reindex]
+
+end Equiv
+
+/-- A numerical type is equivalent to each of its reindexings, along the reindexing
+equivalence. -/
+@[expose]
+def equivReindex : T.Equiv (T.reindex e) where
+  toEquiv := e
+  multiplicity_apply i := congrArg T.multiplicity (e.symm_apply_apply i)
+  weight_apply i := congrArg T.weight (e.symm_apply_apply i)
+  intersection_apply i j := congrArg₂ T.intersection (e.symm_apply_apply i) (e.symm_apply_apply j)
+  genus_apply i := congrArg T.genus (e.symm_apply_apply i)
+
+/-- The bijection underlying `TauCeti.NumericalType.equivReindex` is the reindexing equivalence. -/
+@[simp]
+lemma equivReindex_toEquiv : (T.equivReindex e).toEquiv = e := rfl
+
+/-- Two numerical types are equivalent exactly when one is a reindexing of the other. -/
+lemma nonempty_equiv_iff {T' : NumericalType.{v}} :
+    Nonempty (T.Equiv T') ↔ ∃ e : T.Component ≃ T'.Component, T.reindex e = T' :=
+  ⟨fun ⟨f⟩ ↦ ⟨f.toEquiv, f.reindex_eq⟩, fun ⟨e, he⟩ ↦ he ▸ ⟨T.equivReindex e⟩⟩
 
 /-! ### Worked examples -/
 

--- a/TauCeti/AlgebraicGeometry/Curves/StableReduction/NumericalType.lean
+++ b/TauCeti/AlgebraicGeometry/Curves/StableReduction/NumericalType.lean
@@ -175,14 +175,29 @@ lemma exists_mem_notMem_adj (s : Set T.Component) (hne : s.Nonempty) (hs : s ≠
     ∃ i ∈ s, ∃ j ∉ s, T.Adj i j :=
   (forall_reflTransGen_iff T.Adj).1 T.reflTransGen_adj s hne hs
 
-/-- The connectedness axiom of a numerical type, for a symmetric matrix `A` of intersection
-numbers, is equivalent to the absence of a disconnecting cut; the right-hand side is the form in
-which [Stacks, Tag 0C6Z](https://stacks.math.columbia.edu/tag/0C6Z) states the condition, so this
-is what supplies the `connected` field when a numerical type is constructed. -/
-lemma reflTransGen_adj_iff {C : Type*} (A : Matrix C C ℤ) :
+/-- For a matrix `A` of intersection numbers whose off-diagonal entries are nonnegative, the
+connectedness axiom of a numerical type is equivalent to the absence of a disconnecting cut: no
+nonempty proper set of indices `s` has all its cross-intersections zero. The right-hand side is
+the form in which [Stacks, Tag 0C6Z](https://stacks.math.columbia.edu/tag/0C6Z) states the
+condition, so this is what supplies the `connected` field when a numerical type is constructed.
+
+The nonnegativity hypothesis is what turns a nonzero cross-intersection into a positive one, and
+so cannot be dropped. -/
+lemma reflTransGen_adj_iff {C : Type*} (A : Matrix C C ℤ) (hA : ∀ i j, i ≠ j → 0 ≤ A i j) :
     (∀ i j, Relation.ReflTransGen (fun i j ↦ i ≠ j ∧ 0 < A i j) i j) ↔
-      ∀ s : Set C, s.Nonempty → s ≠ Set.univ → ∃ i ∈ s, ∃ j ∉ s, i ≠ j ∧ 0 < A i j :=
-  forall_reflTransGen_iff _
+      ∀ s : Set C, s.Nonempty → s ≠ Set.univ → ¬ ∀ i ∈ s, ∀ j ∉ s, A i j = 0 := by
+  rw [forall_reflTransGen_iff]
+  refine forall_congr' fun s ↦ imp_congr_right fun _ ↦ imp_congr_right fun _ ↦ ?_
+  constructor
+  · rintro ⟨i, hi, j, hj, -, hpos⟩ hcut
+    exact hpos.ne' (hcut i hi j hj)
+  · intro hcut
+    by_contra hcon
+    refine hcut fun i hi j hj ↦ ?_
+    have hij : i ≠ j := fun h ↦ hj (h ▸ hi)
+    refine le_antisymm ?_ (hA i j hij)
+    by_contra hle
+    exact hcon ⟨i, hi, j, hj, hij, not_le.1 hle⟩
 
 /-! ### Self-intersections -/
 

--- a/TauCeti/AlgebraicGeometry/Curves/StableReduction/NumericalType.lean
+++ b/TauCeti/AlgebraicGeometry/Curves/StableReduction/NumericalType.lean
@@ -7,12 +7,12 @@ module
 
 public import Mathlib.Algebra.Order.BigOperators.Group.Finset
 public import Mathlib.LinearAlgebra.Matrix.Symmetric
+-- the no-disconnected-cut criterion that discharges the `connected` field of a numerical type
+public import TauCeti.LinearAlgebra.Matrix.Connected
 import Mathlib.LinearAlgebra.Matrix.Notation
 import Mathlib.Tactic.FinCases
 import Mathlib.Tactic.Linarith
-import Mathlib.Tactic.LinearCombination
-import Mathlib.Tactic.Ring
-import TauCeti.Algebra.BigOperators.Finset.OffDiagonal
+import TauCeti.LinearAlgebra.Matrix.Symmetric
 import TauCeti.Logic.Relation
 
 /-!
@@ -33,8 +33,9 @@ an equivalence of component sets, and its signed genus
 The arithmetic subtlety in the genus formula is that the individual half-diagonals `aᵢᵢ / 2` need
 not be integers, so the halving may only be performed once, on the whole sum. That this is
 legitimate is `TauCeti.NumericalType.even_sum_multiplicity_mul_diagonal`: pairing the fibre
-relation against the multiplicity vector gives `∑ᵢⱼ mᵢ mⱼ aᵢⱼ = 0`, whose off-diagonal part is
-even by symmetry, so `∑ᵢ mᵢ² aᵢᵢ` is even; and `mᵢ² ≡ mᵢ` modulo two.
+relation against the multiplicity vector gives `∑ᵢⱼ mᵢ mⱼ aᵢⱼ = 0`, and for a symmetric integer
+matrix that forces `∑ᵢ mᵢ aᵢᵢ` to be even
+(`Matrix.IsSymm.even_sum_mul_diag_of_dotProduct_mulVec_eq_zero`).
 
 ## Main definitions
 
@@ -55,10 +56,10 @@ even by symmetry, so `∑ᵢ mᵢ² aᵢᵢ` is even; and `mᵢ² ≡ mᵢ` modu
 * `TauCeti.NumericalType.intersection_self_nonpos` and
   `TauCeti.NumericalType.intersection_self_neg`: self-intersections are nonpositive, and are
   negative as soon as there is more than one component.
-* `Matrix.forall_reflTransGen_ne_and_pos_iff` and
-  `TauCeti.NumericalType.exists_mem_notMem_adj`: connectedness of the intersection graph is the
-  same as the absence of a disconnecting cut, the form in which
-  [Stacks, Tag 0C6Z](https://stacks.math.columbia.edu/tag/0C6Z) states the condition.
+* `TauCeti.NumericalType.exists_mem_notMem_adj`: every nonempty proper set of components meets
+  its complement, the no-disconnected-cut form in which
+  [Stacks, Tag 0C6Z](https://stacks.math.columbia.edu/tag/0C6Z) states the connectedness
+  condition.
 * `TauCeti.NumericalType.arithmeticGenus_reindex`: the signed genus does not depend on the chosen
   indexing of the components.
 
@@ -71,44 +72,17 @@ the halving be distributed over the sum: `oddDiagonalExample` has odd diagonal e
 Symmetry of the intersection matrix is recorded through Mathlib's `Matrix.IsSymm` rather than as
 a bare pointwise equation, so that a reindexed matrix inherits it from `Matrix.IsSymm.submatrix`.
 
-The no-disconnected-cut criterion is stated for a bare matrix, in the `Matrix` namespace, because
-it has to be available before a numerical type exists: it is what discharges the `connected` field
-when one is built.
+The no-disconnected-cut criterion in the other direction, which is what discharges the `connected`
+field when a numerical type is built, has to be available before the type exists, so it is stated
+for a bare matrix:
+`Matrix.forall_reflTransGen_ne_and_pos_iff` in `TauCeti.LinearAlgebra.Matrix.Connected`, which
+this file re-exports.
 -/
 
 -- The `NumericalType` structure, the signed genus and the two worked examples follow the
 -- signatures written down in `StableReduction/Suggested.lean` of the Tau Ceti roadmap.
 
 public section
-
-namespace Matrix
-
-/-- For a matrix `A` whose off-diagonal entries are nonnegative, connectedness of the graph
-joining distinct indices `i`, `j` with `0 < A i j` is equivalent to the absence of a disconnecting
-cut: no nonempty proper set of indices `s` has all its cross-entries zero. The right-hand side is
-the form in which [Stacks, Tag 0C6Z](https://stacks.math.columbia.edu/tag/0C6Z) states the
-connectedness condition on a numerical type, so this is what supplies the `connected` field of
-`TauCeti.NumericalType` when one is constructed.
-
-The nonnegativity hypothesis is what turns a nonzero cross-entry into a positive one, and so
-cannot be dropped. -/
-lemma forall_reflTransGen_ne_and_pos_iff {C R : Type*} [PartialOrder R] [Zero R]
-    (A : Matrix C C R) (hA : ∀ i j, i ≠ j → 0 ≤ A i j) :
-    (∀ i j, Relation.ReflTransGen (fun i j ↦ i ≠ j ∧ 0 < A i j) i j) ↔
-      ∀ s : Set C, s.Nonempty → s ≠ Set.univ → ¬ ∀ i ∈ s, ∀ j ∉ s, A i j = 0 := by
-  rw [TauCeti.forall_reflTransGen_iff]
-  refine forall_congr' fun s ↦ imp_congr_right fun _ ↦ imp_congr_right fun _ ↦ ?_
-  constructor
-  · rintro ⟨i, hi, j, hj, -, hpos⟩ hcut
-    exact hpos.ne' (hcut i hi j hj)
-  · intro hcut
-    by_contra hcon
-    refine hcut fun i hi j hj ↦ ?_
-    have hij : i ≠ j := fun h ↦ hj (h ▸ hi)
-    by_contra hne
-    exact hcon ⟨i, hi, j, hj, hij, lt_of_le_of_ne (hA i j hij) (Ne.symm hne)⟩
-
-end Matrix
 
 namespace TauCeti
 
@@ -239,47 +213,15 @@ lemma intersection_self_neg (h : 1 < Fintype.card T.Component) (i : T.Component)
 /-- The multiplicity-weighted sum of the self-intersections of a numerical type is even.
 
 This is what makes the halving in the genus formula exact; the individual terms `mᵢ aᵢᵢ` need not
-be even, as `oddDiagonalExample` shows. -/
+be even, as `oddDiagonalExample` shows. The fibre relation says that the intersection matrix kills
+the multiplicity vector, so this is an instance of
+`Matrix.IsSymm.even_sum_mul_diag_of_dotProduct_mulVec_eq_zero`. -/
 lemma even_sum_multiplicity_mul_diagonal :
     Even (∑ i, (T.multiplicity i : ℤ) * T.intersection i i) := by
-  have hoff : Even (∑ i, ∑ j ∈ univ.erase i,
-      (T.multiplicity i : ℤ) * (T.multiplicity j : ℤ) * T.intersection i j) :=
-    TauCeti.even_sum_sum_erase (s := univ)
-      (f := fun i j ↦ (T.multiplicity i : ℤ) * (T.multiplicity j : ℤ) * T.intersection i j)
-      (fun i _ j _ ↦ by rw [T.intersection_comm i j]; ring)
-  have htotal : ∑ i, ∑ j,
-      (T.multiplicity i : ℤ) * (T.multiplicity j : ℤ) * T.intersection i j = 0 := by
-    refine Finset.sum_eq_zero fun i _ ↦ ?_
-    have hrow : ∑ j, (T.multiplicity i : ℤ) * (T.multiplicity j : ℤ) * T.intersection i j
-        = (T.multiplicity i : ℤ) * ∑ j, (T.multiplicity j : ℤ) * T.intersection i j := by
-      rw [Finset.mul_sum]
-      exact Finset.sum_congr rfl fun j _ ↦ by ring
-    rw [hrow, T.fiber_relation i, mul_zero]
-  have hdiag : (2 : ℤ) ∣
-      ∑ i, (T.multiplicity i : ℤ) * (T.multiplicity i : ℤ) * T.intersection i i := by
-    have hsplit : ∑ i, (T.multiplicity i : ℤ) * (T.multiplicity i : ℤ) * T.intersection i i
-        = -∑ i, ∑ j ∈ univ.erase i,
-            (T.multiplicity i : ℤ) * (T.multiplicity j : ℤ) * T.intersection i j := by
-      rw [eq_neg_iff_add_eq_zero, ← Finset.sum_add_distrib, ← htotal]
-      exact Finset.sum_congr rfl fun i _ ↦ Finset.add_sum_erase univ
-        (fun j ↦ (T.multiplicity i : ℤ) * (T.multiplicity j : ℤ) * T.intersection i j)
-        (mem_univ i)
-    rw [hsplit]
-    exact dvd_neg.2 hoff.two_dvd
-  have hcorr : (2 : ℤ) ∣ ∑ i, ((T.multiplicity i : ℤ) * (T.multiplicity i : ℤ) *
-      T.intersection i i - (T.multiplicity i : ℤ) * T.intersection i i) := by
-    refine Finset.dvd_sum fun i _ ↦ ?_
-    obtain ⟨c, hc⟩ := by
-      simpa [mul_sub] using (Int.even_mul_pred_self (T.multiplicity i : ℤ)).two_dvd
-    exact ⟨c * T.intersection i i, by linear_combination T.intersection i i * hc⟩
-  have key : ∑ i, (T.multiplicity i : ℤ) * T.intersection i i =
-      (∑ i, (T.multiplicity i : ℤ) * (T.multiplicity i : ℤ) * T.intersection i i) -
-        ∑ i, ((T.multiplicity i : ℤ) * (T.multiplicity i : ℤ) * T.intersection i i -
-          (T.multiplicity i : ℤ) * T.intersection i i) := by
-    rw [Finset.sum_sub_distrib]
-    ring
-  rw [even_iff_two_dvd, key]
-  exact dvd_sub hdiag hcorr
+  have hker : T.intersection.mulVec (fun j ↦ (T.multiplicity j : ℤ)) = 0 := funext fun i ↦ by
+    simpa [Matrix.mulVec, dotProduct, mul_comm] using T.fiber_relation i
+  exact T.intersection_isSymm.even_sum_mul_diag_of_dotProduct_mulVec_eq_zero
+    (by rw [hker, dotProduct_zero])
 
 /-! ### The signed genus -/
 
@@ -294,6 +236,14 @@ number. -/
 def arithmeticGenus : ℤ :=
   1 + (∑ i, (T.multiplicity i : ℤ) * (T.weight i : ℤ) * ((T.genus i : ℤ) - 1)) -
     (∑ i, (T.multiplicity i : ℤ) * T.intersection i i) / 2
+
+/-- The defining formula of the signed genus, with the halving performed once on the whole sum
+`∑ᵢ mᵢ aᵢᵢ`. -/
+lemma arithmeticGenus_def :
+    T.arithmeticGenus =
+      1 + (∑ i, (T.multiplicity i : ℤ) * (T.weight i : ℤ) * ((T.genus i : ℤ) - 1)) -
+        (∑ i, (T.multiplicity i : ℤ) * T.intersection i i) / 2 := by
+  rw [arithmeticGenus]
 
 /-- The genus formula with the halving cleared, which is the shape in which it is used. -/
 lemma two_mul_arithmeticGenus :

--- a/TauCeti/AlgebraicGeometry/Curves/StableReduction/NumericalType.lean
+++ b/TauCeti/AlgebraicGeometry/Curves/StableReduction/NumericalType.lean
@@ -92,7 +92,7 @@ namespace TauCeti
 
 open Finset
 
-universe u v w
+universe u v w x
 
 /-- A numerical type, in the sense of
 [Stacks, Tag 0C6Z](https://stacks.math.columbia.edu/tag/0C6Z).
@@ -377,6 +377,7 @@ lemma arithmeticGenus_reindex : (T.reindex e).arithmeticGenus = T.arithmeticGenu
 [Stacks, Tag 0C6Z](https://stacks.math.columbia.edu/tag/0C6Z): a bijection of component sets
 matching multiplicities, weights, intersection numbers and genera. Two numerical types are
 equivalent when `Nonempty (T.Equiv T')`. -/
+@[ext]
 structure Equiv (T' : NumericalType.{v}) where
   /-- The underlying bijection of component sets. -/
   toEquiv : T.Component ≃ T'.Component
@@ -394,7 +395,7 @@ attribute [simp] Equiv.multiplicity_apply Equiv.weight_apply Equiv.intersection_
 
 namespace Equiv
 
-variable {T} {T' : NumericalType.{v}} {T'' : NumericalType.{w}}
+variable {T} {T' : NumericalType.{v}} {T'' : NumericalType.{w}} {T''' : NumericalType.{x}}
 
 /-- The identity equivalence of a numerical type. -/
 def refl : T.Equiv T where
@@ -433,6 +434,35 @@ def trans (f : T.Equiv T') (g : T'.Equiv T'') : T.Equiv T'' where
 @[simp]
 lemma trans_toEquiv (f : T.Equiv T') (g : T'.Equiv T'') :
     (f.trans g).toEquiv = f.toEquiv.trans g.toEquiv := (rfl)
+
+/-- The inverse of the identity equivalence is the identity. -/
+@[simp]
+lemma refl_symm : (refl : T.Equiv T).symm = refl := by ext i; simp
+
+/-- Inverting an equivalence of numerical types twice returns it. -/
+@[simp]
+lemma symm_symm (f : T.Equiv T') : f.symm.symm = f := by ext i; simp
+
+/-- The identity equivalence is a left unit for composition. -/
+@[simp]
+lemma refl_trans (f : T.Equiv T') : (refl : T.Equiv T).trans f = f := by ext i; simp
+
+/-- The identity equivalence is a right unit for composition. -/
+@[simp]
+lemma trans_refl (f : T.Equiv T') : f.trans (refl : T'.Equiv T') = f := by ext i; simp
+
+/-- An equivalence of numerical types composed with its inverse is the identity. -/
+@[simp]
+lemma self_trans_symm (f : T.Equiv T') : f.trans f.symm = refl := by ext i; simp
+
+/-- The inverse of an equivalence of numerical types composed with it is the identity. -/
+@[simp]
+lemma symm_trans_self (f : T.Equiv T') : f.symm.trans f = refl := by ext i; simp
+
+/-- Composition of equivalences of numerical types is associative. -/
+@[simp]
+lemma trans_assoc (f : T.Equiv T') (g : T'.Equiv T'') (h : T''.Equiv T''') :
+    (f.trans g).trans h = f.trans (g.trans h) := by ext i; simp
 
 /-- An equivalence of numerical types identifies the target with the reindexed source. -/
 lemma reindex_eq (f : T.Equiv T') : T.reindex f.toEquiv = T' :=

--- a/TauCeti/AlgebraicGeometry/Curves/StableReduction/NumericalType.lean
+++ b/TauCeti/AlgebraicGeometry/Curves/StableReduction/NumericalType.lean
@@ -155,7 +155,7 @@ lemma Adj.symm {i j : T.Component} (h : T.Adj i j) : T.Adj j i :=
 no-disconnected-cut form of the connectedness axiom. -/
 lemma exists_mem_notMem_adj (s : Set T.Component) (hne : s.Nonempty) (hs : s ≠ Set.univ) :
     ∃ i ∈ s, ∃ j ∉ s, T.Adj i j :=
-  (TauCeti.forall_reflTransGen_iff T.Adj).1 T.reflTransGen_adj s hne hs
+  (Relation.forall_reflTransGen_iff T.Adj).1 T.reflTransGen_adj s hne hs
 
 /-! ### Self-intersections -/
 

--- a/TauCeti/LinearAlgebra/Matrix/Connected.lean
+++ b/TauCeti/LinearAlgebra/Matrix/Connected.lean
@@ -1,0 +1,56 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.LinearAlgebra.Matrix.Defs
+public import TauCeti.Logic.Relation
+
+/-!
+# Connectedness of the graph of a matrix
+
+A square matrix `A` with entries in a partially ordered type determines a graph on its index set,
+joining distinct indices `i`, `j` with `0 < A i j`. When the off-diagonal entries are
+nonnegative, connectedness of this graph is the same as the absence of a disconnecting cut: no
+nonempty proper set of indices has all its cross-entries zero. This is the form in which
+[Stacks, Tag 0C6Z](https://stacks.math.columbia.edu/tag/0C6Z) states the connectedness condition
+on the intersection matrix of a numerical type.
+
+## Main results
+
+* `Matrix.forall_reflTransGen_ne_and_pos_iff`: for a matrix with nonnegative off-diagonal
+  entries, connectedness of its graph is the absence of a disconnecting cut.
+-/
+
+public section
+
+namespace Matrix
+
+/-- For a matrix `A` whose off-diagonal entries are nonnegative, connectedness of the graph
+joining distinct indices `i`, `j` with `0 < A i j` is equivalent to the absence of a disconnecting
+cut: no nonempty proper set of indices `s` has all its cross-entries zero. The right-hand side is
+the form in which [Stacks, Tag 0C6Z](https://stacks.math.columbia.edu/tag/0C6Z) states the
+connectedness condition on a numerical type, so this is what supplies the `connected` field of
+`TauCeti.NumericalType` when one is constructed.
+
+The nonnegativity hypothesis is what turns a nonzero cross-entry into a positive one, and so
+cannot be dropped. -/
+lemma forall_reflTransGen_ne_and_pos_iff {C R : Type*} [PartialOrder R] [Zero R]
+    (A : Matrix C C R) (hA : ∀ i j, i ≠ j → 0 ≤ A i j) :
+    (∀ i j, Relation.ReflTransGen (fun i j ↦ i ≠ j ∧ 0 < A i j) i j) ↔
+      ∀ s : Set C, s.Nonempty → s ≠ Set.univ → ¬ ∀ i ∈ s, ∀ j ∉ s, A i j = 0 := by
+  rw [TauCeti.forall_reflTransGen_iff]
+  refine forall_congr' fun s ↦ imp_congr_right fun _ ↦ imp_congr_right fun _ ↦ ?_
+  constructor
+  · rintro ⟨i, hi, j, hj, -, hpos⟩ hcut
+    exact hpos.ne' (hcut i hi j hj)
+  · intro hcut
+    by_contra hcon
+    refine hcut fun i hi j hj ↦ ?_
+    have hij : i ≠ j := fun h ↦ hj (h ▸ hi)
+    by_contra hne
+    exact hcon ⟨i, hi, j, hj, hij, lt_of_le_of_ne (hA i j hij) (Ne.symm hne)⟩
+
+end Matrix

--- a/TauCeti/LinearAlgebra/Matrix/Connected.lean
+++ b/TauCeti/LinearAlgebra/Matrix/Connected.lean
@@ -41,7 +41,7 @@ lemma forall_reflTransGen_ne_and_pos_iff {C R : Type*} [PartialOrder R] [Zero R]
     (A : Matrix C C R) (hA : ∀ i j, i ≠ j → 0 ≤ A i j) :
     (∀ i j, Relation.ReflTransGen (fun i j ↦ i ≠ j ∧ 0 < A i j) i j) ↔
       ∀ s : Set C, s.Nonempty → s ≠ Set.univ → ¬ ∀ i ∈ s, ∀ j ∉ s, A i j = 0 := by
-  rw [TauCeti.forall_reflTransGen_iff]
+  rw [Relation.forall_reflTransGen_iff]
   refine forall_congr' fun s ↦ imp_congr_right fun _ ↦ imp_congr_right fun _ ↦ ?_
   constructor
   · rintro ⟨i, hi, j, hj, -, hpos⟩ hcut

--- a/TauCeti/LinearAlgebra/Matrix/Connected.lean
+++ b/TauCeti/LinearAlgebra/Matrix/Connected.lean
@@ -9,31 +9,37 @@ public import Mathlib.LinearAlgebra.Matrix.Defs
 public import TauCeti.Logic.Relation
 
 /-!
-# Connectedness of the graph of a matrix
+# Strong connectivity of the directed graph of a matrix
 
-A square matrix `A` with entries in a partially ordered type determines a graph on its index set,
-joining distinct indices `i`, `j` with `0 < A i j`. When the off-diagonal entries are
-nonnegative, connectedness of this graph is the same as the absence of a disconnecting cut: no
-nonempty proper set of indices has all its cross-entries zero. This is the form in which
+A square matrix `A` with entries in a partially ordered type determines a directed graph on its
+index set, with an edge from `i` to a distinct `j` when `0 < A i j`. When the off-diagonal
+entries are nonnegative, strong connectivity of this directed graph is the same as the absence of
+a disconnecting cut: no nonempty proper set of indices has all of its outgoing entries zero.
+
+For a symmetric `A` the directed graph is an ordinary graph and strong connectivity is ordinary
+connectedness; the cut condition is then the form in which
 [Stacks, Tag 0C6Z](https://stacks.math.columbia.edu/tag/0C6Z) states the connectedness condition
 on the intersection matrix of a numerical type.
 
 ## Main results
 
 * `Matrix.forall_reflTransGen_ne_and_pos_iff`: for a matrix with nonnegative off-diagonal
-  entries, connectedness of its graph is the absence of a disconnecting cut.
+  entries, strong connectivity of its directed graph is the absence of a disconnecting cut.
 -/
 
 public section
 
 namespace Matrix
 
-/-- For a matrix `A` whose off-diagonal entries are nonnegative, connectedness of the graph
-joining distinct indices `i`, `j` with `0 < A i j` is equivalent to the absence of a disconnecting
-cut: no nonempty proper set of indices `s` has all its cross-entries zero. The right-hand side is
-the form in which [Stacks, Tag 0C6Z](https://stacks.math.columbia.edu/tag/0C6Z) states the
-connectedness condition on a numerical type, so this is what supplies the `connected` field of
-`TauCeti.NumericalType` when one is constructed.
+/-- For a matrix `A` whose off-diagonal entries are nonnegative, strong connectivity of the
+directed graph with an edge from `i` to a distinct `j` when `0 < A i j` is equivalent to the
+absence of a disconnecting cut: no nonempty proper set of indices `s` has all of its outgoing
+entries `A i j`, for `i ∈ s` and `j ∉ s`, zero. No symmetry of `A` is assumed, so the left-hand
+side is connectedness of an ordinary graph only when `A` is symmetric, as the intersection matrix
+of a numerical type is. The right-hand side is then the form in which
+[Stacks, Tag 0C6Z](https://stacks.math.columbia.edu/tag/0C6Z) states the connectedness condition
+on a numerical type, so this is what supplies the `connected` field of `TauCeti.NumericalType`
+when one is constructed.
 
 The nonnegativity hypothesis is what turns a nonzero cross-entry into a positive one, and so
 cannot be dropped. -/

--- a/TauCeti/LinearAlgebra/Matrix/Symmetric.lean
+++ b/TauCeti/LinearAlgebra/Matrix/Symmetric.lean
@@ -41,7 +41,7 @@ theorem IsSymm.even_sum_mul_diag_iff_even_dotProduct_mulVec {ι : Type*} [Fintyp
     Even (∑ i, m i * A i i) ↔ Even (m ⬝ᵥ A *ᵥ m) := by
   classical
   have hoff : Even (∑ i, ∑ j ∈ univ.erase i, m i * m j * A i j) :=
-    TauCeti.even_sum_sum_erase univ fun i _ j _ ↦ by rw [hA.apply i j]; ring
+    univ.even_sum_sum_erase fun i _ j _ ↦ by rw [hA.apply i j]; ring
   have hcorr : Even (∑ i, (m i * m i * A i i - m i * A i i)) := by
     rw [even_iff_two_dvd]
     refine Finset.dvd_sum fun i _ ↦ ?_

--- a/TauCeti/LinearAlgebra/Matrix/Symmetric.lean
+++ b/TauCeti/LinearAlgebra/Matrix/Symmetric.lean
@@ -22,6 +22,8 @@ particular `∑ᵢ mᵢ aᵢᵢ` is even whenever `mᵀ A m = 0`, for instance w
 
 ## Main results
 
+* `Matrix.IsSymm.even_sum_mul_diag_iff_even_dotProduct_mulVec`: if `A` is a symmetric integer
+  matrix then `∑ᵢ mᵢ aᵢᵢ` is even if and only if `mᵀ A m` is.
 * `Matrix.IsSymm.even_sum_mul_diag_of_dotProduct_mulVec_eq_zero`: if `A` is a symmetric integer
   matrix and `mᵀ A m = 0`, then `∑ᵢ mᵢ aᵢᵢ` is even.
 -/
@@ -32,34 +34,40 @@ namespace Matrix
 
 open Finset
 
+/-- If `A` is a symmetric integer matrix and `m` is an integer vector, then `∑ᵢ mᵢ aᵢᵢ` has the
+same parity as the quadratic form `mᵀ A m`. The individual terms `mᵢ aᵢᵢ` need not be even. -/
+theorem IsSymm.even_sum_mul_diag_iff_even_dotProduct_mulVec {ι : Type*} [Fintype ι]
+    {A : Matrix ι ι ℤ} (hA : A.IsSymm) (m : ι → ℤ) :
+    Even (∑ i, m i * A i i) ↔ Even (m ⬝ᵥ A *ᵥ m) := by
+  classical
+  have hoff : Even (∑ i, ∑ j ∈ univ.erase i, m i * m j * A i j) :=
+    TauCeti.even_sum_sum_erase univ fun i _ j _ ↦ by rw [hA.apply i j]; ring
+  have hcorr : Even (∑ i, (m i * m i * A i i - m i * A i i)) := by
+    rw [even_iff_two_dvd]
+    refine Finset.dvd_sum fun i _ ↦ ?_
+    obtain ⟨c, hc⟩ := (Int.even_mul_pred_self (m i)).two_dvd
+    exact ⟨c * A i i, by linear_combination A i i * hc⟩
+  have htotal : m ⬝ᵥ A *ᵥ m = ∑ i, ∑ j, m i * m j * A i j := by
+    simp only [dotProduct, mulVec, Finset.mul_sum]
+    exact Finset.sum_congr rfl fun i _ ↦ Finset.sum_congr rfl fun j _ ↦ by ring
+  -- Splitting off the diagonal, `mᵀ A m` is `∑ᵢ mᵢ aᵢᵢ` plus the two even sums above.
+  have hsum : m ⬝ᵥ A *ᵥ m = (∑ i, m i * A i i) +
+      ((∑ i, (m i * m i * A i i - m i * A i i)) +
+        ∑ i, ∑ j ∈ univ.erase i, m i * m j * A i j) := by
+    have hrow (i : ι) : ∑ j, m i * m j * A i j = m i * A i i +
+        ((m i * m i * A i i - m i * A i i) + ∑ j ∈ univ.erase i, m i * m j * A i j) := by
+      rw [← Finset.add_sum_erase univ (fun j ↦ m i * m j * A i j) (mem_univ i)]
+      ring
+    rw [htotal, Finset.sum_congr rfl fun i _ ↦ hrow i, Finset.sum_add_distrib,
+      Finset.sum_add_distrib]
+  rw [hsum, Int.even_add]
+  exact ⟨fun h ↦ iff_of_true h (hcorr.add hoff), fun h ↦ h.mpr (hcorr.add hoff)⟩
+
 /-- If `A` is a symmetric integer matrix and `m` is an integer vector with `mᵀ A m = 0`, then
 `∑ᵢ mᵢ aᵢᵢ` is even. The individual terms `mᵢ aᵢᵢ` need not be even. -/
 theorem IsSymm.even_sum_mul_diag_of_dotProduct_mulVec_eq_zero {ι : Type*} [Fintype ι]
     {A : Matrix ι ι ℤ} (hA : A.IsSymm) {m : ι → ℤ} (hm : m ⬝ᵥ A *ᵥ m = 0) :
-    Even (∑ i, m i * A i i) := by
-  classical
-  have hoff : Even (∑ i, ∑ j ∈ univ.erase i, m i * m j * A i j) :=
-    TauCeti.even_sum_sum_erase univ fun i _ j _ ↦ by rw [hA.apply i j]; ring
-  have htotal : ∑ i, ∑ j, m i * m j * A i j = 0 := by
-    rw [← hm]
-    simp only [dotProduct, mulVec, Finset.mul_sum]
-    exact Finset.sum_congr rfl fun i _ ↦ Finset.sum_congr rfl fun j _ ↦ by ring
-  have hdiag : (2 : ℤ) ∣ ∑ i, m i * m i * A i i := by
-    have hsplit : ∑ i, m i * m i * A i i = -∑ i, ∑ j ∈ univ.erase i, m i * m j * A i j := by
-      rw [eq_neg_iff_add_eq_zero, ← Finset.sum_add_distrib, ← htotal]
-      exact Finset.sum_congr rfl fun i _ ↦
-        Finset.add_sum_erase univ (fun j ↦ m i * m j * A i j) (mem_univ i)
-    rw [hsplit]
-    exact dvd_neg.2 hoff.two_dvd
-  have hcorr : (2 : ℤ) ∣ ∑ i, (m i * m i * A i i - m i * A i i) := by
-    refine Finset.dvd_sum fun i _ ↦ ?_
-    obtain ⟨c, hc⟩ := (Int.even_mul_pred_self (m i)).two_dvd
-    exact ⟨c * A i i, by linear_combination A i i * hc⟩
-  have key : ∑ i, m i * A i i =
-      (∑ i, m i * m i * A i i) - ∑ i, (m i * m i * A i i - m i * A i i) := by
-    rw [Finset.sum_sub_distrib]
-    ring
-  rw [even_iff_two_dvd, key]
-  exact dvd_sub hdiag hcorr
+    Even (∑ i, m i * A i i) :=
+  (hA.even_sum_mul_diag_iff_even_dotProduct_mulVec m).2 (hm ▸ Even.zero)
 
 end Matrix

--- a/TauCeti/LinearAlgebra/Matrix/Symmetric.lean
+++ b/TauCeti/LinearAlgebra/Matrix/Symmetric.lean
@@ -1,0 +1,65 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Group.Even
+public import Mathlib.LinearAlgebra.Matrix.Symmetric
+import Mathlib.Algebra.Ring.Int.Parity
+import Mathlib.Tactic.LinearCombination
+import Mathlib.Tactic.Ring
+import TauCeti.Algebra.BigOperators.Finset.OffDiagonal
+
+/-!
+# Parity of the diagonal of a symmetric integer matrix
+
+For a symmetric integer matrix `A` and an integer vector `m`, the quadratic form
+`mᵀ A m = ∑ᵢⱼ mᵢ mⱼ aᵢⱼ` agrees modulo two with `∑ᵢ mᵢ aᵢᵢ`: its off-diagonal part is even
+because the summand is symmetric under swapping the indices, and `mᵢ² ≡ mᵢ` modulo two. In
+particular `∑ᵢ mᵢ aᵢᵢ` is even whenever `mᵀ A m = 0`, for instance whenever `A m = 0`.
+
+## Main results
+
+* `Matrix.IsSymm.even_sum_mul_diag_of_dotProduct_mulVec_eq_zero`: if `A` is a symmetric integer
+  matrix and `mᵀ A m = 0`, then `∑ᵢ mᵢ aᵢᵢ` is even.
+-/
+
+public section
+
+namespace Matrix
+
+open Finset
+
+/-- If `A` is a symmetric integer matrix and `m` is an integer vector with `mᵀ A m = 0`, then
+`∑ᵢ mᵢ aᵢᵢ` is even. The individual terms `mᵢ aᵢᵢ` need not be even. -/
+theorem IsSymm.even_sum_mul_diag_of_dotProduct_mulVec_eq_zero {ι : Type*} [Fintype ι]
+    {A : Matrix ι ι ℤ} (hA : A.IsSymm) {m : ι → ℤ} (hm : m ⬝ᵥ A *ᵥ m = 0) :
+    Even (∑ i, m i * A i i) := by
+  classical
+  have hoff : Even (∑ i, ∑ j ∈ univ.erase i, m i * m j * A i j) :=
+    TauCeti.even_sum_sum_erase univ fun i _ j _ ↦ by rw [hA.apply i j]; ring
+  have htotal : ∑ i, ∑ j, m i * m j * A i j = 0 := by
+    rw [← hm]
+    simp only [dotProduct, mulVec, Finset.mul_sum]
+    exact Finset.sum_congr rfl fun i _ ↦ Finset.sum_congr rfl fun j _ ↦ by ring
+  have hdiag : (2 : ℤ) ∣ ∑ i, m i * m i * A i i := by
+    have hsplit : ∑ i, m i * m i * A i i = -∑ i, ∑ j ∈ univ.erase i, m i * m j * A i j := by
+      rw [eq_neg_iff_add_eq_zero, ← Finset.sum_add_distrib, ← htotal]
+      exact Finset.sum_congr rfl fun i _ ↦
+        Finset.add_sum_erase univ (fun j ↦ m i * m j * A i j) (mem_univ i)
+    rw [hsplit]
+    exact dvd_neg.2 hoff.two_dvd
+  have hcorr : (2 : ℤ) ∣ ∑ i, (m i * m i * A i i - m i * A i i) := by
+    refine Finset.dvd_sum fun i _ ↦ ?_
+    obtain ⟨c, hc⟩ := (Int.even_mul_pred_self (m i)).two_dvd
+    exact ⟨c * A i i, by linear_combination A i i * hc⟩
+  have key : ∑ i, m i * A i i =
+      (∑ i, m i * m i * A i i) - ∑ i, (m i * m i * A i i - m i * A i i) := by
+    rw [Finset.sum_sub_distrib]
+    ring
+  rw [even_iff_two_dvd, key]
+  exact dvd_sub hdiag hcorr
+
+end Matrix

--- a/TauCeti/Logic/Relation.lean
+++ b/TauCeti/Logic/Relation.lean
@@ -1,0 +1,62 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Data.Set.Basic
+public import Mathlib.Logic.Relation
+
+/-!
+# Totality of a reflexive transitive closure as the absence of a closed proper subset
+
+Read `r : α → α → Prop` as the edge relation of a directed graph. Saying that
+`Relation.ReflTransGen r` relates every pair of points is the "any two points are joined by a
+chain" form of connectedness; saying that every nonempty proper subset of `α` has an edge leaving
+it is the "no disconnecting cut" form. `TauCeti.forall_reflTransGen_iff` is the translation
+between the two, for an arbitrary relation on an arbitrary type.
+
+## Main results
+
+* `TauCeti.forall_reflTransGen_iff`: totality of `Relation.ReflTransGen r` is exactly the absence
+  of a nonempty proper subset with no outgoing edge.
+-/
+
+public section
+
+namespace TauCeti
+
+/-- **Totality of a reflexive transitive closure is the absence of a disconnecting cut.** Every
+pair of points is joined by an `r`-chain exactly when every nonempty proper subset `s` carries an
+edge from a point of `s` to a point outside `s`. -/
+theorem forall_reflTransGen_iff {α : Type*} (r : α → α → Prop) :
+    (∀ i j, Relation.ReflTransGen r i j) ↔
+      ∀ s : Set α, s.Nonempty → s ≠ Set.univ → ∃ i ∈ s, ∃ j ∉ s, r i j := by
+  constructor
+  · rintro h s ⟨a, ha⟩ hs
+    obtain ⟨b, hb⟩ : ∃ b, b ∉ s := by
+      by_contra hcon
+      exact hs (Set.eq_univ_of_forall fun x ↦ by
+        by_contra hx
+        exact hcon ⟨x, hx⟩)
+    have key : ∀ x y, Relation.ReflTransGen r x y → x ∈ s → y ∉ s → ∃ i ∈ s, ∃ j ∉ s, r i j := by
+      intro x y hxy
+      induction hxy with
+      | refl => exact fun hx hy ↦ absurd hx hy
+      | @tail c d _ hcd ih =>
+        intro hx hd
+        by_cases hc : c ∈ s
+        · exact ⟨c, hc, d, hd, hcd⟩
+        · exact ih hx hc
+    exact key a b (h a b) ha hb
+  · intro h i j
+    by_contra hij
+    have hs : {k | Relation.ReflTransGen r i k} ≠ Set.univ := by
+      intro hs
+      have hj : j ∈ {k | Relation.ReflTransGen r i k} := by rw [hs]; trivial
+      exact hij hj
+    obtain ⟨a, ha, b, hb, hab⟩ := h _ ⟨i, Relation.ReflTransGen.refl⟩ hs
+    exact hb (Relation.ReflTransGen.tail ha hab)
+
+end TauCeti

--- a/TauCeti/Logic/Relation.lean
+++ b/TauCeti/Logic/Relation.lean
@@ -14,18 +14,18 @@ public import Mathlib.Logic.Relation
 Read `r : α → α → Prop` as the edge relation of a directed graph. Saying that
 `Relation.ReflTransGen r` relates every pair of points is the "any two points are joined by a
 chain" form of connectedness; saying that every nonempty proper subset of `α` has an edge leaving
-it is the "no disconnecting cut" form. `TauCeti.forall_reflTransGen_iff` is the translation
+it is the "no disconnecting cut" form. `Relation.forall_reflTransGen_iff` is the translation
 between the two, for an arbitrary relation on an arbitrary type.
 
 ## Main results
 
-* `TauCeti.forall_reflTransGen_iff`: totality of `Relation.ReflTransGen r` is exactly the absence
+* `Relation.forall_reflTransGen_iff`: totality of `Relation.ReflTransGen r` is exactly the absence
   of a nonempty proper subset with no outgoing edge.
 -/
 
 public section
 
-namespace TauCeti
+namespace Relation
 
 /-- **Totality of a reflexive transitive closure is the absence of a disconnecting cut.** Every
 pair of points is joined by an `r`-chain exactly when every nonempty proper subset `s` carries an
@@ -59,4 +59,4 @@ theorem forall_reflTransGen_iff {α : Type*} (r : α → α → Prop) :
     obtain ⟨a, ha, b, hb, hab⟩ := h _ ⟨i, Relation.ReflTransGen.refl⟩ hs
     exact hb (Relation.ReflTransGen.tail ha hab)
 
-end TauCeti
+end Relation


### PR DESCRIPTION
This PR defines the abstract numerical type of [Stacks, Tag 0C6Z](https://stacks.math.columbia.edu/tag/0C6Z) and proves the integrality that its signed genus depends on. A `TauCeti.NumericalType` records a finite nonempty component set with multiplicities `mᵢ`, weights `wᵢ` and genera `gᵢ`, together with a symmetric matrix of intersection numbers `A = (aᵢⱼ)` that has nonnegative off-diagonal entries, a connected associated graph, `∑ⱼ aᵢⱼ mⱼ = 0`, and `wᵢ ∣ aᵢⱼ`. On top of that the file supplies: `intersection_comm` and the adjacency relation `Adj`; `Matrix.forall_reflTransGen_ne_and_pos_iff`, which identifies the connectedness axiom with the absence of a disconnecting cut (the form the source states it in) and so is what discharges the `connected` field when a type is built, with `exists_mem_notMem_adj` as its consequence for a given type; `intersection_self_nonpos` and `intersection_self_neg`, the latter for types with more than one component; `reindex` along an equivalence of component sets with its four projection lemmas; the bundled equivalence of numerical types `NumericalType.Equiv` (a bijection of component sets matching multiplicities, weights, intersection numbers and genera) with `refl`, `symm`, `trans`, `equivReindex`, `Equiv.reindex_eq`, `nonempty_equiv_iff` (two types are equivalent exactly when one is a reindexing of the other) and `Equiv.arithmeticGenus_eq`; and `arithmeticGenus`, the signed genus `g(T) = 1 + ∑ᵢ mᵢ (wᵢ (gᵢ - 1) - aᵢᵢ / 2)`, valued in `ℤ` because abstract numerical types can have negative genus, with its defining formula `arithmeticGenus_def`.

The mathematical content is `even_sum_multiplicity_mul_diagonal`: `∑ᵢ mᵢ aᵢᵢ` is even. Pairing the fibre relation against the multiplicity vector gives `∑ᵢⱼ mᵢ mⱼ aᵢⱼ = 0`; the off-diagonal part of that double sum is even because the summand is symmetric under swapping the indices, so `∑ᵢ mᵢ² aᵢᵢ` is even, and `mᵢ² ≡ mᵢ` modulo two. The argument uses only symmetry, and it compares parities rather than using the vanishing, so it is proved for an arbitrary symmetric integer matrix as the equivalence `Matrix.IsSymm.even_sum_mul_diag_iff_even_dotProduct_mulVec`, with the vanishing-hypothesis form `Matrix.IsSymm.even_sum_mul_diag_of_dotProduct_mulVec_eq_zero` and the numerical-type statement as its corollaries. This is exactly what licenses the definition: the individual half-diagonals `aᵢᵢ / 2` need not be integers, so the halving may only be performed once, on the whole sum, and `two_mul_arithmeticGenus` records the resulting division-free form `2 g(T) = 2 + 2 ∑ᵢ mᵢ wᵢ (gᵢ - 1) - ∑ᵢ mᵢ aᵢᵢ`. Two worked examples from the roadmap's acceptance criteria are compiled: the type with `m = (1,1)`, `w = (2,2)`, `gᵢ = (1,1)` and `A = [[-2,2],[2,-2]]` has signed genus three, its genus-zero variant has signed genus `-1`, and a type with odd diagonal entries has signed genus two, which is the check that the halving is not distributed over the sum.

The milestone served is Layer 6, "numerical types and Picard torsion", first bullet: "Define an abstract numerical type exactly as in Stacks tag 0C6Z ... Prove equivalence of graph connectedness with the source's no-disconnected-cut condition, and develop reindexing and equivalence of types", together with the third bullet's "Prove `∑ᵢ mᵢ aᵢᵢ` even, so this rational expression is an integer". Layer 6 feeds Layer 7's genus-`g ≥ 2` nodal reduction and hence the roadmap's first summit, classical stable reduction. The roadmap's own "Ordering and work lanes" section opens this lane independently: "Combinatorial/Picard lane: Layer 6, whose abstract numerical-type theory can start before all scheme comparisons exist" — no scheme-level prerequisite is used or needed here, and no other roadmap is drawn on. After this PR, Layer 6 still owes the weighted Picard group `Pic(T)` as the cokernel of `eᵢ ↦ ∑ⱼ (aᵢⱼ / wⱼ) eⱼ` with its injection into `Coker(A)`, its rank-one finite generation and prime torsion, the classification and boundedness of minimal types, and every comparison with an actual regular model, which waits on the scheme-level layers.

Placement follows the roadmap's suggested home for its own reduction theory, `TauCeti/AlgebraicGeometry/Curves/StableReduction/`. The declarations live in the bare `TauCeti` namespace, matching the open Layer 0 work on `TauCeti.FiniteDVRExtension`. The two results that are not about numerical types live in generic modules: the cut criterion in `TauCeti/LinearAlgebra/Matrix/Connected.lean` (re-exported by the numerical-type module, whose `connected` field it discharges) and the parity lemma in `TauCeti/LinearAlgebra/Matrix/Symmetric.lean`, alongside the supporting `TauCeti/Logic/Relation.lean` and `TauCeti/Algebra/BigOperators/Finset/OffDiagonal.lean`. No Mathlib code is vendored. The structure follows the `NumericalType` sketch in `TauCetiRoadmap/StableReduction/Suggested.lean` field for field, with one deliberate change: symmetry of the intersection matrix is recorded as `Matrix.IsSymm` rather than as a bare pointwise equation, so that a reindexed matrix inherits it from Mathlib's `Matrix.IsSymm.submatrix`; `intersection_comm` recovers the pointwise form. `reindex` carries `@[expose]` because its component set is a field of the structure, so its projection lemmas cannot be stated by a downstream user otherwise.

Roadmap: StableReduction

<!--tauceti-target:v1 {"focus":"StableReduction","id":"numericaltype"}-->

🤖 Prepared with Claude Code



