### PR TITLE
feat: add the CAR occupation projections

### DIFF
--- a/TauCeti/Algebra/Lie/GeneralLinear/CAR/Occupation.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/CAR/Occupation.lean
@@ -16,11 +16,12 @@ the normalized quadratic elements
 `pᵢⱼ = 1/2 dᵢⱼ dⱼᵢ`.
 
 When `i ≠ j`, these are occupation projections for the hyperbolic plane spanned by `Eᵢⱼ` and
-`Eⱼᵢ`. The CAR relations give `pᵢⱼ + pⱼᵢ = 1`, their two orders are orthogonal, and hence each is
-idempotent. Projections associated to distinct unordered pairs commute. Finally, the diagonal
-normal-ordered lift is the sum `Fᵢᵢ = ∑ k, pᵢₖ`; for a linearly ordered index type this can be
-oriented using only the positive pairs. These formulas supply the commuting zero-one operators
-used to calculate weights in the left regular CAR module.
+`Eⱼᵢ`. Their two orders are orthogonal. When `2` is invertible, the CAR relations also give
+`pᵢⱼ + pⱼᵢ = 1`; in characteristic two the normalization vanishes instead, so the elements remain
+idempotent in every characteristic. Projections associated to distinct unordered pairs commute.
+Finally, the diagonal normal-ordered lift is the sum `Fᵢᵢ = ∑ k, pᵢₖ`; for a linearly ordered index
+type this can be oriented using only the positive pairs. These formulas supply the commuting
+zero-one operators used to calculate weights in the left regular CAR module.
 
 ## Main definitions
 
@@ -30,6 +31,7 @@ used to calculate weights in the left regular CAR module.
 
 * `TauCeti.carOccupationProjection_add_swap`: `pᵢⱼ + pⱼᵢ = 1`.
 * `TauCeti.isIdempotentElem_carOccupationProjection`: off-diagonal `pᵢⱼ` are idempotent.
+* `TauCeti.carOccupationProjection_mul_self`: the corresponding multiplication normal form.
 * `TauCeti.carOccupationProjection_comm_of_ne_of_ne_swap`: distinct unordered pairs commute.
 * `TauCeti.glCliffordHom_single_diagonal_eq_sum_occupation`: `Fᵢᵢ = ∑ k, pᵢₖ`.
 
@@ -37,6 +39,11 @@ used to calculate weights in the left regular CAR module.
 
 * D. Panyushev, *The exterior algebra and "spin" of an orthogonal g-module*,
   Transformation Groups 6 (2001), 371–396, Proposition 2.4 and Example 2.5(1).
