### PR TITLE
feat: test functions are dense in W^{1,p}(ℝⁿ)

### DIFF
--- a/TauCeti/Analysis/Normed/Lp/ProdLp.lean
+++ b/TauCeti/Analysis/Normed/Lp/ProdLp.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Analysis.Normed.Lp.ProdLp
-public import Mathlib.Analysis.MeanInequalitiesPow
 
 /-!
 # The triangle bound for the `ℓ^p` product norm
@@ -33,10 +32,14 @@ variable {p : ℝ≥0∞} [Fact (1 ≤ p)] {α β : Type*} [SeminormedAddCommGro
 /-- The `ℓ^p` norm of a pair is at most the sum of the norms of its two components. -/
 theorem _root_.WithLp.prod_norm_le_norm_fst_add_norm_snd (x : WithLp p (α × β)) :
     ‖x‖ ≤ ‖x.fst‖ + ‖x.snd‖ := by
-  rcases p.dichotomy with rfl | hp
-  · rw [WithLp.prod_norm_eq_sup]
-    exact sup_le (le_add_of_nonneg_right (norm_nonneg _)) (le_add_of_nonneg_left (norm_nonneg _))
-  · rw [WithLp.prod_norm_eq_add (zero_lt_one.trans_le hp)]
-    exact Real.rpow_add_rpow_le_add (norm_nonneg _) (norm_nonneg _) hp
+  have hx : WithLp.idemFst x + WithLp.idemSnd x = x := by
+    rw [WithLp.idemFst_apply, WithLp.idemSnd_apply, ← WithLp.toLp_add, Prod.mk_add_mk, add_zero,
+      zero_add]
+    rfl
+  calc ‖x‖ = ‖WithLp.idemFst x + WithLp.idemSnd x‖ := by rw [hx]
+    _ ≤ ‖WithLp.idemFst x‖ + ‖WithLp.idemSnd x‖ := norm_add_le _ _
+    _ = ‖x.fst‖ + ‖x.snd‖ := by
+        rw [WithLp.idemFst_apply, WithLp.idemSnd_apply, WithLp.norm_toLp_fst,
+          WithLp.norm_toLp_snd]
 
 end TauCeti

--- a/TauCeti/Analysis/Normed/Lp/ProdLp.lean
+++ b/TauCeti/Analysis/Normed/Lp/ProdLp.lean
@@ -1,0 +1,42 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.Normed.Lp.ProdLp
+public import Mathlib.Analysis.MeanInequalitiesPow
+
+/-!
+# The triangle bound for the `ℓ^p` product norm
+
+Mathlib bounds each factor of `WithLp p (α × β)` by the whole (`WithLp.norm_fst_le` and
+`WithLp.norm_snd_le`) and computes the norm exactly for `p = 1` and `p = 2`.  This file records
+the opposite bound, valid for every exponent `1 ≤ p ≤ ∞`: the `ℓ^p` norm of a pair is at most the
+sum of the norms of its two components, with equality exactly at `p = 1`.
+
+## Main statements
+
+* `WithLp.prod_norm_le_norm_fst_add_norm_snd` — the bound `‖x‖ ≤ ‖x.fst‖ + ‖x.snd‖`.
+-/
+
+public section
+
+open scoped ENNReal
+
+namespace TauCeti
+
+variable {p : ℝ≥0∞} [Fact (1 ≤ p)] {α β : Type*} [SeminormedAddCommGroup α]
+  [SeminormedAddCommGroup β]
+
+/-- The `ℓ^p` norm of a pair is at most the sum of the norms of its two components. -/
+theorem _root_.WithLp.prod_norm_le_norm_fst_add_norm_snd (x : WithLp p (α × β)) :
+    ‖x‖ ≤ ‖x.fst‖ + ‖x.snd‖ := by
+  rcases p.dichotomy with rfl | hp
+  · rw [WithLp.prod_norm_eq_sup]
+    exact sup_le (le_add_of_nonneg_right (norm_nonneg _)) (le_add_of_nonneg_left (norm_nonneg _))
+  · rw [WithLp.prod_norm_eq_add (zero_lt_one.trans_le hp)]
+    exact Real.rpow_add_rpow_le_add (norm_nonneg _) (norm_nonneg _) hp
+
+end TauCeti

--- a/TauCeti/Analysis/Normed/Lp/ProdLp.lean
+++ b/TauCeti/Analysis/Normed/Lp/ProdLp.lean
@@ -31,12 +31,10 @@ variable {p : ℝ≥0∞} [Fact (1 ≤ p)] {α β : Type*} [SeminormedAddCommGro
 
 /-- The `ℓ^p` norm of a pair is at most the sum of the norms of its two components. -/
 theorem _root_.WithLp.prod_norm_le_norm_fst_add_norm_snd (x : WithLp p (α × β)) :
-    ‖x‖ ≤ ‖x.fst‖ + ‖x.snd‖ := by
-  have hx : WithLp.idemFst x + WithLp.idemSnd x = x := by
-    rw [WithLp.idemFst_apply, WithLp.idemSnd_apply, ← WithLp.toLp_add, Prod.mk_add_mk, add_zero,
-      zero_add]
-    rfl
-  calc ‖x‖ = ‖WithLp.idemFst x + WithLp.idemSnd x‖ := by rw [hx]
+    ‖x‖ ≤ ‖x.fst‖ + ‖x.snd‖ :=
+  calc ‖x‖ = ‖WithLp.idemFst x + WithLp.idemSnd x‖ :=
+        congrArg norm ((DFunLike.congr_fun WithLp.idemFst_add_idemSnd x).trans
+          (AddMonoid.End.one_apply x)).symm
     _ ≤ ‖WithLp.idemFst x‖ + ‖WithLp.idemSnd x‖ := norm_add_le _ _
     _ = ‖x.fst‖ + ‖x.snd‖ := by
         rw [WithLp.idemFst_apply, WithLp.idemSnd_apply, WithLp.norm_toLp_fst,

--- a/TauCeti/Analysis/Normed/Lp/ProdLp.lean
+++ b/TauCeti/Analysis/Normed/Lp/ProdLp.lean
@@ -14,7 +14,7 @@ public import Mathlib.Analysis.MeanInequalitiesPow
 Mathlib bounds each factor of `WithLp p (α × β)` by the whole (`WithLp.norm_fst_le` and
 `WithLp.norm_snd_le`) and computes the norm exactly for `p = 1` and `p = 2`.  This file records
 the opposite bound, valid for every exponent `1 ≤ p ≤ ∞`: the `ℓ^p` norm of a pair is at most the
-sum of the norms of its two components, with equality exactly at `p = 1`.
+sum of the norms of its two components.  For `p = 1` the bound is an identity for every pair.
 
 ## Main statements
 

--- a/TauCeti/Analysis/Sobolev/Translation.lean
+++ b/TauCeti/Analysis/Sobolev/Translation.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.Analysis.Sobolev.W1p.Extension
 public import TauCeti.MeasureTheory.Function.Lp.Translation
+import Mathlib.MeasureTheory.Group.Integral
 
 /-!
 # The `Lᵖ` translation estimate on `W^{1,p}_0`
@@ -68,6 +69,8 @@ estimate give the fixed-bounded-support and translation inputs for Fréchet--Kol
   zero extensions of a gradient-bounded family have uniformly small translation increments.
 * `TauCeti.W1p0.exists_pos_forall_eLpNorm_value_extendByZeroL_comp_add_sub_le_of_norm_le`:
   zero extensions of a norm-bounded family have uniformly small translation increments.
+* `TauCeti.Sobolev1JetLp.translateLp_mem_w1pSubmodule`: translation preserves `W^{1,p}(ℝⁿ)`,
+  since on the whole space the weak-derivative identities are translation invariant.
 
 ## References
 
@@ -235,6 +238,66 @@ theorem W1p0.exists_pos_forall_eLpNorm_value_extendByZeroL_comp_add_sub_le_of_no
     (C := C) (epsilon := epsilon) ?_ hepsilon
   intro u hu
   exact (W1p.norm_gradient_le (u : W1p mu Omega p)).trans (hS u hu)
+
+/-! ### Translation preserves `W^{1,p}(ℝⁿ)` -/
+
+section TranslateJet
+
+/-- The whole-space restriction of an additive Haar measure is the measure itself. -/
+local instance : (mu.restrict ((⊤ : Opens E) : Set E)).IsAddHaarMeasure := by
+  rw [Opens.coe_top, Measure.restrict_univ]
+  infer_instance
+
+/-- The translate `y ↦ φ (y + h)` of a whole-space test function. -/
+private def translateTestFunction (phi : 𝓓((⊤ : Opens E), ℝ)) (h : E) :
+    𝓓((⊤ : Opens E), ℝ) :=
+  ⟨fun y => phi (y + h), phi.contDiff.comp (contDiff_id.add contDiff_const),
+    phi.hasCompactSupport.comp_homeomorph (Homeomorph.addRight h), subset_univ _⟩
+
+omit [MeasurableSpace E] [FiniteDimensional ℝ E] [BorelSpace E] in
+private theorem translateTestFunction_apply (phi : 𝓓((⊤ : Opens E), ℝ)) (h y : E) :
+    translateTestFunction phi h y = phi (y + h) :=
+  rfl
+
+omit [MeasurableSpace E] [FiniteDimensional ℝ E] [BorelSpace E] in
+private theorem lineDeriv_translateTestFunction (phi : 𝓓((⊤ : Opens E), ℝ)) (h y v : E) :
+    lineDeriv ℝ (translateTestFunction phi h : E → ℝ) y v =
+      lineDeriv ℝ (phi : E → ℝ) (y + h) v := by
+  simp only [lineDeriv, translateTestFunction_apply, add_right_comm y _ h]
+
+omit [FiniteDimensional ℝ E] in
+/-- **Translation preserves `W^{1,p}(ℝⁿ)`.**  On the whole space the weak-derivative identities
+are invariant under translation: testing the translated jet against `φ` is testing the original
+jet against the translate of `φ`. -/
+theorem Sobolev1JetLp.translateLp_mem_w1pSubmodule (h : E) {J : Sobolev1JetLp mu ⊤ p}
+    (hJ : J ∈ w1pSubmodule mu ⊤ p) :
+    (mu.restrict ((⊤ : Opens E) : Set E)).translateLp p h J ∈ w1pSubmodule mu ⊤ p := by
+  set nu := mu.restrict ((⊤ : Opens E) : Set E)
+  rw [mem_w1pSubmodule_iff] at hJ ⊢
+  intro phi v
+  let f : E → ℝ := fun y =>
+    lineDeriv ℝ (translateTestFunction phi (-h) : E → ℝ) y v * Sobolev1JetLp.value J y +
+      translateTestFunction phi (-h) y * Sobolev1JetLp.candidateWeakFDeriv J y v
+  have hq : Filter.Tendsto (· + h) (ae nu) (ae nu) :=
+    (measurePreserving_add_right nu h).quasiMeasurePreserving.tendsto_ae
+  calc
+    ∫ x in (⊤ : Opens E), (lineDeriv ℝ (phi : E → ℝ) x v *
+        Sobolev1JetLp.value (nu.translateLp p h J) x +
+        phi x * Sobolev1JetLp.candidateWeakFDeriv (nu.translateLp p h J) x v) ∂mu
+        = ∫ x in (⊤ : Opens E), f (x + h) ∂mu := by
+      apply integral_congr_ae
+      filter_upwards [Sobolev1JetLp.value_apply_ae (nu.translateLp p h J),
+        Sobolev1JetLp.gradient_apply_ae (nu.translateLp p h J),
+        Measure.coeFn_translateLp (mu := nu) h J,
+        hq.eventually (Sobolev1JetLp.value_apply_ae J),
+        hq.eventually (Sobolev1JetLp.gradient_apply_ae J)] with x hvK hgK hK hvJ hgJ
+      simp only [f, Sobolev1JetLp.candidateWeakFDeriv_apply, lineDeriv_translateTestFunction,
+        translateTestFunction_apply, add_neg_cancel_right, hvK, hgK, hK, Function.comp_apply,
+        hvJ, hgJ]
+    _ = ∫ x in (⊤ : Opens E), f x ∂mu := integral_add_right_eq_self f h
+    _ = 0 := hJ (translateTestFunction phi (-h)) v
+
+end TranslateJet
 
 end Sobolev
 

--- a/TauCeti/Analysis/Sobolev/W1p/Density.lean
+++ b/TauCeti/Analysis/Sobolev/W1p/Density.lean
@@ -7,7 +7,7 @@ module
 
 public import TauCeti.Analysis.Sobolev.W1p.Mollification
 public import TauCeti.Analysis.Sobolev.W1p.Multiplication
-public import TauCeti.MeasureTheory.Function.Lp.MollificationBridge
+import TauCeti.Analysis.Normed.Lp.ProdLp
 import TauCeti.MeasureTheory.Function.Lp.DominatedConvergence
 
 /-!
@@ -27,12 +27,11 @@ nonzero constants from `W^{1,p}_0(Ω)`; so the statement is genuinely about the 
 
 The mollification operator `TauCeti.W1p.normedBumpL` on `W^{1,p}(ℝⁿ)` converges to the identity
 (`TauCeti.W1p.tendsto_normedBumpL`).  If the jet of `u` vanishes outside a compact set, its
-mollification has a smooth compactly supported representative by
-`TauCeti.normedBumpLp_ae_eq_convolution`, so it is a test function.  A general `u` is first
-truncated by the rescaled bumps `ψ(x / R)`: the Leibniz rule of `TauCeti.W1p.contDiffSMul`
-computes the truncated jet, which agrees with the jet of `u` on the ball of radius `R` and is
-dominated by a fixed multiple of it, so the truncations converge to `u` by dominated convergence.
-Closedness of `W^{1,p}_0(ℝⁿ)` then gives the theorem.
+mollification is a test function (`TauCeti.W1p.normedBumpL_mem_range_of_ae_eq_zero`).  A general
+`u` is first truncated by the rescaled bumps `ψ(x / R)`: the Leibniz rule of
+`TauCeti.W1p.contDiffSMul` computes the truncated jet, which agrees with the jet of `u` on the
+ball of radius `R` and is dominated by a fixed multiple of it, so the truncations converge to `u`
+by dominated convergence.  Closedness of `W^{1,p}_0(ℝⁿ)` then gives the theorem.
 
 ## Main declarations
 
@@ -50,8 +49,8 @@ public section
 
 noncomputable section
 
-open Filter MeasureTheory Metric Set TopologicalSpace
-open scoped Convolution Distributions ENNReal Gradient InnerProductSpace Topology
+open Filter MeasureTheory Metric TopologicalSpace
+open scoped ENNReal Gradient Topology
 
 namespace TauCeti
 
@@ -63,54 +62,6 @@ variable {E : Type*} [MeasurableSpace E] [NormedAddCommGroup E] [InnerProductSpa
 local instance : (mu.restrict ((⊤ : Opens E) : Set E)).IsAddHaarMeasure := by
   rw [Opens.coe_top, Measure.restrict_univ]
   infer_instance
-
-/-! ### Compactly supported Sobolev functions -/
-
-omit [MeasurableSpace E] [InnerProductSpace ℝ E] [FiniteDimensional ℝ E] [BorelSpace E] in
-/-- The Euclidean jet norm is at most the sum of the norms of its two components. -/
-private theorem norm_sobolev1Jet_le (y : Sobolev1Jet E) : ‖y‖ ≤ ‖y.fst‖ + ‖y.snd‖ := by
-  refine (sq_le_sq₀ (norm_nonneg y) (by positivity)).1 ?_
-  rw [WithLp.prod_norm_sq_eq_of_L2]
-  nlinarith [norm_nonneg y.fst, norm_nonneg y.snd]
-
-/-- The mollification of a Sobolev function whose jet vanishes outside a compact set is a test
-function. -/
-private theorem normedBumpL_mem_range_of_ae_eq_zero (hp : p ≠ ∞) (phi : ContDiffBump (0 : E))
-    {u : W1p mu ⊤ p} {K : Set E} (hK : IsCompact K)
-    (hu : ∀ᵐ x ∂(mu.restrict ((⊤ : Opens E) : Set E)), x ∉ K →
-      (u : Sobolev1JetLp mu ⊤ p) x = 0) :
-    W1p.normedBumpL hp phi u ∈ LinearMap.range (W1p.ofTestFunctionₗ mu ⊤ p) := by
-  set nu := mu.restrict ((⊤ : Opens E) : Set E)
-  set J : Sobolev1JetLp mu ⊤ p := u.1 with hJdef
-  let Jt : E → Sobolev1Jet E := K.indicator J
-  have hJt_mem : MemLp Jt p nu := (Lp.memLp J).indicator hK.measurableSet
-  have hJt_cpt : HasCompactSupport Jt :=
-    HasCompactSupport.intro hK fun x hx => indicator_of_notMem hx _
-  have hJ_eq : hJt_mem.toLp Jt = J := by
-    apply Lp.ext
-    filter_upwards [hJt_mem.coeFn_toLp, hu] with x hx hux
-    rw [hx]
-    by_cases hxK : x ∈ K
-    · exact indicator_of_mem hxK _
-    · simp only [Jt, indicator_of_notMem hxK, hux hxK]
-  let conv : E → Sobolev1Jet E := phi.normed nu ⋆[ContinuousLinearMap.lsmul ℝ ℝ, nu] Jt
-  have hbridge : ((W1p.normedBumpL hp phi u : W1p mu ⊤ p) : Sobolev1JetLp mu ⊤ p) =ᵐ[nu] conv := by
-    rw [W1p.coe_normedBumpL, ← hJdef, ← hJ_eq]
-    exact normedBumpLp_ae_eq_convolution hp phi hJt_mem hJt_cpt
-  have hconv_smooth : ContDiff ℝ (⊤ : ℕ∞) conv :=
-    phi.hasCompactSupport_normed.contDiff_convolution_left (ContinuousLinearMap.lsmul ℝ ℝ)
-      phi.contDiff_normed (hJt_mem.locallyIntegrable Fact.out)
-  have hconv_cpt : HasCompactSupport conv :=
-    phi.hasCompactSupport_normed.convolution (ContinuousLinearMap.lsmul ℝ ℝ) hJt_cpt
-  let Phi : 𝓓((⊤ : Opens E), ℝ) :=
-    ⟨fun x => WithLp.fstL 2 ℝ ℝ E (conv x), (WithLp.fstL 2 ℝ ℝ E).contDiff.comp hconv_smooth,
-      hconv_cpt.comp_left (map_zero _), subset_univ _⟩
-  refine ⟨Phi, W1p.ext_value (Lp.ext ?_)⟩
-  rw [W1p.value_ofTestFunctionₗ]
-  filter_upwards [testFunctionLp_apply_ae (mu := mu) p Phi,
-    W1p.value_apply_ae (W1p.normedBumpL hp phi u), hbridge] with x hPhi hvalue hconv
-  rw [hPhi, hvalue, hconv]
-  rfl
 
 /-! ### Truncation -/
 
@@ -195,24 +146,112 @@ private def truncate {C : ℝ} (hC : 0 ≤ C) (hbound : ∀ n (x : E), ‖∇ (t
       linarith [truncCutoff_le_one n x])
     (fun x _ => by linarith [hbound n x]) u
 
+/-- The value of the truncation is `ψ(x / (n + 1)) u`. -/
+private theorem value_truncate_ae {C : ℝ} (hC : 0 ≤ C)
+    (hbound : ∀ n (x : E), ‖∇ (truncCutoff n) x‖ ≤ C) (n : ℕ) (u : W1p mu ⊤ p) :
+    ∀ᵐ x ∂(mu.restrict ((⊤ : Opens E) : Set E)),
+      W1p.value (truncate hC hbound n u) x = truncCutoff n x • W1p.value u x := by
+  rw [truncate]
+  exact W1p.value_contDiffSMul_ae _ _ _ _ u
+
+/-- The weak gradient of the truncation is `ψ(x / (n + 1)) ∇u + u ∇ψ(x / (n + 1))`. -/
+private theorem gradient_truncate_ae {C : ℝ} (hC : 0 ≤ C)
+    (hbound : ∀ n (x : E), ‖∇ (truncCutoff n) x‖ ≤ C) (n : ℕ) (u : W1p mu ⊤ p) :
+    ∀ᵐ x ∂(mu.restrict ((⊤ : Opens E) : Set E)),
+      W1p.gradient (truncate hC hbound n u) x
+        = truncCutoff n x • W1p.gradient u x + W1p.value u x • ∇ (truncCutoff n) x := by
+  rw [truncate]
+  exact W1p.gradient_contDiffSMul_ae _ _ _ _ u
+
 /-- The truncation `ψ(x / (n + 1)) u` vanishes outside the ball of radius `2 (n + 1)`. -/
 private theorem truncate_ae_eq_zero {C : ℝ} (hC : 0 ≤ C)
     (hbound : ∀ n (x : E), ‖∇ (truncCutoff n) x‖ ≤ C) (n : ℕ) (u : W1p mu ⊤ p) :
     ∀ᵐ x ∂(mu.restrict ((⊤ : Opens E) : Set E)), x ∉ closedBall (0 : E) (2 * ((n : ℝ) + 1)) →
       (truncate hC hbound n u : Sobolev1JetLp mu ⊤ p) x = 0 := by
   filter_upwards [W1p.value_apply_ae (truncate hC hbound n u),
-    W1p.gradient_apply_ae (truncate hC hbound n u),
-    W1p.value_contDiffSMul_ae (p := p) _ _ _ _ u,
-    W1p.gradient_contDiffSMul_ae (p := p) _ _ _ _ u] with x hv hg hvT hgT hx
+    W1p.gradient_apply_ae (truncate hC hbound n u), value_truncate_ae hC hbound n u,
+    gradient_truncate_ae hC hbound n u] with x hv hg hvT hgT hx
   have hx' : 2 * ((n : ℝ) + 1) < ‖x‖ := by
     simpa only [mem_closedBall_zero_iff, not_le] using hx
   have hpsi := truncCutoff_eventuallyEq_zero hx'
   have hfst : ((truncate hC hbound n u : Sobolev1JetLp mu ⊤ p) x).fst = 0 := by
-    rw [← hv, truncate, hvT, hpsi.eq_of_nhds, zero_smul]
+    rw [← hv, hvT, hpsi.eq_of_nhds, zero_smul]
   have hsnd : ((truncate hC hbound n u : Sobolev1JetLp mu ⊤ p) x).snd = 0 := by
-    rw [← hg, truncate, hgT, hpsi.eq_of_nhds, hpsi.gradient_eq.trans (gradient_fun_const _ _),
+    rw [← hg, hgT, hpsi.eq_of_nhds, hpsi.gradient_eq.trans (gradient_fun_const _ _),
       zero_smul, smul_zero, add_zero]
   exact (WithLp.ext_iff _).2 (Prod.ext hfst hsnd)
+
+/-- The value of the truncation error `ψ(x / (n + 1)) u - u` is `(ψ(x / (n + 1)) - 1) u`. -/
+private theorem fst_coe_truncate_sub_ae {C : ℝ} (hC : 0 ≤ C)
+    (hbound : ∀ n (x : E), ‖∇ (truncCutoff n) x‖ ≤ C) (n : ℕ) (u : W1p mu ⊤ p) :
+    ∀ᵐ x ∂(mu.restrict ((⊤ : Opens E) : Set E)),
+      ((truncate hC hbound n u : Sobolev1JetLp mu ⊤ p) x - (u : Sobolev1JetLp mu ⊤ p) x).fst
+        = (truncCutoff n x - 1) • W1p.value u x := by
+  filter_upwards [W1p.value_apply_ae (truncate hC hbound n u), W1p.value_apply_ae u,
+    value_truncate_ae hC hbound n u] with x hvT hvu hvn
+  rw [WithLp.sub_fst, ← hvT, ← hvu, hvn, sub_smul, one_smul]
+
+/-- The weak gradient of the truncation error `ψ(x / (n + 1)) u - u` is
+`(ψ(x / (n + 1)) - 1) ∇u + u ∇ψ(x / (n + 1))`. -/
+private theorem snd_coe_truncate_sub_ae {C : ℝ} (hC : 0 ≤ C)
+    (hbound : ∀ n (x : E), ‖∇ (truncCutoff n) x‖ ≤ C) (n : ℕ) (u : W1p mu ⊤ p) :
+    ∀ᵐ x ∂(mu.restrict ((⊤ : Opens E) : Set E)),
+      ((truncate hC hbound n u : Sobolev1JetLp mu ⊤ p) x - (u : Sobolev1JetLp mu ⊤ p) x).snd
+        = (truncCutoff n x - 1) • W1p.gradient u x + W1p.value u x • ∇ (truncCutoff n) x := by
+  filter_upwards [W1p.gradient_apply_ae (truncate hC hbound n u), W1p.gradient_apply_ae u,
+    gradient_truncate_ae hC hbound n u] with x hgT hgu hgn
+  rw [WithLp.sub_snd, ← hgT, ← hgu, hgn, sub_smul, one_smul]
+  abel
+
+/-- The truncation error is at most `(2 + C)` times the jet of `u`, uniformly in `n`. -/
+private theorem norm_coe_truncate_sub_le {C : ℝ} (hC : 0 ≤ C)
+    (hbound : ∀ n (x : E), ‖∇ (truncCutoff n) x‖ ≤ C) (n : ℕ) (u : W1p mu ⊤ p) :
+    ∀ᵐ x ∂(mu.restrict ((⊤ : Opens E) : Set E)),
+      ‖(truncate hC hbound n u : Sobolev1JetLp mu ⊤ p) x - (u : Sobolev1JetLp mu ⊤ p) x‖
+        ≤ (2 + C) * ‖(u : Sobolev1JetLp mu ⊤ p) x‖ := by
+  filter_upwards [fst_coe_truncate_sub_ae hC hbound n u, snd_coe_truncate_sub_ae hC hbound n u,
+    W1p.value_apply_ae u, W1p.gradient_apply_ae u] with x hfst hsnd hvu hgu
+  set a := W1p.value u x
+  set G := W1p.gradient u x
+  set s := truncCutoff n x
+  have hs0 : 0 ≤ s := truncCutoff_nonneg n x
+  have hs1 : s ≤ 1 := truncCutoff_le_one n x
+  have hs : |s - 1| ≤ 1 := abs_le.2 ⟨by linarith, by linarith⟩
+  have ha : ‖a‖ ≤ ‖(u : Sobolev1JetLp mu ⊤ p) x‖ :=
+    hvu ▸ WithLp.norm_fst_le (x := (u : Sobolev1JetLp mu ⊤ p) x)
+  have hG : ‖G‖ ≤ ‖(u : Sobolev1JetLp mu ⊤ p) x‖ :=
+    hgu ▸ WithLp.norm_snd_le (x := (u : Sobolev1JetLp mu ⊤ p) x)
+  refine (WithLp.prod_norm_le_norm_fst_add_norm_snd _).trans ?_
+  rw [hfst, hsnd]
+  have h1 : ‖(s - 1) • a‖ ≤ ‖a‖ := by
+    rw [norm_smul, Real.norm_eq_abs]
+    exact mul_le_of_le_one_left (norm_nonneg _) hs
+  have h2 : ‖(s - 1) • G + a • ∇ (truncCutoff n) x‖ ≤ ‖G‖ + ‖a‖ * C := by
+    refine (norm_add_le _ _).trans (add_le_add ?_ ?_)
+    · rw [norm_smul, Real.norm_eq_abs]
+      exact mul_le_of_le_one_left (norm_nonneg _) hs
+    · rw [norm_smul]
+      exact mul_le_mul_of_nonneg_left (hbound n x) (norm_nonneg _)
+  nlinarith [norm_nonneg a, norm_nonneg G]
+
+/-- At each point the truncations are eventually equal to `u`: the cutoff is one on the ball of
+radius `n + 1`. -/
+private theorem eventually_coe_truncate_eq {C : ℝ} (hC : 0 ≤ C)
+    (hbound : ∀ n (x : E), ‖∇ (truncCutoff n) x‖ ≤ C) (u : W1p mu ⊤ p) :
+    ∀ᵐ x ∂(mu.restrict ((⊤ : Opens E) : Set E)), ∀ᶠ n in atTop,
+      (truncate hC hbound n u : Sobolev1JetLp mu ⊤ p) x = (u : Sobolev1JetLp mu ⊤ p) x := by
+  filter_upwards [ae_all_iff.2 fun n => fst_coe_truncate_sub_ae hC hbound n u,
+    ae_all_iff.2 fun n => snd_coe_truncate_sub_ae hC hbound n u] with x hfst hsnd
+  filter_upwards [tendsto_natCast_atTop_atTop.eventually_gt_atTop ‖x‖] with n hn
+  have hpsi := truncCutoff_eventuallyEq_one (E := E) (n := n) (x := x) (by linarith)
+  have hfst0 : ((truncate hC hbound n u : Sobolev1JetLp mu ⊤ p) x
+      - (u : Sobolev1JetLp mu ⊤ p) x).fst = 0 := by
+    rw [hfst n, hpsi.eq_of_nhds, sub_self, zero_smul]
+  have hsnd0 : ((truncate hC hbound n u : Sobolev1JetLp mu ⊤ p) x
+      - (u : Sobolev1JetLp mu ⊤ p) x).snd = 0 := by
+    rw [hsnd n, hpsi.eq_of_nhds, hpsi.gradient_eq.trans (gradient_fun_const _ _), sub_self,
+      zero_smul, smul_zero, add_zero]
+  exact sub_eq_zero.1 ((WithLp.ext_iff _).2 (Prod.ext hfst0 hsnd0))
 
 /-- **The truncations converge.**  The truncated jet agrees with the jet of `u` on the ball of
 radius `n + 1`, and differs from it by at most `(2 + C)` times its norm. -/
@@ -220,67 +259,9 @@ private theorem tendsto_truncate (hp : p ≠ ∞) {C : ℝ} (hC : 0 ≤ C)
     (hbound : ∀ n (x : E), ‖∇ (truncCutoff n) x‖ ≤ C) (u : W1p mu ⊤ p) :
     Tendsto (fun n => truncate hC hbound n u) atTop (𝓝 u) := by
   rw [tendsto_subtype_rng, Lp.tendsto_Lp_iff_tendsto_eLpNorm']
-  have hv (n : ℕ) := W1p.value_contDiffSMul_ae (p := p) (mu := mu) (Omega := ⊤)
-    (contDiff_truncCutoff n) (M := 1 + C) (by linarith)
-    (fun x _ => by
-      rw [abs_of_nonneg (truncCutoff_nonneg n x)]
-      linarith [truncCutoff_le_one n x])
-    (fun x _ => by linarith [hbound n x]) u
-  have hg (n : ℕ) := W1p.gradient_contDiffSMul_ae (p := p) (mu := mu) (Omega := ⊤)
-    (contDiff_truncCutoff n) (M := 1 + C) (by linarith)
-    (fun x _ => by
-      rw [abs_of_nonneg (truncCutoff_nonneg n x)]
-      linarith [truncCutoff_le_one n x])
-    (fun x _ => by linarith [hbound n x]) u
-  refine tendsto_eLpNorm_sub_of_eventually_eq (zero_lt_one.trans_le Fact.out).ne' hp
+  exact tendsto_eLpNorm_sub_of_eventually_eq (zero_lt_one.trans_le Fact.out).ne' hp
     (fun n => Lp.aestronglyMeasurable _) (Lp.memLp _) (by linarith : (0 : ℝ) ≤ 2 + C)
-    (fun n => ?_) ?_
-  · filter_upwards [W1p.value_apply_ae (truncate hC hbound n u),
-      W1p.gradient_apply_ae (truncate hC hbound n u), W1p.value_apply_ae u,
-      W1p.gradient_apply_ae u, hv n, hg n] with x hvT hgT hvu hgu hvn hgn
-    set a := W1p.value u x
-    set G := W1p.gradient u x
-    set s := truncCutoff n x
-    have hs0 : 0 ≤ s := truncCutoff_nonneg n x
-    have hs1 : s ≤ 1 := truncCutoff_le_one n x
-    have hs : |s - 1| ≤ 1 := abs_le.2 ⟨by linarith, by linarith⟩
-    have ha : ‖a‖ ≤ ‖(u : Sobolev1JetLp mu ⊤ p) x‖ :=
-      hvu ▸ WithLp.norm_fst_le (x := (u : Sobolev1JetLp mu ⊤ p) x)
-    have hG : ‖G‖ ≤ ‖(u : Sobolev1JetLp mu ⊤ p) x‖ :=
-      hgu ▸ WithLp.norm_snd_le (x := (u : Sobolev1JetLp mu ⊤ p) x)
-    have hfst : ((truncate hC hbound n u : Sobolev1JetLp mu ⊤ p) x -
-        (u : Sobolev1JetLp mu ⊤ p) x).fst = (s - 1) • a := by
-      rw [WithLp.sub_fst, ← hvT, ← hvu, truncate, hvn, sub_smul, one_smul]
-    have hsnd : ((truncate hC hbound n u : Sobolev1JetLp mu ⊤ p) x -
-        (u : Sobolev1JetLp mu ⊤ p) x).snd = (s - 1) • G + a • ∇ (truncCutoff n) x := by
-      rw [WithLp.sub_snd, ← hgT, ← hgu, truncate, hgn, sub_smul, one_smul]
-      abel
-    refine (norm_sobolev1Jet_le _).trans ?_
-    rw [hfst, hsnd]
-    have h1 : ‖(s - 1) • a‖ ≤ ‖a‖ := by
-      rw [norm_smul, Real.norm_eq_abs]
-      exact mul_le_of_le_one_left (norm_nonneg _) hs
-    have h2 : ‖(s - 1) • G + a • ∇ (truncCutoff n) x‖ ≤ ‖G‖ + ‖a‖ * C := by
-      refine (norm_add_le _ _).trans (add_le_add ?_ ?_)
-      · rw [norm_smul, Real.norm_eq_abs]
-        exact mul_le_of_le_one_left (norm_nonneg _) hs
-      · rw [norm_smul]
-        exact mul_le_mul_of_nonneg_left (hbound n x) (norm_nonneg _)
-    nlinarith [norm_nonneg a, norm_nonneg G]
-  · filter_upwards [ae_all_iff.2 fun n => W1p.value_apply_ae (truncate hC hbound n u),
-      ae_all_iff.2 fun n => W1p.gradient_apply_ae (truncate hC hbound n u),
-      W1p.value_apply_ae u, W1p.gradient_apply_ae u, ae_all_iff.2 hv, ae_all_iff.2 hg]
-      with x hvT hgT hvu hgu hvn hgn
-    filter_upwards [tendsto_natCast_atTop_atTop.eventually_gt_atTop ‖x‖] with n hn
-    have hpsi := truncCutoff_eventuallyEq_one (E := E) (n := n) (x := x) (by linarith)
-    have hfst : ((truncate hC hbound n u : Sobolev1JetLp mu ⊤ p) x -
-        (u : Sobolev1JetLp mu ⊤ p) x).fst = 0 := by
-      rw [WithLp.sub_fst, ← hvT n, ← hvu, truncate, hvn n, hpsi.eq_of_nhds, one_smul, sub_self]
-    have hsnd : ((truncate hC hbound n u : Sobolev1JetLp mu ⊤ p) x -
-        (u : Sobolev1JetLp mu ⊤ p) x).snd = 0 := by
-      rw [WithLp.sub_snd, ← hgT n, ← hgu, truncate, hgn n, hpsi.eq_of_nhds,
-        hpsi.gradient_eq.trans (gradient_fun_const _ _), one_smul, smul_zero, add_zero, sub_self]
-    exact sub_eq_zero.1 ((WithLp.ext_iff _).2 (Prod.ext hfst hsnd))
+    (fun n => norm_coe_truncate_sub_le hC hbound n u) (eventually_coe_truncate_eq hC hbound u)
 
 /-! ### Density -/
 
@@ -297,16 +278,16 @@ theorem W1p.mem_w1p0Submodule_top (hp : p ≠ ∞) (u : W1p mu ⊤ p) :
   have hclosed := (w1p0Submodule mu ⊤ p).isClosed
   have htrunc (n : ℕ) : truncate hC hgrad n u ∈ w1p0Submodule mu ⊤ p :=
     hclosed.mem_of_tendsto (W1p.tendsto_normedBumpL hp hphi _) (Eventually.of_forall fun k => by
-      obtain ⟨Phi, hPhi⟩ := normedBumpL_mem_range_of_ae_eq_zero hp (phi k)
+      obtain ⟨Phi, hPhi⟩ := W1p.normedBumpL_mem_range_of_ae_eq_zero hp (phi k)
         (isCompact_closedBall (0 : E) (2 * ((n : ℝ) + 1))) (truncate_ae_eq_zero hC hgrad n u)
       rw [← hPhi]
       exact W1p.ofTestFunctionₗ_mem_w1p0Submodule Phi)
   exact hclosed.mem_of_tendsto (tendsto_truncate hp hC hgrad u) (Eventually.of_forall htrunc)
 
 /-- **`W^{1,p}_0(ℝⁿ) = W^{1,p}(ℝⁿ)`** for `1 ≤ p < ∞`: on the whole space the zero-boundary
-condition is no condition at all.  When `E` has positive dimension, the analogous equality fails
-for a nonempty bounded domain, and it fails for `p = ∞`, where the constant `1` is not a limit
-of test functions. -/
+condition is no condition at all.  Both restrictions are needed when `E` has positive dimension:
+there the analogous equality fails for a nonempty bounded domain, and it fails for `p = ∞`, where
+the constant `1` is not a limit of test functions. -/
 theorem w1p0Submodule_top_eq_top (hp : p ≠ ∞) : w1p0Submodule mu ⊤ p = ⊤ :=
   eq_top_iff.2 fun u _ => W1p.mem_w1p0Submodule_top hp u
 

--- a/TauCeti/Analysis/Sobolev/W1p/Density.lean
+++ b/TauCeti/Analysis/Sobolev/W1p/Density.lean
@@ -1,0 +1,460 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.Sobolev.W1p.Multiplication
+public import TauCeti.MeasureTheory.Function.Lp.MollificationBridge
+
+/-!
+# Test functions are dense in `W^{1,p}(ℝⁿ)`
+
+For `1 ≤ p < ∞`, every function in the whole-space Sobolev space `W^{1,p}(ℝⁿ)` is a
+`W^{1,p}`-limit of test functions:
+
+`W^{1,p}_0(ℝⁿ) = W^{1,p}(ℝⁿ)`.
+
+The ambient space is any finite-dimensional real inner product space `E` with an additive Haar
+measure; `ℝⁿ` stands for the whole-space case `Ω = ⊤` below.  For a bounded domain the two spaces
+differ, so the statement is genuinely about the whole space.
+
+## Mollification on `W^{1,p}(ℝⁿ)`
+
+The smooth approximate identity `TauCeti.normedBumpLp` averages the translates of an `Lᵖ` class
+against a normalized bump.  Applied to value-gradient jets it preserves `W^{1,p}(ℝⁿ)`: translation
+preserves the weak-derivative identities on the whole space
+(`TauCeti.Sobolev1JetLp.translateLp_mem_w1pSubmodule`), and the average is a Bochner integral of
+translates, which stays in the closed subspace `W^{1,p}(ℝⁿ)`.  This gives the mollification
+operator `TauCeti.W1p.normedBumpL` on `W^{1,p}(ℝⁿ)`, and the strong convergence of the
+approximate identity on jets is exactly its convergence to the identity in the Sobolev norm
+(`TauCeti.W1p.tendsto_normedBumpL`).  No commutation of derivatives with convolution is needed:
+the weak gradient is mollified together with the value because both are components of one jet.
+
+## Density of test functions
+
+If the jet of `u` vanishes outside a compact set, its mollification has a smooth compactly
+supported representative by `TauCeti.normedBumpLp_ae_eq_convolution`, so it is a test function.
+A general `u` is first truncated by the rescaled bumps `ψ(x / R)`: the Leibniz rule of
+`TauCeti.W1p.contDiffSMul` computes the truncated jet, which agrees with the jet of `u` on the
+ball of radius `R` and is dominated by a fixed multiple of it, so the truncations converge to `u`
+by dominated convergence.  Closedness of `W^{1,p}_0(ℝⁿ)` then gives the theorem.
+
+## Main declarations
+
+* `TauCeti.Sobolev1JetLp.translateLp_mem_w1pSubmodule`: translation preserves `W^{1,p}(ℝⁿ)`.
+* `TauCeti.W1p.normedBumpL`: mollification by a normalized smooth bump, as a continuous linear
+  operator on `W^{1,p}(ℝⁿ)`.
+* `TauCeti.W1p.tendsto_normedBumpL`: mollifications with shrinking bumps converge in `W^{1,p}`.
+* `TauCeti.w1p0Submodule_top_eq_top`: `W^{1,p}_0(ℝⁿ) = W^{1,p}(ℝⁿ)` for `p < ∞`.
+* `TauCeti.W1p.denseRange_ofTestFunctionₗ_top`: test functions are dense in `W^{1,p}(ℝⁿ)`.
+
+## References
+
+L. C. Evans, *Partial Differential Equations*, §5.3.1; H. Brezis, *Functional Analysis, Sobolev
+Spaces and Partial Differential Equations*, Theorem 9.2.
+-/
+
+public section
+
+noncomputable section
+
+open Filter MeasureTheory Metric Set TopologicalSpace
+open scoped Convolution Distributions ENNReal Gradient InnerProductSpace Topology
+
+namespace TauCeti
+
+variable {E : Type*} [MeasurableSpace E] [NormedAddCommGroup E] [InnerProductSpace ℝ E]
+  [FiniteDimensional ℝ E] [BorelSpace E] {mu : Measure E} [mu.IsAddHaarMeasure]
+  {p : ENNReal} [Fact (1 ≤ p)]
+
+/-- The whole-space restriction of an additive Haar measure is the measure itself. -/
+local instance : (mu.restrict ((⊤ : Opens E) : Set E)).IsAddHaarMeasure := by
+  rw [Opens.coe_top, Measure.restrict_univ]
+  infer_instance
+
+/-! ### Translation on `W^{1,p}(ℝⁿ)` -/
+
+/-- The translate `y ↦ φ (y + h)` of a whole-space test function. -/
+private def translateTestFunction (phi : 𝓓((⊤ : Opens E), ℝ)) (h : E) :
+    𝓓((⊤ : Opens E), ℝ) :=
+  ⟨fun y => phi (y + h), phi.contDiff.comp (contDiff_id.add contDiff_const),
+    phi.hasCompactSupport.comp_homeomorph (Homeomorph.addRight h), subset_univ _⟩
+
+omit [MeasurableSpace E] [FiniteDimensional ℝ E] [BorelSpace E] in
+private theorem translateTestFunction_apply (phi : 𝓓((⊤ : Opens E), ℝ)) (h y : E) :
+    translateTestFunction phi h y = phi (y + h) :=
+  rfl
+
+omit [MeasurableSpace E] [FiniteDimensional ℝ E] [BorelSpace E] in
+private theorem lineDeriv_translateTestFunction (phi : 𝓓((⊤ : Opens E), ℝ)) (h y v : E) :
+    lineDeriv ℝ (translateTestFunction phi h : E → ℝ) y v =
+      lineDeriv ℝ (phi : E → ℝ) (y + h) v := by
+  simp only [lineDeriv, translateTestFunction_apply, add_right_comm y _ h]
+
+omit [FiniteDimensional ℝ E] in
+/-- **Translation preserves `W^{1,p}(ℝⁿ)`.**  On the whole space the weak-derivative identities
+are invariant under translation: testing the translated jet against `φ` is testing the original
+jet against the translate of `φ`. -/
+theorem Sobolev1JetLp.translateLp_mem_w1pSubmodule (h : E) {J : Sobolev1JetLp mu ⊤ p}
+    (hJ : J ∈ w1pSubmodule mu ⊤ p) :
+    (mu.restrict ((⊤ : Opens E) : Set E)).translateLp p h J ∈ w1pSubmodule mu ⊤ p := by
+  set nu := mu.restrict ((⊤ : Opens E) : Set E)
+  rw [mem_w1pSubmodule_iff] at hJ ⊢
+  intro phi v
+  let f : E → ℝ := fun y =>
+    lineDeriv ℝ (translateTestFunction phi (-h) : E → ℝ) y v * Sobolev1JetLp.value J y +
+      translateTestFunction phi (-h) y * Sobolev1JetLp.candidateWeakFDeriv J y v
+  have hq : Tendsto (· + h) (ae nu) (ae nu) :=
+    (measurePreserving_add_right nu h).quasiMeasurePreserving.tendsto_ae
+  calc
+    ∫ x in (⊤ : Opens E), (lineDeriv ℝ (phi : E → ℝ) x v *
+        Sobolev1JetLp.value (nu.translateLp p h J) x +
+        phi x * Sobolev1JetLp.candidateWeakFDeriv (nu.translateLp p h J) x v) ∂mu
+        = ∫ x in (⊤ : Opens E), f (x + h) ∂mu := by
+      apply integral_congr_ae
+      filter_upwards [Sobolev1JetLp.value_apply_ae (nu.translateLp p h J),
+        Sobolev1JetLp.gradient_apply_ae (nu.translateLp p h J),
+        Measure.coeFn_translateLp (mu := nu) h J,
+        hq.eventually (Sobolev1JetLp.value_apply_ae J),
+        hq.eventually (Sobolev1JetLp.gradient_apply_ae J)] with x hvK hgK hK hvJ hgJ
+      simp only [f, Sobolev1JetLp.candidateWeakFDeriv_apply, lineDeriv_translateTestFunction,
+        translateTestFunction_apply, add_neg_cancel_right, hvK, hgK, hK, Function.comp_apply,
+        hvJ, hgJ]
+    _ = ∫ x in (⊤ : Opens E), f x ∂mu := integral_add_right_eq_self f h
+    _ = 0 := hJ (translateTestFunction phi (-h)) v
+
+/-! ### Mollification on `W^{1,p}(ℝⁿ)` -/
+
+/-- **Mollification preserves `W^{1,p}(ℝⁿ)`.**  The mollified jet is a Bochner integral of
+translates of the jet, each of which lies in the closed subspace `W^{1,p}(ℝⁿ)`. -/
+theorem Sobolev1JetLp.normedBumpLp_mem_w1pSubmodule (hp : p ≠ ∞) (phi : ContDiffBump (0 : E))
+    {J : Sobolev1JetLp mu ⊤ p} (hJ : J ∈ w1pSubmodule mu ⊤ p) :
+    normedBumpLp hp phi (mu.restrict ((⊤ : Opens E) : Set E)) J ∈ w1pSubmodule mu ⊤ p := by
+  set nu := mu.restrict ((⊤ : Opens E) : Set E)
+  let S := (w1pSubmodule mu ⊤ p).toSubmodule
+  let g : E → S := fun t =>
+    ⟨phi.normed nu t • nu.translateLp p (-t) J,
+      S.smul_mem _ (Sobolev1JetLp.translateLp_mem_w1pSubmodule (-t) hJ)⟩
+  have hint : normedBumpLp hp phi nu J = S.subtypeₗᵢ (∫ t, g t ∂nu) := by
+    rw [← LinearIsometry.integral_comp_comm, normedBumpLp_apply]
+    rfl
+  rw [hint]
+  exact (∫ t, g t ∂nu).2
+
+/-- **Mollification on `W^{1,p}(ℝⁿ)`**: averaging the translates of a Sobolev function against
+the normalized form of a smooth bump, as a continuous linear operator.  The value and the weak
+gradient are mollified together, as the two components of one `Lᵖ` jet. -/
+def W1p.normedBumpL (hp : p ≠ ∞) (phi : ContDiffBump (0 : E)) :
+    W1p mu ⊤ p →L[ℝ] W1p mu ⊤ p :=
+  ContinuousLinearMap.codRestrict
+    ((normedBumpLp hp phi (mu.restrict ((⊤ : Opens E) : Set E))).comp
+      (w1pSubmodule mu ⊤ p).toSubmodule.subtypeL)
+    (w1pSubmodule mu ⊤ p).toSubmodule
+    fun u => Sobolev1JetLp.normedBumpLp_mem_w1pSubmodule hp phi u.2
+
+/-- The jet of the mollification is the mollification of the jet. -/
+theorem W1p.coe_normedBumpL (hp : p ≠ ∞) (phi : ContDiffBump (0 : E)) (u : W1p mu ⊤ p) :
+    ((W1p.normedBumpL hp phi u : W1p mu ⊤ p) : Sobolev1JetLp mu ⊤ p) =
+      normedBumpLp hp phi (mu.restrict ((⊤ : Opens E) : Set E)) (u : Sobolev1JetLp mu ⊤ p) :=
+  (rfl)
+
+/-- **Mollification converges in `W^{1,p}(ℝⁿ)`.**  For `1 ≤ p < ∞`, mollifying a Sobolev
+function with normalized smooth bumps whose radii shrink to zero converges to it in the Sobolev
+norm. -/
+theorem W1p.tendsto_normedBumpL (hp : p ≠ ∞) {I : Type*} {l : Filter I}
+    {phi : I → ContDiffBump (0 : E)} (hphi : Tendsto (fun i => (phi i).rOut) l (𝓝 0))
+    (u : W1p mu ⊤ p) :
+    Tendsto (fun i => W1p.normedBumpL hp (phi i) u) l (𝓝 u) := by
+  rw [tendsto_subtype_rng]
+  exact tendsto_normedBumpLp hp hphi (u : Sobolev1JetLp mu ⊤ p)
+
+/-! ### Compactly supported Sobolev functions -/
+
+omit [MeasurableSpace E] [InnerProductSpace ℝ E] [FiniteDimensional ℝ E] [BorelSpace E] in
+/-- A jet with vanishing value and gradient components vanishes. -/
+private theorem sobolev1Jet_eq_zero {y : Sobolev1Jet E} (hfst : y.fst = 0) (hsnd : y.snd = 0) :
+    y = 0 := by
+  have hsq := WithLp.prod_norm_sq_eq_of_L2 y
+  rw [hfst, hsnd, norm_zero, norm_zero] at hsq
+  exact norm_eq_zero.1 (pow_eq_zero_iff two_ne_zero |>.1 (by simpa using hsq))
+
+omit [MeasurableSpace E] [InnerProductSpace ℝ E] [FiniteDimensional ℝ E] [BorelSpace E] in
+/-- The Euclidean jet norm is at most the sum of the norms of its two components. -/
+private theorem norm_sobolev1Jet_le (y : Sobolev1Jet E) : ‖y‖ ≤ ‖y.fst‖ + ‖y.snd‖ := by
+  refine (sq_le_sq₀ (norm_nonneg y) (by positivity)).1 ?_
+  rw [WithLp.prod_norm_sq_eq_of_L2]
+  nlinarith [norm_nonneg y.fst, norm_nonneg y.snd]
+
+/-- The mollification of a Sobolev function whose jet vanishes outside a compact set is a test
+function. -/
+private theorem normedBumpL_mem_range_of_ae_eq_zero (hp : p ≠ ∞) (phi : ContDiffBump (0 : E))
+    {u : W1p mu ⊤ p} {K : Set E} (hK : IsCompact K)
+    (hu : ∀ᵐ x ∂(mu.restrict ((⊤ : Opens E) : Set E)), x ∉ K →
+      (u : Sobolev1JetLp mu ⊤ p) x = 0) :
+    W1p.normedBumpL hp phi u ∈ LinearMap.range (W1p.ofTestFunctionₗ mu ⊤ p) := by
+  set nu := mu.restrict ((⊤ : Opens E) : Set E)
+  set J : Sobolev1JetLp mu ⊤ p := u.1
+  let Jt : E → Sobolev1Jet E := K.indicator J
+  have hJt_mem : MemLp Jt p nu := (Lp.memLp J).indicator hK.measurableSet
+  have hJt_cpt : HasCompactSupport Jt :=
+    HasCompactSupport.intro hK fun x hx => indicator_of_notMem hx _
+  have hJ_eq : hJt_mem.toLp Jt = J := by
+    apply Lp.ext
+    filter_upwards [hJt_mem.coeFn_toLp, hu] with x hx hux
+    rw [hx]
+    by_cases hxK : x ∈ K
+    · exact indicator_of_mem hxK _
+    · change K.indicator J x = J x
+      rw [indicator_of_notMem hxK, hux hxK]
+  let conv : E → Sobolev1Jet E := phi.normed nu ⋆[ContinuousLinearMap.lsmul ℝ ℝ, nu] Jt
+  have hbridge : ((W1p.normedBumpL hp phi u : W1p mu ⊤ p) : Sobolev1JetLp mu ⊤ p) =ᵐ[nu] conv := by
+    rw [W1p.coe_normedBumpL]
+    change ⇑(normedBumpLp hp phi nu J) =ᵐ[nu] conv
+    rw [← hJ_eq]
+    exact normedBumpLp_ae_eq_convolution hp phi hJt_mem hJt_cpt
+  have hconv_smooth : ContDiff ℝ (⊤ : ℕ∞) conv :=
+    phi.hasCompactSupport_normed.contDiff_convolution_left (ContinuousLinearMap.lsmul ℝ ℝ)
+      phi.contDiff_normed (hJt_mem.locallyIntegrable Fact.out)
+  have hconv_cpt : HasCompactSupport conv :=
+    phi.hasCompactSupport_normed.convolution (ContinuousLinearMap.lsmul ℝ ℝ) hJt_cpt
+  let Phi : 𝓓((⊤ : Opens E), ℝ) :=
+    ⟨fun x => WithLp.fstL 2 ℝ ℝ E (conv x), (WithLp.fstL 2 ℝ ℝ E).contDiff.comp hconv_smooth,
+      hconv_cpt.comp_left (map_zero _), subset_univ _⟩
+  refine ⟨Phi, W1p.ext_value (Lp.ext ?_)⟩
+  rw [W1p.value_ofTestFunctionₗ]
+  filter_upwards [testFunctionLp_apply_ae (mu := mu) p Phi,
+    W1p.value_apply_ae (W1p.normedBumpL hp phi u), hbridge] with x hPhi hvalue hconv
+  rw [hPhi, hvalue, hconv]
+  rfl
+
+/-! ### Truncation -/
+
+/-- The smooth bump equal to one on the unit ball and supported in the ball of radius two. -/
+private def unitBump : ContDiffBump (0 : E) := ⟨1, 2, one_pos, one_lt_two⟩
+
+omit [MeasurableSpace E] [BorelSpace E] in
+private theorem exists_norm_fderiv_unitBump_le :
+    ∃ C, 0 ≤ C ∧ ∀ x, ‖fderiv ℝ (unitBump (E := E)) x‖ ≤ C := by
+  obtain ⟨C, hC⟩ := (((unitBump (E := E)).contDiff (n := 1)).continuous_fderiv
+    one_ne_zero).norm.bddAbove_range_of_hasCompactSupport
+      ((unitBump (E := E)).hasCompactSupport.fderiv ℝ).norm
+  exact ⟨C, (norm_nonneg _).trans (hC ⟨0, rfl⟩), fun x => hC ⟨x, rfl⟩⟩
+
+/-- The truncating cutoff `x ↦ ψ (x / (n + 1))`, equal to one on the ball of radius `n + 1`. -/
+private def truncCutoff (n : ℕ) : E → ℝ :=
+  fun x => unitBump (E := E) (((n : ℝ) + 1)⁻¹ • x)
+
+omit [MeasurableSpace E] [BorelSpace E] in
+private theorem contDiff_truncCutoff (n : ℕ) : ContDiff ℝ (⊤ : ℕ∞) (truncCutoff (E := E) n) :=
+  (unitBump (E := E)).contDiff.comp (contDiff_const_smul _)
+
+omit [MeasurableSpace E] [BorelSpace E] in
+private theorem truncCutoff_nonneg (n : ℕ) (x : E) : 0 ≤ truncCutoff n x :=
+  (unitBump (E := E)).nonneg
+
+omit [MeasurableSpace E] [BorelSpace E] in
+private theorem truncCutoff_le_one (n : ℕ) (x : E) : truncCutoff n x ≤ 1 :=
+  (unitBump (E := E)).le_one
+
+omit [MeasurableSpace E] [BorelSpace E] in
+private theorem norm_gradient_truncCutoff_le {C : ℝ}
+    (hbound : ∀ x, ‖fderiv ℝ (unitBump (E := E)) x‖ ≤ C) (n : ℕ) (x : E) :
+    ‖∇ (truncCutoff n) x‖ ≤ C := by
+  have hn : (0 : ℝ) < (n : ℝ) + 1 := by positivity
+  rw [gradient, LinearIsometryEquiv.norm_map]
+  change ‖fderiv ℝ (fun y => unitBump (E := E) (((n : ℝ) + 1)⁻¹ • y)) x‖ ≤ C
+  rw [fderiv_comp_smul, norm_smul, Real.norm_eq_abs, abs_of_pos (inv_pos.2 hn)]
+  calc ((n : ℝ) + 1)⁻¹ * ‖fderiv ℝ (unitBump (E := E)) (((n : ℝ) + 1)⁻¹ • x)‖
+      ≤ 1 * C := mul_le_mul (inv_le_one_of_one_le₀ (by linarith)) (hbound _)
+        (norm_nonneg _) zero_le_one
+    _ = C := one_mul C
+
+omit [MeasurableSpace E] [BorelSpace E] in
+/-- Near a point of norm less than `n + 1`, the cutoff is identically one. -/
+private theorem truncCutoff_eventuallyEq_one {n : ℕ} {x : E} (hx : ‖x‖ < (n : ℝ) + 1) :
+    truncCutoff n =ᶠ[𝓝 x] fun _ => 1 := by
+  have hn : (0 : ℝ) < (n : ℝ) + 1 := by positivity
+  filter_upwards [isOpen_ball.mem_nhds (mem_ball_zero_iff.2 hx)] with y hy
+  apply (unitBump (E := E)).one_of_mem_closedBall
+  rw [mem_closedBall_zero_iff, norm_smul, Real.norm_eq_abs, abs_of_pos (inv_pos.2 hn)]
+  change ((n : ℝ) + 1)⁻¹ * ‖y‖ ≤ 1
+  rw [inv_mul_le_iff₀ hn, mul_one]
+  exact (mem_ball_zero_iff.1 hy).le
+
+omit [MeasurableSpace E] [BorelSpace E] in
+/-- Near a point of norm greater than `2 (n + 1)`, the cutoff is identically zero. -/
+private theorem truncCutoff_eventuallyEq_zero {n : ℕ} {x : E}
+    (hx : 2 * ((n : ℝ) + 1) < ‖x‖) :
+    truncCutoff n =ᶠ[𝓝 x] fun _ => 0 := by
+  have hn : (0 : ℝ) < (n : ℝ) + 1 := by positivity
+  filter_upwards [isOpen_lt continuous_const continuous_norm |>.mem_nhds hx] with y hy
+  apply (unitBump (E := E)).zero_of_le_dist
+  rw [dist_zero_right, norm_smul, Real.norm_eq_abs, abs_of_pos (inv_pos.2 hn)]
+  change 2 ≤ ((n : ℝ) + 1)⁻¹ * ‖y‖
+  rw [le_inv_mul_iff₀ hn]
+  linarith
+
+omit [MeasurableSpace E] [BorelSpace E] in
+private theorem gradient_eq_zero_of_eventuallyEq {f : E → ℝ} {x : E} {c : ℝ}
+    (hf : f =ᶠ[𝓝 x] fun _ => c) : ∇ f x = 0 := by
+  rw [gradient, hf.fderiv_eq, fderiv_const_apply, map_zero]
+
+/-- The truncation `ψ(x / (n + 1)) u` of a Sobolev function, with `C` bounding the gradients of
+all the cutoffs. -/
+private def truncate {C : ℝ} (hC : 0 ≤ C) (hbound : ∀ n (x : E), ‖∇ (truncCutoff n) x‖ ≤ C)
+    (n : ℕ) (u : W1p mu ⊤ p) : W1p mu ⊤ p :=
+  W1p.contDiffSMul (truncCutoff n) (contDiff_truncCutoff n) (M := 1 + C) (by linarith)
+    (fun x _ => by
+      rw [abs_of_nonneg (truncCutoff_nonneg n x)]
+      linarith [truncCutoff_le_one n x])
+    (fun x _ => by linarith [hbound n x]) u
+
+/-- The truncation `ψ(x / (n + 1)) u` vanishes outside the ball of radius `2 (n + 1)`. -/
+private theorem truncate_ae_eq_zero {C : ℝ} (hC : 0 ≤ C)
+    (hbound : ∀ n (x : E), ‖∇ (truncCutoff n) x‖ ≤ C) (n : ℕ) (u : W1p mu ⊤ p) :
+    ∀ᵐ x ∂(mu.restrict ((⊤ : Opens E) : Set E)), x ∉ closedBall (0 : E) (2 * ((n : ℝ) + 1)) →
+      (truncate hC hbound n u : Sobolev1JetLp mu ⊤ p) x = 0 := by
+  filter_upwards [W1p.value_apply_ae (truncate hC hbound n u),
+    W1p.gradient_apply_ae (truncate hC hbound n u),
+    W1p.value_contDiffSMul_ae (p := p) _ _ _ _ u,
+    W1p.gradient_contDiffSMul_ae (p := p) _ _ _ _ u] with x hv hg hvT hgT hx
+  have hx' : 2 * ((n : ℝ) + 1) < ‖x‖ := by
+    simpa only [mem_closedBall_zero_iff, not_le] using hx
+  have hpsi := truncCutoff_eventuallyEq_zero hx'
+  apply sobolev1Jet_eq_zero
+  · rw [← hv, truncate, hvT, hpsi.eq_of_nhds, zero_smul]
+  · rw [← hg, truncate, hgT, hpsi.eq_of_nhds, gradient_eq_zero_of_eventuallyEq hpsi, zero_smul,
+      smul_zero, add_zero]
+
+omit [MeasurableSpace E] [InnerProductSpace ℝ E] [FiniteDimensional ℝ E] [BorelSpace E] in
+/-- Dominated convergence in `Lᵖ`, in the form used for truncation: if `f n` agrees with `g`
+eventually at almost every point and `‖f n - g‖` is dominated by a fixed multiple of `‖g‖`, then
+`f n → g` in `Lᵖ`. -/
+private theorem tendsto_eLpNorm_sub_of_eventually_eq {α F : Type*} [MeasurableSpace α]
+    {m : Measure α} [NormedAddCommGroup F] {q : ℝ≥0∞} (hq0 : q ≠ 0) (hq : q ≠ ∞)
+    {f : ℕ → α → F} {g : α → F} (hf : ∀ n, AEStronglyMeasurable (f n) m) (hg : MemLp g q m)
+    {C : ℝ} (hC : 0 ≤ C) (hbound : ∀ n, ∀ᵐ x ∂m, ‖f n x - g x‖ ≤ C * ‖g x‖)
+    (hlim : ∀ᵐ x ∂m, ∀ᶠ n in atTop, f n x = g x) :
+    Tendsto (fun n => eLpNorm (f n - g) q m) atTop (𝓝 0) := by
+  have hr : 0 < q.toReal := ENNReal.toReal_pos hq0 hq
+  simp_rw [eLpNorm_eq_lintegral_rpow_enorm_toReal hq0 hq]
+  have hlint : Tendsto (fun n => ∫⁻ x, ‖(f n - g) x‖ₑ ^ q.toReal ∂m) atTop (𝓝 0) := by
+    have hdom := tendsto_lintegral_filter_of_dominated_convergence' (μ := m)
+      (F := fun n x => ‖(f n - g) x‖ₑ ^ q.toReal) (f := fun _ => 0)
+      (fun x => (ENNReal.ofReal C * ‖g x‖ₑ) ^ q.toReal)
+      (Eventually.of_forall fun n => ((hf n).sub hg.1).enorm.pow_const _)
+      (Eventually.of_forall fun n => (hbound n).mono fun x hx => by
+        refine ENNReal.rpow_le_rpow ?_ hr.le
+        rw [Pi.sub_apply, ← ofReal_norm, ← ofReal_norm, ← ENNReal.ofReal_mul hC]
+        exact ENNReal.ofReal_le_ofReal hx)
+      (by
+        simp_rw [ENNReal.mul_rpow_of_nonneg _ _ hr.le]
+        rw [lintegral_const_mul' _ _ (ENNReal.rpow_ne_top_of_nonneg hr.le ENNReal.ofReal_ne_top)]
+        exact ENNReal.mul_ne_top (ENNReal.rpow_ne_top_of_nonneg hr.le ENNReal.ofReal_ne_top)
+          (lintegral_rpow_enorm_lt_top_of_eLpNorm_lt_top hq0 hq hg.2).ne)
+      (hlim.mono fun x hx => tendsto_const_nhds.congr' (hx.mono fun n hn => by
+        simp [hn, ENNReal.zero_rpow_of_pos hr]))
+    simpa only [lintegral_zero] using hdom
+  have h0 : (0 : ℝ≥0∞) ^ (1 / q.toReal) = 0 := ENNReal.zero_rpow_of_pos (one_div_pos.2 hr)
+  simpa only [h0] using hlint.ennrpow_const (1 / q.toReal)
+
+/-- **The truncations converge.**  The truncated jet agrees with the jet of `u` on the ball of
+radius `n + 1`, and differs from it by at most `(2 + C)` times its norm. -/
+private theorem tendsto_truncate (hp : p ≠ ∞) {C : ℝ} (hC : 0 ≤ C)
+    (hbound : ∀ n (x : E), ‖∇ (truncCutoff n) x‖ ≤ C) (u : W1p mu ⊤ p) :
+    Tendsto (fun n => truncate hC hbound n u) atTop (𝓝 u) := by
+  rw [tendsto_subtype_rng, Lp.tendsto_Lp_iff_tendsto_eLpNorm']
+  have hv (n : ℕ) := W1p.value_contDiffSMul_ae (p := p) (mu := mu) (Omega := ⊤)
+    (contDiff_truncCutoff n) (M := 1 + C) (by linarith)
+    (fun x _ => by
+      rw [abs_of_nonneg (truncCutoff_nonneg n x)]
+      linarith [truncCutoff_le_one n x])
+    (fun x _ => by linarith [hbound n x]) u
+  have hg (n : ℕ) := W1p.gradient_contDiffSMul_ae (p := p) (mu := mu) (Omega := ⊤)
+    (contDiff_truncCutoff n) (M := 1 + C) (by linarith)
+    (fun x _ => by
+      rw [abs_of_nonneg (truncCutoff_nonneg n x)]
+      linarith [truncCutoff_le_one n x])
+    (fun x _ => by linarith [hbound n x]) u
+  refine tendsto_eLpNorm_sub_of_eventually_eq (zero_lt_one.trans_le Fact.out).ne' hp
+    (fun n => Lp.aestronglyMeasurable _) (Lp.memLp _) (by linarith : (0 : ℝ) ≤ 2 + C)
+    (fun n => ?_) ?_
+  · filter_upwards [W1p.value_apply_ae (truncate hC hbound n u),
+      W1p.gradient_apply_ae (truncate hC hbound n u), W1p.value_apply_ae u,
+      W1p.gradient_apply_ae u, hv n, hg n] with x hvT hgT hvu hgu hvn hgn
+    set a := W1p.value u x
+    set G := W1p.gradient u x
+    set s := truncCutoff n x
+    have hs0 : 0 ≤ s := truncCutoff_nonneg n x
+    have hs1 : s ≤ 1 := truncCutoff_le_one n x
+    have hs : |s - 1| ≤ 1 := abs_le.2 ⟨by linarith, by linarith⟩
+    have ha : ‖a‖ ≤ ‖(u : Sobolev1JetLp mu ⊤ p) x‖ :=
+      hvu ▸ WithLp.norm_fst_le (x := (u : Sobolev1JetLp mu ⊤ p) x)
+    have hG : ‖G‖ ≤ ‖(u : Sobolev1JetLp mu ⊤ p) x‖ :=
+      hgu ▸ WithLp.norm_snd_le (x := (u : Sobolev1JetLp mu ⊤ p) x)
+    have hfst : ((truncate hC hbound n u : Sobolev1JetLp mu ⊤ p) x -
+        (u : Sobolev1JetLp mu ⊤ p) x).fst = (s - 1) • a := by
+      rw [WithLp.sub_fst, ← hvT, ← hvu, truncate, hvn, sub_smul, one_smul]
+    have hsnd : ((truncate hC hbound n u : Sobolev1JetLp mu ⊤ p) x -
+        (u : Sobolev1JetLp mu ⊤ p) x).snd = (s - 1) • G + a • ∇ (truncCutoff n) x := by
+      rw [WithLp.sub_snd, ← hgT, ← hgu, truncate, hgn, sub_smul, one_smul]
+      abel
+    refine (norm_sobolev1Jet_le _).trans ?_
+    rw [hfst, hsnd]
+    have h1 : ‖(s - 1) • a‖ ≤ ‖a‖ := by
+      rw [norm_smul, Real.norm_eq_abs]
+      exact mul_le_of_le_one_left (norm_nonneg _) hs
+    have h2 : ‖(s - 1) • G + a • ∇ (truncCutoff n) x‖ ≤ ‖G‖ + ‖a‖ * C := by
+      refine (norm_add_le _ _).trans (add_le_add ?_ ?_)
+      · rw [norm_smul, Real.norm_eq_abs]
+        exact mul_le_of_le_one_left (norm_nonneg _) hs
+      · rw [norm_smul]
+        exact mul_le_mul_of_nonneg_left (hbound n x) (norm_nonneg _)
+    nlinarith [norm_nonneg a, norm_nonneg G]
+  · filter_upwards [ae_all_iff.2 fun n => W1p.value_apply_ae (truncate hC hbound n u),
+      ae_all_iff.2 fun n => W1p.gradient_apply_ae (truncate hC hbound n u),
+      W1p.value_apply_ae u, W1p.gradient_apply_ae u, ae_all_iff.2 hv, ae_all_iff.2 hg]
+      with x hvT hgT hvu hgu hvn hgn
+    filter_upwards [tendsto_natCast_atTop_atTop.eventually_gt_atTop ‖x‖] with n hn
+    have hpsi := truncCutoff_eventuallyEq_one (E := E) (n := n) (x := x) (by linarith)
+    refine sub_eq_zero.1 (sobolev1Jet_eq_zero ?_ ?_)
+    · rw [WithLp.sub_fst, ← hvT n, ← hvu, truncate, hvn n, hpsi.eq_of_nhds, one_smul, sub_self]
+    · rw [WithLp.sub_snd, ← hgT n, ← hgu, truncate, hgn n, hpsi.eq_of_nhds,
+        gradient_eq_zero_of_eventuallyEq hpsi, one_smul, smul_zero, add_zero, sub_self]
+
+/-! ### Density -/
+
+/-- **Every function in `W^{1,p}(ℝⁿ)` is a limit of test functions**, for `1 ≤ p < ∞`.  Truncate
+by rescaled cutoffs, then mollify the compactly supported truncations. -/
+theorem W1p.mem_w1p0Submodule_top (hp : p ≠ ∞) (u : W1p mu ⊤ p) :
+    u ∈ w1p0Submodule mu ⊤ p := by
+  obtain ⟨C, hC, hbound⟩ := exists_norm_fderiv_unitBump_le (E := E)
+  have hgrad := norm_gradient_truncCutoff_le hbound
+  let phi : ℕ → ContDiffBump (0 : E) := fun k =>
+    ⟨1 / ((k : ℝ) + 1) / 2, 1 / ((k : ℝ) + 1), by positivity, half_lt_self (by positivity)⟩
+  have hphi : Tendsto (fun k => (phi k).rOut) atTop (𝓝 0) :=
+    tendsto_one_div_add_atTop_nhds_zero_nat
+  have hclosed := (w1p0Submodule mu ⊤ p).isClosed
+  have htrunc (n : ℕ) : truncate hC hgrad n u ∈ w1p0Submodule mu ⊤ p :=
+    hclosed.mem_of_tendsto (W1p.tendsto_normedBumpL hp hphi _) (Eventually.of_forall fun k => by
+      obtain ⟨Phi, hPhi⟩ := normedBumpL_mem_range_of_ae_eq_zero hp (phi k)
+        (isCompact_closedBall (0 : E) (2 * ((n : ℝ) + 1))) (truncate_ae_eq_zero hC hgrad n u)
+      rw [← hPhi]
+      exact W1p.ofTestFunctionₗ_mem_w1p0Submodule Phi)
+  exact hclosed.mem_of_tendsto (tendsto_truncate hp hC hgrad u) (Eventually.of_forall htrunc)
+
+/-- **`W^{1,p}_0(ℝⁿ) = W^{1,p}(ℝⁿ)`** for `1 ≤ p < ∞`: on the whole space the zero-boundary
+condition is no condition at all.  This fails for a bounded domain, and it fails for `p = ∞`,
+where test functions are not dense. -/
+theorem w1p0Submodule_top_eq_top (hp : p ≠ ∞) : w1p0Submodule mu ⊤ p = ⊤ :=
+  eq_top_iff.2 fun u _ => W1p.mem_w1p0Submodule_top hp u
+
+/-- **Test functions are dense in `W^{1,p}(ℝⁿ)`** for `1 ≤ p < ∞`. -/
+theorem W1p.denseRange_ofTestFunctionₗ_top (hp : p ≠ ∞) :
+    DenseRange (W1p.ofTestFunctionₗ mu ⊤ p) := fun u => by
+  rw [← coe_w1p0Submodule]
+  exact W1p.mem_w1p0Submodule_top hp u
+
+end TauCeti

--- a/TauCeti/Analysis/Sobolev/W1p/Density.lean
+++ b/TauCeti/Analysis/Sobolev/W1p/Density.lean
@@ -8,6 +8,7 @@ module
 public import TauCeti.Analysis.Sobolev.W1p.Mollification
 public import TauCeti.Analysis.Sobolev.W1p.Multiplication
 public import TauCeti.MeasureTheory.Function.Lp.MollificationBridge
+import TauCeti.MeasureTheory.Function.Lp.DominatedConvergence
 
 /-!
 # Test functions are dense in `W^{1,p}(ℝⁿ)`
@@ -212,38 +213,6 @@ private theorem truncate_ae_eq_zero {C : ℝ} (hC : 0 ≤ C)
     rw [← hg, truncate, hgT, hpsi.eq_of_nhds, hpsi.gradient_eq.trans (gradient_fun_const _ _),
       zero_smul, smul_zero, add_zero]
   exact (WithLp.ext_iff _).2 (Prod.ext hfst hsnd)
-
-omit [MeasurableSpace E] [InnerProductSpace ℝ E] [FiniteDimensional ℝ E] [BorelSpace E] in
-/-- Dominated convergence in `Lᵖ`, in the form used for truncation: if `f n` agrees with `g`
-eventually at almost every point and `‖f n - g‖` is dominated by a fixed multiple of `‖g‖`, then
-`f n → g` in `Lᵖ`. -/
-private theorem tendsto_eLpNorm_sub_of_eventually_eq {α F : Type*} [MeasurableSpace α]
-    {m : Measure α} [NormedAddCommGroup F] {q : ℝ≥0∞} (hq0 : q ≠ 0) (hq : q ≠ ∞)
-    {f : ℕ → α → F} {g : α → F} (hf : ∀ n, AEStronglyMeasurable (f n) m) (hg : MemLp g q m)
-    {C : ℝ} (hC : 0 ≤ C) (hbound : ∀ n, ∀ᵐ x ∂m, ‖f n x - g x‖ ≤ C * ‖g x‖)
-    (hlim : ∀ᵐ x ∂m, ∀ᶠ n in atTop, f n x = g x) :
-    Tendsto (fun n => eLpNorm (f n - g) q m) atTop (𝓝 0) := by
-  have hr : 0 < q.toReal := ENNReal.toReal_pos hq0 hq
-  simp_rw [eLpNorm_eq_lintegral_rpow_enorm_toReal hq0 hq]
-  have hlint : Tendsto (fun n => ∫⁻ x, ‖(f n - g) x‖ₑ ^ q.toReal ∂m) atTop (𝓝 0) := by
-    have hdom := tendsto_lintegral_filter_of_dominated_convergence' (μ := m)
-      (F := fun n x => ‖(f n - g) x‖ₑ ^ q.toReal) (f := fun _ => 0)
-      (fun x => (ENNReal.ofReal C * ‖g x‖ₑ) ^ q.toReal)
-      (Eventually.of_forall fun n => ((hf n).sub hg.1).enorm.pow_const _)
-      (Eventually.of_forall fun n => (hbound n).mono fun x hx => by
-        refine ENNReal.rpow_le_rpow ?_ hr.le
-        rw [Pi.sub_apply, ← ofReal_norm, ← ofReal_norm, ← ENNReal.ofReal_mul hC]
-        exact ENNReal.ofReal_le_ofReal hx)
-      (by
-        simp_rw [ENNReal.mul_rpow_of_nonneg _ _ hr.le]
-        rw [lintegral_const_mul' _ _ (ENNReal.rpow_ne_top_of_nonneg hr.le ENNReal.ofReal_ne_top)]
-        exact ENNReal.mul_ne_top (ENNReal.rpow_ne_top_of_nonneg hr.le ENNReal.ofReal_ne_top)
-          (lintegral_rpow_enorm_lt_top_of_eLpNorm_lt_top hq0 hq hg.2).ne)
-      (hlim.mono fun x hx => tendsto_const_nhds.congr' (hx.mono fun n hn => by
-        simp [hn, ENNReal.zero_rpow_of_pos hr]))
-    simpa only [lintegral_zero] using hdom
-  have h0 : (0 : ℝ≥0∞) ^ (1 / q.toReal) = 0 := ENNReal.zero_rpow_of_pos (one_div_pos.2 hr)
-  simpa only [h0] using hlint.ennrpow_const (1 / q.toReal)
 
 /-- **The truncations converge.**  The truncated jet agrees with the jet of `u` on the ball of
 radius `n + 1`, and differs from it by at most `(2 + C)` times its norm. -/

--- a/TauCeti/Analysis/Sobolev/W1p/Density.lean
+++ b/TauCeti/Analysis/Sobolev/W1p/Density.lean
@@ -260,8 +260,10 @@ private theorem tendsto_truncate (hp : p ≠ ∞) {C : ℝ} (hC : 0 ≤ C)
     Tendsto (fun n => truncate hC hbound n u) atTop (𝓝 u) := by
   rw [tendsto_subtype_rng, Lp.tendsto_Lp_iff_tendsto_eLpNorm']
   exact tendsto_eLpNorm_sub_of_eventually_eq (zero_lt_one.trans_le Fact.out).ne' hp
-    (fun n => Lp.aestronglyMeasurable _) (Lp.memLp _) (by linarith : (0 : ℝ) ≤ 2 + C)
-    (fun n => norm_coe_truncate_sub_le hC hbound n u) (eventually_coe_truncate_eq hC hbound u)
+    (Eventually.of_forall fun n => Lp.aestronglyMeasurable _) (Lp.memLp _)
+    (by linarith : (0 : ℝ) ≤ 2 + C)
+    (Eventually.of_forall fun n => norm_coe_truncate_sub_le hC hbound n u)
+    (eventually_coe_truncate_eq hC hbound u)
 
 /-! ### Density -/
 

--- a/TauCeti/Analysis/Sobolev/W1p/Density.lean
+++ b/TauCeti/Analysis/Sobolev/W1p/Density.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.Analysis.Sobolev.W1p.Mollification
 public import TauCeti.Analysis.Sobolev.W1p.Multiplication
 public import TauCeti.MeasureTheory.Function.Lp.MollificationBridge
 
@@ -17,36 +18,24 @@ For `1 ≤ p < ∞`, every function in the whole-space Sobolev space `W^{1,p}(�
 `W^{1,p}_0(ℝⁿ) = W^{1,p}(ℝⁿ)`.
 
 The ambient space is any finite-dimensional real inner product space `E` with an additive Haar
-measure; `ℝⁿ` stands for the whole-space case `Ω = ⊤` below.  For a bounded domain the two spaces
-differ, so the statement is genuinely about the whole space.
-
-## Mollification on `W^{1,p}(ℝⁿ)`
-
-The smooth approximate identity `TauCeti.normedBumpLp` averages the translates of an `Lᵖ` class
-against a normalized bump.  Applied to value-gradient jets it preserves `W^{1,p}(ℝⁿ)`: translation
-preserves the weak-derivative identities on the whole space
-(`TauCeti.Sobolev1JetLp.translateLp_mem_w1pSubmodule`), and the average is a Bochner integral of
-translates, which stays in the closed subspace `W^{1,p}(ℝⁿ)`.  This gives the mollification
-operator `TauCeti.W1p.normedBumpL` on `W^{1,p}(ℝⁿ)`, and the strong convergence of the
-approximate identity on jets is exactly its convergence to the identity in the Sobolev norm
-(`TauCeti.W1p.tendsto_normedBumpL`).  No commutation of derivatives with convolution is needed:
-the weak gradient is mollified together with the value because both are components of one jet.
+measure; `ℝⁿ` stands for the whole-space case `Ω = ⊤` below.  For a nonempty bounded domain in a
+space of positive dimension the two spaces differ, since the Poincaré inequality excludes the
+nonzero constants from `W^{1,p}_0(Ω)`; so the statement is genuinely about the whole space.
 
 ## Density of test functions
 
-If the jet of `u` vanishes outside a compact set, its mollification has a smooth compactly
-supported representative by `TauCeti.normedBumpLp_ae_eq_convolution`, so it is a test function.
-A general `u` is first truncated by the rescaled bumps `ψ(x / R)`: the Leibniz rule of
-`TauCeti.W1p.contDiffSMul` computes the truncated jet, which agrees with the jet of `u` on the
-ball of radius `R` and is dominated by a fixed multiple of it, so the truncations converge to `u`
-by dominated convergence.  Closedness of `W^{1,p}_0(ℝⁿ)` then gives the theorem.
+The mollification operator `TauCeti.W1p.normedBumpL` on `W^{1,p}(ℝⁿ)` converges to the identity
+(`TauCeti.W1p.tendsto_normedBumpL`).  If the jet of `u` vanishes outside a compact set, its
+mollification has a smooth compactly supported representative by
+`TauCeti.normedBumpLp_ae_eq_convolution`, so it is a test function.  A general `u` is first
+truncated by the rescaled bumps `ψ(x / R)`: the Leibniz rule of `TauCeti.W1p.contDiffSMul`
+computes the truncated jet, which agrees with the jet of `u` on the ball of radius `R` and is
+dominated by a fixed multiple of it, so the truncations converge to `u` by dominated convergence.
+Closedness of `W^{1,p}_0(ℝⁿ)` then gives the theorem.
 
 ## Main declarations
 
-* `TauCeti.Sobolev1JetLp.translateLp_mem_w1pSubmodule`: translation preserves `W^{1,p}(ℝⁿ)`.
-* `TauCeti.W1p.normedBumpL`: mollification by a normalized smooth bump, as a continuous linear
-  operator on `W^{1,p}(ℝⁿ)`.
-* `TauCeti.W1p.tendsto_normedBumpL`: mollifications with shrinking bumps converge in `W^{1,p}`.
+* `TauCeti.W1p.mem_w1p0Submodule_top`: every `u ∈ W^{1,p}(ℝⁿ)` lies in `W^{1,p}_0(ℝⁿ)`.
 * `TauCeti.w1p0Submodule_top_eq_top`: `W^{1,p}_0(ℝⁿ) = W^{1,p}(ℝⁿ)` for `p < ∞`.
 * `TauCeti.W1p.denseRange_ofTestFunctionₗ_top`: test functions are dense in `W^{1,p}(ℝⁿ)`.
 
@@ -74,111 +63,7 @@ local instance : (mu.restrict ((⊤ : Opens E) : Set E)).IsAddHaarMeasure := by
   rw [Opens.coe_top, Measure.restrict_univ]
   infer_instance
 
-/-! ### Translation on `W^{1,p}(ℝⁿ)` -/
-
-/-- The translate `y ↦ φ (y + h)` of a whole-space test function. -/
-private def translateTestFunction (phi : 𝓓((⊤ : Opens E), ℝ)) (h : E) :
-    𝓓((⊤ : Opens E), ℝ) :=
-  ⟨fun y => phi (y + h), phi.contDiff.comp (contDiff_id.add contDiff_const),
-    phi.hasCompactSupport.comp_homeomorph (Homeomorph.addRight h), subset_univ _⟩
-
-omit [MeasurableSpace E] [FiniteDimensional ℝ E] [BorelSpace E] in
-private theorem translateTestFunction_apply (phi : 𝓓((⊤ : Opens E), ℝ)) (h y : E) :
-    translateTestFunction phi h y = phi (y + h) :=
-  rfl
-
-omit [MeasurableSpace E] [FiniteDimensional ℝ E] [BorelSpace E] in
-private theorem lineDeriv_translateTestFunction (phi : 𝓓((⊤ : Opens E), ℝ)) (h y v : E) :
-    lineDeriv ℝ (translateTestFunction phi h : E → ℝ) y v =
-      lineDeriv ℝ (phi : E → ℝ) (y + h) v := by
-  simp only [lineDeriv, translateTestFunction_apply, add_right_comm y _ h]
-
-omit [FiniteDimensional ℝ E] in
-/-- **Translation preserves `W^{1,p}(ℝⁿ)`.**  On the whole space the weak-derivative identities
-are invariant under translation: testing the translated jet against `φ` is testing the original
-jet against the translate of `φ`. -/
-theorem Sobolev1JetLp.translateLp_mem_w1pSubmodule (h : E) {J : Sobolev1JetLp mu ⊤ p}
-    (hJ : J ∈ w1pSubmodule mu ⊤ p) :
-    (mu.restrict ((⊤ : Opens E) : Set E)).translateLp p h J ∈ w1pSubmodule mu ⊤ p := by
-  set nu := mu.restrict ((⊤ : Opens E) : Set E)
-  rw [mem_w1pSubmodule_iff] at hJ ⊢
-  intro phi v
-  let f : E → ℝ := fun y =>
-    lineDeriv ℝ (translateTestFunction phi (-h) : E → ℝ) y v * Sobolev1JetLp.value J y +
-      translateTestFunction phi (-h) y * Sobolev1JetLp.candidateWeakFDeriv J y v
-  have hq : Tendsto (· + h) (ae nu) (ae nu) :=
-    (measurePreserving_add_right nu h).quasiMeasurePreserving.tendsto_ae
-  calc
-    ∫ x in (⊤ : Opens E), (lineDeriv ℝ (phi : E → ℝ) x v *
-        Sobolev1JetLp.value (nu.translateLp p h J) x +
-        phi x * Sobolev1JetLp.candidateWeakFDeriv (nu.translateLp p h J) x v) ∂mu
-        = ∫ x in (⊤ : Opens E), f (x + h) ∂mu := by
-      apply integral_congr_ae
-      filter_upwards [Sobolev1JetLp.value_apply_ae (nu.translateLp p h J),
-        Sobolev1JetLp.gradient_apply_ae (nu.translateLp p h J),
-        Measure.coeFn_translateLp (mu := nu) h J,
-        hq.eventually (Sobolev1JetLp.value_apply_ae J),
-        hq.eventually (Sobolev1JetLp.gradient_apply_ae J)] with x hvK hgK hK hvJ hgJ
-      simp only [f, Sobolev1JetLp.candidateWeakFDeriv_apply, lineDeriv_translateTestFunction,
-        translateTestFunction_apply, add_neg_cancel_right, hvK, hgK, hK, Function.comp_apply,
-        hvJ, hgJ]
-    _ = ∫ x in (⊤ : Opens E), f x ∂mu := integral_add_right_eq_self f h
-    _ = 0 := hJ (translateTestFunction phi (-h)) v
-
-/-! ### Mollification on `W^{1,p}(ℝⁿ)` -/
-
-/-- **Mollification preserves `W^{1,p}(ℝⁿ)`.**  The mollified jet is a Bochner integral of
-translates of the jet, each of which lies in the closed subspace `W^{1,p}(ℝⁿ)`. -/
-theorem Sobolev1JetLp.normedBumpLp_mem_w1pSubmodule (hp : p ≠ ∞) (phi : ContDiffBump (0 : E))
-    {J : Sobolev1JetLp mu ⊤ p} (hJ : J ∈ w1pSubmodule mu ⊤ p) :
-    normedBumpLp hp phi (mu.restrict ((⊤ : Opens E) : Set E)) J ∈ w1pSubmodule mu ⊤ p := by
-  set nu := mu.restrict ((⊤ : Opens E) : Set E)
-  let S := (w1pSubmodule mu ⊤ p).toSubmodule
-  let g : E → S := fun t =>
-    ⟨phi.normed nu t • nu.translateLp p (-t) J,
-      S.smul_mem _ (Sobolev1JetLp.translateLp_mem_w1pSubmodule (-t) hJ)⟩
-  have hint : normedBumpLp hp phi nu J = S.subtypeₗᵢ (∫ t, g t ∂nu) := by
-    rw [← LinearIsometry.integral_comp_comm, normedBumpLp_apply]
-    rfl
-  rw [hint]
-  exact (∫ t, g t ∂nu).2
-
-/-- **Mollification on `W^{1,p}(ℝⁿ)`**: averaging the translates of a Sobolev function against
-the normalized form of a smooth bump, as a continuous linear operator.  The value and the weak
-gradient are mollified together, as the two components of one `Lᵖ` jet. -/
-def W1p.normedBumpL (hp : p ≠ ∞) (phi : ContDiffBump (0 : E)) :
-    W1p mu ⊤ p →L[ℝ] W1p mu ⊤ p :=
-  ContinuousLinearMap.codRestrict
-    ((normedBumpLp hp phi (mu.restrict ((⊤ : Opens E) : Set E))).comp
-      (w1pSubmodule mu ⊤ p).toSubmodule.subtypeL)
-    (w1pSubmodule mu ⊤ p).toSubmodule
-    fun u => Sobolev1JetLp.normedBumpLp_mem_w1pSubmodule hp phi u.2
-
-/-- The jet of the mollification is the mollification of the jet. -/
-theorem W1p.coe_normedBumpL (hp : p ≠ ∞) (phi : ContDiffBump (0 : E)) (u : W1p mu ⊤ p) :
-    ((W1p.normedBumpL hp phi u : W1p mu ⊤ p) : Sobolev1JetLp mu ⊤ p) =
-      normedBumpLp hp phi (mu.restrict ((⊤ : Opens E) : Set E)) (u : Sobolev1JetLp mu ⊤ p) :=
-  (rfl)
-
-/-- **Mollification converges in `W^{1,p}(ℝⁿ)`.**  For `1 ≤ p < ∞`, mollifying a Sobolev
-function with normalized smooth bumps whose radii shrink to zero converges to it in the Sobolev
-norm. -/
-theorem W1p.tendsto_normedBumpL (hp : p ≠ ∞) {I : Type*} {l : Filter I}
-    {phi : I → ContDiffBump (0 : E)} (hphi : Tendsto (fun i => (phi i).rOut) l (𝓝 0))
-    (u : W1p mu ⊤ p) :
-    Tendsto (fun i => W1p.normedBumpL hp (phi i) u) l (𝓝 u) := by
-  rw [tendsto_subtype_rng]
-  exact tendsto_normedBumpLp hp hphi (u : Sobolev1JetLp mu ⊤ p)
-
 /-! ### Compactly supported Sobolev functions -/
-
-omit [MeasurableSpace E] [InnerProductSpace ℝ E] [FiniteDimensional ℝ E] [BorelSpace E] in
-/-- A jet with vanishing value and gradient components vanishes. -/
-private theorem sobolev1Jet_eq_zero {y : Sobolev1Jet E} (hfst : y.fst = 0) (hsnd : y.snd = 0) :
-    y = 0 := by
-  have hsq := WithLp.prod_norm_sq_eq_of_L2 y
-  rw [hfst, hsnd, norm_zero, norm_zero] at hsq
-  exact norm_eq_zero.1 (pow_eq_zero_iff two_ne_zero |>.1 (by simpa using hsq))
 
 omit [MeasurableSpace E] [InnerProductSpace ℝ E] [FiniteDimensional ℝ E] [BorelSpace E] in
 /-- The Euclidean jet norm is at most the sum of the norms of its two components. -/
@@ -195,7 +80,7 @@ private theorem normedBumpL_mem_range_of_ae_eq_zero (hp : p ≠ ∞) (phi : Cont
       (u : Sobolev1JetLp mu ⊤ p) x = 0) :
     W1p.normedBumpL hp phi u ∈ LinearMap.range (W1p.ofTestFunctionₗ mu ⊤ p) := by
   set nu := mu.restrict ((⊤ : Opens E) : Set E)
-  set J : Sobolev1JetLp mu ⊤ p := u.1
+  set J : Sobolev1JetLp mu ⊤ p := u.1 with hJdef
   let Jt : E → Sobolev1Jet E := K.indicator J
   have hJt_mem : MemLp Jt p nu := (Lp.memLp J).indicator hK.measurableSet
   have hJt_cpt : HasCompactSupport Jt :=
@@ -206,13 +91,10 @@ private theorem normedBumpL_mem_range_of_ae_eq_zero (hp : p ≠ ∞) (phi : Cont
     rw [hx]
     by_cases hxK : x ∈ K
     · exact indicator_of_mem hxK _
-    · change K.indicator J x = J x
-      rw [indicator_of_notMem hxK, hux hxK]
+    · simp only [Jt, indicator_of_notMem hxK, hux hxK]
   let conv : E → Sobolev1Jet E := phi.normed nu ⋆[ContinuousLinearMap.lsmul ℝ ℝ, nu] Jt
   have hbridge : ((W1p.normedBumpL hp phi u : W1p mu ⊤ p) : Sobolev1JetLp mu ⊤ p) =ᵐ[nu] conv := by
-    rw [W1p.coe_normedBumpL]
-    change ⇑(normedBumpLp hp phi nu J) =ᵐ[nu] conv
-    rw [← hJ_eq]
+    rw [W1p.coe_normedBumpL, ← hJdef, ← hJ_eq]
     exact normedBumpLp_ae_eq_convolution hp phi hJt_mem hJt_cpt
   have hconv_smooth : ContDiff ℝ (⊤ : ℕ∞) conv :=
     phi.hasCompactSupport_normed.contDiff_convolution_left (ContinuousLinearMap.lsmul ℝ ℝ)
@@ -233,6 +115,14 @@ private theorem normedBumpL_mem_range_of_ae_eq_zero (hp : p ≠ ∞) (phi : Cont
 
 /-- The smooth bump equal to one on the unit ball and supported in the ball of radius two. -/
 private def unitBump : ContDiffBump (0 : E) := ⟨1, 2, one_pos, one_lt_two⟩
+
+omit [MeasurableSpace E] [InnerProductSpace ℝ E] [FiniteDimensional ℝ E] [BorelSpace E] in
+private theorem unitBump_rIn : (unitBump (E := E)).rIn = 1 :=
+  rfl
+
+omit [MeasurableSpace E] [InnerProductSpace ℝ E] [FiniteDimensional ℝ E] [BorelSpace E] in
+private theorem unitBump_rOut : (unitBump (E := E)).rOut = 2 :=
+  rfl
 
 omit [MeasurableSpace E] [BorelSpace E] in
 private theorem exists_norm_fderiv_unitBump_le :
@@ -264,7 +154,7 @@ private theorem norm_gradient_truncCutoff_le {C : ℝ}
     ‖∇ (truncCutoff n) x‖ ≤ C := by
   have hn : (0 : ℝ) < (n : ℝ) + 1 := by positivity
   rw [gradient, LinearIsometryEquiv.norm_map]
-  change ‖fderiv ℝ (fun y => unitBump (E := E) (((n : ℝ) + 1)⁻¹ • y)) x‖ ≤ C
+  unfold truncCutoff
   rw [fderiv_comp_smul, norm_smul, Real.norm_eq_abs, abs_of_pos (inv_pos.2 hn)]
   calc ((n : ℝ) + 1)⁻¹ * ‖fderiv ℝ (unitBump (E := E)) (((n : ℝ) + 1)⁻¹ • x)‖
       ≤ 1 * C := mul_le_mul (inv_le_one_of_one_le₀ (by linarith)) (hbound _)
@@ -278,9 +168,8 @@ private theorem truncCutoff_eventuallyEq_one {n : ℕ} {x : E} (hx : ‖x‖ < (
   have hn : (0 : ℝ) < (n : ℝ) + 1 := by positivity
   filter_upwards [isOpen_ball.mem_nhds (mem_ball_zero_iff.2 hx)] with y hy
   apply (unitBump (E := E)).one_of_mem_closedBall
-  rw [mem_closedBall_zero_iff, norm_smul, Real.norm_eq_abs, abs_of_pos (inv_pos.2 hn)]
-  change ((n : ℝ) + 1)⁻¹ * ‖y‖ ≤ 1
-  rw [inv_mul_le_iff₀ hn, mul_one]
+  rw [mem_closedBall_zero_iff, norm_smul, Real.norm_eq_abs, abs_of_pos (inv_pos.2 hn),
+    unitBump_rIn, inv_mul_le_iff₀ hn, mul_one]
   exact (mem_ball_zero_iff.1 hy).le
 
 omit [MeasurableSpace E] [BorelSpace E] in
@@ -291,15 +180,9 @@ private theorem truncCutoff_eventuallyEq_zero {n : ℕ} {x : E}
   have hn : (0 : ℝ) < (n : ℝ) + 1 := by positivity
   filter_upwards [isOpen_lt continuous_const continuous_norm |>.mem_nhds hx] with y hy
   apply (unitBump (E := E)).zero_of_le_dist
-  rw [dist_zero_right, norm_smul, Real.norm_eq_abs, abs_of_pos (inv_pos.2 hn)]
-  change 2 ≤ ((n : ℝ) + 1)⁻¹ * ‖y‖
-  rw [le_inv_mul_iff₀ hn]
+  rw [dist_zero_right, norm_smul, Real.norm_eq_abs, abs_of_pos (inv_pos.2 hn), unitBump_rOut,
+    le_inv_mul_iff₀ hn]
   linarith
-
-omit [MeasurableSpace E] [BorelSpace E] in
-private theorem gradient_eq_zero_of_eventuallyEq {f : E → ℝ} {x : E} {c : ℝ}
-    (hf : f =ᶠ[𝓝 x] fun _ => c) : ∇ f x = 0 := by
-  rw [gradient, hf.fderiv_eq, fderiv_const_apply, map_zero]
 
 /-- The truncation `ψ(x / (n + 1)) u` of a Sobolev function, with `C` bounding the gradients of
 all the cutoffs. -/
@@ -323,10 +206,12 @@ private theorem truncate_ae_eq_zero {C : ℝ} (hC : 0 ≤ C)
   have hx' : 2 * ((n : ℝ) + 1) < ‖x‖ := by
     simpa only [mem_closedBall_zero_iff, not_le] using hx
   have hpsi := truncCutoff_eventuallyEq_zero hx'
-  apply sobolev1Jet_eq_zero
-  · rw [← hv, truncate, hvT, hpsi.eq_of_nhds, zero_smul]
-  · rw [← hg, truncate, hgT, hpsi.eq_of_nhds, gradient_eq_zero_of_eventuallyEq hpsi, zero_smul,
-      smul_zero, add_zero]
+  have hfst : ((truncate hC hbound n u : Sobolev1JetLp mu ⊤ p) x).fst = 0 := by
+    rw [← hv, truncate, hvT, hpsi.eq_of_nhds, zero_smul]
+  have hsnd : ((truncate hC hbound n u : Sobolev1JetLp mu ⊤ p) x).snd = 0 := by
+    rw [← hg, truncate, hgT, hpsi.eq_of_nhds, hpsi.gradient_eq.trans (gradient_fun_const _ _),
+      zero_smul, smul_zero, add_zero]
+  exact (WithLp.ext_iff _).2 (Prod.ext hfst hsnd)
 
 omit [MeasurableSpace E] [InnerProductSpace ℝ E] [FiniteDimensional ℝ E] [BorelSpace E] in
 /-- Dominated convergence in `Lᵖ`, in the form used for truncation: if `f n` agrees with `g`
@@ -419,10 +304,14 @@ private theorem tendsto_truncate (hp : p ≠ ∞) {C : ℝ} (hC : 0 ≤ C)
       with x hvT hgT hvu hgu hvn hgn
     filter_upwards [tendsto_natCast_atTop_atTop.eventually_gt_atTop ‖x‖] with n hn
     have hpsi := truncCutoff_eventuallyEq_one (E := E) (n := n) (x := x) (by linarith)
-    refine sub_eq_zero.1 (sobolev1Jet_eq_zero ?_ ?_)
-    · rw [WithLp.sub_fst, ← hvT n, ← hvu, truncate, hvn n, hpsi.eq_of_nhds, one_smul, sub_self]
-    · rw [WithLp.sub_snd, ← hgT n, ← hgu, truncate, hgn n, hpsi.eq_of_nhds,
-        gradient_eq_zero_of_eventuallyEq hpsi, one_smul, smul_zero, add_zero, sub_self]
+    have hfst : ((truncate hC hbound n u : Sobolev1JetLp mu ⊤ p) x -
+        (u : Sobolev1JetLp mu ⊤ p) x).fst = 0 := by
+      rw [WithLp.sub_fst, ← hvT n, ← hvu, truncate, hvn n, hpsi.eq_of_nhds, one_smul, sub_self]
+    have hsnd : ((truncate hC hbound n u : Sobolev1JetLp mu ⊤ p) x -
+        (u : Sobolev1JetLp mu ⊤ p) x).snd = 0 := by
+      rw [WithLp.sub_snd, ← hgT n, ← hgu, truncate, hgn n, hpsi.eq_of_nhds,
+        hpsi.gradient_eq.trans (gradient_fun_const _ _), one_smul, smul_zero, add_zero, sub_self]
+    exact sub_eq_zero.1 ((WithLp.ext_iff _).2 (Prod.ext hfst hsnd))
 
 /-! ### Density -/
 
@@ -446,8 +335,9 @@ theorem W1p.mem_w1p0Submodule_top (hp : p ≠ ∞) (u : W1p mu ⊤ p) :
   exact hclosed.mem_of_tendsto (tendsto_truncate hp hC hgrad u) (Eventually.of_forall htrunc)
 
 /-- **`W^{1,p}_0(ℝⁿ) = W^{1,p}(ℝⁿ)`** for `1 ≤ p < ∞`: on the whole space the zero-boundary
-condition is no condition at all.  This fails for a bounded domain, and it fails for `p = ∞`,
-where test functions are not dense. -/
+condition is no condition at all.  When `E` has positive dimension, the analogous equality fails
+for a nonempty bounded domain, and it fails for `p = ∞`, where the constant `1` is not a limit
+of test functions. -/
 theorem w1p0Submodule_top_eq_top (hp : p ≠ ∞) : w1p0Submodule mu ⊤ p = ⊤ :=
   eq_top_iff.2 fun u _ => W1p.mem_w1p0Submodule_top hp u
 

--- a/TauCeti/Analysis/Sobolev/W1p/Mollification.lean
+++ b/TauCeti/Analysis/Sobolev/W1p/Mollification.lean
@@ -6,7 +6,9 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Analysis.Sobolev.Translation
+public import TauCeti.Analysis.Sobolev.W1p.Zero
 public import TauCeti.MeasureTheory.Function.Lp.ApproximateIdentity
+public import TauCeti.MeasureTheory.Function.Lp.MollificationBridge
 
 /-!
 # Mollification on `W^{1,p}(ℝⁿ)`
@@ -21,6 +23,10 @@ approximate identity on jets is exactly its convergence to the identity in the S
 (`TauCeti.W1p.tendsto_normedBumpL`).  No commutation of derivatives with convolution is needed:
 the weak gradient is mollified together with the value because both are components of one jet.
 
+If the jet of `u` vanishes outside a compact set, the mollified jet has a smooth compactly
+supported representative (`TauCeti.normedBumpLp_ae_eq_convolution`), so the mollification is a
+test function (`TauCeti.W1p.normedBumpL_mem_range_of_ae_eq_zero`).
+
 The ambient space is any finite-dimensional real inner product space `E` with an additive Haar
 measure; `ℝⁿ` stands for the whole-space case `Ω = ⊤`.
 
@@ -31,6 +37,8 @@ measure; `ℝⁿ` stands for the whole-space case `Ω = ⊤`.
   operator on `W^{1,p}(ℝⁿ)`.
 * `TauCeti.W1p.norm_normedBumpL_le_one`: this operator is a contraction.
 * `TauCeti.W1p.tendsto_normedBumpL`: mollifications with shrinking bumps converge in `W^{1,p}`.
+* `TauCeti.W1p.normedBumpL_mem_range_of_ae_eq_zero`: mollifying a Sobolev function whose jet
+  vanishes outside a compact set produces a test function.
 
 ## References
 
@@ -42,8 +50,8 @@ public section
 
 noncomputable section
 
-open Filter MeasureTheory TopologicalSpace
-open scoped ENNReal Topology
+open Filter MeasureTheory Set TopologicalSpace
+open scoped Convolution Distributions ENNReal Topology
 
 namespace TauCeti
 
@@ -106,5 +114,45 @@ theorem W1p.tendsto_normedBumpL (hp : p ≠ ∞) {I : Type*} {l : Filter I}
     Tendsto (fun i => W1p.normedBumpL hp (phi i) u) l (𝓝 u) := by
   rw [tendsto_subtype_rng]
   exact tendsto_normedBumpLp hp hphi (u : Sobolev1JetLp mu ⊤ p)
+
+/-- **A compactly supported Sobolev function mollifies to a test function.**  If the jet of `u`
+vanishes almost everywhere outside a compact set, its mollification has a smooth compactly
+supported representative. -/
+theorem W1p.normedBumpL_mem_range_of_ae_eq_zero (hp : p ≠ ∞) (phi : ContDiffBump (0 : E))
+    {u : W1p mu ⊤ p} {K : Set E} (hK : IsCompact K)
+    (hu : ∀ᵐ x ∂(mu.restrict ((⊤ : Opens E) : Set E)), x ∉ K →
+      (u : Sobolev1JetLp mu ⊤ p) x = 0) :
+    W1p.normedBumpL hp phi u ∈ LinearMap.range (W1p.ofTestFunctionₗ mu ⊤ p) := by
+  set nu := mu.restrict ((⊤ : Opens E) : Set E)
+  set J : Sobolev1JetLp mu ⊤ p := u.1 with hJdef
+  let Jt : E → Sobolev1Jet E := K.indicator J
+  have hJt_mem : MemLp Jt p nu := (Lp.memLp J).indicator hK.measurableSet
+  have hJt_cpt : HasCompactSupport Jt :=
+    HasCompactSupport.intro hK fun x hx => indicator_of_notMem hx _
+  have hJ_eq : hJt_mem.toLp Jt = J := by
+    apply Lp.ext
+    filter_upwards [hJt_mem.coeFn_toLp, hu] with x hx hux
+    rw [hx]
+    by_cases hxK : x ∈ K
+    · exact indicator_of_mem hxK _
+    · simp only [Jt, indicator_of_notMem hxK, hux hxK]
+  let conv : E → Sobolev1Jet E := phi.normed nu ⋆[ContinuousLinearMap.lsmul ℝ ℝ, nu] Jt
+  have hbridge : ((W1p.normedBumpL hp phi u : W1p mu ⊤ p) : Sobolev1JetLp mu ⊤ p) =ᵐ[nu] conv := by
+    rw [W1p.coe_normedBumpL, ← hJdef, ← hJ_eq]
+    exact normedBumpLp_ae_eq_convolution hp phi hJt_mem hJt_cpt
+  have hconv_smooth : ContDiff ℝ (⊤ : ℕ∞) conv :=
+    phi.hasCompactSupport_normed.contDiff_convolution_left (ContinuousLinearMap.lsmul ℝ ℝ)
+      phi.contDiff_normed (hJt_mem.locallyIntegrable Fact.out)
+  have hconv_cpt : HasCompactSupport conv :=
+    phi.hasCompactSupport_normed.convolution (ContinuousLinearMap.lsmul ℝ ℝ) hJt_cpt
+  let Phi : 𝓓((⊤ : Opens E), ℝ) :=
+    ⟨fun x => WithLp.fstL 2 ℝ ℝ E (conv x), (WithLp.fstL 2 ℝ ℝ E).contDiff.comp hconv_smooth,
+      hconv_cpt.comp_left (map_zero _), subset_univ _⟩
+  refine ⟨Phi, W1p.ext_value (Lp.ext ?_)⟩
+  rw [W1p.value_ofTestFunctionₗ]
+  filter_upwards [testFunctionLp_apply_ae (mu := mu) p Phi,
+    W1p.value_apply_ae (W1p.normedBumpL hp phi u), hbridge] with x hPhi hvalue hconv
+  rw [hPhi, hvalue, hconv]
+  rfl
 
 end TauCeti

--- a/TauCeti/Analysis/Sobolev/W1p/Mollification.lean
+++ b/TauCeti/Analysis/Sobolev/W1p/Mollification.lean
@@ -1,0 +1,110 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.Sobolev.Translation
+public import TauCeti.MeasureTheory.Function.Lp.ApproximateIdentity
+
+/-!
+# Mollification on `W^{1,p}(ℝⁿ)`
+
+The smooth approximate identity `TauCeti.normedBumpLp` averages the translates of an `Lᵖ` class
+against a normalized bump.  Applied to value-gradient jets it preserves `W^{1,p}(ℝⁿ)`: translation
+preserves the weak-derivative identities on the whole space
+(`TauCeti.Sobolev1JetLp.translateLp_mem_w1pSubmodule`), and the average is a Bochner integral of
+translates, which stays in the closed subspace `W^{1,p}(ℝⁿ)`.  This gives the mollification
+operator `TauCeti.W1p.normedBumpL` on `W^{1,p}(ℝⁿ)`, and the strong convergence of the
+approximate identity on jets is exactly its convergence to the identity in the Sobolev norm
+(`TauCeti.W1p.tendsto_normedBumpL`).  No commutation of derivatives with convolution is needed:
+the weak gradient is mollified together with the value because both are components of one jet.
+
+The ambient space is any finite-dimensional real inner product space `E` with an additive Haar
+measure; `ℝⁿ` stands for the whole-space case `Ω = ⊤`.
+
+## Main declarations
+
+* `TauCeti.Sobolev1JetLp.normedBumpLp_mem_w1pSubmodule`: mollification preserves `W^{1,p}(ℝⁿ)`.
+* `TauCeti.W1p.normedBumpL`: mollification by a normalized smooth bump, as a continuous linear
+  operator on `W^{1,p}(ℝⁿ)`.
+* `TauCeti.W1p.norm_normedBumpL_le_one`: this operator is a contraction.
+* `TauCeti.W1p.tendsto_normedBumpL`: mollifications with shrinking bumps converge in `W^{1,p}`.
+
+## References
+
+L. C. Evans, *Partial Differential Equations*, §5.3.1; H. Brezis, *Functional Analysis, Sobolev
+Spaces and Partial Differential Equations*, Theorem 9.2.
+-/
+
+public section
+
+noncomputable section
+
+open Filter MeasureTheory TopologicalSpace
+open scoped ENNReal Topology
+
+namespace TauCeti
+
+variable {E : Type*} [MeasurableSpace E] [NormedAddCommGroup E] [InnerProductSpace ℝ E]
+  [FiniteDimensional ℝ E] [BorelSpace E] {mu : Measure E} [mu.IsAddHaarMeasure]
+  {p : ENNReal} [Fact (1 ≤ p)]
+
+/-- The whole-space restriction of an additive Haar measure is the measure itself. -/
+local instance : (mu.restrict ((⊤ : Opens E) : Set E)).IsAddHaarMeasure := by
+  rw [Opens.coe_top, Measure.restrict_univ]
+  infer_instance
+
+/-- **Mollification preserves `W^{1,p}(ℝⁿ)`.**  The mollified jet is a Bochner integral of
+translates of the jet, each of which lies in the closed subspace `W^{1,p}(ℝⁿ)`. -/
+theorem Sobolev1JetLp.normedBumpLp_mem_w1pSubmodule (hp : p ≠ ∞) (phi : ContDiffBump (0 : E))
+    {J : Sobolev1JetLp mu ⊤ p} (hJ : J ∈ w1pSubmodule mu ⊤ p) :
+    normedBumpLp hp phi (mu.restrict ((⊤ : Opens E) : Set E)) J ∈ w1pSubmodule mu ⊤ p := by
+  set nu := mu.restrict ((⊤ : Opens E) : Set E)
+  let S := (w1pSubmodule mu ⊤ p).toSubmodule
+  let g : E → S := fun t =>
+    ⟨phi.normed nu t • nu.translateLp p (-t) J,
+      S.smul_mem _ (Sobolev1JetLp.translateLp_mem_w1pSubmodule (-t) hJ)⟩
+  have hint : normedBumpLp hp phi nu J = S.subtypeₗᵢ (∫ t, g t ∂nu) := by
+    rw [← LinearIsometry.integral_comp_comm, normedBumpLp_apply]
+    simp only [g, Submodule.coe_subtypeₗᵢ, Submodule.coe_subtype]
+  rw [hint]
+  exact (∫ t, g t ∂nu).2
+
+/-- **Mollification on `W^{1,p}(ℝⁿ)`**: averaging the translates of a Sobolev function against
+the normalized form of a smooth bump, as a continuous linear operator.  The value and the weak
+gradient are mollified together, as the two components of one `Lᵖ` jet. -/
+def W1p.normedBumpL (hp : p ≠ ∞) (phi : ContDiffBump (0 : E)) :
+    W1p mu ⊤ p →L[ℝ] W1p mu ⊤ p :=
+  ContinuousLinearMap.codRestrict
+    ((normedBumpLp hp phi (mu.restrict ((⊤ : Opens E) : Set E))).comp
+      (w1pSubmodule mu ⊤ p).toSubmodule.subtypeL)
+    (w1pSubmodule mu ⊤ p).toSubmodule
+    fun u => Sobolev1JetLp.normedBumpLp_mem_w1pSubmodule hp phi u.2
+
+/-- The jet of the mollification is the mollification of the jet. -/
+theorem W1p.coe_normedBumpL (hp : p ≠ ∞) (phi : ContDiffBump (0 : E)) (u : W1p mu ⊤ p) :
+    ((W1p.normedBumpL hp phi u : W1p mu ⊤ p) : Sobolev1JetLp mu ⊤ p) =
+      normedBumpLp hp phi (mu.restrict ((⊤ : Opens E) : Set E)) (u : Sobolev1JetLp mu ⊤ p) :=
+  (rfl)
+
+/-- Mollification by a normalized nonnegative bump does not increase the `W^{1,p}` norm when
+`p < ∞`. -/
+theorem W1p.norm_normedBumpL_le_one (hp : p ≠ ∞) (phi : ContDiffBump (0 : E)) :
+    ‖W1p.normedBumpL (mu := mu) hp phi‖ ≤ 1 := by
+  refine ContinuousLinearMap.opNorm_le_bound _ zero_le_one fun u => ?_
+  rw [← Submodule.norm_coe, W1p.coe_normedBumpL, ← Submodule.norm_coe u]
+  exact ContinuousLinearMap.le_of_opNorm_le _ (norm_normedBumpLp_le_one hp phi) _
+
+/-- **Mollification converges in `W^{1,p}(ℝⁿ)`.**  For `1 ≤ p < ∞`, mollifying a Sobolev
+function with normalized smooth bumps whose radii shrink to zero converges to it in the Sobolev
+norm. -/
+theorem W1p.tendsto_normedBumpL (hp : p ≠ ∞) {I : Type*} {l : Filter I}
+    {phi : I → ContDiffBump (0 : E)} (hphi : Tendsto (fun i => (phi i).rOut) l (𝓝 0))
+    (u : W1p mu ⊤ p) :
+    Tendsto (fun i => W1p.normedBumpL hp (phi i) u) l (𝓝 u) := by
+  rw [tendsto_subtype_rng]
+  exact tendsto_normedBumpLp hp hphi (u : Sobolev1JetLp mu ⊤ p)
+
+end TauCeti

--- a/TauCeti/MeasureTheory/Function/Lp/DominatedConvergence.lean
+++ b/TauCeti/MeasureTheory/Function/Lp/DominatedConvergence.lean
@@ -13,8 +13,8 @@ import Mathlib.MeasureTheory.Integral.Lebesgue.DominatedConvergence
 # Dominated convergence in `Lᵖ` for eventually equal approximations
 
 For a finite nonzero exponent `q`, if the functions `f n` eventually agree with `g` at almost
-every point and the errors `‖f n - g‖` are dominated by a fixed multiple of `‖g‖`, where
-`g ∈ Lᵖ`, then `f n → g` in the `Lᵖ` seminorm.  This is the shape produced by truncating a
+every point and the errors `‖f n - g‖` are eventually dominated by a fixed multiple of `‖g‖`,
+where `g ∈ Lᵖ`, then `f n → g` in the `Lᵖ` seminorm.  This is the shape produced by truncating a
 function by cutoffs that are eventually `1` on every bounded set.
 
 ## Main declarations
@@ -30,13 +30,14 @@ open Filter MeasureTheory
 open scoped ENNReal Topology
 
 /-- **Dominated convergence in `Lᵖ`.** For a finite nonzero exponent, if `f n` eventually agrees
-with `g` at almost every point and `‖f n - g‖` is dominated by a fixed multiple of `‖g‖`, where
-`g ∈ Lᵖ`, then `f n → g` in the `Lᵖ` seminorm. -/
+with `g` at almost every point and `‖f n - g‖` is eventually dominated by a fixed multiple of
+`‖g‖`, where `g ∈ Lᵖ`, then `f n → g` in the `Lᵖ` seminorm.  Both the measurability of `f n` and
+the domination are only needed eventually along `l`. -/
 theorem tendsto_eLpNorm_sub_of_eventually_eq {α ι F : Type*} [MeasurableSpace α]
     {m : Measure α} [NormedAddCommGroup F] {l : Filter ι} [l.IsCountablyGenerated] {q : ℝ≥0∞}
     (hq0 : q ≠ 0) (hq : q ≠ ∞) {f : ι → α → F} {g : α → F}
-    (hf : ∀ n, AEStronglyMeasurable (f n) m) (hg : MemLp g q m)
-    {C : ℝ} (hC : 0 ≤ C) (hbound : ∀ n, ∀ᵐ x ∂m, ‖f n x - g x‖ ≤ C * ‖g x‖)
+    (hf : ∀ᶠ n in l, AEStronglyMeasurable (f n) m) (hg : MemLp g q m)
+    {C : ℝ} (hC : 0 ≤ C) (hbound : ∀ᶠ n in l, ∀ᵐ x ∂m, ‖f n x - g x‖ ≤ C * ‖g x‖)
     (hlim : ∀ᵐ x ∂m, ∀ᶠ n in l, f n x = g x) :
     Tendsto (fun n => eLpNorm (f n - g) q m) l (𝓝 0) := by
   have hr : 0 < q.toReal := ENNReal.toReal_pos hq0 hq
@@ -45,8 +46,8 @@ theorem tendsto_eLpNorm_sub_of_eventually_eq {α ι F : Type*} [MeasurableSpace 
     have hdom := tendsto_lintegral_filter_of_dominated_convergence' (μ := m)
       (F := fun n x => ‖(f n - g) x‖ₑ ^ q.toReal) (f := fun _ => 0)
       (fun x => (ENNReal.ofReal C * ‖g x‖ₑ) ^ q.toReal)
-      (Eventually.of_forall fun n => ((hf n).sub hg.1).enorm.pow_const _)
-      (Eventually.of_forall fun n => (hbound n).mono fun x hx => by
+      (hf.mono fun n hn => (hn.sub hg.1).enorm.pow_const _)
+      (hbound.mono fun _ hn => hn.mono fun x hx => by
         refine ENNReal.rpow_le_rpow ?_ hr.le
         rw [Pi.sub_apply, ← ofReal_norm, ← ofReal_norm, ← ENNReal.ofReal_mul hC]
         exact ENNReal.ofReal_le_ofReal hx)

--- a/TauCeti/MeasureTheory/Function/Lp/DominatedConvergence.lean
+++ b/TauCeti/MeasureTheory/Function/Lp/DominatedConvergence.lean
@@ -1,0 +1,64 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.MeasureTheory.Function.LpSeminorm.Basic
+import Mathlib.Analysis.SpecialFunctions.Pow.Continuity
+import Mathlib.MeasureTheory.Integral.Lebesgue.DominatedConvergence
+
+/-!
+# Dominated convergence in `Lᵖ` for eventually equal approximations
+
+For a finite nonzero exponent `q`, if the functions `f n` eventually agree with `g` at almost
+every point and the errors `‖f n - g‖` are dominated by a fixed multiple of `‖g‖`, where
+`g ∈ Lᵖ`, then `f n → g` in the `Lᵖ` seminorm.  This is the shape produced by truncating a
+function by cutoffs that are eventually `1` on every bounded set.
+
+## Main declarations
+
+* `TauCeti.tendsto_eLpNorm_sub_of_eventually_eq`: the convergence `eLpNorm (f n - g) q m → 0`.
+-/
+
+public section
+
+namespace TauCeti
+
+open Filter MeasureTheory
+open scoped ENNReal Topology
+
+/-- **Dominated convergence in `Lᵖ`.** For a finite nonzero exponent, if `f n` eventually agrees
+with `g` at almost every point and `‖f n - g‖` is dominated by a fixed multiple of `‖g‖`, where
+`g ∈ Lᵖ`, then `f n → g` in the `Lᵖ` seminorm. -/
+theorem tendsto_eLpNorm_sub_of_eventually_eq {α ι F : Type*} [MeasurableSpace α]
+    {m : Measure α} [NormedAddCommGroup F] {l : Filter ι} [l.IsCountablyGenerated] {q : ℝ≥0∞}
+    (hq0 : q ≠ 0) (hq : q ≠ ∞) {f : ι → α → F} {g : α → F}
+    (hf : ∀ n, AEStronglyMeasurable (f n) m) (hg : MemLp g q m)
+    {C : ℝ} (hC : 0 ≤ C) (hbound : ∀ n, ∀ᵐ x ∂m, ‖f n x - g x‖ ≤ C * ‖g x‖)
+    (hlim : ∀ᵐ x ∂m, ∀ᶠ n in l, f n x = g x) :
+    Tendsto (fun n => eLpNorm (f n - g) q m) l (𝓝 0) := by
+  have hr : 0 < q.toReal := ENNReal.toReal_pos hq0 hq
+  simp_rw [eLpNorm_eq_lintegral_rpow_enorm_toReal hq0 hq]
+  have hlint : Tendsto (fun n => ∫⁻ x, ‖(f n - g) x‖ₑ ^ q.toReal ∂m) l (𝓝 0) := by
+    have hdom := tendsto_lintegral_filter_of_dominated_convergence' (μ := m)
+      (F := fun n x => ‖(f n - g) x‖ₑ ^ q.toReal) (f := fun _ => 0)
+      (fun x => (ENNReal.ofReal C * ‖g x‖ₑ) ^ q.toReal)
+      (Eventually.of_forall fun n => ((hf n).sub hg.1).enorm.pow_const _)
+      (Eventually.of_forall fun n => (hbound n).mono fun x hx => by
+        refine ENNReal.rpow_le_rpow ?_ hr.le
+        rw [Pi.sub_apply, ← ofReal_norm, ← ofReal_norm, ← ENNReal.ofReal_mul hC]
+        exact ENNReal.ofReal_le_ofReal hx)
+      (by
+        simp_rw [ENNReal.mul_rpow_of_nonneg _ _ hr.le]
+        rw [lintegral_const_mul' _ _ (ENNReal.rpow_ne_top_of_nonneg hr.le ENNReal.ofReal_ne_top)]
+        exact ENNReal.mul_ne_top (ENNReal.rpow_ne_top_of_nonneg hr.le ENNReal.ofReal_ne_top)
+          (lintegral_rpow_enorm_lt_top_of_eLpNorm_lt_top hq0 hq hg.2).ne)
+      (hlim.mono fun x hx => tendsto_const_nhds.congr' (hx.mono fun n hn => by
+        simp [hn, ENNReal.zero_rpow_of_pos hr]))
+    simpa only [lintegral_zero] using hdom
+  have h0 : (0 : ℝ≥0∞) ^ (1 / q.toReal) = 0 := ENNReal.zero_rpow_of_pos (one_div_pos.2 hr)
+  simpa only [h0] using hlint.ennrpow_const (1 / q.toReal)
+
+end TauCeti


### PR DESCRIPTION
This PR proves that test functions are dense in the whole-space Sobolev space: for `1 ≤ p < ∞`, `W^{1,p}_0(ℝⁿ) = W^{1,p}(ℝⁿ)` (`TauCeti.w1p0Submodule_top_eq_top`, with `TauCeti.W1p.denseRange_ofTestFunctionₗ_top`). Along the way it builds mollification as a bounded operator on `W^{1,p}(ℝⁿ)` (`TauCeti.W1p.normedBumpL`, a contraction by `TauCeti.W1p.norm_normedBumpL_le_one`) and shows that it converges to the identity in the Sobolev norm as the bump radius shrinks (`TauCeti.W1p.tendsto_normedBumpL`). Here `ℝⁿ` means any finite-dimensional real inner product space with an additive Haar measure, i.e. `Ω = ⊤`.

Roadmap: PDE

The target is Lane A.2 of `PDE/README.md` ("Density and `W^{k,p}_0`"), which asks for mollification to give density of smooth functions (Meyers–Serrin, `H = W`) and states that "`W^{k,p}_0 = W^{k,p}` for `Ω = ℝⁿ`". This PR proves that equality at `k = 1`, i.e. the whole-space case of the density milestone. The domain case of A.2 is still open after this PR: Meyers–Serrin density of `C^∞ ∩ W^{1,p}(Ω)` in `W^{1,p}(Ω)` for an arbitrary open `Ω`, which localizes this whole-space mollification with a partition of unity.

The proof uses no pointwise commutation of weak derivatives with convolution. Translation preserves the weak-derivative identities on the whole space (`TauCeti.Sobolev1JetLp.translateLp_mem_w1pSubmodule`). The existing `Lᵖ` approximate identity `TauCeti.normedBumpLp` is a Bochner integral of translates, so applied to value-gradient jets it stays in the closed subspace `W^{1,p}(ℝⁿ)`. Its strong convergence on jets is then exactly convergence in the Sobolev norm.

For a jet vanishing outside a compact set, `TauCeti.normedBumpLp_ae_eq_convolution` gives the mollification a smooth, compactly supported representative, i.e. a test function. A general `u` is first truncated by rescaled bumps `ψ(x / (n + 1))` using the Leibniz operator `TauCeti.W1p.contDiffSMul`. The truncated jet agrees with the jet of `u` on the ball of radius `n + 1` and is dominated by `(2 + C)` times it, so the truncations converge by dominated convergence. Closedness of `W^{1,p}_0(ℝⁿ)` finishes the proof.

Files:

- `TauCeti/Analysis/Sobolev/Translation.lean` gains `TauCeti.Sobolev1JetLp.translateLp_mem_w1pSubmodule`, which says translation preserves `W^{1,p}(ℝⁿ)`.
- `TauCeti/Analysis/Sobolev/W1p/Mollification.lean` (new) holds the mollification operator `TauCeti.W1p.normedBumpL` and its API.
- `TauCeti/MeasureTheory/Function/Lp/DominatedConvergence.lean` (new) holds `TauCeti.tendsto_eLpNorm_sub_of_eventually_eq`, a dominated-convergence theorem in `Lᵖ`: if `f n` eventually equals `g` almost everywhere and `‖f n - g‖ ≤ C ‖g‖`, then `f n → g` in `Lᵖ`.
- `TauCeti/Analysis/Sobolev/W1p/Density.lean` (new) holds truncation and the density theorem.

The PR vendors nothing and changes no existing declaration. One consequence I left for a separate PR: the `u ∈ W^{1,p}_0(ℝⁿ)` hypothesis of `TauCeti.W1p.eLpNorm_value_comp_add_sub_value_le_mul_enorm_gradient` is now redundant.

<!--tauceti-target:v1 {"focus":"PDE","id":"w1p0-eq-w1p-whole-space"}-->

🤖 Prepared with Claude Code

