### PR TITLE
feat(ModularForms): coefficient vanishing of a good Hecke eigenvector

### DIFF
--- a/TauCeti/NumberTheory/ArithmeticFunction/PrimeRecurrence.lean
+++ b/TauCeti/NumberTheory/ArithmeticFunction/PrimeRecurrence.lean
@@ -21,8 +21,8 @@ eigenform with `a₁ = 0` at the good indices, where `c` is the eigenvalue at `p
 
 ## Main results
 
-* `TauCeti.eq_zero_of_forall_prime_mul_eq_of_one_eq_zero_of_ne_zero_of_coprime`: the vanishing,
-  by strong induction along the least prime factor.
+* `TauCeti.eq_zero_of_forall_prime_mul_eq_of_one_eq_zero_of_ne_zero_of_coprime`: the vanishing
+  at the indices coprime to `L`.
 
 ## References
 
@@ -40,12 +40,13 @@ variable {R : Type*} [NonUnitalNonAssocRing R]
 /-- **A sequence with a Hecke-type prime recurrence and `a₁ = 0` vanishes at the indices
 coprime to `L`.** If at every prime `p` coprime to `L` there are scalars `c`, `d` with
 `a_{pm} = c · a_m − d · a_{m/p}` (the last term only when `p ∣ m`) for every `m` coprime to `L`,
-and `a₁ = 0`, then `a_n = 0` for every `n ≠ 0` coprime to `L`: the recurrence along the least
-prime factor of `n` expresses `a_n` through terms at smaller indices coprime to `L`. -/
+and `a₁ = 0`, then `a_n = 0` for every `n ≠ 0` coprime to `L`. -/
 theorem eq_zero_of_forall_prime_mul_eq_of_one_eq_zero_of_ne_zero_of_coprime {a : ℕ → R} {L : ℕ}
     (ha : ∀ p : ℕ, p.Prime → Nat.Coprime p L → ∃ c d : R, ∀ m : ℕ, Nat.Coprime m L →
       a (p * m) = c * a m - if p ∣ m then d * a (m / p) else 0)
     (h1 : a 1 = 0) (n : ℕ) (hn0 : n ≠ 0) (hn : Nat.Coprime n L) : a n = 0 := by
+  -- Strong induction on `n`: the recurrence at the least prime factor of `n` expresses `a n`
+  -- through terms at smaller indices, which remain coprime to `L`.
   induction n using Nat.strong_induction_on with
   | _ n ih =>
   rcases Nat.lt_or_ge n 2 with hn2 | hn2

--- a/TauCeti/NumberTheory/ArithmeticFunction/PrimeRecurrence.lean
+++ b/TauCeti/NumberTheory/ArithmeticFunction/PrimeRecurrence.lean
@@ -21,7 +21,7 @@ eigenform with `a₁ = 0` at the good indices, where `c` is the eigenvalue at `p
 
 ## Main results
 
-* `TauCeti.eq_zero_of_coprime_of_forall_prime_mul_eq`: the vanishing, by strong induction along
+* `TauCeti.eq_zero_of_forall_prime_mul_eq_of_coprime`: the vanishing, by strong induction along
   the least prime factor.
 
 ## References
@@ -42,7 +42,7 @@ coprime to `L`.** If at every prime `p` coprime to `L` there are scalars `c`, `d
 `a_{pm} = c · a_m − d · a_{m/p}` (the last term only when `p ∣ m`) for every `m` coprime to `L`,
 and `a₁ = 0`, then `a_n = 0` for every `n ≠ 0` coprime to `L`: the recurrence along the least
 prime factor of `n` expresses `a_n` through terms at smaller indices coprime to `L`. -/
-theorem eq_zero_of_coprime_of_forall_prime_mul_eq {a : ℕ → R} {L : ℕ}
+theorem eq_zero_of_forall_prime_mul_eq_of_coprime {a : ℕ → R} {L : ℕ}
     (ha : ∀ p : ℕ, p.Prime → Nat.Coprime p L → ∃ c d : R, ∀ m : ℕ, Nat.Coprime m L →
       a (p * m) = c * a m - if p ∣ m then d * a (m / p) else 0)
     (h1 : a 1 = 0) (n : ℕ) (hn0 : n ≠ 0) (hn : Nat.Coprime n L) : a n = 0 := by

--- a/TauCeti/NumberTheory/ArithmeticFunction/PrimeRecurrence.lean
+++ b/TauCeti/NumberTheory/ArithmeticFunction/PrimeRecurrence.lean
@@ -12,12 +12,12 @@ public import Mathlib.Tactic.IntervalCases
 /-!
 # Sequences with a Hecke-type recurrence at the primes
 
-A sequence `a : ℕ → R` satisfying, at every prime `p` coprime to an auxiliary `L`, a recurrence
-`a_{pm} = c · a_m − d · a_{m/p}` (the last term present only when `p ∣ m`) for some scalars
-`c`, `d`, is determined at the indices coprime to `L` by `a₁`: if `a₁ = 0` then `a_n = 0` for
-every `n ≠ 0` coprime to `L`. This is the combinatorial content of the vanishing of the Fourier
-coefficients of a Hecke eigenform with `a₁ = 0` at the good indices, where `c` is the eigenvalue
-at `p` and `d = χ(p) p^{k−1}`.
+A sequence `a : ℕ → R` satisfying, at every prime `p` coprime to an auxiliary `L` and every `m`
+coprime to `L`, a recurrence `a_{pm} = c · a_m − d · a_{m/p}` (the last term present only when
+`p ∣ m`) for some scalars `c`, `d`, vanishes at every `n ≠ 0` coprime to `L` as soon as `a₁ = 0`.
+This is the combinatorial content of the vanishing of the Fourier coefficients of a Hecke
+eigenform with `a₁ = 0` at the good indices, where `c` is the eigenvalue at `p` and
+`d = χ(p) p^{k−1}`.
 
 ## Main results
 
@@ -33,11 +33,11 @@ variable {R : Type*} [NonUnitalNonAssocRing R]
 
 /-- **A sequence with a Hecke-type prime recurrence and `a₁ = 0` vanishes at the indices
 coprime to `L`.** If at every prime `p` coprime to `L` there are scalars `c`, `d` with
-`a_{pm} = c · a_m − d · a_{m/p}` (the last term only when `p ∣ m`) for every `m`, and `a₁ = 0`,
-then `a_n = 0` for every `n ≠ 0` coprime to `L`: the recurrence along the least prime factor of
-`n` expresses `a_n` through terms at smaller indices coprime to `L`. -/
+`a_{pm} = c · a_m − d · a_{m/p}` (the last term only when `p ∣ m`) for every `m` coprime to `L`,
+and `a₁ = 0`, then `a_n = 0` for every `n ≠ 0` coprime to `L`: the recurrence along the least
+prime factor of `n` expresses `a_n` through terms at smaller indices coprime to `L`. -/
 theorem eq_zero_of_coprime_of_forall_prime_mul_eq {a : ℕ → R} {L : ℕ}
-    (ha : ∀ p : ℕ, p.Prime → Nat.Coprime p L → ∃ c d : R, ∀ m : ℕ,
+    (ha : ∀ p : ℕ, p.Prime → Nat.Coprime p L → ∃ c d : R, ∀ m : ℕ, Nat.Coprime m L →
       a (p * m) = c * a m - if p ∣ m then d * a (m / p) else 0)
     (h1 : a 1 = 0) (n : ℕ) (hn0 : n ≠ 0) (hn : Nat.Coprime n L) : a n = 0 := by
   induction n using Nat.strong_induction_on with
@@ -54,7 +54,7 @@ theorem eq_zero_of_coprime_of_forall_prime_mul_eq {a : ℕ → R} {L : ℕ}
   have hmn : m < n :=
     hm ▸ (Nat.lt_mul_iff_one_lt_left (Nat.pos_of_ne_zero hm0)).mpr hp.one_lt
   obtain ⟨c, d, hcd⟩ := ha _ hp hpL
-  rw [hm, hcd m, ih m hmn hm0 hmL, mul_zero, zero_sub]
+  rw [hm, hcd m hmL, ih m hmn hm0 hmL, mul_zero, zero_sub]
   split_ifs with hpm
   · rw [ih (m / n.minFac) ((Nat.div_le_self m _).trans_lt hmn)
       (Nat.div_ne_zero_iff_of_dvd hpm |>.mpr ⟨hm0, hp.ne_zero⟩)

--- a/TauCeti/NumberTheory/ArithmeticFunction/PrimeRecurrence.lean
+++ b/TauCeti/NumberTheory/ArithmeticFunction/PrimeRecurrence.lean
@@ -21,8 +21,8 @@ eigenform with `a₁ = 0` at the good indices, where `c` is the eigenvalue at `p
 
 ## Main results
 
-* `TauCeti.eq_zero_of_forall_prime_mul_eq_of_coprime`: the vanishing, by strong induction along
-  the least prime factor.
+* `TauCeti.eq_zero_of_forall_prime_mul_eq_of_one_eq_zero_of_ne_zero_of_coprime`: the vanishing,
+  by strong induction along the least prime factor.
 
 ## References
 
@@ -42,7 +42,7 @@ coprime to `L`.** If at every prime `p` coprime to `L` there are scalars `c`, `d
 `a_{pm} = c · a_m − d · a_{m/p}` (the last term only when `p ∣ m`) for every `m` coprime to `L`,
 and `a₁ = 0`, then `a_n = 0` for every `n ≠ 0` coprime to `L`: the recurrence along the least
 prime factor of `n` expresses `a_n` through terms at smaller indices coprime to `L`. -/
-theorem eq_zero_of_forall_prime_mul_eq_of_coprime {a : ℕ → R} {L : ℕ}
+theorem eq_zero_of_forall_prime_mul_eq_of_one_eq_zero_of_ne_zero_of_coprime {a : ℕ → R} {L : ℕ}
     (ha : ∀ p : ℕ, p.Prime → Nat.Coprime p L → ∃ c d : R, ∀ m : ℕ, Nat.Coprime m L →
       a (p * m) = c * a m - if p ∣ m then d * a (m / p) else 0)
     (h1 : a 1 = 0) (n : ℕ) (hn0 : n ≠ 0) (hn : Nat.Coprime n L) : a n = 0 := by

--- a/TauCeti/NumberTheory/ArithmeticFunction/PrimeRecurrence.lean
+++ b/TauCeti/NumberTheory/ArithmeticFunction/PrimeRecurrence.lean
@@ -1,0 +1,64 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Data.Nat.GCD.Basic
+public import Mathlib.Data.Nat.Prime.Basic
+public import Mathlib.Tactic.IntervalCases
+
+/-!
+# Sequences with a Hecke-type recurrence at the primes
+
+A sequence `a : ℕ → R` satisfying, at every prime `p` coprime to an auxiliary `L`, a recurrence
+`a_{pm} = c · a_m − d · a_{m/p}` (the last term present only when `p ∣ m`) for some scalars
+`c`, `d`, is determined at the indices coprime to `L` by `a₁`: if `a₁ = 0` then `a_n = 0` for
+every `n ≠ 0` coprime to `L`. This is the combinatorial content of the vanishing of the Fourier
+coefficients of a Hecke eigenform with `a₁ = 0` at the good indices, where `c` is the eigenvalue
+at `p` and `d = χ(p) p^{k−1}`.
+
+## Main results
+
+* `TauCeti.eq_zero_of_coprime_of_forall_prime_mul_eq`: the vanishing, by strong induction along
+  the least prime factor.
+-/
+
+public section
+
+namespace TauCeti
+
+variable {R : Type*} [CommRing R]
+
+/-- **A sequence with a Hecke-type prime recurrence and `a₁ = 0` vanishes at the indices
+coprime to `L`.** If at every prime `p` coprime to `L` there are scalars `c`, `d` with
+`a_{pm} = c · a_m − d · a_{m/p}` (the last term only when `p ∣ m`) for every `m`, and `a₁ = 0`,
+then `a_n = 0` for every `n ≠ 0` coprime to `L`: the recurrence along the least prime factor of
+`n` expresses `a_n` through terms at smaller indices coprime to `L`. -/
+theorem eq_zero_of_coprime_of_forall_prime_mul_eq {a : ℕ → R} {L : ℕ}
+    (ha : ∀ p : ℕ, p.Prime → Nat.Coprime p L → ∃ c d : R, ∀ m : ℕ,
+      a (p * m) = c * a m - if p ∣ m then d * a (m / p) else 0)
+    (h1 : a 1 = 0) (n : ℕ) (hn0 : n ≠ 0) (hn : Nat.Coprime n L) : a n = 0 := by
+  induction n using Nat.strong_induction_on with
+  | _ n ih =>
+  rcases Nat.lt_or_ge n 2 with hn2 | hn2
+  · interval_cases n
+    · exact absurd rfl hn0
+    · exact h1
+  have hp : n.minFac.Prime := Nat.minFac_prime (by omega)
+  obtain ⟨m, hm⟩ := Nat.minFac_dvd n
+  have hpL : Nat.Coprime n.minFac L := Nat.Coprime.coprime_dvd_left (Nat.minFac_dvd n) hn
+  have hmL : Nat.Coprime m L := Nat.Coprime.coprime_dvd_left (Dvd.intro_left _ hm.symm) hn
+  have hm0 : m ≠ 0 := fun h0 ↦ hn0 (by rw [hm, h0, mul_zero])
+  have hmn : m < n :=
+    hm ▸ (Nat.lt_mul_iff_one_lt_left (Nat.pos_of_ne_zero hm0)).mpr hp.one_lt
+  obtain ⟨c, d, hcd⟩ := ha _ hp hpL
+  rw [hm, hcd m, ih m hmn hm0 hmL, mul_zero, zero_sub]
+  split_ifs with hpm
+  · rw [ih (m / n.minFac) ((Nat.div_le_self m _).trans_lt hmn)
+      (Nat.div_ne_zero_iff_of_dvd hpm |>.mpr ⟨hm0, hp.ne_zero⟩)
+      (Nat.Coprime.coprime_div_left hmL hpm), mul_zero, neg_zero]
+  · exact neg_zero
+
+end TauCeti

--- a/TauCeti/NumberTheory/ArithmeticFunction/PrimeRecurrence.lean
+++ b/TauCeti/NumberTheory/ArithmeticFunction/PrimeRecurrence.lean
@@ -29,7 +29,7 @@ public section
 
 namespace TauCeti
 
-variable {R : Type*} [CommRing R]
+variable {R : Type*} [NonUnitalNonAssocRing R]
 
 /-- **A sequence with a Hecke-type prime recurrence and `a₁ = 0` vanishes at the indices
 coprime to `L`.** If at every prime `p` coprime to `L` there are scalars `c`, `d` with

--- a/TauCeti/NumberTheory/ArithmeticFunction/PrimeRecurrence.lean
+++ b/TauCeti/NumberTheory/ArithmeticFunction/PrimeRecurrence.lean
@@ -7,7 +7,7 @@ module
 
 public import Mathlib.Data.Nat.GCD.Basic
 public import Mathlib.Data.Nat.Prime.Basic
-public import Mathlib.Tactic.IntervalCases
+import Mathlib.Tactic.IntervalCases
 
 /-!
 # Sequences with a Hecke-type recurrence at the primes
@@ -23,6 +23,12 @@ eigenform with `a₁ = 0` at the good indices, where `c` is the eigenvalue at `p
 
 * `TauCeti.eq_zero_of_coprime_of_forall_prime_mul_eq`: the vanishing, by strong induction along
   the least prime factor.
