### PR TITLE
feat: prove compact Spin groups are path-connected

### DIFF
--- a/TauCeti/Topology/Algebra/CliffordAlgebra/Spin/Connected.lean
+++ b/TauCeti/Topology/Algebra/CliffordAlgebra/Spin/Connected.lean
@@ -1,0 +1,113 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.LinearAlgebra.CliffordAlgebra.Spin.Real.Generation
+public import TauCeti.Topology.Algebra.CliffordAlgebra.Spin.ReflectionPair
+public import TauCeti.Topology.Algebra.CliffordAlgebra.Spin.Rotation
+
+/-!
+# Path-connectedness of compact real Spin groups
+
+For the positive-definite real Clifford form in dimension at least two, the identity path
+component contains the scalar `-1` and every normalized reflection-pair lift. Every anisotropic
+vector can be normalized without changing its reflection, so reflection-pair generation forces
+the identity path component to be the whole Spin group.
+
+## Main result
+
+* `CliffordAlgebra.pathConnectedSpace_realCliffordSpinGroupZero_add_two` proves that every
+  compact real Spin group of dimension at least two is path-connected.
+
+## References
+
+* H. B. Lawson and M.-L. Michelsohn, *Spin Geometry* (1989), Chapter I, Sections 2 and 6.
+-/
+
+public section
+
+namespace CliffordAlgebra
+
+open TauCeti
+
+private theorem sqrt_norm_ne_zero_realCliffordForm_zero {n : ℕ} (v : Fin n → ℝ)
+    [Invertible (realCliffordForm n 0 v)] :
+    Real.sqrt (realCliffordForm n 0 v) ≠ 0 := by
+  have hv0 : v ≠ 0 := by
+    intro hv
+    subst v
+    exact (isUnit_of_invertible
+      (realCliffordForm n 0 (0 : Fin n → ℝ))).ne_zero (by simp)
+  have hvpos : 0 < realCliffordForm n 0 v :=
+    posDef_realCliffordForm_zero n v hv0
+  exact ne_of_gt (Real.sqrt_pos.2 hvpos)
+
+private theorem normalized_norm_realCliffordForm_zero {n : ℕ} (v : Fin n → ℝ)
+    [Invertible (realCliffordForm n 0 v)] :
+    realCliffordForm n 0
+        ((Real.sqrt (realCliffordForm n 0 v))⁻¹ • v) = 1 := by
+  have hvpos : 0 < realCliffordForm n 0 v :=
+    Real.sqrt_pos.mp <| lt_of_le_of_ne (Real.sqrt_nonneg _)
+      (sqrt_norm_ne_zero_realCliffordForm_zero v).symm
+  have hsqrt := sqrt_norm_ne_zero_realCliffordForm_zero v
+  calc
+    realCliffordForm n 0 ((Real.sqrt (realCliffordForm n 0 v))⁻¹ • v) =
+        (Real.sqrt (realCliffordForm n 0 v))⁻¹ *
+          (Real.sqrt (realCliffordForm n 0 v))⁻¹ * realCliffordForm n 0 v := by
+      rw [QuadraticMap.map_smul]
+      rfl
+    _ = 1 := by
+      field_simp
+      simpa [pow_two] using (Real.sq_sqrt hvpos.le).symm
+
+/-- The compact real Spin group is path-connected in every dimension at least two. -/
+theorem pathConnectedSpace_realCliffordSpinGroupZero_add_two (n : ℕ) :
+    PathConnectedSpace (realCliffordSpinGroupZero (n + 2)) := by
+  let Q := realCliffordForm (n + 2) 0
+  let H := Subgroup.pathComponentOne (spinGroup Q)
+  have hH : H = ⊤ := by
+    apply subgroup_eq_top_of_negOne_mem_of_reflection_pair_lift_mem Q
+      (posDef_realCliffordForm_zero (n + 2)).anisotropic.nondegenerate H
+    · change Joined 1 (spinGroup.negOne Q _)
+      exact joined_one_negOne_realCliffordSpinGroupZero_add_two n
+    · intro v w _ _
+      let a := (Real.sqrt (Q v))⁻¹
+      let b := (Real.sqrt (Q w))⁻¹
+      have hva : a ≠ 0 :=
+        inv_ne_zero (sqrt_norm_ne_zero_realCliffordForm_zero v)
+      have hwb : b ≠ 0 :=
+        inv_ne_zero (sqrt_norm_ne_zero_realCliffordForm_zero w)
+      let _ : Invertible a := (isUnit_iff_ne_zero.mpr hva).invertible
+      let _ : Invertible b := (isUnit_iff_ne_zero.mpr hwb).invertible
+      have hv : Q (a • v) = 1 := normalized_norm_realCliffordForm_zero v
+      have hw : Q (b • w) = 1 := normalized_norm_realCliffordForm_zero w
+      let _ : Invertible (Q (a • v)) := hv.symm ▸ invertibleOne
+      let _ : Invertible (Q (b • w)) := hw.symm ▸ invertibleOne
+      let x := spinReflectionPair Q (a • v) (b • w) hv hw
+      refine ⟨x, ?_, ?_⟩
+      · change Joined 1 x
+        exact joined_one_spinReflectionPair_realCliffordForm_zero
+          (by omega) (a • v) (b • w) hv hw
+      · rw [coe_spinToSpecialOrthogonal_spinReflectionPair]
+        simp only [Subgroup.coe_mul, QuadraticMap.coe_reflectionOrthogonal]
+        have hvref : QuadraticMap.reflection Q (a • v) =
+            QuadraticMap.reflection Q v := by
+          convert QuadraticMap.reflection_smul_eq Q v a using 1
+          congr 1
+          exact Subsingleton.elim _ _
+        have hwref : QuadraticMap.reflection Q (b • w) =
+            QuadraticMap.reflection Q w := by
+          convert QuadraticMap.reflection_smul_eq Q w b using 1
+          congr 1
+          exact Subsingleton.elim _ _
+        rw [hvref, hwref]
+  apply pathConnectedSpace_iff_eq.mpr
+  refine ⟨1, ?_⟩
+  change (H : Set (spinGroup Q)) = Set.univ
+  rw [hH]
+  rfl
+
+end CliffordAlgebra

