### PR TITLE
feat: assemble the Chebotarev discard estimates

### DIFF
--- a/TauCeti/NumberTheory/Chebotarev/PrimeCounting/Discard.lean
+++ b/TauCeti/NumberTheory/Chebotarev/PrimeCounting/Discard.lean
@@ -11,15 +11,16 @@ public import TauCeti.NumberTheory.Chebotarev.PrimeCounting.VonMangoldt
 /-!
 # Negligible terms in Frobenius prime counting
 
-Passing from a Frobenius prime-power sum to a prime sum of residue degree one discards three
-terms: higher prime powers in the chosen Frobenius class, primes of absolute residue degree above
-one, and prime powers over a finite exceptional set. Each term is `o(x)` for a different reason.
-This file records that their sum is `o(x)`, in the form needed by weighted crossing arguments.
+Weighted crossing arguments bound the error incurred when passing from a Frobenius prime-power sum
+to a prime sum of residue degree one by three functions. These account for higher prime powers in
+the chosen Frobenius class and use unrestricted sums to majorize the contributions from primes of
+absolute residue degree above one and from a finite exceptional set. Each majorant is `o(x)` for a
+different reason. This file records that their sum is `o(x)`.
 
 ## Main result
 
-* `NumberField.Chebotarev.frobeniusDiscard_isLittleO`: the total discarded contribution is
-  negligible compared with `x`.
+* `NumberField.Chebotarev.frobeniusDiscard_isLittleO`: the sum of three majorants for the discard
+  error is negligible compared with `x`.
 -/
 
 public section
@@ -33,11 +34,12 @@ open IsDedekindDomain (HeightOneSpectrum)
 variable {K L : Type*} [Field K] [NumberField K] [Field L] [NumberField L] [Algebra K L]
   [IsGalois K L]
 
-/-- The total contribution discarded when a Frobenius prime-power sum is restricted to
-residue-degree-one primes outside a finite exceptional set is `o(x)`.
+/-- The sum of three majorants for the error incurred when a Frobenius prime-power sum is restricted
+to residue-degree-one primes outside a finite exceptional set is `o(x)`.
 
-The three summands respectively remove higher prime powers in the Frobenius fibre, primes whose
-absolute residue degree is greater than one, and all prime powers based at an exceptional prime.
+The first summand is the higher-prime-power contribution in the Frobenius fibre. The other two are
+unrestricted weighted sums over all primes of absolute residue degree greater than one and all
+prime powers based at an exceptional prime.
 -/
 -- Source: `TauCetiRoadmap/Chebotarev/Suggested.lean` and README §11.3(4).
 theorem frobeniusDiscard_isLittleO (C : ConjClasses (L ≃ₐ[K] L))

--- a/TauCeti/NumberTheory/Chebotarev/PrimeCounting/Discard.lean
+++ b/TauCeti/NumberTheory/Chebotarev/PrimeCounting/Discard.lean
@@ -15,8 +15,6 @@ Passing from a Frobenius prime-power sum to a prime sum of residue degree one di
 terms: higher prime powers in the chosen Frobenius class, primes of absolute residue degree above
 one, and prime powers over a finite exceptional set. Each term is `o(x)` for a different reason.
 This file records that their sum is `o(x)`, in the form needed by weighted crossing arguments.
-The statement follows `TauCetiRoadmap/Chebotarev/Suggested.lean` and
-`TauCetiRoadmap/Chebotarev/README.md` §11.3(4).
 
 ## Main result
 