+
+## References
+
+* [T. Miyake, *Modular forms*][miyake1989], §4.6 — the vanishing induction this lemma is the
+  arithmetic core of.
+* [F. Diamond and J. Shurman, *A first course in modular forms*][diamondshurman2005], §5.8.
 -/
 
 public section

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Eigenvector.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Eigenvector.lean
@@ -22,21 +22,23 @@ coefficients of `F` alone:
 
 `a_{pm}(F) = c · a_m(F) − χ(p) p^{k−1} a_{m/p}(F)`, the last term present only when `p ∣ m`.
 
-Running it along the least prime factor shows that a cusp form which is an eigenvector at every
+Running it along the least prime factor shows that a form which is an eigenvector at every
 prime outside an auxiliary level `L` (a multiple of `N`) and has `a₁ = 0` has `a_n = 0` at every
-index `n` coprime to `L`. This is the form in which strong multiplicity one consumes eigen-ness
-(Miyake's Theorem 4.6.12 assumes agreement at the indices prime to such an `L`): the difference
-of two newforms whose eigenvalues agree outside `L` has `a₁ = 1 − 1 = 0`, so its coefficients at
-the indices prime to `L` all vanish, and the descent argument then places it in the old
-subspace.
+nonzero index `n` coprime to `L` — at `n = 0` as well when it is a cusp form. This is the form
+in which strong multiplicity one consumes eigen-ness (Miyake's Theorem 4.6.12 assumes agreement
+at the indices prime to such an `L`): the difference of two newforms whose eigenvalues agree
+outside `L` has `a₁ = 1 − 1 = 0`, so its coefficients at the indices prime to `L` all vanish,
+and the descent argument then places it in the old subspace.
 
 ## Main results
 
 * `HeckeRing.GL2.qExpansion_coeff_mul_of_heckeRingHomCharSpace_eq_smul`,
   `HeckeRing.GL2.qExpansion_coeff_mul_of_heckeRingHomCuspCharSpace_eq_smul`: the coefficient
   recurrence of an eigenvector, on `M_k(N, χ)` and on `S_k(N, χ)`.
-* `HeckeRing.GL2.qExpansion_coeff_eq_zero_of_coprime_of_forall_prime`: a cusp form that is an
-  eigenvector at every prime `p ∤ L` and has `a₁ = 0` has `a_n = 0` at every `n` coprime to `L`.
+* `HeckeRing.GL2.qExpansion_coeff_eq_zero_of_coprime_of_forall_prime_of_ne_zero`,
+  `HeckeRing.GL2.qExpansion_coeff_eq_zero_of_coprime_of_forall_prime`: a form in `M_k(N, χ)`
+  (respectively `S_k(N, χ)`) that is an eigenvector at every prime `p ∤ L` and has `a₁ = 0` has
+  `a_n = 0` at every `n ≠ 0` (respectively every `n`) coprime to `L`.
 
 ## References
 
@@ -55,14 +57,6 @@ namespace HeckeRing.GL2
 
 variable {N p : ℕ} [NeZero N] {k : ℤ} {χ : (ZMod N)ˣ →* ℂˣ}
 
-omit [NeZero N] in
-/-- The transport of a scalar through the `m`-th Fourier coefficient. -/
-private theorem qExpansion_coeff_smul {F : Type*} [FunLike F ℍ ℂ]
-    [ModularFormClass F ((Gamma1 N).map (mapGL ℝ)) k] (c : ℂ) (f : F) (m : ℕ) :
-    (qExpansion 1 (c • ⇑f)).coeff m = c * (qExpansion 1 f).coeff m := by
-  rw [ModularForm.qExpansion_smul one_pos (TauCeti.one_mem_strictPeriods_Gamma1_map _), map_smul,
-    smul_eq_mul]
-
 /-- **The coefficient recurrence of an eigenvector at a good prime, on `M_k(N, χ)`.** If the ring
 generator at `p ∤ N` acts on `F ∈ M_k(N, χ)` by the scalar `c`, then
 `a_{pm}(F) = c · a_m(F) − χ(p) p^{k−1} a_{m/p}(F)`, the last term present only when `p ∣ m`. -/
@@ -80,7 +74,9 @@ theorem qExpansion_coeff_mul_of_heckeRingHomCharSpace_eq_smul (hp : p.Prime)
       using congrArg Subtype.val hF
   have h := qExpansion_coeff_heckeSlashGamma1ModularFormEnd_diagCosetGamma1_of_mem_modFormCharSpace
     k hp hpN χ F.2 m
-  rw [← heckeTNat_def, hT, FunLike.coe_smul, qExpansion_coeff_smul] at h
+  rw [← heckeTNat_def, hT, FunLike.coe_smul,
+    ModularForm.qExpansion_smul one_pos (TauCeti.one_mem_strictPeriods_Gamma1_map _), map_smul,
+    smul_eq_mul] at h
   linear_combination -h
 
 /-- **The coefficient recurrence of an eigenvector at a good prime, on `S_k(N, χ)`.** If the ring
@@ -100,45 +96,79 @@ theorem qExpansion_coeff_mul_of_heckeRingHomCuspCharSpace_eq_smul (hp : p.Prime)
       heckeRingHomCuspCharSpace_heckeTGeneratorGamma0 k χ hp] using congrArg Subtype.val hF
   have h := qExpansion_coeff_heckeSlashGamma1CuspFormEnd_diagCosetGamma1_of_mem_cuspFormCharSpace
     k hp hpN χ F.2 m
-  rw [← heckeTCuspNat_def, hT, FunLike.coe_smul, qExpansion_coeff_smul] at h
+  rw [← heckeTCuspNat_def, hT, FunLike.coe_smul,
+    ModularForm.qExpansion_smul one_pos (TauCeti.one_mem_strictPeriods_Gamma1_map _), map_smul,
+    smul_eq_mul] at h
   linear_combination -h
 
-/-- **Coefficient vanishing from the prime eigenvalues.** Let `L` be a multiple of `N`. A cusp
-form `F ∈ S_k(N, χ)` that is an eigenvector of the ring generator at every prime `p ∤ L` and has
-`a₁(F) = 0` has `a_n(F) = 0` at every `n` coprime to `L`: the recurrence
-`qExpansion_coeff_mul_of_heckeRingHomCuspCharSpace_eq_smul` along the least prime factor of `n`
-expresses `a_n` through coefficients at smaller indices coprime to `L`. The auxiliary level `L`
-is the finite slack of strong multiplicity one: eigen-ness is assumed only away from finitely
-many primes beyond those dividing `N`. -/
+omit [NeZero N] in
+/-- The induction behind coefficient vanishing, on a bare sequence: if `a₁ = 0` and, at every
+prime `p ∤ L`, `a_{pm} = c · a_m − d · a_{m/p}` (the last term only when `p ∣ m`) for some scalars
+`c`, `d`, then `a_n = 0` at every `n ≠ 0` coprime to `L`: the recurrence along the least prime
+factor of `n` expresses `a_n` through coefficients at smaller indices coprime to `L`. -/
+private theorem eq_zero_of_coprime_of_forall_prime_mul_eq {a : ℕ → ℂ} {L : ℕ}
+    (ha : ∀ p : ℕ, p.Prime → Nat.Coprime p L → ∃ c d : ℂ, ∀ m : ℕ,
+      a (p * m) = c * a m - if p ∣ m then d * a (m / p) else 0)
+    (h1 : a 1 = 0) (n : ℕ) (hn0 : n ≠ 0) (hn : Nat.Coprime n L) : a n = 0 := by
+  induction n using Nat.strong_induction_on with
+  | _ n ih =>
+  rcases Nat.lt_or_ge n 2 with hn2 | hn2
+  · interval_cases n
+    · exact absurd rfl hn0
+    · exact h1
+  have hp : n.minFac.Prime := Nat.minFac_prime (by omega)
+  obtain ⟨m, hm⟩ := Nat.minFac_dvd n
+  have hpL : Nat.Coprime n.minFac L := Nat.Coprime.coprime_dvd_left (Nat.minFac_dvd n) hn
+  have hmL : Nat.Coprime m L := Nat.Coprime.coprime_dvd_left (Dvd.intro_left _ hm.symm) hn
+  have hm0 : m ≠ 0 := fun h0 ↦ hn0 (by rw [hm, h0, mul_zero])
+  have hmn : m < n :=
+    hm ▸ (Nat.lt_mul_iff_one_lt_left (Nat.pos_of_ne_zero hm0)).mpr hp.one_lt
+  obtain ⟨c, d, hcd⟩ := ha _ hp hpL
+  rw [hm, hcd m, ih m hmn hm0 hmL, mul_zero, zero_sub]
+  split_ifs with hpm
+  · rw [ih (m / n.minFac) ((Nat.div_le_self m _).trans_lt hmn)
+      (Nat.div_ne_zero_iff_of_dvd hpm |>.mpr ⟨hm0, hp.ne_zero⟩)
+      (Nat.Coprime.coprime_div_left hmL hpm), mul_zero, neg_zero]
+  · exact neg_zero
+
+/-- **Coefficient vanishing from the prime eigenvalues, on `M_k(N, χ)`.** Let `L` be a multiple of
+`N`. A form `F ∈ M_k(N, χ)` that is an eigenvector of the ring generator at every prime `p ∤ L`
+and has `a₁(F) = 0` has `a_n(F) = 0` at every `n ≠ 0` coprime to `L`, by the recurrence
+`qExpansion_coeff_mul_of_heckeRingHomCharSpace_eq_smul` along the least prime factor of `n`.
+The auxiliary level `L` is the finite slack of strong multiplicity one: eigen-ness is assumed
+only away from finitely many primes beyond those dividing `N`. -/
+theorem qExpansion_coeff_eq_zero_of_coprime_of_forall_prime_of_ne_zero {F : modFormCharSpace k χ}
+    {L : ℕ} (hNL : N ∣ L) (ha : ∀ p : ℕ, p.Prime → Nat.Coprime p L →
+      ∃ c : ℂ, heckeRingHomCharSpace k χ (heckeTCompositeGamma0 N p) F = c • F)
+    (h1 : (qExpansion 1 (F : ModularForm ((Gamma1 N).map (mapGL ℝ)) k)).coeff 1 = 0) (n : ℕ)
+    (hn0 : n ≠ 0) (hn : Nat.Coprime n L) :
+    (qExpansion 1 (F : ModularForm ((Gamma1 N).map (mapGL ℝ)) k)).coeff n = 0 :=
+  eq_zero_of_coprime_of_forall_prime_mul_eq
+    (a := fun n ↦ (qExpansion 1 (F : ModularForm ((Gamma1 N).map (mapGL ℝ)) k)).coeff n)
+    (fun p hp hpL ↦ by
+    obtain ⟨c, hc⟩ := ha p hp hpL
+    exact ⟨c, _, qExpansion_coeff_mul_of_heckeRingHomCharSpace_eq_smul hp
+      (hpL.coprime_dvd_right hNL) hc⟩) h1 n hn0 hn
+
+/-- **Coefficient vanishing from the prime eigenvalues, on `S_k(N, χ)`.** Let `L` be a multiple of
+`N`. A cusp form `F ∈ S_k(N, χ)` that is an eigenvector of the ring generator at every prime
+`p ∤ L` and has `a₁(F) = 0` has `a_n(F) = 0` at every `n` coprime to `L`: at `n = 0` by
+cuspidality, otherwise by the recurrence
+`qExpansion_coeff_mul_of_heckeRingHomCuspCharSpace_eq_smul` along the least prime factor of `n`.
+This is the form strong multiplicity one consumes. -/
 theorem qExpansion_coeff_eq_zero_of_coprime_of_forall_prime {F : cuspFormCharSpace k χ} {L : ℕ}
     (hNL : N ∣ L) (ha : ∀ p : ℕ, p.Prime → Nat.Coprime p L →
       ∃ c : ℂ, heckeRingHomCuspCharSpace k χ (heckeTCompositeGamma0 N p) F = c • F)
     (h1 : (qExpansion 1 (F : CuspForm ((Gamma1 N).map (mapGL ℝ)) k)).coeff 1 = 0) (n : ℕ)
     (hn : Nat.Coprime n L) :
     (qExpansion 1 (F : CuspForm ((Gamma1 N).map (mapGL ℝ)) k)).coeff n = 0 := by
