### PR TITLE
refactor(CentralSimple): extract the splitting criterion behind Wedderburn

### DIFF
--- a/TauCeti/Algebra/CentralSimple/SeparablyClosed.lean
+++ b/TauCeti/Algebra/CentralSimple/SeparablyClosed.lean
@@ -137,11 +137,9 @@ variable (A : Type u) [Ring A] [Algebra K A] [Algebra.IsCentral K A] [IsSimpleRi
 `K`-algebra is a full matrix algebra over `K`. -/
 theorem exists_algEquiv_matrix_of_isSepClosed :
     ∃ (n : ℕ) (_ : NeZero n), Module.finrank K A = n ^ 2 ∧
-      Nonempty (A ≃ₐ[K] Matrix (Fin n) (Fin n) K) := by
-  obtain ⟨n, hn, D, _, _, _, _, hrank, ⟨e⟩⟩ :=
-    exists_algEquiv_matrix_centralDivisionRing K A
-  refine ⟨n, hn, ?_, ⟨e.trans (AlgEquiv.mapMatrix (baseFieldAlgEquivOfIsSepClosed K D))⟩⟩
-  rw [hrank, finrank_eq_one_of_isSepClosed K D, mul_one]
+      Nonempty (A ≃ₐ[K] Matrix (Fin n) (Fin n) K) :=
+  exists_algEquiv_matrix_of_forall_nonempty_algEquiv K A fun D ↦
+    ⟨baseFieldAlgEquivOfIsSepClosed K D⟩
 
 end IsSimpleRing
 

--- a/TauCeti/Algebra/CentralSimple/Wedderburn.lean
+++ b/TauCeti/Algebra/CentralSimple/Wedderburn.lean
@@ -38,6 +38,11 @@ the failure being exactly that its structure map is not surjective.
   simple algebras**. A finite-dimensional central simple `K`-algebra `A` is
   `Matrix (Fin n) (Fin n) D` for a finite-dimensional **central** division `K`-algebra `D`, and
   `finrank K A = n ^ 2 * finrank K D`.
+* `TauCeti.IsSimpleRing.exists_algEquiv_matrix_of_forall_nonempty_algEquiv`: over a field whose
+  finite-dimensional central division algebras are all the field itself, every
+  finite-dimensional central simple algebra is a full matrix algebra over that field. This is
+  the criterion behind the two matrix presentations below, over a finite and over a separably
+  closed base field.
 * `TauCeti.baseFieldAlgEquivOfFinite`: a finite central division algebra over a field is the base
   field.
 * `TauCeti.IsSimpleRing.exists_algEquiv_matrix_of_finite`: a central simple algebra over a

--- a/TauCeti/Algebra/CentralSimple/Wedderburn.lean
+++ b/TauCeti/Algebra/CentralSimple/Wedderburn.lean
@@ -40,9 +40,10 @@ the failure being exactly that its structure map is not surjective.
   `finrank K A = n ^ 2 * finrank K D`.
 * `TauCeti.IsSimpleRing.exists_algEquiv_matrix_of_forall_nonempty_algEquiv`: over a field whose
   finite-dimensional central division algebras are all the field itself, every
-  finite-dimensional central simple algebra is a full matrix algebra over that field. This is
-  the criterion behind the two matrix presentations below, over a finite and over a separably
-  closed base field.
+  finite-dimensional central simple algebra is a full matrix algebra over that field. It is the
+  criterion behind `TauCeti.IsSimpleRing.exists_algEquiv_matrix_of_finite` below and
+  `TauCeti.IsSimpleRing.exists_algEquiv_matrix_of_isSepClosed` in
+  `TauCeti/Algebra/CentralSimple/SeparablyClosed.lean`.
 * `TauCeti.baseFieldAlgEquivOfFinite`: a finite central division algebra over a field is the base
   field.
 * `TauCeti.IsSimpleRing.exists_algEquiv_matrix_of_finite`: a central simple algebra over a
@@ -107,12 +108,10 @@ theorem exists_algEquiv_matrix_centralDivisionRing [Algebra.IsCentral K A] [IsSi
 /-- **A field whose central division algebras are all itself splits every central simple
 algebra.** Given the Wedderburn presentation `A ≃ₐ Mₙ(D)`, the hypothesis collapses `D` to `K`.
 
-This is the common content of `TauCeti.IsSimpleRing.exists_algEquiv_matrix_of_finite` and
-`TauCeti.IsSimpleRing.exists_algEquiv_matrix_of_isSepClosed`; each supplies the hypothesis from a
-different property of `K`. It takes a universally quantified hypothesis rather than a class
-because the class one wants -- triviality of the Brauer group -- is only definable further
-downstream, where this statement reappears as
-`TauCeti.Algebra.isSplittingField_self_of_isBrauerTrivial`. -/
+The hypothesis says that `K` admits no finite-dimensional central division algebra other than
+itself, equivalently that its Brauer group is trivial. It holds over a finite field, by little
+Wedderburn, and over a separably closed field, where Jacobson--Noether would otherwise produce a
+separable element outside the base field. -/
 theorem exists_algEquiv_matrix_of_forall_nonempty_algEquiv [Algebra.IsCentral K A]
     [IsSimpleRing A] [FiniteDimensional K A]
     (h : ∀ (D : Type u) [DivisionRing D] [Algebra K D] [Algebra.IsCentral K D]

--- a/TauCeti/Algebra/CentralSimple/Wedderburn.lean
+++ b/TauCeti/Algebra/CentralSimple/Wedderburn.lean
@@ -99,6 +99,26 @@ theorem exists_algEquiv_matrix_centralDivisionRing [Algebra.IsCentral K A] [IsSi
   rw [e.toLinearEquiv.finrank_eq, Module.finrank_matrix, Fintype.card_fin]
   ring
 
+/-- **A field whose central division algebras are all itself splits every central simple
+algebra.** Given the Wedderburn presentation `A ≃ₐ Mₙ(D)`, the hypothesis collapses `D` to `K`.
+
+This is the common content of `TauCeti.IsSimpleRing.exists_algEquiv_matrix_of_finite` and
+`TauCeti.IsSimpleRing.exists_algEquiv_matrix_of_isSepClosed`; each supplies the hypothesis from a
+different property of `K`. It takes a universally quantified hypothesis rather than a class
+because the class one wants -- triviality of the Brauer group -- is only definable further
+downstream, where this statement reappears as
+`TauCeti.Algebra.isSplittingField_self_of_isBrauerTrivial`. -/
+theorem exists_algEquiv_matrix_of_forall_nonempty_algEquiv [Algebra.IsCentral K A]
+    [IsSimpleRing A] [FiniteDimensional K A]
+    (h : ∀ (D : Type u) [DivisionRing D] [Algebra K D] [Algebra.IsCentral K D]
+      [FiniteDimensional K D], Nonempty (D ≃ₐ[K] K)) :
+    ∃ (n : ℕ) (_ : NeZero n), Module.finrank K A = n ^ 2 ∧
+      Nonempty (A ≃ₐ[K] Matrix (Fin n) (Fin n) K) := by
+  obtain ⟨n, hn, D, _, _, _, _, hrank, ⟨e⟩⟩ := exists_algEquiv_matrix_centralDivisionRing K A
+  obtain ⟨d⟩ := h D
+  refine ⟨n, hn, ?_, ⟨e.trans (AlgEquiv.mapMatrix d)⟩⟩
+  rw [hrank, d.toLinearEquiv.finrank_eq, Module.finrank_self, mul_one]
+
 end IsSimpleRing
 
 /-! ### Finite central division algebras and finite base fields -/
@@ -150,11 +170,10 @@ This is the finite-field analogue of Mathlib's
 suffice, since `A` could be a proper field extension of `K`. -/
 theorem exists_algEquiv_matrix_of_finite :
     ∃ (n : ℕ) (_ : NeZero n), Module.finrank K A = n ^ 2 ∧
-      Nonempty (A ≃ₐ[K] Matrix (Fin n) (Fin n) K) := by
-  obtain ⟨n, hn, D, _, _, _, _, hrank, ⟨e⟩⟩ := exists_algEquiv_matrix_centralDivisionRing K A
-  have : Finite D := Module.finite_of_finite K
-  refine ⟨n, hn, ?_, ⟨e.trans (AlgEquiv.mapMatrix (baseFieldAlgEquivOfFinite K D))⟩⟩
-  rw [hrank, finrank_eq_one_of_finite K D, mul_one]
+      Nonempty (A ≃ₐ[K] Matrix (Fin n) (Fin n) K) :=
+  exists_algEquiv_matrix_of_forall_nonempty_algEquiv K A fun D ↦
+    have : Finite D := Module.finite_of_finite K
+    ⟨baseFieldAlgEquivOfFinite K D⟩
 
 end IsSimpleRing
 


### PR DESCRIPTION
`IsSimpleRing.exists_algEquiv_matrix_of_finite` and `_of_isSepClosed` ran the same argument — take the Wedderburn presentation `A ≃ₐ Mₙ(D)`, collapse `D` to `K`, recompute the rank — and differed only in the collapsing step.

This names that argument `exists_algEquiv_matrix_of_forall_nonempty_algEquiv`. Both consumers become applications naming the base-field equivalence they use, so `baseFieldAlgEquivOfFinite` and `baseFieldAlgEquivOfIsSepClosed` are consumed rather than duplicated.

The hypothesis is universally quantified rather than a class because the class one wants — triviality of the Brauer group — is only definable downstream of this file, where the same statement reappears as `Algebra.isSplittingField_self_of_isBrauerTrivial`. Restating these two over a Brauer-group hypothesis would be an import cycle.

Note this leaves `finrank_eq_one_of_finite` and `finrank_eq_one_of_isSepClosed` without in-repository callers. They are kept deliberately: both are `@[simp]`, both are advertised main results, and "a finite central division algebra over a field is one-dimensional over it" is API a downstream user wants whether or not this file happens to call it.

Found by a duplicate-statement scan.

Roadmap: RepresentationTheory

🤖 Generated with [Claude Code](https://claude.com/claude-code)
