### PR TITLE
feat(EllipticCurve): the projective point count of a Weierstrass model

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/PointCount.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/PointCount.lean
@@ -1,0 +1,87 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.AlgebraicGeometry.EllipticCurve.Affine.Point
+
+/-!
+# The point count of a Weierstrass model
+
+`pointCount` counts the `F`-points of the projective Weierstrass model: the solutions of the
+affine equation, singular or not, together with the point at infinity, `[0 : 1 : 0]` being the only
+point on `z = 0`. It is `Nat.card` of the solutions plus one, so it is the honest number of points
+whenever that solution type is finite. It is the count against which the Frobenius trace
+`q + 1 − #W(F)` is taken over a finite field, which is the setting it exists for.
+
+Counting the singular point is the whole content of the convention, and it is what makes the trace
+return the classical local invariant at *every* Weierstrass model: `a_q` at an elliptic one, and
+`1`, `−1`, `0` at split multiplicative, nonsplit multiplicative and additive reduction. Against the
+nonsingular locus instead it would omit the one singular rational point and return `2`, `0`, `1` at
+those three, which is no classical invariant. So the definition carries no ellipticity hypothesis:
+there is no junk value to avoid.
+
+The `+ 1` is the line at infinity's contribution. `pointCount_eq_card_point` asks exactly for
+finiteness of the solution subtype, which a finite base supplies: adjoining the point at infinity
+then raises its `Nat.card` by one, which is what makes the comparison with Mathlib's point type go
+through.
+
+## Main definitions
+
+* `WeierstrassCurve.pointCount`: the `Nat.card` count of the projective Weierstrass model's
+  `F`-points.
+
+## Main results
+
+* `WeierstrassCurve.pointCount_eq_card_point`: on an elliptic model whose affine solutions form a
+  finite type — a finite base being one case of that — it is the cardinality of Mathlib's point
+  type.
+
+## Provenance
+
+Not ported. The AINTLIB `HasseWeil` project (Chris Birkbeck, Apache 2.0, commit
+`513e83879e2f8cbc626eb9e04d660e92be16ccba`) has a `pointCount` of the same name in
+`HasseWeil/Frobenius.lean`, but it is `Fintype.card E.Point` on an elliptic curve carrying a
+`Fintype` instance as a hypothesis: the nonsingular-locus count, under the restriction where the
+two agree. The definition here is the projective one and is taken for an arbitrary Weierstrass
+model, so the comparison with the point type becomes a theorem.
+
+## References
+
+* [J. Silverman, *The Arithmetic of Elliptic Curves*][silverman2009], V.1, V.2.
+-/
+
+public section
+
+namespace TauCeti
+
+variable {F : Type*} [Field F] (W : WeierstrassCurve F)
+
+/-- **The number of `F`-points of the projective Weierstrass model**, the singular point included
+when there is one: `Nat.card` of the solutions of the affine equation, singular or not, plus one
+for the point at infinity. It is the honest count whenever that solution type is finite. -/
+noncomputable def _root_.WeierstrassCurve.pointCount : ℕ :=
+  Nat.card {p : F × F // W.toAffine.Equation p.1 p.2} + 1
+
+/-- The defining equation of `pointCount`. -/
+@[simp]
+-- Needed as a lemma rather than left to unfolding: `pointCount`'s body is not exposed across a
+-- module boundary, so `rfl` for this equation fails in a downstream file.
+theorem _root_.WeierstrassCurve.pointCount_def :
+    W.pointCount = Nat.card {p : F × F // W.toAffine.Equation p.1 p.2} + 1 := (rfl)
+
+/-- **On an elliptic model the projective count is the cardinality of Mathlib's point type.**
+An elliptic model has no singular point to include, so the solutions of the equation are exactly
+the nonsingular ones, and the point at infinity is the one Mathlib's type adjoins. -/
+theorem _root_.WeierstrassCurve.pointCount_eq_card_point
+    [Finite {p : F × F // W.toAffine.Equation p.1 p.2}] [W.IsElliptic] :
+    W.pointCount = Nat.card W.toAffine.Point := by
+  rw [WeierstrassCurve.pointCount_def, Nat.card_congr W.toAffine.pointEquiv]
+  -- `WithZero` is the `Option` the cardinality lemma is stated for
+  exact Finite.card_option.symm
+
+end TauCeti
+
+end


### PR DESCRIPTION
Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"EllipticCurves/Suggested.lean:layer3:pointCount"}-->

Provenance: original. The AINTLIB `HasseWeil` project (Chris Birkbeck, Apache-2.0, `513e83879e2f8cbc626eb9e04d660e92be16ccba`) has a `pointCount` of the same name in `HasseWeil/Frobenius.lean`, but it is `Fintype.card E.Point` for an elliptic curve carrying a `Fintype` instance as a hypothesis — the nonsingular-locus count, in the special case where the two conventions agree. Nothing is taken from it.

## What this adds

`TauCeti/AlgebraicGeometry/EllipticCurve/PointCount.lean` (new), for a Weierstrass curve `W` over a field `F`:

- `WeierstrassCurve.pointCount`: the cardinality of the projective model's `F`-points, the singular point included when there is one — the solutions of the affine equation, singular or not, together with the point at infinity.
- `WeierstrassCurve.pointCount_eq_card_point`: on an elliptic model whose affine solutions are finite, it is `Nat.card W.toAffine.Point`.

## Why this shape

- **Counting the singular point is the whole content of the convention.** Against this count the Frobenius trace returns the classical local invariant at *every* Weierstrass model: `a_q` at an elliptic one, and `1`, `−1`, `0` at split multiplicative, nonsplit multiplicative and additive reduction. Against the nonsingular locus it would return `2`, `0`, `1` at those three, which is no classical invariant. Hence no ellipticity hypothesis: there is no junk value to avoid.
- **The definition is the roadmap's, verbatim**: `Nat.card` of the affine solutions, plus one for the line at infinity. Finiteness is not a hypothesis of the definition — the `unusedArguments` linter rejects one the body does not use — and appears on `pointCount_eq_card_point`, which needs it to compare two cardinalities. That hypothesis is finiteness of the solution subtype rather than of the field, which is what the proof actually uses and is weaker: a curve over an infinite field can have finitely many rational points.
- **`pointCount_def` is `@[simp]` and required, not redundant.** The file is a module-system file with a plain `public section`, so `pointCount`'s body is not exposed across the module boundary: a downstream `rfl` for this equation fails to elaborate, which I checked with a probe module. The repository already carries the same lemma-plus-comment shape for `Isogeny.Hom.id_def`. Being the only public reduction rule for an opaque definition, it is tagged `@[simp]`.

The roadmap attribution is in this description only, on the `Roadmap:` line above and in the Roadmap section below, which is where `rubrics/documentation.md` directs it: roadmap targets and layer numbers do not belong in a module docstring. The file's Provenance section keeps only the mathematical sources.

## Roadmap

`TauCetiRoadmap/EllipticCurves/Suggested.lean`, Layer 3 ("elliptic curves over finite fields — the Hasse bound"), seeds `pointCount` and `pointCount_eq_card_point`; `README.md` §Layer 3 records that the point count "is the whole content of the convention". The companion finiteness statement `WeierstrassCurve.Affine.finite_point` is already on `main`.

The remaining Layer-3 counting milestones — that a Weierstrass model has at most one singular point, and the resulting comparison at `Δ = 0` — are separate topics and are not attempted here.