-  induction n using Nat.strong_induction_on with
-  | _ n ih =>
-  rcases Nat.lt_or_ge n 2 with hn2 | hn2
-  · interval_cases n
-    · exact CuspFormClass.qExpansion_coeff_zero _ one_pos
-        (TauCeti.one_mem_strictPeriods_Gamma1_map N)
-    · exact h1
-  have hp : n.minFac.Prime := Nat.minFac_prime (by omega)
-  obtain ⟨m, hm⟩ := Nat.minFac_dvd n
-  have hpL : Nat.Coprime n.minFac L := Nat.Coprime.coprime_dvd_left (Nat.minFac_dvd n) hn
-  have hmL : Nat.Coprime m L := Nat.Coprime.coprime_dvd_left (Dvd.intro_left _ hm.symm) hn
-  have hmn : m < n := by
-    rcases Nat.eq_zero_or_pos m with h0 | h0
-    · rw [h0, mul_zero] at hm
-      omega
-    · calc m < n.minFac * m := (Nat.lt_mul_iff_one_lt_left h0).mpr hp.one_lt
-        _ = n := hm.symm
-  obtain ⟨c, hc⟩ := ha _ hp hpL
-  rw [hm, qExpansion_coeff_mul_of_heckeRingHomCuspCharSpace_eq_smul hp
-    (hpL.coprime_dvd_right hNL) hc m, ih m hmn hmL, mul_zero, zero_sub]
-  split_ifs with hpm
-  · rw [ih (m / n.minFac) ((Nat.div_le_self m _).trans_lt hmn)
-      (Nat.Coprime.coprime_div_left hmL hpm), mul_zero, neg_zero]
-  · exact neg_zero
+  rcases eq_or_ne n 0 with rfl | hn0
+  · exact CuspFormClass.qExpansion_coeff_zero _ one_pos (TauCeti.one_mem_strictPeriods_Gamma1_map N)
+  exact eq_zero_of_coprime_of_forall_prime_mul_eq
+    (a := fun n ↦ (qExpansion 1 (F : CuspForm ((Gamma1 N).map (mapGL ℝ)) k)).coeff n)
+    (fun p hp hpL ↦ by
+    obtain ⟨c, hc⟩ := ha p hp hpL
+    exact ⟨c, _, qExpansion_coeff_mul_of_heckeRingHomCuspCharSpace_eq_smul hp
+      (hpL.coprime_dvd_right hNL) hc⟩) h1 n hn0 hn
 
 end HeckeRing.GL2

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Eigenvector.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Eigenvector.lean
@@ -37,13 +37,13 @@ and the descent argument then places it in the old subspace.
 * `qExpansion_coeff_prime_mul_of_heckeRingHomCharSpace_heckeTCompositeGamma0_eq_smul` and its
   cusp-form counterpart `…_of_heckeRingHomCuspCharSpace_…`: the coefficient recurrence of an
   eigenvector, on `M_k(N, χ)` and on `S_k(N, χ)`.
-* `qExpansion_coeff_eq_zero_of_coprime_of_forall_prime_heckeRingHomCharSpace_of_ne_zero` and
+* `qExpansion_coeff_eq_zero_of_forall_prime_heckeRingHomCharSpace_of_ne_zero_of_coprime` and
   `…_heckeRingHomCuspCharSpace`: a form eigen at every prime away from a multiple `L` of `N`,
   with `a₁ = 0`, has `a_n = 0` at every `n` coprime to `L` (and `n ≠ 0` in the modular-form
   case).
 * `heckeTNat_eq_smul_of_heckeRingHomCharSpace_heckeTCompositeGamma0_eq_smul` and its cusp-form
   counterpart: a Hecke-ring eigenvector at a good prime is an eigenvector of the classical
-  operator, the comparison `Newforms/Newform.lean` records as not proved there.
+  operator `heckeTNat` (resp. `heckeTCuspNat`).
 
 ## References
 
@@ -66,7 +66,7 @@ variable {N p : ℕ} [NeZero N] {k : ℤ} {χ : (ZMod N)ˣ →* ℂˣ}
 `M_k(N, χ)`. The Hecke ring's composite element at a prime is its generator
 (`heckeTCompositeGamma0_prime`), which acts as the classical operator
 (`heckeRingHomCharSpace_heckeTGeneratorGamma0`); so an eigen-equation for the ring action is one
-for `heckeTNat`. This is the comparison `Newforms/Newform.lean` records as not proved there. -/
+for `heckeTNat`. -/
 theorem heckeTNat_eq_smul_of_heckeRingHomCharSpace_heckeTCompositeGamma0_eq_smul [NeZero p]
     (hp : p.Prime) {F : modFormCharSpace k χ} {c : ℂ}
     (hF : heckeRingHomCharSpace k χ (heckeTCompositeGamma0 N p) F = c • F) :
@@ -131,13 +131,13 @@ and has `a₁(F) = 0` has `a_n(F) = 0` at every `n ≠ 0` coprime to `L`, by the
   prime factor of `n`.
 For `L ≠ 0`, the auxiliary level is the finite slack of strong multiplicity one: eigen-ness is
 assumed only away from finitely many primes beyond those dividing `N`. -/
-theorem qExpansion_coeff_eq_zero_of_coprime_of_forall_prime_heckeRingHomCharSpace_of_ne_zero
+theorem qExpansion_coeff_eq_zero_of_forall_prime_heckeRingHomCharSpace_of_ne_zero_of_coprime
     {F : modFormCharSpace k χ} {L : ℕ} (hNL : N ∣ L) (ha : ∀ p : ℕ, p.Prime → Nat.Coprime p L →
       ∃ c : ℂ, heckeRingHomCharSpace k χ (heckeTCompositeGamma0 N p) F = c • F)
     (h1 : (qExpansion 1 (F : ModularForm ((Gamma1 N).map (mapGL ℝ)) k)).coeff 1 = 0) (n : ℕ)
     (hn0 : n ≠ 0) (hn : Nat.Coprime n L) :
     (qExpansion 1 (F : ModularForm ((Gamma1 N).map (mapGL ℝ)) k)).coeff n = 0 :=
