### PR TITLE
feat: homotopy groups, asphericity and K(G, 1) are homotopy invariants

### DIFF
--- a/TauCeti/AlgebraicTopology/EilenbergMacLane/Basic.lean
+++ b/TauCeti/AlgebraicTopology/EilenbergMacLane/Basic.lean
@@ -5,10 +5,8 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.AlgebraicTopology.FundamentalGroup.Homeomorph
 public import TauCeti.AlgebraicTopology.FundamentalGroup.Product
 public import TauCeti.Topology.Homotopy.HomotopyGroup.BasepointChange
-public import TauCeti.Topology.Homotopy.HomotopyGroup.Homeomorph
 public import TauCeti.Topology.Homotopy.HomotopyGroup.Product
 
 /-!
@@ -21,8 +19,9 @@ aspherical space whose fundamental group is isomorphic to `G`.
 The definitions are properties rather than structures carrying chosen isomorphisms. Thus they
 are invariant under changing an exhibited fundamental-group isomorphism, and do not retain
 noncanonical data. This file records independence of the base point, invariance under
-homeomorphism and under isomorphism of the target group, as well as closure under binary and
-indexed products.
+isomorphism of the target group, as well as closure under binary and indexed products.
+Invariance under homotopy equivalence, and so in particular under homeomorphism, is in
+`TauCeti.AlgebraicTopology.EilenbergMacLane.HomotopyEquiv`.
 
 The product results reuse the existing product isomorphisms for fundamental and higher
 homotopy groups.
@@ -40,9 +39,6 @@ item 13, "`K(G, 1)` spaces". Concrete circle and torus examples are respectively
   of type `K(G, 1)`.
 * `TauCeti.IsAspherical.of_basepoint`, `TauCeti.IsEilenbergMacLaneSpaceOne.of_basepoint`:
   neither property depends on the base point.
-* `TauCeti.IsAspherical.of_homeomorph`,
-  `TauCeti.IsEilenbergMacLaneSpaceOne.of_homeomorph`:
-  invariance under pointed homeomorphisms.
 * `TauCeti.IsAspherical.prod`, `TauCeti.IsAspherical.pi`,
   `TauCeti.IsEilenbergMacLaneSpaceOne.prod`, `TauCeti.IsEilenbergMacLaneSpaceOne.pi`:
   closure under products.
