### PR TITLE
refactor: state the general-linear points API in simp-normal form

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Frobenius/GeneralLinear.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Frobenius/GeneralLinear.lean
@@ -111,7 +111,7 @@ private theorem mapRingHom_mem_hopfIdealPointsSubgroup (φ : A →+* B)
     {g : Matrix.GeneralLinearGroup (Fin n) A} (hg : g ∈ hopfIdealPointsSubgroup n I A) :
     Matrix.GeneralLinearGroup.map φ g ∈ hopfIdealPointsSubgroup n I B := by
   have h := map_mem_hopfIdealPointsSubgroup n I φ.toIntAlgHom hg
-  rwa [AlgHom.toRingHom_eq_coe, RingHom.toIntAlgHom_toRingHom] at h
+  rwa [RingHom.toIntAlgHom_toRingHom] at h
 
 /-- The map of matrix points induced by a ring homomorphism of value rings applies it entrywise.
 Private, for the same reason as `mapRingHom_mem_hopfIdealPointsSubgroup`. -/
@@ -119,8 +119,7 @@ private theorem coe_mapRingHomHopfIdealPointsSubgroup (φ : A →+* B)
     (g : hopfIdealPointsSubgroup n I A) :
     (mapHopfIdealPointsSubgroup n I φ.toIntAlgHom g : Matrix.GeneralLinearGroup (Fin n) B) =
       Matrix.GeneralLinearGroup.map φ g := by
-  rw [coe_mapHopfIdealPointsSubgroup, AlgHom.toRingHom_eq_coe,
-    RingHom.toIntAlgHom_toRingHom]
+  rw [coe_mapHopfIdealPointsSubgroup, RingHom.toIntAlgHom_toRingHom]
 
 end RingHomTransport
 
@@ -141,8 +140,7 @@ theorem pointToGeneralLinear_iterateFrobeniusPoints
   have hmapValue : Bialgebra.iterateFrobeniusPoints p k f =
       AlgHom.mapValue (H := coordinateHopfAlgebra ℤ n) (iterateFrobenius A p k).toIntAlgHom f := by
     rw [Bialgebra.iterateFrobeniusPoints_apply, AlgHom.mapValue_apply]
-  rw [hmapValue, pointToGeneralLinear_mapValue, AlgHom.toRingHom_eq_coe,
-    RingHom.toIntAlgHom_toRingHom]
+  rw [hmapValue, pointToGeneralLinear_mapValue, RingHom.toIntAlgHom_toRingHom]
 
 /-- The `p ^ k`-power Frobenius on the points of the general linear coordinate Hopf algebra is the
 entrywise `p ^ k`-power map on invertible matrices.
@@ -308,8 +306,7 @@ theorem map_hopfIdealPointsSubgroup_frobeniusFixedSubring :
       exact Subtype.ext h0
     · have h := pointsMulEquiv_mapValue (R := ℤ) n
         (frobeniusFixedSubring A p k).subtype.toIntAlgHom f
-      rw [AlgHom.toRingHom_eq_coe, RingHom.toIntAlgHom_toRingHom, hfmap,
-        MulEquiv.apply_symm_apply] at h
+      rw [RingHom.toIntAlgHom_toRingHom, hfmap, MulEquiv.apply_symm_apply] at h
       exact h.symm
 
 variable (A) in

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Dynamic/PointMaps.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Dynamic/PointMaps.lean
@@ -33,7 +33,8 @@ theorem pointsMulEquiv_ofPolyPoint
     (F : WithConv (coordinateHopfAlgebra R N →ₐ[R] Polynomial A)) :
     pointsMulEquiv N (Cocharacter.ofPolyPoint A F) =
       Matrix.GeneralLinearGroup.map
-        (Polynomial.toLaurentAlg.restrictScalars R).toRingHom (pointsMulEquiv N F) := by
+        (Polynomial.toLaurentAlg.restrictScalars R :
+          Polynomial A →ₐ[R] LaurentPolynomial A) (pointsMulEquiv N F) := by
   rw [Cocharacter.ofPolyPoint_apply, ← AlgHom.mapValue_apply, pointsMulEquiv_mapValue]
 
 /-- Evaluating a polynomial-valued general-linear point at zero evaluates every matrix entry
@@ -42,7 +43,8 @@ theorem pointsMulEquiv_evalZeroPoint
     (F : WithConv (coordinateHopfAlgebra R N →ₐ[R] Polynomial A)) :
     pointsMulEquiv N (Cocharacter.evalZeroPoint A F) =
       Matrix.GeneralLinearGroup.map
-        ((Polynomial.aeval (0 : A)).restrictScalars R).toRingHom (pointsMulEquiv N F) := by
+        ((Polynomial.aeval (0 : A)).restrictScalars R : Polynomial A →ₐ[R] A)
+        (pointsMulEquiv N F) := by
   rw [Cocharacter.evalZeroPoint_apply, ← AlgHom.mapValue_apply, pointsMulEquiv_mapValue]
 
 end TauCeti.GeneralLinear.Dynamic

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Dynamic/Weight/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Dynamic/Weight/Basic.lean
@@ -85,7 +85,7 @@ theorem pointsMulEquiv_conjugate_weightCocharacter (w : Fin N → ℤ)
     pointsMulEquiv N (Cocharacter.conjugate A (weightCocharacter (R := R) w) g) =
       diagGL (weightDiagonalUnits w (MultiplicativeGroup.genericUnit A)) *
         Matrix.GeneralLinearGroup.map
-          (IsScalarTower.toAlgHom R A (LaurentPolynomial A)).toRingHom
+          (IsScalarTower.toAlgHom R A (LaurentPolynomial A) : A →+* LaurentPolynomial A)
           (pointsMulEquiv N g) *
         (diagGL (weightDiagonalUnits w (MultiplicativeGroup.genericUnit A)))⁻¹ := by
   rw [Cocharacter.conjugate_apply, map_mul, map_mul, map_inv,
@@ -172,7 +172,7 @@ private theorem det_weightPolynomialMatrix (w : Fin N → ℤ)
     pointsMulEquiv_conjugate_weightCocharacter, Units.val_mul, Units.val_mul,
     Matrix.det_units_conj]
   exact (RingHom.map_det
-    (IsScalarTower.toAlgHom R A (LaurentPolynomial A)).toRingHom
+    (IsScalarTower.toAlgHom R A (LaurentPolynomial A) : A →+* LaurentPolynomial A)
     (pointsMulEquiv N g : Matrix (Fin N) (Fin N) A)).symm
 
 /-- The polynomial-valued general-linear point extending weight conjugation. -/

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/FunctorOfPoints.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/FunctorOfPoints.lean
@@ -250,7 +250,7 @@ theorem pointToGeneralLinear_mapValue (phi : A →ₐ[R] B)
     (f : WithConv (coordinateHopfAlgebra R n →ₐ[R] A)) :
     pointToGeneralLinear n
         (AlgHom.mapValue (H := coordinateHopfAlgebra R n) phi f) =
