### PR TITLE
refactor(AlgebraicGroup): share the transport of Hopf-ideal point functoriality

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/HopfIdealPoints/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/HopfIdealPoints/Basic.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.FunctorOfPoints
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Points.Order
+public import TauCeti.Algebra.Group.Subgroup.Map
 
 /-!
 # General-linear points cut out by Hopf ideals
@@ -29,6 +30,9 @@ vanishing on the Hopf ideal and is functorial in the value algebra.
   value algebra.
 * `TauCeti.GeneralLinear.mapHopfIdealPointsSubgroup_injective`: an injective homomorphism of
   value algebras induces an injective map of point subgroups.
+* `TauCeti.GeneralLinear.mapHopfIdealPointsSubgroupCongr`: that functoriality read through
+  presentations of two subgroups as point subgroups, so that a carrier defined by a Hopf ideal
+  states its induced map in its own named API.
 -/
 
 public section
@@ -177,6 +181,77 @@ theorem mapHopfIdealPointsSubgroup_injective
   intro g g' h
   refine Subtype.ext (hmap ?_)
   rw [← coe_mapHopfIdealPointsSubgroup, ← coe_mapHopfIdealPointsSubgroup, h]
+
+/-! ### Transport along a presentation of the point subgroup
+
+A carrier cut out by a Hopf ideal typically carries its own `points A` together with a lemma
+`points_def : points A = hopfIdealPointsSubgroup n I A`. The declarations below read the
+functoriality above through two such presentations, so that a carrier states its induced map in
+its own named API rather than in the presentation that API is defined by. -/
+
+/-- `TauCeti.GeneralLinear.mapHopfIdealPointsSubgroup` read through presentations of two subgroups
+as Hopf-ideal point subgroups of the general linear group. -/
+noncomputable def mapHopfIdealPointsSubgroupCongr
+    (I : HopfIdeal R (coordinateHopfAlgebra R n))
+    {PA : Subgroup (Matrix.GeneralLinearGroup (Fin n) A)}
+    {PB : Subgroup (Matrix.GeneralLinearGroup (Fin n) B)}
+    (hA : PA = hopfIdealPointsSubgroup n I A) (hB : PB = hopfIdealPointsSubgroup n I B)
+    (φ : A →ₐ[R] B) : PA →* PB :=
+  (mapHopfIdealPointsSubgroup n I φ).subgroupCongr hA hB
+
+/-- The transported map applies the value-algebra homomorphism entrywise. -/
+@[simp]
+theorem coe_mapHopfIdealPointsSubgroupCongr
+    (I : HopfIdeal R (coordinateHopfAlgebra R n))
+    {PA : Subgroup (Matrix.GeneralLinearGroup (Fin n) A)}
+    {PB : Subgroup (Matrix.GeneralLinearGroup (Fin n) B)}
+    (hA : PA = hopfIdealPointsSubgroup n I A) (hB : PB = hopfIdealPointsSubgroup n I B)
+    (φ : A →ₐ[R] B) (g : PA) :
+    (mapHopfIdealPointsSubgroupCongr n I hA hB φ g :
+        Matrix.GeneralLinearGroup (Fin n) B) =
+      Matrix.GeneralLinearGroup.map (φ : A →+* B) g := by
+  simp only [mapHopfIdealPointsSubgroupCongr, MonoidHom.coe_subgroupCongr_apply,
+    coe_mapHopfIdealPointsSubgroup]
+
+/-- The identity value-algebra homomorphism induces the identity on a presented point subgroup. -/
+@[simp]
+theorem mapHopfIdealPointsSubgroupCongr_id
+    (I : HopfIdeal R (coordinateHopfAlgebra R n))
+    {PA : Subgroup (Matrix.GeneralLinearGroup (Fin n) A)}
+    (hA : PA = hopfIdealPointsSubgroup n I A) :
+    mapHopfIdealPointsSubgroupCongr n I hA hA (AlgHom.id R A) = MonoidHom.id PA := by
+  rw [mapHopfIdealPointsSubgroupCongr, mapHopfIdealPointsSubgroup_id,
+    MonoidHom.subgroupCongr_id]
+
+/-- The maps induced on presented point subgroups compose.
+
+Not a `simp` lemma: the middle subgroup and its presentation appear only on the right-hand side,
+so `simp` would have to invent them and would rewrite into an unrelated instantiation. Rewrite
+pointwise through `TauCeti.GeneralLinear.coe_mapHopfIdealPointsSubgroupCongr` instead. -/
+theorem mapHopfIdealPointsSubgroupCongr_comp
+    {C : Type*} [CommRing C] [Algebra R C]
+    (I : HopfIdeal R (coordinateHopfAlgebra R n))
+    {PA : Subgroup (Matrix.GeneralLinearGroup (Fin n) A)}
+    {PB : Subgroup (Matrix.GeneralLinearGroup (Fin n) B)}
+    {PC : Subgroup (Matrix.GeneralLinearGroup (Fin n) C)}
+    (hA : PA = hopfIdealPointsSubgroup n I A) (hB : PB = hopfIdealPointsSubgroup n I B)
+    (hC : PC = hopfIdealPointsSubgroup n I C) (φ : A →ₐ[R] B) (ψ : B →ₐ[R] C) :
+    mapHopfIdealPointsSubgroupCongr n I hA hC (ψ.comp φ) =
+      (mapHopfIdealPointsSubgroupCongr n I hB hC ψ).comp
+        (mapHopfIdealPointsSubgroupCongr n I hA hB φ) := by
+  simp only [mapHopfIdealPointsSubgroupCongr, mapHopfIdealPointsSubgroup_comp,
+    MonoidHom.subgroupCongr_comp hA hB hC]
+
+/-- An injective value-algebra homomorphism induces an injective map of presented point
+subgroups. -/
+theorem mapHopfIdealPointsSubgroupCongr_injective
+    (I : HopfIdeal R (coordinateHopfAlgebra R n))
+    {PA : Subgroup (Matrix.GeneralLinearGroup (Fin n) A)}
+    {PB : Subgroup (Matrix.GeneralLinearGroup (Fin n) B)}
+    (hA : PA = hopfIdealPointsSubgroup n I A) (hB : PB = hopfIdealPointsSubgroup n I B)
+    {φ : A →ₐ[R] B} (hφ : Function.Injective φ) :
+    Function.Injective (mapHopfIdealPointsSubgroupCongr n I hA hB φ) :=
+  MonoidHom.subgroupCongr_injective hA hB (mapHopfIdealPointsSubgroup_injective n I hφ)
 
 /-- Larger Hopf ideals cut out smaller general-linear point subgroups. -/
 theorem hopfIdealPointsSubgroup_le_of_le

--- a/TauCeti/Algebra/Group/Subgroup/Map.lean
+++ b/TauCeti/Algebra/Group/Subgroup/Map.lean
@@ -140,13 +140,15 @@ def _root_.MonoidHom.subgroupCongr {A A' : Subgroup G} {B B' : Subgroup H}
   ((MulEquiv.subgroupCongr hB).symm.toMonoidHom).comp
     (f.comp (MulEquiv.subgroupCongr hA).toMonoidHom)
 
