### PR TITLE
feat: bound the CAR weight spectrum

### DIFF
--- a/TauCeti/Algebra/Lie/GeneralLinear/CAR/WeightSpectrum.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/CAR/WeightSpectrum.lean
@@ -16,14 +16,13 @@ For the left regular action of `gl_n` on the Clifford algebra of its trace form,
 of a highest weight is one of the half-integral expressions `m + 1/2` for a natural number `m < n`.
 
 The diagonal lift is a sum of commuting occupation projections together with its scalar diagonal
-term. Orienting every off-diagonal pair positively gives `n - 1` commuting idempotents. Removing
-the diagonal `1/2` from a highest-weight equation reduces the result to the general spectrum
-theorem for a sum of commuting idempotents.
+term. Removing the diagonal `1/2` from a highest-weight equation leaves `n - 1` commuting
+idempotents, reducing the result to the general spectrum theorem for their sum.
 
 ## Main results
 
-* `TauCeti.IsGlHighestWeightVector.exists_carWeight_eq_natCast_add_inv_two`: every coordinate of a
-  CAR highest weight has the form `m + 1/2` with `m < n`.
+* `TauCeti.IsGlHighestWeightVector.exists_weight_apply_eq_natCast_add_inv_two`: every coordinate of
+  a CAR highest weight has the form `m + 1/2` with `m < n`.
 
 ## References
 
@@ -43,45 +42,6 @@ noncomputable section
 
 variable {K n : Type*} [Field K] [Fintype n] [LinearOrder n]
 
-/-- The occupation projection attached to `k ≠ i`, oriented by the order on the index type. -/
-private def orientedCarOccupationElement (i k : n) :
-    CliffordAlgebra (traceQuadraticForm K n) :=
-  if k < i then 1 - carOccupationElement (K := K) k i
-  else carOccupationElement (K := K) i k
-
-/-- The diagonal member of the oriented family is the scalar `1/2`. -/
-private theorem orientedCarOccupationElement_self (i : n) :
-    orientedCarOccupationElement (K := K) i i = (2 : K)⁻¹ • 1 := by
-  simp [orientedCarOccupationElement]
-
-/-- Every off-diagonal member of the oriented family is idempotent. -/
-private theorem orientedCarOccupationElement_idempotent {i k : n} (hki : k ≠ i) :
-    IsIdempotentElem (orientedCarOccupationElement (K := K) i k) := by
-  rw [orientedCarOccupationElement]
-  split_ifs with h
-  · exact (isIdempotentElem_carOccupationElement (K := K) (ne_of_lt h)).one_sub
-  · exact isIdempotentElem_carOccupationElement (K := K) hki.symm
-
-/-- The oriented occupation elements with a fixed diagonal index commute. -/
-private theorem commute_orientedCarOccupationElement (i k l : n) :
-    Commute (orientedCarOccupationElement (K := K) i k)
-      (orientedCarOccupationElement (K := K) i l) := by
-  rw [orientedCarOccupationElement, orientedCarOccupationElement]
-  split_ifs <;>
-    first
-    | exact commute_carOccupationElement (K := K)
-    | exact (Commute.one_left _).sub_left commute_carOccupationElement
-    | exact (Commute.one_right _).sub_right commute_carOccupationElement
-    | exact ((Commute.one_left _).sub_left
-        ((Commute.one_right _).sub_right commute_carOccupationElement))
-
-/-- Expanding the oriented family recovers the positive-occupation diagonal sum. -/
-private theorem sum_orientedCarOccupationElement (i : n) :
-    (∑ k, orientedCarOccupationElement (K := K) i k) =
-      ∑ k, if k < i then 1 - carOccupationElement (K := K) k i
-        else carOccupationElement (K := K) i k := by
-  rfl
-
 namespace IsGlHighestWeightVector
 
 variable [h2 : Invertible (2 : K)] [decEq : DecidableEq n]
@@ -91,29 +51,27 @@ than the matrix size, shifted by `1/2`.
 
 This statement supplies the coordinate restriction; it does not assert that every expression is
 attained by a given vector. -/
-theorem exists_carWeight_eq_natCast_add_inv_two {μ : n → K}
+theorem exists_weight_apply_eq_natCast_add_inv_two {μ : n → K}
     {v : CliffordAlgebra (traceQuadraticForm K n)}
     (hv : IsGlHighestWeightVector μ v) (i : n) :
     ∃ m : ℕ, m < Fintype.card n ∧ μ i = (m : K) + (2 : K)⁻¹ := by
   cases Subsingleton.elim decEq (Classical.decEq n)
   let _ : DecidableEq n := Classical.decEq n
   let s := Finset.univ.erase i
