### PR TITLE
feat(ModularForms): the descent slash sum lowers the level of the nebentypus at p² ∣ N

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/Newforms/Descent/Sum.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Descent/Sum.lean
@@ -8,6 +8,8 @@ module
 public import Mathlib.Data.ZMod.Units
 public import TauCeti.NumberTheory.ModularForms.Newforms.Descent.Action
 
+import TauCeti.NumberTheory.ModularForms.CongruenceSubgroups.Units
+
 /-!
 # The descent slash sum is `Γ₀(N / p)`-invariant
 
@@ -26,8 +28,9 @@ the sum is `Γ₀(N / p)`-invariant whenever `f` is `Γ₀(N)`-invariant.
 * `TauCeti.descendSlash_zero`, `TauCeti.descendSlash_add`, `TauCeti.descendSlash_smul`:
   `f ↦ descendSlash k p N f` is linear.
 * `TauCeti.descendSlash_slash_mapGL_of_mem_Gamma0`: for `p² ∣ N` and `γ ∈ Γ₀(N / p)`, if
-  `f ∣[k] α = u • f` for every `α ∈ Γ₀(N)` with the lower-right entry of `γ` modulo `N / p`, then
-  `descendSlash k p N f ∣[k] γ = u • descendSlash k p N f`.
+  `f ∣[k] δ = u • f` for every `δ ∈ Γ₀(N)` with the lower-right entry of `γ` modulo `N / p`, then
+  `descendSlash k p N f ∣[k] γ = u • descendSlash k p N f`, for a scalar `u` from any `α` acting
+  compatibly on `ℂ`.
 * `TauCeti.descendSlash_slash_mapGL_of_nebentypus`: if `f` transforms under `Γ₀(N)` by `χ`, and
   `χ` is the pull-back of `χ₀` modulo `N / p`, then `descendSlash k p N f` transforms under
   `Γ₀(N / p)` by `χ₀` — the descent lowers the level of the nebentypus.
@@ -89,16 +92,17 @@ positive determinant (`descendMatrix_det_pos`). -/
   exact Finset.sum_congr rfl fun v _ ↦
     ModularForm.smul_slash_of_det_pos k (descendMatrix_det_pos p N v) f c
 
-/-- **The descent slash sum is `Γ₀(N / p)`-equivariant at `p² ∣ N`.** If `f ∣[k] α = u • f` for
-every `α ∈ Γ₀(N)` with the same lower-right entry modulo `N / p` as `γ ∈ Γ₀(N / p)`, then
-`descendSlash k p N f ∣[k] γ = u • descendSlash k p N f`. The hypothesis is imposed only at those
-matrices, which are all the factorisation ever produces; the scalar `u` is left free so that
-invariance and the nebentypus transport `descendSlash_slash_mapGL_of_nebentypus` are both
-instances. -/
+/-- **The descent slash sum is `Γ₀(N / p)`-equivariant at `p² ∣ N`.** If `f ∣[k] δ = u • f` for
+every `δ ∈ Γ₀(N)` with the same lower-right entry modulo `N / p` as `γ ∈ Γ₀(N / p)`, then
+`descendSlash k p N f ∣[k] γ = u • descendSlash k p N f`. With `u = 1` this is the
+`Γ₀(N / p)`-invariance of the descent sum of a `Γ₀(N)`-invariant function; with `u` a character
+value it is the nebentypus transport `descendSlash_slash_mapGL_of_nebentypus`. The scalar may
+come from any `α` acting compatibly on `ℂ`, as in `descendSlash_smul`. -/
 theorem descendSlash_slash_mapGL_of_mem_Gamma0 (k : ℤ) [NeZero p] (hpsq : p ^ 2 ∣ N)
-    {γ : SL(2, ℤ)} (hγ : γ ∈ Gamma0 (N / p)) {f : ℍ → ℂ} {u : ℂ}
-    (hf : ∀ α ∈ Gamma0 N, ((α 1 1 : ℤ) : ZMod (N / p)) = ((γ 1 1 : ℤ) : ZMod (N / p)) →
-      f ∣[k] (mapGL ℝ α : GL (Fin 2) ℝ) = u • f) :
+    {γ : SL(2, ℤ)} (hγ : γ ∈ Gamma0 (N / p)) {α : Type*} [DistribSMul α ℂ] [IsScalarTower α ℂ ℂ]
+    {f : ℍ → ℂ} {u : α}
+    (hf : ∀ δ ∈ Gamma0 N, ((δ 1 1 : ℤ) : ZMod (N / p)) = ((γ 1 1 : ℤ) : ZMod (N / p)) →
+      f ∣[k] (mapGL ℝ δ : GL (Fin 2) ℝ) = u • f) :
     descendSlash k p N f ∣[k] (mapGL ℝ γ : GL (Fin 2) ℝ) = u • descendSlash k p N f := by
   rw [descendSlash_def, SlashAction.sum_slash, Finset.smul_sum]
   have key : ∀ v : Fin (descendMatrixCount p N),
