### PR TITLE
feat(ModularForms): the descent slash sum is bounded and vanishes at the cusps

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/Newforms/Descent/Cosets.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Descent/Cosets.lean
@@ -258,11 +258,11 @@ of `descendMatrixRat_det`. -/
 theorem descendMatrix_det (p N : ℕ) [NeZero p]
     (v : Fin (descendMatrixCount p N)) :
     (descendMatrix p N v : Matrix (Fin 2) (Fin 2) ℝ).det = (p : ℝ) := by
-  have h := descendMatrixRat_det p N v
-  rw [Matrix.det_fin_two] at h ⊢
-  rw [descendMatrix_eq_map]
-  simp only [Matrix.GeneralLinearGroup.map_apply]
-  rw [← map_mul, ← map_mul, ← map_sub, h, map_natCast]
+  have hmap : ((Matrix.GeneralLinearGroup.map (algebraMap ℚ ℝ) (descendMatrixRat p N v) :
+      GL (Fin 2) ℝ) : Matrix (Fin 2) (Fin 2) ℝ) =
+      (algebraMap ℚ ℝ).mapMatrix (descendMatrixRat p N v : Matrix (Fin 2) (Fin 2) ℚ) :=
+    Matrix.ext fun i j ↦ Matrix.GeneralLinearGroup.map_apply _ i j _
+  rw [descendMatrix_eq_map, hmap, ← RingHom.map_det, descendMatrixRat_det, map_natCast]
 
 /-- Every member of the descent family has positive determinant, namely `p`. -/
 theorem descendMatrix_det_pos (p N : ℕ) [NeZero p] (v : Fin (descendMatrixCount p N)) :

--- a/TauCeti/NumberTheory/ModularForms/Newforms/Descent/Cosets.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Descent/Cosets.lean
@@ -34,7 +34,8 @@ identity rather than merely lower-triangular.
   `Fin (descendMatrixCount p N)`.
 * `TauCeti.descendMatrix`: the family itself, the image of `descendMatrixRat` in `GL₂(ℝ)`
   (`descendMatrix_eq_map`); `descendMatrixRat_of_lt`/`descendMatrixRat_of_le` and
-  `descendMatrix_of_lt`/`descendMatrix_of_le` describe the members.
+  `descendMatrix_of_lt`/`descendMatrix_of_le` describe the members, and `descendMatrixRat_det`/
+  `descendMatrix_det` their determinant.
 
 ## Main results
 
@@ -234,24 +235,34 @@ theorem descendMatrix_of_le {p N : ℕ} [NeZero p]
         Matrix.SpecialLinearGroup.mapGL ℝ (descendExtraGamma p N) := by
   rw [descendMatrix_eq_map, descendMatrixRat_of_le h, map_mul, Matrix.SpecialLinearGroup.map_mapGL]
 
-/-- **Every member of the descent family has determinant `p`.** Every element of the double coset
-`Γ₀(N) diag(1, p) Γ₀(N)` that the descent sum runs over has determinant `p`, so this is a
-necessary condition for lying in it, not a characterisation of it; that these matrices lie in the
-double coset is not proved here. -/
+/-- **Every member of the rational descent family has determinant `p`.** Every element of the
+double coset `Γ₀(N) diag(1, p) Γ₀(N)` that the descent sum runs over has determinant `p`, so this
+is a necessary condition for lying in it, not a characterisation of it; that these matrices lie
+in the double coset is not proved here. -/
+@[simp]
+theorem descendMatrixRat_det (p N : ℕ) [NeZero p] (v : Fin (descendMatrixCount p N)) :
+    (descendMatrixRat p N v : Matrix (Fin 2) (Fin 2) ℚ).det = (p : ℚ) := by
+  have hγ : (Matrix.SpecialLinearGroup.mapGL ℚ (descendExtraGamma p N) :
+      Matrix (Fin 2) (Fin 2) ℚ).det = 1 := by
+    rw [← Matrix.GeneralLinearGroup.val_det_apply, Matrix.SpecialLinearGroup.det_mapGL,
+      Units.val_one]
+  rw [descendMatrixRat]
+  split_ifs
+  · simp [Matrix.det_fin_two]
+  · rw [Matrix.GeneralLinearGroup.coe_mul, Matrix.det_mul, hγ, mul_one]
+    simp [Matrix.det_fin_two]
+
+/-- **Every member of the descent family has determinant `p`**: the image under `algebraMap ℚ ℝ`
+of `descendMatrixRat_det`. -/
 @[simp]
 theorem descendMatrix_det (p N : ℕ) [NeZero p]
     (v : Fin (descendMatrixCount p N)) :
     (descendMatrix p N v : Matrix (Fin 2) (Fin 2) ℝ).det = (p : ℝ) := by
