### PR TITLE
feat: identify type-D root generators in the Clifford model

### DIFF
--- a/TauCeti/Algebra/Lie/Orthogonal/TypeD/RootGenerators.lean
+++ b/TauCeti/Algebra/Lie/Orthogonal/TypeD/RootGenerators.lean
@@ -8,6 +8,7 @@ module
 public import TauCeti.Algebra.Lie.Orthogonal.TypeD.DiagonalCartan
 public import TauCeti.LinearAlgebra.RootSystem.ClassicalTypeD
 public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.Assembly
+import TauCeti.LinearAlgebra.Matrix.ToLin
 
 /-!
 # The numbered simple-root generators of the split type-D Lie algebra
@@ -195,6 +196,74 @@ theorem loweringMatrix_of_fork {K : Type*} [Ring K] {i : Fin n}
   change Matrix.fromBlocks 0 0 (forkBlock (K := K) n hn).transpose 0 = _
   rw [forkBlock_transpose]
   rfl
+
+/-- A chain raising matrix sends a coordinate basis vector to the difference of its two
+selected coordinates. -/
+theorem toLinAlgEquiv_raisingMatrix_apply_basis_of_chain {K M : Type*} [CommRing K]
+    [AddCommGroup M] [Module K M] (bas : Module.Basis (Fin n ⊕ Fin n) K M) {i : Fin n}
+    (hi : (i : ℕ) + 1 < n) (c : Fin n ⊕ Fin n) :
+    Matrix.toLinAlgEquiv bas (raisingMatrix n hn i) (bas c) =
+      (if Sum.inl (chainNext n i hi) = c then bas (.inl i) else 0) -
+        if Sum.inr i = c then bas (.inr (chainNext n i hi)) else 0 := by
+  have hmat : raisingMatrix (K := K) n hn i =
+      Matrix.single (.inl i) (.inl (chainNext n i hi)) 1 -
+        Matrix.single (.inr (chainNext n i hi)) (.inr i) 1 := by
+    rw [raisingMatrix_of_chain n hn hi]
+    ext (j | j) (k | k) <;> simp [Matrix.fromBlocks, Matrix.single_apply]
+  rw [hmat, map_sub, LinearMap.sub_apply, TauCeti.toLinAlgEquiv_single_apply_basis,
+    TauCeti.toLinAlgEquiv_single_apply_basis]
+  simp
+
+/-- The fork raising matrix sends a coordinate basis vector to the alternating pair selected by
+the fork coordinates. -/
+theorem toLinAlgEquiv_raisingMatrix_apply_basis_of_fork {K M : Type*} [CommRing K]
+    [AddCommGroup M] [Module K M] (bas : Module.Basis (Fin n ⊕ Fin n) K M) {i : Fin n}
+    (hi : ¬(i : ℕ) + 1 < n) (c : Fin n ⊕ Fin n) :
+    Matrix.toLinAlgEquiv bas (raisingMatrix n hn i) (bas c) =
+      (if Sum.inr (forkRight n hn) = c then bas (.inl (forkLeft n hn)) else 0) -
+        if Sum.inr (forkLeft n hn) = c then bas (.inl (forkRight n hn)) else 0 := by
+  have hmat : raisingMatrix (K := K) n hn i =
+      Matrix.single (.inl (forkLeft n hn)) (.inr (forkRight n hn)) 1 -
+        Matrix.single (.inl (forkRight n hn)) (.inr (forkLeft n hn)) 1 := by
+    rw [raisingMatrix_of_fork n hn hi]
+    ext (j | j) (k | k) <;> simp [Matrix.fromBlocks, Matrix.single_apply]
+  rw [hmat, map_sub, LinearMap.sub_apply, TauCeti.toLinAlgEquiv_single_apply_basis,
+    TauCeti.toLinAlgEquiv_single_apply_basis]
+  simp
+
+/-- A chain lowering matrix sends a coordinate basis vector to the difference of its two
+selected coordinates. -/
+theorem toLinAlgEquiv_loweringMatrix_apply_basis_of_chain {K M : Type*} [CommRing K]
+    [AddCommGroup M] [Module K M] (bas : Module.Basis (Fin n ⊕ Fin n) K M) {i : Fin n}
+    (hi : (i : ℕ) + 1 < n) (c : Fin n ⊕ Fin n) :
+    Matrix.toLinAlgEquiv bas (loweringMatrix n hn i) (bas c) =
+      (if Sum.inl i = c then bas (.inl (chainNext n i hi)) else 0) -
+        if Sum.inr (chainNext n i hi) = c then bas (.inr i) else 0 := by
+  have hmat : loweringMatrix (K := K) n hn i =
+      Matrix.single (.inl (chainNext n i hi)) (.inl i) 1 -
+        Matrix.single (.inr i) (.inr (chainNext n i hi)) 1 := by
+    rw [loweringMatrix_of_chain n hn hi]
+    ext (j | j) (k | k) <;> simp [Matrix.fromBlocks, Matrix.single_apply]
+  rw [hmat, map_sub, LinearMap.sub_apply, TauCeti.toLinAlgEquiv_single_apply_basis,
+    TauCeti.toLinAlgEquiv_single_apply_basis]
+  simp
+
+/-- The fork lowering matrix sends a coordinate basis vector to the alternating pair selected by
+the fork coordinates. -/
+theorem toLinAlgEquiv_loweringMatrix_apply_basis_of_fork {K M : Type*} [CommRing K]
+    [AddCommGroup M] [Module K M] (bas : Module.Basis (Fin n ⊕ Fin n) K M) {i : Fin n}
+    (hi : ¬(i : ℕ) + 1 < n) (c : Fin n ⊕ Fin n) :
+    Matrix.toLinAlgEquiv bas (loweringMatrix n hn i) (bas c) =
+      (if Sum.inl (forkLeft n hn) = c then bas (.inr (forkRight n hn)) else 0) -
+        if Sum.inl (forkRight n hn) = c then bas (.inr (forkLeft n hn)) else 0 := by
+  have hmat : loweringMatrix (K := K) n hn i =
+      Matrix.single (.inr (forkRight n hn)) (.inl (forkLeft n hn)) 1 -
+        Matrix.single (.inr (forkLeft n hn)) (.inl (forkRight n hn)) 1 := by
+    rw [loweringMatrix_of_fork n hn hi]
+    ext (j | j) (k | k) <;> simp [Matrix.fromBlocks, Matrix.single_apply]
+  rw [hmat, map_sub, LinearMap.sub_apply, TauCeti.toLinAlgEquiv_single_apply_basis,
+    TauCeti.toLinAlgEquiv_single_apply_basis]
+  simp
 
 private theorem fromBlocks_mem_typeD {K : Type*} [CommRing K]
     (A B C : Matrix (Fin n) (Fin n) K) (hB : B.transpose = -B) (hC : C.transpose = -C) :

--- a/TauCeti/Algebra/Lie/Orthogonal/TypeD/RootGenerators.lean
+++ b/TauCeti/Algebra/Lie/Orthogonal/TypeD/RootGenerators.lean
@@ -39,9 +39,9 @@ The lowering generators are their transposes. The resulting matrices lie in the 
 Lie algebra and are square-zero in its standard representation.
 
 These are the carrier-specific numbered root vectors needed to feed the type-`D` spin lattice
-into Tau Ceti's existing Kostant-form and toral-closure machinery. Identifying their action with
-quadratic Clifford elements, and then proving the divided-power stability needed by the full-weight
-spin lattice, are deliberately left to the next carrier step.
+into Tau Ceti's existing Kostant-form and toral-closure machinery. Their images under the
+even-polarization quadratic equivalence are computed by
+`SpinPolarizationData.typeDQuadraticEquiv_rootGenerator`.
 
 ## Main definitions and results
 

--- a/TauCeti/Algebra/Lie/Orthogonal/TypeD/RootGenerators.lean
+++ b/TauCeti/Algebra/Lie/Orthogonal/TypeD/RootGenerators.lean
@@ -95,8 +95,24 @@ def forkLeft : Fin n := ⟨n - 2, by omega⟩
 /-- The terminal coordinate in the standard type-`Dₙ` realization. -/
 def forkRight : Fin n := ⟨n - 1, by omega⟩
 
+/-- The underlying index of `forkLeft`. -/
+@[simp]
+theorem forkLeft_val : (forkLeft n hn : ℕ) = n - 2 := by
+  simp [forkLeft]
+
+/-- The underlying index of `forkRight`. -/
+@[simp]
+theorem forkRight_val : (forkRight n hn : ℕ) = n - 1 := by
+  simp [forkRight]
+
 /-- The successor of a nonterminal simple-root index. -/
 def chainNext (i : Fin n) (hi : (i : ℕ) + 1 < n) : Fin n := ⟨(i : ℕ) + 1, hi⟩