-  have hsum : (∑ k ∈ s, orientedCarOccupationElement (K := K) i k) • v =
+  have hsum : (∑ k ∈ s, carOccupationElement (K := K) i k) • v =
       (μ i - (2 : K)⁻¹) • v := by
     rw [smul_eq_mul]
     have hdiag := hv.lie_single_self_eq_smul i
     rw [car_lie_def,
-      @glCliffordHom_single_self_eq_sum_positive_occupation K n inferInstance inferInstance h2
-        inferInstance i] at hdiag
-    rw [← sum_orientedCarOccupationElement] at hdiag
+      @glCliffordHom_single_self_eq_sum_occupation K n inferInstance inferInstance h2 i] at hdiag
     rw [← Finset.sum_erase_add _ _ (Finset.mem_univ i), add_mul,
-      orientedCarOccupationElement_self, smul_mul_assoc, one_mul] at hdiag
+      carOccupationElement_self, smul_mul_assoc, one_mul] at hdiag
     rw [sub_smul]
     exact eq_sub_of_add_eq hdiag
   obtain ⟨m, hm, hμ⟩ := exists_eq_natCast_of_sum_smul_eq_smul s
-    (orientedCarOccupationElement (K := K) i)
-    (fun k hk => orientedCarOccupationElement_idempotent (Finset.ne_of_mem_erase hk))
-    (fun k _ l _ _ => commute_orientedCarOccupationElement i k l) hv.ne_zero hsum
+    (carOccupationElement (K := K) i)
+    (fun k hk => isIdempotentElem_carOccupationElement (Finset.ne_of_mem_erase hk).symm)
+    (fun _ _ _ _ _ => commute_carOccupationElement (K := K)) hv.ne_zero hsum
   refine ⟨m, ?_, eq_add_of_sub_eq hμ⟩
   have hcard : 0 < Fintype.card n := Fintype.card_pos_iff.mpr ⟨i⟩
   have hm' : m ≤ Fintype.card n - 1 := by

--- a/TauCeti/Algebra/Lie/GeneralLinear/CAR/WeightSpectrum.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/CAR/WeightSpectrum.lean
@@ -41,8 +41,6 @@ namespace TauCeti
 
 noncomputable section
 
-attribute [local instance] Classical.decEq
-
 variable {K n : Type*} [Field K] [Fintype n] [LinearOrder n]
 
 /-- The occupation projection attached to `k ≠ i`, oriented by the order on the index type. -/
@@ -77,9 +75,16 @@ private theorem commute_orientedCarOccupationElement (i k l : n) :
     | exact ((Commute.one_left _).sub_left
         ((Commute.one_right _).sub_right commute_carOccupationElement))
 
+/-- Expanding the oriented family recovers the positive-occupation diagonal sum. -/
+private theorem sum_orientedCarOccupationElement (i : n) :
+    (∑ k, orientedCarOccupationElement (K := K) i k) =
+      ∑ k, if k < i then 1 - carOccupationElement (K := K) k i
+        else carOccupationElement (K := K) i k := by
+  rfl
+
 namespace IsGlHighestWeightVector
 
-variable [h2 : Invertible (2 : K)]
+variable [h2 : Invertible (2 : K)] [decEq : DecidableEq n]
 
 /-- Every coordinate of a highest weight in the left regular CAR module is a natural number less
 than the matrix size, shifted by `1/2`.
@@ -90,16 +95,17 @@ theorem exists_carWeight_eq_natCast_add_inv_two {μ : n → K}
     {v : CliffordAlgebra (traceQuadraticForm K n)}
     (hv : IsGlHighestWeightVector μ v) (i : n) :
     ∃ m : ℕ, m < Fintype.card n ∧ μ i = (m : K) + (2 : K)⁻¹ := by
+  cases Subsingleton.elim decEq (Classical.decEq n)
+  let _ : DecidableEq n := Classical.decEq n
   let s := Finset.univ.erase i
   have hsum : (∑ k ∈ s, orientedCarOccupationElement (K := K) i k) • v =
       (μ i - (2 : K)⁻¹) • v := by
-    change (∑ k ∈ s, orientedCarOccupationElement (K := K) i k) * v =
-      (μ i - (2 : K)⁻¹) • v
+    rw [smul_eq_mul]
     have hdiag := hv.lie_single_self_eq_smul i
     rw [car_lie_def,
       @glCliffordHom_single_self_eq_sum_positive_occupation K n inferInstance inferInstance h2
         inferInstance i] at hdiag
-    change (∑ k, orientedCarOccupationElement (K := K) i k) * v = μ i • v at hdiag
+    rw [← sum_orientedCarOccupationElement] at hdiag
     rw [← Finset.sum_erase_add _ _ (Finset.mem_univ i), add_mul,
       orientedCarOccupationElement_self, smul_mul_assoc, one_mul] at hdiag
     rw [sub_smul]

--- a/TauCeti/Algebra/Lie/GeneralLinear/CAR/WeightSpectrum.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/CAR/WeightSpectrum.lean
@@ -6,8 +6,8 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.Lie.GeneralLinear.CAR.HighestWeight
-public import TauCeti.Algebra.Lie.GeneralLinear.CAR.Occupation
-public import TauCeti.RingTheory.Idempotents.Eigenvalue
+import TauCeti.Algebra.Lie.GeneralLinear.CAR.Occupation
+import TauCeti.RingTheory.Idempotents.Eigenvalue
 
 /-!
 # The coordinate spectrum of CAR highest weights
