### PR TITLE
refactor(EllipticCurve): name the repeated evaluation transports in the formal-group evaluation files

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Eval.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Eval.lean
@@ -430,6 +430,16 @@ theorem hasEval_formalInverseEval {I : Ideal O} (hI : IsAdic I) {t : O} (ht : t 
     simpa using W.formalInverseEval_mem (k := 1)
       (hI.isTopologicallyNilpotent_of_mem ht) (by simpa using ht)
 
+/-- **The inverse series evaluates to the inverse of the parameter**: the algebra map
+`PowerSeries.aeval` and the `eval₂` defining `formalInverseEval` agree on `formalInverse`. -/
+private theorem aeval_formalInverse {t : O} (hE : PowerSeries.HasEval t) :
+    PowerSeries.aeval hE W.formalInverse = W.formalInverseEval t := by
+  -- the coercion lands on `eval₂ (algebraMap O O)`, which is `RingHom.id O` only up to
+  -- definitional unfolding, so the ascription is what lets `rw` fire
+  have hcoe : ∀ f : PowerSeries O, PowerSeries.aeval hE f = eval₂ (RingHom.id O) t f :=
+    congrFun (PowerSeries.coe_aeval hE)
+  rw [hcoe, ← W.formalInverseEval_def]
+
 /-- **The `w`-expansion at an inverted parameter**: `w(ι(t)) = -(w(t) * d(t)⁻¹)`, the evaluation of
 the series identity `subst_formalInverse_formalW`. -/
 theorem formalWEval_formalInverseEval {t : O} (hE : PowerSeries.HasEval t)
@@ -438,13 +448,12 @@ theorem formalWEval_formalInverseEval {t : O} (hE : PowerSeries.HasEval t)
       -(W.formalWEval t * W.formalInverseDenomInvEval t) := by
   have hcoe : ∀ f : PowerSeries O, PowerSeries.aeval hE f = eval₂ (RingHom.id O) t f :=
     congrFun (PowerSeries.coe_aeval hE)
-  have hsub : PowerSeries.aeval hE W.formalInverse = W.formalInverseEval t := by
-    rw [hcoe, ← W.formalInverseEval_def]
-  have hV' : PowerSeries.HasEval (PowerSeries.aeval hE W.formalInverse) := hsub ▸ hV
+  have hV' : PowerSeries.HasEval (PowerSeries.aeval hE W.formalInverse) :=
+    W.aeval_formalInverse hE ▸ hV
   have h := PowerSeries.aeval_subst W.hasSubst_formalInverse
     (PowerSeries.continuous_aeval hE) hV' W.formalW
   rw [W.subst_formalInverse_formalW, map_neg, map_mul,
-    congrFun (PowerSeries.coe_aeval hV') W.formalW, hsub] at h
+    congrFun (PowerSeries.coe_aeval hV') W.formalW, W.aeval_formalInverse hE] at h
   simpa [hcoe, formalWEval, formalInverseEval, formalInverseDenomInvEval] using h.symm
 
 /-- **The formal inverse fixes the `x`-coordinate.** `ι(t) = -(t · d(t)⁻¹)` and
@@ -507,13 +516,12 @@ theorem formalInverseEval_formalInverseEval {t : O} (hE : PowerSeries.HasEval t)
     W.formalInverseEval (W.formalInverseEval t) = t := by
   have hcoe : ∀ f : PowerSeries O, PowerSeries.aeval hE f = eval₂ (RingHom.id O) t f :=
     congrFun (PowerSeries.coe_aeval hE)
-  have hsub : PowerSeries.aeval hE W.formalInverse = W.formalInverseEval t := by
-    rw [hcoe, ← W.formalInverseEval_def]
-  have hV' : PowerSeries.HasEval (PowerSeries.aeval hE W.formalInverse) := hsub ▸ hV
+  have hV' : PowerSeries.HasEval (PowerSeries.aeval hE W.formalInverse) :=
+    W.aeval_formalInverse hE ▸ hV
   have h := PowerSeries.aeval_subst W.hasSubst_formalInverse
     (PowerSeries.continuous_aeval hE) hV' W.formalInverse
   rw [W.subst_formalInverse_self,
-    congrFun (PowerSeries.coe_aeval hV') W.formalInverse, hsub] at h
+    congrFun (PowerSeries.coe_aeval hV') W.formalInverse, W.aeval_formalInverse hE] at h
   simpa [hcoe, formalInverseEval, PowerSeries.eval₂_X] using h.symm
 
 end WeierstrassCurve

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/PairEval.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/PairEval.lean
@@ -334,6 +334,16 @@ theorem hasEval_formalThirdRootEval {t₁ t₂ : O} (h₁ : PowerSeries.HasEval 
     (MvPowerSeries.continuous_aeval (hasEval_pair h₁ h₂)) hnil
   simpa [formalThirdRootEval, MvPowerSeries.coe_aeval, Algebra.algebraMap_self] using h
 
+/-- **The third-root series can be substituted into at a pair of parameters**: it evaluates to
+`formalThirdRootEval`, which is itself substitutable. -/
+private theorem hasEval_aeval_formalThirdRoot {t₁ t₂ : O} (h₁ : PowerSeries.HasEval t₁)
+    (h₂ : PowerSeries.HasEval t₂) :
+    PowerSeries.HasEval (MvPowerSeries.aeval (hasEval_pair h₁ h₂) W.formalThirdRoot) := by
+  -- the coercion lands on `eval₂ (algebraMap O O)` while `formalThirdRootEval` is defined with
+  -- `eval₂ (RingHom.id O)`; `Algebra.algebraMap_self` is what identifies the two
+  simpa [formalThirdRootEval, MvPowerSeries.coe_aeval, Algebra.algebraMap_self] using
+    W.hasEval_formalThirdRootEval h₁ h₂
+
 /-- **The evaluated on-line identity**: `w(t₃(t₁, t₂)) = λ(t₁, t₂) * t₃(t₁, t₂) + ν(t₁, t₂)`, so
 the `w`-expansion read at the third root agrees with the chord line read there. Over a field, where
 the parameters carry the coordinates `x = t / w` and `y = -1 / w`, this is what says the third root
@@ -342,14 +352,9 @@ theorem formalWEval_formalThirdRootEval {t₁ t₂ : O} (h₁ : PowerSeries.HasE
     (h₂ : PowerSeries.HasEval t₂) :
     W.formalWEval (W.formalThirdRootEval t₁ t₂) =
       W.formalSlopeEval t₁ t₂ * W.formalThirdRootEval t₁ t₂ + W.formalInterceptEval t₁ t₂ := by
-  have hae : MvPowerSeries.aeval (hasEval_pair h₁ h₂) W.formalThirdRoot =
-      W.formalThirdRootEval t₁ t₂ :=
-    congrFun (MvPowerSeries.coe_aeval (hasEval_pair h₁ h₂)) W.formalThirdRoot
-  have hT' : PowerSeries.HasEval (MvPowerSeries.aeval (hasEval_pair h₁ h₂) W.formalThirdRoot) := by
-    rw [hae]; exact W.hasEval_formalThirdRootEval h₁ h₂
   have h := MvPowerSeries.aeval_subst W.hasSubst_formalThirdRoot
     (MvPowerSeries.continuous_aeval (hasEval_pair h₁ h₂))
-    (PowerSeries.hasEval hT') W.formalW
+    (PowerSeries.hasEval (W.hasEval_aeval_formalThirdRoot h₁ h₂)) W.formalW
   -- distribute while the evaluation is still an algebra map: after `coe_aeval` rewrites it to
   -- `eval₂`, `map_add` and `map_mul` no longer apply.
   rw [W.subst_formalThirdRoot_formalW, map_add, map_mul] at h
@@ -386,14 +391,9 @@ chord through them. -/
 theorem formalAddEval_eq {t₁ t₂ : O} (h₁ : PowerSeries.HasEval t₁)
     (h₂ : PowerSeries.HasEval t₂) :
     W.formalAddEval t₁ t₂ = W.formalInverseEval (W.formalThirdRootEval t₁ t₂) := by
-  have hae : MvPowerSeries.aeval (hasEval_pair h₁ h₂) W.formalThirdRoot =
-      W.formalThirdRootEval t₁ t₂ :=
-    congrFun (MvPowerSeries.coe_aeval (hasEval_pair h₁ h₂)) W.formalThirdRoot
-  have hT' : PowerSeries.HasEval (MvPowerSeries.aeval (hasEval_pair h₁ h₂) W.formalThirdRoot) := by
-    rw [hae]; exact W.hasEval_formalThirdRootEval h₁ h₂
   have h := MvPowerSeries.aeval_subst W.hasSubst_formalThirdRoot
     (MvPowerSeries.continuous_aeval (hasEval_pair h₁ h₂))
-    (PowerSeries.hasEval hT') W.formalInverse
+    (PowerSeries.hasEval (W.hasEval_aeval_formalThirdRoot h₁ h₂)) W.formalInverse
   rw [← W.formalAdd_def] at h
   simpa [formalAddEval, W.formalInverseEval_def, MvPowerSeries.coe_aeval, PowerSeries.eval₂,
     ← W.formalThirdRootEval_def] using h


### PR DESCRIPTION
Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"EllipticCurves/improvement:formalgroup-eval-transports"}-->

Provenance: improvement work on code already on `main`; nothing new is ported.

## What this changes

Two verbatim duplications in the formal-group evaluation files, each with two call sites:

- `FormalGroup/Eval.lean`: `formalWEval_formalInverseEval` and `formalInverseEval_formalInverseEval` both opened by proving that `PowerSeries.aeval` applied to `formalInverse` is `formalInverseEval`. That is now the private `aeval_formalInverse`, and the two proofs use it directly.
- `FormalGroup/PairEval.lean`: `formalWEval_formalThirdRootEval` and `formalAddEval_eq` both opened with the same five lines establishing that the evaluated third-root series can itself be substituted into. That is now the private `hasEval_aeval_formalThirdRoot`; the intermediate equation was used only to reach it, so both copies disappear.

No statement changes; both new declarations are private.

## Why

Each opening is a fact about the evaluation maps, not about the identity being proved, so naming it keeps the four theorems about their own content. `aeval_formalInverse` also carries the one brittleness note worth recording: `PowerSeries.coe_aeval` produces `eval₂ (algebraMap O O)`, which is `RingHom.id O` only up to unfolding, so the rewrite needs the ascribed form. That subtlety was previously re-derived at each site.
