### PR TITLE
feat: split off the hyperbolic plane

### DIFF
--- a/TauCeti/LinearAlgebra/QuadraticForm/Hyperbolic.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/Hyperbolic.lean
@@ -12,8 +12,8 @@ public import TauCeti.LinearAlgebra.QuadraticForm.RegularFormClass.Basic
 /-!
 # The hyperbolic plane
 
-The hyperbolic plane over a commutative ring is the diagonal quadratic form `⟨1, -1⟩`. When two
-is invertible, it is nondegenerate, represents every scalar, and is isometric to the `xy`-form
+The hyperbolic plane over a commutative ring in which two is invertible is the diagonal quadratic
+form `⟨1, -1⟩`. It is nondegenerate, represents every scalar, and is isometric to the `xy`-form
 `QuadraticForm.dualProd`. Over a field in which two is invertible (that is, of characteristic not
 two), every plane `⟨a, -a⟩` with `a ≠ 0` is isometric to it.
 
@@ -27,14 +27,14 @@ hypothesis and is proved directly in `TauCeti/LinearAlgebra/QuadraticForm/Repres
 
 ## Main definitions
 
-* `TauCeti.hyperbolicPlane`: the diagonal form `⟨1, -1⟩`.
+* `TauCeti.hyperbolicPlane`: the diagonal form `⟨1, -1⟩`, over a commutative ring in which two is
+  invertible.
 
 ## Main results
 
-* `TauCeti.represents_hyperbolicPlane`: when two is invertible, the hyperbolic plane represents
-  every scalar.
-* `TauCeti.equivalent_hyperbolicPlane_dualProd`: when two is invertible, the hyperbolic plane is
-  isometric to the `xy`-form `QuadraticForm.dualProd`.
+* `TauCeti.represents_hyperbolicPlane`: the hyperbolic plane represents every scalar.
+* `TauCeti.equivalent_hyperbolicPlane_dualProd`: the hyperbolic plane is isometric to the
+  `xy`-form `QuadraticForm.dualProd`.
 * `TauCeti.equivalent_weightedSumSquares_self_neg`: in characteristic not two, every
   `⟨a, -a⟩`, for `a ≠ 0`, is hyperbolic.
 * `TauCeti.exists_hyperbolicPlane_prod_equivalent`: in characteristic not two, every
@@ -57,13 +57,18 @@ section CommRing
 
 variable {R : Type u} [CommRing R]
 
-/-- The hyperbolic plane `⟨1, -1⟩`. -/
-def hyperbolicPlane (R : Type u) [CommRing R] : QuadraticForm R (Fin 2 → R) :=
+/-- The hyperbolic plane `⟨1, -1⟩` over a commutative ring in which two is invertible.
+
+The invertibility hypothesis is not used by the formula; it confines the definition to the
+setting where the diagonal form `⟨1, -1⟩` is the hyperbolic plane. In characteristic two it is
+`⟨1, 1⟩`, whose polar form vanishes identically. -/
+def hyperbolicPlane (R : Type u) [CommRing R] [_i2 : Invertible (2 : R)] :
+    QuadraticForm R (Fin 2 → R) :=
   weightedSumSquares R ![(1 : R), -1]
 
 /-- Evaluation of the hyperbolic plane in its diagonal coordinates. -/
 @[simp]
-theorem hyperbolicPlane_apply (x : Fin 2 → R) :
+theorem hyperbolicPlane_apply [Invertible (2 : R)] (x : Fin 2 → R) :
     hyperbolicPlane R x = x 0 ^ 2 - x 1 ^ 2 := by
   simp [hyperbolicPlane, weightedSumSquares_apply, Fin.sum_univ_two, pow_two]
   ring
@@ -107,37 +112,41 @@ theorem represents_hyperbolicPlane [Invertible (2 : R)] (a : R) :
 `QuadraticForm.dualProd R R`, whose value at `(f, z)` is `f z`. -/
 theorem equivalent_hyperbolicPlane_dualProd [Invertible (2 : R)] :
     (hyperbolicPlane R).Equivalent (QuadraticForm.dualProd R R) := by
-  have key : ∀ f : Module.Dual R R, f 1 • (LinearMap.id : R →ₗ[R] R) = f := fun f ↦ by
-    ext
-    simp
+  -- The isometry is Mathlib's `QuadraticForm.toDualProd` for the square form `QuadraticMap.sq`,
+  -- which is bijective in this rank-one case.
   have h2 : (2 : R) * ⅟(2 : R) = 1 := mul_invOf_self 2
-  let e : (R × R) ≃ₗ[R] Module.Dual R R × R :=
-    { toFun := fun p ↦ ((p.1 + p.2) • (LinearMap.id : R →ₗ[R] R), p.1 - p.2)
-      invFun := fun q ↦ ((q.1 1 + q.2) * ⅟(2 : R), (q.1 1 - q.2) * ⅟(2 : R))
-      map_add' := fun p q ↦ Prod.ext
-        (by simp only [Prod.fst_add, Prod.snd_add, ← add_smul]; congr 1; ring)
-        (by simp only [Prod.fst_add, Prod.snd_add]; ring)
-      map_smul' := fun a p ↦ Prod.ext
-        (by simp only [Prod.smul_fst, Prod.smul_snd, smul_eq_mul, RingHom.id_apply, ← mul_smul]
-            congr 1
-            ring)
-        (by simp only [Prod.smul_fst, Prod.smul_snd, smul_eq_mul, RingHom.id_apply]; ring)
-      left_inv := fun p ↦ by
-        dsimp only
-        refine Prod.ext ?_ ?_ <;>
-          simp only [LinearMap.smul_apply, LinearMap.id_coe, id_eq, smul_eq_mul, mul_one]
-        · linear_combination p.1 * h2
-        · linear_combination p.2 * h2
-      right_inv := fun q ↦ by
-        dsimp only
-        refine Prod.ext ?_ ?_
-        · rw [show (q.1 1 + q.2) * ⅟(2 : R) + (q.1 1 - q.2) * ⅟(2 : R) = q.1 1 from by
-            linear_combination q.1 1 * h2]
-          exact key q.1
-        · linear_combination q.2 * h2 }
-  refine ⟨⟨(LinearEquiv.finTwoArrow R R).trans e, fun x ↦ ?_⟩⟩
-  simp [e]
-  ring
+  have hdual (f : Module.Dual R R) (y : R) : f y = y * f 1 := by
+    rw [← smul_eq_mul, ← map_smul, smul_eq_mul, mul_one]
+  -- `toDualProd` sends `(a, b)` to the dual vector `(a + b) * ·` paired with `a - b`.
+  have happ (p : R × R) :
+      QuadraticForm.toDualProd (QuadraticMap.sq : QuadraticForm R R) p =
+        (LinearMap.mul R R (p.1 + p.2), p.1 - p.2) := by
+    refine Prod.ext (LinearMap.ext fun y ↦ ?_) rfl
+    simp only [QuadraticForm.toDualProd_apply, associated_sq, map_add, LinearMap.add_apply,
+      LinearMap.mul_apply_apply]
+  have hbij : Function.Bijective
+      (QuadraticForm.toDualProd (QuadraticMap.sq : QuadraticForm R R)) := by
+    refine ⟨fun p q hpq ↦ ?_, fun q ↦ ?_⟩
+    · rw [happ, happ, Prod.mk.injEq] at hpq
+      have hadd : p.1 + p.2 = q.1 + q.2 := by
+        have h := congrArg (fun f : Module.Dual R R ↦ f 1) hpq.1
+        simpa using h
+      refine Prod.ext ?_ ?_
+      · linear_combination ⅟(2 : R) * hadd + ⅟(2 : R) * hpq.2 - (p.1 - q.1) * h2
+      · linear_combination ⅟(2 : R) * hadd - ⅟(2 : R) * hpq.2 - (p.2 - q.2) * h2
+    · refine ⟨((q.1 1 + q.2) * ⅟(2 : R), (q.1 1 - q.2) * ⅟(2 : R)), ?_⟩
+      rw [happ]
+      refine Prod.ext (LinearMap.ext fun y ↦ ?_) (by linear_combination q.2 * h2)
+      rw [LinearMap.mul_apply_apply, hdual q.1 y]
+      linear_combination (y * q.1 1) * h2
+  have hprod : (hyperbolicPlane R).Equivalent
+      ((QuadraticMap.sq : QuadraticForm R R).prod (-QuadraticMap.sq)) :=
+    ⟨{ toLinearEquiv := LinearEquiv.finTwoArrow R R
+       map_app' x := by
+         simp [hyperbolicPlane_apply, pow_two, sub_eq_add_neg] }⟩
+  exact hprod.trans
+    ⟨{ toLinearEquiv := LinearEquiv.ofBijective _ hbij
+       map_app' p := (QuadraticForm.toDualProd (QuadraticMap.sq : QuadraticForm R R)).map_app p }⟩
 
 end CommRing
 

--- a/TauCeti/LinearAlgebra/QuadraticForm/Hyperbolic.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/Hyperbolic.lean
@@ -12,13 +12,14 @@ public import TauCeti.LinearAlgebra.QuadraticForm.RegularFormClass.Basic
 # The hyperbolic plane
 
 The hyperbolic plane over a commutative ring is the diagonal quadratic form `⟨1, -1⟩`. When
-two is invertible, it is nondegenerate and represents every scalar. Over a field, every plane
-`⟨a, -a⟩` with `a ≠ 0` is isometric to it.
+two is invertible, it is nondegenerate and represents every scalar. Over a field in which two is
+invertible (that is, of characteristic not two), every plane `⟨a, -a⟩` with `a ≠ 0` is isometric
+to it.
 
-The main result is the hyperbolic splitting theorem: every finite-dimensional nondegenerate
-isotropic quadratic form splits as the orthogonal sum of a hyperbolic plane and another
-nondegenerate form. The proof uses an isotropic pair whose polar pairing is one, then takes its
-orthogonal complement.
+The main result is the hyperbolic splitting theorem: over a field of characteristic not two, every
+finite-dimensional nondegenerate isotropic quadratic form splits as the orthogonal sum of a
+hyperbolic plane and another nondegenerate form. It is the inductive step of Witt decomposition:
+iterating it splits off hyperbolic planes until the remaining part is anisotropic.
 
 ## Main definitions
 
@@ -26,11 +27,12 @@ orthogonal complement.
 
 ## Main results
 
-* `TauCeti.represents_hyperbolicPlane`: the hyperbolic plane represents every scalar.
-* `TauCeti.equivalent_weightedSumSquares_self_neg`: every `⟨a, -a⟩`, for `a ≠ 0`, is
-  hyperbolic.
-* `TauCeti.exists_hyperbolicPlane_prod_equivalent`: every finite-dimensional nondegenerate
-  isotropic form splits off a hyperbolic plane.
+* `TauCeti.represents_hyperbolicPlane`: when two is invertible, the hyperbolic plane represents
+  every scalar.
+* `TauCeti.equivalent_weightedSumSquares_self_neg`: in characteristic not two, every
+  `⟨a, -a⟩`, for `a ≠ 0`, is hyperbolic.
+* `TauCeti.exists_hyperbolicPlane_prod_equivalent`: in characteristic not two, every
+  finite-dimensional nondegenerate isotropic form splits off a hyperbolic plane.
 
 ## References
 
@@ -68,22 +70,22 @@ theorem nondegenerate_hyperbolicPlane [Invertible (2 : R)] :
   rw [QuadraticMap.mem_radical_iff'] at hx
   have hxQ := hx.1
   rw [hyperbolicPlane_apply] at hxQ
-  funext i
-  fin_cases i
-  · change x 0 = 0
+  have h0 : x 0 = 0 := by
     have h := hx.2 ![1, 0]
     simp only [hyperbolicPlane_apply, Matrix.cons_val_zero, Matrix.cons_val_one,
       Pi.add_apply] at h
     apply (isUnit_of_invertible (2 : R)).mul_right_eq_zero.mp
     linear_combination h - hxQ
-  · change x 1 = 0
+  have h1 : x 1 = 0 := by
     have h := hx.2 ![0, 1]
     simp only [hyperbolicPlane_apply, Matrix.cons_val_zero, Matrix.cons_val_one,
       Pi.add_apply] at h
     apply (isUnit_of_invertible (2 : R)).mul_right_eq_zero.mp
     linear_combination hxQ - h
+  ext i
+  fin_cases i <;> simp [h0, h1]
 
-/-- The hyperbolic plane represents every scalar. -/
+/-- When two is invertible, the hyperbolic plane represents every scalar. -/
 theorem represents_hyperbolicPlane [Invertible (2 : R)] (a : R) :
     (hyperbolicPlane R).Represents a := by
   rw [represents_iff, Set.mem_range]
@@ -99,7 +101,8 @@ end CommRing
 
 variable {K : Type u} [Field K]
 
-/-- Every diagonal plane `⟨a, -a⟩` with `a` a unit is isometric to the hyperbolic plane. -/
+/-- Over a field in which two is invertible, every diagonal plane `⟨a, -a⟩` with `a` a unit is
+isometric to the hyperbolic plane. -/
 theorem equivalent_weightedSumSquares_self_neg [Invertible (2 : K)] (a : Kˣ) :
     (weightedSumSquares K ![(a : K), -(a : K)]).Equivalent (hyperbolicPlane K) := by
   have hdisc : IsSquare (a * (-a) * ((1 : Kˣ) * (-1))) := by
@@ -115,37 +118,6 @@ theorem equivalent_weightedSumSquares_self_neg [Invertible (2 : K)] (a : Kˣ) :
     (a := a) (b := -a) (c := 1) (d := -1) (e := a) hdisc hsource htarget
 
 variable {V : Type v} [AddCommGroup V] [Module K V]
-
-/-- A nondegenerate isotropic quadratic form contains two isotropic vectors whose polar pairing
-is one. -/
-theorem _root_.QuadraticMap.Nondegenerate.exists_isotropic_pair
-    {Q : QuadraticForm K V} (hQ : Q.Nondegenerate) (hiso : ¬Q.Anisotropic) :
-    ∃ x y : V, x ≠ 0 ∧ Q x = 0 ∧ Q y = 0 ∧ polar Q x y = 1 := by
-  obtain ⟨x, hx, hxQ⟩ := (not_anisotropic_iff_exists Q).mp hiso
-  obtain ⟨w, hw⟩ : ∃ w, polar Q x w ≠ 0 := by
-    by_contra h
-    push Not at h
-    apply hx
-    have hxrad : x ∈ Q.radical := by
-      rw [mem_radical_iff']
-      refine ⟨hxQ, fun z ↦ ?_⟩
-      rw [QuadraticMap.map_add Q, hxQ, h z, zero_add, add_zero]
-    rw [hQ.radical_eq_bot] at hxrad
-    exact hxrad
-  let z := w - (Q w / polar Q x w) • x
-  have hzQ : Q z = 0 := by
-    have hw' : polar Q w x ≠ 0 := by simpa only [polar_comm] using hw
-    dsimp [z]
-    simp only [sub_eq_add_neg, ← neg_smul, QuadraticMap.map_add, Q.map_smul, hxQ,
-      polar_smul_right, polar_comm, smul_eq_mul, mul_zero, add_zero]
-    field_simp [hw']
-    ring
-  have hxz : polar Q x z = polar Q x w := by
-    simp [z, polar_sub_right, polar_smul_right, polar_self, hxQ]
-  let y := (polar Q x w)⁻¹ • z
-  refine ⟨x, y, hx, hxQ, ?_, ?_⟩
-  · simp [y, Q.map_smul, hzQ]
-  · simp [y, polar_smul_right, hxz, hw]
 
 private def hyperbolicPairMap (x y : V) : K × K →ₗ[K] V where
   toFun p := (p.1 + p.2) • x + (p.1 - p.2) • y
@@ -193,8 +165,9 @@ private noncomputable def hyperbolicPairIsometryEquiv [Invertible (2 : K)]
       polar_smul_right, hxy, smul_eq_mul, mul_zero, add_zero, mul_one]
     ring
 
-/-- Every finite-dimensional nondegenerate isotropic quadratic form splits as the orthogonal sum
-of a hyperbolic plane and a nondegenerate diagonal form. -/
+/-- Over a field in which two is invertible, every finite-dimensional nondegenerate isotropic
+quadratic form splits as the orthogonal sum of a hyperbolic plane and a nondegenerate diagonal
+form. -/
 theorem exists_hyperbolicPlane_prod_equivalent [FiniteDimensional K V] [Invertible (2 : K)]
     (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) (hiso : ¬Q.Anisotropic) :
     ∃ p : RegularFormPresentation K,
@@ -226,13 +199,18 @@ theorem exists_hyperbolicPlane_prod_equivalent [FiniteDimensional K V] [Invertib
     rw [← QuadraticMap.nondegenerate_associated_iff]
     rw [QuadraticMap.associated_restrict]
     exact hBorth
+  have hBpolar : LinearMap.BilinForm.orthogonal B W =
+      LinearMap.BilinForm.orthogonal Q.polarBilin W := by
+    ext v
+    simp only [LinearMap.BilinForm.mem_orthogonal_iff, B, associated_isOrtho, isOrtho_polarBilin]
+  rw [hBpolar] at hcomp horth
   obtain ⟨p, hp⟩ := exists_presentedForm_equivalent
-    (Q.restrict (LinearMap.BilinForm.orthogonal B W)) horth
+    (Q.restrict (LinearMap.BilinForm.orthogonal Q.polarBilin W)) horth
   have hdecomp : Q.Equivalent
-      ((Q.restrict W).prod (Q.restrict (LinearMap.BilinForm.orthogonal B W))) :=
+      ((Q.restrict W).prod (Q.restrict (LinearMap.BilinForm.orthogonal Q.polarBilin W))) :=
     ⟨(QuadraticMap.IsometryEquiv.prodRestrictOrthogonal Q W hcomp).symm⟩
   have hreplace :
-      ((Q.restrict W).prod (Q.restrict (LinearMap.BilinForm.orthogonal B W))).Equivalent
+      ((Q.restrict W).prod (Q.restrict (LinearMap.BilinForm.orthogonal Q.polarBilin W))).Equivalent
         ((hyperbolicPlane K).prod (presentedForm p)) :=
     QuadraticMap.Equivalent.prod
       (⟨eH.symm⟩ : (Q.restrict W).Equivalent (hyperbolicPlane K)) hp

--- a/TauCeti/LinearAlgebra/QuadraticForm/Hyperbolic.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/Hyperbolic.lean
@@ -104,7 +104,7 @@ variable {V : Type v} [AddCommGroup V] [Module K V]
 
 /-- A nondegenerate isotropic quadratic form contains two isotropic vectors whose polar pairing
 is one. -/
-theorem _root_.QuadraticMap.Nondegenerate.exists_isotropic_pair [Invertible (2 : K)]
+theorem _root_.QuadraticMap.Nondegenerate.exists_isotropic_pair
     {Q : QuadraticForm K V} (hQ : Q.Nondegenerate) (hiso : ¬Q.Anisotropic) :
     ∃ x y : V, x ≠ 0 ∧ Q x = 0 ∧ Q y = 0 ∧ polar Q x y = 1 := by
   obtain ⟨x, hx, hxQ⟩ := (not_anisotropic_iff_exists Q).mp hiso

--- a/TauCeti/LinearAlgebra/QuadraticForm/Hyperbolic.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/Hyperbolic.lean
@@ -1,0 +1,232 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.LinearAlgebra.QuadraticForm.Binary
+public import TauCeti.LinearAlgebra.QuadraticForm.RegularFormClass.Basic
+
+/-!
+# The hyperbolic plane
+
+The hyperbolic plane over a field of characteristic different from two is the diagonal quadratic
+form `⟨1, -1⟩`. It represents every scalar. More generally, every plane `⟨a, -a⟩` with
+`a ≠ 0` is isometric to it.
+
+The main result is the hyperbolic splitting theorem: every nondegenerate isotropic quadratic form
+splits as the orthogonal sum of a hyperbolic plane and another nondegenerate form. The proof uses
+an isotropic pair whose polar pairing is one, then takes its orthogonal complement.
+
+## Main definitions
+
+* `TauCeti.hyperbolicPlane`: the diagonal form `⟨1, -1⟩`.
+
+## Main results
+
+* `TauCeti.hyperbolicPlane_represents`: the hyperbolic plane represents every scalar.
+* `TauCeti.equivalent_weightedSumSquares_self_neg`: every `⟨a, -a⟩`, for `a ≠ 0`, is
+  hyperbolic.
+* `TauCeti.exists_hyperbolicPlane_prod_equivalent`: every nondegenerate isotropic form splits off
+  a hyperbolic plane.
+
+## References
+
+* T. Y. Lam, *Introduction to Quadratic Forms over Fields* (2005), Chapter I, §3.
+-/
+
+public section
+
+open QuadraticMap QuadraticForm
+
+namespace TauCeti
+
+universe u v
+
+section CommRing
+
+variable {R : Type u} [CommRing R]
+
+/-- The hyperbolic plane `⟨1, -1⟩`. -/
+def hyperbolicPlane (R : Type u) [CommRing R] : QuadraticForm R (Fin 2 → R) :=
+  weightedSumSquares R ![(1 : R), -1]
+
+/-- Evaluation of the hyperbolic plane in its diagonal coordinates. -/
+@[simp]
+theorem hyperbolicPlane_apply (x : Fin 2 → R) :
+    hyperbolicPlane R x = x 0 ^ 2 - x 1 ^ 2 := by
+  simp [hyperbolicPlane, weightedSumSquares_apply, Fin.sum_univ_two, pow_two]
+  ring
+
+end CommRing
+
+variable {K : Type u} [Field K]
+
+/-- The hyperbolic plane is nondegenerate when two is invertible. -/
+theorem hyperbolicPlane_nondegenerate [Invertible (2 : K)] :
+    (hyperbolicPlane K).Nondegenerate := by
+  let p : RegularFormPresentation K := ⟨2, ![(1 : Kˣ), (-1 : Kˣ)]⟩
+  have hp : presentedForm p = hyperbolicPlane K := by
+    ext x
+    rw [presentedForm_eq_weightedSumSquares]
+    simp [hyperbolicPlane, weightedSumSquares_apply, Fin.sum_univ_two, p, Units.smul_def]
+  rw [← hp]
+  exact nondegenerate_presentedForm p
+
+/-- The hyperbolic plane represents every scalar. -/
+theorem hyperbolicPlane_represents [Invertible (2 : K)] (a : K) :
+    (hyperbolicPlane K).Represents a := by
+  rw [represents_iff, Set.mem_range]
+  refine ⟨![(a + 1) / 2, (a - 1) / 2], ?_⟩
+  rw [hyperbolicPlane_apply]
+  simp only [Matrix.cons_val_zero, Matrix.cons_val_one]
+  have htwo : (2 : K) ≠ 0 := (isUnit_of_invertible (2 : K)).ne_zero
+  field_simp [htwo]
+  ring
+
+/-- Every diagonal plane `⟨a, -a⟩` with `a` a unit is isometric to the hyperbolic plane. -/
+theorem equivalent_weightedSumSquares_self_neg [Invertible (2 : K)] (a : Kˣ) :
+    (weightedSumSquares K ![(a : K), -(a : K)]).Equivalent (hyperbolicPlane K) := by
+  have hdisc : IsSquare (a * (-a) * ((1 : Kˣ) * (-1))) := by
+    refine ⟨a, ?_⟩
+    simp
+  have hsource : a ∈ unitValueSet
+      (weightedSumSquares K ![(a : K), -(a : K)]) :=
+    mem_unitValueSet_binary_left a (-(a : K))
+  have htarget : a ∈ unitValueSet (hyperbolicPlane K) := by
+    rw [mem_unitValueSet]
+    exact hyperbolicPlane_represents (a : K)
+  exact equivalent_binary_of_isSquare_of_mem_unitValueSet
+    (a := a) (b := -a) (c := 1) (d := -1) (e := a) hdisc hsource htarget
+
+variable {V : Type v} [AddCommGroup V] [Module K V]
+
+/-- A nondegenerate isotropic quadratic form contains two isotropic vectors whose polar pairing
+is one. -/
+theorem _root_.QuadraticMap.Nondegenerate.exists_isotropic_pair [Invertible (2 : K)]
+    {Q : QuadraticForm K V} (hQ : Q.Nondegenerate) (hiso : ¬Q.Anisotropic) :
+    ∃ x y : V, x ≠ 0 ∧ Q x = 0 ∧ Q y = 0 ∧ polar Q x y = 1 := by
+  obtain ⟨x, hx, hxQ⟩ := (not_anisotropic_iff_exists Q).mp hiso
+  obtain ⟨w, hw⟩ : ∃ w, polar Q x w ≠ 0 := by
+    by_contra h
+    push Not at h
+    apply hx
+    have hxrad : x ∈ Q.radical := by
+      rw [mem_radical_iff']
+      refine ⟨hxQ, fun z ↦ ?_⟩
+      rw [QuadraticMap.map_add Q, hxQ, h z, zero_add, add_zero]
+    rw [hQ.radical_eq_bot] at hxrad
+    exact hxrad
+  let z := w - (Q w / polar Q x w) • x
+  have hzQ : Q z = 0 := by
+    have hw' : polar Q w x ≠ 0 := by simpa only [polar_comm] using hw
+    dsimp [z]
+    rw [sub_eq_add_neg, ← neg_smul, QuadraticMap.map_add Q, Q.map_smul, hxQ,
+      polar_smul_right, polar_comm]
+    simp only [smul_eq_mul]
+    field_simp [hw']
+    ring
+  have hxz : polar Q x z = polar Q x w := by
+    simp [z, polar_sub_right, polar_smul_right, polar_self, hxQ]
+  let y := (polar Q x w)⁻¹ • z
+  refine ⟨x, y, hx, hxQ, ?_, ?_⟩
+  · simp [y, Q.map_smul, hzQ]
+  · simp [y, polar_smul_right, hxz, hw]
+
+private def hyperbolicPairMap (x y : V) : K × K →ₗ[K] V where
+  toFun p := (p.1 + p.2) • x + (p.1 - p.2) • y
+  map_add' p q := by
+    simp only [Prod.fst_add, Prod.snd_add]
+    module
+  map_smul' a p := by
+    simp only [Prod.smul_fst, Prod.smul_snd, RingHom.id_apply]
+    module
+
+private theorem hyperbolicPairMap_injective [Invertible (2 : K)]
+    (Q : QuadraticForm K V) {x y : V} (hxQ : Q x = 0) (hyQ : Q y = 0)
+    (hxy : polar Q x y = 1) : Function.Injective (hyperbolicPairMap (K := K) x y) := by
+  intro p q hpq
+  have hpqzero : hyperbolicPairMap (K := K) x y (p - q) = 0 := by
+    rw [map_sub, hpq, sub_self]
+  have hsub : (p - q).1 - (p - q).2 = 0 := by
+    have := congrArg (polar Q x) hpqzero
+    simpa [hyperbolicPairMap, polar_add_right, polar_smul_right, polar_self, hxQ, hxy] using this
+  have hadd : (p - q).1 + (p - q).2 = 0 := by
+    have := congrArg (fun z ↦ polar Q z y) hpqzero
+    simpa [hyperbolicPairMap, polar_add_left, polar_smul_left, polar_self, hyQ, hxy,
+      polar_comm] using this
+  have hpq' : p - q = 0 := by
+    apply Prod.ext <;> simp only [Prod.fst_zero, Prod.snd_zero]
+    · apply (mul_left_cancel₀ (isUnit_of_invertible (2 : K)).ne_zero)
+      linear_combination hadd + hsub
+    · apply (mul_left_cancel₀ (isUnit_of_invertible (2 : K)).ne_zero)
+      linear_combination hadd - hsub
+  exact sub_eq_zero.mp hpq'
+
+private noncomputable def hyperbolicPairIsometryEquiv [Invertible (2 : K)]
+    (Q : QuadraticForm K V) (x y : V) (hxQ : Q x = 0) (hyQ : Q y = 0)
+    (hxy : polar Q x y = 1) :
+    (hyperbolicPlane K).IsometryEquiv
+      (Q.restrict (LinearMap.range (hyperbolicPairMap (K := K) x y))) where
+  toLinearEquiv := (LinearEquiv.finTwoArrow K K).trans
+    (LinearEquiv.ofInjective (hyperbolicPairMap (K := K) x y)
+      (hyperbolicPairMap_injective Q hxQ hyQ hxy))
+  map_app' v := by
+    -- Expose the range equivalence so the quadratic-form calculation sees its underlying map.
+    change Q ((v 0 + v 1) • x + (v 0 - v 1) • y) = hyperbolicPlane K v
+    rw [hyperbolicPlane_apply, QuadraticMap.map_add Q, Q.map_smul, Q.map_smul, hxQ, hyQ,
+      polar_smul_left, polar_smul_right, hxy]
+    simp only [smul_eq_mul, mul_one]
+    ring
+
+/-- Every nondegenerate isotropic quadratic form splits as the orthogonal sum of a hyperbolic
+plane and a nondegenerate diagonal form. -/
+theorem exists_hyperbolicPlane_prod_equivalent [FiniteDimensional K V] [Invertible (2 : K)]
+    (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) (hiso : ¬Q.Anisotropic) :
+    ∃ p : RegularFormPresentation K,
+      Q.Equivalent ((hyperbolicPlane K).prod (presentedForm p)) := by
+  obtain ⟨x, y, hx, hxQ, hyQ, hxy⟩ := hQ.exists_isotropic_pair hiso
+  let W := LinearMap.range (hyperbolicPairMap (K := K) x y)
+  let eH := hyperbolicPairIsometryEquiv Q x y hxQ hyQ hxy
+  have hWQ : (Q.restrict W).Nondegenerate := by
+    rw [QuadraticMap.nondegenerate_iff_radical_eq_bot]
+    have hr := eH.map_radical
+    rw [hyperbolicPlane_nondegenerate.radical_eq_bot, Submodule.map_bot] at hr
+    exact hr.symm
+  let B := QuadraticMap.associated Q
+  have associated_restrict (S : Submodule K V) :
+      QuadraticMap.associated (Q.restrict S) = LinearMap.BilinForm.restrict B S := by
+    ext a b
+    rfl
+  have hBW : (LinearMap.BilinForm.restrict B W).Nondegenerate := by
+    rw [← associated_restrict]
+    exact QuadraticMap.nondegenerate_associated_iff.mpr hWQ
+  have hcomp : IsCompl W (LinearMap.BilinForm.orthogonal B W) :=
+    LinearMap.BilinForm.isCompl_orthogonal_of_restrict_nondegenerate
+      (LinearMap.BilinForm.isSymm_iff.mpr (QuadraticForm.associated_isSymm K Q)).isRefl hBW
+  have horth : (Q.restrict (LinearMap.BilinForm.orthogonal B W)).Nondegenerate := by
+    have hB : B.Nondegenerate := QuadraticMap.nondegenerate_associated_iff.mpr hQ
+    have hBsymm :=
+      (LinearMap.BilinForm.isSymm_iff.mpr (QuadraticForm.associated_isSymm K Q)).isRefl
+    have hBorth :
+        (LinearMap.BilinForm.restrict B (LinearMap.BilinForm.orthogonal B W)).Nondegenerate := by
+      rw [LinearMap.BilinForm.restrict_nondegenerate_iff_isCompl_orthogonal hBsymm,
+        LinearMap.BilinForm.orthogonal_orthogonal hB hBsymm]
+      exact hcomp.symm
+    rw [← QuadraticMap.nondegenerate_associated_iff]
+    rw [associated_restrict]
+    exact hBorth
+  obtain ⟨p, hp⟩ := exists_presentedForm_equivalent
+    (Q.restrict (LinearMap.BilinForm.orthogonal B W)) horth
+  have hdecomp : Q.Equivalent
+      ((Q.restrict W).prod (Q.restrict (LinearMap.BilinForm.orthogonal B W))) :=
+    ⟨(QuadraticMap.IsometryEquiv.prodRestrictOrthogonal Q W hcomp).symm⟩
+  have hreplace :
+      ((Q.restrict W).prod (Q.restrict (LinearMap.BilinForm.orthogonal B W))).Equivalent
+        ((hyperbolicPlane K).prod (presentedForm p)) :=
+    QuadraticMap.Equivalent.prod
+      (⟨eH.symm⟩ : (Q.restrict W).Equivalent (hyperbolicPlane K)) hp
+  exact ⟨p, hdecomp.trans hreplace⟩
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/QuadraticForm/Hyperbolic.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/Hyperbolic.lean
@@ -35,7 +35,7 @@ hypothesis and is proved directly in `TauCeti/LinearAlgebra/QuadraticForm/Repres
 * `TauCeti.represents_hyperbolicPlane`: the hyperbolic plane represents every scalar.
 * `TauCeti.equivalent_hyperbolicPlane_dualProd`: the hyperbolic plane is isometric to the
   `xy`-form `QuadraticForm.dualProd`.