@@ -40,11 +40,13 @@ namespace TauCeti
 
 noncomputable section
 
+attribute [local instance] Classical.decEq
+
 variable {K n : Type*} [Field K] [Fintype n] [LinearOrder n]
 
 namespace IsGlHighestWeightVector
 
-variable [h2 : Invertible (2 : K)] [decEq : DecidableEq n]
+variable [h2 : Invertible (2 : K)]
 
 /-- Every coordinate of a highest weight in the left regular CAR module is a natural number less
 than the matrix size, shifted by `1/2`.
@@ -55,8 +57,6 @@ theorem exists_weight_apply_eq_natCast_add_inv_two {μ : n → K}
     {v : CliffordAlgebra (traceQuadraticForm K n)}
     (hv : IsGlHighestWeightVector μ v) (i : n) :
     ∃ m : ℕ, m < Fintype.card n ∧ μ i = (m : K) + (2 : K)⁻¹ := by
-  cases Subsingleton.elim decEq (Classical.decEq n)
-  let _ : DecidableEq n := Classical.decEq n
   let s := Finset.univ.erase i
   have hsum : (∑ k ∈ s, carOccupationElement (K := K) i k) • v =
       (μ i - (2 : K)⁻¹) • v := by
@@ -68,7 +68,7 @@ theorem exists_weight_apply_eq_natCast_add_inv_two {μ : n → K}
       carOccupationElement_self, smul_mul_assoc, one_mul] at hdiag
     rw [sub_smul]
     exact eq_sub_of_add_eq hdiag
-  obtain ⟨m, hm, hμ⟩ := exists_eq_natCast_of_sum_smul_eq_smul s
+  obtain ⟨m, hm, hμ⟩ := s.exists_eq_natCast_of_sum_smul_eq_smul
     (carOccupationElement (K := K) i)
     (fun k hk => isIdempotentElem_carOccupationElement (Finset.ne_of_mem_erase hk).symm)
     (fun _ _ _ _ _ => commute_carOccupationElement (K := K)) hv.ne_zero hsum