-  have hγ : (Matrix.SpecialLinearGroup.mapGL ℝ (descendExtraGamma p N) :
-      Matrix (Fin 2) (Fin 2) ℝ).det = 1 := by
-    rw [← Matrix.GeneralLinearGroup.val_det_apply, Matrix.SpecialLinearGroup.det_mapGL,
-      Units.val_one]
-  rw [descendMatrix_eq_map, descendMatrixRat]
-  split_ifs
-  · simp [Matrix.det_fin_two]
-  · rw [map_mul, Matrix.SpecialLinearGroup.map_mapGL, Matrix.GeneralLinearGroup.coe_mul,
-      Matrix.det_mul, hγ, mul_one]
-    simp [Matrix.det_fin_two]
+  have h := descendMatrixRat_det p N v
+  rw [Matrix.det_fin_two] at h ⊢
+  rw [descendMatrix_eq_map]
+  simp only [Matrix.GeneralLinearGroup.map_apply]
+  rw [← map_mul, ← map_mul, ← map_sub, h, map_natCast]
 
 /-- Every member of the descent family has positive determinant, namely `p`. -/
 theorem descendMatrix_det_pos (p N : ℕ) [NeZero p] (v : Fin (descendMatrixCount p N)) :

--- a/TauCeti/NumberTheory/ModularForms/Newforms/Descent/Cosets.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Descent/Cosets.lean
@@ -33,7 +33,8 @@ identity rather than merely lower-triangular.
 * `TauCeti.descendMatrixRat`: the family before the embedding into `GL₂(ℝ)`, indexed by
   `Fin (descendMatrixCount p N)`.
 * `TauCeti.descendMatrix`: the family itself, the image of `descendMatrixRat` in `GL₂(ℝ)`
-  (`descendMatrix_eq_map`).
+  (`descendMatrix_eq_map`); `descendMatrixRat_of_lt`/`descendMatrixRat_of_le` and
+  `descendMatrix_of_lt`/`descendMatrix_of_le` describe the members.
 
 ## Main results
 
