### PR TITLE
feat: commute quadratic localization with base change

### DIFF
--- a/TauCeti/LinearAlgebra/QuadraticForm/BaseChange.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/BaseChange.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.LinearAlgebra.QuadraticForm.TensorProduct
+public import Mathlib.LinearAlgebra.TensorProduct.Tower
 public import TauCeti.LinearAlgebra.QuadraticForm.Representation
 import Mathlib.LinearAlgebra.TensorProduct.Prod
 import TauCeti.LinearAlgebra.BilinearForm.BaseChange
@@ -15,8 +16,9 @@ import TauCeti.LinearAlgebra.BilinearForm.BaseChange
 
 This file supplies the functorial API for extending quadratic spaces along a commutative algebra.
 It lifts isometries and isometric equivalences by extending their underlying linear maps, records
-the interaction with the additive operations on forms, and proves that finite-dimensional
-nondegenerate forms remain nondegenerate over a field extension.
+the interaction with the additive operations on forms, compares direct and successive extension
+through a scalar tower, and proves that finite-dimensional nondegenerate forms remain
+nondegenerate over a field extension.
 
 These results complement Mathlib's construction `QuadraticForm.baseChange` and its pure-tensor
 evaluation theorem.  They allow localizations of a quadratic space to inherit maps and regularity
@@ -268,6 +270,62 @@ theorem baseChange_smul (r : R) (Q : _root_.QuadraticForm R M) :
 end QuadraticForm
 
 end CommRing
+
+section ScalarTower
+
+variable {R : Type uR} {A : Type uA} {B : Type uN}
+variable [CommRing R] [CommRing A] [CommRing B]
+variable [Algebra R A] [Algebra A B] [Algebra R B] [IsScalarTower R A B]
+variable [Invertible (2 : R)] [Invertible (2 : A)]
+variable {M : Type uM} [AddCommGroup M] [Module R M]
+
+namespace QuadraticForm
+
+/-- Direct base change through a scalar tower is isometric to successive base change.
+
+The underlying linear equivalence is the inverse of Mathlib's canonical cancellation
+`B ⊗[A] (A ⊗[R] M) ≃ B ⊗[R] M`. -/
+def baseChangeBaseChange (Q : _root_.QuadraticForm R M) :
+    (Q.baseChange B).IsometryEquiv ((Q.baseChange A).baseChange B) where
+  toLinearEquiv :=
+    (TensorProduct.AlgebraTensorModule.cancelBaseChange R A B B M).symm
+  map_app' x := by
+    have h : ((Q.baseChange A).baseChange B).comp
+        (TensorProduct.AlgebraTensorModule.cancelBaseChange R A B B M).symm.toLinearMap =
+        Q.baseChange B := by
+      apply _root_.baseChange_ext
+      intro m
+      simp only [QuadraticMap.comp_apply, LinearEquiv.coe_coe,
+        TensorProduct.AlgebraTensorModule.cancelBaseChange_symm_tmul,
+        _root_.QuadraticForm.baseChange_tmul, mul_one, smul_assoc, one_smul]
+    exact DFunLike.congr_fun h x
+
+/-- The linear equivalence underlying repeated base change is Mathlib's canonical tensor-product
+cancellation, read in the direction from direct to successive base change. -/
+@[simp]
+theorem baseChangeBaseChange_toLinearEquiv (Q : _root_.QuadraticForm R M) :
+    (baseChangeBaseChange (A := A) (B := B) Q).toLinearEquiv =
+      (TensorProduct.AlgebraTensorModule.cancelBaseChange R A B B M).symm :=
+  (rfl)
+
+/-- On a pure tensor, the scalar-tower base-change equivalence inserts the intermediate unit
+tensor. -/
+@[simp]
+theorem baseChangeBaseChange_tmul (Q : _root_.QuadraticForm R M) (b : B) (m : M) :
+    baseChangeBaseChange (A := A) Q (b ⊗ₜ m) = b ⊗ₜ (1 ⊗ₜ m) :=
+  TensorProduct.AlgebraTensorModule.cancelBaseChange_symm_tmul R A B b m
+
+/-- The inverse scalar-tower base-change equivalence multiplies the intermediate scalar into
+the outer tensor factor. -/
+@[simp]
+theorem baseChangeBaseChange_symm_tmul (Q : _root_.QuadraticForm R M)
+    (b : B) (a : A) (m : M) :
+    (baseChangeBaseChange (A := A) Q).symm (b ⊗ₜ (a ⊗ₜ m)) = (a • b) ⊗ₜ m :=
+  TensorProduct.AlgebraTensorModule.cancelBaseChange_tmul R A B b m a
+
+end QuadraticForm
+
+end ScalarTower
 
 section Field
 