@@ -134,13 +138,11 @@ theorem descendSlash_slash_mapGL_of_nebentypus (k : ℤ) [NeZero p] (hpsq : p ^ 
       = (↑(χ₀ ((Gamma0Map (N / p)).toHomUnits γ)) : ℂ) • descendSlash k p N f := by
   apply descendSlash_slash_mapGL_of_mem_Gamma0 k hpsq γ.2
   intro δ hδ hd
-  have hmap : ZMod.unitsMap (Nat.div_dvd_of_dvd ((dvd_pow_self p two_ne_zero).trans hpsq))
-      ((Gamma0Map N).toHomUnits ⟨δ, hδ⟩) = (Gamma0Map (N / p)).toHomUnits γ := by
-    ext
-    rw [ZMod.unitsMap_val, MonoidHom.coe_toHomUnits, MonoidHom.coe_toHomUnits, Gamma0Map_apply,
-      Gamma0Map_apply,
-      ZMod.cast_intCast (Nat.div_dvd_of_dvd ((dvd_pow_self p two_ne_zero).trans hpsq))]
-    exact hd
+  have hdvd : N / p ∣ N := Nat.div_dvd_of_dvd ((dvd_pow_self p two_ne_zero).trans hpsq)
+  have hmap : ZMod.unitsMap hdvd ((Gamma0Map N).toHomUnits ⟨δ, hδ⟩) =
+      (Gamma0Map (N / p)).toHomUnits γ := by
+    rw [← Gamma0Map_toHomUnits_of_dvd hdvd ⟨δ, hδ⟩ (Gamma0_le_Gamma0_of_dvd hdvd hδ)]
+    exact Units.ext hd
   rw [hf ⟨δ, hδ⟩, hcomp, MonoidHom.comp_apply, hmap]
 
 end TauCeti

--- a/TauCeti/NumberTheory/ModularForms/Newforms/Descent/Sum.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Descent/Sum.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import Mathlib.Data.ZMod.Units
 public import TauCeti.NumberTheory.ModularForms.Newforms.Descent.Action
 
 /-!
@@ -12,8 +13,9 @@ public import TauCeti.NumberTheory.ModularForms.Newforms.Descent.Action
 
 `Newforms/Descent/Action.lean` shows that, at a prime `p` with `p² ∣ N`, right multiplication by
 `γ ∈ Γ₀(N / p)` permutes the family `descendMatrix p N` up to `Γ₀(N)`. This file draws the
-consequence that the descent consumes: the sum of the slashes of `f` along the family is
-`Γ₀(N / p)`-invariant whenever `f` is `Γ₀(N)`-invariant.
+consequence that the descent consumes: if `f` transforms under `Γ₀(N)` by a scalar, the sum of
+the slashes of `f` along the family transforms under `Γ₀(N / p)` by that scalar; in particular
+the sum is `Γ₀(N / p)`-invariant whenever `f` is `Γ₀(N)`-invariant.
 
 ## Main definitions
 
@@ -23,17 +25,18 @@ consequence that the descent consumes: the sum of the slashes of `f` along the f
 
 * `TauCeti.descendSlash_zero`, `TauCeti.descendSlash_add`, `TauCeti.descendSlash_smul`:
   `f ↦ descendSlash k p N f` is linear.
-* `TauCeti.descendSlash_slash_mapGL_of_mem_Gamma0`: for `p² ∣ N`, if `f` is `Γ₀(N)`-invariant
-  then `descendSlash k p N f` is `Γ₀(N / p)`-invariant.
+* `TauCeti.descendSlash_slash_mapGL_of_mem_Gamma0`: for `p² ∣ N` and `γ ∈ Γ₀(N / p)`, if
+  `f ∣[k] α = u • f` for every `α ∈ Γ₀(N)` with the lower-right entry of `γ` modulo `N / p`, then
+  `descendSlash k p N f ∣[k] γ = u • descendSlash k p N f`.
+* `TauCeti.descendSlash_slash_mapGL_of_nebentypus`: if `f` transforms under `Γ₀(N)` by `χ`, and
+  `χ` is the pull-back of `χ₀` modulo `N / p`, then `descendSlash k p N f` transforms under
+  `Γ₀(N / p)` by `χ₀` — the descent lowers the level of the nebentypus.
 
 ## Scope
 
-Only the `p² ∣ N` case, and only invariance: the factorisation in `Action.lean` records that
-the witness lies in `Γ₀(N)` but not its lower-right entry, so the nebentypus transport that
-`HeckeSlash/UpperTri/Invariance.lean` derives for the upper-triangular sum is not available here
-yet. The behaviour at cusps is likewise not claimed.
+Only the `p² ∣ N` case. The behaviour at cusps is not claimed.
 
-Corresponds to the `Γ₀(N / p)`-slash step of `miyake_hecke_descend_char` in the AINTLIB
+Corresponds to the `p² ∣ N` case of `miyake_hecke_descend_char` in the AINTLIB
 `LeanModularForms` project (`LeanModularForms/StrongMultiplicityOne/HeckeDescent.lean`,
 Chris Birkbeck, commit `2baa76f742bdb4fb8ee323fabba41203bd390e08`, Apache-2.0,
 <https://github.com/CBirkbeck/AINTLIB/tree/main/projects/LeanModularForms>).
@@ -86,24 +89,58 @@ positive determinant (`descendMatrix_det_pos`). -/
   exact Finset.sum_congr rfl fun v _ ↦
     ModularForm.smul_slash_of_det_pos k (descendMatrix_det_pos p N v) f c
 
-/-- **The descent slash sum is `Γ₀(N / p)`-invariant at `p² ∣ N`.** If `f` is invariant under
-`Γ₀(N)`, then `descendSlash k p N f` is invariant under the larger group `Γ₀(N / p)`: the descent
-lowers the level. -/
+/-- **The descent slash sum is `Γ₀(N / p)`-equivariant at `p² ∣ N`.** If `f ∣[k] α = u • f` for
+every `α ∈ Γ₀(N)` with the same lower-right entry modulo `N / p` as `γ ∈ Γ₀(N / p)`, then
+`descendSlash k p N f ∣[k] γ = u • descendSlash k p N f`. The hypothesis is imposed only at those
+matrices, which are all the factorisation ever produces; the scalar `u` is left free so that
+invariance and the nebentypus transport `descendSlash_slash_mapGL_of_nebentypus` are both
+instances. -/
 theorem descendSlash_slash_mapGL_of_mem_Gamma0 (k : ℤ) [NeZero p] (hpsq : p ^ 2 ∣ N)
-    {γ : SL(2, ℤ)} (hγ : γ ∈ Gamma0 (N / p)) {f : ℍ → ℂ}
-    (hf : ∀ α ∈ Gamma0 N, f ∣[k] (mapGL ℝ α : GL (Fin 2) ℝ) = f) :
-    descendSlash k p N f ∣[k] (mapGL ℝ γ : GL (Fin 2) ℝ) = descendSlash k p N f := by
-  rw [descendSlash_def, SlashAction.sum_slash]
+    {γ : SL(2, ℤ)} (hγ : γ ∈ Gamma0 (N / p)) {f : ℍ → ℂ} {u : ℂ}
+    (hf : ∀ α ∈ Gamma0 N, ((α 1 1 : ℤ) : ZMod (N / p)) = ((γ 1 1 : ℤ) : ZMod (N / p)) →
+      f ∣[k] (mapGL ℝ α : GL (Fin 2) ℝ) = u • f) :
+    descendSlash k p N f ∣[k] (mapGL ℝ γ : GL (Fin 2) ℝ) = u • descendSlash k p N f := by
+  rw [descendSlash_def, SlashAction.sum_slash, Finset.smul_sum]
   have key : ∀ v : Fin (descendMatrixCount p N),
       (f ∣[k] descendMatrix p N v) ∣[k] (mapGL ℝ γ : GL (Fin 2) ℝ)
-        = f ∣[k] descendMatrix p N (descendShift p N hpsq γ v) := fun v ↦ by
-    obtain ⟨α, hα, -, hmul⟩ := exists_mem_Gamma0_descendMatrix_mul p N hpsq hγ v
-    rw [← SlashAction.slash_mul, hmul, SlashAction.slash_mul, hf α hα]
+        = u • (f ∣[k] descendMatrix p N (descendShift p N hpsq γ v)) := fun v ↦ by
+    obtain ⟨α, hα, hd, hmul⟩ := exists_mem_Gamma0_descendMatrix_mul p N hpsq hγ v
+    have hα11 : ((α 1 1 : ℤ) : ZMod (N / p)) = ((γ 1 1 : ℤ) : ZMod (N / p)) := by
+      rw [hd]
+      push_cast
+      rw [Gamma0_mem.mp hγ]
+      ring
+    rw [← SlashAction.slash_mul, hmul, SlashAction.slash_mul, hf α hα hα11,
+      ModularForm.smul_slash_of_det_pos k (descendMatrix_det_pos p N _) f u]
   rw [Finset.sum_congr rfl fun v _ ↦ key v]
   exact Fintype.sum_bijective (descendShift p N hpsq γ)
     (descendShift_bijective hpsq
       (Gamma0_le_Gamma0_of_dvd (Nat.dvd_div_of_mul_dvd (by rwa [← pow_two])) hγ))
-    (fun v ↦ f ∣[k] descendMatrix p N (descendShift p N hpsq γ v))
-    (fun v ↦ f ∣[k] descendMatrix p N v) fun _ ↦ rfl
+    (fun v ↦ u • (f ∣[k] descendMatrix p N (descendShift p N hpsq γ v)))
+    (fun v ↦ u • (f ∣[k] descendMatrix p N v)) fun _ ↦ rfl
+
+/-- **The descent sum lowers the level of the nebentypus at `p² ∣ N`.** If `f` transforms under
+`Γ₀(N)` by `χ`, and `χ` is the pull-back of a character `χ₀` modulo `N / p` (the hypothesis
+`hcomp`, in the shape `cuspFormOfSmulSlashScaleGL_mem_cuspFormCharSpace` takes), then
+`descendSlash k p N f` transforms under `Γ₀(N / p)` by `χ₀`. -/
+theorem descendSlash_slash_mapGL_of_nebentypus (k : ℤ) [NeZero p] (hpsq : p ^ 2 ∣ N)
+    {χ : (ZMod N)ˣ →* ℂˣ} {χ₀ : (ZMod (N / p))ˣ →* ℂˣ}
+    (hcomp : χ = χ₀.comp
+      (ZMod.unitsMap (Nat.div_dvd_of_dvd ((dvd_pow_self p two_ne_zero).trans hpsq))))
+    (γ : ↥(Gamma0 (N / p))) {f : ℍ → ℂ}
+    (hf : ∀ δ : ↥(Gamma0 N), f ∣[k] (mapGL ℝ (δ : SL(2, ℤ)) : GL (Fin 2) ℝ)
+      = (↑(χ ((Gamma0Map N).toHomUnits δ)) : ℂ) • f) :
+    descendSlash k p N f ∣[k] (mapGL ℝ (γ : SL(2, ℤ)) : GL (Fin 2) ℝ)
+      = (↑(χ₀ ((Gamma0Map (N / p)).toHomUnits γ)) : ℂ) • descendSlash k p N f := by
+  apply descendSlash_slash_mapGL_of_mem_Gamma0 k hpsq γ.2
+  intro δ hδ hd
+  have hmap : ZMod.unitsMap (Nat.div_dvd_of_dvd ((dvd_pow_self p two_ne_zero).trans hpsq))
+      ((Gamma0Map N).toHomUnits ⟨δ, hδ⟩) = (Gamma0Map (N / p)).toHomUnits γ := by
+    ext
+    rw [ZMod.unitsMap_val, MonoidHom.coe_toHomUnits, MonoidHom.coe_toHomUnits, Gamma0Map_apply,
+      Gamma0Map_apply,
+      ZMod.cast_intCast (Nat.div_dvd_of_dvd ((dvd_pow_self p two_ne_zero).trans hpsq))]
+    exact hd
+  rw [hf ⟨δ, hδ⟩, hcomp, MonoidHom.comp_apply, hmap]
 
 end TauCeti

--- a/TauCeti/NumberTheory/ModularForms/Newforms/Descent/Sum.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Descent/Sum.lean
@@ -31,6 +31,8 @@ the sum is `Γ₀(N / p)`-invariant whenever `f` is `Γ₀(N)`-invariant.
   `f ∣[k] δ = u • f` for every `δ ∈ Γ₀(N)` with the lower-right entry of `γ` modulo `N / p`, then
   `descendSlash k p N f ∣[k] γ = u • descendSlash k p N f`, for a scalar `u` from any `α` acting
   compatibly on `ℂ`.
+* `TauCeti.descendSlash_slash_mapGL_eq_self_of_mem_Gamma0`: its case `u = 1` — the descent sum
+  of a `Γ₀(N)`-invariant function is `Γ₀(N / p)`-invariant.
 * `TauCeti.descendSlash_slash_mapGL_of_nebentypus`: if `f` transforms under `Γ₀(N)` by `χ`, and
   `χ` is the pull-back of `χ₀` modulo `N / p`, then `descendSlash k p N f` transforms under
   `Γ₀(N / p)` by `χ₀` — the descent lowers the level of the nebentypus.
@@ -122,6 +124,16 @@ theorem descendSlash_slash_mapGL_of_mem_Gamma0 (k : ℤ) [NeZero p] (hpsq : p ^ 
       (Gamma0_le_Gamma0_of_dvd (Nat.dvd_div_of_mul_dvd (by rwa [← pow_two])) hγ))
     (fun v ↦ u • (f ∣[k] descendMatrix p N (descendShift p N hpsq γ v)))
     (fun v ↦ u • (f ∣[k] descendMatrix p N v)) fun _ ↦ rfl
+
+/-- **The descent slash sum is `Γ₀(N / p)`-invariant at `p² ∣ N`**: if `f` is invariant under
+`Γ₀(N)`, then `descendSlash k p N f` is invariant under the larger group `Γ₀(N / p)` — the
+descent lowers the level. The case `u = 1` of `descendSlash_slash_mapGL_of_mem_Gamma0`. -/
+theorem descendSlash_slash_mapGL_eq_self_of_mem_Gamma0 (k : ℤ) [NeZero p] (hpsq : p ^ 2 ∣ N)
+    {γ : SL(2, ℤ)} (hγ : γ ∈ Gamma0 (N / p)) {f : ℍ → ℂ}
+    (hf : ∀ δ ∈ Gamma0 N, f ∣[k] (mapGL ℝ δ : GL (Fin 2) ℝ) = f) :
+    descendSlash k p N f ∣[k] (mapGL ℝ γ : GL (Fin 2) ℝ) = descendSlash k p N f := by
+  simpa using descendSlash_slash_mapGL_of_mem_Gamma0 k hpsq hγ (u := (1 : ℂ))
+    fun δ hδ _ ↦ by rw [hf δ hδ, one_smul]
 
 /-- **The descent sum lowers the level of the nebentypus at `p² ∣ N`.** If `f` transforms under
 `Γ₀(N)` by `χ`, and `χ` is the pull-back of a character `χ₀` modulo `N / p` (the hypothesis


### PR DESCRIPTION
The nebentypus half of the descent at `p² ∣ N`, in `Newforms/Descent/Sum.lean`.

**Generalisation of the invariance (#6242).** `descendSlash_slash_mapGL_of_mem_Gamma0` now carries a scalar `u` and imposes the hypothesis only where the factorisation needs it: if `f ∣[k] α = u • f` for every `α ∈ Γ₀(N)` whose lower-right entry agrees with that of `γ ∈ Γ₀(N / p)` modulo `N / p`, then `descendSlash k p N f ∣[k] γ = u • descendSlash k p N f`. The witness's lower-right entry from #6245 is exactly what discharges the restricted hypothesis. Plain invariance is the instance `u = 1` with the hypothesis weakened.

**The transport.** `descendSlash_slash_mapGL_of_nebentypus`: if `f` transforms under `Γ₀(N)` by `χ`, and `χ = χ₀.comp (ZMod.unitsMap _)` is the pull-back of a character `χ₀` modulo `N / p`, then `descendSlash k p N f` transforms under `Γ₀(N / p)` by `χ₀` — the descent lowers the level of the nebentypus. The `hcomp` hypothesis is in the shape `cuspFormOfSmulSlashScaleGL_mem_cuspFormCharSpace` already takes.

Together with #6296 (cusps) this is what packages the descent of a form in `S_k(N, χ)` as a form in `S_k(N / p, χ₀)` at `p² ∣ N`; the `p ∥ N` case follows #6253.

No `tauceti-target:v1` marker: like #6098, #6152, #6158, #6242, #6245, #6253 and #6296 before it, this is a prerequisite for the Layer 4 Atkin–Lehner Main Lemma node (the per-character route `mainLemma_charSpace_routeB`, which the roadmap records as "Miyake's sieve/conductor descent") rather than the node itself, and the contract asks for a deterministic target identifier, not an invented one.

Roadmap: ModularForms
Provenance: CBirkbeck/AINTLIB @ 2baa76f742bdb4fb8ee323fabba41203bd390e08, Apache-2.0, `projects/LeanModularForms/LeanModularForms/StrongMultiplicityOne/HeckeDescent.lean` (`miyake_hecke_descend_char`, the `p² ∣ N` case): the source proves the transport for cusp forms of level `Γ₁(N)` through its coset list; here it is a function-level statement over the family of #6098.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQieFQn95rzgvYRvNdX3hR
