### PR TITLE
feat(ModularForms): the descent slash sum is Γ₀(N / p)-equivariant at every prime p ∣ N

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/Newforms/Descent/Sum.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Descent/Sum.lean
@@ -167,12 +167,14 @@ theorem descendSlash_slash_mapGL_of_nebentypus (k : ℤ) [NeZero p] (hpsq : p ^ 
 /-- **The descent slash sum is `Γ₀(N / p)`-equivariant at `p ∥ N`**: the counterpart of
 `descendSlash_slash_mapGL_of_mem_Gamma0` when `p` exactly divides `N`, with the family permuted
 by `descendIndexShift` (`exists_mem_Gamma0_descendMatrix_mul_of_not_sq_dvd`). -/
-theorem descendSlash_slash_mapGL_of_mem_Gamma0_of_not_sq_dvd (k : ℤ) [NeZero p] (hp : p.Prime)
-    (hpN : p ∣ N) (hpsq : ¬ p ^ 2 ∣ N) {γ : SL(2, ℤ)} (hγ : γ ∈ Gamma0 (N / p)) {α : Type*}
-    [DistribSMul α ℂ] [IsScalarTower α ℂ ℂ] {f : ℍ → ℂ} {u : α}
+theorem descendSlash_slash_mapGL_of_mem_Gamma0_of_not_sq_dvd (k : ℤ) (hp : p.Prime) (hpN : p ∣ N)
+    (hpsq : ¬ p ^ 2 ∣ N) {γ : SL(2, ℤ)} (hγ : γ ∈ Gamma0 (N / p)) {α : Type*} [DistribSMul α ℂ]
+    [IsScalarTower α ℂ ℂ] {f : ℍ → ℂ} {u : α}
     (hf : ∀ δ ∈ Gamma0 N, ((δ 1 1 : ℤ) : ZMod (N / p)) = ((γ 1 1 : ℤ) : ZMod (N / p)) →
       f ∣[k] (mapGL ℝ δ : GL (Fin 2) ℝ) = u • f) :
+    haveI : NeZero p := ⟨hp.ne_zero⟩
     descendSlash k p N f ∣[k] (mapGL ℝ γ : GL (Fin 2) ℝ) = u • descendSlash k p N f := by
+  have : NeZero p := ⟨hp.ne_zero⟩
   have : Fact p.Prime := ⟨hp⟩
   rw [descendSlash_def, SlashAction.sum_slash, Finset.smul_sum]
   have key : ∀ v : Fin (descendMatrixCount p N),
@@ -189,35 +191,41 @@ theorem descendSlash_slash_mapGL_of_mem_Gamma0_of_not_sq_dvd (k : ℤ) [NeZero p
 /-- **The descent slash sum is `Γ₀(N / p)`-equivariant at every prime `p ∣ N`**: the two cases
 `p² ∣ N` (`descendSlash_slash_mapGL_of_mem_Gamma0`) and `p ∥ N`
 (`descendSlash_slash_mapGL_of_mem_Gamma0_of_not_sq_dvd`) together. -/
-theorem descendSlash_slash_mapGL_of_mem_Gamma0_of_prime (k : ℤ) [NeZero p] (hp : p.Prime)
-    (hpN : p ∣ N) {γ : SL(2, ℤ)} (hγ : γ ∈ Gamma0 (N / p)) {α : Type*} [DistribSMul α ℂ]
-    [IsScalarTower α ℂ ℂ] {f : ℍ → ℂ} {u : α}
+theorem descendSlash_slash_mapGL_of_mem_Gamma0_of_prime (k : ℤ) (hp : p.Prime) (hpN : p ∣ N)
+    {γ : SL(2, ℤ)} (hγ : γ ∈ Gamma0 (N / p)) {α : Type*} [DistribSMul α ℂ] [IsScalarTower α ℂ ℂ]
+    {f : ℍ → ℂ} {u : α}
     (hf : ∀ δ ∈ Gamma0 N, ((δ 1 1 : ℤ) : ZMod (N / p)) = ((γ 1 1 : ℤ) : ZMod (N / p)) →
       f ∣[k] (mapGL ℝ δ : GL (Fin 2) ℝ) = u • f) :
+    haveI : NeZero p := ⟨hp.ne_zero⟩
     descendSlash k p N f ∣[k] (mapGL ℝ γ : GL (Fin 2) ℝ) = u • descendSlash k p N f := by
+  have : NeZero p := ⟨hp.ne_zero⟩
   by_cases hpsq : p ^ 2 ∣ N
   · exact descendSlash_slash_mapGL_of_mem_Gamma0 k hpsq hγ hf
   · exact descendSlash_slash_mapGL_of_mem_Gamma0_of_not_sq_dvd k hp hpN hpsq hγ hf
 
 /-- **The descent slash sum is `Γ₀(N / p)`-invariant at every prime `p ∣ N`**: the case `u = 1`
 of `descendSlash_slash_mapGL_of_mem_Gamma0_of_prime`. -/
-theorem descendSlash_slash_mapGL_eq_self_of_mem_Gamma0_of_prime (k : ℤ) [NeZero p]
-    (hp : p.Prime) (hpN : p ∣ N) {γ : SL(2, ℤ)} (hγ : γ ∈ Gamma0 (N / p)) {f : ℍ → ℂ}
+theorem descendSlash_slash_mapGL_eq_self_of_mem_Gamma0_of_prime (k : ℤ) (hp : p.Prime)
+    (hpN : p ∣ N) {γ : SL(2, ℤ)} (hγ : γ ∈ Gamma0 (N / p)) {f : ℍ → ℂ}
     (hf : ∀ δ ∈ Gamma0 N, f ∣[k] (mapGL ℝ δ : GL (Fin 2) ℝ) = f) :
+    haveI : NeZero p := ⟨hp.ne_zero⟩
     descendSlash k p N f ∣[k] (mapGL ℝ γ : GL (Fin 2) ℝ) = descendSlash k p N f := by
+  have : NeZero p := ⟨hp.ne_zero⟩
   simpa using descendSlash_slash_mapGL_of_mem_Gamma0_of_prime k hp hpN hγ (u := (1 : ℂ))
     fun δ hδ _ ↦ by rw [hf δ hδ, one_smul]
 
 /-- **The descent sum lowers the level of the nebentypus at every prime `p ∣ N`**: the every-prime
 form of `descendSlash_slash_mapGL_of_nebentypus`. -/
-theorem descendSlash_slash_mapGL_of_nebentypus_of_prime (k : ℤ) [NeZero p] (hp : p.Prime)
-    (hpN : p ∣ N) {χ : (ZMod N)ˣ →* ℂˣ} {χ₀ : (ZMod (N / p))ˣ →* ℂˣ}
+theorem descendSlash_slash_mapGL_of_nebentypus_of_prime (k : ℤ) (hp : p.Prime) (hpN : p ∣ N)
+    {χ : (ZMod N)ˣ →* ℂˣ} {χ₀ : (ZMod (N / p))ˣ →* ℂˣ}
     (hcomp : χ = χ₀.comp (ZMod.unitsMap (Nat.div_dvd_of_dvd hpN))) (γ : ↥(Gamma0 (N / p)))
     {f : ℍ → ℂ}
     (hf : ∀ δ : ↥(Gamma0 N), f ∣[k] (mapGL ℝ (δ : SL(2, ℤ)) : GL (Fin 2) ℝ)
       = (↑(χ ((Gamma0Map N).toHomUnits δ)) : ℂ) • f) :
+    haveI : NeZero p := ⟨hp.ne_zero⟩
     descendSlash k p N f ∣[k] (mapGL ℝ (γ : SL(2, ℤ)) : GL (Fin 2) ℝ)
       = (↑(χ₀ ((Gamma0Map (N / p)).toHomUnits γ)) : ℂ) • descendSlash k p N f := by
+  have : NeZero p := ⟨hp.ne_zero⟩
   apply descendSlash_slash_mapGL_of_mem_Gamma0_of_prime k hp hpN γ.2
   intro δ hδ hd
   have hdvd : N / p ∣ N := Nat.div_dvd_of_dvd hpN

--- a/TauCeti/NumberTheory/ModularForms/Newforms/Descent/Sum.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Descent/Sum.lean
@@ -38,11 +38,11 @@ that the descent consumes: if `f` transforms under `Γ₀(N)` by a scalar, the s
 * `TauCeti.descendSlash_slash_mapGL_of_nebentypus`: if `f` transforms under `Γ₀(N)` by `χ`, and
   `χ` is the pull-back of `χ₀` modulo `N / p`, then `descendSlash k p N f` transforms under
   `Γ₀(N / p)` by `χ₀` — the descent lowers the level of the nebentypus.
-* `TauCeti.descendSlash_slash_mapGL_of_mem_Gamma0_of_not_sq_dvd`: the equivariance when `p`
-  exactly divides `N`, and `TauCeti.descendSlash_slash_mapGL_of_mem_Gamma0_of_prime`,
+* `TauCeti.descendSlash_slash_mapGL_of_mem_Gamma0_of_prime`,
   `TauCeti.descendSlash_slash_mapGL_eq_self_of_mem_Gamma0_of_prime`,
   `TauCeti.descendSlash_slash_mapGL_of_nebentypus_of_prime`: the three statements at every prime
-  `p ∣ N`, the two cases combined.
+  `p ∣ N`, the `p² ∣ N` case above and the `p ∥ N` case (a private lemma, with the family
+  permuted by `descendIndexShift`) combined.
 
 ## Scope
 
@@ -164,12 +164,11 @@ theorem descendSlash_slash_mapGL_of_nebentypus (k : ℤ) [NeZero p] (hpsq : p ^ 
     exact Units.ext hd
   rw [hf ⟨δ, hδ⟩, hcomp, MonoidHom.comp_apply, hmap]
 
-/-- **The descent slash sum is `Γ₀(N / p)`-equivariant at `p ∥ N`**: the counterpart of
-`descendSlash_slash_mapGL_of_mem_Gamma0` when `p` exactly divides `N`, with the family permuted
-by `descendIndexShift` (`exists_mem_Gamma0_descendMatrix_mul_of_not_sq_dvd`). -/
-theorem descendSlash_slash_mapGL_of_mem_Gamma0_of_not_sq_dvd (k : ℤ) (hp : p.Prime) (hpN : p ∣ N)
-    (hpsq : ¬ p ^ 2 ∣ N) {γ : SL(2, ℤ)} (hγ : γ ∈ Gamma0 (N / p)) {α : Type*} [DistribSMul α ℂ]
-    [IsScalarTower α ℂ ℂ] {f : ℍ → ℂ} {u : α}
+/-- The `p ∥ N` case of `descendSlash_slash_mapGL_of_mem_Gamma0_of_prime`, with the family
+permuted by `descendIndexShift` (`exists_mem_Gamma0_descendMatrix_mul_of_not_sq_dvd`). -/
+private theorem descendSlash_slash_mapGL_of_mem_Gamma0_of_not_sq_dvd (k : ℤ) (hp : p.Prime)
+    (hpN : p ∣ N) (hpsq : ¬ p ^ 2 ∣ N) {γ : SL(2, ℤ)} (hγ : γ ∈ Gamma0 (N / p)) {α : Type*}
+    [DistribSMul α ℂ] [IsScalarTower α ℂ ℂ] {f : ℍ → ℂ} {u : α}
     (hf : ∀ δ ∈ Gamma0 N, ((δ 1 1 : ℤ) : ZMod (N / p)) = ((γ 1 1 : ℤ) : ZMod (N / p)) →
       f ∣[k] (mapGL ℝ δ : GL (Fin 2) ℝ) = u • f) :
     haveI : NeZero p := ⟨hp.ne_zero⟩
@@ -188,9 +187,9 @@ theorem descendSlash_slash_mapGL_of_mem_Gamma0_of_not_sq_dvd (k : ℤ) (hp : p.P
     (fun v ↦ u • (f ∣[k] descendMatrix p N (descendIndexShift p N hpsq γ v)))
     (fun v ↦ u • (f ∣[k] descendMatrix p N v)) fun _ ↦ rfl
 
-/-- **The descent slash sum is `Γ₀(N / p)`-equivariant at every prime `p ∣ N`**: the two cases
-`p² ∣ N` (`descendSlash_slash_mapGL_of_mem_Gamma0`) and `p ∥ N`
-(`descendSlash_slash_mapGL_of_mem_Gamma0_of_not_sq_dvd`) together. -/
+/-- **The descent slash sum is `Γ₀(N / p)`-equivariant at every prime `p ∣ N`**: the case
+`p² ∣ N` is `descendSlash_slash_mapGL_of_mem_Gamma0`; when `p` exactly divides `N` the family is
+permuted by `descendIndexShift` instead. -/
 theorem descendSlash_slash_mapGL_of_mem_Gamma0_of_prime (k : ℤ) (hp : p.Prime) (hpN : p ∣ N)
     {γ : SL(2, ℤ)} (hγ : γ ∈ Gamma0 (N / p)) {α : Type*} [DistribSMul α ℂ] [IsScalarTower α ℂ ℂ]
     {f : ℍ → ℂ} {u : α}

--- a/TauCeti/NumberTheory/ModularForms/Newforms/Descent/Sum.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Descent/Sum.lean
@@ -14,11 +14,12 @@ import TauCeti.NumberTheory.ModularForms.CongruenceSubgroups.Units
 /-!
 # The descent slash sum is `Γ₀(N / p)`-invariant
 
-`Newforms/Descent/Action.lean` shows that, at a prime `p` with `p² ∣ N`, right multiplication by
-`γ ∈ Γ₀(N / p)` permutes the family `descendMatrix p N` up to `Γ₀(N)`. This file draws the
-consequence that the descent consumes: if `f` transforms under `Γ₀(N)` by a scalar, the sum of
-the slashes of `f` along the family transforms under `Γ₀(N / p)` by that scalar; in particular
-the sum is `Γ₀(N / p)`-invariant whenever `f` is `Γ₀(N)`-invariant.
+`Newforms/Descent/Action.lean` shows that, at a prime `p ∣ N`, right multiplication by
+`γ ∈ Γ₀(N / p)` permutes the family `descendMatrix p N` up to `Γ₀(N)` — by `descendShift` when
+`p² ∣ N`, by `descendIndexShift` when `p` exactly divides `N`. This file draws the consequence
+that the descent consumes: if `f` transforms under `Γ₀(N)` by a scalar, the sum of the slashes of
+`f` along the family transforms under `Γ₀(N / p)` by that scalar; in particular the sum is
+`Γ₀(N / p)`-invariant whenever `f` is `Γ₀(N)`-invariant.
 
 ## Main definitions
 
@@ -37,12 +38,17 @@ the sum is `Γ₀(N / p)`-invariant whenever `f` is `Γ₀(N)`-invariant.
 * `TauCeti.descendSlash_slash_mapGL_of_nebentypus`: if `f` transforms under `Γ₀(N)` by `χ`, and
   `χ` is the pull-back of `χ₀` modulo `N / p`, then `descendSlash k p N f` transforms under
   `Γ₀(N / p)` by `χ₀` — the descent lowers the level of the nebentypus.
+* `TauCeti.descendSlash_slash_mapGL_of_mem_Gamma0_of_not_sq_dvd`: the equivariance when `p`
+  exactly divides `N`, and `TauCeti.descendSlash_slash_mapGL_of_mem_Gamma0_of_prime`,
+  `TauCeti.descendSlash_slash_mapGL_eq_self_of_mem_Gamma0_of_prime`,
+  `TauCeti.descendSlash_slash_mapGL_of_nebentypus_of_prime`: the three statements at every prime
+  `p ∣ N`, the two cases combined.
 
 ## Scope
 
-Only the `p² ∣ N` case. The behaviour at cusps is not claimed.
+The behaviour at cusps is not claimed; it is `Newforms/Descent/Cusps.lean`.
 
-Corresponds to the `p² ∣ N` case of `miyake_hecke_descend_char` in the AINTLIB
+Corresponds to `miyake_hecke_descend_char` in the AINTLIB
 `LeanModularForms` project (`LeanModularForms/StrongMultiplicityOne/HeckeDescent.lean`,
 Chris Birkbeck, commit `2baa76f742bdb4fb8ee323fabba41203bd390e08`, Apache-2.0,
 <https://github.com/CBirkbeck/AINTLIB/tree/main/projects/LeanModularForms>).
@@ -152,6 +158,69 @@ theorem descendSlash_slash_mapGL_of_nebentypus (k : ℤ) [NeZero p] (hpsq : p ^ 
   apply descendSlash_slash_mapGL_of_mem_Gamma0 k hpsq γ.2
   intro δ hδ hd
   have hdvd : N / p ∣ N := Nat.div_dvd_of_dvd ((dvd_pow_self p two_ne_zero).trans hpsq)
+  have hmap : ZMod.unitsMap hdvd ((Gamma0Map N).toHomUnits ⟨δ, hδ⟩) =
+      (Gamma0Map (N / p)).toHomUnits γ := by
+    rw [← Gamma0Map_toHomUnits_of_dvd hdvd ⟨δ, hδ⟩ (Gamma0_le_Gamma0_of_dvd hdvd hδ)]
+    exact Units.ext hd
+  rw [hf ⟨δ, hδ⟩, hcomp, MonoidHom.comp_apply, hmap]
+
+/-- **The descent slash sum is `Γ₀(N / p)`-equivariant at `p ∥ N`**: the counterpart of
+`descendSlash_slash_mapGL_of_mem_Gamma0` when `p` exactly divides `N`, with the family permuted
+by `descendIndexShift` (`exists_mem_Gamma0_descendMatrix_mul_of_not_sq_dvd`). -/
+theorem descendSlash_slash_mapGL_of_mem_Gamma0_of_not_sq_dvd (k : ℤ) [NeZero p] (hp : p.Prime)
+    (hpN : p ∣ N) (hpsq : ¬ p ^ 2 ∣ N) {γ : SL(2, ℤ)} (hγ : γ ∈ Gamma0 (N / p)) {α : Type*}
+    [DistribSMul α ℂ] [IsScalarTower α ℂ ℂ] {f : ℍ → ℂ} {u : α}
+    (hf : ∀ δ ∈ Gamma0 N, ((δ 1 1 : ℤ) : ZMod (N / p)) = ((γ 1 1 : ℤ) : ZMod (N / p)) →
+      f ∣[k] (mapGL ℝ δ : GL (Fin 2) ℝ) = u • f) :
+    descendSlash k p N f ∣[k] (mapGL ℝ γ : GL (Fin 2) ℝ) = u • descendSlash k p N f := by
+  have : Fact p.Prime := ⟨hp⟩
+  rw [descendSlash_def, SlashAction.sum_slash, Finset.smul_sum]
+  have key : ∀ v : Fin (descendMatrixCount p N),
+      (f ∣[k] descendMatrix p N v) ∣[k] (mapGL ℝ γ : GL (Fin 2) ℝ)
+        = u • (f ∣[k] descendMatrix p N (descendIndexShift p N hpsq γ v)) := fun v ↦ by
+    obtain ⟨α, hα, hd, hmul⟩ := exists_mem_Gamma0_descendMatrix_mul_of_not_sq_dvd hpN hpsq hγ v
+    rw [← SlashAction.slash_mul, hmul, SlashAction.slash_mul, hf α hα hd,
+      ModularForm.smul_slash_of_det_pos k (descendMatrix_det_pos p N _) f u]
+  rw [Finset.sum_congr rfl fun v _ ↦ key v]
+  exact Fintype.sum_bijective (descendIndexShift p N hpsq γ) (descendIndexShift_bijective hpsq γ)
+    (fun v ↦ u • (f ∣[k] descendMatrix p N (descendIndexShift p N hpsq γ v)))
+    (fun v ↦ u • (f ∣[k] descendMatrix p N v)) fun _ ↦ rfl
+
+/-- **The descent slash sum is `Γ₀(N / p)`-equivariant at every prime `p ∣ N`**: the two cases
+`p² ∣ N` (`descendSlash_slash_mapGL_of_mem_Gamma0`) and `p ∥ N`
+(`descendSlash_slash_mapGL_of_mem_Gamma0_of_not_sq_dvd`) together. -/
+theorem descendSlash_slash_mapGL_of_mem_Gamma0_of_prime (k : ℤ) [NeZero p] (hp : p.Prime)
+    (hpN : p ∣ N) {γ : SL(2, ℤ)} (hγ : γ ∈ Gamma0 (N / p)) {α : Type*} [DistribSMul α ℂ]
+    [IsScalarTower α ℂ ℂ] {f : ℍ → ℂ} {u : α}
+    (hf : ∀ δ ∈ Gamma0 N, ((δ 1 1 : ℤ) : ZMod (N / p)) = ((γ 1 1 : ℤ) : ZMod (N / p)) →
+      f ∣[k] (mapGL ℝ δ : GL (Fin 2) ℝ) = u • f) :
+    descendSlash k p N f ∣[k] (mapGL ℝ γ : GL (Fin 2) ℝ) = u • descendSlash k p N f := by
+  by_cases hpsq : p ^ 2 ∣ N
+  · exact descendSlash_slash_mapGL_of_mem_Gamma0 k hpsq hγ hf
+  · exact descendSlash_slash_mapGL_of_mem_Gamma0_of_not_sq_dvd k hp hpN hpsq hγ hf
+
+/-- **The descent slash sum is `Γ₀(N / p)`-invariant at every prime `p ∣ N`**: the case `u = 1`
+of `descendSlash_slash_mapGL_of_mem_Gamma0_of_prime`. -/
+theorem descendSlash_slash_mapGL_eq_self_of_mem_Gamma0_of_prime (k : ℤ) [NeZero p]
+    (hp : p.Prime) (hpN : p ∣ N) {γ : SL(2, ℤ)} (hγ : γ ∈ Gamma0 (N / p)) {f : ℍ → ℂ}
+    (hf : ∀ δ ∈ Gamma0 N, f ∣[k] (mapGL ℝ δ : GL (Fin 2) ℝ) = f) :
+    descendSlash k p N f ∣[k] (mapGL ℝ γ : GL (Fin 2) ℝ) = descendSlash k p N f := by
+  simpa using descendSlash_slash_mapGL_of_mem_Gamma0_of_prime k hp hpN hγ (u := (1 : ℂ))
+    fun δ hδ _ ↦ by rw [hf δ hδ, one_smul]
+
+/-- **The descent sum lowers the level of the nebentypus at every prime `p ∣ N`**: the every-prime
+form of `descendSlash_slash_mapGL_of_nebentypus`. -/
+theorem descendSlash_slash_mapGL_of_nebentypus_of_prime (k : ℤ) [NeZero p] (hp : p.Prime)
+    (hpN : p ∣ N) {χ : (ZMod N)ˣ →* ℂˣ} {χ₀ : (ZMod (N / p))ˣ →* ℂˣ}
+    (hcomp : χ = χ₀.comp (ZMod.unitsMap (Nat.div_dvd_of_dvd hpN))) (γ : ↥(Gamma0 (N / p)))
+    {f : ℍ → ℂ}
+    (hf : ∀ δ : ↥(Gamma0 N), f ∣[k] (mapGL ℝ (δ : SL(2, ℤ)) : GL (Fin 2) ℝ)
+      = (↑(χ ((Gamma0Map N).toHomUnits δ)) : ℂ) • f) :
+    descendSlash k p N f ∣[k] (mapGL ℝ (γ : SL(2, ℤ)) : GL (Fin 2) ℝ)
+      = (↑(χ₀ ((Gamma0Map (N / p)).toHomUnits γ)) : ℂ) • descendSlash k p N f := by
+  apply descendSlash_slash_mapGL_of_mem_Gamma0_of_prime k hp hpN γ.2
+  intro δ hδ hd
+  have hdvd : N / p ∣ N := Nat.div_dvd_of_dvd hpN
   have hmap : ZMod.unitsMap hdvd ((Gamma0Map N).toHomUnits ⟨δ, hδ⟩) =
       (Gamma0Map (N / p)).toHomUnits γ := by
     rw [← Gamma0Map_toHomUnits_of_dvd hdvd ⟨δ, hδ⟩ (Gamma0_le_Gamma0_of_dvd hdvd hδ)]


### PR DESCRIPTION
The descent slash sum `descendSlash k p N f = ∑ v, f ∣[k] descendMatrix p N v` (`Newforms/Descent/Sum.lean`) was shown `Γ₀(N / p)`-equivariant only when `p² ∣ N` (#6242). With the `p ∥ N` action of the family merged (#6253, `exists_mem_Gamma0_descendMatrix_mul_of_not_sq_dvd` and the bijection `descendIndexShift_bijective`), this PR completes the invariance at every prime `p ∣ N`, in `Newforms/Descent/Sum.lean`:

- A private lemma for the `p ∥ N` case of the equivariance, the family permuted by `descendIndexShift` (`exists_mem_Gamma0_descendMatrix_mul_of_not_sq_dvd`).
- `descendSlash_slash_mapGL_of_mem_Gamma0_of_prime`, `descendSlash_slash_mapGL_eq_self_of_mem_Gamma0_of_prime`, `descendSlash_slash_mapGL_of_nebentypus_of_prime`: the equivariance, the invariance (`u = 1`) and the nebentypus transport at every prime `p ∣ N`, combining the two cases inside the proof. The `p² ∣ N` originals stay, since they need no primality.

This is what bundling the descent sum as a cusp form of level `N / p` in `S_k(N / p, χ₀)` (Miyake Lemma 4.6.14, the next item) consumes.

Roadmap: ModularForms

No `tauceti-target:v1` marker: like #6242 and #6253 before it, this is a prerequisite for the Layer 4 Atkin–Lehner Main Lemma node (the per-character route `mainLemma_charSpace_routeB`) rather than the node itself, and the contract asks for a deterministic target identifier, not an invented one.

Provenance: github.com/CBirkbeck/AINTLIB @ `eb9621e7bcb0ce220ad53983ec45d987cb5b9002` (Apache-2.0, Chris Birkbeck), `projects/LeanModularForms/LeanModularForms/StrongMultiplicityOne/HeckeDescent.lean` — the `p ∤ N/p` case of `miyake_hecke_descend_char`. Re-proved here from this repository's `descendSlash` and the #6253 action; no proof code transcribed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQieFQn95rzgvYRvNdX3hR
