### PR TITLE
feat: make smooth families continuous in the weak Whitney topology

### DIFF
--- a/TauCeti/Analysis/Calculus/IteratedFDeriv/Prod.lean
+++ b/TauCeti/Analysis/Calculus/IteratedFDeriv/Prod.lean
@@ -1,0 +1,51 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.Calculus.ContDiff.Operations
+
+/-!
+# Iterated derivatives in one variable of a product
+
+The iterated derivative of a slice `x ↦ f (p, x)` is the total iterated derivative of `f`
+restricted to directions in the second factor. Consequently these partial derivatives vary
+continuously in both variables when `f` is sufficiently differentiable. This gives the
+joint derivative continuity needed for smooth families in function spaces.
+-/
+
+public section
+
+namespace TauCeti
+
+variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
+  {P : Type*} [NormedAddCommGroup P] [NormedSpace 𝕜 P]
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+  {F : Type*} [NormedAddCommGroup F] [NormedSpace 𝕜 F]
+  {n : WithTop ℕ∞} {f : P × E → F}
+
+/-- The iterated derivative in the second variable is the total iterated derivative restricted
+to directions with zero first component. -/
+theorem iteratedFDeriv_prod_right (hf : ContDiff 𝕜 n f) (m : ℕ) (hm : m ≤ n)
+    (p : P) (x : E) :
+    iteratedFDeriv 𝕜 m (fun y ↦ f (p, y)) x =
+      (iteratedFDeriv 𝕜 m f (p, x)).compContinuousLinearMap
+        (fun _ ↦ ContinuousLinearMap.inr 𝕜 P E) := by
+  have h := (ContinuousLinearMap.inr 𝕜 P E).iteratedFDeriv_comp_right
+    (hf.comp (contDiff_const.add contDiff_id) :
+      ContDiff 𝕜 n (fun z : P × E ↦ f ((p, 0) + z))) x hm
+  simpa only [Function.comp_def, ContinuousLinearMap.inr_apply, Prod.mk_add_mk,
+    add_zero, zero_add, iteratedFDeriv_comp_add_left] using h
+
+/-- The iterated derivatives in the second variable of a `C^n` function are jointly continuous
+in the parameter and the evaluation point, through order `n`. -/
+theorem continuous_iteratedFDeriv_prod_right (hf : ContDiff 𝕜 n f) (m : ℕ) (hm : m ≤ n) :
+    Continuous (fun z : P × E ↦ iteratedFDeriv 𝕜 m (fun y ↦ f (z.1, y)) z.2) := by
+  simp_rw [iteratedFDeriv_prod_right hf m hm]
+  exact (ContinuousMultilinearMap.compContinuousLinearMapL
+    (fun _ : Fin m ↦ ContinuousLinearMap.inr 𝕜 P E)).continuous.comp
+      (hf.continuous_iteratedFDeriv hm)
+
+end TauCeti

--- a/TauCeti/Analysis/Calculus/IteratedFDeriv/Prod.lean
+++ b/TauCeti/Analysis/Calculus/IteratedFDeriv/Prod.lean
@@ -18,7 +18,7 @@ joint derivative continuity needed for smooth families in function spaces.
 
 public section
 
-namespace TauCeti
+namespace _root_.ContDiff
 
 variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
   {P : Type*} [NormedAddCommGroup P] [NormedSpace 𝕜 P]
@@ -48,4 +48,5 @@ theorem continuous_iteratedFDeriv_prod_right (hf : ContDiff 𝕜 n f) (m : ℕ) 
     (fun _ : Fin m ↦ ContinuousLinearMap.inr 𝕜 P E)).continuous.comp
       (hf.continuous_iteratedFDeriv hm)
 
-end TauCeti
+end ContDiff
+end _root_

--- a/TauCeti/Geometry/Manifold/ContMDiffMap/SmoothFamily.lean
+++ b/TauCeti/Geometry/Manifold/ContMDiffMap/SmoothFamily.lean
@@ -43,6 +43,15 @@ theorem continuous_weakWhitney_of_contDiff
   continuous_weakWhitney_of_continuous_iteratedFDeriv
     (fun m hm ↦ continuous_iteratedFDeriv_prod_right hf m hm)
 