-* `TauCeti.equivalent_weightedSumSquares_self_neg`: in characteristic not two, every
+* `TauCeti.equivalent_weightedSumSquares_self_neg_hyperbolicPlane`: in characteristic not two, every
   `⟨a, -a⟩`, for `a ≠ 0`, is hyperbolic.
 * `TauCeti.exists_hyperbolicPlane_prod_equivalent`: in characteristic not two, every
   finite-dimensional nondegenerate isotropic form splits off a hyperbolic plane.
@@ -115,8 +115,6 @@ theorem equivalent_hyperbolicPlane_dualProd [Invertible (2 : R)] :
   -- The isometry is Mathlib's `QuadraticForm.toDualProd` for the square form `QuadraticMap.sq`,
   -- which is bijective in this rank-one case.
   have h2 : (2 : R) * ⅟(2 : R) = 1 := mul_invOf_self 2
-  have hdual (f : Module.Dual R R) (y : R) : f y = y * f 1 := by
-    rw [← smul_eq_mul, ← map_smul, smul_eq_mul, mul_one]
   -- `toDualProd` sends `(a, b)` to the dual vector `(a + b) * ·` paired with `a - b`.
   have happ (p : R × R) :
       QuadraticForm.toDualProd (QuadraticMap.sq : QuadraticForm R R) p =