+* D. Shlyakhtenko, *Failure of Strong Convergence of Matrices with Fermionic Entries*,
+  arXiv:2606.28648, §2.3.
+* D. Shlyakhtenko, [`car-matrices`](https://github.com/shlyakhtenko/car-matrices),
+  `MatrixNormShort/SpinExtraction.lean` at commit `659be0c6466c3ef9dbbe0e0a313f2cbb2c37d5f9`,
+  the related Lean formalization of pair projectors and their commutation and idempotence.
 * C. Chevalley, *The Algebraic Theory of Spinors*, Columbia University Press, 1954.
 -/
 
@@ -71,6 +78,7 @@ theorem carOccupationProjection_self (i : n) :
 theorem carOccupationProjection_mul_swap {i j : n} (hij : i ≠ j) :
     carOccupationProjection (K := K) i j * carOccupationProjection (K := K) j i = 0 := by
   rw [carOccupationProjection, carOccupationProjection, smul_mul_assoc, mul_smul_comm, smul_smul]
+  -- Expose the common scalar and reassociate so `simp` can see the nilpotent middle pair.
   change ((2 : K)⁻¹ * (2 : K)⁻¹) •
     ((carD (K := K) i j * carD j i) * (carD j i * carD i j)) = 0
   rw [mul_assoc (carD (K := K) i j) (carD j i) (carD j i * carD i j),
@@ -104,14 +112,25 @@ theorem carOccupationProjection_swap (i j : n) :
     carOccupationProjection (K := K) j i = 1 - carOccupationProjection (K := K) i j :=
   eq_sub_iff_add_eq.mpr (carOccupationProjection_add_swap (K := K) j i)
 
-/-- Every off-diagonal occupation element is an idempotent. -/
+end Half
+
+/-- Every off-diagonal occupation element is an idempotent. When the field has characteristic two,
+the normalization scalar is zero; otherwise this follows from orthogonality and complementarity. -/
 theorem isIdempotentElem_carOccupationProjection {i j : n} (hij : i ≠ j) :
     IsIdempotentElem (carOccupationProjection (K := K) i j) := by
-  exact (IsIdempotentElem.of_mul_add
-    (carOccupationProjection_mul_swap (K := K) hij)
-    (carOccupationProjection_add_swap (K := K) i j)).1
+  by_cases h2 : (2 : K) = 0
+  · simp [carOccupationProjection, h2, IsIdempotentElem]
+  · let _ : Invertible (2 : K) := invertibleOfNonzero h2
+    exact (IsIdempotentElem.of_mul_add
+      (carOccupationProjection_mul_swap (K := K) hij)
+      (carOccupationProjection_add_swap (K := K) i j)).1
 
-end Half
+/-- Multiplication by an off-diagonal occupation element twice is multiplication by it once. -/
+@[simp]
+theorem carOccupationProjection_mul_self {i j : n} (hij : i ≠ j) :
+    carOccupationProjection (K := K) i j * carOccupationProjection (K := K) i j =
+      carOccupationProjection (K := K) i j :=
+  (isIdempotentElem_carOccupationProjection (K := K) hij).eq
 
 /-- Occupation elements for different unordered matrix-unit pairs commute. The two inequalities
 exclude equality in either orientation, exactly the cases in which a cross-contraction can be
@@ -136,6 +155,7 @@ theorem carOccupationProjection_comm_of_ne_of_ne_swap {i j k l : n}
     traceQuadraticForm_ι_single_mul_ι_single_comm_of_not_paired j i l k 1 1 <| by
       intro h
       exact hneSwap (Prod.ext h.1 h.2.symm)
+  -- Expose the scalar-normalized products before cancelling their common scalar action.
   change ((2 : K)⁻¹ • (carD i j * carD j i)) * ((2 : K)⁻¹ • (carD k l * carD l k)) =
     ((2 : K)⁻¹ • (carD k l * carD l k)) * ((2 : K)⁻¹ • (carD i j * carD j i))
   have hsmul (x y : CliffordAlgebra (traceQuadraticForm K n)) :

--- a/TauCeti/Algebra/Lie/GeneralLinear/CAR/Occupation.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/CAR/Occupation.lean
@@ -8,7 +8,7 @@ module
 public import TauCeti.Algebra.Lie.GeneralLinear.Clifford
 
 /-!
-# Occupation projections in the CAR algebra
+# Occupation elements in the CAR algebra
 
 For the Clifford algebra of the trace form on matrices, write `dᵢⱼ = ι(Eᵢⱼ)`. This file studies
 the normalized quadratic elements
@@ -21,18 +21,18 @@ When `i ≠ j`, these are occupation projections for the hyperbolic plane spanne
 idempotent in every characteristic. All of the occupation elements commute with one another.
 Finally, the diagonal normal-ordered lift is the sum `Fᵢᵢ = ∑ k, pᵢₖ`; for a linearly ordered index
 type this can be oriented using only the positive pairs. These formulas supply the commuting
-zero-one operators used to calculate weights in the left regular CAR module.
+off-diagonal zero-one operators used to calculate weights in the left regular CAR module.
 
 ## Main definitions
 
-* `TauCeti.carOccupationProjection`: the normalized quadratic element `pᵢⱼ`.
+* `TauCeti.carOccupationElement`: the normalized quadratic element `pᵢⱼ`.
 
 ## Main results
 
-* `TauCeti.carOccupationProjection_add_swap`: `pᵢⱼ + pⱼᵢ = 1`.
-* `TauCeti.isIdempotentElem_carOccupationProjection`: off-diagonal `pᵢⱼ` are idempotent.
-* `TauCeti.carOccupationProjection_mul_self`: the corresponding multiplication normal form.
-* `TauCeti.commute_carOccupationProjection`: all occupation elements commute.
+* `TauCeti.carOccupationElement_add_swap`: `pᵢⱼ + pⱼᵢ = 1`.
+* `TauCeti.isIdempotentElem_carOccupationElement`: off-diagonal `pᵢⱼ` are idempotent.
+* `TauCeti.carOccupationElement_mul_self`: the corresponding multiplication normal form.
+* `TauCeti.commute_carOccupationElement`: all occupation elements commute.
 * `TauCeti.glCliffordHom_single_self_eq_sum_occupation`: `Fᵢᵢ = ∑ k, pᵢₖ`.
 
 ## References
@@ -61,15 +61,23 @@ private noncomputable abbrev carD (i j : n) :
     CliffordAlgebra (traceQuadraticForm K n) :=
   ι (traceQuadraticForm K n) (Matrix.single i j 1)
 
+private theorem polar_single_single_eq_zero (i j k l : n)
+    (h : ¬(j = k ∧ l = i)) :
+    QuadraticMap.polar (traceQuadraticForm K n)
+      (Matrix.single i j 1) (Matrix.single k l 1) = 0 := by
+  rw [← QuadraticMap.polarBilin_apply_apply, polarBilin_traceQuadraticForm,
+    ← traceBilinForm_apply, traceBilinForm_single_single, ite_eq_right h]
+  simp
+
 /-- The occupation element for the ordered matrix-unit pair `(i, j)`, normalized so that it is an
 idempotent off the diagonal. For `i = j` it is the scalar `1/2`. -/
-noncomputable def carOccupationProjection (i j : n) :
+noncomputable def carOccupationElement (i j : n) :
     CliffordAlgebra (traceQuadraticForm K n) :=
   (2 : K)⁻¹ • (carD i j * carD j i)
 
 /-- The occupation element written directly in terms of the two matrix-unit generators. -/
-theorem carOccupationProjection_def [decEq : DecidableEq n] (i j : n) :
-    carOccupationProjection (K := K) i j =
+theorem carOccupationElement_def [decEq : DecidableEq n] (i j : n) :
+    carOccupationElement (K := K) i j =
       (2 : K)⁻¹ •
         (ι (traceQuadraticForm K n) (Matrix.single i j 1) *
           ι (traceQuadraticForm K n) (Matrix.single j i 1)) := by
@@ -78,15 +86,15 @@ theorem carOccupationProjection_def [decEq : DecidableEq n] (i j : n) :
 
 /-- The diagonal occupation element is the scalar `1/2`. -/
 @[simp]
-theorem carOccupationProjection_self (i : n) :
-    carOccupationProjection (K := K) i i = (2 : K)⁻¹ • 1 := by
-  simp [carOccupationProjection, carD]
+theorem carOccupationElement_self (i : n) :
+    carOccupationElement (K := K) i i = (2 : K)⁻¹ • 1 := by
+  simp [carOccupationElement, carD]
 
 /-- Oppositely oriented off-diagonal occupation elements are orthogonal in this order. -/
 @[simp]
-theorem carOccupationProjection_mul_swap {i j : n} (hij : i ≠ j) :
-    carOccupationProjection (K := K) i j * carOccupationProjection (K := K) j i = 0 := by
-  rw [carOccupationProjection, carOccupationProjection, smul_mul_assoc, mul_smul_comm, smul_smul]
+theorem carOccupationElement_mul_swap {i j : n} (hij : i ≠ j) :
+    carOccupationElement (K := K) i j * carOccupationElement (K := K) j i = 0 := by
+  rw [carOccupationElement, carOccupationElement, smul_mul_assoc, mul_smul_comm, smul_smul]
   -- Expose the common scalar and reassociate so `simp` can see the nilpotent middle pair.
   change ((2 : K)⁻¹ * (2 : K)⁻¹) •
     ((carD (K := K) i j * carD j i) * (carD j i * carD i j)) = 0
@@ -101,43 +109,43 @@ variable [Invertible (2 : K)]
 /-- The two orientations of an occupation element are complementary. This also holds on the
 diagonal, where both terms are the scalar `1/2`. -/
 @[simp]
-theorem carOccupationProjection_add_swap (i j : n) :
-    carOccupationProjection (K := K) i j + carOccupationProjection (K := K) j i = 1 := by
-  rw [carOccupationProjection, carOccupationProjection, ← smul_add]
+theorem carOccupationElement_add_swap (i j : n) :
+    carOccupationElement (K := K) i j + carOccupationElement (K := K) j i = 1 := by
+  rw [carOccupationElement, carOccupationElement, ← smul_add]
   have hcar := traceQuadraticForm_ι_single_mul_ι_single_add_swap
     (R := K) i j j i 1 1
   simp only [one_mul] at hcar
   rw [hcar, Algebra.smul_def, ← map_mul]
   simp
 
-/-- Reversing an occupation element gives its complementary projection. -/
-theorem carOccupationProjection_swap (i j : n) :
-    carOccupationProjection (K := K) j i = 1 - carOccupationProjection (K := K) i j :=
-  eq_sub_iff_add_eq.mpr (carOccupationProjection_add_swap (K := K) j i)
+/-- Reversing an occupation element gives its complement. -/
+theorem carOccupationElement_swap (i j : n) :
+    carOccupationElement (K := K) j i = 1 - carOccupationElement (K := K) i j :=
+  eq_sub_iff_add_eq.mpr (carOccupationElement_add_swap (K := K) j i)
 
 end Half
 
 /-- Every off-diagonal occupation element is idempotent over every field. -/
-theorem isIdempotentElem_carOccupationProjection {i j : n} (hij : i ≠ j) :
-    IsIdempotentElem (carOccupationProjection (K := K) i j) := by
+theorem isIdempotentElem_carOccupationElement {i j : n} (hij : i ≠ j) :
+    IsIdempotentElem (carOccupationElement (K := K) i j) := by
   by_cases h2 : (2 : K) = 0
-  · simp [carOccupationProjection, h2, IsIdempotentElem]
+  · simp [carOccupationElement, h2, IsIdempotentElem]
   · let _ : Invertible (2 : K) := invertibleOfNonzero h2
     exact (IsIdempotentElem.of_mul_add
-      (carOccupationProjection_mul_swap (K := K) hij)
-      (carOccupationProjection_add_swap (K := K) i j)).1
+      (carOccupationElement_mul_swap (K := K) hij)
+      (carOccupationElement_add_swap (K := K) i j)).1
 
 /-- Multiplication by an off-diagonal occupation element twice is multiplication by it once. -/
 @[simp]
-theorem carOccupationProjection_mul_self {i j : n} (hij : i ≠ j) :
-    carOccupationProjection (K := K) i j * carOccupationProjection (K := K) i j =
-      carOccupationProjection (K := K) i j :=
-  (isIdempotentElem_carOccupationProjection (K := K) hij).eq
+theorem carOccupationElement_mul_self {i j : n} (hij : i ≠ j) :
+    carOccupationElement (K := K) i j * carOccupationElement (K := K) i j =
+      carOccupationElement (K := K) i j :=
+  (isIdempotentElem_carOccupationElement (K := K) hij).eq
 
 /-- All occupation elements commute, including equal and oppositely oriented pairs. -/
-theorem commute_carOccupationProjection {i j k l : n} :
-    Commute (carOccupationProjection (K := K) i j)
-      (carOccupationProjection (K := K) k l) := by
+theorem commute_carOccupationElement {i j k l : n} :
+    Commute (carOccupationElement (K := K) i j)
+      (carOccupationElement (K := K) k l) := by
   by_cases heq : (i, j) = (k, l)
   · cases heq
     exact Commute.refl _
@@ -150,13 +158,9 @@ theorem commute_carOccupationProjection {i j k l : n} :
       intro hij
       subst j
       exact heq rfl
-    change carOccupationProjection (K := K) i j * carOccupationProjection (K := K) j i =
-      carOccupationProjection (K := K) j i * carOccupationProjection (K := K) i j
-    rw [carOccupationProjection_mul_swap (K := K) hij,
-      carOccupationProjection_mul_swap (K := K) hij.symm]
-  · rw [commute_iff_lie_eq, carOccupationProjection, carOccupationProjection]
-    change ⁅(2 : K)⁻¹ • (carD i j * carD j i),
-      (2 : K)⁻¹ • (carD k l * carD l k)⁆ = 0
+    rw [commute_iff_lie_eq, Ring.lie_def, carOccupationElement_mul_swap (K := K) hij,
+      carOccupationElement_mul_swap (K := K) hij.symm, sub_self]
+  · rw [commute_iff_lie_eq, carOccupationElement, carOccupationElement]
     rw [Ring.lie_def, smul_mul_assoc, mul_smul_comm, smul_smul,
       smul_mul_assoc, mul_smul_comm, smul_smul, ← smul_sub, ← Ring.lie_def,
       lie_ι_mul_ι_ι_mul_ι]
@@ -174,24 +178,16 @@ theorem commute_carOccupationProjection {i j k l : n} :
       exact heq rfl
     have hpzy : QuadraticMap.polar (traceQuadraticForm K n)
         (Matrix.single k l 1) (Matrix.single j i 1) = 0 := by
-      rw [← QuadraticMap.polarBilin_apply_apply, polarBilin_traceQuadraticForm,
-        ← traceBilinForm_apply, traceBilinForm_single_single, ite_eq_right hzy]
-      simp
+      exact polar_single_single_eq_zero (K := K) k l j i hzy
     have hpzx : QuadraticMap.polar (traceQuadraticForm K n)
         (Matrix.single k l 1) (Matrix.single i j 1) = 0 := by
-      rw [← QuadraticMap.polarBilin_apply_apply, polarBilin_traceQuadraticForm,
-        ← traceBilinForm_apply, traceBilinForm_single_single, ite_eq_right hzx]
-      simp
+      exact polar_single_single_eq_zero (K := K) k l i j hzx
     have hpwy : QuadraticMap.polar (traceQuadraticForm K n)
         (Matrix.single l k 1) (Matrix.single j i 1) = 0 := by
-      rw [← QuadraticMap.polarBilin_apply_apply, polarBilin_traceQuadraticForm,
-        ← traceBilinForm_apply, traceBilinForm_single_single, ite_eq_right hwy]
-      simp
+      exact polar_single_single_eq_zero (K := K) l k j i hwy
     have hpxw : QuadraticMap.polar (traceQuadraticForm K n)
         (Matrix.single i j 1) (Matrix.single l k 1) = 0 := by
-      rw [← QuadraticMap.polarBilin_apply_apply, polarBilin_traceQuadraticForm,
-        ← traceBilinForm_apply, traceBilinForm_single_single, ite_eq_right hxw]
-      simp
+      exact polar_single_single_eq_zero (K := K) i j l k hxw
     simp [hpzy, hpzx, hpwy, hpxw]
 
 section Diagonal
@@ -202,22 +198,22 @@ variable [Invertible (2 : K)]
 index fixed. The diagonal summand is the scalar `1/2`. -/
 theorem glCliffordHom_single_self_eq_sum_occupation (i : n) :
     glCliffordHom (K := K) (n := n) (Matrix.single i i 1) =
-      ∑ k : n, carOccupationProjection (K := K) i k := by
+      ∑ k : n, carOccupationElement (K := K) i k := by
   rw [glCliffordHom_single, Finset.smul_sum]
-  rfl
+  simp only [carOccupationElement, carD]
 
 /-- Orient the diagonal lift using only positive-pair occupation projections. Below `i`, the
 opposite orientation is replaced by its complement. -/
 theorem glCliffordHom_single_self_eq_sum_positive_occupation
     [LinearOrder n] (i : n) :
     glCliffordHom (K := K) (n := n) (Matrix.single i i 1) =
-      ∑ k : n, if k < i then 1 - carOccupationProjection (K := K) k i
-        else carOccupationProjection (K := K) i k := by
+      ∑ k : n, if k < i then 1 - carOccupationElement (K := K) k i
+        else carOccupationElement (K := K) i k := by
   rw [glCliffordHom_single_self_eq_sum_occupation]
   apply Finset.sum_congr rfl
   intro k _
   split_ifs with hki
-  · exact eq_sub_iff_add_eq.mpr (carOccupationProjection_add_swap (K := K) i k)
+  · exact eq_sub_iff_add_eq.mpr (carOccupationElement_add_swap (K := K) i k)
   · rfl
 
 end Diagonal

--- a/TauCeti/Algebra/Lie/GeneralLinear/CAR/Occupation.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/CAR/Occupation.lean
@@ -1,0 +1,205 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Lie.GeneralLinear.Clifford
+
+/-!
+# Occupation projections in the CAR algebra
+
+For the Clifford algebra of the trace form on matrices, write `dᵢⱼ = ι(Eᵢⱼ)`. This file studies
+the normalized quadratic elements
+
+`pᵢⱼ = 1/2 dᵢⱼ dⱼᵢ`.
+
+When `i ≠ j`, these are occupation projections for the hyperbolic plane spanned by `Eᵢⱼ` and
+`Eⱼᵢ`. The CAR relations give `pᵢⱼ + pⱼᵢ = 1`, their two orders are orthogonal, and hence each is
+idempotent. Projections associated to distinct unordered pairs commute. Finally, the diagonal
+normal-ordered lift is the sum `Fᵢᵢ = ∑ k, pᵢₖ`; for a linearly ordered index type this can be
+oriented using only the positive pairs. These formulas supply the commuting zero-one operators
+used to calculate weights in the left regular CAR module.
+
+## Main definitions
+
+* `TauCeti.carOccupationProjection`: the normalized quadratic element `pᵢⱼ`.
+
+## Main results
+
+* `TauCeti.carOccupationProjection_add_swap`: `pᵢⱼ + pⱼᵢ = 1`.
+* `TauCeti.isIdempotentElem_carOccupationProjection`: off-diagonal `pᵢⱼ` are idempotent.
+* `TauCeti.carOccupationProjection_comm_of_ne_of_ne_swap`: distinct unordered pairs commute.
+* `TauCeti.glCliffordHom_single_diagonal_eq_sum_occupation`: `Fᵢᵢ = ∑ k, pᵢₖ`.
+
+## References
+
+* D. Panyushev, *The exterior algebra and "spin" of an orthogonal g-module*,
+  Transformation Groups 6 (2001), 371–396, Proposition 2.4 and Example 2.5(1).
+* C. Chevalley, *The Algebraic Theory of Spinors*, Columbia University Press, 1954.
+-/
+
+public section
+
+namespace TauCeti
+
+open CliffordAlgebra
+
+variable {K n : Type*} [Field K] [Fintype n]
+
+attribute [local instance] Classical.decEq
+
+private noncomputable abbrev carD (i j : n) :
+    CliffordAlgebra (traceQuadraticForm K n) :=
+  ι (traceQuadraticForm K n) (Matrix.single i j 1)
+
+/-- The occupation element for the ordered matrix-unit pair `(i, j)`, normalized so that it is an
+idempotent off the diagonal. For `i = j` it is the scalar `1/2`. -/
+noncomputable def carOccupationProjection (i j : n) :
+    CliffordAlgebra (traceQuadraticForm K n) :=
+  (2 : K)⁻¹ • (carD i j * carD j i)
+
+/-- The diagonal occupation element is the scalar `1/2`. -/
+@[simp]
+theorem carOccupationProjection_self (i : n) :
+    carOccupationProjection (K := K) i i = (2 : K)⁻¹ • 1 := by
+  simp [carOccupationProjection, carD]
+
+/-- Oppositely oriented off-diagonal occupation elements are orthogonal in this order. -/
+@[simp]
+theorem carOccupationProjection_mul_swap {i j : n} (hij : i ≠ j) :
+    carOccupationProjection (K := K) i j * carOccupationProjection (K := K) j i = 0 := by
+  rw [carOccupationProjection, carOccupationProjection, smul_mul_assoc, mul_smul_comm, smul_smul]
+  change ((2 : K)⁻¹ * (2 : K)⁻¹) •
+    ((carD (K := K) i j * carD j i) * (carD j i * carD i j)) = 0
+  rw [mul_assoc (carD (K := K) i j) (carD j i) (carD j i * carD i j),
+    ← mul_assoc (carD (K := K) j i) (carD j i) (carD i j)]
+  simp [carD, hij]
+
+/-- Oppositely oriented off-diagonal occupation elements are orthogonal in the reverse order. -/
+@[simp]
+theorem carOccupationProjection_swap_mul {i j : n} (hij : i ≠ j) :
+    carOccupationProjection (K := K) j i * carOccupationProjection (K := K) i j = 0 :=
+  carOccupationProjection_mul_swap (K := K) hij.symm
+
+section Half
+
+variable [Invertible (2 : K)]
+
+/-- The two orientations of an occupation element are complementary. This also holds on the
+diagonal, where both terms are the scalar `1/2`. -/
+@[simp]
+theorem carOccupationProjection_add_swap (i j : n) :
+    carOccupationProjection (K := K) i j + carOccupationProjection (K := K) j i = 1 := by
+  rw [carOccupationProjection, carOccupationProjection, ← smul_add]
+  have hcar := traceQuadraticForm_ι_single_mul_ι_single_add_swap
+    (R := K) i j j i 1 1
+  simp only [one_mul] at hcar
+  rw [hcar, Algebra.smul_def, ← map_mul]
+  simp
+
+/-- Reversing an occupation element gives its complementary projection. -/
+theorem carOccupationProjection_swap (i j : n) :
+    carOccupationProjection (K := K) j i = 1 - carOccupationProjection (K := K) i j :=
+  eq_sub_iff_add_eq.mpr (carOccupationProjection_add_swap (K := K) j i)
+
+/-- Every off-diagonal occupation element is an idempotent. -/
+theorem isIdempotentElem_carOccupationProjection {i j : n} (hij : i ≠ j) :
+    IsIdempotentElem (carOccupationProjection (K := K) i j) := by
+  exact (IsIdempotentElem.of_mul_add
+    (carOccupationProjection_mul_swap (K := K) hij)
+    (carOccupationProjection_add_swap (K := K) i j)).1
+
+end Half
+
+/-- Occupation elements for different unordered matrix-unit pairs commute. The two inequalities
+exclude equality in either orientation, exactly the cases in which a cross-contraction can be
+nonzero. -/
+theorem carOccupationProjection_comm_of_ne_of_ne_swap {i j k l : n}
+    (hne : (i, j) ≠ (k, l)) (hneSwap : (i, j) ≠ (l, k)) :
+    Commute (carOccupationProjection (K := K) i j)
+      (carOccupationProjection (K := K) k l) := by
+  have hac : carD (K := K) i j * carD k l = -(carD k l * carD i j) :=
+    traceQuadraticForm_ι_single_mul_ι_single_comm_of_not_paired i j k l 1 1 <| by
+      intro h
+      exact hneSwap (Prod.ext h.2.symm h.1)
+  have had : carD (K := K) i j * carD l k = -(carD l k * carD i j) :=
+    traceQuadraticForm_ι_single_mul_ι_single_comm_of_not_paired i j l k 1 1 <| by
+      intro h
+      exact hne (Prod.ext h.2.symm h.1)
+  have hbc : carD (K := K) j i * carD k l = -(carD k l * carD j i) :=
+    traceQuadraticForm_ι_single_mul_ι_single_comm_of_not_paired j i k l 1 1 <| by
+      intro h
+      exact hne (Prod.ext h.1 h.2.symm)
+  have hbd : carD (K := K) j i * carD l k = -(carD l k * carD j i) :=
+    traceQuadraticForm_ι_single_mul_ι_single_comm_of_not_paired j i l k 1 1 <| by
+      intro h
+      exact hneSwap (Prod.ext h.1 h.2.symm)
+  change ((2 : K)⁻¹ • (carD i j * carD j i)) * ((2 : K)⁻¹ • (carD k l * carD l k)) =
+    ((2 : K)⁻¹ • (carD k l * carD l k)) * ((2 : K)⁻¹ • (carD i j * carD j i))
+  have hsmul (x y : CliffordAlgebra (traceQuadraticForm K n)) :
+      ((2 : K)⁻¹ • x) * ((2 : K)⁻¹ • y) = ((2 : K)⁻¹ * (2 : K)⁻¹) • (x * y) := by
+    rw [smul_mul_assoc, mul_smul_comm, smul_smul]
+  rw [hsmul, hsmul]
+  apply congrArg (((2 : K)⁻¹ * (2 : K)⁻¹) • ·)
+  calc
+    (carD i j * carD j i) * (carD k l * carD l k) =
+        carD i j * (carD j i * carD k l) * carD l k := by
+      simp only [mul_assoc]
+    _ = -(carD i j * (carD k l * carD j i)) * carD l k := by rw [hbc]; simp
+    _ = (carD k l * carD i j) * carD j i * carD l k := by
+      rw [← mul_assoc (carD (K := K) i j) (carD k l) (carD j i), hac]
+      simp only [neg_mul, neg_neg, mul_assoc]
+    _ = carD k l * carD i j * (carD j i * carD l k) := by simp only [mul_assoc]
+    _ = -(carD k l * carD i j * (carD l k * carD j i)) := by rw [hbd]; simp
+    _ = (carD k l * carD l k) * (carD i j * carD j i) := by
+      rw [mul_assoc (carD (K := K) k l) (carD i j) (carD l k * carD j i),
+        ← mul_assoc (carD (K := K) i j) (carD l k) (carD j i), had]
+      simp only [neg_mul, mul_neg, neg_neg, mul_assoc]
+
+/-- Positive-pair occupation elements commute unless the pairs are equal. Positivity rules out the
+reverse-orientation exception in `carOccupationProjection_comm_of_ne_of_ne_swap`. -/
+theorem carOccupationProjection_comm_of_lt_of_lt [LinearOrder n] {i j k l : n}
+    (hij : i < j) (hkl : k < l) (hne : (i, j) ≠ (k, l)) :
+    Commute (carOccupationProjection (K := K) i j)
+      (carOccupationProjection (K := K) k l) := by
+  apply carOccupationProjection_comm_of_ne_of_ne_swap hne
+  intro h
+  have hil : i = l := congrArg Prod.fst h
+  have hjk : j = k := congrArg Prod.snd h
+  have hji : j < i := calc
+    j = k := hjk
+    _ < l := hkl
+    _ = i := hil.symm
+  exact (not_lt_of_ge hij.le) hji
+
+section Diagonal
+
+variable [Invertible (2 : K)]
+
+/-- A diagonal normal-ordered generator is the sum of all occupation elements with its first
+index fixed. The diagonal summand is the scalar `1/2`. -/
+theorem glCliffordHom_single_diagonal_eq_sum_occupation (i : n) :
+    glCliffordHom (K := K) (n := n) (Matrix.single i i 1) =
+      ∑ k : n, carOccupationProjection (K := K) i k := by
+  rw [glCliffordHom_single, Finset.smul_sum]
+  rfl
+
+/-- Orient the diagonal lift using only positive-pair occupation projections. Below `i`, the
+opposite orientation is replaced by its complement. -/
+theorem glCliffordHom_single_diagonal_eq_sum_positive_occupation
+    [LinearOrder n] (i : n) :
+    glCliffordHom (K := K) (n := n) (Matrix.single i i 1) =
+      ∑ k : n, if k < i then 1 - carOccupationProjection (K := K) k i
+        else carOccupationProjection (K := K) i k := by
+  rw [glCliffordHom_single_diagonal_eq_sum_occupation]
+  apply Finset.sum_congr rfl
+  intro k _
+  split_ifs with hki
+  · exact eq_sub_iff_add_eq.mpr (carOccupationProjection_add_swap (K := K) i k)
+  · rfl
+
+end Diagonal
+
+end TauCeti

--- a/TauCeti/Algebra/Lie/GeneralLinear/CAR/Occupation.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/CAR/Occupation.lean
@@ -18,7 +18,7 @@ the normalized quadratic elements
 When `i ≠ j`, these are occupation projections for the hyperbolic plane spanned by `Eᵢⱼ` and
 `Eⱼᵢ`. Their two orders are orthogonal. When `2` is invertible, the CAR relations also give
 `pᵢⱼ + pⱼᵢ = 1`; in characteristic two the normalization vanishes instead, so the elements remain
-idempotent in every characteristic. Projections associated to distinct unordered pairs commute.
+idempotent in every characteristic. All of the occupation elements commute with one another.
 Finally, the diagonal normal-ordered lift is the sum `Fᵢᵢ = ∑ k, pᵢₖ`; for a linearly ordered index
 type this can be oriented using only the positive pairs. These formulas supply the commuting
 zero-one operators used to calculate weights in the left regular CAR module.
@@ -32,8 +32,8 @@ zero-one operators used to calculate weights in the left regular CAR module.
 * `TauCeti.carOccupationProjection_add_swap`: `pᵢⱼ + pⱼᵢ = 1`.
 * `TauCeti.isIdempotentElem_carOccupationProjection`: off-diagonal `pᵢⱼ` are idempotent.
 * `TauCeti.carOccupationProjection_mul_self`: the corresponding multiplication normal form.
-* `TauCeti.carOccupationProjection_comm_of_ne_of_ne_swap`: distinct unordered pairs commute.
-* `TauCeti.glCliffordHom_single_diagonal_eq_sum_occupation`: `Fᵢᵢ = ∑ k, pᵢₖ`.
+* `TauCeti.commute_carOccupationProjection`: all occupation elements commute.
+* `TauCeti.glCliffordHom_single_self_eq_sum_occupation`: `Fᵢᵢ = ∑ k, pᵢₖ`.
 
 ## References
 
@@ -67,6 +67,15 @@ noncomputable def carOccupationProjection (i j : n) :
     CliffordAlgebra (traceQuadraticForm K n) :=
   (2 : K)⁻¹ • (carD i j * carD j i)
 
+/-- The occupation element written directly in terms of the two matrix-unit generators. -/
+theorem carOccupationProjection_def [decEq : DecidableEq n] (i j : n) :
+    carOccupationProjection (K := K) i j =
+      (2 : K)⁻¹ •
+        (ι (traceQuadraticForm K n) (Matrix.single i j 1) *
+          ι (traceQuadraticForm K n) (Matrix.single j i 1)) := by
+  cases Subsingleton.elim decEq (Classical.decEq n)
+  rfl
+
 /-- The diagonal occupation element is the scalar `1/2`. -/
 @[simp]
 theorem carOccupationProjection_self (i : n) :
@@ -84,12 +93,6 @@ theorem carOccupationProjection_mul_swap {i j : n} (hij : i ≠ j) :
   rw [mul_assoc (carD (K := K) i j) (carD j i) (carD j i * carD i j),
     ← mul_assoc (carD (K := K) j i) (carD j i) (carD i j)]
   simp [carD, hij]
-
-/-- Oppositely oriented off-diagonal occupation elements are orthogonal in the reverse order. -/
-@[simp]
-theorem carOccupationProjection_swap_mul {i j : n} (hij : i ≠ j) :
-    carOccupationProjection (K := K) j i * carOccupationProjection (K := K) i j = 0 :=
-  carOccupationProjection_mul_swap (K := K) hij.symm
 
 section Half
 
@@ -114,8 +117,7 @@ theorem carOccupationProjection_swap (i j : n) :
 
 end Half
 
-/-- Every off-diagonal occupation element is an idempotent. When the field has characteristic two,
-the normalization scalar is zero; otherwise this follows from orthogonality and complementarity. -/
+/-- Every off-diagonal occupation element is idempotent over every field. -/
 theorem isIdempotentElem_carOccupationProjection {i j : n} (hij : i ≠ j) :
     IsIdempotentElem (carOccupationProjection (K := K) i j) := by
   by_cases h2 : (2 : K) = 0
@@ -132,67 +134,65 @@ theorem carOccupationProjection_mul_self {i j : n} (hij : i ≠ j) :
       carOccupationProjection (K := K) i j :=
   (isIdempotentElem_carOccupationProjection (K := K) hij).eq
 
-/-- Occupation elements for different unordered matrix-unit pairs commute. The two inequalities
-exclude equality in either orientation, exactly the cases in which a cross-contraction can be
-nonzero. -/
-theorem carOccupationProjection_comm_of_ne_of_ne_swap {i j k l : n}
-    (hne : (i, j) ≠ (k, l)) (hneSwap : (i, j) ≠ (l, k)) :
+/-- All occupation elements commute, including equal and oppositely oriented pairs. -/
+theorem commute_carOccupationProjection {i j k l : n} :
     Commute (carOccupationProjection (K := K) i j)
       (carOccupationProjection (K := K) k l) := by
-  have hac : carD (K := K) i j * carD k l = -(carD k l * carD i j) :=
-    traceQuadraticForm_ι_single_mul_ι_single_comm_of_not_paired i j k l 1 1 <| by
-      intro h
-      exact hneSwap (Prod.ext h.2.symm h.1)
-  have had : carD (K := K) i j * carD l k = -(carD l k * carD i j) :=
-    traceQuadraticForm_ι_single_mul_ι_single_comm_of_not_paired i j l k 1 1 <| by
-      intro h
-      exact hne (Prod.ext h.2.symm h.1)
-  have hbc : carD (K := K) j i * carD k l = -(carD k l * carD j i) :=
-    traceQuadraticForm_ι_single_mul_ι_single_comm_of_not_paired j i k l 1 1 <| by
-      intro h
-      exact hne (Prod.ext h.1 h.2.symm)
-  have hbd : carD (K := K) j i * carD l k = -(carD l k * carD j i) :=
-    traceQuadraticForm_ι_single_mul_ι_single_comm_of_not_paired j i l k 1 1 <| by
-      intro h
-      exact hneSwap (Prod.ext h.1 h.2.symm)
-  -- Expose the scalar-normalized products before cancelling their common scalar action.
-  change ((2 : K)⁻¹ • (carD i j * carD j i)) * ((2 : K)⁻¹ • (carD k l * carD l k)) =
-    ((2 : K)⁻¹ • (carD k l * carD l k)) * ((2 : K)⁻¹ • (carD i j * carD j i))
-  have hsmul (x y : CliffordAlgebra (traceQuadraticForm K n)) :
-      ((2 : K)⁻¹ • x) * ((2 : K)⁻¹ • y) = ((2 : K)⁻¹ * (2 : K)⁻¹) • (x * y) := by
-    rw [smul_mul_assoc, mul_smul_comm, smul_smul]
-  rw [hsmul, hsmul]
-  apply congrArg (((2 : K)⁻¹ * (2 : K)⁻¹) • ·)
-  calc
-    (carD i j * carD j i) * (carD k l * carD l k) =
-        carD i j * (carD j i * carD k l) * carD l k := by
-      simp only [mul_assoc]
-    _ = -(carD i j * (carD k l * carD j i)) * carD l k := by rw [hbc]; simp
-    _ = (carD k l * carD i j) * carD j i * carD l k := by
-      rw [← mul_assoc (carD (K := K) i j) (carD k l) (carD j i), hac]
-      simp only [neg_mul, neg_neg, mul_assoc]
-    _ = carD k l * carD i j * (carD j i * carD l k) := by simp only [mul_assoc]
-    _ = -(carD k l * carD i j * (carD l k * carD j i)) := by rw [hbd]; simp
-    _ = (carD k l * carD l k) * (carD i j * carD j i) := by
-      rw [mul_assoc (carD (K := K) k l) (carD i j) (carD l k * carD j i),
-        ← mul_assoc (carD (K := K) i j) (carD l k) (carD j i), had]
-      simp only [neg_mul, mul_neg, neg_neg, mul_assoc]
-
-/-- Positive-pair occupation elements commute unless the pairs are equal. Positivity rules out the
-reverse-orientation exception in `carOccupationProjection_comm_of_ne_of_ne_swap`. -/
-theorem carOccupationProjection_comm_of_lt_of_lt [LinearOrder n] {i j k l : n}
-    (hij : i < j) (hkl : k < l) (hne : (i, j) ≠ (k, l)) :
-    Commute (carOccupationProjection (K := K) i j)
-      (carOccupationProjection (K := K) k l) := by
-  apply carOccupationProjection_comm_of_ne_of_ne_swap hne
-  intro h
-  have hil : i = l := congrArg Prod.fst h
-  have hjk : j = k := congrArg Prod.snd h
-  have hji : j < i := calc
-    j = k := hjk
-    _ < l := hkl
-    _ = i := hil.symm
-  exact (not_lt_of_ge hij.le) hji
+  by_cases heq : (i, j) = (k, l)
+  · cases heq
+    exact Commute.refl _
+  by_cases hswap : (i, j) = (l, k)
+  · have hil : i = l := congrArg Prod.fst hswap
+    have hjk : j = k := congrArg Prod.snd hswap
+    subst l
+    subst k
+    have hij : i ≠ j := by
+      intro hij
+      subst j
+      exact heq rfl
+    change carOccupationProjection (K := K) i j * carOccupationProjection (K := K) j i =
+      carOccupationProjection (K := K) j i * carOccupationProjection (K := K) i j
+    rw [carOccupationProjection_mul_swap (K := K) hij,
+      carOccupationProjection_mul_swap (K := K) hij.symm]
+  · rw [commute_iff_lie_eq, carOccupationProjection, carOccupationProjection]
+    change ⁅(2 : K)⁻¹ • (carD i j * carD j i),
+      (2 : K)⁻¹ • (carD k l * carD l k)⁆ = 0
+    rw [Ring.lie_def, smul_mul_assoc, mul_smul_comm, smul_smul,
+      smul_mul_assoc, mul_smul_comm, smul_smul, ← smul_sub, ← Ring.lie_def,
+      lie_ι_mul_ι_ι_mul_ι]
+    have hzy : ¬(l = j ∧ i = k) := by
+      rintro ⟨rfl, rfl⟩
+      exact heq rfl
+    have hzx : ¬(l = i ∧ j = k) := by
+      rintro ⟨rfl, rfl⟩
+      exact hswap rfl
+    have hwy : ¬(k = j ∧ i = l) := by
+      rintro ⟨rfl, rfl⟩
+      exact hswap rfl
+    have hxw : ¬(j = l ∧ k = i) := by
+      rintro ⟨rfl, rfl⟩
+      exact heq rfl
+    have hpzy : QuadraticMap.polar (traceQuadraticForm K n)
+        (Matrix.single k l 1) (Matrix.single j i 1) = 0 := by
+      rw [← QuadraticMap.polarBilin_apply_apply, polarBilin_traceQuadraticForm,
+        ← traceBilinForm_apply, traceBilinForm_single_single, ite_eq_right hzy]
+      simp
+    have hpzx : QuadraticMap.polar (traceQuadraticForm K n)
+        (Matrix.single k l 1) (Matrix.single i j 1) = 0 := by
+      rw [← QuadraticMap.polarBilin_apply_apply, polarBilin_traceQuadraticForm,
+        ← traceBilinForm_apply, traceBilinForm_single_single, ite_eq_right hzx]
+      simp
+    have hpwy : QuadraticMap.polar (traceQuadraticForm K n)
+        (Matrix.single l k 1) (Matrix.single j i 1) = 0 := by
+      rw [← QuadraticMap.polarBilin_apply_apply, polarBilin_traceQuadraticForm,
+        ← traceBilinForm_apply, traceBilinForm_single_single, ite_eq_right hwy]
+      simp
+    have hpxw : QuadraticMap.polar (traceQuadraticForm K n)
+        (Matrix.single i j 1) (Matrix.single l k 1) = 0 := by
+      rw [← QuadraticMap.polarBilin_apply_apply, polarBilin_traceQuadraticForm,
+        ← traceBilinForm_apply, traceBilinForm_single_single, ite_eq_right hxw]
+      simp
+    simp [hpzy, hpzx, hpwy, hpxw]
 
 section Diagonal
 
@@ -200,7 +200,7 @@ variable [Invertible (2 : K)]
 
 /-- A diagonal normal-ordered generator is the sum of all occupation elements with its first
 index fixed. The diagonal summand is the scalar `1/2`. -/
-theorem glCliffordHom_single_diagonal_eq_sum_occupation (i : n) :
+theorem glCliffordHom_single_self_eq_sum_occupation (i : n) :
     glCliffordHom (K := K) (n := n) (Matrix.single i i 1) =
       ∑ k : n, carOccupationProjection (K := K) i k := by
   rw [glCliffordHom_single, Finset.smul_sum]
@@ -208,12 +208,12 @@ theorem glCliffordHom_single_diagonal_eq_sum_occupation (i : n) :
 
 /-- Orient the diagonal lift using only positive-pair occupation projections. Below `i`, the
 opposite orientation is replaced by its complement. -/
-theorem glCliffordHom_single_diagonal_eq_sum_positive_occupation
+theorem glCliffordHom_single_self_eq_sum_positive_occupation
     [LinearOrder n] (i : n) :
     glCliffordHom (K := K) (n := n) (Matrix.single i i 1) =
       ∑ k : n, if k < i then 1 - carOccupationProjection (K := K) k i
         else carOccupationProjection (K := K) i k := by
-  rw [glCliffordHom_single_diagonal_eq_sum_occupation]
+  rw [glCliffordHom_single_self_eq_sum_occupation]
   apply Finset.sum_congr rfl
   intro k _
   split_ifs with hki


### PR DESCRIPTION
This PR adds the normalized CAR occupation elements needed for the `gl_N`-on-`M_N` worked instance of the Layer 9 Kostant isotypy milestone.

Roadmap: RepresentationTheory

## Summary

Define `pᵢⱼ = 1/2 dᵢⱼ dⱼᵢ` in the Clifford algebra of the matrix trace form and prove the characteristic equations needed by the next weight calculation: diagonal value, complementary orientations, orthogonality, off-diagonal idempotence, unconditional pairwise commutation, and the expression of each diagonal normal-ordered generator `Fᵢᵢ` as an oriented sum of occupation elements. The repeated polar-form calculation is factored through one private trace-form helper. The module credits Panyushev's worked instance, Shlyakhtenko's §2.3 occupation construction, and its companion public Lean formalization.

## Roadmap target

This advances RepresentationTheory/SpinRepresentations, Layer 9, **the worked instance: `gl_N` on `M_N(ℂ)` (the CAR algebra)**, whose target is the isotypic decomposition with staircase highest weight `ν = (N - 1/2, …, 1/2)`. After this PR, the remaining mathematical step is to use simultaneous occupation eigenspaces to force that staircase weight in every simple constituent, then combine it with the single-weight isotypy criterion and complete reducibility before proving the multiplicity formula.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"car-occupation-projections"}-->