--- a/TauCeti/Algebra/Lie/GeneralLinear/CAR/WeightSpectrum.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/CAR/WeightSpectrum.lean
@@ -1,0 +1,121 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Lie.GeneralLinear.CAR.HighestWeight
+public import TauCeti.Algebra.Lie.GeneralLinear.CAR.Occupation
+public import TauCeti.RingTheory.Idempotents.Eigenvalue
+
+/-!
+# The coordinate spectrum of CAR highest weights
+
+For the left regular action of `gl_n` on the Clifford algebra of its trace form, every coordinate
+of a highest weight is one of the half-integral expressions `m + 1/2` for a natural number `m < n`.
+
+The diagonal lift is a sum of commuting occupation projections together with its scalar diagonal
+term. Orienting every off-diagonal pair positively gives `n - 1` commuting idempotents. Removing
+the diagonal `1/2` from a highest-weight equation reduces the result to the general spectrum
+theorem for a sum of commuting idempotents.
+
+## Main results
+
+* `TauCeti.IsGlHighestWeightVector.exists_carWeight_eq_natCast_add_inv_two`: every coordinate of a
+  CAR highest weight has the form `m + 1/2` with `m < n`.
+
+## References
+
+* D. Panyushev, *The exterior algebra and "spin" of an orthogonal g-module*, Transformation Groups
+  6 (2001), 371–396, Proposition 2.4 and Example 2.5(1).
+* D. Shlyakhtenko, *Failure of Strong Convergence of Matrices with Fermionic Entries*,
+  arXiv:2606.28648, §2.3.
+-/
+
+public section
+
+open scoped BigOperators TauCeti
+
+namespace TauCeti
+
+noncomputable section
+
+attribute [local instance] Classical.decEq
+
+variable {K n : Type*} [Field K] [Fintype n] [LinearOrder n]
+
+/-- The occupation projection attached to `k ≠ i`, oriented by the order on the index type. -/
+private def orientedCarOccupationElement (i k : n) :
+    CliffordAlgebra (traceQuadraticForm K n) :=
+  if k < i then 1 - carOccupationElement (K := K) k i
+  else carOccupationElement (K := K) i k
+
+/-- The diagonal member of the oriented family is the scalar `1/2`. -/
+private theorem orientedCarOccupationElement_self (i : n) :
+    orientedCarOccupationElement (K := K) i i = (2 : K)⁻¹ • 1 := by
+  simp [orientedCarOccupationElement]
+
+/-- Every off-diagonal member of the oriented family is idempotent. -/
+private theorem orientedCarOccupationElement_idempotent {i k : n} (hki : k ≠ i) :
+    IsIdempotentElem (orientedCarOccupationElement (K := K) i k) := by
+  rw [orientedCarOccupationElement]
+  split_ifs with h
+  · exact (isIdempotentElem_carOccupationElement (K := K) (ne_of_lt h)).one_sub
+  · exact isIdempotentElem_carOccupationElement (K := K) hki.symm
+
+/-- The oriented occupation elements with a fixed diagonal index commute. -/
+private theorem commute_orientedCarOccupationElement (i k l : n) :
+    Commute (orientedCarOccupationElement (K := K) i k)
+      (orientedCarOccupationElement (K := K) i l) := by
+  rw [orientedCarOccupationElement, orientedCarOccupationElement]
+  split_ifs <;>
+    first
+    | exact commute_carOccupationElement (K := K)
+    | exact (Commute.one_left _).sub_left commute_carOccupationElement
+    | exact (Commute.one_right _).sub_right commute_carOccupationElement
+    | exact ((Commute.one_left _).sub_left
+        ((Commute.one_right _).sub_right commute_carOccupationElement))
+
+namespace IsGlHighestWeightVector
+
+variable [h2 : Invertible (2 : K)]
+
+/-- Every coordinate of a highest weight in the left regular CAR module is a natural number less
+than the matrix size, shifted by `1/2`.
+
+This statement supplies the coordinate restriction; it does not assert that every expression is
+attained by a given vector. -/
+theorem exists_carWeight_eq_natCast_add_inv_two {μ : n → K}
+    {v : CliffordAlgebra (traceQuadraticForm K n)}
+    (hv : IsGlHighestWeightVector μ v) (i : n) :
+    ∃ m : ℕ, m < Fintype.card n ∧ μ i = (m : K) + (2 : K)⁻¹ := by
+  let s := Finset.univ.erase i
+  have hsum : (∑ k ∈ s, orientedCarOccupationElement (K := K) i k) • v =
+      (μ i - (2 : K)⁻¹) • v := by
+    change (∑ k ∈ s, orientedCarOccupationElement (K := K) i k) * v =
+      (μ i - (2 : K)⁻¹) • v
+    have hdiag := hv.lie_single_self_eq_smul i
+    rw [car_lie_def,
+      @glCliffordHom_single_self_eq_sum_positive_occupation K n inferInstance inferInstance h2
+        inferInstance i] at hdiag
+    change (∑ k, orientedCarOccupationElement (K := K) i k) * v = μ i • v at hdiag
+    rw [← Finset.sum_erase_add _ _ (Finset.mem_univ i), add_mul,
+      orientedCarOccupationElement_self, smul_mul_assoc, one_mul] at hdiag
+    rw [sub_smul]
+    exact eq_sub_of_add_eq hdiag
+  obtain ⟨m, hm, hμ⟩ := exists_eq_natCast_of_sum_smul_eq_smul s
+    (orientedCarOccupationElement (K := K) i)
+    (fun k hk => orientedCarOccupationElement_idempotent (Finset.ne_of_mem_erase hk))
+    (fun k _ l _ _ => commute_orientedCarOccupationElement i k l) hv.ne_zero hsum
+  refine ⟨m, ?_, eq_add_of_sub_eq hμ⟩
+  have hcard : 0 < Fintype.card n := Fintype.card_pos_iff.mpr ⟨i⟩
+  have hm' : m ≤ Fintype.card n - 1 := by
+    simpa only [s, Finset.card_erase_of_mem (Finset.mem_univ i), Finset.card_univ] using hm
+  omega
+
+end IsGlHighestWeightVector
+
+end
+
+end TauCeti

--- a/TauCeti/Algebra/Lie/GeneralLinear/CAR/WeightSpectrum.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/CAR/WeightSpectrum.lean
@@ -10,17 +10,20 @@ import TauCeti.Algebra.Lie.GeneralLinear.CAR.Occupation
 import TauCeti.RingTheory.Idempotents.Eigenvalue
 
 /-!
-# The coordinate spectrum of CAR highest weights
+# The coordinate spectrum of CAR diagonal eigenvectors
 
-For the left regular action of `gl_n` on the Clifford algebra of its trace form, every coordinate
-of a highest weight is one of the half-integral expressions `m + 1/2` for a natural number `m < n`.
+For the left regular action of `gl_n` on the Clifford algebra of its trace form, every eigenvalue
+of a diagonal matrix unit on a nonzero vector is one of the half-integral expressions `m + 1/2`
+for a natural number `m < n`. In particular, this restricts every coordinate of a highest weight.
 
 The diagonal lift is a sum of commuting occupation projections together with its scalar diagonal
-term. Removing the diagonal `1/2` from a highest-weight equation leaves `n - 1` commuting
+term. Removing the diagonal `1/2` from a diagonal eigenvector equation leaves `n - 1` commuting
 idempotents, reducing the result to the general spectrum theorem for their sum.
 
 ## Main results
 
