### PR TITLE
refactor(Algebra): publish the functoriality of RingHom.toIntAlgHom

### DIFF
--- a/TauCeti/Algebra/Algebra/Hom.lean
+++ b/TauCeti/Algebra/Algebra/Hom.lean
@@ -9,7 +9,12 @@ module
 public import Mathlib.Algebra.Algebra.Hom
 
 /-!
-# The structure map of the algebra induced by an algebra homomorphism
+# Bridging lemmas between `AlgHom` and `RingHom`
+
+Two small families of identities relating the bundled homomorphism types, each of which several
+files would otherwise restate inline.
+
+## The structure map of the algebra induced by an algebra homomorphism
 
 An algebra homomorphism `f : A →ₐ[R] B` induces an `A`-algebra structure on `B`, namely
 `f.toRingHom.toAlgebra`. Mathlib's `RingHom.algebraMap_toAlgebra` identifies the structure map of
@@ -20,12 +25,25 @@ f z` therefore applies it pointwise by hand, through `congrArg DFunLike.coe` and
 This file states the pointwise form once, for an `AlgHom`, which is the shape those consumers want:
 the right-hand side is `f z` rather than `f.toRingHom z`.
 
+## Functoriality of `RingHom.toIntAlgHom`
+
+Every ring is a `ℤ`-algebra, so a ring homomorphism is a `ℤ`-algebra homomorphism; Mathlib bundles
+that as `RingHom.toIntAlgHom` but carries no *named* identity, composition or round-trip lemma for
+it; the round-trips are reachable only through `RingHom.equivIntAlgHom`, which is not the shape
+`rw` wants. Any file transporting an equality of ring homomorphisms into `AlgHom` needs these, and
+several do.
+
 ## Main results
 
 * `AlgHom.algebraMap_toAlgebra_apply`: `algebraMap A B z = f z` for the algebra structure
   `f.toRingHom.toAlgebra` induced by `f : A →ₐ[R] B`.
+* `RingHom.toIntAlgHom_id`, `RingHom.toIntAlgHom_comp`: `RingHom.toIntAlgHom` is functorial.
+* `RingHom.toIntAlgHom_toRingHom`, `AlgHom.toRingHom_toIntAlgHom`: it is inverse to
+  `AlgHom.toRingHom` in both directions.
 
 ## Implementation notes
+
+### The structure map
 
 The codomain is a `CommSemiring`, not a `Semiring`. That is forced rather than chosen:
 `RingHom.toAlgebra` is itself stated for `[CommSemiring R] [CommSemiring S]`
@@ -38,6 +56,13 @@ the unprimed `toAlgebra`.
 This is original work, not ported: Mathlib carries the un-applied `RingHom.algebraMap_toAlgebra`
 but no pointwise `AlgHom` form, though it does carry the analogous `_apply` lemmas for the other
 `AlgHom` coercions (`AlgHom.toLinearMap_apply`, `AlgHom.toLieHom_apply`).
+
+### Functoriality of `RingHom.toIntAlgHom`
+
+The two round-trip lemmas are stated through the coercion rather than `.toRingHom`, because
+Mathlib's `AlgHom.toRingHom_eq_coe` is a `simp` lemma making the coercion the simp-normal form:
+a `.toRingHom` left-hand side is rewritten before the lemma can fire, so the `simp` attribute
+would be dead.
 -/
 
 public section
@@ -56,3 +81,38 @@ theorem AlgHom.algebraMap_toAlgebra_apply {R A B : Type*} [CommSemiring R] [Comm
     [CommSemiring B] [Algebra R A] [Algebra R B] (f : A →ₐ[R] B) (z : A) :
     @algebraMap A B _ _ f.toRingHom.toAlgebra z = f z := by
   rw [RingHom.algebraMap_toAlgebra, AlgHom.toRingHom_eq_coe, AlgHom.coe_toRingHom]
+
+/-! ### Functoriality of `RingHom.toIntAlgHom` -/
+
+section ToIntAlgHom
+
+variable {R : Type*} {S : Type*} {T : Type*} [Ring R] [Ring S] [Ring T]
+
+/-- `RingHom.toIntAlgHom` sends the identity ring homomorphism to the identity `ℤ`-algebra
+homomorphism. -/
+@[simp]
+theorem RingHom.toIntAlgHom_id : (RingHom.id R).toIntAlgHom = AlgHom.id ℤ R :=
+  AlgHom.ext fun _ ↦ rfl
+
+/-- `RingHom.toIntAlgHom` preserves composition. -/
+@[simp]
+theorem RingHom.toIntAlgHom_comp (f : S →+* T) (g : R →+* S) :
+    (f.comp g).toIntAlgHom = f.toIntAlgHom.comp g.toIntAlgHom :=
+  AlgHom.ext fun _ ↦ rfl
+
+/-- `RingHom.toIntAlgHom` is a right inverse of `AlgHom.toRingHom`.
+
+Stated through the coercion rather than `.toRingHom`, because Mathlib's `AlgHom.toRingHom_eq_coe`
+is a `simp` lemma making the coercion the simp-normal form; a `.toRingHom` left-hand side would
+be rewritten before this could fire. -/
+@[simp]
+theorem RingHom.toIntAlgHom_toRingHom (f : R →+* S) : (f.toIntAlgHom : R →+* S) = f :=
+  RingHom.ext fun _ ↦ rfl
+
+/-- `RingHom.toIntAlgHom` is a left inverse of `AlgHom.toRingHom` on `ℤ`-algebra homomorphisms.
+Stated through the coercion, for the reason given above. -/
+@[simp]
+theorem AlgHom.toRingHom_toIntAlgHom (φ : R →ₐ[ℤ] S) : ((φ : R →+* S)).toIntAlgHom = φ :=
+  AlgHom.ext fun _ ↦ rfl
+
+end ToIntAlgHom

--- a/TauCeti/Algebra/Algebra/Hom.lean
+++ b/TauCeti/Algebra/Algebra/Hom.lean
@@ -100,7 +100,9 @@ theorem RingHom.toIntAlgHom_comp (f : S →+* T) (g : R →+* S) :
     (f.comp g).toIntAlgHom = f.toIntAlgHom.comp g.toIntAlgHom :=
   AlgHom.ext fun _ ↦ rfl
 
-/-- `RingHom.toIntAlgHom` is a right inverse of `AlgHom.toRingHom`.
+/-- Reading a ring homomorphism as a `ℤ`-algebra homomorphism and back recovers it: composing
+`AlgHom.toRingHom` after `RingHom.toIntAlgHom` is the identity, so `RingHom.toIntAlgHom` is a
+right inverse of `AlgHom.toRingHom`.
 
 Stated through the coercion rather than `.toRingHom`, because Mathlib's `AlgHom.toRingHom_eq_coe`
 is a `simp` lemma making the coercion the simp-normal form; a `.toRingHom` left-hand side would
@@ -109,7 +111,10 @@ be rewritten before this could fire. -/
 theorem RingHom.toIntAlgHom_toRingHom (f : R →+* S) : (f.toIntAlgHom : R →+* S) = f :=
   RingHom.ext fun _ ↦ rfl
 
-/-- `RingHom.toIntAlgHom` is a left inverse of `AlgHom.toRingHom` on `ℤ`-algebra homomorphisms.
+/-- Reading a `ℤ`-algebra homomorphism as a ring homomorphism and back recovers it: composing
+`RingHom.toIntAlgHom` after `AlgHom.toRingHom` is the identity, so `RingHom.toIntAlgHom` is a
+left inverse of `AlgHom.toRingHom`.
+
 Stated through the coercion, for the reason given above. -/
 @[simp]
 theorem AlgHom.toRingHom_toIntAlgHom (φ : R →ₐ[ℤ] S) : ((φ : R →+* S)).toIntAlgHom = φ :=

--- a/TauCeti/Algebra/AlgebraicGroup/Frobenius/GeneralLinear.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Frobenius/GeneralLinear.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+import TauCeti.Algebra.Algebra.Hom
 public import TauCeti.Algebra.AlgebraicGroup.Frobenius.FixedPoints
 public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.HopfIdealPoints.Basic
 public import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Frobenius
@@ -94,14 +95,6 @@ namespace TauCeti.GeneralLinear
 
 universe w
 
-/-- `RingHom.toIntAlgHom` is a section of `AlgHom.toRingHom`. Kept private: it is a wrapper
-identity, used only because the value-algebra interface of the general-linear points consumes
-`ℤ`-algebra homomorphisms while Mathlib's Frobenius and the inclusion of a subring are ring
-homomorphisms. -/
-private lemma toRingHom_toIntAlgHom {R S : Type*} [Ring R] [Ring S] (φ : R →+* S) :
-    φ.toIntAlgHom.toRingHom = φ :=
-  RingHom.ext fun _ => rfl
-
 variable (n p k : ℕ)
 
 section RingHomTransport
@@ -111,14 +104,14 @@ variable {A B : Type w} [CommRing A] [CommRing B]
 
 /-- Applying a ring homomorphism entrywise preserves the matrix points cut out by a Hopf ideal
 over `ℤ`. Private: it is `TauCeti.GeneralLinear.map_mem_hopfIdealPointsSubgroup` read through
-`toRingHom_toIntAlgHom`, since the points consume `ℤ`-algebra homomorphisms while the two maps this
-file applies to them — the Frobenius and the inclusion of the Frobenius-fixed subring — are ring
-homomorphisms. -/
+`RingHom.toIntAlgHom_toRingHom`, since the points consume `ℤ`-algebra homomorphisms while the
+two maps this file applies to them — the Frobenius and the inclusion of the Frobenius-fixed
+subring — are ring homomorphisms. -/
 private theorem mapRingHom_mem_hopfIdealPointsSubgroup (φ : A →+* B)
     {g : Matrix.GeneralLinearGroup (Fin n) A} (hg : g ∈ hopfIdealPointsSubgroup n I A) :
     Matrix.GeneralLinearGroup.map φ g ∈ hopfIdealPointsSubgroup n I B := by
   have h := map_mem_hopfIdealPointsSubgroup n I φ.toIntAlgHom hg
-  rwa [toRingHom_toIntAlgHom] at h
+  rwa [AlgHom.toRingHom_eq_coe, RingHom.toIntAlgHom_toRingHom] at h
 
 /-- The map of matrix points induced by a ring homomorphism of value rings applies it entrywise.
 Private, for the same reason as `mapRingHom_mem_hopfIdealPointsSubgroup`. -/
@@ -126,7 +119,8 @@ private theorem coe_mapRingHomHopfIdealPointsSubgroup (φ : A →+* B)
     (g : hopfIdealPointsSubgroup n I A) :
     (mapHopfIdealPointsSubgroup n I φ.toIntAlgHom g : Matrix.GeneralLinearGroup (Fin n) B) =
       Matrix.GeneralLinearGroup.map φ g := by
-  rw [coe_mapHopfIdealPointsSubgroup, toRingHom_toIntAlgHom]
+  rw [coe_mapHopfIdealPointsSubgroup, AlgHom.toRingHom_eq_coe,
+    RingHom.toIntAlgHom_toRingHom]
 
 end RingHomTransport
 
@@ -147,7 +141,8 @@ theorem pointToGeneralLinear_iterateFrobeniusPoints
   have hmapValue : Bialgebra.iterateFrobeniusPoints p k f =
       AlgHom.mapValue (H := coordinateHopfAlgebra ℤ n) (iterateFrobenius A p k).toIntAlgHom f := by
     rw [Bialgebra.iterateFrobeniusPoints_apply, AlgHom.mapValue_apply]
-  rw [hmapValue, pointToGeneralLinear_mapValue, toRingHom_toIntAlgHom]
+  rw [hmapValue, pointToGeneralLinear_mapValue, AlgHom.toRingHom_eq_coe,
+    RingHom.toIntAlgHom_toRingHom]
 
 /-- The `p ^ k`-power Frobenius on the points of the general linear coordinate Hopf algebra is the
 entrywise `p ^ k`-power map on invertible matrices.
@@ -233,22 +228,17 @@ theorem iterateFrobeniusHopfIdealPoints_eq_self_iff (x : hopfIdealPointsSubgroup
 @[simp]
 theorem iterateFrobeniusHopfIdealPoints_zero :
     iterateFrobeniusHopfIdealPoints n p 0 I A = MonoidHom.id _ := by
-  have h : (iterateFrobenius A p 0).toIntAlgHom = AlgHom.id ℤ A := by
-    rw [iterateFrobenius_zero]
-    exact AlgHom.ext fun _ => rfl
-  rw [iterateFrobeniusHopfIdealPoints, h, mapHopfIdealPointsSubgroup_id]
+  rw [iterateFrobeniusHopfIdealPoints, iterateFrobenius_zero, RingHom.toIntAlgHom_id,
+    mapHopfIdealPointsSubgroup_id]
 
 /-- Frobenius iterates add under composition on the matrix points cut out by a Hopf ideal. -/
 theorem iterateFrobeniusHopfIdealPoints_add (m : ℕ) :
     iterateFrobeniusHopfIdealPoints n p (k + m) I A =
       (iterateFrobeniusHopfIdealPoints n p k I A).comp
         (iterateFrobeniusHopfIdealPoints n p m I A) := by
-  have h : (iterateFrobenius A p (k + m)).toIntAlgHom =
-      (iterateFrobenius A p k).toIntAlgHom.comp (iterateFrobenius A p m).toIntAlgHom := by
-    rw [iterateFrobenius_add]
-    exact AlgHom.ext fun _ => rfl
   rw [iterateFrobeniusHopfIdealPoints, iterateFrobeniusHopfIdealPoints,
-    iterateFrobeniusHopfIdealPoints, h, mapHopfIdealPointsSubgroup_comp]
+    iterateFrobeniusHopfIdealPoints, iterateFrobenius_add, RingHom.toIntAlgHom_comp,
+    mapHopfIdealPointsSubgroup_comp]
 
 /-- The points of a closed subgroup scheme fixed by the Frobenius, read as a subgroup of `GLₙ(A)`,
 are the points of that subgroup scheme that the entrywise Frobenius fixes. -/
@@ -318,7 +308,8 @@ theorem map_hopfIdealPointsSubgroup_frobeniusFixedSubring :
       exact Subtype.ext h0
     · have h := pointsMulEquiv_mapValue (R := ℤ) n
         (frobeniusFixedSubring A p k).subtype.toIntAlgHom f
-      rw [toRingHom_toIntAlgHom, hfmap, MulEquiv.apply_symm_apply] at h
+      rw [AlgHom.toRingHom_eq_coe, RingHom.toIntAlgHom_toRingHom, hfmap,
+        MulEquiv.apply_symm_apply] at h
       exact h.symm
 
 variable (A) in

--- a/TauCeti/Algebra/AlgebraicGroup/Frobenius/Points.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Frobenius/Points.lean
@@ -19,10 +19,10 @@ a monoid endomorphism of the points represented by `H`. When `H` is a Hopf algeb
 convolution points form a group. If `H` is also commutative, they are the points of the affine
 group scheme `Spec H`.
 
-This is the field-endomorphism part of the pinned Chevalley--Demazure interface in Layer 9 of the
-ReductiveGroups roadmap. Once a pinned group's integral coordinate Hopf algebra is constructed,
-`iterateFrobeniusPoints p n` supplies the `p ^ n`-power endomorphism on its points over an
-algebraic closure. The construction itself needs neither algebraic closedness nor finite type.
+This is the field-endomorphism part of the pinned Chevalley--Demazure interface: once a pinned
+group's integral coordinate Hopf algebra is constructed, `iterateFrobeniusPoints p n` supplies the
+`p ^ n`-power endomorphism on its points over an algebraic closure. The construction itself
+needs neither algebraic closedness nor finite type.
 
 ## Main definitions and results
 
@@ -40,9 +40,7 @@ The construction post-composes with Mathlib's `iterateFrobenius`, whose laws sup
 here, and reuses Tau Ceti's convolution-valued functor of points. Those laws are equalities of
 ring homomorphisms, while `AlgHom.mapValue` consumes `ℤ`-algebra homomorphisms; the functoriality
 of `RingHom.toIntAlgHom` that transports the one into the other lives in
-`TauCeti/Algebra/Algebra/Hom.lean`. This file advances the “points over an algebraically closed
-field” target in Layer 9 of `TauCetiRoadmap/ReductiveGroups/README.md`; that target explicitly
-requests the `q`-power Frobenius as its first field-endomorphism case.
+`TauCeti/Algebra/Algebra/Hom.lean`.
 -/
 
 public section

--- a/TauCeti/Algebra/AlgebraicGroup/Frobenius/Points.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Frobenius/Points.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Algebra.CharP.Frobenius
+import TauCeti.Algebra.Algebra.Hom
 public import TauCeti.Algebra.AlgebraicGroup.FunctorOfPoints
 
 /-!
@@ -37,10 +38,9 @@ algebraic closure. The construction itself needs neither algebraic closedness no
 
 The construction post-composes with Mathlib's `iterateFrobenius`, whose laws supply every proof
 here, and reuses Tau Ceti's convolution-valued functor of points. Those laws are equalities of
-ring homomorphisms, while `AlgHom.mapValue` consumes `ℤ`-algebra homomorphisms; Mathlib has
-`RingHom.toIntAlgHom_coe` and `toIntAlgHom_apply` but no identity or composition lemma for
-`RingHom.toIntAlgHom`, so three private lemmas below record its functoriality and transport the
-Mathlib equalities into `AlgHom`. This file advances the “points over an algebraically closed
+ring homomorphisms, while `AlgHom.mapValue` consumes `ℤ`-algebra homomorphisms; the functoriality
+of `RingHom.toIntAlgHom` that transports the one into the other lives in
+`TauCeti/Algebra/Algebra/Hom.lean`. This file advances the “points over an algebraically closed
 field” target in Layer 9 of `TauCetiRoadmap/ReductiveGroups/README.md`; that target explicitly
 requests the `q`-power Frobenius as its first field-endomorphism case.
 -/
@@ -54,30 +54,6 @@ namespace TauCeti
 namespace Bialgebra
 
 universe u v w
-
-section ToIntAlgHom
-
-variable {R : Type*} {S : Type*} {T : Type*} [Ring R] [Ring S] [Ring T]
-
-/-- `RingHom.toIntAlgHom` sends the identity ring homomorphism to the identity `ℤ`-algebra
-homomorphism. Kept private: it is a wrapper identity used only to transport Mathlib's ring
-homomorphism equalities into `AlgHom`. -/
-private lemma toIntAlgHom_id : (RingHom.id R).toIntAlgHom = AlgHom.id ℤ R :=
-  AlgHom.ext fun _ ↦ rfl
-
-/-- `RingHom.toIntAlgHom` preserves composition. Kept private: it is a wrapper identity used only
-to transport Mathlib's ring homomorphism equalities into `AlgHom`. -/
-private lemma toIntAlgHom_comp (f : S →+* T) (g : R →+* S) :
-    (f.comp g).toIntAlgHom = f.toIntAlgHom.comp g.toIntAlgHom :=
-  AlgHom.ext fun _ ↦ rfl
-
-/-- `RingHom.toIntAlgHom` is a left inverse of `AlgHom.toRingHom` on `ℤ`-algebra homomorphisms.
-Kept private: it is a wrapper identity used only to transport Mathlib's ring homomorphism
-equalities into `AlgHom`. -/
-private lemma toIntAlgHom_toRingHom (φ : R →ₐ[ℤ] S) : φ.toRingHom.toIntAlgHom = φ :=
-  AlgHom.ext fun _ ↦ rfl
-
-end ToIntAlgHom
 
 variable (p n : ℕ)
 variable {H : Type u} [Semiring H] [_root_.Bialgebra ℤ H]
@@ -113,14 +89,14 @@ implementation-level `iterateFrobenius` expression instead. -/
 /-- The zeroth Frobenius iterate is the identity on points. -/
 @[simp] theorem iterateFrobeniusPoints_zero :
     iterateFrobeniusPoints p 0 (H := H) (A := A) = MonoidHom.id _ := by
-  rw [iterateFrobeniusPoints, iterateFrobenius_zero, toIntAlgHom_id, AlgHom.mapValue_id]
+  rw [iterateFrobeniusPoints, iterateFrobenius_zero, RingHom.toIntAlgHom_id, AlgHom.mapValue_id]
 
 /-- Frobenius iterates add under composition on the monoid of points. -/
 theorem iterateFrobeniusPoints_add (m : ℕ) :
     iterateFrobeniusPoints p (n + m) (H := H) (A := A) =
       (iterateFrobeniusPoints p n).comp (iterateFrobeniusPoints p m) := by
   rw [iterateFrobeniusPoints, iterateFrobeniusPoints, iterateFrobeniusPoints,
-    iterateFrobenius_add, toIntAlgHom_comp, AlgHom.mapValue_comp]
+    iterateFrobenius_add, RingHom.toIntAlgHom_comp, AlgHom.mapValue_comp]
 
 variable {B : Type w} [CommRing B] [ExpChar B p]
 
@@ -135,7 +111,8 @@ theorem mapValue_comp_iterateFrobeniusPoints (φ : A →ₐ[ℤ] B) :
   have hφ : φ.comp (iterateFrobenius A p n).toIntAlgHom =
       (iterateFrobenius B p n).toIntAlgHom.comp φ := by
     have h := congrArg RingHom.toIntAlgHom (φ.toRingHom.iterateFrobenius_comm p n)
-    rwa [toIntAlgHom_comp, toIntAlgHom_comp, toIntAlgHom_toRingHom] at h
+    simpa only [RingHom.toIntAlgHom_comp, AlgHom.toRingHom_eq_coe,
+      AlgHom.toRingHom_toIntAlgHom] using h
   rw [iterateFrobeniusPoints, iterateFrobeniusPoints, ← AlgHom.mapValue_comp,
     ← AlgHom.mapValue_comp, hφ]
 

--- a/TauCeti/Algebra/Lie/E6/DoubledMinuscule/PointsFunctor.lean
+++ b/TauCeti/Algebra/Lie/E6/DoubledMinuscule/PointsFunctor.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.HopfIdealPoints.Functor
+import TauCeti.Algebra.Algebra.Hom
 public import TauCeti.Algebra.Lie.E6.DoubledMinuscule.GroupScheme
 
 /-!
@@ -86,11 +87,10 @@ def pointsMap (f : A →+* B) : points A →* points B :=
 theorem coe_pointsMap (f : A →+* B) (g : points A) :
     (pointsMap f g : Matrix.GeneralLinearGroup (Fin 54) B) =
       Matrix.GeneralLinearGroup.map f g := by
-  have hring : f.toIntAlgHom.toRingHom = f := RingHom.ext (RingHom.toIntAlgHom_apply f)
   rw [pointsMap]
   simp only [MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom,
     MulEquiv.subgroupCongr_symm_apply, GeneralLinear.coe_mapHopfIdealPointsSubgroup,
-    MulEquiv.subgroupCongr_apply, hring]
+    MulEquiv.subgroupCongr_apply, AlgHom.toRingHom_eq_coe, RingHom.toIntAlgHom_toRingHom]
 
 /-- Entrywise, the induced map applies the homomorphism of value rings to each matrix entry. -/
 theorem coe_pointsMap_apply (f : A →+* B) (g : points A) (i j : Fin 54) :
@@ -102,8 +102,7 @@ theorem coe_pointsMap_apply (f : A →+* B) (g : points A) (i j : Fin 54) :
 /-- The identity homomorphism induces the identity on doubled type-`E₆` carrier points. -/
 @[simp]
 theorem pointsMap_id : pointsMap (RingHom.id A) = MonoidHom.id _ := by
-  have hid : (RingHom.id A).toIntAlgHom = AlgHom.id ℤ A := AlgHom.ext fun _ ↦ rfl
-  rw [pointsMap, hid, GeneralLinear.mapHopfIdealPointsSubgroup_id]
+  rw [pointsMap, RingHom.toIntAlgHom_id, GeneralLinear.mapHopfIdealPointsSubgroup_id]
   apply MonoidHom.ext
   intro g
   exact (MulEquiv.subgroupCongr (points_def A)).symm_apply_apply g
@@ -112,11 +111,9 @@ theorem pointsMap_id : pointsMap (RingHom.id A) = MonoidHom.id _ := by
 @[simp]
 theorem pointsMap_comp {C : Type*} [CommRing C] (f : A →+* B) (g : B →+* C) :
     pointsMap (g.comp f) = (pointsMap g).comp (pointsMap f) := by
-  have hcomp : (g.comp f).toIntAlgHom = g.toIntAlgHom.comp f.toIntAlgHom :=
-    AlgHom.ext fun _ ↦ rfl
   apply MonoidHom.ext
   intro x
-  simp only [pointsMap, MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, hcomp,
+  simp only [pointsMap, MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, RingHom.toIntAlgHom_comp,
     GeneralLinear.mapHopfIdealPointsSubgroup_comp, MulEquiv.apply_symm_apply]
 
 /-- An injective homomorphism of value rings induces an injective map on doubled type-`E₆` carrier

--- a/TauCeti/Algebra/Lie/E6/Minuscule/PointsFunctor.lean
+++ b/TauCeti/Algebra/Lie/E6/Minuscule/PointsFunctor.lean
@@ -6,6 +6,7 @@ Authors: Codex
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.HopfIdealPoints.Functor
+import TauCeti.Algebra.Algebra.Hom
 public import TauCeti.Algebra.Lie.E6.Minuscule.GroupScheme
 
 /-!
@@ -74,11 +75,10 @@ def pointsMap (f : A →+* B) : points A →* points B :=
 theorem coe_pointsMap (f : A →+* B) (g : points A) :
     (pointsMap f g : Matrix.GeneralLinearGroup (Fin 27) B) =
       Matrix.GeneralLinearGroup.map f g := by
-  have hring : f.toIntAlgHom.toRingHom = f := RingHom.ext (RingHom.toIntAlgHom_apply f)
   rw [pointsMap]
   simp only [MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom,
     MulEquiv.subgroupCongr_symm_apply, GeneralLinear.coe_mapHopfIdealPointsSubgroup,
-    MulEquiv.subgroupCongr_apply, hring]
+    MulEquiv.subgroupCongr_apply, AlgHom.toRingHom_eq_coe, RingHom.toIntAlgHom_toRingHom]
 
 /-- Entrywise, the induced map applies the homomorphism of value rings to each matrix entry. -/
 theorem coe_pointsMap_apply (f : A →+* B) (g : points A) (i j : Fin 27) :
@@ -90,8 +90,7 @@ theorem coe_pointsMap_apply (f : A →+* B) (g : points A) (i j : Fin 27) :
 /-- The identity homomorphism induces the identity on type-`E₆` carrier points. -/
 @[simp]
 theorem pointsMap_id : pointsMap (RingHom.id A) = MonoidHom.id _ := by
-  have hid : (RingHom.id A).toIntAlgHom = AlgHom.id ℤ A := AlgHom.ext fun _ ↦ rfl
-  rw [pointsMap, hid, GeneralLinear.mapHopfIdealPointsSubgroup_id]
+  rw [pointsMap, RingHom.toIntAlgHom_id, GeneralLinear.mapHopfIdealPointsSubgroup_id]
   apply MonoidHom.ext
   intro g
   exact (MulEquiv.subgroupCongr (points_def A)).symm_apply_apply g
@@ -100,11 +99,9 @@ theorem pointsMap_id : pointsMap (RingHom.id A) = MonoidHom.id _ := by
 @[simp]
 theorem pointsMap_comp {C : Type*} [CommRing C] (f : A →+* B) (g : B →+* C) :
     pointsMap (g.comp f) = (pointsMap g).comp (pointsMap f) := by
-  have hcomp : (g.comp f).toIntAlgHom = g.toIntAlgHom.comp f.toIntAlgHom :=
-    AlgHom.ext fun _ ↦ rfl
   apply MonoidHom.ext
   intro x
-  simp only [pointsMap, MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, hcomp,
+  simp only [pointsMap, MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, RingHom.toIntAlgHom_comp,
     GeneralLinear.mapHopfIdealPointsSubgroup_comp, MulEquiv.apply_symm_apply]
 
 /-- An injective homomorphism of value rings induces an injective map on type-`E₆` carrier

--- a/TauCeti/Algebra/Lie/E7/Minuscule/PointsFunctor.lean
+++ b/TauCeti/Algebra/Lie/E7/Minuscule/PointsFunctor.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.HopfIdealPoints.Functor
+import TauCeti.Algebra.Algebra.Hom
 public import TauCeti.Algebra.Lie.E7.Minuscule.Carrier
 
 /-!
@@ -84,11 +85,10 @@ def pointsMap (f : A →+* B) : points A →* points B :=
 theorem coe_pointsMap (f : A →+* B) (g : points A) :
     (pointsMap f g : Matrix.GeneralLinearGroup (Fin 56) B) =
       Matrix.GeneralLinearGroup.map f g := by
-  have hring : f.toIntAlgHom.toRingHom = f := RingHom.ext (RingHom.toIntAlgHom_apply f)
   rw [pointsMap]
   simp only [MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom,
     MulEquiv.subgroupCongr_symm_apply, GeneralLinear.coe_mapHopfIdealPointsSubgroup,
-    MulEquiv.subgroupCongr_apply, hring]
+    MulEquiv.subgroupCongr_apply, AlgHom.toRingHom_eq_coe, RingHom.toIntAlgHom_toRingHom]
 
 /-- Entrywise, the induced map applies the homomorphism of value rings to each matrix entry. -/
 theorem coe_pointsMap_apply (f : A →+* B) (g : points A) (i j : Fin 56) :
@@ -100,8 +100,7 @@ theorem coe_pointsMap_apply (f : A →+* B) (g : points A) (i j : Fin 56) :
 /-- The identity homomorphism induces the identity on type-`E₇` carrier points. -/
 @[simp]
 theorem pointsMap_id : pointsMap (RingHom.id A) = MonoidHom.id _ := by
-  have hid : (RingHom.id A).toIntAlgHom = AlgHom.id ℤ A := AlgHom.ext fun _ ↦ rfl
-  rw [pointsMap, hid, GeneralLinear.mapHopfIdealPointsSubgroup_id]
+  rw [pointsMap, RingHom.toIntAlgHom_id, GeneralLinear.mapHopfIdealPointsSubgroup_id]
   apply MonoidHom.ext
   intro g
   exact (MulEquiv.subgroupCongr (points_def A)).symm_apply_apply g
@@ -110,11 +109,9 @@ theorem pointsMap_id : pointsMap (RingHom.id A) = MonoidHom.id _ := by
 @[simp]
 theorem pointsMap_comp {C : Type*} [CommRing C] (f : A →+* B) (g : B →+* C) :
     pointsMap (g.comp f) = (pointsMap g).comp (pointsMap f) := by
-  have hcomp : (g.comp f).toIntAlgHom = g.toIntAlgHom.comp f.toIntAlgHom :=
-    AlgHom.ext fun _ ↦ rfl
   apply MonoidHom.ext
   intro x
-  simp only [pointsMap, MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, hcomp,
+  simp only [pointsMap, MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, RingHom.toIntAlgHom_comp,
     GeneralLinear.mapHopfIdealPointsSubgroup_comp, MulEquiv.apply_symm_apply]
 
 /-- An injective homomorphism of value rings induces an injective map on type-`E₇` carrier

--- a/TauCeti/Algebra/Lie/Orthogonal/TypeB/SpinCarrier/PointsFunctor.lean
+++ b/TauCeti/Algebra/Lie/Orthogonal/TypeB/SpinCarrier/PointsFunctor.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.HopfIdealPoints.Functor
+import TauCeti.Algebra.Algebra.Hom
 public import TauCeti.Algebra.Lie.Orthogonal.TypeB.SpinCarrier.Basic
 
 /-!
@@ -74,11 +75,10 @@ def pointsMap (f : A →+* B) : points n A →* points n B :=
 theorem coe_pointsMap (f : A →+* B) (g : points n A) :
     (pointsMap n f g : Matrix.GeneralLinearGroup (Fin (dimension n)) B) =
       Matrix.GeneralLinearGroup.map f g := by
-  have hring : f.toIntAlgHom.toRingHom = f := RingHom.ext (RingHom.toIntAlgHom_apply f)
   rw [pointsMap]
   simp only [MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom,
     MulEquiv.subgroupCongr_symm_apply, GeneralLinear.coe_mapHopfIdealPointsSubgroup,
-    MulEquiv.subgroupCongr_apply, hring]
+    MulEquiv.subgroupCongr_apply, AlgHom.toRingHom_eq_coe, RingHom.toIntAlgHom_toRingHom]
 
 /-- Entrywise, the induced map applies the homomorphism of value rings to each matrix entry. -/
 theorem coe_pointsMap_apply (f : A →+* B) (g : points n A)
@@ -92,8 +92,7 @@ theorem coe_pointsMap_apply (f : A →+* B) (g : points n A)
 /-- The identity homomorphism induces the identity on type-`Bₙ₊₁` spin-carrier points. -/
 @[simp]
 theorem pointsMap_id : pointsMap n (RingHom.id A) = MonoidHom.id _ := by
-  have hid : (RingHom.id A).toIntAlgHom = AlgHom.id ℤ A := AlgHom.ext fun _ ↦ rfl
-  rw [pointsMap, hid, GeneralLinear.mapHopfIdealPointsSubgroup_id]
+  rw [pointsMap, RingHom.toIntAlgHom_id, GeneralLinear.mapHopfIdealPointsSubgroup_id]
   apply MonoidHom.ext
   intro g
   exact (MulEquiv.subgroupCongr (points_def n A)).symm_apply_apply g
@@ -102,11 +101,9 @@ theorem pointsMap_id : pointsMap n (RingHom.id A) = MonoidHom.id _ := by
 @[simp]
 theorem pointsMap_comp {C : Type*} [CommRing C] (f : A →+* B) (g : B →+* C) :
     pointsMap n (g.comp f) = (pointsMap n g).comp (pointsMap n f) := by
-  have hcomp : (g.comp f).toIntAlgHom = g.toIntAlgHom.comp f.toIntAlgHom :=
-    AlgHom.ext fun _ ↦ rfl
   apply MonoidHom.ext
   intro x
-  simp only [pointsMap, MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, hcomp,
+  simp only [pointsMap, MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, RingHom.toIntAlgHom_comp,
     GeneralLinear.mapHopfIdealPointsSubgroup_comp, MulEquiv.apply_symm_apply]
 
 /-- An injective homomorphism of value rings induces an injective map on type-`Bₙ₊₁`

--- a/TauCeti/Algebra/Lie/Orthogonal/TypeD/SpinCarrier/PointsFunctor.lean
+++ b/TauCeti/Algebra/Lie/Orthogonal/TypeD/SpinCarrier/PointsFunctor.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.HopfIdealPoints.Functor
+import TauCeti.Algebra.Algebra.Hom
 public import TauCeti.Algebra.Lie.Orthogonal.TypeD.SpinCarrier.Basic
 
 /-!
@@ -64,11 +65,10 @@ def pointsMap (f : A →+* B) : points n hn A →* points n hn B :=
 theorem coe_pointsMap (f : A →+* B) (g : points n hn A) :
     (pointsMap n hn f g : Matrix.GeneralLinearGroup (Fin (dimension n)) B) =
       Matrix.GeneralLinearGroup.map f g := by
-  have hring : f.toIntAlgHom.toRingHom = f := RingHom.ext (RingHom.toIntAlgHom_apply f)
   rw [pointsMap]
   simp only [MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom,
     MulEquiv.subgroupCongr_symm_apply, GeneralLinear.coe_mapHopfIdealPointsSubgroup,
-    MulEquiv.subgroupCongr_apply, hring]
+    MulEquiv.subgroupCongr_apply, AlgHom.toRingHom_eq_coe, RingHom.toIntAlgHom_toRingHom]
 
 /-- Entrywise, the induced map applies the homomorphism of value rings to each matrix entry. -/
 theorem coe_pointsMap_apply (f : A →+* B) (g : points n hn A)
@@ -82,8 +82,7 @@ theorem coe_pointsMap_apply (f : A →+* B) (g : points n hn A)
 /-- The identity homomorphism induces the identity on type-`Dₙ` spin-carrier points. -/
 @[simp]
 theorem pointsMap_id : pointsMap n hn (RingHom.id A) = MonoidHom.id _ := by
-  have hid : (RingHom.id A).toIntAlgHom = AlgHom.id ℤ A := AlgHom.ext fun _ ↦ rfl
-  rw [pointsMap, hid, GeneralLinear.mapHopfIdealPointsSubgroup_id]
+  rw [pointsMap, RingHom.toIntAlgHom_id, GeneralLinear.mapHopfIdealPointsSubgroup_id]
   apply MonoidHom.ext
   intro g
   exact (MulEquiv.subgroupCongr (points_def n hn A)).symm_apply_apply g
@@ -92,11 +91,9 @@ theorem pointsMap_id : pointsMap n hn (RingHom.id A) = MonoidHom.id _ := by
 @[simp]
 theorem pointsMap_comp {C : Type*} [CommRing C] (f : A →+* B) (g : B →+* C) :
     pointsMap n hn (g.comp f) = (pointsMap n hn g).comp (pointsMap n hn f) := by
-  have hcomp : (g.comp f).toIntAlgHom = g.toIntAlgHom.comp f.toIntAlgHom :=
-    AlgHom.ext fun _ ↦ rfl
   apply MonoidHom.ext
   intro x
-  simp only [pointsMap, MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, hcomp,
+  simp only [pointsMap, MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, RingHom.toIntAlgHom_comp,
     GeneralLinear.mapHopfIdealPointsSubgroup_comp, MulEquiv.apply_symm_apply]
 
 /-- An injective homomorphism of value rings induces an injective map on type-`Dₙ` spin-carrier

--- a/TauCeti/Algebra/Lie/Sl2/Kostant/GroupScheme.lean
+++ b/TauCeti/Algebra/Lie/Sl2/Kostant/GroupScheme.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.Lie.Sl2.Kostant.Points
+import TauCeti.Algebra.Algebra.Hom
 public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Scheme.ToralClosure.Torus
 public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Scheme.ToralClosure.Points
 
@@ -414,11 +415,10 @@ theorem coe_rankOneCarrierPointsMap
     (f : A →+* B) (g : rankOneCarrierPoints A) :
     (rankOneCarrierPointsMap f g : Matrix.GeneralLinearGroup (Fin 2) B) =
       Matrix.GeneralLinearGroup.map f g := by
-  have hring : f.toIntAlgHom.toRingHom = f := RingHom.ext (RingHom.toIntAlgHom_apply f)
   rw [rankOneCarrierPointsMap]
   simp only [MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom,
     MulEquiv.subgroupCongr_symm_apply, GeneralLinear.coe_mapHopfIdealPointsSubgroup,
-    MulEquiv.subgroupCongr_apply, hring]
+    MulEquiv.subgroupCongr_apply, AlgHom.toRingHom_eq_coe, RingHom.toIntAlgHom_toRingHom]
 
 /-- Entrywise, the induced map applies the value-ring homomorphism to each matrix entry. -/
 theorem coe_rankOneCarrierPointsMap_apply
@@ -433,8 +433,7 @@ theorem coe_rankOneCarrierPointsMap_apply
 @[simp]
 theorem rankOneCarrierPointsMap_id {A : Type u} [CommRing A] :
     rankOneCarrierPointsMap (RingHom.id A) = MonoidHom.id _ := by
-  have hid : (RingHom.id A).toIntAlgHom = AlgHom.id ℤ A := AlgHom.ext fun _ ↦ rfl
-  rw [rankOneCarrierPointsMap, hid, GeneralLinear.mapHopfIdealPointsSubgroup_id]
+  rw [rankOneCarrierPointsMap, RingHom.toIntAlgHom_id, GeneralLinear.mapHopfIdealPointsSubgroup_id]
   apply MonoidHom.ext
   intro g
   exact (MulEquiv.subgroupCongr
@@ -447,11 +446,10 @@ theorem rankOneCarrierPointsMap_comp
     (f : A →+* B) (g : B →+* C) :
     rankOneCarrierPointsMap (g.comp f) =
       (rankOneCarrierPointsMap g).comp (rankOneCarrierPointsMap f) := by
-  have hcomp : (g.comp f).toIntAlgHom = g.toIntAlgHom.comp f.toIntAlgHom :=
-    AlgHom.ext fun _ ↦ rfl
   apply MonoidHom.ext
   intro x
-  simp only [rankOneCarrierPointsMap, MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, hcomp,
+  simp only [rankOneCarrierPointsMap, MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom,
+    RingHom.toIntAlgHom_comp,
     GeneralLinear.mapHopfIdealPointsSubgroup_comp, MulEquiv.apply_symm_apply]
 
 /-- An injective value-ring homomorphism induces an injective map on rank-one carrier points. -/

--- a/TauCeti/Algebra/Lie/Sl2/Kostant/Weyl.lean
+++ b/TauCeti/Algebra/Lie/Sl2/Kostant/Weyl.lean
@@ -5,6 +5,7 @@ Authors: Codex
 -/
 module
 
+import TauCeti.Algebra.Algebra.Hom
 public import TauCeti.Algebra.Group.NormalizerQuotient.Basic
 public import TauCeti.Algebra.Lie.Sl2.Kostant.GroupScheme
 public import TauCeti.Algebra.Lie.Sl2.Weyl.Standard
@@ -94,9 +95,8 @@ theorem rankOneCarrierPointsMap_weylPoint
   simp only [rankOneWeylPoint, MulEquiv.subgroupCongr_symm_apply]
   have hmap := congrArg Subtype.val
     (map_kostantToralWeylPoint e h ρ M hM hnil b rankOneWeight φ 0 1)
-  have hring : φ.toIntAlgHom.toRingHom = φ := RingHom.ext (RingHom.toIntAlgHom_apply φ)
-  simpa only [GeneralLinear.coe_mapHopfIdealPointsSubgroup,
-    MulEquiv.subgroupCongr_apply, hring] using hmap
+  simpa only [GeneralLinear.coe_mapHopfIdealPointsSubgroup, MulEquiv.subgroupCongr_apply,
+    AlgHom.toRingHom_eq_coe, RingHom.toIntAlgHom_toRingHom] using hmap
 
 /-- The integral rank-one Weyl automorphism sends a standard lattice basis vector to the reversed
 basis vector with the usual sign. -/

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/PointsFunctor.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/PointsFunctor.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.HopfIdealPoints.Functor
+import TauCeti.Algebra.Algebra.Hom
 public import TauCeti.Algebra.Lie.SpecialLinear.StandardCarrier.Basic
 
 /-!
@@ -99,10 +100,10 @@ theorem coe_pointsMap (f : A →+* B) (g : points r A) :
       Matrix.GeneralLinearGroup.map f g := by
   -- `mapHopfIdealPointsSubgroup` is stated for the `ℤ`-algebra map induced by `f`, whose
   -- underlying ring homomorphism is `f` again.
-  have hring : f.toIntAlgHom.toRingHom = f := RingHom.ext (RingHom.toIntAlgHom_apply f)
   rw [pointsMap]
   simp only [MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, MulEquiv.subgroupCongr_symm_apply,
-    GeneralLinear.coe_mapHopfIdealPointsSubgroup, MulEquiv.subgroupCongr_apply, hring]
+    GeneralLinear.coe_mapHopfIdealPointsSubgroup, MulEquiv.subgroupCongr_apply,
+    AlgHom.toRingHom_eq_coe, RingHom.toIntAlgHom_toRingHom]
 
 /-- Entrywise, the induced map applies the homomorphism of value rings to each matrix entry. -/
 theorem coe_pointsMap_apply (f : A →+* B) (g : points r A) (i j : Fin (r + 1)) :
@@ -115,9 +116,7 @@ theorem coe_pointsMap_apply (f : A →+* B) (g : points r A) (i j : Fin (r + 1))
 /-- The identity homomorphism of value rings induces the identity on type-`A_r` carrier points. -/
 @[simp]
 theorem pointsMap_id : pointsMap r (RingHom.id A) = MonoidHom.id _ := by
-  have hid : (RingHom.id A).toIntAlgHom = AlgHom.id ℤ A :=
-    AlgHom.ext fun _ ↦ rfl
-  rw [pointsMap, hid, GeneralLinear.mapHopfIdealPointsSubgroup_id]
+  rw [pointsMap, RingHom.toIntAlgHom_id, GeneralLinear.mapHopfIdealPointsSubgroup_id]
   apply MonoidHom.ext
   intro g
   exact (MulEquiv.subgroupCongr (points_def r A)).symm_apply_apply g
@@ -126,11 +125,9 @@ theorem pointsMap_id : pointsMap r (RingHom.id A) = MonoidHom.id _ := by
 @[simp]
 theorem pointsMap_comp {C : Type*} [CommRing C] (f : A →+* B) (g : B →+* C) :
     pointsMap r (g.comp f) = (pointsMap r g).comp (pointsMap r f) := by
-  have hcomp : (g.comp f).toIntAlgHom = g.toIntAlgHom.comp f.toIntAlgHom :=
-    AlgHom.ext fun _ ↦ rfl
   apply MonoidHom.ext
   intro x
-  simp only [pointsMap, MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, hcomp,
+  simp only [pointsMap, MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, RingHom.toIntAlgHom_comp,
     GeneralLinear.mapHopfIdealPointsSubgroup_comp, MulEquiv.apply_symm_apply]
 
 /-- An injective homomorphism of value rings induces an injective map on type-`A_r` carrier

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/UpperTriangular.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/UpperTriangular.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.UpperTriangular.Basic
+import TauCeti.Algebra.Algebra.Hom
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Order
 public import TauCeti.Algebra.Lie.SpecialLinear.StandardCarrier.DeterminantOne
 public import TauCeti.Algebra.Lie.SpecialLinear.StandardCarrier.PointsFunctor
@@ -302,18 +303,17 @@ theorem coe_upperTriangularPointsMap {A : Type v} {B : Type v'} [CommRing A] [Co
       Matrix.GeneralLinearGroup.map f g := by
   -- `mapHopfIdealPointsSubgroup` is stated for the `ℤ`-algebra map induced by `f`, whose
   -- underlying ring homomorphism is `f` again.
-  have hring : f.toIntAlgHom.toRingHom = f := RingHom.ext (RingHom.toIntAlgHom_apply f)
   rw [upperTriangularPointsMap]
   simp only [MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, MulEquiv.subgroupCongr_symm_apply,
-    GeneralLinear.coe_mapHopfIdealPointsSubgroup, MulEquiv.subgroupCongr_apply, hring]
+    GeneralLinear.coe_mapHopfIdealPointsSubgroup, MulEquiv.subgroupCongr_apply,
+    AlgHom.toRingHom_eq_coe, RingHom.toIntAlgHom_toRingHom]
 
 /-- The identity homomorphism of value rings induces the identity on upper-triangular carrier
 points. -/
 @[simp]
 theorem upperTriangularPointsMap_id (A : Type v) [CommRing A] :
     upperTriangularPointsMap r (RingHom.id A) = MonoidHom.id (upperTriangularPoints r A) := by
-  have hid : (RingHom.id A).toIntAlgHom = AlgHom.id ℤ A := AlgHom.ext fun _ ↦ rfl
-  rw [upperTriangularPointsMap, hid, GeneralLinear.mapHopfIdealPointsSubgroup_id]
+  rw [upperTriangularPointsMap, RingHom.toIntAlgHom_id, GeneralLinear.mapHopfIdealPointsSubgroup_id]
   apply MonoidHom.ext
   intro g
   exact (MulEquiv.subgroupCongr (upperTriangularPoints_def r A)).symm_apply_apply g
@@ -324,11 +324,10 @@ theorem upperTriangularPointsMap_comp {A : Type v} {B : Type v'} {C : Type*}
     [CommRing A] [CommRing B] [CommRing C] (f : A →+* B) (g : B →+* C) :
     upperTriangularPointsMap r (g.comp f) =
       (upperTriangularPointsMap r g).comp (upperTriangularPointsMap r f) := by
-  have hcomp : (g.comp f).toIntAlgHom = g.toIntAlgHom.comp f.toIntAlgHom :=
-    AlgHom.ext fun _ ↦ rfl
   apply MonoidHom.ext
   intro x
-  simp only [upperTriangularPointsMap, MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, hcomp,
+  simp only [upperTriangularPointsMap, MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom,
+    RingHom.toIntAlgHom_comp,
     GeneralLinear.mapHopfIdealPointsSubgroup_comp, MulEquiv.apply_symm_apply]
 
 /-- The group-valued functor of matrix points of the upper-triangular subgroup scheme of the

--- a/TauCeti/Algebra/Lie/Symplectic/StandardCarrier/PointsFunctor.lean
+++ b/TauCeti/Algebra/Lie/Symplectic/StandardCarrier/PointsFunctor.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.HopfIdealPoints.Functor
+import TauCeti.Algebra.Algebra.Hom
 public import TauCeti.Algebra.Lie.Symplectic.StandardCarrier.Scheme
 
 /-!
@@ -83,10 +84,10 @@ def pointsMap (f : A →+* B) : points n A →* points n B :=
 theorem coe_pointsMap (f : A →+* B) (g : points n A) :
     (pointsMap n f g : Matrix.GeneralLinearGroup (Fin ((n + 1) + (n + 1))) B) =
       Matrix.GeneralLinearGroup.map f g := by
-  have hring : f.toIntAlgHom.toRingHom = f := RingHom.ext (RingHom.toIntAlgHom_apply f)
   rw [pointsMap]
   simp only [MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, MulEquiv.subgroupCongr_symm_apply,
-    GeneralLinear.coe_mapHopfIdealPointsSubgroup, MulEquiv.subgroupCongr_apply, hring]
+    GeneralLinear.coe_mapHopfIdealPointsSubgroup, MulEquiv.subgroupCongr_apply,
+    AlgHom.toRingHom_eq_coe, RingHom.toIntAlgHom_toRingHom]
 
 /-- Entrywise, the induced map applies the homomorphism of value rings to each matrix entry. -/
 theorem coe_pointsMap_apply (f : A →+* B) (g : points n A)
@@ -100,9 +101,7 @@ theorem coe_pointsMap_apply (f : A →+* B) (g : points n A)
 /-- The identity homomorphism induces the identity on type-C carrier points. -/
 @[simp]
 theorem pointsMap_id : pointsMap n (RingHom.id A) = MonoidHom.id _ := by
-  have hid : (RingHom.id A).toIntAlgHom = AlgHom.id ℤ A :=
-    AlgHom.ext fun _ ↦ rfl
-  rw [pointsMap, hid,
+  rw [pointsMap, RingHom.toIntAlgHom_id,
     GeneralLinear.mapHopfIdealPointsSubgroup_id]
   apply MonoidHom.ext
   intro g
@@ -112,11 +111,9 @@ theorem pointsMap_id : pointsMap n (RingHom.id A) = MonoidHom.id _ := by
 @[simp]
 theorem pointsMap_comp {C : Type*} [CommRing C] (f : A →+* B) (g : B →+* C) :
     pointsMap n (g.comp f) = (pointsMap n g).comp (pointsMap n f) := by
-  have hcomp : (g.comp f).toIntAlgHom = g.toIntAlgHom.comp f.toIntAlgHom :=
-    AlgHom.ext fun _ ↦ rfl
   apply MonoidHom.ext
   intro x
-  simp only [pointsMap, MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, hcomp,
+  simp only [pointsMap, MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, RingHom.toIntAlgHom_comp,
     GeneralLinear.mapHopfIdealPointsSubgroup_comp, MulEquiv.apply_symm_apply]
 
 /-- An injective homomorphism of value rings induces an injective map on type-C carrier points. -/

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/ToralClosure/Weyl.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/ToralClosure/Weyl.lean
@@ -5,6 +5,7 @@ Authors: Codex
 -/
 module
 
+import TauCeti.Algebra.Algebra.Hom
 public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Scheme.ToralClosure.Points
 public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Weyl.Torus
 
@@ -130,10 +131,10 @@ theorem map_kostantToralWeylPoint {A : Type v} {B : Type v'} [CommRing A] [CommR
         (kostantToralPointsSubgroup_def e h ρ M hM hnil b wt B)
         (kostantToralWeylPoint e h ρ M hM hnil b wt i j B) := by
   apply Subtype.ext
-  have hring : φ.toIntAlgHom.toRingHom = φ := RingHom.ext (RingHom.toIntAlgHom_apply φ)
   simp only [GeneralLinear.coe_mapHopfIdealPointsSubgroup, kostantToralWeylPoint,
     MulEquiv.subgroupCongr_apply, Subgroup.coe_mul, map_mul,
-    coe_kostantToralRootSubgroupPoints, hring]
+    coe_kostantToralRootSubgroupPoints, AlgHom.toRingHom_eq_coe,
+    RingHom.toIntAlgHom_toRingHom]
   rw [map_kostantRootSubgroupMatrix e h ρ M hM i (hnil i) b φ,
     map_kostantRootSubgroupMatrix e h ρ M hM j (hnil j) b φ,
     AdditiveGroup.mapValue_gaPointsMulEquiv_symm_apply,

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/PointsFunctor.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/PointsFunctor.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.HopfIdealPoints.Functor
+import TauCeti.Algebra.Algebra.Hom
 public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.GeckLattice.GroupScheme
 
 /-!
@@ -110,10 +111,10 @@ theorem coe_geckPointsMap (f : A →+* B) (g : t.geckPoints ht A) :
       Matrix.GeneralLinearGroup.map f g := by
   -- `mapHopfIdealPointsSubgroup` is stated for the `ℤ`-algebra map that `f` induces, whose
   -- underlying ring homomorphism is `f` again.
-  have hring : f.toIntAlgHom.toRingHom = f := RingHom.ext (RingHom.toIntAlgHom_apply f)
   rw [geckPointsMap]
   simp only [MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, MulEquiv.subgroupCongr_symm_apply,
-    GeneralLinear.coe_mapHopfIdealPointsSubgroup, MulEquiv.subgroupCongr_apply, hring]
+    GeneralLinear.coe_mapHopfIdealPointsSubgroup, MulEquiv.subgroupCongr_apply,
+    AlgHom.toRingHom_eq_coe, RingHom.toIntAlgHom_toRingHom]
 
 /-- Entrywise, the induced map on the points of the pinned Geck carrier applies the homomorphism
 of value rings to each matrix entry. -/


### PR DESCRIPTION
Mathlib's `RingHom.toIntAlgHom` turns a ring homomorphism into the `ℤ`-algebra homomorphism it always was. Mathlib gives it `toIntAlgHom_coe`, `toIntAlgHom_apply`, `toIntAlgHom_injective` and `equivIntAlgHom`, but no identity, composition or round-trip lemma — so every caller that has a ring homomorphism and needs to feed it to an `AlgHom`-valued interface has had to re-derive those three facts on the spot.

In this tree that had happened 36 times: four `private` wrapper lemmas — three in `AlgebraicGroup/Frobenius/Points.lean`, one in `AlgebraicGroup/Frobenius/GeneralLinear.lean` — and 32 inline `have`s. Every one of them was `AlgHom.ext fun _ ↦ rfl` or `RingHom.ext (RingHom.toIntAlgHom_apply _)` under a different local name.

This states the four facts once, publicly, in `Algebra/Algebra/Hom.lean` — the file that already holds this tree's `AlgHom`/`RingHom` bridging — and deletes every copy. They are applied at 40 sites across 14 files.

### Why the round-trip lemmas use the coercion

```lean
RingHom.toIntAlgHom_toRingHom (f : R →+* S) : (f.toIntAlgHom : R →+* S) = f
AlgHom.toRingHom_toIntAlgHom  (φ : R →ₐ[ℤ] S) : ((φ : R →+* S)).toIntAlgHom = φ
```

Mathlib's `AlgHom.toRingHom_eq_coe` is a `simp` lemma making the coercion the simp-normal form, so a `.toRingHom` left-hand side is rewritten away before either lemma can fire — stated that way and marked `@[simp]`, they would be dead. The cost is that a call site starting from a `.toRingHom` term names `AlgHom.toRingHom_eq_coe` first. The deleted private wrappers took the other trade and were unusable by `simp`.

### Scope

No statement changes, and no proof gets longer: each deleted `have` is replaced by the corresponding lemma name in the `rw`/`simp only` list that already consumed it. Outside proof bodies the edits are fourteen added imports — all plain rather than `public`, since everything in `Algebra/Algebra/Hom.lean` is a `Prop` and can never appear in a statement — two module docstrings, and one `private` theorem docstring that named a wrapper this removes.

A follow-up PR builds on this one to share the transport of Hopf-ideal point functoriality across the ten `GLₙ` carriers; it is kept separate because that change is about `Subgroup` transport and touches a disjoint set of files.

Verified locally: `lake build` (11024 jobs), `lake exe axioms` (109062 declarations, allowlist clean), `scripts/lint-style.sh`.

Roadmap: ReductiveGroups

🤖 Generated with [Claude Code](https://claude.com/claude-code)
