### PR TITLE
docs(EllipticCurve): make module-docstring references resolve

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Basic.lean
@@ -29,11 +29,14 @@ a typeclass diamond.
 
 ## Main results
 
-* `WeierstrassCurve.Affine.CoordinateRing.algHom_ext`: two pullbacks agreeing on the two
-  coordinates are equal.
+* `TauCeti.CoordinatePullback.mapsInfinity_iff`: pointedness says exactly that the source
+  coordinate ring is integral over the target acting through the pullback.
+* `TauCeti.CoordinatePullback.mapsInfinity_id`: the integrality witness for the identity pullback,
+  which with `mapsInfinity_iff` is what makes `TauCeti.Isogeny.id` an isogeny.
 
 The coordinate-ring universal property used to build and move pullbacks is stated at its natural
-generality in `Affine/Eval.lean`. `Isogeny/MulByInt/Basic.lean` makes `[n]` from the
+generality in `Affine/Eval.lean`, as `WeierstrassCurve.Affine.CoordinateRing.algHom_ext`.
+`Isogeny/MulByInt/Basic.lean` makes `[n]` from the
 division-polynomial point, and `Isogeny/BaseChange.lean` carries a pullback along a change of base
 field by carrying its point. The identity and Frobenius pullbacks instead come directly from their
 underlying ring maps.

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Hom/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Hom/Basic.lean
@@ -53,8 +53,8 @@ needs the rational addition formulas rather than anything in this file.
   map included — which is what the value `degree 0 = 0` is chosen for.
 * `TauCeti.Isogeny.Hom.comp_eq_zero_iff`: a composite vanishes exactly when a factor does, so the
   endomorphism monoid has no zero divisors.
-* `TauCeti.Isogeny.Hom.instNontrivial`: the carrier has more than one element, which is what
-  lets Mathlib's theory of nontrivial monoids with zero apply to it.
+* `TauCeti.Isogeny.Hom.instNontrivialEnd`: the endomorphism carrier has more than one element,
+  which is what lets Mathlib's theory of nontrivial monoids with zero apply to it.
 
 ## Implementation notes
 
@@ -347,7 +347,7 @@ theorem one_def : (1 : Hom W₁ W₁) = id W₁ := (rfl)
 /-- **The carrier has more than one element**: the zero map has degree `0` and the identity
 degree `1`. Supplying this makes Mathlib's generic theory of nontrivial monoids with zero apply,
 `not_isUnit_zero` among it. -/
-instance : Nontrivial (Hom W₁ W₁) :=
+instance instNontrivialEnd : Nontrivial (Hom W₁ W₁) :=
   ⟨⟨0, id W₁, fun h => zero_ne_one (α := ℕ) (by rw [← degree_zero (W₁ := W₁) (W₂ := W₁), h,
     degree_id])⟩⟩
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Neg.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Neg.lean
@@ -126,7 +126,7 @@ variable {W₁ W₂ W₃ : WeierstrassCurve.Affine F}
 
 /-- **Negation on the hom carrier**, by postcomposition with the negation isogeny. This is the
 `Neg` structure of the carrier's additive group; the addition is not built here. -/
-noncomputable instance : Neg (Hom W₁ W₂) :=
+noncomputable instance instNeg : Neg (Hom W₁ W₂) :=
   ⟨fun f => (ofIsogeny (negIsogeny W₂)).comp f⟩
 
 -- Deliberately not `@[simp]`: unfolding `-f` to a composition would make `-` vanish from every

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/ShortWeierstrass.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/ShortWeierstrass.lean
@@ -102,7 +102,7 @@ variable {R S : Type*} [CommRing R] [CommRing S] (A B : R)
 /-- `shortCurve A B` is in short normal form. This instance is the point of the definition: it
 hands the curve to Mathlib's whole `*_of_isShortNF` family, so every invariant — the `b`- and
 `c`-families, `Δ` and `j` — comes for free rather than being restated here. -/
-instance : (shortCurve A B).IsShortNF := ⟨(rfl), (rfl), (rfl)⟩
+instance instIsShortNFShortCurve : (shortCurve A B).IsShortNF := ⟨(rfl), (rfl), (rfl)⟩
 
 /-- A ring hom carries `shortCurve` to `shortCurve` on the images of the coefficients. Mathlib has
 no instance propagating `IsShortNF` along `map`, so this is what keeps a base change — `ℤ → ℚ` in

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Universal.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Universal.lean
@@ -308,8 +308,9 @@ open Polynomial (CC)
 /-- The `a₁` coefficient of `pointedCurve` is the image of the indeterminate `A₁` in the universal
 field, and likewise for `pointedCurve_a₂` through `pointedCurve_a₆`.
 
