### PR TITLE
feat(Huber): a change of presentation leaves the localisation topology and uniformity alone

### DIFF
--- a/TauCeti/RingTheory/Huber/LocalizationTopology/Basic.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/Basic.lean
@@ -835,14 +835,11 @@ theorem isTopologicalRing_locTopology [IsTopologicalRing A] (P : PairOfDefinitio
 
 /-- **Presentations with the same ring of definition have the same neighbourhood filtration.**
 `locIdealImage` depends on `(T, s)` only through `locSubring P T s S`, so two presentations
-sharing that subring give the same subgroups of `Aₛ` at every level.
-
-The transport is along `RingEquiv.subringCongr`, which is the identity on carriers; stating the
-conclusion as an equality of subsets of `Aₛ` keeps the two `Ideal` types from meeting. -/
+sharing that subring give the same subgroup of `Aₛ` at every level. -/
 theorem locIdealImage_congr (P : PairOfDefinition A) (T T' : Finset A) (s s' : A)
     (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S] [IsLocalization.Away s' S]
     (h : locSubring P T' s' S = locSubring P T s S) (n : ℕ) :
-    (locIdealImage P T' s' S n : Set S) = (locIdealImage P T s S n : Set S) := by
+    locIdealImage P T' s' S n = locIdealImage P T s S n := by
   have hc : ((RingEquiv.subringCongr h : _ →+* _).comp (toLocSubring P T' s' S))
       = toLocSubring P T s S := RingHom.ext fun _ ↦ Subtype.ext rfl
   have hc' : (((RingEquiv.subringCongr h).symm : _ →+* _).comp (toLocSubring P T s S))
@@ -854,7 +851,7 @@ theorem locIdealImage_congr (P : PairOfDefinition A) (T T' : Finset A) (s s' : A
       = locIdeal P T' s' S := by
     rw [locIdeal_def, locIdeal_def, Ideal.map_map, hc']
   ext x
-  simp only [SetLike.mem_coe, mem_locIdealImage_iff]
+  simp only [mem_locIdealImage_iff]
   constructor
   · rintro ⟨d, hd, rfl⟩
     refine ⟨RingEquiv.subringCongr h d, ?_, RingEquiv.coe_subringCongr_apply h d⟩

--- a/TauCeti/RingTheory/Huber/LocalizationTopology/Basic.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/Basic.lean
@@ -37,6 +37,9 @@ universal property in `LocalizationTopology.UniversalProperty`, the completion `
 
 * `locSubring_eq_of_coe_eq_image_mul_left`: rescaling numerators and denominator by one common
   factor leaves `D` unchanged — the first step of a change of presentation.
+* `locIdealImage_congr` and `locTopology_congr`: presentations sharing a ring of definition share
+  the whole neighbourhood filtration, and so the topology — the step that lets a rescaled
+  presentation stand in for the original.
 * `hasBasis_nhds_zero_locTopology`, `isTopologicalRing_locTopology` and
   `nonarchimedeanRing_locTopology`: the contract of `locTopology`, to be used in place of
   unfolding the construction.
@@ -827,6 +830,58 @@ theorem isTopologicalRing_locTopology [IsTopologicalRing A] (P : PairOfDefinitio
     (hden : HasDenominatorPower P T s S) :
     @IsTopologicalRing _ (locTopology P T s S hden) _ :=
   (locBasis P T s S hden).toRingFilterBasis.isTopologicalRing
+
+/-! ### A change of presentation leaves the topology alone -/
+
+/-- **Presentations with the same ring of definition have the same neighbourhood filtration.**
+`locIdealImage` depends on `(T, s)` only through `locSubring P T s S`, so two presentations
+sharing that subring give the same subgroups of `Aₛ` at every level.
+
+The transport is along `RingEquiv.subringCongr`, which is the identity on carriers; stating the
+conclusion as an equality of subsets of `Aₛ` keeps the two `Ideal` types from meeting. -/
+theorem locIdealImage_congr (P : PairOfDefinition A) (T T' : Finset A) (s s' : A)
+    (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S] [IsLocalization.Away s' S]
+    (h : locSubring P T' s' S = locSubring P T s S) (n : ℕ) :
+    (locIdealImage P T' s' S n : Set S) = (locIdealImage P T s S n : Set S) := by
+  have hc : ((RingEquiv.subringCongr h : _ →+* _).comp (toLocSubring P T' s' S))
+      = toLocSubring P T s S := RingHom.ext fun _ ↦ Subtype.ext rfl
+  have hc' : (((RingEquiv.subringCongr h).symm : _ →+* _).comp (toLocSubring P T s S))
+      = toLocSubring P T' s' S := RingHom.ext fun _ ↦ Subtype.ext rfl
+  have hmap : Ideal.map (RingEquiv.subringCongr h : _ →+* _) (locIdeal P T' s' S)
+      = locIdeal P T s S := by
+    rw [locIdeal_def, locIdeal_def, Ideal.map_map, hc]
+  have hmap' : Ideal.map ((RingEquiv.subringCongr h).symm : _ →+* _) (locIdeal P T s S)
+      = locIdeal P T' s' S := by
+    rw [locIdeal_def, locIdeal_def, Ideal.map_map, hc']
+  ext x
+  simp only [SetLike.mem_coe, mem_locIdealImage_iff]
+  constructor
+  · rintro ⟨d, hd, rfl⟩
+    refine ⟨RingEquiv.subringCongr h d, ?_, RingEquiv.coe_subringCongr_apply h d⟩
+    rw [← hmap, ← Ideal.map_pow]
+    exact Ideal.mem_map_of_mem _ hd
+  · rintro ⟨d, hd, rfl⟩
+    refine ⟨(RingEquiv.subringCongr h).symm d, ?_, RingEquiv.coe_subringCongr_apply h.symm d⟩
+    rw [← hmap', ← Ideal.map_pow]
+    exact Ideal.mem_map_of_mem _ hd
+
+/-- **A change of presentation with the same ring of definition leaves `locTopology` alone.**
+
+This is what lets a presentation be replaced by another one — for instance a rescaled one — while
+the topology on `Aₛ`, and hence its completion, stays the same object. -/
+theorem locTopology_congr [IsTopologicalRing A] (P : PairOfDefinition A) (T T' : Finset A)
+    (s s' : A) (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
+    [IsLocalization.Away s' S] (hden : HasDenominatorPower P T s S)
+    (hden' : HasDenominatorPower P T' s' S) (h : locSubring P T' s' S = locSubring P T s S) :
+    locTopology P T' s' S hden' = locTopology P T s S hden := by
+  have hb' := hasBasis_nhds_zero_locTopology P T' s' S hden'
+  rw [funext fun n ↦ locIdealImage_congr P T T' s s' S h n] at hb'
+  exact IsTopologicalAddGroup.ext
+    (@IsTopologicalRing.isTopologicalAddGroup S _ (locTopology P T' s' S hden')
+      (isTopologicalRing_locTopology P T' s' S hden'))
+    (@IsTopologicalRing.isTopologicalAddGroup S _ (locTopology P T s S hden)
+      (isTopologicalRing_locTopology P T s S hden))
+    (hb'.eq_of_same_basis (hasBasis_nhds_zero_locTopology P T s S hden))
 
 /-- `locTopology` is nonarchimedean: `Aₛ` inherits a basis of open additive subgroups at zero. -/
 theorem nonarchimedeanRing_locTopology [IsTopologicalRing A] (P : PairOfDefinition A)

--- a/TauCeti/RingTheory/Huber/LocalizationTopology/Basic.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/Basic.lean
@@ -841,9 +841,15 @@ theorem locIdealImage_congr (P : PairOfDefinition A) (T T' : Finset A) (s s' : A
     (h : locSubring P T' s' S = locSubring P T s S) (n : ℕ) :
     locIdealImage P T' s' S n = locIdealImage P T s S n := by
   have hc : ((RingEquiv.subringCongr h : _ →+* _).comp (toLocSubring P T' s' S))
-      = toLocSubring P T s S := RingHom.ext fun _ ↦ Subtype.ext rfl
+      = toLocSubring P T s S :=
+    RingHom.ext fun a ↦ Subtype.ext <| by
+      rw [RingHom.comp_apply, RingEquiv.coe_toRingHom, RingEquiv.coe_subringCongr_apply,
+        toLocSubring_apply, toLocSubring_apply]
   have hc' : (((RingEquiv.subringCongr h).symm : _ →+* _).comp (toLocSubring P T s S))
-      = toLocSubring P T' s' S := RingHom.ext fun _ ↦ Subtype.ext rfl
+      = toLocSubring P T' s' S :=
+    RingHom.ext fun a ↦ Subtype.ext <| by
+      rw [RingHom.comp_apply, RingEquiv.coe_toRingHom, RingEquiv.subringCongr_symm,
+        RingEquiv.coe_subringCongr_apply, toLocSubring_apply, toLocSubring_apply]
   have hmap : Ideal.map (RingEquiv.subringCongr h : _ →+* _) (locIdeal P T' s' S)
       = locIdeal P T s S := by
     rw [locIdeal_def, locIdeal_def, Ideal.map_map, hc]

--- a/TauCeti/RingTheory/Huber/LocalizationTopology/Completion.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/Completion.lean
@@ -29,8 +29,9 @@ complete Hausdorff targets.
 
 * `locUniformSpace_toTopologicalSpace`: the topology `locUniformSpace` induces is `locTopology`.
   This is what a proof rewrites against, so no body in this file needs exposing.
-* `locUniformSpace_congr`: presentations sharing a ring of definition share the uniformity. So
-  `A⟨T/s⟩` and the restriction maps out of it do not depend on which such presentation is used.
+* `locUniformSpace_congr`: presentations sharing a ring of definition share the uniformity, so
+  the two completions `A⟨T/s⟩` are the same object. Whether the restriction maps out of them
+  agree is a further question, and is not settled here.
 * `isUniformAddGroup_locUniformSpace` and `isTopologicalRing_locUniformSpace`: the two companions
   of `locUniformSpace`. Since `locTopology` is not an instance, a statement about `A⟨T/s⟩` has to
   name its structures; these three declarations are what it names.
@@ -138,9 +139,8 @@ theorem isTopologicalRing_locUniformSpace [IsTopologicalRing A] (P : PairOfDefin
   isTopologicalRing_locTopology P T s S hden
 
 /-- **A change of presentation with the same ring of definition leaves `locUniformSpace` alone.**
-`restrictionRingHomOfSubset` is stated under `locUniformSpace`, so this is what makes a rescaled
-presentation give a map between the same objects as the original — the form Wedhorn's
-Proposition 8.30 needs. -/
+`restrictionRingHomOfSubset` is stated under `locUniformSpace`, so this identifies the rings such
+a map runs between. Identifying the maps themselves needs more than this. -/
 theorem locUniformSpace_congr [IsTopologicalRing A] (P : PairOfDefinition A) (T T' : Finset A)
     (s s' : A) (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
     [IsLocalization.Away s' S] (hden : HasDenominatorPower P T s S)

--- a/TauCeti/RingTheory/Huber/LocalizationTopology/Completion.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/Completion.lean
@@ -28,6 +28,8 @@ complete Hausdorff targets.
 ## Main results
 
 * `locUniformSpace_toTopologicalSpace`: the topology `locUniformSpace` induces is `locTopology`.
+* `locUniformSpace_congr`: presentations sharing a ring of definition share the uniformity, so a
+  rescaled presentation gives the same `A⟨T/s⟩` and the same maps out of it.
   This is what a proof rewrites against, so no body in this file needs exposing.
 * `isUniformAddGroup_locUniformSpace` and `isTopologicalRing_locUniformSpace`: the two companions
   of `locUniformSpace`. Since `locTopology` is not an instance, a statement about `A⟨T/s⟩` has to
@@ -115,6 +117,22 @@ theorem locUniformSpace_toTopologicalSpace [IsTopologicalRing A] (P : PairOfDefi
     (T : Finset A) (s : A) (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
     (hden : HasDenominatorPower P T s S) :
     (locUniformSpace P T s S hden).toTopologicalSpace = locTopology P T s S hden := (rfl)
+
+/-- **A change of presentation with the same ring of definition leaves `locUniformSpace` alone.**
+`locUniformSpace` is the right uniformity of `locTopology`, so it moves with it.
+
+This is the form Wedhorn's Proposition 8.30 needs: `restrictionRingHomOfSubset` is stated under
+`locUniformSpace`, so without this a rescaled presentation would give a map between different
+objects. -/
+theorem locUniformSpace_congr [IsTopologicalRing A] (P : PairOfDefinition A) (T T' : Finset A)
+    (s s' : A) (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
+    [IsLocalization.Away s' S] (hden : HasDenominatorPower P T s S)
+    (hden' : HasDenominatorPower P T' s' S) (h : locSubring P T' s' S = locSubring P T s S) :
+    locUniformSpace P T' s' S hden' = locUniformSpace P T s S hden := by
+  unfold locUniformSpace
+  congr 1
+  · exact locTopology_congr P T T' s s' S hden hden' h
+  · exact proof_irrel_heq _ _
 
 /-- `Aₛ` is a uniform additive group for `locUniformSpace`. The companion of `locUniformSpace`:
 the two together are what `UniformSpace.Completion S` needs. -/

--- a/TauCeti/RingTheory/Huber/LocalizationTopology/Completion.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/Completion.lean
@@ -28,9 +28,9 @@ complete Hausdorff targets.
 ## Main results
 
 * `locUniformSpace_toTopologicalSpace`: the topology `locUniformSpace` induces is `locTopology`.
-* `locUniformSpace_congr`: presentations sharing a ring of definition share the uniformity, so a
-  rescaled presentation gives the same `A⟨T/s⟩` and the same maps out of it.
   This is what a proof rewrites against, so no body in this file needs exposing.
+* `locUniformSpace_congr`: presentations sharing a ring of definition share the uniformity. So
+  `A⟨T/s⟩` and the restriction maps out of it do not depend on which such presentation is used.
 * `isUniformAddGroup_locUniformSpace` and `isTopologicalRing_locUniformSpace`: the two companions
   of `locUniformSpace`. Since `locTopology` is not an instance, a statement about `A⟨T/s⟩` has to
   name its structures; these three declarations are what it names.
@@ -118,22 +118,6 @@ theorem locUniformSpace_toTopologicalSpace [IsTopologicalRing A] (P : PairOfDefi
     (hden : HasDenominatorPower P T s S) :
     (locUniformSpace P T s S hden).toTopologicalSpace = locTopology P T s S hden := (rfl)
 
-/-- **A change of presentation with the same ring of definition leaves `locUniformSpace` alone.**
-`locUniformSpace` is the right uniformity of `locTopology`, so it moves with it.
-
-This is the form Wedhorn's Proposition 8.30 needs: `restrictionRingHomOfSubset` is stated under
-`locUniformSpace`, so without this a rescaled presentation would give a map between different
-objects. -/
-theorem locUniformSpace_congr [IsTopologicalRing A] (P : PairOfDefinition A) (T T' : Finset A)
-    (s s' : A) (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
-    [IsLocalization.Away s' S] (hden : HasDenominatorPower P T s S)
-    (hden' : HasDenominatorPower P T' s' S) (h : locSubring P T' s' S = locSubring P T s S) :
-    locUniformSpace P T' s' S hden' = locUniformSpace P T s S hden := by
-  unfold locUniformSpace
-  congr 1
-  · exact locTopology_congr P T T' s s' S hden hden' h
-  · exact proof_irrel_heq _ _
-
 /-- `Aₛ` is a uniform additive group for `locUniformSpace`. The companion of `locUniformSpace`:
 the two together are what `UniformSpace.Completion S` needs. -/
 theorem isUniformAddGroup_locUniformSpace [IsTopologicalRing A] (P : PairOfDefinition A)
@@ -152,6 +136,26 @@ theorem isTopologicalRing_locUniformSpace [IsTopologicalRing A] (P : PairOfDefin
     letI := locUniformSpace P T s S hden
     IsTopologicalRing S :=
   isTopologicalRing_locTopology P T s S hden
+
+/-- **A change of presentation with the same ring of definition leaves `locUniformSpace` alone.**
+`restrictionRingHomOfSubset` is stated under `locUniformSpace`, so this is what makes a rescaled
+presentation give a map between the same objects as the original — the form Wedhorn's
+Proposition 8.30 needs. -/
+theorem locUniformSpace_congr [IsTopologicalRing A] (P : PairOfDefinition A) (T T' : Finset A)
+    (s s' : A) (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
+    [IsLocalization.Away s' S] (hden : HasDenominatorPower P T s S)
+    (hden' : HasDenominatorPower P T' s' S) (h : locSubring P T' s' S = locSubring P T s S) :
+    locUniformSpace P T' s' S hden' = locUniformSpace P T s S hden := by
+  have htop : (locUniformSpace P T' s' S hden').toTopologicalSpace
+      = (locUniformSpace P T s S hden).toTopologicalSpace := by
+    rw [locUniformSpace_toTopologicalSpace, locUniformSpace_toTopologicalSpace]
+    exact locTopology_congr P T T' s s' S hden hden' h
+  rw [← @IsUniformAddGroup.rightUniformSpace_eq S (locUniformSpace P T' s' S hden') _
+      (isUniformAddGroup_locUniformSpace P T' s' S hden'),
+    ← @IsUniformAddGroup.rightUniformSpace_eq S (locUniformSpace P T s S hden) _
+      (isUniformAddGroup_locUniformSpace P T s S hden)]
+  congr 1
+  exact proof_irrel_heq _ _
 
 /-- `Aₛ` is a Huber ring for the topology `locUniformSpace` induces. The third companion of
 `locUniformSpace`, alongside the two above. A consumer working at the uniformity can reach the


### PR DESCRIPTION
Two presentations that give the same ring of definition `D` give the same neighbourhood
filtration on `Aₛ`, and therefore the same topology.

## Why this is needed

`locSubring_eq_of_coe_eq_image_mul_left` (#6229) says that rescaling a presentation `(T, s)` to
`(u · T, u · s)` by a unit leaves `D` unchanged. On its own that says nothing about the topology,
and the topology is what matters: `locTopology` determines the uniform structure, hence the
completion `A⟨T/s⟩`, hence whether a restriction map out of a rescaled presentation is even the
same map as the original one.

With the rescaling transports now all merged — #6176, #6195, #6229, #6254 and #6339 — this is
the remaining step before Proposition 8.30 can drop its topological-nilpotence hypothesis, which
`Laurent/Flat.lean`'s own module docstring names as what leaves it "short of Proposition 8.30 in
general".

## What is added

* `locIdealImage_congr` — presentations sharing `D` have equal `locIdealImage` at every level,
  as subsets of `Aₛ`.
* `locTopology_congr` — hence equal `locTopology`.
* `locUniformSpace_congr` — hence equal `locUniformSpace`, since that is the right uniformity of
  `locTopology`.

The third is the one Proposition 8.30 actually consumes: `restrictionRingHomOfSubset` is stated
under `locUniformSpace`, so the topology equality alone would still leave a rescaled presentation
producing a map between different objects. Each of the three is the next one's only consumer,
which is why they ship together.

## The one interesting point

`locIdealImage P T s S n` mentions `locSubring P T s S` **in its type**, so the obvious proof does
not work. `rw` with the subring equality fails with *motive is not type correct*: the power
`Ideal … ^ n` carries an `IsScalarTower ↥(locSubring …)` instance depending on the subring being
rewritten, so the motive cannot be abstracted. `simp only [h]` makes no progress either — the
subring is not a visible subterm.

It goes through `RingEquiv.subringCongr` instead, and the conclusion is stated as an equality of
*subsets* of `Aₛ` so that the two `Ideal` types never have to be identified.

One performance note, in case it saves someone the same detour: proving
`↑(subringCongr h d) = ↑d` by `rfl` exceeds the kernel's budget, because `subringCongr` is built
on `Set.equivOfEq` and the kernel then transports over the whole `locSubring` definition.
`RingEquiv.coe_subringCongr_apply` costs nothing, since it was checked once in Mathlib at generic
subrings. The same applies to letting `rw [Ideal.map_map]` close by its own automatic `rfl`
rather than rewriting with a separately proved ring-hom equality.

## Notes

* No `sorry`, no `native_decide`, no `maxHeartbeats`. Build green (2042 jobs), `runLinter` clean.
* Two files, `LocalizationTopology/Basic.lean` (+55) and `.../Completion.lean` (+18); the
  larger is 1108 lines against the 1500 ceiling.
* Proofs are 22, 10 and 6 lines, so no `/decompose-proof` hand-off. The `congr` in the last one
  leaves a `HEq` between two `IsTopologicalAddGroup` proofs; both are proofs of propositions, so
  `proof_irrel_heq` closes it.
* No `tauceti-target` marker: this supplies a prerequisite of a roadmap-ordered step rather than
  authoring the step, and the marker contract wants a deterministic target id rather than a slug.

Provenance: none copied. Swept against AINTLIB (`github.com/CBirkbeck/AINTLIB`, Apache-2.0,
revision `2baa76f742bdb4fb8ee323fabba41203bd390e08`) for `locIdealImage_congr` and
`locTopology_congr` — absent. The Mathlib pieces used (`RingEquiv.subringCongr`,
`RingEquiv.coe_subringCongr_apply`, `Ideal.map_map`, `Ideal.map_pow`,
`Filter.HasBasis.eq_of_same_basis`, `IsTopologicalAddGroup.ext`) are used, not reproduced.

Roadmap: AdicSpaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kb8uv44XKmG5Mw9BvLjsb1