+
+/-- The underlying index of `chainNext`. -/
+@[simp]
+theorem chainNext_val (i : Fin n) (hi : (i : ℕ) + 1 < n) :
+    (chainNext n i hi : ℕ) = (i : ℕ) + 1 := by
+  simp [chainNext]
 
 /-- A chain node and its successor are distinct. -/
 theorem ne_chainNext (i : Fin n) (hi : (i : ℕ) + 1 < n) : i ≠ chainNext n i hi := by

--- a/TauCeti/RepresentationTheory/Spin/Polarization/TypeD/RootGenerators.lean
+++ b/TauCeti/RepresentationTheory/Spin/Polarization/TypeD/RootGenerators.lean
@@ -44,8 +44,6 @@ root weights.
 
 * N. Bourbaki, *Groupes et algèbres de Lie*, Chapters 4--6, Plate IV.
 * C. Chevalley, *The Algebraic Theory of Spinors*, Chapter II.
-* The proof interface follows the matrix-action pattern in
-  `TauCeti.RepresentationTheory.Spin.Polarization.TypeB.RootGenerators`.
 -/
 
 public section

--- a/TauCeti/RepresentationTheory/Spin/Polarization/TypeD/RootGenerators.lean
+++ b/TauCeti/RepresentationTheory/Spin/Polarization/TypeD/RootGenerators.lean
@@ -1,0 +1,310 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Lie.Orthogonal.TypeD.RootGenerators
+public import TauCeti.RepresentationTheory.Spin.Polarization.TypeD.Basic
+public import TauCeti.RepresentationTheory.Spin.Polarization.TypeD.RootBivectors
+
+/-!
+# Type-D root generators in the quadratic Clifford model
+
+An even polarization identifies the split orthogonal Lie algebra of type `D` with the quadratic
+Lie subalgebra of its Clifford algebra. This file evaluates that equivalence on the
+Bourbaki-numbered root and coroot generators.
+
+For a chain node, the positive and negative matrix generators become
+
+```text
+eᵢ ↦ β(bᵢ, b'ᵢ₊₁),        fᵢ ↦ β(bᵢ₊₁, b'ᵢ),
+```
+
+while the fork generators become
+
+```text
+e ↦ β(bₙ₋₂, bₙ₋₁),        f ↦ β(b'ₙ₋₁, b'ₙ₋₂).
+```
+
+The reversed order in the last formula pins the sign: with these choices, the positive and
+negative representatives bracket to the numbered coroot on both sides of the equivalence. Thus
+the matrix and Clifford descriptions use the same Chevalley normalization, not merely the same
+root weights.
+
+## Main results
+
+* `TauCeti.SpinPolarizationData.typeDQuadraticEquiv_rootGenerator`: the signed family of matrix
+  root generators maps to the corresponding Clifford representatives.
+* `TauCeti.SpinPolarizationData.typeDQuadraticEquiv_cartanGenerator`: the numbered matrix coroot
+  maps to the Clifford simple-coroot representative.
+
+## References
+
+* N. Bourbaki, *Groupes et algèbres de Lie*, Chapters 4--6, Plate IV.
+* C. Chevalley, *The Algebraic Theory of Spinors*, Chapter II.
+-/
+
+public section
+
+open CliffordAlgebra QuadraticMap
+
+namespace TauCeti.SpinPolarizationData
+
+attribute [local instance 100] LieRing.ofAssociativeRing
+
+variable {K V : Type*} [Field K] [AddCommGroup V] [Module K V]
+  {Q : QuadraticForm K V} (P : SpinPolarizationData Q)
+  {n : ℕ} (b : Module.Basis (Fin n) K P.W) [Invertible (2 : K)]
+
+/-- Recognize the image of a type-`D` matrix as one Clifford bivector by comparing its action on
+the hyperbolic basis. -/
+private theorem typeDQuadraticEquiv_eq_bivector (hline : P.line = ⊥)
+    (A : LieAlgebra.Orthogonal.typeD (Fin n) K) (x y : V)
+    (h : ∀ c : Fin n ⊕ Fin n,
+      Matrix.toLinAlgEquiv (P.typeDBasis b hline) A (P.typeDBasis b hline c) =
+        polar Q y (P.typeDBasis b hline c) • x -
+          polar Q x (P.typeDBasis b hline c) • y) :
+    P.typeDQuadraticEquiv b hline A =
+      ⟨bivector Q x y, bivector_mem_quadraticLieSubalgebra Q x y⟩ := by
+  let _ : Module.Finite K V := Module.Finite.of_basis (P.typeDBasis b hline)
+  exact quadraticLieSubalgebra_eq_bivector_of_lie_ι Q
+    (P.nondegenerate_of_line_eq_bot hline) _ _
+    (P.typeDQuadraticEquiv_lie_ι b hline A) (P.typeDBasis b hline) x y h
+
+private theorem typeDQuadraticEquiv_rootGenerator_inl_of_add_one_lt
+    (hn : 4 ≤ n) (hline : P.line = ⊥) {i : Fin n} (hi : (i : ℕ) + 1 < n) :
+    P.typeDQuadraticEquiv b hline (TypeDStd.rootGenerator n hn (.inl i)) =
+      ⟨bivector Q (b i : V) (P.dualVector b ⟨(i : ℕ) + 1, hi⟩ : V),
+        bivector_mem_quadraticLieSubalgebra Q _ _⟩ := by
+  apply P.typeDQuadraticEquiv_eq_bivector b hline
+  rintro (j | j)
+  · rw [Matrix.toLinAlgEquiv_self]
+    simp only [TypeDStd.val_rootGenerator_inl, TypeDStd.raisingMatrix_of_chain n hn hi,
+      Fintype.sum_sum_type, Matrix.fromBlocks_apply₁₁, Matrix.fromBlocks_apply₂₁,
+      Matrix.single_apply, Matrix.zero_apply, zero_smul, Finset.sum_const_zero,
+      add_zero, P.typeDBasis_inl, P.polar_W_eq_zero, sub_zero]
+    rw [Finset.sum_eq_single i]
+    · rw [polar_comm, P.polar_dualVector]
+      simp [Fin.ext_iff, eq_comm]
+    · intro a _ hai
+      simp only [ite_smul, zero_smul]
+      split
+      · rename_i h
+        exact (hai h.1.symm).elim
+      · rfl
+    · simp
+  · rw [Matrix.toLinAlgEquiv_self]
+    simp only [TypeDStd.val_rootGenerator_inl, TypeDStd.raisingMatrix_of_chain n hn hi,
+      Fintype.sum_sum_type, Matrix.fromBlocks_apply₁₂, Matrix.fromBlocks_apply₂₂,
+      Matrix.neg_apply, Matrix.transpose_apply, Matrix.single_apply, Matrix.zero_apply,
+      neg_smul, zero_smul, Finset.sum_const_zero, zero_add,
+      P.typeDBasis_inr, P.polar_W'_eq_zero, zero_sub]
+    rw [Finset.sum_eq_single ⟨(i : ℕ) + 1, hi⟩]
+    · rw [P.polar_dualVector]
+      simp [Fin.ext_iff]
+    · intro a _ hai
+      simp only [ite_smul, zero_smul]
+      split
+      · rename_i h
+        have ha : a = ⟨(i : ℕ) + 1, hi⟩ := by
+          apply Fin.ext
+          simpa using congrArg Fin.val h.2.symm
+        exact (hai ha).elim
+      · simp
+    · simp
+
+private theorem typeDQuadraticEquiv_rootGenerator_inl_of_not_add_one_lt
+    (hn : 4 ≤ n) (hline : P.line = ⊥) {i : Fin n} (hi : ¬(i : ℕ) + 1 < n) :
+    P.typeDQuadraticEquiv b hline (TypeDStd.rootGenerator n hn (.inl i)) =
+      ⟨bivector Q (b (TypeDStd.forkLeft n hn) : V)
+          (b (TypeDStd.forkRight n hn) : V),
+        bivector_mem_quadraticLieSubalgebra Q _ _⟩ := by
+  apply P.typeDQuadraticEquiv_eq_bivector b hline
+  rintro (j | j)
+  · rw [Matrix.toLinAlgEquiv_self]
+    simp [TypeDStd.val_rootGenerator_inl, TypeDStd.raisingMatrix_of_fork n hn hi,
+      Fintype.sum_sum_type, P.typeDBasis_inl, P.polar_W_eq_zero]
+  · rw [Matrix.toLinAlgEquiv_self]
+    simp only [TypeDStd.val_rootGenerator_inl, TypeDStd.raisingMatrix_of_fork n hn hi,
+      Fintype.sum_sum_type, Matrix.fromBlocks_apply₁₂, Matrix.fromBlocks_apply₂₂,
+      Matrix.sub_apply, Matrix.single_apply, Matrix.zero_apply, zero_smul,
+      Finset.sum_const_zero, add_zero, P.typeDBasis_inl, P.typeDBasis_inr,
+      zero_smul, sub_smul]
+    rw [Finset.sum_sub_distrib, Finset.sum_eq_single (TypeDStd.forkLeft n hn),
+      Finset.sum_eq_single (TypeDStd.forkRight n hn)]
+    · rw [P.polar_dualVector, P.polar_dualVector]
+      simp [eq_comm]
+    · intro a _ ha
+      simp only [ite_smul, zero_smul]
+      split
+      · rename_i h
+        exact (ha h.1.symm).elim
+      · rfl
+    · simp
+    · intro a _ ha
+      simp only [ite_smul, zero_smul]
+      split
+      · rename_i h
+        exact (ha h.1.symm).elim
+      · rfl
+    · simp
+
+private theorem typeDQuadraticEquiv_rootGenerator_inr_of_add_one_lt
+    (hn : 4 ≤ n) (hline : P.line = ⊥) {i : Fin n} (hi : (i : ℕ) + 1 < n) :
+    P.typeDQuadraticEquiv b hline (TypeDStd.rootGenerator n hn (.inr i)) =
+      ⟨bivector Q (b ⟨(i : ℕ) + 1, hi⟩ : V) (P.dualVector b i : V),
+        bivector_mem_quadraticLieSubalgebra Q _ _⟩ := by
+  apply P.typeDQuadraticEquiv_eq_bivector b hline
+  rintro (j | j)
+  · rw [Matrix.toLinAlgEquiv_self]
+    simp only [TypeDStd.val_rootGenerator_inr, TypeDStd.loweringMatrix_of_chain n hn hi,
+      Fintype.sum_sum_type, Matrix.fromBlocks_apply₁₁, Matrix.fromBlocks_apply₂₁,
+      Matrix.transpose_apply, Matrix.single_apply, Matrix.zero_apply, zero_smul,
+      Finset.sum_const_zero, add_zero, P.typeDBasis_inl, P.polar_W_eq_zero, sub_zero]
+    rw [Finset.sum_eq_single ⟨(i : ℕ) + 1, hi⟩]
+    · rw [polar_comm, P.polar_dualVector]
+      simp [Fin.ext_iff, eq_comm]
+    · intro a _ hai
+      simp only [ite_smul, zero_smul]
+      split
+      · rename_i h
+        have ha : a = ⟨(i : ℕ) + 1, hi⟩ := by
+          apply Fin.ext
+          simpa using congrArg Fin.val h.2.symm
+        exact (hai ha).elim
+      · rfl
+    · simp
+  · rw [Matrix.toLinAlgEquiv_self]
+    simp only [TypeDStd.val_rootGenerator_inr, TypeDStd.loweringMatrix_of_chain n hn hi,
+      Fintype.sum_sum_type, Matrix.fromBlocks_apply₁₂, Matrix.fromBlocks_apply₂₂,
+      Matrix.neg_apply, Matrix.single_apply, Matrix.zero_apply, zero_smul,
+      Finset.sum_const_zero, zero_add, P.typeDBasis_inr, P.polar_W'_eq_zero,
+      neg_smul, zero_sub]
+    rw [Finset.sum_eq_single i]
+    · rw [P.polar_dualVector]
+      simp [Fin.ext_iff]
+    · intro a _ hai
+      simp only [ite_smul, zero_smul]
+      split
+      · rename_i h
+        exact (hai h.1.symm).elim
+      · simp
+    · simp
+
+private theorem typeDQuadraticEquiv_rootGenerator_inr_of_not_add_one_lt
+    (hn : 4 ≤ n) (hline : P.line = ⊥) {i : Fin n} (hi : ¬(i : ℕ) + 1 < n) :
+    P.typeDQuadraticEquiv b hline (TypeDStd.rootGenerator n hn (.inr i)) =
+      ⟨bivector Q (P.dualVector b (TypeDStd.forkRight n hn) : V)
+          (P.dualVector b (TypeDStd.forkLeft n hn) : V),
+        bivector_mem_quadraticLieSubalgebra Q _ _⟩ := by
+  apply P.typeDQuadraticEquiv_eq_bivector b hline
+  rintro (j | j)
+  · rw [Matrix.toLinAlgEquiv_self]
+    simp only [TypeDStd.val_rootGenerator_inr, TypeDStd.loweringMatrix_of_fork n hn hi,
+      Fintype.sum_sum_type, Matrix.fromBlocks_apply₁₁, Matrix.fromBlocks_apply₂₁,
+      Matrix.neg_apply, Matrix.sub_apply, Matrix.single_apply, Matrix.zero_apply,
+      zero_smul, Finset.sum_const_zero, zero_add, P.typeDBasis_inl, neg_smul, sub_smul]
+    simp only [neg_sub]
+    rw [Finset.sum_sub_distrib, Finset.sum_eq_single (TypeDStd.forkRight n hn),
+      Finset.sum_eq_single (TypeDStd.forkLeft n hn)]
+    · rw [polar_comm, P.polar_dualVector, polar_comm, P.polar_dualVector]
+      simp [eq_comm]
+    · intro a _ ha
+      simp only [ite_smul, zero_smul]
+      split
+      · rename_i h
+        exact (ha h.1.symm).elim
+      · rfl
+    · simp
+    · intro a _ ha
+      simp only [ite_smul, zero_smul]
+      split
+      · rename_i h
+        exact (ha h.1.symm).elim
+      · rfl
+    · simp
+  · rw [Matrix.toLinAlgEquiv_self]
+    simp [TypeDStd.val_rootGenerator_inr, TypeDStd.loweringMatrix_of_fork n hn hi,
+      Fintype.sum_sum_type, P.typeDBasis_inr, P.polar_W'_eq_zero]
+
+/-- **The numbered type-`D` matrix root generators are the corresponding positive and negative
+Clifford root representatives.** This fixes all four chain/fork and sign cases at once. -/
+@[simp]
+theorem typeDQuadraticEquiv_rootGenerator (hn : 4 ≤ n) (hline : P.line = ⊥)
+    (k : Fin n ⊕ Fin n) :
+    (P.typeDQuadraticEquiv b hline (TypeDStd.rootGenerator n hn k) : CliffordAlgebra Q) =
+      match k with
+      | .inl i => P.typeDSimpleRootBivector b (by omega) i
+      | .inr i => P.typeDSimpleNegativeRootBivector b (by omega) i := by
+  cases k with
+  | inl i =>
+      simp only
+      by_cases hi : (i : ℕ) + 1 < n
+      · exact (congrArg Subtype.val
+          (P.typeDQuadraticEquiv_rootGenerator_inl_of_add_one_lt b hn hline hi)).trans
+            (P.typeDSimpleRootBivector_of_add_one_lt b (by omega) hi).symm
+      · have hfork :
+            bivector Q (b (TypeDStd.forkLeft n hn) : V)
+                (b (TypeDStd.forkRight n hn) : V) =
+              P.typeDSimpleRootBivector b (by omega) i := by
+          have hleft : TypeDStd.forkLeft n hn = ⟨n - 2, by omega⟩ := by
+            apply Fin.ext
+            simp
+          have hright : TypeDStd.forkRight n hn = ⟨n - 1, by omega⟩ := by
+            apply Fin.ext
+            simp
+          exact (congrArg₂ (fun x y : V => bivector Q x y)
+            (congrArg (fun j => (b j : V)) hleft)
+            (congrArg (fun j => (b j : V)) hright)).trans
+              (P.typeDSimpleRootBivector_of_not_add_one_lt b (by omega) hi).symm
+        exact (congrArg Subtype.val
+          (P.typeDQuadraticEquiv_rootGenerator_inl_of_not_add_one_lt b hn hline hi)).trans hfork
+  | inr i =>
+      simp only
+      by_cases hi : (i : ℕ) + 1 < n
+      · exact (congrArg Subtype.val
+          (P.typeDQuadraticEquiv_rootGenerator_inr_of_add_one_lt b hn hline hi)).trans
+            (P.typeDSimpleNegativeRootBivector_of_add_one_lt b (by omega) hi).symm
+      · have hfork :
+            bivector Q (P.dualVector b (TypeDStd.forkRight n hn) : V)
+                (P.dualVector b (TypeDStd.forkLeft n hn) : V) =
+              P.typeDSimpleNegativeRootBivector b (by omega) i := by
+          have hleft : TypeDStd.forkLeft n hn = ⟨n - 2, by omega⟩ := by
+            apply Fin.ext
+            simp
+          have hright : TypeDStd.forkRight n hn = ⟨n - 1, by omega⟩ := by
+            apply Fin.ext
+            simp
+          exact (congrArg₂ (fun x y : V => bivector Q x y)
+            (congrArg (fun j => (P.dualVector b j : V)) hright)
+            (congrArg (fun j => (P.dualVector b j : V)) hleft)).trans
+              (P.typeDSimpleNegativeRootBivector_of_not_add_one_lt b (by omega) hi).symm
+        exact (congrArg Subtype.val
+          (P.typeDQuadraticEquiv_rootGenerator_inr_of_not_add_one_lt b hn hline hi)).trans hfork
+
+/-- **The numbered type-`D` matrix coroot maps to the corresponding Clifford simple-coroot
+representative.** In particular, the two root-generator normalizations have the same bracket. -/
+@[simp]
+theorem typeDQuadraticEquiv_cartanGenerator (hn : 4 ≤ n) (hline : P.line = ⊥)
+    (i : Fin n) :
+    (P.typeDQuadraticEquiv b hline
+        (TypeDStd.cartanGenerator n hn i) : CliffordAlgebra Q) =
+      P.typeDSimpleCorootBivector b (by omega) i := by
+  have hroot :
+      ⁅TypeDStd.rootGenerator (K := K) n hn (.inl i),
+          TypeDStd.rootGenerator (K := K) n hn (.inr i)⁆ =
+        TypeDStd.cartanGenerator (K := K) n hn i := by
+    rw [TypeDStd.lie_rootGenerator_inl_inr (K := K), ite_eq_left rfl]
+  rw [← hroot, (P.typeDQuadraticEquiv b hline).map_lie,
+    LieSubalgebra.coe_bracket]
+  change ⁅(P.typeDQuadraticEquiv b hline
+      (TypeDStd.rootGenerator n hn (.inl i)) : CliffordAlgebra Q),
+    (P.typeDQuadraticEquiv b hline
+      (TypeDStd.rootGenerator n hn (.inr i)) : CliffordAlgebra Q)⁆ = _
+  rw [P.typeDQuadraticEquiv_rootGenerator b hn hline (.inl i),
+    P.typeDQuadraticEquiv_rootGenerator b hn hline (.inr i)]
+  exact P.lie_typeDSimpleRootBivector_typeDSimpleNegativeRootBivector (K := K) b (by omega) i
+
+end TauCeti.SpinPolarizationData

--- a/TauCeti/RepresentationTheory/Spin/Polarization/TypeD/RootGenerators.lean
+++ b/TauCeti/RepresentationTheory/Spin/Polarization/TypeD/RootGenerators.lean
@@ -78,59 +78,89 @@ private theorem polar_dualVector_left (i j : Fin n) :
     polar Q (P.dualVector b i : V) (b j : V) = if j = i then 1 else 0 := by
   rw [polar_comm, P.polar_dualVector]
 
+@[simp]
+private theorem chainNext_eq_mk {i : Fin n} (hi : (i : ℕ) + 1 < n) :
+    TypeDStd.chainNext n i hi = ⟨(i : ℕ) + 1, hi⟩ :=
+  Fin.ext (TypeDStd.chainNext_val n i hi)
+
+@[simp]
+private theorem forkLeft_eq_mk (hn : 4 ≤ n) :
+    TypeDStd.forkLeft n hn = ⟨n - 2, by omega⟩ :=
+  Fin.ext (TypeDStd.forkLeft_val n hn)
+
+@[simp]
+private theorem forkRight_eq_mk (hn : 4 ≤ n) :
+    TypeDStd.forkRight n hn = ⟨n - 1, by omega⟩ :=
+  Fin.ext (TypeDStd.forkRight_val n hn)
+
 private theorem typeDQuadraticEquiv_rootGenerator_inl_of_add_one_lt
     (hn : 4 ≤ n) (hline : P.line = ⊥) {i : Fin n} (hi : (i : ℕ) + 1 < n) :
-    P.typeDQuadraticEquiv b hline (TypeDStd.rootGenerator n hn (.inl i)) =
-      ⟨bivector Q (b i : V) (P.dualVector b (TypeDStd.chainNext n i hi) : V),
-        bivector_mem_quadraticLieSubalgebra Q _ _⟩ := by
-  apply P.typeDQuadraticEquiv_eq_bivector b hline
-  rintro (j | j)
-  all_goals rw [TypeDStd.val_rootGenerator_inl,
-    TypeDStd.toLinAlgEquiv_raisingMatrix_apply_basis_of_chain n hn
-      (P.typeDBasis b hline) hi]
-  · simp [P.typeDBasis_inl, P.polar_W_eq_zero, P.polar_dualVector_left, eq_comm]
-  · simp [P.typeDBasis_inr, P.polar_W'_eq_zero, P.polar_dualVector, eq_comm]
+    (P.typeDQuadraticEquiv b hline
+        (TypeDStd.rootGenerator n hn (.inl i)) : CliffordAlgebra Q) =
+      P.typeDSimpleRootBivector b (by omega) i := by
+  calc
+    _ = bivector Q (b i : V) (P.dualVector b ⟨(i : ℕ) + 1, hi⟩ : V) :=
+      congrArg Subtype.val (P.typeDQuadraticEquiv_eq_bivector b hline _ _ _ (by
+        rintro (j | j)
+        all_goals rw [TypeDStd.val_rootGenerator_inl,
+          TypeDStd.toLinAlgEquiv_raisingMatrix_apply_basis_of_chain n hn
+            (P.typeDBasis b hline) hi]
+        · simp [P.typeDBasis_inl, P.polar_W_eq_zero, P.polar_dualVector_left, eq_comm]
+        · simp [P.typeDBasis_inr, P.polar_W'_eq_zero, P.polar_dualVector]))
+    _ = _ := by
+      exact (P.typeDSimpleRootBivector_of_add_one_lt b (by omega) hi).symm
 
 private theorem typeDQuadraticEquiv_rootGenerator_inl_of_not_add_one_lt
     (hn : 4 ≤ n) (hline : P.line = ⊥) {i : Fin n} (hi : ¬(i : ℕ) + 1 < n) :
-    P.typeDQuadraticEquiv b hline (TypeDStd.rootGenerator n hn (.inl i)) =
-      ⟨bivector Q (b (TypeDStd.forkLeft n hn) : V)
-          (b (TypeDStd.forkRight n hn) : V),
-        bivector_mem_quadraticLieSubalgebra Q _ _⟩ := by
-  apply P.typeDQuadraticEquiv_eq_bivector b hline
-  rintro (j | j)
-  all_goals rw [TypeDStd.val_rootGenerator_inl,
-    TypeDStd.toLinAlgEquiv_raisingMatrix_apply_basis_of_fork n hn
-      (P.typeDBasis b hline) hi]
-  · simp [P.typeDBasis_inl, P.polar_W_eq_zero, eq_comm]
-  · simp [P.typeDBasis_inr, P.polar_dualVector, eq_comm]
+    (P.typeDQuadraticEquiv b hline
+        (TypeDStd.rootGenerator n hn (.inl i)) : CliffordAlgebra Q) =
+      P.typeDSimpleRootBivector b (by omega) i := by
+  calc
+    _ = bivector Q (b ⟨n - 2, by omega⟩ : V) (b ⟨n - 1, by omega⟩ : V) :=
+      congrArg Subtype.val (P.typeDQuadraticEquiv_eq_bivector b hline _ _ _ (by
+        rintro (j | j)
+        all_goals rw [TypeDStd.val_rootGenerator_inl,
+          TypeDStd.toLinAlgEquiv_raisingMatrix_apply_basis_of_fork n hn
+            (P.typeDBasis b hline) hi]
+        · simp [P.typeDBasis_inl, P.polar_W_eq_zero, eq_comm]
+        · simp [P.typeDBasis_inr, P.polar_dualVector, eq_comm]))
+    _ = _ := by
+      exact (P.typeDSimpleRootBivector_of_not_add_one_lt b (by omega) hi).symm
 
 private theorem typeDQuadraticEquiv_rootGenerator_inr_of_add_one_lt
     (hn : 4 ≤ n) (hline : P.line = ⊥) {i : Fin n} (hi : (i : ℕ) + 1 < n) :
-    P.typeDQuadraticEquiv b hline (TypeDStd.rootGenerator n hn (.inr i)) =
-      ⟨bivector Q (b (TypeDStd.chainNext n i hi) : V) (P.dualVector b i : V),
-        bivector_mem_quadraticLieSubalgebra Q _ _⟩ := by
-  apply P.typeDQuadraticEquiv_eq_bivector b hline
-  rintro (j | j)
-  all_goals rw [TypeDStd.val_rootGenerator_inr,
-    TypeDStd.toLinAlgEquiv_loweringMatrix_apply_basis_of_chain n hn
-      (P.typeDBasis b hline) hi]
-  · simp [P.typeDBasis_inl, P.polar_W_eq_zero, P.polar_dualVector_left, eq_comm]
-  · simp [P.typeDBasis_inr, P.polar_W'_eq_zero, P.polar_dualVector, eq_comm]
+    (P.typeDQuadraticEquiv b hline
+        (TypeDStd.rootGenerator n hn (.inr i)) : CliffordAlgebra Q) =
+      P.typeDSimpleNegativeRootBivector b (by omega) i := by
+  calc
+    _ = bivector Q (b ⟨(i : ℕ) + 1, hi⟩ : V) (P.dualVector b i : V) :=
+      congrArg Subtype.val (P.typeDQuadraticEquiv_eq_bivector b hline _ _ _ (by
+        rintro (j | j)
+        all_goals rw [TypeDStd.val_rootGenerator_inr,
+          TypeDStd.toLinAlgEquiv_loweringMatrix_apply_basis_of_chain n hn
+            (P.typeDBasis b hline) hi]
+        · simp [P.typeDBasis_inl, P.polar_W_eq_zero, P.polar_dualVector_left, eq_comm]
+        · simp [P.typeDBasis_inr, P.polar_W'_eq_zero, P.polar_dualVector, eq_comm]))
+    _ = _ := by
+      exact (P.typeDSimpleNegativeRootBivector_of_add_one_lt b (by omega) hi).symm
 
 private theorem typeDQuadraticEquiv_rootGenerator_inr_of_not_add_one_lt
     (hn : 4 ≤ n) (hline : P.line = ⊥) {i : Fin n} (hi : ¬(i : ℕ) + 1 < n) :
-    P.typeDQuadraticEquiv b hline (TypeDStd.rootGenerator n hn (.inr i)) =
-      ⟨bivector Q (P.dualVector b (TypeDStd.forkRight n hn) : V)
-          (P.dualVector b (TypeDStd.forkLeft n hn) : V),
-        bivector_mem_quadraticLieSubalgebra Q _ _⟩ := by
-  apply P.typeDQuadraticEquiv_eq_bivector b hline
-  rintro (j | j)
-  all_goals rw [TypeDStd.val_rootGenerator_inr,
-    TypeDStd.toLinAlgEquiv_loweringMatrix_apply_basis_of_fork n hn
-      (P.typeDBasis b hline) hi]
-  · simp [P.typeDBasis_inl, P.polar_dualVector_left, eq_comm]
-  · simp [P.typeDBasis_inr, P.polar_W'_eq_zero, eq_comm]
+    (P.typeDQuadraticEquiv b hline
+        (TypeDStd.rootGenerator n hn (.inr i)) : CliffordAlgebra Q) =
+      P.typeDSimpleNegativeRootBivector b (by omega) i := by
+  calc
+    _ = bivector Q (P.dualVector b ⟨n - 1, by omega⟩ : V)
+        (P.dualVector b ⟨n - 2, by omega⟩ : V) :=
+      congrArg Subtype.val (P.typeDQuadraticEquiv_eq_bivector b hline _ _ _ (by
+        rintro (j | j)
+        all_goals rw [TypeDStd.val_rootGenerator_inr,
+          TypeDStd.toLinAlgEquiv_loweringMatrix_apply_basis_of_fork n hn
+            (P.typeDBasis b hline) hi]
+        · simp [P.typeDBasis_inl, P.polar_dualVector_left, eq_comm]
+        · simp [P.typeDBasis_inr, P.polar_W'_eq_zero, eq_comm]))
+    _ = _ := by
+      exact (P.typeDSimpleNegativeRootBivector_of_not_add_one_lt b (by omega) hi).symm
 
 /-- **The numbered type-`D` matrix root generators are the corresponding positive and negative
 Clifford root representatives.** This fixes all four chain/fork and sign cases at once. -/
@@ -143,57 +173,13 @@ theorem typeDQuadraticEquiv_rootGenerator (hn : 4 ≤ n) (hline : P.line = ⊥)
       | .inr i => P.typeDSimpleNegativeRootBivector b (by omega) i := by
   cases k with
   | inl i =>
-      simp only
       by_cases hi : (i : ℕ) + 1 < n
-      · have hnext : TypeDStd.chainNext n i hi = ⟨(i : ℕ) + 1, hi⟩ := by
-          apply Fin.ext
-          simp
-        exact (congrArg Subtype.val
-          (P.typeDQuadraticEquiv_rootGenerator_inl_of_add_one_lt b hn hline hi)).trans
-            ((congrArg (fun j => bivector Q (b i : V) (P.dualVector b j : V)) hnext).trans
-              (P.typeDSimpleRootBivector_of_add_one_lt b (by omega) hi).symm)
-      · have hfork :
-            bivector Q (b (TypeDStd.forkLeft n hn) : V)
-                (b (TypeDStd.forkRight n hn) : V) =
-              P.typeDSimpleRootBivector b (by omega) i := by
-          have hleft : TypeDStd.forkLeft n hn = ⟨n - 2, by omega⟩ := by
-            apply Fin.ext
-            simp
-          have hright : TypeDStd.forkRight n hn = ⟨n - 1, by omega⟩ := by
-            apply Fin.ext
-            simp
-          exact (congrArg₂ (fun x y : V => bivector Q x y)
-            (congrArg (fun j => (b j : V)) hleft)
-            (congrArg (fun j => (b j : V)) hright)).trans
-              (P.typeDSimpleRootBivector_of_not_add_one_lt b (by omega) hi).symm
-        exact (congrArg Subtype.val
-          (P.typeDQuadraticEquiv_rootGenerator_inl_of_not_add_one_lt b hn hline hi)).trans hfork
+      · simpa using P.typeDQuadraticEquiv_rootGenerator_inl_of_add_one_lt b hn hline hi
+      · simpa using P.typeDQuadraticEquiv_rootGenerator_inl_of_not_add_one_lt b hn hline hi
   | inr i =>
-      simp only
       by_cases hi : (i : ℕ) + 1 < n
-      · have hnext : TypeDStd.chainNext n i hi = ⟨(i : ℕ) + 1, hi⟩ := by
-          apply Fin.ext
-          simp
-        exact (congrArg Subtype.val
-          (P.typeDQuadraticEquiv_rootGenerator_inr_of_add_one_lt b hn hline hi)).trans
-            ((congrArg (fun j => bivector Q (b j : V) (P.dualVector b i : V)) hnext).trans
-              (P.typeDSimpleNegativeRootBivector_of_add_one_lt b (by omega) hi).symm)
-      · have hfork :
-            bivector Q (P.dualVector b (TypeDStd.forkRight n hn) : V)
-                (P.dualVector b (TypeDStd.forkLeft n hn) : V) =
-              P.typeDSimpleNegativeRootBivector b (by omega) i := by
-          have hleft : TypeDStd.forkLeft n hn = ⟨n - 2, by omega⟩ := by
-            apply Fin.ext
-            simp
-          have hright : TypeDStd.forkRight n hn = ⟨n - 1, by omega⟩ := by
-            apply Fin.ext
-            simp
-          exact (congrArg₂ (fun x y : V => bivector Q x y)
-            (congrArg (fun j => (P.dualVector b j : V)) hright)
-            (congrArg (fun j => (P.dualVector b j : V)) hleft)).trans
-              (P.typeDSimpleNegativeRootBivector_of_not_add_one_lt b (by omega) hi).symm
-        exact (congrArg Subtype.val
-          (P.typeDQuadraticEquiv_rootGenerator_inr_of_not_add_one_lt b hn hline hi)).trans hfork
+      · simpa using P.typeDQuadraticEquiv_rootGenerator_inr_of_add_one_lt b hn hline hi
+      · simpa using P.typeDQuadraticEquiv_rootGenerator_inr_of_not_add_one_lt b hn hline hi
 
 /-- **The numbered type-`D` matrix coroot maps to the corresponding Clifford simple-coroot
 representative.** In particular, the two root-generator normalizations have the same bracket. -/

--- a/TauCeti/RepresentationTheory/Spin/Polarization/TypeD/RootGenerators.lean
+++ b/TauCeti/RepresentationTheory/Spin/Polarization/TypeD/RootGenerators.lean
@@ -78,17 +78,14 @@ private theorem polar_dualVector_left (i j : Fin n) :
     polar Q (P.dualVector b i : V) (b j : V) = if j = i then 1 else 0 := by
   rw [polar_comm, P.polar_dualVector]
 
-@[simp]
 private theorem chainNext_eq_mk {i : Fin n} (hi : (i : ℕ) + 1 < n) :
     TypeDStd.chainNext n i hi = ⟨(i : ℕ) + 1, hi⟩ :=
   Fin.ext (TypeDStd.chainNext_val n i hi)
 
-@[simp]
 private theorem forkLeft_eq_mk (hn : 4 ≤ n) :
     TypeDStd.forkLeft n hn = ⟨n - 2, by omega⟩ :=
   Fin.ext (TypeDStd.forkLeft_val n hn)
 
-@[simp]
 private theorem forkRight_eq_mk (hn : 4 ≤ n) :
     TypeDStd.forkRight n hn = ⟨n - 1, by omega⟩ :=
   Fin.ext (TypeDStd.forkRight_val n hn)
@@ -105,8 +102,10 @@ private theorem typeDQuadraticEquiv_rootGenerator_inl_of_add_one_lt
         all_goals rw [TypeDStd.val_rootGenerator_inl,
           TypeDStd.toLinAlgEquiv_raisingMatrix_apply_basis_of_chain n hn
             (P.typeDBasis b hline) hi]
-        · simp [P.typeDBasis_inl, P.polar_W_eq_zero, P.polar_dualVector_left, eq_comm]
-        · simp [P.typeDBasis_inr, P.polar_W'_eq_zero, P.polar_dualVector]))
+        · simp [chainNext_eq_mk, P.typeDBasis_inl, P.polar_W_eq_zero,
+            P.polar_dualVector_left, eq_comm]
+        · simp [chainNext_eq_mk, P.typeDBasis_inr, P.polar_W'_eq_zero,
+            P.polar_dualVector]))
     _ = _ := by
       exact (P.typeDSimpleRootBivector_of_add_one_lt b (by omega) hi).symm
 
@@ -122,8 +121,10 @@ private theorem typeDQuadraticEquiv_rootGenerator_inl_of_not_add_one_lt
         all_goals rw [TypeDStd.val_rootGenerator_inl,
           TypeDStd.toLinAlgEquiv_raisingMatrix_apply_basis_of_fork n hn
             (P.typeDBasis b hline) hi]
-        · simp [P.typeDBasis_inl, P.polar_W_eq_zero, eq_comm]
-        · simp [P.typeDBasis_inr, P.polar_dualVector, eq_comm]))
+        · simp [forkLeft_eq_mk, forkRight_eq_mk, P.typeDBasis_inl,
+            P.polar_W_eq_zero, eq_comm]
+        · simp [forkLeft_eq_mk, forkRight_eq_mk, P.typeDBasis_inr,
+            P.polar_dualVector, eq_comm]))
     _ = _ := by
       exact (P.typeDSimpleRootBivector_of_not_add_one_lt b (by omega) hi).symm
 
@@ -139,8 +140,10 @@ private theorem typeDQuadraticEquiv_rootGenerator_inr_of_add_one_lt
         all_goals rw [TypeDStd.val_rootGenerator_inr,
           TypeDStd.toLinAlgEquiv_loweringMatrix_apply_basis_of_chain n hn
             (P.typeDBasis b hline) hi]
-        · simp [P.typeDBasis_inl, P.polar_W_eq_zero, P.polar_dualVector_left, eq_comm]
-        · simp [P.typeDBasis_inr, P.polar_W'_eq_zero, P.polar_dualVector, eq_comm]))
+        · simp [chainNext_eq_mk, P.typeDBasis_inl, P.polar_W_eq_zero,
+            P.polar_dualVector_left, eq_comm]
+        · simp [chainNext_eq_mk, P.typeDBasis_inr, P.polar_W'_eq_zero,
+            P.polar_dualVector, eq_comm]))
     _ = _ := by
       exact (P.typeDSimpleNegativeRootBivector_of_add_one_lt b (by omega) hi).symm
 
@@ -157,8 +160,10 @@ private theorem typeDQuadraticEquiv_rootGenerator_inr_of_not_add_one_lt
         all_goals rw [TypeDStd.val_rootGenerator_inr,
           TypeDStd.toLinAlgEquiv_loweringMatrix_apply_basis_of_fork n hn
             (P.typeDBasis b hline) hi]
-        · simp [P.typeDBasis_inl, P.polar_dualVector_left, eq_comm]
-        · simp [P.typeDBasis_inr, P.polar_W'_eq_zero, eq_comm]))
+        · simp [forkLeft_eq_mk, forkRight_eq_mk, P.typeDBasis_inl,
+            P.polar_dualVector_left, eq_comm]
+        · simp [forkLeft_eq_mk, forkRight_eq_mk, P.typeDBasis_inr,
+            P.polar_W'_eq_zero, eq_comm]))
     _ = _ := by
       exact (P.typeDSimpleNegativeRootBivector_of_not_add_one_lt b (by omega) hi).symm
 

--- a/TauCeti/RepresentationTheory/Spin/Polarization/TypeD/RootGenerators.lean
+++ b/TauCeti/RepresentationTheory/Spin/Polarization/TypeD/RootGenerators.lean
@@ -44,6 +44,8 @@ root weights.
 
 * N. Bourbaki, *Groupes et algèbres de Lie*, Chapters 4--6, Plate IV.
 * C. Chevalley, *The Algebraic Theory of Spinors*, Chapter II.
+* The proof interface follows the matrix-action pattern in
+  `TauCeti.RepresentationTheory.Spin.Polarization.TypeB.RootGenerators`.
 -/
 
 public section
@@ -73,47 +75,23 @@ private theorem typeDQuadraticEquiv_eq_bivector (hline : P.line = ⊥)
     (P.nondegenerate_of_line_eq_bot hline) _ _
     (P.typeDQuadraticEquiv_lie_ι b hline A) (P.typeDBasis b hline) x y h
 
+omit [Invertible (2 : K)] in
+private theorem polar_dualVector_left (i j : Fin n) :
+    polar Q (P.dualVector b i : V) (b j : V) = if j = i then 1 else 0 := by
+  rw [polar_comm, P.polar_dualVector]
+
 private theorem typeDQuadraticEquiv_rootGenerator_inl_of_add_one_lt
     (hn : 4 ≤ n) (hline : P.line = ⊥) {i : Fin n} (hi : (i : ℕ) + 1 < n) :
     P.typeDQuadraticEquiv b hline (TypeDStd.rootGenerator n hn (.inl i)) =
-      ⟨bivector Q (b i : V) (P.dualVector b ⟨(i : ℕ) + 1, hi⟩ : V),
+      ⟨bivector Q (b i : V) (P.dualVector b (TypeDStd.chainNext n i hi) : V),
         bivector_mem_quadraticLieSubalgebra Q _ _⟩ := by
   apply P.typeDQuadraticEquiv_eq_bivector b hline
   rintro (j | j)
-  · rw [Matrix.toLinAlgEquiv_self]
-    simp only [TypeDStd.val_rootGenerator_inl, TypeDStd.raisingMatrix_of_chain n hn hi,
-      Fintype.sum_sum_type, Matrix.fromBlocks_apply₁₁, Matrix.fromBlocks_apply₂₁,
-      Matrix.single_apply, Matrix.zero_apply, zero_smul, Finset.sum_const_zero,
-      add_zero, P.typeDBasis_inl, P.polar_W_eq_zero, sub_zero]
-    rw [Finset.sum_eq_single i]
-    · rw [polar_comm, P.polar_dualVector]
-      simp [Fin.ext_iff, eq_comm]
-    · intro a _ hai
-      simp only [ite_smul, zero_smul]
-      split
-      · rename_i h
-        exact (hai h.1.symm).elim
-      · rfl
-    · simp
-  · rw [Matrix.toLinAlgEquiv_self]
-    simp only [TypeDStd.val_rootGenerator_inl, TypeDStd.raisingMatrix_of_chain n hn hi,
-      Fintype.sum_sum_type, Matrix.fromBlocks_apply₁₂, Matrix.fromBlocks_apply₂₂,
-      Matrix.neg_apply, Matrix.transpose_apply, Matrix.single_apply, Matrix.zero_apply,
-      neg_smul, zero_smul, Finset.sum_const_zero, zero_add,
-      P.typeDBasis_inr, P.polar_W'_eq_zero, zero_sub]
-    rw [Finset.sum_eq_single ⟨(i : ℕ) + 1, hi⟩]
-    · rw [P.polar_dualVector]
-      simp [Fin.ext_iff]
-    · intro a _ hai
-      simp only [ite_smul, zero_smul]
-      split
-      · rename_i h
-        have ha : a = ⟨(i : ℕ) + 1, hi⟩ := by
-          apply Fin.ext
-          simpa using congrArg Fin.val h.2.symm
-        exact (hai ha).elim
-      · simp
-    · simp
+  all_goals rw [TypeDStd.val_rootGenerator_inl,
+    TypeDStd.toLinAlgEquiv_raisingMatrix_apply_basis_of_chain n hn
+      (P.typeDBasis b hline) hi]
+  · simp [P.typeDBasis_inl, P.polar_W_eq_zero, P.polar_dualVector_left, eq_comm]
+  · simp [P.typeDBasis_inr, P.polar_W'_eq_zero, P.polar_dualVector, eq_comm]
 
 private theorem typeDQuadraticEquiv_rootGenerator_inl_of_not_add_one_lt
     (hn : 4 ≤ n) (hline : P.line = ⊥) {i : Fin n} (hi : ¬(i : ℕ) + 1 < n) :
@@ -123,75 +101,24 @@ private theorem typeDQuadraticEquiv_rootGenerator_inl_of_not_add_one_lt
         bivector_mem_quadraticLieSubalgebra Q _ _⟩ := by
   apply P.typeDQuadraticEquiv_eq_bivector b hline
   rintro (j | j)
-  · rw [Matrix.toLinAlgEquiv_self]
-    simp [TypeDStd.val_rootGenerator_inl, TypeDStd.raisingMatrix_of_fork n hn hi,
-      Fintype.sum_sum_type, P.typeDBasis_inl, P.polar_W_eq_zero]
-  · rw [Matrix.toLinAlgEquiv_self]
-    simp only [TypeDStd.val_rootGenerator_inl, TypeDStd.raisingMatrix_of_fork n hn hi,
-      Fintype.sum_sum_type, Matrix.fromBlocks_apply₁₂, Matrix.fromBlocks_apply₂₂,
-      Matrix.sub_apply, Matrix.single_apply, Matrix.zero_apply, zero_smul,
-      Finset.sum_const_zero, add_zero, P.typeDBasis_inl, P.typeDBasis_inr,
-      zero_smul, sub_smul]
-    rw [Finset.sum_sub_distrib, Finset.sum_eq_single (TypeDStd.forkLeft n hn),
-      Finset.sum_eq_single (TypeDStd.forkRight n hn)]
-    · rw [P.polar_dualVector, P.polar_dualVector]
-      simp [eq_comm]
-    · intro a _ ha
-      simp only [ite_smul, zero_smul]
-      split
-      · rename_i h
-        exact (ha h.1.symm).elim
-      · rfl
-    · simp
-    · intro a _ ha
-      simp only [ite_smul, zero_smul]
-      split
-      · rename_i h
-        exact (ha h.1.symm).elim
-      · rfl
-    · simp
+  all_goals rw [TypeDStd.val_rootGenerator_inl,
+    TypeDStd.toLinAlgEquiv_raisingMatrix_apply_basis_of_fork n hn
+      (P.typeDBasis b hline) hi]
+  · simp [P.typeDBasis_inl, P.polar_W_eq_zero, eq_comm]
+  · simp [P.typeDBasis_inr, P.polar_dualVector, eq_comm]
 
 private theorem typeDQuadraticEquiv_rootGenerator_inr_of_add_one_lt
     (hn : 4 ≤ n) (hline : P.line = ⊥) {i : Fin n} (hi : (i : ℕ) + 1 < n) :
     P.typeDQuadraticEquiv b hline (TypeDStd.rootGenerator n hn (.inr i)) =
-      ⟨bivector Q (b ⟨(i : ℕ) + 1, hi⟩ : V) (P.dualVector b i : V),
+      ⟨bivector Q (b (TypeDStd.chainNext n i hi) : V) (P.dualVector b i : V),
         bivector_mem_quadraticLieSubalgebra Q _ _⟩ := by
   apply P.typeDQuadraticEquiv_eq_bivector b hline
   rintro (j | j)
-  · rw [Matrix.toLinAlgEquiv_self]
-    simp only [TypeDStd.val_rootGenerator_inr, TypeDStd.loweringMatrix_of_chain n hn hi,
-      Fintype.sum_sum_type, Matrix.fromBlocks_apply₁₁, Matrix.fromBlocks_apply₂₁,
-      Matrix.transpose_apply, Matrix.single_apply, Matrix.zero_apply, zero_smul,
-      Finset.sum_const_zero, add_zero, P.typeDBasis_inl, P.polar_W_eq_zero, sub_zero]
-    rw [Finset.sum_eq_single ⟨(i : ℕ) + 1, hi⟩]
-    · rw [polar_comm, P.polar_dualVector]
-      simp [Fin.ext_iff, eq_comm]
-    · intro a _ hai
-      simp only [ite_smul, zero_smul]
-      split
-      · rename_i h
-        have ha : a = ⟨(i : ℕ) + 1, hi⟩ := by
-          apply Fin.ext
-          simpa using congrArg Fin.val h.2.symm
-        exact (hai ha).elim
-      · rfl
-    · simp
-  · rw [Matrix.toLinAlgEquiv_self]
-    simp only [TypeDStd.val_rootGenerator_inr, TypeDStd.loweringMatrix_of_chain n hn hi,
-      Fintype.sum_sum_type, Matrix.fromBlocks_apply₁₂, Matrix.fromBlocks_apply₂₂,
-      Matrix.neg_apply, Matrix.single_apply, Matrix.zero_apply, zero_smul,
-      Finset.sum_const_zero, zero_add, P.typeDBasis_inr, P.polar_W'_eq_zero,
-      neg_smul, zero_sub]
-    rw [Finset.sum_eq_single i]
-    · rw [P.polar_dualVector]
-      simp [Fin.ext_iff]
-    · intro a _ hai
-      simp only [ite_smul, zero_smul]
-      split
-      · rename_i h
-        exact (hai h.1.symm).elim
-      · simp
-    · simp
+  all_goals rw [TypeDStd.val_rootGenerator_inr,
+    TypeDStd.toLinAlgEquiv_loweringMatrix_apply_basis_of_chain n hn
+      (P.typeDBasis b hline) hi]
+  · simp [P.typeDBasis_inl, P.polar_W_eq_zero, P.polar_dualVector_left, eq_comm]
+  · simp [P.typeDBasis_inr, P.polar_W'_eq_zero, P.polar_dualVector, eq_comm]
 
 private theorem typeDQuadraticEquiv_rootGenerator_inr_of_not_add_one_lt
     (hn : 4 ≤ n) (hline : P.line = ⊥) {i : Fin n} (hi : ¬(i : ℕ) + 1 < n) :
@@ -201,33 +128,11 @@ private theorem typeDQuadraticEquiv_rootGenerator_inr_of_not_add_one_lt
         bivector_mem_quadraticLieSubalgebra Q _ _⟩ := by
   apply P.typeDQuadraticEquiv_eq_bivector b hline
   rintro (j | j)
-  · rw [Matrix.toLinAlgEquiv_self]
-    simp only [TypeDStd.val_rootGenerator_inr, TypeDStd.loweringMatrix_of_fork n hn hi,
-      Fintype.sum_sum_type, Matrix.fromBlocks_apply₁₁, Matrix.fromBlocks_apply₂₁,
-      Matrix.neg_apply, Matrix.sub_apply, Matrix.single_apply, Matrix.zero_apply,
-      zero_smul, Finset.sum_const_zero, zero_add, P.typeDBasis_inl, neg_smul, sub_smul]
-    simp only [neg_sub]
-    rw [Finset.sum_sub_distrib, Finset.sum_eq_single (TypeDStd.forkRight n hn),
-      Finset.sum_eq_single (TypeDStd.forkLeft n hn)]
-    · rw [polar_comm, P.polar_dualVector, polar_comm, P.polar_dualVector]
-      simp [eq_comm]
-    · intro a _ ha
-      simp only [ite_smul, zero_smul]
-      split
-      · rename_i h
-        exact (ha h.1.symm).elim
-      · rfl
-    · simp
-    · intro a _ ha
-      simp only [ite_smul, zero_smul]
-      split
-      · rename_i h
-        exact (ha h.1.symm).elim
-      · rfl
-    · simp
-  · rw [Matrix.toLinAlgEquiv_self]
-    simp [TypeDStd.val_rootGenerator_inr, TypeDStd.loweringMatrix_of_fork n hn hi,
-      Fintype.sum_sum_type, P.typeDBasis_inr, P.polar_W'_eq_zero]
+  all_goals rw [TypeDStd.val_rootGenerator_inr,
+    TypeDStd.toLinAlgEquiv_loweringMatrix_apply_basis_of_fork n hn
+      (P.typeDBasis b hline) hi]
+  · simp [P.typeDBasis_inl, P.polar_dualVector_left, eq_comm]
+  · simp [P.typeDBasis_inr, P.polar_W'_eq_zero, eq_comm]
 
 /-- **The numbered type-`D` matrix root generators are the corresponding positive and negative
 Clifford root representatives.** This fixes all four chain/fork and sign cases at once. -/
@@ -242,9 +147,13 @@ theorem typeDQuadraticEquiv_rootGenerator (hn : 4 ≤ n) (hline : P.line = ⊥)
   | inl i =>
       simp only
       by_cases hi : (i : ℕ) + 1 < n
-      · exact (congrArg Subtype.val
+      · have hnext : TypeDStd.chainNext n i hi = ⟨(i : ℕ) + 1, hi⟩ := by
+          apply Fin.ext
+          simp
+        exact (congrArg Subtype.val
           (P.typeDQuadraticEquiv_rootGenerator_inl_of_add_one_lt b hn hline hi)).trans
-            (P.typeDSimpleRootBivector_of_add_one_lt b (by omega) hi).symm
+            ((congrArg (fun j => bivector Q (b i : V) (P.dualVector b j : V)) hnext).trans
+              (P.typeDSimpleRootBivector_of_add_one_lt b (by omega) hi).symm)
       · have hfork :
             bivector Q (b (TypeDStd.forkLeft n hn) : V)
                 (b (TypeDStd.forkRight n hn) : V) =
@@ -264,9 +173,13 @@ theorem typeDQuadraticEquiv_rootGenerator (hn : 4 ≤ n) (hline : P.line = ⊥)
   | inr i =>
       simp only
       by_cases hi : (i : ℕ) + 1 < n
-      · exact (congrArg Subtype.val
+      · have hnext : TypeDStd.chainNext n i hi = ⟨(i : ℕ) + 1, hi⟩ := by
+          apply Fin.ext
+          simp
+        exact (congrArg Subtype.val
           (P.typeDQuadraticEquiv_rootGenerator_inr_of_add_one_lt b hn hline hi)).trans
-            (P.typeDSimpleNegativeRootBivector_of_add_one_lt b (by omega) hi).symm
+            ((congrArg (fun j => bivector Q (b j : V) (P.dualVector b i : V)) hnext).trans
+              (P.typeDSimpleNegativeRootBivector_of_add_one_lt b (by omega) hi).symm)
       · have hfork :
             bivector Q (P.dualVector b (TypeDStd.forkRight n hn) : V)
                 (P.dualVector b (TypeDStd.forkLeft n hn) : V) =
@@ -297,14 +210,26 @@ theorem typeDQuadraticEquiv_cartanGenerator (hn : 4 ≤ n) (hline : P.line = ⊥
           TypeDStd.rootGenerator (K := K) n hn (.inr i)⁆ =
         TypeDStd.cartanGenerator (K := K) n hn i := by
     rw [TypeDStd.lie_rootGenerator_inl_inr (K := K), ite_eq_left rfl]
-  rw [← hroot, (P.typeDQuadraticEquiv b hline).map_lie,
-    LieSubalgebra.coe_bracket]
-  change ⁅(P.typeDQuadraticEquiv b hline
-      (TypeDStd.rootGenerator n hn (.inl i)) : CliffordAlgebra Q),
+  have hmap :
+      P.typeDQuadraticEquiv b hline (TypeDStd.cartanGenerator n hn i) =
+        ⁅P.typeDQuadraticEquiv b hline (TypeDStd.rootGenerator n hn (.inl i)),
+          P.typeDQuadraticEquiv b hline (TypeDStd.rootGenerator n hn (.inr i))⁆ := by
+    rw [← hroot, (P.typeDQuadraticEquiv b hline).map_lie]
+  calc
     (P.typeDQuadraticEquiv b hline
-      (TypeDStd.rootGenerator n hn (.inr i)) : CliffordAlgebra Q)⁆ = _
-  rw [P.typeDQuadraticEquiv_rootGenerator b hn hline (.inl i),
-    P.typeDQuadraticEquiv_rootGenerator b hn hline (.inr i)]
-  exact P.lie_typeDSimpleRootBivector_typeDSimpleNegativeRootBivector (K := K) b (by omega) i
+          (TypeDStd.cartanGenerator n hn i) : CliffordAlgebra Q) =
+        (⁅P.typeDQuadraticEquiv b hline (TypeDStd.rootGenerator n hn (.inl i)),
+            P.typeDQuadraticEquiv b hline (TypeDStd.rootGenerator n hn (.inr i))⁆ :
+          quadraticLieSubalgebra Q) := congrArg Subtype.val hmap
+    _ = ⁅(P.typeDQuadraticEquiv b hline
+          (TypeDStd.rootGenerator n hn (.inl i)) : CliffordAlgebra Q),
+        (P.typeDQuadraticEquiv b hline
+          (TypeDStd.rootGenerator n hn (.inr i)) : CliffordAlgebra Q)⁆ := by
+      rw [LieSubalgebra.coe_bracket]
+    _ = P.typeDSimpleCorootBivector b (by omega) i := by
+      rw [P.typeDQuadraticEquiv_rootGenerator b hn hline (.inl i),
+        P.typeDQuadraticEquiv_rootGenerator b hn hline (.inr i)]
+      exact P.lie_typeDSimpleRootBivector_typeDSimpleNegativeRootBivector
+        (K := K) b (by omega) i
 
 end TauCeti.SpinPolarizationData


### PR DESCRIPTION
This PR identifies the numbered type-D matrix root and coroot generators in the quadratic Clifford model for the split-Cartan/Borel milestone of SpinRepresentations Layer 5.

Roadmap: RepresentationTheory

## Summary

It evaluates the even-polarization Lie equivalence on every positive and negative Bourbaki-numbered simple-root generator. Four generic matrix-on-basis lemmas factor the chain/fork and sign calculations through `TauCeti.toLinAlgEquiv_single_apply_basis`; the Clifford comparison then follows from their action on the hyperbolic basis. The coroot comparison uses the matched Chevalley brackets, fixing the fork parity/sign convention rather than inferring it from weights alone. Small value lemmas for the opaque standard-coordinate indices complete the public matrix-generator API. The CI repair keeps the private full-index equalities out of the global simp set and invokes them explicitly inside the comparison proofs, so they no longer make the public coordinate lemmas simp-normal-form duplicates.

## Roadmap target

This supplies the missing matrix-to-Clifford root-vector comparison required by the Layer 5 target “a split Cartan and Borel, matched to the abstract root datum.” The next work is to assemble the compatible Borel from these root spaces and identify the two half-spin modules with the two fork-node fundamental highest weights; only after that does PR #6251 regain eligibility as the downstream Spin4 root-operator step.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"typedquadraticequiv-rootgenerator"}-->

## Verification

- Exact head: `97531335b42499c02fc2005d58f822b20e529a1c`
- Local Lean build: `spinrep-validate cache`; `spinrep-validate run -- lake build` — passed (`Build completed successfully (11177 jobs).`)
- Axiom audit: `spinrep-validate run -- lake exe axioms` — passed (`axioms: audited 111975 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`)
- Lint: `spinrep-validate run -- bash scripts/lint-env.sh` with GNU `sed` on macOS — passed (`LINT-ENV: PASS — no new violations (63 grandfathered, 7 ratchetable).`)
- Public CI: passed (`sandboxed-build`, run `34677466919`, 10m33s)

## Scale and generality

The comparison is uniform in the rank `n`, field `K`, quadratic space, even polarization, and basis; its `4 ≤ n`, `P.line = ⊥`, and invertibility-of-two assumptions are exactly those required by the existing type-D generator and quadratic-equivalence endpoints. The PR adds 312 lines and removes 3 across two files: a 224-line comparison module and 88 matrix-side additions, including the coordinate and reusable basis-action equations.

## Scope

- **Consumes:** `TypeDStd.rootGenerator`, `TypeDStd.cartanGenerator`, `SpinPolarizationData.typeDQuadraticEquiv`, the Clifford simple-root representatives, and their Chevalley bracket.
- **Provides:** simplification theorems for the signed root-generator family and its coroots, generic raising/lowering action equations, and value lemmas for `forkLeft`, `forkRight`, and `chainNext`.
- **Fits:** the immediate compatible-Borel/root-space construction, then the fork-node half-spin highest-weight identification required before PR #6251.
- **Boundary:** it does not define the Borel, assert a highest-weight classification, or perform the downstream D2 root-operator computation.

<sub>🤖 GPT-5.6 Sol high · TauCetiWorker @ [7518d4150b846c4524423341570c031027a1d92c](https://github.com/utensil/TauCetiWorker/commit/7518d4150b846c4524423341570c031027a1d92c) · rubrics @ [afb424eda89e8ac96d9eb69f6a88972055a4cd1b](https://github.com/utensil/TauCetiReview/commit/afb424eda89e8ac96d9eb69f6a88972055a4cd1b) · local review @ [b533e561b6d44df071c31335ed4a63ae647507d2](https://github.com/utensil/formal-land/commit/b533e561b6d44df071c31335ed4a63ae647507d2) · fixed: documentation, proof-quality, reuse</sub>