--- a/TauCeti/Topology/Algebra/CliffordAlgebra/Spin/Connected.lean
+++ b/TauCeti/Topology/Algebra/CliffordAlgebra/Spin/Connected.lean
@@ -71,8 +71,8 @@ theorem pathConnectedSpace_realCliffordSpinGroupZero_add_two (n : ℕ) :
   have hH : H = ⊤ := by
     apply subgroup_eq_top_of_negOne_mem_of_reflection_pair_lift_mem Q
       (posDef_realCliffordForm_zero (n + 2)).anisotropic.nondegenerate H
-    · change Joined 1 (spinGroup.negOne Q _)
-      exact joined_one_negOne_realCliffordSpinGroupZero_add_two n
+    · exact mem_pathComponent_iff.mpr
+        (joined_one_negOne_realCliffordSpinGroupZero_add_two n)
     · intro v w _ _
       let a := (Real.sqrt (Q v))⁻¹
       let b := (Real.sqrt (Q w))⁻¹
@@ -88,9 +88,9 @@ theorem pathConnectedSpace_realCliffordSpinGroupZero_add_two (n : ℕ) :
       let _ : Invertible (Q (b • w)) := hw.symm ▸ invertibleOne
       let x := spinReflectionPair Q (a • v) (b • w) hv hw
       refine ⟨x, ?_, ?_⟩
-      · change Joined 1 x
-        exact joined_one_spinReflectionPair_realCliffordForm_zero
-          (by omega) (a • v) (b • w) hv hw
+      · exact mem_pathComponent_iff.mpr
+          (joined_one_spinReflectionPair_realCliffordForm_zero
+            (by omega) (a • v) (b • w) hv hw)
       · rw [coe_spinToSpecialOrthogonal_spinReflectionPair]
         simp only [Subgroup.coe_mul, QuadraticMap.coe_reflectionOrthogonal]
         have hvref : QuadraticMap.reflection Q (a • v) =