-      Matrix.GeneralLinearGroup.map phi.toRingHom (pointToGeneralLinear n f) := by
+      Matrix.GeneralLinearGroup.map (phi : A →+* B) (pointToGeneralLinear n f) := by
   apply Matrix.GeneralLinearGroup.ext
   intro i j
   simp
@@ -259,14 +259,14 @@ theorem pointToGeneralLinear_mapValue (phi : A →ₐ[R] B)
 private theorem pointToGeneralLinear_toConv_comp (phi : A →ₐ[R] B)
     (f : WithConv (coordinateHopfAlgebra R n →ₐ[R] A)) :
     pointToGeneralLinear n (toConv (phi.comp f.ofConv)) =
-      Matrix.GeneralLinearGroup.map phi.toRingHom (pointToGeneralLinear n f) := by
+      Matrix.GeneralLinearGroup.map (phi : A →+* B) (pointToGeneralLinear n f) := by
   simpa only [AlgHom.mapValue_apply] using pointToGeneralLinear_mapValue n phi f
 
 /-- The pointwise group equivalence is natural in the value algebra. -/
 theorem pointsMulEquiv_mapValue (phi : A →ₐ[R] B)
     (f : WithConv (coordinateHopfAlgebra R n →ₐ[R] A)) :
     pointsMulEquiv n (AlgHom.mapValue (H := coordinateHopfAlgebra R n) phi f) =
-      Matrix.GeneralLinearGroup.map phi.toRingHom (pointsMulEquiv n f) := by
+      Matrix.GeneralLinearGroup.map (phi : A →+* B) (pointsMulEquiv n f) := by
   exact pointToGeneralLinear_mapValue n phi f
 
 /-- Naturality of the inverse pointwise equivalence in the value algebra. -/
@@ -275,7 +275,7 @@ theorem mapValue_pointsMulEquiv_symm_apply (phi : A →ₐ[R] B)
     AlgHom.mapValue (H := coordinateHopfAlgebra R n) phi
         ((pointsMulEquiv (R := R) n).symm g) =
       (pointsMulEquiv (R := R) n).symm
-        (Matrix.GeneralLinearGroup.map phi.toRingHom g) := by
+        (Matrix.GeneralLinearGroup.map (phi : A →+* B) g) := by
   apply (pointsMulEquiv (R := R) (A := B) n).injective
   rw [pointsMulEquiv_mapValue]
   simp
@@ -285,7 +285,7 @@ private theorem toConv_comp_generalLinearToPoint_ofConv (phi : A →ₐ[R] B)
     (g : Matrix.GeneralLinearGroup (Fin n) A) :
     toConv (phi.comp (generalLinearToPoint (R := R) n g).ofConv) =
       generalLinearToPoint (R := R) n
-        (Matrix.GeneralLinearGroup.map phi.toRingHom g) := by
+        (Matrix.GeneralLinearGroup.map (phi : A →+* B) g) := by
   simpa only [AlgHom.mapValue_apply, pointsMulEquiv_symm_apply] using
     mapValue_pointsMulEquiv_symm_apply n phi g
 

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/HopfIdealPoints/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/HopfIdealPoints/Basic.lean
@@ -108,7 +108,7 @@ theorem map_mem_hopfIdealPointsSubgroup
     (I : HopfIdeal R (coordinateHopfAlgebra R n)) (φ : A →ₐ[R] B)
     {g : Matrix.GeneralLinearGroup (Fin n) A}
     (hg : g ∈ hopfIdealPointsSubgroup n I A) :
-    Matrix.GeneralLinearGroup.map φ.toRingHom g ∈ hopfIdealPointsSubgroup n I B := by
+    Matrix.GeneralLinearGroup.map (φ : A →+* B) g ∈ hopfIdealPointsSubgroup n I B := by
   obtain ⟨q, hq, rfl⟩ := hg
   refine ⟨AlgHom.mapValue φ q,
     CommHopfAlgCat.mapValue_mem_quotientPointsSubgroup
@@ -120,7 +120,7 @@ homomorphism of value algebras. -/
 noncomputable def mapHopfIdealPointsSubgroup
     (I : HopfIdeal R (coordinateHopfAlgebra R n)) (φ : A →ₐ[R] B) :
     hopfIdealPointsSubgroup n I A →* hopfIdealPointsSubgroup n I B :=
