### PR TITLE
feat(ModularForms): the descent of a nebentypus cusp form is a cusp form of level N / p

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/Newforms/Descent/CuspForm.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Descent/CuspForm.lean
@@ -1,0 +1,102 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.NumberTheory.ModularForms.DiamondOperators
+public import TauCeti.NumberTheory.ModularForms.Newforms.Descent.Cusps
+public import TauCeti.NumberTheory.ModularForms.Newforms.Descent.Sum
+
+/-!
+# The descent of a cusp form to the lower level
+
+For a prime `p ∣ N` and `f ∈ S_k(Γ₁(N), χ)` whose nebentypus `χ` is the pull-back of a character
+`χ₀` modulo `N / p`, the descent slash sum `descendSlash k p N f` (`Newforms/Descent/Sum.lean`) is
+a cusp form of level `Γ₁(N / p)`, in the space of `χ₀`: it is `Γ₀(N / p)`-equivariant with
+nebentypus `χ₀` (`descendSlash_slash_mapGL_of_nebentypus_of_prime`), holomorphic as a sum of
+slashes of `f`, and vanishes at the cusps (`Newforms/Descent/Cusps.lean`). This is the operator
+`f ↦ ∑_v f ∣[k] descendMatrix p N v` of Miyake's Lemma 4.6.14, bundled.
+
+## Main definitions
+
+* `TauCeti.descendCuspForm`: the descent of `f` as a cusp form of level `Γ₁(N / p)`.
+
+## Main results
+
+* `TauCeti.coe_descendCuspForm`: its underlying function is `descendSlash k p N f`.
+* `TauCeti.descendCuspForm_mem_cuspFormCharSpace`: it lies in `S_k(Γ₁(N / p), χ₀)`.
+
+## Provenance
+
+Adapted from the AINTLIB `LeanModularForms` project (Chris Birkbeck, Apache-2.0,
+<https://github.com/CBirkbeck/AINTLIB> @ `eb9621e7bcb0ce220ad53983ec45d987cb5b9002`),
+`projects/LeanModularForms/LeanModularForms/StrongMultiplicityOne/DescentCharSpace.lean`,
+`descendSlashSumCuspForm` and `descendSlashSumCuspForm_mem_charSpace`. The source proves the
+three cusp-form fields from scratch (`miyake_hecke_descend_Gamma1_inv`, `_cusp`, `_char`); here
+they are the merged invariance, cusp and nebentypus results about `descendSlash`.
+
+## References
+
+* [T. Miyake, *Modular forms*][miyake1989], Lemma 4.6.14.
+-/
+
+public section
+
+open Matrix.SpecialLinearGroup UpperHalfPlane CongruenceSubgroup
+
+open scoped Manifold MatrixGroups ModularForm
+
+namespace TauCeti
+
+variable {p N : ℕ} (k : ℤ) [NeZero N]
+
+/-- **The descent of a cusp form.** For `p ∣ N` prime and `f ∈ S_k(Γ₁(N), χ)` with `χ` the
+pull-back of `χ₀` modulo `N / p`, the descent slash sum of `f` as a cusp form of level
+`Γ₁(N / p)`. -/
+noncomputable def descendCuspForm (hp : p.Prime) (hpN : p ∣ N) {χ : (ZMod N)ˣ →* ℂˣ}
+    {χ₀ : (ZMod (N / p))ˣ →* ℂˣ} (hcomp : χ = χ₀.comp (ZMod.unitsMap (Nat.div_dvd_of_dvd hpN)))
+    {f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k} (hf : f ∈ cuspFormCharSpace k χ) :
+    CuspForm ((Gamma1 (N / p)).map (mapGL ℝ)) k :=
+  haveI : NeZero p := ⟨hp.ne_zero⟩
+  haveI : NeZero (N / p) := ⟨(Nat.div_pos (Nat.le_of_dvd (NeZero.pos N) hpN) hp.pos).ne'⟩
+  { toFun := descendSlash k p N f
+    slash_action_eq' := fun γ hγ ↦ by
+      obtain ⟨δ, hδ, rfl⟩ := Subgroup.mem_map.mp hγ
+      rw [descendSlash_slash_mapGL_of_nebentypus_of_prime k hp hpN hcomp
+        ⟨δ, Gamma1_in_Gamma0 (N / p) hδ⟩ ((mem_cuspFormCharSpace_iff_nebentypus k χ f).mp hf)]
+      have h1 : (Gamma0Map (N / p)).toHomUnits ⟨δ, Gamma1_in_Gamma0 (N / p) hδ⟩ = 1 :=
+        Units.ext (by
+          rw [MonoidHom.coe_toHomUnits, Gamma0Map_apply]
+          exact (mem_Gamma1_iff.mp hδ).2)
+      rw [h1, map_one, Units.val_one, one_smul]
+    holo' := by
+      change MDifferentiable 𝓘(ℂ) 𝓘(ℂ) (descendSlash k p N f)
+      rw [descendSlash_def]
+      exact MDifferentiable.sum fun v _ ↦ (ModularFormClass.holo f).slash k _
+    zero_at_cusps' := fun hc ↦ isZeroAt_descendSlash k
+      (fun c hc ↦ f.zero_at_cusps' (Subgroup.IsArithmetic.isCusp_of_isCusp c hc)) hc }
+
+/-- The underlying function of the descent is the descent slash sum. -/
+lemma coe_descendCuspForm (hp : p.Prime) (hpN : p ∣ N) {χ : (ZMod N)ˣ →* ℂˣ}
+    {χ₀ : (ZMod (N / p))ˣ →* ℂˣ} (hcomp : χ = χ₀.comp (ZMod.unitsMap (Nat.div_dvd_of_dvd hpN)))
+    {f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k} (hf : f ∈ cuspFormCharSpace k χ) :
+    haveI : NeZero p := ⟨hp.ne_zero⟩
+    ⇑(descendCuspForm k hp hpN hcomp hf) = descendSlash k p N f :=
+  (rfl)
+
+/-- **The descent lowers the level of the nebentypus**: the descent of `f ∈ S_k(Γ₁(N), χ)` lies
+in `S_k(Γ₁(N / p), χ₀)`. -/
+theorem descendCuspForm_mem_cuspFormCharSpace (hp : p.Prime) (hpN : p ∣ N)
+    {χ : (ZMod N)ˣ →* ℂˣ} {χ₀ : (ZMod (N / p))ˣ →* ℂˣ}
+    (hcomp : χ = χ₀.comp (ZMod.unitsMap (Nat.div_dvd_of_dvd hpN)))
+    {f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k} (hf : f ∈ cuspFormCharSpace k χ) :
+    descendCuspForm k hp hpN hcomp hf ∈ cuspFormCharSpace k χ₀ := by
+  have : NeZero p := ⟨hp.ne_zero⟩
+  rw [mem_cuspFormCharSpace_iff_nebentypus, coe_descendCuspForm]
+  intro γ
+  exact descendSlash_slash_mapGL_of_nebentypus_of_prime k hp hpN hcomp γ
+    ((mem_cuspFormCharSpace_iff_nebentypus k χ f).mp hf)
+
+end TauCeti

--- a/TauCeti/NumberTheory/ModularForms/Newforms/Descent/CuspForm.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Descent/CuspForm.lean
@@ -7,7 +7,6 @@ module
 
 public import TauCeti.NumberTheory.ModularForms.DiamondOperators
 public import TauCeti.NumberTheory.ModularForms.Newforms.Descent.Cusps
-public import TauCeti.NumberTheory.ModularForms.Newforms.Descent.Sum
 
 /-!
 # The descent of a cusp form to the lower level
@@ -33,9 +32,7 @@ slashes of `f`, and vanishes at the cusps (`Newforms/Descent/Cusps.lean`). This 
 Adapted from the AINTLIB `LeanModularForms` project (Chris Birkbeck, Apache-2.0,
 <https://github.com/CBirkbeck/AINTLIB> @ `eb9621e7bcb0ce220ad53983ec45d987cb5b9002`),
 `projects/LeanModularForms/LeanModularForms/StrongMultiplicityOne/DescentCharSpace.lean`,
-`descendSlashSumCuspForm` and `descendSlashSumCuspForm_mem_charSpace`. The source proves the
-three cusp-form fields from scratch (`miyake_hecke_descend_Gamma1_inv`, `_cusp`, `_char`); here
-they are the merged invariance, cusp and nebentypus results about `descendSlash`.
+`descendSlashSumCuspForm` and `descendSlashSumCuspForm_mem_charSpace`.
 
 ## References
 
@@ -71,14 +68,12 @@ noncomputable def descendCuspForm (hp : p.Prime) (hpN : p ∣ N) {χ : (ZMod N)�
           rw [MonoidHom.coe_toHomUnits, Gamma0Map_apply]
           exact (mem_Gamma1_iff.mp hδ).2)
       rw [h1, map_one, Units.val_one, one_smul]
-    holo' := by
-      change MDifferentiable 𝓘(ℂ) 𝓘(ℂ) (descendSlash k p N f)
-      rw [descendSlash_def]
-      exact MDifferentiable.sum fun v _ ↦ (ModularFormClass.holo f).slash k _
+    holo' := mdifferentiable_descendSlash k p N (ModularFormClass.holo f)
     zero_at_cusps' := fun hc ↦ isZeroAt_descendSlash k
       (fun c hc ↦ f.zero_at_cusps' (Subgroup.IsArithmetic.isCusp_of_isCusp c hc)) hc }
 
 /-- The underlying function of the descent is the descent slash sum. -/
+@[simp]
 lemma coe_descendCuspForm (hp : p.Prime) (hpN : p ∣ N) {χ : (ZMod N)ˣ →* ℂˣ}
     {χ₀ : (ZMod (N / p))ˣ →* ℂˣ} (hcomp : χ = χ₀.comp (ZMod.unitsMap (Nat.div_dvd_of_dvd hpN)))
     {f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k} (hf : f ∈ cuspFormCharSpace k χ) :

--- a/TauCeti/NumberTheory/ModularForms/Newforms/Descent/Sum.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Descent/Sum.lean
@@ -58,7 +58,7 @@ public section
 
 open CongruenceSubgroup HeckeRing.GL2 Matrix Matrix.SpecialLinearGroup UpperHalfPlane
 
-open scoped MatrixGroups ModularForm
+open scoped Manifold MatrixGroups ModularForm
 
 namespace TauCeti
 
@@ -78,6 +78,12 @@ lemma descendSlash_apply (k : ℤ) (p N : ℕ) [NeZero p] (f : ℍ → ℂ) (τ 
     descendSlash k p N f τ
       = ∑ v : Fin (descendMatrixCount p N), (f ∣[k] descendMatrix p N v) τ := by
   rw [descendSlash_def, Finset.sum_apply]
+
+/-- The descent slash sum of a holomorphic function is holomorphic: each slash is. -/
+theorem mdifferentiable_descendSlash (k : ℤ) (p N : ℕ) [NeZero p] {f : ℍ → ℂ}
+    (hf : MDifferentiable 𝓘(ℂ) 𝓘(ℂ) f) : MDifferentiable 𝓘(ℂ) 𝓘(ℂ) (descendSlash k p N f) := by
+  rw [descendSlash_def]
+  exact MDifferentiable.sum fun v _ ↦ hf.slash k _
 
 /-- The descent slash sum sends the zero function to zero. -/
 @[simp] lemma descendSlash_zero (k : ℤ) (p N : ℕ) [NeZero p] : descendSlash k p N 0 = 0 := by


### PR DESCRIPTION
For a prime `p ∣ N` and `f ∈ S_k(Γ₁(N), χ)` whose nebentypus `χ` is the pull-back of a character `χ₀` modulo `N / p`, the descent slash sum `descendSlash k p N f` (`Newforms/Descent/Sum.lean`) is a cusp form of level `Γ₁(N / p)` lying in `S_k(Γ₁(N / p), χ₀)`: the operator `f ↦ ∑_v f ∣[k] descendMatrix p N v` of Miyake's Lemma 4.6.14, bundled. This is the form the strong-multiplicity-one main lemma (Miyake 4.6.8) descends along.

**New file** `TauCeti/NumberTheory/ModularForms/Newforms/Descent/CuspForm.lean` (namespace `TauCeti`):

- `descendCuspForm`: the descent of `f` as a cusp form of level `Γ₁(N / p)`. Its three fields are the merged results about `descendSlash`: `Γ₁(N / p)`-invariance from the every-prime nebentypus transport `descendSlash_slash_mapGL_of_nebentypus_of_prime` (#6323), evaluated at `χ₀(1) = 1`; holomorphy as a sum of slashes of `f`; vanishing at the cusps from `isZeroAt_descendSlash` (`Newforms/Descent/Cusps.lean`), with the cusps of `Γ₁(N / p)` those of `Γ₁(N)` (`Subgroup.IsArithmetic.isCusp_of_isCusp`).
- `coe_descendCuspForm` (`@[simp]`): its underlying function is `descendSlash k p N f`.
- In `Newforms/Descent/Sum.lean`: `mdifferentiable_descendSlash`, the descent of a holomorphic function is holomorphic (each slash is); it supplies the bundle's holomorphy field.
- `descendCuspForm_mem_cuspFormCharSpace`: it lies in `S_k(Γ₁(N / p), χ₀)` — the descent lowers the level of the nebentypus.

Roadmap: ModularForms

No `tauceti-target:v1` marker: like #6323 and #6330 before it, this is a prerequisite for the Layer 4 Atkin–Lehner Main Lemma node (the per-character route `mainLemma_charSpace_routeB`, through Miyake's Lemma 4.6.14) rather than the node itself, and the contract asks for a deterministic target identifier, not an invented one.

Provenance: github.com/CBirkbeck/AINTLIB @ `eb9621e7bcb0ce220ad53983ec45d987cb5b9002` (Apache-2.0, Chris Birkbeck), `projects/LeanModularForms/LeanModularForms/StrongMultiplicityOne/DescentCharSpace.lean` — `descendSlashSumCuspForm` and `descendSlashSumCuspForm_mem_charSpace`. The source proves the three cusp-form fields from scratch (`miyake_hecke_descend_Gamma1_inv`, `_cusp`, `_char`); here they are the merged invariance, cusp and nebentypus results about `descendSlash`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQieFQn95rzgvYRvNdX3hR