-/-- The transported homomorphism has the same underlying values as the original: it reads its
-argument through `hA` and returns the same element of the ambient group. -/
+/-- The transported homomorphism takes the same value in the ambient group as the original does
+at the corresponding element. -/
 @[simp]
 theorem _root_.MonoidHom.coe_subgroupCongr_apply {A A' : Subgroup G} {B B' : Subgroup H}
     (hA : A' = A) (hB : B' = B) (f : A →* B) (x : A') :
-    (f.subgroupCongr hA hB x : H) = f ⟨x, hA ▸ x.2⟩ :=
-  (rfl)
+    (f.subgroupCongr hA hB x : H) = f ⟨x, hA ▸ x.2⟩ := by
+  simp only [MonoidHom.subgroupCongr, MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom,
+    MulEquiv.subgroupCongr_symm_apply]
+  exact congrArg (fun y => (f y : H)) (Subtype.ext (MulEquiv.subgroupCongr_apply hA x))
 
 /-- Transporting the identity homomorphism along one equality of subgroups, on both sides, gives
 the identity. -/
@@ -168,14 +170,14 @@ theorem _root_.MonoidHom.subgroupCongr_comp {A A' : Subgroup G} {B B' : Subgroup
     simp only [MonoidHom.subgroupCongr, MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom,
       MulEquiv.apply_symm_apply]
 
-/-- Transport preserves injectivity: it composes the original homomorphism with two bijections. -/
+/-- Transport along equalities of the domain and codomain preserves injectivity. -/
 theorem _root_.MonoidHom.subgroupCongr_injective {A A' : Subgroup G} {B B' : Subgroup H}
     (hA : A' = A) (hB : B' = B) {f : A →* B} (hf : Function.Injective f) :
     Function.Injective (f.subgroupCongr hA hB) :=
   (MulEquiv.subgroupCongr hB).symm.injective.comp
     (hf.comp (MulEquiv.subgroupCongr hA).injective)
 
-/-- Transport preserves surjectivity: it composes the original homomorphism with two bijections. -/
+/-- Transport along equalities of the domain and codomain preserves surjectivity. -/
 theorem _root_.MonoidHom.subgroupCongr_surjective {A A' : Subgroup G} {B B' : Subgroup H}
     (hA : A' = A) (hB : B' = B) {f : A →* B} (hf : Function.Surjective f) :
     Function.Surjective (f.subgroupCongr hA hB) :=

--- a/TauCeti/Algebra/Group/Subgroup/Map.lean
+++ b/TauCeti/Algebra/Group/Subgroup/Map.lean
@@ -138,20 +138,27 @@ def _root_.MonoidHom.subgroupCongr {A A' : Subgroup G} {B B' : Subgroup H}
   ((MulEquiv.subgroupCongr hB).symm.toMonoidHom).comp
     (f.comp (MulEquiv.subgroupCongr hA).toMonoidHom)
 
+/-- The transported homomorphism has the same underlying values as the original: it reads its
+argument through `hA` and returns the same element of the ambient group. -/
 @[simp]
 theorem _root_.MonoidHom.coe_subgroupCongr_apply {A A' : Subgroup G} {B B' : Subgroup H}
     (hA : A' = A) (hB : B' = B) (f : A →* B) (x : A') :
     (f.subgroupCongr hA hB x : H) = f ⟨x, hA ▸ x.2⟩ :=
   (rfl)
 
+/-- Transporting the identity homomorphism along one equality of subgroups, on both sides, gives
+the identity. -/
 @[simp]
 theorem _root_.MonoidHom.subgroupCongr_id {A A' : Subgroup G} (hA : A' = A) :
     (MonoidHom.id A).subgroupCongr hA hA = MonoidHom.id A' :=
   MonoidHom.ext fun x => (MulEquiv.subgroupCongr hA).symm_apply_apply x
 
--- Not `@[simp]`: the middle subgroup `B'` and its presentation `hB` occur only on the
--- right-hand side, so `simp` would have to invent them and would rewrite into an unrelated
--- instantiation.
+/-- Transport commutes with composition: transporting `g.comp f` along the outer two equalities
+agrees with transporting `f` and `g` separately through a common middle subgroup.
+
+Not a `simp` lemma: the middle subgroup `B'` and its presentation `hB` occur only on the
+right-hand side, so `simp` would have to invent them and would rewrite into an unrelated
+instantiation. -/
 theorem _root_.MonoidHom.subgroupCongr_comp {A A' : Subgroup G} {B B' : Subgroup H}
     {C C' : Subgroup K} (hA : A' = A) (hB : B' = B) (hC : C' = C) (f : A →* B) (g : B →* C) :
     (g.comp f).subgroupCongr hA hC = (g.subgroupCongr hB hC).comp (f.subgroupCongr hA hB) :=
@@ -159,6 +166,7 @@ theorem _root_.MonoidHom.subgroupCongr_comp {A A' : Subgroup G} {B B' : Subgroup
     simp only [MonoidHom.subgroupCongr, MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom,
       MulEquiv.apply_symm_apply]
 
+/-- Transport preserves injectivity: it composes the original homomorphism with two bijections. -/
 theorem _root_.MonoidHom.subgroupCongr_injective {A A' : Subgroup G} {B B' : Subgroup H}
     (hA : A' = A) (hB : B' = B) {f : A →* B} (hf : Function.Injective f) :
     Function.Injective (f.subgroupCongr hA hB) :=

--- a/TauCeti/Algebra/Group/Subgroup/Map.lean
+++ b/TauCeti/Algebra/Group/Subgroup/Map.lean
@@ -45,6 +45,8 @@ uses it rather than repeating the composition of `MulEquiv.subgroupMap` with
 * `Subgroup.map_conj_map`: the image of a conjugate subgroup is the conjugate of the image.
 * `Subgroup.map_mk'_map_quotientGroupMap`: taking images in quotients commutes with the maps
   induced on quotients.
+* `MonoidHom.subgroupCongr_injective`, `MonoidHom.subgroupCongr_surjective`: transport along
+  equalities of the domain and codomain preserves injectivity and surjectivity.
 -/
 
 public section
@@ -172,6 +174,13 @@ theorem _root_.MonoidHom.subgroupCongr_injective {A A' : Subgroup G} {B B' : Sub
     Function.Injective (f.subgroupCongr hA hB) :=
   (MulEquiv.subgroupCongr hB).symm.injective.comp
     (hf.comp (MulEquiv.subgroupCongr hA).injective)
+
+/-- Transport preserves surjectivity: it composes the original homomorphism with two bijections. -/
+theorem _root_.MonoidHom.subgroupCongr_surjective {A A' : Subgroup G} {B B' : Subgroup H}
+    (hA : A' = A) (hB : B' = B) {f : A →* B} (hf : Function.Surjective f) :
+    Function.Surjective (f.subgroupCongr hA hB) :=
+  (MulEquiv.subgroupCongr hB).symm.surjective.comp
+    (hf.comp (MulEquiv.subgroupCongr hA).surjective)
 
 /-! ## Transporting the derived subgroup -/
 

--- a/TauCeti/Algebra/Group/Subgroup/Map.lean
+++ b/TauCeti/Algebra/Group/Subgroup/Map.lean
@@ -28,6 +28,9 @@ uses it rather than repeating the composition of `MulEquiv.subgroupMap` with
 * `TauCeti.Subgroup.congrOfMapEq`: the isomorphism of subgroups restricted from an isomorphism of
   groups carrying the one onto the other.
 * `TauCeti.commutatorCongr`: its instance for the derived subgroup.
+* `MonoidHom.subgroupCongr`: a homomorphism of subgroups transported along equalities of its
+  domain and codomain, for reading a construction through two presentations of the subgroups it
+  connects.
 
 ## Main results
 
@@ -127,6 +130,40 @@ theorem Subgroup.congrOfMapEq_symm (e : G ≃* H) {A : Subgroup G} {B : Subgroup
     (Subgroup.congrOfMapEq e h).symm =
       Subgroup.congrOfMapEq e.symm ((_root_.Subgroup.map_symm_eq_iff_map_eq A).mpr h) :=
   MulEquiv.ext fun _ => Subtype.ext (by simp)
+
+/-- The homomorphism of subgroups obtained from a homomorphism between two other subgroups by
+transporting along equalities of the domain and of the codomain. -/
+def _root_.MonoidHom.subgroupCongr {A A' : Subgroup G} {B B' : Subgroup H}
+    (hA : A' = A) (hB : B' = B) (f : A →* B) : A' →* B' :=
+  ((MulEquiv.subgroupCongr hB).symm.toMonoidHom).comp
+    (f.comp (MulEquiv.subgroupCongr hA).toMonoidHom)
+
+@[simp]
+theorem _root_.MonoidHom.coe_subgroupCongr_apply {A A' : Subgroup G} {B B' : Subgroup H}
+    (hA : A' = A) (hB : B' = B) (f : A →* B) (x : A') :
+    (f.subgroupCongr hA hB x : H) = f ⟨x, hA ▸ x.2⟩ :=
+  (rfl)
+
+@[simp]
+theorem _root_.MonoidHom.subgroupCongr_id {A A' : Subgroup G} (hA : A' = A) :
+    (MonoidHom.id A).subgroupCongr hA hA = MonoidHom.id A' :=
+  MonoidHom.ext fun x => (MulEquiv.subgroupCongr hA).symm_apply_apply x
+
+-- Not `@[simp]`: the middle subgroup `B'` and its presentation `hB` occur only on the
+-- right-hand side, so `simp` would have to invent them and would rewrite into an unrelated
+-- instantiation.
+theorem _root_.MonoidHom.subgroupCongr_comp {A A' : Subgroup G} {B B' : Subgroup H}
+    {C C' : Subgroup K} (hA : A' = A) (hB : B' = B) (hC : C' = C) (f : A →* B) (g : B →* C) :
+    (g.comp f).subgroupCongr hA hC = (g.subgroupCongr hB hC).comp (f.subgroupCongr hA hB) :=
+  MonoidHom.ext fun x => by
+    simp only [MonoidHom.subgroupCongr, MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom,
+      MulEquiv.apply_symm_apply]
+
+theorem _root_.MonoidHom.subgroupCongr_injective {A A' : Subgroup G} {B B' : Subgroup H}
+    (hA : A' = A) (hB : B' = B) {f : A →* B} (hf : Function.Injective f) :
+    Function.Injective (f.subgroupCongr hA hB) :=
+  (MulEquiv.subgroupCongr hB).symm.injective.comp
+    (hf.comp (MulEquiv.subgroupCongr hA).injective)
 
 /-! ## Transporting the derived subgroup -/
 

--- a/TauCeti/Algebra/Lie/E6/DoubledMinuscule/PointsFunctor.lean
+++ b/TauCeti/Algebra/Lie/E6/DoubledMinuscule/PointsFunctor.lean
@@ -78,19 +78,15 @@ variable {A : Type v} {B : Type v'} [CommRing A] [CommRing B]
 value rings. It is the entrywise map on `GL₅₄`, restricted to the subgroup cut out by the
 carrier's defining ideal. -/
 def pointsMap (f : A →+* B) : points A →* points B :=
-  ((MulEquiv.subgroupCongr (points_def B)).symm.toMonoidHom).comp
-    ((GeneralLinear.mapHopfIdealPointsSubgroup 54 definingIdeal f.toIntAlgHom).comp
-      (MulEquiv.subgroupCongr (points_def A)).toMonoidHom)
+  GeneralLinear.mapHopfIdealPointsSubgroupCongr 54 definingIdeal
+    (points_def A) (points_def B) f.toIntAlgHom
 
 /-- The induced map on doubled type-`E₆` carrier points is the entrywise map. -/
 @[simp]
 theorem coe_pointsMap (f : A →+* B) (g : points A) :
     (pointsMap f g : Matrix.GeneralLinearGroup (Fin 54) B) =
       Matrix.GeneralLinearGroup.map f g := by
-  rw [pointsMap]
-  simp only [MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom,
-    MulEquiv.subgroupCongr_symm_apply, GeneralLinear.coe_mapHopfIdealPointsSubgroup,
-    MulEquiv.subgroupCongr_apply, RingHom.toIntAlgHom_toRingHom]
+  simp [pointsMap]
 
 /-- Entrywise, the induced map applies the homomorphism of value rings to each matrix entry. -/
 theorem coe_pointsMap_apply (f : A →+* B) (g : points A) (i j : Fin 54) :
@@ -102,28 +98,22 @@ theorem coe_pointsMap_apply (f : A →+* B) (g : points A) (i j : Fin 54) :
 /-- The identity homomorphism induces the identity on doubled type-`E₆` carrier points. -/
 @[simp]
 theorem pointsMap_id : pointsMap (RingHom.id A) = MonoidHom.id _ := by
-  rw [pointsMap, RingHom.toIntAlgHom_id, GeneralLinear.mapHopfIdealPointsSubgroup_id]
-  apply MonoidHom.ext
-  intro g
-  exact (MulEquiv.subgroupCongr (points_def A)).symm_apply_apply g
+  simp [pointsMap]
 
 /-- The induced maps on doubled type-`E₆` carrier points compose. -/
 @[simp]
 theorem pointsMap_comp {C : Type*} [CommRing C] (f : A →+* B) (g : B →+* C) :
     pointsMap (g.comp f) = (pointsMap g).comp (pointsMap f) := by
-  apply MonoidHom.ext
-  intro x
-  simp only [pointsMap, MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, RingHom.toIntAlgHom_comp,
-    GeneralLinear.mapHopfIdealPointsSubgroup_comp, MulEquiv.apply_symm_apply]
+  simp only [pointsMap, RingHom.toIntAlgHom_comp]
+  exact GeneralLinear.mapHopfIdealPointsSubgroupCongr_comp 54 definingIdeal
+    (points_def A) (points_def B) (points_def C) f.toIntAlgHom g.toIntAlgHom
 
 /-- An injective homomorphism of value rings induces an injective map on doubled type-`E₆` carrier
 points. -/
 theorem pointsMap_injective {f : A →+* B} (hf : Function.Injective f) :
-    Function.Injective (pointsMap f) := by
-  rw [pointsMap]
-  exact (MulEquiv.subgroupCongr (points_def B)).symm.injective.comp
-    ((GeneralLinear.mapHopfIdealPointsSubgroup_injective 54 definingIdeal hf).comp
-      (MulEquiv.subgroupCongr (points_def A)).injective)
+    Function.Injective (pointsMap f) :=
+  GeneralLinear.mapHopfIdealPointsSubgroupCongr_injective 54 definingIdeal
+    (points_def A) (points_def B) (φ := f.toIntAlgHom) hf
 
 /-- The induced map carries a numbered root-subgroup parameter along the homomorphism of value
 rings. -/

--- a/TauCeti/Algebra/Lie/E6/Minuscule/PointsFunctor.lean
+++ b/TauCeti/Algebra/Lie/E6/Minuscule/PointsFunctor.lean
@@ -66,19 +66,15 @@ variable {A : Type v} {B : Type v'} [CommRing A] [CommRing B]
 rings. It is the entrywise map on `GL₂₇`, restricted to the subgroup cut out by the carrier's
 defining ideal. -/
 def pointsMap (f : A →+* B) : points A →* points B :=
-  ((MulEquiv.subgroupCongr (points_def B)).symm.toMonoidHom).comp
-    ((GeneralLinear.mapHopfIdealPointsSubgroup 27 definingIdeal f.toIntAlgHom).comp
-      (MulEquiv.subgroupCongr (points_def A)).toMonoidHom)
+  GeneralLinear.mapHopfIdealPointsSubgroupCongr 27 definingIdeal
+    (points_def A) (points_def B) f.toIntAlgHom
 
 /-- The induced map on type-`E₆` carrier points is the entrywise map. -/
 @[simp]
 theorem coe_pointsMap (f : A →+* B) (g : points A) :
     (pointsMap f g : Matrix.GeneralLinearGroup (Fin 27) B) =
       Matrix.GeneralLinearGroup.map f g := by
-  rw [pointsMap]
-  simp only [MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom,
-    MulEquiv.subgroupCongr_symm_apply, GeneralLinear.coe_mapHopfIdealPointsSubgroup,
-    MulEquiv.subgroupCongr_apply, RingHom.toIntAlgHom_toRingHom]
+  simp [pointsMap]
 
 /-- Entrywise, the induced map applies the homomorphism of value rings to each matrix entry. -/
 theorem coe_pointsMap_apply (f : A →+* B) (g : points A) (i j : Fin 27) :
@@ -90,28 +86,22 @@ theorem coe_pointsMap_apply (f : A →+* B) (g : points A) (i j : Fin 27) :
 /-- The identity homomorphism induces the identity on type-`E₆` carrier points. -/
 @[simp]
 theorem pointsMap_id : pointsMap (RingHom.id A) = MonoidHom.id _ := by
-  rw [pointsMap, RingHom.toIntAlgHom_id, GeneralLinear.mapHopfIdealPointsSubgroup_id]
-  apply MonoidHom.ext
-  intro g
-  exact (MulEquiv.subgroupCongr (points_def A)).symm_apply_apply g
+  simp [pointsMap]
 
 /-- The induced maps on type-`E₆` carrier points compose. -/
 @[simp]
 theorem pointsMap_comp {C : Type*} [CommRing C] (f : A →+* B) (g : B →+* C) :
     pointsMap (g.comp f) = (pointsMap g).comp (pointsMap f) := by
-  apply MonoidHom.ext
-  intro x
-  simp only [pointsMap, MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, RingHom.toIntAlgHom_comp,
-    GeneralLinear.mapHopfIdealPointsSubgroup_comp, MulEquiv.apply_symm_apply]
+  simp only [pointsMap, RingHom.toIntAlgHom_comp]
+  exact GeneralLinear.mapHopfIdealPointsSubgroupCongr_comp 27 definingIdeal
+    (points_def A) (points_def B) (points_def C) f.toIntAlgHom g.toIntAlgHom
 
 /-- An injective homomorphism of value rings induces an injective map on type-`E₆` carrier
 points. -/
 theorem pointsMap_injective {f : A →+* B} (hf : Function.Injective f) :
-    Function.Injective (pointsMap f) := by
-  rw [pointsMap]
-  exact (MulEquiv.subgroupCongr (points_def B)).symm.injective.comp
-    ((GeneralLinear.mapHopfIdealPointsSubgroup_injective 27 definingIdeal hf).comp
-      (MulEquiv.subgroupCongr (points_def A)).injective)
+    Function.Injective (pointsMap f) :=
+  GeneralLinear.mapHopfIdealPointsSubgroupCongr_injective 27 definingIdeal
+    (points_def A) (points_def B) (φ := f.toIntAlgHom) hf
 
 /-- The induced map carries a numbered root-subgroup parameter along the homomorphism of value
 rings. -/

--- a/TauCeti/Algebra/Lie/E7/Minuscule/PointsFunctor.lean
+++ b/TauCeti/Algebra/Lie/E7/Minuscule/PointsFunctor.lean
@@ -76,19 +76,15 @@ variable {A : Type v} {B : Type v'} [CommRing A] [CommRing B]
 rings. It is the entrywise map on `GL₅₆`, restricted to the subgroup cut out by the carrier's
 defining ideal. -/
 def pointsMap (f : A →+* B) : points A →* points B :=
-  ((MulEquiv.subgroupCongr (points_def B)).symm.toMonoidHom).comp
-    ((GeneralLinear.mapHopfIdealPointsSubgroup 56 definingIdeal f.toIntAlgHom).comp
-      (MulEquiv.subgroupCongr (points_def A)).toMonoidHom)
+  GeneralLinear.mapHopfIdealPointsSubgroupCongr 56 definingIdeal
+    (points_def A) (points_def B) f.toIntAlgHom
 
 /-- The induced map on type-`E₇` carrier points is the entrywise map. -/
 @[simp]
 theorem coe_pointsMap (f : A →+* B) (g : points A) :
     (pointsMap f g : Matrix.GeneralLinearGroup (Fin 56) B) =
       Matrix.GeneralLinearGroup.map f g := by
-  rw [pointsMap]
-  simp only [MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom,
-    MulEquiv.subgroupCongr_symm_apply, GeneralLinear.coe_mapHopfIdealPointsSubgroup,
-    MulEquiv.subgroupCongr_apply, RingHom.toIntAlgHom_toRingHom]
+  simp [pointsMap]
 
 /-- Entrywise, the induced map applies the homomorphism of value rings to each matrix entry. -/
 theorem coe_pointsMap_apply (f : A →+* B) (g : points A) (i j : Fin 56) :
@@ -100,28 +96,22 @@ theorem coe_pointsMap_apply (f : A →+* B) (g : points A) (i j : Fin 56) :
 /-- The identity homomorphism induces the identity on type-`E₇` carrier points. -/
 @[simp]
 theorem pointsMap_id : pointsMap (RingHom.id A) = MonoidHom.id _ := by
-  rw [pointsMap, RingHom.toIntAlgHom_id, GeneralLinear.mapHopfIdealPointsSubgroup_id]
-  apply MonoidHom.ext
-  intro g
-  exact (MulEquiv.subgroupCongr (points_def A)).symm_apply_apply g
+  simp [pointsMap]
 
 /-- The induced maps on type-`E₇` carrier points compose. -/
 @[simp]
 theorem pointsMap_comp {C : Type*} [CommRing C] (f : A →+* B) (g : B →+* C) :
     pointsMap (g.comp f) = (pointsMap g).comp (pointsMap f) := by
-  apply MonoidHom.ext
-  intro x
-  simp only [pointsMap, MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, RingHom.toIntAlgHom_comp,
-    GeneralLinear.mapHopfIdealPointsSubgroup_comp, MulEquiv.apply_symm_apply]
+  simp only [pointsMap, RingHom.toIntAlgHom_comp]
+  exact GeneralLinear.mapHopfIdealPointsSubgroupCongr_comp 56 definingIdeal
+    (points_def A) (points_def B) (points_def C) f.toIntAlgHom g.toIntAlgHom
 
 /-- An injective homomorphism of value rings induces an injective map on type-`E₇` carrier
 points. -/
 theorem pointsMap_injective {f : A →+* B} (hf : Function.Injective f) :
-    Function.Injective (pointsMap f) := by
-  rw [pointsMap]
-  exact (MulEquiv.subgroupCongr (points_def B)).symm.injective.comp
-    ((GeneralLinear.mapHopfIdealPointsSubgroup_injective 56 definingIdeal hf).comp
-      (MulEquiv.subgroupCongr (points_def A)).injective)
+    Function.Injective (pointsMap f) :=
+  GeneralLinear.mapHopfIdealPointsSubgroupCongr_injective 56 definingIdeal
+    (points_def A) (points_def B) (φ := f.toIntAlgHom) hf
 
 /-- The induced map carries a numbered root-subgroup parameter along the homomorphism of value
 rings. -/

--- a/TauCeti/Algebra/Lie/Orthogonal/TypeB/SpinCarrier/PointsFunctor.lean
+++ b/TauCeti/Algebra/Lie/Orthogonal/TypeB/SpinCarrier/PointsFunctor.lean
@@ -65,20 +65,15 @@ variable {A : Type v} {B : Type w} [CommRing A] [CommRing B]
 /-- The map on type-`Bₙ₊₁` spin-carrier points induced by a homomorphism of value rings. It is
 the entrywise map on the ambient general linear group, restricted to the carrier subgroup. -/
 def pointsMap (f : A →+* B) : points n A →* points n B :=
-  ((MulEquiv.subgroupCongr (points_def n B)).symm.toMonoidHom).comp
-    ((GeneralLinear.mapHopfIdealPointsSubgroup (dimension n) (definingIdeal n)
-          f.toIntAlgHom).comp
-      (MulEquiv.subgroupCongr (points_def n A)).toMonoidHom)
+  GeneralLinear.mapHopfIdealPointsSubgroupCongr (dimension n) (definingIdeal n)
+    (points_def n A) (points_def n B) f.toIntAlgHom
 
 /-- The induced map on type-`Bₙ₊₁` spin-carrier points is the entrywise matrix map. -/
 @[simp]
 theorem coe_pointsMap (f : A →+* B) (g : points n A) :
     (pointsMap n f g : Matrix.GeneralLinearGroup (Fin (dimension n)) B) =
       Matrix.GeneralLinearGroup.map f g := by
-  rw [pointsMap]
-  simp only [MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom,
-    MulEquiv.subgroupCongr_symm_apply, GeneralLinear.coe_mapHopfIdealPointsSubgroup,
-    MulEquiv.subgroupCongr_apply, RingHom.toIntAlgHom_toRingHom]
+  simp [pointsMap]
 
 /-- Entrywise, the induced map applies the homomorphism of value rings to each matrix entry. -/
 theorem coe_pointsMap_apply (f : A →+* B) (g : points n A)
@@ -92,29 +87,22 @@ theorem coe_pointsMap_apply (f : A →+* B) (g : points n A)
 /-- The identity homomorphism induces the identity on type-`Bₙ₊₁` spin-carrier points. -/
 @[simp]
 theorem pointsMap_id : pointsMap n (RingHom.id A) = MonoidHom.id _ := by
-  rw [pointsMap, RingHom.toIntAlgHom_id, GeneralLinear.mapHopfIdealPointsSubgroup_id]
-  apply MonoidHom.ext
-  intro g
-  exact (MulEquiv.subgroupCongr (points_def n A)).symm_apply_apply g
+  simp [pointsMap]
 
 /-- The induced maps on type-`Bₙ₊₁` spin-carrier points compose. -/
 @[simp]
 theorem pointsMap_comp {C : Type*} [CommRing C] (f : A →+* B) (g : B →+* C) :
     pointsMap n (g.comp f) = (pointsMap n g).comp (pointsMap n f) := by
-  apply MonoidHom.ext
-  intro x
-  simp only [pointsMap, MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, RingHom.toIntAlgHom_comp,
-    GeneralLinear.mapHopfIdealPointsSubgroup_comp, MulEquiv.apply_symm_apply]
+  simp only [pointsMap, RingHom.toIntAlgHom_comp]
+  exact GeneralLinear.mapHopfIdealPointsSubgroupCongr_comp (dimension n) (definingIdeal n)
+    (points_def n A) (points_def n B) (points_def n C) f.toIntAlgHom g.toIntAlgHom
 
 /-- An injective homomorphism of value rings induces an injective map on type-`Bₙ₊₁`
 spin-carrier points. -/
 theorem pointsMap_injective {f : A →+* B} (hf : Function.Injective f) :
-    Function.Injective (pointsMap n f) := by
-  rw [pointsMap]
-  exact (MulEquiv.subgroupCongr (points_def n B)).symm.injective.comp
-    ((GeneralLinear.mapHopfIdealPointsSubgroup_injective
-      (dimension n) (definingIdeal n) hf).comp
-        (MulEquiv.subgroupCongr (points_def n A)).injective)
+    Function.Injective (pointsMap n f) :=
+  GeneralLinear.mapHopfIdealPointsSubgroupCongr_injective (dimension n) (definingIdeal n)
+    (points_def n A) (points_def n B) (φ := f.toIntAlgHom) hf
 
 /-- The induced map carries a numbered root-subgroup parameter along the homomorphism of value
 rings. -/

--- a/TauCeti/Algebra/Lie/Orthogonal/TypeD/SpinCarrier/Frobenius.lean
+++ b/TauCeti/Algebra/Lie/Orthogonal/TypeD/SpinCarrier/Frobenius.lean
@@ -122,13 +122,12 @@ For `p` prime, `0 < k`, and `A` an algebraic closure of `ZMod p`, this is the Fr
 intended for a future construction of the `Dₙ(p ^ k)`, `²Dₙ(p ^ k)` and `³D₄(p ^ k)` Steinberg
 maps. -/
 def frobenius : points n hn A →* points n hn A :=
-  (pointsEquivKostantToralPoints n hn A).symm.toMonoidHom.comp
-    ((kostantToralFrobenius
-        (TauCeti.serreRootGenerator (CartanMatrix.D n))
-        (TauCeti.serreH ℚ (CartanMatrix.D n)) (rep n hn) (lattice n).toAddSubgroup
-        (rep_kostantForm_mem_lattice n hn)
-        (isNilpotent_rep_rootGenerator n hn) (latticeBasis n) (basisWeight n) p k A).comp
-      (pointsEquivKostantToralPoints n hn A).toMonoidHom)
+  (kostantToralFrobenius
+      (TauCeti.serreRootGenerator (CartanMatrix.D n))
+      (TauCeti.serreH ℚ (CartanMatrix.D n)) (rep n hn) (lattice n).toAddSubgroup
+      (rep_kostantForm_mem_lattice n hn)
+      (isNilpotent_rep_rootGenerator n hn) (latticeBasis n) (basisWeight n) p k A).subgroupCongr
+    (points_eq_kostantToralPointsSubgroup n hn A) (points_eq_kostantToralPointsSubgroup n hn A)
 
 /-- Along the presentation as generic toral-closure points, the carrier Frobenius is the generic
 Kostant toral Frobenius. Private: it is the transport equation through which the public equations
@@ -141,7 +140,8 @@ private theorem pointsEquivKostantToralPoints_frobenius (g : points n hn A) :
         (rep_kostantForm_mem_lattice n hn)
         (isNilpotent_rep_rootGenerator n hn) (latticeBasis n) (basisWeight n) p k A
         (pointsEquivKostantToralPoints n hn A g) := by
-  simp only [frobenius, MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, MulEquiv.apply_symm_apply]
+  apply Subtype.ext
+  simp [frobenius]
 
 /-- The Frobenius endomorphism of the type-`Dₙ` spin carrier acts by entrywise Frobenius.
 

--- a/TauCeti/Algebra/Lie/Orthogonal/TypeD/SpinCarrier/PointsFunctor.lean
+++ b/TauCeti/Algebra/Lie/Orthogonal/TypeD/SpinCarrier/PointsFunctor.lean
@@ -55,20 +55,15 @@ variable {A : Type v} {B : Type w} [CommRing A] [CommRing B]
 /-- The map on type-`Dₙ` spin-carrier points induced by a homomorphism of value rings. It is the
 entrywise map on the ambient general linear group, restricted to the carrier subgroup. -/
 def pointsMap (f : A →+* B) : points n hn A →* points n hn B :=
-  ((MulEquiv.subgroupCongr (points_def n hn B)).symm.toMonoidHom).comp
-    ((GeneralLinear.mapHopfIdealPointsSubgroup (dimension n) (definingIdeal n hn)
-          f.toIntAlgHom).comp
-      (MulEquiv.subgroupCongr (points_def n hn A)).toMonoidHom)
+  GeneralLinear.mapHopfIdealPointsSubgroupCongr (dimension n) (definingIdeal n hn)
+    (points_def n hn A) (points_def n hn B) f.toIntAlgHom
 
 /-- The induced map on type-`Dₙ` spin-carrier points is the entrywise matrix map. -/
 @[simp]
 theorem coe_pointsMap (f : A →+* B) (g : points n hn A) :
     (pointsMap n hn f g : Matrix.GeneralLinearGroup (Fin (dimension n)) B) =
       Matrix.GeneralLinearGroup.map f g := by
-  rw [pointsMap]
-  simp only [MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom,
-    MulEquiv.subgroupCongr_symm_apply, GeneralLinear.coe_mapHopfIdealPointsSubgroup,
-    MulEquiv.subgroupCongr_apply, RingHom.toIntAlgHom_toRingHom]
+  simp [pointsMap]
 
 /-- Entrywise, the induced map applies the homomorphism of value rings to each matrix entry. -/
 theorem coe_pointsMap_apply (f : A →+* B) (g : points n hn A)
@@ -82,29 +77,22 @@ theorem coe_pointsMap_apply (f : A →+* B) (g : points n hn A)
 /-- The identity homomorphism induces the identity on type-`Dₙ` spin-carrier points. -/
 @[simp]
 theorem pointsMap_id : pointsMap n hn (RingHom.id A) = MonoidHom.id _ := by
-  rw [pointsMap, RingHom.toIntAlgHom_id, GeneralLinear.mapHopfIdealPointsSubgroup_id]
-  apply MonoidHom.ext
-  intro g
-  exact (MulEquiv.subgroupCongr (points_def n hn A)).symm_apply_apply g
+  simp [pointsMap]
 
 /-- The induced maps on type-`Dₙ` spin-carrier points compose. -/
 @[simp]
 theorem pointsMap_comp {C : Type*} [CommRing C] (f : A →+* B) (g : B →+* C) :
     pointsMap n hn (g.comp f) = (pointsMap n hn g).comp (pointsMap n hn f) := by
-  apply MonoidHom.ext
-  intro x
-  simp only [pointsMap, MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, RingHom.toIntAlgHom_comp,
-    GeneralLinear.mapHopfIdealPointsSubgroup_comp, MulEquiv.apply_symm_apply]
+  simp only [pointsMap, RingHom.toIntAlgHom_comp]
+  exact GeneralLinear.mapHopfIdealPointsSubgroupCongr_comp (dimension n) (definingIdeal n hn)
+    (points_def n hn A) (points_def n hn B) (points_def n hn C) f.toIntAlgHom g.toIntAlgHom
 
 /-- An injective homomorphism of value rings induces an injective map on type-`Dₙ` spin-carrier
 points. -/
 theorem pointsMap_injective {f : A →+* B} (hf : Function.Injective f) :
-    Function.Injective (pointsMap n hn f) := by
-  rw [pointsMap]
-  exact (MulEquiv.subgroupCongr (points_def n hn B)).symm.injective.comp
-    ((GeneralLinear.mapHopfIdealPointsSubgroup_injective
-      (dimension n) (definingIdeal n hn) hf).comp
-        (MulEquiv.subgroupCongr (points_def n hn A)).injective)
+    Function.Injective (pointsMap n hn f) :=
+  GeneralLinear.mapHopfIdealPointsSubgroupCongr_injective (dimension n) (definingIdeal n hn)
+    (points_def n hn A) (points_def n hn B) (φ := f.toIntAlgHom) hf
 
 /-- The induced map carries a numbered root-subgroup parameter along the homomorphism of value
 rings. -/

--- a/TauCeti/Algebra/Lie/Sl2/Kostant/GroupScheme.lean
+++ b/TauCeti/Algebra/Lie/Sl2/Kostant/GroupScheme.lean
@@ -403,10 +403,10 @@ private theorem rankOneCarrierPoints_eq_hopfIdealPoints
 noncomputable def rankOneCarrierPointsMap
     {A : Type u} {B : Type v} [CommRing A] [CommRing B]
     (f : A →+* B) : rankOneCarrierPoints A →* rankOneCarrierPoints B :=
-  ((MulEquiv.subgroupCongr (rankOneCarrierPoints_eq_hopfIdealPoints B)).symm.toMonoidHom).comp
-    ((GeneralLinear.mapHopfIdealPointsSubgroup 2
-      (kostantToralDefiningIdeal e h ρ M hM hnil b rankOneWeight) f.toIntAlgHom).comp
-      (MulEquiv.subgroupCongr (rankOneCarrierPoints_eq_hopfIdealPoints A)).toMonoidHom)
+  GeneralLinear.mapHopfIdealPointsSubgroupCongr 2
+    (kostantToralDefiningIdeal e h ρ M hM hnil b rankOneWeight)
+    (rankOneCarrierPoints_eq_hopfIdealPoints A)
+    (rankOneCarrierPoints_eq_hopfIdealPoints B) f.toIntAlgHom
 
 /-- The induced map on rank-one carrier points is the entrywise map. -/
 @[simp]
@@ -415,10 +415,7 @@ theorem coe_rankOneCarrierPointsMap
     (f : A →+* B) (g : rankOneCarrierPoints A) :
     (rankOneCarrierPointsMap f g : Matrix.GeneralLinearGroup (Fin 2) B) =
       Matrix.GeneralLinearGroup.map f g := by
-  rw [rankOneCarrierPointsMap]
-  simp only [MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom,
-    MulEquiv.subgroupCongr_symm_apply, GeneralLinear.coe_mapHopfIdealPointsSubgroup,
-    MulEquiv.subgroupCongr_apply, RingHom.toIntAlgHom_toRingHom]
+  simp [rankOneCarrierPointsMap]
 
 /-- Entrywise, the induced map applies the value-ring homomorphism to each matrix entry. -/
 theorem coe_rankOneCarrierPointsMap_apply
@@ -433,11 +430,7 @@ theorem coe_rankOneCarrierPointsMap_apply
 @[simp]
 theorem rankOneCarrierPointsMap_id {A : Type u} [CommRing A] :
     rankOneCarrierPointsMap (RingHom.id A) = MonoidHom.id _ := by
-  rw [rankOneCarrierPointsMap, RingHom.toIntAlgHom_id, GeneralLinear.mapHopfIdealPointsSubgroup_id]
-  apply MonoidHom.ext
-  intro g
-  exact (MulEquiv.subgroupCongr
-    (rankOneCarrierPoints_eq_hopfIdealPoints A)).symm_apply_apply g
+  simp [rankOneCarrierPointsMap]
 
 /-- The induced maps on rank-one carrier points compose. -/
 @[simp]
@@ -446,23 +439,22 @@ theorem rankOneCarrierPointsMap_comp
     (f : A →+* B) (g : B →+* C) :
     rankOneCarrierPointsMap (g.comp f) =
       (rankOneCarrierPointsMap g).comp (rankOneCarrierPointsMap f) := by
-  apply MonoidHom.ext
-  intro x
-  simp only [rankOneCarrierPointsMap, MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom,
-    RingHom.toIntAlgHom_comp,
-    GeneralLinear.mapHopfIdealPointsSubgroup_comp, MulEquiv.apply_symm_apply]
+  simp only [rankOneCarrierPointsMap, RingHom.toIntAlgHom_comp]
+  exact GeneralLinear.mapHopfIdealPointsSubgroupCongr_comp 2
+    (kostantToralDefiningIdeal e h ρ M hM hnil b rankOneWeight)
+    (rankOneCarrierPoints_eq_hopfIdealPoints A)
+    (rankOneCarrierPoints_eq_hopfIdealPoints B)
+    (rankOneCarrierPoints_eq_hopfIdealPoints C) f.toIntAlgHom g.toIntAlgHom
 
 /-- An injective value-ring homomorphism induces an injective map on rank-one carrier points. -/
 theorem rankOneCarrierPointsMap_injective
     {A : Type u} {B : Type v} [CommRing A] [CommRing B]
     {f : A →+* B} (hf : Function.Injective f) :
-    Function.Injective (rankOneCarrierPointsMap f) := by
-  rw [rankOneCarrierPointsMap]
-  exact (MulEquiv.subgroupCongr
-    (rankOneCarrierPoints_eq_hopfIdealPoints B)).symm.injective.comp
-    ((GeneralLinear.mapHopfIdealPointsSubgroup_injective 2
-      (kostantToralDefiningIdeal e h ρ M hM hnil b rankOneWeight) hf).comp
-      (MulEquiv.subgroupCongr (rankOneCarrierPoints_eq_hopfIdealPoints A)).injective)
+    Function.Injective (rankOneCarrierPointsMap f) :=
+  GeneralLinear.mapHopfIdealPointsSubgroupCongr_injective 2
+    (kostantToralDefiningIdeal e h ρ M hM hnil b rankOneWeight)
+    (rankOneCarrierPoints_eq_hopfIdealPoints A) (rankOneCarrierPoints_eq_hopfIdealPoints B)
+    (φ := f.toIntAlgHom) hf
 
 /-- The induced map carries rank-one root-subgroup parameters along the value-ring map. -/
 @[simp]

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/Frobenius.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/Frobenius.lean
@@ -98,12 +98,11 @@ private theorem coe_pointsEquivKostantToralPoints (g : points r A) :
 For `p` prime, `0 < k`, and `A` an algebraic closure of `ZMod p`, this is the Frobenius component
 intended for a future construction of the `A_r(p ^ k)` Steinberg map. -/
 def frobenius : points r A →* points r A :=
-  (pointsEquivKostantToralPoints r A).symm.toMonoidHom.comp
-    ((TauCeti.UniversalEnvelopingAlgebra.kostantToralFrobenius (rootGenerator r)
+  (TauCeti.UniversalEnvelopingAlgebra.kostantToralFrobenius (rootGenerator r)
       (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
       (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice r hu hv)
-      (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) p k A).comp
-        (pointsEquivKostantToralPoints r A).toMonoidHom)
+      (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) p k A).subgroupCongr
+    (points_eq_kostantToralPointsSubgroup r A) (points_eq_kostantToralPointsSubgroup r A)
 
 private theorem pointsEquivKostantToralPoints_frobenius (g : points r A) :
     pointsEquivKostantToralPoints r A (frobenius r p k A g) =
@@ -112,8 +111,8 @@ private theorem pointsEquivKostantToralPoints_frobenius (g : points r A) :
         (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice r hu hv)
         (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) p k A
         (pointsEquivKostantToralPoints r A g) := by
-  simp only [frobenius, MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom,
-    MulEquiv.apply_symm_apply]
+  apply Subtype.ext
+  simp [frobenius]
 
 /-- The Frobenius endomorphism of the type-`A_r` carrier acts by entrywise Frobenius.
 

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/PointsFunctor.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/PointsFunctor.lean
@@ -89,21 +89,15 @@ value rings.** It is `TauCeti.GeneralLinear.mapHopfIdealPointsSubgroup` read at 
 defining Hopf ideal, transported along `TauCeti.SlStd.points_def` so that it is stated in the named
 type-`A` API rather than in the presentation that API is defined by. -/
 def pointsMap (f : A →+* B) : points r A →* points r B :=
-  ((MulEquiv.subgroupCongr (points_def r B)).symm.toMonoidHom).comp
-    ((GeneralLinear.mapHopfIdealPointsSubgroup (r + 1) (definingIdeal r) f.toIntAlgHom).comp
-      (MulEquiv.subgroupCongr (points_def r A)).toMonoidHom)
+  GeneralLinear.mapHopfIdealPointsSubgroupCongr (r + 1) (definingIdeal r)
+    (points_def r A) (points_def r B) f.toIntAlgHom
 
 /-- The induced map on type-`A_r` carrier points is the entrywise map. -/
 @[simp]
 theorem coe_pointsMap (f : A →+* B) (g : points r A) :
     (pointsMap r f g : Matrix.GeneralLinearGroup (Fin (r + 1)) B) =
       Matrix.GeneralLinearGroup.map f g := by
-  -- `mapHopfIdealPointsSubgroup` is stated for the `ℤ`-algebra map induced by `f`, whose
-  -- underlying ring homomorphism is `f` again.
-  rw [pointsMap]
-  simp only [MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, MulEquiv.subgroupCongr_symm_apply,
-    GeneralLinear.coe_mapHopfIdealPointsSubgroup, MulEquiv.subgroupCongr_apply,
-    RingHom.toIntAlgHom_toRingHom]
+  simp [pointsMap]
 
 /-- Entrywise, the induced map applies the homomorphism of value rings to each matrix entry. -/
 theorem coe_pointsMap_apply (f : A →+* B) (g : points r A) (i j : Fin (r + 1)) :
@@ -116,28 +110,22 @@ theorem coe_pointsMap_apply (f : A →+* B) (g : points r A) (i j : Fin (r + 1))
 /-- The identity homomorphism of value rings induces the identity on type-`A_r` carrier points. -/
 @[simp]
 theorem pointsMap_id : pointsMap r (RingHom.id A) = MonoidHom.id _ := by
-  rw [pointsMap, RingHom.toIntAlgHom_id, GeneralLinear.mapHopfIdealPointsSubgroup_id]
-  apply MonoidHom.ext
-  intro g
-  exact (MulEquiv.subgroupCongr (points_def r A)).symm_apply_apply g
+  simp [pointsMap]
 
 /-- The induced maps on type-`A_r` carrier points compose. -/
 @[simp]
 theorem pointsMap_comp {C : Type*} [CommRing C] (f : A →+* B) (g : B →+* C) :
     pointsMap r (g.comp f) = (pointsMap r g).comp (pointsMap r f) := by
-  apply MonoidHom.ext
-  intro x
-  simp only [pointsMap, MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, RingHom.toIntAlgHom_comp,
-    GeneralLinear.mapHopfIdealPointsSubgroup_comp, MulEquiv.apply_symm_apply]
+  simp only [pointsMap, RingHom.toIntAlgHom_comp]
+  exact GeneralLinear.mapHopfIdealPointsSubgroupCongr_comp (r + 1) (definingIdeal r)
+    (points_def r A) (points_def r B) (points_def r C) f.toIntAlgHom g.toIntAlgHom
 
 /-- An injective homomorphism of value rings induces an injective map on type-`A_r` carrier
 points. -/
 theorem pointsMap_injective {f : A →+* B} (hf : Function.Injective f) :
-    Function.Injective (pointsMap r f) := by
-  rw [pointsMap]
-  exact (MulEquiv.subgroupCongr (points_def r B)).symm.injective.comp
-    ((GeneralLinear.mapHopfIdealPointsSubgroup_injective (r + 1) (definingIdeal r) hf).comp
-      (MulEquiv.subgroupCongr (points_def r A)).injective)
+    Function.Injective (pointsMap r f) :=
+  GeneralLinear.mapHopfIdealPointsSubgroupCongr_injective (r + 1) (definingIdeal r)
+    (points_def r A) (points_def r B) (φ := f.toIntAlgHom) hf
 
 /-- The induced map carries a numbered root-subgroup parameter along the homomorphism of value
 rings. -/

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/UpperTriangular.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/UpperTriangular.lean
@@ -290,10 +290,8 @@ theorem coe_pointsMulEquiv_mapPointsFunctor_quotientMapOfLe (A : CommAlgCat.{v} 
 entrywise map. -/
 noncomputable def upperTriangularPointsMap {A : Type v} {B : Type v'} [CommRing A] [CommRing B]
     (f : A →+* B) : upperTriangularPoints r A →* upperTriangularPoints r B :=
-  ((MulEquiv.subgroupCongr (upperTriangularPoints_def r B)).symm.toMonoidHom).comp
-    ((GeneralLinear.mapHopfIdealPointsSubgroup (r + 1) (upperTriangularDefiningIdeal r)
-        f.toIntAlgHom).comp
-      (MulEquiv.subgroupCongr (upperTriangularPoints_def r A)).toMonoidHom)
+  GeneralLinear.mapHopfIdealPointsSubgroupCongr (r + 1) (upperTriangularDefiningIdeal r)
+    (upperTriangularPoints_def r A) (upperTriangularPoints_def r B) f.toIntAlgHom
 
 /-- The induced map on upper-triangular carrier points is the entrywise map. -/
 @[simp]
@@ -301,22 +299,14 @@ theorem coe_upperTriangularPointsMap {A : Type v} {B : Type v'} [CommRing A] [Co
     (f : A →+* B) (g : upperTriangularPoints r A) :
     (upperTriangularPointsMap r f g : Matrix.GeneralLinearGroup (Fin (r + 1)) B) =
       Matrix.GeneralLinearGroup.map f g := by
-  -- `mapHopfIdealPointsSubgroup` is stated for the `ℤ`-algebra map induced by `f`, whose
-  -- underlying ring homomorphism is `f` again.
-  rw [upperTriangularPointsMap]
-  simp only [MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, MulEquiv.subgroupCongr_symm_apply,
-    GeneralLinear.coe_mapHopfIdealPointsSubgroup, MulEquiv.subgroupCongr_apply,
-    RingHom.toIntAlgHom_toRingHom]
+  simp [upperTriangularPointsMap]
 
 /-- The identity homomorphism of value rings induces the identity on upper-triangular carrier
 points. -/
 @[simp]
 theorem upperTriangularPointsMap_id (A : Type v) [CommRing A] :
     upperTriangularPointsMap r (RingHom.id A) = MonoidHom.id (upperTriangularPoints r A) := by
-  rw [upperTriangularPointsMap, RingHom.toIntAlgHom_id, GeneralLinear.mapHopfIdealPointsSubgroup_id]
-  apply MonoidHom.ext
-  intro g
-  exact (MulEquiv.subgroupCongr (upperTriangularPoints_def r A)).symm_apply_apply g
+  simp [upperTriangularPointsMap]
 
 /-- The induced maps on upper-triangular carrier points compose. -/
 @[simp]
@@ -324,11 +314,10 @@ theorem upperTriangularPointsMap_comp {A : Type v} {B : Type v'} {C : Type*}
     [CommRing A] [CommRing B] [CommRing C] (f : A →+* B) (g : B →+* C) :
     upperTriangularPointsMap r (g.comp f) =
       (upperTriangularPointsMap r g).comp (upperTriangularPointsMap r f) := by
-  apply MonoidHom.ext
-  intro x
-  simp only [upperTriangularPointsMap, MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom,
-    RingHom.toIntAlgHom_comp,
-    GeneralLinear.mapHopfIdealPointsSubgroup_comp, MulEquiv.apply_symm_apply]
+  simp only [upperTriangularPointsMap, RingHom.toIntAlgHom_comp]
+  exact GeneralLinear.mapHopfIdealPointsSubgroupCongr_comp (r + 1) (upperTriangularDefiningIdeal r)
+    (upperTriangularPoints_def r A) (upperTriangularPoints_def r B)
+    (upperTriangularPoints_def r C) f.toIntAlgHom g.toIntAlgHom
 
 /-- The group-valued functor of matrix points of the upper-triangular subgroup scheme of the
 type-`A_r` carrier. -/

--- a/TauCeti/Algebra/Lie/Symplectic/StandardCarrier/Frobenius.lean
+++ b/TauCeti/Algebra/Lie/Symplectic/StandardCarrier/Frobenius.lean
@@ -105,12 +105,11 @@ private theorem coe_pointsEquivKostantToralPoints (g : points n A) :
 For `p` prime, `0 < k`, and `A` an algebraic closure of `ZMod p`, this is the Frobenius component
 intended for a future construction of the `C_(n+1)(p ^ k)` Steinberg map. -/
 def frobenius : points n A →* points n A :=
-  (pointsEquivKostantToralPoints n A).symm.toMonoidHom.comp
-    ((TauCeti.UniversalEnvelopingAlgebra.kostantToralFrobenius (rootGenerator n)
+  (TauCeti.UniversalEnvelopingAlgebra.kostantToralFrobenius (rootGenerator n)
       (cartanGenerator n) (rep n) (lattice n).toAddSubgroup
       (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice n hu hv)
-      (isNilpotent_rep_rootGenerator n) (latticeBasis n) (basisWeight n) p k A).comp
-        (pointsEquivKostantToralPoints n A).toMonoidHom)
+      (isNilpotent_rep_rootGenerator n) (latticeBasis n) (basisWeight n) p k A).subgroupCongr
+    (points_eq_kostantToralPointsSubgroup n A) (points_eq_kostantToralPointsSubgroup n A)
 
 private theorem pointsEquivKostantToralPoints_frobenius (g : points n A) :
     pointsEquivKostantToralPoints n A (frobenius n p k A g) =
@@ -119,8 +118,8 @@ private theorem pointsEquivKostantToralPoints_frobenius (g : points n A) :
         (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice n hu hv)
         (isNilpotent_rep_rootGenerator n) (latticeBasis n) (basisWeight n) p k A
         (pointsEquivKostantToralPoints n A g) := by
-  simp only [frobenius, MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom,
-    MulEquiv.apply_symm_apply]
+  apply Subtype.ext
+  simp [frobenius]
 
 /-- The Frobenius endomorphism of the type-`C_(n+1)` carrier acts by entrywise Frobenius.
 

--- a/TauCeti/Algebra/Lie/Symplectic/StandardCarrier/PointsFunctor.lean
+++ b/TauCeti/Algebra/Lie/Symplectic/StandardCarrier/PointsFunctor.lean
@@ -74,20 +74,15 @@ variable {A : Type v} {B : Type v'} [CommRing A] [CommRing B]
 rings. It is the entrywise map on the ambient general linear group, restricted to the subgroup
 cut out by the carrier's defining ideal. -/
 def pointsMap (f : A →+* B) : points n A →* points n B :=
-  ((MulEquiv.subgroupCongr (points_def n B)).symm.toMonoidHom).comp
-    ((GeneralLinear.mapHopfIdealPointsSubgroup ((n + 1) + (n + 1)) (definingIdeal n)
-          f.toIntAlgHom).comp
-      (MulEquiv.subgroupCongr (points_def n A)).toMonoidHom)
+  GeneralLinear.mapHopfIdealPointsSubgroupCongr ((n + 1) + (n + 1)) (definingIdeal n)
+    (points_def n A) (points_def n B) f.toIntAlgHom
 
 /-- The induced map on type-C carrier points is the entrywise map. -/
 @[simp]
 theorem coe_pointsMap (f : A →+* B) (g : points n A) :
     (pointsMap n f g : Matrix.GeneralLinearGroup (Fin ((n + 1) + (n + 1))) B) =
       Matrix.GeneralLinearGroup.map f g := by
-  rw [pointsMap]
-  simp only [MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, MulEquiv.subgroupCongr_symm_apply,
-    GeneralLinear.coe_mapHopfIdealPointsSubgroup, MulEquiv.subgroupCongr_apply,
-    RingHom.toIntAlgHom_toRingHom]
+  simp [pointsMap]
 
 /-- Entrywise, the induced map applies the homomorphism of value rings to each matrix entry. -/
 theorem coe_pointsMap_apply (f : A →+* B) (g : points n A)
@@ -101,29 +96,21 @@ theorem coe_pointsMap_apply (f : A →+* B) (g : points n A)
 /-- The identity homomorphism induces the identity on type-C carrier points. -/
 @[simp]
 theorem pointsMap_id : pointsMap n (RingHom.id A) = MonoidHom.id _ := by
-  rw [pointsMap, RingHom.toIntAlgHom_id,
-    GeneralLinear.mapHopfIdealPointsSubgroup_id]
-  apply MonoidHom.ext
-  intro g
-  exact (MulEquiv.subgroupCongr (points_def n A)).symm_apply_apply g
+  simp [pointsMap]
 
 /-- The induced maps on type-C carrier points compose. -/
 @[simp]
 theorem pointsMap_comp {C : Type*} [CommRing C] (f : A →+* B) (g : B →+* C) :
     pointsMap n (g.comp f) = (pointsMap n g).comp (pointsMap n f) := by
-  apply MonoidHom.ext
-  intro x
-  simp only [pointsMap, MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, RingHom.toIntAlgHom_comp,
-    GeneralLinear.mapHopfIdealPointsSubgroup_comp, MulEquiv.apply_symm_apply]
+  simp only [pointsMap, RingHom.toIntAlgHom_comp]
+  exact GeneralLinear.mapHopfIdealPointsSubgroupCongr_comp ((n + 1) + (n + 1)) (definingIdeal n)
+    (points_def n A) (points_def n B) (points_def n C) f.toIntAlgHom g.toIntAlgHom
 
 /-- An injective homomorphism of value rings induces an injective map on type-C carrier points. -/
 theorem pointsMap_injective {f : A →+* B} (hf : Function.Injective f) :
-    Function.Injective (pointsMap n f) := by
-  rw [pointsMap]
-  exact (MulEquiv.subgroupCongr (points_def n B)).symm.injective.comp
-    ((GeneralLinear.mapHopfIdealPointsSubgroup_injective
-      ((n + 1) + (n + 1)) (definingIdeal n) hf).comp
-        (MulEquiv.subgroupCongr (points_def n A)).injective)
+    Function.Injective (pointsMap n f) :=
+  GeneralLinear.mapHopfIdealPointsSubgroupCongr_injective ((n + 1) + (n + 1)) (definingIdeal n)
+    (points_def n A) (points_def n B) (φ := f.toIntAlgHom) hf
 
 /-- The induced map carries a numbered root-subgroup parameter along the homomorphism of value
 rings. -/

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/ToralClosure/Frobenius.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/ToralClosure/Frobenius.lean
@@ -148,12 +148,10 @@ identity. -/
 noncomputable def kostantToralFrobenius :
     kostantToralPointsSubgroup e h ρ M hM hnil b wt A →*
       kostantToralPointsSubgroup e h ρ M hM hnil b wt A :=
-  ((MulEquiv.subgroupCongr
-        (kostantToralPointsSubgroup_def e h ρ M hM hnil b wt A)).symm.toMonoidHom).comp
-    (((GeneralLinear.iterateFrobeniusHopfIdealPoints n p k
-          (kostantToralDefiningIdeal e h ρ M hM hnil b wt) A)).comp
-      (MulEquiv.subgroupCongr
-        (kostantToralPointsSubgroup_def e h ρ M hM hnil b wt A)).toMonoidHom)
+  (GeneralLinear.iterateFrobeniusHopfIdealPoints n p k
+        (kostantToralDefiningIdeal e h ρ M hM hnil b wt) A).subgroupCongr
+    (kostantToralPointsSubgroup_def e h ρ M hM hnil b wt A)
+    (kostantToralPointsSubgroup_def e h ρ M hM hnil b wt A)
 
 /-- The Frobenius endomorphism of the points of a toral closure acts by the entrywise
 Frobenius. -/
@@ -162,9 +160,8 @@ theorem coe_kostantToralFrobenius (g : kostantToralPointsSubgroup e h ρ M hM hn
     (kostantToralFrobenius e h ρ M hM hnil b wt p k A g :
         Matrix.GeneralLinearGroup (Fin n) A) =
       Matrix.GeneralLinearGroup.map (iterateFrobenius A p k) g := by
-  rw [kostantToralFrobenius]
-  simp only [MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, MulEquiv.subgroupCongr_symm_apply,
-    GeneralLinear.coe_iterateFrobeniusHopfIdealPoints, MulEquiv.subgroupCongr_apply]
+  rw [kostantToralFrobenius, MonoidHom.coe_subgroupCongr_apply,
+    GeneralLinear.coe_iterateFrobeniusHopfIdealPoints]
 
 /-- Entrywise, the Frobenius endomorphism of the points of a toral closure raises each entry to
 the `p ^ k`-th power. -/

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/PointsFunctor.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/PointsFunctor.lean
@@ -99,22 +99,15 @@ rings.** It is `TauCeti.GeneralLinear.mapHopfIdealPointsSubgroup` read at the ca
 Hopf ideal, transported along `TauCeti.DynkinType.geckPoints_def` so that it is stated in the
 named Geck API a consumer works in rather than in the presentation that API is defined by. -/
 def geckPointsMap (f : A →+* B) : t.geckPoints ht A →* t.geckPoints ht B :=
-  ((MulEquiv.subgroupCongr (t.geckPoints_def ht B)).symm.toMonoidHom).comp
-    ((GeneralLinear.mapHopfIdealPointsSubgroup (t.geckDim ht) (t.geckDefiningIdeal ht)
-          f.toIntAlgHom).comp
-      (MulEquiv.subgroupCongr (t.geckPoints_def ht A)).toMonoidHom)
+  GeneralLinear.mapHopfIdealPointsSubgroupCongr (t.geckDim ht) (t.geckDefiningIdeal ht)
+    (t.geckPoints_def ht A) (t.geckPoints_def ht B) f.toIntAlgHom
 
 /-- The induced map on the points of the pinned Geck carrier is the entrywise one. -/
 @[simp]
 theorem coe_geckPointsMap (f : A →+* B) (g : t.geckPoints ht A) :
     (t.geckPointsMap ht f g : Matrix.GeneralLinearGroup (Fin (t.geckDim ht)) B) =
       Matrix.GeneralLinearGroup.map f g := by
-  -- `mapHopfIdealPointsSubgroup` is stated for the `ℤ`-algebra map that `f` induces, whose
-  -- underlying ring homomorphism is `f` again.
-  rw [geckPointsMap]
-  simp only [MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, MulEquiv.subgroupCongr_symm_apply,
-    GeneralLinear.coe_mapHopfIdealPointsSubgroup, MulEquiv.subgroupCongr_apply,
-    RingHom.toIntAlgHom_toRingHom]
+  simp [geckPointsMap]
 
 /-- Entrywise, the induced map on the points of the pinned Geck carrier applies the homomorphism
 of value rings to each matrix entry. -/
@@ -130,25 +123,24 @@ theorem coe_geckPointsMap_apply (f : A →+* B) (g : t.geckPoints ht A)
 Geck carrier. -/
 @[simp]
 theorem geckPointsMap_id : t.geckPointsMap ht (RingHom.id A) = MonoidHom.id _ := by
-  refine MonoidHom.ext fun g => Subtype.ext (Matrix.GeneralLinearGroup.ext fun r c => ?_)
-  rw [coe_geckPointsMap_apply, MonoidHom.id_apply, RingHom.id_apply]
+  simp [geckPointsMap]
 
 /-- The induced maps on the points of the pinned Geck carrier compose. -/
 @[simp]
 theorem geckPointsMap_comp {C : Type*} [CommRing C] (f : A →+* B) (g : B →+* C) :
     t.geckPointsMap ht (g.comp f) =
       (t.geckPointsMap ht g).comp (t.geckPointsMap ht f) := by
-  refine MonoidHom.ext fun x => Subtype.ext (Matrix.GeneralLinearGroup.ext fun r c => ?_)
-  rw [coe_geckPointsMap_apply, MonoidHom.comp_apply, coe_geckPointsMap_apply,
-    coe_geckPointsMap_apply, RingHom.comp_apply]
+  simp only [geckPointsMap, RingHom.toIntAlgHom_comp]
+  exact GeneralLinear.mapHopfIdealPointsSubgroupCongr_comp (t.geckDim ht) (t.geckDefiningIdeal ht)
+    (t.geckPoints_def ht A) (t.geckPoints_def ht B)
+    (t.geckPoints_def ht C) f.toIntAlgHom g.toIntAlgHom
 
 /-- An injective homomorphism of value rings induces an injective map on the points of the pinned
 Geck carrier. -/
 theorem geckPointsMap_injective {f : A →+* B} (hf : Function.Injective f) :
-    Function.Injective (t.geckPointsMap ht f) := by
-  intro x y hxy
-  refine Subtype.ext (Matrix.GeneralLinearGroup.ext fun r c => hf ?_)
-  rw [← coe_geckPointsMap_apply, ← coe_geckPointsMap_apply, hxy]
+    Function.Injective (t.geckPointsMap ht f) :=
+  GeneralLinear.mapHopfIdealPointsSubgroupCongr_injective (t.geckDim ht) (t.geckDefiningIdeal ht)
+    (t.geckPoints_def ht A) (t.geckPoints_def ht B) (φ := f.toIntAlgHom) hf
 
 /-- **The induced map carries a numbered root-subgroup point along the homomorphism of value
 rings.** -/


### PR DESCRIPTION
Ten carriers cut out by a Hopf ideal in `GLₙ` each carried their own `pointsMap` with `coe_`, `_id`, `_comp` and (in nine of the ten) `_injective`. Their proofs were the same argument in each case — `mapHopfIdealPointsSubgroup` conjugated by `MulEquiv.subgroupCongr` against the carrier's own `points_def : points A = hopfIdealPointsSubgroup n I A` — and in seven of the ten they were byte-identical up to a dimension and a defining ideal.

The shared content is pure group theory, so it is extracted as such rather than as a general-linear utility:

* **`MonoidHom.subgroupCongr`** in `Algebra/Group/Subgroup/Map.lean` — a homomorphism of subgroups transported along equalities of its domain and codomain, with `coe_`, `_id`, `_comp` and `_injective`. It sits next to the existing `Subgroup.congrOfMapEq`, which it does not subsume (that one takes `A.map e = B` and yields a `MulEquiv`). Mathlib has only `MulEquiv.subgroupCongr`, the equality-of-subgroups case, not the transport of a map.
* **`mapHopfIdealPointsSubgroupCongr`** in `GeneralLinear/HopfIdealPoints/Basic.lean` — one line on top of it, stated at the level the rest of that file uses: generic in the base ring `R`, taking `A →ₐ[R] B`.

All ten carriers use it, and so does the toral-closure Frobenius, whose hand-rolled conjugation is replaced by the same combinator.

Twenty of the carrier proofs — every `coe_` and every `_id` — collapse to a single `simp [pointsMap]`, because `coe_mapHopfIdealPointsSubgroupCongr` and `mapHopfIdealPointsSubgroupCongr_id` are `simp` lemmas and reach them through the simp set. `_comp` and `_injective` are still named explicitly, at 10 and 9 sites.

`mapHopfIdealPointsSubgroupCongr_comp` is deliberately **not** a `simp` lemma: the middle subgroup and its presentation appear only on the right-hand side, so `simp` would have to invent them and would rewrite into an unrelated instantiation. Its docstring records this.

Statements are unchanged throughout: the only altered declaration lines are the nine `_injective` companions, where `:= by` becomes `:=`. Outside proof bodies the sole edits are one added import and two module docstrings.

### Relation to #6317

This was written before #6317 and rebased on top of it. The interaction is small and was checked by trial merge before either landed: the ten carrier `coe_pointsMap` proofs conflict textually, because #6317 edits the `simp only` list that this PR deletes outright — resolved in favour of `simp [pointsMap]`, which subsumes it. `coe_mapHopfIdealPointsSubgroupCongr` is stated through the coercion, so it now agrees with `coe_mapHopfIdealPointsSubgroup` as restated by #6317, and its proof no longer needs `AlgHom.toRingHom_eq_coe`.

### The carrier Frobenius maps

Three of the four `StandardCarrier`/`SpinCarrier` `Frobenius.lean` files — `SpecialLinear`, `Symplectic` and `Orthogonal/TypeD` — defined `frobenius` by conjugating `kostantToralFrobenius` with a `private` abbreviation that is itself a `MulEquiv.subgroupCongr`. That is the construction extracted here, so they use `MonoidHom.subgroupCongr` now (`ec1de8b`, addressing the `generality` finding). The fourth, `Orthogonal/TypeB`, already delegates to its carrier's `pointsMap` and is untouched.

Each file's `private` transport equation is reproved through the published `MonoidHom.coe_subgroupCongr_apply` rather than by unfolding, and gets shorter for it. Unfolding is not on the table: `MonoidHom.subgroupCongr` is a `def` without `@[expose]`, so its body does not cross the module boundary, and exposing it to save a rewrite would be the wrong trade.

Their other `private` helpers stay. `pointsEquivKostantToralPoints` and its transport equation each have around fifteen uses in the downstream proofs of those files, so the finding's "remove the now-redundant private equivalences where unused" leaves them in place.

**Still not converted:** `rankOneCarrierRootSubgroupHom` and its torus sibling in `Sl2/Kostant/GroupScheme.lean` transport only the codomain — their domain is `Multiplicative A`, not a subgroup — so `MonoidHom.subgroupCongr`, which moves both ends, does not reach them.

A further simplification is possible but out of scope here: `SpecialLinear` already carries `frobenius_eq_pointsMap`, so these three could collapse to `TypeB`'s form and delegate to `pointsMap` outright. That changes more proofs than this PR should.

Verified locally: `lake build` (11127 jobs), `lake exe axioms` (111144 declarations, allowlist clean), `scripts/lint-style.sh`.

Roadmap: ReductiveGroups

🤖 Generated with [Claude Code](https://claude.com/claude-code)