--- a/TauCeti/LinearAlgebra/QuadraticForm/BaseChange.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/BaseChange.lean
@@ -276,7 +276,7 @@ section ScalarTower
 variable {R : Type uR} {A : Type uA} {B : Type uN}
 variable [CommRing R] [CommRing A] [CommRing B]
 variable [Algebra R A] [Algebra A B] [Algebra R B] [IsScalarTower R A B]
-variable [Invertible (2 : R)] [Invertible (2 : A)]
+variable [Invertible (2 : R)]
 variable {M : Type uM} [AddCommGroup M] [Module R M]
 
 namespace QuadraticForm
@@ -286,19 +286,23 @@ namespace QuadraticForm
 The underlying linear equivalence is the inverse of Mathlib's canonical cancellation
 `B ⊗[A] (A ⊗[R] M) ≃ B ⊗[R] M`. -/
 def baseChangeBaseChange (Q : _root_.QuadraticForm R M) :
-    (Q.baseChange B).IsometryEquiv ((Q.baseChange A).baseChange B) where
-  toLinearEquiv :=
-    (TensorProduct.AlgebraTensorModule.cancelBaseChange R A B B M).symm
-  map_app' x := by
-    have h : ((Q.baseChange A).baseChange B).comp
-        (TensorProduct.AlgebraTensorModule.cancelBaseChange R A B B M).symm.toLinearMap =
-        Q.baseChange B := by
-      apply _root_.baseChange_ext
-      intro m
-      simp only [QuadraticMap.comp_apply, LinearEquiv.coe_coe,
-        TensorProduct.AlgebraTensorModule.cancelBaseChange_symm_tmul,
-        _root_.QuadraticForm.baseChange_tmul, mul_one, smul_assoc, one_smul]
-    exact DFunLike.congr_fun h x
+    letI : Invertible (2 : A) :=
+      (Invertible.map (algebraMap R A) 2).copy 2 (map_ofNat _ _).symm
+    (Q.baseChange B).IsometryEquiv ((Q.baseChange A).baseChange B) :=
+  letI : Invertible (2 : A) :=
+    (Invertible.map (algebraMap R A) 2).copy 2 (map_ofNat _ _).symm
+  { toLinearEquiv :=
+      (TensorProduct.AlgebraTensorModule.cancelBaseChange R A B B M).symm
+    map_app' x := by
+      have h : ((Q.baseChange A).baseChange B).comp
+          (TensorProduct.AlgebraTensorModule.cancelBaseChange R A B B M).symm.toLinearMap =
+          Q.baseChange B := by
+        apply _root_.baseChange_ext
+        intro m
+        simp only [QuadraticMap.comp_apply, LinearEquiv.coe_coe,
+          TensorProduct.AlgebraTensorModule.cancelBaseChange_symm_tmul,
+          _root_.QuadraticForm.baseChange_tmul, mul_one, smul_assoc, one_smul]
+      exact DFunLike.congr_fun h x }
 
 /-- The linear equivalence underlying repeated base change is Mathlib's canonical tensor-product
 cancellation, read in the direction from direct to successive base change. -/

--- a/TauCeti/NumberTheory/QuadraticForm/Global/CompletionTower.lean
+++ b/TauCeti/NumberTheory/QuadraticForm/Global/CompletionTower.lean
@@ -48,6 +48,8 @@ def atFinitePlaceBaseChange (Q : _root_.QuadraticForm K V)
       (Invertible.map (algebraMap K (v.adicCompletion K)) 2).copy 2 (map_ofNat _ _).symm
     (atFinitePlace (Q.baseChange L) w).IsometryEquiv
       ((atFinitePlace Q v).baseChange (w.adicCompletion L)) := by
+  letI : Invertible (2 : L) :=
+    (Invertible.map (algebraMap K L) 2).copy 2 (map_ofNat _ _).symm
   letI : Invertible (2 : v.adicCompletion K) :=
     (Invertible.map (algebraMap K (v.adicCompletion K)) 2).copy 2 (map_ofNat _ _).symm
   let e := (baseChangeBaseChange (A := L) (B := w.adicCompletion L) Q).symm.trans
@@ -55,7 +57,13 @@ def atFinitePlaceBaseChange (Q : _root_.QuadraticForm K V)
   exact
     { toLinearEquiv := e.toLinearEquiv
       map_app' := fun x ↦ by
-        rw [atFinitePlace_def, atFinitePlace_def]
+        have hQ : atFinitePlace (Q.baseChange L) w =
+            (Q.baseChange L).baseChange (w.adicCompletion L) := by
+          rw [atFinitePlace_def]
+          apply _root_.baseChange_ext
+          intro y
+          simp [Algebra.smul_def]
+        rw [hQ, atFinitePlace_def]
         exact e.map_app x }
 
 /-- The localization/base-change isometry is the composite of the two canonical tensor-product

