### PR TITLE
feat: prove conjugacy of profinite Sylow subgroups

### DIFF
--- a/TauCeti/Algebra/Group/Subgroup/Map.lean
+++ b/TauCeti/Algebra/Group/Subgroup/Map.lean
@@ -39,6 +39,9 @@ uses it rather than repeating the composition of `MulEquiv.subgroupMap` with
   centreless group.
 * `TauCeti.Subgroup.map_commutator_eq_commutator`: a surjective homomorphism carries the derived
   subgroup onto the derived subgroup.
+* `Subgroup.map_conj_map`: the image of a conjugate subgroup is the conjugate of the image.
+* `Subgroup.map_mk'_map_quotientGroupMap`: taking images in quotients commutes with the maps
+  induced on quotients.
 -/
 
 public section
@@ -160,5 +163,25 @@ theorem commutatorCongr_trans (e : G ≃* H) (f : H ≃* K) :
 theorem commutatorCongr_symm (e : G ≃* H) :
     (commutatorCongr e).symm = commutatorCongr e.symm :=
   Subgroup.congrOfMapEq_symm e _
+
+/-- The image of a conjugate subgroup `gRg⁻¹` under a homomorphism `f` is the conjugate of `f(R)`
+by `f g`. -/
+theorem _root_.Subgroup.map_conj_map (R : Subgroup G) (f : G →* H) (g : G) :
+    (R.map (MulAut.conj g).toMonoidHom).map f = (R.map f).map (MulAut.conj (f g)).toMonoidHom := by
+  have hf : f.comp (MulAut.conj g).toMonoidHom = (MulAut.conj (f g)).toMonoidHom.comp f :=
+    MonoidHom.ext fun x ↦ by simp
+  rw [Subgroup.map_map, Subgroup.map_map, hf]
+
+/-- The image of a subgroup in `G ⧸ N`, pushed forward along the map `G ⧸ N →* H ⧸ M` induced by
+`f`, is the image in `H ⧸ M` of the image of the subgroup under `f`. -/
+@[simp]
+theorem _root_.Subgroup.map_mk'_map_quotientGroupMap (R : Subgroup G) {N : Subgroup G}
+    {M : Subgroup H} [N.Normal] [M.Normal] (f : G →* H) (h : N ≤ M.comap f) :
+    (R.map (QuotientGroup.mk' N)).map (QuotientGroup.map N M f h) =
+      (R.map f).map (QuotientGroup.mk' M) := by
+  have hf : (QuotientGroup.map N M f h).comp (QuotientGroup.mk' N) =
+      (QuotientGroup.mk' M).comp f :=
+    MonoidHom.ext fun x ↦ QuotientGroup.map_mk' N M f h x
+  rw [Subgroup.map_map, Subgroup.map_map, hf]
 
 end TauCeti

--- a/TauCeti/Topology/Algebra/Group/Profinite/ProP/Basic.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/ProP/Basic.lean
@@ -30,6 +30,8 @@ separate topological fact is supplied by `QuotientGroup.instTotallyDisconnectedS
 * `isProP_iff_isPGroup`: for a discrete topology, pro-`p` agrees with `IsPGroup`.
 * `IsProP.of_surjective`: a continuous surjective image of a pro-`p` group is pro-`p`.
 * `IsProP.quotient`: a quotient of a pro-`p` group by a normal subgroup is pro-`p`.
+* `IsProP.isPGroup_map_mk'`: the image of a pro-`p` subgroup in the quotient by an open normal
+  subgroup is a `p`-group.
 * `isProP_congr`: the predicate is invariant under topological group isomorphism.
 
 ## References
@@ -112,6 +114,19 @@ theorem quotient (hG : IsProP p G) (N : Subgroup G) [N.Normal] : IsProP p (G ⧸
 /-- A topological group isomorphism carries the pro-`p` property to its target. -/
 theorem of_equiv (hG : IsProP p G) (e : G ≃ₜ* H) : IsProP p H :=
   hG.of_surjective e.toMulEquiv.toMonoidHom e.continuous e.surjective
+
+/-- The image of a pro-`p` subgroup in the quotient by an open normal subgroup is a
+`p`-group. -/
+theorem isPGroup_map_mk' [IsTopologicalGroup G] {P : Subgroup G} (hP : IsProP p P)
+    (U : OpenNormalSubgroup G) : IsPGroup p (P.map (QuotientGroup.mk' U.toSubgroup)) := by
+  let f : P →* G ⧸ U.toSubgroup :=
+    (QuotientGroup.mk' U.toSubgroup).domRestrict P
+  have hf : Continuous f := QuotientGroup.continuous_mk.comp continuous_subtype_val
+  have hrange : IsProP p f.range :=
+    hP.of_surjective f.rangeRestrict
+      (continuous_induced_rng.mpr hf) f.rangeRestrict_surjective
+  rw [← MonoidHom.domRestrict_range]
+  exact isProP_iff_isPGroup.mp hrange
 
 end IsProP
 

--- a/TauCeti/Topology/Algebra/Group/Profinite/ProP/Basic.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/ProP/Basic.lean
@@ -30,6 +30,8 @@ separate topological fact is supplied by `QuotientGroup.instTotallyDisconnectedS
 * `isProP_iff_isPGroup`: for a discrete topology, pro-`p` agrees with `IsPGroup`.
 * `IsProP.of_surjective`: a continuous surjective image of a pro-`p` group is pro-`p`.
 * `IsProP.quotient`: a quotient of a pro-`p` group by a normal subgroup is pro-`p`.
+* `IsProP.isPGroup_range`: a continuous homomorphism from a pro-`p` group to a discrete group
+  has a `p`-group as its range.
 * `IsProP.isPGroup_map_mk'`: the image of a pro-`p` subgroup in the quotient by an open normal
   subgroup is a `p`-group.
 * `isProP_congr`: the predicate is invariant under topological group isomorphism.
@@ -115,18 +117,19 @@ theorem quotient (hG : IsProP p G) (N : Subgroup G) [N.Normal] : IsProP p (G ⧸
 theorem of_equiv (hG : IsProP p G) (e : G ≃ₜ* H) : IsProP p H :=
   hG.of_surjective e.toMulEquiv.toMonoidHom e.continuous e.surjective
 
+/-- The range of a continuous homomorphism from a pro-`p` group to a discrete group is a
+`p`-group. -/
+theorem isPGroup_range [DiscreteTopology H] (hG : IsProP p G) (f : G →* H)
+    (hf : Continuous f) : IsPGroup p f.range :=
+  isProP_iff_isPGroup.mp <| hG.of_surjective (H := f.range) f.rangeRestrict
+    (continuous_induced_rng.mpr hf) f.rangeRestrict_surjective
+
 /-- The image of a pro-`p` subgroup in the quotient by an open normal subgroup is a
 `p`-group. -/
 theorem isPGroup_map_mk' [IsTopologicalGroup G] {P : Subgroup G} (hP : IsProP p P)
     (U : OpenNormalSubgroup G) : IsPGroup p (P.map (QuotientGroup.mk' U.toSubgroup)) := by
-  let f : P →* G ⧸ U.toSubgroup :=
-    (QuotientGroup.mk' U.toSubgroup).domRestrict P
-  have hf : Continuous f := QuotientGroup.continuous_mk.comp continuous_subtype_val
-  have hrange : IsProP p f.range :=
-    hP.of_surjective f.rangeRestrict
-      (continuous_induced_rng.mpr hf) f.rangeRestrict_surjective
   rw [← MonoidHom.domRestrict_range]
-  exact isProP_iff_isPGroup.mp hrange
+  exact hP.isPGroup_range _ (QuotientGroup.continuous_mk.comp continuous_subtype_val)
 
 end IsProP
 

--- a/TauCeti/Topology/Algebra/Group/Profinite/Sylow/Basic.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Sylow/Basic.lean
@@ -26,6 +26,8 @@ a separate compatible inverse-limit argument.
 ## Main definitions and results
 
 * `IsProPSylow`: the predicate for a Sylow pro-`p` subgroup.
+* `IsProPSylow.isPGroup_map_mk'`: its image in every finite continuous quotient is a
+  `p`-group.
 * `isProPSylow_iff_isClosed_and_isProP_and_not_dvd_profiniteIndex`: its
   supernatural-index formulation.
 * `isProPSylow_iff_isPGroup_and_not_dvd_index`: its specialization to a discrete group.
@@ -80,6 +82,24 @@ index prime to `p`. -/
 theorem not_dvd_index (hP : IsProPSylow p P) (U : OpenNormalSubgroup G) :
     ¬ p ∣ (P.map (QuotientGroup.mk' U.toSubgroup)).index :=
   (isProPSylow_iff.mp hP).2.2 U
+
+section
+
+variable [IsTopologicalGroup G]
+
+/-- The image of a Sylow pro-`p` subgroup in a finite continuous quotient is a `p`-group. -/
+theorem isPGroup_map_mk' (hP : IsProPSylow p P) (U : OpenNormalSubgroup G) :
+    IsPGroup p (P.map (QuotientGroup.mk' U.toSubgroup)) := by
+  let f : P →* G ⧸ U.toSubgroup :=
+    (QuotientGroup.mk' U.toSubgroup).domRestrict P
+  have hf : Continuous f := QuotientGroup.continuous_mk.comp continuous_subtype_val
+  have hrange : IsProP p f.range :=
+    hP.isProP.of_surjective f.rangeRestrict
+      (continuous_induced_rng.mpr hf) f.rangeRestrict_surjective
+  rw [← MonoidHom.domRestrict_range]
+  exact isProP_iff_isPGroup.mp hrange
+
+end
 
 end IsProPSylow
 

--- a/TauCeti/Topology/Algebra/Group/Profinite/Sylow/Basic.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Sylow/Basic.lean
@@ -98,14 +98,15 @@ theorem map_continuousMulEquiv {H : Type v} [Group H] [TopologicalSpace H]
     let V := OpenNormalSubgroup.comap U (e : G →* H) e.continuous
     have hV : (P.map (QuotientGroup.mk' V.toSubgroup)).index =
         ((P.map (e : G →* H)).map (QuotientGroup.mk' U.toSubgroup)).index := by
-      rw [Subgroup.index_map, Subgroup.index_map, QuotientGroup.ker_mk', QuotientGroup.ker_mk',
-        MonoidHom.range_eq_top_of_surjective _ (QuotientGroup.mk'_surjective _),
-        MonoidHom.range_eq_top_of_surjective _ (QuotientGroup.mk'_surjective _),
-        Subgroup.index_top, Subgroup.index_top, mul_one, mul_one,
-        ← Subgroup.index_map_equiv (P ⊔ V.toSubgroup) e.toMulEquiv, Subgroup.map_sup]
-      congr 2
-      exact (congrArg _ (OpenNormalSubgroup.toSubgroup_comap U _ e.continuous)).trans
-        (Subgroup.map_comap_eq_self_of_surjective e.surjective U.toSubgroup)
+      have hU : V.toSubgroup.map (e : G →* H) = U.toSubgroup :=
+        (congrArg _ (OpenNormalSubgroup.toSubgroup_comap U _ e.continuous)).trans
+          (Subgroup.map_comap_eq_self_of_surjective e.surjective U.toSubgroup)
+      calc (P.map (QuotientGroup.mk' V.toSubgroup)).index
+          = (P ⊔ V.toSubgroup).index := P.index_map_mk'_eq_index_sup V.toSubgroup
+        _ = ((P ⊔ V.toSubgroup).map (e : G →* H)).index :=
+          (Subgroup.index_map_equiv _ e.toMulEquiv).symm
+        _ = (P.map (e : G →* H) ⊔ U.toSubgroup).index := by rw [Subgroup.map_sup, hU]
+        _ = _ := ((P.map (e : G →* H)).index_map_mk'_eq_index_sup U.toSubgroup).symm
     exact hV ▸ hP.not_dvd_index V
 
 /-- A conjugate of a Sylow pro-`p` subgroup is a Sylow pro-`p` subgroup. -/

--- a/TauCeti/Topology/Algebra/Group/Profinite/Sylow/Basic.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Sylow/Basic.lean
@@ -26,8 +26,8 @@ a separate compatible inverse-limit argument.
 ## Main definitions and results
 
 * `IsProPSylow`: the predicate for a Sylow pro-`p` subgroup.
-* `IsProPSylow.isPGroup_map_mk'`: its image in every finite continuous quotient is a
-  `p`-group.
+* `IsProPSylow.map_continuousMulEquiv`, `IsProPSylow.map_conj`: the predicate is preserved by
+  isomorphisms of topological groups, in particular by conjugation.
 * `isProPSylow_iff_isClosed_and_isProP_and_not_dvd_profiniteIndex`: its
   supernatural-index formulation.
 * `isProPSylow_iff_isPGroup_and_not_dvd_index`: its specialization to a discrete group.
@@ -44,7 +44,7 @@ public section
 
 namespace TauCeti
 
-universe u
+universe u v
 
 /-- A subgroup `P` of a topological group is a **Sylow pro-`p` subgroup** when it is closed,
 is itself pro-`p`, and its image in every quotient by an open normal subgroup has index not
@@ -83,23 +83,39 @@ theorem not_dvd_index (hP : IsProPSylow p P) (U : OpenNormalSubgroup G) :
     ¬ p ∣ (P.map (QuotientGroup.mk' U.toSubgroup)).index :=
   (isProPSylow_iff.mp hP).2.2 U
 
-section
+/-- The image of a Sylow pro-`p` subgroup under an isomorphism of topological groups is a Sylow
+pro-`p` subgroup. -/
+theorem map_continuousMulEquiv {H : Type v} [Group H] [TopologicalSpace H]
+    (hP : IsProPSylow p P) (e : G ≃ₜ* H) : IsProPSylow p (P.map (e : G →* H)) := by
+  refine isProPSylow_iff.mpr ⟨?_, ?_, fun U ↦ ?_⟩
+  · rw [Subgroup.coe_map]
+    exact e.toHomeomorph.isClosedMap _ hP.isClosed
+  · exact hP.isProP.of_surjective ((e : G →* H).subgroupMap P)
+      (continuous_induced_rng.mpr (e.continuous.comp continuous_subtype_val))
+      ((e : G →* H).subgroupMap_surjective P)
+  · -- The image of `P.map e` in `H ⧸ U` has the same index as the image of `P` in
+    -- `G ⧸ U.comap e`, since both indices are those of `P ⊔ U.comap e` transported along `e`.
+    let V := OpenNormalSubgroup.comap U (e : G →* H) e.continuous
+    have hV : (P.map (QuotientGroup.mk' V.toSubgroup)).index =
+        ((P.map (e : G →* H)).map (QuotientGroup.mk' U.toSubgroup)).index := by
+      rw [Subgroup.index_map, Subgroup.index_map, QuotientGroup.ker_mk', QuotientGroup.ker_mk',
+        MonoidHom.range_eq_top_of_surjective _ (QuotientGroup.mk'_surjective _),
+        MonoidHom.range_eq_top_of_surjective _ (QuotientGroup.mk'_surjective _),
+        Subgroup.index_top, Subgroup.index_top, mul_one, mul_one,
+        ← Subgroup.index_map_equiv (P ⊔ V.toSubgroup) e.toMulEquiv, Subgroup.map_sup]
+      congr 2
+      exact (congrArg _ (OpenNormalSubgroup.toSubgroup_comap U _ e.continuous)).trans
+        (Subgroup.map_comap_eq_self_of_surjective e.surjective U.toSubgroup)
+    exact hV ▸ hP.not_dvd_index V
 
-variable [IsTopologicalGroup G]
-
-/-- The image of a Sylow pro-`p` subgroup in a finite continuous quotient is a `p`-group. -/
-theorem isPGroup_map_mk' (hP : IsProPSylow p P) (U : OpenNormalSubgroup G) :
-    IsPGroup p (P.map (QuotientGroup.mk' U.toSubgroup)) := by
-  let f : P →* G ⧸ U.toSubgroup :=
-    (QuotientGroup.mk' U.toSubgroup).domRestrict P
-  have hf : Continuous f := QuotientGroup.continuous_mk.comp continuous_subtype_val
-  have hrange : IsProP p f.range :=
-    hP.isProP.of_surjective f.rangeRestrict
-      (continuous_induced_rng.mpr hf) f.rangeRestrict_surjective
-  rw [← MonoidHom.domRestrict_range]
-  exact isProP_iff_isPGroup.mp hrange
-
-end
+/-- A conjugate of a Sylow pro-`p` subgroup is a Sylow pro-`p` subgroup. -/
+theorem map_conj [IsTopologicalGroup G] (hP : IsProPSylow p P) (g : G) :
+    IsProPSylow p (P.map (MulAut.conj g).toMonoidHom) :=
+  hP.map_continuousMulEquiv
+    { MulAut.conj g with
+      continuous_toFun := IsTopologicalGroup.continuous_conj g
+      continuous_invFun := (IsTopologicalGroup.continuous_conj g⁻¹).congr fun x ↦ by
+        rw [inv_inv]; exact (MulAut.conj_symm_apply g x).symm }
 
 end IsProPSylow
 

--- a/TauCeti/Topology/Algebra/Group/Profinite/Sylow/Conjugacy.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Sylow/Conjugacy.lean
@@ -1,0 +1,165 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Topology.Algebra.Group.Profinite.Sylow.Basic
+public import TauCeti.Topology.Algebra.Group.Profinite.Basic
+
+/-!
+# Conjugacy of Sylow subgroups in profinite groups
+
+Any two Sylow pro-`p` subgroups of a profinite group are conjugate. At every finite continuous
+quotient their images are ordinary Sylow subgroups, so finite Sylow theory supplies a nonempty
+set of conjugators. The inverse images of these finite sets form a downward-directed family of
+closed subsets of the ambient compact group. An element of their intersection conjugates the
+two closed subgroups in every finite quotient, and hence conjugates the subgroups themselves.
+
+## Main results
+
+* `IsProPSylow.exists_map_conj_eq`: any two Sylow pro-`p` subgroups are conjugate.
+* `IsProPSylow.eq_of_normal`: a normal Sylow pro-`p` subgroup is unique.
+
+## References
+
+* L. Ribes and P. Zalesskii, *Profinite Groups*, Section 2.3.
+-/
+
+public section
+
+namespace TauCeti
+
+universe u
+
+variable {p : ℕ} [Fact p.Prime]
+variable {G : Type u} [Group G] [TopologicalSpace G] [IsTopologicalGroup G]
+  [CompactSpace G] [TotallyDisconnectedSpace G]
+variable {P Q : Subgroup G}
+
+omit [Fact p.Prime] [TopologicalSpace G] [IsTopologicalGroup G] [CompactSpace G]
+  [TotallyDisconnectedSpace G] in
+private theorem map_mk'_map_quotient {U V : Subgroup G} [U.Normal] [V.Normal]
+    (hVU : V ≤ U) (R : Subgroup G) :
+    (R.map (QuotientGroup.mk' V)).map
+        (QuotientGroup.map V U (.id G) (by simpa using hVU)) =
+      R.map (QuotientGroup.mk' U) := by
+  rw [Subgroup.map_map]
+  congr 1
+
+omit [Fact p.Prime] [TopologicalSpace G] [IsTopologicalGroup G] [CompactSpace G]
+  [TotallyDisconnectedSpace G] in
+private theorem map_conj_mk'_map_quotient {U V : Subgroup G} [U.Normal] [V.Normal]
+    (hVU : V ≤ U) (R : Subgroup G) (g : G) :
+    ((R.map (QuotientGroup.mk' V)).map
+        (MulAut.conj (g : G ⧸ V)).toMonoidHom).map
+          (QuotientGroup.map V U (.id G) (by simpa using hVU)) =
+      (R.map (QuotientGroup.mk' U)).map
+        (MulAut.conj (g : G ⧸ U)).toMonoidHom := by
+  simp only [Subgroup.map_map]
+  congr 1
+
+omit [Fact p.Prime] [TopologicalSpace G] [IsTopologicalGroup G] [CompactSpace G]
+  [TotallyDisconnectedSpace G] in
+private theorem map_conj_map_mk' (U : Subgroup G) [U.Normal]
+    (R : Subgroup G) (g : G) :
+    (R.map (MulAut.conj g).toMonoidHom).map (QuotientGroup.mk' U) =
+      (R.map (QuotientGroup.mk' U)).map
+        (MulAut.conj (g : G ⧸ U)).toMonoidHom := by
+  simp only [Subgroup.map_map]
+  congr 1
+
+namespace IsProPSylow
+
+/-- Any two Sylow pro-`p` subgroups of a profinite group are conjugate. -/
+theorem exists_map_conj_eq (hP : IsProPSylow p P) (hQ : IsProPSylow p Q) :
+    ∃ g : G, Q = P.map (MulAut.conj g).toMonoidHom := by
+  let PSylow (U : OpenNormalSubgroup G) : Sylow p (G ⧸ U.toSubgroup) :=
+    (hP.isPGroup_map_mk' U).toSylow (hP.not_dvd_index U)
+  let QSylow (U : OpenNormalSubgroup G) : Sylow p (G ⧸ U.toSubgroup) :=
+    (hQ.isPGroup_map_mk' U).toSylow (hQ.not_dvd_index U)
+  let conjugators (U : OpenNormalSubgroup G) : Set (G ⧸ U.toSubgroup) :=
+    {x | x • PSylow U = QSylow U}
+  let t (U : OpenNormalSubgroup G) : Set G :=
+    (QuotientGroup.mk' U.toSubgroup) ⁻¹' conjugators U
+  have ht_nonempty (U : OpenNormalSubgroup G) : (t U).Nonempty := by
+    obtain ⟨x, hx⟩ := MulAction.exists_smul_eq (G ⧸ U.toSubgroup) (PSylow U) (QSylow U)
+    obtain ⟨g, rfl⟩ := QuotientGroup.mk'_surjective U.toSubgroup x
+    exact ⟨g, hx⟩
+  have ht_closed (U : OpenNormalSubgroup G) : IsClosed (t U) :=
+    (isClosed_discrete (conjugators U)).preimage QuotientGroup.continuous_mk
+  have ht_mono {U V : OpenNormalSubgroup G} (hVU : V ≤ U) : t V ⊆ t U := by
+    intro g hg
+    -- Unfold the two local set abbreviations to expose the finite-level conjugacy equation.
+    change (QuotientGroup.mk g : G ⧸ V.toSubgroup) • PSylow V = QSylow V at hg
+    change (QuotientGroup.mk g : G ⧸ U.toSubgroup) • PSylow U = QSylow U
+    apply Sylow.ext
+    have hsub := congrArg (fun S : Sylow p (G ⧸ V.toSubgroup) ↦
+      (S : Subgroup (G ⧸ V.toSubgroup))) hg
+    -- Coercing the bundled Sylow equality exposes the subgroup images defining `PSylow`.
+    change (((P.map (QuotientGroup.mk' V.toSubgroup)).map
+        (MulAut.conj (g : G ⧸ V.toSubgroup)).toMonoidHom) =
+      Q.map (QuotientGroup.mk' V.toSubgroup)) at hsub
+    have hVU' : V.toSubgroup ≤ U.toSubgroup := fun _ hx ↦ hVU hx
+    have hmap := congrArg (fun S : Subgroup (G ⧸ V.toSubgroup) ↦
+      S.map (QuotientGroup.map V.toSubgroup U.toSubgroup (.id G) hVU')) hsub
+    -- `Sylow.ext` leaves an equality of underlying subgroups at level `U`.
+    change (P.map (QuotientGroup.mk' U.toSubgroup)).map
+        (MulAut.conj (g : G ⧸ U.toSubgroup)).toMonoidHom =
+      Q.map (QuotientGroup.mk' U.toSubgroup)
+    rw [map_conj_mk'_map_quotient hVU', map_mk'_map_quotient hVU'] at hmap
+    exact hmap
+  have ht_directed : Directed (· ⊇ ·) t := by
+    intro U V
+    exact ⟨U ⊓ V, ht_mono inf_le_left, ht_mono inf_le_right⟩
+  let _ : Nonempty (OpenNormalSubgroup G) :=
+    ⟨{ toOpenSubgroup := ⊤, isNormal' := Subgroup.normal_top }⟩
+  obtain ⟨g, hg⟩ := IsCompact.nonempty_iInter_of_directed_nonempty_isCompact_isClosed t
+    ht_directed ht_nonempty (fun U ↦ (ht_closed U).isCompact) ht_closed
+  refine ⟨g, ?_⟩
+  let R := P.map (MulAut.conj g).toMonoidHom
+  -- Name the conjugate subgroup so the closed-subgroup reconstruction theorem applies directly.
+  change Q = R
+  have hconj_apply : (MulAut.conj g : G → G) = fun x ↦ g * x * g⁻¹ := by
+    funext x
+    exact MulAut.conj_apply g x
+  have hconj : Continuous (MulAut.conj g : G → G) := by
+    rw [hconj_apply]
+    exact ((continuous_const : Continuous (fun _ : G ↦ g)).mul
+        (continuous_id : Continuous (fun x : G ↦ x))).mul
+      (continuous_const : Continuous (fun _ : G ↦ g⁻¹))
+  have hRclosed : IsClosed (R : Set G) := by
+    dsimp only [R]
+    rw [Subgroup.coe_map]
+    exact (hP.isClosed.isCompact.image hconj).isClosed
+  rw [Subgroup.eq_iInf_sup_openNormalSubgroup Q hQ.isClosed,
+    Subgroup.eq_iInf_sup_openNormalSubgroup R hRclosed]
+  congr 1
+  funext U
+  have hgU := Set.mem_iInter.mp hg U
+  -- Unfold the local conjugator sets at this quotient.
+  change (QuotientGroup.mk g : G ⧸ U.toSubgroup) • PSylow U = QSylow U at hgU
+  have hsub := congrArg (fun S : Sylow p (G ⧸ U.toSubgroup) ↦
+    (S : Subgroup (G ⧸ U.toSubgroup))) hgU
+  -- Coerce the bundled Sylow equality to its underlying subgroup equality.
+  change ((P.map (QuotientGroup.mk' U.toSubgroup)).map
+      (MulAut.conj (g : G ⧸ U.toSubgroup)).toMonoidHom) =
+    Q.map (QuotientGroup.mk' U.toSubgroup) at hsub
+  have himages : R.map (QuotientGroup.mk' U.toSubgroup) =
+      Q.map (QuotientGroup.mk' U.toSubgroup) := by
+    dsimp only [R]
+    rw [map_conj_map_mk']
+    exact hsub
+  have hcomap := congrArg (Subgroup.comap (QuotientGroup.mk' U.toSubgroup)) himages
+  simpa only [Subgroup.comap_map_eq, QuotientGroup.ker_mk'] using hcomap.symm
+
+/-- A normal Sylow pro-`p` subgroup is the unique Sylow pro-`p` subgroup. -/
+theorem eq_of_normal (hP : IsProPSylow p P) (hQ : IsProPSylow p Q) (hn : P.Normal) :
+    P = Q := by
+  obtain ⟨g, rfl⟩ := hP.exists_map_conj_eq hQ
+  exact (@Subgroup.Normal.map_conj_eq G _ P hn g).symm
+
+end IsProPSylow
+
+end TauCeti

--- a/TauCeti/Topology/Algebra/Group/Profinite/Sylow/Conjugacy.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Sylow/Conjugacy.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Topology.Algebra.Group.Profinite.Sylow.Basic
+import TauCeti.Algebra.Group.Subgroup.Map
 
 /-!
 # Conjugacy of Sylow subgroups in profinite groups
@@ -36,38 +37,6 @@ variable {p : ℕ} [Fact p.Prime]
 variable {G : Type u} [Group G] [TopologicalSpace G] [IsTopologicalGroup G]
   [CompactSpace G] [TotallyDisconnectedSpace G]
 variable {P Q : Subgroup G}
-
-omit [Fact p.Prime] [TopologicalSpace G] [IsTopologicalGroup G] [CompactSpace G]
-  [TotallyDisconnectedSpace G] in
-private theorem map_mk'_map_quotient {U V : Subgroup G} [U.Normal] [V.Normal]
-    (hVU : V ≤ U) (R : Subgroup G) :
-    (R.map (QuotientGroup.mk' V)).map
-        (QuotientGroup.map V U (.id G) (by simpa using hVU)) =
-      R.map (QuotientGroup.mk' U) := by
-  rw [Subgroup.map_map]
-  congr 1
-
-omit [Fact p.Prime] [TopologicalSpace G] [IsTopologicalGroup G] [CompactSpace G]
-  [TotallyDisconnectedSpace G] in
-private theorem map_conj_mk'_map_quotient {U V : Subgroup G} [U.Normal] [V.Normal]
-    (hVU : V ≤ U) (R : Subgroup G) (g : G) :
-    ((R.map (QuotientGroup.mk' V)).map
-        (MulAut.conj (g : G ⧸ V)).toMonoidHom).map
-          (QuotientGroup.map V U (.id G) (by simpa using hVU)) =
-      (R.map (QuotientGroup.mk' U)).map
-        (MulAut.conj (g : G ⧸ U)).toMonoidHom := by
-  simp only [Subgroup.map_map]
-  congr 1
-
-omit [Fact p.Prime] [TopologicalSpace G] [IsTopologicalGroup G] [CompactSpace G]
-  [TotallyDisconnectedSpace G] in
-private theorem map_conj_map_mk' (U : Subgroup G) [U.Normal]
-    (R : Subgroup G) (g : G) :
-    (R.map (MulAut.conj g).toMonoidHom).map (QuotientGroup.mk' U) =
-      (R.map (QuotientGroup.mk' U)).map
-        (MulAut.conj (g : G ⧸ U)).toMonoidHom := by
-  simp only [Subgroup.map_map]
-  congr 1
 
 namespace IsProPSylow
 
@@ -100,8 +69,12 @@ theorem exists_map_conj_eq (hP : IsProPSylow p P) (hQ : IsProPSylow p Q) :
   have ht_mono {U V : OpenNormalSubgroup G} (hVU : V ≤ U) : t V ⊆ t U := by
     intro g hg
     have hVU' : V.toSubgroup ≤ U.toSubgroup := fun _ hx ↦ hVU hx
+    have hmap (R : Subgroup G) : (R.map (QuotientGroup.mk' V.toSubgroup)).map
+        (QuotientGroup.map V.toSubgroup U.toSubgroup (.id G) (by simpa using hVU')) =
+          R.map (QuotientGroup.mk' U.toSubgroup) := by
+      rw [Subgroup.map_mk'_map_quotientGroupMap, Subgroup.map_id]
     rw [mem_t] at hg ⊢
-    rw [← map_conj_mk'_map_quotient hVU', ← map_mk'_map_quotient hVU' Q, hg]
+    rw [← hmap Q, ← hg, Subgroup.map_conj_map, hmap P, QuotientGroup.map_mk, MonoidHom.id_apply]
   have ht_directed : Directed (· ⊇ ·) t := by
     intro U V
     exact ⟨U ⊓ V, ht_mono inf_le_left, ht_mono inf_le_right⟩
@@ -114,7 +87,10 @@ theorem exists_map_conj_eq (hP : IsProPSylow p P) (hQ : IsProPSylow p Q) :
     Subgroup.eq_iInf_sup_openNormalSubgroup _ (hP.map_conj g).isClosed]
   congr 1
   funext U
-  have himages := (map_conj_map_mk' U.toSubgroup P g).trans (mem_t.mp (Set.mem_iInter.mp hg U))
+  have himages : (P.map (MulAut.conj g).toMonoidHom).map (QuotientGroup.mk' U.toSubgroup) =
+      Q.map (QuotientGroup.mk' U.toSubgroup) := by
+    rw [Subgroup.map_conj_map, QuotientGroup.mk'_apply]
+    exact mem_t.mp (Set.mem_iInter.mp hg U)
   have hcomap := congrArg (Subgroup.comap (QuotientGroup.mk' U.toSubgroup)) himages
   simpa only [Subgroup.comap_map_eq, QuotientGroup.ker_mk'] using hcomap
 

--- a/TauCeti/Topology/Algebra/Group/Profinite/Sylow/Conjugacy.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Sylow/Conjugacy.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Topology.Algebra.Group.Profinite.Sylow.Basic
-public import TauCeti.Topology.Algebra.Group.Profinite.Basic
 
 /-!
 # Conjugacy of Sylow subgroups in profinite groups
@@ -74,15 +73,24 @@ namespace IsProPSylow
 
 /-- Any two Sylow pro-`p` subgroups of a profinite group are conjugate. -/
 theorem exists_map_conj_eq (hP : IsProPSylow p P) (hQ : IsProPSylow p Q) :
-    ∃ g : G, Q = P.map (MulAut.conj g).toMonoidHom := by
+    ∃ g : G, P.map (MulAut.conj g).toMonoidHom = Q := by
   let PSylow (U : OpenNormalSubgroup G) : Sylow p (G ⧸ U.toSubgroup) :=
-    (hP.isPGroup_map_mk' U).toSylow (hP.not_dvd_index U)
+    (hP.isProP.isPGroup_map_mk' U).toSylow (hP.not_dvd_index U)
   let QSylow (U : OpenNormalSubgroup G) : Sylow p (G ⧸ U.toSubgroup) :=
-    (hQ.isPGroup_map_mk' U).toSylow (hQ.not_dvd_index U)
+    (hQ.isProP.isPGroup_map_mk' U).toSylow (hQ.not_dvd_index U)
   let conjugators (U : OpenNormalSubgroup G) : Set (G ⧸ U.toSubgroup) :=
     {x | x • PSylow U = QSylow U}
   let t (U : OpenNormalSubgroup G) : Set G :=
     (QuotientGroup.mk' U.toSubgroup) ⁻¹' conjugators U
+  have mem_t {U : OpenNormalSubgroup G} {g : G} : g ∈ t U ↔
+      (P.map (QuotientGroup.mk' U.toSubgroup)).map
+          (MulAut.conj (g : G ⧸ U.toSubgroup)).toMonoidHom =
+        Q.map (QuotientGroup.mk' U.toSubgroup) := by
+    simp only [t, conjugators, PSylow, QSylow, Set.mem_preimage, Set.mem_ofPred_eq,
+      Sylow.ext_iff, Sylow.coe_subgroup_smul, IsPGroup.toSylow_coe]
+    -- Mathlib defines the pointwise `MulAut` action on subgroups as `Subgroup.map`
+    -- (`Subgroup.pointwise_smul_def` is `rfl`) and provides no rewrite lemma to `toMonoidHom`.
+    exact Iff.rfl
   have ht_nonempty (U : OpenNormalSubgroup G) : (t U).Nonempty := by
     obtain ⟨x, hx⟩ := MulAction.exists_smul_eq (G ⧸ U.toSubgroup) (PSylow U) (QSylow U)
     obtain ⟨g, rfl⟩ := QuotientGroup.mk'_surjective U.toSubgroup x
@@ -91,25 +99,9 @@ theorem exists_map_conj_eq (hP : IsProPSylow p P) (hQ : IsProPSylow p Q) :
     (isClosed_discrete (conjugators U)).preimage QuotientGroup.continuous_mk
   have ht_mono {U V : OpenNormalSubgroup G} (hVU : V ≤ U) : t V ⊆ t U := by
     intro g hg
-    -- Unfold the two local set abbreviations to expose the finite-level conjugacy equation.
-    change (QuotientGroup.mk g : G ⧸ V.toSubgroup) • PSylow V = QSylow V at hg
-    change (QuotientGroup.mk g : G ⧸ U.toSubgroup) • PSylow U = QSylow U
-    apply Sylow.ext
-    have hsub := congrArg (fun S : Sylow p (G ⧸ V.toSubgroup) ↦
-      (S : Subgroup (G ⧸ V.toSubgroup))) hg
-    -- Coercing the bundled Sylow equality exposes the subgroup images defining `PSylow`.
-    change (((P.map (QuotientGroup.mk' V.toSubgroup)).map
-        (MulAut.conj (g : G ⧸ V.toSubgroup)).toMonoidHom) =
-      Q.map (QuotientGroup.mk' V.toSubgroup)) at hsub
     have hVU' : V.toSubgroup ≤ U.toSubgroup := fun _ hx ↦ hVU hx
-    have hmap := congrArg (fun S : Subgroup (G ⧸ V.toSubgroup) ↦
-      S.map (QuotientGroup.map V.toSubgroup U.toSubgroup (.id G) hVU')) hsub
-    -- `Sylow.ext` leaves an equality of underlying subgroups at level `U`.
-    change (P.map (QuotientGroup.mk' U.toSubgroup)).map
-        (MulAut.conj (g : G ⧸ U.toSubgroup)).toMonoidHom =
-      Q.map (QuotientGroup.mk' U.toSubgroup)
-    rw [map_conj_mk'_map_quotient hVU', map_mk'_map_quotient hVU'] at hmap
-    exact hmap
+    rw [mem_t] at hg ⊢
+    rw [← map_conj_mk'_map_quotient hVU', ← map_mk'_map_quotient hVU' Q, hg]
   have ht_directed : Directed (· ⊇ ·) t := by
     intro U V
     exact ⟨U ⊓ V, ht_mono inf_le_left, ht_mono inf_le_right⟩
@@ -118,41 +110,13 @@ theorem exists_map_conj_eq (hP : IsProPSylow p P) (hQ : IsProPSylow p Q) :
   obtain ⟨g, hg⟩ := IsCompact.nonempty_iInter_of_directed_nonempty_isCompact_isClosed t
     ht_directed ht_nonempty (fun U ↦ (ht_closed U).isCompact) ht_closed
   refine ⟨g, ?_⟩
-  let R := P.map (MulAut.conj g).toMonoidHom
-  -- Name the conjugate subgroup so the closed-subgroup reconstruction theorem applies directly.
-  change Q = R
-  have hconj_apply : (MulAut.conj g : G → G) = fun x ↦ g * x * g⁻¹ := by
-    funext x
-    exact MulAut.conj_apply g x
-  have hconj : Continuous (MulAut.conj g : G → G) := by
-    rw [hconj_apply]
-    exact ((continuous_const : Continuous (fun _ : G ↦ g)).mul
-        (continuous_id : Continuous (fun x : G ↦ x))).mul
-      (continuous_const : Continuous (fun _ : G ↦ g⁻¹))
-  have hRclosed : IsClosed (R : Set G) := by
-    dsimp only [R]
-    rw [Subgroup.coe_map]
-    exact (hP.isClosed.isCompact.image hconj).isClosed
   rw [Subgroup.eq_iInf_sup_openNormalSubgroup Q hQ.isClosed,
-    Subgroup.eq_iInf_sup_openNormalSubgroup R hRclosed]
+    Subgroup.eq_iInf_sup_openNormalSubgroup _ (hP.map_conj g).isClosed]
   congr 1
   funext U
-  have hgU := Set.mem_iInter.mp hg U
-  -- Unfold the local conjugator sets at this quotient.
-  change (QuotientGroup.mk g : G ⧸ U.toSubgroup) • PSylow U = QSylow U at hgU
-  have hsub := congrArg (fun S : Sylow p (G ⧸ U.toSubgroup) ↦
-    (S : Subgroup (G ⧸ U.toSubgroup))) hgU
-  -- Coerce the bundled Sylow equality to its underlying subgroup equality.
-  change ((P.map (QuotientGroup.mk' U.toSubgroup)).map
-      (MulAut.conj (g : G ⧸ U.toSubgroup)).toMonoidHom) =
-    Q.map (QuotientGroup.mk' U.toSubgroup) at hsub
-  have himages : R.map (QuotientGroup.mk' U.toSubgroup) =
-      Q.map (QuotientGroup.mk' U.toSubgroup) := by
-    dsimp only [R]
-    rw [map_conj_map_mk']
-    exact hsub
+  have himages := (map_conj_map_mk' U.toSubgroup P g).trans (mem_t.mp (Set.mem_iInter.mp hg U))
   have hcomap := congrArg (Subgroup.comap (QuotientGroup.mk' U.toSubgroup)) himages
-  simpa only [Subgroup.comap_map_eq, QuotientGroup.ker_mk'] using hcomap.symm
+  simpa only [Subgroup.comap_map_eq, QuotientGroup.ker_mk'] using hcomap
 
 /-- A normal Sylow pro-`p` subgroup is the unique Sylow pro-`p` subgroup. -/
 theorem eq_of_normal (hP : IsProPSylow p P) (hQ : IsProPSylow p Q) (hn : P.Normal) :

--- a/TauCeti/Topology/Algebra/Group/Profinite/Sylow/Conjugacy.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Sylow/Conjugacy.lean
@@ -95,8 +95,9 @@ theorem exists_map_conj_eq (hP : IsProPSylow p P) (hQ : IsProPSylow p Q) :
   simpa only [Subgroup.comap_map_eq, QuotientGroup.ker_mk'] using hcomap
 
 /-- A normal Sylow pro-`p` subgroup is the unique Sylow pro-`p` subgroup. -/
-theorem eq_of_normal (hP : IsProPSylow p P) (hQ : IsProPSylow p Q) (hn : P.Normal) :
-    P = Q := by
+theorem eq_of_normal (p : ℕ) [Fact p.Prime] (G : Type u) [Group G] [TopologicalSpace G]
+    [IsTopologicalGroup G] [CompactSpace G] [TotallyDisconnectedSpace G] (P Q : Subgroup G)
+    (hP : IsProPSylow p P) (hQ : IsProPSylow p Q) (hn : P.Normal) : P = Q := by
   obtain ⟨g, rfl⟩ := hP.exists_map_conj_eq hQ
   exact (@Subgroup.Normal.map_conj_eq G _ P hn g).symm
 


### PR DESCRIPTION
This PR proves that any two Sylow pro-`p` subgroups of a profinite group are conjugate, and deduces the frozen corollary `IsProPSylow.eq_of_normal` that a normal Sylow pro-`p` subgroup is unique. It advances `TauCetiRoadmap/ProfiniteProPGroups/README.md`, Layer 2 milestone “Conjugacy and the poset,” specifically the target “Any two `p`-Sylow subgroups are conjugate” and its normal-uniqueness consequence.

This is the most effective current step because the Layer 1 index API and the Layer 2 Sylow predicate are on `main`, while existence is already covered by open PR #6239; conjugacy is the next distinct theorem needed by the containment, maximality, functoriality, and later `cd_p` comparison paths. After this PR, the milestone still needs containment of every closed pro-`p` subgroup in a Sylow subgroup and the equivalence with maximal closed pro-`p` subgroups; Layer 2 functoriality remains separate.

At each finite continuous quotient, the new `IsProP.isPGroup_map_mk'` (the image of a pro-`p` subgroup in the quotient by an open normal subgroup is a `p`-group, added to `ProP/Basic.lean`) combines with the existing prime-to-`p` index clause to produce an ordinary Mathlib `Sylow` subgroup. Finite Sylow conjugacy makes the set of quotient-level conjugators nonempty. These sets pull back to a downward-directed family of closed subsets of the ambient compact group, and a point in their intersection conjugates the two closed subgroups in every finite quotient. The existing closed-subgroup reconstruction theorem then gives equality upstairs.

The implementation reuses Mathlib’s `MulAction.exists_smul_eq`, `IsCompact.nonempty_iInter_of_directed_nonempty_isCompact_isClosed`, subgroup image/comap laws, and Tau Ceti’s `Subgroup.eq_iInf_sup_openNormalSubgroup`; no Mathlib infrastructure is vendored. The argument follows Ribes–Zalesskii, *Profinite Groups*, §2.3, cited in the module documentation.

The predicate also gains its transport API: `IsProPSylow.map_continuousMulEquiv` (preservation under isomorphisms of topological groups) and its specialization `IsProPSylow.map_conj`, which the conjugacy proof uses for closedness of the conjugate.

The new conjugacy module contains 129 lines. The required prefix-layout move, with all in-repository imports already absent, is:

| Old module | New module |
| --- | --- |
| `TauCeti.Topology.Algebra.Group.Profinite.Sylow` | `TauCeti.Topology.Algebra.Group.Profinite.Sylow.Basic` |

Roadmap: ProfiniteProPGroups

<!--tauceti-target:v1 {"focus":"ProfiniteProPGroups","id":"is-pro-p-sylow-conjugacy"}-->

🤖 Prepared with Codex

