### PR TITLE
feat(EllipticCurve): the isogeny 1 − π

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Frobenius.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Frobenius.lean
@@ -37,6 +37,7 @@ on it. The instance Mathlib's map needs is installed locally where it is require
 * `TauCeti.Isogeny.isPurelyInseparable_frobeniusIsogeny`: the induced function-field extension
   is purely inseparable.
 * `TauCeti.Isogeny.degree_frobeniusIsogeny`: the Frobenius isogeny has degree `q`.
+* `TauCeti.Isogeny.frobeniusIsogeny_ne_id`: the Frobenius isogeny is not the identity.
 * `TauCeti.Isogeny.separableDegree_frobeniusIsogeny` and
   `TauCeti.Isogeny.inseparableDegree_frobeniusIsogeny`: its separable and inseparable degrees
   are `1` and `q`, respectively.
@@ -145,6 +146,13 @@ theorem degree_frobeniusIsogeny : (frobeniusIsogeny W).degree = Nat.card F := by
   let _ := Fintype.ofFinite F
   rw [degree_def, fieldPullback_frobeniusIsogeny W]
   exact WeierstrassCurve.Affine.finrank_fieldRange_frobeniusAlgHom W
+
+/-- **Frobenius is not the identity**: its degree is the size of the field, not one. -/
+@[simp]
+theorem frobeniusIsogeny_ne_id : frobeniusIsogeny W ≠ id W := fun h ↦ by
+  have hdeg := congrArg degree h
+  rw [degree_frobeniusIsogeny, degree_id] at hdeg
+  exact (Finite.one_lt_card (α := F)).ne' hdeg
 
 /-- **The Frobenius isogeny has separable degree one**, as pure inseparability in Silverman
 II.2.11(b) requires. -/

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/OneSubFrobenius.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/OneSubFrobenius.lean
@@ -1,0 +1,65 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.Frobenius
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.Hom.Add
+
+/-!
+# The isogeny `1 − π`
+
+For an elliptic curve `W` over a finite field `F`, the difference of the identity and the Frobenius
+isogeny `π` in the endomorphism carrier `Hom W W` is nonzero — the two have different degrees, by
+`TauCeti.Isogeny.frobeniusIsogeny_ne_id` — and so is an isogeny `W → W`. Its kernel is the group
+of `F`-rational points, and its degree is the number of them; this file provides the isogeny itself.
+
+## Main definitions
+
+* `TauCeti.Isogeny.oneSubFrobeniusIsogeny`: the isogeny `1 − π`.
+
+## Main results
+
+* `TauCeti.Isogeny.id_ne_ofIsogeny_frobeniusIsogeny`: `π` is not the identity in `Hom W W`.
+* `TauCeti.Isogeny.ofIsogeny_oneSubFrobeniusIsogeny`: in `Hom W W`, the isogeny `1 − π` is
+  `1 − π`.
+
+## References
+
+* [J. Silverman, *The Arithmetic of Elliptic Curves*][silverman2009], V.2.
+-/
+
+public section
+
+namespace TauCeti.Isogeny
+
+variable {F : Type*} [Field F] [Finite F] (W : WeierstrassCurve.Affine F)
+
+/-- **`π` is not the identity of the endomorphism carrier**, stated in the form `simp` normalises
+`1 - π = 0` to. -/
+@[simp]
+theorem id_ne_ofIsogeny_frobeniusIsogeny : Hom.id W ≠ Hom.ofIsogeny (frobeniusIsogeny W) :=
+  fun h ↦ frobeniusIsogeny_ne_id W
+    (Hom.ofIsogeny_injective (by rw [← Hom.id_def]; exact h.symm))
+
+variable [W.IsElliptic]
+
+/-- **The isogeny `1 − π`**: the difference of the identity and the Frobenius isogeny. -/
+noncomputable def oneSubFrobeniusIsogeny : Isogeny W W :=
+  have hne : (1 : Hom W W) ≠ Hom.ofIsogeny (frobeniusIsogeny W) := by
+    rw [Hom.one_def]
+    exact id_ne_ofIsogeny_frobeniusIsogeny W
+  Hom.toIsogeny (sub_ne_zero.2 hne)
+
+/-- **`1 − π` in the endomorphism carrier**: the isogeny `oneSubFrobeniusIsogeny` is the
+difference of `1` and the Frobenius isogeny in `Hom W W`. -/
+@[simp]
+theorem ofIsogeny_oneSubFrobeniusIsogeny :
+    Hom.ofIsogeny (oneSubFrobeniusIsogeny W) = 1 - Hom.ofIsogeny (frobeniusIsogeny W) :=
+  Hom.ofIsogeny_toIsogeny _
+
+end TauCeti.Isogeny
+
+end


### PR DESCRIPTION
Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"EllipticCurves/STATUS.md:frontier:hasse-bound:one-sub-frobenius"}-->

Provenance: original; composes `Isogeny.frobeniusIsogeny`, `degree_frobeniusIsogeny` (`Isogeny/Frobenius.lean`), `degree_id` (`Isogeny/Degree.lean`) and the additive group on `Isogeny.Hom` (`Isogeny/Hom/Add.lean`). The AINTLIB `HasseWeil` project (Chris Birkbeck, Apache-2.0, `513e83879e2f8cbc626eb9e04d660e92be16ccba`) builds its `1 − π` in `HasseWeil/AdditionPullback/Frobenius.lean` by explicit pole-order computation in the addition formula, in a foundation where isogenies carry their point map; nothing is taken from it.

## What this adds

For a Weierstrass curve `W` over a finite field `F`:

- `Isogeny.frobeniusIsogeny_ne_id` (in `TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Frobenius.lean`, next to `degree_frobeniusIsogeny`): Frobenius is not the identity (its degree is `Nat.card F ≥ 2`, the identity's is `1`).
- `TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/OneSubFrobenius.lean` (new), for `W` elliptic: `Isogeny.oneSubFrobenius : Isogeny W W`, the isogeny `1 − π`, with `ofIsogeny_oneSubFrobenius : ofIsogeny (oneSubFrobenius W) = 1 - ofIsogeny (frobeniusIsogeny W)` in the endomorphism carrier.

## Why now

`TauCetiRoadmap/EllipticCurves/STATUS.md`, "The frontier": "**The Hasse bound.** Nothing of it is present. It needs `deg (1 − π_q) = #E(𝔽_q)` and Cauchy–Schwarz on the degree form, so it sits behind the first bullet." With the first bullet (the additive group on `Hom`) in place, `1 − π` is a nonzero element of `Hom W W` by a degree count and hence an isogeny; this PR names it. Its degree and its kernel are the next steps.
