### PR TITLE
feat: the Euler characteristic of a permutation triple

### DIFF
--- a/TauCeti/Combinatorics/PermutationTriple/DisjointSum.lean
+++ b/TauCeti/Combinatorics/PermutationTriple/DisjointSum.lean
@@ -20,7 +20,7 @@ on the first `m` labels and by the second on the last `n`.
 ## Main results
 
 * `TauCeti.PermutationTriple.disjointSum`: the construction, componentwise
-  `TauCeti.finSumPerm`.
+  `Equiv.Perm.finSumPerm`.
 * `TauCeti.PermutationTriple.cycleData_disjointSum`,
   `TauCeti.PermutationTriple.cycleCounts_disjointSum`: the cycle data of a disjoint sum is the
   concatenation of the cycle data of its summands, and the cycle counts add.

--- a/TauCeti/Combinatorics/PermutationTriple/DisjointSum.lean
+++ b/TauCeti/Combinatorics/PermutationTriple/DisjointSum.lean
@@ -1,0 +1,154 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Combinatorics.PermutationTriple.CycleData
+public import TauCeti.GroupTheory.Perm.SumCongr
+
+/-!
+# Disjoint sums of permutation triples
+
+Two covers of the thrice-punctured sphere may be laid side by side, and the resulting cover has
+the disjoint union of their sheets. On the combinatorial side this is the juxtaposition of two
+permutation triples: `TauCeti.PermutationTriple.disjointSum` takes a triple of degree `m` and one
+of degree `n` to a triple of degree `m + n`, acting through `finSumFinEquiv` by the first triple
+on the first `m` labels and by the second on the last `n`.
+
+## Main results
+
+* `TauCeti.PermutationTriple.disjointSum`: the construction, componentwise
+  `TauCeti.finSumPerm`.
+* `TauCeti.PermutationTriple.cycleData_disjointSum`,
+  `TauCeti.PermutationTriple.cycleCounts_disjointSum`: the cycle data of a disjoint sum is the
+  concatenation of the cycle data of its summands, and the cycle counts add.
+* `TauCeti.PermutationTriple.monodromyGroup_disjointSum_le`: the monodromy group of a disjoint
+  sum consists of relabelings acting separately on the two blocks, and each of the two components
+  lies in the monodromy group of the corresponding summand. The inclusion is strict in general —
+  the monodromy group of the disjoint sum of a triple with itself is the diagonal, not the whole
+  product.
+* `TauCeti.PermutationTriple.not_isConnected_disjointSum`: a disjoint sum of two triples of
+  nonzero degree is disconnected.
+
+## References
+
+* S. K. Lando, A. K. Zvonkin, *Graphs on Surfaces and Their Applications*, Encyclopaedia of
+  Mathematical Sciences 141, Springer 2004, §1.5.
+-/
+
+public section
+
+namespace TauCeti
+
+open Equiv Equiv.Perm
+
+namespace PermutationTriple
+
+variable {m n : ℕ}
+
+/-- The disjoint sum of two permutation triples: the triple of degree `m + n` whose components
+act by those of `s` on the first `m` labels and by those of `t` on the last `n`. It is the
+combinatorial shadow of laying two covers of the thrice-punctured sphere side by side. -/
+def disjointSum (s : PermutationTriple m) (t : PermutationTriple n) :
+    PermutationTriple (m + n) where
+  σ0 := finSumPerm s.σ0 t.σ0
+  σ1 := finSumPerm s.σ1 t.σ1
+  σinf := finSumPerm s.σinf t.σinf
+  product_eq_one := by
+    rw [finSumPerm_mul, finSumPerm_mul, s.product_eq_one, t.product_eq_one, finSumPerm_one]
+
+variable (s : PermutationTriple m) (t : PermutationTriple n)
+
+@[simp] theorem disjointSum_σ0 : (s.disjointSum t).σ0 = finSumPerm s.σ0 t.σ0 := (rfl)
+
+@[simp] theorem disjointSum_σ1 : (s.disjointSum t).σ1 = finSumPerm s.σ1 t.σ1 := (rfl)
+
+@[simp] theorem disjointSum_σinf : (s.disjointSum t).σinf = finSumPerm s.σinf t.σinf := (rfl)
+
+/-- The disjoint sum of two trivial triples is trivial. -/
+@[simp] theorem disjointSum_one_one :
+    (1 : PermutationTriple m).disjointSum (1 : PermutationTriple n) = 1 :=
+  ext_of_two (by simp) (by simp)
+
+/-- Relabeling the two summands separately relabels their disjoint sum. -/
+theorem disjointSum_smul (τ : Perm (Fin m)) (υ : Perm (Fin n)) :
+    (τ • s).disjointSum (υ • t) = finSumPerm τ υ • s.disjointSum t :=
+  ext_of_two (by simp [finSumPerm_mul]) (by simp [finSumPerm_mul])
+
+/-! ### Cycle data -/
+
+/-- The full cycle partitions of a disjoint sum are the concatenations of those of the two
+summands, branch point by branch point. -/
+@[simp]
+theorem cycleData_disjointSum :
+    (s.disjointSum t).cycleData =
+      (s.cycleData.1 + t.cycleData.1, s.cycleData.2.1 + t.cycleData.2.1,
+        s.cycleData.2.2 + t.cycleData.2.2) := by
+  have h0 : (s.disjointSum t).cycleData.1 = s.cycleData.1 + t.cycleData.1 := by simp
+  have h1 : (s.disjointSum t).cycleData.2.1 = s.cycleData.2.1 + t.cycleData.2.1 := by simp
+  have h2 : (s.disjointSum t).cycleData.2.2 = s.cycleData.2.2 + t.cycleData.2.2 := by simp
+  rw [← h0, ← h1, ← h2]
+
+/-- The cycle counts of a disjoint sum are the sums of the cycle counts of the two summands,
+branch point by branch point. -/
+@[simp]
+theorem cycleCounts_disjointSum :
+    (s.disjointSum t).cycleCounts =
+      (s.cycleCounts.1 + t.cycleCounts.1, s.cycleCounts.2.1 + t.cycleCounts.2.1,
+        s.cycleCounts.2.2 + t.cycleCounts.2.2) := by
+  have h0 : (s.disjointSum t).cycleCounts.1 = s.cycleCounts.1 + t.cycleCounts.1 := by simp
+  have h1 : (s.disjointSum t).cycleCounts.2.1 = s.cycleCounts.2.1 + t.cycleCounts.2.1 := by simp
+  have h2 : (s.disjointSum t).cycleCounts.2.2 = s.cycleCounts.2.2 + t.cycleCounts.2.2 := by simp
+  rw [← h0, ← h1, ← h2]
+
+/-! ### Monodromy and connectedness -/
+
+/-- The monodromy group of a disjoint sum acts separately on the two blocks of labels, through
+the monodromy groups of the two summands. The inclusion is not an equality in general: the
+disjoint sum of a triple with itself has diagonal monodromy. -/
+theorem monodromyGroup_disjointSum_le :
+    (s.disjointSum t).monodromyGroup ≤
+      (s.monodromyGroup.prod t.monodromyGroup).map (finSumPermHom m n) := by
+  rw [← closure_triple_eq_monodromyGroup (s.disjointSum t)]
+  refine (Subgroup.closure_le _).mpr ?_
+  rintro g (rfl | rfl | rfl)
+  · exact Subgroup.mem_map.mpr
+      ⟨(s.σ0, t.σ0), Subgroup.mem_prod.mpr ⟨s.σ0_mem_monodromyGroup, t.σ0_mem_monodromyGroup⟩,
+        by simp⟩
+  · exact Subgroup.mem_map.mpr
+      ⟨(s.σ1, t.σ1), Subgroup.mem_prod.mpr ⟨s.σ1_mem_monodromyGroup, t.σ1_mem_monodromyGroup⟩,
+        by simp⟩
+  · exact Subgroup.mem_map.mpr
+      ⟨(s.σinf, t.σinf),
+        Subgroup.mem_prod.mpr ⟨s.σinf_mem_monodromyGroup, t.σinf_mem_monodromyGroup⟩, by simp⟩
+
+/-- Every element of the monodromy group of a disjoint sum preserves the first block of labels,
+which is the reason the sum is disconnected. -/
+theorem apply_castAdd_mem_range_castAdd_of_mem_monodromyGroup {g : Perm (Fin (m + n))}
+    (hg : g ∈ (s.disjointSum t).monodromyGroup) (i : Fin m) :
+    g (Fin.castAdd n i) ∈ Set.range (Fin.castAdd n : Fin m → Fin (m + n)) := by
+  obtain ⟨p, -, rfl⟩ := Subgroup.mem_map.mp (monodromyGroup_disjointSum_le s t hg)
+  exact ⟨p.1 i, by simp⟩
+
+/-- A disjoint sum of two triples of nonzero degree is disconnected: no relabeling in its
+monodromy group carries a label of the first block to one of the second. -/
+theorem not_isConnected_disjointSum (hm : m ≠ 0) (hn : n ≠ 0) :
+    ¬ (s.disjointSum t).IsConnected := by
+  intro hc
+  have htrans := hc.isPretransitive
+  obtain ⟨i⟩ : Nonempty (Fin m) := Fin.pos_iff_nonempty.mp (Nat.pos_of_ne_zero hm)
+  obtain ⟨j⟩ : Nonempty (Fin n) := Fin.pos_iff_nonempty.mp (Nat.pos_of_ne_zero hn)
+  obtain ⟨g, hg⟩ := htrans.exists_smul_eq (Fin.castAdd n i) (Fin.natAdd m j)
+  obtain ⟨i', hi'⟩ :=
+    apply_castAdd_mem_range_castAdd_of_mem_monodromyGroup s t g.2 i
+  have hval : (Fin.castAdd n i' : Fin (m + n)).val = (Fin.natAdd m j : Fin (m + n)).val := by
+    rw [hi']
+    exact congrArg Fin.val (hg : (g : Perm (Fin (m + n))) (Fin.castAdd n i) = Fin.natAdd m j)
+  simp only [Fin.val_castAdd, Fin.val_natAdd] at hval
+  omega
+
+end PermutationTriple
+
+end TauCeti

--- a/TauCeti/Combinatorics/PermutationTriple/DisjointSum.lean
+++ b/TauCeti/Combinatorics/PermutationTriple/DisjointSum.lean
@@ -73,9 +73,10 @@ variable (s : PermutationTriple m) (t : PermutationTriple n)
   ext_of_two (by simp) (by simp)
 
 /-- Relabeling the two summands separately relabels their disjoint sum. -/
+@[simp]
 theorem disjointSum_smul (τ : Perm (Fin m)) (υ : Perm (Fin n)) :
     (τ • s).disjointSum (υ • t) = finSumPerm τ υ • s.disjointSum t :=
-  ext_of_two (by simp [finSumPerm_mul]) (by simp [finSumPerm_mul])
+  ext_of_two (by simp) (by simp)
 
 /-! ### Cycle data -/
 

--- a/TauCeti/Combinatorics/PermutationTriple/EulerCharacteristic.lean
+++ b/TauCeti/Combinatorics/PermutationTriple/EulerCharacteristic.lean
@@ -24,10 +24,7 @@ component contributes a cycle of its own.
 ## Main results
 
 * `TauCeti.PermutationTriple.even_eulerChar`: the Euler characteristic is even, equivalently
-  `2 ∣ 2 - χ(t)`. This is the parity that makes the genus an integer, and it is a consequence of
-  the defining relation `σinf * σ1 * σ0 = 1` alone: applying `Equiv.Perm.sign` to the relation and
-  reading each sign off `Equiv.Perm.sign_eq_neg_one_pow_card_sub_orbitCount` says exactly that
-  `3n - (cycleCount σ0 + cycleCount σ1 + cycleCount σinf)` is even.
+  `2 ∣ 2 - χ(t)`. For connected triples, this is the divisibility needed to define the genus.
 * `TauCeti.PermutationTriple.eulerChar_disjointSum`: the Euler characteristic is additive over
   `TauCeti.PermutationTriple.disjointSum`, as an Euler characteristic of a disjoint union should
   be.
@@ -37,10 +34,6 @@ component contributes a cycle of its own.
   on the numbering of the sheets either.
 * `TauCeti.PermutationTriple.eulerChar_one`: the trivial `n`-sheeted cover has Euler
   characteristic `2n`, the `n` spheres it consists of contributing `2` each.
-
-The bound `χ(t) ≤ 2` for a connected triple, and with it the genus, are not proved here: they
-need the transposition step lemma for `TauCeti.orbitCount` and an induction along a minimal
-factorization of `σ1`.
 
 ## References
 
@@ -64,13 +57,13 @@ obtained by gluing the associated cover, computed from the combinatorics alone. 
 noncomputable def eulerChar (t : PermutationTriple n) : ℤ :=
   (orbitCount t.σ0 : ℤ) + orbitCount t.σ1 + orbitCount t.σinf - n
 
-theorem eulerChar_eq (t : PermutationTriple n) :
+theorem eulerChar_def (t : PermutationTriple n) :
     t.eulerChar = (orbitCount t.σ0 : ℤ) + orbitCount t.σ1 + orbitCount t.σinf - n := (rfl)
 
 /-- The Euler characteristic, read off the packaged cycle counts of a triple. -/
 theorem eulerChar_eq_cycleCounts (t : PermutationTriple n) :
     t.eulerChar = (t.cycleCounts.1 : ℤ) + t.cycleCounts.2.1 + t.cycleCounts.2.2 - n := by
-  simp [eulerChar_eq]
+  simp [eulerChar_def]
 
 /-! ### Invariance -/
 
@@ -78,7 +71,7 @@ theorem eulerChar_eq_cycleCounts (t : PermutationTriple n) :
 @[simp]
 theorem eulerChar_smul (τ : Perm (Fin n)) (t : PermutationTriple n) :
     (τ • t).eulerChar = t.eulerChar := by
-  rw [eulerChar_eq, eulerChar_eq]
+  rw [eulerChar_def, eulerChar_def]
   simp [orbitCount_conj]
 
 /-- Isomorphic triples have the same Euler characteristic. -/
@@ -92,48 +85,35 @@ theorem eulerChar_eq_of_equivalent {t t' : PermutationTriple n} (h : Equivalent 
 theorem eulerChar_transport (e : Fin n ≃ Fin m) (t : PermutationTriple n) :
     (transport e t).eulerChar = t.eulerChar := by
   obtain rfl : n = m := by simpa using Fintype.card_congr e
-  rw [eulerChar_eq, eulerChar_eq]
+  rw [eulerChar_def, eulerChar_def]
   simp [Equiv.permCongrHom_coe]
 
 /-- The trivial `n`-sheeted cover is a disjoint union of `n` spheres. -/
 @[simp]
 theorem eulerChar_one : (1 : PermutationTriple n).eulerChar = 2 * n := by
-  rw [eulerChar_eq]
+  rw [eulerChar_def]
   simp only [one_σ0, one_σ1, one_σinf, orbitCount_one, Nat.card_eq_fintype_card,
     Fintype.card_fin]
   ring
 
 /-! ### Parity -/
 
-/-- The number of orbits of a permutation of `Fin n` is at most `n`, the orbits being the classes
-of a partition of the sheets. -/
-private theorem orbitCount_le (σ : Perm (Fin n)) : orbitCount σ ≤ n := by
-  rw [Perm.orbitCount_eq_card_parts_partition]
-  calc
-    σ.partition.parts.card = σ.partition.parts.card • 1 := by simp
-    _ ≤ σ.partition.parts.sum :=
-      Multiset.card_nsmul_le_sum fun k hk ↦ σ.partition.parts_pos hk
-    _ = n := by simpa using σ.partition.parts_sum
-
-/-- The Euler characteristic of a permutation triple is even. Equivalently, by
-`TauCeti.PermutationTriple.two_dvd_two_sub_eulerChar`, the genus `(2 - χ) / 2` is an integer.
-The only input is the defining relation of a triple: the product of the three signs is the sign
-of the identity, and each sign is the parity of the degree less the number of cycles. -/
+/-- The Euler characteristic of a permutation triple is even. -/
 theorem even_eulerChar (t : PermutationTriple n) : Even t.eulerChar := by
   have hsign : Perm.sign t.σinf * Perm.sign t.σ1 * Perm.sign t.σ0 = 1 := by
     rw [← Perm.sign_mul, ← Perm.sign_mul, t.product_eq_one, Perm.sign_one]
   rw [Perm.sign_eq_neg_one_pow_card_sub_orbitCount, Perm.sign_eq_neg_one_pow_card_sub_orbitCount,
     Perm.sign_eq_neg_one_pow_card_sub_orbitCount, Fintype.card_fin, ← pow_add, ← pow_add] at hsign
   obtain ⟨k, hk⟩ := (neg_one_pow_eq_one_iff_even (R := ℤˣ) (by decide)).mp hsign
-  have h0 := orbitCount_le t.σ0
-  have h1 := orbitCount_le t.σ1
-  have hinf := orbitCount_le t.σinf
+  have h0 : orbitCount t.σ0 ≤ n := by simpa using t.σ0.orbitCount_le_card
+  have h1 : orbitCount t.σ1 ≤ n := by simpa using t.σ1.orbitCount_le_card
+  have hinf : orbitCount t.σinf ≤ n := by simpa using t.σinf.orbitCount_le_card
   refine ⟨(n : ℤ) - k, ?_⟩
-  rw [eulerChar_eq]
+  rw [eulerChar_def]
   omega
 
-/-- The genus of a permutation triple is `(2 - χ) / 2`, and this is the divisibility that makes
-that an integer. -/
+/-- Two divides `2 - χ` for every permutation triple. For connected triples, this is the
+divisibility needed to define the genus. -/
 theorem two_dvd_two_sub_eulerChar (t : PermutationTriple n) : (2 : ℤ) ∣ 2 - t.eulerChar := by
   obtain ⟨k, hk⟩ := even_eulerChar t
   exact ⟨1 - k, by omega⟩
@@ -145,7 +125,7 @@ carried by disjoint sets of sheets. -/
 @[simp]
 theorem eulerChar_disjointSum (s : PermutationTriple m) (t : PermutationTriple n) :
     (s.disjointSum t).eulerChar = s.eulerChar + t.eulerChar := by
-  rw [eulerChar_eq, eulerChar_eq, eulerChar_eq]
+  rw [eulerChar_def, eulerChar_def, eulerChar_def]
   simp only [disjointSum_σ0, disjointSum_σ1, disjointSum_σinf, orbitCount_finSumPerm]
   push_cast
   ring
@@ -158,7 +138,7 @@ example : (ofTwo (finRotate 3) 1).eulerChar = 2 := by
   have h0 : (finRotate 3).partition.parts = {3} := by decide
   have h1 : (1 : Perm (Fin 3)).partition.parts = {1, 1, 1} := by decide
   have hinf : ((1 : Perm (Fin 3)) * finRotate 3)⁻¹.partition.parts = {3} := by decide
-  rw [eulerChar_eq, Perm.orbitCount_eq_card_parts_partition,
+  rw [eulerChar_def, Perm.orbitCount_eq_card_parts_partition,
     Perm.orbitCount_eq_card_parts_partition, Perm.orbitCount_eq_card_parts_partition,
     ofTwo_σ0, ofTwo_σ1, ofTwo_σinf, h0, h1, hinf]
   decide

--- a/TauCeti/Combinatorics/PermutationTriple/EulerCharacteristic.lean
+++ b/TauCeti/Combinatorics/PermutationTriple/EulerCharacteristic.lean
@@ -1,0 +1,172 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Combinatorics.PermutationTriple.DisjointSum
+import Mathlib.Logic.Equiv.Fin.Rotate
+
+/-!
+# The Euler characteristic of a permutation triple
+
+The surface carrying the cover encoded by a degree-`n` permutation triple `t` is glued from `n`
+faces, and its cells are counted by the cycles of the three components. Its Euler characteristic
+is therefore the integer
+
+`χ(t) = cycleCount σ0 + cycleCount σ1 + cycleCount σinf − n`,
+
+which this file defines as `TauCeti.PermutationTriple.eulerChar` — combinatorially, without
+constructing the surface. The cycle counts are `TauCeti.orbitCount`, so a fixed point of a
+component contributes a cycle of its own.
+
+## Main results
+
+* `TauCeti.PermutationTriple.even_eulerChar`: the Euler characteristic is even, equivalently
+  `2 ∣ 2 - χ(t)`. This is the parity that makes the genus an integer, and it is a consequence of
+  the defining relation `σinf * σ1 * σ0 = 1` alone: applying `Equiv.Perm.sign` to the relation and
+  reading each sign off `Equiv.Perm.sign_eq_neg_one_pow_card_sub_orbitCount` says exactly that
+  `3n - (cycleCount σ0 + cycleCount σ1 + cycleCount σinf)` is even.
+* `TauCeti.PermutationTriple.eulerChar_disjointSum`: the Euler characteristic is additive over
+  `TauCeti.PermutationTriple.disjointSum`, as an Euler characteristic of a disjoint union should
+  be.
+* `TauCeti.PermutationTriple.eulerChar_smul`,
+  `TauCeti.PermutationTriple.eulerChar_eq_of_equivalent`: it is an invariant of the isomorphism
+  class of a triple, and `TauCeti.PermutationTriple.eulerChar_transport` says it does not depend
+  on the numbering of the sheets either.
+* `TauCeti.PermutationTriple.eulerChar_one`: the trivial `n`-sheeted cover has Euler
+  characteristic `2n`, the `n` spheres it consists of contributing `2` each.
+
+The bound `χ(t) ≤ 2` for a connected triple, and with it the genus, are not proved here: they
+need the transposition step lemma for `TauCeti.orbitCount` and an induction along a minimal
+factorization of `σ1`.
+
+## References
+
+* S. K. Lando, A. K. Zvonkin, *Graphs on Surfaces and Their Applications*, Encyclopaedia of
+  Mathematical Sciences 141, Springer 2004, Proposition 1.5.3.
+-/
+
+public section
+
+namespace TauCeti
+
+open Equiv Equiv.Perm
+
+namespace PermutationTriple
+
+variable {m n : ℕ}
+
+/-- The Euler characteristic of a permutation triple: the total number of cycles of its three
+components, fixed points included, less the degree. It is the Euler characteristic of the surface
+obtained by gluing the associated cover, computed from the combinatorics alone. -/
+noncomputable def eulerChar (t : PermutationTriple n) : ℤ :=
+  (orbitCount t.σ0 : ℤ) + orbitCount t.σ1 + orbitCount t.σinf - n
+
+theorem eulerChar_eq (t : PermutationTriple n) :
+    t.eulerChar = (orbitCount t.σ0 : ℤ) + orbitCount t.σ1 + orbitCount t.σinf - n := (rfl)
+
+/-- The Euler characteristic, read off the packaged cycle counts of a triple. -/
+theorem eulerChar_eq_cycleCounts (t : PermutationTriple n) :
+    t.eulerChar = (t.cycleCounts.1 : ℤ) + t.cycleCounts.2.1 + t.cycleCounts.2.2 - n := by
+  simp [eulerChar_eq]
+
+/-! ### Invariance -/
+
+/-- Relabeling the sheets does not change the Euler characteristic. -/
+@[simp]
+theorem eulerChar_smul (τ : Perm (Fin n)) (t : PermutationTriple n) :
+    (τ • t).eulerChar = t.eulerChar := by
+  rw [eulerChar_eq, eulerChar_eq]
+  simp [orbitCount_conj]
+
+/-- Isomorphic triples have the same Euler characteristic. -/
+theorem eulerChar_eq_of_equivalent {t t' : PermutationTriple n} (h : Equivalent t t') :
+    t.eulerChar = t'.eulerChar := by
+  obtain ⟨τ, rfl⟩ := equivalent_iff_exists_smul_eq.mp h
+  exact (eulerChar_smul τ t).symm
+
+/-- Renumbering the sheets does not change the Euler characteristic. -/
+@[simp]
+theorem eulerChar_transport (e : Fin n ≃ Fin m) (t : PermutationTriple n) :
+    (transport e t).eulerChar = t.eulerChar := by
+  obtain rfl : n = m := by simpa using Fintype.card_congr e
+  rw [eulerChar_eq, eulerChar_eq]
+  simp [Equiv.permCongrHom_coe]
+
+/-- The trivial `n`-sheeted cover is a disjoint union of `n` spheres. -/
+@[simp]
+theorem eulerChar_one : (1 : PermutationTriple n).eulerChar = 2 * n := by
+  rw [eulerChar_eq]
+  simp only [one_σ0, one_σ1, one_σinf, orbitCount_one, Nat.card_eq_fintype_card,
+    Fintype.card_fin]
+  ring
+
+/-! ### Parity -/
+
+/-- The number of orbits of a permutation of `Fin n` is at most `n`, the orbits being the classes
+of a partition of the sheets. -/
+private theorem orbitCount_le (σ : Perm (Fin n)) : orbitCount σ ≤ n := by
+  rw [Perm.orbitCount_eq_card_parts_partition]
+  calc
+    σ.partition.parts.card = σ.partition.parts.card • 1 := by simp
+    _ ≤ σ.partition.parts.sum :=
+      Multiset.card_nsmul_le_sum fun k hk ↦ σ.partition.parts_pos hk
+    _ = n := by simpa using σ.partition.parts_sum
+
+/-- The Euler characteristic of a permutation triple is even. Equivalently, by
+`TauCeti.PermutationTriple.two_dvd_two_sub_eulerChar`, the genus `(2 - χ) / 2` is an integer.
+The only input is the defining relation of a triple: the product of the three signs is the sign
+of the identity, and each sign is the parity of the degree less the number of cycles. -/
+theorem even_eulerChar (t : PermutationTriple n) : Even t.eulerChar := by
+  have hsign : Perm.sign t.σinf * Perm.sign t.σ1 * Perm.sign t.σ0 = 1 := by
+    rw [← Perm.sign_mul, ← Perm.sign_mul, t.product_eq_one, Perm.sign_one]
+  rw [Perm.sign_eq_neg_one_pow_card_sub_orbitCount, Perm.sign_eq_neg_one_pow_card_sub_orbitCount,
+    Perm.sign_eq_neg_one_pow_card_sub_orbitCount, Fintype.card_fin, ← pow_add, ← pow_add] at hsign
+  obtain ⟨k, hk⟩ := (neg_one_pow_eq_one_iff_even (R := ℤˣ) (by decide)).mp hsign
+  have h0 := orbitCount_le t.σ0
+  have h1 := orbitCount_le t.σ1
+  have hinf := orbitCount_le t.σinf
+  refine ⟨(n : ℤ) - k, ?_⟩
+  rw [eulerChar_eq]
+  omega
+
+/-- The genus of a permutation triple is `(2 - χ) / 2`, and this is the divisibility that makes
+that an integer. -/
+theorem two_dvd_two_sub_eulerChar (t : PermutationTriple n) : (2 : ℤ) ∣ 2 - t.eulerChar := by
+  obtain ⟨k, hk⟩ := even_eulerChar t
+  exact ⟨1 - k, by omega⟩
+
+/-! ### Disjoint sums -/
+
+/-- The Euler characteristic is additive over disjoint sums of triples, the two summands being
+carried by disjoint sets of sheets. -/
+@[simp]
+theorem eulerChar_disjointSum (s : PermutationTriple m) (t : PermutationTriple n) :
+    (s.disjointSum t).eulerChar = s.eulerChar + t.eulerChar := by
+  rw [eulerChar_eq, eulerChar_eq, eulerChar_eq]
+  simp only [disjointSum_σ0, disjointSum_σ1, disjointSum_σinf, orbitCount_finSumPerm]
+  push_cast
+  ring
+
+/-! ### Worked examples
+
+The monodromy of `z ↦ z ^ 3`, and a disjoint union of two trivial covers. -/
+
+example : (ofTwo (finRotate 3) 1).eulerChar = 2 := by
+  have h0 : (finRotate 3).partition.parts = {3} := by decide
+  have h1 : (1 : Perm (Fin 3)).partition.parts = {1, 1, 1} := by decide
+  have hinf : ((1 : Perm (Fin 3)) * finRotate 3)⁻¹.partition.parts = {3} := by decide
+  rw [eulerChar_eq, Perm.orbitCount_eq_card_parts_partition,
+    Perm.orbitCount_eq_card_parts_partition, Perm.orbitCount_eq_card_parts_partition,
+    ofTwo_σ0, ofTwo_σ1, ofTwo_σinf, h0, h1, hinf]
+  decide
+
+example : ((1 : PermutationTriple 2).disjointSum (1 : PermutationTriple 3)).eulerChar = 10 := by
+  rw [eulerChar_disjointSum, eulerChar_one, eulerChar_one]
+  norm_num
+
+end PermutationTriple
+
+end TauCeti

--- a/TauCeti/GroupTheory/Perm/OrbitCount.lean
+++ b/TauCeti/GroupTheory/Perm/OrbitCount.lean
@@ -202,18 +202,37 @@ theorem _root_.Equiv.Perm.orbitCount_eq_card_parts_partition (σ : Equiv.Perm α
   rw [hfixed, Equiv.Perm.card_parts_partition, Equiv.Perm.cycleType_def]
   simp
 
+end Finite
+
+section Finite
+
+variable [Fintype α]
+
+/-- The number of orbits of a permutation of a finite type is at most the number of elements of
+the type. -/
+theorem _root_.Equiv.Perm.orbitCount_le_card (σ : Equiv.Perm α) :
+    orbitCount σ ≤ Fintype.card α := by
+  classical
+  rw [orbitCount_eq_card_parts_partition]
+  calc
+    σ.partition.parts.card = σ.partition.parts.card • 1 := by simp
+    _ ≤ σ.partition.parts.sum :=
+      Multiset.card_nsmul_le_sum fun n hn ↦ σ.partition.parts_pos hn
+    _ = Fintype.card α := σ.partition.parts_sum
+
+end Finite
+
+section Finite
+
+variable [Fintype α] [DecidableEq α]
+
 /-- The sign of a finite permutation is the parity of the number of points minus the number of
 orbits. Fixed points contribute once to both numbers and hence do not affect the sign. -/
 theorem _root_.Equiv.Perm.sign_eq_neg_one_pow_card_sub_orbitCount (σ : Equiv.Perm α) :
     Equiv.Perm.sign σ = (-1 : ℤˣ) ^ (Fintype.card α - orbitCount σ) := by
+  classical
   rw [Equiv.Perm.sign_of_parts_partition, ← orbitCount_eq_card_parts_partition]
-  have hle : orbitCount σ ≤ Fintype.card α := by
-    rw [orbitCount_eq_card_parts_partition]
-    calc
-      σ.partition.parts.card = σ.partition.parts.card • 1 := by simp
-      _ ≤ σ.partition.parts.sum :=
-        Multiset.card_nsmul_le_sum fun n hn ↦ σ.partition.parts_pos hn
-      _ = Fintype.card α := σ.partition.parts_sum
+  have hle := σ.orbitCount_le_card
   have h : Fintype.card α + orbitCount σ =
       (Fintype.card α - orbitCount σ) + 2 * orbitCount σ := by
     omega

--- a/TauCeti/GroupTheory/Perm/OrbitCount.lean
+++ b/TauCeti/GroupTheory/Perm/OrbitCount.lean
@@ -26,6 +26,8 @@ are compared with.
   nontrivial cycle factors of the permutation together with its fixed points.
 * `Equiv.Perm.orbitCount_eq_card_parts_partition`: on a finite type, the orbit count is the number
   of parts in Mathlib's full, fixed-point-aware permutation partition.
+* `Equiv.Perm.orbitCount_le_card`: on a finite type, a permutation has at most as many orbits as
+  the type has points, the orbits being the classes of a partition of it.
 * `Equiv.Perm.sign_eq_neg_one_pow_card_sub_orbitCount`: the sign is determined by the parity of
   the number of points minus the number of orbits.
 * `TauCeti.orbitCount_add_one_eq_of_semiconj`: if `σ : Equiv.Perm α` is carried by an injection
@@ -220,17 +222,12 @@ theorem _root_.Equiv.Perm.orbitCount_le_card (σ : Equiv.Perm α) :
       Multiset.card_nsmul_le_sum fun n hn ↦ σ.partition.parts_pos hn
     _ = Fintype.card α := σ.partition.parts_sum
 
-end Finite
-
-section Finite
-
-variable [Fintype α] [DecidableEq α]
+variable [DecidableEq α]
 
 /-- The sign of a finite permutation is the parity of the number of points minus the number of
 orbits. Fixed points contribute once to both numbers and hence do not affect the sign. -/
 theorem _root_.Equiv.Perm.sign_eq_neg_one_pow_card_sub_orbitCount (σ : Equiv.Perm α) :
     Equiv.Perm.sign σ = (-1 : ℤˣ) ^ (Fintype.card α - orbitCount σ) := by
-  classical
   rw [Equiv.Perm.sign_of_parts_partition, ← orbitCount_eq_card_parts_partition]
   have hle := σ.orbitCount_le_card
   have h : Fintype.card α + orbitCount σ =

--- a/TauCeti/GroupTheory/Perm/OrbitCount.lean
+++ b/TauCeti/GroupTheory/Perm/OrbitCount.lean
@@ -206,30 +206,22 @@ theorem _root_.Equiv.Perm.orbitCount_eq_card_parts_partition (σ : Equiv.Perm α
 
 end Finite
 
+/-- The number of orbits of a permutation of a finite type is at most the number of elements of
+the type: every orbit contains a point. -/
+theorem _root_.Equiv.Perm.orbitCount_le_card [Finite α] (σ : Equiv.Perm α) :
+    orbitCount σ ≤ Nat.card α :=
+  Nat.card_le_card_of_surjective _ Quotient.mk''_surjective
+
 section Finite
 
-variable [Fintype α]
-
-/-- The number of orbits of a permutation of a finite type is at most the number of elements of
-the type. -/
-theorem _root_.Equiv.Perm.orbitCount_le_card (σ : Equiv.Perm α) :
-    orbitCount σ ≤ Fintype.card α := by
-  classical
-  rw [orbitCount_eq_card_parts_partition]
-  calc
-    σ.partition.parts.card = σ.partition.parts.card • 1 := by simp
-    _ ≤ σ.partition.parts.sum :=
-      Multiset.card_nsmul_le_sum fun n hn ↦ σ.partition.parts_pos hn
-    _ = Fintype.card α := σ.partition.parts_sum
-
-variable [DecidableEq α]
+variable [Fintype α] [DecidableEq α]
 
 /-- The sign of a finite permutation is the parity of the number of points minus the number of
 orbits. Fixed points contribute once to both numbers and hence do not affect the sign. -/
 theorem _root_.Equiv.Perm.sign_eq_neg_one_pow_card_sub_orbitCount (σ : Equiv.Perm α) :
     Equiv.Perm.sign σ = (-1 : ℤˣ) ^ (Fintype.card α - orbitCount σ) := by
   rw [Equiv.Perm.sign_of_parts_partition, ← orbitCount_eq_card_parts_partition]
-  have hle := σ.orbitCount_le_card
+  have hle := σ.orbitCount_le_card.trans_eq Nat.card_eq_fintype_card
   have h : Fintype.card α + orbitCount σ =
       (Fintype.card α - orbitCount σ) + 2 * orbitCount σ := by
     omega

--- a/TauCeti/GroupTheory/Perm/SumCongr.lean
+++ b/TauCeti/GroupTheory/Perm/SumCongr.lean
@@ -171,6 +171,7 @@ theorem _root_.Equiv.Perm.finSumPerm_inv (σ : Perm (Fin m)) (τ : Perm (Fin n))
     (finSumPerm σ τ)⁻¹ = finSumPerm σ⁻¹ τ⁻¹ :=
   (map_inv (finSumPermHom m n) (σ, τ)).symm
 
+@[simp]
 theorem _root_.Equiv.Perm.finSumPerm_mul (σ σ' : Perm (Fin m)) (τ τ' : Perm (Fin n)) :
     finSumPerm σ τ * finSumPerm σ' τ' = finSumPerm (σ * σ') (τ * τ') :=
   (map_mul (finSumPermHom m n) (σ, τ) (σ', τ')).symm

--- a/TauCeti/GroupTheory/Perm/SumCongr.lean
+++ b/TauCeti/GroupTheory/Perm/SumCongr.lean
@@ -83,9 +83,9 @@ variable [Fintype α] [DecidableEq α] [Fintype β] [DecidableEq β]
 @[simp]
 theorem _root_.Equiv.Perm.cycleType_sumCongr (σ : Perm α) (τ : Perm β) :
     (Perm.sumCongr σ τ).cycleType = σ.cycleType + τ.cycleType := by
-  have h := Perm.sumCongr_mul σ (1 : Perm β) (1 : Perm α) τ
-  simp only [mul_one, one_mul] at h
-  rw [← h, (Perm.disjoint_sumCongr_one_one_sumCongr σ τ).cycleType_mul,
+  have h : Perm.sumCongr σ τ = Perm.sumCongr σ (1 : Perm β) * Perm.sumCongr (1 : Perm α) τ := by
+    rw [Perm.sumCongr_mul, mul_one, one_mul]
+  rw [h, (Perm.disjoint_sumCongr_one_one_sumCongr σ τ).cycleType_mul,
     Perm.sumCongr_one_eq_extendDomain, Perm.one_sumCongr_eq_extendDomain,
     cycleType_extendDomain, cycleType_extendDomain]
 
@@ -128,74 +128,65 @@ theorem _root_.Equiv.Perm.orbitCount_sumCongr [Finite α] [Finite β] (σ : Perm
 
 variable {m n : ℕ}
 
-end TauCeti
-
-namespace Equiv.Perm
-
-open TauCeti
+/-- The permutation of `Fin (m + n)` that acts as `σ` on the first `m` labels and as `τ` on the
+last `n`, the two blocks being separated by `finSumFinEquiv`. -/
+def _root_.Equiv.Perm.finSumPerm (σ : Perm (Fin m)) (τ : Perm (Fin n)) : Perm (Fin (m + n)) :=
+  finSumFinEquiv.permCongr (Perm.sumCongr σ τ)
 
 /-- Permuting the first `m` labels and the last `n` labels separately, as a monoid homomorphism.
 Its range is the subgroup of `Equiv.Perm (Fin (m + n))` preserving the two blocks. -/
-def finSumPermHom (m n : ℕ) : Perm (Fin m) × Perm (Fin n) →* Perm (Fin (m + n)) :=
-  finSumFinEquiv.permCongrHom.toMonoidHom.comp (sumCongrHom (Fin m) (Fin n))
-
-/-- The permutation of `Fin (m + n)` that acts as `σ` on the first `m` labels and as `τ` on the
-last `n`, the two blocks being separated by `finSumFinEquiv`. -/
-def finSumPerm (σ : Perm (Fin m)) (τ : Perm (Fin n)) : Perm (Fin (m + n)) :=
-  finSumPermHom m n (σ, τ)
+def _root_.Equiv.Perm.finSumPermHom (m n : ℕ) :
+    Perm (Fin m) × Perm (Fin n) →* Perm (Fin (m + n)) :=
+  finSumFinEquiv.permCongrHom.toMonoidHom.comp (Perm.sumCongrHom (Fin m) (Fin n))
 
 @[simp]
-theorem finSumPermHom_apply (p : Perm (Fin m) × Perm (Fin n)) :
-    finSumPermHom m n p = finSumPerm p.1 p.2 := by
-  rfl
+theorem _root_.Equiv.Perm.finSumPermHom_apply (p : Perm (Fin m) × Perm (Fin n)) :
+    finSumPermHom m n p = finSumPerm p.1 p.2 := (rfl)
 
-theorem finSumPerm_apply (σ : Perm (Fin m)) (τ : Perm (Fin n)) (x : Fin (m + n)) :
-    finSumPerm σ τ x = finSumFinEquiv (Sum.map σ τ (finSumFinEquiv.symm x)) := by
-  rfl
+theorem _root_.Equiv.Perm.finSumPerm_apply (σ : Perm (Fin m)) (τ : Perm (Fin n))
+    (x : Fin (m + n)) :
+    finSumPerm σ τ x = finSumFinEquiv (Sum.map σ τ (finSumFinEquiv.symm x)) := (rfl)
 
 @[simp]
-theorem finSumPerm_apply_castAdd (σ : Perm (Fin m)) (τ : Perm (Fin n)) (i : Fin m) :
+theorem _root_.Equiv.Perm.finSumPerm_apply_castAdd (σ : Perm (Fin m)) (τ : Perm (Fin n))
+    (i : Fin m) :
     finSumPerm σ τ (Fin.castAdd n i) = Fin.castAdd n (σ i) := by
-  rw [← finSumFinEquiv_apply_left, finSumPerm_apply,
-    Equiv.symm_apply_apply, Sum.map_inl, finSumFinEquiv_apply_left]
+  rw [← finSumFinEquiv_apply_left, finSumPerm_apply, Equiv.symm_apply_apply, Sum.map_inl,
+    finSumFinEquiv_apply_left]
 
 @[simp]
-theorem finSumPerm_apply_natAdd (σ : Perm (Fin m)) (τ : Perm (Fin n)) (j : Fin n) :
+theorem _root_.Equiv.Perm.finSumPerm_apply_natAdd (σ : Perm (Fin m)) (τ : Perm (Fin n))
+    (j : Fin n) :
     finSumPerm σ τ (Fin.natAdd m j) = Fin.natAdd m (τ j) := by
-  rw [← finSumFinEquiv_apply_right, finSumPerm_apply,
-    Equiv.symm_apply_apply, Sum.map_inr, finSumFinEquiv_apply_right]
+  rw [← finSumFinEquiv_apply_right, finSumPerm_apply, Equiv.symm_apply_apply, Sum.map_inr,
+    finSumFinEquiv_apply_right]
 
 @[simp]
-theorem finSumPerm_one : finSumPerm (1 : Perm (Fin m)) (1 : Perm (Fin n)) = 1 := by
-  change finSumPermHom m n (1, 1) = 1
-  exact map_one (finSumPermHom m n)
+theorem _root_.Equiv.Perm.finSumPerm_one :
+    finSumPerm (1 : Perm (Fin m)) (1 : Perm (Fin n)) = 1 :=
+  map_one (finSumPermHom m n)
 
 @[simp]
-theorem finSumPerm_inv (σ : Perm (Fin m)) (τ : Perm (Fin n)) :
-    (finSumPerm σ τ)⁻¹ = finSumPerm σ⁻¹ τ⁻¹ := by
-  change (finSumPermHom m n (σ, τ))⁻¹ = finSumPermHom m n (σ⁻¹, τ⁻¹)
-  exact (map_inv (finSumPermHom m n) (σ, τ)).symm
+theorem _root_.Equiv.Perm.finSumPerm_inv (σ : Perm (Fin m)) (τ : Perm (Fin n)) :
+    (finSumPerm σ τ)⁻¹ = finSumPerm σ⁻¹ τ⁻¹ :=
+  (map_inv (finSumPermHom m n) (σ, τ)).symm
 
-theorem finSumPerm_mul (σ σ' : Perm (Fin m)) (τ τ' : Perm (Fin n)) :
-    finSumPerm σ τ * finSumPerm σ' τ' = finSumPerm (σ * σ') (τ * τ') := by
-  change finSumPermHom m n (σ, τ) * finSumPermHom m n (σ', τ') =
-    finSumPermHom m n (σ * σ', τ * τ')
-  exact (map_mul (finSumPermHom m n) (σ, τ) (σ', τ')).symm
+theorem _root_.Equiv.Perm.finSumPerm_mul (σ σ' : Perm (Fin m)) (τ τ' : Perm (Fin n)) :
+    finSumPerm σ τ * finSumPerm σ' τ' = finSumPerm (σ * σ') (τ * τ') :=
+  (map_mul (finSumPermHom m n) (σ, τ) (σ', τ')).symm
 
 /-- The full cycle partition of `Equiv.Perm.finSumPerm σ τ` is the concatenation of those of `σ`
 and of `τ`. -/
 @[simp]
-theorem parts_partition_finSumPerm (σ : Perm (Fin m)) (τ : Perm (Fin n)) :
+theorem _root_.Equiv.Perm.parts_partition_finSumPerm (σ : Perm (Fin m)) (τ : Perm (Fin n)) :
     (finSumPerm σ τ).partition.parts = σ.partition.parts + τ.partition.parts := by
-  change (finSumFinEquiv.permCongr (Perm.sumCongr σ τ)).partition.parts = _
-  rw [parts_partition_permCongr, parts_partition_sumCongr]
+  rw [finSumPerm, parts_partition_permCongr, parts_partition_sumCongr]
 
 /-- The number of orbits of `Equiv.Perm.finSumPerm σ τ`, fixed points included, is the sum of the
 numbers of orbits of `σ` and of `τ`. -/
 @[simp]
-theorem orbitCount_finSumPerm (σ : Perm (Fin m)) (τ : Perm (Fin n)) :
+theorem _root_.Equiv.Perm.orbitCount_finSumPerm (σ : Perm (Fin m)) (τ : Perm (Fin n)) :
     orbitCount (finSumPerm σ τ) = orbitCount σ + orbitCount τ := by
-  change orbitCount (finSumFinEquiv.permCongr (Perm.sumCongr σ τ)) = _
-  rw [orbitCount_permCongr, orbitCount_sumCongr]
+  rw [finSumPerm, orbitCount_permCongr, orbitCount_sumCongr]
 
-end Equiv.Perm
+end TauCeti

--- a/TauCeti/GroupTheory/Perm/SumCongr.lean
+++ b/TauCeti/GroupTheory/Perm/SumCongr.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Logic.Equiv.Fin.Basic
-public import TauCeti.GroupTheory.Perm.Partition
 public import TauCeti.GroupTheory.Perm.OrbitCount
 import Mathlib.Tactic.Abel
 
@@ -14,9 +13,7 @@ import Mathlib.Tactic.Abel
 # The cycles of a permutation acting separately on the two halves of a sum
 
 `Equiv.Perm.sumCongr σ τ` permutes `α ⊕ β` by `σ` on the left summand and by `τ` on the right
-one. Nothing in the pin records how its cycles are assembled from those of `σ` and of `τ`, and
-that is what this file supplies: every cycle of `Equiv.Perm.sumCongr σ τ` stays inside one of the
-two halves, so all the cycle data simply concatenates.
+one. Every cycle stays inside one of the two halves, so all the cycle data simply concatenates.
 
 ## Main results
 
@@ -24,19 +21,9 @@ two halves, so all the cycle data simply concatenates.
   `Equiv.Perm.parts_partition_sumCongr`: the cycle type, the number of moved points and the parts
   of the full, fixed-point-aware partition are additive.
 * `Equiv.Perm.orbitCount_sumCongr`: so is the number of orbits, fixed points included.
-* `TauCeti.finSumPerm`: the same construction read on `Fin (m + n)` through `finSumFinEquiv`,
-  with `TauCeti.finSumPermHom` packaging it as a monoid homomorphism from
+* `Equiv.Perm.finSumPerm`: the same construction read on `Fin (m + n)` through
+  `finSumFinEquiv`, with `Equiv.Perm.finSumPermHom` packaging it as a monoid homomorphism from
   `Equiv.Perm (Fin m) × Equiv.Perm (Fin n)`, and with the two cycle-counting results transported.
-
-## Implementation notes
-
-The additivity of `Equiv.Perm.cycleType` is obtained by splitting `Equiv.Perm.sumCongr σ τ` as the
-product of the two disjoint permutations `Equiv.Perm.sumCongr σ 1` and `Equiv.Perm.sumCongr 1 τ`,
-and identifying each factor with an `Equiv.Perm.extendDomain` along `Equiv.sumIsLeft` respectively
-`Equiv.sumIsRight`, for which the pin already has `Equiv.Perm.cycleType_extendDomain`. Everything
-else is read off that identity: the number of moved points through
-`Equiv.Perm.sum_cycleType`, the parts of the partition through `Equiv.Perm.parts_partition`, and
-the orbit count through `Equiv.Perm.orbitCount_eq_card_parts_partition`.
 -/
 
 public section
@@ -86,11 +73,6 @@ theorem _root_.Equiv.Perm.disjoint_sumCongr_one_one_sumCongr (σ : Perm α) (τ 
   · exact Or.inr rfl
   · exact Or.inl rfl
 
-/-- A sum permutation is the product of its two halves. -/
-theorem _root_.Equiv.Perm.sumCongr_eq_mul (σ : Perm α) (τ : Perm β) :
-    Perm.sumCongr σ τ = Perm.sumCongr σ (1 : Perm β) * Perm.sumCongr (1 : Perm α) τ := by
-  rw [Perm.sumCongr_mul, mul_one, one_mul]
-
 /-! ### Additivity of the cycle data -/
 
 section Finite
@@ -101,7 +83,9 @@ variable [Fintype α] [DecidableEq α] [Fintype β] [DecidableEq β]
 @[simp]
 theorem _root_.Equiv.Perm.cycleType_sumCongr (σ : Perm α) (τ : Perm β) :
     (Perm.sumCongr σ τ).cycleType = σ.cycleType + τ.cycleType := by
-  rw [Perm.sumCongr_eq_mul, (Perm.disjoint_sumCongr_one_one_sumCongr σ τ).cycleType_mul,
+  have h := Perm.sumCongr_mul σ (1 : Perm β) (1 : Perm α) τ
+  simp only [mul_one, one_mul] at h
+  rw [← h, (Perm.disjoint_sumCongr_one_one_sumCongr σ τ).cycleType_mul,
     Perm.sumCongr_one_eq_extendDomain, Perm.one_sumCongr_eq_extendDomain,
     cycleType_extendDomain, cycleType_extendDomain]
 
@@ -144,63 +128,74 @@ theorem _root_.Equiv.Perm.orbitCount_sumCongr [Finite α] [Finite β] (σ : Perm
 
 variable {m n : ℕ}
 
+end TauCeti
+
+namespace Equiv.Perm
+
+open TauCeti
+
+/-- Permuting the first `m` labels and the last `n` labels separately, as a monoid homomorphism.
+Its range is the subgroup of `Equiv.Perm (Fin (m + n))` preserving the two blocks. -/
+def finSumPermHom (m n : ℕ) : Perm (Fin m) × Perm (Fin n) →* Perm (Fin (m + n)) :=
+  finSumFinEquiv.permCongrHom.toMonoidHom.comp (sumCongrHom (Fin m) (Fin n))
+
 /-- The permutation of `Fin (m + n)` that acts as `σ` on the first `m` labels and as `τ` on the
 last `n`, the two blocks being separated by `finSumFinEquiv`. -/
 def finSumPerm (σ : Perm (Fin m)) (τ : Perm (Fin n)) : Perm (Fin (m + n)) :=
-  finSumFinEquiv.permCongr (Perm.sumCongr σ τ)
+  finSumPermHom m n (σ, τ)
+
+@[simp]
+theorem finSumPermHom_apply (p : Perm (Fin m) × Perm (Fin n)) :
+    finSumPermHom m n p = finSumPerm p.1 p.2 := by
+  rfl
 
 theorem finSumPerm_apply (σ : Perm (Fin m)) (τ : Perm (Fin n)) (x : Fin (m + n)) :
-    finSumPerm σ τ x = finSumFinEquiv (Sum.map σ τ (finSumFinEquiv.symm x)) := (rfl)
+    finSumPerm σ τ x = finSumFinEquiv (Sum.map σ τ (finSumFinEquiv.symm x)) := by
+  rfl
 
 @[simp]
 theorem finSumPerm_apply_castAdd (σ : Perm (Fin m)) (τ : Perm (Fin n)) (i : Fin m) :
     finSumPerm σ τ (Fin.castAdd n i) = Fin.castAdd n (σ i) := by
-  rw [← finSumFinEquiv_apply_left, finSumPerm, Equiv.permCongr_apply,
-    Equiv.symm_apply_apply, Perm.sumCongr_apply, Sum.map_inl, finSumFinEquiv_apply_left]
+  rw [← finSumFinEquiv_apply_left, finSumPerm_apply,
+    Equiv.symm_apply_apply, Sum.map_inl, finSumFinEquiv_apply_left]
 
 @[simp]
 theorem finSumPerm_apply_natAdd (σ : Perm (Fin m)) (τ : Perm (Fin n)) (j : Fin n) :
     finSumPerm σ τ (Fin.natAdd m j) = Fin.natAdd m (τ j) := by
-  rw [← finSumFinEquiv_apply_right, finSumPerm, Equiv.permCongr_apply,
-    Equiv.symm_apply_apply, Perm.sumCongr_apply, Sum.map_inr, finSumFinEquiv_apply_right]
+  rw [← finSumFinEquiv_apply_right, finSumPerm_apply,
+    Equiv.symm_apply_apply, Sum.map_inr, finSumFinEquiv_apply_right]
 
 @[simp]
 theorem finSumPerm_one : finSumPerm (1 : Perm (Fin m)) (1 : Perm (Fin n)) = 1 := by
-  rw [finSumPerm, Perm.sumCongr_one, ← Equiv.permCongrHom_coe, map_one]
+  change finSumPermHom m n (1, 1) = 1
+  exact map_one (finSumPermHom m n)
 
 @[simp]
 theorem finSumPerm_inv (σ : Perm (Fin m)) (τ : Perm (Fin n)) :
     (finSumPerm σ τ)⁻¹ = finSumPerm σ⁻¹ τ⁻¹ := by
-  rw [finSumPerm, finSumPerm, ← Equiv.permCongrHom_coe, ← map_inv, ← Perm.sumCongr_inv]
+  change (finSumPermHom m n (σ, τ))⁻¹ = finSumPermHom m n (σ⁻¹, τ⁻¹)
+  exact (map_inv (finSumPermHom m n) (σ, τ)).symm
 
 theorem finSumPerm_mul (σ σ' : Perm (Fin m)) (τ τ' : Perm (Fin n)) :
     finSumPerm σ τ * finSumPerm σ' τ' = finSumPerm (σ * σ') (τ * τ') := by
-  rw [finSumPerm, finSumPerm, finSumPerm, ← Equiv.permCongrHom_coe, ← map_mul,
-    Perm.sumCongr_mul]
+  change finSumPermHom m n (σ, τ) * finSumPermHom m n (σ', τ') =
+    finSumPermHom m n (σ * σ', τ * τ')
+  exact (map_mul (finSumPermHom m n) (σ, τ) (σ', τ')).symm
 
-/-- Permuting the first `m` labels and the last `n` labels separately, as a monoid homomorphism.
-Its range is the subgroup of `Equiv.Perm (Fin (m + n))` preserving the two blocks. -/
-def finSumPermHom (m n : ℕ) : Perm (Fin m) × Perm (Fin n) →* Perm (Fin (m + n)) where
-  toFun p := finSumPerm p.1 p.2
-  map_one' := finSumPerm_one
-  map_mul' _ _ := (finSumPerm_mul _ _ _ _).symm
-
-@[simp]
-theorem finSumPermHom_apply (p : Perm (Fin m) × Perm (Fin n)) :
-    finSumPermHom m n p = finSumPerm p.1 p.2 := (rfl)
-
-/-- The full cycle partition of `TauCeti.finSumPerm σ τ` is the concatenation of those of `σ`
+/-- The full cycle partition of `Equiv.Perm.finSumPerm σ τ` is the concatenation of those of `σ`
 and of `τ`. -/
 @[simp]
 theorem parts_partition_finSumPerm (σ : Perm (Fin m)) (τ : Perm (Fin n)) :
     (finSumPerm σ τ).partition.parts = σ.partition.parts + τ.partition.parts := by
-  rw [finSumPerm, parts_partition_permCongr, parts_partition_sumCongr]
+  change (finSumFinEquiv.permCongr (Perm.sumCongr σ τ)).partition.parts = _
+  rw [parts_partition_permCongr, parts_partition_sumCongr]
 
-/-- The number of orbits of `TauCeti.finSumPerm σ τ`, fixed points included, is the sum of the
+/-- The number of orbits of `Equiv.Perm.finSumPerm σ τ`, fixed points included, is the sum of the
 numbers of orbits of `σ` and of `τ`. -/
 @[simp]
 theorem orbitCount_finSumPerm (σ : Perm (Fin m)) (τ : Perm (Fin n)) :
     orbitCount (finSumPerm σ τ) = orbitCount σ + orbitCount τ := by
-  rw [finSumPerm, orbitCount_permCongr, orbitCount_sumCongr]
+  change orbitCount (finSumFinEquiv.permCongr (Perm.sumCongr σ τ)) = _
+  rw [orbitCount_permCongr, orbitCount_sumCongr]
 
-end TauCeti
+end Equiv.Perm

--- a/TauCeti/GroupTheory/Perm/SumCongr.lean
+++ b/TauCeti/GroupTheory/Perm/SumCongr.lean
@@ -1,0 +1,206 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Logic.Equiv.Fin.Basic
+public import TauCeti.GroupTheory.Perm.Partition
+public import TauCeti.GroupTheory.Perm.OrbitCount
+import Mathlib.Tactic.Abel
+
+/-!
+# The cycles of a permutation acting separately on the two halves of a sum
+
+`Equiv.Perm.sumCongr σ τ` permutes `α ⊕ β` by `σ` on the left summand and by `τ` on the right
+one. Nothing in the pin records how its cycles are assembled from those of `σ` and of `τ`, and
+that is what this file supplies: every cycle of `Equiv.Perm.sumCongr σ τ` stays inside one of the
+two halves, so all the cycle data simply concatenates.
+
+## Main results
+
+* `Equiv.Perm.cycleType_sumCongr`, `Equiv.Perm.card_support_sumCongr`,
+  `Equiv.Perm.parts_partition_sumCongr`: the cycle type, the number of moved points and the parts
+  of the full, fixed-point-aware partition are additive.
+* `Equiv.Perm.orbitCount_sumCongr`: so is the number of orbits, fixed points included.
+* `TauCeti.finSumPerm`: the same construction read on `Fin (m + n)` through `finSumFinEquiv`,
+  with `TauCeti.finSumPermHom` packaging it as a monoid homomorphism from
+  `Equiv.Perm (Fin m) × Equiv.Perm (Fin n)`, and with the two cycle-counting results transported.
+
+## Implementation notes
+
+The additivity of `Equiv.Perm.cycleType` is obtained by splitting `Equiv.Perm.sumCongr σ τ` as the
+product of the two disjoint permutations `Equiv.Perm.sumCongr σ 1` and `Equiv.Perm.sumCongr 1 τ`,
+and identifying each factor with an `Equiv.Perm.extendDomain` along `Equiv.sumIsLeft` respectively
+`Equiv.sumIsRight`, for which the pin already has `Equiv.Perm.cycleType_extendDomain`. Everything
+else is read off that identity: the number of moved points through
+`Equiv.Perm.sum_cycleType`, the parts of the partition through `Equiv.Perm.parts_partition`, and
+the orbit count through `Equiv.Perm.orbitCount_eq_card_parts_partition`.
+-/
+
+public section
+
+namespace TauCeti
+
+open Equiv Equiv.Perm
+
+variable {α β : Type*}
+
+/-! ### Splitting a sum permutation into its two halves -/
+
+/-- A permutation of the left summand, extended by the identity, is the extension of its domain
+along `Equiv.sumIsLeft`. -/
+theorem _root_.Equiv.Perm.sumCongr_one_eq_extendDomain (σ : Perm α) :
+    Perm.sumCongr σ (1 : Perm β) =
+      σ.extendDomain (Equiv.sumIsLeft (α := α) (β := β)).symm := by
+  refine Equiv.ext fun x => ?_
+  match x with
+  | Sum.inl a =>
+    simpa using
+      (σ.extendDomain_apply_image (Equiv.sumIsLeft (α := α) (β := β)).symm a).symm
+  | Sum.inr b =>
+    rw [Perm.extendDomain_apply_not_subtype _ _ (by simp)]
+    rfl
+
+/-- A permutation of the right summand, extended by the identity, is the extension of its domain
+along `Equiv.sumIsRight`. -/
+theorem _root_.Equiv.Perm.one_sumCongr_eq_extendDomain (τ : Perm β) :
+    Perm.sumCongr (1 : Perm α) τ =
+      τ.extendDomain (Equiv.sumIsRight (α := α) (β := β)).symm := by
+  refine Equiv.ext fun x => ?_
+  match x with
+  | Sum.inl a =>
+    rw [Perm.extendDomain_apply_not_subtype _ _ (by simp)]
+    rfl
+  | Sum.inr b =>
+    simpa using
+      (τ.extendDomain_apply_image (Equiv.sumIsRight (α := α) (β := β)).symm b).symm
+
+/-- The two halves of a sum permutation are disjoint: each of them fixes everything the other
+can move. -/
+theorem _root_.Equiv.Perm.disjoint_sumCongr_one_one_sumCongr (σ : Perm α) (τ : Perm β) :
+    Perm.Disjoint (Perm.sumCongr σ (1 : Perm β)) (Perm.sumCongr (1 : Perm α) τ) := by
+  rw [Perm.disjoint_iff_eq_or_eq]
+  rintro (a | b)
+  · exact Or.inr rfl
+  · exact Or.inl rfl
+
+/-- A sum permutation is the product of its two halves. -/
+theorem _root_.Equiv.Perm.sumCongr_eq_mul (σ : Perm α) (τ : Perm β) :
+    Perm.sumCongr σ τ = Perm.sumCongr σ (1 : Perm β) * Perm.sumCongr (1 : Perm α) τ := by
+  rw [Perm.sumCongr_mul, mul_one, one_mul]
+
+/-! ### Additivity of the cycle data -/
+
+section Finite
+
+variable [Fintype α] [DecidableEq α] [Fintype β] [DecidableEq β]
+
+/-- The cycles of `Equiv.Perm.sumCongr σ τ` are those of `σ` together with those of `τ`. -/
+@[simp]
+theorem _root_.Equiv.Perm.cycleType_sumCongr (σ : Perm α) (τ : Perm β) :
+    (Perm.sumCongr σ τ).cycleType = σ.cycleType + τ.cycleType := by
+  rw [Perm.sumCongr_eq_mul, (Perm.disjoint_sumCongr_one_one_sumCongr σ τ).cycleType_mul,
+    Perm.sumCongr_one_eq_extendDomain, Perm.one_sumCongr_eq_extendDomain,
+    cycleType_extendDomain, cycleType_extendDomain]
+
+/-- The points moved by `Equiv.Perm.sumCongr σ τ` are those moved by `σ` together with those
+moved by `τ`. -/
+@[simp]
+theorem _root_.Equiv.Perm.card_support_sumCongr (σ : Perm α) (τ : Perm β) :
+    (Perm.sumCongr σ τ).support.card = σ.support.card + τ.support.card := by
+  rw [← sum_cycleType, ← sum_cycleType, ← sum_cycleType, cycleType_sumCongr, Multiset.sum_add]
+
+/-- The full, fixed-point-aware cycle partition of a sum permutation is the concatenation of the
+two partitions it is assembled from. Unlike `Equiv.Perm.cycleType_sumCongr` this keeps track of
+the fixed points, and it is the form the Euler characteristic of a disjoint sum of permutation
+triples is computed from. -/
+@[simp]
+theorem _root_.Equiv.Perm.parts_partition_sumCongr (σ : Perm α) (τ : Perm β) :
+    (Perm.sumCongr σ τ).partition.parts = σ.partition.parts + τ.partition.parts := by
+  have hα : σ.support.card ≤ Fintype.card α := by simpa using σ.support.card_le_univ
+  have hβ : τ.support.card ≤ Fintype.card β := by simpa using τ.support.card_le_univ
+  have hsub : Fintype.card α + Fintype.card β - (σ.support.card + τ.support.card) =
+      (Fintype.card α - σ.support.card) + (Fintype.card β - τ.support.card) := by omega
+  rw [parts_partition, parts_partition, parts_partition, cycleType_sumCongr,
+    card_support_sumCongr, Fintype.card_sum, hsub, Multiset.replicate_add]
+  abel
+
+end Finite
+
+/-- The orbits of `Equiv.Perm.sumCongr σ τ`, fixed points included, are those of `σ` together
+with those of `τ`. -/
+@[simp]
+theorem _root_.Equiv.Perm.orbitCount_sumCongr [Finite α] [Finite β] (σ : Perm α) (τ : Perm β) :
+    orbitCount (Perm.sumCongr σ τ) = orbitCount σ + orbitCount τ := by
+  classical
+  cases nonempty_fintype α
+  cases nonempty_fintype β
+  rw [orbitCount_eq_card_parts_partition, orbitCount_eq_card_parts_partition,
+    orbitCount_eq_card_parts_partition, parts_partition_sumCongr, Multiset.card_add]
+
+/-! ### The sum of a permutation of `Fin m` and a permutation of `Fin n` -/
+
+variable {m n : ℕ}
+
+/-- The permutation of `Fin (m + n)` that acts as `σ` on the first `m` labels and as `τ` on the
+last `n`, the two blocks being separated by `finSumFinEquiv`. -/
+def finSumPerm (σ : Perm (Fin m)) (τ : Perm (Fin n)) : Perm (Fin (m + n)) :=
+  finSumFinEquiv.permCongr (Perm.sumCongr σ τ)
+
+theorem finSumPerm_apply (σ : Perm (Fin m)) (τ : Perm (Fin n)) (x : Fin (m + n)) :
+    finSumPerm σ τ x = finSumFinEquiv (Sum.map σ τ (finSumFinEquiv.symm x)) := (rfl)
+
+@[simp]
+theorem finSumPerm_apply_castAdd (σ : Perm (Fin m)) (τ : Perm (Fin n)) (i : Fin m) :
+    finSumPerm σ τ (Fin.castAdd n i) = Fin.castAdd n (σ i) := by
+  rw [← finSumFinEquiv_apply_left, finSumPerm, Equiv.permCongr_apply,
+    Equiv.symm_apply_apply, Perm.sumCongr_apply, Sum.map_inl, finSumFinEquiv_apply_left]
+
+@[simp]
+theorem finSumPerm_apply_natAdd (σ : Perm (Fin m)) (τ : Perm (Fin n)) (j : Fin n) :
+    finSumPerm σ τ (Fin.natAdd m j) = Fin.natAdd m (τ j) := by
+  rw [← finSumFinEquiv_apply_right, finSumPerm, Equiv.permCongr_apply,
+    Equiv.symm_apply_apply, Perm.sumCongr_apply, Sum.map_inr, finSumFinEquiv_apply_right]
+
+@[simp]
+theorem finSumPerm_one : finSumPerm (1 : Perm (Fin m)) (1 : Perm (Fin n)) = 1 := by
+  rw [finSumPerm, Perm.sumCongr_one, ← Equiv.permCongrHom_coe, map_one]
+
+@[simp]
+theorem finSumPerm_inv (σ : Perm (Fin m)) (τ : Perm (Fin n)) :
+    (finSumPerm σ τ)⁻¹ = finSumPerm σ⁻¹ τ⁻¹ := by
+  rw [finSumPerm, finSumPerm, ← Equiv.permCongrHom_coe, ← map_inv, ← Perm.sumCongr_inv]
+
+theorem finSumPerm_mul (σ σ' : Perm (Fin m)) (τ τ' : Perm (Fin n)) :
+    finSumPerm σ τ * finSumPerm σ' τ' = finSumPerm (σ * σ') (τ * τ') := by
+  rw [finSumPerm, finSumPerm, finSumPerm, ← Equiv.permCongrHom_coe, ← map_mul,
+    Perm.sumCongr_mul]
+
+/-- Permuting the first `m` labels and the last `n` labels separately, as a monoid homomorphism.
+Its range is the subgroup of `Equiv.Perm (Fin (m + n))` preserving the two blocks. -/
+def finSumPermHom (m n : ℕ) : Perm (Fin m) × Perm (Fin n) →* Perm (Fin (m + n)) where
+  toFun p := finSumPerm p.1 p.2
+  map_one' := finSumPerm_one
+  map_mul' _ _ := (finSumPerm_mul _ _ _ _).symm
+
+@[simp]
+theorem finSumPermHom_apply (p : Perm (Fin m) × Perm (Fin n)) :
+    finSumPermHom m n p = finSumPerm p.1 p.2 := (rfl)
+
+/-- The full cycle partition of `TauCeti.finSumPerm σ τ` is the concatenation of those of `σ`
+and of `τ`. -/
+@[simp]
+theorem parts_partition_finSumPerm (σ : Perm (Fin m)) (τ : Perm (Fin n)) :
+    (finSumPerm σ τ).partition.parts = σ.partition.parts + τ.partition.parts := by
+  rw [finSumPerm, parts_partition_permCongr, parts_partition_sumCongr]
+
+/-- The number of orbits of `TauCeti.finSumPerm σ τ`, fixed points included, is the sum of the
+numbers of orbits of `σ` and of `τ`. -/
+@[simp]
+theorem orbitCount_finSumPerm (σ : Perm (Fin m)) (τ : Perm (Fin n)) :
+    orbitCount (finSumPerm σ τ) = orbitCount σ + orbitCount τ := by
+  rw [finSumPerm, orbitCount_permCongr, orbitCount_sumCongr]
+
+end TauCeti


### PR DESCRIPTION
This PR defines the Euler characteristic of a permutation triple and proves the two things about
it that do not presuppose the connected bound: it is even, and it is additive over disjoint sums
of triples. It serves Layer 0.6, "Euler characteristic and genus", of `BelyiMaps/README.md`, whose
first two numbered items are exactly the parity `2 ∣ (2 - χ(t))` and the juxtaposition
`PermutationTriple m → PermutationTriple n → PermutationTriple (m + n)` along `finSumFinEquiv`
"with `χ` additive, cycle data concatenating, and monodromy the product acting componentwise".

`TauCeti.PermutationTriple.eulerChar t` is `orbitCount σ0 + orbitCount σ1 + orbitCount σinf - n`
as an integer, using the repository's fixed-point-aware `TauCeti.orbitCount` (the roadmap defers
`cycleCount` itself to `PolynomialGaloisGroups`, and `TauCeti.PermutationTriple.cycleCounts` on
`main` is already phrased in `orbitCount`; `eulerChar_eq_cycleCounts` records the packaged form).
`even_eulerChar` is the parity, and it needs no more than the defining relation of a triple:
applying `Equiv.Perm.sign` to `σinf * σ1 * σ0 = 1` and reading each sign off the sign identity
`Equiv.Perm.sign_eq_neg_one_pow_card_sub_orbitCount`, already on `main` in
`TauCeti/GroupTheory/Perm/OrbitCount.lean`, says that `3n - (c₀ + c₁ + c∞)` is even, which is the
parity of `χ(t)`. `two_dvd_two_sub_eulerChar` is the roadmap's phrasing of the same fact, the one
that will make the genus an integer. The invariance lemmas `eulerChar_smul`,
`eulerChar_eq_of_equivalent` and `eulerChar_transport` match the shape of the existing
`cycleData_smul` family, and `eulerChar_one` computes the trivial `n`-sheeted cover to `2n`.

`TauCeti.PermutationTriple.disjointSum` is the juxtaposition: componentwise
`TauCeti.finSumPerm`, which acts by the first triple on the first `m` labels and by the second on
the last `n`. `cycleData_disjointSum` is the concatenation of the two ordered full cycle
partitions, `cycleCounts_disjointSum` and `eulerChar_disjointSum` the resulting additivity.
For the monodromy clause, `monodromyGroup_disjointSum_le` states the inclusion in the image of
`Subgroup.prod` of the two monodromy groups under the block-diagonal homomorphism
`TauCeti.finSumPermHom`; only the inclusion holds, since the disjoint sum of a triple with itself
has diagonal monodromy, and the docstring says so. That inclusion is what
`not_isConnected_disjointSum` runs on: a disjoint sum of two triples of nonzero degree is
disconnected, because every element of its monodromy group carries the first block of labels into
itself.

The prerequisite the pin does not supply is how the cycles of `Equiv.Perm.sumCongr σ τ` are
assembled, so `TauCeti/GroupTheory/Perm/SumCongr.lean` supplies it: splitting
`Equiv.Perm.sumCongr σ τ` into the two disjoint factors `Equiv.Perm.sumCongr σ 1` and
`Equiv.Perm.sumCongr 1 τ`, and identifying each with an `Equiv.Perm.extendDomain` along
`Equiv.sumIsLeft` respectively `Equiv.sumIsRight`, turns Mathlib's
`Equiv.Perm.cycleType_extendDomain` into `Equiv.Perm.cycleType_sumCongr`, and from there
`Equiv.Perm.card_support_sumCongr`, `Equiv.Perm.parts_partition_sumCongr` and
`Equiv.Perm.orbitCount_sumCongr` follow. The `Fin (m + n)` forms are transported along
`finSumFinEquiv` through the repository's own `Equiv.Perm.parts_partition_permCongr` and
`Equiv.orbitCount_permCongr`. Nothing is vendored from Mathlib; the file's declarations live in
the `Equiv.Perm` namespace, next to the pinned statements they extend, as
`TauCeti/GroupTheory/Perm/Partition.lean` and `OrbitCount.lean` already do. The one repeated
argument is the bound `orbitCount σ ≤ n`, kept `private` here because the open PR #6219
introduces the same bound as a public `Equiv.Perm.orbitCount_le_card`; once that lands this proof
should call it instead.

What Layer 0.6 still owes after this PR: the converse half of item 2 — every triple decomposes,
up to relabeling, as the disjoint sum of its restrictions to the monodromy orbits — the connected
bound `χ(t) ≤ 2` of item 3, whose transposition step lemma is the in-flight PR #6219, the general
bound `χ(t) ≤ 2 · (number of monodromy orbits)` of item 4, and the genus, which the roadmap
defines only once those bounds are in scope so that no statement subtracts naturals.

New files: `TauCeti/GroupTheory/Perm/SumCongr.lean` (206 lines),
`TauCeti/Combinatorics/PermutationTriple/DisjointSum.lean` (154 lines),
`TauCeti/Combinatorics/PermutationTriple/EulerCharacteristic.lean` (172 lines). No existing file
is modified.

Roadmap: BelyiMaps

<!--tauceti-target:v1 {"focus":"BelyiMaps","id":"euler-characteristic-permutation-triple"}-->

🤖 Prepared with Claude Code