-  (((Matrix.GeneralLinearGroup.map φ.toRingHom).domRestrict
+  (((Matrix.GeneralLinearGroup.map (φ : A →+* B)).domRestrict
     (hopfIdealPointsSubgroup n I A)).codRestrict
       (hopfIdealPointsSubgroup n I B)
       fun g => map_mem_hopfIdealPointsSubgroup n I φ g.property)
@@ -132,7 +132,7 @@ theorem coe_mapHopfIdealPointsSubgroup
     (I : HopfIdeal R (coordinateHopfAlgebra R n)) (φ : A →ₐ[R] B)
     (g : hopfIdealPointsSubgroup n I A) :
     (mapHopfIdealPointsSubgroup n I φ g : Matrix.GeneralLinearGroup (Fin n) B) =
-      Matrix.GeneralLinearGroup.map φ.toRingHom g := by
+      Matrix.GeneralLinearGroup.map (φ : A →+* B) g := by
   rfl
 
 /-- The identity value-algebra homomorphism induces the identity on a general-linear Hopf-ideal
@@ -146,8 +146,7 @@ theorem mapHopfIdealPointsSubgroup_id
   apply MonoidHom.ext
   intro g
   apply Subtype.ext
-  have h_id : (AlgHom.id R A).toRingHom = RingHom.id A := AlgHom.id_toRingHom R A
-  rw [coe_mapHopfIdealPointsSubgroup, MonoidHom.id_apply, h_id,
+  rw [coe_mapHopfIdealPointsSubgroup, MonoidHom.id_apply, AlgHom.id_toRingHom,
     Matrix.GeneralLinearGroup.map_id, MonoidHom.id_apply]
 
 /-- Maps between general-linear Hopf-ideal point subgroups preserve composition of value-algebra
@@ -163,11 +162,9 @@ theorem mapHopfIdealPointsSubgroup_comp
   apply MonoidHom.ext
   intro g
   apply Subtype.ext
-  have h_comp : (ψ.comp φ).toRingHom = ψ.toRingHom.comp φ.toRingHom :=
-    AlgHom.comp_toRingHom ψ φ
   rw [coe_mapHopfIdealPointsSubgroup, MonoidHom.comp_apply,
     coe_mapHopfIdealPointsSubgroup, coe_mapHopfIdealPointsSubgroup,
-    h_comp, Matrix.GeneralLinearGroup.map_comp, MonoidHom.comp_apply]
+    AlgHom.comp_toRingHom, Matrix.GeneralLinearGroup.map_comp, MonoidHom.comp_apply]
 
 /-- An injective homomorphism of value algebras induces an injective map of general-linear
 Hopf-ideal point subgroups: reading a matrix point over a subalgebra as a point over the ambient
@@ -175,7 +172,7 @@ algebra loses no information. -/
 theorem mapHopfIdealPointsSubgroup_injective
     (I : HopfIdeal R (coordinateHopfAlgebra R n)) {φ : A →ₐ[R] B} (hφ : Function.Injective φ) :
     Function.Injective (mapHopfIdealPointsSubgroup n I φ) := by
-  have hmap : Function.Injective (Matrix.GeneralLinearGroup.map (n := Fin n) φ.toRingHom) :=
+  have hmap : Function.Injective (Matrix.GeneralLinearGroup.map (n := Fin n) (φ : A →+* B)) :=
     Units.map_injective (Matrix.map_injective hφ)
   intro g g' h
   refine Subtype.ext (hmap ?_)

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Projective.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Projective.lean
@@ -130,7 +130,7 @@ theorem pglPointsFunctor_map {R : Type u} [CommRing R]
     {A B : CommAlgCat.{w} R} (φ : A ⟶ B) :
     (pglPointsFunctor n).map φ =
       eqToHom (pglPointsFunctor_obj n A) ≫
-        GrpCat.ofHom (Matrix.ProjGenLinGroup.map (n := Fin n) φ.hom.toRingHom) ≫
+        GrpCat.ofHom (Matrix.ProjGenLinGroup.map (n := Fin n) φ.hom) ≫
           eqToHom (pglPointsFunctor_obj n B).symm :=
   (rfl)
 

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/UpperTriangular/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/UpperTriangular/Basic.lean
@@ -421,7 +421,8 @@ private noncomputable def hopfIdealPointsSubgroupNatIso :
           GeneralLinear.coe_mapHopfIdealPointsSubgroup,
           UpperTriangularGroup.coe_map,
           hopfIdealPointsSubgroupMulEquiv,
-          MulEquiv.subgroupCongr_apply (hopfIdealPointsSubgroup_eq R n)]
+          MulEquiv.subgroupCongr_apply (hopfIdealPointsSubgroup_eq R n),
+          AlgHom.toRingHom_eq_coe]
       have h := congrArg
         (fun f ↦ eqToHom
             (GeneralLinear.hopfIdealPointsSubgroupFunctor_obj n
@@ -611,7 +612,7 @@ theorem pointsMulEquiv_rootSubgroupCoordinateMap (hij : i < j)
     apply WithConv.ext
     exact AlgHom.comp_id f.ofConv
   have hcoe_ring (x : AdditiveGroup.coordinateHopfAlgebra R) :
-      f.ofConv.toRingHom x = f.ofConv x :=
+      (f.ofConv : _ →+* _) x = f.ofConv x :=
     congrFun (AlgHom.coe_toRingHom f.ofConv) x
   apply (GeneralLinear.pointsMulEquiv (R := R) (A := A) n).injective
   rw [GeneralLinear.pointsMulEquiv_mapValue,

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Projective.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Projective.lean
@@ -170,7 +170,7 @@ theorem pslPointsFunctor_map {R : Type u} [CommRing R]
     {A B : CommAlgCat.{w} R} (φ : A ⟶ B) :
     (pslPointsFunctor n).map φ =
       eqToHom (pslPointsFunctor_obj n A) ≫
-        GrpCat.ofHom (projectiveMap n φ.hom.toRingHom) ≫
+        GrpCat.ofHom (projectiveMap n φ.hom) ≫
           eqToHom (pslPointsFunctor_obj n B).symm :=
   by unfold pslPointsFunctor; rfl
 

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialOrthogonal/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialOrthogonal/Basic.lean
@@ -327,7 +327,7 @@ theorem pointsMulEquiv_mapValue {B : Type v} [CommRing B] [Algebra R B]
     (f : WithConv (coordinateHopfAlgebra R n →ₐ[R] A)) :
     pointsMulEquiv R n (A := B)
         (AlgHom.mapValue (H := coordinateHopfAlgebra R n) phi f) =
-      Matrix.SpecialOrthogonalGroup.map phi.toRingHom
+      Matrix.SpecialOrthogonalGroup.map (phi : A →+* B)
         (pointsMulEquiv R n (A := A) f) := by
   apply Subtype.ext
   have hcoe_lhs := pointsMulEquiv_coe R n
@@ -338,7 +338,7 @@ theorem pointsMulEquiv_mapValue {B : Type v} [CommRing B] [Algebra R B]
   rw [← hcoe_lhs, hnatural, GeneralLinear.pointsMulEquiv_mapValue,
     Matrix.SpecialOrthogonalGroup.coe_map]
   simpa only [Matrix.GeneralLinearGroup.val_map_apply] using
-    congrArg (fun M : Matrix (Fin n) (Fin n) A ↦ M.map phi.toRingHom) hcoe_rhs
+    congrArg (fun M : Matrix (Fin n) (Fin n) A ↦ M.map (phi : A →+* B)) hcoe_rhs
 
 /-- Naturality of the inverse pointwise equivalence in the value algebra. -/
 theorem mapValue_pointsMulEquiv_symm_apply {B : Type v} [CommRing B] [Algebra R B]

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialOrthogonal/Smooth.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialOrthogonal/Smooth.lean
@@ -73,8 +73,9 @@ private instance instFormallySmoothCoordinateHopfAlgebra [Invertible (2 : R)] :
   have hg : pointsMulEquiv R n (A := B) g = t :=
     (pointsMulEquiv R n (A := B)).apply_symm_apply t
   rw [hg]
-  have hq : (Ideal.Quotient.mkₐ R I).toRingHom = Ideal.Quotient.mk I :=
-    Ideal.Quotient.mkₐ_toRingHom (R₁ := R) I
+  have hq : ((Ideal.Quotient.mkₐ R I : B →ₐ[R] B ⧸ I) : B →+* B ⧸ I) = Ideal.Quotient.mk I := by
+    rw [← AlgHom.toRingHom_eq_coe]
+    exact Ideal.Quotient.mkₐ_toRingHom (R₁ := R) I
   rw [hq]
   exact ht
 

--- a/TauCeti/Algebra/AlgebraicGroup/Symplectic/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Symplectic/Basic.lean
@@ -262,7 +262,7 @@ theorem pointsMulEquiv_mapValue (phi : A →ₐ[R] B)
       (CommAlgCat.of R A)) :
     pointsMulEquiv (R := R) (A := B) m
         (AlgHom.mapValue (H := coordinateHopfAlgebra R m) phi f) =
-      GLSymplecticFin.map m A phi.toRingHom
+      GLSymplecticFin.map m A (phi : A →+* B)
         (pointsMulEquiv (R := R) (A := A) m f) := by
   apply Subtype.ext
   have hcoe_lhs := pointsMulEquiv_coe (R := R) (A := B) m

--- a/TauCeti/Algebra/AlgebraicGroup/Symplectic/Smooth.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Symplectic/Smooth.lean
@@ -56,7 +56,7 @@ private theorem pointsMulEquivGLSymplectic_mapValue
     (f : WithConv (coordinateHopfAlgebra R m →ₐ[R] A)) :
     pointsMulEquivGLSymplectic R m (A := B)
         (AlgHom.mapValue (H := coordinateHopfAlgebra R m) phi f) =
-      GLSymplectic.map (Fin m) phi.toRingHom
+      GLSymplectic.map (Fin m) (phi : A →+* B)
         (pointsMulEquivGLSymplectic R m (A := A) f) := by
   apply Subtype.ext
   apply Matrix.GeneralLinearGroup.ext

--- a/TauCeti/Algebra/Lie/E6/DoubledMinuscule/PointsFunctor.lean
+++ b/TauCeti/Algebra/Lie/E6/DoubledMinuscule/PointsFunctor.lean
@@ -90,7 +90,7 @@ theorem coe_pointsMap (f : A →+* B) (g : points A) :
   rw [pointsMap]
   simp only [MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom,
     MulEquiv.subgroupCongr_symm_apply, GeneralLinear.coe_mapHopfIdealPointsSubgroup,
-    MulEquiv.subgroupCongr_apply, AlgHom.toRingHom_eq_coe, RingHom.toIntAlgHom_toRingHom]
+    MulEquiv.subgroupCongr_apply, RingHom.toIntAlgHom_toRingHom]
 
 /-- Entrywise, the induced map applies the homomorphism of value rings to each matrix entry. -/
 theorem coe_pointsMap_apply (f : A →+* B) (g : points A) (i j : Fin 54) :
@@ -171,7 +171,7 @@ map. -/
 @[simp]
 theorem pointsFunctor_map {A B : CommAlgCat.{v} ℤ} (f : A ⟶ B) :
     pointsFunctor.map f =
-      eqToHom (pointsFunctor_obj A) ≫ GrpCat.ofHom (pointsMap f.hom.toRingHom) ≫
+      eqToHom (pointsFunctor_obj A) ≫ GrpCat.ofHom (pointsMap f.hom) ≫
         eqToHom (pointsFunctor_obj B).symm :=
   (rfl)
 
@@ -231,7 +231,7 @@ theorem pointsMulEquiv_mapPoints {A B : CommAlgCat.{v} ℤ} (f : A ⟶ B)
         (HopfAlgebra.mapPoints
           (H := CommHopfAlgCat.quotient
             (GeneralLinear.coordinateHopfAlgebra ℤ 54) definingIdeal) f q) =
-      pointsMap f.hom.toRingHom (pointsMulEquiv A q) := by
+      pointsMap f.hom (pointsMulEquiv A q) := by
   apply Subtype.ext
   rw [coe_pointsMap]
   simp only [pointsMulEquiv, MulEquiv.trans_apply, MulEquiv.subgroupCongr_symm_apply]

--- a/TauCeti/Algebra/Lie/E6/Minuscule/PointsFunctor.lean
+++ b/TauCeti/Algebra/Lie/E6/Minuscule/PointsFunctor.lean
@@ -78,7 +78,7 @@ theorem coe_pointsMap (f : A →+* B) (g : points A) :
   rw [pointsMap]
   simp only [MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom,
     MulEquiv.subgroupCongr_symm_apply, GeneralLinear.coe_mapHopfIdealPointsSubgroup,
-    MulEquiv.subgroupCongr_apply, AlgHom.toRingHom_eq_coe, RingHom.toIntAlgHom_toRingHom]
+    MulEquiv.subgroupCongr_apply, RingHom.toIntAlgHom_toRingHom]
 
 /-- Entrywise, the induced map applies the homomorphism of value rings to each matrix entry. -/
 theorem coe_pointsMap_apply (f : A →+* B) (g : points A) (i j : Fin 27) :