-None of the five is `@[simp]`: `simp` already rewrites `pointedCurve.a₁` with Mathlib's
-`Affine.baseChange_a₁`, to `algebraMap _ _ curve.a₁`, so tagging these would put a non-normal-form
+None of the five is `@[simp]`: `pointedCurve` is `curve.baseChange Universal.Field`, which unfolds
+to `curve.map (algebraMap _ _)`, so `simp` already rewrites `pointedCurve.a₁` with Mathlib's
+`WeierstrassCurve.map_a₁`, to `algebraMap _ _ curve.a₁`; tagging these would put a non-normal-form
 left-hand side in the simp set. They are the `polyToField` reading of the same coefficients, for
 use by name. -/
 lemma pointedCurve_a₁ : pointedCurve.a₁ = polyToField (CC curve.a₁) := (rfl)

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic/SpecialIsogeny.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic/SpecialIsogeny.lean
@@ -55,7 +55,6 @@ endomorphism over an arbitrary commutative ring.
 
 ## Main definitions
 
-* `Matrix.pairMinor`: the `2 × 2` minor of a matrix on an ordered row pair and column pair.
 * `Matrix.symplecticSpecialIsogeny`: the matrix of `2 × 2` minors on the four form-free index
   pairs.
 * `TauCeti.specialIsogeny`: the resulting endomorphism of `TauCeti.GLSymplecticFin 2 R` in
@@ -63,7 +62,6 @@ endomorphism over an arbitrary commutative ring.
 
 ## Main results
 
-* `Matrix.pairMinor_mul_fin_four`: Cauchy--Binet for `2 × 2` minors of a `4 × 4` product.
 * `TauCeti.pairMinor_row_add_eq_neg_jFin` and
   `TauCeti.pairMinor_column_add_eq_neg_jFin`: the symplectic condition read on minors, along rows
   and along columns.


### PR DESCRIPTION
Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"EllipticCurves/improvement:docstring-references"}-->

Provenance: improvement work on code already on `main`; nothing is ported and no statement changes.

## What this changes

Module-docstring references that do not resolve to the thing they name. Six files; the only Lean changes are three instance names.

**Three bullets name an instance that is declared anonymously**, so the name they cite appears nowhere else in the repository:

| Bullet | Declaration |
|---|---|
| `ShortWeierstrass.lean:34` cites `WeierstrassCurve.instIsShortNFShortCurve` | `:105` `instance : (shortCurve A B).IsShortNF` |
| `Isogeny/Hom/Basic.lean:56` cites `TauCeti.Isogeny.Hom.instNontrivial` | `:350` `instance : Nontrivial (Hom W₁ W₁)` |
| `Isogeny/Neg.lean:28` cites `TauCeti.Isogeny.Hom.instNeg` | `:129` `noncomputable instance : Neg (Hom W₁ W₂)` |

The three instances are now named explicitly, which is what the bullets promise and what makes them stable: Lean's generated name appends the head symbol of each type argument, so the anonymous forms are not the cited names. The repository already takes this line at `LinearAlgebra/End/InvertibleTwo.lean:100`, where an instance is named rather than anonymous for a related reason. The `Nontrivial` bullet also said "the carrier", while the instance is only about the endomorphism carrier `Hom W₁ W₁`; it now says so, and the instance is named `instNontrivialEnd` to match.

**Two "Main" sections list declarations belonging to other modules.** `Isogeny/Basic.lean:32` had `WeierstrassCurve.Affine.CoordinateRing.algHom_ext` as its *entire* Main-results section, though that lemma is declared in `Affine/Eval.lean`; the section now lists what this file proves, and `algHom_ext` is named in the prose that already points at `Affine/Eval.lean`. `Symplectic/SpecialIsogeny.lean:58,66` listed `Matrix.pairMinor` and `Matrix.pairMinor_mul_fin_four`, both declared in `LinearAlgebra/Matrix/Minor.lean` and already listed in that file's own docstring; the two bullets are dropped.

**One docstring justifies a `@[simp]` decision by citing a Mathlib lemma that does not exist.** `Universal.lean:311` says `simp` rewrites `pointedCurve.a₁` with `Affine.baseChange_a₁`. Mathlib has no `baseChange_a₁`: `baseChange` is a plain `def` with no `@[simps]`, and it is `map` that carries `@[simps]`, so the lemma that fires is `WeierstrassCurve.map_a₁`, in the `WeierstrassCurve` namespace rather than `WeierstrassCurve.Affine`. The paragraph now names it and says why it applies.

## Why

Each of these is a reference a reader would follow and not find, and the `@[simp]` paragraph justifies a real decision about five lemmas with a lemma name that cannot be checked.