+* `TauCeti.exists_eq_natCast_add_inv_two_of_lie_single_self_eq_smul`: every diagonal matrix-unit
+  eigenvalue has the form `m + 1/2` with `m < n`.
 * `TauCeti.IsGlHighestWeightVector.exists_weight_apply_eq_natCast_add_inv_two`: every coordinate of
   a CAR highest weight has the form `m + 1/2` with `m < n`.
 
@@ -42,11 +45,39 @@ noncomputable section
 
 attribute [local instance] Classical.decEq
 
-variable {K n : Type*} [Field K] [Fintype n] [LinearOrder n]
+variable {K n : Type*} [Field K] [Fintype n]
+
+variable [h2 : Invertible (2 : K)]
+
+/-- Every eigenvalue of a diagonal matrix unit on a nonzero vector in the left regular CAR module
+is a natural number less than the matrix size, shifted by `1/2`. -/
+theorem exists_eq_natCast_add_inv_two_of_lie_single_self_eq_smul {μ : K}
+    {v : CliffordAlgebra (traceQuadraticForm K n)} {i : n} (hv : v ≠ 0)
+    (hdiag : ⁅Matrix.single i i (1 : K), v⁆ = μ • v) :
+    ∃ m : ℕ, m < Fintype.card n ∧ μ = (m : K) + (2 : K)⁻¹ := by
+  let s := Finset.univ.erase i
+  have hsum : (∑ k ∈ s, carOccupationElement (K := K) i k) • v =
+      (μ - (2 : K)⁻¹) • v := by
+    rw [smul_eq_mul]
+    rw [car_lie_def,
+      @glCliffordHom_single_self_eq_sum_occupation K n inferInstance inferInstance h2 i] at hdiag
+    rw [← Finset.sum_erase_add _ _ (Finset.mem_univ i), add_mul,
+      carOccupationElement_self, smul_mul_assoc, one_mul] at hdiag
+    rw [sub_smul]
+    exact eq_sub_of_add_eq hdiag
+  obtain ⟨m, hm, hμ⟩ := s.exists_eq_natCast_of_sum_smul_eq_smul
+    (carOccupationElement (K := K) i)
+    (fun k hk => isIdempotentElem_carOccupationElement (Finset.ne_of_mem_erase hk).symm)
+    (fun _ _ _ _ _ => commute_carOccupationElement (K := K)) hv hsum
+  refine ⟨m, ?_, eq_add_of_sub_eq hμ⟩
+  have hcard : 0 < Fintype.card n := Fintype.card_pos_iff.mpr ⟨i⟩
+  have hm' : m ≤ Fintype.card n - 1 := by
+    simpa only [s, Finset.card_erase_of_mem (Finset.mem_univ i), Finset.card_univ] using hm
+  omega
 
 namespace IsGlHighestWeightVector
 
-variable [h2 : Invertible (2 : K)]
+variable [LinearOrder n]
 
 /-- Every coordinate of a highest weight in the left regular CAR module is a natural number less
 than the matrix size, shifted by `1/2`.
@@ -57,26 +88,8 @@ theorem exists_weight_apply_eq_natCast_add_inv_two {μ : n → K}
     {v : CliffordAlgebra (traceQuadraticForm K n)}
     (hv : IsGlHighestWeightVector μ v) (i : n) :
     ∃ m : ℕ, m < Fintype.card n ∧ μ i = (m : K) + (2 : K)⁻¹ := by
-  let s := Finset.univ.erase i
-  have hsum : (∑ k ∈ s, carOccupationElement (K := K) i k) • v =
-      (μ i - (2 : K)⁻¹) • v := by
-    rw [smul_eq_mul]
-    have hdiag := hv.lie_single_self_eq_smul i
-    rw [car_lie_def,
-      @glCliffordHom_single_self_eq_sum_occupation K n inferInstance inferInstance h2 i] at hdiag
-    rw [← Finset.sum_erase_add _ _ (Finset.mem_univ i), add_mul,
-      carOccupationElement_self, smul_mul_assoc, one_mul] at hdiag
-    rw [sub_smul]
-    exact eq_sub_of_add_eq hdiag
-  obtain ⟨m, hm, hμ⟩ := s.exists_eq_natCast_of_sum_smul_eq_smul
-    (carOccupationElement (K := K) i)
-    (fun k hk => isIdempotentElem_carOccupationElement (Finset.ne_of_mem_erase hk).symm)
-    (fun _ _ _ _ _ => commute_carOccupationElement (K := K)) hv.ne_zero hsum
-  refine ⟨m, ?_, eq_add_of_sub_eq hμ⟩
-  have hcard : 0 < Fintype.card n := Fintype.card_pos_iff.mpr ⟨i⟩
-  have hm' : m ≤ Fintype.card n - 1 := by
-    simpa only [s, Finset.card_erase_of_mem (Finset.mem_univ i), Finset.card_univ] using hm
-  omega
+  exact exists_eq_natCast_add_inv_two_of_lie_single_self_eq_smul hv.ne_zero
+    (hv.lie_single_self_eq_smul i)
 
 end IsGlHighestWeightVector
 