@@ -159,7 +159,7 @@ theorem pointsFunctor_obj (A : CommAlgCat.{v} ℤ) :
 @[simp]
 theorem pointsFunctor_map {A B : CommAlgCat.{v} ℤ} (f : A ⟶ B) :
     pointsFunctor.map f =
-      eqToHom (pointsFunctor_obj A) ≫ GrpCat.ofHom (pointsMap f.hom.toRingHom) ≫
+      eqToHom (pointsFunctor_obj A) ≫ GrpCat.ofHom (pointsMap f.hom) ≫
         eqToHom (pointsFunctor_obj B).symm :=
   (rfl)
 
@@ -218,7 +218,7 @@ theorem pointsMulEquiv_mapPoints {A B : CommAlgCat.{v} ℤ} (f : A ⟶ B)
         (HopfAlgebra.mapPoints
           (H := CommHopfAlgCat.quotient
             (GeneralLinear.coordinateHopfAlgebra ℤ 27) definingIdeal) f q) =
-      pointsMap f.hom.toRingHom (pointsMulEquiv A q) := by
+      pointsMap f.hom (pointsMulEquiv A q) := by
   apply Subtype.ext
   rw [coe_pointsMap]
   simp only [pointsMulEquiv, MulEquiv.trans_apply, MulEquiv.subgroupCongr_symm_apply]

