### PR TITLE
feat(EllipticCurve): derivations and the addition law on a Weierstrass curve

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Formula/Derivation.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Formula/Derivation.lean
@@ -18,11 +18,11 @@ a derivation on `K` over `R`. Writing `W_X` and `W_Y` for the partial derivative
 
 ## Main statements
 
-* `WeierstrassCurve.Affine.Equation.polynomialX_smul_add_polynomialY_smul_eq_zero`: at a point
-  `(x, y)` of `W⁄K`, `W_X(x, y) • D x + W_Y(x, y) • D y = 0`, the differential of the Weierstrass
-  equation, over any commutative ring `K`.
-* `WeierstrassCurve.Affine.derivation_polynomialX_evalEval`,
-  `WeierstrassCurve.Affine.derivation_polynomialY_evalEval` and
+* `Equation.evalEval_polynomialX_smul_add_evalEval_polynomialY_smul_eq_zero` (in the namespace
+  `WeierstrassCurve.Affine`): at a point `(x, y)` of `W⁄K`, `W_X(x, y) • D x + W_Y(x, y) • D y = 0`,
+  the differential of the Weierstrass equation, over any commutative ring `K`.
+* `WeierstrassCurve.Affine.derivation_evalEval_polynomialX`,
+  `WeierstrassCurve.Affine.derivation_evalEval_polynomialY` and
   `WeierstrassCurve.Affine.derivation_addX`: the chain rule for `W_X`, `W_Y` and `addX`.
 * `WeierstrassCurve.Affine.Equation.derivation_Y_eq_smul_derivation_X`: over a field, at a point
   where `W_Y` does not vanish, `D y = (-W_X(x, y) / W_Y(x, y)) • D x`.
@@ -30,7 +30,7 @@ a derivation on `K` over `R`. Writing `W_X` and `W_Y` for the partial derivative
   `WeierstrassCurve.Affine.derivation_slope_self_of_Y_ne`: the chain rule for the chord and the
   tangent slope.
 * `WeierstrassCurve.Affine.derivation_addX_slope`: if `(x₃, y₃)` is the sum of two points
-  `(x₁, y₁)` and `(x₂, y₂)` of `W⁄K` at which `W_Y` does not vanish, then
+  `(x₁, y₁)` and `(x₂, y₂)` of `W⁄K` at which `W_Y` does not vanish (when `x₁ ≠ x₂`), then
   `D x₃ = W_Y(x₃, y₃) • (W_Y(x₁, y₁)⁻¹ • D x₁ + W_Y(x₂, y₂)⁻¹ • D x₂)`; when `W_Y(x₃, y₃)` is
   nonzero as well, `WeierstrassCurve.Affine.inv_smul_derivation_addX_slope` divides by it:
   `W_Y(x₃, y₃)⁻¹ • D x₃ = W_Y(x₁, y₁)⁻¹ • D x₁ + W_Y(x₂, y₂)⁻¹ • D x₂`.
@@ -73,7 +73,7 @@ theorem sub_negY (x y : K) : y - W.negY x y = W.polynomialY.evalEval x y := by
   ring
 
 /-- **`W_Y` does not vanish at a point which is not its own negative.** -/
-theorem polynomialY_evalEval_ne_zero_of_Y_ne {x y : K} (hy : y ≠ W.negY x y) :
+theorem evalEval_polynomialY_ne_zero_of_Y_ne {x y : K} (hy : y ≠ W.negY x y) :
     W.polynomialY.evalEval x y ≠ 0 :=
   fun h ↦ hy (sub_eq_zero.1 ((W.sub_negY x y).trans h))
 