@@ -106,8 +106,7 @@ theorem pathConnectedSpace_realCliffordSpinGroupZero_add_two (n : ℕ) :
         rw [hvref, hwref]
   apply pathConnectedSpace_iff_eq.mpr
   refine ⟨1, ?_⟩
-  change (H : Set (spinGroup Q)) = Set.univ
-  rw [hH]
-  rfl
+  simpa only [H, Subgroup.coe_pathComponentOne] using
+    (Subgroup.coe_eq_univ.mpr hH)
 
 end CliffordAlgebra

--- a/TauCeti/Topology/Algebra/CliffordAlgebra/Spin/Connected.lean
+++ b/TauCeti/Topology/Algebra/CliffordAlgebra/Spin/Connected.lean
@@ -5,7 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.LinearAlgebra.CliffordAlgebra.Spin.Real.Generation
+public import TauCeti.LinearAlgebra.CliffordAlgebra.Spin.Generation
 public import TauCeti.Topology.Algebra.CliffordAlgebra.Spin.ReflectionPair
 public import TauCeti.Topology.Algebra.CliffordAlgebra.Spin.Rotation
 


### PR DESCRIPTION
This PR proves path-connectedness of compact real Spin groups in dimension at least two for the SpinRepresentations Layer 7 compact-Spin connectivity milestone.

Roadmap: RepresentationTheory

## Summary

It shows that the identity path component contains the central element `-1` and every reflection-pair generator. Arbitrary anisotropic vectors are normalized by the inverse square root of their positive Clifford norm; reflection invariance under nonzero rescaling then connects the normalized lifts to the previously constructed reflection-pair paths. The existing generation theorem forces the identity component to be the whole Spin group.

## Roadmap target

This completes the path-connectedness part of SpinRepresentations Layer 7, “Connectivity of the compact spin group,” for `Spin(n)` when `n ≥ 2`. After this PR, simple connectivity for `Spin(n)` when `n ≥ 3` and the universal-cover statement remain.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"compact-spin-connectedness"}-->

## Verification

- Exact head: `d552c2cdd9c4d97c1efa1587a40b1d39a3cab8f1`
- Local Lean build: `lake exe cache get`, then `lake build` — pass; `Build completed successfully (11130 jobs).`
- Axiom audit: `lake exe axioms` — pass; `axioms: audited 111169 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`
- Lint: `lake exe module-system`, GNU-sed `scripts/lint-env.sh`, `python3 scripts/lint-dot-notation.py`, `bash scripts/lint-style.sh`, and `git diff --check` — pass with no new violations.
- Public CI: pending for the repaired head.

## Scale and generality

This adds 112 lines in one topology module and one public theorem. Its `n + 2` indexing states the sharp dimension range used by the sphere path construction, without a separate positivity hypothesis or a redundant weaker connectedness instance. The square-root normalization helpers are private implementation details.

## Scope

- **Consumes:** `subgroup_eq_top_of_negOne_mem_of_reflection_pair_lift_mem`, `joined_one_negOne_realCliffordSpinGroupZero_add_two`, `joined_one_spinReflectionPair_realCliffordForm_zero`, and Mathlib's `Subgroup.pathComponentOne` and `pathConnectedSpace_iff_eq`.
- **Provides:** `CliffordAlgebra.pathConnectedSpace_realCliffordSpinGroupZero_add_two`.
- **Fits:** path-connected compact Spin groups are the immediate connectedness input for the Layer 7 simple-connectivity and universal-cover theorem.
- **Boundary:** this PR does not prove simple connectivity, construct the universal cover, or add a global typeclass instance.

<sub>🤖 GPT-5.6 Sol high · TauCetiWorker @ [7518d4150b846c4524423341570c031027a1d92c](https://github.com/utensil/TauCetiWorker/commit/7518d4150b846c4524423341570c031027a1d92c) · rubrics @ [afb424eda89e8ac96d9eb69f6a88972055a4cd1b](https://github.com/utensil/TauCetiReview/commit/afb424eda89e8ac96d9eb69f6a88972055a4cd1b) · local review @ [b533e561b6d44df071c31335ed4a63ae647507d2](https://github.com/utensil/formal-land/commit/b533e561b6d44df071c31335ed4a63ae647507d2) · fixed: placement, proof-quality</sub>