@@ -137,7 +135,7 @@ theorem equivalent_hyperbolicPlane_dualProd [Invertible (2 : R)] :
     · refine ⟨((q.1 1 + q.2) * ⅟(2 : R), (q.1 1 - q.2) * ⅟(2 : R)), ?_⟩
       rw [happ]
       refine Prod.ext (LinearMap.ext fun y ↦ ?_) (by linear_combination q.2 * h2)
-      rw [LinearMap.mul_apply_apply, hdual q.1 y]
+      rw [LinearMap.mul_apply_apply, ← Dual.apply_one_mul_eq q.1 y]
       linear_combination (y * q.1 1) * h2
   have hprod : (hyperbolicPlane R).Equivalent
       ((QuadraticMap.sq : QuadraticForm R R).prod (-QuadraticMap.sq)) :=
@@ -154,7 +152,7 @@ variable {K : Type u} [Field K]
 
 /-- Over a field in which two is invertible, every diagonal plane `⟨a, -a⟩` with `a` a unit is
 isometric to the hyperbolic plane. -/
-theorem equivalent_weightedSumSquares_self_neg [Invertible (2 : K)] (a : Kˣ) :
+theorem equivalent_weightedSumSquares_self_neg_hyperbolicPlane [Invertible (2 : K)] (a : Kˣ) :
     (weightedSumSquares K ![(a : K), -(a : K)]).Equivalent (hyperbolicPlane K) := by
   have hdisc : IsSquare (a * (-a) * ((1 : Kˣ) * (-1))) := by
     refine ⟨a, ?_⟩
