### PR TITLE
fix: make lint-env's linter-set parse work outside GNU userland

### DIFF
--- a/scripts/lint-env.sh
+++ b/scripts/lint-env.sh
@@ -355,12 +355,12 @@ if ! run_lean "$DOCDRIVER" > "$TMP/docscan.txt" 2>&1; then
   cat "$TMP/docscan.txt"
   fail "driver failure: the docstring-scan driver did not elaborate cleanly — see output above"
 fi
-nsets=$(grep -c "^LINTERSET \(base\|tacticAlt\) $LINTERSETMARKER\$" "$TMP/docscan.txt" || true)
+nsets=$(grep -cE "^LINTERSET (base|tacticAlt) $LINTERSETMARKER\$" "$TMP/docscan.txt" || true)
 if [ "${nsets:-0}" -ne 1 ]; then
   cat "$TMP/docscan.txt"
   fail "driver failure: expected exactly 1 selected-linter-set line, found ${nsets:-0}"
 fi
-selected_linters=$(sed -n "s/^LINTERSET \(base\|tacticAlt\) $LINTERSETMARKER\$/\1/p" "$TMP/docscan.txt")
+selected_linters=$(sed -nE "s/^LINTERSET (base|tacticAlt) $LINTERSETMARKER\$/\1/p" "$TMP/docscan.txt")
 case "$selected_linters" in
   base) LINTERS="$LINTERS_BASE" ;;
   tacticAlt) LINTERS="$LINTERS_TACTIC_ALT" ;;


### PR DESCRIPTION
This gate is useful to run locally, but on macOS it aborts with `internal error: unrecognized selected linter set ''`. It selected the set with a BRE `\(base\|tacticAlt\)`, and `\|` is a GNU extension that BSD `sed` takes as a literal `|`, so the substitution never fired. The `grep -c` guard above did not catch it first because BSD `grep` does honour `\|`. CI runs on Linux, so `main` was never affected.

Both patterns now spell the alternation as an ERE, which `grep -E` and `sed -E` read identically everywhere: `grep -E` is POSIX, and `sed -E` is POSIX.1-2024, BSD, and GNU sed since 4.2. Nothing else changes — the `case` below still decides which set names are accepted.

Verified on macOS 15 (BSD sed/grep). Presumed to also work on other platforms.

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)