-  TauCeti.eq_zero_of_coprime_of_forall_prime_mul_eq
+  TauCeti.eq_zero_of_forall_prime_mul_eq_of_coprime
     (a := fun n ↦ (qExpansion 1 (F : ModularForm ((Gamma1 N).map (mapGL ℝ)) k)).coeff n)
     (fun p hp hpL ↦ by
     obtain ⟨c, hc⟩ := ha p hp hpL
@@ -152,7 +152,7 @@ cuspidality, otherwise by the recurrence
 `qExpansion_coeff_prime_mul_of_heckeRingHomCuspCharSpace_heckeTCompositeGamma0_eq_smul` along the
   least prime factor
 of `n`. This is the form strong multiplicity one consumes. -/
-theorem qExpansion_coeff_eq_zero_of_coprime_of_forall_prime_heckeRingHomCuspCharSpace
+theorem qExpansion_coeff_eq_zero_of_forall_prime_heckeRingHomCuspCharSpace_of_coprime
     {F : cuspFormCharSpace k χ} {L : ℕ} (hNL : N ∣ L) (ha : ∀ p : ℕ, p.Prime → Nat.Coprime p L →
       ∃ c : ℂ, heckeRingHomCuspCharSpace k χ (heckeTCompositeGamma0 N p) F = c • F)
     (h1 : (qExpansion 1 (F : CuspForm ((Gamma1 N).map (mapGL ℝ)) k)).coeff 1 = 0) (n : ℕ)
@@ -160,7 +160,7 @@ theorem qExpansion_coeff_eq_zero_of_coprime_of_forall_prime_heckeRingHomCuspChar
     (qExpansion 1 (F : CuspForm ((Gamma1 N).map (mapGL ℝ)) k)).coeff n = 0 := by
   rcases eq_or_ne n 0 with rfl | hn0
   · exact CuspFormClass.qExpansion_coeff_zero _ one_pos (TauCeti.one_mem_strictPeriods_Gamma1_map N)
-  exact TauCeti.eq_zero_of_coprime_of_forall_prime_mul_eq
+  exact TauCeti.eq_zero_of_forall_prime_mul_eq_of_coprime
     (a := fun n ↦ (qExpansion 1 (F : CuspForm ((Gamma1 N).map (mapGL ℝ)) k)).coeff n)
     (fun p hp hpL ↦ by
     obtain ⟨c, hc⟩ := ha p hp hpL

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Eigenvector.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Eigenvector.lean
@@ -6,36 +6,37 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.NumberTheory.HeckeRing.GL2.Gamma0.Diagonal.Composite
-public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Nebentypus.Action
 public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Nebentypus.Prime
 public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Recurrence
 
 /-!
 # Fourier coefficients of a Hecke-ring eigenvector at the good primes
 
-Let `F ∈ S_k(N, χ)` be an eigenvector of the `Γ₀(N)` Hecke-ring generator at a prime `p ∤ N`,
-acting through `heckeRingHomCuspCharSpace`, with eigenvalue `c`. Through the identification of
-that generator with the classical `T_p`
-(`coe_twistedHeckeSlashCuspFormCharEnd_diagCosetGamma0_of_prime`) and the coefficient formula
-`a_m(T_p F) = a_{pm}(F) + χ(p) p^{k−1} a_{m/p}(F)` of `HeckeSlash/Recurrence.lean`, the
-eigenvector equation becomes a recurrence on the Fourier coefficients of `F` alone:
+Let `F ∈ M_k(N, χ)` (or `S_k(N, χ)`) be an eigenvector of the `Γ₀(N)` Hecke-ring generator at a
+prime `p ∤ N`, acting through `heckeRingHomCharSpace` (`heckeRingHomCuspCharSpace`), with
+eigenvalue `c`. Through the identification of that generator with the classical `T_p`
+(`heckeRingHomCharSpace_heckeTGeneratorGamma0`, `heckeRingHomCuspCharSpace_heckeTGeneratorGamma0`)
+and the coefficient formula `a_m(T_p F) = a_{pm}(F) + χ(p) p^{k−1} a_{m/p}(F)` of
+`HeckeSlash/Recurrence.lean`, the eigenvector equation becomes a recurrence on the Fourier
+coefficients of `F` alone:
 
 `a_{pm}(F) = c · a_m(F) − χ(p) p^{k−1} a_{m/p}(F)`, the last term present only when `p ∣ m`.
 
-Running it along the least prime factor shows that a form which is an eigenvector at *every*
-good prime and has `a₁ = 0` has `a_n = 0` at every index `n` coprime to the level. This is the
-form in which strong multiplicity one consumes eigen-ness: the difference of two newforms with
-the same good eigenvalues has `a₁ = 1 − 1 = 0`, so all its good coefficients vanish, and the
-descent argument then places it in the old subspace.
+Running it along the least prime factor shows that a cusp form which is an eigenvector at every
+prime outside an auxiliary level `L` (a multiple of `N`) and has `a₁ = 0` has `a_n = 0` at every
+index `n` coprime to `L`. This is the form in which strong multiplicity one consumes eigen-ness
+(Miyake's Theorem 4.6.12 assumes agreement at the indices prime to such an `L`): the difference
+of two newforms whose eigenvalues agree outside `L` has `a₁ = 1 − 1 = 0`, so its coefficients at
+the indices prime to `L` all vanish, and the descent argument then places it in the old
+subspace.
 
 ## Main results
 
-* `HeckeRing.GL2.coe_heckeRingHomCuspCharSpace_heckeTCompositeGamma0_prime`: the ring element
-  at a prime acts on `S_k(N, χ)` as the classical `T_p`, at the level of functions.
-* `HeckeRing.GL2.qExpansion_coeff_mul_of_heckeRingHomCuspCharSpace_eq_smul`: the coefficient
-  recurrence of an eigenvector.
-* `HeckeRing.GL2.qExpansion_coeff_eq_zero_of_coprime_of_forall_prime`: an eigenvector at every
-  good prime with `a₁ = 0` has `a_n = 0` at every `n` coprime to `N`.
+* `HeckeRing.GL2.qExpansion_coeff_mul_of_heckeRingHomCharSpace_eq_smul`,
+  `HeckeRing.GL2.qExpansion_coeff_mul_of_heckeRingHomCuspCharSpace_eq_smul`: the coefficient
+  recurrence of an eigenvector, on `M_k(N, χ)` and on `S_k(N, χ)`.
+* `HeckeRing.GL2.qExpansion_coeff_eq_zero_of_coprime_of_forall_prime`: a cusp form that is an
+  eigenvector at every prime `p ∤ L` and has `a₁ = 0` has `a_n = 0` at every `n` coprime to `L`.
 
 ## References
 
@@ -54,20 +55,36 @@ namespace HeckeRing.GL2
 
 variable {N p : ℕ} [NeZero N] {k : ℤ} {χ : (ZMod N)ˣ →* ℂˣ}
 
-/-- **The ring element at a prime is the classical `T_p`**, on the functions underlying
-the character space: `heckeTCompositeGamma0 N p` is the generator `heckeTGeneratorGamma0 N p`,
-which acts through `heckeRingHomCuspCharSpace` as `heckeTCuspNat k p` does on the underlying
-cusp form (`coe_heckeRingHomCuspCharSpace_heckeTGeneratorGamma0`). -/
-theorem coe_heckeRingHomCuspCharSpace_heckeTCompositeGamma0_prime (hp : p.Prime)
-    (F : cuspFormCharSpace k χ) :
-    ⇑((heckeRingHomCuspCharSpace k χ (heckeTCompositeGamma0 N p) F :
-        CuspForm ((Gamma1 N).map (mapGL ℝ)) k)) =
-      ⇑(heckeTCuspNat k p (_hn := ⟨hp.ne_zero⟩) (F : CuspForm ((Gamma1 N).map (mapGL ℝ)) k)) := by
-  rw [heckeTCompositeGamma0_prime N hp,
-    coe_heckeRingHomCuspCharSpace_heckeTGeneratorGamma0 k χ hp F]
+omit [NeZero N] in
+/-- The transport of a scalar through the `m`-th Fourier coefficient. -/
+private theorem qExpansion_coeff_smul {F : Type*} [FunLike F ℍ ℂ]
+    [ModularFormClass F ((Gamma1 N).map (mapGL ℝ)) k] (c : ℂ) (f : F) (m : ℕ) :
+    (qExpansion 1 (c • ⇑f)).coeff m = c * (qExpansion 1 f).coeff m := by
+  rw [ModularForm.qExpansion_smul one_pos (TauCeti.one_mem_strictPeriods_Gamma1_map _), map_smul,
+    smul_eq_mul]
 
-/-- **The coefficient recurrence of an eigenvector at a good prime.** If the ring generator at
-`p ∤ N` acts on `F ∈ S_k(N, χ)` by the scalar `c`, then
+/-- **The coefficient recurrence of an eigenvector at a good prime, on `M_k(N, χ)`.** If the ring
+generator at `p ∤ N` acts on `F ∈ M_k(N, χ)` by the scalar `c`, then
+`a_{pm}(F) = c · a_m(F) − χ(p) p^{k−1} a_{m/p}(F)`, the last term present only when `p ∣ m`. -/
+theorem qExpansion_coeff_mul_of_heckeRingHomCharSpace_eq_smul (hp : p.Prime)
+    (hpN : Nat.Coprime p N) {F : modFormCharSpace k χ} {c : ℂ}
+    (hF : heckeRingHomCharSpace k χ (heckeTCompositeGamma0 N p) F = c • F) (m : ℕ) :
+    (qExpansion 1 (F : ModularForm ((Gamma1 N).map (mapGL ℝ)) k)).coeff (p * m) =
+      c * (qExpansion 1 (F : ModularForm ((Gamma1 N).map (mapGL ℝ)) k)).coeff m -
+        if p ∣ m then (χ (ZMod.unitOfCoprime p hpN) : ℂ) * (p : ℂ) ^ (k - 1) *
+          (qExpansion 1 (F : ModularForm ((Gamma1 N).map (mapGL ℝ)) k)).coeff (m / p) else 0 := by
+  have : NeZero p := ⟨hp.ne_zero⟩
+  have hT : heckeTNat k p (F : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) =
+      c • (F : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) := by
+    simpa [heckeTCompositeGamma0_prime N hp, heckeRingHomCharSpace_heckeTGeneratorGamma0 k χ hp]
+      using congrArg Subtype.val hF
+  have h := qExpansion_coeff_heckeSlashGamma1ModularFormEnd_diagCosetGamma1_of_mem_modFormCharSpace
+    k hp hpN χ F.2 m
+  rw [← heckeTNat_def, hT, FunLike.coe_smul, qExpansion_coeff_smul] at h
+  linear_combination -h
+
+/-- **The coefficient recurrence of an eigenvector at a good prime, on `S_k(N, χ)`.** If the ring
+generator at `p ∤ N` acts on `F ∈ S_k(N, χ)` by the scalar `c`, then
 `a_{pm}(F) = c · a_m(F) − χ(p) p^{k−1} a_{m/p}(F)`, the last term present only when `p ∣ m`. -/
 theorem qExpansion_coeff_mul_of_heckeRingHomCuspCharSpace_eq_smul (hp : p.Prime)
     (hpN : Nat.Coprime p N) {F : cuspFormCharSpace k χ} {c : ℂ}
@@ -77,24 +94,27 @@ theorem qExpansion_coeff_mul_of_heckeRingHomCuspCharSpace_eq_smul (hp : p.Prime)
         if p ∣ m then (χ (ZMod.unitOfCoprime p hpN) : ℂ) * (p : ℂ) ^ (k - 1) *
           (qExpansion 1 (F : CuspForm ((Gamma1 N).map (mapGL ℝ)) k)).coeff (m / p) else 0 := by
   have : NeZero p := ⟨hp.ne_zero⟩
+  have hT : heckeTCuspNat k p (F : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) =
+      c • (F : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) := by
+    simpa [heckeTCompositeGamma0_prime N hp,
+      heckeRingHomCuspCharSpace_heckeTGeneratorGamma0 k χ hp] using congrArg Subtype.val hF
   have h := qExpansion_coeff_heckeSlashGamma1CuspFormEnd_diagCosetGamma1_of_mem_cuspFormCharSpace
     k hp hpN χ F.2 m
-  rw [← heckeTCuspNat_def, ← coe_heckeRingHomCuspCharSpace_heckeTCompositeGamma0_prime hp F,
-    hF, Submodule.coe_smul, FunLike.coe_smul,
-    ModularForm.qExpansion_smul one_pos (TauCeti.one_mem_strictPeriods_Gamma1_map _), map_smul,
-    smul_eq_mul] at h
+  rw [← heckeTCuspNat_def, hT, FunLike.coe_smul, qExpansion_coeff_smul] at h
   linear_combination -h
 
-/-- **Coefficient vanishing from the prime eigenvalues.** A form `F ∈ S_k(N, χ)` that is an
-eigenvector of the ring generator at every prime `p ∤ N` and has `a₁(F) = 0` has `a_n(F) = 0` at
-every `n` coprime to `N`: the recurrence
+/-- **Coefficient vanishing from the prime eigenvalues.** Let `L` be a multiple of `N`. A cusp
+form `F ∈ S_k(N, χ)` that is an eigenvector of the ring generator at every prime `p ∤ L` and has
+`a₁(F) = 0` has `a_n(F) = 0` at every `n` coprime to `L`: the recurrence
 `qExpansion_coeff_mul_of_heckeRingHomCuspCharSpace_eq_smul` along the least prime factor of `n`
-expresses `a_n` through coefficients at smaller indices coprime to `N`. -/
-theorem qExpansion_coeff_eq_zero_of_coprime_of_forall_prime {F : cuspFormCharSpace k χ}
-    (a : ℕ → ℂ) (ha : ∀ p : ℕ, p.Prime → Nat.Coprime p N →
-      heckeRingHomCuspCharSpace k χ (heckeTCompositeGamma0 N p) F = a p • F)
+expresses `a_n` through coefficients at smaller indices coprime to `L`. The auxiliary level `L`
+is the finite slack of strong multiplicity one: eigen-ness is assumed only away from finitely
+many primes beyond those dividing `N`. -/
+theorem qExpansion_coeff_eq_zero_of_coprime_of_forall_prime {F : cuspFormCharSpace k χ} {L : ℕ}
+    (hNL : N ∣ L) (ha : ∀ p : ℕ, p.Prime → Nat.Coprime p L →
+      ∃ c : ℂ, heckeRingHomCuspCharSpace k χ (heckeTCompositeGamma0 N p) F = c • F)
     (h1 : (qExpansion 1 (F : CuspForm ((Gamma1 N).map (mapGL ℝ)) k)).coeff 1 = 0) (n : ℕ)
-    (hn : Nat.Coprime n N) :
+    (hn : Nat.Coprime n L) :
     (qExpansion 1 (F : CuspForm ((Gamma1 N).map (mapGL ℝ)) k)).coeff n = 0 := by
   induction n using Nat.strong_induction_on with
   | _ n ih =>
@@ -105,19 +125,20 @@ theorem qExpansion_coeff_eq_zero_of_coprime_of_forall_prime {F : cuspFormCharSpa
     · exact h1
   have hp : n.minFac.Prime := Nat.minFac_prime (by omega)
   obtain ⟨m, hm⟩ := Nat.minFac_dvd n
-  have hpN : Nat.Coprime n.minFac N := Nat.Coprime.coprime_dvd_left (Nat.minFac_dvd n) hn
-  have hmN : Nat.Coprime m N := Nat.Coprime.coprime_dvd_left (Dvd.intro_left _ hm.symm) hn
+  have hpL : Nat.Coprime n.minFac L := Nat.Coprime.coprime_dvd_left (Nat.minFac_dvd n) hn
+  have hmL : Nat.Coprime m L := Nat.Coprime.coprime_dvd_left (Dvd.intro_left _ hm.symm) hn
   have hmn : m < n := by
     rcases Nat.eq_zero_or_pos m with h0 | h0
     · rw [h0, mul_zero] at hm
       omega
     · calc m < n.minFac * m := (Nat.lt_mul_iff_one_lt_left h0).mpr hp.one_lt
         _ = n := hm.symm
-  rw [hm, qExpansion_coeff_mul_of_heckeRingHomCuspCharSpace_eq_smul hp hpN (ha _ hp hpN) m,
-    ih m hmn hmN, mul_zero, zero_sub]
+  obtain ⟨c, hc⟩ := ha _ hp hpL
+  rw [hm, qExpansion_coeff_mul_of_heckeRingHomCuspCharSpace_eq_smul hp
+    (hpL.coprime_dvd_right hNL) hc m, ih m hmn hmL, mul_zero, zero_sub]
   split_ifs with hpm
   · rw [ih (m / n.minFac) ((Nat.div_le_self m _).trans_lt hmn)
-      (Nat.Coprime.coprime_div_left hmN hpm), mul_zero, neg_zero]
+      (Nat.Coprime.coprime_div_left hmL hpm), mul_zero, neg_zero]
   · exact neg_zero
 
 end HeckeRing.GL2

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Eigenvector.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Eigenvector.lean
@@ -24,8 +24,9 @@ coefficients of `F` alone:
 `a_{pm}(F) = c · a_m(F) − χ(p) p^{k−1} a_{m/p}(F)`, the last term present only when `p ∣ m`.
 
 Running it along the least prime factor shows that a form which is an eigenvector at every
-prime outside an auxiliary level `L` (a multiple of `N`) and has `a₁ = 0` has `a_n = 0` at every
-nonzero index `n` coprime to `L` — at `n = 0` as well when it is a cusp form. This is the form
+prime outside an auxiliary level `L` (a multiple of `N`; for `L ≠ 0` these are all but finitely
+many primes) and has `a₁ = 0` has `a_n = 0` at every nonzero index `n` coprime to `L` — at
+`n = 0` as well when it is a cusp form. This is the form
 in which strong multiplicity one consumes eigen-ness (Miyake's Theorem 4.6.12 assumes agreement
 at the indices prime to such an `L`): the difference of two newforms whose eigenvalues agree
 outside `L` has `a₁ = 1 − 1 = 0`, so its coefficients at the indices prime to `L` all vanish,
@@ -33,8 +34,8 @@ and the descent argument then places it in the old subspace.
 
 ## Main results
 
-* `HeckeRing.GL2.qExpansion_coeff_mul_of_heckeRingHomCharSpace_eq_smul`,
-  `HeckeRing.GL2.qExpansion_coeff_mul_of_heckeRingHomCuspCharSpace_eq_smul`: the coefficient
+* `HeckeRing.GL2.qExpansion_coeff_prime_mul_of_heckeRingHomCharSpace_eq_smul`,
+  `HeckeRing.GL2.qExpansion_coeff_prime_mul_of_heckeRingHomCuspCharSpace_eq_smul`: the coefficient
   recurrence of an eigenvector, on `M_k(N, χ)` and on `S_k(N, χ)`.
 * `HeckeRing.GL2.qExpansion_coeff_eq_zero_of_coprime_of_forall_prime_of_ne_zero`,
   `HeckeRing.GL2.qExpansion_coeff_eq_zero_of_coprime_of_forall_prime`: a form in `M_k(N, χ)`
@@ -61,7 +62,7 @@ variable {N p : ℕ} [NeZero N] {k : ℤ} {χ : (ZMod N)ˣ →* ℂˣ}
 /-- **The coefficient recurrence of an eigenvector at a good prime, on `M_k(N, χ)`.** If the ring
 generator at `p ∤ N` acts on `F ∈ M_k(N, χ)` by the scalar `c`, then
 `a_{pm}(F) = c · a_m(F) − χ(p) p^{k−1} a_{m/p}(F)`, the last term present only when `p ∣ m`. -/
-theorem qExpansion_coeff_mul_of_heckeRingHomCharSpace_eq_smul (hp : p.Prime)
+theorem qExpansion_coeff_prime_mul_of_heckeRingHomCharSpace_eq_smul (hp : p.Prime)
     (hpN : Nat.Coprime p N) {F : modFormCharSpace k χ} {c : ℂ}
     (hF : heckeRingHomCharSpace k χ (heckeTCompositeGamma0 N p) F = c • F) (m : ℕ) :
     (qExpansion 1 (F : ModularForm ((Gamma1 N).map (mapGL ℝ)) k)).coeff (p * m) =
@@ -83,7 +84,7 @@ theorem qExpansion_coeff_mul_of_heckeRingHomCharSpace_eq_smul (hp : p.Prime)
 /-- **The coefficient recurrence of an eigenvector at a good prime, on `S_k(N, χ)`.** If the ring
 generator at `p ∤ N` acts on `F ∈ S_k(N, χ)` by the scalar `c`, then
 `a_{pm}(F) = c · a_m(F) − χ(p) p^{k−1} a_{m/p}(F)`, the last term present only when `p ∣ m`. -/
-theorem qExpansion_coeff_mul_of_heckeRingHomCuspCharSpace_eq_smul (hp : p.Prime)
+theorem qExpansion_coeff_prime_mul_of_heckeRingHomCuspCharSpace_eq_smul (hp : p.Prime)
     (hpN : Nat.Coprime p N) {F : cuspFormCharSpace k χ} {c : ℂ}
     (hF : heckeRingHomCuspCharSpace k χ (heckeTCompositeGamma0 N p) F = c • F) (m : ℕ) :
     (qExpansion 1 (F : CuspForm ((Gamma1 N).map (mapGL ℝ)) k)).coeff (p * m) =
@@ -105,9 +106,9 @@ theorem qExpansion_coeff_mul_of_heckeRingHomCuspCharSpace_eq_smul (hp : p.Prime)
 /-- **Coefficient vanishing from the prime eigenvalues, on `M_k(N, χ)`.** Let `L` be a multiple of
 `N`. A form `F ∈ M_k(N, χ)` that is an eigenvector of the ring generator at every prime `p ∤ L`
 and has `a₁(F) = 0` has `a_n(F) = 0` at every `n ≠ 0` coprime to `L`, by the recurrence
-`qExpansion_coeff_mul_of_heckeRingHomCharSpace_eq_smul` along the least prime factor of `n`.
-The auxiliary level `L` is the finite slack of strong multiplicity one: eigen-ness is assumed
-only away from finitely many primes beyond those dividing `N`. -/
+`qExpansion_coeff_prime_mul_of_heckeRingHomCharSpace_eq_smul` along the least prime factor of `n`.
+For `L ≠ 0`, the auxiliary level is the finite slack of strong multiplicity one: eigen-ness is
+assumed only away from finitely many primes beyond those dividing `N`. -/
 theorem qExpansion_coeff_eq_zero_of_coprime_of_forall_prime_of_ne_zero {F : modFormCharSpace k χ}
     {L : ℕ} (hNL : N ∣ L) (ha : ∀ p : ℕ, p.Prime → Nat.Coprime p L →
       ∃ c : ℂ, heckeRingHomCharSpace k χ (heckeTCompositeGamma0 N p) F = c • F)
@@ -118,15 +119,15 @@ theorem qExpansion_coeff_eq_zero_of_coprime_of_forall_prime_of_ne_zero {F : modF
     (a := fun n ↦ (qExpansion 1 (F : ModularForm ((Gamma1 N).map (mapGL ℝ)) k)).coeff n)
     (fun p hp hpL ↦ by
     obtain ⟨c, hc⟩ := ha p hp hpL
-    exact ⟨c, _, qExpansion_coeff_mul_of_heckeRingHomCharSpace_eq_smul hp
+    exact ⟨c, _, qExpansion_coeff_prime_mul_of_heckeRingHomCharSpace_eq_smul hp
       (hpL.coprime_dvd_right hNL) hc⟩) h1 n hn0 hn
 
 /-- **Coefficient vanishing from the prime eigenvalues, on `S_k(N, χ)`.** Let `L` be a multiple of
 `N`. A cusp form `F ∈ S_k(N, χ)` that is an eigenvector of the ring generator at every prime
 `p ∤ L` and has `a₁(F) = 0` has `a_n(F) = 0` at every `n` coprime to `L`: at `n = 0` by
 cuspidality, otherwise by the recurrence
-`qExpansion_coeff_mul_of_heckeRingHomCuspCharSpace_eq_smul` along the least prime factor of `n`.
-This is the form strong multiplicity one consumes. -/
+`qExpansion_coeff_prime_mul_of_heckeRingHomCuspCharSpace_eq_smul` along the least prime factor
+of `n`. This is the form strong multiplicity one consumes. -/
 theorem qExpansion_coeff_eq_zero_of_coprime_of_forall_prime {F : cuspFormCharSpace k χ} {L : ℕ}
     (hNL : N ∣ L) (ha : ∀ p : ℕ, p.Prime → Nat.Coprime p L →
       ∃ c : ℂ, heckeRingHomCuspCharSpace k χ (heckeTCompositeGamma0 N p) F = c • F)
@@ -139,7 +140,7 @@ theorem qExpansion_coeff_eq_zero_of_coprime_of_forall_prime {F : cuspFormCharSpa
     (a := fun n ↦ (qExpansion 1 (F : CuspForm ((Gamma1 N).map (mapGL ℝ)) k)).coeff n)
     (fun p hp hpL ↦ by
     obtain ⟨c, hc⟩ := ha p hp hpL
-    exact ⟨c, _, qExpansion_coeff_mul_of_heckeRingHomCuspCharSpace_eq_smul hp
+    exact ⟨c, _, qExpansion_coeff_prime_mul_of_heckeRingHomCuspCharSpace_eq_smul hp
       (hpL.coprime_dvd_right hNL) hc⟩) h1 n hn0 hn
 
 end HeckeRing.GL2

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Eigenvector.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Eigenvector.lean
@@ -37,7 +37,7 @@ and the descent argument then places it in the old subspace.
 * `qExpansion_coeff_prime_mul_of_heckeRingHomCharSpace_heckeTCompositeGamma0_eq_smul` and its
   cusp-form counterpart `…_of_heckeRingHomCuspCharSpace_…`: the coefficient recurrence of an
   eigenvector, on `M_k(N, χ)` and on `S_k(N, χ)`.
-* `qExpansion_coeff_eq_zero_of_forall_prime_heckeRingHomCharSpace_of_one_eq_zero_of_coprime` and
+* `qExpansion_coeff_eq_zero_of_forall_prime_heckeRingHom_of_one_eq_zero_of_ne_zero_of_coprime` and
   `…_heckeRingHomCuspCharSpace_…`: a form eigen at every prime away from a multiple `L` of `N`,
   with `a₁ = 0`, has `a_n = 0` at every `n` coprime to `L` (and `n ≠ 0` in the modular-form
   case).
@@ -127,7 +127,7 @@ theorem qExpansion_coeff_prime_mul_of_heckeRingHomCuspCharSpace_heckeTCompositeG
 and has `a₁(F) = 0` has `a_n(F) = 0` at every `n ≠ 0` coprime to `L`.
 For `L ≠ 0`, the auxiliary level is the finite slack of strong multiplicity one: eigen-ness is
 assumed only away from finitely many primes beyond those dividing `N`. -/
-theorem qExpansion_coeff_eq_zero_of_forall_prime_heckeRingHomCharSpace_of_one_eq_zero_of_coprime
+theorem qExpansion_coeff_eq_zero_of_forall_prime_heckeRingHom_of_one_eq_zero_of_ne_zero_of_coprime
     {F : modFormCharSpace k χ} {L : ℕ} (hNL : N ∣ L) (ha : ∀ p : ℕ, p.Prime → Nat.Coprime p L →
       ∃ c : ℂ, heckeRingHomCharSpace k χ (heckeTCompositeGamma0 N p) F = c • F)
     (h1 : (qExpansion 1 (F : ModularForm ((Gamma1 N).map (mapGL ℝ)) k)).coeff 1 = 0) (n : ℕ)
@@ -146,7 +146,7 @@ theorem qExpansion_coeff_eq_zero_of_forall_prime_heckeRingHomCharSpace_of_one_eq
 `p ∤ L` and has `a₁(F) = 0` has `a_n(F) = 0` at every `n` coprime to `L` — with no `n ≠ 0`
 hypothesis, unlike the modular-form version, since a cusp form already has `a₀ = 0`. This is the
 form strong multiplicity one consumes. -/
-theorem qExpansion_coeff_eq_zero_of_forall_prime_heckeRingHomCuspCharSpace_of_one_eq_zero_of_coprime
+theorem qExpansion_coeff_eq_zero_of_forall_prime_heckeRingHomCusp_of_one_eq_zero_of_coprime
     {F : cuspFormCharSpace k χ} {L : ℕ} (hNL : N ∣ L) (ha : ∀ p : ℕ, p.Prime → Nat.Coprime p L →
       ∃ c : ℂ, heckeRingHomCuspCharSpace k χ (heckeTCompositeGamma0 N p) F = c • F)
     (h1 : (qExpansion 1 (F : CuspForm ((Gamma1 N).map (mapGL ℝ)) k)).coeff 1 = 0) (n : ℕ)

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Eigenvector.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Eigenvector.lean
@@ -37,8 +37,8 @@ and the descent argument then places it in the old subspace.
 * `qExpansion_coeff_prime_mul_of_heckeRingHomCharSpace_heckeTCompositeGamma0_eq_smul` and its
   cusp-form counterpart `…_of_heckeRingHomCuspCharSpace_…`: the coefficient recurrence of an
   eigenvector, on `M_k(N, χ)` and on `S_k(N, χ)`.
-* `qExpansion_coeff_eq_zero_of_forall_prime_heckeRingHomCharSpace_of_ne_zero_of_coprime` and
-  `…_heckeRingHomCuspCharSpace`: a form eigen at every prime away from a multiple `L` of `N`,
+* `qExpansion_coeff_eq_zero_of_forall_prime_heckeRingHomCharSpace_of_one_eq_zero_of_coprime` and
+  `…_heckeRingHomCuspCharSpace_…`: a form eigen at every prime away from a multiple `L` of `N`,
   with `a₁ = 0`, has `a_n = 0` at every `n` coprime to `L` (and `n ≠ 0` in the modular-form
   case).
 * `heckeTNat_eq_smul_of_heckeRingHomCharSpace_heckeTCompositeGamma0_eq_smul` and its cusp-form
@@ -131,13 +131,13 @@ and has `a₁(F) = 0` has `a_n(F) = 0` at every `n ≠ 0` coprime to `L`, by the
   prime factor of `n`.
 For `L ≠ 0`, the auxiliary level is the finite slack of strong multiplicity one: eigen-ness is
 assumed only away from finitely many primes beyond those dividing `N`. -/
-theorem qExpansion_coeff_eq_zero_of_forall_prime_heckeRingHomCharSpace_of_ne_zero_of_coprime
+theorem qExpansion_coeff_eq_zero_of_forall_prime_heckeRingHomCharSpace_of_one_eq_zero_of_coprime
     {F : modFormCharSpace k χ} {L : ℕ} (hNL : N ∣ L) (ha : ∀ p : ℕ, p.Prime → Nat.Coprime p L →
       ∃ c : ℂ, heckeRingHomCharSpace k χ (heckeTCompositeGamma0 N p) F = c • F)
     (h1 : (qExpansion 1 (F : ModularForm ((Gamma1 N).map (mapGL ℝ)) k)).coeff 1 = 0) (n : ℕ)
     (hn0 : n ≠ 0) (hn : Nat.Coprime n L) :
     (qExpansion 1 (F : ModularForm ((Gamma1 N).map (mapGL ℝ)) k)).coeff n = 0 :=
-  TauCeti.eq_zero_of_forall_prime_mul_eq_of_coprime
+  TauCeti.eq_zero_of_forall_prime_mul_eq_of_one_eq_zero_of_ne_zero_of_coprime
     (a := fun n ↦ (qExpansion 1 (F : ModularForm ((Gamma1 N).map (mapGL ℝ)) k)).coeff n)
     (fun p hp hpL ↦ by
     obtain ⟨c, hc⟩ := ha p hp hpL
@@ -152,7 +152,7 @@ cuspidality, otherwise by the recurrence
 `qExpansion_coeff_prime_mul_of_heckeRingHomCuspCharSpace_heckeTCompositeGamma0_eq_smul` along the
   least prime factor
 of `n`. This is the form strong multiplicity one consumes. -/
-theorem qExpansion_coeff_eq_zero_of_forall_prime_heckeRingHomCuspCharSpace_of_coprime
+theorem qExpansion_coeff_eq_zero_of_forall_prime_heckeRingHomCuspCharSpace_of_one_eq_zero_of_coprime
     {F : cuspFormCharSpace k χ} {L : ℕ} (hNL : N ∣ L) (ha : ∀ p : ℕ, p.Prime → Nat.Coprime p L →
       ∃ c : ℂ, heckeRingHomCuspCharSpace k χ (heckeTCompositeGamma0 N p) F = c • F)
     (h1 : (qExpansion 1 (F : CuspForm ((Gamma1 N).map (mapGL ℝ)) k)).coeff 1 = 0) (n : ℕ)
@@ -160,7 +160,7 @@ theorem qExpansion_coeff_eq_zero_of_forall_prime_heckeRingHomCuspCharSpace_of_co
     (qExpansion 1 (F : CuspForm ((Gamma1 N).map (mapGL ℝ)) k)).coeff n = 0 := by
   rcases eq_or_ne n 0 with rfl | hn0
   · exact CuspFormClass.qExpansion_coeff_zero _ one_pos (TauCeti.one_mem_strictPeriods_Gamma1_map N)
-  exact TauCeti.eq_zero_of_forall_prime_mul_eq_of_coprime
+  exact TauCeti.eq_zero_of_forall_prime_mul_eq_of_one_eq_zero_of_ne_zero_of_coprime
     (a := fun n ↦ (qExpansion 1 (F : CuspForm ((Gamma1 N).map (mapGL ℝ)) k)).coeff n)
     (fun p hp hpL ↦ by
     obtain ⟨c, hc⟩ := ha p hp hpL

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Eigenvector.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Eigenvector.lean
@@ -119,8 +119,8 @@ theorem qExpansion_coeff_eq_zero_of_coprime_of_forall_prime_of_ne_zero {F : modF
     (a := fun n ↦ (qExpansion 1 (F : ModularForm ((Gamma1 N).map (mapGL ℝ)) k)).coeff n)
     (fun p hp hpL ↦ by
     obtain ⟨c, hc⟩ := ha p hp hpL
-    exact ⟨c, _, qExpansion_coeff_prime_mul_of_heckeRingHomCharSpace_eq_smul hp
-      (hpL.coprime_dvd_right hNL) hc⟩) h1 n hn0 hn
+    exact ⟨c, _, fun m _ ↦ qExpansion_coeff_prime_mul_of_heckeRingHomCharSpace_eq_smul hp
+      (hpL.coprime_dvd_right hNL) hc m⟩) h1 n hn0 hn
 
 /-- **Coefficient vanishing from the prime eigenvalues, on `S_k(N, χ)`.** Let `L` be a multiple of
 `N`. A cusp form `F ∈ S_k(N, χ)` that is an eigenvector of the ring generator at every prime
@@ -140,7 +140,7 @@ theorem qExpansion_coeff_eq_zero_of_coprime_of_forall_prime {F : cuspFormCharSpa
     (a := fun n ↦ (qExpansion 1 (F : CuspForm ((Gamma1 N).map (mapGL ℝ)) k)).coeff n)
     (fun p hp hpL ↦ by
     obtain ⟨c, hc⟩ := ha p hp hpL
-    exact ⟨c, _, qExpansion_coeff_prime_mul_of_heckeRingHomCuspCharSpace_eq_smul hp
-      (hpL.coprime_dvd_right hNL) hc⟩) h1 n hn0 hn
+    exact ⟨c, _, fun m _ ↦ qExpansion_coeff_prime_mul_of_heckeRingHomCuspCharSpace_eq_smul hp
+      (hpL.coprime_dvd_right hNL) hc m⟩) h1 n hn0 hn
 
 end HeckeRing.GL2

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Eigenvector.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Eigenvector.lean
@@ -63,10 +63,8 @@ namespace HeckeRing.GL2
 variable {N p : ℕ} [NeZero N] {k : ℤ} {χ : (ZMod N)ˣ →* ℂˣ}
 
 /-- **A ring eigenvector at a good prime is an eigenvector of the classical `T_p`**, on
-`M_k(N, χ)`. The Hecke ring's composite element at a prime is its generator
-(`heckeTCompositeGamma0_prime`), which acts as the classical operator
-(`heckeRingHomCharSpace_heckeTGeneratorGamma0`); so an eigen-equation for the ring action is one
-for `heckeTNat`. -/
+`M_k(N, χ)`: at a prime the Hecke ring's action and `heckeTNat` are the same operator, so the two
+eigen-equations are the same statement. -/
 theorem heckeTNat_eq_smul_of_heckeRingHomCharSpace_heckeTCompositeGamma0_eq_smul [NeZero p]
     (hp : p.Prime) {F : modFormCharSpace k χ} {c : ℂ}
     (hF : heckeRingHomCharSpace k χ (heckeTCompositeGamma0 N p) F = c • F) :
@@ -126,9 +124,7 @@ theorem qExpansion_coeff_prime_mul_of_heckeRingHomCuspCharSpace_heckeTCompositeG
 
 /-- **Coefficient vanishing from the prime eigenvalues, on `M_k(N, χ)`.** Let `L` be a multiple of
 `N`. A form `F ∈ M_k(N, χ)` that is an eigenvector of the ring generator at every prime `p ∤ L`
-and has `a₁(F) = 0` has `a_n(F) = 0` at every `n ≠ 0` coprime to `L`, by the recurrence
-`qExpansion_coeff_prime_mul_of_heckeRingHomCharSpace_heckeTCompositeGamma0_eq_smul` along the least
-  prime factor of `n`.
+and has `a₁(F) = 0` has `a_n(F) = 0` at every `n ≠ 0` coprime to `L`.
 For `L ≠ 0`, the auxiliary level is the finite slack of strong multiplicity one: eigen-ness is
 assumed only away from finitely many primes beyond those dividing `N`. -/
 theorem qExpansion_coeff_eq_zero_of_forall_prime_heckeRingHomCharSpace_of_one_eq_zero_of_coprime
@@ -147,11 +143,9 @@ theorem qExpansion_coeff_eq_zero_of_forall_prime_heckeRingHomCharSpace_of_one_eq
 
 /-- **Coefficient vanishing from the prime eigenvalues, on `S_k(N, χ)`.** Let `L` be a multiple of
 `N`. A cusp form `F ∈ S_k(N, χ)` that is an eigenvector of the ring generator at every prime
-`p ∤ L` and has `a₁(F) = 0` has `a_n(F) = 0` at every `n` coprime to `L`: at `n = 0` by
-cuspidality, otherwise by the recurrence
-`qExpansion_coeff_prime_mul_of_heckeRingHomCuspCharSpace_heckeTCompositeGamma0_eq_smul` along the
-  least prime factor
-of `n`. This is the form strong multiplicity one consumes. -/
+`p ∤ L` and has `a₁(F) = 0` has `a_n(F) = 0` at every `n` coprime to `L` — with no `n ≠ 0`
+hypothesis, unlike the modular-form version, since a cusp form already has `a₀ = 0`. This is the
+form strong multiplicity one consumes. -/
 theorem qExpansion_coeff_eq_zero_of_forall_prime_heckeRingHomCuspCharSpace_of_one_eq_zero_of_coprime
     {F : cuspFormCharSpace k χ} {L : ℕ} (hNL : N ∣ L) (ha : ∀ p : ℕ, p.Prime → Nat.Coprime p L →
       ∃ c : ℂ, heckeRingHomCuspCharSpace k χ (heckeTCompositeGamma0 N p) F = c • F)

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Eigenvector.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Eigenvector.lean
@@ -1,0 +1,123 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.NumberTheory.HeckeRing.GL2.Gamma0.Diagonal.Composite
+public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Nebentypus.Action
+public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Nebentypus.Prime
+public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Recurrence
+
+/-!
+# Fourier coefficients of a Hecke-ring eigenvector at the good primes
+
+Let `F ∈ S_k(N, χ)` be an eigenvector of the `Γ₀(N)` Hecke-ring generator at a prime `p ∤ N`,
+acting through `heckeRingHomCuspCharSpace`, with eigenvalue `c`. Through the identification of
+that generator with the classical `T_p`
+(`coe_twistedHeckeSlashCuspFormCharEnd_diagCosetGamma0_of_prime`) and the coefficient formula
+`a_m(T_p F) = a_{pm}(F) + χ(p) p^{k−1} a_{m/p}(F)` of `HeckeSlash/Recurrence.lean`, the
+eigenvector equation becomes a recurrence on the Fourier coefficients of `F` alone:
+
+`a_{pm}(F) = c · a_m(F) − χ(p) p^{k−1} a_{m/p}(F)`, the last term present only when `p ∣ m`.
+
+Running it along the least prime factor shows that a form which is an eigenvector at *every*
+good prime and has `a₁ = 0` has `a_n = 0` at every index `n` coprime to the level. This is the
+form in which strong multiplicity one consumes eigen-ness: the difference of two newforms with
+the same good eigenvalues has `a₁ = 1 − 1 = 0`, so all its good coefficients vanish, and the
+descent argument then places it in the old subspace.
+
+## Main results
+
+* `HeckeRing.GL2.coe_heckeRingHomCuspCharSpace_heckeTCompositeGamma0_prime`: the ring element
+  at a prime acts on `S_k(N, χ)` as the classical `T_p`, at the level of functions.
+* `HeckeRing.GL2.qExpansion_coeff_mul_of_heckeRingHomCuspCharSpace_eq_smul`: the coefficient
+  recurrence of an eigenvector.
+* `HeckeRing.GL2.qExpansion_coeff_eq_zero_of_coprime_of_forall_prime`: an eigenvector at every
+  good prime with `a₁ = 0` has `a_n = 0` at every `n` coprime to `N`.
+
+## References
+
+* [F. Diamond and J. Shurman, *A first course in modular forms*][diamondshurman2005],
+  Proposition 5.3.1 and §5.8.
+* [T. Miyake, *Modular forms*][miyake1989], §4.6.
+-/
+
+public section
+
+open Matrix.SpecialLinearGroup UpperHalfPlane CongruenceSubgroup
+
+open scoped MatrixGroups
+
+namespace HeckeRing.GL2
+
+variable {N p : ℕ} [NeZero N] {k : ℤ} {χ : (ZMod N)ˣ →* ℂˣ}
+
+/-- **The ring element at a prime is the classical `T_p`**, on the functions underlying
+the character space: `heckeTCompositeGamma0 N p` is the generator `heckeTGeneratorGamma0 N p`,
+which acts through `heckeRingHomCuspCharSpace` as `heckeTCuspNat k p` does on the underlying
+cusp form (`coe_heckeRingHomCuspCharSpace_heckeTGeneratorGamma0`). -/
+theorem coe_heckeRingHomCuspCharSpace_heckeTCompositeGamma0_prime (hp : p.Prime)
+    (F : cuspFormCharSpace k χ) :
+    ⇑((heckeRingHomCuspCharSpace k χ (heckeTCompositeGamma0 N p) F :
+        CuspForm ((Gamma1 N).map (mapGL ℝ)) k)) =
+      ⇑(heckeTCuspNat k p (_hn := ⟨hp.ne_zero⟩) (F : CuspForm ((Gamma1 N).map (mapGL ℝ)) k)) := by
+  rw [heckeTCompositeGamma0_prime N hp,
+    coe_heckeRingHomCuspCharSpace_heckeTGeneratorGamma0 k χ hp F]
+
+/-- **The coefficient recurrence of an eigenvector at a good prime.** If the ring generator at
+`p ∤ N` acts on `F ∈ S_k(N, χ)` by the scalar `c`, then
+`a_{pm}(F) = c · a_m(F) − χ(p) p^{k−1} a_{m/p}(F)`, the last term present only when `p ∣ m`. -/
+theorem qExpansion_coeff_mul_of_heckeRingHomCuspCharSpace_eq_smul (hp : p.Prime)
+    (hpN : Nat.Coprime p N) {F : cuspFormCharSpace k χ} {c : ℂ}
+    (hF : heckeRingHomCuspCharSpace k χ (heckeTCompositeGamma0 N p) F = c • F) (m : ℕ) :
+    (qExpansion 1 (F : CuspForm ((Gamma1 N).map (mapGL ℝ)) k)).coeff (p * m) =
+      c * (qExpansion 1 (F : CuspForm ((Gamma1 N).map (mapGL ℝ)) k)).coeff m -
+        if p ∣ m then (χ (ZMod.unitOfCoprime p hpN) : ℂ) * (p : ℂ) ^ (k - 1) *
+          (qExpansion 1 (F : CuspForm ((Gamma1 N).map (mapGL ℝ)) k)).coeff (m / p) else 0 := by
+  have : NeZero p := ⟨hp.ne_zero⟩
+  have h := qExpansion_coeff_heckeSlashGamma1CuspFormEnd_diagCosetGamma1_of_mem_cuspFormCharSpace
+    k hp hpN χ F.2 m
+  rw [← heckeTCuspNat_def, ← coe_heckeRingHomCuspCharSpace_heckeTCompositeGamma0_prime hp F,
+    hF, Submodule.coe_smul, FunLike.coe_smul,
+    ModularForm.qExpansion_smul one_pos (TauCeti.one_mem_strictPeriods_Gamma1_map _), map_smul,
+    smul_eq_mul] at h
+  linear_combination -h
+
+/-- **Coefficient vanishing from the prime eigenvalues.** A form `F ∈ S_k(N, χ)` that is an
+eigenvector of the ring generator at every prime `p ∤ N` and has `a₁(F) = 0` has `a_n(F) = 0` at
+every `n` coprime to `N`: the recurrence
+`qExpansion_coeff_mul_of_heckeRingHomCuspCharSpace_eq_smul` along the least prime factor of `n`
+expresses `a_n` through coefficients at smaller indices coprime to `N`. -/
+theorem qExpansion_coeff_eq_zero_of_coprime_of_forall_prime {F : cuspFormCharSpace k χ}
+    (a : ℕ → ℂ) (ha : ∀ p : ℕ, p.Prime → Nat.Coprime p N →
+      heckeRingHomCuspCharSpace k χ (heckeTCompositeGamma0 N p) F = a p • F)
+    (h1 : (qExpansion 1 (F : CuspForm ((Gamma1 N).map (mapGL ℝ)) k)).coeff 1 = 0) (n : ℕ)
+    (hn : Nat.Coprime n N) :
+    (qExpansion 1 (F : CuspForm ((Gamma1 N).map (mapGL ℝ)) k)).coeff n = 0 := by
+  induction n using Nat.strong_induction_on with
+  | _ n ih =>
+  rcases Nat.lt_or_ge n 2 with hn2 | hn2
+  · interval_cases n
+    · exact CuspFormClass.qExpansion_coeff_zero _ one_pos
+        (TauCeti.one_mem_strictPeriods_Gamma1_map N)
+    · exact h1
+  have hp : n.minFac.Prime := Nat.minFac_prime (by omega)
+  obtain ⟨m, hm⟩ := Nat.minFac_dvd n
+  have hpN : Nat.Coprime n.minFac N := Nat.Coprime.coprime_dvd_left (Nat.minFac_dvd n) hn
+  have hmN : Nat.Coprime m N := Nat.Coprime.coprime_dvd_left (Dvd.intro_left _ hm.symm) hn
+  have hmn : m < n := by
+    rcases Nat.eq_zero_or_pos m with h0 | h0
+    · rw [h0, mul_zero] at hm
+      omega
+    · calc m < n.minFac * m := (Nat.lt_mul_iff_one_lt_left h0).mpr hp.one_lt
+        _ = n := hm.symm
+  rw [hm, qExpansion_coeff_mul_of_heckeRingHomCuspCharSpace_eq_smul hp hpN (ha _ hp hpN) m,
+    ih m hmn hmN, mul_zero, zero_sub]
+  split_ifs with hpm
+  · rw [ih (m / n.minFac) ((Nat.div_le_self m _).trans_lt hmn)
+      (Nat.Coprime.coprime_div_left hmN hpm), mul_zero, neg_zero]
+  · exact neg_zero
+
+end HeckeRing.GL2

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Eigenvector.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Eigenvector.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.NumberTheory.ArithmeticFunction.PrimeRecurrence
 public import TauCeti.NumberTheory.HeckeRing.GL2.Gamma0.Diagonal.Composite
 public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Nebentypus.Prime
 public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Recurrence
@@ -101,36 +102,6 @@ theorem qExpansion_coeff_mul_of_heckeRingHomCuspCharSpace_eq_smul (hp : p.Prime)
     smul_eq_mul] at h
   linear_combination -h
 
-omit [NeZero N] in
-/-- The induction behind coefficient vanishing, on a bare sequence: if `a₁ = 0` and, at every
-prime `p ∤ L`, `a_{pm} = c · a_m − d · a_{m/p}` (the last term only when `p ∣ m`) for some scalars
-`c`, `d`, then `a_n = 0` at every `n ≠ 0` coprime to `L`: the recurrence along the least prime
-factor of `n` expresses `a_n` through coefficients at smaller indices coprime to `L`. -/
-private theorem eq_zero_of_coprime_of_forall_prime_mul_eq {a : ℕ → ℂ} {L : ℕ}
-    (ha : ∀ p : ℕ, p.Prime → Nat.Coprime p L → ∃ c d : ℂ, ∀ m : ℕ,
-      a (p * m) = c * a m - if p ∣ m then d * a (m / p) else 0)
-    (h1 : a 1 = 0) (n : ℕ) (hn0 : n ≠ 0) (hn : Nat.Coprime n L) : a n = 0 := by
-  induction n using Nat.strong_induction_on with
-  | _ n ih =>
-  rcases Nat.lt_or_ge n 2 with hn2 | hn2
-  · interval_cases n
-    · exact absurd rfl hn0
-    · exact h1
-  have hp : n.minFac.Prime := Nat.minFac_prime (by omega)
-  obtain ⟨m, hm⟩ := Nat.minFac_dvd n
-  have hpL : Nat.Coprime n.minFac L := Nat.Coprime.coprime_dvd_left (Nat.minFac_dvd n) hn
-  have hmL : Nat.Coprime m L := Nat.Coprime.coprime_dvd_left (Dvd.intro_left _ hm.symm) hn
-  have hm0 : m ≠ 0 := fun h0 ↦ hn0 (by rw [hm, h0, mul_zero])
-  have hmn : m < n :=
-    hm ▸ (Nat.lt_mul_iff_one_lt_left (Nat.pos_of_ne_zero hm0)).mpr hp.one_lt
-  obtain ⟨c, d, hcd⟩ := ha _ hp hpL
-  rw [hm, hcd m, ih m hmn hm0 hmL, mul_zero, zero_sub]
-  split_ifs with hpm
-  · rw [ih (m / n.minFac) ((Nat.div_le_self m _).trans_lt hmn)
-      (Nat.div_ne_zero_iff_of_dvd hpm |>.mpr ⟨hm0, hp.ne_zero⟩)
-      (Nat.Coprime.coprime_div_left hmL hpm), mul_zero, neg_zero]
-  · exact neg_zero
-
 /-- **Coefficient vanishing from the prime eigenvalues, on `M_k(N, χ)`.** Let `L` be a multiple of
 `N`. A form `F ∈ M_k(N, χ)` that is an eigenvector of the ring generator at every prime `p ∤ L`
 and has `a₁(F) = 0` has `a_n(F) = 0` at every `n ≠ 0` coprime to `L`, by the recurrence
@@ -143,7 +114,7 @@ theorem qExpansion_coeff_eq_zero_of_coprime_of_forall_prime_of_ne_zero {F : modF
     (h1 : (qExpansion 1 (F : ModularForm ((Gamma1 N).map (mapGL ℝ)) k)).coeff 1 = 0) (n : ℕ)
     (hn0 : n ≠ 0) (hn : Nat.Coprime n L) :
     (qExpansion 1 (F : ModularForm ((Gamma1 N).map (mapGL ℝ)) k)).coeff n = 0 :=
-  eq_zero_of_coprime_of_forall_prime_mul_eq
+  TauCeti.eq_zero_of_coprime_of_forall_prime_mul_eq
     (a := fun n ↦ (qExpansion 1 (F : ModularForm ((Gamma1 N).map (mapGL ℝ)) k)).coeff n)
     (fun p hp hpL ↦ by
     obtain ⟨c, hc⟩ := ha p hp hpL
@@ -164,7 +135,7 @@ theorem qExpansion_coeff_eq_zero_of_coprime_of_forall_prime {F : cuspFormCharSpa
     (qExpansion 1 (F : CuspForm ((Gamma1 N).map (mapGL ℝ)) k)).coeff n = 0 := by
   rcases eq_or_ne n 0 with rfl | hn0
   · exact CuspFormClass.qExpansion_coeff_zero _ one_pos (TauCeti.one_mem_strictPeriods_Gamma1_map N)
-  exact eq_zero_of_coprime_of_forall_prime_mul_eq
+  exact TauCeti.eq_zero_of_coprime_of_forall_prime_mul_eq
     (a := fun n ↦ (qExpansion 1 (F : CuspForm ((Gamma1 N).map (mapGL ℝ)) k)).coeff n)
     (fun p hp hpL ↦ by
     obtain ⟨c, hc⟩ := ha p hp hpL

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Eigenvector.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Eigenvector.lean
@@ -5,7 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.NumberTheory.ArithmeticFunction.PrimeRecurrence
+import TauCeti.NumberTheory.ArithmeticFunction.PrimeRecurrence
 public import TauCeti.NumberTheory.HeckeRing.GL2.Gamma0.Diagonal.Composite
 public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Nebentypus.Prime
 public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Recurrence
@@ -34,13 +34,16 @@ and the descent argument then places it in the old subspace.
 
 ## Main results
 
-* `HeckeRing.GL2.qExpansion_coeff_prime_mul_of_heckeRingHomCharSpace_eq_smul`,
-  `HeckeRing.GL2.qExpansion_coeff_prime_mul_of_heckeRingHomCuspCharSpace_eq_smul`: the coefficient
-  recurrence of an eigenvector, on `M_k(N, χ)` and on `S_k(N, χ)`.
-* `HeckeRing.GL2.qExpansion_coeff_eq_zero_of_coprime_of_forall_prime_of_ne_zero`,
-  `HeckeRing.GL2.qExpansion_coeff_eq_zero_of_coprime_of_forall_prime`: a form in `M_k(N, χ)`
-  (respectively `S_k(N, χ)`) that is an eigenvector at every prime `p ∤ L` and has `a₁ = 0` has
-  `a_n = 0` at every `n ≠ 0` (respectively every `n`) coprime to `L`.
+* `qExpansion_coeff_prime_mul_of_heckeRingHomCharSpace_heckeTCompositeGamma0_eq_smul` and its
+  cusp-form counterpart `…_of_heckeRingHomCuspCharSpace_…`: the coefficient recurrence of an
+  eigenvector, on `M_k(N, χ)` and on `S_k(N, χ)`.
+* `qExpansion_coeff_eq_zero_of_coprime_of_forall_prime_heckeRingHomCharSpace_of_ne_zero` and
+  `…_heckeRingHomCuspCharSpace`: a form eigen at every prime away from a multiple `L` of `N`,
+  with `a₁ = 0`, has `a_n = 0` at every `n` coprime to `L` (and `n ≠ 0` in the modular-form
+  case).
+* `heckeTNat_eq_smul_of_heckeRingHomCharSpace_heckeTCompositeGamma0_eq_smul` and its cusp-form
+  counterpart: a Hecke-ring eigenvector at a good prime is an eigenvector of the classical
+  operator, the comparison `Newforms/Newform.lean` records as not proved there.
 
 ## References
 
@@ -59,21 +62,41 @@ namespace HeckeRing.GL2
 
 variable {N p : ℕ} [NeZero N] {k : ℤ} {χ : (ZMod N)ˣ →* ℂˣ}
 
+/-- **A ring eigenvector at a good prime is an eigenvector of the classical `T_p`**, on
+`M_k(N, χ)`. The Hecke ring's composite element at a prime is its generator
+(`heckeTCompositeGamma0_prime`), which acts as the classical operator
+(`heckeRingHomCharSpace_heckeTGeneratorGamma0`); so an eigen-equation for the ring action is one
+for `heckeTNat`. This is the comparison `Newforms/Newform.lean` records as not proved there. -/
+theorem heckeTNat_eq_smul_of_heckeRingHomCharSpace_heckeTCompositeGamma0_eq_smul [NeZero p]
+    (hp : p.Prime) {F : modFormCharSpace k χ} {c : ℂ}
+    (hF : heckeRingHomCharSpace k χ (heckeTCompositeGamma0 N p) F = c • F) :
+    heckeTNat k p (F : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) =
+      c • (F : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) := by
+  simpa [heckeTCompositeGamma0_prime N hp, heckeRingHomCharSpace_heckeTGeneratorGamma0 k χ hp]
+    using congrArg Subtype.val hF
+
+/-- **A ring eigenvector at a good prime is an eigenvector of the classical `T_p`**, on
+`S_k(N, χ)`. -/
+theorem heckeTCuspNat_eq_smul_of_heckeRingHomCuspCharSpace_heckeTCompositeGamma0_eq_smul
+    [NeZero p] (hp : p.Prime) {F : cuspFormCharSpace k χ} {c : ℂ}
+    (hF : heckeRingHomCuspCharSpace k χ (heckeTCompositeGamma0 N p) F = c • F) :
+    heckeTCuspNat k p (F : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) =
+      c • (F : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) := by
+  simpa [heckeTCompositeGamma0_prime N hp,
+    heckeRingHomCuspCharSpace_heckeTGeneratorGamma0 k χ hp] using congrArg Subtype.val hF
+
 /-- **The coefficient recurrence of an eigenvector at a good prime, on `M_k(N, χ)`.** If the ring
 generator at `p ∤ N` acts on `F ∈ M_k(N, χ)` by the scalar `c`, then
 `a_{pm}(F) = c · a_m(F) − χ(p) p^{k−1} a_{m/p}(F)`, the last term present only when `p ∣ m`. -/
-theorem qExpansion_coeff_prime_mul_of_heckeRingHomCharSpace_eq_smul (hp : p.Prime)
-    (hpN : Nat.Coprime p N) {F : modFormCharSpace k χ} {c : ℂ}
+theorem qExpansion_coeff_prime_mul_of_heckeRingHomCharSpace_heckeTCompositeGamma0_eq_smul
+    (hp : p.Prime) (hpN : Nat.Coprime p N) {F : modFormCharSpace k χ} {c : ℂ}
     (hF : heckeRingHomCharSpace k χ (heckeTCompositeGamma0 N p) F = c • F) (m : ℕ) :
     (qExpansion 1 (F : ModularForm ((Gamma1 N).map (mapGL ℝ)) k)).coeff (p * m) =
       c * (qExpansion 1 (F : ModularForm ((Gamma1 N).map (mapGL ℝ)) k)).coeff m -
         if p ∣ m then (χ (ZMod.unitOfCoprime p hpN) : ℂ) * (p : ℂ) ^ (k - 1) *
           (qExpansion 1 (F : ModularForm ((Gamma1 N).map (mapGL ℝ)) k)).coeff (m / p) else 0 := by
   have : NeZero p := ⟨hp.ne_zero⟩
-  have hT : heckeTNat k p (F : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) =
-      c • (F : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) := by
-    simpa [heckeTCompositeGamma0_prime N hp, heckeRingHomCharSpace_heckeTGeneratorGamma0 k χ hp]
-      using congrArg Subtype.val hF
+  have hT := heckeTNat_eq_smul_of_heckeRingHomCharSpace_heckeTCompositeGamma0_eq_smul hp hF
   have h := qExpansion_coeff_heckeSlashGamma1ModularFormEnd_diagCosetGamma1_of_mem_modFormCharSpace
     k hp hpN χ F.2 m
   rw [← heckeTNat_def, hT, FunLike.coe_smul,
@@ -84,18 +107,16 @@ theorem qExpansion_coeff_prime_mul_of_heckeRingHomCharSpace_eq_smul (hp : p.Prim
 /-- **The coefficient recurrence of an eigenvector at a good prime, on `S_k(N, χ)`.** If the ring
 generator at `p ∤ N` acts on `F ∈ S_k(N, χ)` by the scalar `c`, then
 `a_{pm}(F) = c · a_m(F) − χ(p) p^{k−1} a_{m/p}(F)`, the last term present only when `p ∣ m`. -/
-theorem qExpansion_coeff_prime_mul_of_heckeRingHomCuspCharSpace_eq_smul (hp : p.Prime)
-    (hpN : Nat.Coprime p N) {F : cuspFormCharSpace k χ} {c : ℂ}
+theorem qExpansion_coeff_prime_mul_of_heckeRingHomCuspCharSpace_heckeTCompositeGamma0_eq_smul
+    (hp : p.Prime) (hpN : Nat.Coprime p N) {F : cuspFormCharSpace k χ} {c : ℂ}
     (hF : heckeRingHomCuspCharSpace k χ (heckeTCompositeGamma0 N p) F = c • F) (m : ℕ) :
     (qExpansion 1 (F : CuspForm ((Gamma1 N).map (mapGL ℝ)) k)).coeff (p * m) =
       c * (qExpansion 1 (F : CuspForm ((Gamma1 N).map (mapGL ℝ)) k)).coeff m -
         if p ∣ m then (χ (ZMod.unitOfCoprime p hpN) : ℂ) * (p : ℂ) ^ (k - 1) *
           (qExpansion 1 (F : CuspForm ((Gamma1 N).map (mapGL ℝ)) k)).coeff (m / p) else 0 := by
   have : NeZero p := ⟨hp.ne_zero⟩
-  have hT : heckeTCuspNat k p (F : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) =
-      c • (F : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) := by
-    simpa [heckeTCompositeGamma0_prime N hp,
-      heckeRingHomCuspCharSpace_heckeTGeneratorGamma0 k χ hp] using congrArg Subtype.val hF
+  have hT :=
+    heckeTCuspNat_eq_smul_of_heckeRingHomCuspCharSpace_heckeTCompositeGamma0_eq_smul hp hF
   have h := qExpansion_coeff_heckeSlashGamma1CuspFormEnd_diagCosetGamma1_of_mem_cuspFormCharSpace
     k hp hpN χ F.2 m
   rw [← heckeTCuspNat_def, hT, FunLike.coe_smul,
@@ -106,11 +127,12 @@ theorem qExpansion_coeff_prime_mul_of_heckeRingHomCuspCharSpace_eq_smul (hp : p.
 /-- **Coefficient vanishing from the prime eigenvalues, on `M_k(N, χ)`.** Let `L` be a multiple of
 `N`. A form `F ∈ M_k(N, χ)` that is an eigenvector of the ring generator at every prime `p ∤ L`
 and has `a₁(F) = 0` has `a_n(F) = 0` at every `n ≠ 0` coprime to `L`, by the recurrence
-`qExpansion_coeff_prime_mul_of_heckeRingHomCharSpace_eq_smul` along the least prime factor of `n`.
+`qExpansion_coeff_prime_mul_of_heckeRingHomCharSpace_heckeTCompositeGamma0_eq_smul` along the least
+  prime factor of `n`.
 For `L ≠ 0`, the auxiliary level is the finite slack of strong multiplicity one: eigen-ness is
 assumed only away from finitely many primes beyond those dividing `N`. -/
-theorem qExpansion_coeff_eq_zero_of_coprime_of_forall_prime_of_ne_zero {F : modFormCharSpace k χ}
-    {L : ℕ} (hNL : N ∣ L) (ha : ∀ p : ℕ, p.Prime → Nat.Coprime p L →
+theorem qExpansion_coeff_eq_zero_of_coprime_of_forall_prime_heckeRingHomCharSpace_of_ne_zero
+    {F : modFormCharSpace k χ} {L : ℕ} (hNL : N ∣ L) (ha : ∀ p : ℕ, p.Prime → Nat.Coprime p L →
       ∃ c : ℂ, heckeRingHomCharSpace k χ (heckeTCompositeGamma0 N p) F = c • F)
     (h1 : (qExpansion 1 (F : ModularForm ((Gamma1 N).map (mapGL ℝ)) k)).coeff 1 = 0) (n : ℕ)
     (hn0 : n ≠ 0) (hn : Nat.Coprime n L) :
@@ -119,17 +141,19 @@ theorem qExpansion_coeff_eq_zero_of_coprime_of_forall_prime_of_ne_zero {F : modF
     (a := fun n ↦ (qExpansion 1 (F : ModularForm ((Gamma1 N).map (mapGL ℝ)) k)).coeff n)
     (fun p hp hpL ↦ by
     obtain ⟨c, hc⟩ := ha p hp hpL
-    exact ⟨c, _, fun m _ ↦ qExpansion_coeff_prime_mul_of_heckeRingHomCharSpace_eq_smul hp
-      (hpL.coprime_dvd_right hNL) hc m⟩) h1 n hn0 hn
+    exact ⟨c, _, fun m _ ↦
+      qExpansion_coeff_prime_mul_of_heckeRingHomCharSpace_heckeTCompositeGamma0_eq_smul hp
+        (hpL.coprime_dvd_right hNL) hc m⟩) h1 n hn0 hn
 
 /-- **Coefficient vanishing from the prime eigenvalues, on `S_k(N, χ)`.** Let `L` be a multiple of
 `N`. A cusp form `F ∈ S_k(N, χ)` that is an eigenvector of the ring generator at every prime
 `p ∤ L` and has `a₁(F) = 0` has `a_n(F) = 0` at every `n` coprime to `L`: at `n = 0` by
 cuspidality, otherwise by the recurrence
-`qExpansion_coeff_prime_mul_of_heckeRingHomCuspCharSpace_eq_smul` along the least prime factor
+`qExpansion_coeff_prime_mul_of_heckeRingHomCuspCharSpace_heckeTCompositeGamma0_eq_smul` along the
+  least prime factor
 of `n`. This is the form strong multiplicity one consumes. -/
-theorem qExpansion_coeff_eq_zero_of_coprime_of_forall_prime {F : cuspFormCharSpace k χ} {L : ℕ}
-    (hNL : N ∣ L) (ha : ∀ p : ℕ, p.Prime → Nat.Coprime p L →
+theorem qExpansion_coeff_eq_zero_of_coprime_of_forall_prime_heckeRingHomCuspCharSpace
+    {F : cuspFormCharSpace k χ} {L : ℕ} (hNL : N ∣ L) (ha : ∀ p : ℕ, p.Prime → Nat.Coprime p L →
       ∃ c : ℂ, heckeRingHomCuspCharSpace k χ (heckeTCompositeGamma0 N p) F = c • F)
     (h1 : (qExpansion 1 (F : CuspForm ((Gamma1 N).map (mapGL ℝ)) k)).coeff 1 = 0) (n : ℕ)
     (hn : Nat.Coprime n L) :
@@ -140,7 +164,8 @@ theorem qExpansion_coeff_eq_zero_of_coprime_of_forall_prime {F : cuspFormCharSpa
     (a := fun n ↦ (qExpansion 1 (F : CuspForm ((Gamma1 N).map (mapGL ℝ)) k)).coeff n)
     (fun p hp hpL ↦ by
     obtain ⟨c, hc⟩ := ha p hp hpL
-    exact ⟨c, _, fun m _ ↦ qExpansion_coeff_prime_mul_of_heckeRingHomCuspCharSpace_eq_smul hp
-      (hpL.coprime_dvd_right hNL) hc m⟩) h1 n hn0 hn
+    exact ⟨c, _, fun m _ ↦
+      qExpansion_coeff_prime_mul_of_heckeRingHomCuspCharSpace_heckeTCompositeGamma0_eq_smul hp
+        (hpL.coprime_dvd_right hNL) hc m⟩) h1 n hn0 hn
 
 end HeckeRing.GL2


### PR DESCRIPTION
Let `F ∈ M_k(N, χ)` or `S_k(N, χ)` be an eigenvector, with eigenvalue `c`, of the `Γ₀(N)` Hecke-ring element at a prime `p ∤ N` acting through `heckeRingHomCharSpace` / `heckeRingHomCuspCharSpace`. This PR turns that eigenvector equation into a recurrence on the Fourier coefficients of `F` alone, and runs the recurrence to show that a cusp form which is an eigenvector at every prime outside an auxiliary level `L` (a multiple of `N`) and has `a₁ = 0` vanishes at every index coprime to `L`.

**New file** `TauCeti/NumberTheory/ArithmeticFunction/PrimeRecurrence.lean` (namespace `TauCeti`):

* `eq_zero_of_coprime_of_forall_prime_mul_eq`: a sequence `a : ℕ → R` over a (non-unital, non-associative) ring with `a₁ = 0` and, at every prime `p` coprime to `L`, a Hecke-type recurrence `a_{pm} = c · a_m − d · a_{m/p}` (last term only when `p ∣ m`) at every `m` coprime to `L`, for some scalars `c`, `d`, vanishes at every `n ≠ 0` coprime to `L` — strong induction along the least prime factor of `n`. This is the combinatorial content of the vanishing theorem below, kept general.

**New file** `TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Eigenvector.lean` (namespace `HeckeRing.GL2`):

* `qExpansion_coeff_prime_mul_of_heckeRingHomCharSpace_eq_smul`, `qExpansion_coeff_prime_mul_of_heckeRingHomCuspCharSpace_eq_smul`: **the coefficient recurrence of an eigenvector at a good prime**, on `M_k(N, χ)` and on `S_k(N, χ)`: `a_{pm}(F) = c · a_m(F) − χ(p) p^{k−1} a_{m/p}(F)` (last term only when `p ∣ m`). The eigenvector equation is read as the bundled operator equality `T_p F = c • F` through `heckeTCompositeGamma0_prime` and the identification of the generator with `T_p` (`heckeRingHom(Cusp)CharSpace_heckeTGeneratorGamma0`, #6313), then transported through the coefficient map (`ModularForm.qExpansion_smul`, as in `Recurrence.lean`) and combined with the Diamond–Shurman coefficient formula of `HeckeSlash/Recurrence.lean`.
* `qExpansion_coeff_eq_zero_of_coprime_of_forall_prime_of_ne_zero`, `qExpansion_coeff_eq_zero_of_coprime_of_forall_prime`: **coefficient vanishing.** For `L` with `N ∣ L`, a form `F ∈ M_k(N, χ)` that is an eigenvector of the ring element at every prime `p ∤ L` and has `a₁(F) = 0` has `a_n(F) = 0` at every `n ≠ 0` coprime to `L`; a cusp form `F ∈ S_k(N, χ)` that is an eigenvector of the ring element at every prime `p ∤ L` (some scalar at each such prime) and has `a₁(F) = 0` has `a_n(F) = 0` at every `n` coprime to `L` — both instantiate the general recurrence lemma above with the coefficient recurrence (the cusp-form case adds `n = 0` by cuspidality). The auxiliary level `L` is Miyake's hypothesis for Theorem 4.6.12 (the roadmap's Layer 5 entry: "agreement at all `n` prime to an auxiliary `L`"); `L = N` recovers the all-good-primes statement.

**Role in strong multiplicity one.** For two newforms whose eigenvalues agree at the primes outside `L`, the difference is an eigenvector at every such prime with `a₁ = 1 − 1 = 0`; this lemma makes all of its coefficients at the indices prime to `L` vanish, which is the input to the descent main lemma placing the difference in the old subspace.

Roadmap: ModularForms

No `tauceti-target:v1` marker: like #6311 and #6313 before it, this is a prerequisite for the Layer 5 strong-multiplicity-one node (the coefficient input to the descent main lemma) rather than the node itself, and the contract asks for a deterministic target identifier, not an invented one.

Provenance: none adapted; the coefficient recurrence is Diamond–Shurman Proposition 5.3.1 read on an eigenvector, and the induction is the standard one (Miyake §4.6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQieFQn95rzgvYRvNdX3hR

