### PR TITLE
feat(ModularForms): the descent slash sum does not see the level away from p

### DIFF
--- a/TauCeti/Data/ZMod/Divisibility.lean
+++ b/TauCeti/Data/ZMod/Divisibility.lean
@@ -37,6 +37,8 @@ proof uses, and the name places the divisibility in Mathlib's operand order.
   whenever `b` is a unit modulo `n`.
 * `ZMod.natCast_dvd_val_sub_of_unitsMap_eq`: two units with the same image under `ZMod.unitsMap`
   along `d ∣ N` have representatives congruent modulo `d`, as integers.
+* `ZMod.intCast_lcm_eq_of_eq_of_eq`: one residue modulo `lcm a b` from the residues modulo `a`
+  and `b` — the Chinese remainder theorem for a single integer.
 -/
 
 public section
@@ -69,5 +71,14 @@ theorem natCast_dvd_val_sub_of_unitsMap_eq {N : ℕ} [NeZero N] {d : ℕ} (hd : 
   push_cast
   rw [natCast_val (u' : ZMod N), natCast_val (u : ZMod N),
     ← castHom_apply (h := hd) (u' : ZMod N), ← castHom_apply (h := hd) (u : ZMod N), h_cast]
+
+/-- **One residue modulo a least common multiple** from the residues modulo the two moduli: the
+Chinese remainder theorem `Int.modEq_and_modEq_iff_modEq_lcm`, read in `ZMod`. -/
+theorem intCast_lcm_eq_of_eq_of_eq {a b : ℕ} {x y : ℤ} (ha : (x : ZMod a) = y)
+    (hb : (x : ZMod b) = y) : (x : ZMod (Nat.lcm a b)) = y := by
+  rw [ZMod.intCast_eq_intCast_iff] at ha hb ⊢
+  have hlcm : (↑(Nat.lcm a b) : ℤ) = ↑(Int.lcm (a : ℤ) (b : ℤ)) := by simp [Int.lcm, Nat.lcm]
+  rw [hlcm, ← Int.modEq_and_modEq_iff_modEq_lcm]
+  exact ⟨ha, hb⟩
 
 end ZMod

--- a/TauCeti/Data/ZMod/Divisibility.lean
+++ b/TauCeti/Data/ZMod/Divisibility.lean
@@ -37,6 +37,7 @@ proof uses, and the name places the divisibility in Mathlib's operand order.
   whenever `b` is a unit modulo `n`.
 * `ZMod.natCast_dvd_val_sub_of_unitsMap_eq`: two units with the same image under `ZMod.unitsMap`
   along `d ∣ N` have representatives congruent modulo `d`, as integers.
+* `ZMod.intCast_eq_intCast_of_coprime`: the Chinese remainder theorem for a single residue.
 -/
 
 public section
@@ -69,5 +70,13 @@ theorem natCast_dvd_val_sub_of_unitsMap_eq {N : ℕ} [NeZero N] {d : ℕ} (hd : 
   push_cast
   rw [natCast_val (u' : ZMod N), natCast_val (u : ZMod N),
     ← castHom_apply (h := hd) (u' : ZMod N), ← castHom_apply (h := hd) (u : ZMod N), h_cast]
+
+/-- **The Chinese remainder theorem for one residue**: an integer congruent to `y` modulo two
+coprime moduli is congruent to `y` modulo their product. -/
+theorem intCast_eq_intCast_of_coprime {a b : ℕ} (hab : Nat.Coprime a b) {x y : ℤ}
+    (ha : (x : ZMod a) = y) (hb : (x : ZMod b) = y) : (x : ZMod (a * b)) = y := by
+  rw [ZMod.intCast_eq_intCast_iff] at ha hb ⊢
+  push_cast
+  exact (Int.modEq_and_modEq_iff_modEq_mul (by simpa using hab)).mp ⟨ha, hb⟩
 
 end ZMod

--- a/TauCeti/Data/ZMod/Divisibility.lean
+++ b/TauCeti/Data/ZMod/Divisibility.lean
@@ -37,7 +37,6 @@ proof uses, and the name places the divisibility in Mathlib's operand order.
   whenever `b` is a unit modulo `n`.
 * `ZMod.natCast_dvd_val_sub_of_unitsMap_eq`: two units with the same image under `ZMod.unitsMap`
   along `d ∣ N` have representatives congruent modulo `d`, as integers.
-* `ZMod.intCast_eq_intCast_of_coprime`: the Chinese remainder theorem for a single residue.
 -/
 
 public section
@@ -70,13 +69,5 @@ theorem natCast_dvd_val_sub_of_unitsMap_eq {N : ℕ} [NeZero N] {d : ℕ} (hd : 
   push_cast
   rw [natCast_val (u' : ZMod N), natCast_val (u : ZMod N),
     ← castHom_apply (h := hd) (u' : ZMod N), ← castHom_apply (h := hd) (u : ZMod N), h_cast]
-
-/-- **The Chinese remainder theorem for one residue**: an integer congruent to `y` modulo two
-coprime moduli is congruent to `y` modulo their product. -/
-theorem intCast_eq_intCast_of_coprime {a b : ℕ} (hab : Nat.Coprime a b) {x y : ℤ}
-    (ha : (x : ZMod a) = y) (hb : (x : ZMod b) = y) : (x : ZMod (a * b)) = y := by
-  rw [ZMod.intCast_eq_intCast_iff] at ha hb ⊢
-  push_cast
-  exact (Int.modEq_and_modEq_iff_modEq_mul (by simpa using hab)).mp ⟨ha, hb⟩
 
 end ZMod

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/UpperTriFactorization.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/UpperTriFactorization.lean
@@ -255,10 +255,9 @@ theorem exists_mem_Gamma0_upperTriRep_mul_of_mem_Gamma0 [NeZero p] (hpN : p ∣ 
   ring
 
 /-- **Conjugating an element of `Γ(N)` through `[1, 0; 0, p]` lands in `Γ₁(N)`**, for `p ∣ N`:
-`[1, 0; 0, p] · δ = ε · [1, 0; 0, p]` with `ε ∈ Γ₁(N)`. This is the factorisation
-`exists_mem_Gamma0_upperTriRep_mul_of_mem_Gamma0` at offset `0`, where the offset map fixes `0`
-because `δ ≡ 1 (mod p)`, and the witness lies in `Γ₁(N)` because its lower-right entry is that
-of `δ`. -/
+`[1, 0; 0, p] · δ = ε · [1, 0; 0, p]` with `ε ∈ Γ₁(N)`. This is what lets a `Γ₁(N)`-invariant
+function absorb a change of the extra representative of the descent family
+(`Newforms/Descent/LevelCommute.lean`). -/
 theorem exists_mem_Gamma1_upperTriRep_mul_of_mem_Gamma [NeZero p] (hpN : p ∣ N) {δ : SL(2, ℤ)}
     (hδ : δ ∈ Gamma N) :
     ∃ ε ∈ Gamma1 N, upperTriRep p ⟨0, NeZero.pos p⟩ * mapGL ℚ δ =

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/UpperTriFactorization.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/UpperTriFactorization.lean
@@ -254,4 +254,23 @@ theorem exists_mem_Gamma0_upperTriRep_mul_of_mem_Gamma0 [NeZero p] (hpN : p ∣ 
   rw [Gamma0_mem.mp hγ]
   ring
 
+/-- **Conjugating an element of `Γ(N)` through `[1, 0; 0, p]` lands in `Γ₁(N)`**, for `p ∣ N`:
+`[1, 0; 0, p] · δ = ε · [1, 0; 0, p]` with `ε ∈ Γ₁(N)`. This is the factorisation
+`exists_mem_Gamma0_upperTriRep_mul_of_mem_Gamma0` at offset `0`, where the offset map fixes `0`
+because `δ ≡ 1 (mod p)`, and the witness lies in `Γ₁(N)` because its lower-right entry is that
+of `δ`. -/
+theorem exists_mem_Gamma1_upperTriRep_mul_of_mem_Gamma [NeZero p] (hpN : p ∣ N) {δ : SL(2, ℤ)}
+    (hδ : δ ∈ Gamma N) :
+    ∃ ε ∈ Gamma1 N, upperTriRep p ⟨0, NeZero.pos p⟩ * mapGL ℚ δ =
+      mapGL ℚ ε * upperTriRep p ⟨0, NeZero.pos p⟩ := by
+  obtain ⟨h00, h01, -, -⟩ := Gamma_mem.mp (Gamma_le_Gamma_of_dvd hpN hδ)
+  obtain ⟨ε, hε, hdd, hmul⟩ :=
+    exists_mem_Gamma0_upperTriRep_mul_of_mem_Gamma0 hpN (Gamma_le_Gamma0 N hδ) ⟨0, NeZero.pos p⟩
+  have hshift : upperTriShift p δ ⟨0, NeZero.pos p⟩ = ⟨0, NeZero.pos p⟩ := by
+    rw [upperTriShift_eq_iff (by simp [h00])]
+    simp [h01]
+  refine ⟨ε, mem_Gamma1_iff.mpr ⟨hε, ?_⟩, ?_⟩
+  · rw [hdd, (Gamma_mem.mp hδ).2.2.2]
+  · rwa [hshift] at hmul
+
 end HeckeRing.GL2

--- a/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups/Basic.lean
@@ -93,8 +93,7 @@ infrastructure independent of the diamond operators.
 * `CongruenceSubgroup.Gamma_gcd_eq_sup`: `Γ(gcd a b) = Γ(a) ⊔ Γ(b)` — Shimura's Lemma 3.28,
   the Chinese remainder theorem for `SL₂`.
 * `CongruenceSubgroup.Gamma_lcm_eq_inf`: `Γ(lcm a b) = Γ(a) ⊓ Γ(b)`, with the coprime case
-  `CongruenceSubgroup.Gamma_mul_eq_inf_of_coprime` and its element form
-  `CongruenceSubgroup.mem_Gamma_mul_of_coprime`.
+  `CongruenceSubgroup.Gamma_mul_eq_inf_of_coprime`.
 
 ## References
 
@@ -745,15 +744,6 @@ theorem exists_mem_Gamma_map_intCast_zmod_eq {d d' : ℕ} (hcop : Nat.Coprime d 
   rw [MonoidHom.prod_apply, Prod.mk.injEq] at hγ
   exact ⟨γ, Gamma_mem'.mpr hγ.2, hγ.1⟩
 
-/-- One integer residue modulo the least common multiple, from the residues modulo the two
-levels: the Chinese remainder theorem in the form `Int.modEq_and_modEq_iff_modEq_lcm`. -/
-private lemma intCast_zmod_lcm_eq_of_eq {a b : ℕ} {x y : ℤ} (ha : (x : ZMod a) = y)
-    (hb : (x : ZMod b) = y) : (x : ZMod (Nat.lcm a b)) = y := by
-  rw [ZMod.intCast_eq_intCast_iff] at ha hb ⊢
-  have hlcm : (↑(Nat.lcm a b) : ℤ) = ↑(Int.lcm (a : ℤ) (b : ℤ)) := by simp [Int.lcm, Nat.lcm]
-  rw [hlcm, ← Int.modEq_and_modEq_iff_modEq_lcm]
-  exact ⟨ha, hb⟩
-
 /-- **`Γ(lcm a b) = Γ(a) ⊓ Γ(b)`**: a matrix is congruent to the identity modulo two levels
 exactly when it is modulo their least common multiple. -/
 theorem Gamma_lcm_eq_inf (a b : ℕ) : Gamma (Nat.lcm a b) = Gamma a ⊓ Gamma b := by
@@ -762,23 +752,17 @@ theorem Gamma_lcm_eq_inf (a b : ℕ) : Gamma (Nat.lcm a b) = Gamma a ⊓ Gamma b
   obtain ⟨ha, hb⟩ := Subgroup.mem_inf.mp hγ
   rw [Gamma_mem] at ha hb ⊢
   refine ⟨?_, ?_, ?_, ?_⟩
-  · simpa using intCast_zmod_lcm_eq_of_eq (y := 1) (by simpa using ha.1) (by simpa using hb.1)
-  · simpa using intCast_zmod_lcm_eq_of_eq (y := 0) (by simpa using ha.2.1)
+  · simpa using ZMod.intCast_lcm_eq_of_eq_of_eq (y := 1) (by simpa using ha.1) (by simpa using hb.1)
+  · simpa using ZMod.intCast_lcm_eq_of_eq_of_eq (y := 0) (by simpa using ha.2.1)
       (by simpa using hb.2.1)
-  · simpa using intCast_zmod_lcm_eq_of_eq (y := 0) (by simpa using ha.2.2.1)
+  · simpa using ZMod.intCast_lcm_eq_of_eq_of_eq (y := 0) (by simpa using ha.2.2.1)
       (by simpa using hb.2.2.1)
-  · simpa using intCast_zmod_lcm_eq_of_eq (y := 1) (by simpa using ha.2.2.2)
+  · simpa using ZMod.intCast_lcm_eq_of_eq_of_eq (y := 1) (by simpa using ha.2.2.2)
       (by simpa using hb.2.2.2)
 
 /-- **`Γ(a b) = Γ(a) ⊓ Γ(b)` for coprime `a` and `b`**: `Gamma_lcm_eq_inf` at coprime levels. -/
 theorem Gamma_mul_eq_inf_of_coprime {a b : ℕ} (hab : Nat.Coprime a b) :
     Gamma (a * b) = Gamma a ⊓ Gamma b := by
   rw [← hab.lcm_eq_mul, Gamma_lcm_eq_inf]
-
-/-- The element form of `Gamma_mul_eq_inf_of_coprime`. -/
-theorem mem_Gamma_mul_of_coprime {a b : ℕ} (hab : Nat.Coprime a b) {γ : SL(2, ℤ)}
-    (ha : γ ∈ Gamma a) (hb : γ ∈ Gamma b) : γ ∈ Gamma (a * b) := by
-  rw [Gamma_mul_eq_inf_of_coprime hab]
-  exact Subgroup.mem_inf.mpr ⟨ha, hb⟩
 
 end CongruenceSubgroup

--- a/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups/Basic.lean
@@ -92,7 +92,9 @@ infrastructure independent of the diamond operators.
   prime `p` and `k ≥ 1`.
 * `CongruenceSubgroup.Gamma_gcd_eq_sup`: `Γ(gcd a b) = Γ(a) ⊔ Γ(b)` — Shimura's Lemma 3.28,
   the Chinese remainder theorem for `SL₂`.
-* `CongruenceSubgroup.mem_Gamma_mul_of_coprime`: `Γ(a) ⊓ Γ(b) ≤ Γ(a b)` for coprime `a`, `b`.
+* `CongruenceSubgroup.Gamma_lcm_eq_inf`: `Γ(lcm a b) = Γ(a) ⊓ Γ(b)`, with the coprime case
+  `CongruenceSubgroup.Gamma_mul_eq_inf_of_coprime` and its element form
+  `CongruenceSubgroup.mem_Gamma_mul_of_coprime`.
 
 ## References
 
@@ -743,19 +745,40 @@ theorem exists_mem_Gamma_map_intCast_zmod_eq {d d' : ℕ} (hcop : Nat.Coprime d 
   rw [MonoidHom.prod_apply, Prod.mk.injEq] at hγ
   exact ⟨γ, Gamma_mem'.mpr hγ.2, hγ.1⟩
 
-/-- **`Γ(a) ⊓ Γ(b) ≤ Γ(a b)` for coprime `a` and `b`**: a matrix congruent to the identity modulo
-two coprime levels is congruent to it modulo their product. -/
-theorem mem_Gamma_mul_of_coprime {a b : ℕ} (hab : Nat.Coprime a b) {γ : SL(2, ℤ)}
-    (ha : γ ∈ Gamma a) (hb : γ ∈ Gamma b) : γ ∈ Gamma (a * b) := by
+/-- One integer residue modulo the least common multiple, from the residues modulo the two
+levels: the Chinese remainder theorem in the form `Int.modEq_and_modEq_iff_modEq_lcm`. -/
+private lemma intCast_zmod_lcm_eq_of_eq {a b : ℕ} {x y : ℤ} (ha : (x : ZMod a) = y)
+    (hb : (x : ZMod b) = y) : (x : ZMod (Nat.lcm a b)) = y := by
+  rw [ZMod.intCast_eq_intCast_iff] at ha hb ⊢
+  have hlcm : (↑(Nat.lcm a b) : ℤ) = ↑(Int.lcm (a : ℤ) (b : ℤ)) := by simp [Int.lcm, Nat.lcm]
+  rw [hlcm, ← Int.modEq_and_modEq_iff_modEq_lcm]
+  exact ⟨ha, hb⟩
+
+/-- **`Γ(lcm a b) = Γ(a) ⊓ Γ(b)`**: a matrix is congruent to the identity modulo two levels
+exactly when it is modulo their least common multiple. -/
+theorem Gamma_lcm_eq_inf (a b : ℕ) : Gamma (Nat.lcm a b) = Gamma a ⊓ Gamma b := by
+  refine le_antisymm (le_inf (Gamma_le_Gamma_of_dvd (Nat.dvd_lcm_left a b))
+    (Gamma_le_Gamma_of_dvd (Nat.dvd_lcm_right a b))) fun γ hγ ↦ ?_
+  obtain ⟨ha, hb⟩ := Subgroup.mem_inf.mp hγ
   rw [Gamma_mem] at ha hb ⊢
   refine ⟨?_, ?_, ?_, ?_⟩
-  · simpa using ZMod.intCast_eq_intCast_of_coprime hab (y := 1) (by simpa using ha.1)
-      (by simpa using hb.1)
-  · simpa using ZMod.intCast_eq_intCast_of_coprime hab (y := 0) (by simpa using ha.2.1)
+  · simpa using intCast_zmod_lcm_eq_of_eq (y := 1) (by simpa using ha.1) (by simpa using hb.1)
+  · simpa using intCast_zmod_lcm_eq_of_eq (y := 0) (by simpa using ha.2.1)
       (by simpa using hb.2.1)
-  · simpa using ZMod.intCast_eq_intCast_of_coprime hab (y := 0) (by simpa using ha.2.2.1)
+  · simpa using intCast_zmod_lcm_eq_of_eq (y := 0) (by simpa using ha.2.2.1)
       (by simpa using hb.2.2.1)
-  · simpa using ZMod.intCast_eq_intCast_of_coprime hab (y := 1) (by simpa using ha.2.2.2)
+  · simpa using intCast_zmod_lcm_eq_of_eq (y := 1) (by simpa using ha.2.2.2)
       (by simpa using hb.2.2.2)
+
+/-- **`Γ(a b) = Γ(a) ⊓ Γ(b)` for coprime `a` and `b`**: `Gamma_lcm_eq_inf` at coprime levels. -/
+theorem Gamma_mul_eq_inf_of_coprime {a b : ℕ} (hab : Nat.Coprime a b) :
+    Gamma (a * b) = Gamma a ⊓ Gamma b := by
+  rw [← hab.lcm_eq_mul, Gamma_lcm_eq_inf]
+
+/-- The element form of `Gamma_mul_eq_inf_of_coprime`. -/
+theorem mem_Gamma_mul_of_coprime {a b : ℕ} (hab : Nat.Coprime a b) {γ : SL(2, ℤ)}
+    (ha : γ ∈ Gamma a) (hb : γ ∈ Gamma b) : γ ∈ Gamma (a * b) := by
+  rw [Gamma_mul_eq_inf_of_coprime hab]
+  exact Subgroup.mem_inf.mpr ⟨ha, hb⟩
 
 end CongruenceSubgroup

--- a/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups/Basic.lean
@@ -92,6 +92,7 @@ infrastructure independent of the diamond operators.
   prime `p` and `k ≥ 1`.
 * `CongruenceSubgroup.Gamma_gcd_eq_sup`: `Γ(gcd a b) = Γ(a) ⊔ Γ(b)` — Shimura's Lemma 3.28,
   the Chinese remainder theorem for `SL₂`.
+* `CongruenceSubgroup.mem_Gamma_mul_of_coprime`: `Γ(a) ⊓ Γ(b) ≤ Γ(a b)` for coprime `a`, `b`.
 
 ## References
 
@@ -741,5 +742,20 @@ theorem exists_mem_Gamma_map_intCast_zmod_eq {d d' : ℕ} (hcop : Nat.Coprime d 
   obtain ⟨γ, hγ⟩ := Matrix.SpecialLinearGroup.map_intCast_zmod_prod_surjective hcop (A, 1)
   rw [MonoidHom.prod_apply, Prod.mk.injEq] at hγ
   exact ⟨γ, Gamma_mem'.mpr hγ.2, hγ.1⟩
+
+/-- **`Γ(a) ⊓ Γ(b) ≤ Γ(a b)` for coprime `a` and `b`**: a matrix congruent to the identity modulo
+two coprime levels is congruent to it modulo their product. -/
+theorem mem_Gamma_mul_of_coprime {a b : ℕ} (hab : Nat.Coprime a b) {γ : SL(2, ℤ)}
+    (ha : γ ∈ Gamma a) (hb : γ ∈ Gamma b) : γ ∈ Gamma (a * b) := by
+  rw [Gamma_mem] at ha hb ⊢
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · simpa using ZMod.intCast_eq_intCast_of_coprime hab (y := 1) (by simpa using ha.1)
+      (by simpa using hb.1)
+  · simpa using ZMod.intCast_eq_intCast_of_coprime hab (y := 0) (by simpa using ha.2.1)
+      (by simpa using hb.2.1)
+  · simpa using ZMod.intCast_eq_intCast_of_coprime hab (y := 0) (by simpa using ha.2.2.1)
+      (by simpa using hb.2.2.1)
+  · simpa using ZMod.intCast_eq_intCast_of_coprime hab (y := 1) (by simpa using ha.2.2.2)
+      (by simpa using hb.2.2.2)
 
 end CongruenceSubgroup

--- a/TauCeti/NumberTheory/ModularForms/Newforms/Descent/LevelCommute.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Descent/LevelCommute.lean
@@ -54,9 +54,7 @@ namespace TauCeti
 
 variable {p l N : ℕ}
 
-/-- The descent family has the same size at `l N` as at `N` when `l` is coprime to `p`. Not a
-simp lemma: the coprimality hypothesis is not something `simp` can discharge, so the `simpNF`
-linter rejects it. -/
+/-- The descent family has the same size at `l N` as at `N` when `l` is coprime to `p`. -/
 theorem descendMatrixCount_mul_left_of_coprime (hpl : Nat.Coprime p l) (N : ℕ) :
     descendMatrixCount p (l * N) = descendMatrixCount p N := by
   by_cases h : p ^ 2 ∣ N
@@ -83,16 +81,22 @@ private theorem descendExtraGamma_mul_inv_mem_Gamma (hp : p.Prime) (hpN : p ∣ 
     have h2 : descendExtraGamma p N ∈ Gamma (N / p) :=
       Gamma_mem'.mpr (descendExtraGamma_map_intCast_zmod_div_eq_one hp hpN hpsq)
     exact (Gamma (N / p)).mul_mem h1 ((Gamma (N / p)).inv_mem h2)
-  have := mem_Gamma_mul_of_coprime hcop hδp hδq
+  have : descendExtraGamma p (l * N) * (descendExtraGamma p N)⁻¹ ∈ Gamma (p * (N / p)) := by
+    rw [Gamma_mul_eq_inf_of_coprime hcop]
+    exact Subgroup.mem_inf.mpr ⟨hδp, hδq⟩
   rwa [Nat.mul_div_cancel' hpN] at this
 
 /-- **The extra representatives at levels `l N` and `N` differ on the left by `Γ₁(N)`.** -/
 theorem exists_mem_Gamma1_descendMatrix_mul_left_eq (hp : p.Prime) (hpN : p ∣ N)
-    (hpsq : ¬ p ^ 2 ∣ N) (hpl : Nat.Coprime p l) {v : Fin (descendMatrixCount p N)}
-    (hv : p ≤ v.val) {w : Fin (descendMatrixCount p (l * N))} (hw : p ≤ w.val) :
+    (hpl : Nat.Coprime p l) {v : Fin (descendMatrixCount p N)} (hv : p ≤ v.val)
+    {w : Fin (descendMatrixCount p (l * N))} (hw : p ≤ w.val) :
     haveI : NeZero p := ⟨hp.ne_zero⟩
     ∃ ε ∈ Gamma1 N, descendMatrix p (l * N) w = mapGL ℝ ε * descendMatrix p N v := by
   have : NeZero p := ⟨hp.ne_zero⟩
+  have hpsq : ¬ p ^ 2 ∣ N := fun h ↦ by
+    have h1 := v.isLt
+    have h2 := descendMatrixCount_of_sq_dvd h
+    omega
   obtain ⟨ε, hε, hεmul⟩ := exists_mem_Gamma1_upperTriRep_mul_of_mem_Gamma (p := p) hpN
     (descendExtraGamma_mul_inv_mem_Gamma hp hpN hpsq hpl)
   refine ⟨ε, hε, ?_⟩
@@ -120,12 +124,7 @@ theorem descendSlash_mul_left_of_coprime (k : ℤ) (hp : p.Prime) (hpN : p ∣ N
     have hidx : (⟨(finCongr (descendMatrixCount_mul_left_of_coprime hpl N) w).val, hw'⟩ : Fin p)
         = ⟨w.val, hw⟩ := Fin.ext (by simp)
     rw [descendMatrix_of_lt hw, descendMatrix_of_lt hw', hidx]
-  · have hpsq : ¬ p ^ 2 ∣ N := fun h ↦ by
-      have h1 := w.isLt
-      have h2 := descendMatrixCount_mul_left_of_coprime hpl N
-      have h3 := descendMatrixCount_of_sq_dvd h
-      omega
-    obtain ⟨ε, hε, hεeq⟩ := exists_mem_Gamma1_descendMatrix_mul_left_eq hp hpN hpsq hpl
+  · obtain ⟨ε, hε, hεeq⟩ := exists_mem_Gamma1_descendMatrix_mul_left_eq hp hpN hpl
       (v := finCongr (descendMatrixCount_mul_left_of_coprime hpl N) w) (by simpa using hw)
       (Nat.not_lt.mp hw)
     rw [hεeq, SlashAction.slash_mul, hf ε hε]

--- a/TauCeti/NumberTheory/ModularForms/Newforms/Descent/LevelCommute.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Descent/LevelCommute.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.NumberTheory.HeckeRing.GL2.Gamma0.UpperTriFactorization
 public import TauCeti.NumberTheory.ModularForms.Newforms.Descent.Sum
 
 /-!
@@ -56,6 +55,7 @@ namespace TauCeti
 variable {p l N : ℕ}
 
 /-- The descent family has the same size at `l N` as at `N` when `l` is coprime to `p`. -/
+@[simp]
 theorem descendMatrixCount_mul_left_of_coprime (hpl : Nat.Coprime p l) (N : ℕ) :
     descendMatrixCount p (l * N) = descendMatrixCount p N := by
   by_cases h : p ^ 2 ∣ N

--- a/TauCeti/NumberTheory/ModularForms/Newforms/Descent/LevelCommute.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Descent/LevelCommute.lean
@@ -54,8 +54,9 @@ namespace TauCeti
 
 variable {p l N : ℕ}
 
-/-- The descent family has the same size at `l N` as at `N` when `l` is coprime to `p`. -/
-@[simp]
+/-- The descent family has the same size at `l N` as at `N` when `l` is coprime to `p`. Not a
+simp lemma: the coprimality hypothesis is not something `simp` can discharge, so the `simpNF`
+linter rejects it. -/
 theorem descendMatrixCount_mul_left_of_coprime (hpl : Nat.Coprime p l) (N : ℕ) :
     descendMatrixCount p (l * N) = descendMatrixCount p N := by
   by_cases h : p ^ 2 ∣ N

--- a/TauCeti/NumberTheory/ModularForms/Newforms/Descent/LevelCommute.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Descent/LevelCommute.lean
@@ -1,0 +1,177 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.NumberTheory.ModularForms.Newforms.Descent.Sum
+
+import TauCeti.LinearAlgebra.Matrix.SpecialLinearGroup.Basic
+
+/-!
+# The descent slash sum does not see the level away from `p`
+
+The descent family `descendMatrix p N` at a prime `p ∣ N` consists of the `p` upper-triangular
+matrices `[1, v; 0, p]`, which do not depend on `N` at all, together with — exactly when
+`p² ∤ N` — one extra representative `[1, 0; 0, p] · γ_N`, where `γ_N ∈ SL(2, ℤ)` is chosen
+congruent to `S` modulo `p` and to `1` modulo `N / p`. Replacing `N` by `l N` with `l` coprime
+to `p` leaves the count unchanged and replaces `γ_N` by some `γ_{lN}`, which satisfies the same
+two congruences; so `γ_{lN} γ_N⁻¹` is congruent to `1` modulo `p` and modulo `N / p`, hence
+modulo `N`, and conjugating it through `[1, 0; 0, p]` produces an element of `Γ₁(N)`
+(`exists_mem_Gamma1_descendMatrix_mul_left_eq`). A function invariant under `Γ₁(N)` therefore
+has the same descent slash sum at the two levels (`descendSlash_mul_left_of_coprime`): Miyake's
+Lemma 4.6.6, in the form the level-lowering induction consumes.
+
+## Main results
+
+* `TauCeti.descendMatrixCount_mul_left_of_coprime`: the size of the descent family at `l N`
+  equals its size at `N` when `l` is coprime to `p`.
+* `TauCeti.exists_mem_Gamma1_descendMatrix_mul_left_eq`: the extra representatives at levels
+  `l N` and `N` differ on the left by an element of `Γ₁(N)`.
+* `TauCeti.descendSlash_mul_left_of_coprime`: **the descent slash sum is the same at levels
+  `l N` and `N`** for every function invariant under `Γ₁(N)`.
+
+## Provenance
+
+`descendCosetList_slash_sum_rep_invariance` and `descendCosetList_slash_sum_commute` of the
+AINTLIB `LeanModularForms` project (`StrongMultiplicityOne/LevelCommute.lean`, Chris Birkbeck,
+commit `2baa76f742bdb4fb8ee323fabba41203bd390e08`, Apache-2.0,
+<https://github.com/CBirkbeck/AINTLIB/tree/main/projects/LeanModularForms>), which assume a
+nebentypus; here the invariance is derived from `Γ₁(N)` alone, since the two extra
+representatives differ by an element of `Γ(N)` conjugated into `Γ₁(N)`.
+
+## References
+
+* [T. Miyake, *Modular forms*][miyake1989], Lemma 4.6.6.
+-/
+
+public section
+
+open CongruenceSubgroup HeckeRing.GL2 Matrix Matrix.SpecialLinearGroup UpperHalfPlane
+
+open scoped MatrixGroups ModularForm
+
+namespace TauCeti
+
+variable {p l N : ℕ}
+
+/-- The descent family has the same size at `l N` as at `N` when `l` is coprime to `p`. -/
+theorem descendMatrixCount_mul_left_of_coprime (hpl : Nat.Coprime p l) (N : ℕ) :
+    descendMatrixCount p (l * N) = descendMatrixCount p N := by
+  by_cases h : p ^ 2 ∣ N
+  · rw [descendMatrixCount_of_sq_dvd h, descendMatrixCount_of_sq_dvd (Dvd.dvd.mul_left h l)]
+  · rw [descendMatrixCount_of_not_sq_dvd h, descendMatrixCount_of_not_sq_dvd
+      (mt (Nat.Coprime.pow_left 2 hpl).dvd_mul_left.mp h)]
+
+/-- The Chinese remainder theorem for a single integer residue. -/
+private theorem intCast_zmod_mul_eq_of_coprime {a b : ℕ} (hab : Nat.Coprime a b) {x y : ℤ}
+    (ha : (x : ZMod a) = y) (hb : (x : ZMod b) = y) : (x : ZMod (a * b)) = y := by
+  rw [ZMod.intCast_eq_intCast_iff] at ha hb ⊢
+  push_cast
+  exact (Int.modEq_and_modEq_iff_modEq_mul (by simpa using hab)).mp ⟨ha, hb⟩
+
+/-- `Γ(a) ⊓ Γ(b) ≤ Γ(a b)` for coprime `a` and `b`. -/
+private theorem mem_Gamma_mul_of_coprime {a b : ℕ} (hab : Nat.Coprime a b) {γ : SL(2, ℤ)}
+    (ha : γ ∈ Gamma a) (hb : γ ∈ Gamma b) : γ ∈ Gamma (a * b) := by
+  rw [Gamma_mem] at ha hb ⊢
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · simpa using intCast_zmod_mul_eq_of_coprime hab (y := 1) (by simpa using ha.1)
+      (by simpa using hb.1)
+  · simpa using intCast_zmod_mul_eq_of_coprime hab (y := 0) (by simpa using ha.2.1)
+      (by simpa using hb.2.1)
+  · simpa using intCast_zmod_mul_eq_of_coprime hab (y := 0) (by simpa using ha.2.2.1)
+      (by simpa using hb.2.2.1)
+  · simpa using intCast_zmod_mul_eq_of_coprime hab (y := 1) (by simpa using ha.2.2.2)
+      (by simpa using hb.2.2.2)
+
+/-- The extra matrices at levels `l N` and `N` differ by an element of `Γ(N)`. -/
+private theorem descendExtraGamma_mul_inv_mem_Gamma (hp : p.Prime) (hpN : p ∣ N)
+    (hpsq : ¬ p ^ 2 ∣ N) (hpl : Nat.Coprime p l) :
+    descendExtraGamma p (l * N) * (descendExtraGamma p N)⁻¹ ∈ Gamma N := by
+  have hpN' : p ∣ l * N := Dvd.dvd.mul_left hpN l
+  have hpsq' : ¬ p ^ 2 ∣ l * N := mt (Nat.Coprime.pow_left 2 hpl).dvd_mul_left.mp hpsq
+  have hcop : Nat.Coprime p (N / p) := hp.coprime_iff_not_dvd.mpr fun h ↦ hpsq <| by
+    rw [sq, ← Nat.mul_div_cancel' hpN]
+    exact Nat.mul_dvd_mul_left p h
+  have hδp : descendExtraGamma p (l * N) * (descendExtraGamma p N)⁻¹ ∈ Gamma p := by
+    rw [Gamma_mem', map_mul, map_inv, descendExtraGamma_map_intCast_zmod_eq_S hp hpN' hpsq',
+      descendExtraGamma_map_intCast_zmod_eq_S hp hpN hpsq, mul_inv_cancel]
+  have hδq : descendExtraGamma p (l * N) * (descendExtraGamma p N)⁻¹ ∈ Gamma (N / p) := by
+    have h1 : descendExtraGamma p (l * N) ∈ Gamma (N / p) :=
+      Gamma_le_Gamma_of_dvd (by rw [Nat.mul_div_assoc l hpN]; exact dvd_mul_left _ _)
+        (Gamma_mem'.mpr (descendExtraGamma_map_intCast_zmod_div_eq_one hp hpN' hpsq'))
+    have h2 : descendExtraGamma p N ∈ Gamma (N / p) :=
+      Gamma_mem'.mpr (descendExtraGamma_map_intCast_zmod_div_eq_one hp hpN hpsq)
+    exact (Gamma (N / p)).mul_mem h1 ((Gamma (N / p)).inv_mem h2)
+  have := mem_Gamma_mul_of_coprime hcop hδp hδq
+  rwa [Nat.mul_div_cancel' hpN] at this
+
+/-- The matrix `[a, b; p c, d]` built from `δ = [a, p b; c, d]`: the conjugate of `δ` through
+`[1, 0; 0, p]`, which is again integral of determinant one. -/
+private def upperTriConj (p : ℕ) (δ : SL(2, ℤ)) (b : ℤ) (hb : δ 0 1 = p * b) : SL(2, ℤ) :=
+  ⟨!![δ 0 0, b; (p : ℤ) * δ 1 0, δ 1 1], by
+    rw [Matrix.det_fin_two_of]
+    linear_combination fin_two_mul_sub_mul_eq_one δ + δ 1 0 * hb⟩
+
+private theorem coe_upperTriConj (p : ℕ) (δ : SL(2, ℤ)) (b : ℤ) (hb : δ 0 1 = p * b) :
+    (↑(upperTriConj p δ b hb) : Matrix (Fin 2) (Fin 2) ℤ) = !![δ 0 0, b; (p : ℤ) * δ 1 0, δ 1 1] :=
+  rfl
+
+/-- Conjugating an element of `Γ(N)` through `[1, 0; 0, p]`, for `p ∣ N`, lands in `Γ₁(N)`:
+`[1, 0; 0, p] · δ = ε · [1, 0; 0, p]` with `ε = [a, b / p; p c, d]`. -/
+private theorem exists_mem_Gamma1_upperTriRep_mul_mapGL [NeZero p] (hpN : p ∣ N)
+    {δ : SL(2, ℤ)} (hδ : δ ∈ Gamma N) :
+    ∃ ε ∈ Gamma1 N, upperTriRep p ⟨0, NeZero.pos p⟩ * mapGL ℚ δ =
+      mapGL ℚ ε * upperTriRep p ⟨0, NeZero.pos p⟩ := by
+  rw [Gamma_mem] at hδ
+  obtain ⟨h00, h01, h10, h11⟩ := hδ
+  obtain ⟨b, hb⟩ : (p : ℤ) ∣ δ 0 1 :=
+    (Int.natCast_dvd_natCast.mpr hpN).trans ((ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mp h01)
+  refine ⟨upperTriConj p δ b hb, ?_, ?_⟩
+  · rw [Gamma1_mem]
+    refine ⟨?_, ?_, ?_⟩ <;> simp [coe_upperTriConj, h00, h10, h11]
+  · apply Units.ext
+    rw [Units.val_mul, Units.val_mul, coe_upperTriRep, coe_mapGL_int_rat_fin_two,
+      coe_mapGL_int_rat_fin_two, coe_upperTriConj]
+    ext i j
+    fin_cases i <;> fin_cases j <;> simp [Matrix.mul_apply, Fin.sum_univ_two, hb] <;> ring
+
+/-- **The extra representatives at levels `l N` and `N` differ on the left by `Γ₁(N)`.** -/
+theorem exists_mem_Gamma1_descendMatrix_mul_left_eq [NeZero p] (hp : p.Prime) (hpN : p ∣ N)
+    (hpsq : ¬ p ^ 2 ∣ N) (hpl : Nat.Coprime p l) {v : Fin (descendMatrixCount p N)}
+    (hv : p ≤ v.val) {w : Fin (descendMatrixCount p (l * N))} (hw : p ≤ w.val) :
+    ∃ ε ∈ Gamma1 N, descendMatrix p (l * N) w = mapGL ℝ ε * descendMatrix p N v := by
+  obtain ⟨ε, hε, hεmul⟩ := exists_mem_Gamma1_upperTriRep_mul_mapGL (p := p) hpN
+    (descendExtraGamma_mul_inv_mem_Gamma hp hpN hpsq hpl)
+  refine ⟨ε, hε, ?_⟩
+  have hQ : upperTriRep p ⟨0, NeZero.pos p⟩ * mapGL ℚ (descendExtraGamma p (l * N)) =
+      mapGL ℚ ε * (upperTriRep p ⟨0, NeZero.pos p⟩ * mapGL ℚ (descendExtraGamma p N)) := by
+    rw [← mul_assoc, ← hεmul, mul_assoc, ← map_mul, inv_mul_cancel_right]
+  simpa only [descendMatrix_of_le hw, descendMatrix_of_le hv, map_mul, map_mapGL]
+    using congrArg (Matrix.GeneralLinearGroup.map (algebraMap ℚ ℝ)) hQ
+
+/-- **Miyake, Lemma 4.6.6 — the descent slash sum does not see the level away from `p`.** For
+`l` coprime to `p` and `f` invariant under `Γ₁(N)`, the descent slash sums of `f` at levels `l N`
+and `N` coincide. -/
+theorem descendSlash_mul_left_of_coprime (k : ℤ) [NeZero p] (hp : p.Prime) (hpN : p ∣ N)
+    (hpl : Nat.Coprime p l) {f : ℍ → ℂ}
+    (hf : ∀ ε ∈ Gamma1 N, f ∣[k] (mapGL ℝ ε : GL (Fin 2) ℝ) = f) :
+    descendSlash k p (l * N) f = descendSlash k p N f := by
+  rw [descendSlash_def, descendSlash_def]
+  refine Fintype.sum_equiv (finCongr (descendMatrixCount_mul_left_of_coprime hpl N)) _ _
+    fun w ↦ ?_
+  by_cases hw : w.val < p
+  · rw [descendMatrix_of_lt hw, descendMatrix_of_lt (v := finCongr _ w) (by simpa using hw)]
+    rfl
+  · have hpsq : ¬ p ^ 2 ∣ N := fun h ↦ by
+      have h1 := w.isLt
+      have h2 := descendMatrixCount_mul_left_of_coprime hpl N
+      have h3 := descendMatrixCount_of_sq_dvd h
+      omega
+    obtain ⟨ε, hε, hεeq⟩ := exists_mem_Gamma1_descendMatrix_mul_left_eq hp hpN hpsq hpl
+      (v := finCongr (descendMatrixCount_mul_left_of_coprime hpl N) w) (by simpa using hw)
+      (Nat.not_lt.mp hw)
+    rw [hεeq, SlashAction.slash_mul, hf ε hε]
+
+end TauCeti

--- a/TauCeti/NumberTheory/ModularForms/Newforms/Descent/LevelCommute.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Descent/LevelCommute.lean
@@ -5,9 +5,8 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.NumberTheory.HeckeRing.GL2.Gamma0.UpperTriFactorization
 public import TauCeti.NumberTheory.ModularForms.Newforms.Descent.Sum
-
-import TauCeti.LinearAlgebra.Matrix.SpecialLinearGroup.Basic
 
 /-!
 # The descent slash sum does not see the level away from `p`
@@ -64,27 +63,6 @@ theorem descendMatrixCount_mul_left_of_coprime (hpl : Nat.Coprime p l) (N : ℕ)
   · rw [descendMatrixCount_of_not_sq_dvd h, descendMatrixCount_of_not_sq_dvd
       (mt (Nat.Coprime.pow_left 2 hpl).dvd_mul_left.mp h)]
 
-/-- The Chinese remainder theorem for a single integer residue. -/
-private theorem intCast_zmod_mul_eq_of_coprime {a b : ℕ} (hab : Nat.Coprime a b) {x y : ℤ}
-    (ha : (x : ZMod a) = y) (hb : (x : ZMod b) = y) : (x : ZMod (a * b)) = y := by
-  rw [ZMod.intCast_eq_intCast_iff] at ha hb ⊢
-  push_cast
-  exact (Int.modEq_and_modEq_iff_modEq_mul (by simpa using hab)).mp ⟨ha, hb⟩
-
-/-- `Γ(a) ⊓ Γ(b) ≤ Γ(a b)` for coprime `a` and `b`. -/
-private theorem mem_Gamma_mul_of_coprime {a b : ℕ} (hab : Nat.Coprime a b) {γ : SL(2, ℤ)}
-    (ha : γ ∈ Gamma a) (hb : γ ∈ Gamma b) : γ ∈ Gamma (a * b) := by
-  rw [Gamma_mem] at ha hb ⊢
-  refine ⟨?_, ?_, ?_, ?_⟩
-  · simpa using intCast_zmod_mul_eq_of_coprime hab (y := 1) (by simpa using ha.1)
-      (by simpa using hb.1)
-  · simpa using intCast_zmod_mul_eq_of_coprime hab (y := 0) (by simpa using ha.2.1)
-      (by simpa using hb.2.1)
-  · simpa using intCast_zmod_mul_eq_of_coprime hab (y := 0) (by simpa using ha.2.2.1)
-      (by simpa using hb.2.2.1)
-  · simpa using intCast_zmod_mul_eq_of_coprime hab (y := 1) (by simpa using ha.2.2.2)
-      (by simpa using hb.2.2.2)
-
 /-- The extra matrices at levels `l N` and `N` differ by an element of `Γ(N)`. -/
 private theorem descendExtraGamma_mul_inv_mem_Gamma (hp : p.Prime) (hpN : p ∣ N)
     (hpsq : ¬ p ^ 2 ∣ N) (hpl : Nat.Coprime p l) :
@@ -107,42 +85,14 @@ private theorem descendExtraGamma_mul_inv_mem_Gamma (hp : p.Prime) (hpN : p ∣ 
   have := mem_Gamma_mul_of_coprime hcop hδp hδq
   rwa [Nat.mul_div_cancel' hpN] at this
 
-/-- The matrix `[a, b; p c, d]` built from `δ = [a, p b; c, d]`: the conjugate of `δ` through
-`[1, 0; 0, p]`, which is again integral of determinant one. -/
-private def upperTriConj (p : ℕ) (δ : SL(2, ℤ)) (b : ℤ) (hb : δ 0 1 = p * b) : SL(2, ℤ) :=
-  ⟨!![δ 0 0, b; (p : ℤ) * δ 1 0, δ 1 1], by
-    rw [Matrix.det_fin_two_of]
-    linear_combination fin_two_mul_sub_mul_eq_one δ + δ 1 0 * hb⟩
-
-private theorem coe_upperTriConj (p : ℕ) (δ : SL(2, ℤ)) (b : ℤ) (hb : δ 0 1 = p * b) :
-    (↑(upperTriConj p δ b hb) : Matrix (Fin 2) (Fin 2) ℤ) = !![δ 0 0, b; (p : ℤ) * δ 1 0, δ 1 1] :=
-  rfl
-
-/-- Conjugating an element of `Γ(N)` through `[1, 0; 0, p]`, for `p ∣ N`, lands in `Γ₁(N)`:
-`[1, 0; 0, p] · δ = ε · [1, 0; 0, p]` with `ε = [a, b / p; p c, d]`. -/
-private theorem exists_mem_Gamma1_upperTriRep_mul_mapGL [NeZero p] (hpN : p ∣ N)
-    {δ : SL(2, ℤ)} (hδ : δ ∈ Gamma N) :
-    ∃ ε ∈ Gamma1 N, upperTriRep p ⟨0, NeZero.pos p⟩ * mapGL ℚ δ =
-      mapGL ℚ ε * upperTriRep p ⟨0, NeZero.pos p⟩ := by
-  rw [Gamma_mem] at hδ
-  obtain ⟨h00, h01, h10, h11⟩ := hδ
-  obtain ⟨b, hb⟩ : (p : ℤ) ∣ δ 0 1 :=
-    (Int.natCast_dvd_natCast.mpr hpN).trans ((ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mp h01)
-  refine ⟨upperTriConj p δ b hb, ?_, ?_⟩
-  · rw [Gamma1_mem]
-    refine ⟨?_, ?_, ?_⟩ <;> simp [coe_upperTriConj, h00, h10, h11]
-  · apply Units.ext
-    rw [Units.val_mul, Units.val_mul, coe_upperTriRep, coe_mapGL_int_rat_fin_two,
-      coe_mapGL_int_rat_fin_two, coe_upperTriConj]
-    ext i j
-    fin_cases i <;> fin_cases j <;> simp [Matrix.mul_apply, Fin.sum_univ_two, hb] <;> ring
-
 /-- **The extra representatives at levels `l N` and `N` differ on the left by `Γ₁(N)`.** -/
-theorem exists_mem_Gamma1_descendMatrix_mul_left_eq [NeZero p] (hp : p.Prime) (hpN : p ∣ N)
+theorem exists_mem_Gamma1_descendMatrix_mul_left_eq (hp : p.Prime) (hpN : p ∣ N)
     (hpsq : ¬ p ^ 2 ∣ N) (hpl : Nat.Coprime p l) {v : Fin (descendMatrixCount p N)}
     (hv : p ≤ v.val) {w : Fin (descendMatrixCount p (l * N))} (hw : p ≤ w.val) :
+    haveI : NeZero p := ⟨hp.ne_zero⟩
     ∃ ε ∈ Gamma1 N, descendMatrix p (l * N) w = mapGL ℝ ε * descendMatrix p N v := by
-  obtain ⟨ε, hε, hεmul⟩ := exists_mem_Gamma1_upperTriRep_mul_mapGL (p := p) hpN
+  have : NeZero p := ⟨hp.ne_zero⟩
+  obtain ⟨ε, hε, hεmul⟩ := exists_mem_Gamma1_upperTriRep_mul_of_mem_Gamma (p := p) hpN
     (descendExtraGamma_mul_inv_mem_Gamma hp hpN hpsq hpl)
   refine ⟨ε, hε, ?_⟩
   have hQ : upperTriRep p ⟨0, NeZero.pos p⟩ * mapGL ℚ (descendExtraGamma p (l * N)) =
@@ -154,16 +104,21 @@ theorem exists_mem_Gamma1_descendMatrix_mul_left_eq [NeZero p] (hp : p.Prime) (h
 /-- **Miyake, Lemma 4.6.6 — the descent slash sum does not see the level away from `p`.** For
 `l` coprime to `p` and `f` invariant under `Γ₁(N)`, the descent slash sums of `f` at levels `l N`
 and `N` coincide. -/
-theorem descendSlash_mul_left_of_coprime (k : ℤ) [NeZero p] (hp : p.Prime) (hpN : p ∣ N)
+theorem descendSlash_mul_left_of_coprime (k : ℤ) (hp : p.Prime) (hpN : p ∣ N)
     (hpl : Nat.Coprime p l) {f : ℍ → ℂ}
     (hf : ∀ ε ∈ Gamma1 N, f ∣[k] (mapGL ℝ ε : GL (Fin 2) ℝ) = f) :
+    haveI : NeZero p := ⟨hp.ne_zero⟩
     descendSlash k p (l * N) f = descendSlash k p N f := by
+  have : NeZero p := ⟨hp.ne_zero⟩
   rw [descendSlash_def, descendSlash_def]
   refine Fintype.sum_equiv (finCongr (descendMatrixCount_mul_left_of_coprime hpl N)) _ _
     fun w ↦ ?_
   by_cases hw : w.val < p
-  · rw [descendMatrix_of_lt hw, descendMatrix_of_lt (v := finCongr _ w) (by simpa using hw)]
-    rfl
+  · have hw' : (finCongr (descendMatrixCount_mul_left_of_coprime hpl N) w).val < p := by
+      simpa using hw
+    have hidx : (⟨(finCongr (descendMatrixCount_mul_left_of_coprime hpl N) w).val, hw'⟩ : Fin p)
+        = ⟨w.val, hw⟩ := Fin.ext (by simp)
+    rw [descendMatrix_of_lt hw, descendMatrix_of_lt hw', hidx]
   · have hpsq : ¬ p ^ 2 ∣ N := fun h ↦ by
       have h1 := w.isLt
       have h2 := descendMatrixCount_mul_left_of_coprime hpl N


### PR DESCRIPTION
Miyake's Lemma 4.6.6 for the descent slash sum, in a new file `Newforms/Descent/LevelCommute.lean`: the sum does not see the part of the level away from `p`.

The family `descendMatrix p N` consists of the `p` matrices `[1, v; 0, p]`, which do not depend on `N`, plus — exactly when `p² ∤ N` — one extra representative `[1, 0; 0, p] · γ_N` with `γ_N ≡ S (mod p)` and `γ_N ≡ 1 (mod N / p)`. For `l` coprime to `p`:

* `descendMatrixCount_mul_left_of_coprime`: the family at `l N` has the same size as at `N`.
* `exists_mem_Gamma1_descendMatrix_mul_left_eq`: the extra representatives at `l N` and `N` differ on the left by an element of `Γ₁(N)`. Their quotient `γ_{lN} γ_N⁻¹` is congruent to `1` modulo `p` and modulo `N / p`, hence lies in `Γ(N)`; conjugating an element of `Γ(N)` through `[1, 0; 0, p]` gives `[a, b/p; p c, d] ∈ Γ₁(N)`.
* `descendSlash_mul_left_of_coprime`: **`descendSlash k p (l * N) f = descendSlash k p N f`** for every function `f` invariant under `Γ₁(N)`.

AINTLIB assumes a nebentypus for the rep-invariance; here `Γ₁(N)`-invariance suffices, since the two extra representatives differ by `Γ(N)` conjugated into `Γ₁(N)`. The level-raising variant (`V_l` against the sum, Miyake's `δ_l` form) is a separate statement and is not claimed here.

No `tauceti-target:v1` marker: like #6098, #6152, #6158, #6242, #6245, #6253, #6296 and #6297 before it, this is a prerequisite for the Layer 4 Atkin–Lehner Main Lemma node (the per-character route `mainLemma_charSpace_routeB`, which the roadmap records as "Miyake's sieve/conductor descent") rather than the node itself, and the contract asks for a deterministic target identifier, not an invented one.

Roadmap: ModularForms
Provenance: CBirkbeck/AINTLIB @ 2baa76f742bdb4fb8ee323fabba41203bd390e08, Apache-2.0, `projects/LeanModularForms/LeanModularForms/StrongMultiplicityOne/LevelCommute.lean` (`descendCosetList_slash_sum_rep_invariance`, `descendCosetList_slash_sum_commute`, `miyake_4_6_6_level_commute`): the source's invariance assumes a nebentypus and argues through its coset list; here it is derived from `Γ₁(N)` alone over the family of #6098.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQieFQn95rzgvYRvNdX3hR
