### PR TITLE
feat: prove invariant group algebra descent is surjective

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/GroupAlgebra/Galois/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GroupAlgebra/Galois/BaseChange.lean
@@ -1,0 +1,67 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.GroupAlgebra.Galois.Invariants
+import TauCeti.RepresentationTheory.GaloisDescent.Span
+
+/-!
+# Scalar extension of an invariant group algebra
+
+The natural map from `L ⊗[k] (L[M])^Gal(L/k)` to `L[M]` is surjective when the
+automorphism group of `L/k` is finite. Here the action twists both the coefficients and the
+exponents, with the latter specified by an integral representation on the abelian group `M`.
+The scalar-extension map is Mathlib's `AlgHom.liftEquiv` applied to the invariant-subalgebra
+inclusion; it sends `a ⊗ x` to `a • x`.
+
+This supplies the surjectivity part of the coordinate descent for groups of multiplicative
+type, including non-split tori. Identifying the scalar extension with the split coordinate
+algebra additionally requires injectivity; transporting the Hopf structure requires the analogous
+identification on tensor squares.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Theorem 12.23 and Appendix A.64.
+-/
+
+public section
+
+open scoped TensorProduct
+
+namespace TauCeti.GaloisDescent
+
+variable {k L M : Type*} [Field k] [Field L] [Algebra k L] [AddCommGroup M]
+
+/-- Scalar extension of the invariant group-algebra inclusion is surjective. In particular,
+this holds over every finite Galois extension, without a characteristic restriction or a
+finite-generation hypothesis on the exponent group. -/
+theorem groupAlgebraInvariantsBaseChange_surjective
+    [Finite (L ≃ₐ[k] L)] (rho : Representation ℤ (L ≃ₐ[k] L) M) :
+    Function.Surjective
+      (AlgHom.liftEquiv k L (groupAlgebraInvariants rho)
+        (MonoidAlgebra L (Multiplicative M)) (groupAlgebraInvariants rho).val) := by
+  let ρ : Representation k (L ≃ₐ[k] L) (MonoidAlgebra L (Multiplicative M)) :=
+    { toFun := fun σ ↦ (groupAlgebraAction rho σ).toLinearMap
+      map_one' := by ext x; simp
+      map_mul' := by intros; ext x; simp }
+  have hspan : Submodule.span L (groupAlgebraInvariants rho :
+      Set (MonoidAlgebra L (Multiplicative M))) = ⊤ := by
+    have hinv : (ρ.invariants : Set (MonoidAlgebra L (Multiplicative M))) =
+        (groupAlgebraInvariants rho : Set (MonoidAlgebra L (Multiplicative M))) := by
+      ext x
+      simp [Representation.mem_invariants, ρ]
+    rw [← hinv]
+    exact span_invariants_eq_top (ρ := ρ) (groupAlgebraAction_smul rho)
+  let f := AlgHom.liftEquiv k L (groupAlgebraInvariants rho)
+    (MonoidAlgebra L (Multiplicative M)) (groupAlgebraInvariants rho).val
+  apply (LinearMap.range_eq_top (f := f.toLinearMap)).mp
+  apply top_unique
+  rw [← hspan, Submodule.span_le]
+  intro x hx
+  exact ⟨1 ⊗ₜ[k] (⟨x, hx⟩ : groupAlgebraInvariants rho), by
+    simp [f]⟩
+
+end TauCeti.GaloisDescent

--- a/TauCeti/Algebra/AlgebraicGroup/GroupAlgebra/Galois/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GroupAlgebra/Galois/BaseChange.lean
@@ -38,7 +38,7 @@ variable {k L M : Type*} [Field k] [Field L] [Algebra k L] [AddCommGroup M]
 /-- Scalar extension of the invariant group-algebra inclusion is surjective. In particular,
 this holds over every finite Galois extension, without a characteristic restriction or a
 finite-generation hypothesis on the exponent group. -/
-theorem groupAlgebraInvariantsBaseChange_surjective
+theorem liftEquiv_groupAlgebraInvariants_surjective
     [Finite (L ≃ₐ[k] L)] (rho : Representation ℤ (L ≃ₐ[k] L) M) :
     Function.Surjective
       (AlgHom.liftEquiv k L (groupAlgebraInvariants rho)

--- a/TauCeti/RepresentationTheory/GaloisDescent/Span.lean
+++ b/TauCeti/RepresentationTheory/GaloisDescent/Span.lean
@@ -1,0 +1,69 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import Mathlib.RepresentationTheory.Invariants
+import Mathlib.LinearAlgebra.Basis.VectorSpace
+import Mathlib.LinearAlgebra.LinearIndependent.Lemmas
+
+/-!
+# Invariant vectors span a semilinear representation
+
+For a field `L` over a commutative ring `k` with finite automorphism group, every semilinear
+representation is spanned over `L` by its invariant vectors. No finite-dimensionality of the
+vector space is required. This is the surjectivity step in Galois descent, applied in particular
+to the coordinate algebra of a split torus with a Galois action on its character lattice.
+
+The proof uses Dedekind's independence of field automorphisms: a linear functional vanishing
+on every invariant orbit sum must vanish on every vector. It does not divide by the order of
+the automorphism group, so the result applies in positive characteristic as well.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Appendix A.64 (Galois descent).
+-/
+
+public section
+
+namespace TauCeti.GaloisDescent
+
+variable {k L V : Type*} [CommRing k] [Field L] [Algebra k L]
+variable [AddCommGroup V] [Module k V] [Module L V]
+variable [Finite (L ≃ₐ[k] L)]
+
+/-- Invariant vectors of a semilinear action span the vector space over the coefficient field.
+Only finiteness of the automorphism group is needed; the extension need not be Galois. -/
+theorem span_invariants_eq_top
+    {ρ : Representation k (L ≃ₐ[k] L) V}
+    (hsemi : ∀ (σ : L ≃ₐ[k] L) (a : L) (v : V),
+      ρ σ (a • v) = σ a • ρ σ v) :
+    Submodule.span L (ρ.invariants : Set V) = ⊤ := by
+  classical
+  let := Fintype.ofFinite (L ≃ₐ[k] L)
+  by_contra hspan
+  obtain ⟨f, hf, hker⟩ :=
+    (Submodule.span L (ρ.invariants : Set V)).exists_le_ker_of_lt_top
+      (lt_top_iff_ne_top.mpr hspan)
+  apply hf
+  ext v
+  have horbit (a : L) : ∑ σ : L ≃ₐ[k] L, ρ σ (a • v) ∈ ρ.invariants := by
+    rw [Representation.mem_invariants]
+    intro τ
+    simpa only [Representation.norm, LinearMap.sum_apply] using
+      ρ.self_norm_apply τ (a • v)
+  have hsum : ∑ σ : L ≃ₐ[k] L, f (ρ σ v) • σ.toAlgHom.toLinearMap = 0 := by
+    ext a
+    have hz := hker (Submodule.subset_span (horbit a))
+    have hz' : f (∑ σ : L ≃ₐ[k] L, ρ σ (a • v)) = 0 := hz
+    simpa only [map_sum, hsemi, map_smul, LinearMap.sum_apply, LinearMap.smul_apply,
+      AlgHom.toLinearMap_apply, AlgEquiv.coe_toAlgHom, smul_eq_mul, mul_comm,
+      LinearMap.zero_apply] using hz'
+  have hli := (linearIndependent_algHom_toLinearMap k L L).comp
+    (fun σ : L ≃ₐ[k] L ↦ σ.toAlgHom) AlgEquiv.coe_toAlgHom_injective
+  have hz := (Fintype.linearIndependent_iff.mp hli _ hsum) (1 : L ≃ₐ[k] L)
+  simpa using hz
+
+end TauCeti.GaloisDescent

--- a/TauCeti/RepresentationTheory/GaloisDescent/Span.lean
+++ b/TauCeti/RepresentationTheory/GaloisDescent/Span.lean
@@ -17,9 +17,8 @@ representation is spanned over `L` by its invariant vectors. No finite-dimension
 vector space is required. This is the surjectivity step in Galois descent, applied in particular
 to the coordinate algebra of a split torus with a Galois action on its character lattice.
 
-The proof uses Dedekind's independence of field automorphisms: a linear functional vanishing
-on every invariant orbit sum must vanish on every vector. It does not divide by the order of
-the automorphism group, so the result applies in positive characteristic as well.
+The result has no characteristic restriction and does not require the order of the
+automorphism group to be invertible in `L`.
 
 ## References
 


### PR DESCRIPTION
This PR proves that scalar extension of the Galois-invariant group-algebra inclusion is surjective, advancing [ReductiveGroups/README.md, Layer 4, “Tori: split and non-split”](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/ReductiveGroups/README.md#layer-4-jordan-decomposition-diagonalizable-groups-tori). Every element of `L[Multiplicative M]` is an `L`-linear combination of elements fixed by the simultaneous coefficient-and-exponent action, so the canonical map `L ⊗[k] groupAlgebraInvariants rho →ₐ[L] L[Multiplicative M]` is onto.

This is the next missing step in the inverse construction from Galois lattices to tori: the finite Galois action field, semilinear group-algebra action (#3605), invariant algebra (#3717), and finite-type theorem (#3938) are already merged. The immediate consumer is the scalar-extension comparison `L ⊗[k] groupAlgebraInvariants rho ≃ₐ[L] L[Multiplicative M]`, which needs this surjectivity proof. After this PR, the milestone still needs injectivity of that comparison for finite Galois extensions, descent of the Hopf structure through the corresponding tensor comparisons, and assembly of the torus–Galois-lattice anti-equivalence.

The general theorem `GaloisDescent.span_invariants_eq_top` uses Dedekind's independence of field automorphisms: a linear functional annihilating all invariant orbit sums has zero coefficient at every automorphism, including the identity, and hence vanishes. It requires only a commutative base ring, a coefficient field with finite automorphism group, and a semilinear action; no finite-dimensionality or invertibility of the group order is assumed. The group-algebra application likewise needs neither finite generation of `M` nor a characteristic restriction.

Add `TauCeti/RepresentationTheory/GaloisDescent/Span.lean` (69 lines) and `TauCeti/Algebra/AlgebraicGroup/GroupAlgebra/Galois/BaseChange.lean` (67 lines), for 136 lines total. The scalar-extension map is the existing `AlgHom.liftEquiv` applied to the invariant-subalgebra inclusion. The proof reuses `Representation.self_norm_apply`, `Submodule.exists_le_ker_of_lt_top`, and `linearIndependent_algHom_toLinearMap`. No Mathlib infrastructure or external formalization is vendored; the mathematical reference is Milne, *Algebraic Groups* (2017), Theorem 12.23 and Appendix A.64, cited in the modules.

Self-review against API design, reuse, and generality replaced manual orbit reindexing with the existing norm lemma, avoided a redundant map definition, and weakened the general theorem's unused base-field assumption to a commutative ring. The public surface consists of two theorems, with the general result in the representation-theory directory and its coordinate-algebra application beside the existing invariants.

Validation: the targeted `lake build` passes for both new modules, and `tauceti-axioms --changed-since-merge-base origin/main` accepts all four audited declarations. The prescribed lint wrapper stops at its stale default-set guard because it omits `tacticAlt`; a temporary copy adding exactly that missing linter, matching the approved set in current main, passes both changed modules with zero violations and zero grandfathered findings. No repository scripts or linter configuration are changed. `git diff --cached --check` passes.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"groupalgebrainvariantsbasechange-surjective"}-->

🤖 Prepared with Codex
