### PR TITLE
docs: state two module docstrings in the present tense

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Discriminant.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Discriminant.lean
@@ -22,13 +22,12 @@ no domain or factorisation hypothesis on the ring.
 
 The Nagell–Lutz route needs the on-curve form — with `κ = ψ₂(x, y) = 2y + a₁x + a₃` Mathlib's
 `2`-division polynomial at a point, take `d = κ²`, which on the curve *is* `Ψ₂Sq(x)` by
-`evalEval_ψ₂_sq`. That specialisation is still deliberately **not** stated here, but the reason has
-changed. It used to be that nothing could discharge its hypothesis `κ² ∣ 4·Ψ₃(x)`; the point-level
-`[n]`-multiplication material has since landed, and `Torsion/Discriminant.lean` supplies exactly
-that premise from a torsion point and concludes `κ² ∣ 4Δ`. Having the specialisation here as well
-would name twice what that file already does with the point in hand, so this module keeps to the
-polynomial statement and lets its consumer instantiate it. For a short model (`a₁ = a₃ = 0`, so
-`κ = 2y`) the consumer's conclusion reads `(2y)² ∣ 4Δ`.
+`evalEval_ψ₂_sq`. That specialisation is deliberately **not** stated here: discharging its
+hypothesis `κ² ∣ 4·Ψ₃(x)` takes a torsion point, and `Torsion/Discriminant.lean` uses one to prove
+the nonzero branch of the disjunction `κ = 0 ∨ κ² ∣ 4Δ`. Stating the specialisation here as well
+would name the same result twice, so this module keeps to the polynomial statement and lets its
+consumer instantiate it. For a short model (`a₁ = a₃ = 0`, so
+`κ = 2y`) the consumer's conclusion reads `2y = 0 ∨ (2y)² ∣ 4Δ`.
 
 ## Main results
 

--- a/TauCeti/LinearAlgebra/Matrix/Triangular.lean
+++ b/TauCeti/LinearAlgebra/Matrix/Triangular.lean
@@ -19,10 +19,11 @@ entrywise, because `∑ k, A i k * B k i` has a single surviving term — and co
 that, such as the diagonal of an inverse. It also defines upper-unitriangular matrices and proves
 that strictly upper-triangular matrices are nilpotent.
 
-The result previously lived in `TauCeti.Algebra.Lie.GeneralLinear.Borel`, phrased through
-membership in the Borel subalgebra. It is a statement about matrices with no Lie theory in it,
-so it is stated here for `Matrix.IsUpperTriangular` and consumed there; that also lets modules
-which have no business importing Lie-algebra theory use it.
+The diagonal results are stated for `Matrix.IsUpperTriangular` rather than through membership in
+the Borel subalgebra, since there is no Lie theory in them. It is
+`Matrix.mul_apply_diag_of_isUpperTriangular` that `TauCeti.Algebra.Lie.GeneralLinear.Borel`
+consumes in that form, and all of them are available to modules with no business importing
+Lie-algebra theory.
 
 ## Main results
 


### PR DESCRIPTION
Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"EllipticCurves/improvement:timeless-docstrings"}-->

Provenance: improvement work on code already on `main`; no Lean changes at all.

## What this changes

Two module docstrings that narrate how the repository changed rather than describing its present state. Docstrings are read against current `main`, where the earlier state they refer to is not available.

- `DivisionPolynomial/Discriminant.lean:25` explained why a specialisation is not stated here by saying that "the reason has changed", that "it used to be that nothing could discharge its hypothesis", and that material "has since landed". The reason it gives for the present arrangement survives without any of that: discharging the hypothesis takes a torsion point, and `Torsion/Discriminant.lean` supplies it, so stating the specialisation here too would name the same result twice.
- `LinearAlgebra/Matrix/Triangular.lean:22` said the result "previously lived in `TauCeti.Algebra.Lie.GeneralLinear.Borel`, phrased through membership in the Borel subalgebra". The cited module does exist and consumes these results, so the sentence is a placement rationale wearing a history: it now says that the results are stated for `Matrix.IsUpperTriangular` because there is no Lie theory in them, and that `Borel.lean` consumes them in that form.

## Why

A docstring that describes a transition is stale the moment the transition is old, and neither passage loses any content when stated in the present tense.
