### PR TITLE
feat(ModularForms): the twisted Γ₀(N) Hecke operator of diag(1, p) is the classical Tₚ on S_k(N, χ)

### DIFF
--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/Diagonal/PrimeCosets.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/Diagonal/PrimeCosets.lean
@@ -187,7 +187,6 @@ entry is `σ₀₀ p ≡ 1 (mod N)`, by the determinant of `σ`. -/
 @[simp] theorem Delta0UpperUnit_mapGL_mul_scaleRep (hp : 0 < p) (hσ10 : σ 1 0 = (N : ℤ))
     (hσ11 : σ 1 1 = (p : ℤ)) (hmem : mapGL ℚ σ * scaleRep p ∈ Delta0 N) :
     Delta0UpperUnit N ⟨mapGL ℚ σ * scaleRep p, hmem⟩ = 1 := by
-  have hdet := Matrix.SpecialLinearGroup.fin_two_mul_sub_mul_eq_one σ
   have h : (Delta0UpperUnit N ⟨mapGL ℚ σ * scaleRep p, hmem⟩ : ZMod N)
       = ((!![σ 0 0 * (p : ℤ), σ 0 1; σ 1 0 * (p : ℤ), σ 1 1] : Matrix (Fin 2) (Fin 2) ℤ) 0 0
           : ZMod N) := by
@@ -200,8 +199,7 @@ entry is `σ₀₀ p ≡ 1 (mod N)`, by the determinant of `σ`. -/
     fin_cases i <;> fin_cases l <;> simp [Matrix.mul_apply, Fin.sum_univ_two]
   have h1 : ((σ 0 0 * (p : ℤ) : ℤ) : ZMod N) = 1 := by
     have : σ 0 0 * (p : ℤ) = 1 + σ 0 1 * (N : ℤ) := by
-      rw [← hσ10]
-      linear_combination hdet - σ 0 0 * hσ11
+      linear_combination mul_sub_mul_eq_one_of_lowerRow hσ10 hσ11
     rw [this]
     push_cast
     simp

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/Diagonal/PrimeCosets.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/Diagonal/PrimeCosets.lean
@@ -168,7 +168,7 @@ theorem doubleCoset_natDiagGL_Gamma0_eq_iUnion_rightCosets_of_dvd (hp : p.Prime)
 /-! ### The upper-left units of the representatives -/
 
 /-- **The upper-left unit of an upper-triangular representative is `1`.** -/
-@[simp] theorem Delta0UpperUnit_upperTriRep [NeZero p] (j : Fin p)
+@[simp] theorem Delta0UpperUnit_upperTriRep (j : Fin p)
     (hmem : upperTriRep p j ∈ Delta0 N) : Delta0UpperUnit N ⟨upperTriRep p j, hmem⟩ = 1 := by
   have h : (Delta0UpperUnit N ⟨upperTriRep p j, hmem⟩ : ZMod N)
       = ((!![1, (j : ℕ); 0, (p : ℕ)] : Matrix (Fin 2) (Fin 2) ℤ) 0 0 : ZMod N) := by

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/Diagonal/PrimeCosets.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/Diagonal/PrimeCosets.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.NumberTheory.HeckeRing.GL2.Gamma0.UpperTriFactorization
+public import TauCeti.NumberTheory.HeckeRing.GL2.Gamma0.UpperUnit
 public import TauCeti.NumberTheory.HeckeRing.GL2.Gamma1.CoprimeCosets
 
 -- Only a proof needs the field structure on `ZMod p` (to read `p ∤ a` as invertibility).
@@ -39,6 +40,9 @@ coset of `σ · diag(p, 1)` because `σ ∈ Γ₀(N)`.
   of `diagCosetGamma0 N ![1, p]` through `HeckeCoset.toSet_eq_doubleCoset_rep` and
   `diagCosetGamma0_toSet`, these are the shapes the twisted slash-sum machinery of
   `HeckeSlash/Nebentypus/Independence.lean` consumes.
+* `HeckeRing.GL2.Delta0UpperUnit_upperTriRep`, `HeckeRing.GL2.Delta0UpperUnit_mapGL_mul_scaleRep`:
+  the upper-left unit of either kind of representative is `1`, so the twisting character of
+  `HeckeSlash/Nebentypus/*` is trivial on both.
 
 ## Provenance
 
@@ -160,5 +164,47 @@ theorem doubleCoset_natDiagGL_Gamma0_eq_iUnion_rightCosets_of_dvd (hp : p.Prime)
     exact ⟨mapGL ℚ (ModularGroup.T ^ (j : ℤ)),
       Subgroup.mem_map_of_mem _ (Gamma1_in_Gamma0 N (T_zpow_mem_Gamma1 N _)),
       natDiagGL_mul_mapGL_T_zpow hp.pos j⟩