--- a/TauCeti/RingTheory/Idempotents/Eigenvalue.lean
+++ b/TauCeti/RingTheory/Idempotents/Eigenvalue.lean
@@ -1,0 +1,88 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.BigOperators.Ring.Finset
+public import Mathlib.Algebra.Module.Torsion.Free
+public import Mathlib.Algebra.Ring.Idempotent
+
+/-!
+# Eigenvalues of sums of commuting idempotents
+
+A finite family of pairwise commuting idempotents has a particularly rigid spectrum. If its sum
+scales a nonzero vector in a torsion-free module over an integral domain, then the scalar is the
+image of a natural number no larger than the size of the family.
+
+The proof removes one idempotent at a time. On a given eigenvector, that idempotent either vanishes,
+leaving the eigenvalue unchanged, or produces a nonzero eigenvector for the remaining sum with the
+eigenvalue reduced by one.
+
+## Main results
+
+* `TauCeti.exists_eq_natCast_of_sum_smul_eq_smul`: an eigenvalue of a finite sum of commuting
+  idempotents is a bounded natural-number cast.
+-/
+
+public section
+
+namespace TauCeti
+
+open scoped BigOperators
+
+variable {K A M ι : Type*} [CommRing K] [IsDomain K] [Ring A]
+  [AddCommGroup M] [Module K M] [Module A M] [SMulCommClass A K M]
+  [Module.IsTorsionFree K M]
+
+/-- If a finite sum of pairwise commuting idempotents scales a nonzero vector, its eigenvalue is
+the cast of a natural number bounded by the number of idempotents.
+
+No finite-dimensionality or splitting hypothesis is needed. The torsion-free assumption is exactly
+what makes a scalar determined by its action on the nonzero vector. -/
+theorem exists_eq_natCast_of_sum_smul_eq_smul
+    (s : Finset ι) (p : ι → A)
+    (hp : ∀ i ∈ s, IsIdempotentElem (p i))
+    (hcomm : (s : Set ι).Pairwise fun i j => Commute (p i) (p j))
+    {x : M} (hx : x ≠ 0) {μ : K}
+    (heigen : (∑ i ∈ s, p i) • x = μ • x) :
+    ∃ m : ℕ, m ≤ s.card ∧ μ = (m : K) := by
+  classical
+  induction s using Finset.induction_on generalizing μ x with
+  | empty =>
+      have hμ : μ = 0 := by
+        apply smul_left_injective K hx
+        simpa using heigen.symm
+      exact ⟨0, by simp, by simpa using hμ⟩
+  | @insert a s ha ih =>
+      have hpa : IsIdempotentElem (p a) := hp a (by simp)
+      have hp_s : ∀ i ∈ s, IsIdempotentElem (p i) := fun i hi => hp i (by simp [hi])
+      have hcomm_s : (s : Set ι).Pairwise fun i j => Commute (p i) (p j) :=
+        hcomm.mono (by simp)
+      have hcomm_sum : Commute (p a) (∑ i ∈ s, p i) :=
+        Commute.sum_right s p (p a) fun i hi =>
+          hcomm (by simp) (by simp [hi]) (by exact fun hai => ha (hai ▸ hi))
+      by_cases hpx : p a • x = 0
+      · obtain ⟨m, hm, hμ⟩ := ih hp_s hcomm_s hx (μ := μ) (by
+          rw [Finset.sum_insert ha, add_smul, hpx, zero_add] at heigen
+          exact heigen)
+        exact ⟨m, hm.trans (by simp [Finset.card_insert_of_notMem ha]), hμ⟩
+      · obtain ⟨m, hm, hμ⟩ := ih hp_s hcomm_s hpx (μ := μ - 1) (by
+          have hrest : (∑ i ∈ s, p i) • x = μ • x - p a • x := by
+            rw [Finset.sum_insert ha, add_smul] at heigen
+            exact eq_sub_of_add_eq' heigen
+          calc
+            (∑ i ∈ s, p i) • (p a • x) =
+                ((∑ i ∈ s, p i) * p a) • x := (mul_smul _ _ _).symm
+            _ = (p a * ∑ i ∈ s, p i) • x := by rw [hcomm_sum.eq]
+            _ = p a • ((∑ i ∈ s, p i) • x) := mul_smul _ _ _
+            _ = p a • (μ • x - p a • x) := by rw [hrest]
+            _ = (μ - 1) • (p a • x) := by
+              rw [smul_sub, smul_comm, ← mul_smul, hpa.eq, sub_smul, one_smul])
+        refine ⟨m + 1, ?_, ?_⟩
+        · simpa [Finset.card_insert_of_notMem ha] using Nat.add_le_add_right hm 1
+        · rw [Nat.cast_add, Nat.cast_one]
+          exact eq_add_of_sub_eq hμ
+
+end TauCeti