@@ -165,13 +166,11 @@ theorem descendExtraGamma_eq_one_of_not {p N : ℕ} (h : ¬ (p.Prime ∧ p ∣ N
     descendExtraGamma p N = 1 := by
   simp [descendExtraGamma, h]
 
-/-- **The descent family at `p`** (Miyake, Lemma 4.5.11). The `p` upper-triangular matrices
-`[1, v; 0, p]` for `v < p`, together with — when `p²` does not divide `N`, so that
-`descendMatrixCount` is `p + 1` — the further matrix `[1, 0; 0, p] * descendExtraGamma p N`.
-
-Over `ℚ` the upper-triangular part is `HeckeRing.GL2.upperTriRep`, this repository's `T_p`
-representative family; the descent family is its image in `GL₂(ℝ)`, where the slash action of a
-modular form lives.
+/-- **The descent family at `p`, over `ℚ`** (Miyake, Lemma 4.5.11): a family in `GL₂(ℚ)` made of
+the `p` upper-triangular matrices `upperTriRep p v = [1, v; 0, p]` for `v < p` — this
+repository's `T_p` representative family — together with, when `p²` does not divide `N`, so
+that `descendMatrixCount` is `p + 1`, the further matrix `[1, 0; 0, p] * mapGL ℚ γ_p`, where
+`γ_p = descendExtraGamma p N` is embedded into `GL₂(ℚ)` by `mapGL ℚ`.
 
 Neither `p ∣ N` nor primality of `p` is required: the construction uses only `p ≠ 0`, to name the
 zero index of `Fin p`. Those two hypotheses are what make the family the *descent* family at a
@@ -194,6 +193,28 @@ theorem descendMatrix_eq_map (p N : ℕ) [NeZero p] (v : Fin (descendMatrixCount
     descendMatrix p N v = Matrix.GeneralLinearGroup.map (algebraMap ℚ ℝ) (descendMatrixRat p N v) :=
   (rfl)
 
+/-- The members of the rational descent family below index `p` are the upper-triangular
+matrices `[1, v; 0, p]`. -/
+@[simp]
+theorem descendMatrixRat_of_lt {p N : ℕ} [NeZero p]
+    {v : Fin (descendMatrixCount p N)} (h : v.val < p) :
+    descendMatrixRat p N v = upperTriRep p ⟨v.val, h⟩ := by
+  rw [descendMatrixRat]
+  split_ifs
+  rfl
+
+/-- The member of the rational descent family at index `p`, present exactly when `p²` does not
+divide `N`, is `[1, 0; 0, p]` times the extra matrix. -/
+@[simp]
+theorem descendMatrixRat_of_le {p N : ℕ} [NeZero p]
+    {v : Fin (descendMatrixCount p N)} (h : p ≤ v.val) :
+    descendMatrixRat p N v = upperTriRep p ⟨0, NeZero.pos p⟩ *
+      Matrix.SpecialLinearGroup.mapGL ℚ (descendExtraGamma p N) := by
+  rw [descendMatrixRat]
+  split_ifs with h'
+  · exact absurd h' (Nat.not_lt.mpr h)
+  · rfl
+
 /-- The members of the descent family below index `p` are the upper-triangular matrices
 `[1, v; 0, p]`. -/
 @[simp]
@@ -201,9 +222,7 @@ theorem descendMatrix_of_lt {p N : ℕ} [NeZero p]
     {v : Fin (descendMatrixCount p N)} (h : v.val < p) :
     descendMatrix p N v =
       Matrix.GeneralLinearGroup.map (algebraMap ℚ ℝ) (upperTriRep p ⟨v.val, h⟩) := by
-  rw [descendMatrix_eq_map, descendMatrixRat]
-  split_ifs
-  rfl
+  rw [descendMatrix_eq_map, descendMatrixRat_of_lt h]
 
 /-- The member of the descent family at index `p`, present exactly when `p²` does not divide `N`,
 is `[1, 0; 0, p]` times the extra matrix. -/
@@ -213,10 +232,7 @@ theorem descendMatrix_of_le {p N : ℕ} [NeZero p]
     descendMatrix p N v =
       Matrix.GeneralLinearGroup.map (algebraMap ℚ ℝ) (upperTriRep p ⟨0, NeZero.pos p⟩) *
         Matrix.SpecialLinearGroup.mapGL ℝ (descendExtraGamma p N) := by
-  rw [descendMatrix_eq_map, descendMatrixRat]
-  split_ifs with h'
-  · exact absurd h' (Nat.not_lt.mpr h)
-  · rw [map_mul, Matrix.SpecialLinearGroup.map_mapGL]
+  rw [descendMatrix_eq_map, descendMatrixRat_of_le h, map_mul, Matrix.SpecialLinearGroup.map_mapGL]
 
 /-- **Every member of the descent family has determinant `p`.** Every element of the double coset
 `Γ₀(N) diag(1, p) Γ₀(N)` that the descent sum runs over has determinant `p`, so this is a

--- a/TauCeti/NumberTheory/ModularForms/Newforms/Descent/Cosets.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Descent/Cosets.lean
@@ -258,11 +258,8 @@ of `descendMatrixRat_det`. -/
 theorem descendMatrix_det (p N : ℕ) [NeZero p]
     (v : Fin (descendMatrixCount p N)) :
     (descendMatrix p N v : Matrix (Fin 2) (Fin 2) ℝ).det = (p : ℝ) := by
-  have hmap : ((Matrix.GeneralLinearGroup.map (algebraMap ℚ ℝ) (descendMatrixRat p N v) :
-      GL (Fin 2) ℝ) : Matrix (Fin 2) (Fin 2) ℝ) =
-      (algebraMap ℚ ℝ).mapMatrix (descendMatrixRat p N v : Matrix (Fin 2) (Fin 2) ℚ) :=
-    Matrix.ext fun i j ↦ Matrix.GeneralLinearGroup.map_apply _ i j _
-  rw [descendMatrix_eq_map, hmap, ← RingHom.map_det, descendMatrixRat_det, map_natCast]
+  rw [descendMatrix_eq_map, Matrix.GeneralLinearGroup.val_map_apply, ← RingHom.mapMatrix_apply,
+    ← RingHom.map_det, descendMatrixRat_det, map_natCast]
 
 /-- Every member of the descent family has positive determinant, namely `p`. -/
 theorem descendMatrix_det_pos (p N : ℕ) [NeZero p] (v : Fin (descendMatrixCount p N)) :

--- a/TauCeti/NumberTheory/ModularForms/Newforms/Descent/Cosets.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Descent/Cosets.lean
@@ -30,7 +30,10 @@ identity rather than merely lower-triangular.
 * `TauCeti.descendMatrixCount`: the size of the family, `p` when `p² ∣ N` and `p + 1` otherwise.
 * `TauCeti.descendExtraGamma`: the extra matrix, with the junk value `1` outside the hypotheses
   that make the choice.
-* `TauCeti.descendMatrix`: the family itself, indexed by `Fin (descendMatrixCount p N)`.
+* `TauCeti.descendMatrixRat`: the family before the embedding into `GL₂(ℝ)`, indexed by
+  `Fin (descendMatrixCount p N)`.
+* `TauCeti.descendMatrix`: the family itself, the image of `descendMatrixRat` in `GL₂(ℝ)`
+  (`descendMatrix_eq_map`).
 
 ## Main results
 
@@ -175,13 +178,21 @@ zero index of `Fin p`. Those two hypotheses are what make the family the *descen
 prime — without `p ∣ N` the matrix `descendExtraGamma p N` is `1` and the extra member degenerates
 to `[1, 0; 0, p]`, which the first branch already lists at `v = 0` — so they belong on the later
 results that establish descent, not on the family itself. -/
+noncomputable def descendMatrixRat (p N : ℕ) [NeZero p] :
+    Fin (descendMatrixCount p N) → GL (Fin 2) ℚ := fun v ↦
+  if h : v.val < p then upperTriRep p ⟨v.val, h⟩
+  else upperTriRep p ⟨0, NeZero.pos p⟩ * Matrix.SpecialLinearGroup.mapGL ℚ (descendExtraGamma p N)
+
+/-- **The descent family**, the image of `descendMatrixRat p N` in `GL₂(ℝ)`, where the slash
+action of a modular form lives. -/
 noncomputable def descendMatrix (p N : ℕ) [NeZero p] :
     Fin (descendMatrixCount p N) → GL (Fin 2) ℝ := fun v ↦
-  if h : v.val < p then
-    Matrix.GeneralLinearGroup.map (algebraMap ℚ ℝ) (upperTriRep p ⟨v.val, h⟩)
-  else
-    Matrix.GeneralLinearGroup.map (algebraMap ℚ ℝ) (upperTriRep p ⟨0, NeZero.pos p⟩) *
-      Matrix.SpecialLinearGroup.mapGL ℝ (descendExtraGamma p N)
+  Matrix.GeneralLinearGroup.map (algebraMap ℚ ℝ) (descendMatrixRat p N v)
+
+/-- The descent family is the image of the rational descent family. -/
+theorem descendMatrix_eq_map (p N : ℕ) [NeZero p] (v : Fin (descendMatrixCount p N)) :
+    descendMatrix p N v = Matrix.GeneralLinearGroup.map (algebraMap ℚ ℝ) (descendMatrixRat p N v) :=
+  (rfl)
 
 /-- The members of the descent family below index `p` are the upper-triangular matrices
 `[1, v; 0, p]`. -/
@@ -190,7 +201,7 @@ theorem descendMatrix_of_lt {p N : ℕ} [NeZero p]
     {v : Fin (descendMatrixCount p N)} (h : v.val < p) :
     descendMatrix p N v =
       Matrix.GeneralLinearGroup.map (algebraMap ℚ ℝ) (upperTriRep p ⟨v.val, h⟩) := by
-  rw [descendMatrix]
+  rw [descendMatrix_eq_map, descendMatrixRat]
   split_ifs
   rfl
 
@@ -202,10 +213,10 @@ theorem descendMatrix_of_le {p N : ℕ} [NeZero p]
     descendMatrix p N v =
       Matrix.GeneralLinearGroup.map (algebraMap ℚ ℝ) (upperTriRep p ⟨0, NeZero.pos p⟩) *
         Matrix.SpecialLinearGroup.mapGL ℝ (descendExtraGamma p N) := by
-  rw [descendMatrix]
+  rw [descendMatrix_eq_map, descendMatrixRat]
   split_ifs with h'
   · exact absurd h' (Nat.not_lt.mpr h)
-  · rfl
+  · rw [map_mul, Matrix.SpecialLinearGroup.map_mapGL]
 
 /-- **Every member of the descent family has determinant `p`.** Every element of the double coset
 `Γ₀(N) diag(1, p) Γ₀(N)` that the descent sum runs over has determinant `p`, so this is a
@@ -219,10 +230,11 @@ theorem descendMatrix_det (p N : ℕ) [NeZero p]
       Matrix (Fin 2) (Fin 2) ℝ).det = 1 := by
     rw [← Matrix.GeneralLinearGroup.val_det_apply, Matrix.SpecialLinearGroup.det_mapGL,
       Units.val_one]
-  rw [descendMatrix]
+  rw [descendMatrix_eq_map, descendMatrixRat]
   split_ifs
   · simp [Matrix.det_fin_two]
-  · rw [Matrix.GeneralLinearGroup.coe_mul, Matrix.det_mul, hγ, mul_one]
+  · rw [map_mul, Matrix.SpecialLinearGroup.map_mapGL, Matrix.GeneralLinearGroup.coe_mul,
+      Matrix.det_mul, hγ, mul_one]
     simp [Matrix.det_fin_two]
 
 /-- Every member of the descent family has positive determinant, namely `p`. -/

--- a/TauCeti/NumberTheory/ModularForms/Newforms/Descent/Cusps.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Descent/Cusps.lean
@@ -1,0 +1,60 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.NumberTheory.ModularForms.Cusps.Rat.Slash
+public import TauCeti.NumberTheory.ModularForms.Newforms.Descent.Sum
+
+/-!
+# The descent slash sum at the cusps
+
+Every member of the descent family is the image of a rational matrix (`descendMatrix_eq_map`),
+so the descent slash sum is a finite sum of rational slashes, and a function vanishing, resp.
+bounded, at every cusp keeps that property after it (`OnePoint.isZeroAt_sum_rat_slash`,
+`OnePoint.isBoundedAt_sum_rat_slash`). This is the cusp half of the statement that the descent
+sends cusp forms to cusp forms; the other half, invariance, is `Descent/Sum.lean`.
+
+## Main results
+
+* `TauCeti.isZeroAt_descendSlash`: the descent slash sum of a function vanishing at every cusp
+  vanishes at every cusp.
+* `TauCeti.isBoundedAt_descendSlash`: the same for boundedness.
+
+Corresponds to `miyake_hecke_descend_cusp` of the AINTLIB `LeanModularForms` project
+(`LeanModularForms/StrongMultiplicityOne/HeckeDescent.lean`, Chris Birkbeck, commit
+`2baa76f742bdb4fb8ee323fabba41203bd390e08`, Apache-2.0,
+<https://github.com/CBirkbeck/AINTLIB/tree/main/projects/LeanModularForms>), which argues
+summand by summand for cusp forms of level `Γ₁(N)`; here the family's rationality feeds the
+general finite-sum statement, for any function and any arithmetic group.
+-/
+
+public section
+
+open UpperHalfPlane
+
+open scoped MatrixGroups ModularForm
+
+namespace TauCeti
+
+variable {p N : ℕ} (k : ℤ) {Γ : Subgroup (GL (Fin 2) ℝ)} [Γ.IsArithmetic] {f : ℍ → ℂ}
+  {c : OnePoint ℝ}
+
+/-- **The descent slash sum vanishes at every cusp** when the function does. -/
+theorem isZeroAt_descendSlash [NeZero p] (hf : ∀ c : OnePoint ℝ, IsCusp c Γ → c.IsZeroAt f k)
+    (hc : IsCusp c Γ) : c.IsZeroAt (descendSlash k p N f) k := by
+  rw [descendSlash_def]
+  simp_rw [descendMatrix_eq_map, ← ModularForm.rat_slash]
+  exact OnePoint.isZeroAt_sum_rat_slash k _ _ hf hc
+
+/-- **The descent slash sum is bounded at every cusp** when the function is. -/
+theorem isBoundedAt_descendSlash [NeZero p]
+    (hf : ∀ c : OnePoint ℝ, IsCusp c Γ → c.IsBoundedAt f k) (hc : IsCusp c Γ) :
+    c.IsBoundedAt (descendSlash k p N f) k := by
+  rw [descendSlash_def]
+  simp_rw [descendMatrix_eq_map, ← ModularForm.rat_slash]
+  exact OnePoint.isBoundedAt_sum_rat_slash k _ _ hf hc
+
+end TauCeti


### PR DESCRIPTION
The cusp half of "the descent sends cusp forms to cusp forms", in `Newforms/Descent/Cusps.lean`, together with the small refactor of the family that makes it a one-liner.

**`Descent/Cosets.lean`.** The family is now built in `GL₂(ℚ)` first: `descendMatrixRat p N` lists `[1, v; 0, p]` and, when `p² ∤ N`, `[1, 0; 0, p] · γ_p`; `descendMatrix p N` is its image under `algebraMap ℚ ℝ`, with `descendMatrix_eq_map` recording that (the two `descendMatrix_of_*` lemmas and `descendMatrix_det` are re-proved through it, statements unchanged).

**`Descent/Cusps.lean`.** Since every member of the family is the image of a rational matrix, the descent slash sum `descendSlash k p N f = ∑ v, f ∣[k] descendMatrix p N v` is a finite sum of rational slashes, and the general statements `OnePoint.isZeroAt_sum_rat_slash` / `OnePoint.isBoundedAt_sum_rat_slash` give:

* `isZeroAt_descendSlash`: if `f` vanishes at every cusp of an arithmetic group, so does `descendSlash k p N f`;
* `isBoundedAt_descendSlash`: the same for boundedness.

Both are stated for functions and any arithmetic `Γ`, so that the descent of a cusp form can be packaged as a cusp form once the invariance (#6242, merged) is fed in.

Roadmap: ModularForms
No `tauceti-target:v1` marker: like #6098, #6152, #6158, #6242, #6245 and #6253 before it, this is a prerequisite for the Layer 4 Atkin–Lehner Main Lemma node (the per-character route `mainLemma_charSpace_routeB`, which the roadmap records as "Miyake's sieve/conductor descent") rather than the node itself, and the contract asks for a deterministic target identifier, not an invented one.
Provenance: CBirkbeck/AINTLIB @ 2baa76f742bdb4fb8ee323fabba41203bd390e08, Apache-2.0, `projects/LeanModularForms/LeanModularForms/StrongMultiplicityOne/HeckeDescent.lean` (`miyake_hecke_descend_cusp`, `descendCosetList_lift_eq_glMap`): the source argues summand by summand for cusp forms of level `Γ₁(N)`; here the rationality of the family feeds the general finite-sum statements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQieFQn95rzgvYRvNdX3hR