--- a/TauCeti/Algebra/Lie/E7/Minuscule/PointsFunctor.lean
+++ b/TauCeti/Algebra/Lie/E7/Minuscule/PointsFunctor.lean
@@ -88,7 +88,7 @@ theorem coe_pointsMap (f : A →+* B) (g : points A) :
   rw [pointsMap]
   simp only [MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom,
     MulEquiv.subgroupCongr_symm_apply, GeneralLinear.coe_mapHopfIdealPointsSubgroup,
-    MulEquiv.subgroupCongr_apply, AlgHom.toRingHom_eq_coe, RingHom.toIntAlgHom_toRingHom]
+    MulEquiv.subgroupCongr_apply, RingHom.toIntAlgHom_toRingHom]
 
 /-- Entrywise, the induced map applies the homomorphism of value rings to each matrix entry. -/
 theorem coe_pointsMap_apply (f : A →+* B) (g : points A) (i j : Fin 56) :
@@ -169,7 +169,7 @@ theorem pointsFunctor_obj (A : CommAlgCat.{v} ℤ) :
 @[simp]
 theorem pointsFunctor_map {A B : CommAlgCat.{v} ℤ} (f : A ⟶ B) :
     pointsFunctor.map f =
-      eqToHom (pointsFunctor_obj A) ≫ GrpCat.ofHom (pointsMap f.hom.toRingHom) ≫
+      eqToHom (pointsFunctor_obj A) ≫ GrpCat.ofHom (pointsMap f.hom) ≫
         eqToHom (pointsFunctor_obj B).symm :=
   (rfl)
 
@@ -228,7 +228,7 @@ theorem pointsMulEquiv_mapPoints {A B : CommAlgCat.{v} ℤ} (f : A ⟶ B)
         (HopfAlgebra.mapPoints
           (H := CommHopfAlgCat.quotient
             (GeneralLinear.coordinateHopfAlgebra ℤ 56) definingIdeal) f q) =
-      pointsMap f.hom.toRingHom (pointsMulEquiv A q) := by
+      pointsMap f.hom (pointsMulEquiv A q) := by
   apply Subtype.ext
   rw [coe_pointsMap]
   simp only [pointsMulEquiv, MulEquiv.trans_apply, MulEquiv.subgroupCongr_symm_apply]

--- a/TauCeti/Algebra/Lie/Orthogonal/TypeB/SpinCarrier/BaseChange.lean
+++ b/TauCeti/Algebra/Lie/Orthogonal/TypeB/SpinCarrier/BaseChange.lean
@@ -215,14 +215,14 @@ theorem baseChangePointsMulEquiv_mapPoints {B C : CommAlgCat.{w} A} (f : B ⟶ C
           (H := CommHopfAlgCat.quotient
             (GeneralLinear.coordinateHopfAlgebra A (dimension n))
             (baseChangeDefiningIdeal n A)) f q) =
-      pointsMap n f.hom.toRingHom (baseChangePointsMulEquiv n A B q) := by
+      pointsMap n f.hom (baseChangePointsMulEquiv n A B q) := by
   simp only [baseChangePointsMulEquiv, MulEquiv.trans_apply]
   rw [CommHopfAlgCat.baseChangeIsoPointsMulEquiv_mapPoints,
     pointsMulEquiv_mapPoints n
       ((TauCeti.CommAlgCat.restrictScalars (algebraMap ℤ A)).map f)]
   have hring :
-      ((TauCeti.CommAlgCat.restrictScalars (algebraMap ℤ A)).map f).hom.toRingHom =
-        f.hom.toRingHom := by
+      ((((TauCeti.CommAlgCat.restrictScalars (algebraMap ℤ A)).map f).hom : ↑B →+* ↑C)) =
+        (f.hom : ↑B →+* ↑C) := by
     rw [TauCeti.CommAlgCat.restrictScalars_map,
       TauCeti.CommAlgCat.restrictScalarsMap_hom]
     exact RingHom.ext fun x ↦ AlgHom.restrictScalars_apply ℤ f.hom x

--- a/TauCeti/Algebra/Lie/Orthogonal/TypeB/SpinCarrier/PointsFunctor.lean
+++ b/TauCeti/Algebra/Lie/Orthogonal/TypeB/SpinCarrier/PointsFunctor.lean
@@ -78,7 +78,7 @@ theorem coe_pointsMap (f : A →+* B) (g : points n A) :
   rw [pointsMap]
   simp only [MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom,
     MulEquiv.subgroupCongr_symm_apply, GeneralLinear.coe_mapHopfIdealPointsSubgroup,
-    MulEquiv.subgroupCongr_apply, AlgHom.toRingHom_eq_coe, RingHom.toIntAlgHom_toRingHom]
+    MulEquiv.subgroupCongr_apply, RingHom.toIntAlgHom_toRingHom]
 
 /-- Entrywise, the induced map applies the homomorphism of value rings to each matrix entry. -/
 theorem coe_pointsMap_apply (f : A →+* B) (g : points n A)
@@ -167,7 +167,7 @@ entrywise map. -/
 theorem pointsFunctor_map {A B : CommAlgCat.{v} ℤ} (f : A ⟶ B) :
     (pointsFunctor n).map f =
       eqToHom (pointsFunctor_obj n A) ≫
-        GrpCat.ofHom (pointsMap n f.hom.toRingHom) ≫
+        GrpCat.ofHom (pointsMap n f.hom) ≫
         eqToHom (pointsFunctor_obj n B).symm :=
   (rfl)
 