+end TauCeti
+
+namespace _root_.ContMDiffMap
+
+variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+  {F : Type*} [NormedAddCommGroup F] [NormedSpace 𝕜 F]
+  {n : WithTop ℕ∞}
+
 /-- Curry a jointly `C^n` map into a continuous family of `C^n` maps, where the inner map
 space carries the weak Whitney topology. -/
 noncomputable def weakWhitneyCurry
@@ -51,7 +60,7 @@ noncomputable def weakWhitneyCurry
     C(P, C^n⟮𝓘(𝕜, E), E; 𝓘(𝕜, F), F⟯) where
   toFun p := ⟨fun x ↦ f (p, x),
     (f.contMDiff.contDiff.comp (contDiff_const.prodMk contDiff_id)).contMDiff⟩
-  continuous_toFun := continuous_weakWhitney_of_contDiff f.contMDiff.contDiff
+  continuous_toFun := TauCeti.continuous_weakWhitney_of_contDiff f.contMDiff.contDiff
 
 @[simp]
 theorem weakWhitneyCurry_apply
@@ -60,4 +69,4 @@ theorem weakWhitneyCurry_apply
     weakWhitneyCurry f p x = f (p, x) :=
   (rfl)
 
-end TauCeti
+end _root_.ContMDiffMap

--- a/TauCeti/Geometry/Manifold/ContMDiffMap/SmoothFamily.lean
+++ b/TauCeti/Geometry/Manifold/ContMDiffMap/SmoothFamily.lean
@@ -17,10 +17,6 @@ in `E` restricts the total derivative to directions in the second factor, so eac
 varies jointly continuously in `(p, x)`. Compact-open currying then gives continuity into
 the function space. In particular the construction applies to smooth families (`n = ∞`).
 
-We also characterize continuity of arbitrary families by their compact-open derivative maps.
-When `E` is locally compact, this is equivalent to joint continuity of every spatial derivative;
-no differentiability in the parameter is required for this characterization.
-
 The topology is the weak topology of M. Hirsch, *Differential Topology*, Graduate Texts in
 Mathematics 33, Chapter 2, §1. Only the forward implication from joint smoothness is asserted:
 a continuous family in the weak Whitney topology need not be smooth in its parameter.