--- a/TauCeti/RingTheory/Idempotents/Eigenvalue.lean
+++ b/TauCeti/RingTheory/Idempotents/Eigenvalue.lean
@@ -6,16 +6,16 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Algebra.BigOperators.Ring.Finset
-public import Mathlib.Algebra.Module.Torsion.Free
+public import Mathlib.Algebra.NoZeroSMulDivisors.Defs
 public import Mathlib.Algebra.Ring.Idempotent
 
 /-!
 # Eigenvalues of sums of commuting idempotents
 
 A finite family of pairwise commuting idempotents has a particularly rigid spectrum. If its sum
-scales a nonzero vector in a torsion-free module over a cancellation ring, then the scalar is the
-image of a natural number no larger than the size of the family. This bounds the possible
-eigenvalues without requiring finite-dimensionality or a simultaneous eigenspace decomposition.
+scales a nonzero vector in a module with no zero scalar divisors, then the scalar is the image of a
+natural number no larger than the size of the family. This bounds the possible eigenvalues without
+requiring finite-dimensionality or a simultaneous eigenspace decomposition.
 
 ## Main results
 
@@ -29,15 +29,15 @@ open scoped BigOperators
 
 namespace Finset
 
-variable {K A M ι : Type*} [Ring K] [IsCancelMulZero K] [Semiring A]
+variable {K A M ι : Type*} [Ring K] [Semiring A]
   [AddCommGroup M] [Module K M] [Module A M] [SMulCommClass A K M]
-  [Module.IsTorsionFree K M]
+  [NoZeroSMulDivisors K M]
 
 /-- If a finite sum of pairwise commuting idempotents scales a nonzero vector, its eigenvalue is
 the cast of a natural number bounded by the number of idempotents.
 
-No finite-dimensionality or splitting hypothesis is needed. The torsion-free assumption is exactly
-what makes a scalar determined by its action on the nonzero vector. -/
+No finite-dimensionality or splitting hypothesis is needed. The no-zero-scalar-divisors assumption
+is exactly what makes a scalar determined by its action on the nonzero vector. -/
 theorem exists_eq_natCast_of_sum_smul_eq_smul
     (s : Finset ι) (p : ι → A)
     (hp : ∀ i ∈ s, IsIdempotentElem (p i))
@@ -49,8 +49,7 @@ theorem exists_eq_natCast_of_sum_smul_eq_smul
   induction s using Finset.induction_on generalizing μ x with
   | empty =>
       have hμ : μ = 0 := by
-        apply smul_left_injective K hx
-        simpa using heigen.symm
+        exact (eq_zero_or_eq_zero_of_smul_eq_zero (by simpa using heigen.symm)).resolve_right hx
       exact ⟨0, by simp, by simpa using hμ⟩
   | @insert a s ha ih =>
       have hpa : IsIdempotentElem (p a) := hp a (by simp)

--- a/TauCeti/RingTheory/Idempotents/Eigenvalue.lean
+++ b/TauCeti/RingTheory/Idempotents/Eigenvalue.lean
@@ -19,17 +19,17 @@ eigenvalues without requiring finite-dimensionality or a simultaneous eigenspace
 
 ## Main results
 
-* `TauCeti.exists_eq_natCast_of_sum_smul_eq_smul`: an eigenvalue of a finite sum of commuting
-  idempotents is a bounded natural-number cast.
+* `Finset.exists_eq_natCast_of_sum_smul_eq_smul`: an eigenvalue of a finite sum of
+  commuting idempotents is a bounded natural-number cast.
 -/
 
 public section
 
-namespace TauCeti
-
 open scoped BigOperators
 
-variable {K A M ι : Type*} [Ring K] [IsCancelMulZero K] [Ring A]
+namespace Finset
+
+variable {K A M ι : Type*} [Ring K] [IsCancelMulZero K] [Semiring A]
   [AddCommGroup M] [Module K M] [Module A M] [SMulCommClass A K M]
   [Module.IsTorsionFree K M]
 
@@ -82,4 +82,4 @@ theorem exists_eq_natCast_of_sum_smul_eq_smul
         · rw [Nat.cast_add, Nat.cast_one]
           exact eq_add_of_sub_eq hμ
 
-end TauCeti
+end Finset

--- a/TauCeti/RingTheory/Idempotents/Eigenvalue.lean
+++ b/TauCeti/RingTheory/Idempotents/Eigenvalue.lean
@@ -13,12 +13,9 @@ public import Mathlib.Algebra.Ring.Idempotent
 # Eigenvalues of sums of commuting idempotents
 
 A finite family of pairwise commuting idempotents has a particularly rigid spectrum. If its sum
-scales a nonzero vector in a torsion-free module over an integral domain, then the scalar is the
-image of a natural number no larger than the size of the family.
-
-The proof removes one idempotent at a time. On a given eigenvector, that idempotent either vanishes,
-leaving the eigenvalue unchanged, or produces a nonzero eigenvector for the remaining sum with the
-eigenvalue reduced by one.
+scales a nonzero vector in a torsion-free module over a cancellation ring, then the scalar is the
+image of a natural number no larger than the size of the family. This bounds the possible
+eigenvalues without requiring finite-dimensionality or a simultaneous eigenspace decomposition.
 
 ## Main results
 