@@ -97,16 +93,6 @@ theorem of_basepoint (h : IsAspherical X x) (x' : X) : IsAspherical X x' := by
   let : Subsingleton (π_ (n + 2) X x) := h.subsingleton_homotopyGroup n
   obtain ⟨φ⟩ := nonempty_homotopyGroupMulEquiv (N := Fin (n + 2)) (x := x) (y := x')
   exact φ.toEquiv.subsingleton_congr.mp inferInstance
-
-/-- Asphericity is preserved by a pointed homeomorphism. -/
-theorem of_homeomorph (hX : IsAspherical X x) (e : X ≃ₜ Y) (he : e x = y) :
-    IsAspherical Y y := by
-  let : PathConnectedSpace X := hX.pathConnectedSpace
-  refine ⟨e.surjective.pathConnectedSpace e.continuous, fun n ↦ ?_⟩
-  let : Subsingleton (π_ (n + 2) X x) := hX.subsingleton_homotopyGroup n
-  exact
-    (HomotopyGroup.homeomorphMulEquivOfEq (N := Fin (n + 2)) e he).toEquiv
-      |>.subsingleton_congr.mp inferInstance
 
 /-- The product of two aspherical spaces is aspherical. -/
 theorem prod (hX : IsAspherical X x) (hY : IsAspherical Y y) :
@@ -179,13 +165,6 @@ theorem of_basepoint (h : IsEilenbergMacLaneSpaceOne G X x) (x' : X) :
 theorem of_mulEquiv (h : IsEilenbergMacLaneSpaceOne G X x) (e : G ≃* H) :
     IsEilenbergMacLaneSpaceOne H X x :=
   ⟨h.isAspherical, h.nonempty_fundamentalGroupMulEquiv.map fun f ↦ f.trans e⟩
-
-/-- The `K(G, 1)` property is preserved by a pointed homeomorphism. -/
-theorem of_homeomorph (h : IsEilenbergMacLaneSpaceOne G X x) (e : X ≃ₜ Y) (he : e x = y) :
-    IsEilenbergMacLaneSpaceOne G Y y :=
-  ⟨h.isAspherical.of_homeomorph e he,
-    h.nonempty_fundamentalGroupMulEquiv.map fun f ↦
-      (FundamentalGroup.homeomorphMulEquivOfEq e he).symm.trans f⟩
 
 variable {G₁ : Type u} {G₂ : Type v} [Group G₁] [Group G₂]
   {X₁ : Type w} {X₂ : Type w'} [TopologicalSpace X₁] [TopologicalSpace X₂]

--- a/TauCeti/AlgebraicTopology/EilenbergMacLane/Basic.lean
+++ b/TauCeti/AlgebraicTopology/EilenbergMacLane/Basic.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.AlgebraicTopology.FundamentalGroup.Homeomorph
 public import TauCeti.AlgebraicTopology.FundamentalGroup.Product
+public import TauCeti.Topology.Homotopy.HomotopyGroup.BasepointChange
 public import TauCeti.Topology.Homotopy.HomotopyGroup.Homeomorph
 public import TauCeti.Topology.Homotopy.HomotopyGroup.Product
 
@@ -19,8 +20,9 @@ aspherical space whose fundamental group is isomorphic to `G`.
 
 The definitions are properties rather than structures carrying chosen isomorphisms. Thus they
 are invariant under changing an exhibited fundamental-group isomorphism, and do not retain
-noncanonical data. This file records invariance under homeomorphism and under isomorphism of
-the target group, as well as closure under binary and indexed products.
+noncanonical data. This file records independence of the base point, invariance under
+homeomorphism and under isomorphism of the target group, as well as closure under binary and
+indexed products.
 
 The product results reuse the existing product isomorphisms for fundamental and higher
 homotopy groups.
@@ -36,6 +38,8 @@ item 13, "`K(G, 1)` spaces". Concrete circle and torus examples are respectively
   dimensions at least two.
 * `TauCeti.IsEilenbergMacLaneSpaceOne`: the property of being an Eilenberg--Mac Lane space
   of type `K(G, 1)`.
+* `TauCeti.IsAspherical.of_basepoint`, `TauCeti.IsEilenbergMacLaneSpaceOne.of_basepoint`:
+  neither property depends on the base point.
 * `TauCeti.IsAspherical.of_homeomorph`,
   `TauCeti.IsEilenbergMacLaneSpaceOne.of_homeomorph`:
   invariance under pointed homeomorphisms.
@@ -84,6 +88,15 @@ protected theorem pathConnectedSpace (h : IsAspherical X x) : PathConnectedSpace
 protected theorem subsingleton_homotopyGroup (h : IsAspherical X x) (n : ℕ) :
     Subsingleton (π_ (n + 2) X x) :=
   h.2 n
+
+/-- **Asphericity does not depend on the base point.** An aspherical space is path connected, so
+its homotopy groups at any two points are isomorphic. -/
+theorem of_basepoint (h : IsAspherical X x) (x' : X) : IsAspherical X x' := by
+  let : PathConnectedSpace X := h.pathConnectedSpace
+  refine IsAspherical.mk h.pathConnectedSpace fun n ↦ ?_
+  let : Subsingleton (π_ (n + 2) X x) := h.subsingleton_homotopyGroup n
+  obtain ⟨φ⟩ := nonempty_homotopyGroupMulEquiv (N := Fin (n + 2)) (x := x) (y := x')
+  exact φ.toEquiv.subsingleton_congr.mp inferInstance
 
 /-- Asphericity is preserved by a pointed homeomorphism. -/
 theorem of_homeomorph (hX : IsAspherical X x) (e : X ≃ₜ Y) (he : e x = y) :
@@ -153,6 +166,14 @@ protected theorem isAspherical (h : IsEilenbergMacLaneSpaceOne G X x) :
 protected theorem nonempty_fundamentalGroupMulEquiv (h : IsEilenbergMacLaneSpaceOne G X x) :
     Nonempty (FundamentalGroup X x ≃* G) :=
   h.2
+
+/-- **The `K(G, 1)` property does not depend on the base point.** -/
+theorem of_basepoint (h : IsEilenbergMacLaneSpaceOne G X x) (x' : X) :
+    IsEilenbergMacLaneSpaceOne G X x' := by
+  let : PathConnectedSpace X := h.isAspherical.pathConnectedSpace
+  exact IsEilenbergMacLaneSpaceOne.mk (h.isAspherical.of_basepoint x')
+    (h.nonempty_fundamentalGroupMulEquiv.map fun f ↦
+      (_root_.FundamentalGroup.fundamentalGroupMulEquivOfPathConnected x' x).trans f)
 
 /-- Transporting the target group along an isomorphism preserves the `K(G, 1)` property. -/
 theorem of_mulEquiv (h : IsEilenbergMacLaneSpaceOne G X x) (e : G ≃* H) :

--- a/TauCeti/AlgebraicTopology/EilenbergMacLane/HomotopyEquiv.lean
+++ b/TauCeti/AlgebraicTopology/EilenbergMacLane/HomotopyEquiv.lean
@@ -17,11 +17,8 @@ aspherical space is path connected, so base-point change identifies its homotopy
 points. With that, homotopy invariance follows from the invariance of the homotopy groups
 themselves, since a homotopy equivalence carries no base point with it.
 
-This is the homotopy-invariant form of the stability statements in
-`TauCeti.AlgebraicTopology.EilenbergMacLane.Basic`, which record stability under a *pointed
-homeomorphism*. Those remain the tool for a homeomorphism: they depend only on the homotopy
-groups of homeomorphic spaces, not on base-point change, and they place the conclusion at the
-prescribed image base point.
+These are the canonical invariance statements for both properties. In particular they cover a
+homeomorphism `e : X ≃ₜ Y`, through `e.toHomotopyEquiv`, at any base point of `Y`.
 
 ## Main declarations
 
@@ -63,7 +60,7 @@ variable {G : Type*} [Group G]
 theorem of_homotopyEquiv (h : IsEilenbergMacLaneSpaceOne G X x) (e : X ≃ₕ Y) (y : Y) :
     IsEilenbergMacLaneSpaceOne G Y y := by
   let : PathConnectedSpace X := h.isAspherical.pathConnectedSpace
-  obtain ⟨φ⟩ := FundamentalGroup.nonempty_homotopyEquivMulEquiv e x y
+  obtain ⟨φ⟩ := FundamentalGroup.nonempty_fundamentalGroupMulEquiv_of_homotopyEquiv e x y
   exact IsEilenbergMacLaneSpaceOne.mk (h.isAspherical.of_homotopyEquiv e y)
     (h.nonempty_fundamentalGroupMulEquiv.map fun f => φ.symm.trans f)
 

--- a/TauCeti/AlgebraicTopology/EilenbergMacLane/HomotopyEquiv.lean
+++ b/TauCeti/AlgebraicTopology/EilenbergMacLane/HomotopyEquiv.lean
@@ -60,7 +60,7 @@ variable {G : Type*} [Group G]
 theorem of_homotopyEquiv (h : IsEilenbergMacLaneSpaceOne G X x) (e : X ≃ₕ Y) (y : Y) :
     IsEilenbergMacLaneSpaceOne G Y y := by
   let : PathConnectedSpace X := h.isAspherical.pathConnectedSpace
-  obtain ⟨φ⟩ := FundamentalGroup.nonempty_fundamentalGroupMulEquiv_of_homotopyEquiv e x y
+  obtain ⟨φ⟩ := e.nonempty_fundamentalGroupMulEquiv x y
   exact IsEilenbergMacLaneSpaceOne.mk (h.isAspherical.of_homotopyEquiv e y)
     (h.nonempty_fundamentalGroupMulEquiv.map fun f => φ.symm.trans f)
 

--- a/TauCeti/AlgebraicTopology/EilenbergMacLane/HomotopyEquiv.lean
+++ b/TauCeti/AlgebraicTopology/EilenbergMacLane/HomotopyEquiv.lean
@@ -11,10 +11,11 @@ public import TauCeti.AlgebraicTopology.FundamentalGroup.HomotopyEquiv
 /-!
 # Asphericity and the `K(G, 1)` property are homotopy invariants
 
-Both properties are stated at a base point, but neither depends on it: an aspherical space is
-path connected, so base-point change identifies its homotopy groups at any two points. With that,
-homotopy invariance follows from the invariance of the homotopy groups themselves, since a
-homotopy equivalence carries no base point with it.
+Both properties are stated at a base point, but neither depends on it
+(`TauCeti.IsAspherical.of_basepoint`, `TauCeti.IsEilenbergMacLaneSpaceOne.of_basepoint`): an
+aspherical space is path connected, so base-point change identifies its homotopy groups at any two
+points. With that, homotopy invariance follows from the invariance of the homotopy groups
+themselves, since a homotopy equivalence carries no base point with it.
 
 This is the homotopy-invariant form of the stability statements in
 `TauCeti.AlgebraicTopology.EilenbergMacLane.Basic`, which record stability under a *pointed
@@ -24,18 +25,13 @@ prescribed image base point.
 
 ## Main declarations
 
-* `TauCeti.IsAspherical.of_basepoint`, `TauCeti.IsEilenbergMacLaneSpaceOne.of_basepoint`:
-  neither property depends on the base point.
 * `TauCeti.IsAspherical.of_homotopyEquiv`: **asphericity is a homotopy invariant.**
 * `TauCeti.IsEilenbergMacLaneSpaceOne.of_homotopyEquiv`: **being a `K(G, 1)` space is a homotopy
   invariant.**
 
 ## References
 
-These generalise the stability under a homeomorphism that
-`TauCetiRoadmap/UniversalCovers/README.md`, Stage 4, item 14, "recognition of `K(G, 1)` spaces",
-asks for, and which is on `main` as `TauCeti.IsAspherical.of_homeomorph` and
-`TauCeti.IsEilenbergMacLaneSpaceOne.of_homeomorph`; compare Section 1.B of [hatcher02].
+Compare Section 1.B of [hatcher02].
 -/
 
 public section
@@ -47,15 +43,6 @@ open scoped Topology Topology.Homotopy ContinuousMap
 variable {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y] {x : X}
 
 namespace IsAspherical
-
-/-- **Asphericity does not depend on the base point.** An aspherical space is path connected, so
-its homotopy groups at any two points are isomorphic. -/
-theorem of_basepoint (h : IsAspherical X x) (y : X) : IsAspherical X y := by
-  let : PathConnectedSpace X := h.pathConnectedSpace
-  refine IsAspherical.mk h.pathConnectedSpace fun n => ?_
-  let : Subsingleton (π_ (n + 2) X x) := h.subsingleton_homotopyGroup n
-  obtain ⟨φ⟩ := nonempty_homotopyGroupMulEquiv (N := Fin (n + 2)) (x := x) (y := y)
-  exact φ.toEquiv.subsingleton_congr.mp inferInstance
 
 /-- **Asphericity is a homotopy invariant.** A space homotopy equivalent to an aspherical space
 is aspherical, at every base point. -/
@@ -71,14 +58,6 @@ end IsAspherical
 namespace IsEilenbergMacLaneSpaceOne
 
 variable {G : Type*} [Group G]
-
-/-- **The `K(G, 1)` property does not depend on the base point.** -/
-theorem of_basepoint (h : IsEilenbergMacLaneSpaceOne G X x) (y : X) :
-    IsEilenbergMacLaneSpaceOne G X y := by
-  let : PathConnectedSpace X := h.isAspherical.pathConnectedSpace
-  exact IsEilenbergMacLaneSpaceOne.mk (h.isAspherical.of_basepoint y)
-    (h.nonempty_fundamentalGroupMulEquiv.map fun f =>
-      (_root_.FundamentalGroup.fundamentalGroupMulEquivOfPathConnected y x).trans f)
 
 /-- **Being an Eilenberg--Mac Lane space of type `K(G, 1)` is a homotopy invariant.** -/
 theorem of_homotopyEquiv (h : IsEilenbergMacLaneSpaceOne G X x) (e : X ≃ₕ Y) (y : Y) :

--- a/TauCeti/AlgebraicTopology/EilenbergMacLane/HomotopyEquiv.lean
+++ b/TauCeti/AlgebraicTopology/EilenbergMacLane/HomotopyEquiv.lean
@@ -32,8 +32,10 @@ prescribed image base point.
 
 ## References
 
-This is the homotopy-invariance half of `TauCetiRoadmap/UniversalCovers/README.md`, Stage 4,
-item 14, "recognition of `K(G, 1)` spaces"; compare Section 1.B of [hatcher02].
+These generalise the stability under a homeomorphism that
+`TauCetiRoadmap/UniversalCovers/README.md`, Stage 4, item 14, "recognition of `K(G, 1)` spaces",
+asks for, and which is on `main` as `TauCeti.IsAspherical.of_homeomorph` and
+`TauCeti.IsEilenbergMacLaneSpaceOne.of_homeomorph`; compare Section 1.B of [hatcher02].
 -/
 
 public section

--- a/TauCeti/AlgebraicTopology/EilenbergMacLane/HomotopyEquiv.lean
+++ b/TauCeti/AlgebraicTopology/EilenbergMacLane/HomotopyEquiv.lean
@@ -1,0 +1,91 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicTopology.EilenbergMacLane.Basic
+public import TauCeti.AlgebraicTopology.FundamentalGroup.HomotopyEquiv
+
+/-!
+# Asphericity and the `K(G, 1)` property are homotopy invariants
+
+Both properties are stated at a base point, but neither depends on it: an aspherical space is
+path connected, so base-point change identifies its homotopy groups at any two points. With that,
+homotopy invariance follows from the invariance of the homotopy groups themselves, since a
+homotopy equivalence carries no base point with it.
+
+This is the homotopy-invariant form of the stability statements in
+`TauCeti.AlgebraicTopology.EilenbergMacLane.Basic`, which record stability under a *pointed
+homeomorphism*. Those remain the tool for a homeomorphism: they depend only on the homotopy
+groups of homeomorphic spaces, not on base-point change, and they place the conclusion at the
+prescribed image base point.
+
+## Main declarations
+
+* `TauCeti.IsAspherical.of_basepoint`, `TauCeti.IsEilenbergMacLaneSpaceOne.of_basepoint`:
+  neither property depends on the base point.
+* `TauCeti.IsAspherical.of_homotopyEquiv`: **asphericity is a homotopy invariant.**
+* `TauCeti.IsEilenbergMacLaneSpaceOne.of_homotopyEquiv`: **being a `K(G, 1)` space is a homotopy
+  invariant.**
+
+## References
+
+This is the homotopy-invariance half of `TauCetiRoadmap/UniversalCovers/README.md`, Stage 4,
+item 14, "recognition of `K(G, 1)` spaces"; compare Section 1.B of [hatcher02].
+-/
+
+public section
+
+namespace TauCeti
+
+open scoped Topology Topology.Homotopy ContinuousMap
+
+variable {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y] {x : X}
+
+namespace IsAspherical
+
+/-- **Asphericity does not depend on the base point.** An aspherical space is path connected, so
+its homotopy groups at any two points are isomorphic. -/
+theorem of_basepoint (h : IsAspherical X x) (y : X) : IsAspherical X y := by
+  let : PathConnectedSpace X := h.pathConnectedSpace
+  refine IsAspherical.mk h.pathConnectedSpace fun n => ?_
+  let : Subsingleton (π_ (n + 2) X x) := h.subsingleton_homotopyGroup n
+  obtain ⟨φ⟩ := nonempty_homotopyGroupMulEquiv (N := Fin (n + 2)) (x := x) (y := y)
+  exact φ.toEquiv.subsingleton_congr.mp inferInstance
+
+/-- **Asphericity is a homotopy invariant.** A space homotopy equivalent to an aspherical space
+is aspherical, at every base point. -/
+theorem of_homotopyEquiv (h : IsAspherical X x) (e : X ≃ₕ Y) (y : Y) : IsAspherical Y y := by
+  let : PathConnectedSpace X := h.pathConnectedSpace
+  refine IsAspherical.mk e.pathConnectedSpace fun n => ?_
+  let : Subsingleton (π_ (n + 2) X x) := h.subsingleton_homotopyGroup n
+  obtain ⟨φ⟩ := nonempty_homotopyGroupMulEquiv_of_homotopyEquiv (N := Fin (n + 2)) e x y
+  exact φ.toEquiv.subsingleton_congr.mp inferInstance
+
+end IsAspherical
+
+namespace IsEilenbergMacLaneSpaceOne
+
+variable {G : Type*} [Group G]
+
+/-- **The `K(G, 1)` property does not depend on the base point.** -/
+theorem of_basepoint (h : IsEilenbergMacLaneSpaceOne G X x) (y : X) :
+    IsEilenbergMacLaneSpaceOne G X y := by
+  let : PathConnectedSpace X := h.isAspherical.pathConnectedSpace
+  exact IsEilenbergMacLaneSpaceOne.mk (h.isAspherical.of_basepoint y)
+    (h.nonempty_fundamentalGroupMulEquiv.map fun f =>
+      (_root_.FundamentalGroup.fundamentalGroupMulEquivOfPathConnected y x).trans f)
+
+/-- **Being an Eilenberg--Mac Lane space of type `K(G, 1)` is a homotopy invariant.** -/
+theorem of_homotopyEquiv (h : IsEilenbergMacLaneSpaceOne G X x) (e : X ≃ₕ Y) (y : Y) :
+    IsEilenbergMacLaneSpaceOne G Y y := by
+  let : PathConnectedSpace X := h.isAspherical.pathConnectedSpace
+  obtain ⟨φ⟩ := FundamentalGroup.nonempty_homotopyEquivMulEquiv e x y
+  exact IsEilenbergMacLaneSpaceOne.mk (h.isAspherical.of_homotopyEquiv e y)
+    (h.nonempty_fundamentalGroupMulEquiv.map fun f => φ.symm.trans f)
+
+end IsEilenbergMacLaneSpaceOne
+
+end TauCeti

--- a/TauCeti/AlgebraicTopology/FundamentalGroup/HomotopyEquiv.lean
+++ b/TauCeti/AlgebraicTopology/FundamentalGroup/HomotopyEquiv.lean
@@ -23,16 +23,15 @@ homeomorphism is what is available.
 
 ## Main declarations
 
-* `TauCeti.FundamentalGroup.homotopyEquivMulEquiv`: `π₁(X, x) ≃* π₁(Y, e x)` for a homotopy
-  equivalence `e : X ≃ₕ Y`.
-* `TauCeti.FundamentalGroup.nonempty_homotopyEquivMulEquiv`: over a path connected space, the
+* `FundamentalGroup.homotopyEquivMulEquiv`: `π₁(X, x) ≃* π₁(Y, e x)` for a homotopy
+  equivalence `e : X ≃ₕ Y`, with `FundamentalGroup.homotopyEquivMulEquiv_apply` and
+  `FundamentalGroup.homotopyEquivMulEquiv_symm_apply`.
+* `FundamentalGroup.nonempty_homotopyEquivMulEquiv`: over a path connected space, the
   fundamental groups at *any* pair of base points are isomorphic.
 -/
 
 public section
 noncomputable section
-
-namespace TauCeti
 
 namespace FundamentalGroup
 
@@ -41,11 +40,38 @@ open scoped ContinuousMap
 variable {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
 
 /-- **A homotopy equivalence induces an isomorphism of fundamental groups.** -/
-@[expose] def homotopyEquivMulEquiv (e : X ≃ₕ Y) (x : X) :
+def homotopyEquivMulEquiv (e : X ≃ₕ Y) (x : X) :
     _root_.FundamentalGroup X x ≃* _root_.FundamentalGroup Y (e.toFun x) :=
   _root_.HomotopyGroup.pi1MulEquivFundamentalGroup.symm.trans
-    ((homotopyGroupMulEquivOfHomotopyEquiv (N := Fin 1) e x).trans
+    ((_root_.HomotopyGroup.mulEquivOfHomotopyEquiv (N := Fin 1) e x).trans
       _root_.HomotopyGroup.pi1MulEquivFundamentalGroup)
+
+/-- Read through `π_ 1`, the isomorphism induced by a homotopy equivalence `e` is the map that
+`e.toFun` induces on homotopy groups. -/
+@[simp]
+theorem homotopyEquivMulEquiv_apply (e : X ≃ₕ Y) (x : X) (a : _root_.FundamentalGroup X x) :
+    homotopyEquivMulEquiv e x a =
+      _root_.HomotopyGroup.pi1MulEquivFundamentalGroup
+        (_root_.HomotopyGroup.map e.toFun rfl
+          (_root_.HomotopyGroup.pi1MulEquivFundamentalGroup.symm a)) := by
+  rw [homotopyEquivMulEquiv, MulEquiv.trans_apply, MulEquiv.trans_apply,
+    _root_.HomotopyGroup.mulEquivOfHomotopyEquiv_apply]
+
+/-- Read through `π_ 1`, the inverse of the isomorphism induced by a homotopy equivalence `e` is
+the map that `e.invFun` induces on homotopy groups, followed by base-point change along the trace
+of the round trip `e.invFun ∘ e.toFun ≃ id`. -/
+@[simp]
+theorem homotopyEquivMulEquiv_symm_apply (e : X ≃ₕ Y) (x : X)
+    (b : _root_.FundamentalGroup Y (e.toFun x)) :
+    (homotopyEquivMulEquiv e x).symm b =
+      _root_.HomotopyGroup.pi1MulEquivFundamentalGroup
+        (TauCeti.homotopyGroupTransport
+          ((e.left_inv.some.evalAt x).cast (ContinuousMap.comp_apply e.invFun e.toFun x).symm
+            (ContinuousMap.id_apply x).symm)
+          (_root_.HomotopyGroup.map e.invFun rfl
+            (_root_.HomotopyGroup.pi1MulEquivFundamentalGroup.symm b))) := by
+  rw [homotopyEquivMulEquiv, MulEquiv.symm_trans_apply, MulEquiv.symm_trans_apply,
+    MulEquiv.symm_symm, _root_.HomotopyGroup.mulEquivOfHomotopyEquiv_symm_apply]
 
 /-- Over a path connected space, homotopy equivalence identifies the fundamental groups at *any*
 pair of base points, by composing with base-point change. -/
@@ -56,5 +82,3 @@ theorem nonempty_homotopyEquivMulEquiv [PathConnectedSpace X] (e : X ≃ₕ Y) (
     (_root_.FundamentalGroup.fundamentalGroupMulEquivOfPathConnected (e.toFun x) y)⟩
 
 end FundamentalGroup
-
-end TauCeti

--- a/TauCeti/AlgebraicTopology/FundamentalGroup/HomotopyEquiv.lean
+++ b/TauCeti/AlgebraicTopology/FundamentalGroup/HomotopyEquiv.lean
@@ -23,17 +23,15 @@ homeomorphism is what is available.
 
 ## Main declarations
 
-* `TauCeti.FundamentalGroup.homotopyEquivMulEquiv`: `π₁(X, x) ≃* π₁(Y, e x)` for a homotopy
-  equivalence `e : X ≃ₕ Y`, with `TauCeti.FundamentalGroup.homotopyEquivMulEquiv_apply` and
-  `TauCeti.FundamentalGroup.homotopyEquivMulEquiv_symm_apply`.
-* `TauCeti.FundamentalGroup.nonempty_homotopyEquivMulEquiv`: over a path connected space, the
+* `FundamentalGroup.homotopyEquivMulEquiv`: `π₁(X, x) ≃* π₁(Y, e x)` for a homotopy
+  equivalence `e : X ≃ₕ Y`, with `FundamentalGroup.homotopyEquivMulEquiv_apply` and
+  `FundamentalGroup.homotopyEquivMulEquiv_symm_apply`.
+* `FundamentalGroup.nonempty_homotopyEquivMulEquiv`: over a path connected space, the
   fundamental groups at *any* pair of base points are isomorphic.
 -/
 
 public section
 noncomputable section
-
-namespace TauCeti
 
 namespace FundamentalGroup
 
@@ -84,5 +82,3 @@ theorem nonempty_homotopyEquivMulEquiv [PathConnectedSpace X] (e : X ≃ₕ Y) (
     (_root_.FundamentalGroup.fundamentalGroupMulEquivOfPathConnected (e.toFun x) y)⟩
 
 end FundamentalGroup
-
-end TauCeti

--- a/TauCeti/AlgebraicTopology/FundamentalGroup/HomotopyEquiv.lean
+++ b/TauCeti/AlgebraicTopology/FundamentalGroup/HomotopyEquiv.lean
@@ -22,26 +22,27 @@ homeomorphism is what is available.
 
 ## Main declarations
 
-* `FundamentalGroup.homotopyEquivMulEquiv`: `π₁(X, x) ≃* π₁(Y, e x)` for a homotopy
-  equivalence `e : X ≃ₕ Y`, with `FundamentalGroup.homotopyEquivMulEquiv_apply` and
-  `FundamentalGroup.homotopyEquivMulEquiv_symm_apply`.
-* `FundamentalGroup.homotopyEquivMulEquiv_refl`, `FundamentalGroup.homotopyEquivMulEquiv_trans`:
-  the construction respects identities and composition of homotopy equivalences.
-* `FundamentalGroup.nonempty_fundamentalGroupMulEquiv_of_homotopyEquiv`: over a path connected
+* `ContinuousMap.HomotopyEquiv.fundamentalGroupMulEquiv`: `π₁(X, x) ≃* π₁(Y, e x)` for a homotopy
+  equivalence `e : X ≃ₕ Y`, with `ContinuousMap.HomotopyEquiv.fundamentalGroupMulEquiv_apply` and
+  `ContinuousMap.HomotopyEquiv.fundamentalGroupMulEquiv_symm_apply`.
+* `ContinuousMap.HomotopyEquiv.fundamentalGroupMulEquiv_refl`,
+  `ContinuousMap.HomotopyEquiv.fundamentalGroupMulEquiv_trans`: the construction respects
+  identities and composition of homotopy equivalences.
+* `ContinuousMap.HomotopyEquiv.nonempty_fundamentalGroupMulEquiv`: over a path connected
   space, the fundamental groups at *any* pair of base points are isomorphic.
 -/
 
 public section
 noncomputable section
 
-namespace FundamentalGroup
+namespace TauCeti
 
 open scoped ContinuousMap
 
 variable {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
 
 /-- **A homotopy equivalence induces an isomorphism of fundamental groups.** -/
-def homotopyEquivMulEquiv (e : X ≃ₕ Y) (x : X) :
+def _root_.ContinuousMap.HomotopyEquiv.fundamentalGroupMulEquiv (e : X ≃ₕ Y) (x : X) :
     _root_.FundamentalGroup X x ≃* _root_.FundamentalGroup Y (e.toFun x) :=
   _root_.HomotopyGroup.pi1MulEquivFundamentalGroup.symm.trans
     ((_root_.HomotopyGroup.mulEquivOfHomotopyEquiv (N := Fin 1) e x).trans
@@ -50,46 +51,48 @@ def homotopyEquivMulEquiv (e : X ≃ₕ Y) (x : X) :
 /-- Read through `π_ 1`, the isomorphism induced by a homotopy equivalence `e` is the map that
 `e.toFun` induces on homotopy groups. -/
 @[simp]
-theorem homotopyEquivMulEquiv_apply (e : X ≃ₕ Y) (x : X) (a : _root_.FundamentalGroup X x) :
-    homotopyEquivMulEquiv e x a =
+theorem _root_.ContinuousMap.HomotopyEquiv.fundamentalGroupMulEquiv_apply (e : X ≃ₕ Y) (x : X)
+    (a : _root_.FundamentalGroup X x) :
+    e.fundamentalGroupMulEquiv x a =
       _root_.HomotopyGroup.pi1MulEquivFundamentalGroup
         (_root_.HomotopyGroup.map e.toFun rfl
           (_root_.HomotopyGroup.pi1MulEquivFundamentalGroup.symm a)) := by
-  rw [homotopyEquivMulEquiv, MulEquiv.trans_apply, MulEquiv.trans_apply,
-    _root_.HomotopyGroup.mulEquivOfHomotopyEquiv_apply]
+  rw [ContinuousMap.HomotopyEquiv.fundamentalGroupMulEquiv, MulEquiv.trans_apply,
+    MulEquiv.trans_apply, _root_.HomotopyGroup.mulEquivOfHomotopyEquiv_apply]
 
 /-- Read through `π_ 1`, the inverse of the isomorphism induced by a homotopy equivalence `e` is
 the map that `e.invFun` induces on homotopy groups, followed by base-point change along the trace
 of the round trip `e.invFun ∘ e.toFun ≃ id`. -/
 @[simp]
-theorem homotopyEquivMulEquiv_symm_apply (e : X ≃ₕ Y) (x : X)
-    (b : _root_.FundamentalGroup Y (e.toFun x)) :
-    (homotopyEquivMulEquiv e x).symm b =
+theorem _root_.ContinuousMap.HomotopyEquiv.fundamentalGroupMulEquiv_symm_apply (e : X ≃ₕ Y)
+    (x : X) (b : _root_.FundamentalGroup Y (e.toFun x)) :
+    (e.fundamentalGroupMulEquiv x).symm b =
       _root_.HomotopyGroup.pi1MulEquivFundamentalGroup
-        (TauCeti.homotopyGroupTransport
+        (homotopyGroupTransport
           ((e.left_inv.some.evalAt x).cast (ContinuousMap.comp_apply e.invFun e.toFun x).symm
             (ContinuousMap.id_apply x).symm)
           (_root_.HomotopyGroup.map e.invFun rfl
             (_root_.HomotopyGroup.pi1MulEquivFundamentalGroup.symm b))) := by
-  rw [homotopyEquivMulEquiv, MulEquiv.symm_trans_apply, MulEquiv.symm_trans_apply,
-    MulEquiv.symm_symm, _root_.HomotopyGroup.mulEquivOfHomotopyEquiv_symm_apply]
+  rw [ContinuousMap.HomotopyEquiv.fundamentalGroupMulEquiv, MulEquiv.symm_trans_apply,
+    MulEquiv.symm_trans_apply, MulEquiv.symm_symm,
+    _root_.HomotopyGroup.mulEquivOfHomotopyEquiv_symm_apply]
 
 /-- The identity homotopy equivalence induces the identity isomorphism of fundamental groups. -/
 @[simp]
-theorem homotopyEquivMulEquiv_refl (x : X) :
-    homotopyEquivMulEquiv (ContinuousMap.HomotopyEquiv.refl X) x = MulEquiv.refl _ :=
+theorem _root_.ContinuousMap.HomotopyEquiv.fundamentalGroupMulEquiv_refl (x : X) :
+    (ContinuousMap.HomotopyEquiv.refl X).fundamentalGroupMulEquiv x = MulEquiv.refl _ :=
   MulEquiv.ext fun a => by
-    rw [homotopyEquivMulEquiv, MulEquiv.trans_apply, MulEquiv.trans_apply,
-      _root_.HomotopyGroup.mulEquivOfHomotopyEquiv_refl]
+    rw [ContinuousMap.HomotopyEquiv.fundamentalGroupMulEquiv, MulEquiv.trans_apply,
+      MulEquiv.trans_apply, _root_.HomotopyGroup.mulEquivOfHomotopyEquiv_refl]
     exact MulEquiv.apply_symm_apply _ a
 
 /-- The isomorphism of fundamental groups induced by a composite of homotopy equivalences is the
 composite of the induced isomorphisms. -/
 @[simp]
-theorem homotopyEquivMulEquiv_trans {Z : Type*} [TopologicalSpace Z] (e : X ≃ₕ Y) (e' : Y ≃ₕ Z)
-    (x : X) :
-    homotopyEquivMulEquiv (e.trans e') x =
-      (homotopyEquivMulEquiv e x).trans (homotopyEquivMulEquiv e' (e.toFun x)) :=
+theorem _root_.ContinuousMap.HomotopyEquiv.fundamentalGroupMulEquiv_trans {Z : Type*}
+    [TopologicalSpace Z] (e : X ≃ₕ Y) (e' : Y ≃ₕ Z) (x : X) :
+    (e.trans e').fundamentalGroupMulEquiv x =
+      (e.fundamentalGroupMulEquiv x).trans (e'.fundamentalGroupMulEquiv (e.toFun x)) :=
   MulEquiv.ext fun a => by
     -- The two sides live over the base points `(e.trans e').toFun x` and `e'.toFun (e.toFun x)`,
     -- which agree only after unfolding `HomotopyEquiv.trans`, so `rw` cannot rewrite the goal;
@@ -99,20 +102,20 @@ theorem homotopyEquivMulEquiv_trans {Z : Type*} [TopologicalSpace Z] (e : X ≃�
         (_root_.HomotopyGroup.pi1MulEquivFundamentalGroup.symm a)).symm.trans
         (congrArg (_root_.HomotopyGroup.map e'.toFun rfl)
           (MulEquiv.symm_apply_apply _root_.HomotopyGroup.pi1MulEquivFundamentalGroup _).symm))
-    exact (homotopyEquivMulEquiv_apply (e.trans e') x a).trans (h.trans
+    exact ((e.trans e').fundamentalGroupMulEquiv_apply x a).trans (h.trans
       ((congrArg (fun b : _root_.FundamentalGroup Y (e.toFun x) =>
           _root_.HomotopyGroup.pi1MulEquivFundamentalGroup (_root_.HomotopyGroup.map e'.toFun rfl
             (_root_.HomotopyGroup.pi1MulEquivFundamentalGroup.symm b)))
-        (homotopyEquivMulEquiv_apply e x a).symm).trans
-        (homotopyEquivMulEquiv_apply e' (e.toFun x) _).symm))
+        (e.fundamentalGroupMulEquiv_apply x a).symm).trans
+        (e'.fundamentalGroupMulEquiv_apply (e.toFun x) _).symm))
 
 /-- Over a path connected space, homotopy equivalence identifies the fundamental groups at *any*
 pair of base points, by composing with base-point change. -/
-theorem nonempty_fundamentalGroupMulEquiv_of_homotopyEquiv [PathConnectedSpace X] (e : X ≃ₕ Y)
-    (x : X) (y : Y) :
+theorem _root_.ContinuousMap.HomotopyEquiv.nonempty_fundamentalGroupMulEquiv
+    [PathConnectedSpace X] (e : X ≃ₕ Y) (x : X) (y : Y) :
     Nonempty (_root_.FundamentalGroup X x ≃* _root_.FundamentalGroup Y y) := by
   have : PathConnectedSpace Y := e.pathConnectedSpace
-  exact ⟨(homotopyEquivMulEquiv e x).trans
+  exact ⟨(e.fundamentalGroupMulEquiv x).trans
     (_root_.FundamentalGroup.fundamentalGroupMulEquivOfPathConnected (e.toFun x) y)⟩
 
-end FundamentalGroup
+end TauCeti

--- a/TauCeti/AlgebraicTopology/FundamentalGroup/HomotopyEquiv.lean
+++ b/TauCeti/AlgebraicTopology/FundamentalGroup/HomotopyEquiv.lean
@@ -23,15 +23,17 @@ homeomorphism is what is available.
 
 ## Main declarations
 
-* `FundamentalGroup.homotopyEquivMulEquiv`: `π₁(X, x) ≃* π₁(Y, e x)` for a homotopy
-  equivalence `e : X ≃ₕ Y`, with `FundamentalGroup.homotopyEquivMulEquiv_apply` and
-  `FundamentalGroup.homotopyEquivMulEquiv_symm_apply`.
-* `FundamentalGroup.nonempty_homotopyEquivMulEquiv`: over a path connected space, the
+* `TauCeti.FundamentalGroup.homotopyEquivMulEquiv`: `π₁(X, x) ≃* π₁(Y, e x)` for a homotopy
+  equivalence `e : X ≃ₕ Y`, with `TauCeti.FundamentalGroup.homotopyEquivMulEquiv_apply` and
+  `TauCeti.FundamentalGroup.homotopyEquivMulEquiv_symm_apply`.
+* `TauCeti.FundamentalGroup.nonempty_homotopyEquivMulEquiv`: over a path connected space, the
   fundamental groups at *any* pair of base points are isomorphic.
 -/
 
 public section
 noncomputable section
+
+namespace TauCeti
 
 namespace FundamentalGroup
 
@@ -82,3 +84,5 @@ theorem nonempty_homotopyEquivMulEquiv [PathConnectedSpace X] (e : X ≃ₕ Y) (
     (_root_.FundamentalGroup.fundamentalGroupMulEquivOfPathConnected (e.toFun x) y)⟩
 
 end FundamentalGroup
+
+end TauCeti

--- a/TauCeti/AlgebraicTopology/FundamentalGroup/HomotopyEquiv.lean
+++ b/TauCeti/AlgebraicTopology/FundamentalGroup/HomotopyEquiv.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.AlgebraicTopology.FundamentalGroupoid.FundamentalGroup
 public import TauCeti.Topology.Homotopy.HomotopyGroup.HomotopyEquiv
 
 /-!
@@ -26,8 +25,10 @@ homeomorphism is what is available.
 * `FundamentalGroup.homotopyEquivMulEquiv`: `π₁(X, x) ≃* π₁(Y, e x)` for a homotopy
   equivalence `e : X ≃ₕ Y`, with `FundamentalGroup.homotopyEquivMulEquiv_apply` and
   `FundamentalGroup.homotopyEquivMulEquiv_symm_apply`.
-* `FundamentalGroup.nonempty_homotopyEquivMulEquiv`: over a path connected space, the
-  fundamental groups at *any* pair of base points are isomorphic.
+* `FundamentalGroup.homotopyEquivMulEquiv_refl`, `FundamentalGroup.homotopyEquivMulEquiv_trans`:
+  the construction respects identities and composition of homotopy equivalences.
+* `FundamentalGroup.nonempty_fundamentalGroupMulEquiv_of_homotopyEquiv`: over a path connected
+  space, the fundamental groups at *any* pair of base points are isomorphic.
 -/
 
 public section
@@ -73,9 +74,42 @@ theorem homotopyEquivMulEquiv_symm_apply (e : X ≃ₕ Y) (x : X)
   rw [homotopyEquivMulEquiv, MulEquiv.symm_trans_apply, MulEquiv.symm_trans_apply,
     MulEquiv.symm_symm, _root_.HomotopyGroup.mulEquivOfHomotopyEquiv_symm_apply]
 
+/-- The identity homotopy equivalence induces the identity isomorphism of fundamental groups. -/
+@[simp]
+theorem homotopyEquivMulEquiv_refl (x : X) :
+    homotopyEquivMulEquiv (ContinuousMap.HomotopyEquiv.refl X) x = MulEquiv.refl _ :=
+  MulEquiv.ext fun a => by
+    rw [homotopyEquivMulEquiv, MulEquiv.trans_apply, MulEquiv.trans_apply,
+      _root_.HomotopyGroup.mulEquivOfHomotopyEquiv_refl]
+    exact MulEquiv.apply_symm_apply _ a
+
+/-- The isomorphism of fundamental groups induced by a composite of homotopy equivalences is the
+composite of the induced isomorphisms. -/
+@[simp]
+theorem homotopyEquivMulEquiv_trans {Z : Type*} [TopologicalSpace Z] (e : X ≃ₕ Y) (e' : Y ≃ₕ Z)
+    (x : X) :
+    homotopyEquivMulEquiv (e.trans e') x =
+      (homotopyEquivMulEquiv e x).trans (homotopyEquivMulEquiv e' (e.toFun x)) :=
+  MulEquiv.ext fun a => by
+    -- The two sides live over the base points `(e.trans e').toFun x` and `e'.toFun (e.toFun x)`,
+    -- which agree only after unfolding `HomotopyEquiv.trans`, so `rw` cannot rewrite the goal;
+    -- chain the application lemmas instead.
+    have h := congrArg _root_.HomotopyGroup.pi1MulEquivFundamentalGroup
+      ((_root_.HomotopyGroup.map_comp_apply (N := Fin 1) e'.toFun rfl e.toFun rfl
+        (_root_.HomotopyGroup.pi1MulEquivFundamentalGroup.symm a)).symm.trans
+        (congrArg (_root_.HomotopyGroup.map e'.toFun rfl)
+          (MulEquiv.symm_apply_apply _root_.HomotopyGroup.pi1MulEquivFundamentalGroup _).symm))
+    exact (homotopyEquivMulEquiv_apply (e.trans e') x a).trans (h.trans
+      ((congrArg (fun b : _root_.FundamentalGroup Y (e.toFun x) =>
+          _root_.HomotopyGroup.pi1MulEquivFundamentalGroup (_root_.HomotopyGroup.map e'.toFun rfl
+            (_root_.HomotopyGroup.pi1MulEquivFundamentalGroup.symm b)))
+        (homotopyEquivMulEquiv_apply e x a).symm).trans
+        (homotopyEquivMulEquiv_apply e' (e.toFun x) _).symm))
+
 /-- Over a path connected space, homotopy equivalence identifies the fundamental groups at *any*
 pair of base points, by composing with base-point change. -/
-theorem nonempty_homotopyEquivMulEquiv [PathConnectedSpace X] (e : X ≃ₕ Y) (x : X) (y : Y) :
+theorem nonempty_fundamentalGroupMulEquiv_of_homotopyEquiv [PathConnectedSpace X] (e : X ≃ₕ Y)
+    (x : X) (y : Y) :
     Nonempty (_root_.FundamentalGroup X x ≃* _root_.FundamentalGroup Y y) := by
   have : PathConnectedSpace Y := e.pathConnectedSpace
   exact ⟨(homotopyEquivMulEquiv e x).trans

--- a/TauCeti/AlgebraicTopology/FundamentalGroup/HomotopyEquiv.lean
+++ b/TauCeti/AlgebraicTopology/FundamentalGroup/HomotopyEquiv.lean
@@ -1,0 +1,60 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.AlgebraicTopology.FundamentalGroupoid.FundamentalGroup
+public import TauCeti.Topology.Homotopy.HomotopyGroup.HomotopyEquiv
+
+/-!
+# The fundamental group is a homotopy invariant
+
+A homotopy equivalence induces an isomorphism of fundamental groups. This is read off from the
+corresponding statement for higher homotopy groups in dimension one, through Mathlib's
+`HomotopyGroup.pi1MulEquivFundamentalGroup`, rather than reproved: the free-homotopy trace
+argument is dimension independent, and `π_ 1` is the fundamental group.
+
+This strengthens `TauCeti.FundamentalGroup.homeomorphMulEquiv`, which covers the case of a
+homeomorphism, but the two are independent as API: the homeomorphism version has an explicit
+inverse and needs no finiteness or decidability instances, so it stays the tool of choice when a
+homeomorphism is what is available.
+
+## Main declarations
+
+* `TauCeti.FundamentalGroup.homotopyEquivMulEquiv`: `π₁(X, x) ≃* π₁(Y, e x)` for a homotopy
+  equivalence `e : X ≃ₕ Y`.
+* `TauCeti.FundamentalGroup.nonempty_homotopyEquivMulEquiv`: over a path connected space, the
+  fundamental groups at *any* pair of base points are isomorphic.
+-/
+
+public section
+noncomputable section
+
+namespace TauCeti
+
+namespace FundamentalGroup
+
+open scoped ContinuousMap
+
+variable {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
+
+/-- **A homotopy equivalence induces an isomorphism of fundamental groups.** -/
+@[expose] def homotopyEquivMulEquiv (e : X ≃ₕ Y) (x : X) :
+    _root_.FundamentalGroup X x ≃* _root_.FundamentalGroup Y (e.toFun x) :=
+  _root_.HomotopyGroup.pi1MulEquivFundamentalGroup.symm.trans
+    ((homotopyGroupMulEquivOfHomotopyEquiv (N := Fin 1) e x).trans
+      _root_.HomotopyGroup.pi1MulEquivFundamentalGroup)
+
+/-- Over a path connected space, homotopy equivalence identifies the fundamental groups at *any*
+pair of base points, by composing with base-point change. -/
+theorem nonempty_homotopyEquivMulEquiv [PathConnectedSpace X] (e : X ≃ₕ Y) (x : X) (y : Y) :
+    Nonempty (_root_.FundamentalGroup X x ≃* _root_.FundamentalGroup Y y) := by
+  have : PathConnectedSpace Y := e.pathConnectedSpace
+  exact ⟨(homotopyEquivMulEquiv e x).trans
+    (_root_.FundamentalGroup.fundamentalGroupMulEquivOfPathConnected (e.toFun x) y)⟩
+
+end FundamentalGroup
+
+end TauCeti

--- a/TauCeti/Topology/Homotopy/HomotopyEquiv.lean
+++ b/TauCeti/Topology/Homotopy/HomotopyEquiv.lean
@@ -1,0 +1,53 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Topology.Homotopy.Equiv
+public import Mathlib.Topology.Homotopy.Path
+
+/-!
+# Path connectedness is a homotopy invariant
+
+A homotopy equivalence `e : X ≃ₕ Y` is not surjective, so path connectedness of `Y` cannot be
+read off from the image of a path in `X`. What replaces surjectivity is the trace of the
+homotopy `e.toFun ∘ e.invFun ≃ id`: evaluated at a point `y`, it is a path from
+`e.toFun (e.invFun y)` to `y`. Two points of `Y` are therefore joined to points in the image of
+`e.toFun`, which are joined to each other because `X` is path connected.
+
+## Main declarations
+
+* `ContinuousMap.HomotopyEquiv.joined_toFun_invFun`: the trace path of the homotopy
+  `e.toFun ∘ e.invFun ≃ id` joins `e.toFun (e.invFun y)` to `y`.
+* `ContinuousMap.HomotopyEquiv.pathConnectedSpace`: a space homotopy equivalent to a path
+  connected space is path connected.
+-/
+
+public section
+
+namespace TauCeti
+
+open scoped ContinuousMap
+
+variable {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
+
+/-- Evaluating the homotopy `e.toFun ∘ e.invFun ≃ id` at `y` gives a path from
+`e.toFun (e.invFun y)` to `y`. -/
+theorem _root_.ContinuousMap.HomotopyEquiv.joined_toFun_invFun (e : X ≃ₕ Y) (y : Y) :
+    Joined (e.toFun (e.invFun y)) y :=
+  ⟨e.right_inv.some.evalAt y⟩
+
+/-- **Path connectedness is a homotopy invariant.** A space homotopy equivalent to a path
+connected space is path connected. -/
+theorem _root_.ContinuousMap.HomotopyEquiv.pathConnectedSpace [PathConnectedSpace X]
+    (e : X ≃ₕ Y) : PathConnectedSpace Y where
+  nonempty := (PathConnectedSpace.nonempty (X := X)).map e.toFun
+  joined y₀ y₁ :=
+    ((e.joined_toFun_invFun y₀).symm.trans
+        (Joined.map ⟨PathConnectedSpace.somePath (e.invFun y₀) (e.invFun y₁)⟩
+          e.toFun.continuous)).trans
+      (e.joined_toFun_invFun y₁)
+
+end TauCeti

--- a/TauCeti/Topology/Homotopy/HomotopyEquiv.lean
+++ b/TauCeti/Topology/Homotopy/HomotopyEquiv.lean
@@ -17,6 +17,10 @@ homotopy `e.toFun ∘ e.invFun ≃ id`: evaluated at a point `y`, it is a path f
 `e.toFun (e.invFun y)` to `y`. Two points of `Y` are therefore joined to points in the image of
 `e.toFun`, which are joined to each other because `X` is path connected.
 
+This is the prerequisite for the base-point-free homotopy-group statements in
+`TauCeti.Topology.Homotopy.HomotopyGroup.HomotopyEquiv`, which need the target space to be path
+connected before base-point change is available there.
+
 ## Main declarations
 
 * `ContinuousMap.HomotopyEquiv.joined_toFun_invFun`: the trace path of the homotopy

--- a/TauCeti/Topology/Homotopy/HomotopyEquiv.lean
+++ b/TauCeti/Topology/Homotopy/HomotopyEquiv.lean
@@ -23,8 +23,6 @@ connected before base-point change is available there.
 
 ## Main declarations
 
-* `ContinuousMap.HomotopyEquiv.joined_toFun_invFun`: the trace path of the homotopy
-  `e.toFun ∘ e.invFun ≃ id` joins `e.toFun (e.invFun y)` to `y`.
 * `ContinuousMap.HomotopyEquiv.pathConnectedSpace`: a space homotopy equivalent to a path
   connected space is path connected.
 -/
@@ -37,21 +35,18 @@ open scoped ContinuousMap
 
 variable {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
 
-/-- Evaluating the homotopy `e.toFun ∘ e.invFun ≃ id` at `y` gives a path from
-`e.toFun (e.invFun y)` to `y`. -/
-theorem _root_.ContinuousMap.HomotopyEquiv.joined_toFun_invFun (e : X ≃ₕ Y) (y : Y) :
-    Joined (e.toFun (e.invFun y)) y :=
-  ⟨e.right_inv.some.evalAt y⟩
-
 /-- **Path connectedness is a homotopy invariant.** A space homotopy equivalent to a path
 connected space is path connected. -/
 theorem _root_.ContinuousMap.HomotopyEquiv.pathConnectedSpace [PathConnectedSpace X]
     (e : X ≃ₕ Y) : PathConnectedSpace Y where
   nonempty := (PathConnectedSpace.nonempty (X := X)).map e.toFun
   joined y₀ y₁ :=
-    ((e.joined_toFun_invFun y₀).symm.trans
+    -- Evaluating the homotopy `e.toFun ∘ e.invFun ≃ id` at `y` is a path from
+    -- `e.toFun (e.invFun y)` to `y`.
+    have trace : ∀ y : Y, Joined (e.toFun (e.invFun y)) y := fun y => ⟨e.right_inv.some.evalAt y⟩
+    ((trace y₀).symm.trans
         (Joined.map ⟨PathConnectedSpace.somePath (e.invFun y₀) (e.invFun y₁)⟩
           e.toFun.continuous)).trans
-      (e.joined_toFun_invFun y₁)
+      (trace y₁)
 
 end TauCeti

--- a/TauCeti/Topology/Homotopy/HomotopyGroup/BasepointChange.lean
+++ b/TauCeti/Topology/Homotopy/HomotopyGroup/BasepointChange.lean
@@ -42,7 +42,7 @@ product as the class of a concatenation `GenLoop.transAt i` in any cube directio
   `TauCeti.homotopyGroupTransport_refl`, `TauCeti.homotopyGroupTransport_trans` and
   `TauCeti.homotopyGroupTransport_congr`.
 * `TauCeti.homotopyGroupEquivOfPath`: transport is a bijection, with inverse the transport
-  along the reversed path.
+  along the reversed path, with `TauCeti.homotopyGroupEquivOfPath_apply`.
 * `TauCeti.homotopyGroupMulEquivOfPath`: **a path from `x` to `y` induces a group isomorphism
   `HomotopyGroup N X x ≃* HomotopyGroup N X y`.**
 * `TauCeti.nonempty_homotopyGroupMulEquiv`: on a path-connected space, all the homotopy groups
@@ -350,6 +350,16 @@ theorem homotopyGroupEquivOfPath_mk (γ : Path x y) (f : Ω^ N X x) :
     homotopyGroupEquivOfPath γ (⟦f⟧ : HomotopyGroup N X x) = ⟦GenLoop.transport γ f⟧ := by
   unfold homotopyGroupEquivOfPath
   exact homotopyGroupTransport_mk γ f
+
+/-- Base-point change, as an equivalence, acts by transport.
+
+This is deliberately not a `simp` lemma: `homotopyGroupEquivOfPath_mk` already rewrites an
+application to a representative, and tagging both would leave no normal form for the equivalence
+applied to a class. -/
+theorem homotopyGroupEquivOfPath_apply (γ : Path x y) (a : HomotopyGroup N X x) :
+    homotopyGroupEquivOfPath γ a = homotopyGroupTransport γ a := by
+  unfold homotopyGroupEquivOfPath
+  rfl
 
 @[simp]
 theorem homotopyGroupEquivOfPath_symm_mk (γ : Path x y) (f : Ω^ N X y) :

--- a/TauCeti/Topology/Homotopy/HomotopyGroup/BasepointChange.lean
+++ b/TauCeti/Topology/Homotopy/HomotopyGroup/BasepointChange.lean
@@ -42,7 +42,8 @@ product as the class of a concatenation `GenLoop.transAt i` in any cube directio
   `TauCeti.homotopyGroupTransport_refl`, `TauCeti.homotopyGroupTransport_trans` and
   `TauCeti.homotopyGroupTransport_congr`.
 * `TauCeti.homotopyGroupEquivOfPath`: transport is a bijection, with inverse the transport
-  along the reversed path, with `TauCeti.homotopyGroupEquivOfPath_apply`.
+  along the reversed path, with `TauCeti.homotopyGroupEquivOfPath_apply` and
+  `TauCeti.homotopyGroupEquivOfPath_symm_apply`.
 * `TauCeti.homotopyGroupMulEquivOfPath`: **a path from `x` to `y` induces a group isomorphism
   `HomotopyGroup N X x ≃* HomotopyGroup N X y`.**
 * `TauCeti.nonempty_homotopyGroupMulEquiv`: on a path-connected space, all the homotopy groups
@@ -351,13 +352,17 @@ theorem homotopyGroupEquivOfPath_mk (γ : Path x y) (f : Ω^ N X x) :
   unfold homotopyGroupEquivOfPath
   exact homotopyGroupTransport_mk γ f
 
-/-- Base-point change, as an equivalence, acts by transport.
-
-This is deliberately not a `simp` lemma: `homotopyGroupEquivOfPath_mk` already rewrites an
-application to a representative, and tagging both would leave no normal form for the equivalence
-applied to a class. -/
+/-- Base-point change, as an equivalence, acts by transport. -/
+@[simp]
 theorem homotopyGroupEquivOfPath_apply (γ : Path x y) (a : HomotopyGroup N X x) :
     homotopyGroupEquivOfPath γ a = homotopyGroupTransport γ a := by
+  unfold homotopyGroupEquivOfPath
+  rfl
+
+/-- The inverse base-point-change equivalence acts by transport along the reversed path. -/
+@[simp]
+theorem homotopyGroupEquivOfPath_symm_apply (γ : Path x y) (a : HomotopyGroup N X y) :
+    (homotopyGroupEquivOfPath γ).symm a = homotopyGroupTransport γ.symm a := by
   unfold homotopyGroupEquivOfPath
   rfl
 

--- a/TauCeti/Topology/Homotopy/HomotopyGroup/BasepointChange.lean
+++ b/TauCeti/Topology/Homotopy/HomotopyGroup/BasepointChange.lean
@@ -42,8 +42,10 @@ product as the class of a concatenation `GenLoop.transAt i` in any cube directio
   `TauCeti.homotopyGroupTransport_refl`, `TauCeti.homotopyGroupTransport_trans` and
   `TauCeti.homotopyGroupTransport_congr`.
 * `TauCeti.homotopyGroupEquivOfPath`: transport is a bijection, with inverse the transport
-  along the reversed path, with `TauCeti.homotopyGroupEquivOfPath_apply` and
-  `TauCeti.homotopyGroupEquivOfPath_symm_apply`.
+  along the reversed path, with `TauCeti.homotopyGroupEquivOfPath_apply`,
+  `TauCeti.homotopyGroupEquivOfPath_symm_apply` and the same four functoriality laws
+  `TauCeti.homotopyGroupEquivOfPath_refl`, `TauCeti.homotopyGroupEquivOfPath_trans`,
+  `TauCeti.homotopyGroupEquivOfPath_congr` and `TauCeti.homotopyGroupEquivOfPath_symm`.
 * `TauCeti.homotopyGroupMulEquivOfPath`: **a path from `x` to `y` induces a group isomorphism
   `HomotopyGroup N X x ≃* HomotopyGroup N X y`.**
 * `TauCeti.nonempty_homotopyGroupMulEquiv`: on a path-connected space, all the homotopy groups
@@ -372,6 +374,37 @@ theorem homotopyGroupEquivOfPath_symm_mk (γ : Path x y) (f : Ω^ N X y) :
       ⟦GenLoop.transport γ.symm f⟧ := by
   unfold homotopyGroupEquivOfPath
   exact homotopyGroupTransport_mk γ.symm f
+
+/-- The equivalence for a constant path is the identity. -/
+@[simp]
+theorem homotopyGroupEquivOfPath_refl :
+    homotopyGroupEquivOfPath (N := N) (Path.refl x) = Equiv.refl (HomotopyGroup N X x) := by
+  ext a
+  rw [homotopyGroupEquivOfPath_apply, homotopyGroupTransport_refl]
+  rfl
+
+/-- The equivalence for a concatenated path is the composite equivalence. -/
+@[simp]
+theorem homotopyGroupEquivOfPath_trans {w : X} (γ : Path x y) (δ : Path y w) :
+    homotopyGroupEquivOfPath (N := N) (γ.trans δ) =
+      (homotopyGroupEquivOfPath γ).trans (homotopyGroupEquivOfPath δ) := by
+  ext a
+  rw [homotopyGroupEquivOfPath_apply, Equiv.trans_apply, homotopyGroupEquivOfPath_apply,
+    homotopyGroupEquivOfPath_apply]
+  exact congrFun (homotopyGroupTransport_trans γ δ) a
+
+/-- Homotopic paths induce the same base-point-change equivalence. -/
+theorem homotopyGroupEquivOfPath_congr {γ δ : Path x y} (h : γ.Homotopic δ) :
+    homotopyGroupEquivOfPath (N := N) γ = homotopyGroupEquivOfPath δ := by
+  ext a
+  rw [homotopyGroupEquivOfPath_apply, homotopyGroupEquivOfPath_apply]
+  exact congrFun (homotopyGroupTransport_congr h) a
+
+/-- Reversing the path gives the inverse equivalence. -/
+theorem homotopyGroupEquivOfPath_symm (γ : Path x y) :
+    (homotopyGroupEquivOfPath γ).symm = homotopyGroupEquivOfPath (N := N) γ.symm := by
+  ext a
+  rw [homotopyGroupEquivOfPath_symm_apply, homotopyGroupEquivOfPath_apply]
 
 /-- **Base-point change for higher homotopy groups.** A path from `x` to `y` induces a group
 isomorphism between the homotopy groups based at `x` and at `y`. -/

--- a/TauCeti/Topology/Homotopy/HomotopyGroup/HomotopyEquiv.lean
+++ b/TauCeti/Topology/Homotopy/HomotopyGroup/HomotopyEquiv.lean
@@ -166,6 +166,7 @@ def equivOfHomotopyEquiv (e : X ≃ₕ Y) (x : X) :
     HomotopyGroup N X x ≃ HomotopyGroup N Y (e.toFun x) :=
   Equiv.ofBijective _ (map_bijective_of_homotopyEquiv e x)
 
+/-- The bijection induced by a homotopy equivalence acts as the map induced by `e.toFun`. -/
 @[simp]
 theorem equivOfHomotopyEquiv_apply (e : X ≃ₕ Y) (x : X) (a : HomotopyGroup N X x) :
     equivOfHomotopyEquiv e x a = map e.toFun rfl a :=
@@ -178,6 +179,8 @@ def mulEquivOfHomotopyEquiv [Nonempty N] [DecidableEq N] (e : X ≃ₕ Y) (x : X
     HomotopyGroup N X x ≃* HomotopyGroup N Y (e.toFun x) :=
   MulEquiv.ofBijective (mapHom e.toFun rfl) (map_bijective_of_homotopyEquiv e x)
 
+/-- The group isomorphism induced by a homotopy equivalence acts as the map induced by
+`e.toFun`. -/
 @[simp]
 theorem mulEquivOfHomotopyEquiv_apply [Nonempty N] [DecidableEq N] (e : X ≃ₕ Y) (x : X)
     (a : HomotopyGroup N X x) :

--- a/TauCeti/Topology/Homotopy/HomotopyGroup/HomotopyEquiv.lean
+++ b/TauCeti/Topology/Homotopy/HomotopyGroup/HomotopyEquiv.lean
@@ -20,25 +20,21 @@ loop `p` through `H` is a homotopy along the trace, in the sense of
 `TauCeti.GenLoop.HomotopyAlong`, from `f ∘ p` to `g ∘ p`, and such a homotopy is canonical by
 `TauCeti.GenLoop.HomotopyAlong.homotopic_transport`.
 
+The trace formula takes the base points of the two induced maps as equations, as
+`HomotopyGroup.map` does, and the trace is recast along them with `Path.cast`. This is what lets
+a round trip `g ∘ f ≃ id` be stated at the base points `g (f x)` and `x` themselves, rather than at
+`(g.comp f) x` and `(ContinuousMap.id X) x`.
+
 Applied to a homotopy equivalence `e : X ≃ₕ Y`, this makes each round trip of `e` bijective on
 homotopy groups after correcting the base point. Both round trips are needed: a homotopy inverse
 recovers the identity only up to a free homotopy, so one composite alone gives injectivity of the
 map induced by `e.toFun` and surjectivity of the map induced by `e.invFun`, and the other
-composite is what upgrades the latter to a bijection.
+composite is what upgrades the latter to a bijection. The inverse of the resulting bijection is
+the map induced by `e.invFun`, corrected by base-point change along the trace of the round trip.
 
 The statements about the induced map alone need no finiteness of the index type beyond
-`[Finite N]`; only the transport formula, which mentions the collar construction, asks for the
-`[Fintype N]` that the cube radius uses.
-
-This is the free-homotopy layer of the higher-homotopy-group API asked for in Stage 3, item 9 of
-`TauCetiRoadmap/UniversalCovers/README.md` ("functoriality ... and basepoint-change
-isomorphisms"): it is exactly those two pieces of the API, from
-`TauCeti.Topology.Homotopy.HomotopyGroup.Map` and
-`TauCeti.Topology.Homotopy.HomotopyGroup.BasepointChange`, combined. It generalises two
-statements of that same API: the pointed-homotopy invariance
-`HomotopyGroup.map_eq_of_homotopicRel` of `TauCeti.Topology.Homotopy.HomotopyGroup.Homotopy`,
-whose homotopy is required to fix the base point, and the homeomorphism invariance
-`HomotopyGroup.homeomorphMulEquiv` of `TauCeti.Topology.Homotopy.HomotopyGroup.Homeomorph`.
+`[Finite N]`; the statements that mention transport, which uses the collar construction, ask for
+the `[Fintype N]` that the cube radius uses.
 
 ## Main declarations
 
@@ -46,10 +42,11 @@ whose homotopy is required to fix the base point, and the homeomorphism invarian
   homotopy along the trace of that homotopy at the base point.
 * `TauCeti.homotopyGroupTransport_map`: **freely homotopic maps induce the same map on homotopy
   groups, up to transport along the trace of the homotopy.**
-* `TauCeti.bijective_homotopyGroupMap_of_homotopyEquiv`: a homotopy equivalence induces a
-  bijection on homotopy groups.
-* `TauCeti.homotopyGroupEquivOfHomotopyEquiv`, `TauCeti.homotopyGroupMulEquivOfHomotopyEquiv`:
-  that bijection, as an equivalence and, in positive dimensions, as a group isomorphism.
+* `TauCeti.homotopyGroupTransport_map_map`: the case of a round trip `g ∘ f ≃ id`.
+* `HomotopyGroup.map_bijective_of_homotopyEquiv`: a homotopy equivalence induces a bijection on
+  homotopy groups.
+* `HomotopyGroup.equivOfHomotopyEquiv`, `HomotopyGroup.mulEquivOfHomotopyEquiv`: that bijection,
+  as an equivalence and, in positive dimensions, as a group isomorphism.
 
 ## References
 
@@ -60,10 +57,10 @@ That a homotopy equivalence induces isomorphisms on all homotopy groups is Propo
 public section
 noncomputable section
 
-namespace TauCeti
-
 open scoped unitInterval Topology Topology.Homotopy ContinuousMap
 open Topology.Homotopy
+
+namespace TauCeti
 
 variable {N X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
 
@@ -76,8 +73,10 @@ namespace GenLoop
 /-- Dragging a generalized loop `p` based at `x` through a homotopy `H` from `f` to `g` is a
 homotopy from `f ∘ p` to `g ∘ p` along the trace of `H` at `x`: on the cube boundary `p` is
 constant at `x`, so there the dragged loop traces `H.evalAt x`. -/
-def homotopyAlongMap {f g : C(X, Y)} (H : f.Homotopy g) {x : X} (p : Ω^ N X x) :
-    HomotopyAlong (H.evalAt x) (_root_.GenLoop.map f rfl p) (_root_.GenLoop.map g rfl p) where
+def homotopyAlongMap {f g : C(X, Y)} (H : f.Homotopy g) {x : X} {y₀ y₁ : Y} (hf : f x = y₀)
+    (hg : g x = y₁) (p : Ω^ N X x) :
+    HomotopyAlong ((H.evalAt x).cast hf.symm hg.symm) (_root_.GenLoop.map f hf p)
+      (_root_.GenLoop.map g hg p) where
   toContinuousMap := ⟨fun tz => H (tz.1, p tz.2), by fun_prop⟩
   map_zero_left z := H.apply_zero (p z)
   map_one_left z := H.apply_one (p z)
@@ -85,26 +84,44 @@ def homotopyAlongMap {f g : C(X, Y)} (H : f.Homotopy g) {x : X} (p : Ω^ N X x) 
 
 /-- **Freely homotopic maps agree on generalized loops, up to transport along the trace of the
 homotopy at the base point.** -/
-theorem homotopic_map_transport {f g : C(X, Y)} (H : f.Homotopy g) {x : X} (p : Ω^ N X x) :
-    _root_.GenLoop.Homotopic (_root_.GenLoop.map g rfl p)
-      (transport (H.evalAt x) (_root_.GenLoop.map f rfl p)) :=
-  (homotopyAlongMap H p).homotopic_transport
+theorem homotopic_map_transport {f g : C(X, Y)} (H : f.Homotopy g) {x : X} {y₀ y₁ : Y}
+    (hf : f x = y₀) (hg : g x = y₁) (p : Ω^ N X x) :
+    _root_.GenLoop.Homotopic (_root_.GenLoop.map g hg p)
+      (transport ((H.evalAt x).cast hf.symm hg.symm) (_root_.GenLoop.map f hf p)) :=
+  (homotopyAlongMap H hf hg p).homotopic_transport
 
 end GenLoop
 
 /-- **Freely homotopic maps induce the same map on homotopy groups, after transporting along the
 trace of the homotopy at the base point.** For a homotopy that fixes the base point the trace is
 constant, and this is the pointed statement `HomotopyGroup.map_eq_of_homotopicRel`. -/
-theorem homotopyGroupTransport_map {f g : C(X, Y)} (H : f.Homotopy g) {x : X}
-    (a : HomotopyGroup N X x) :
-    homotopyGroupTransport (H.evalAt x) (_root_.HomotopyGroup.map f rfl a) =
-      _root_.HomotopyGroup.map g rfl a := by
+theorem homotopyGroupTransport_map {f g : C(X, Y)} (H : f.Homotopy g) {x : X} {y₀ y₁ : Y}
+    (hf : f x = y₀) (hg : g x = y₁) (a : HomotopyGroup N X x) :
+    homotopyGroupTransport ((H.evalAt x).cast hf.symm hg.symm) (_root_.HomotopyGroup.map f hf a) =
+      _root_.HomotopyGroup.map g hg a := by
   induction a using Quotient.inductionOn with
   | h p =>
     rw [_root_.HomotopyGroup.map_mk, homotopyGroupTransport_mk, _root_.HomotopyGroup.map_mk]
-    exact (Quotient.sound (GenLoop.homotopic_map_transport H p)).symm
+    exact (Quotient.sound (GenLoop.homotopic_map_transport H hf hg p)).symm
+
+/-- If `g ∘ f` is freely homotopic to the identity, then transport along the trace of the
+homotopy undoes the composite of the maps that `f` and `g` induce on homotopy groups. -/
+theorem homotopyGroupTransport_map_map {f : C(X, Y)} {g : C(Y, X)}
+    (H : (g.comp f).Homotopy (ContinuousMap.id X)) (x : X) (a : HomotopyGroup N X x) :
+    homotopyGroupTransport
+        ((H.evalAt x).cast (ContinuousMap.comp_apply g f x).symm (ContinuousMap.id_apply x).symm)
+        (_root_.HomotopyGroup.map g rfl (_root_.HomotopyGroup.map f rfl a)) = a := by
+  rw [_root_.HomotopyGroup.map_comp_apply]
+  exact (homotopyGroupTransport_map H _ (ContinuousMap.id_apply x) a).trans
+    (_root_.HomotopyGroup.map_id_apply a)
 
 end Transport
+
+end TauCeti
+
+namespace HomotopyGroup
+
+variable {N X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
 
 section Finite
 
@@ -113,83 +130,103 @@ variable [Finite N]
 /-- If `g ∘ f` is freely homotopic to the identity, the composite of the maps that `f` and `g`
 induce on homotopy groups is a bijection: it is base-point change along the trace of the
 homotopy, reversed. -/
-theorem bijective_homotopyGroupMap_comp_of_homotopy_id {f : C(X, Y)} {g : C(Y, X)}
+theorem map_comp_map_bijective_of_homotopy_id {f : C(X, Y)} {g : C(Y, X)}
     (H : (g.comp f).Homotopy (ContinuousMap.id X)) (x : X) :
-    Function.Bijective (_root_.HomotopyGroup.map (N := N) g rfl ∘
-      _root_.HomotopyGroup.map (N := N) f (rfl : f x = f x)) := by
+    Function.Bijective (map (N := N) g rfl ∘ map (N := N) f (rfl : f x = f x)) := by
   have : Fintype N := Fintype.ofFinite N
-  have key : ∀ a : HomotopyGroup N X x,
-      homotopyGroupTransport (H.evalAt x)
-        (_root_.HomotopyGroup.map g rfl (_root_.HomotopyGroup.map f rfl a)) = a := by
-    intro a
-    have hcomp : _root_.HomotopyGroup.map (N := N) g rfl
-        (_root_.HomotopyGroup.map f (rfl : f x = f x) a) =
-          _root_.HomotopyGroup.map (g.comp f) rfl a :=
-      _root_.HomotopyGroup.map_comp_apply g rfl f rfl a
-    rw [hcomp]
-    exact (homotopyGroupTransport_map H a).trans (_root_.HomotopyGroup.map_id_apply a)
-  have hfun : _root_.HomotopyGroup.map (N := N) g rfl ∘
-      _root_.HomotopyGroup.map (N := N) f (rfl : f x = f x) =
-        (homotopyGroupEquivOfPath (H.evalAt x)).symm := by
+  have hfun : map (N := N) g rfl ∘ map (N := N) f (rfl : f x = f x) =
+      (TauCeti.homotopyGroupEquivOfPath ((H.evalAt x).cast (ContinuousMap.comp_apply g f x).symm
+        (ContinuousMap.id_apply x).symm)).symm := by
     funext a
-    -- `rw [Equiv.eq_symm_apply]` fails here: the two sides sit over base points that agree only
-    -- up to unfolding `ContinuousMap.comp` and `ContinuousMap.id`, so the rewrite is not
-    -- type-correct at `implicit` transparency. In term mode the defeq is accepted.
-    exact ((homotopyGroupEquivOfPath (H.evalAt x)).eq_symm_apply).mpr
-      ((homotopyGroupEquivOfPath_apply _ _).trans (key a))
+    rw [Function.comp_apply, Equiv.eq_symm_apply, TauCeti.homotopyGroupEquivOfPath_apply]
+    exact TauCeti.homotopyGroupTransport_map_map H x a
   rw [hfun]
-  exact (homotopyGroupEquivOfPath (H.evalAt x)).symm.bijective
+  exact Equiv.bijective _
 
 /-- **A homotopy equivalence induces a bijection on homotopy groups.** -/
-theorem bijective_homotopyGroupMap_of_homotopyEquiv (e : X ≃ₕ Y) (x : X) :
-    Function.Bijective
-      (_root_.HomotopyGroup.map (N := N) e.toFun (rfl : e.toFun x = e.toFun x)) := by
+theorem map_bijective_of_homotopyEquiv (e : X ≃ₕ Y) (x : X) :
+    Function.Bijective (map (N := N) e.toFun (rfl : e.toFun x = e.toFun x)) := by
   -- The left inverse makes the composite `e.invFun⁎ ∘ e.toFun⁎` bijective at `x`, the right
   -- inverse makes `e.toFun⁎ ∘ e.invFun⁎` bijective at `e.toFun x`. The map `e.invFun⁎` is common
   -- to the two composites, so it is injective as well as surjective, and then so is `e.toFun⁎`.
-  have hleft := bijective_homotopyGroupMap_comp_of_homotopy_id (N := N) e.left_inv.some x
-  have hright :=
-    bijective_homotopyGroupMap_comp_of_homotopy_id (N := N) e.right_inv.some (e.toFun x)
-  have hmid : Function.Injective (_root_.HomotopyGroup.map (N := N) e.invFun
+  -- The surjectivity of `e.toFun⁎` cannot be read off the second composite directly: there
+  -- `e.toFun⁎` is based at `e.invFun (e.toFun x)`, not at `x`.
+  have hleft := map_comp_map_bijective_of_homotopy_id (N := N) e.left_inv.some x
+  have hright := map_comp_map_bijective_of_homotopy_id (N := N) e.right_inv.some (e.toFun x)
+  have hmid : Function.Injective (map (N := N) e.invFun
       (rfl : e.invFun (e.toFun x) = e.invFun (e.toFun x))) := hright.injective.of_comp
   refine ⟨hleft.injective.of_comp, fun b => ?_⟩
-  obtain ⟨a, ha⟩ := hleft.surjective (_root_.HomotopyGroup.map e.invFun rfl b)
+  obtain ⟨a, ha⟩ := hleft.surjective (map e.invFun rfl b)
   rw [Function.comp_apply] at ha
   exact ⟨a, hmid ha⟩
 
 /-- The bijection on homotopy groups induced by a homotopy equivalence. -/
-@[expose] def homotopyGroupEquivOfHomotopyEquiv (e : X ≃ₕ Y) (x : X) :
+def equivOfHomotopyEquiv (e : X ≃ₕ Y) (x : X) :
     HomotopyGroup N X x ≃ HomotopyGroup N Y (e.toFun x) :=
-  Equiv.ofBijective _ (bijective_homotopyGroupMap_of_homotopyEquiv e x)
+  Equiv.ofBijective _ (map_bijective_of_homotopyEquiv e x)
 
 @[simp]
-theorem homotopyGroupEquivOfHomotopyEquiv_apply (e : X ≃ₕ Y) (x : X) (a : HomotopyGroup N X x) :
-    homotopyGroupEquivOfHomotopyEquiv e x a = _root_.HomotopyGroup.map e.toFun rfl a :=
-  rfl
+theorem equivOfHomotopyEquiv_apply (e : X ≃ₕ Y) (x : X) (a : HomotopyGroup N X x) :
+    equivOfHomotopyEquiv e x a = map e.toFun rfl a :=
+  (rfl)
 
-/-- **Homotopy equivalent spaces have isomorphic homotopy groups.** In positive dimensions the
-bijection induced by a homotopy equivalence is a group isomorphism, being induced by a continuous
-map. -/
-@[expose] def homotopyGroupMulEquivOfHomotopyEquiv [Nonempty N] [DecidableEq N] (e : X ≃ₕ Y)
-    (x : X) : HomotopyGroup N X x ≃* HomotopyGroup N Y (e.toFun x) :=
-  MulEquiv.ofBijective (_root_.HomotopyGroup.mapHom e.toFun rfl)
-    (bijective_homotopyGroupMap_of_homotopyEquiv e x)
+/-- **A homotopy equivalence induces a group isomorphism on homotopy groups.** In positive
+dimensions the bijection induced by a homotopy equivalence is a group isomorphism, being induced
+by a continuous map. -/
+def mulEquivOfHomotopyEquiv [Nonempty N] [DecidableEq N] (e : X ≃ₕ Y) (x : X) :
+    HomotopyGroup N X x ≃* HomotopyGroup N Y (e.toFun x) :=
+  MulEquiv.ofBijective (mapHom e.toFun rfl) (map_bijective_of_homotopyEquiv e x)
 
 @[simp]
-theorem homotopyGroupMulEquivOfHomotopyEquiv_apply [Nonempty N] [DecidableEq N] (e : X ≃ₕ Y)
-    (x : X) (a : HomotopyGroup N X x) :
-    homotopyGroupMulEquivOfHomotopyEquiv e x a = _root_.HomotopyGroup.map e.toFun rfl a :=
-  rfl
+theorem mulEquivOfHomotopyEquiv_apply [Nonempty N] [DecidableEq N] (e : X ≃ₕ Y) (x : X)
+    (a : HomotopyGroup N X x) :
+    mulEquivOfHomotopyEquiv e x a = map e.toFun rfl a :=
+  (rfl)
+
+end Finite
+
+variable [Fintype N]
+
+/-- The inverse of the bijection induced by a homotopy equivalence `e` is the map induced by
+`e.invFun`, followed by base-point change along the trace of the round trip
+`e.invFun ∘ e.toFun ≃ id`. -/
+@[simp]
+theorem equivOfHomotopyEquiv_symm_apply (e : X ≃ₕ Y) (x : X) (b : HomotopyGroup N Y (e.toFun x)) :
+    (equivOfHomotopyEquiv e x).symm b =
+      TauCeti.homotopyGroupTransport
+        ((e.left_inv.some.evalAt x).cast (ContinuousMap.comp_apply e.invFun e.toFun x).symm
+          (ContinuousMap.id_apply x).symm) (map e.invFun rfl b) := by
+  obtain ⟨a, rfl⟩ := (equivOfHomotopyEquiv e x).surjective b
+  rw [Equiv.symm_apply_apply, equivOfHomotopyEquiv_apply,
+    TauCeti.homotopyGroupTransport_map_map]
+
+/-- The inverse of the group isomorphism induced by a homotopy equivalence `e` is the map induced
+by `e.invFun`, followed by base-point change along the trace of the round trip
+`e.invFun ∘ e.toFun ≃ id`. -/
+@[simp]
+theorem mulEquivOfHomotopyEquiv_symm_apply [Nonempty N] [DecidableEq N] (e : X ≃ₕ Y) (x : X)
+    (b : HomotopyGroup N Y (e.toFun x)) :
+    (mulEquivOfHomotopyEquiv e x).symm b =
+      TauCeti.homotopyGroupTransport
+        ((e.left_inv.some.evalAt x).cast (ContinuousMap.comp_apply e.invFun e.toFun x).symm
+          (ContinuousMap.id_apply x).symm) (map e.invFun rfl b) := by
+  obtain ⟨a, rfl⟩ := (mulEquivOfHomotopyEquiv e x).surjective b
+  rw [MulEquiv.symm_apply_apply, mulEquivOfHomotopyEquiv_apply,
+    TauCeti.homotopyGroupTransport_map_map]
+
+end HomotopyGroup
+
+namespace TauCeti
+
+variable {N X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
 
 /-- Over a path connected space, homotopy equivalence identifies the homotopy groups in a fixed
 positive dimension at *any* pair of base points, by composing with base-point change. -/
-theorem nonempty_homotopyGroupMulEquiv_of_homotopyEquiv [Nonempty N] [DecidableEq N]
+theorem nonempty_homotopyGroupMulEquiv_of_homotopyEquiv [Finite N] [Nonempty N] [DecidableEq N]
     [PathConnectedSpace X] (e : X ≃ₕ Y) (x : X) (y : Y) :
     Nonempty (HomotopyGroup N X x ≃* HomotopyGroup N Y y) := by
   have : PathConnectedSpace Y := e.pathConnectedSpace
   obtain ⟨φ⟩ := nonempty_homotopyGroupMulEquiv (N := N) (X := Y) (x := e.toFun x) (y := y)
-  exact ⟨(homotopyGroupMulEquivOfHomotopyEquiv e x).trans φ⟩
-
-end Finite
+  exact ⟨(HomotopyGroup.mulEquivOfHomotopyEquiv e x).trans φ⟩
 
 end TauCeti

--- a/TauCeti/Topology/Homotopy/HomotopyGroup/HomotopyEquiv.lean
+++ b/TauCeti/Topology/Homotopy/HomotopyGroup/HomotopyEquiv.lean
@@ -46,7 +46,8 @@ the `[Fintype N]` that the cube radius uses.
 * `HomotopyGroup.map_bijective_of_homotopyEquiv`: a homotopy equivalence induces a bijection on
   homotopy groups.
 * `HomotopyGroup.equivOfHomotopyEquiv`, `HomotopyGroup.mulEquivOfHomotopyEquiv`: that bijection,
-  as an equivalence and, in positive dimensions, as a group isomorphism.
+  as an equivalence and, in positive dimensions, as a group isomorphism, with their identity and
+  composition laws.
 
 ## References
 
@@ -182,6 +183,36 @@ theorem mulEquivOfHomotopyEquiv_apply [Nonempty N] [DecidableEq N] (e : X ≃ₕ
     (a : HomotopyGroup N X x) :
     mulEquivOfHomotopyEquiv e x a = map e.toFun rfl a :=
   (rfl)
+
+/-- The identity homotopy equivalence induces the identity on homotopy groups. -/
+@[simp]
+theorem equivOfHomotopyEquiv_refl (x : X) :
+    equivOfHomotopyEquiv (N := N) (ContinuousMap.HomotopyEquiv.refl X) x = Equiv.refl _ :=
+  Equiv.ext map_id_apply
+
+/-- The bijection induced by a composite of homotopy equivalences is the composite of the
+induced bijections. -/
+@[simp]
+theorem equivOfHomotopyEquiv_trans {Z : Type*} [TopologicalSpace Z] (e : X ≃ₕ Y) (e' : Y ≃ₕ Z)
+    (x : X) :
+    equivOfHomotopyEquiv (N := N) (e.trans e') x =
+      (equivOfHomotopyEquiv e x).trans (equivOfHomotopyEquiv e' (e.toFun x)) :=
+  Equiv.ext fun a => (map_comp_apply _ rfl _ rfl a).symm
+
+/-- The identity homotopy equivalence induces the identity isomorphism on homotopy groups. -/
+@[simp]
+theorem mulEquivOfHomotopyEquiv_refl [Nonempty N] [DecidableEq N] (x : X) :
+    mulEquivOfHomotopyEquiv (N := N) (ContinuousMap.HomotopyEquiv.refl X) x = MulEquiv.refl _ :=
+  MulEquiv.ext map_id_apply
+
+/-- The isomorphism induced by a composite of homotopy equivalences is the composite of the
+induced isomorphisms. -/
+@[simp]
+theorem mulEquivOfHomotopyEquiv_trans [Nonempty N] [DecidableEq N] {Z : Type*}
+    [TopologicalSpace Z] (e : X ≃ₕ Y) (e' : Y ≃ₕ Z) (x : X) :
+    mulEquivOfHomotopyEquiv (N := N) (e.trans e') x =
+      (mulEquivOfHomotopyEquiv e x).trans (mulEquivOfHomotopyEquiv e' (e.toFun x)) :=
+  MulEquiv.ext fun a => (map_comp_apply _ rfl _ rfl a).symm
 
 end Finite
 

--- a/TauCeti/Topology/Homotopy/HomotopyGroup/HomotopyEquiv.lean
+++ b/TauCeti/Topology/Homotopy/HomotopyGroup/HomotopyEquiv.lean
@@ -30,6 +30,16 @@ The statements about the induced map alone need no finiteness of the index type 
 `[Finite N]`; only the transport formula, which mentions the collar construction, asks for the
 `[Fintype N]` that the cube radius uses.
 
+This is the free-homotopy layer of the higher-homotopy-group API asked for in Stage 3, item 9 of
+`TauCetiRoadmap/UniversalCovers/README.md` ("functoriality ... and basepoint-change
+isomorphisms"): it is exactly those two pieces of the API, from
+`TauCeti.Topology.Homotopy.HomotopyGroup.Map` and
+`TauCeti.Topology.Homotopy.HomotopyGroup.BasepointChange`, combined. It generalises two
+statements of that same API: the pointed-homotopy invariance
+`HomotopyGroup.map_eq_of_homotopicRel` of `TauCeti.Topology.Homotopy.HomotopyGroup.Homotopy`,
+whose homotopy is required to fix the base point, and the homeomorphism invariance
+`HomotopyGroup.homeomorphMulEquiv` of `TauCeti.Topology.Homotopy.HomotopyGroup.Homeomorph`.
+
 ## Main declarations
 
 * `TauCeti.GenLoop.homotopyAlongMap`: dragging a generalized loop through a homotopy is a

--- a/TauCeti/Topology/Homotopy/HomotopyGroup/HomotopyEquiv.lean
+++ b/TauCeti/Topology/Homotopy/HomotopyGroup/HomotopyEquiv.lean
@@ -1,0 +1,185 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Topology.Homotopy.HomotopyEquiv
+public import TauCeti.Topology.Homotopy.HomotopyGroup.BasepointChange
+public import TauCeti.Topology.Homotopy.HomotopyGroup.Map
+
+/-!
+# Homotopy groups are invariant under homotopy equivalence
+
+Postcomposition with a continuous map induces a map on homotopy groups, and maps homotopic
+relative to the base point induce the same one. A *free* homotopy `H` from `f` to `g` moves the
+base point along its trace `H.evalAt x`, and the two induced maps then differ exactly by
+base-point change. This is immediate from the machinery already in place: dragging a generalized
+loop `p` through `H` is a homotopy along the trace, in the sense of
+`TauCeti.GenLoop.HomotopyAlong`, from `f ∘ p` to `g ∘ p`, and such a homotopy is canonical by
+`TauCeti.GenLoop.HomotopyAlong.homotopic_transport`.
+
+Applied to a homotopy equivalence `e : X ≃ₕ Y`, this makes each round trip of `e` bijective on
+homotopy groups after correcting the base point. Both round trips are needed: a homotopy inverse
+recovers the identity only up to a free homotopy, so one composite alone gives injectivity of the
+map induced by `e.toFun` and surjectivity of the map induced by `e.invFun`, and the other
+composite is what upgrades the latter to a bijection.
+
+The statements about the induced map alone need no finiteness of the index type beyond
+`[Finite N]`; only the transport formula, which mentions the collar construction, asks for the
+`[Fintype N]` that the cube radius uses.
+
+## Main declarations
+
+* `TauCeti.GenLoop.homotopyAlongMap`: dragging a generalized loop through a homotopy is a
+  homotopy along the trace of that homotopy at the base point.
+* `TauCeti.homotopyGroupTransport_map`: **freely homotopic maps induce the same map on homotopy
+  groups, up to transport along the trace of the homotopy.**
+* `TauCeti.bijective_homotopyGroupMap_of_homotopyEquiv`: a homotopy equivalence induces a
+  bijection on homotopy groups.
+* `TauCeti.homotopyGroupEquivOfHomotopyEquiv`, `TauCeti.homotopyGroupMulEquivOfHomotopyEquiv`:
+  that bijection, as an equivalence and, in positive dimensions, as a group isomorphism.
+
+## References
+
+That a homotopy equivalence induces isomorphisms on all homotopy groups is Proposition 4.21 of
+[hatcher02]; the trace formula for a free homotopy is the discussion preceding it in Section 4.1.
+-/
+
+public section
+noncomputable section
+
+namespace TauCeti
+
+open scoped unitInterval Topology Topology.Homotopy ContinuousMap
+open Topology.Homotopy
+
+variable {N X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
+
+section Transport
+
+variable [Fintype N]
+
+namespace GenLoop
+
+/-- Dragging a generalized loop `p` based at `x` through a homotopy `H` from `f` to `g` is a
+homotopy from `f ∘ p` to `g ∘ p` along the trace of `H` at `x`: on the cube boundary `p` is
+constant at `x`, so there the dragged loop traces `H.evalAt x`. -/
+def homotopyAlongMap {f g : C(X, Y)} (H : f.Homotopy g) {x : X} (p : Ω^ N X x) :
+    HomotopyAlong (H.evalAt x) (_root_.GenLoop.map f rfl p) (_root_.GenLoop.map g rfl p) where
+  toContinuousMap := ⟨fun tz => H (tz.1, p tz.2), by fun_prop⟩
+  map_zero_left z := H.apply_zero (p z)
+  map_one_left z := H.apply_one (p z)
+  map_boundary t z hz := congrArg (fun w => H (t, w)) (_root_.GenLoop.boundary p z hz)
+
+/-- **Freely homotopic maps agree on generalized loops, up to transport along the trace of the
+homotopy at the base point.** -/
+theorem homotopic_map_transport {f g : C(X, Y)} (H : f.Homotopy g) {x : X} (p : Ω^ N X x) :
+    _root_.GenLoop.Homotopic (_root_.GenLoop.map g rfl p)
+      (transport (H.evalAt x) (_root_.GenLoop.map f rfl p)) :=
+  (homotopyAlongMap H p).homotopic_transport
+
+end GenLoop
+
+/-- **Freely homotopic maps induce the same map on homotopy groups, after transporting along the
+trace of the homotopy at the base point.** For a homotopy that fixes the base point the trace is
+constant, and this is the pointed statement `HomotopyGroup.map_eq_of_homotopicRel`. -/
+theorem homotopyGroupTransport_map {f g : C(X, Y)} (H : f.Homotopy g) {x : X}
+    (a : HomotopyGroup N X x) :
+    homotopyGroupTransport (H.evalAt x) (_root_.HomotopyGroup.map f rfl a) =
+      _root_.HomotopyGroup.map g rfl a := by
+  induction a using Quotient.inductionOn with
+  | h p =>
+    rw [_root_.HomotopyGroup.map_mk, homotopyGroupTransport_mk, _root_.HomotopyGroup.map_mk]
+    exact (Quotient.sound (GenLoop.homotopic_map_transport H p)).symm
+
+end Transport
+
+section Finite
+
+variable [Finite N]
+
+/-- If `g ∘ f` is freely homotopic to the identity, the composite of the maps that `f` and `g`
+induce on homotopy groups is a bijection: it is base-point change along the trace of the
+homotopy, reversed. -/
+theorem bijective_homotopyGroupMap_comp_of_homotopy_id {f : C(X, Y)} {g : C(Y, X)}
+    (H : (g.comp f).Homotopy (ContinuousMap.id X)) (x : X) :
+    Function.Bijective (_root_.HomotopyGroup.map (N := N) g rfl ∘
+      _root_.HomotopyGroup.map (N := N) f (rfl : f x = f x)) := by
+  have : Fintype N := Fintype.ofFinite N
+  have key : ∀ a : HomotopyGroup N X x,
+      homotopyGroupTransport (H.evalAt x)
+        (_root_.HomotopyGroup.map g rfl (_root_.HomotopyGroup.map f rfl a)) = a := by
+    intro a
+    have hcomp : _root_.HomotopyGroup.map (N := N) g rfl
+        (_root_.HomotopyGroup.map f (rfl : f x = f x) a) =
+          _root_.HomotopyGroup.map (g.comp f) rfl a :=
+      _root_.HomotopyGroup.map_comp_apply g rfl f rfl a
+    rw [hcomp]
+    exact (homotopyGroupTransport_map H a).trans (_root_.HomotopyGroup.map_id_apply a)
+  have hfun : _root_.HomotopyGroup.map (N := N) g rfl ∘
+      _root_.HomotopyGroup.map (N := N) f (rfl : f x = f x) =
+        (homotopyGroupEquivOfPath (H.evalAt x)).symm := by
+    funext a
+    -- `rw [Equiv.eq_symm_apply]` fails here: the two sides sit over base points that agree only
+    -- up to unfolding `ContinuousMap.comp` and `ContinuousMap.id`, so the rewrite is not
+    -- type-correct at `implicit` transparency. In term mode the defeq is accepted.
+    exact ((homotopyGroupEquivOfPath (H.evalAt x)).eq_symm_apply).mpr
+      ((homotopyGroupEquivOfPath_apply _ _).trans (key a))
+  rw [hfun]
+  exact (homotopyGroupEquivOfPath (H.evalAt x)).symm.bijective
+
+/-- **A homotopy equivalence induces a bijection on homotopy groups.** -/
+theorem bijective_homotopyGroupMap_of_homotopyEquiv (e : X ≃ₕ Y) (x : X) :
+    Function.Bijective
+      (_root_.HomotopyGroup.map (N := N) e.toFun (rfl : e.toFun x = e.toFun x)) := by
+  -- The left inverse makes the composite `e.invFun⁎ ∘ e.toFun⁎` bijective at `x`, the right
+  -- inverse makes `e.toFun⁎ ∘ e.invFun⁎` bijective at `e.toFun x`. The map `e.invFun⁎` is common
+  -- to the two composites, so it is injective as well as surjective, and then so is `e.toFun⁎`.
+  have hleft := bijective_homotopyGroupMap_comp_of_homotopy_id (N := N) e.left_inv.some x
+  have hright :=
+    bijective_homotopyGroupMap_comp_of_homotopy_id (N := N) e.right_inv.some (e.toFun x)
+  have hmid : Function.Injective (_root_.HomotopyGroup.map (N := N) e.invFun
+      (rfl : e.invFun (e.toFun x) = e.invFun (e.toFun x))) := hright.injective.of_comp
+  refine ⟨hleft.injective.of_comp, fun b => ?_⟩
+  obtain ⟨a, ha⟩ := hleft.surjective (_root_.HomotopyGroup.map e.invFun rfl b)
+  rw [Function.comp_apply] at ha
+  exact ⟨a, hmid ha⟩
+
+/-- The bijection on homotopy groups induced by a homotopy equivalence. -/
+@[expose] def homotopyGroupEquivOfHomotopyEquiv (e : X ≃ₕ Y) (x : X) :
+    HomotopyGroup N X x ≃ HomotopyGroup N Y (e.toFun x) :=
+  Equiv.ofBijective _ (bijective_homotopyGroupMap_of_homotopyEquiv e x)
+
+@[simp]
+theorem homotopyGroupEquivOfHomotopyEquiv_apply (e : X ≃ₕ Y) (x : X) (a : HomotopyGroup N X x) :
+    homotopyGroupEquivOfHomotopyEquiv e x a = _root_.HomotopyGroup.map e.toFun rfl a :=
+  rfl
+
+/-- **Homotopy equivalent spaces have isomorphic homotopy groups.** In positive dimensions the
+bijection induced by a homotopy equivalence is a group isomorphism, being induced by a continuous
+map. -/
+@[expose] def homotopyGroupMulEquivOfHomotopyEquiv [Nonempty N] [DecidableEq N] (e : X ≃ₕ Y)
+    (x : X) : HomotopyGroup N X x ≃* HomotopyGroup N Y (e.toFun x) :=
+  MulEquiv.ofBijective (_root_.HomotopyGroup.mapHom e.toFun rfl)
+    (bijective_homotopyGroupMap_of_homotopyEquiv e x)
+
+@[simp]
+theorem homotopyGroupMulEquivOfHomotopyEquiv_apply [Nonempty N] [DecidableEq N] (e : X ≃ₕ Y)
+    (x : X) (a : HomotopyGroup N X x) :
+    homotopyGroupMulEquivOfHomotopyEquiv e x a = _root_.HomotopyGroup.map e.toFun rfl a :=
+  rfl
+
+/-- Over a path connected space, homotopy equivalence identifies the homotopy groups in a fixed
+positive dimension at *any* pair of base points, by composing with base-point change. -/
+theorem nonempty_homotopyGroupMulEquiv_of_homotopyEquiv [Nonempty N] [DecidableEq N]
+    [PathConnectedSpace X] (e : X ≃ₕ Y) (x : X) (y : Y) :
+    Nonempty (HomotopyGroup N X x ≃* HomotopyGroup N Y y) := by
+  have : PathConnectedSpace Y := e.pathConnectedSpace
+  obtain ⟨φ⟩ := nonempty_homotopyGroupMulEquiv (N := N) (X := Y) (x := e.toFun x) (y := y)
+  exact ⟨(homotopyGroupMulEquivOfHomotopyEquiv e x).trans φ⟩
+
+end Finite
+
+end TauCeti


### PR DESCRIPTION
This PR proves that homotopy groups are invariant under homotopy equivalence, and derives from that the homotopy invariance of asphericity and of the `K(G, 1)` property. The key step is the trace formula for a *free* homotopy: if `H` runs from `f` to `g`, then the two induced maps on `π_n` differ exactly by base-point change along `H.evalAt x`. Dragging a generalized loop through `H` is a `TauCeti.GenLoop.HomotopyAlong` for that trace, so the already-merged canonicity statement `GenLoop.HomotopyAlong.homotopic_transport` gives the formula with no new analysis. Applying it to both round trips of a homotopy equivalence `e : X ≃ₕ Y` makes the map induced by `e.invFun` injective and surjective, hence the map induced by `e.toFun` bijective; in dimension one this reads as an isomorphism of fundamental groups through Mathlib's `HomotopyGroup.pi1MulEquivFundamentalGroup`.

**Roadmap path.** The designated milestone is Stage 3, item 9 of `TauCetiRoadmap/UniversalCovers/README.md`, "`π_n` API: functoriality (`π_n` of a continuous map), pointed maps, ..., and basepoint-change isomorphisms", of which the roadmap says "Mathlib's `HomotopyGroup` is thin here; this is the bulk of the work". The trace formula is precisely those two listed pieces combined: it corrects functoriality (`TauCeti/Topology/Homotopy/HomotopyGroup/Map.lean`) by base-point change (`.../BasepointChange.lean`), and it generalises two statements of that same API that are already on `main` under the same roadmap item — the pointed-homotopy invariance `HomotopyGroup.map_eq_of_homotopicRel` (`.../HomotopyGroup/Homotopy.lean`, whose homotopy must fix the base point) and the homeomorphism invariance `HomotopyGroup.homeomorphMulEquiv` (`.../HomotopyGroup/Homeomorph.lean`, which cites Stage 3 item 9 in its own module docstring).

The downstream consumers are likewise named. Stage 4, item 14, "Recognition of `K(G, 1)` spaces", asks for stability of asphericity and the `K(G, 1)` property "under products, indexed products and homeomorphism"; the homeomorphism half is on `main` as `TauCeti.IsAspherical.of_homeomorph` and `TauCeti.IsEilenbergMacLaneSpaceOne.of_homeomorph`, and this PR generalises exactly those two statements from `≃ₜ` to `≃ₕ` (replacing them), together with `TauCeti.FundamentalGroup.homeomorphMulEquiv`. Further out, `TauCetiRoadmap/AlgebraicTopology/README.md` assigns "induced maps on homotopy groups" to the universal-covers roadmap and consumes them; its Stage 8, items 5 and 7, extend Whitehead's theorem and the homology-sphere corollary from CW complexes "to spaces of CW type", and that roadmap's `Suggested.lean` spells a space of CW type out as a `FiniteCWTypeModel` whose link to its model is a field `homotopyEquiv : M ≃ₕ X`. Transporting homotopy groups along that field is what this PR supplies.

Four files are added and two are edited. `TauCeti/Topology/Homotopy/HomotopyEquiv.lean` proves that path connectedness is a homotopy invariant, which is what replaces surjectivity when moving between the two spaces. `TauCeti/Topology/Homotopy/HomotopyGroup/HomotopyEquiv.lean` holds the trace formula `TauCeti.homotopyGroupTransport_map` (with the base points of the two induced maps given as equations, as in `HomotopyGroup.map`, and the trace recast with `Path.cast`) and the induced bijection `HomotopyGroup.equivOfHomotopyEquiv` / `HomotopyGroup.mulEquivOfHomotopyEquiv`, with forward and inverse application lemmas. `TauCeti/AlgebraicTopology/FundamentalGroup/HomotopyEquiv.lean` reads off the fundamental group case, `ContinuousMap.HomotopyEquiv.fundamentalGroupMulEquiv`, rather than reproving it. `TauCeti/AlgebraicTopology/EilenbergMacLane/HomotopyEquiv.lean` holds the two homotopy-invariance statements, and the base-point independence lemmas `IsAspherical.of_basepoint` and `IsEilenbergMacLaneSpaceOne.of_basepoint` are added beside the definitions in `TauCeti/AlgebraicTopology/EilenbergMacLane/Basic.lean`. The other edit, to `TauCeti/Topology/Homotopy/HomotopyGroup/BasepointChange.lean`, adds the missing computation lemma `homotopyGroupEquivOfPath_apply`, which belongs beside the equivalence it describes.

The homeomorphism versions `TauCeti.IsAspherical.of_homeomorph` and `TauCeti.IsEilenbergMacLaneSpaceOne.of_homeomorph` are removed from `TauCeti/AlgebraicTopology/EilenbergMacLane/Basic.lean`: they are strict special cases of the `of_homotopyEquiv` theorems (apply those to `e.toHomotopyEquiv`), which also drop the base-point equation. They had no other in-repository uses. `TauCeti.FundamentalGroup.homeomorphMulEquiv` is kept, since it is data with an explicit inverse. The induced equivalences come with identity and composition laws (`*_refl`, `*_trans`), including the fundamental-group specialisation.

No Mathlib source is vendored. The development consumes `ContinuousMap.Homotopy.evalAt`, `ContinuousMap.HomotopyEquiv`, `HomotopyGroup.pi1MulEquivFundamentalGroup` and `FundamentalGroup.fundamentalGroupMulEquivOfPathConnected` from the pinned Mathlib. The mathematics is Proposition 4.21 of Hatcher, *Algebraic Topology*, together with the free-homotopy discussion preceding it in Section 4.1.

Roadmap: UniversalCovers

<!--tauceti-target:v1 {"focus":"UniversalCovers","id":"homotopygroupmulequivofhomotopyequiv"}-->

🤖 Prepared with Claude Code