--- a/TauCeti/NumberTheory/Chebotarev/PrimeCounting/Discard.lean
+++ b/TauCeti/NumberTheory/Chebotarev/PrimeCounting/Discard.lean
@@ -1,0 +1,51 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.NumberTheory.ArithmeticDirichletSeries.ResidueDegree
+public import TauCeti.NumberTheory.Chebotarev.PrimeCounting.VonMangoldt
+
+/-!
+# Negligible terms in Frobenius prime counting
+
+Passing from a Frobenius prime-power sum to a prime sum of residue degree one discards three
+terms: higher prime powers in the chosen Frobenius class, primes of absolute residue degree above
+one, and prime powers over a finite exceptional set. Each term is `o(x)` for a different reason.
+This file records that their sum is `o(x)`, in the form needed by weighted crossing arguments.
+
+## Main result
+
+* `NumberField.Chebotarev.frobeniusDiscard_isLittleO`: the total discarded contribution is
+  negligible compared with `x`.
+-/
+
+public section
+
+namespace NumberField.Chebotarev
+
+open Filter TauCeti
+open scoped Asymptotics NumberField
+open IsDedekindDomain (HeightOneSpectrum)
+
+variable {K L : Type*} [Field K] [NumberField K] [Field L] [NumberField L] [Algebra K L]
+  [IsGalois K L]
+
+/-- The total contribution discarded when a Frobenius prime-power sum is restricted to
+residue-degree-one primes outside a finite exceptional set is `o(x)`.
+
+The three summands respectively remove higher prime powers in the Frobenius fibre, primes whose
+absolute residue degree is greater than one, and all prime powers based at an exceptional prime.
+-/
+theorem frobeniusDiscard_isLittleO (C : ConjClasses (L ≃ₐ[K] L))
+    (T : Finset (HeightOneSpectrum (𝓞 K))) :
+    (fun x : ℝ ↦ frobeniusPsi K L C x - frobeniusTheta K L C x +
+        primeTheta K (higherDegreePrimes K) x +
+        primePsi K (T : Set (HeightOneSpectrum (𝓞 K))) x) =o[atTop] fun x : ℝ ↦ x :=
+  ((frobeniusPsi_sub_frobeniusTheta_isLittleO C).add
+    (primeTheta_higherDegreePrimes_isLittleO K)).add
+      (primePsi_isLittleO_of_finite T.finite_toSet)
+
+end NumberField.Chebotarev

--- a/TauCeti/NumberTheory/Chebotarev/PrimeCounting/Discard.lean
+++ b/TauCeti/NumberTheory/Chebotarev/PrimeCounting/Discard.lean
@@ -15,6 +15,8 @@ Passing from a Frobenius prime-power sum to a prime sum of residue degree one di
 terms: higher prime powers in the chosen Frobenius class, primes of absolute residue degree above
 one, and prime powers over a finite exceptional set. Each term is `o(x)` for a different reason.
 This file records that their sum is `o(x)`, in the form needed by weighted crossing arguments.
+The statement follows `TauCetiRoadmap/Chebotarev/Suggested.lean` and
+`TauCetiRoadmap/Chebotarev/README.md` §11.3(4).
 
 ## Main result
 

--- a/TauCeti/NumberTheory/Chebotarev/PrimeCounting/Discard.lean
+++ b/TauCeti/NumberTheory/Chebotarev/PrimeCounting/Discard.lean
@@ -39,6 +39,7 @@ residue-degree-one primes outside a finite exceptional set is `o(x)`.
 The three summands respectively remove higher prime powers in the Frobenius fibre, primes whose
 absolute residue degree is greater than one, and all prime powers based at an exceptional prime.
 -/
+-- Source: `TauCetiRoadmap/Chebotarev/Suggested.lean` and README §11.3(4).
 theorem frobeniusDiscard_isLittleO (C : ConjClasses (L ≃ₐ[K] L))
     (T : Finset (HeightOneSpectrum (𝓞 K))) :
     (fun x : ℝ ↦ frobeniusPsi K L C x - frobeniusTheta K L C x +


### PR DESCRIPTION
This PR assembles the three independent negligible contributions in Frobenius prime counting into the single total-discard theorem consumed by weighted crossings: the Frobenius higher-prime-power tail, the weighted contribution of primes of absolute residue degree above one, and all prime powers over a finite exceptional set.

The exact roadmap sources are `TauCetiRoadmap/Chebotarev/README.md`, Layer 11.3(4), “The total discarded error,” and its pinned representative declaration in `TauCetiRoadmap/Chebotarev/Suggested.lean`. The new theorem `NumberField.Chebotarev.frobeniusDiscard_isLittleO` states that the sum of those three contributions is `o(x)` and reuses `frobeniusPsi_sub_frobeniusTheta_isLittleO`, `primeTheta_higherDegreePrimes_isLittleO`, and `primePsi_isLittleO_of_finite` directly. This closes the four-estimate milestone in Layer 11.3. After this PR, the counting spine still needs the Layer 12 weighted transfer package, beginning with the exact residue-degree-one contraction once the Layer 8 fixed-field fibre machinery lands.

This is the most effective current step because Layers 11.3(1)–(3) are already on `main`, while the earlier Layer 8.2 fibre-count target and its immediate prerequisites are covered by open PRs; this small assembly completes an independent prerequisite explicitly required at every Layer 12 crossing without overlapping them.

The implementation is one 51-line module, `TauCeti/NumberTheory/Chebotarev/PrimeCounting/Discard.lean`. Its public surface is one theorem, its finite exceptional set uses the existing `Finset` carrier from the roadmap, and its proof is the additive closure of the three existing little-o estimates. No Mathlib code or external formalization is vendored.

Roadmap: Chebotarev

<!--tauceti-target:v1 {"focus":"Chebotarev","id":"total-discarded-error"}-->

🤖 Prepared with Codex