@@ -32,7 +29,7 @@ namespace TauCeti
 
 open scoped BigOperators
 
-variable {K A M ι : Type*} [CommRing K] [IsDomain K] [Ring A]
+variable {K A M ι : Type*} [Ring K] [IsCancelMulZero K] [Ring A]
   [AddCommGroup M] [Module K M] [Module A M] [SMulCommClass A K M]
   [Module.IsTorsionFree K M]
 


### PR DESCRIPTION
This PR constrains every diagonal eigenvalue in the left-regular CAR module, and hence every coordinate of a highest weight, to `m + 1/2` with `m < N` for the `RepresentationTheory/SpinRepresentations/README.md` Layer 9 worked `gl_N`-on-`M_N` isotypy milestone.

Roadmap: RepresentationTheory

## Summary

Prove that an eigenvalue of a finite sum of pairwise commuting idempotents on a nonzero vector is a bounded natural-number cast over any ring acting on a module with no zero scalar divisors. Apply this result to an arbitrary nonzero eigenvector of a CAR diagonal matrix unit after removing the normal-ordering half, then derive the highest-weight coordinate restriction as a direct corollary. The proof reuses the existing occupation sum, self-action, idempotence, and commutation API instead of introducing a parallel oriented representation.

## Roadmap target

This advances the Layer 9 worked-instance target that the left-regular `Cliff(M_N)` is isotypic with highest weight `ν = (N - 1/2, …, 1/2)`. After this PR, combine the discrete coordinate values with dominance and the CAR Casimir equation to identify every constituent weight with the staircase, then prove isotypy and the stated dimension and multiplicity formulas.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"car-weight-coordinate-spectrum"}-->

## Verification

- Exact head: `1202f0aba49ca4022a5363e8175999bbfc0dbc86`
- Local Lean build: `lake exe cache get` and `lake build` — pass (`Build completed successfully (11084 jobs).`)
- Axiom audit: `lake exe axioms` — pass (`axioms: audited 110237 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`)
- Lint: `env PATH=/opt/homebrew/opt/gnu-sed/libexec/gnubin:$PATH bash scripts/lint-env.sh && python3 scripts/lint-dot-notation.py && bash scripts/lint-style.sh && lake exe module-system` — pass (`LINT-ENV: PASS — no new violations (63 grandfathered, 7 ratchetable).`; `lint-dot-notation: 761 total, 1293 grandfathered, 0 new, 532 ratchetable`; 4,921 conforming headers; 4,922 module-system modules)
- Proof golf: `ut-lean-golf` structural survey — extracted the order-free diagonal-eigenvector theorem, retained the canonical occupation and generic idempotent-spectrum APIs, and kept the highest-weight result as the direct consumer; the full build and public API boundary pass
- Public CI: pending after repair publication

## Scale and generality

The generic theorem works over any ring acting on a module with `NoZeroSMulDivisors K M`, for any compatible semiring action, without separately assuming scalar-ring cancellation, torsion-freeness, commutativity, finite-dimensionality, or splitting. The CAR diagonal theorem works over any field with invertible `2` and any finite index type, without an order; only the highest-weight corollary requires a finite linear order. The aggregate change adds three public theorems and no public definitions in 182 inserted lines across two modules.

## Scope

- **Consumes:** `IsIdempotentElem`, the `Commute` sum API, `carOccupationElement`, `glCliffordHom_single_self_eq_sum_occupation`, `carOccupationElement_self`, `isIdempotentElem_carOccupationElement`, `commute_carOccupationElement`, and `IsGlHighestWeightVector.lie_single_self_eq_smul`
- **Provides:** `Finset.exists_eq_natCast_of_sum_smul_eq_smul`, `TauCeti.exists_eq_natCast_add_inv_two_of_lie_single_self_eq_smul`, and `TauCeti.IsGlHighestWeightVector.exists_weight_apply_eq_natCast_add_inv_two`
- **Fits:** supplies the discrete coordinate-spectrum input consumed together with the CAR Casimir scalar by the Layer 9 constituent-weight uniqueness argument
- **Boundary:** does not claim that the coordinate spectrum alone proves staircase uniqueness, isotypy, simple dimension, or multiplicity

<sub>🤖 GPT-5.6 Sol high · TauCetiWorker @ [7518d4150b846c4524423341570c031027a1d92c](https://github.com/utensil/TauCetiWorker/commit/7518d4150b846c4524423341570c031027a1d92c) · rubrics @ [afb424eda89e8ac96d9eb69f6a88972055a4cd1b](https://github.com/utensil/TauCetiReview/commit/afb424eda89e8ac96d9eb69f6a88972055a4cd1b) · local review @ [b533e561b6d44df071c31335ed4a63ae647507d2](https://github.com/utensil/formal-land/commit/b533e561b6d44df071c31335ed4a63ae647507d2) · fixed: api-design, documentation, generality, naming, proof-quality, reuse</sub>