@@ -233,8 +231,9 @@ theorem exists_hyperbolicPlane_prod_equivalent [FiniteDimensional K V] [Invertib
     exact hr.symm
   let B := QuadraticMap.associated Q
   have hBW : (LinearMap.BilinForm.restrict B W).Nondegenerate := by
-    rw [← QuadraticMap.associated_restrict]
-    exact QuadraticMap.nondegenerate_associated_iff.mpr hWQ
+    have h : (QuadraticMap.associated (Q.comp W.subtype)).Nondegenerate :=
+      QuadraticMap.nondegenerate_associated_iff.mpr hWQ
+    rwa [QuadraticMap.associated_comp] at h
   have hcomp : IsCompl W (LinearMap.BilinForm.orthogonal B W) :=
     LinearMap.BilinForm.isCompl_orthogonal_of_restrict_nondegenerate
       (LinearMap.BilinForm.isSymm_iff.mpr (QuadraticForm.associated_isSymm K Q)).isRefl hBW
@@ -247,9 +246,11 @@ theorem exists_hyperbolicPlane_prod_equivalent [FiniteDimensional K V] [Invertib
       rw [LinearMap.BilinForm.restrict_nondegenerate_iff_isCompl_orthogonal hBsymm,
         LinearMap.BilinForm.orthogonal_orthogonal hB hBsymm]
       exact hcomp.symm
-    rw [← QuadraticMap.nondegenerate_associated_iff]
-    rw [QuadraticMap.associated_restrict]
-    exact hBorth
+    have h : (QuadraticMap.associated
+        (Q.comp (LinearMap.BilinForm.orthogonal B W).subtype)).Nondegenerate := by
+      rw [QuadraticMap.associated_comp]
+      exact hBorth
+    exact QuadraticMap.nondegenerate_associated_iff.mp h
   have hBpolar : LinearMap.BilinForm.orthogonal B W =
       LinearMap.BilinForm.orthogonal Q.polarBilin W := by
     ext v

--- a/TauCeti/LinearAlgebra/QuadraticForm/Hyperbolic.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/Hyperbolic.lean
@@ -11,13 +11,14 @@ public import TauCeti.LinearAlgebra.QuadraticForm.RegularFormClass.Basic
 /-!
 # The hyperbolic plane
 
-The hyperbolic plane over a field of characteristic different from two is the diagonal quadratic
-form `⟨1, -1⟩`. It represents every scalar. More generally, every plane `⟨a, -a⟩` with
-`a ≠ 0` is isometric to it.
+The hyperbolic plane over a commutative ring is the diagonal quadratic form `⟨1, -1⟩`. When
+two is invertible, it is nondegenerate and represents every scalar. Over a field, every plane
+`⟨a, -a⟩` with `a ≠ 0` is isometric to it.
 
-The main result is the hyperbolic splitting theorem: every nondegenerate isotropic quadratic form
-splits as the orthogonal sum of a hyperbolic plane and another nondegenerate form. The proof uses
-an isotropic pair whose polar pairing is one, then takes its orthogonal complement.
+The main result is the hyperbolic splitting theorem: every finite-dimensional nondegenerate
+isotropic quadratic form splits as the orthogonal sum of a hyperbolic plane and another
+nondegenerate form. The proof uses an isotropic pair whose polar pairing is one, then takes its
+orthogonal complement.
 
 ## Main definitions
 
@@ -25,11 +26,11 @@ an isotropic pair whose polar pairing is one, then takes its orthogonal compleme
 
 ## Main results
 
-* `TauCeti.hyperbolicPlane_represents`: the hyperbolic plane represents every scalar.
+* `TauCeti.represents_hyperbolicPlane`: the hyperbolic plane represents every scalar.
 * `TauCeti.equivalent_weightedSumSquares_self_neg`: every `⟨a, -a⟩`, for `a ≠ 0`, is
   hyperbolic.
-* `TauCeti.exists_hyperbolicPlane_prod_equivalent`: every nondegenerate isotropic form splits off
-  a hyperbolic plane.
+* `TauCeti.exists_hyperbolicPlane_prod_equivalent`: every finite-dimensional nondegenerate
+  isotropic form splits off a hyperbolic plane.
 
 ## References
 
@@ -59,31 +60,44 @@ theorem hyperbolicPlane_apply (x : Fin 2 → R) :
   simp [hyperbolicPlane, weightedSumSquares_apply, Fin.sum_univ_two, pow_two]
   ring
 
+/-- The hyperbolic plane is nondegenerate when two is invertible. -/
+theorem nondegenerate_hyperbolicPlane [Invertible (2 : R)] :
+    (hyperbolicPlane R).Nondegenerate := by
+  rw [QuadraticMap.nondegenerate_iff_radical_eq_bot, Submodule.eq_bot_iff]
+  intro x hx
+  rw [QuadraticMap.mem_radical_iff'] at hx
+  have hxQ := hx.1
+  rw [hyperbolicPlane_apply] at hxQ
+  funext i
+  fin_cases i
+  · change x 0 = 0
+    have h := hx.2 ![1, 0]
+    simp only [hyperbolicPlane_apply, Matrix.cons_val_zero, Matrix.cons_val_one,
+      Pi.add_apply] at h
+    apply (isUnit_of_invertible (2 : R)).mul_right_eq_zero.mp
+    linear_combination h - hxQ
+  · change x 1 = 0
+    have h := hx.2 ![0, 1]
+    simp only [hyperbolicPlane_apply, Matrix.cons_val_zero, Matrix.cons_val_one,
+      Pi.add_apply] at h
+    apply (isUnit_of_invertible (2 : R)).mul_right_eq_zero.mp
+    linear_combination hxQ - h
+
+/-- The hyperbolic plane represents every scalar. -/
+theorem represents_hyperbolicPlane [Invertible (2 : R)] (a : R) :
+    (hyperbolicPlane R).Represents a := by
+  rw [represents_iff, Set.mem_range]
+  refine ⟨![(a + 1) * ⅟(2 : R), (a - 1) * ⅟(2 : R)], ?_⟩
+  rw [hyperbolicPlane_apply]
+  simp only [Matrix.cons_val_zero, Matrix.cons_val_one]
+  calc
+    ((a + 1) * ⅟(2 : R)) ^ 2 - ((a - 1) * ⅟(2 : R)) ^ 2 =
+        a * ((2 : R) * ⅟(2 : R)) ^ 2 := by ring
+    _ = a := by rw [mul_invOf_self, one_pow, mul_one]
+
 end CommRing
 
 variable {K : Type u} [Field K]
-
-/-- The hyperbolic plane is nondegenerate when two is invertible. -/
-theorem hyperbolicPlane_nondegenerate [Invertible (2 : K)] :
-    (hyperbolicPlane K).Nondegenerate := by
-  let p : RegularFormPresentation K := ⟨2, ![(1 : Kˣ), (-1 : Kˣ)]⟩
-  have hp : presentedForm p = hyperbolicPlane K := by
-    ext x
-    rw [presentedForm_eq_weightedSumSquares]
-    simp [hyperbolicPlane, weightedSumSquares_apply, Fin.sum_univ_two, p, Units.smul_def]
-  rw [← hp]
-  exact nondegenerate_presentedForm p
-
-/-- The hyperbolic plane represents every scalar. -/
-theorem hyperbolicPlane_represents [Invertible (2 : K)] (a : K) :
-    (hyperbolicPlane K).Represents a := by
-  rw [represents_iff, Set.mem_range]
-  refine ⟨![(a + 1) / 2, (a - 1) / 2], ?_⟩
-  rw [hyperbolicPlane_apply]
-  simp only [Matrix.cons_val_zero, Matrix.cons_val_one]
-  have htwo : (2 : K) ≠ 0 := (isUnit_of_invertible (2 : K)).ne_zero
-  field_simp [htwo]
-  ring
 
 /-- Every diagonal plane `⟨a, -a⟩` with `a` a unit is isometric to the hyperbolic plane. -/
 theorem equivalent_weightedSumSquares_self_neg [Invertible (2 : K)] (a : Kˣ) :
@@ -96,7 +110,7 @@ theorem equivalent_weightedSumSquares_self_neg [Invertible (2 : K)] (a : Kˣ) :
     mem_unitValueSet_binary_left a (-(a : K))
   have htarget : a ∈ unitValueSet (hyperbolicPlane K) := by
     rw [mem_unitValueSet]
-    exact hyperbolicPlane_represents (a : K)
+    exact represents_hyperbolicPlane (a : K)
   exact equivalent_binary_of_isSquare_of_mem_unitValueSet
     (a := a) (b := -a) (c := 1) (d := -1) (e := a) hdisc hsource htarget
 
@@ -122,9 +136,8 @@ theorem _root_.QuadraticMap.Nondegenerate.exists_isotropic_pair
   have hzQ : Q z = 0 := by
     have hw' : polar Q w x ≠ 0 := by simpa only [polar_comm] using hw
     dsimp [z]
-    rw [sub_eq_add_neg, ← neg_smul, QuadraticMap.map_add Q, Q.map_smul, hxQ,
-      polar_smul_right, polar_comm]
-    simp only [smul_eq_mul]
+    simp only [sub_eq_add_neg, ← neg_smul, QuadraticMap.map_add, Q.map_smul, hxQ,
+      polar_smul_right, polar_comm, smul_eq_mul, mul_zero, add_zero]
     field_simp [hw']
     ring
   have hxz : polar Q x z = polar Q x w := by
@@ -175,13 +188,13 @@ private noncomputable def hyperbolicPairIsometryEquiv [Invertible (2 : K)]
   map_app' v := by
     -- Expose the range equivalence so the quadratic-form calculation sees its underlying map.
     change Q ((v 0 + v 1) • x + (v 0 - v 1) • y) = hyperbolicPlane K v
-    rw [hyperbolicPlane_apply, QuadraticMap.map_add Q, Q.map_smul, Q.map_smul, hxQ, hyQ,
-      polar_smul_left, polar_smul_right, hxy]
-    simp only [smul_eq_mul, mul_one]
+    rw [QuadraticMap.map_add Q]
+    simp only [hyperbolicPlane_apply, Q.map_smul, hxQ, hyQ, polar_smul_left,
+      polar_smul_right, hxy, smul_eq_mul, mul_zero, add_zero, mul_one]
     ring
 
-/-- Every nondegenerate isotropic quadratic form splits as the orthogonal sum of a hyperbolic
-plane and a nondegenerate diagonal form. -/
+/-- Every finite-dimensional nondegenerate isotropic quadratic form splits as the orthogonal sum
+of a hyperbolic plane and a nondegenerate diagonal form. -/
 theorem exists_hyperbolicPlane_prod_equivalent [FiniteDimensional K V] [Invertible (2 : K)]
     (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) (hiso : ¬Q.Anisotropic) :
     ∃ p : RegularFormPresentation K,
@@ -192,15 +205,11 @@ theorem exists_hyperbolicPlane_prod_equivalent [FiniteDimensional K V] [Invertib
   have hWQ : (Q.restrict W).Nondegenerate := by
     rw [QuadraticMap.nondegenerate_iff_radical_eq_bot]
     have hr := eH.map_radical
-    rw [hyperbolicPlane_nondegenerate.radical_eq_bot, Submodule.map_bot] at hr
+    rw [nondegenerate_hyperbolicPlane.radical_eq_bot, Submodule.map_bot] at hr
     exact hr.symm
   let B := QuadraticMap.associated Q
-  have associated_restrict (S : Submodule K V) :
-      QuadraticMap.associated (Q.restrict S) = LinearMap.BilinForm.restrict B S := by
-    ext a b
-    rfl
   have hBW : (LinearMap.BilinForm.restrict B W).Nondegenerate := by
-    rw [← associated_restrict]
+    rw [← QuadraticMap.associated_restrict]
     exact QuadraticMap.nondegenerate_associated_iff.mpr hWQ
   have hcomp : IsCompl W (LinearMap.BilinForm.orthogonal B W) :=
     LinearMap.BilinForm.isCompl_orthogonal_of_restrict_nondegenerate
@@ -215,7 +224,7 @@ theorem exists_hyperbolicPlane_prod_equivalent [FiniteDimensional K V] [Invertib
         LinearMap.BilinForm.orthogonal_orthogonal hB hBsymm]
       exact hcomp.symm
     rw [← QuadraticMap.nondegenerate_associated_iff]
-    rw [associated_restrict]
+    rw [QuadraticMap.associated_restrict]
     exact hBorth
   obtain ⟨p, hp⟩ := exists_presentedForm_equivalent
     (Q.restrict (LinearMap.BilinForm.orthogonal B W)) horth

--- a/TauCeti/LinearAlgebra/QuadraticForm/Hyperbolic.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/Hyperbolic.lean
@@ -5,21 +5,25 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import Mathlib.LinearAlgebra.QuadraticForm.Dual
 public import TauCeti.LinearAlgebra.QuadraticForm.Binary
 public import TauCeti.LinearAlgebra.QuadraticForm.RegularFormClass.Basic
 
 /-!
 # The hyperbolic plane
 
-The hyperbolic plane over a commutative ring is the diagonal quadratic form `⟨1, -1⟩`. When
-two is invertible, it is nondegenerate and represents every scalar. Over a field in which two is
-invertible (that is, of characteristic not two), every plane `⟨a, -a⟩` with `a ≠ 0` is isometric
-to it.
+The hyperbolic plane over a commutative ring is the diagonal quadratic form `⟨1, -1⟩`. When two
+is invertible, it is nondegenerate, represents every scalar, and is isometric to the `xy`-form
+`QuadraticForm.dualProd`. Over a field in which two is invertible (that is, of characteristic not
+two), every plane `⟨a, -a⟩` with `a ≠ 0` is isometric to it.
 
 The main result is the hyperbolic splitting theorem: over a field of characteristic not two, every
 finite-dimensional nondegenerate isotropic quadratic form splits as the orthogonal sum of a
 hyperbolic plane and another nondegenerate form. It is the inductive step of Witt decomposition:
-iterating it splits off hyperbolic planes until the remaining part is anisotropic.
+iterating it splits off hyperbolic planes until the remaining part is anisotropic. The companion
+statement that such a form is universal is
+`QuadraticMap.represents_of_nondegenerate_of_not_anisotropic`, which needs no finiteness
+hypothesis and is proved directly in `TauCeti/LinearAlgebra/QuadraticForm/Representation.lean`.
 
 ## Main definitions
 
@@ -29,6 +33,8 @@ iterating it splits off hyperbolic planes until the remaining part is anisotropi
 
 * `TauCeti.represents_hyperbolicPlane`: when two is invertible, the hyperbolic plane represents
   every scalar.
+* `TauCeti.equivalent_hyperbolicPlane_dualProd`: when two is invertible, the hyperbolic plane is
+  isometric to the `xy`-form `QuadraticForm.dualProd`.
 * `TauCeti.equivalent_weightedSumSquares_self_neg`: in characteristic not two, every
   `⟨a, -a⟩`, for `a ≠ 0`, is hyperbolic.
 * `TauCeti.exists_hyperbolicPlane_prod_equivalent`: in characteristic not two, every
@@ -96,6 +102,42 @@ theorem represents_hyperbolicPlane [Invertible (2 : R)] (a : R) :
     ((a + 1) * ⅟(2 : R)) ^ 2 - ((a - 1) * ⅟(2 : R)) ^ 2 =
         a * ((2 : R) * ⅟(2 : R)) ^ 2 := by ring
     _ = a := by rw [mul_invOf_self, one_pow, mul_one]
+
+/-- When two is invertible, the hyperbolic plane is isometric to the `xy`-form
+`QuadraticForm.dualProd R R`, whose value at `(f, z)` is `f z`. -/
+theorem equivalent_hyperbolicPlane_dualProd [Invertible (2 : R)] :
+    (hyperbolicPlane R).Equivalent (QuadraticForm.dualProd R R) := by
+  have key : ∀ f : Module.Dual R R, f 1 • (LinearMap.id : R →ₗ[R] R) = f := fun f ↦ by
+    ext
+    simp
+  have h2 : (2 : R) * ⅟(2 : R) = 1 := mul_invOf_self 2
+  let e : (R × R) ≃ₗ[R] Module.Dual R R × R :=
+    { toFun := fun p ↦ ((p.1 + p.2) • (LinearMap.id : R →ₗ[R] R), p.1 - p.2)
+      invFun := fun q ↦ ((q.1 1 + q.2) * ⅟(2 : R), (q.1 1 - q.2) * ⅟(2 : R))
+      map_add' := fun p q ↦ Prod.ext
+        (by simp only [Prod.fst_add, Prod.snd_add, ← add_smul]; congr 1; ring)
+        (by simp only [Prod.fst_add, Prod.snd_add]; ring)
+      map_smul' := fun a p ↦ Prod.ext
+        (by simp only [Prod.smul_fst, Prod.smul_snd, smul_eq_mul, RingHom.id_apply, ← mul_smul]
+            congr 1
+            ring)
+        (by simp only [Prod.smul_fst, Prod.smul_snd, smul_eq_mul, RingHom.id_apply]; ring)
+      left_inv := fun p ↦ by
+        dsimp only
+        refine Prod.ext ?_ ?_ <;>
+          simp only [LinearMap.smul_apply, LinearMap.id_coe, id_eq, smul_eq_mul, mul_one]
+        · linear_combination p.1 * h2
+        · linear_combination p.2 * h2
+      right_inv := fun q ↦ by
+        dsimp only
+        refine Prod.ext ?_ ?_
+        · rw [show (q.1 1 + q.2) * ⅟(2 : R) + (q.1 1 - q.2) * ⅟(2 : R) = q.1 1 from by
+            linear_combination q.1 1 * h2]
+          exact key q.1
+        · linear_combination q.2 * h2 }
+  refine ⟨⟨(LinearEquiv.finTwoArrow R R).trans e, fun x ↦ ?_⟩⟩
+  simp [e]
+  ring
 
 end CommRing
 

--- a/TauCeti/LinearAlgebra/QuadraticForm/Prod.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/Prod.lean
@@ -6,6 +6,8 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.LinearAlgebra.QuadraticForm.Prod
+public import Mathlib.LinearAlgebra.BilinearForm.Orthogonal
+public import Mathlib.LinearAlgebra.Projection
 public import TauCeti.LinearAlgebra.QuadraticForm.OrthogonalGroup
 
 /-!
@@ -17,6 +19,9 @@ file adds the two remaining structural ones: the associator, and the deletion of
 module is trivial. Together with `QuadraticMap.IsometryEquiv.prodComm` they are what makes
 orthogonal sum a commutative monoid operation on isometry classes of quadratic forms.
 
+For a quadratic form over a field of characteristic different from two, it also records the
+isometry associated to an orthogonal direct-sum decomposition of the underlying space.
+
 It also combines special orthogonal transformations of two finite free quadratic maps with a
 common codomain into a special orthogonal transformation of their product.
 
@@ -24,6 +29,8 @@ common codomain into a special orthogonal transformation of their product.
 
 * `QuadraticMap.IsometryEquiv.prodAssoc`: `LinearEquiv.prodAssoc` is isometric.
 * `QuadraticMap.IsometryEquiv.uniqueProd`: `LinearEquiv.uniqueProd` is isometric.
+* `QuadraticMap.IsometryEquiv.prodRestrictOrthogonal`: an orthogonal direct sum is isometric to
+  the original form.
 * `QuadraticMap.specialOrthogonalGroupProd`: combine two special orthogonal transformations.
 -/
 
@@ -83,6 +90,39 @@ theorem IsometryEquiv.uniqueProd_symm_apply [Unique M₁] (Q₁ : QuadraticMap R
   -- Expose the underlying linear equivalence so its public inverse application lemma applies.
   change (LinearEquiv.uniqueProd (R := R) (M := M₂) (M₂ := M₁)).symm m = _
   exact LinearEquiv.uniqueProd_symm_apply m
+
+section OrthogonalDecomposition
+
+variable {K V : Type*} [Field K] [AddCommGroup V] [Module K V] [Invertible (2 : K)]
+
+/-- An orthogonal direct-sum decomposition of a quadratic space gives an isometry from the
+product of the two restricted forms to the original form. -/
+noncomputable def IsometryEquiv.prodRestrictOrthogonal (Q : QuadraticForm K V)
+    (W : Submodule K V)
+    (hW : IsCompl W (LinearMap.BilinForm.orthogonal (QuadraticMap.associated Q) W)) :
+    ((Q.restrict W).prod
+      (Q.restrict (LinearMap.BilinForm.orthogonal (QuadraticMap.associated Q) W))).IsometryEquiv Q
+    where
+  toLinearEquiv := W.prodEquivOfIsCompl
+    (LinearMap.BilinForm.orthogonal (QuadraticMap.associated Q) W) hW
+  map_app' x := by
+    -- Expose the complementary-subspace equivalence as addition of the two components.
+    change Q ((x.1 : V) + x.2) = Q x.1 + Q x.2
+    rw [QuadraticMap.map_add Q]
+    have horth : Q.IsOrtho (x.1 : V) (x.2 : V) := by
+      exact QuadraticMap.associated_isOrtho.mp (x.2.2 x.1 x.1.2)
+    rw [horth.polar_eq_zero, add_zero]
+
+/-- The orthogonal-decomposition isometry sends a pair to the sum of its components. -/
+@[simp]
+theorem IsometryEquiv.prodRestrictOrthogonal_apply (Q : QuadraticForm K V)
+    (W : Submodule K V)
+    (hW : IsCompl W (LinearMap.BilinForm.orthogonal (QuadraticMap.associated Q) W))
+    (x : W × LinearMap.BilinForm.orthogonal (QuadraticMap.associated Q) W) :
+    IsometryEquiv.prodRestrictOrthogonal Q W hW x = (x.1 : V) + x.2 := by
+  exact Submodule.coe_prodEquivOfIsCompl' W _ hW x
+
+end OrthogonalDecomposition
 
 end QuadraticMap
 

--- a/TauCeti/LinearAlgebra/QuadraticForm/Prod.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/Prod.lean
@@ -19,8 +19,8 @@ file adds the two remaining structural ones: the associator, and the deletion of
 module is trivial. Together with `QuadraticMap.IsometryEquiv.prodComm` they are what makes
 orthogonal sum a commutative monoid operation on isometry classes of quadratic forms.
 
-For a quadratic form over a field of characteristic different from two, it also records the
-isometry associated to an orthogonal direct-sum decomposition of the underlying space.
+For a quadratic form over a commutative ring in which two is invertible, it also records the
+isometry associated to an orthogonal direct-sum decomposition of the underlying module.
 
 It also combines special orthogonal transformations of two finite free quadratic maps with a
 common codomain into a special orthogonal transformation of their product.
@@ -93,12 +93,12 @@ theorem IsometryEquiv.uniqueProd_symm_apply [Unique M₁] (Q₁ : QuadraticMap R
 
 section OrthogonalDecomposition
 
-variable {K V : Type*} [Field K] [AddCommGroup V] [Module K V] [Invertible (2 : K)]
+variable {R V : Type*} [CommRing R] [AddCommGroup V] [Module R V] [Invertible (2 : R)]
 
 /-- An orthogonal direct-sum decomposition of a quadratic space gives an isometry from the
 product of the two restricted forms to the original form. -/
-noncomputable def IsometryEquiv.prodRestrictOrthogonal (Q : QuadraticForm K V)
-    (W : Submodule K V)
+noncomputable def IsometryEquiv.prodRestrictOrthogonal (Q : QuadraticForm R V)
+    (W : Submodule R V)
     (hW : IsCompl W (LinearMap.BilinForm.orthogonal (QuadraticMap.associated Q) W)) :
     ((Q.restrict W).prod
       (Q.restrict (LinearMap.BilinForm.orthogonal (QuadraticMap.associated Q) W))).IsometryEquiv Q
@@ -115,8 +115,8 @@ noncomputable def IsometryEquiv.prodRestrictOrthogonal (Q : QuadraticForm K V)
 
 /-- The orthogonal-decomposition isometry sends a pair to the sum of its components. -/
 @[simp]
-theorem IsometryEquiv.prodRestrictOrthogonal_apply (Q : QuadraticForm K V)
-    (W : Submodule K V)
+theorem IsometryEquiv.prodRestrictOrthogonal_apply (Q : QuadraticForm R V)
+    (W : Submodule R V)
     (hW : IsCompl W (LinearMap.BilinForm.orthogonal (QuadraticMap.associated Q) W))
     (x : W × LinearMap.BilinForm.orthogonal (QuadraticMap.associated Q) W) :
     IsometryEquiv.prodRestrictOrthogonal Q W hW x = (x.1 : V) + x.2 := by

--- a/TauCeti/LinearAlgebra/QuadraticForm/Prod.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/Prod.lean
@@ -19,8 +19,8 @@ file adds the two remaining structural ones: the associator, and the deletion of
 module is trivial. Together with `QuadraticMap.IsometryEquiv.prodComm` they are what makes
 orthogonal sum a commutative monoid operation on isometry classes of quadratic forms.
 
-For a quadratic form over a commutative ring in which two is invertible, it also records the
-isometry associated to an orthogonal direct-sum decomposition of the underlying module.
+For a quadratic form over a commutative ring, it also records the isometry associated to a
+direct-sum decomposition of the underlying module that is orthogonal for the polar form.
 
 It also combines special orthogonal transformations of two finite free quadratic maps with a
 common codomain into a special orthogonal transformation of their product.
@@ -93,34 +93,39 @@ theorem IsometryEquiv.uniqueProd_symm_apply [Unique M₁] (Q₁ : QuadraticMap R
 
 section OrthogonalDecomposition
 
-variable {R V : Type*} [CommRing R] [AddCommGroup V] [Module R V] [Invertible (2 : R)]
+variable {R V : Type*} [CommRing R] [AddCommGroup V] [Module R V]
 
-/-- An orthogonal direct-sum decomposition of a quadratic space gives an isometry from the
-product of the two restricted forms to the original form. -/
+/-- An orthogonal direct-sum decomposition of a quadratic space, orthogonal for the polar form,
+gives an isometry from the product of the two restricted forms to the original form. -/
 noncomputable def IsometryEquiv.prodRestrictOrthogonal (Q : QuadraticForm R V)
-    (W : Submodule R V)
-    (hW : IsCompl W (LinearMap.BilinForm.orthogonal (QuadraticMap.associated Q) W)) :
+    (W : Submodule R V) (hW : IsCompl W (LinearMap.BilinForm.orthogonal Q.polarBilin W)) :
     ((Q.restrict W).prod
-      (Q.restrict (LinearMap.BilinForm.orthogonal (QuadraticMap.associated Q) W))).IsometryEquiv Q
-    where
-  toLinearEquiv := W.prodEquivOfIsCompl
-    (LinearMap.BilinForm.orthogonal (QuadraticMap.associated Q) W) hW
+      (Q.restrict (LinearMap.BilinForm.orthogonal Q.polarBilin W))).IsometryEquiv Q where
+  toLinearEquiv := W.prodEquivOfIsCompl (LinearMap.BilinForm.orthogonal Q.polarBilin W) hW
   map_app' x := by
     -- Expose the complementary-subspace equivalence as addition of the two components.
     change Q ((x.1 : V) + x.2) = Q x.1 + Q x.2
-    rw [QuadraticMap.map_add Q]
-    have horth : Q.IsOrtho (x.1 : V) (x.2 : V) := by
-      exact QuadraticMap.associated_isOrtho.mp (x.2.2 x.1 x.1.2)
-    rw [horth.polar_eq_zero, add_zero]
+    rw [QuadraticMap.map_add Q, (isOrtho_polarBilin.mp (x.2.2 x.1 x.1.2)).polar_eq_zero,
+      add_zero]
 
 /-- The orthogonal-decomposition isometry sends a pair to the sum of its components. -/
 @[simp]
 theorem IsometryEquiv.prodRestrictOrthogonal_apply (Q : QuadraticForm R V)
-    (W : Submodule R V)
-    (hW : IsCompl W (LinearMap.BilinForm.orthogonal (QuadraticMap.associated Q) W))
-    (x : W × LinearMap.BilinForm.orthogonal (QuadraticMap.associated Q) W) :
-    IsometryEquiv.prodRestrictOrthogonal Q W hW x = (x.1 : V) + x.2 := by
-  exact Submodule.coe_prodEquivOfIsCompl' W _ hW x
+    (W : Submodule R V) (hW : IsCompl W (LinearMap.BilinForm.orthogonal Q.polarBilin W))
+    (x : W × LinearMap.BilinForm.orthogonal Q.polarBilin W) :
+    IsometryEquiv.prodRestrictOrthogonal Q W hW x = (x.1 : V) + x.2 :=
+  Submodule.coe_prodEquivOfIsCompl' W _ hW x
+
+/-- The inverse of the orthogonal-decomposition isometry sends a vector to its two projections
+along the decomposition. -/
+@[simp]
+theorem IsometryEquiv.prodRestrictOrthogonal_symm_apply (Q : QuadraticForm R V)
+    (W : Submodule R V) (hW : IsCompl W (LinearMap.BilinForm.orthogonal Q.polarBilin W))
+    (v : V) :
+    (IsometryEquiv.prodRestrictOrthogonal Q W hW).symm v =
+      (W.projectionOnto _ hW v, (LinearMap.BilinForm.orthogonal Q.polarBilin W).projectionOnto W
+        hW.symm v) :=
+  Submodule.prodEquivOfIsCompl_symm_apply hW v
 
 end OrthogonalDecomposition
 

--- a/TauCeti/LinearAlgebra/QuadraticForm/Radical.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/Radical.lean
@@ -23,6 +23,8 @@ its polar form is `2 • B`, and nondegeneracy passes from `B` to it as soon as 
 
 * `QuadraticMap.radical_neg`: negating a quadratic map does not change its radical.
 * `QuadraticMap.radical_prod`: the radical of an orthogonal product is the product of the radicals.
+* `QuadraticMap.associated_restrict`: the associated bilinear form of a restriction is the
+  restriction of the associated bilinear form.
 * `QuadraticMap.Nondegenerate.prod`: nondegeneracy passes to an orthogonal product.
 * `QuadraticMap.Nondegenerate.ne_zero`: a nondegenerate quadratic form on a nontrivial module is
   nonzero.
@@ -43,6 +45,15 @@ namespace QuadraticMap
 
 variable {R M P : Type*} [CommRing R] [AddCommGroup M] [AddCommGroup P]
   [Module R M] [Module R P]
+
+/-- The associated bilinear form of a restricted quadratic form is the restriction of its
+associated bilinear form. -/
+@[simp]
+theorem associated_restrict [Invertible (2 : R)] (Q : QuadraticForm R M) (S : Submodule R M) :
+    QuadraticMap.associated (Q.restrict S) =
+      LinearMap.BilinForm.restrict (QuadraticMap.associated Q) S := by
+  ext x y
+  rfl
 
 /-- Negating a quadratic map does not change its radical. -/
 @[simp]

--- a/TauCeti/LinearAlgebra/QuadraticForm/Radical.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/Radical.lean
@@ -23,8 +23,6 @@ its polar form is `2 • B`, and nondegeneracy passes from `B` to it as soon as 
 
 * `QuadraticMap.radical_neg`: negating a quadratic map does not change its radical.
 * `QuadraticMap.radical_prod`: the radical of an orthogonal product is the product of the radicals.
-* `QuadraticMap.associated_restrict`: the associated bilinear form of a restriction is the
-  restriction of the associated bilinear form.
 * `QuadraticMap.Nondegenerate.prod`: nondegeneracy passes to an orthogonal product.
 * `QuadraticMap.Nondegenerate.ne_zero`: a nondegenerate quadratic form on a nontrivial module is
   nonzero.
@@ -45,15 +43,6 @@ namespace QuadraticMap
 
 variable {R M P : Type*} [CommRing R] [AddCommGroup M] [AddCommGroup P]
   [Module R M] [Module R P]
-
-/-- The associated bilinear form of a restricted quadratic form is the restriction of its
-associated bilinear form. -/
-@[simp]
-theorem associated_restrict [Invertible (2 : R)] (Q : QuadraticForm R M) (S : Submodule R M) :
-    QuadraticMap.associated (Q.restrict S) =
-      LinearMap.BilinForm.restrict (QuadraticMap.associated Q) S := by
-  ext x y
-  rfl
 
 /-- Negating a quadratic map does not change its radical. -/
 @[simp]

--- a/TauCeti/LinearAlgebra/QuadraticForm/Representation.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/Representation.lean
@@ -16,9 +16,10 @@ This file defines representation of values by a quadratic map and the represente
 It proves the elementary square-class invariance of the latter and the criterion that, for a form
 with trivial radical, representing a unit is equivalent to isotropy after adjoining the
 one-dimensional form with that unit as its negative coefficient. A nondegenerate form has trivial
-radical by Mathlib's `radical_eq_bot` theorem. These results provide the basic bridge from value
-questions to isotropy questions, following Lam, *Introduction to Quadratic Forms over Fields*,
-I.2.3 and I.3.5.
+radical by Mathlib's `radical_eq_bot` theorem. A nondegenerate isotropic form over a field also
+contains an isotropic pair: two isotropic vectors whose polar pairing is one. These results
+provide the basic bridge from value questions to isotropy questions, following Lam,
+*Introduction to Quadratic Forms over Fields*, I.2.3 and I.3.5.
 -/
 
 public section
@@ -147,6 +148,37 @@ theorem _root_.QuadraticMap.represents_of_nondegenerate_of_not_anisotropic
     (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) (hiso : ¬Q.Anisotropic) (a : K) :
     Represents Q a :=
   represents_of_radical_eq_bot_of_not_anisotropic Q hQ.radical_eq_bot hiso a
+
+/-- A nondegenerate isotropic quadratic form contains two isotropic vectors whose polar pairing
+is one. -/
+theorem _root_.QuadraticMap.Nondegenerate.exists_isotropic_pair
+    {Q : QuadraticForm K V} (hQ : Q.Nondegenerate) (hiso : ¬Q.Anisotropic) :
+    ∃ x y : V, x ≠ 0 ∧ Q x = 0 ∧ Q y = 0 ∧ polar Q x y = 1 := by
+  obtain ⟨x, hx, hxQ⟩ := (not_anisotropic_iff_exists Q).mp hiso
+  obtain ⟨w, hw⟩ : ∃ w, polar Q x w ≠ 0 := by
+    by_contra h
+    push Not at h
+    apply hx
+    have hxrad : x ∈ Q.radical := by
+      rw [mem_radical_iff']
+      refine ⟨hxQ, fun z ↦ ?_⟩
+      rw [QuadraticMap.map_add Q, hxQ, h z, zero_add, add_zero]
+    rw [hQ.radical_eq_bot] at hxrad
+    exact hxrad
+  let z := w - (Q w / polar Q x w) • x
+  have hzQ : Q z = 0 := by
+    have hw' : polar Q w x ≠ 0 := by simpa only [polar_comm] using hw
+    dsimp [z]
+    simp only [sub_eq_add_neg, ← neg_smul, QuadraticMap.map_add, Q.map_smul, hxQ,
+      polar_smul_right, polar_comm, smul_eq_mul, mul_zero, add_zero]
+    field_simp [hw']
+    ring
+  have hxz : polar Q x z = polar Q x w := by
+    simp [z, polar_sub_right, polar_smul_right, polar_self, hxQ]
+  let y := (polar Q x w)⁻¹ • z
+  refine ⟨x, y, hx, hxQ, ?_, ?_⟩
+  · simp [y, Q.map_smul, hzQ]
+  · simp [y, polar_smul_right, hxz, hw]
 
 /-- Multiplying a represented scalar by the square of a unit preserves representation. -/
 @[simp] theorem _root_.QuadraticMap.represents_mul_sq_iff (Q : QuadraticMap R M R) (a : R)


### PR DESCRIPTION
This PR defines the hyperbolic plane `⟨1, -1⟩`, proves that it represents every scalar, identifies every regular plane `⟨a, -a⟩` with it, and proves that every finite-dimensional nondegenerate isotropic quadratic form splits as its orthogonal sum with a nondegenerate diagonal form.

It completes the QuadraticFormInvariants Layer 1 milestone “The hyperbolic plane.” The representation criterion and binary normal-form prerequisites are already on `main`, making this the next complete critical-path result and the direct input to Witt decomposition. After this PR, Layer 1 still requires Witt decomposition and uniqueness, followed by cancellation and extension, while Layer 0 independently retains the full Witt-chain equivalence and descent work.

The proof constructs a normalized isotropic pair, identifies its span with the hyperbolic plane, and splits the ambient space using the orthogonal complement. It reuses Mathlib's `Submodule.prodEquivOfIsCompl` and bilinear-form orthogonal-complement API, together with Tau Ceti's binary equivalence criterion and regular-form presentations; no upstream infrastructure is vendored.

Roadmap: QuadraticFormInvariants

<!--tauceti-target:v1 {"focus":"QuadraticFormInvariants","id":"hyperbolic-plane"}-->

🤖 Prepared with Codex