--- a/TauCeti/NumberTheory/QuadraticForm/Global/CompletionTower.lean
+++ b/TauCeti/NumberTheory/QuadraticForm/Global/CompletionTower.lean
@@ -1,0 +1,125 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.NumberTheory.NumberField.LocalGlobal.Completion
+public import TauCeti.NumberTheory.QuadraticForm.Global.Localization
+
+/-!
+# Quadratic forms in towers of number-field completions
+
+For an extension of number fields `L/K` and finite places `w` above `v`, localization commutes
+with scalar extension from `K` to `L`.  The comparison uses the canonical completion map
+`K_v → L_w`, and identifies both iterated tensor-product spaces with `L_w ⊗[K] V`.
+
+This compatibility is the bridge needed to transfer local properties of a quadratic form over
+`K` to the completions of a field extension.  In particular, it allows an isotropic vector over
+`K_v` to be extended to every `L_w` above it.
+
+## References
+
+* [J. Neukirch, *Algebraic Number Theory*][Neukirch1992], Chapter II, §6.
+-/
+
+public section
+noncomputable section
+
+open IsDedekindDomain NumberField
+open scoped AdicCompletionExtension TensorProduct
+
+universe uK uL uV
+
+namespace QuadraticForm
+
+variable {K : Type uK} [Field K] [NumberField K]
+variable {L : Type uL} [Field L] [NumberField L] [Algebra K L]
+variable {V : Type uV} [AddCommGroup V] [Module K V]
+
+/-- Localization after extending a quadratic form from `K` to `L` is canonically isometric to
+extending its localization along the completion map `K_v → L_w`. -/
+def atFinitePlaceBaseChange (Q : _root_.QuadraticForm K V)
+    (v : HeightOneSpectrum (NumberField.RingOfIntegers K))
+    (w : HeightOneSpectrum (NumberField.RingOfIntegers L))
+    [w.asIdeal.LiesOver v.asIdeal] :
+    letI : Invertible (2 : v.adicCompletion K) :=
+      (Invertible.map (algebraMap K (v.adicCompletion K)) 2).copy 2 (map_ofNat _ _).symm
+    (atFinitePlace (Q.baseChange L) w).IsometryEquiv
+      ((atFinitePlace Q v).baseChange (w.adicCompletion L)) := by
+  letI : Invertible (2 : v.adicCompletion K) :=
+    (Invertible.map (algebraMap K (v.adicCompletion K)) 2).copy 2 (map_ofNat _ _).symm
+  let e := (baseChangeBaseChange (A := L) (B := w.adicCompletion L) Q).symm.trans
+    (baseChangeBaseChange (A := v.adicCompletion K) (B := w.adicCompletion L) Q)
+  exact
+    { toLinearEquiv := e.toLinearEquiv
+      map_app' := fun x ↦ by
+        rw [atFinitePlace_def, atFinitePlace_def]
+        exact e.map_app x }
+
+/-- The localization/base-change isometry is the composite of the two canonical tensor-product
+cancellations through `L_w ⊗[K] V`. -/
+@[simp]
+theorem atFinitePlaceBaseChange_toLinearEquiv (Q : _root_.QuadraticForm K V)
+    (v : HeightOneSpectrum (NumberField.RingOfIntegers K))
+    (w : HeightOneSpectrum (NumberField.RingOfIntegers L))
+    [w.asIdeal.LiesOver v.asIdeal] :
+    letI : Invertible (2 : v.adicCompletion K) :=
+      (Invertible.map (algebraMap K (v.adicCompletion K)) 2).copy 2 (map_ofNat _ _).symm
+    (atFinitePlaceBaseChange Q v w).toLinearEquiv =
+      (TensorProduct.AlgebraTensorModule.cancelBaseChange K L (w.adicCompletion L)
+        (w.adicCompletion L) V).trans
+        (TensorProduct.AlgebraTensorModule.cancelBaseChange K (v.adicCompletion K)
+          (w.adicCompletion L) (w.adicCompletion L) V).symm := by
+  let _ : Invertible (2 : v.adicCompletion K) :=
+    (Invertible.map (algebraMap K (v.adicCompletion K)) 2).copy 2 (map_ofNat _ _).symm
+  simp only [atFinitePlaceBaseChange, QuadraticMap.IsometryEquiv.trans,
+    QuadraticMap.IsometryEquiv.symm, baseChangeBaseChange_toLinearEquiv,
+    LinearEquiv.symm_symm]
+
+/-- The localization/base-change comparison sends a twice-pure tensor to the same global vector,
+with the intermediate scalar transported along `K_v → L_w`. -/
+@[simp]
+theorem atFinitePlaceBaseChange_tmul (Q : _root_.QuadraticForm K V)
+    (v : HeightOneSpectrum (NumberField.RingOfIntegers K))
+    (w : HeightOneSpectrum (NumberField.RingOfIntegers L))
+    [w.asIdeal.LiesOver v.asIdeal] (b : w.adicCompletion L) (a : L) (x : V) :
+    atFinitePlaceBaseChange Q v w (b ⊗ₜ (a ⊗ₜ x)) =
+      (algebraMap L (w.adicCompletion L) a * b) ⊗ₜ (1 ⊗ₜ x) := by
+  let _ : Invertible (2 : v.adicCompletion K) :=
+    (Invertible.map (algebraMap K (v.adicCompletion K)) 2).copy 2 (map_ofNat _ _).symm
+  have h := DFunLike.congr_fun (atFinitePlaceBaseChange_toLinearEquiv Q v w)
+    (b ⊗ₜ (a ⊗ₜ x))
+  have hf := congrFun (QuadraticMap.IsometryEquiv.coe_toLinearEquiv
+    (atFinitePlaceBaseChange Q v w)) (b ⊗ₜ (a ⊗ₜ x))
+  apply hf.symm.trans
+  simpa only [LinearEquiv.trans_apply,
+    TensorProduct.AlgebraTensorModule.cancelBaseChange_tmul,
+    TensorProduct.AlgebraTensorModule.cancelBaseChange_symm_tmul, Algebra.smul_def] using h
+
+/-- The inverse localization/base-change comparison multiplies a completion scalar by the image
+of its intermediate `K_v`-scalar. -/
+@[simp]
+theorem atFinitePlaceBaseChange_symm_tmul (Q : _root_.QuadraticForm K V)
+    (v : HeightOneSpectrum (NumberField.RingOfIntegers K))
+    (w : HeightOneSpectrum (NumberField.RingOfIntegers L))
+    [w.asIdeal.LiesOver v.asIdeal] (b : w.adicCompletion L)
+    (a : v.adicCompletion K) (x : V) :
+    (atFinitePlaceBaseChange Q v w).symm (b ⊗ₜ (a ⊗ₜ x)) =
+      (algebraMap (v.adicCompletion K) (w.adicCompletion L) a * b) ⊗ₜ (1 ⊗ₜ x) := by
+  apply (atFinitePlaceBaseChange Q v w).symm_apply_eq.mpr
+  symm
+  rw [atFinitePlaceBaseChange_tmul]
+  simp only [map_one, one_mul]
+  rw [← Algebra.smul_def]
+  calc
+    (a • b) ⊗ₜ (1 ⊗ₜ x) = b ⊗ₜ (a • (1 ⊗ₜ x)) :=
+      TensorProduct.smul_tmul a b (1 ⊗ₜ x)
+    _ = b ⊗ₜ (a ⊗ₜ x) := by
+      apply congrArg (fun y : v.adicCompletion K ⊗[K] V ↦
+        b ⊗ₜ[v.adicCompletion K] y)
+      simpa only [smul_eq_mul, mul_one] using
+        (TensorProduct.smul_tmul' a (1 : v.adicCompletion K) x)
+
+end QuadraticForm


### PR DESCRIPTION
This PR identifies direct base change of a quadratic form through a scalar tower with successive base change, then specializes the comparison to an extension of number fields: for `w` above `v`, localization of `Q ⊗_K L` at `w` is canonically isometric to base change of `Q_v` along `completionAlgHom : K_v → L_w`. It exposes the underlying tensor-product cancellation and forward and inverse pure-tensor computation rules.

The exact roadmap target is `GlobalQuadraticForms/README.md`, Layer 0.1 “Canonical localizations,” specifically its repeated-base-change tower item. This directly serves Layer 5.1’s quaternary Hasse–Minkowski case, which passes to `E = K(√d(Q))` and must compare every localization of `Q ⊗_K E` with scalar extension of the corresponding localization of `Q`. It is the most effective current step because the Number Field Arithmetic supplier `completionAlgHom` has landed, while Layer 0.2’s local predicates are already in flight in #6220. After this PR, Layer 0.1 still needs diagonal and invariant compatibility; Layer 0 also retains complex-place automaticity in 0.3.

The generic construction reuses Mathlib’s `TensorProduct.AlgebraTensorModule.cancelBaseChange`, and the specialization reuses Tau Ceti’s canonical `completionAlgHom`, scalar-tower instance, and finite localization. No Mathlib implementation is vendored. The completion-tower interpretation follows Neukirch, *Algebraic Number Theory*, Chapter II, §6, cited in the new module.

The new module `TauCeti/NumberTheory/QuadraticForm/Global/CompletionTower.lean` contains 125 lines; the existing generic base-change module gains 60 lines and its overview is updated.

Roadmap: GlobalQuadraticForms

<!--tauceti-target:v1 {"focus":"GlobalQuadraticForms","id":"repeated-base-change-completion-towers"}-->

🤖 Prepared with Codex
