### PR TITLE
chore: register the ported group-scheme smoothness lemma as a shim

### DIFF
--- a/TauCeti/mathlib-shims.json
+++ b/TauCeti/mathlib-shims.json
@@ -197,4 +197,15 @@
     "modules": [
       "Mathlib.RingTheory.Valuation.ValuativeRel.Comap"
     ]
-  }]
+  },
+  {
+    "note": "Ported from Mathlib: the proof is adapted from the private lemma `AlgebraicGeometry.smooth_of_grpObj_of_isAlgClosed` underlying `AlgebraicGeometry.smooth_of_grpObj`, added in mathlib4#37988 (https://github.com/leanprover-community/mathlib4/pull/37988, 2026-05-08). The upstream counterpart with this statement is `private`, so it cannot be imported; the public `smooth_of_grpObj` is strictly more general but is stated over `GeometricallyReduced f`, and neither library has the bridge \"reduced over a perfect field is geometrically reduced\" at scheme level. Supplying that bridge upstream retires this source; until then there is no deterministic migration, hence the landing sentinel.",
+    "landing_sentinel": true,
+    "sources": [
+      "TauCeti/AlgebraicGeometry/Group/Smooth.lean"
+    ],
+    "modules": [
+      "Mathlib.AlgebraicGeometry.Group.Smooth"
+    ]
+  }
+]

--- a/TauCeti/mathlib-shims.json
+++ b/TauCeti/mathlib-shims.json
@@ -199,7 +199,7 @@
     ]
   },
   {
-    "note": "Ported from Mathlib: the proof is adapted from the private lemma `AlgebraicGeometry.smooth_of_grpObj_of_isAlgClosed` underlying `AlgebraicGeometry.smooth_of_grpObj`, added in mathlib4#37988 (https://github.com/leanprover-community/mathlib4/pull/37988, 2026-05-08). The upstream counterpart with this statement is `private`, so it cannot be imported; the public `smooth_of_grpObj` is strictly more general but is stated over `GeometricallyReduced f`, and neither library has the bridge \"reduced over a perfect field is geometrically reduced\" at scheme level. Supplying that bridge upstream retires this source; until then there is no deterministic migration, hence the landing sentinel.",
+    "note": "Ported from Mathlib: the proof is adapted from the private lemma `AlgebraicGeometry.smooth_of_grpObj_of_isAlgClosed` underlying `AlgebraicGeometry.smooth_of_grpObj`, added by Christian Merten (`chrisflav`) in mathlib4#37988 (https://github.com/leanprover-community/mathlib4/pull/37988, 2026-05-08). The upstream counterpart with this statement is `private`, so it cannot be imported; the public `smooth_of_grpObj` is strictly more general but is stated over `GeometricallyReduced f`, and neither library has the bridge \"reduced over a perfect field is geometrically reduced\" at scheme level. Supplying that bridge upstream retires this source; until then there is no deterministic migration, hence the landing sentinel.",
     "landing_sentinel": true,
     "sources": [
       "TauCeti/AlgebraicGeometry/Group/Smooth.lean"


### PR DESCRIPTION
`TauCeti.AlgebraicGeometry.smooth_of_grpObj_of_isAlgClosed_of_isReduced` is adapted from the private lemma `AlgebraicGeometry.smooth_of_grpObj_of_isAlgClosed` underlying `AlgebraicGeometry.smooth_of_grpObj`, which landed in [mathlib4#37988](https://github.com/leanprover-community/mathlib4/pull/37988) on 2026-05-08 — four months before the Tau Ceti file. The two proofs agree line for line.

The source does credit it, in a comment above `public section`:

```lean
-- The proof is adapted from the private algebraically-closed-field lemma underlying
-- `AlgebraicGeometry.smooth_of_grpObj` in Mathlib.
```

but `docs/mathlib-shim-registry.md` asks that ported material keep "the upstream project or PR, author, and URL" in the registry note, and nothing tracked this source at all.

**Registered as a landing sentinel, not an exact replacement.** The upstream counterpart with this exact statement is `private`, so it cannot be imported; the public `smooth_of_grpObj` is strictly more general but is stated over `GeometricallyReduced f`, and that hypothesis does not currently follow from `[IsAlgClosed K] [IsReduced G]` in either library:

```lean
example {K : Type u} [Field K] [IsAlgClosed K] {G : Scheme.{u}}
    (f : G ⟶ Spec (.of K)) [LocallyOfFiniteType f] [GrpObj (Over.mk f)] [IsReduced G] :
    Smooth f := by
  have : GeometricallyReduced f := inferInstance   -- ✗ failed to synthesize
  exact smooth_of_grpObj f
```

The missing step is "reduced over a perfect field is geometrically reduced" at scheme level. Supplying it upstream retires this source; until then there is no deterministic migration, which is what the sentinel records.

`scripts/check-expired-mathlib-shims.py` accepts the entry and reports it warning-only — exit 0 even under `--fail-on-available`, so it cannot redden an unrelated PR.

Found by a cross-library duplicate-statement scan of Tau Ceti against pinned Mathlib.

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