+
+/-! ### The upper-left units of the representatives -/
+
+/-- **The upper-left unit of an upper-triangular representative is `1`.** -/
+@[simp] theorem Delta0UpperUnit_upperTriRep [NeZero p] (j : Fin p)
+    (hmem : upperTriRep p j ∈ Delta0 N) : Delta0UpperUnit N ⟨upperTriRep p j, hmem⟩ = 1 := by
+  have h : (Delta0UpperUnit N ⟨upperTriRep p j, hmem⟩ : ZMod N)
+      = ((!![1, (j : ℕ); 0, (p : ℕ)] : Matrix (Fin 2) (Fin 2) ℤ) 0 0 : ZMod N) := by
+    refine Delta0UpperUnit_apply_val N ?_
+    -- The witness equation is stated for the `GL₂(ℚ)` matrix underlying the `Δ₀(N)` element;
+    -- that element is the subtype `⟨upperTriRep p j, hmem⟩`, whose coercion to `GL₂(ℚ)` is
+    -- `upperTriRep p j` by definition, which is what `change` exposes.
+    change ((upperTriRep p j : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ) = _
+    rw [coe_upperTriRep]
+    ext i l
+    fin_cases i <;> fin_cases l <;> simp
+  exact Units.ext (by simpa using h)
+
+/-- **The upper-left unit of the twisted representative `σ · diag(p, 1)` is `1`**: its upper-left
+entry is `σ₀₀ p ≡ 1 (mod N)`, by the determinant of `σ`. -/
+@[simp] theorem Delta0UpperUnit_mapGL_mul_scaleRep (hp : 0 < p) (hσ10 : σ 1 0 = (N : ℤ))
+    (hσ11 : σ 1 1 = (p : ℤ)) (hmem : mapGL ℚ σ * scaleRep p ∈ Delta0 N) :
+    Delta0UpperUnit N ⟨mapGL ℚ σ * scaleRep p, hmem⟩ = 1 := by
+  have hdet := Matrix.SpecialLinearGroup.fin_two_mul_sub_mul_eq_one σ
+  have h : (Delta0UpperUnit N ⟨mapGL ℚ σ * scaleRep p, hmem⟩ : ZMod N)
+      = ((!![σ 0 0 * (p : ℤ), σ 0 1; σ 1 0 * (p : ℤ), σ 1 1] : Matrix (Fin 2) (Fin 2) ℤ) 0 0
+          : ZMod N) := by
+    refine Delta0UpperUnit_apply_val N ?_
+    -- As above: the `Δ₀(N)` element is the subtype `⟨mapGL ℚ σ * scaleRep p, hmem⟩`, and its
+    -- underlying `GL₂(ℚ)` matrix is the product, which `change` exposes.
+    change ((mapGL ℚ σ * scaleRep p : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ) = _
+    rw [Units.val_mul, coe_mapGL_int_rat_fin_two, coe_scaleRep p hp]
+    ext i l
+    fin_cases i <;> fin_cases l <;> simp [Matrix.mul_apply, Fin.sum_univ_two]
+  have h1 : ((σ 0 0 * (p : ℤ) : ℤ) : ZMod N) = 1 := by
+    have : σ 0 0 * (p : ℤ) = 1 + σ 0 1 * (N : ℤ) := by
+      rw [← hσ10]
+      linear_combination hdet - σ 0 0 * hσ11
+    rw [this]
+    push_cast
+    simp
+  exact Units.ext (by simpa [h1] using h)
 
 end HeckeRing.GL2

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Prime.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Prime.lean
@@ -1,0 +1,177 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.NumberTheory.HeckeRing.GL2.Gamma0.Diagonal.PrimeCosets
+public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Nebentypus.ModularForm
+public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Operators
+public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Prime
+
+/-!
+# The twisted operator of `diag(1, p)` is the classical `Tₚ` on `S_k(N, χ)`
+
+The `Γ₀(N)` Hecke ring acts on the nebentypus space `S_k(N, χ)` through the `χ`-twisted slash
+sums (`HeckeSlash/Nebentypus/*`), while the classical `Tₚ` on `S_k(Γ₁(N))` is the untwisted sum
+over `Γ₁(N)` cosets (`HeckeSlash/Prime.lean`). This file identifies the two at every prime `p`:
+on `S_k(N, χ)` the twisted operator of the generator `diag(1, p)` **is** the classical `Tₚ`.
+
+## Why the twist disappears
+
+Over `Γ₀(N)` the right cosets of `diag(1, p)` are named by the same `p + 1` representatives as
+over `Γ₁(N)` (`Gamma0/Diagonal/PrimeCosets.lean`): `!![1, j; 0, p]` and `σ · diag(p, 1)` with
+`σ ∈ Γ₀(N)` of bottom row `(N, p)`. The twisting character reads the upper-left unit of a
+representative: it is `1` on the upper-triangular ones, and on `σ · diag(p, 1)` it is `χ(σ₀₀ p)`,
+which is `1` because `σ₀₀ p ≡ 1 (mod N)` by the determinant. So every weight is `1`, and the only
+character that survives is the nebentypus factor `χ(p)` produced by slashing `f` by `σ` — exactly
+the factor the classical formula carries on the `Γ₁(N)` side.
+
+## Main results
+
+* `HeckeRing.GL2.coe_twistedHeckeSlashCuspFormCharEnd_diagCosetGamma0_of_prime`: for `p ∤ N`
+  prime and `f ∈ S_k(N, χ)`, the twisted operator of `diagCosetGamma0 N ![1, p]` at `f` is
+  `heckeTCuspNat k p f`, as functions on `ℍ`.
+* `HeckeRing.GL2.coe_twistedHeckeSlashCuspFormCharEnd_diagCosetGamma0_of_dvd`: the same at a
+  prime `p ∣ N`, where both operators are the upper-triangular `Uₚ`.
+* `HeckeRing.GL2.delta0NebentypusChar_upperTriRep`,
+  `HeckeRing.GL2.delta0NebentypusChar_mapGL_mul_scaleRep`: the twisting character is `1` on both
+  kinds of representative.
+
+## Scope
+
+Only cusp forms; the modular-form version is not treated here.
+
+## Provenance
+
+The prime case of `heckeRingHomCharSpace_D_p_eq_scalar_charRestrict` of the AINTLIB
+`LeanModularForms` project (`LeanModularForms/HeckeRIngs/GL2/Unified/NebentypusHeckeRingHom.lean`,
+Chris Birkbeck, commit `2baa76f742bdb4fb8ee323fabba41203bd390e08`, Apache-2.0,
+<https://github.com/CBirkbeck/AINTLIB/tree/main/projects/LeanModularForms>). In the source the
+twist runs the other way, so its statement carries a factor `χ(p)⁻¹`; with this repository's
+convention (`Nebentypus/Basic.lean`, "Which way the character goes") the factor is `1` and the
+identification is exact.
+-/
+
+public section
+
+open Matrix Matrix.SpecialLinearGroup UpperHalfPlane CongruenceSubgroup DoubleCoset HeckeRing.GLn
+
+open scoped MatrixGroups ModularForm Pointwise
+
+namespace HeckeRing.GL2
+
+variable {N p : ℕ} (k : ℤ) (χ : (ZMod N)ˣ →* ℂˣ)
+
+/-- The twisting character is trivial on an upper-triangular representative: its upper-left
+entry is `1`. -/
+lemma delta0NebentypusChar_upperTriRep (j : Fin p) (hmem : upperTriRep p j ∈ Delta0 N) :
+    delta0NebentypusChar N χ ⟨upperTriRep p j, hmem⟩ = 1 := by
+  rw [delta0NebentypusChar_apply]
+  have h : (Delta0UpperUnit N ⟨upperTriRep p j, hmem⟩ : ZMod N)
+      = ((!![1, (j : ℕ); 0, (p : ℕ)] : Matrix (Fin 2) (Fin 2) ℤ) 0 0 : ZMod N) := by
+    refine Delta0UpperUnit_apply_val N ?_
+    change ((upperTriRep p j : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ) = _
+    rw [coe_upperTriRep]
+    ext i l
+    fin_cases i <;> fin_cases l <;> simp
+  have hu : Delta0UpperUnit N ⟨upperTriRep p j, hmem⟩ = 1 := Units.ext (by simpa using h)
+  rw [hu, map_one]
+
+/-- The twisting character is trivial on the twisted representative `σ · diag(p, 1)`: its
+upper-left entry is `σ₀₀ p ≡ 1 (mod N)`, by the determinant of `σ`. -/
+lemma delta0NebentypusChar_mapGL_mul_scaleRep (hp : 0 < p) {σ : SL(2, ℤ)}
+    (hσ10 : σ 1 0 = (N : ℤ)) (hσ11 : σ 1 1 = (p : ℤ))
+    (hmem : mapGL ℚ σ * scaleRep p ∈ Delta0 N) :
+    delta0NebentypusChar N χ ⟨mapGL ℚ σ * scaleRep p, hmem⟩ = 1 := by
+  rw [delta0NebentypusChar_apply]
+  have hdet := Matrix.SpecialLinearGroup.fin_two_mul_sub_mul_eq_one σ
+  have h : (Delta0UpperUnit N ⟨mapGL ℚ σ * scaleRep p, hmem⟩ : ZMod N)
+      = ((!![σ 0 0 * (p : ℤ), σ 0 1; σ 1 0 * (p : ℤ), σ 1 1] : Matrix (Fin 2) (Fin 2) ℤ) 0 0
+          : ZMod N) := by
+    refine Delta0UpperUnit_apply_val N ?_
+    change ((mapGL ℚ σ * scaleRep p : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ) = _
+    rw [Units.val_mul, coe_mapGL_int_rat_fin_two, coe_scaleRep p hp]
+    ext i l
+    fin_cases i <;> fin_cases l <;> simp [Matrix.mul_apply, Fin.sum_univ_two]
+  have h1 : ((σ 0 0 * (p : ℤ) : ℤ) : ZMod N) = 1 := by
+    have : σ 0 0 * (p : ℤ) = 1 + σ 0 1 * (N : ℤ) := by
+      rw [← hσ10]
+      linear_combination hdet - σ 0 0 * hσ11
+    rw [this]
+    push_cast
+    simp
+  have hu : Delta0UpperUnit N ⟨mapGL ℚ σ * scaleRep p, hmem⟩ = 1 :=
+    Units.ext (by simpa [h1] using h)
+  rw [hu, map_one]
+
+/-- The double coset of the chosen representative of `diagCosetGamma0 N ![1, p]` is that of
+`diag(1, p)`: `HeckeCoset.toSet_eq_doubleCoset_rep` read against `diagCosetGamma0_toSet`. -/
+private theorem doubleCoset_out_diagCosetGamma0 (p : ℕ) :
+    doubleCoset ((diagCosetGamma0 N ![1, p] fun _ ↦ Nat.coprime_one_left N).out :
+        GL (Fin 2) ℚ) ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ)) =
+      doubleCoset (natDiagGL 2 ![1, p]) ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ)) := by
+  rw [← HeckeCoset.rep_def]
+  exact (HeckeCoset.toSet_eq_doubleCoset_rep _).symm.trans (diagCosetGamma0_toSet N _ _)
+
+/-- **The twisted operator of `diag(1, p)` on `S_k(N, χ)` is the classical `Tₚ`**, at a prime
+`p ∤ N`: the `Γ₀(N)` right cosets of `diag(1, p)` are named by the same representatives as the
+`Γ₁(N)` ones, the twisting character is trivial on all of them, and on the twisted representative
+`σ · diag(p, 1)` the slash by `σ ∈ Γ₀(N)` produces the nebentypus factor `χ(p)` that the classical
+formula carries. -/
+theorem coe_twistedHeckeSlashCuspFormCharEnd_diagCosetGamma0_of_prime [NeZero N] (hp : p.Prime)
+    (h : Nat.Coprime p N) (f : cuspFormCharSpace k χ) :
+    ⇑((twistedHeckeSlashCuspFormCharEnd k χ
+        (diagCosetGamma0 N ![1, p] fun _ ↦ Nat.coprime_one_left N) f :
+          CuspForm ((Gamma1 N).map (mapGL ℝ)) k)) =
+      ⇑(heckeTCuspNat k p (_hn := ⟨hp.ne_zero⟩) (f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k)) := by
+  have : NeZero p := ⟨hp.ne_zero⟩
+  have hσ : gamma0Twist N p h ∈ Gamma0 N :=
+    Gamma0_mem.mpr (by rw [gamma0Twist_apply_one_zero h]; exact_mod_cast ZMod.natCast_self N)
+  rw [coe_twistedHeckeSlashCuspFormCharEnd_eq_sum k χ _ (primeRep (gamma0Twist N p h) p)
+      ((doubleCoset_out_diagCosetGamma0 p).trans
+        (doubleCoset_natDiagGL_Gamma0_eq_iUnion_rightCosets_of_prime hp
+          (gamma0Twist_apply_one_zero h) (gamma0Twist_apply_one_one h)))
+      (op_primeRep_smul_injective (G := Gamma0 N) hp.one_lt (gamma0Twist_apply_one_one h)) f,
+    Fintype.sum_option, heckeTCuspNat_def,
+    coe_heckeSlashGamma1CuspFormEnd_diagCosetGamma1_of_mem_cuspFormCharSpace k hp h χ f.2,
+    heckeSlashUpperTri_def]
+  simp only [primeRep_some, primeRep_none, delta0NebentypusChar_upperTriRep χ,
+    delta0NebentypusChar_mapGL_mul_scaleRep χ hp.pos (gamma0Twist_apply_one_zero h)
+      (gamma0Twist_apply_one_one h), Units.val_one, one_smul]
+  have hslash : ⇑(f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k)
+        ∣[k] (mapGL ℚ (gamma0Twist N p h) * scaleRep p)
+      = (χ (ZMod.unitOfCoprime p h) : ℂ)
+        • (⇑(f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) ∣[k] scaleRep p) := by
+    have hunit : (Gamma0Map N).toHomUnits ⟨gamma0Twist N p h, hσ⟩ = ZMod.unitOfCoprime p h := by
+      refine Units.ext ?_
+      rw [MonoidHom.coe_toHomUnits, Gamma0Map_apply, gamma0Twist_apply_one_one h,
+        ZMod.coe_unitOfCoprime]
+      push_cast
+      rfl
+    rw [SlashAction.slash_mul, ModularForm.rat_slash k (mapGL ℚ (gamma0Twist N p h)), map_mapGL,
+      (mem_cuspFormCharSpace_iff_nebentypus k χ _).mp f.2 ⟨gamma0Twist N p h, hσ⟩, hunit,
+      ModularForm.rat_smul_slash_of_det_pos k (det_scaleRep_pos p)]
+  rw [hslash]
+  exact add_comm _ _
+
+/-- **At a prime dividing the level, the twisted operator of `diag(1, p)` is `Uₚ`**: the `Γ₀(N)`
+right cosets of `diag(1, p)` are the `p` upper-triangular ones, every weight is `1`, and the
+classical `Tₚ` is the upper-triangular operator (`heckeTCuspNat_eq_upperTri`). -/
+theorem coe_twistedHeckeSlashCuspFormCharEnd_diagCosetGamma0_of_dvd [NeZero N] (hp : p.Prime)
+    (hpN : p ∣ N) (f : cuspFormCharSpace k χ) :
+    ⇑((twistedHeckeSlashCuspFormCharEnd k χ
+        (diagCosetGamma0 N ![1, p] fun _ ↦ Nat.coprime_one_left N) f :
+          CuspForm ((Gamma1 N).map (mapGL ℝ)) k)) =
+      ⇑(heckeTCuspNat k p (_hn := NeZero.of_dvd hpN)
+        (f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k)) := by
+  have : NeZero p := NeZero.of_dvd hpN
+  rw [coe_twistedHeckeSlashCuspFormCharEnd_eq_sum k χ _ (upperTriRep p)
+      ((doubleCoset_out_diagCosetGamma0 p).trans
+        (doubleCoset_natDiagGL_Gamma0_eq_iUnion_rightCosets_of_dvd hp hpN))
+      (op_upperTriRep_smul_injective (G := Gamma0 N)) f,
+    heckeTCuspNat_eq_upperTri k hpN, coe_heckeSlashUpperTriCuspFormEnd, heckeSlashUpperTri_def]
+  simp only [delta0NebentypusChar_upperTriRep χ, Units.val_one, one_smul]
+
+end HeckeRing.GL2

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Prime.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Prime.lean
@@ -41,18 +41,22 @@ statements read it through the coercions to functions.
 * `HeckeRing.GL2.twistedHeckeSlashSum_diagCosetGamma0_of_prime`,
   `HeckeRing.GL2.twistedHeckeSlashSum_diagCosetGamma0_of_dvd`: on a function with nebentypus
   `χ`, the twisted slash sum of `diag(1, p)` is the classical `Tₚ` formula.
-* `HeckeRing.GL2.coe_twistedHeckeSlashModularFormCharEnd_diagCosetGamma0_of_prime`,
-  `…_of_dvd`, and `HeckeRing.GL2.coe_twistedHeckeSlashCuspFormCharEnd_diagCosetGamma0_of_prime`,
-  `…_of_dvd`: the twisted operator of `diagCosetGamma0 N ![1, p]` is `heckeTNat k p`, resp.
-  `heckeTCuspNat k p`, as functions on `ℍ`.
-* `HeckeRing.GL2.heckeRingHomCharSpace_heckeTGeneratorGamma0_of_prime`, `…_of_dvd`, and
-  `HeckeRing.GL2.heckeRingHomCuspCharSpace_heckeTGeneratorGamma0_of_prime`, `…_of_dvd`: **the
-  Hecke-ring action of the generator `heckeTGeneratorGamma0 N p` on `M_k(N, χ)`, resp.
-  `S_k(N, χ)`, is the classical operator**, as an equality of forms.
+* `HeckeRing.GL2.coe_twistedHeckeSlashModularFormCharEnd_diagCosetGamma0` and
+  `HeckeRing.GL2.coe_twistedHeckeSlashCuspFormCharEnd_diagCosetGamma0`: at every prime `p`, the
+  twisted operator of `diagCosetGamma0 N ![1, p]` is `heckeTNat k p`, resp. `heckeTCuspNat k p`,
+  as functions on `ℍ`.
+* `HeckeRing.GL2.heckeTNat_mem_modFormCharSpace` and
+  `HeckeRing.GL2.heckeTCuspNat_mem_cuspFormCharSpace`: the classical `Tₚ` preserves the nebentypus
+  spaces.
+* `HeckeRing.GL2.heckeRingHomCharSpace_heckeTGeneratorGamma0` and
+  `HeckeRing.GL2.heckeRingHomCuspCharSpace_heckeTGeneratorGamma0`: **the Hecke-ring action of the
+  generator `heckeTGeneratorGamma0 N p` on `M_k(N, χ)`, resp. `S_k(N, χ)`, is the classical
+  operator restricted to the space**, as an equality of endomorphisms; the `coe_…` companions
+  read the same identity on a single form.
 
 ## Scope
 
-Prime indices only; prime powers and multiplicativity are follow-ups.
+This file treats prime indices only.
 
 ## Provenance
 
@@ -127,36 +131,28 @@ theorem twistedHeckeSlashSum_diagCosetGamma0_of_dvd [NeZero N] (hp : p.Prime) (h
   simp only [delta0NebentypusChar_apply, Delta0UpperUnit_upperTriRep, map_one, Units.val_one,
     one_smul]
 
-/-- **At a prime not dividing the level, the twisted operator of `diag(1, p)` on `M_k(N, χ)` is
-the classical `Tₚ`**, as functions on `ℍ`. -/
-theorem coe_twistedHeckeSlashModularFormCharEnd_diagCosetGamma0_of_prime [NeZero N]
-    (hp : p.Prime) (h : Nat.Coprime p N) (f : modFormCharSpace k χ) :
+/-- **At every prime, the twisted operator of `diag(1, p)` on `M_k(N, χ)` is the classical `Tₚ`**,
+as functions on `ℍ`: `Uₚ f + χ(p) • (f ∣[k] diag(p, 1))` when `p ∤ N`, and `Uₚ f` when `p ∣ N`. -/
+theorem coe_twistedHeckeSlashModularFormCharEnd_diagCosetGamma0 [NeZero N] (hp : p.Prime)
+    (f : modFormCharSpace k χ) :
     ⇑((twistedHeckeSlashModularFormCharEnd k χ
         (diagCosetGamma0 N ![1, p] fun _ ↦ Nat.coprime_one_left N) f :
           ModularForm ((Gamma1 N).map (mapGL ℝ)) k)) =
       ⇑(heckeTNat k p (_hn := ⟨hp.ne_zero⟩) (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k)) := by
   have : NeZero p := ⟨hp.ne_zero⟩
-  rw [coe_twistedHeckeSlashModularFormCharEnd, twistedHeckeSlashSum_diagCosetGamma0_of_prime k χ
-    hp h ((coe_mem_functionCharSpace_iff k χ _).mpr f.2), heckeTNat_def,
-    coe_heckeSlashGamma1ModularFormEnd_diagCosetGamma1_of_mem_modFormCharSpace k hp h χ f.2]
+  have hF := (coe_mem_functionCharSpace_iff k χ _).mpr f.2
+  rw [coe_twistedHeckeSlashModularFormCharEnd]
+  by_cases hpN : p ∣ N
+  · rw [twistedHeckeSlashSum_diagCosetGamma0_of_dvd k χ hp hpN hF, heckeTNat_eq_upperTri k hpN,
+      coe_heckeSlashUpperTriModularFormEnd]
+  · have h := hp.coprime_iff_not_dvd.mpr hpN
+    rw [twistedHeckeSlashSum_diagCosetGamma0_of_prime k χ hp h hF, heckeTNat_def,
+      coe_heckeSlashGamma1ModularFormEnd_diagCosetGamma1_of_mem_modFormCharSpace k hp h χ f.2]
 
-/-- **At a prime dividing the level, the twisted operator of `diag(1, p)` on `M_k(N, χ)` is
-`Uₚ`**, as functions on `ℍ`. -/
-theorem coe_twistedHeckeSlashModularFormCharEnd_diagCosetGamma0_of_dvd [NeZero N]
-    (hp : p.Prime) (hpN : p ∣ N) (f : modFormCharSpace k χ) :
-    ⇑((twistedHeckeSlashModularFormCharEnd k χ
-        (diagCosetGamma0 N ![1, p] fun _ ↦ Nat.coprime_one_left N) f :
-          ModularForm ((Gamma1 N).map (mapGL ℝ)) k)) =
-      ⇑(heckeTNat k p (_hn := ⟨hp.ne_zero⟩) (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k)) := by
-  have : NeZero p := ⟨hp.ne_zero⟩
-  rw [coe_twistedHeckeSlashModularFormCharEnd, twistedHeckeSlashSum_diagCosetGamma0_of_dvd k χ
-    hp hpN ((coe_mem_functionCharSpace_iff k χ _).mpr f.2), heckeTNat_eq_upperTri k hpN,
-    coe_heckeSlashUpperTriModularFormEnd]
-
-/-- **At a prime not dividing the level, the twisted operator of `diag(1, p)` on `S_k(N, χ)` is
-the classical `Tₚ`**, as functions on `ℍ`. -/
-theorem coe_twistedHeckeSlashCuspFormCharEnd_diagCosetGamma0_of_prime [NeZero N] (hp : p.Prime)
-    (h : Nat.Coprime p N) (f : cuspFormCharSpace k χ) :
+/-- **At every prime, the twisted operator of `diag(1, p)` on `S_k(N, χ)` is the classical `Tₚ`**,
+as functions on `ℍ`: `Uₚ f + χ(p) • (f ∣[k] diag(p, 1))` when `p ∤ N`, and `Uₚ f` when `p ∣ N`. -/
+theorem coe_twistedHeckeSlashCuspFormCharEnd_diagCosetGamma0 [NeZero N] (hp : p.Prime)
+    (f : cuspFormCharSpace k χ) :
     ⇑((twistedHeckeSlashCuspFormCharEnd k χ
         (diagCosetGamma0 N ![1, p] fun _ ↦ Nat.coprime_one_left N) f :
           CuspForm ((Gamma1 N).map (mapGL ℝ)) k)) =
@@ -164,66 +160,67 @@ theorem coe_twistedHeckeSlashCuspFormCharEnd_diagCosetGamma0_of_prime [NeZero N]
   have : NeZero p := ⟨hp.ne_zero⟩
   have hF : ⇑(f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) ∈ functionCharSpace k χ :=
     (mem_functionCharSpace_iff k χ _).mpr ((mem_cuspFormCharSpace_iff_nebentypus k χ _).mp f.2)
-  rw [coe_twistedHeckeSlashCuspFormCharEnd, twistedHeckeSlashSum_diagCosetGamma0_of_prime k χ
-    hp h hF, heckeTCuspNat_def,
-    coe_heckeSlashGamma1CuspFormEnd_diagCosetGamma1_of_mem_cuspFormCharSpace k hp h χ f.2]
+  rw [coe_twistedHeckeSlashCuspFormCharEnd]
+  by_cases hpN : p ∣ N
+  · rw [twistedHeckeSlashSum_diagCosetGamma0_of_dvd k χ hp hpN hF, heckeTCuspNat_eq_upperTri k hpN,
+      coe_heckeSlashUpperTriCuspFormEnd]
+  · have h := hp.coprime_iff_not_dvd.mpr hpN
+    rw [twistedHeckeSlashSum_diagCosetGamma0_of_prime k χ hp h hF, heckeTCuspNat_def,
+      coe_heckeSlashGamma1CuspFormEnd_diagCosetGamma1_of_mem_cuspFormCharSpace k hp h χ f.2]
 
-/-- **At a prime dividing the level, the twisted operator of `diag(1, p)` on `S_k(N, χ)` is
-`Uₚ`**, as functions on `ℍ`. -/
-theorem coe_twistedHeckeSlashCuspFormCharEnd_diagCosetGamma0_of_dvd [NeZero N] (hp : p.Prime)
-    (hpN : p ∣ N) (f : cuspFormCharSpace k χ) :
-    ⇑((twistedHeckeSlashCuspFormCharEnd k χ
-        (diagCosetGamma0 N ![1, p] fun _ ↦ Nat.coprime_one_left N) f :
-          CuspForm ((Gamma1 N).map (mapGL ℝ)) k)) =
-      ⇑(heckeTCuspNat k p (_hn := ⟨hp.ne_zero⟩) (f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k)) := by
-  have : NeZero p := ⟨hp.ne_zero⟩
-  have hF : ⇑(f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) ∈ functionCharSpace k χ :=
-    (mem_functionCharSpace_iff k χ _).mpr ((mem_cuspFormCharSpace_iff_nebentypus k χ _).mp f.2)
-  rw [coe_twistedHeckeSlashCuspFormCharEnd, twistedHeckeSlashSum_diagCosetGamma0_of_dvd k χ
-    hp hpN hF, heckeTCuspNat_eq_upperTri k hpN, coe_heckeSlashUpperTriCuspFormEnd]
-
-/-- **The Hecke-ring generator at a prime `p ∤ N` acts on `M_k(N, χ)` as the classical `Tₚ`.** -/
-theorem heckeRingHomCharSpace_heckeTGeneratorGamma0_of_prime [NeZero N] (hp : p.Prime)
-    (h : Nat.Coprime p N) (f : modFormCharSpace k χ) :
+/-- **The Hecke-ring generator at a prime acts on `M_k(N, χ)` as the classical `Tₚ`**, on each
+form. -/
+theorem coe_heckeRingHomCharSpace_heckeTGeneratorGamma0 [NeZero N] (hp : p.Prime)
+    (f : modFormCharSpace k χ) :
     (heckeRingHomCharSpace k χ (heckeTGeneratorGamma0 N p) f :
         ModularForm ((Gamma1 N).map (mapGL ℝ)) k) =
       heckeTNat k p (_hn := ⟨hp.ne_zero⟩) (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) := by
   rw [heckeTGeneratorGamma0_eq_single N hp.pos, heckeRingHomCharSpace_apply,
     twistedHeckeSlashModularFormCharLinearMap_single, one_smul]
   exact DFunLike.coe_injective
-    (coe_twistedHeckeSlashModularFormCharEnd_diagCosetGamma0_of_prime k χ hp h f)
+    (coe_twistedHeckeSlashModularFormCharEnd_diagCosetGamma0 k χ hp f)
 
-/-- **The Hecke-ring generator at a prime `p ∣ N` acts on `M_k(N, χ)` as `Uₚ = Tₚ`.** -/
-theorem heckeRingHomCharSpace_heckeTGeneratorGamma0_of_dvd [NeZero N] (hp : p.Prime)
-    (hpN : p ∣ N) (f : modFormCharSpace k χ) :
-    (heckeRingHomCharSpace k χ (heckeTGeneratorGamma0 N p) f :
-        ModularForm ((Gamma1 N).map (mapGL ℝ)) k) =
-      heckeTNat k p (_hn := ⟨hp.ne_zero⟩) (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) := by
-  rw [heckeTGeneratorGamma0_eq_single N hp.pos, heckeRingHomCharSpace_apply,
-    twistedHeckeSlashModularFormCharLinearMap_single, one_smul]
-  exact DFunLike.coe_injective
-    (coe_twistedHeckeSlashModularFormCharEnd_diagCosetGamma0_of_dvd k χ hp hpN f)
-
-/-- **The Hecke-ring generator at a prime `p ∤ N` acts on `S_k(N, χ)` as the classical `Tₚ`.** -/
-theorem heckeRingHomCuspCharSpace_heckeTGeneratorGamma0_of_prime [NeZero N] (hp : p.Prime)
-    (h : Nat.Coprime p N) (f : cuspFormCharSpace k χ) :
+/-- **The Hecke-ring generator at a prime acts on `S_k(N, χ)` as the classical `Tₚ`**, on each
+form. -/
+theorem coe_heckeRingHomCuspCharSpace_heckeTGeneratorGamma0 [NeZero N] (hp : p.Prime)
+    (f : cuspFormCharSpace k χ) :
     (heckeRingHomCuspCharSpace k χ (heckeTGeneratorGamma0 N p) f :
         CuspForm ((Gamma1 N).map (mapGL ℝ)) k) =
       heckeTCuspNat k p (_hn := ⟨hp.ne_zero⟩) (f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) := by
   rw [heckeTGeneratorGamma0_eq_single N hp.pos, heckeRingHomCuspCharSpace_apply,
     twistedHeckeSlashCuspFormCharLinearMap_single, one_smul]
   exact DFunLike.coe_injective
-    (coe_twistedHeckeSlashCuspFormCharEnd_diagCosetGamma0_of_prime k χ hp h f)
+    (coe_twistedHeckeSlashCuspFormCharEnd_diagCosetGamma0 k χ hp f)
 
-/-- **The Hecke-ring generator at a prime `p ∣ N` acts on `S_k(N, χ)` as `Uₚ = Tₚ`.** -/
-theorem heckeRingHomCuspCharSpace_heckeTGeneratorGamma0_of_dvd [NeZero N] (hp : p.Prime)
-    (hpN : p ∣ N) (f : cuspFormCharSpace k χ) :
-    (heckeRingHomCuspCharSpace k χ (heckeTGeneratorGamma0 N p) f :
-        CuspForm ((Gamma1 N).map (mapGL ℝ)) k) =
-      heckeTCuspNat k p (_hn := ⟨hp.ne_zero⟩) (f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) := by
-  rw [heckeTGeneratorGamma0_eq_single N hp.pos, heckeRingHomCuspCharSpace_apply,
-    twistedHeckeSlashCuspFormCharLinearMap_single, one_smul]
-  exact DFunLike.coe_injective
-    (coe_twistedHeckeSlashCuspFormCharEnd_diagCosetGamma0_of_dvd k χ hp hpN f)
+/-- **The classical `Tₚ` preserves `M_k(N, χ)`**: it agrees there with the Hecke-ring action. -/
+theorem heckeTNat_mem_modFormCharSpace [NeZero N] (hp : p.Prime)
+    {f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k} (hf : f ∈ modFormCharSpace k χ) :
+    heckeTNat k p (_hn := ⟨hp.ne_zero⟩) f ∈ modFormCharSpace k χ :=
+  coe_heckeRingHomCharSpace_heckeTGeneratorGamma0 k χ hp ⟨f, hf⟩ ▸
+    (heckeRingHomCharSpace k χ (heckeTGeneratorGamma0 N p) ⟨f, hf⟩).2
+
+/-- **The classical `Tₚ` preserves `S_k(N, χ)`**: it agrees there with the Hecke-ring action. -/
+theorem heckeTCuspNat_mem_cuspFormCharSpace [NeZero N] (hp : p.Prime)
+    {f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k} (hf : f ∈ cuspFormCharSpace k χ) :
+    heckeTCuspNat k p (_hn := ⟨hp.ne_zero⟩) f ∈ cuspFormCharSpace k χ :=
+  coe_heckeRingHomCuspCharSpace_heckeTGeneratorGamma0 k χ hp ⟨f, hf⟩ ▸
+    (heckeRingHomCuspCharSpace k χ (heckeTGeneratorGamma0 N p) ⟨f, hf⟩).2
+
+/-- **The Hecke-ring generator at a prime acts on `M_k(N, χ)` as the classical `Tₚ`**, as an
+equality of endomorphisms of the space. -/
+theorem heckeRingHomCharSpace_heckeTGeneratorGamma0 [NeZero N] (hp : p.Prime) :
+    heckeRingHomCharSpace k χ (heckeTGeneratorGamma0 N p) =
+      (heckeTNat k p (_hn := ⟨hp.ne_zero⟩)).restrict
+        fun _ hf ↦ heckeTNat_mem_modFormCharSpace k χ hp hf :=
+  LinearMap.ext fun f ↦ Subtype.ext (coe_heckeRingHomCharSpace_heckeTGeneratorGamma0 k χ hp f)
+
+/-- **The Hecke-ring generator at a prime acts on `S_k(N, χ)` as the classical `Tₚ`**, as an
+equality of endomorphisms of the space. -/
+theorem heckeRingHomCuspCharSpace_heckeTGeneratorGamma0 [NeZero N] (hp : p.Prime) :
+    heckeRingHomCuspCharSpace k χ (heckeTGeneratorGamma0 N p) =
+      (heckeTCuspNat k p (_hn := ⟨hp.ne_zero⟩)).restrict
+        fun _ hf ↦ heckeTCuspNat_mem_cuspFormCharSpace k χ hp hf :=
+  LinearMap.ext fun f ↦
+    Subtype.ext (coe_heckeRingHomCuspCharSpace_heckeTGeneratorGamma0 k χ hp f)
 
 end HeckeRing.GL2

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Prime.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Prime.lean
@@ -6,42 +6,54 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.NumberTheory.HeckeRing.GL2.Gamma0.Diagonal.PrimeCosets
+public import TauCeti.NumberTheory.HeckeRing.GL2.Gamma0.Diagonal.PrimePower
+public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Nebentypus.Action
 public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Nebentypus.ModularForm
 public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Operators
-public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Prime
 
 /-!
-# The twisted operator of `diag(1, p)` is the classical `Tₚ` on `S_k(N, χ)`
+# The twisted operator of `diag(1, p)` is the classical `Tₚ` on `M_k(N, χ)` and `S_k(N, χ)`
 
-The `Γ₀(N)` Hecke ring acts on the nebentypus space `S_k(N, χ)` through the `χ`-twisted slash
-sums (`HeckeSlash/Nebentypus/*`), while the classical `Tₚ` on `S_k(Γ₁(N))` is the untwisted sum
-over `Γ₁(N)` cosets (`HeckeSlash/Prime.lean`). This file identifies the two at every prime `p`:
-on `S_k(N, χ)` the twisted operator of the generator `diag(1, p)` **is** the classical `Tₚ`.
+The `Γ₀(N)` Hecke ring acts on the nebentypus spaces `M_k(N, χ)` and `S_k(N, χ)` through the
+`χ`-twisted slash sums (`HeckeSlash/Nebentypus/*`), while the classical `Tₚ` on `M_k(Γ₁(N))` and
+`S_k(Γ₁(N))` is the untwisted sum over `Γ₁(N)` cosets (`HeckeSlash/Prime.lean`). This file
+identifies the two at every prime `p`: on the nebentypus spaces the twisted operator of the
+generator `diag(1, p)` **is** the classical `Tₚ`.
 
 ## Why the twist disappears
 
-Over `Γ₀(N)` the right cosets of `diag(1, p)` are named by the same `p + 1` representatives as
-over `Γ₁(N)` (`Gamma0/Diagonal/PrimeCosets.lean`): `!![1, j; 0, p]` and `σ · diag(p, 1)` with
-`σ ∈ Γ₀(N)` of bottom row `(N, p)`. The twisting character reads the upper-left unit of a
-representative: it is `1` on the upper-triangular ones, and on `σ · diag(p, 1)` it is `χ(σ₀₀ p)`,
-which is `1` because `σ₀₀ p ≡ 1 (mod N)` by the determinant. So every weight is `1`, and the only
-character that survives is the nebentypus factor `χ(p)` produced by slashing `f` by `σ` — exactly
-the factor the classical formula carries on the `Γ₁(N)` side.
+At a prime `p ∤ N`, the `Γ₀(N)` right cosets of `diag(1, p)` are named by the same `p + 1`
+representatives as over `Γ₁(N)` (`Gamma0/Diagonal/PrimeCosets.lean`): `!![1, j; 0, p]` and
+`σ · diag(p, 1)` with `σ ∈ Γ₀(N)` of bottom row `(N, p)`. The twisting character reads the
+upper-left unit of a representative: it is `1` on the upper-triangular ones, and on
+`σ · diag(p, 1)` it is `χ(σ₀₀ p)`, which is `1` because `σ₀₀ p ≡ 1 (mod N)` by the determinant
+(`Delta0UpperUnit_upperTriRep`, `Delta0UpperUnit_mapGL_mul_scaleRep`). So every weight is `1`,
+and the only character that survives is the nebentypus factor `χ(p)` produced by slashing `f` by
+`σ` — exactly the factor the classical formula carries on the `Γ₁(N)` side. At a prime `p ∣ N`
+there are only the `p` upper-triangular representatives, all of weight `1`, and both operators
+are the upper-triangular `Uₚ`.
+
+The computation happens once, on functions with the nebentypus `χ`
+(`twistedHeckeSlashSum_diagCosetGamma0_of_prime`, `…_of_dvd`); the modular-form and cusp-form
+statements read it through the coercions to functions.
 
 ## Main results
 
-* `HeckeRing.GL2.coe_twistedHeckeSlashCuspFormCharEnd_diagCosetGamma0_of_prime`: for `p ∤ N`
-  prime and `f ∈ S_k(N, χ)`, the twisted operator of `diagCosetGamma0 N ![1, p]` at `f` is
-  `heckeTCuspNat k p f`, as functions on `ℍ`.
-* `HeckeRing.GL2.coe_twistedHeckeSlashCuspFormCharEnd_diagCosetGamma0_of_dvd`: the same at a
-  prime `p ∣ N`, where both operators are the upper-triangular `Uₚ`.
-* `HeckeRing.GL2.delta0NebentypusChar_upperTriRep`,
-  `HeckeRing.GL2.delta0NebentypusChar_mapGL_mul_scaleRep`: the twisting character is `1` on both
-  kinds of representative.
+* `HeckeRing.GL2.twistedHeckeSlashSum_diagCosetGamma0_of_prime`,
+  `HeckeRing.GL2.twistedHeckeSlashSum_diagCosetGamma0_of_dvd`: on a function with nebentypus
+  `χ`, the twisted slash sum of `diag(1, p)` is the classical `Tₚ` formula.
+* `HeckeRing.GL2.coe_twistedHeckeSlashModularFormCharEnd_diagCosetGamma0_of_prime`,
+  `…_of_dvd`, and `HeckeRing.GL2.coe_twistedHeckeSlashCuspFormCharEnd_diagCosetGamma0_of_prime`,
+  `…_of_dvd`: the twisted operator of `diagCosetGamma0 N ![1, p]` is `heckeTNat k p`, resp.
+  `heckeTCuspNat k p`, as functions on `ℍ`.
+* `HeckeRing.GL2.heckeRingHomCharSpace_heckeTGeneratorGamma0_of_prime`, `…_of_dvd`, and
+  `HeckeRing.GL2.heckeRingHomCuspCharSpace_heckeTGeneratorGamma0_of_prime`, `…_of_dvd`: **the
+  Hecke-ring action of the generator `heckeTGeneratorGamma0 N p` on `M_k(N, χ)`, resp.
+  `S_k(N, χ)`, is the classical operator**, as an equality of forms.
 
 ## Scope
 
-Only cusp forms; the modular-form version is not treated here.
+Prime indices only; prime powers and multiplicativity are follow-ups.
 
 ## Provenance
 
@@ -64,50 +76,11 @@ namespace HeckeRing.GL2
 
 variable {N p : ℕ} (k : ℤ) (χ : (ZMod N)ˣ →* ℂˣ)
 
-/-- The twisting character is trivial on an upper-triangular representative: its upper-left
-entry is `1`. -/
-lemma delta0NebentypusChar_upperTriRep (j : Fin p) (hmem : upperTriRep p j ∈ Delta0 N) :
-    delta0NebentypusChar N χ ⟨upperTriRep p j, hmem⟩ = 1 := by
-  rw [delta0NebentypusChar_apply]
-  have h : (Delta0UpperUnit N ⟨upperTriRep p j, hmem⟩ : ZMod N)
-      = ((!![1, (j : ℕ); 0, (p : ℕ)] : Matrix (Fin 2) (Fin 2) ℤ) 0 0 : ZMod N) := by
-    refine Delta0UpperUnit_apply_val N ?_
-    change ((upperTriRep p j : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ) = _
-    rw [coe_upperTriRep]
-    ext i l
-    fin_cases i <;> fin_cases l <;> simp
-  have hu : Delta0UpperUnit N ⟨upperTriRep p j, hmem⟩ = 1 := Units.ext (by simpa using h)
-  rw [hu, map_one]
-
-/-- The twisting character is trivial on the twisted representative `σ · diag(p, 1)`: its
-upper-left entry is `σ₀₀ p ≡ 1 (mod N)`, by the determinant of `σ`. -/
-lemma delta0NebentypusChar_mapGL_mul_scaleRep (hp : 0 < p) {σ : SL(2, ℤ)}
-    (hσ10 : σ 1 0 = (N : ℤ)) (hσ11 : σ 1 1 = (p : ℤ))
-    (hmem : mapGL ℚ σ * scaleRep p ∈ Delta0 N) :
-    delta0NebentypusChar N χ ⟨mapGL ℚ σ * scaleRep p, hmem⟩ = 1 := by
-  rw [delta0NebentypusChar_apply]
-  have hdet := Matrix.SpecialLinearGroup.fin_two_mul_sub_mul_eq_one σ
-  have h : (Delta0UpperUnit N ⟨mapGL ℚ σ * scaleRep p, hmem⟩ : ZMod N)
-      = ((!![σ 0 0 * (p : ℤ), σ 0 1; σ 1 0 * (p : ℤ), σ 1 1] : Matrix (Fin 2) (Fin 2) ℤ) 0 0
-          : ZMod N) := by
-    refine Delta0UpperUnit_apply_val N ?_
-    change ((mapGL ℚ σ * scaleRep p : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ) = _
-    rw [Units.val_mul, coe_mapGL_int_rat_fin_two, coe_scaleRep p hp]
-    ext i l
-    fin_cases i <;> fin_cases l <;> simp [Matrix.mul_apply, Fin.sum_univ_two]
-  have h1 : ((σ 0 0 * (p : ℤ) : ℤ) : ZMod N) = 1 := by
-    have : σ 0 0 * (p : ℤ) = 1 + σ 0 1 * (N : ℤ) := by
-      rw [← hσ10]
-      linear_combination hdet - σ 0 0 * hσ11
-    rw [this]
-    push_cast
-    simp
-  have hu : Delta0UpperUnit N ⟨mapGL ℚ σ * scaleRep p, hmem⟩ = 1 :=
-    Units.ext (by simpa [h1] using h)
-  rw [hu, map_one]
-
 /-- The double coset of the chosen representative of `diagCosetGamma0 N ![1, p]` is that of
-`diag(1, p)`: `HeckeCoset.toSet_eq_doubleCoset_rep` read against `diagCosetGamma0_toSet`. -/
+`diag(1, p)`: `HeckeCoset.toSet_eq_doubleCoset_rep` read against `diagCosetGamma0_toSet`. Kept
+private: the public decompositions of `Gamma0/Diagonal/PrimeCosets.lean` are stated at
+`diag(1, p)` itself, and this is only the adaptor to the representative the twisted slash sums
+carry. -/
 private theorem doubleCoset_out_diagCosetGamma0 (p : ℕ) :
     doubleCoset ((diagCosetGamma0 N ![1, p] fun _ ↦ Nat.coprime_one_left N).out :
         GL (Fin 2) ℚ) ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ)) =
@@ -115,11 +88,74 @@ private theorem doubleCoset_out_diagCosetGamma0 (p : ℕ) :
   rw [← HeckeCoset.rep_def]
   exact (HeckeCoset.toSet_eq_doubleCoset_rep _).symm.trans (diagCosetGamma0_toSet N _ _)
 
-/-- **The twisted operator of `diag(1, p)` on `S_k(N, χ)` is the classical `Tₚ`**, at a prime
-`p ∤ N`: the `Γ₀(N)` right cosets of `diag(1, p)` are named by the same representatives as the
-`Γ₁(N)` ones, the twisting character is trivial on all of them, and on the twisted representative
-`σ · diag(p, 1)` the slash by `σ ∈ Γ₀(N)` produces the nebentypus factor `χ(p)` that the classical
-formula carries. -/
+/-- **The twisted slash sum of `diag(1, p)` at a prime `p ∤ N`, on a function with nebentypus
+`χ`**: `Uₚ f + χ(p) • (f ∣[k] diag(p, 1))`, the classical `Tₚ` formula. -/
+theorem twistedHeckeSlashSum_diagCosetGamma0_of_prime [NeZero N] (hp : p.Prime)
+    (h : Nat.Coprime p N) {F : ℍ → ℂ} (hF : F ∈ functionCharSpace k χ) :
+    twistedHeckeSlashSum k χ (diagCosetGamma0 N ![1, p] fun _ ↦ Nat.coprime_one_left N) F =
+      heckeSlashUpperTri k p F + (χ (ZMod.unitOfCoprime p h) : ℂ) • (F ∣[k] scaleRep p) := by
+  have : NeZero p := ⟨hp.ne_zero⟩
+  rw [twistedHeckeSlashSum_eq_sum_of_rightCosets k χ _ (primeRep (gamma0Twist N p h) p)
+      ((doubleCoset_out_diagCosetGamma0 p).trans
+        (doubleCoset_natDiagGL_Gamma0_eq_iUnion_rightCosets_of_prime hp
+          (gamma0Twist_apply_one_zero h) (gamma0Twist_apply_one_one h)))
+      (op_primeRep_smul_injective (G := Gamma0 N) hp.one_lt (gamma0Twist_apply_one_one h)) F hF,
+    Fintype.sum_option, heckeSlashUpperTri_def]
+  simp only [primeRep_some, primeRep_none, delta0NebentypusChar_apply,
+    Delta0UpperUnit_upperTriRep, Delta0UpperUnit_mapGL_mul_scaleRep hp.pos
+      (gamma0Twist_apply_one_zero h) (gamma0Twist_apply_one_one h), map_one, Units.val_one,
+    one_smul]
+  have hslash : F ∣[k] (mapGL ℚ (gamma0Twist N p h) * scaleRep p)
+      = (χ (ZMod.unitOfCoprime p h) : ℂ) • (F ∣[k] scaleRep p) := by
+    rw [SlashAction.slash_mul, ModularForm.rat_slash k (mapGL ℚ (gamma0Twist N p h)), map_mapGL,
+      (mem_functionCharSpace_iff k χ F).mp hF ⟨gamma0Twist N p h, gamma0Twist_mem_Gamma0 h⟩,
+      Gamma0Map_toHomUnits_gamma0Twist h,
+      ModularForm.rat_smul_slash_of_det_pos k (det_scaleRep_pos p)]
+  rw [hslash]
+  exact add_comm _ _
+
+/-- **The twisted slash sum of `diag(1, p)` at a prime `p ∣ N`, on a function with nebentypus
+`χ`**: the upper-triangular operator `Uₚ`. -/
+theorem twistedHeckeSlashSum_diagCosetGamma0_of_dvd [NeZero N] (hp : p.Prime) (hpN : p ∣ N)
+    {F : ℍ → ℂ} (hF : F ∈ functionCharSpace k χ) :
+    twistedHeckeSlashSum k χ (diagCosetGamma0 N ![1, p] fun _ ↦ Nat.coprime_one_left N) F =
+      heckeSlashUpperTri k p F := by
+  have : NeZero p := ⟨hp.ne_zero⟩
+  rw [twistedHeckeSlashSum_eq_sum_of_rightCosets k χ _ (upperTriRep p)
+      ((doubleCoset_out_diagCosetGamma0 p).trans
+        (doubleCoset_natDiagGL_Gamma0_eq_iUnion_rightCosets_of_dvd hp hpN))
+      (op_upperTriRep_smul_injective (G := Gamma0 N)) F hF, heckeSlashUpperTri_def]
+  simp only [delta0NebentypusChar_apply, Delta0UpperUnit_upperTriRep, map_one, Units.val_one,
+    one_smul]
+
+/-- **At a prime not dividing the level, the twisted operator of `diag(1, p)` on `M_k(N, χ)` is
+the classical `Tₚ`**, as functions on `ℍ`. -/
+theorem coe_twistedHeckeSlashModularFormCharEnd_diagCosetGamma0_of_prime [NeZero N]
+    (hp : p.Prime) (h : Nat.Coprime p N) (f : modFormCharSpace k χ) :
+    ⇑((twistedHeckeSlashModularFormCharEnd k χ
+        (diagCosetGamma0 N ![1, p] fun _ ↦ Nat.coprime_one_left N) f :
+          ModularForm ((Gamma1 N).map (mapGL ℝ)) k)) =
+      ⇑(heckeTNat k p (_hn := ⟨hp.ne_zero⟩) (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k)) := by
+  have : NeZero p := ⟨hp.ne_zero⟩
+  rw [coe_twistedHeckeSlashModularFormCharEnd, twistedHeckeSlashSum_diagCosetGamma0_of_prime k χ
+    hp h ((coe_mem_functionCharSpace_iff k χ _).mpr f.2), heckeTNat_def,
+    coe_heckeSlashGamma1ModularFormEnd_diagCosetGamma1_of_mem_modFormCharSpace k hp h χ f.2]
+
+/-- **At a prime dividing the level, the twisted operator of `diag(1, p)` on `M_k(N, χ)` is
+`Uₚ`**, as functions on `ℍ`. -/
+theorem coe_twistedHeckeSlashModularFormCharEnd_diagCosetGamma0_of_dvd [NeZero N]
+    (hp : p.Prime) (hpN : p ∣ N) (f : modFormCharSpace k χ) :
+    ⇑((twistedHeckeSlashModularFormCharEnd k χ
+        (diagCosetGamma0 N ![1, p] fun _ ↦ Nat.coprime_one_left N) f :
+          ModularForm ((Gamma1 N).map (mapGL ℝ)) k)) =
+      ⇑(heckeTNat k p (_hn := ⟨hp.ne_zero⟩) (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k)) := by
+  have : NeZero p := ⟨hp.ne_zero⟩
+  rw [coe_twistedHeckeSlashModularFormCharEnd, twistedHeckeSlashSum_diagCosetGamma0_of_dvd k χ
+    hp hpN ((coe_mem_functionCharSpace_iff k χ _).mpr f.2), heckeTNat_eq_upperTri k hpN,
+    coe_heckeSlashUpperTriModularFormEnd]
+
+/-- **At a prime not dividing the level, the twisted operator of `diag(1, p)` on `S_k(N, χ)` is
+the classical `Tₚ`**, as functions on `ℍ`. -/
 theorem coe_twistedHeckeSlashCuspFormCharEnd_diagCosetGamma0_of_prime [NeZero N] (hp : p.Prime)
     (h : Nat.Coprime p N) (f : cuspFormCharSpace k χ) :
     ⇑((twistedHeckeSlashCuspFormCharEnd k χ
@@ -127,51 +163,68 @@ theorem coe_twistedHeckeSlashCuspFormCharEnd_diagCosetGamma0_of_prime [NeZero N]
           CuspForm ((Gamma1 N).map (mapGL ℝ)) k)) =
       ⇑(heckeTCuspNat k p (_hn := ⟨hp.ne_zero⟩) (f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k)) := by
   have : NeZero p := ⟨hp.ne_zero⟩
-  have hσ : gamma0Twist N p h ∈ Gamma0 N :=
-    Gamma0_mem.mpr (by rw [gamma0Twist_apply_one_zero h]; exact_mod_cast ZMod.natCast_self N)
-  rw [coe_twistedHeckeSlashCuspFormCharEnd_eq_sum k χ _ (primeRep (gamma0Twist N p h) p)
-      ((doubleCoset_out_diagCosetGamma0 p).trans
-        (doubleCoset_natDiagGL_Gamma0_eq_iUnion_rightCosets_of_prime hp
-          (gamma0Twist_apply_one_zero h) (gamma0Twist_apply_one_one h)))
-      (op_primeRep_smul_injective (G := Gamma0 N) hp.one_lt (gamma0Twist_apply_one_one h)) f,
-    Fintype.sum_option, heckeTCuspNat_def,
-    coe_heckeSlashGamma1CuspFormEnd_diagCosetGamma1_of_mem_cuspFormCharSpace k hp h χ f.2,
-    heckeSlashUpperTri_def]
-  simp only [primeRep_some, primeRep_none, delta0NebentypusChar_upperTriRep χ,
-    delta0NebentypusChar_mapGL_mul_scaleRep χ hp.pos (gamma0Twist_apply_one_zero h)
-      (gamma0Twist_apply_one_one h), Units.val_one, one_smul]
-  have hslash : ⇑(f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k)
-        ∣[k] (mapGL ℚ (gamma0Twist N p h) * scaleRep p)
-      = (χ (ZMod.unitOfCoprime p h) : ℂ)
-        • (⇑(f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) ∣[k] scaleRep p) := by
-    have hunit : (Gamma0Map N).toHomUnits ⟨gamma0Twist N p h, hσ⟩ = ZMod.unitOfCoprime p h := by
-      refine Units.ext ?_
-      rw [MonoidHom.coe_toHomUnits, Gamma0Map_apply, gamma0Twist_apply_one_one h,
-        ZMod.coe_unitOfCoprime]
-      push_cast
-      rfl
-    rw [SlashAction.slash_mul, ModularForm.rat_slash k (mapGL ℚ (gamma0Twist N p h)), map_mapGL,
-      (mem_cuspFormCharSpace_iff_nebentypus k χ _).mp f.2 ⟨gamma0Twist N p h, hσ⟩, hunit,
-      ModularForm.rat_smul_slash_of_det_pos k (det_scaleRep_pos p)]
-  rw [hslash]
-  exact add_comm _ _
+  have hF : ⇑(f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) ∈ functionCharSpace k χ :=
+    (mem_functionCharSpace_iff k χ _).mpr ((mem_cuspFormCharSpace_iff_nebentypus k χ _).mp f.2)
+  rw [coe_twistedHeckeSlashCuspFormCharEnd, twistedHeckeSlashSum_diagCosetGamma0_of_prime k χ
+    hp h hF, heckeTCuspNat_def,
+    coe_heckeSlashGamma1CuspFormEnd_diagCosetGamma1_of_mem_cuspFormCharSpace k hp h χ f.2]
 
-/-- **At a prime dividing the level, the twisted operator of `diag(1, p)` is `Uₚ`**: the `Γ₀(N)`
-right cosets of `diag(1, p)` are the `p` upper-triangular ones, every weight is `1`, and the
-classical `Tₚ` is the upper-triangular operator (`heckeTCuspNat_eq_upperTri`). -/
+/-- **At a prime dividing the level, the twisted operator of `diag(1, p)` on `S_k(N, χ)` is
+`Uₚ`**, as functions on `ℍ`. -/
 theorem coe_twistedHeckeSlashCuspFormCharEnd_diagCosetGamma0_of_dvd [NeZero N] (hp : p.Prime)
     (hpN : p ∣ N) (f : cuspFormCharSpace k χ) :
     ⇑((twistedHeckeSlashCuspFormCharEnd k χ
         (diagCosetGamma0 N ![1, p] fun _ ↦ Nat.coprime_one_left N) f :
           CuspForm ((Gamma1 N).map (mapGL ℝ)) k)) =
-      ⇑(heckeTCuspNat k p (_hn := NeZero.of_dvd hpN)
-        (f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k)) := by
-  have : NeZero p := NeZero.of_dvd hpN
-  rw [coe_twistedHeckeSlashCuspFormCharEnd_eq_sum k χ _ (upperTriRep p)
-      ((doubleCoset_out_diagCosetGamma0 p).trans
-        (doubleCoset_natDiagGL_Gamma0_eq_iUnion_rightCosets_of_dvd hp hpN))
-      (op_upperTriRep_smul_injective (G := Gamma0 N)) f,
-    heckeTCuspNat_eq_upperTri k hpN, coe_heckeSlashUpperTriCuspFormEnd, heckeSlashUpperTri_def]
-  simp only [delta0NebentypusChar_upperTriRep χ, Units.val_one, one_smul]
+      ⇑(heckeTCuspNat k p (_hn := ⟨hp.ne_zero⟩) (f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k)) := by
+  have : NeZero p := ⟨hp.ne_zero⟩
+  have hF : ⇑(f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) ∈ functionCharSpace k χ :=
+    (mem_functionCharSpace_iff k χ _).mpr ((mem_cuspFormCharSpace_iff_nebentypus k χ _).mp f.2)
+  rw [coe_twistedHeckeSlashCuspFormCharEnd, twistedHeckeSlashSum_diagCosetGamma0_of_dvd k χ
+    hp hpN hF, heckeTCuspNat_eq_upperTri k hpN, coe_heckeSlashUpperTriCuspFormEnd]
+
+/-- **The Hecke-ring generator at a prime `p ∤ N` acts on `M_k(N, χ)` as the classical `Tₚ`.** -/
+theorem heckeRingHomCharSpace_heckeTGeneratorGamma0_of_prime [NeZero N] (hp : p.Prime)
+    (h : Nat.Coprime p N) (f : modFormCharSpace k χ) :
+    (heckeRingHomCharSpace k χ (heckeTGeneratorGamma0 N p) f :
+        ModularForm ((Gamma1 N).map (mapGL ℝ)) k) =
+      heckeTNat k p (_hn := ⟨hp.ne_zero⟩) (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) := by
+  rw [heckeTGeneratorGamma0_eq_single N hp.pos, heckeRingHomCharSpace_apply,
+    twistedHeckeSlashModularFormCharLinearMap_single, one_smul]
+  exact DFunLike.coe_injective
+    (coe_twistedHeckeSlashModularFormCharEnd_diagCosetGamma0_of_prime k χ hp h f)
+
+/-- **The Hecke-ring generator at a prime `p ∣ N` acts on `M_k(N, χ)` as `Uₚ = Tₚ`.** -/
+theorem heckeRingHomCharSpace_heckeTGeneratorGamma0_of_dvd [NeZero N] (hp : p.Prime)
+    (hpN : p ∣ N) (f : modFormCharSpace k χ) :
+    (heckeRingHomCharSpace k χ (heckeTGeneratorGamma0 N p) f :
+        ModularForm ((Gamma1 N).map (mapGL ℝ)) k) =
+      heckeTNat k p (_hn := ⟨hp.ne_zero⟩) (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) := by
+  rw [heckeTGeneratorGamma0_eq_single N hp.pos, heckeRingHomCharSpace_apply,
+    twistedHeckeSlashModularFormCharLinearMap_single, one_smul]
+  exact DFunLike.coe_injective
+    (coe_twistedHeckeSlashModularFormCharEnd_diagCosetGamma0_of_dvd k χ hp hpN f)
+
+/-- **The Hecke-ring generator at a prime `p ∤ N` acts on `S_k(N, χ)` as the classical `Tₚ`.** -/
+theorem heckeRingHomCuspCharSpace_heckeTGeneratorGamma0_of_prime [NeZero N] (hp : p.Prime)
+    (h : Nat.Coprime p N) (f : cuspFormCharSpace k χ) :
+    (heckeRingHomCuspCharSpace k χ (heckeTGeneratorGamma0 N p) f :
+        CuspForm ((Gamma1 N).map (mapGL ℝ)) k) =
+      heckeTCuspNat k p (_hn := ⟨hp.ne_zero⟩) (f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) := by
+  rw [heckeTGeneratorGamma0_eq_single N hp.pos, heckeRingHomCuspCharSpace_apply,
+    twistedHeckeSlashCuspFormCharLinearMap_single, one_smul]
+  exact DFunLike.coe_injective
+    (coe_twistedHeckeSlashCuspFormCharEnd_diagCosetGamma0_of_prime k χ hp h f)
+
+/-- **The Hecke-ring generator at a prime `p ∣ N` acts on `S_k(N, χ)` as `Uₚ = Tₚ`.** -/
+theorem heckeRingHomCuspCharSpace_heckeTGeneratorGamma0_of_dvd [NeZero N] (hp : p.Prime)
+    (hpN : p ∣ N) (f : cuspFormCharSpace k χ) :
+    (heckeRingHomCuspCharSpace k χ (heckeTGeneratorGamma0 N p) f :
+        CuspForm ((Gamma1 N).map (mapGL ℝ)) k) =
+      heckeTCuspNat k p (_hn := ⟨hp.ne_zero⟩) (f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) := by
+  rw [heckeTGeneratorGamma0_eq_single N hp.pos, heckeRingHomCuspCharSpace_apply,
+    twistedHeckeSlashCuspFormCharLinearMap_single, one_smul]
+  exact DFunLike.coe_injective
+    (coe_twistedHeckeSlashCuspFormCharEnd_diagCosetGamma0_of_dvd k χ hp hpN f)
 
 end HeckeRing.GL2

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Prime.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Prime.lean
@@ -8,7 +8,6 @@ module
 public import TauCeti.NumberTheory.HeckeRing.GL2.Gamma0.Diagonal.PrimeCosets
 public import TauCeti.NumberTheory.HeckeRing.GL2.Gamma0.Diagonal.PrimePower
 public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Nebentypus.Action
-public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Nebentypus.ModularForm
 public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Operators
 
 /-!


### PR DESCRIPTION
Identifies, at every prime `p`, the `Γ₀(N)` Hecke-ring action of the generator `diag(1, p)` on the nebentypus spaces `M_k(N, χ)` and `S_k(N, χ)` with the classical Hecke operator `Tₚ` on `M_k(Γ₁(N))` and `S_k(Γ₁(N))` — the prime case of the roadmap's Layer-2 identification ⚠ item — in a new module `HeckeSlash/Nebentypus/Prime.lean`:

- `twistedHeckeSlashSum_diagCosetGamma0_of_prime`, `…_of_dvd`: on a function with nebentypus `χ`, the twisted slash sum of `diag(1, p)` is the classical `Tₚ` formula `Uₚ f + χ(p) • (f ∣[k] diag(p, 1))` when `p ∤ N`, and `Uₚ f` when `p ∣ N`. This is the one computation; everything below reads it through coercions.
- `coe_twistedHeckeSlashModularFormCharEnd_diagCosetGamma0`, `coe_twistedHeckeSlashCuspFormCharEnd_diagCosetGamma0`: at every prime, the twisted operator of `diagCosetGamma0 N ![1, p]` on a form of the nebentypus space **is** `heckeTNat k p`, resp. `heckeTCuspNat k p`, as functions on `ℍ` (the two cases split inside the proof).
- `coe_heckeRingHomCharSpace_heckeTGeneratorGamma0`, `coe_heckeRingHomCuspCharSpace_heckeTGeneratorGamma0`: the Hecke-ring action of `heckeTGeneratorGamma0 N p` on a form of `M_k(N, χ)`, resp. `S_k(N, χ)`, is the classical operator, as an equality of forms.
- `heckeTNat_mem_modFormCharSpace`, `heckeTCuspNat_mem_cuspFormCharSpace`: the classical `Tₚ` preserves the nebentypus spaces.
- `heckeRingHomCharSpace_heckeTGeneratorGamma0`, `heckeRingHomCuspCharSpace_heckeTGeneratorGamma0`: **the Hecke-ring homomorphism at the generator is the classical operator restricted to the space**, as an equality of endomorphisms (`LinearMap.restrict`).
- In `Gamma0/Diagonal/PrimeCosets.lean`: `Delta0UpperUnit_upperTriRep`, `Delta0UpperUnit_mapGL_mul_scaleRep` (simp): the upper-left unit of every representative used is `1`.

**Why the twist disappears.** Over `Γ₀(N)` the right cosets of `diag(1, p)` are named by the same representatives as over `Γ₁(N)` (#6264): `!![1, j; 0, p]` and `σ · diag(p, 1)` with `σ ∈ Γ₀(N)` of bottom row `(N, p)`. The twisting character reads the upper-left unit of a representative — `1` on the upper-triangular ones and `χ(σ₀₀ p) = 1` on the twisted one (the determinant gives `σ₀₀ p ≡ 1 (mod N)`) — so the only surviving character is the nebentypus factor `χ(p)` from slashing `f` by `σ`, which is exactly the factor of the classical formula `Tₚ f = ∑_j f ∣[k] !![1, j; 0, p] + χ(p) · f ∣[k] diag(p, 1)` on the `Γ₁(N)` side (`HeckeSlash/Prime.lean`). In this repository's convention the identification is therefore exact; AINTLIB's twist runs the other way and its statement carries `χ(p)⁻¹`.

Consequence for the eigenform packaging (#6261): the ring eigenvalue at a good prime is the classical one, with no diamond rescaling.

**Scope.** Prime indices only.

Builds on #6264 (the `Γ₀(N)` coset decomposition, merged): the chosen representative is read through `HeckeCoset.toSet_eq_doubleCoset_rep` and `diagCosetGamma0_toSet`, and the bad-prime case takes `p.Prime` as that decomposition does.

Roadmap: ModularForms

No `tauceti-target:v1` marker: this is the prime case of the Layer-2 identification target, not the whole target (which covers every index `n`), and the contract asks for a deterministic identifier rather than an invented partial one.

Provenance: github.com/CBirkbeck/AINTLIB @ `2baa76f742bdb4fb8ee323fabba41203bd390e08` (Apache-2.0, Chris Birkbeck), `projects/LeanModularForms/LeanModularForms/HeckeRIngs/GL2/Unified/NebentypusHeckeRingHom.lean` — `heckeRingHomCharSpace_D_p_eq_scalar_charRestrict` (with its `χ(p)⁻¹`, from the opposite twist convention). Re-proved here from the repository's `twistedHeckeSlashSum_eq_sum_of_rightCosets`, the #6264 covers and `HeckeSlash/Prime.lean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQieFQn95rzgvYRvNdX3hR