@@ -145,7 +145,7 @@ variable {R K M : Type*} [CommRing R] [CommRing K] [Algebra R K] [AddCommGroup M
 
 /-- **The differential of the Weierstrass equation.** At a point `(x, y)` of `W⁄K`, every
 derivation `D` on `K` over `R` satisfies `W_X(x, y) • D x + W_Y(x, y) • D y = 0`. -/
-theorem Equation.polynomialX_smul_add_polynomialY_smul_eq_zero {x y : K}
+theorem Equation.evalEval_polynomialX_smul_add_evalEval_polynomialY_smul_eq_zero {x y : K}
     (h : (W⁄K).toAffine.Equation x y) :
     (W⁄K).toAffine.polynomialX.evalEval x y • D x +
       (W⁄K).toAffine.polynomialY.evalEval x y • D y = 0 := by
@@ -159,7 +159,8 @@ theorem Equation.polynomialX_smul_add_polynomialY_smul_eq_zero {x y : K}
   linear_combination (norm := module) h0
 
 /-- **The chain rule for `W_X`**: `D (W_X(x, y)) = a₁ • D y - (6x + 2a₂) • D x`. -/
-theorem derivation_polynomialX_evalEval (x y : K) :
+@[simp]
+theorem derivation_evalEval_polynomialX (x y : K) :
     D ((W⁄K).toAffine.polynomialX.evalEval x y) =
       (W⁄K).toAffine.a₁ • D y - (6 * x + 2 * (W⁄K).toAffine.a₂) • D x := by
   have h2 : D (2 : K) = 0 := by simpa using D.map_natCast 2
@@ -169,7 +170,8 @@ theorem derivation_polynomialX_evalEval (x y : K) :
   module
 
 /-- **The chain rule for `W_Y`**: `D (W_Y(x, y)) = 2 • D y + a₁ • D x`. -/
-theorem derivation_polynomialY_evalEval (x y : K) :
+@[simp]
+theorem derivation_evalEval_polynomialY (x y : K) :
     D ((W⁄K).toAffine.polynomialY.evalEval x y) = 2 • D y + (W⁄K).toAffine.a₁ • D x := by
   have h2 : D (2 : K) = 0 := by simpa using D.map_natCast 2
   simp only [evalEval_polynomialY, WeierstrassCurve.baseChange, map_a₁, map_a₃, map_add,
@@ -199,7 +201,8 @@ theorem Equation.derivation_Y_eq_smul_derivation_X {x y : K} (h : (W⁄K).toAffi
       D x := by
   have e : (W⁄K).toAffine.polynomialY.evalEval x y • D y =
       -((W⁄K).toAffine.polynomialX.evalEval x y • D x) :=
-    eq_neg_of_add_eq_zero_right (h.polynomialX_smul_add_polynomialY_smul_eq_zero D)
+    eq_neg_of_add_eq_zero_right
+      (h.evalEval_polynomialX_smul_add_evalEval_polynomialY_smul_eq_zero D)
   rw [neg_div, neg_smul, div_eq_inv_mul, mul_smul, ← smul_neg, ← e, smul_smul, inv_mul_cancel₀ hu,
     one_smul]
 
@@ -245,25 +248,26 @@ private theorem derivation_addX_slope_of_Y_ne [DecidableEq K] {x y : K}
           ((W⁄K).toAffine.addY x x y ((W⁄K).toAffine.slope x x y y)) •
         (((W⁄K).toAffine.polynomialY.evalEval x y)⁻¹ • D x +
           ((W⁄K).toAffine.polynomialY.evalEval x y)⁻¹ • D x) := by
-  have hu := (W⁄K).toAffine.polynomialY_evalEval_ne_zero_of_Y_ne hy
+  have hu := (W⁄K).toAffine.evalEval_polynomialY_ne_zero_of_Y_ne hy
   have c := (W⁄K).toAffine.tangent_coeff (x := x) (y := y)
     (N := -(W⁄K).toAffine.polynomialX.evalEval x y) (u := (W⁄K).toAffine.polynomialY.evalEval x y)
     (by rw [evalEval_polynomialX]; ring) (evalEval_polynomialY x y) hu
   rw [derivation_addX W D, derivation_slope_self_of_Y_ne D hy, map_neg,
-    derivation_polynomialX_evalEval, derivation_polynomialY_evalEval,
+    derivation_evalEval_polynomialX, derivation_evalEval_polynomialY,
     h.derivation_Y_eq_smul_derivation_X D hu, slope_of_Y_ne_eq_evalEval rfl hy,
     evalEval_polynomialY ((W⁄K).toAffine.addX _ _ _)]
   linear_combination (norm := module) c • D x
 
 /-- **The derivation of the `x`-coordinate of a sum of points.** Let `(x₁, y₁)` and `(x₂, y₂)` be
 points of `W⁄K` whose sum `(x₃, y₃)` is affine, at both of which `W_Y = 2Y + a₁X + a₃` does not
-vanish. Then every derivation `D` on `K` over `R` satisfies
+vanish when `x₁ ≠ x₂` (in the tangent case `x₁ = x₂` it cannot vanish). Then every derivation `D`
+on `K` over `R` satisfies
 `D x₃ = W_Y(x₃, y₃) • (W_Y(x₁, y₁)⁻¹ • D x₁ + W_Y(x₂, y₂)⁻¹ • D x₂)`, the additivity of the
 differential `dx / W_Y` with the denominator at the sum cleared. -/
 theorem derivation_addX_slope [DecidableEq K] {x₁ x₂ y₁ y₂ : K} (h₁ : (W⁄K).toAffine.Equation x₁ y₁)
     (h₂ : (W⁄K).toAffine.Equation x₂ y₂) (hxy : ¬(x₁ = x₂ ∧ y₁ = (W⁄K).toAffine.negY x₂ y₂))
-    (hu₁ : (W⁄K).toAffine.polynomialY.evalEval x₁ y₁ ≠ 0)
-    (hu₂ : (W⁄K).toAffine.polynomialY.evalEval x₂ y₂ ≠ 0) :
+    (hu₁ : x₁ ≠ x₂ → (W⁄K).toAffine.polynomialY.evalEval x₁ y₁ ≠ 0)
+    (hu₂ : x₁ ≠ x₂ → (W⁄K).toAffine.polynomialY.evalEval x₂ y₂ ≠ 0) :
     D ((W⁄K).toAffine.addX x₁ x₂ ((W⁄K).toAffine.slope x₁ x₂ y₁ y₂)) =
       (W⁄K).toAffine.polynomialY.evalEval
           ((W⁄K).toAffine.addX x₁ x₂ ((W⁄K).toAffine.slope x₁ x₂ y₁ y₂))
@@ -273,7 +277,7 @@ theorem derivation_addX_slope [DecidableEq K] {x₁ x₂ y₁ y₂ : K} (h₁ : 
   rcases eq_or_ne x₁ x₂ with rfl | hx
   · obtain rfl : y₁ = y₂ := (W⁄K).toAffine.Y_eq_of_Y_ne h₁ h₂ rfl fun hy ↦ hxy ⟨rfl, hy⟩
     exact derivation_addX_slope_of_Y_ne D h₁ fun hy ↦ hxy ⟨rfl, hy⟩
-  · exact derivation_addX_slope_of_X_ne D h₁ h₂ hx hu₁ hu₂
+  · exact derivation_addX_slope_of_X_ne D h₁ h₂ hx (hu₁ hx) (hu₂ hx)
 
 /-- **The differential `dx / W_Y` is additive**: under the hypotheses of `derivation_addX_slope`,
 if `W_Y` does not vanish at the sum either, then
@@ -281,8 +285,8 @@ if `W_Y` does not vanish at the sum either, then
 theorem inv_smul_derivation_addX_slope [DecidableEq K] {x₁ x₂ y₁ y₂ : K}
     (h₁ : (W⁄K).toAffine.Equation x₁ y₁) (h₂ : (W⁄K).toAffine.Equation x₂ y₂)
     (hxy : ¬(x₁ = x₂ ∧ y₁ = (W⁄K).toAffine.negY x₂ y₂))
-    (hu₁ : (W⁄K).toAffine.polynomialY.evalEval x₁ y₁ ≠ 0)
-    (hu₂ : (W⁄K).toAffine.polynomialY.evalEval x₂ y₂ ≠ 0)
+    (hu₁ : x₁ ≠ x₂ → (W⁄K).toAffine.polynomialY.evalEval x₁ y₁ ≠ 0)
+    (hu₂ : x₁ ≠ x₂ → (W⁄K).toAffine.polynomialY.evalEval x₂ y₂ ≠ 0)
     (hu₃ : (W⁄K).toAffine.polynomialY.evalEval
       ((W⁄K).toAffine.addX x₁ x₂ ((W⁄K).toAffine.slope x₁ x₂ y₁ y₂))
       ((W⁄K).toAffine.addY x₁ x₂ y₁ ((W⁄K).toAffine.slope x₁ x₂ y₁ y₂)) ≠ 0) :

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Formula/Derivation.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Formula/Derivation.lean
@@ -1,0 +1,301 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck, The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.AlgebraicGeometry.EllipticCurve.Affine.Formula
+public import Mathlib.RingTheory.Derivation.Basic
+
+/-!
+# Derivations and the addition law on a Weierstrass curve
+
+Let `W` be a Weierstrass curve over `R`, let `K` be an `R`-algebra and let `D : Derivation R K M` be
+a derivation on `K` over `R`. Writing `W_X` and `W_Y` for the partial derivatives `polynomialX` and
+`polynomialY` of the Weierstrass polynomial, this file records how `D` interacts with the points of
+`W⁄K` and with the formulae of the addition law.
+
+## Main statements
+
+* `WeierstrassCurve.Affine.Equation.polynomialX_smul_add_polynomialY_smul_eq_zero`: at a point
+  `(x, y)` of `W⁄K`, `W_X(x, y) • D x + W_Y(x, y) • D y = 0`, the differential of the Weierstrass
+  equation, over any commutative ring `K`.
+* `WeierstrassCurve.Affine.derivation_polynomialX_evalEval`,
+  `WeierstrassCurve.Affine.derivation_polynomialY_evalEval` and
+  `WeierstrassCurve.Affine.derivation_addX`: the chain rule for `W_X`, `W_Y` and `addX`.
+* `WeierstrassCurve.Affine.Equation.derivation_Y_eq_smul_derivation_X`: over a field, at a point
+  where `W_Y` does not vanish, `D y = (-W_X(x, y) / W_Y(x, y)) • D x`.
+* `WeierstrassCurve.Affine.derivation_slope_of_X_ne` and
+  `WeierstrassCurve.Affine.derivation_slope_self_of_Y_ne`: the chain rule for the chord and the
+  tangent slope.
+* `WeierstrassCurve.Affine.derivation_addX_slope`: if `(x₃, y₃)` is the sum of two points
+  `(x₁, y₁)` and `(x₂, y₂)` of `W⁄K` at which `W_Y` does not vanish, then
+  `D x₃ = W_Y(x₃, y₃) • (W_Y(x₁, y₁)⁻¹ • D x₁ + W_Y(x₂, y₂)⁻¹ • D x₂)`; when `W_Y(x₃, y₃)` is
+  nonzero as well, `WeierstrassCurve.Affine.inv_smul_derivation_addX_slope` divides by it:
+  `W_Y(x₃, y₃)⁻¹ • D x₃ = W_Y(x₁, y₁)⁻¹ • D x₁ + W_Y(x₂, y₂)⁻¹ • D x₂`.
+
+The last two identities are the additivity of the differential `dx / W_Y`, with and without the
+denominator at the sum cleared. On an elliptic curve `dx / W_Y` is the invariant differential, and
+the identity is the computation behind the additivity of its pullback along a sum of morphisms
+(Silverman, *The Arithmetic of Elliptic Curves*, III.5.2); the version for two points of `W⁄K` and
+their sum is in `Affine/Point/Derivation.lean`. Everything is stated for an arbitrary derivation,
+so that it applies to the Kähler differentials of a function field without any further hypothesis.
+
+## Provenance
+
+The identity for two points with distinct `x`-coordinates generalises the computation
+`kaehlerD_addPullback_x_eq_one_add_smul_omega` of `HasseWeil/RouteBGeneral.lean` in
+[AINTLIB](https://github.com/CBirkbeck/AINTLIB) (commit `513e83879e2f8cbc626eb9e04d660e92be16ccba`,
+Apache 2.0), where the first point is the generic point of the curve and the second its image under
+an endomorphism, from the Kähler differential to an arbitrary derivation.
+-/
+
+public section
+
+open WeierstrassCurve
+
+namespace WeierstrassCurve.Affine
+
+/-! ### Two formulae, and the coefficient identities
+
+The coefficient identities are between elements of the base field: they are the coefficients of
+`D x₁` and `D x₂` in the derivation of the sum's `x`-coordinate, computed by the chain rule from
+the addition formulae, compared with the coefficients in `derivation_addX_slope`. -/
+
+section Formula
+
+variable {K : Type*} [CommRing K] (W : WeierstrassCurve.Affine K)
+
+/-- **The difference between a point and its negative is `W_Y`**: `y - negY x y = W_Y(x, y)`. -/
+theorem sub_negY (x y : K) : y - W.negY x y = W.polynomialY.evalEval x y := by
+  rw [evalEval_polynomialY, negY]
+  ring
+
+/-- **`W_Y` does not vanish at a point which is not its own negative.** -/
+theorem polynomialY_evalEval_ne_zero_of_Y_ne {x y : K} (hy : y ≠ W.negY x y) :
+    W.polynomialY.evalEval x y ≠ 0 :=
+  fun h ↦ hy (sub_eq_zero.1 ((W.sub_negY x y).trans h))
+
+end Formula
+
+section coefficients
+
+variable {K : Type*} [Field K] (W : WeierstrassCurve.Affine K)
+
+private theorem chord_coeff₁ {x₁ x₂ y₁ y₂ : K} (h₁ : W.Equation x₁ y₁) (h₂ : W.Equation x₂ y₂)
+    (hx : x₁ ≠ x₂) (hu₁ : W.polynomialY.evalEval x₁ y₁ ≠ 0) :
+    (2 * ((y₁ - y₂) / (x₁ - x₂)) + W.a₁) * ((x₁ - x₂)⁻¹ ^ 2 *
+        ((x₁ - x₂) * (-W.polynomialX.evalEval x₁ y₁ / W.polynomialY.evalEval x₁ y₁) -
+          (y₁ - y₂))) - 1 =
+      W.polynomialY.evalEval (W.addX x₁ x₂ ((y₁ - y₂) / (x₁ - x₂)))
+          (W.addY x₁ x₂ y₁ ((y₁ - y₂) / (x₁ - x₂))) / W.polynomialY.evalEval x₁ y₁ := by
+  rw [equation_iff] at h₁ h₂
+  have hd : x₁ - x₂ ≠ 0 := sub_ne_zero.2 hx
+  rw [evalEval_polynomialY (W.addX _ _ _)]
+  simp only [addX, addY, negAddY, negY]
+  generalize hu : W.polynomialY.evalEval x₁ y₁ = u at hu₁ ⊢
+  generalize hn : y₁ - y₂ = n
+  generalize hdd : x₁ - x₂ = d at hd ⊢
+  field_simp [hd, hu₁]
+  subst hu hn hdd
+  rw [evalEval_polynomialX, evalEval_polynomialY]
+  linear_combination (-(2 * (y₁ - y₂) + W.a₁ * (x₁ - x₂))) * h₁ +
+    (2 * (y₁ - y₂) + W.a₁ * (x₁ - x₂)) * h₂
+
+private theorem chord_coeff₂ {x₁ x₂ y₁ y₂ : K} (h₁ : W.Equation x₁ y₁) (h₂ : W.Equation x₂ y₂)
+    (hx : x₁ ≠ x₂) (hu₂ : W.polynomialY.evalEval x₂ y₂ ≠ 0) :
+    (2 * ((y₁ - y₂) / (x₁ - x₂)) + W.a₁) * ((x₁ - x₂)⁻¹ ^ 2 *
+        ((y₁ - y₂) -
+          (x₁ - x₂) * (-W.polynomialX.evalEval x₂ y₂ / W.polynomialY.evalEval x₂ y₂))) - 1 =
+      W.polynomialY.evalEval (W.addX x₁ x₂ ((y₁ - y₂) / (x₁ - x₂)))
+          (W.addY x₁ x₂ y₁ ((y₁ - y₂) / (x₁ - x₂))) / W.polynomialY.evalEval x₂ y₂ := by
+  rw [equation_iff] at h₁ h₂
+  have hd : x₁ - x₂ ≠ 0 := sub_ne_zero.2 hx
+  rw [evalEval_polynomialY (W.addX _ _ _)]
+  simp only [addX, addY, negAddY, negY]
+  generalize hu : W.polynomialY.evalEval x₂ y₂ = u at hu₂ ⊢
+  generalize hn : y₁ - y₂ = n
+  generalize hdd : x₁ - x₂ = d at hd ⊢
+  field_simp [hd, hu₂]
+  subst hu hn hdd
+  rw [evalEval_polynomialX, evalEval_polynomialY]
+  linear_combination (2 * (y₁ - y₂) + W.a₁ * (x₁ - x₂)) * h₁ -
+    (2 * (y₁ - y₂) + W.a₁ * (x₁ - x₂)) * h₂
+
+private theorem tangent_coeff {x y N u : K}
+    (hN : N = 3 * x ^ 2 + 2 * W.a₂ * x + W.a₄ - W.a₁ * y) (hu : u = 2 * y + W.a₁ * x + W.a₃)
+    (hu0 : u ≠ 0) :
+    (2 * (N / u) + W.a₁) * (u⁻¹ ^ 2 * (u * ((3 * (x + x) + 2 * W.a₂) - W.a₁ * (N / u)) -
+      N * (2 * (N / u) + W.a₁))) - (1 + 1) =
+      (2 * W.addY x x y (N / u) + W.a₁ * W.addX x x (N / u) + W.a₃) * (u⁻¹ + u⁻¹) := by
+  simp only [addX, addY, negAddY, negY]
+  field_simp [hu0]
+  subst hN hu
+  ring
+
+end coefficients
+
+/-! ### Derivations at the points of a base change -/
+
+section CommRing
+
+variable {R K M : Type*} [CommRing R] [CommRing K] [Algebra R K] [AddCommGroup M] [Module R M]
+  [Module K M] {W : WeierstrassCurve R} (D : Derivation R K M)
+
+/-- **The differential of the Weierstrass equation.** At a point `(x, y)` of `W⁄K`, every
+derivation `D` on `K` over `R` satisfies `W_X(x, y) • D x + W_Y(x, y) • D y = 0`. -/
+theorem Equation.polynomialX_smul_add_polynomialY_smul_eq_zero {x y : K}
+    (h : (W⁄K).toAffine.Equation x y) :
+    (W⁄K).toAffine.polynomialX.evalEval x y • D x +
+      (W⁄K).toAffine.polynomialY.evalEval x y • D y = 0 := by
+  have h0 := congrArg D (((W⁄K).toAffine.equation_iff' x y).1 h)
+  have h2 : D (2 : K) = 0 := by simpa using D.map_natCast 2
+  have h3 : D (3 : K) = 0 := by simpa using D.map_natCast 3
+  rw [evalEval_polynomialX, evalEval_polynomialY]
+  simp only [WeierstrassCurve.baseChange, map_a₁, map_a₂, map_a₃, map_a₄, map_a₆, sq, pow_three,
+    map_zero, map_sub, map_add, Derivation.leibniz, Derivation.map_algebraMap, smul_zero,
+    add_zero] at h0 ⊢
+  linear_combination (norm := module) h0
+
+/-- **The chain rule for `W_X`**: `D (W_X(x, y)) = a₁ • D y - (6x + 2a₂) • D x`. -/
+theorem derivation_polynomialX_evalEval (x y : K) :
+    D ((W⁄K).toAffine.polynomialX.evalEval x y) =
+      (W⁄K).toAffine.a₁ • D y - (6 * x + 2 * (W⁄K).toAffine.a₂) • D x := by
+  have h2 : D (2 : K) = 0 := by simpa using D.map_natCast 2
+  have h3 : D (3 : K) = 0 := by simpa using D.map_natCast 3
+  simp only [evalEval_polynomialX, WeierstrassCurve.baseChange, map_a₁, map_a₂, map_a₄, sq, map_sub,
+    map_add, Derivation.leibniz, Derivation.map_algebraMap, h2, h3, smul_zero, add_zero]
+  module
+
+/-- **The chain rule for `W_Y`**: `D (W_Y(x, y)) = 2 • D y + a₁ • D x`. -/
+theorem derivation_polynomialY_evalEval (x y : K) :
+    D ((W⁄K).toAffine.polynomialY.evalEval x y) = 2 • D y + (W⁄K).toAffine.a₁ • D x := by
+  have h2 : D (2 : K) = 0 := by simpa using D.map_natCast 2
+  simp only [evalEval_polynomialY, WeierstrassCurve.baseChange, map_a₁, map_a₃, map_add,
+    Derivation.leibniz, Derivation.map_algebraMap, h2, smul_zero, add_zero]
+  module
+
+variable (W) in
+/-- **The chain rule for `addX`**: `D (addX x₁ x₂ ℓ) = (2ℓ + a₁) • D ℓ - D x₁ - D x₂`. -/
+theorem derivation_addX (x₁ x₂ ℓ : K) :
+    D ((W⁄K).toAffine.addX x₁ x₂ ℓ) = (2 * ℓ + (W⁄K).toAffine.a₁) • D ℓ - D x₁ - D x₂ := by
+  simp only [addX, WeierstrassCurve.baseChange, map_a₁, map_a₂, sq, map_sub, map_add,
+    Derivation.leibniz, Derivation.map_algebraMap, smul_zero, add_zero]
+  module
+
+end CommRing
+
+section Field
+
+variable {R K M : Type*} [CommRing R] [Field K] [Algebra R K] [AddCommGroup M] [Module R M]
+  [Module K M] {W : WeierstrassCurve R} (D : Derivation R K M)
+
+/-- **The derivation of the `y`-coordinate is determined by that of the `x`-coordinate**: at a
+point of `W⁄K` where `W_Y` does not vanish, `D y = (-W_X(x, y) / W_Y(x, y)) • D x`. -/
+theorem Equation.derivation_Y_eq_smul_derivation_X {x y : K} (h : (W⁄K).toAffine.Equation x y)
+    (hu : (W⁄K).toAffine.polynomialY.evalEval x y ≠ 0) :
+    D y = (-(W⁄K).toAffine.polynomialX.evalEval x y / (W⁄K).toAffine.polynomialY.evalEval x y) •
+      D x := by
+  have e : (W⁄K).toAffine.polynomialY.evalEval x y • D y =
+      -((W⁄K).toAffine.polynomialX.evalEval x y • D x) :=
+    eq_neg_of_add_eq_zero_right (h.polynomialX_smul_add_polynomialY_smul_eq_zero D)
+  rw [neg_div, neg_smul, div_eq_inv_mul, mul_smul, ← smul_neg, ← e, smul_smul, inv_mul_cancel₀ hu,
+    one_smul]
+
+/-- **The chain rule for the chord slope**: for `x₁ ≠ x₂`,
+`D ℓ = (x₁ - x₂)⁻² • ((x₁ - x₂) • (D y₁ - D y₂) - (y₁ - y₂) • (D x₁ - D x₂))`. -/
+theorem derivation_slope_of_X_ne [DecidableEq K] {x₁ x₂ y₁ y₂ : K} (hx : x₁ ≠ x₂) :
+    D ((W⁄K).toAffine.slope x₁ x₂ y₁ y₂) =
+      (x₁ - x₂)⁻¹ ^ 2 • ((x₁ - x₂) • (D y₁ - D y₂) - (y₁ - y₂) • (D x₁ - D x₂)) := by
+  rw [slope_of_X_ne hx, D.leibniz_div, map_sub, map_sub]
+
+/-- **The chain rule for the tangent slope** `-W_X / W_Y` at a point which is not its own
+negative. -/
+theorem derivation_slope_self_of_Y_ne [DecidableEq K] {x y : K}
+    (hy : y ≠ (W⁄K).toAffine.negY x y) :
+    D ((W⁄K).toAffine.slope x x y y) =
+      ((W⁄K).toAffine.polynomialY.evalEval x y)⁻¹ ^ 2 •
+        ((W⁄K).toAffine.polynomialY.evalEval x y • D (-(W⁄K).toAffine.polynomialX.evalEval x y) -
+          (-(W⁄K).toAffine.polynomialX.evalEval x y) •
+            D ((W⁄K).toAffine.polynomialY.evalEval x y)) := by
+  rw [slope_of_Y_ne_eq_evalEval rfl hy, D.leibniz_div]
+
+private theorem derivation_addX_slope_of_X_ne [DecidableEq K] {x₁ x₂ y₁ y₂ : K}
+    (h₁ : (W⁄K).toAffine.Equation x₁ y₁) (h₂ : (W⁄K).toAffine.Equation x₂ y₂) (hx : x₁ ≠ x₂)
+    (hu₁ : (W⁄K).toAffine.polynomialY.evalEval x₁ y₁ ≠ 0)
+    (hu₂ : (W⁄K).toAffine.polynomialY.evalEval x₂ y₂ ≠ 0) :
+    D ((W⁄K).toAffine.addX x₁ x₂ ((W⁄K).toAffine.slope x₁ x₂ y₁ y₂)) =
+      (W⁄K).toAffine.polynomialY.evalEval
+          ((W⁄K).toAffine.addX x₁ x₂ ((W⁄K).toAffine.slope x₁ x₂ y₁ y₂))
+          ((W⁄K).toAffine.addY x₁ x₂ y₁ ((W⁄K).toAffine.slope x₁ x₂ y₁ y₂)) •
+        (((W⁄K).toAffine.polynomialY.evalEval x₁ y₁)⁻¹ • D x₁ +
+          ((W⁄K).toAffine.polynomialY.evalEval x₂ y₂)⁻¹ • D x₂) := by
+  have c₁ := (W⁄K).toAffine.chord_coeff₁ h₁ h₂ hx hu₁
+  have c₂ := (W⁄K).toAffine.chord_coeff₂ h₁ h₂ hx hu₂
+  rw [derivation_addX W D, derivation_slope_of_X_ne D hx,
+    h₁.derivation_Y_eq_smul_derivation_X D hu₁, h₂.derivation_Y_eq_smul_derivation_X D hu₂,
+    slope_of_X_ne hx]
+  linear_combination (norm := module) c₁ • D x₁ + c₂ • D x₂
+
+private theorem derivation_addX_slope_of_Y_ne [DecidableEq K] {x y : K}
+    (h : (W⁄K).toAffine.Equation x y) (hy : y ≠ (W⁄K).toAffine.negY x y) :
+    D ((W⁄K).toAffine.addX x x ((W⁄K).toAffine.slope x x y y)) =
+      (W⁄K).toAffine.polynomialY.evalEval ((W⁄K).toAffine.addX x x ((W⁄K).toAffine.slope x x y y))
+          ((W⁄K).toAffine.addY x x y ((W⁄K).toAffine.slope x x y y)) •
+        (((W⁄K).toAffine.polynomialY.evalEval x y)⁻¹ • D x +
+          ((W⁄K).toAffine.polynomialY.evalEval x y)⁻¹ • D x) := by
+  have hu := (W⁄K).toAffine.polynomialY_evalEval_ne_zero_of_Y_ne hy
+  have c := (W⁄K).toAffine.tangent_coeff (x := x) (y := y)
+    (N := -(W⁄K).toAffine.polynomialX.evalEval x y) (u := (W⁄K).toAffine.polynomialY.evalEval x y)
+    (by rw [evalEval_polynomialX]; ring) (evalEval_polynomialY x y) hu
+  rw [derivation_addX W D, derivation_slope_self_of_Y_ne D hy, map_neg,
+    derivation_polynomialX_evalEval, derivation_polynomialY_evalEval,
+    h.derivation_Y_eq_smul_derivation_X D hu, slope_of_Y_ne_eq_evalEval rfl hy,
+    evalEval_polynomialY ((W⁄K).toAffine.addX _ _ _)]
+  linear_combination (norm := module) c • D x
+
+/-- **The derivation of the `x`-coordinate of a sum of points.** Let `(x₁, y₁)` and `(x₂, y₂)` be
+points of `W⁄K` whose sum `(x₃, y₃)` is affine, at both of which `W_Y = 2Y + a₁X + a₃` does not
+vanish. Then every derivation `D` on `K` over `R` satisfies
+`D x₃ = W_Y(x₃, y₃) • (W_Y(x₁, y₁)⁻¹ • D x₁ + W_Y(x₂, y₂)⁻¹ • D x₂)`, the additivity of the
+differential `dx / W_Y` with the denominator at the sum cleared. -/
+theorem derivation_addX_slope [DecidableEq K] {x₁ x₂ y₁ y₂ : K} (h₁ : (W⁄K).toAffine.Equation x₁ y₁)
+    (h₂ : (W⁄K).toAffine.Equation x₂ y₂) (hxy : ¬(x₁ = x₂ ∧ y₁ = (W⁄K).toAffine.negY x₂ y₂))
+    (hu₁ : (W⁄K).toAffine.polynomialY.evalEval x₁ y₁ ≠ 0)
+    (hu₂ : (W⁄K).toAffine.polynomialY.evalEval x₂ y₂ ≠ 0) :
+    D ((W⁄K).toAffine.addX x₁ x₂ ((W⁄K).toAffine.slope x₁ x₂ y₁ y₂)) =
+      (W⁄K).toAffine.polynomialY.evalEval
+          ((W⁄K).toAffine.addX x₁ x₂ ((W⁄K).toAffine.slope x₁ x₂ y₁ y₂))
+          ((W⁄K).toAffine.addY x₁ x₂ y₁ ((W⁄K).toAffine.slope x₁ x₂ y₁ y₂)) •
+        (((W⁄K).toAffine.polynomialY.evalEval x₁ y₁)⁻¹ • D x₁ +
+          ((W⁄K).toAffine.polynomialY.evalEval x₂ y₂)⁻¹ • D x₂) := by
+  rcases eq_or_ne x₁ x₂ with rfl | hx
+  · obtain rfl : y₁ = y₂ := (W⁄K).toAffine.Y_eq_of_Y_ne h₁ h₂ rfl fun hy ↦ hxy ⟨rfl, hy⟩
+    exact derivation_addX_slope_of_Y_ne D h₁ fun hy ↦ hxy ⟨rfl, hy⟩
+  · exact derivation_addX_slope_of_X_ne D h₁ h₂ hx hu₁ hu₂
+
+/-- **The differential `dx / W_Y` is additive**: under the hypotheses of `derivation_addX_slope`,
+if `W_Y` does not vanish at the sum either, then
+`W_Y(x₃, y₃)⁻¹ • D x₃ = W_Y(x₁, y₁)⁻¹ • D x₁ + W_Y(x₂, y₂)⁻¹ • D x₂`. -/
+theorem inv_smul_derivation_addX_slope [DecidableEq K] {x₁ x₂ y₁ y₂ : K}
+    (h₁ : (W⁄K).toAffine.Equation x₁ y₁) (h₂ : (W⁄K).toAffine.Equation x₂ y₂)
+    (hxy : ¬(x₁ = x₂ ∧ y₁ = (W⁄K).toAffine.negY x₂ y₂))
+    (hu₁ : (W⁄K).toAffine.polynomialY.evalEval x₁ y₁ ≠ 0)
+    (hu₂ : (W⁄K).toAffine.polynomialY.evalEval x₂ y₂ ≠ 0)
+    (hu₃ : (W⁄K).toAffine.polynomialY.evalEval
+      ((W⁄K).toAffine.addX x₁ x₂ ((W⁄K).toAffine.slope x₁ x₂ y₁ y₂))
+      ((W⁄K).toAffine.addY x₁ x₂ y₁ ((W⁄K).toAffine.slope x₁ x₂ y₁ y₂)) ≠ 0) :
+    ((W⁄K).toAffine.polynomialY.evalEval
+        ((W⁄K).toAffine.addX x₁ x₂ ((W⁄K).toAffine.slope x₁ x₂ y₁ y₂))
+        ((W⁄K).toAffine.addY x₁ x₂ y₁ ((W⁄K).toAffine.slope x₁ x₂ y₁ y₂)))⁻¹ •
+      D ((W⁄K).toAffine.addX x₁ x₂ ((W⁄K).toAffine.slope x₁ x₂ y₁ y₂)) =
+      ((W⁄K).toAffine.polynomialY.evalEval x₁ y₁)⁻¹ • D x₁ +
+        ((W⁄K).toAffine.polynomialY.evalEval x₂ y₂)⁻¹ • D x₂ := by
+  rw [derivation_addX_slope D h₁ h₂ hxy hu₁ hu₂, smul_smul, inv_mul_cancel₀ hu₃, one_smul]
+
+end Field
+
+end WeierstrassCurve.Affine
+
+end

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Point/Derivation.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Point/Derivation.lean
@@ -20,9 +20,11 @@ identity for the coordinates of the addition law, read on the points through `Po
 ## Main statements
 
 * `WeierstrassCurve.Affine.Point.derivation_xCoord_add`: if `W_Y = 2Y + a₁X + a₃` does not vanish
-  at `P` and `Q`, then `D x(P + Q) = W_Y(P + Q) • (W_Y(P)⁻¹ • D x(P) + W_Y(Q)⁻¹ • D x(Q))`.
+  at `P` and `Q` (when their `x`-coordinates differ), then
+  `D x(P + Q) = W_Y(P + Q) • (W_Y(P)⁻¹ • D x(P) + W_Y(Q)⁻¹ • D x(Q))`.
 * `WeierstrassCurve.Affine.Point.inv_smul_derivation_xCoord_add`: for nonzero `P`, `Q` with
-  `P + Q ≠ 0`, if `W_Y` does not vanish at `P`, `Q` and `P + Q`, then
+  `P + Q ≠ 0`, if `W_Y` does not vanish at `P + Q`, nor at `P` and `Q` when their `x`-coordinates
+differ, then
   `W_Y(P + Q)⁻¹ • D x(P + Q) = W_Y(P)⁻¹ • D x(P) + W_Y(Q)⁻¹ • D x(Q)`.
 -/
 
@@ -37,11 +39,11 @@ variable {R K M : Type*} [CommRing R] [Field K] [Algebra R K] [AddCommGroup M] [
   {P Q : (W⁄K).toAffine.Point}
 
 /-- **The derivation of the `x`-coordinate of a sum of points.** For nonzero points `P`, `Q` of
-`W⁄K` with `P + Q ≠ 0`, at both of which `W_Y = 2Y + a₁X + a₃` does not vanish,
-`D x(P + Q) = W_Y(P + Q) • (W_Y(P)⁻¹ • D x(P) + W_Y(Q)⁻¹ • D x(Q))`. -/
+`W⁄K` with `P + Q ≠ 0`, at both of which `W_Y = 2Y + a₁X + a₃` does not vanish when their
+`x`-coordinates differ, `D x(P + Q) = W_Y(P + Q) • (W_Y(P)⁻¹ • D x(P) + W_Y(Q)⁻¹ • D x(Q))`. -/
 theorem derivation_xCoord_add (hP : P ≠ 0) (hQ : Q ≠ 0) (h : P + Q ≠ 0)
-    (huP : (W⁄K).toAffine.polynomialY.evalEval (xCoord P) (yCoord P) ≠ 0)
-    (huQ : (W⁄K).toAffine.polynomialY.evalEval (xCoord Q) (yCoord Q) ≠ 0) :
+    (huP : xCoord P ≠ xCoord Q → (W⁄K).toAffine.polynomialY.evalEval (xCoord P) (yCoord P) ≠ 0)
+    (huQ : xCoord P ≠ xCoord Q → (W⁄K).toAffine.polynomialY.evalEval (xCoord Q) (yCoord Q) ≠ 0) :
     D (xCoord (P + Q)) =
       (W⁄K).toAffine.polynomialY.evalEval (xCoord (P + Q)) (yCoord (P + Q)) •
         (((W⁄K).toAffine.polynomialY.evalEval (xCoord P) (yCoord P))⁻¹ • D (xCoord P) +
@@ -55,11 +57,12 @@ theorem derivation_xCoord_add (hP : P ≠ 0) (hQ : Q ≠ 0) (h : P + Q ≠ 0)
   exact derivation_addX_slope D h₁.left h₂.left hxy huP huQ
 
 /-- **The differential `dx / W_Y` is additive on points**: for nonzero points `P`, `Q` of `W⁄K` with
-`P + Q ≠ 0`, if `W_Y` does not vanish at `P`, `Q` and `P + Q`, then
+`P + Q ≠ 0`, if `W_Y` does not vanish at `P + Q`, nor at `P` and `Q` when their `x`-coordinates
+differ, then
 `W_Y(P + Q)⁻¹ • D x(P + Q) = W_Y(P)⁻¹ • D x(P) + W_Y(Q)⁻¹ • D x(Q)`. -/
 theorem inv_smul_derivation_xCoord_add (hP : P ≠ 0) (hQ : Q ≠ 0) (h : P + Q ≠ 0)
-    (huP : (W⁄K).toAffine.polynomialY.evalEval (xCoord P) (yCoord P) ≠ 0)
-    (huQ : (W⁄K).toAffine.polynomialY.evalEval (xCoord Q) (yCoord Q) ≠ 0)
+    (huP : xCoord P ≠ xCoord Q → (W⁄K).toAffine.polynomialY.evalEval (xCoord P) (yCoord P) ≠ 0)
+    (huQ : xCoord P ≠ xCoord Q → (W⁄K).toAffine.polynomialY.evalEval (xCoord Q) (yCoord Q) ≠ 0)
     (hu : (W⁄K).toAffine.polynomialY.evalEval (xCoord (P + Q)) (yCoord (P + Q)) ≠ 0) :
     ((W⁄K).toAffine.polynomialY.evalEval (xCoord (P + Q)) (yCoord (P + Q)))⁻¹ •
         D (xCoord (P + Q)) =

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Point/Derivation.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Point/Derivation.lean
@@ -1,0 +1,72 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck, The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Affine.Formula.Derivation
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Affine.Point.Basic
+
+/-!
+# Derivations and the sum of two points
+
+For two nonzero points `P`, `Q` of a Weierstrass curve `W⁄K` with `P + Q ≠ 0`, and a derivation `D`
+on `K` over `R`, the derivation of the `x`-coordinate of `P + Q` is expressed through the
+derivations of the `x`-coordinates of `P` and `Q`: this is `Affine/Formula/Derivation.lean`'s
+identity for the coordinates of the addition law, read on the points through `Point.xCoord` and
+`Point.yCoord`.
+
+## Main statements
+
+* `WeierstrassCurve.Affine.Point.derivation_xCoord_add`: if `W_Y = 2Y + a₁X + a₃` does not vanish
+  at `P` and `Q`, then `D x(P + Q) = W_Y(P + Q) • (W_Y(P)⁻¹ • D x(P) + W_Y(Q)⁻¹ • D x(Q))`.
+* `WeierstrassCurve.Affine.Point.inv_smul_derivation_xCoord_add`: for nonzero `P`, `Q` with
+  `P + Q ≠ 0`, if `W_Y` does not vanish at `P`, `Q` and `P + Q`, then
+  `W_Y(P + Q)⁻¹ • D x(P + Q) = W_Y(P)⁻¹ • D x(P) + W_Y(Q)⁻¹ • D x(Q)`.
+-/
+
+public section
+
+open WeierstrassCurve
+
+namespace WeierstrassCurve.Affine.Point
+
+variable {R K M : Type*} [CommRing R] [Field K] [Algebra R K] [AddCommGroup M] [Module R M]
+  [Module K M] {W : WeierstrassCurve R} (D : Derivation R K M) [DecidableEq K]
+  {P Q : (W⁄K).toAffine.Point}
+
+/-- **The derivation of the `x`-coordinate of a sum of points.** For nonzero points `P`, `Q` of
+`W⁄K` with `P + Q ≠ 0`, at both of which `W_Y = 2Y + a₁X + a₃` does not vanish,
+`D x(P + Q) = W_Y(P + Q) • (W_Y(P)⁻¹ • D x(P) + W_Y(Q)⁻¹ • D x(Q))`. -/
+theorem derivation_xCoord_add (hP : P ≠ 0) (hQ : Q ≠ 0) (h : P + Q ≠ 0)
+    (huP : (W⁄K).toAffine.polynomialY.evalEval (xCoord P) (yCoord P) ≠ 0)
+    (huQ : (W⁄K).toAffine.polynomialY.evalEval (xCoord Q) (yCoord Q) ≠ 0) :
+    D (xCoord (P + Q)) =
+      (W⁄K).toAffine.polynomialY.evalEval (xCoord (P + Q)) (yCoord (P + Q)) •
+        (((W⁄K).toAffine.polynomialY.evalEval (xCoord P) (yCoord P))⁻¹ • D (xCoord P) +
+          ((W⁄K).toAffine.polynomialY.evalEval (xCoord Q) (yCoord Q))⁻¹ • D (xCoord Q)) := by
+  obtain ⟨x₁, y₁, h₁, rfl⟩ : ∃ x y h, P = some x y h := ⟨_, _, _, (some_coords hP).symm⟩
+  obtain ⟨x₂, y₂, h₂, rfl⟩ : ∃ x y h, Q = some x y h := ⟨_, _, _, (some_coords hQ).symm⟩
+  have hxy : ¬(x₁ = x₂ ∧ y₁ = (W⁄K).toAffine.negY x₂ y₂) := fun hxy ↦
+    h (add_of_Y_eq hxy.1 hxy.2)
+  rw [add_some hxy]
+  simp only [xCoord_some, yCoord_some] at huP huQ ⊢
+  exact derivation_addX_slope D h₁.left h₂.left hxy huP huQ
+
+/-- **The differential `dx / W_Y` is additive on points**: for nonzero points `P`, `Q` of `W⁄K` with
+`P + Q ≠ 0`, if `W_Y` does not vanish at `P`, `Q` and `P + Q`, then
+`W_Y(P + Q)⁻¹ • D x(P + Q) = W_Y(P)⁻¹ • D x(P) + W_Y(Q)⁻¹ • D x(Q)`. -/
+theorem inv_smul_derivation_xCoord_add (hP : P ≠ 0) (hQ : Q ≠ 0) (h : P + Q ≠ 0)
+    (huP : (W⁄K).toAffine.polynomialY.evalEval (xCoord P) (yCoord P) ≠ 0)
+    (huQ : (W⁄K).toAffine.polynomialY.evalEval (xCoord Q) (yCoord Q) ≠ 0)
+    (hu : (W⁄K).toAffine.polynomialY.evalEval (xCoord (P + Q)) (yCoord (P + Q)) ≠ 0) :
+    ((W⁄K).toAffine.polynomialY.evalEval (xCoord (P + Q)) (yCoord (P + Q)))⁻¹ •
+        D (xCoord (P + Q)) =
+      ((W⁄K).toAffine.polynomialY.evalEval (xCoord P) (yCoord P))⁻¹ • D (xCoord P) +
+        ((W⁄K).toAffine.polynomialY.evalEval (xCoord Q) (yCoord Q))⁻¹ • D (xCoord Q) := by
+  rw [derivation_xCoord_add D hP hQ h huP huQ, smul_smul, inv_mul_cancel₀ hu, one_smul]
+
+end WeierstrassCurve.Affine.Point
+
+end


### PR DESCRIPTION
Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"EllipticCurves/STATUS.md:hasse-bound:invariant-differential-additive-derivation"}-->

Provenance: the AINTLIB `HasseWeil` project (Chris Birkbeck, Apache-2.0, `513e83879e2f8cbc626eb9e04d660e92be16ccba`) proves in `RouteBGeneral.lean` (`kaehlerD_addSlope_general`, `kaehlerD_addPullback_x_general`, `kaehlerD_addPullback_x_general_cleared`, `kaehlerD_addPullback_x_eq_one_add_smul_omega`) that the Kähler differential of the `x`-coordinate of `P + α(P)`, for the generic point `P` of an elliptic curve and an endomorphism `α`, is `W_Y • (1 + a_α) • ω`, by the chain rule on the chord formulae and one ring identity modulo the two Weierstrass equations. This file states that computation for two arbitrary points of a Weierstrass curve over any field and an arbitrary derivation, without the coefficient `a_α`, and adds the tangent case (two equal points), which the source handles through division polynomials (`omegaPullbackCoeff_mulByInt_two`) and which here is one further ring identity. The proof structure (chain rule, clear the denominators, `linear_combination` against the Weierstrass equations) is adapted from the source; no text is copied.

## What this adds

`TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Formula/Derivation.lean` (new; imports only Mathlib's `Affine.Formula` and `Derivation.Basic`). For `W : WeierstrassCurve R`, an `R`-algebra `K` and `D : Derivation R K M`:

- `WeierstrassCurve.Affine.Equation.evalEval_polynomialX_smul_add_evalEval_polynomialY_smul_eq_zero`: at a point `(x, y)` of `W⁄K`, `W_X(x, y) • D x + W_Y(x, y) • D y = 0` — the differential of the Weierstrass equation, over any commutative ring `K`.
- `WeierstrassCurve.Affine.derivation_evalEval_polynomialX`, `derivation_evalEval_polynomialY`, `derivation_addX`: the chain rule for `W_X`, `W_Y` and `addX`, again over any commutative ring.
- `WeierstrassCurve.Affine.sub_negY`, `evalEval_polynomialY_ne_zero_of_Y_ne` (over any commutative ring): `y - negY x y = W_Y(x, y)`, so `W_Y` does not vanish at a point that is not its own negative; the tangent slope there is Mathlib's `slope_of_Y_ne_eq_evalEval`.
- `WeierstrassCurve.Affine.derivation_slope_of_X_ne`, `derivation_slope_self_of_Y_ne`: the chain rule for the chord and the tangent slope.
- `WeierstrassCurve.Affine.Equation.derivation_Y_eq_smul_derivation_X`: over a field, at a point where `W_Y ≠ 0`, `D y = (-W_X / W_Y) • D x`.
- `WeierstrassCurve.Affine.derivation_addX_slope`: for points `(x₁, y₁)`, `(x₂, y₂)` of `W⁄K` whose sum `(x₃, y₃) = (addX x₁ x₂ ℓ, addY x₁ x₂ y₁ ℓ)` (with `ℓ = slope x₁ x₂ y₁ y₂`) is affine and at which `W_Y` does not vanish,
  `D x₃ = W_Y(x₃, y₃) • (W_Y(x₁, y₁)⁻¹ • D x₁ + W_Y(x₂, y₂)⁻¹ • D x₂)`; and `inv_smul_derivation_addX_slope`, which divides by `W_Y(x₃, y₃)` when it is nonzero.

`TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Point/Derivation.lean` (new; imports the file above and `Affine/Point/Basic.lean`):

- `WeierstrassCurve.Affine.Point.derivation_xCoord_add` and `Point.inv_smul_derivation_xCoord_add`: the same two identities phrased on points `P`, `Q` of `W⁄K` and their sum `P + Q`, through `Point.xCoord`/`Point.yCoord` — the form a consumer holding points (the tautological points of two morphisms) applies directly.

The identity is the additivity of the differential `dx / W_Y` — the invariant differential of an elliptic curve — with the denominator at the sum cleared: dividing by `W_Y(x₃, y₃)` when it is nonzero gives the additive form.

## Why this shape

- **An arbitrary derivation, not the Kähler differential of a function field.** The identity is a consequence of the chain rule and the two Weierstrass equations alone, so it is stated at that level: applied to `KaehlerDifferential.D F K(W₁)` and the coordinates of the tautological points of two morphisms `f, g : W₁ → W₂`, it becomes Silverman III.5.2, `(f + g)^*ω = f^*ω + g^*ω`, the step the roadmap's Hasse bound needs for `(1 − π)^*ω = ω`. Nothing about function fields or isogenies enters here.
- **Base change rather than five hypotheses.** The derivation must kill the coefficients of the curve; stating the result for `W⁄K` with `D : Derivation R K M` records that once, in the form `Affine/InvariantDifferential.lean` already uses for the curve over its function field.
- **The hypotheses `x₁ ≠ x₂ → W_Y(xᵢ, yᵢ) ≠ 0` are needed, not convenient.** They are asked only in the chord case: in the tangent case `W_Y` cannot vanish at a point that is not its own negative. In characteristic two a point of order two can have `D xᵢ = 0` with `D yᵢ ≠ 0` (its `y`-coordinate is inseparable over the base), and then `D x₃` depends on `D yᵢ` while the right-hand side does not. The sum's `W_Y(x₃, y₃)` is left as a multiplier so that no hypothesis on the sum is needed.
- **The uniform statement over `slope`.** `slope` is Mathlib's uniform chord-or-tangent slope, so `derivation_addX_slope` covers both cases under Mathlib's own hypothesis `¬(x₁ = x₂ ∧ y₁ = negY x₂ y₂)` for the sum to be affine (`Point.add_some`); the two cases are private lemmas.

## Roadmap

`TauCetiRoadmap/EllipticCurves/STATUS.md`, "The frontier", the Hasse bound: "It needs `deg (1 − π_q) = #E(𝔽_q)`" — whose proof runs through the separability of `1 − π`, that is `(1 − π)^*ω ≠ 0`, which needs `(1 − π)^*ω = 1^*ω − π^*ω`. This file is the coordinate identity behind that additivity; the pullback along a sum of morphisms is a later PR (it needs the additive structure on `Hom`).