@@ -233,7 +233,7 @@ theorem pointsMulEquiv_mapPoints {A B : CommAlgCat.{v} ℤ} (f : A ⟶ B)
           (H := CommHopfAlgCat.quotient
             (GeneralLinear.coordinateHopfAlgebra ℤ (dimension n)) (definingIdeal n))
           f q) =
-      pointsMap n f.hom.toRingHom (pointsMulEquiv n A q) := by
+      pointsMap n f.hom (pointsMulEquiv n A q) := by
   apply Subtype.ext
   rw [coe_pointsMap]
   simp only [pointsMulEquiv, MulEquiv.trans_apply, MulEquiv.subgroupCongr_symm_apply]

--- a/TauCeti/Algebra/Lie/Orthogonal/TypeD/SpinCarrier/BaseChange.lean
+++ b/TauCeti/Algebra/Lie/Orthogonal/TypeD/SpinCarrier/BaseChange.lean
@@ -245,14 +245,14 @@ theorem baseChangePointsMulEquiv_mapPoints {B C : CommAlgCat.{w} A} (f : B ⟶ C
           (H := CommHopfAlgCat.quotient
             (GeneralLinear.coordinateHopfAlgebra A (dimension n))
             (baseChangeDefiningIdeal n hn A)) f q) =
-      pointsMap n hn f.hom.toRingHom (baseChangePointsMulEquiv n hn A B q) := by
+      pointsMap n hn f.hom (baseChangePointsMulEquiv n hn A B q) := by
   simp only [baseChangePointsMulEquiv, MulEquiv.trans_apply]
   rw [CommHopfAlgCat.baseChangeIsoPointsMulEquiv_mapPoints,
     pointsMulEquiv_mapPoints n hn
       ((TauCeti.CommAlgCat.restrictScalars (algebraMap ℤ A)).map f)]
   have hring :
-      ((TauCeti.CommAlgCat.restrictScalars (algebraMap ℤ A)).map f).hom.toRingHom =
-        f.hom.toRingHom := by
+      ((((TauCeti.CommAlgCat.restrictScalars (algebraMap ℤ A)).map f).hom : ↑B →+* ↑C)) =
+        (f.hom : ↑B →+* ↑C) := by
     rw [TauCeti.CommAlgCat.restrictScalars_map,
       TauCeti.CommAlgCat.restrictScalarsMap_hom]
     exact RingHom.ext fun x ↦ AlgHom.restrictScalars_apply ℤ f.hom x

--- a/TauCeti/Algebra/Lie/Orthogonal/TypeD/SpinCarrier/PointsFunctor.lean
+++ b/TauCeti/Algebra/Lie/Orthogonal/TypeD/SpinCarrier/PointsFunctor.lean
@@ -68,7 +68,7 @@ theorem coe_pointsMap (f : A →+* B) (g : points n hn A) :
   rw [pointsMap]
   simp only [MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom,
     MulEquiv.subgroupCongr_symm_apply, GeneralLinear.coe_mapHopfIdealPointsSubgroup,
-    MulEquiv.subgroupCongr_apply, AlgHom.toRingHom_eq_coe, RingHom.toIntAlgHom_toRingHom]
+    MulEquiv.subgroupCongr_apply, RingHom.toIntAlgHom_toRingHom]
 
 /-- Entrywise, the induced map applies the homomorphism of value rings to each matrix entry. -/
 theorem coe_pointsMap_apply (f : A →+* B) (g : points n hn A)
@@ -156,7 +156,7 @@ map. -/
 theorem pointsFunctor_map {A B : CommAlgCat.{v} ℤ} (f : A ⟶ B) :
     (pointsFunctor n hn).map f =
       eqToHom (pointsFunctor_obj n hn A) ≫
-        GrpCat.ofHom (pointsMap n hn f.hom.toRingHom) ≫
+        GrpCat.ofHom (pointsMap n hn f.hom) ≫
         eqToHom (pointsFunctor_obj n hn B).symm :=
   (rfl)
 
@@ -222,7 +222,7 @@ theorem pointsMulEquiv_mapPoints {A B : CommAlgCat.{v} ℤ} (f : A ⟶ B)
           (H := CommHopfAlgCat.quotient
             (GeneralLinear.coordinateHopfAlgebra ℤ (dimension n)) (definingIdeal n hn))
           f q) =
-      pointsMap n hn f.hom.toRingHom (pointsMulEquiv n hn A q) := by
+      pointsMap n hn f.hom (pointsMulEquiv n hn A q) := by
   apply Subtype.ext
   rw [coe_pointsMap]
   simp only [pointsMulEquiv, MulEquiv.trans_apply, MulEquiv.subgroupCongr_symm_apply]

--- a/TauCeti/Algebra/Lie/Sl2/Kostant/GroupScheme.lean
+++ b/TauCeti/Algebra/Lie/Sl2/Kostant/GroupScheme.lean
@@ -418,7 +418,7 @@ theorem coe_rankOneCarrierPointsMap
   rw [rankOneCarrierPointsMap]
   simp only [MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom,
     MulEquiv.subgroupCongr_symm_apply, GeneralLinear.coe_mapHopfIdealPointsSubgroup,
-    MulEquiv.subgroupCongr_apply, AlgHom.toRingHom_eq_coe, RingHom.toIntAlgHom_toRingHom]
+    MulEquiv.subgroupCongr_apply, RingHom.toIntAlgHom_toRingHom]
 
 /-- Entrywise, the induced map applies the value-ring homomorphism to each matrix entry. -/
 theorem coe_rankOneCarrierPointsMap_apply

--- a/TauCeti/Algebra/Lie/Sl2/Kostant/Weyl.lean
+++ b/TauCeti/Algebra/Lie/Sl2/Kostant/Weyl.lean
@@ -96,7 +96,7 @@ theorem rankOneCarrierPointsMap_weylPoint
   have hmap := congrArg Subtype.val
     (map_kostantToralWeylPoint e h ρ M hM hnil b rankOneWeight φ 0 1)
   simpa only [GeneralLinear.coe_mapHopfIdealPointsSubgroup, MulEquiv.subgroupCongr_apply,
-    AlgHom.toRingHom_eq_coe, RingHom.toIntAlgHom_toRingHom] using hmap
+    RingHom.toIntAlgHom_toRingHom] using hmap
 
 /-- The integral rank-one Weyl automorphism sends a standard lattice basis vector to the reversed
 basis vector with the usual sign. -/

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/PointsFunctor.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/PointsFunctor.lean
@@ -103,7 +103,7 @@ theorem coe_pointsMap (f : A →+* B) (g : points r A) :
   rw [pointsMap]
   simp only [MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, MulEquiv.subgroupCongr_symm_apply,
     GeneralLinear.coe_mapHopfIdealPointsSubgroup, MulEquiv.subgroupCongr_apply,
-    AlgHom.toRingHom_eq_coe, RingHom.toIntAlgHom_toRingHom]
+    RingHom.toIntAlgHom_toRingHom]
 
 /-- Entrywise, the induced map applies the homomorphism of value rings to each matrix entry. -/
 theorem coe_pointsMap_apply (f : A →+* B) (g : points r A) (i j : Fin (r + 1)) :