@@ -37,44 +33,6 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
   {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
   {F : Type*} [NormedAddCommGroup F] [NormedSpace 𝕜 F]
   {n : WithTop ℕ∞}
-
-/-- Continuity into the weak Whitney topology is equivalent to continuity of each derivative
-as a map into its compact-open function space. -/
-theorem continuous_weakWhitney_iff {X : Type*} [TopologicalSpace X]
-    {f : X → C^n⟮𝓘(𝕜, E), E; 𝓘(𝕜, F), F⟯} :
-    Continuous f ↔ ∀ (m : ℕ) (hm : m ≤ n),
-      Continuous (fun p ↦ ContMDiffMap.iteratedFDerivContinuousMap (f p) m hm) := by
-  rw [ContMDiffMap.isInducing_weakWhitneyJet.continuous_iff]
-  simp only [continuous_pi_iff, Function.comp_apply, ContMDiffMap.weakWhitneyJet_apply,
-    Subtype.forall]
-
-/-- A family is continuous in the weak Whitney topology if every spatial derivative through
-order `n` varies jointly continuously in the parameter and evaluation point. -/
-theorem continuous_weakWhitney_of_continuous_iteratedFDeriv {X : Type*} [TopologicalSpace X]
-    {f : X → C^n⟮𝓘(𝕜, E), E; 𝓘(𝕜, F), F⟯}
-    (hf : ∀ (m : ℕ), m ≤ n →
-      Continuous (fun z : X × E ↦ iteratedFDeriv 𝕜 m (f z.1) z.2)) :
-    Continuous f := by
-  rw [continuous_weakWhitney_iff]
-  intro m hm
-  apply ContinuousMap.continuous_of_continuous_uncurry
-  simpa only [Function.uncurry_def, ContMDiffMap.iteratedFDerivContinuousMap_apply]
-    using hf m hm
-
-/-- For a locally compact source, continuity of a family in the weak Whitney topology is
-exactly joint continuity of all spatial derivatives through order `n`. -/
-theorem continuous_weakWhitney_iff_continuous_iteratedFDeriv [LocallyCompactSpace E]
-    {X : Type*} [TopologicalSpace X]
-    {f : X → C^n⟮𝓘(𝕜, E), E; 𝓘(𝕜, F), F⟯} :
-    Continuous f ↔ ∀ (m : ℕ), m ≤ n →
-      Continuous (fun z : X × E ↦ iteratedFDeriv 𝕜 m (f z.1) z.2) := by
-  constructor
-  · intro hf m hm
-    simpa only [Function.uncurry_def, ContinuousMap.coe_mk,
-      ContMDiffMap.iteratedFDerivContinuousMap_apply] using
-      ContinuousMap.continuous_uncurry_of_continuous
-        ⟨_, (continuous_weakWhitney_iff.mp hf) m hm⟩
-  · exact continuous_weakWhitney_of_continuous_iteratedFDeriv
 
 /-- A jointly `C^n` family gives a continuous map into the weak Whitney `C^n` map space.
 This requires neither finite dimensionality nor local compactness of the normed spaces. -/

--- a/TauCeti/Geometry/Manifold/ContMDiffMap/SmoothFamily.lean
+++ b/TauCeti/Geometry/Manifold/ContMDiffMap/SmoothFamily.lean
@@ -1,0 +1,105 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.Calculus.IteratedFDeriv.Prod
+public import TauCeti.Geometry.Manifold.ContMDiffMap.WeakWhitney
+
+/-!
+# Smooth families are continuous for the weak Whitney topology
+
+A jointly `C^n` map `P × E → F` gives a continuous family of `C^n` maps `E → F` for the
+weak Whitney topology. This is the chart-level smooth-family construction: differentiating
+in `E` restricts the total derivative to directions in the second factor, so each derivative
+varies jointly continuously in `(p, x)`. Compact-open currying then gives continuity into
+the function space. In particular the construction applies to smooth families (`n = ∞`).
+
+We also characterize continuity of arbitrary families by their compact-open derivative maps.
+When `E` is locally compact, this is equivalent to joint continuity of every spatial derivative;
+no differentiability in the parameter is required for this characterization.
+
+The topology is the weak topology of M. Hirsch, *Differential Topology*, Graduate Texts in
+Mathematics 33, Chapter 2, §1. Only the forward implication from joint smoothness is asserted:
+a continuous family in the weak Whitney topology need not be smooth in its parameter.
+-/
+
+public section
+
+open Topology
+open scoped Manifold
+
+namespace TauCeti
+
+variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+  {F : Type*} [NormedAddCommGroup F] [NormedSpace 𝕜 F]
+  {n : WithTop ℕ∞}
+
+/-- Continuity into the weak Whitney topology is equivalent to continuity of each derivative
+as a map into its compact-open function space. -/
+theorem continuous_weakWhitney_iff {X : Type*} [TopologicalSpace X]
+    {f : X → C^n⟮𝓘(𝕜, E), E; 𝓘(𝕜, F), F⟯} :
+    Continuous f ↔ ∀ (m : ℕ) (hm : m ≤ n),
+      Continuous (fun p ↦ ContMDiffMap.iteratedFDerivContinuousMap (f p) m hm) := by
+  rw [ContMDiffMap.isInducing_weakWhitneyJet.continuous_iff]
+  simp only [continuous_pi_iff, Function.comp_apply, ContMDiffMap.weakWhitneyJet_apply,
+    Subtype.forall]
+
+/-- A family is continuous in the weak Whitney topology if every spatial derivative through
+order `n` varies jointly continuously in the parameter and evaluation point. -/
+theorem continuous_weakWhitney_of_continuous_iteratedFDeriv {X : Type*} [TopologicalSpace X]
+    {f : X → C^n⟮𝓘(𝕜, E), E; 𝓘(𝕜, F), F⟯}
+    (hf : ∀ (m : ℕ), m ≤ n →
+      Continuous (fun z : X × E ↦ iteratedFDeriv 𝕜 m (f z.1) z.2)) :
+    Continuous f := by
+  rw [continuous_weakWhitney_iff]
+  intro m hm
+  apply ContinuousMap.continuous_of_continuous_uncurry
+  simpa only [Function.uncurry_def, ContMDiffMap.iteratedFDerivContinuousMap_apply]
+    using hf m hm
+
+/-- For a locally compact source, continuity of a family in the weak Whitney topology is
+exactly joint continuity of all spatial derivatives through order `n`. -/
+theorem continuous_weakWhitney_iff_continuous_iteratedFDeriv [LocallyCompactSpace E]
+    {X : Type*} [TopologicalSpace X]
+    {f : X → C^n⟮𝓘(𝕜, E), E; 𝓘(𝕜, F), F⟯} :
+    Continuous f ↔ ∀ (m : ℕ), m ≤ n →
+      Continuous (fun z : X × E ↦ iteratedFDeriv 𝕜 m (f z.1) z.2) := by
+  constructor
+  · intro hf m hm
+    simpa only [Function.uncurry_def, ContinuousMap.coe_mk,
+      ContMDiffMap.iteratedFDerivContinuousMap_apply] using
+      ContinuousMap.continuous_uncurry_of_continuous
+        ⟨_, (continuous_weakWhitney_iff.mp hf) m hm⟩
+  · exact continuous_weakWhitney_of_continuous_iteratedFDeriv
+
+/-- A jointly `C^n` family gives a continuous map into the weak Whitney `C^n` map space.
+This requires neither finite dimensionality nor local compactness of the normed spaces. -/
+theorem continuous_weakWhitney_of_contDiff
+    {P : Type*} [NormedAddCommGroup P] [NormedSpace 𝕜 P]
+    {f : P → C^n⟮𝓘(𝕜, E), E; 𝓘(𝕜, F), F⟯}
+    (hf : ContDiff 𝕜 n (fun z : P × E ↦ f z.1 z.2)) : Continuous f :=
+  continuous_weakWhitney_of_continuous_iteratedFDeriv
+    (fun m hm ↦ continuous_iteratedFDeriv_prod_right hf m hm)
+
+/-- Curry a jointly `C^n` map into a continuous family of `C^n` maps, where the inner map
+space carries the weak Whitney topology. -/
+noncomputable def weakWhitneyCurry
+    {P : Type*} [NormedAddCommGroup P] [NormedSpace 𝕜 P]
+    (f : C^n⟮𝓘(𝕜, P × E), P × E; 𝓘(𝕜, F), F⟯) :
+    C(P, C^n⟮𝓘(𝕜, E), E; 𝓘(𝕜, F), F⟯) where
+  toFun p := ⟨fun x ↦ f (p, x),
+    (f.contMDiff.contDiff.comp (contDiff_const.prodMk contDiff_id)).contMDiff⟩
+  continuous_toFun := continuous_weakWhitney_of_contDiff f.contMDiff.contDiff
+
+@[simp]
+theorem weakWhitneyCurry_apply
+    {P : Type*} [NormedAddCommGroup P] [NormedSpace 𝕜 P]
+    (f : C^n⟮𝓘(𝕜, P × E), P × E; 𝓘(𝕜, F), F⟯) (p : P) (x : E) :
+    weakWhitneyCurry f p x = f (p, x) :=
+  (rfl)
+
+end TauCeti

--- a/TauCeti/Geometry/Manifold/ContMDiffMap/SmoothFamily.lean
+++ b/TauCeti/Geometry/Manifold/ContMDiffMap/SmoothFamily.lean
@@ -27,7 +27,7 @@ public section
 open Topology
 open scoped Manifold
 
-namespace TauCeti
+namespace _root_.ContDiff
 
 variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
   {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
@@ -36,14 +36,15 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
 
 /-- A jointly `C^n` family gives a continuous map into the weak Whitney `C^n` map space.
 This requires neither finite dimensionality nor local compactness of the normed spaces. -/
-theorem continuous_weakWhitney_of_contDiff
+theorem continuous_weakWhitney
     {P : Type*} [NormedAddCommGroup P] [NormedSpace 𝕜 P]
     {f : P → C^n⟮𝓘(𝕜, E), E; 𝓘(𝕜, F), F⟯}
     (hf : ContDiff 𝕜 n (fun z : P × E ↦ f z.1 z.2)) : Continuous f :=
-  continuous_weakWhitney_of_continuous_iteratedFDeriv
+  ContMDiffMap.continuous_weakWhitney_of_continuous_iteratedFDeriv
     (fun m hm ↦ continuous_iteratedFDeriv_prod_right hf m hm)
 
-end TauCeti
+end ContDiff
+end _root_
 
 namespace _root_.ContMDiffMap
 
@@ -60,7 +61,7 @@ noncomputable def weakWhitneyCurry
     C(P, C^n⟮𝓘(𝕜, E), E; 𝓘(𝕜, F), F⟯) where
   toFun p := ⟨fun x ↦ f (p, x),
     (f.contMDiff.contDiff.comp (contDiff_const.prodMk contDiff_id)).contMDiff⟩
-  continuous_toFun := TauCeti.continuous_weakWhitney_of_contDiff f.contMDiff.contDiff
+  continuous_toFun := ContDiff.continuous_weakWhitney f.contMDiff.contDiff
 
 @[simp]
 theorem weakWhitneyCurry_apply
@@ -69,4 +70,5 @@ theorem weakWhitneyCurry_apply
     weakWhitneyCurry f p x = f (p, x) :=
   (rfl)
 
-end _root_.ContMDiffMap
+end ContMDiffMap
+end _root_

--- a/TauCeti/Geometry/Manifold/ContMDiffMap/WeakWhitney.lean
+++ b/TauCeti/Geometry/Manifold/ContMDiffMap/WeakWhitney.lean
@@ -22,6 +22,10 @@ manifolds. On a manifold, the same construction is applied to coordinate represe
 compact subsets of chart domains. In particular, the `n = ∞` instance below supplies the
 chart-level topology used to topologize diffeomorphism groups.
 
+We also characterize continuity of arbitrary families by their compact-open derivative maps.
+When `E` is locally compact, this is equivalent to joint continuity of every spatial derivative;
+no differentiability in the parameter is required for this characterization.
+
 ## Main definitions
 
 * `ContMDiffMap.iteratedFDerivContinuousMap`: the `k`th derivative of a bundled `C^n` map,
@@ -202,3 +206,50 @@ theorem tendsto_weakWhitney_iff_eventually_mapsTo {X : Type*} {l : Filter X}
   simp only [ContinuousMap.tendsto_nhds_compactOpen]
 
 end ContMDiffMap
+
+namespace TauCeti
+
+variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+  {F : Type*} [NormedAddCommGroup F] [NormedSpace 𝕜 F]
+  {n : WithTop ℕ∞}
+
+/-- Continuity into the weak Whitney topology is equivalent to continuity of each derivative
+as a map into its compact-open function space. -/
+theorem continuous_weakWhitney_iff {X : Type*} [TopologicalSpace X]
+    {f : X → C^n⟮𝓘(𝕜, E), E; 𝓘(𝕜, F), F⟯} :
+    Continuous f ↔ ∀ (m : ℕ) (hm : m ≤ n),
+      Continuous (fun p ↦ ContMDiffMap.iteratedFDerivContinuousMap (f p) m hm) := by
+  rw [ContMDiffMap.isInducing_weakWhitneyJet.continuous_iff]
+  simp only [continuous_pi_iff, Function.comp_apply, ContMDiffMap.weakWhitneyJet_apply,
+    Subtype.forall]
+
+/-- A family is continuous in the weak Whitney topology if every spatial derivative through
+order `n` varies jointly continuously in the parameter and evaluation point. -/
+theorem continuous_weakWhitney_of_continuous_iteratedFDeriv {X : Type*} [TopologicalSpace X]
+    {f : X → C^n⟮𝓘(𝕜, E), E; 𝓘(𝕜, F), F⟯}
+    (hf : ∀ (m : ℕ), m ≤ n →
+      Continuous (fun z : X × E ↦ iteratedFDeriv 𝕜 m (f z.1) z.2)) :
+    Continuous f := by
+  rw [continuous_weakWhitney_iff]
+  intro m hm
+  apply ContinuousMap.continuous_of_continuous_uncurry
+  simpa only [Function.uncurry_def, ContMDiffMap.iteratedFDerivContinuousMap_apply]
+    using hf m hm
+
+/-- For a locally compact source, continuity of a family in the weak Whitney topology is
+exactly joint continuity of all spatial derivatives through order `n`. -/
+theorem continuous_weakWhitney_iff_continuous_iteratedFDeriv [LocallyCompactSpace E]
+    {X : Type*} [TopologicalSpace X]
+    {f : X → C^n⟮𝓘(𝕜, E), E; 𝓘(𝕜, F), F⟯} :
+    Continuous f ↔ ∀ (m : ℕ), m ≤ n →
+      Continuous (fun z : X × E ↦ iteratedFDeriv 𝕜 m (f z.1) z.2) := by
+  constructor
+  · intro hf m hm
+    simpa only [Function.uncurry_def, ContinuousMap.coe_mk,
+      ContMDiffMap.iteratedFDerivContinuousMap_apply] using
+      ContinuousMap.continuous_uncurry_of_continuous
+        ⟨_, (continuous_weakWhitney_iff.mp hf) m hm⟩
+  · exact continuous_weakWhitney_of_continuous_iteratedFDeriv
+
+end TauCeti

--- a/TauCeti/Geometry/Manifold/ContMDiffMap/WeakWhitney.lean
+++ b/TauCeti/Geometry/Manifold/ContMDiffMap/WeakWhitney.lean
@@ -207,7 +207,7 @@ theorem tendsto_weakWhitney_iff_eventually_mapsTo {X : Type*} {l : Filter X}
 
 end ContMDiffMap
 
-namespace TauCeti
+namespace _root_.ContMDiffMap
 
 variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
   {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
@@ -252,4 +252,4 @@ theorem continuous_weakWhitney_iff_continuous_iteratedFDeriv [LocallyCompactSpac
         ⟨_, (continuous_weakWhitney_iff.mp hf) m hm⟩
   · exact continuous_weakWhitney_of_continuous_iteratedFDeriv
 
-end TauCeti
+end _root_.ContMDiffMap


### PR DESCRIPTION
This PR proves that a jointly `C^n` family between normed spaces induces a continuous map into the weak Whitney `C^n` map space, and packages it as `TauCeti.weakWhitneyCurry`. It identifies spatial iterated derivatives with total derivatives restricted to the second factor, proves their joint continuity, and gives both the compact-open derivative criterion and, for a locally compact source, its joint-continuity characterization.

The exact target is [GeometricTopology/README.md, Layer 3: diffeomorphism groups with the C^∞ topology](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/GeometricTopology/README.md#layer-3-diffeomorphism-groups-with-the-c-topology), specifically the “smooth-families map” from a smooth `F : P × M → M` to a continuous `P → Diff(M)`. The consumer is the roadmap's `ofSmoothFamily`: its continuity proof needs continuity of the spatial derivative families in coordinate representatives. This PR supplies that analytic step in the global-chart setting, building directly on the weak Whitney topology landed in #6203. The collar/gluing track is claimed, and the open PR scan found no overlapping smooth-family work, making this the next available step along the independent Layer 3 path.

After this PR, Layer 3 still needs the chart-domain construction of the topology on compact manifolds, its induced topology on `Diff(M)`, continuity of the group operations, the manifold form of `ofSmoothFamily`, and the continuous orthogonal-group inclusion.

The new modules are `TauCeti/Analysis/Calculus/IteratedFDeriv/Prod.lean` (51 lines) and `TauCeti/Geometry/Manifold/ContMDiffMap/SmoothFamily.lean` (105 lines). The generic derivative calculation lives separately from the function-space topology. The forward theorem works over a nontrivially normed field, at finite or infinite regularity, without finite-dimensionality or local-compactness assumptions; local compactness is required only to recover joint continuity from compact-open continuity.

The function-space construction follows Hirsch, *Differential Topology*, Chapter 2, §1, cited in the module documentation. It reuses Mathlib's translation and continuous-linear precomposition formulas for iterated Fréchet derivatives, `ContinuousMultilinearMap.compContinuousLinearMapL`, and compact-open currying. No Mathlib source or external formalization is vendored.

Roadmap: GeometricTopology

<!--tauceti-target:v1 {"focus":"GeometricTopology","id":"weak-whitney-smooth-family"}-->

🤖 Prepared with Codex