## Verification

- Exact head: `2cd2579649cca8adfce29809de59666dcffb0d03`
- Local Lean build: `lake build` — pass (11,030 jobs)
- Axiom audit: `lake exe axioms` — pass (109,241 declarations; allowlist only)
- Lint: `env PATH=/opt/homebrew/opt/gnu-sed/libexec/gnubin:$PATH bash scripts/lint-env.sh && python3 scripts/lint-dot-notation.py && bash scripts/lint-style.sh && lake exe module-system` — pass, no new violations; headers and module system pass
- Proof golf: `ut-lean-golf` structural survey — uses `CliffordAlgebra.lie_ι_mul_ι_ι_mul_ι`, removes duplicate public specializations, and factors the repeated trace-form polar-zero calculation into one private helper; focused and full builds pass
- Public CI: pending for the updated head

## Scale and generality

The change is one 221-line module with one public definition and ten characteristic theorems. It works over an arbitrary field and finite index type, including characteristic two for idempotence and its simp-normal form; finiteness is intrinsic to the matrix trace form, invertibility of `2` is required only for complement and the normal-ordered diagonal formulas, and a linear order is required only for the positive-pair orientation.

## Scope

- **Consumes:** the trace-form CAR relations `traceQuadraticForm_ι_single_mul_ι_single_add_swap`, the generic product commutator `CliffordAlgebra.lie_ι_mul_ι_ι_mul_ι`, the normal-ordering formula `glCliffordHom_single`, and Mathlib's `IsIdempotentElem.of_mul_add`
- **Provides:** `carOccupationElement`, its consumer-facing matrix-unit equation, complement/orthogonality/off-diagonal-idempotence and unconditional commutation API, a `[simp]` self-product equation, and raw plus positive-oriented diagonal-lift sum formulas
- **Fits:** supplies the commuting zero-one off-diagonal elements required to calculate the highest weight in arbitrary simple submodules of the left-regular CAR representation
- **Boundary:** does not construct simultaneous eigenspaces, prove uniqueness of the staircase weight, prove CAR isotypy, or count its simple summands

<sub>🤖 GPT-5.6 Sol high · TauCetiWorker @ [7518d4150b846c4524423341570c031027a1d92c](https://github.com/utensil/TauCetiWorker/commit/7518d4150b846c4524423341570c031027a1d92c) · rubrics @ [afb424eda89e8ac96d9eb69f6a88972055a4cd1b](https://github.com/utensil/TauCetiReview/commit/afb424eda89e8ac96d9eb69f6a88972055a4cd1b) · local review @ [b533e561b6d44df071c31335ed4a63ae647507d2](https://github.com/utensil/formal-land/commit/b533e561b6d44df071c31335ed4a63ae647507d2) · fixed: attribution, api-design, generality, documentation, proof-quality, ut-consumer-contract, reuse, naming</sub>