@@ -185,7 +185,7 @@ theorem pointsFunctor_obj (A : CommAlgCat.{v} ℤ) :
 theorem pointsFunctor_map {A B : CommAlgCat.{v} ℤ} (f : A ⟶ B) :
     (pointsFunctor r).map f =
       eqToHom (pointsFunctor_obj r A) ≫
-        GrpCat.ofHom (pointsMap r f.hom.toRingHom) ≫
+        GrpCat.ofHom (pointsMap r f.hom) ≫
         eqToHom (pointsFunctor_obj r B).symm :=
   (rfl)
 
@@ -244,7 +244,7 @@ theorem pointsMulEquiv_mapPoints {A B : CommAlgCat.{v} ℤ} (f : A ⟶ B)
         (HopfAlgebra.mapPoints
           (H := CommHopfAlgCat.quotient
             (GeneralLinear.coordinateHopfAlgebra ℤ (r + 1)) (definingIdeal r)) f q) =
-      pointsMap r f.hom.toRingHom (pointsMulEquiv r A q) := by
+      pointsMap r f.hom (pointsMulEquiv r A q) := by
   apply Subtype.ext
   rw [coe_pointsMap]
   simp only [pointsMulEquiv, MulEquiv.trans_apply, MulEquiv.subgroupCongr_symm_apply]

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/UpperTriangular.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/UpperTriangular.lean
@@ -306,7 +306,7 @@ theorem coe_upperTriangularPointsMap {A : Type v} {B : Type v'} [CommRing A] [Co
   rw [upperTriangularPointsMap]
   simp only [MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, MulEquiv.subgroupCongr_symm_apply,
     GeneralLinear.coe_mapHopfIdealPointsSubgroup, MulEquiv.subgroupCongr_apply,
-    AlgHom.toRingHom_eq_coe, RingHom.toIntAlgHom_toRingHom]
+    RingHom.toIntAlgHom_toRingHom]
 
 /-- The identity homomorphism of value rings induces the identity on upper-triangular carrier
 points. -/
@@ -357,7 +357,7 @@ theorem upperTriangularPointsMulEquiv_mapPoints {A B : CommAlgCat.{v} ℤ} (f : 
           (H := CommHopfAlgCat.quotient
             (GeneralLinear.coordinateHopfAlgebra ℤ (r + 1)) (upperTriangularDefiningIdeal r))
           f q) =
-      upperTriangularPointsMap r f.hom.toRingHom (upperTriangularPointsMulEquiv r A q) := by
+      upperTriangularPointsMap r f.hom (upperTriangularPointsMulEquiv r A q) := by
   apply Subtype.ext
   rw [coe_upperTriangularPointsMap]
   simp only [upperTriangularPointsMulEquiv, MulEquiv.trans_apply,

--- a/TauCeti/Algebra/Lie/Symplectic/StandardCarrier/PointsFunctor.lean
+++ b/TauCeti/Algebra/Lie/Symplectic/StandardCarrier/PointsFunctor.lean
@@ -87,7 +87,7 @@ theorem coe_pointsMap (f : A →+* B) (g : points n A) :
   rw [pointsMap]
   simp only [MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, MulEquiv.subgroupCongr_symm_apply,
     GeneralLinear.coe_mapHopfIdealPointsSubgroup, MulEquiv.subgroupCongr_apply,
-    AlgHom.toRingHom_eq_coe, RingHom.toIntAlgHom_toRingHom]
+    RingHom.toIntAlgHom_toRingHom]
 
 /-- Entrywise, the induced map applies the homomorphism of value rings to each matrix entry. -/
 theorem coe_pointsMap_apply (f : A →+* B) (g : points n A)
@@ -173,7 +173,7 @@ theorem pointsFunctor_obj (A : CommAlgCat.{v} ℤ) :
 theorem pointsFunctor_map {A B : CommAlgCat.{v} ℤ} (f : A ⟶ B) :
     (pointsFunctor n).map f =
       eqToHom (pointsFunctor_obj n A) ≫
-        GrpCat.ofHom (pointsMap n f.hom.toRingHom) ≫
+        GrpCat.ofHom (pointsMap n f.hom) ≫
         eqToHom (pointsFunctor_obj n B).symm :=
   (rfl)
 
@@ -237,7 +237,7 @@ theorem pointsMulEquiv_mapPoints {A B : CommAlgCat.{v} ℤ} (f : A ⟶ B)
           (H := CommHopfAlgCat.quotient
             (GeneralLinear.coordinateHopfAlgebra ℤ ((n + 1) + (n + 1))) (definingIdeal n))
           f q) =
-      pointsMap n f.hom.toRingHom (pointsMulEquiv n A q) := by
+      pointsMap n f.hom (pointsMulEquiv n A q) := by
   apply Subtype.ext
   rw [coe_pointsMap]
   simp only [pointsMulEquiv, MulEquiv.trans_apply, MulEquiv.subgroupCongr_symm_apply]

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/ToralClosure/Weyl.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/ToralClosure/Weyl.lean
@@ -133,8 +133,7 @@ theorem map_kostantToralWeylPoint {A : Type v} {B : Type v'} [CommRing A] [CommR
   apply Subtype.ext
   simp only [GeneralLinear.coe_mapHopfIdealPointsSubgroup, kostantToralWeylPoint,
     MulEquiv.subgroupCongr_apply, Subgroup.coe_mul, map_mul,
-    coe_kostantToralRootSubgroupPoints, AlgHom.toRingHom_eq_coe,
-    RingHom.toIntAlgHom_toRingHom]
+    coe_kostantToralRootSubgroupPoints, RingHom.toIntAlgHom_toRingHom]
   rw [map_kostantRootSubgroupMatrix e h ρ M hM i (hnil i) b φ,
     map_kostantRootSubgroupMatrix e h ρ M hM j (hnil j) b φ,
     AdditiveGroup.mapValue_gaPointsMulEquiv_symm_apply,

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/BaseChange.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/BaseChange.lean
@@ -258,7 +258,7 @@ theorem geckBaseChangePointsMulEquiv_mapPoints {B C : CommAlgCat.{w} A} (χ : B 
           (H := CommHopfAlgCat.quotient
             (GeneralLinear.coordinateHopfAlgebra A (t.geckDim ht))
             (t.geckBaseChangeDefiningIdeal ht A)) χ q) =
-      t.geckPointsMap ht χ.hom.toRingHom
+      t.geckPointsMap ht χ.hom
         (t.geckBaseChangePointsMulEquiv ht A B q) := by
   simp only [geckBaseChangePointsMulEquiv, MulEquiv.trans_apply]
   rw [CommHopfAlgCat.baseChangeIsoPointsMulEquiv_mapPoints,

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/PointsFunctor.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/PointsFunctor.lean
@@ -114,7 +114,7 @@ theorem coe_geckPointsMap (f : A →+* B) (g : t.geckPoints ht A) :
   rw [geckPointsMap]
   simp only [MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, MulEquiv.subgroupCongr_symm_apply,
     GeneralLinear.coe_mapHopfIdealPointsSubgroup, MulEquiv.subgroupCongr_apply,
-    AlgHom.toRingHom_eq_coe, RingHom.toIntAlgHom_toRingHom]
+    RingHom.toIntAlgHom_toRingHom]
 
 /-- Entrywise, the induced map on the points of the pinned Geck carrier applies the homomorphism
 of value rings to each matrix entry. -/
@@ -205,7 +205,7 @@ map, transported along the object identification above. -/
 theorem geckPointsFunctor_map {A B : CommAlgCat.{v} ℤ} (f : A ⟶ B) :
     (t.geckPointsFunctor ht).map f =
       eqToHom (t.geckPointsFunctor_obj ht A) ≫
-        GrpCat.ofHom (t.geckPointsMap ht f.hom.toRingHom) ≫
+        GrpCat.ofHom (t.geckPointsMap ht f.hom) ≫
         eqToHom (t.geckPointsFunctor_obj ht B).symm :=
   (rfl)
 
@@ -288,7 +288,7 @@ theorem geckPointsMulEquiv_mapPoints {A B : CommAlgCat.{v} ℤ} (f : A ⟶ B)
           (H := CommHopfAlgCat.quotient
             (GeneralLinear.coordinateHopfAlgebra ℤ (t.geckDim ht)) (t.geckDefiningIdeal ht))
           f q) =
-      t.geckPointsMap ht f.hom.toRingHom (t.geckPointsMulEquiv ht A q) := by
+      t.geckPointsMap ht f.hom (t.geckPointsMulEquiv ht A q) := by
   apply Subtype.ext
   rw [coe_geckPointsMap]
   simp only [geckPointsMulEquiv, MulEquiv.trans_apply, MulEquiv.subgroupCongr_symm_apply]


### PR DESCRIPTION
refactor: state the general-linear points API in simp-normal form

Mathlib makes the coercion the simp-normal form of `AlgHom.toRingHom`
(`AlgHom.toRingHom_eq_coe`, whose source comment reads "make the coercion the
simp-normal form"). A `@[simp]` lemma whose right-hand side says `.toRingHom` is
therefore rewritten again the moment it fires, so every caller lands one rewrite
short of normal form. Across the general-linear points API that was the case
throughout. This restates it.

* `GeneralLinear/HopfIdealPoints/Basic.lean`: `coe_mapHopfIdealPointsSubgroup`,
  its `map_mem_` sibling, and the definition between them read `(φ : A →+* B)`.
* `GeneralLinear/FunctorOfPoints.lean`: the five naturality statements
  (`pointToGeneralLinear_mapValue`, `pointsMulEquiv_mapValue`,
  `mapValue_pointsMulEquiv_symm_apply` and their two private `@[simp]`
  companions) likewise.
* The `@[simp]` statements of the carrier points API — `pointsFunctor_map`,
  `pointsMulEquiv_mapPoints`, and their `BaseChange` and `Projective` siblings —
  drop `.toRingHom` and let the coercion be inserted.
* The cascade that follows from those hubs — the sibling naturality lemmas for
  Symplectic, SpecialOrthogonal, the weight cocharacter and the polynomial point
  maps — is restated rather than bridged.

The payoff is concrete. #6307 had to write

    rw [AlgHom.toRingHom_eq_coe, RingHom.toIntAlgHom_toRingHom]

at every site that feeds a ring homomorphism to these maps: the first step is
there only to *undo* the simp-normal form so that a `.toRingHom`-shaped statement
can fire. With the statements normal those steps are dead, and 14 of them go,
leaving the bare lemma. Two proofs shrink for the same reason:
`AlgHom.id_toRingHom` and `AlgHom.comp_toRingHom` are already stated in coercion
form upstream, so `mapHopfIdealPointsSubgroup_id` and `_comp` now cite them
directly instead of restating them in a `have` that held only up to defeq.

Three uses of `AlgHom.toRingHom_eq_coe` remain and are deliberate: each crosses
into something still stated with `.toRingHom` — Mathlib's
`Ideal.Quotient.mkₐ_toRingHom`, and an untouched `UpperTriangularGroup.map`
definition.

Scope: only statements have a normal form, so definitions are left alone —
inserting the coercion into a functor's `map` field buys nothing and costs
`isDefEq` timeouts. The scheme-presentation lemmas (`groupScheme_one_left` and
its family, which say `Spec.map (CommRingCat.ofHom f.ofConv.toRingHom)`) carry
the same defect in a different API and are left for a follow-up.

Verified locally against this base: `lake build` (11112 jobs),
`scripts/lint-style.sh`, `scripts/lint-dot-notation.py` (0 new, identical to
main), and `scripts/lint-env.sh` (PASS, 63 grandfathered and 7 ratchetable,
unchanged from main).

Roadmap: ReductiveGroups


🤖 Generated with [Claude Code](https://claude.com/claude-code)
