### PR TITLE
feat: the Specht module of the shape (n-1, 1) is the standard representation

### DIFF
--- a/TauCeti/Combinatorics/Young/Partitions.lean
+++ b/TauCeti/Combinatorics/Young/Partitions.lean
@@ -83,6 +83,18 @@ theorem colLen_diagramOf_indiscrete_le_one (n : ℕ) :
     YoungDiagram.mem_iff_lt_colLen.mpr hlt
   exact absurd (YoungDiagram.mem_iff_lt_rowLen.mp hmem) (by omega)
 
+/-- The second row of the Young diagram of the partition `(n+1, 1)` is a single cell. -/
+theorem rowLen_diagramOf_singletonSecondRow_one (n : ℕ) :
+    (diagramOf (Nat.Partition.singletonSecondRow n)).rowLen 1 = 1 := by
+  rw [rowLen_diagramOf, Nat.Partition.sort_parts_singletonSecondRow]
+  rfl
+
+/-- The Young diagram of the partition `(n+1, 1)` has no third row. -/
+theorem rowLen_diagramOf_singletonSecondRow_two (n : ℕ) :
+    (diagramOf (Nat.Partition.singletonSecondRow n)).rowLen 2 = 0 := by
+  rw [rowLen_diagramOf, Nat.Partition.sort_parts_singletonSecondRow]
+  rfl
+
 /-- **The Young diagram of a partition has one row per part**: its rows are the parts, so the
 length of its first column counts them. -/
 @[simp]

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/Extremes.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/Extremes.lean
@@ -49,7 +49,8 @@ on the empty diagram both hold, and there `Sₙ` is trivial and so are both char
 states them, as the action formula together with the dimension: a line on which `σ` acts by `1`
 resp. by `sgn σ`.  No isomorphism with a separately constructed model object is built here.  The
 third named small irreducible, the standard representation `S^{(n-1,1)}`, is not treated here
-either; it is not a line and needs the tabloid combinatorics of the two-row shape.
+either; it is not a line and needs the tabloid combinatorics of the two-row shape, which is
+`TauCeti.RepresentationTheory.Symmetric.Specht.SingletonSecondRow`.
 
 ## Main results
 

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/SingletonSecondRow.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/SingletonSecondRow.lean
@@ -11,12 +11,15 @@ public import TauCeti.RepresentationTheory.Symmetric.Specht.Module
 public import TauCeti.RepresentationTheory.Symmetric.Standard
 
 /-!
-# The Specht module of the shape `(n-1, 1)` is the standard representation
+# The Specht module of the shape `(N-1, 1)` is the standard representation
 
-The third of the named small irreducible representations of `Sₙ`, beside the trivial
-representation `S^{(n)}` and the sign representation `S^{(1ⁿ)}` of
-`TauCeti.RepresentationTheory.Symmetric.Specht.Extremes`, is the `(n-1)`-dimensional **standard
-representation** `S^{(n-1,1)}`.  Unlike those two it is not a line, and identifying it needs the
+Throughout, `N` is the degree of the symmetric group, and `n` the parameter the declarations for
+the concrete partition carry, so that `N = n + 2`.
+
+The third of the named small irreducible representations of `S_N`, beside the trivial
+representation `S^{(N)}` and the sign representation `S^{(1^N)}` of
+`TauCeti.RepresentationTheory.Symmetric.Specht.Extremes`, is the `(N-1)`-dimensional **standard
+representation** `S^{(N-1,1)}`.  Unlike those two it is not a line, and identifying it needs the
 tabloid combinatorics of a shape with two rows.  This file supplies that combinatorics and proves
 the identification.
 
@@ -54,7 +57,7 @@ that naming carries the standard representation of `Fin μ.card` onto the Specht
 follows.  Relabelling the labels of the diagram along `TauCeti.card_diagramOf` states both for the
 partition `(n+1, 1)` itself.
 
-The parallel statement one level up, `M^{(n-1,1)} = triv ⊕ standard`, is proved for the partition
+The parallel statement one level up, `M^{(N-1,1)} = triv ⊕ standard`, is proved for the partition
 `(n+1, 1)` itself in
 `TauCeti.RepresentationTheory.Symmetric.PermutationModule.SingletonSecondRow`; that file names the
 tabloids by the labels through the Young subgroup, which is the stabilizer of a point, whereas the
@@ -68,7 +71,7 @@ polytabloids are indexed by.
 * `TauCeti.labelTabloid` and `TauCeti.labelTabloidEquiv`: the tabloids of a shape `(m, 1)` are the
   labels, `TauCeti.labelTabloidRepresentationEquiv` being the induced identification of `M^μ` with
   the permutation module on the labels.
-* `TauCeti.standardRepresentationEquivSpechtSubrepresentation`: **`S^{(n-1,1)}` is the standard
+* `TauCeti.standardRepresentationEquivSpechtSubrepresentation`: **`S^{(N-1,1)}` is the standard
   representation**, and `TauCeti.standardRepresentationEquivSpechtModuleSingletonSecondRow` the
   same identification for the partition-indexed `TauCeti.spechtModule`.
 
@@ -89,11 +92,8 @@ polytabloids are indexed by.
 ## References
 
 * [G. D. James, *The Representation Theory of the Symmetric Groups*][james1978], Chapter 5, where
-  `S^{(n-1,1)}` is identified with the standard representation.
+  `S^{(N-1,1)}` is identified with the standard representation.
 * [W. Fulton, *Young Tableaux*][fulton1997], Section 7.2.
-* [Schur--Weyl roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md),
-  Layer 4, "the named small irreducibles", which asks for `S^{(n-1,1)}` to be the
-  `(n-1)`-dimensional standard representation.
 -/
 
 public section
@@ -410,7 +410,7 @@ polytabloids of such a shape are exactly the differences of two tabloid basis ve
 span the subrepresentation on which the coefficients sum to zero.
 
 Since `TauCeti.standardRepresentation` is by definition the action carried by the augmentation
-subrepresentation of a permutation module, this is the identification `S^{(n-1,1)} = standard`,
+subrepresentation of a permutation module, this is the identification `S^μ = standard`,
 read on the tabloids; `TauCeti.labelTabloidEquiv` names the tabloids by the labels. -/
 theorem spechtSubrepresentation_eq_augmentationSubrepresentation (h1 : μ.rowLen 1 = 1)
     (h2 : μ.rowLen 2 = 0) :
@@ -584,7 +584,8 @@ private theorem coe_standardRepresentationEquivSpechtSubrepresentationOfCard_app
   exact coe_standardRepresentationEquivSpechtSubrepresentation_apply h1 h2 t v
 
 /-- **The Specht module of a shape `(m, 1)` has dimension one less than the number of labels**:
-the standard representation of `Sₙ` has dimension `n - 1`. -/
+the standard representation of the symmetric group on `μ.card` labels has dimension
+`μ.card - 1`. -/
 theorem finrank_spechtSubrepresentation_of_rowLen (h1 : μ.rowLen 1 = 1) (h2 : μ.rowLen 2 = 0) :
     Module.finrank ℚ (spechtSubrepresentation μ).toSubmodule = μ.card - 1 := by
   obtain ⟨t⟩ := YoungTableau.nonempty μ
@@ -605,7 +606,7 @@ theorem rowLen_diagramOf_singletonSecondRow_two (n : ℕ) :
   rw [rowLen_diagramOf, Nat.Partition.sort_parts_singletonSecondRow]
   rfl
 
-/-- **`S^{(n-1,1)}` has dimension `n - 1`**: the Specht module of the shape `(n+1, 1)` of `n + 2`
+/-- **`S^{(n+1,1)}` has dimension `n + 1`**: the Specht module of the shape `(n+1, 1)` of `n + 2`
 is the `(n+1)`-dimensional standard representation of `S_{n+2}`. -/
 @[simp]
 theorem finrank_spechtModule_singletonSecondRow (n : ℕ) :
@@ -614,7 +615,7 @@ theorem finrank_spechtModule_singletonSecondRow (n : ℕ) :
     (rowLen_diagramOf_singletonSecondRow_one n)
     (rowLen_diagramOf_singletonSecondRow_two n)).trans (by rw [card_diagramOf]; omega)
 
-/-- **`S^{(n-1,1)}` is the standard representation**, for the partition-indexed Specht module
+/-- **`S^{(n+1,1)}` is the standard representation**, for the partition-indexed Specht module
 `TauCeti.spechtModule` the classification of the irreducibles is stated in.  This is
 `TauCeti.standardRepresentationEquivSpechtSubrepresentation` for the shape `(n+1, 1)`, with the
 symmetric group on the labels of the diagram identified with `S_{n+2}` along
@@ -627,7 +628,7 @@ noncomputable def standardRepresentationEquivSpechtModuleSingletonSecondRow (n :
     (rowLen_diagramOf_singletonSecondRow_one n) (rowLen_diagramOf_singletonSecondRow_two n) t
     (card_diagramOf _)
 
-/-- The identification of `S^{(n-1,1)}` with the standard representation is the transport of the
+/-- The identification of `S^{(n+1,1)}` with the standard representation is the transport of the
 tabloids, read on the labels of the diagram along `TauCeti.card_diagramOf`. -/
 @[simp]
 theorem coe_standardRepresentationEquivSpechtModuleSingletonSecondRow_apply (n : ℕ)

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/SingletonSecondRow.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/SingletonSecondRow.lean
@@ -478,6 +478,16 @@ theorem labelTabloidEquiv_apply (h1 : μ.rowLen 1 = 1) (h2 : μ.rowLen 2 = 0) (t
   -- `(rfl)`, not `rfl`: the body of `labelTabloidEquiv` is not `@[expose]`d.
   (rfl)
 
+/-- The naming of the tabloids by the labels, read backwards: the label naming a tabloid is the
+label of the short row of any tableau representing it. -/
+@[simp]
+theorem labelTabloidEquiv_symm_tabloid (h1 : μ.rowLen 1 = 1) (h2 : μ.rowLen 2 = 0)
+    (t u : YoungTableau μ) :
+    (labelTabloidEquiv h1 h2 t).symm (tabloid u) = secondRowLabel h1 u := by
+  rw [Equiv.symm_apply_eq, labelTabloidEquiv_apply, labelTabloid_def,
+    tabloid_eq_iff_secondRowLabel_eq h1 h2]
+  simp
+
 /-- **The Young permutation module of a shape `(m, 1)` is the permutation module on the labels.** -/
 noncomputable def labelTabloidRepresentationEquiv (h1 : μ.rowLen 1 = 1) (h2 : μ.rowLen 2 = 0)
     (t : YoungTableau μ) :

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/SingletonSecondRow.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/SingletonSecondRow.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Combinatorics.Enumerative.Partition.Basic
 public import TauCeti.RepresentationTheory.Rep.OfMulAction
 public import TauCeti.RepresentationTheory.Symmetric.Specht.Module
 public import TauCeti.RepresentationTheory.Symmetric.Standard

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/SingletonSecondRow.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/SingletonSecondRow.lean
@@ -454,10 +454,13 @@ theorem labelTabloid_bijective (h1 : μ.rowLen 1 = 1) (h2 : μ.rowLen 2 = 0) (t 
     rw [labelTabloid_def, tabloid_eq_iff_secondRowLabel_eq h1 h2]
     simp
 
-/-- Naming a tabloid by the label of its short row is equivariant. -/
+/-- Naming a tabloid by the label of its short row is equivariant.  The left-hand side is stated
+with `σ k` rather than the `σ • k` of the equivariance interfaces, since `Equiv.Perm.smul_def`
+is `simp`; the two are definitionally equal. -/
+@[simp]
 theorem labelTabloid_smul (h1 : μ.rowLen 1 = 1) (h2 : μ.rowLen 2 = 0) (t : YoungTableau μ)
     (σ : Equiv.Perm (Fin μ.card)) (k : Fin μ.card) :
-    labelTabloid h1 t (σ • k) = σ • labelTabloid h1 t k := by
+    labelTabloid h1 t (σ k) = σ • labelTabloid h1 t k := by
   rw [labelTabloid_def, labelTabloid_def, ← tabloid_relabel,
     tabloid_eq_iff_secondRowLabel_eq h1 h2]
   simp
@@ -592,18 +595,6 @@ theorem finrank_spechtSubrepresentation_of_rowLen (h1 : μ.rowLen 1 = 1) (h2 : �
     finrank_augmentationSubrepresentation, Fintype.card_fin]
 
 /-! ## The shape `(n+1, 1)` -/
-
-/-- The second row of the diagram of `(n+1, 1)` is a single cell. -/
-theorem rowLen_diagramOf_singletonSecondRow_one (n : ℕ) :
-    (diagramOf (Nat.Partition.singletonSecondRow n)).rowLen 1 = 1 := by
-  rw [rowLen_diagramOf, Nat.Partition.sort_parts_singletonSecondRow]
-  rfl
-
-/-- The diagram of `(n+1, 1)` has no third row. -/
-theorem rowLen_diagramOf_singletonSecondRow_two (n : ℕ) :
-    (diagramOf (Nat.Partition.singletonSecondRow n)).rowLen 2 = 0 := by
-  rw [rowLen_diagramOf, Nat.Partition.sort_parts_singletonSecondRow]
-  rfl
 
 /-- **`S^{(n+1,1)}` has dimension `n + 1`**: the Specht module of the shape `(n+1, 1)` of `n + 2`
 is the `(n+1)`-dimensional standard representation of `S_{n+2}`. -/

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/SingletonSecondRow.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/SingletonSecondRow.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Combinatorics.Enumerative.Partition.Basic
-public import TauCeti.GroupTheory.GroupAction.Transitive
 public import TauCeti.RepresentationTheory.Rep.OfMulAction
 public import TauCeti.RepresentationTheory.Symmetric.Specht.Module
 public import TauCeti.RepresentationTheory.Symmetric.Standard
@@ -52,7 +51,8 @@ named by the label of the short row, equivariantly
 (`TauCeti.labelTabloidEquiv`, `TauCeti.labelTabloid_smul`).  Transporting `ℚ[Fin μ.card]` along
 that naming carries the standard representation of `Fin μ.card` onto the Specht module
 (`TauCeti.standardRepresentationEquivSpechtSubrepresentation`), and the dimension `μ.card - 1`
-follows.
+follows.  Relabelling the labels of the diagram along `TauCeti.card_diagramOf` states both for the
+partition `(n+1, 1)` itself.
 
 The parallel statement one level up, `M^{(n-1,1)} = triv ⊕ standard`, is proved for the partition
 `(n+1, 1)` itself in
@@ -69,7 +69,8 @@ polytabloids are indexed by.
   labels, `TauCeti.labelTabloidRepresentationEquiv` being the induced identification of `M^μ` with
   the permutation module on the labels.
 * `TauCeti.standardRepresentationEquivSpechtSubrepresentation`: **`S^{(n-1,1)}` is the standard
-  representation**.
+  representation**, and `TauCeti.standardRepresentationEquivSpechtModuleSingletonSecondRow` the
+  same identification for the partition-indexed `TauCeti.spechtModule`.
 
 ## Main results
 
@@ -410,7 +411,7 @@ span the subrepresentation on which the coefficients sum to zero.
 
 Since `TauCeti.standardRepresentation` is by definition the action carried by the augmentation
 subrepresentation of a permutation module, this is the identification `S^{(n-1,1)} = standard`,
-read on the tabloids; `TauCeti.tabloidEquivLabel` names the tabloids by the labels. -/
+read on the tabloids; `TauCeti.labelTabloidEquiv` names the tabloids by the labels. -/
 theorem spechtSubrepresentation_eq_augmentationSubrepresentation (h1 : μ.rowLen 1 = 1)
     (h2 : μ.rowLen 2 = 0) :
     spechtSubrepresentation μ =
@@ -544,7 +545,7 @@ noncomputable def standardRepresentationEquivSpechtSubrepresentation (h1 : μ.ro
 
 /-- The underlying equivalence of the identification is the transport of the tabloids. -/
 @[simp]
-theorem coe_standardRepresentationEquivSpechtSubrepresentation (h1 : μ.rowLen 1 = 1)
+theorem coe_standardRepresentationEquivSpechtSubrepresentation_apply (h1 : μ.rowLen 1 = 1)
     (h2 : μ.rowLen 2 = 0) (t : YoungTableau μ)
     (v : (augmentationSubrepresentation ℚ (Equiv.Perm (Fin μ.card)) (Fin μ.card)).toSubmodule) :
     (standardRepresentationEquivSpechtSubrepresentation h1 h2 t v :
@@ -552,6 +553,35 @@ theorem coe_standardRepresentationEquivSpechtSubrepresentation (h1 : μ.rowLen 1
       labelTabloidRepresentationEquiv h1 h2 t (v : MonoidAlgebra ℚ (Fin μ.card)) :=
   -- `(rfl)`, not `rfl`: the body of the equivalence is not `@[expose]`d.
   (rfl)
+
+/-- The identification of the Specht module with the standard representation, read on `Fin N`
+along an identification `μ.card = N` of the labels.  This is the shape in which the
+partition-indexed `TauCeti.spechtModule`, which relabels the symmetric group along
+`TauCeti.card_diagramOf`, consumes it. -/
+private noncomputable def standardRepresentationEquivSpechtSubrepresentationOfCard {N : ℕ}
+    (h1 : μ.rowLen 1 = 1) (h2 : μ.rowLen 2 = 0) (t : YoungTableau μ) (hN : μ.card = N) :
+    (standardRepresentation ℚ (Fin N)).Equiv
+      ((spechtSubrepresentation μ).toRepresentation.comp
+        (finCongr hN.symm).permCongrHom.toMonoidHom) := by
+  subst hN
+  exact standardRepresentationEquivSpechtSubrepresentation h1 h2 t
+
+private theorem coe_standardRepresentationEquivSpechtSubrepresentationOfCard_apply {N : ℕ}
+    (h1 : μ.rowLen 1 = 1) (h2 : μ.rowLen 2 = 0) (t : YoungTableau μ) (hN : μ.card = N)
+    (v : (augmentationSubrepresentation ℚ (Equiv.Perm (Fin N)) (Fin N)).toSubmodule) :
+    (standardRepresentationEquivSpechtSubrepresentationOfCard h1 h2 t hN v :
+        (permutationModule (shapePartition μ)).V) =
+      labelTabloidRepresentationEquiv h1 h2 t
+        (MonoidAlgebra.mapDomainLinearEquiv ℚ ℚ (finCongr hN.symm)
+          (v : MonoidAlgebra ℚ (Fin N))) := by
+  subst hN
+  -- the relabelling is then the identity, but only propositionally: it maps the support along
+  -- `Equiv.refl` rather than leaving it alone
+  have hrefl : (MonoidAlgebra.mapDomainLinearEquiv ℚ ℚ (finCongr (rfl : μ.card = μ.card)))
+      (v : MonoidAlgebra ℚ (Fin μ.card)) = (v : MonoidAlgebra ℚ (Fin μ.card)) := by
+    simp [MonoidAlgebra.mapDomainLinearEquiv]
+  rw [hrefl]
+  exact coe_standardRepresentationEquivSpechtSubrepresentation_apply h1 h2 t v
 
 /-- **The Specht module of a shape `(m, 1)` has dimension one less than the number of labels**:
 the standard representation of `Sₙ` has dimension `n - 1`. -/
@@ -564,13 +594,13 @@ theorem finrank_spechtSubrepresentation_of_rowLen (h1 : μ.rowLen 1 = 1) (h2 : �
 /-! ## The shape `(n+1, 1)` -/
 
 /-- The second row of the diagram of `(n+1, 1)` is a single cell. -/
-theorem rowLen_one_diagramOf_singletonSecondRow (n : ℕ) :
+theorem rowLen_diagramOf_singletonSecondRow_one (n : ℕ) :
     (diagramOf (Nat.Partition.singletonSecondRow n)).rowLen 1 = 1 := by
   rw [rowLen_diagramOf, Nat.Partition.sort_parts_singletonSecondRow]
   rfl
 
 /-- The diagram of `(n+1, 1)` has no third row. -/
-theorem rowLen_two_diagramOf_singletonSecondRow (n : ℕ) :
+theorem rowLen_diagramOf_singletonSecondRow_two (n : ℕ) :
     (diagramOf (Nat.Partition.singletonSecondRow n)).rowLen 2 = 0 := by
   rw [rowLen_diagramOf, Nat.Partition.sort_parts_singletonSecondRow]
   rfl
@@ -581,7 +611,36 @@ is the `(n+1)`-dimensional standard representation of `S_{n+2}`. -/
 theorem finrank_spechtModule_singletonSecondRow (n : ℕ) :
     Module.finrank ℚ (spechtModule (Nat.Partition.singletonSecondRow n)) = n + 1 := by
   exact (finrank_spechtSubrepresentation_of_rowLen
-    (rowLen_one_diagramOf_singletonSecondRow n)
-    (rowLen_two_diagramOf_singletonSecondRow n)).trans (by rw [card_diagramOf]; omega)
+    (rowLen_diagramOf_singletonSecondRow_one n)
+    (rowLen_diagramOf_singletonSecondRow_two n)).trans (by rw [card_diagramOf]; omega)
+
+/-- **`S^{(n-1,1)}` is the standard representation**, for the partition-indexed Specht module
+`TauCeti.spechtModule` the classification of the irreducibles is stated in.  This is
+`TauCeti.standardRepresentationEquivSpechtSubrepresentation` for the shape `(n+1, 1)`, with the
+symmetric group on the labels of the diagram identified with `S_{n+2}` along
+`TauCeti.card_diagramOf`, the relabelling `TauCeti.spechtModule` is defined by. -/
+noncomputable def standardRepresentationEquivSpechtModuleSingletonSecondRow (n : ℕ)
+    (t : YoungTableau (diagramOf (Nat.Partition.singletonSecondRow n))) :
+    (standardRepresentation ℚ (Fin (n + 2))).Equiv
+      (spechtModule (Nat.Partition.singletonSecondRow n)).ρ :=
+  standardRepresentationEquivSpechtSubrepresentationOfCard
+    (rowLen_diagramOf_singletonSecondRow_one n) (rowLen_diagramOf_singletonSecondRow_two n) t
+    (card_diagramOf _)
+
+/-- The identification of `S^{(n-1,1)}` with the standard representation is the transport of the
+tabloids, read on the labels of the diagram along `TauCeti.card_diagramOf`. -/
+@[simp]
+theorem coe_standardRepresentationEquivSpechtModuleSingletonSecondRow_apply (n : ℕ)
+    (t : YoungTableau (diagramOf (Nat.Partition.singletonSecondRow n)))
+    (v : (augmentationSubrepresentation ℚ (Equiv.Perm (Fin (n + 2))) (Fin (n + 2))).toSubmodule) :
+    (standardRepresentationEquivSpechtModuleSingletonSecondRow n t v :
+        (permutationModule
+          (shapePartition (diagramOf (Nat.Partition.singletonSecondRow n)))).V) =
+      labelTabloidRepresentationEquiv (rowLen_diagramOf_singletonSecondRow_one n)
+        (rowLen_diagramOf_singletonSecondRow_two n) t
+        (MonoidAlgebra.mapDomainLinearEquiv ℚ ℚ
+          (finCongr (card_diagramOf (Nat.Partition.singletonSecondRow n)).symm)
+          (v : MonoidAlgebra ℚ (Fin (n + 2)))) :=
+  coe_standardRepresentationEquivSpechtSubrepresentationOfCard_apply _ _ t _ v
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/SingletonSecondRow.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/SingletonSecondRow.lean
@@ -1,0 +1,587 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Combinatorics.Enumerative.Partition.Basic
+public import TauCeti.GroupTheory.GroupAction.Transitive
+public import TauCeti.RepresentationTheory.Rep.OfMulAction
+public import TauCeti.RepresentationTheory.Symmetric.Specht.Module
+public import TauCeti.RepresentationTheory.Symmetric.Standard
+
+/-!
+# The Specht module of the shape `(n-1, 1)` is the standard representation
+
+The third of the named small irreducible representations of `Sₙ`, beside the trivial
+representation `S^{(n)}` and the sign representation `S^{(1ⁿ)}` of
+`TauCeti.RepresentationTheory.Symmetric.Specht.Extremes`, is the `(n-1)`-dimensional **standard
+representation** `S^{(n-1,1)}`.  Unlike those two it is not a line, and identifying it needs the
+tabloid combinatorics of a shape with two rows.  This file supplies that combinatorics and proves
+the identification.
+
+The shape is pinned by its row lengths: `μ.rowLen 1 = 1` says the second row is a single cell, and
+`μ.rowLen 2 = 0` says there is no third row, so `μ` is a shape `(m, 1)`; the partition `(n+1, 1)`
+of `n+2` is `TauCeti.Nat.Partition.singletonSecondRow n`, and both hypotheses hold for its diagram.
+Everything is stated on the diagram, where the polytabloids live, and specialized to that partition
+at the end.
+
+Three facts about such a shape drive the whole file, and each is elementary once the two row
+lengths are fixed.  The second row holds a single label, `TauCeti.YoungTableau.secondRowLabel`; the
+first column holds exactly two, that one and `TauCeti.YoungTableau.firstColumnLabel`; and every
+other column holds exactly one.  Hence the column group of a tableau is
+`{1, (firstColumnLabel secondRowLabel)}` (`TauCeti.YoungTableau.mem_colSubgroup_iff`), so the
+antisymmetrization defining the polytabloid has just two terms and
+
+`e_t = {t} - (a b) · {t}`
+
+is a **difference of two tabloid basis vectors**
+(`TauCeti.YoungTableau.polytabloid_eq_single_sub_single`).  Differences of basis vectors span
+exactly the vectors whose coefficients sum to zero, which is what
+`TauCeti.augmentationSubrepresentation` is; and conversely *every* such difference is a
+polytabloid, because a tableau can be relabelled, without moving the label of its short row, so
+that the top of its first column carries any prescribed other label.  The Specht module is
+therefore the augmentation subrepresentation of the Young permutation module
+(`TauCeti.spechtSubrepresentation_eq_augmentationSubrepresentation`), which is what
+`TauCeti.standardRepresentation` is by definition.
+
+To read that on the labels rather than on the tabloids, the file also names the tabloids of such a
+shape by the labels: a tabloid splits the labels into the long row and a single short one, so it is
+named by the label of the short row, equivariantly
+(`TauCeti.labelTabloidEquiv`, `TauCeti.labelTabloid_smul`).  Transporting `ℚ[Fin μ.card]` along
+that naming carries the standard representation of `Fin μ.card` onto the Specht module
+(`TauCeti.standardRepresentationEquivSpechtSubrepresentation`), and the dimension `μ.card - 1`
+follows.
+
+The parallel statement one level up, `M^{(n-1,1)} = triv ⊕ standard`, is proved for the partition
+`(n+1, 1)` itself in
+`TauCeti.RepresentationTheory.Symmetric.PermutationModule.SingletonSecondRow`; that file names the
+tabloids by the labels through the Young subgroup, which is the stabilizer of a point, whereas the
+naming here is built from the tableau combinatorics, so that it is available on the diagram the
+polytabloids are indexed by.
+
+## Main definitions
+
+* `TauCeti.YoungTableau.secondRowLabel` and `TauCeti.YoungTableau.firstColumnLabel`: the label of
+  the single cell of the second row, and the label above it.
+* `TauCeti.labelTabloid` and `TauCeti.labelTabloidEquiv`: the tabloids of a shape `(m, 1)` are the
+  labels, `TauCeti.labelTabloidRepresentationEquiv` being the induced identification of `M^μ` with
+  the permutation module on the labels.
+* `TauCeti.standardRepresentationEquivSpechtSubrepresentation`: **`S^{(n-1,1)}` is the standard
+  representation**.
+
+## Main results
+
+* `TauCeti.YoungTableau.mem_colSubgroup_iff`: the column group of a tableau of a shape `(m, 1)` has
+  two elements, and `TauCeti.YoungTableau.rowSubgroup_eq_stabilizer`: its row group is the
+  stabilizer of the label of the short row.
+* `TauCeti.YoungTableau.polytabloid_eq_single_sub_single`: a polytabloid of such a shape is a
+  difference of two tabloids, and `TauCeti.YoungTableau.tabloid_eq_iff_secondRowLabel_eq`: a
+  tabloid is named by the label of its short row.
+* `TauCeti.spechtSubrepresentation_eq_augmentationSubrepresentation`: **the Specht module of a
+  shape `(m, 1)` is the augmentation subrepresentation of `M^μ`**.
+* `TauCeti.finrank_spechtSubrepresentation_of_rowLen` and
+  `TauCeti.finrank_spechtModule_singletonSecondRow`: its dimension is one less than the number of
+  labels, so `S^{(n+1,1)}` has dimension `n+1`.
+
+## References
+
+* [G. D. James, *The Representation Theory of the Symmetric Groups*][james1978], Chapter 5, where
+  `S^{(n-1,1)}` is identified with the standard representation.
+* [W. Fulton, *Young Tableaux*][fulton1997], Section 7.2.
+* [Schur--Weyl roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md),
+  Layer 4, "the named small irreducibles", which asks for `S^{(n-1,1)}` to be the
+  `(n-1)`-dimensional standard representation.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace YoungTableau
+
+variable {μ : YoungDiagram}
+
+/-! ## The two cells of the first column -/
+
+private theorem oneZero_mem_cells (h1 : μ.rowLen 1 = 1) : ((1, 0) : ℕ × ℕ) ∈ μ.cells := by
+  rw [YoungDiagram.mem_cells, YoungDiagram.mem_iff_lt_rowLen, h1]
+  omega
+
+private theorem zeroZero_mem_cells (h1 : μ.rowLen 1 = 1) : ((0, 0) : ℕ × ℕ) ∈ μ.cells := by
+  have h := μ.rowLen_anti 0 1 (by omega)
+  rw [YoungDiagram.mem_cells, YoungDiagram.mem_iff_lt_rowLen]
+  omega
+
+/-- The label a tableau puts in the single cell of the second row. -/
+def secondRowLabel (h1 : μ.rowLen 1 = 1) (t : YoungTableau μ) : Fin μ.card :=
+  t ⟨(1, 0), oneZero_mem_cells h1⟩
+
+/-- The label a tableau puts in the top cell of the first column. -/
+def firstColumnLabel (h1 : μ.rowLen 1 = 1) (t : YoungTableau μ) : Fin μ.card :=
+  t ⟨(0, 0), zeroZero_mem_cells h1⟩
+
+@[simp]
+theorem rowIndex_secondRowLabel (h1 : μ.rowLen 1 = 1) (t : YoungTableau μ) :
+    rowIndex t (secondRowLabel h1 t) = 1 :=
+  rowIndex_apply t _
+
+@[simp]
+theorem colIndex_secondRowLabel (h1 : μ.rowLen 1 = 1) (t : YoungTableau μ) :
+    colIndex t (secondRowLabel h1 t) = 0 :=
+  colIndex_apply t _
+
+@[simp]
+theorem rowIndex_firstColumnLabel (h1 : μ.rowLen 1 = 1) (t : YoungTableau μ) :
+    rowIndex t (firstColumnLabel h1 t) = 0 :=
+  rowIndex_apply t _
+
+@[simp]
+theorem colIndex_firstColumnLabel (h1 : μ.rowLen 1 = 1) (t : YoungTableau μ) :
+    colIndex t (firstColumnLabel h1 t) = 0 :=
+  colIndex_apply t _
+
+/-- Relabelling moves the second-row label along. -/
+@[simp]
+theorem secondRowLabel_relabel (h1 : μ.rowLen 1 = 1) (σ : Equiv.Perm (Fin μ.card))
+    (t : YoungTableau μ) : secondRowLabel h1 (relabel σ t) = σ (secondRowLabel h1 t) :=
+  relabel_apply σ t _
+
+/-- Relabelling moves the top label of the first column along. -/
+@[simp]
+theorem firstColumnLabel_relabel (h1 : μ.rowLen 1 = 1) (σ : Equiv.Perm (Fin μ.card))
+    (t : YoungTableau μ) : firstColumnLabel h1 (relabel σ t) = σ (firstColumnLabel h1 t) :=
+  relabel_apply σ t _
+
+/-- On a shape with no third row every label lies in the first or the second row. -/
+theorem rowIndex_le_one (h2 : μ.rowLen 2 = 0) (t : YoungTableau μ) (k : Fin μ.card) :
+    rowIndex t k ≤ 1 := by
+  by_contra hk
+  have hmem := rowIndex_colIndex_mem t k
+  rw [YoungDiagram.mem_iff_lt_rowLen] at hmem
+  have := μ.rowLen_anti 2 (rowIndex t k) (by omega)
+  omega
+
+private theorem colIndex_eq_zero_of_rowIndex_eq_one (h1 : μ.rowLen 1 = 1) (t : YoungTableau μ)
+    {k : Fin μ.card} (hk : rowIndex t k = 1) : colIndex t k = 0 := by
+  have hmem := rowIndex_colIndex_mem t k
+  rw [hk, YoungDiagram.mem_iff_lt_rowLen, h1] at hmem
+  omega
+
+/-- **The second row holds exactly one label.** -/
+theorem rowIndex_eq_one_iff (h1 : μ.rowLen 1 = 1) (t : YoungTableau μ) {k : Fin μ.card} :
+    rowIndex t k = 1 ↔ k = secondRowLabel h1 t := by
+  refine ⟨fun hk => rowIndex_colIndex_injective t ?_, fun hk => by rw [hk, rowIndex_secondRowLabel]⟩
+  simp only [Prod.mk.injEq]
+  exact ⟨by rw [hk, rowIndex_secondRowLabel],
+    by rw [colIndex_eq_zero_of_rowIndex_eq_one h1 t hk, colIndex_secondRowLabel]⟩
+
+/-- The second-row label and the top label of the first column are distinct: they lie in different
+rows. -/
+theorem secondRowLabel_ne_firstColumnLabel (h1 : μ.rowLen 1 = 1) (t : YoungTableau μ) :
+    secondRowLabel h1 t ≠ firstColumnLabel h1 t := fun h => by
+  have := rowIndex_secondRowLabel h1 t
+  rw [h, rowIndex_firstColumnLabel] at this
+  omega
+
+/-- **The first column holds exactly two labels.** -/
+theorem colIndex_eq_zero_iff (h1 : μ.rowLen 1 = 1) (h2 : μ.rowLen 2 = 0) (t : YoungTableau μ)
+    {k : Fin μ.card} :
+    colIndex t k = 0 ↔ k = firstColumnLabel h1 t ∨ k = secondRowLabel h1 t := by
+  refine ⟨fun hk => ?_, ?_⟩
+  · rcases Nat.lt_or_ge (rowIndex t k) 1 with hrow | hrow
+    · refine Or.inl (rowIndex_colIndex_injective t ?_)
+      simp only [Prod.mk.injEq]
+      refine ⟨?_, by rw [hk, colIndex_firstColumnLabel]⟩
+      rw [rowIndex_firstColumnLabel]
+      omega
+    · exact Or.inr ((rowIndex_eq_one_iff h1 t).mp
+        (le_antisymm (rowIndex_le_one h2 t k) hrow))
+  · rintro (rfl | rfl)
+    · exact colIndex_firstColumnLabel h1 t
+    · exact colIndex_secondRowLabel h1 t
+
+/-! ## The row and the column group -/
+
+/-- **On a shape `(m, 1)` the row group is the stabilizer of the second-row label.**  A permutation
+keeps every label in its row exactly when it fixes the one label of the short row. -/
+theorem rowSubgroup_eq_stabilizer (h1 : μ.rowLen 1 = 1) (h2 : μ.rowLen 2 = 0)
+    (t : YoungTableau μ) :
+    rowSubgroup t = MulAction.stabilizer (Equiv.Perm (Fin μ.card)) (secondRowLabel h1 t) := by
+  ext σ
+  rw [mem_rowSubgroup, MulAction.mem_stabilizer_iff, Equiv.Perm.smul_def]
+  refine ⟨fun hσ => ?_, fun hσ k => ?_⟩
+  · have h := hσ (secondRowLabel h1 t)
+    rw [rowIndex_secondRowLabel] at h
+    exact (rowIndex_eq_one_iff h1 t).mp h
+  · rcases eq_or_ne k (secondRowLabel h1 t) with rfl | hk
+    · rw [hσ]
+    · have hk' : σ k ≠ secondRowLabel h1 t := fun h =>
+        hk (σ.injective (h.trans hσ.symm))
+      have h1k : rowIndex t k ≠ 1 := fun h => hk ((rowIndex_eq_one_iff h1 t).mp h)
+      have h2k : rowIndex t (σ k) ≠ 1 := fun h => hk' ((rowIndex_eq_one_iff h1 t).mp h)
+      have := rowIndex_le_one h2 t k
+      have := rowIndex_le_one h2 t (σ k)
+      omega
+
+/-- **On a shape `(m, 1)` the column group has two elements**: the identity and the transposition
+of the two labels of the first column. -/
+theorem mem_colSubgroup_iff (h1 : μ.rowLen 1 = 1) (h2 : μ.rowLen 2 = 0) (t : YoungTableau μ)
+    {σ : Equiv.Perm (Fin μ.card)} :
+    σ ∈ colSubgroup t ↔
+      σ = 1 ∨ σ = Equiv.swap (firstColumnLabel h1 t) (secondRowLabel h1 t) := by
+  classical
+  have hab : firstColumnLabel h1 t ≠ secondRowLabel h1 t :=
+    (secondRowLabel_ne_firstColumnLabel h1 t).symm
+  have hcola : colIndex t (firstColumnLabel h1 t) = 0 := colIndex_firstColumnLabel h1 t
+  have hcolb : colIndex t (secondRowLabel h1 t) = 0 := colIndex_secondRowLabel h1 t
+  rw [mem_colSubgroup]
+  refine ⟨fun hσ => ?_, ?_⟩
+  · -- away from the first column the fibers of the column index are singletons
+    have hfix : ∀ k, colIndex t k ≠ 0 → σ k = k := by
+      intro k hk
+      have hk' : colIndex t (σ k) ≠ 0 := by rw [hσ k]; exact hk
+      have hrow : rowIndex t k = 0 := by
+        have hne : k ≠ secondRowLabel h1 t := fun h => hk (by rw [h, hcolb])
+        have hle := rowIndex_le_one h2 t k
+        have hone : rowIndex t k ≠ 1 := fun h => hne ((rowIndex_eq_one_iff h1 t).mp h)
+        omega
+      have hrow' : rowIndex t (σ k) = 0 := by
+        have hne : σ k ≠ secondRowLabel h1 t := fun h => hk' (by rw [h, hcolb])
+        have hle := rowIndex_le_one h2 t (σ k)
+        have hone : rowIndex t (σ k) ≠ 1 := fun h => hne ((rowIndex_eq_one_iff h1 t).mp h)
+        omega
+      exact rowIndex_colIndex_injective t
+        (by simp only [Prod.mk.injEq]; exact ⟨by rw [hrow, hrow'], hσ k⟩)
+    -- on the first column it permutes the two labels there
+    have hmem : ∀ k, colIndex t k = 0 →
+        σ k = firstColumnLabel h1 t ∨ σ k = secondRowLabel h1 t := fun k hk =>
+      (colIndex_eq_zero_iff h1 h2 t).mp (by rw [hσ k]; exact hk)
+    rcases hmem _ hcola with hsa | hsa
+    · refine Or.inl (Equiv.ext fun k => (?_ : σ k = k))
+      rcases eq_or_ne (colIndex t k) 0 with hk | hk
+      · rcases (colIndex_eq_zero_iff h1 h2 t).mp hk with rfl | rfl
+        · exact hsa
+        · rcases hmem _ hcolb with h | h
+          · exact absurd (σ.injective (h.trans hsa.symm)) hab.symm
+          · exact h
+      · exact hfix k hk
+    · refine Or.inr (Equiv.ext fun k => ?_)
+      have hsb : σ (secondRowLabel h1 t) = firstColumnLabel h1 t := by
+        rcases hmem _ hcolb with h | h
+        · exact h
+        · exact absurd (σ.injective (h.trans hsa.symm)) hab.symm
+      rcases eq_or_ne (colIndex t k) 0 with hk | hk
+      · rcases (colIndex_eq_zero_iff h1 h2 t).mp hk with rfl | rfl
+        · rw [hsa, Equiv.swap_apply_left]
+        · rw [hsb, Equiv.swap_apply_right]
+      · have hka : k ≠ firstColumnLabel h1 t := fun h => hk (by rw [h, hcola])
+        have hkb : k ≠ secondRowLabel h1 t := fun h => hk (by rw [h, hcolb])
+        rw [hfix k hk, Equiv.swap_apply_of_ne_of_ne hka hkb]
+  · rintro (rfl | rfl) k
+    · rfl
+    · rcases eq_or_ne k (firstColumnLabel h1 t) with rfl | hka
+      · rw [Equiv.swap_apply_left, hcola, hcolb]
+      · rcases eq_or_ne k (secondRowLabel h1 t) with rfl | hkb
+        · rw [Equiv.swap_apply_right, hcola, hcolb]
+        · rw [Equiv.swap_apply_of_ne_of_ne hka hkb]
+
+/-! ## The polytabloid of a shape `(m, 1)` -/
+
+/-- The transposition of the two labels of the first column does move the tabloid: the two labels
+lie in different rows. -/
+theorem swap_smul_tabloid_ne (h1 : μ.rowLen 1 = 1) (h2 : μ.rowLen 2 = 0) (t : YoungTableau μ) :
+    Equiv.swap (firstColumnLabel h1 t) (secondRowLabel h1 t) • tabloid t ≠ tabloid t := by
+  rw [Ne, smul_tabloid_eq_self_iff, rowSubgroup_eq_stabilizer h1 h2 t,
+    MulAction.mem_stabilizer_iff, Equiv.Perm.smul_def, Equiv.swap_apply_right]
+  exact (secondRowLabel_ne_firstColumnLabel h1 t).symm
+
+/-- **The polytabloid of a shape `(m, 1)` is a difference of two tabloids.**  The column group of
+`t` consists of the identity and the transposition of the two labels of the first column, so the
+antisymmetrization of `{t}` has just two terms, with opposite signs. -/
+theorem polytabloid_eq_single_sub_single (h1 : μ.rowLen 1 = 1) (h2 : μ.rowLen 2 = 0)
+    (t : YoungTableau μ) :
+    polytabloid t = MonoidAlgebra.single (tabloid t) (1 : ℚ) -
+      MonoidAlgebra.single
+        (Equiv.swap (firstColumnLabel h1 t) (secondRowLabel h1 t) • tabloid t) (1 : ℚ) := by
+  classical
+  have hab : firstColumnLabel h1 t ≠ secondRowLabel h1 t :=
+    (secondRowLabel_ne_firstColumnLabel h1 t).symm
+  have hswap : Equiv.swap (firstColumnLabel h1 t) (secondRowLabel h1 t) ∈ colSubgroup t :=
+    (mem_colSubgroup_iff h1 h2 t).mpr (Or.inr rfl)
+  have hne := swap_smul_tabloid_ne h1 h2 t
+  rw [← MonoidAlgebra.coeff_inj]
+  ext X
+  rw [MonoidAlgebra.coeff_sub, Finsupp.sub_apply, MonoidAlgebra.coeff_single,
+    MonoidAlgebra.coeff_single, Finsupp.single_apply, Finsupp.single_apply]
+  rcases eq_or_ne X (tabloid t) with rfl | hX
+  · rw [polytabloid_coeff_tabloid]
+    simp [hne]
+  rcases eq_or_ne X (Equiv.swap (firstColumnLabel h1 t) (secondRowLabel h1 t) • tabloid t) with
+    rfl | hX'
+  · have hcoeff : (polytabloid t).coeff
+        (Equiv.swap (firstColumnLabel h1 t) (secondRowLabel h1 t) • tabloid t) = -1 := by
+      simpa [hab] using polytabloid_coeff_smul_tabloid t ⟨_, hswap⟩
+    rw [hcoeff]
+    simp [Ne.symm hne]
+  · have hzero : (polytabloid t).coeff X = 0 := by
+      refine polytabloid_coeff_eq_zero_of_forall_ne t fun q hq => ?_
+      rcases (mem_colSubgroup_iff h1 h2 t).mp hq with rfl | rfl
+      · simpa using Ne.symm hX
+      · exact Ne.symm hX'
+    rw [hzero]
+    simp [Ne.symm hX, Ne.symm hX']
+
+
+/-- **A tabloid of a shape `(m, 1)` is named by the label of its short row.** -/
+theorem tabloid_eq_iff_secondRowLabel_eq (h1 : μ.rowLen 1 = 1) (h2 : μ.rowLen 2 = 0)
+    {t u : YoungTableau μ} :
+    tabloid t = tabloid u ↔ secondRowLabel h1 t = secondRowLabel h1 u := by
+  rw [tabloid_eq_iff_rowIndex_eq]
+  refine ⟨fun h => ?_, fun h => funext fun k => ?_⟩
+  · have hk : rowIndex u (secondRowLabel h1 t) = 1 := by
+      rw [← congrFun h (secondRowLabel h1 t), rowIndex_secondRowLabel]
+    exact (rowIndex_eq_one_iff h1 u).mp hk
+  · have ht := rowIndex_le_one h2 t k
+    have hu := rowIndex_le_one h2 u k
+    rcases eq_or_ne k (secondRowLabel h1 t) with rfl | hk
+    · rw [rowIndex_secondRowLabel, h, rowIndex_secondRowLabel]
+    · have htk : rowIndex t k ≠ 1 := fun hh => hk ((rowIndex_eq_one_iff h1 t).mp hh)
+      have huk : rowIndex u k ≠ 1 := fun hh =>
+        hk (((rowIndex_eq_one_iff h1 u).mp hh).trans h.symm)
+      omega
+
+end YoungTableau
+
+/-! ## The Specht module of a shape `(m, 1)` -/
+
+open YoungTableau
+
+variable {μ : YoungDiagram}
+
+/-- **A polytabloid of a shape `(m, 1)` has vanishing coefficient sum**: it is a difference of two
+tabloids. -/
+theorem polytabloid_mem_augmentationSubrepresentation (h1 : μ.rowLen 1 = 1) (h2 : μ.rowLen 2 = 0)
+    (t : YoungTableau μ) :
+    polytabloid t ∈ augmentationSubrepresentation ℚ (Equiv.Perm (Fin μ.card))
+      (Equiv.Perm (Fin μ.card) ⧸ youngSubgroup (shapePartition μ)) := by
+  rw [polytabloid_eq_single_sub_single h1 h2 t]
+  exact single_sub_single_mem_augmentationSubrepresentation _ _
+
+/-- **Every difference of two tabloids of a shape `(m, 1)` is a polytabloid**, hence lies in the
+Specht module: a tableau whose short row carries the label naming the first tabloid can be
+relabelled, without moving that label, so that the top of its first column carries the label naming
+the second. -/
+theorem single_sub_single_mem_spechtSubrepresentation (h1 : μ.rowLen 1 = 1) (h2 : μ.rowLen 2 = 0)
+    (X Y : Equiv.Perm (Fin μ.card) ⧸ youngSubgroup (shapePartition μ)) :
+    (MonoidAlgebra.single X (1 : ℚ) - MonoidAlgebra.single Y 1) ∈ spechtSubrepresentation μ := by
+  rcases eq_or_ne X Y with rfl | hXY
+  · rw [sub_self]
+    exact Submodule.zero_mem _
+  obtain ⟨t, rfl⟩ := tabloid_surjective X
+  obtain ⟨u, rfl⟩ := tabloid_surjective Y
+  have hbc : secondRowLabel h1 t ≠ secondRowLabel h1 u := fun h =>
+    hXY ((tabloid_eq_iff_secondRowLabel_eq h1 h2).mpr h)
+  obtain ⟨σ, hσa, hσb⟩ : ∃ σ : Equiv.Perm (Fin μ.card),
+      σ (firstColumnLabel h1 t) = secondRowLabel h1 u ∧
+        σ (secondRowLabel h1 t) = secondRowLabel h1 t :=
+    ⟨Equiv.swap (firstColumnLabel h1 t) (secondRowLabel h1 u), Equiv.swap_apply_left _ _,
+      Equiv.swap_apply_of_ne_of_ne (secondRowLabel_ne_firstColumnLabel h1 t) hbc⟩
+  have hsecond : secondRowLabel h1 (relabel σ t) = secondRowLabel h1 t := by
+    rw [secondRowLabel_relabel, hσb]
+  have hfirst : firstColumnLabel h1 (relabel σ t) = secondRowLabel h1 u := by
+    rw [firstColumnLabel_relabel, hσa]
+  have htab : tabloid (relabel σ t) = tabloid t :=
+    (tabloid_eq_iff_secondRowLabel_eq h1 h2).mpr hsecond
+  have hswaptab :
+      Equiv.swap (secondRowLabel h1 u) (secondRowLabel h1 t) • tabloid t = tabloid u := by
+    rw [← tabloid_relabel]
+    refine (tabloid_eq_iff_secondRowLabel_eq h1 h2).mpr ?_
+    rw [secondRowLabel_relabel, Equiv.swap_apply_right]
+  have hpoly := polytabloid_eq_single_sub_single h1 h2 (relabel σ t)
+  rw [hfirst, hsecond, htab, hswaptab] at hpoly
+  rw [← hpoly]
+  exact polytabloid_mem_spechtSubrepresentation _
+
+/-- **The Specht module of a shape `(m, 1)` is the standard representation of the tabloids.**  The
+polytabloids of such a shape are exactly the differences of two tabloid basis vectors, and those
+span the subrepresentation on which the coefficients sum to zero.
+
+Since `TauCeti.standardRepresentation` is by definition the action carried by the augmentation
+subrepresentation of a permutation module, this is the identification `S^{(n-1,1)} = standard`,
+read on the tabloids; `TauCeti.tabloidEquivLabel` names the tabloids by the labels. -/
+theorem spechtSubrepresentation_eq_augmentationSubrepresentation (h1 : μ.rowLen 1 = 1)
+    (h2 : μ.rowLen 2 = 0) :
+    spechtSubrepresentation μ =
+      augmentationSubrepresentation ℚ (Equiv.Perm (Fin μ.card))
+        (Equiv.Perm (Fin μ.card) ⧸ youngSubgroup (shapePartition μ)) := by
+  refine Subrepresentation.toSubmodule_injective (le_antisymm ?_ ?_)
+  · rw [spechtSubrepresentation_toSubmodule, Submodule.span_le]
+    rintro _ ⟨t, rfl⟩
+    exact polytabloid_mem_augmentationSubrepresentation h1 h2 t
+  · obtain ⟨t₀⟩ := YoungTableau.nonempty μ
+    rw [toSubmodule_augmentationSubrepresentation,
+      ker_sumCoords_basis_eq_span ℚ _ (tabloid t₀), Submodule.span_le]
+    rintro _ ⟨X, rfl⟩
+    exact single_sub_single_mem_spechtSubrepresentation h1 h2 X (tabloid t₀)
+
+
+
+/-! ## The tabloids of a shape `(m, 1)` are the labels -/
+
+/-- **The tabloid named by a label**: relabel a fixed tableau by the transposition carrying its own
+short-row label to the prescribed one. -/
+noncomputable def labelTabloid (h1 : μ.rowLen 1 = 1) (t : YoungTableau μ) (k : Fin μ.card) :
+    Equiv.Perm (Fin μ.card) ⧸ youngSubgroup (shapePartition μ) :=
+  tabloid (relabel (Equiv.swap (secondRowLabel h1 t) k) t)
+
+theorem labelTabloid_def (h1 : μ.rowLen 1 = 1) (t : YoungTableau μ) (k : Fin μ.card) :
+    labelTabloid h1 t k = tabloid (relabel (Equiv.swap (secondRowLabel h1 t) k) t) :=
+  -- `(rfl)`, not `rfl`: the body of `labelTabloid` is not `@[expose]`d, so this must not be
+  -- inferred `@[defeq]`.
+  (rfl)
+
+theorem labelTabloid_bijective (h1 : μ.rowLen 1 = 1) (h2 : μ.rowLen 2 = 0) (t : YoungTableau μ) :
+    Function.Bijective (labelTabloid h1 t) := by
+  constructor
+  · intro k l hkl
+    rw [labelTabloid_def, labelTabloid_def, tabloid_eq_iff_secondRowLabel_eq h1 h2] at hkl
+    simpa using hkl
+  · intro X
+    obtain ⟨u, rfl⟩ := tabloid_surjective X
+    refine ⟨secondRowLabel h1 u, ?_⟩
+    rw [labelTabloid_def, tabloid_eq_iff_secondRowLabel_eq h1 h2]
+    simp
+
+/-- Naming a tabloid by the label of its short row is equivariant. -/
+theorem labelTabloid_smul (h1 : μ.rowLen 1 = 1) (h2 : μ.rowLen 2 = 0) (t : YoungTableau μ)
+    (σ : Equiv.Perm (Fin μ.card)) (k : Fin μ.card) :
+    labelTabloid h1 t (σ • k) = σ • labelTabloid h1 t k := by
+  rw [labelTabloid_def, labelTabloid_def, ← tabloid_relabel,
+    tabloid_eq_iff_secondRowLabel_eq h1 h2]
+  simp
+
+/-- **The tabloids of a shape `(m, 1)` are the labels.**  A tabloid of such a shape splits the
+labels into a long row and a single short one, so it is named by the label of the short row. -/
+noncomputable def labelTabloidEquiv (h1 : μ.rowLen 1 = 1) (h2 : μ.rowLen 2 = 0)
+    (t : YoungTableau μ) :
+    Fin μ.card ≃ (Equiv.Perm (Fin μ.card) ⧸ youngSubgroup (shapePartition μ)) :=
+  Equiv.ofBijective _ (labelTabloid_bijective h1 h2 t)
+
+@[simp]
+theorem labelTabloidEquiv_apply (h1 : μ.rowLen 1 = 1) (h2 : μ.rowLen 2 = 0) (t : YoungTableau μ)
+    (k : Fin μ.card) : labelTabloidEquiv h1 h2 t k = labelTabloid h1 t k :=
+  -- `(rfl)`, not `rfl`: the body of `labelTabloidEquiv` is not `@[expose]`d.
+  (rfl)
+
+/-- **The Young permutation module of a shape `(m, 1)` is the permutation module on the labels.** -/
+noncomputable def labelTabloidRepresentationEquiv (h1 : μ.rowLen 1 = 1) (h2 : μ.rowLen 2 = 0)
+    (t : YoungTableau μ) :
+    (Representation.ofMulAction ℚ (Equiv.Perm (Fin μ.card)) (Fin μ.card)).Equiv
+      (permutationModule (shapePartition μ)).ρ :=
+  ofMulActionEquivCongr ℚ (labelTabloidEquiv h1 h2 t) fun g k => by
+    rw [labelTabloidEquiv_apply, labelTabloidEquiv_apply]
+    exact labelTabloid_smul h1 h2 t g k
+
+@[simp]
+theorem labelTabloidRepresentationEquiv_apply_single (h1 : μ.rowLen 1 = 1) (h2 : μ.rowLen 2 = 0)
+    (t : YoungTableau μ) (k : Fin μ.card) (r : ℚ) :
+    labelTabloidRepresentationEquiv h1 h2 t (MonoidAlgebra.single k r) =
+      MonoidAlgebra.single (labelTabloid h1 t k) r := by
+  rw [labelTabloidRepresentationEquiv, ofMulActionEquivCongr_apply_single, labelTabloidEquiv_apply]
+
+/-- The transport of `ℚ[Fin μ.card]` onto the Young permutation module carries the augmentation
+subrepresentation of the labels onto the Specht module of the shape. -/
+private theorem map_augmentationSubrepresentation (h1 : μ.rowLen 1 = 1) (h2 : μ.rowLen 2 = 0)
+    (t : YoungTableau μ) :
+    Submodule.map
+        ((labelTabloidRepresentationEquiv h1 h2 t).toLinearEquiv :
+          MonoidAlgebra ℚ (Fin μ.card) →ₗ[ℚ] (permutationModule (shapePartition μ)).V)
+        (augmentationSubrepresentation ℚ (Equiv.Perm (Fin μ.card)) (Fin μ.card)).toSubmodule =
+      (spechtSubrepresentation μ).toSubmodule := by
+  have hsingle : ∀ (k : Fin μ.card) (r : ℚ),
+      ((labelTabloidRepresentationEquiv h1 h2 t).toLinearEquiv :
+          MonoidAlgebra ℚ (Fin μ.card) →ₗ[ℚ] (permutationModule (shapePartition μ)).V)
+        (MonoidAlgebra.single k r) = MonoidAlgebra.single (labelTabloid h1 t k) r :=
+    fun k r => labelTabloidRepresentationEquiv_apply_single h1 h2 t k r
+  have hsum : (MonoidAlgebra.basis
+        (Equiv.Perm (Fin μ.card) ⧸ youngSubgroup (shapePartition μ)) ℚ).sumCoords ∘ₗ
+        ((labelTabloidRepresentationEquiv h1 h2 t).toLinearEquiv :
+          MonoidAlgebra ℚ (Fin μ.card) →ₗ[ℚ] (permutationModule (shapePartition μ)).V) =
+      (MonoidAlgebra.basis (Fin μ.card) ℚ).sumCoords :=
+    Module.Basis.ext (MonoidAlgebra.basis (Fin μ.card) ℚ) fun k => by
+      rw [LinearMap.comp_apply, MonoidAlgebra.basis_apply, hsingle]
+      simp
+  rw [spechtSubrepresentation_eq_augmentationSubrepresentation h1 h2,
+    toSubmodule_augmentationSubrepresentation, toSubmodule_augmentationSubrepresentation,
+    ← hsum, LinearMap.ker_comp]
+  exact Submodule.map_comap_eq_of_surjective
+    (labelTabloidRepresentationEquiv h1 h2 t).toLinearEquiv.surjective _
+
+/-- **The Specht module of a shape `(m, 1)` is the standard representation.**  Naming the tabloids
+by the labels of their short rows carries `ℚ[Fin μ.card]` onto the Young permutation module and its
+augmentation subrepresentation -- the standard representation -- onto the Specht module, which
+`TauCeti.spechtSubrepresentation_eq_augmentationSubrepresentation` identifies as the augmentation
+subrepresentation on the tabloids.
+
+This is the third of the named small irreducibles of `Sₙ`, beside the trivial representation
+`S^{(n)}` and the sign representation `S^{(1ⁿ)}` of
+`TauCeti.RepresentationTheory.Symmetric.Specht.Extremes`. -/
+noncomputable def standardRepresentationEquivSpechtSubrepresentation (h1 : μ.rowLen 1 = 1)
+    (h2 : μ.rowLen 2 = 0) (t : YoungTableau μ) :
+    (standardRepresentation ℚ (Fin μ.card)).Equiv (spechtSubrepresentation μ).toRepresentation :=
+  Representation.Equiv.mk
+    (LinearEquiv.ofSubmodules (labelTabloidRepresentationEquiv h1 h2 t).toLinearEquiv _ _
+      (map_augmentationSubrepresentation h1 h2 t))
+    fun g => LinearMap.ext fun v => Subtype.ext <| by
+      simp only [← toRepresentation_augmentationSubrepresentation, LinearMap.comp_apply,
+        LinearEquiv.coe_coe, LinearEquiv.ofSubmodules_apply,
+        Subrepresentation.toRepresentation_apply, LinearMap.coe_restrict_apply,
+        Representation.Equiv.toLinearEquiv_apply]
+      exact Representation.IntertwiningMap.isIntertwining _ _
+        (labelTabloidRepresentationEquiv h1 h2 t).toIntertwiningMap g v
+
+/-- The underlying equivalence of the identification is the transport of the tabloids. -/
+@[simp]
+theorem coe_standardRepresentationEquivSpechtSubrepresentation (h1 : μ.rowLen 1 = 1)
+    (h2 : μ.rowLen 2 = 0) (t : YoungTableau μ)
+    (v : (augmentationSubrepresentation ℚ (Equiv.Perm (Fin μ.card)) (Fin μ.card)).toSubmodule) :
+    (standardRepresentationEquivSpechtSubrepresentation h1 h2 t v :
+        (permutationModule (shapePartition μ)).V) =
+      labelTabloidRepresentationEquiv h1 h2 t (v : MonoidAlgebra ℚ (Fin μ.card)) :=
+  -- `(rfl)`, not `rfl`: the body of the equivalence is not `@[expose]`d.
+  (rfl)
+
+/-- **The Specht module of a shape `(m, 1)` has dimension one less than the number of labels**:
+the standard representation of `Sₙ` has dimension `n - 1`. -/
+theorem finrank_spechtSubrepresentation_of_rowLen (h1 : μ.rowLen 1 = 1) (h2 : μ.rowLen 2 = 0) :
+    Module.finrank ℚ (spechtSubrepresentation μ).toSubmodule = μ.card - 1 := by
+  obtain ⟨t⟩ := YoungTableau.nonempty μ
+  rw [← (standardRepresentationEquivSpechtSubrepresentation h1 h2 t).toLinearEquiv.finrank_eq,
+    finrank_augmentationSubrepresentation, Fintype.card_fin]
+
+/-! ## The shape `(n+1, 1)` -/
+
+/-- The second row of the diagram of `(n+1, 1)` is a single cell. -/
+theorem rowLen_one_diagramOf_singletonSecondRow (n : ℕ) :
+    (diagramOf (Nat.Partition.singletonSecondRow n)).rowLen 1 = 1 := by
+  rw [rowLen_diagramOf, Nat.Partition.sort_parts_singletonSecondRow]
+  rfl
+
+/-- The diagram of `(n+1, 1)` has no third row. -/
+theorem rowLen_two_diagramOf_singletonSecondRow (n : ℕ) :
+    (diagramOf (Nat.Partition.singletonSecondRow n)).rowLen 2 = 0 := by
+  rw [rowLen_diagramOf, Nat.Partition.sort_parts_singletonSecondRow]
+  rfl
+
+/-- **`S^{(n-1,1)}` has dimension `n - 1`**: the Specht module of the shape `(n+1, 1)` of `n + 2`
+is the `(n+1)`-dimensional standard representation of `S_{n+2}`. -/
+@[simp]
+theorem finrank_spechtModule_singletonSecondRow (n : ℕ) :
+    Module.finrank ℚ (spechtModule (Nat.Partition.singletonSecondRow n)) = n + 1 := by
+  exact (finrank_spechtSubrepresentation_of_rowLen
+    (rowLen_one_diagramOf_singletonSecondRow n)
+    (rowLen_two_diagramOf_singletonSecondRow n)).trans (by rw [card_diagramOf]; omega)
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/SingletonSecondRow.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/SingletonSecondRow.lean
@@ -430,51 +430,77 @@ theorem spechtSubrepresentation_eq_augmentationSubrepresentation (h1 : μ.rowLen
 
 /-! ## The tabloids of a shape `(m, 1)` are the labels -/
 
-/-- **The tabloid named by a label**: relabel a fixed tableau by the transposition carrying its own
-short-row label to the prescribed one. -/
-noncomputable def labelTabloid (h1 : μ.rowLen 1 = 1) (t : YoungTableau μ) (k : Fin μ.card) :
+/-- **The tabloid named by a label**: the tabloid of a shape `(m, 1)` whose short row carries the
+prescribed label.  Relabelling a tableau of the shape by the transposition carrying its own
+short-row label to the prescribed one produces it; which tableau is relabelled is irrelevant, since
+a tabloid of such a shape is named by the label of its short row, so the naming is canonical
+(`TauCeti.labelTabloid_eq_tabloid_relabel`). -/
+noncomputable def labelTabloid (h1 : μ.rowLen 1 = 1) (k : Fin μ.card) :
     Equiv.Perm (Fin μ.card) ⧸ youngSubgroup (shapePartition μ) :=
-  tabloid (relabel (Equiv.swap (secondRowLabel h1 t) k) t)
+  tabloid (relabel (Equiv.swap (secondRowLabel h1 (YoungTableau.nonempty μ).some) k)
+    (YoungTableau.nonempty μ).some)
 
-theorem labelTabloid_def (h1 : μ.rowLen 1 = 1) (t : YoungTableau μ) (k : Fin μ.card) :
-    labelTabloid h1 t k = tabloid (relabel (Equiv.swap (secondRowLabel h1 t) k) t) :=
+/-- The tableau `TauCeti.labelTabloid` relabels is the one `TauCeti.YoungTableau.nonempty`
+chooses; `TauCeti.labelTabloid_eq_tabloid_relabel` is the statement freed of that choice. -/
+private theorem labelTabloid_def (h1 : μ.rowLen 1 = 1) (k : Fin μ.card) :
+    labelTabloid h1 k =
+      tabloid (relabel (Equiv.swap (secondRowLabel h1 (YoungTableau.nonempty μ).some) k)
+        (YoungTableau.nonempty μ).some) :=
   -- `(rfl)`, not `rfl`: the body of `labelTabloid` is not `@[expose]`d, so this must not be
   -- inferred `@[defeq]`.
   (rfl)
 
-theorem labelTabloid_bijective (h1 : μ.rowLen 1 = 1) (h2 : μ.rowLen 2 = 0) (t : YoungTableau μ) :
-    Function.Bijective (labelTabloid h1 t) := by
+/-- Relabelling a tableau by the transposition carrying the label of its short row to `k` puts `k`
+in its short row. -/
+private theorem secondRowLabel_relabel_swap (h1 : μ.rowLen 1 = 1) (t : YoungTableau μ)
+    (k : Fin μ.card) :
+    secondRowLabel h1 (relabel (Equiv.swap (secondRowLabel h1 t) k) t) = k := by
+  rw [secondRowLabel_relabel, Equiv.swap_apply_left]
+
+/-- **The tabloid named by a label is read off any tableau of the shape**: relabel it by the
+transposition carrying the label of its short row to the prescribed one. -/
+theorem labelTabloid_eq_tabloid_relabel (h1 : μ.rowLen 1 = 1) (h2 : μ.rowLen 2 = 0)
+    (t : YoungTableau μ) (k : Fin μ.card) :
+    labelTabloid h1 k = tabloid (relabel (Equiv.swap (secondRowLabel h1 t) k) t) := by
+  rw [labelTabloid_def, tabloid_eq_iff_secondRowLabel_eq h1 h2, secondRowLabel_relabel_swap,
+    secondRowLabel_relabel_swap]
+
+theorem labelTabloid_bijective (h1 : μ.rowLen 1 = 1) (h2 : μ.rowLen 2 = 0) :
+    Function.Bijective (labelTabloid h1) := by
+  obtain ⟨t⟩ := YoungTableau.nonempty μ
   constructor
   · intro k l hkl
-    rw [labelTabloid_def, labelTabloid_def, tabloid_eq_iff_secondRowLabel_eq h1 h2] at hkl
-    simpa using hkl
+    rw [labelTabloid_eq_tabloid_relabel h1 h2 t, labelTabloid_eq_tabloid_relabel h1 h2 t,
+      tabloid_eq_iff_secondRowLabel_eq h1 h2, secondRowLabel_relabel_swap,
+      secondRowLabel_relabel_swap] at hkl
+    exact hkl
   · intro X
     obtain ⟨u, rfl⟩ := tabloid_surjective X
     refine ⟨secondRowLabel h1 u, ?_⟩
-    rw [labelTabloid_def, tabloid_eq_iff_secondRowLabel_eq h1 h2]
-    simp
+    rw [labelTabloid_eq_tabloid_relabel h1 h2 u, tabloid_eq_iff_secondRowLabel_eq h1 h2,
+      secondRowLabel_relabel_swap]
 
 /-- Naming a tabloid by the label of its short row is equivariant.  The left-hand side is stated
 with `σ k` rather than the `σ • k` of the equivariance interfaces, since `Equiv.Perm.smul_def`
 is `simp`; the two are definitionally equal. -/
 @[simp]
-theorem labelTabloid_smul (h1 : μ.rowLen 1 = 1) (h2 : μ.rowLen 2 = 0) (t : YoungTableau μ)
+theorem labelTabloid_smul (h1 : μ.rowLen 1 = 1) (h2 : μ.rowLen 2 = 0)
     (σ : Equiv.Perm (Fin μ.card)) (k : Fin μ.card) :
-    labelTabloid h1 t (σ k) = σ • labelTabloid h1 t k := by
-  rw [labelTabloid_def, labelTabloid_def, ← tabloid_relabel,
-    tabloid_eq_iff_secondRowLabel_eq h1 h2]
+    labelTabloid h1 (σ k) = σ • labelTabloid h1 k := by
+  obtain ⟨t⟩ := YoungTableau.nonempty μ
+  rw [labelTabloid_eq_tabloid_relabel h1 h2 t, labelTabloid_eq_tabloid_relabel h1 h2 t,
+    ← tabloid_relabel, tabloid_eq_iff_secondRowLabel_eq h1 h2, secondRowLabel_relabel_swap]
   simp
 
 /-- **The tabloids of a shape `(m, 1)` are the labels.**  A tabloid of such a shape splits the
 labels into a long row and a single short one, so it is named by the label of the short row. -/
-noncomputable def labelTabloidEquiv (h1 : μ.rowLen 1 = 1) (h2 : μ.rowLen 2 = 0)
-    (t : YoungTableau μ) :
+noncomputable def labelTabloidEquiv (h1 : μ.rowLen 1 = 1) (h2 : μ.rowLen 2 = 0) :
     Fin μ.card ≃ (Equiv.Perm (Fin μ.card) ⧸ youngSubgroup (shapePartition μ)) :=
-  Equiv.ofBijective _ (labelTabloid_bijective h1 h2 t)
+  Equiv.ofBijective _ (labelTabloid_bijective h1 h2)
 
 @[simp]
-theorem labelTabloidEquiv_apply (h1 : μ.rowLen 1 = 1) (h2 : μ.rowLen 2 = 0) (t : YoungTableau μ)
-    (k : Fin μ.card) : labelTabloidEquiv h1 h2 t k = labelTabloid h1 t k :=
+theorem labelTabloidEquiv_apply (h1 : μ.rowLen 1 = 1) (h2 : μ.rowLen 2 = 0) (k : Fin μ.card) :
+    labelTabloidEquiv h1 h2 k = labelTabloid h1 k :=
   -- `(rfl)`, not `rfl`: the body of `labelTabloidEquiv` is not `@[expose]`d.
   (rfl)
 
@@ -482,45 +508,42 @@ theorem labelTabloidEquiv_apply (h1 : μ.rowLen 1 = 1) (h2 : μ.rowLen 2 = 0) (t
 label of the short row of any tableau representing it. -/
 @[simp]
 theorem labelTabloidEquiv_symm_tabloid (h1 : μ.rowLen 1 = 1) (h2 : μ.rowLen 2 = 0)
-    (t u : YoungTableau μ) :
-    (labelTabloidEquiv h1 h2 t).symm (tabloid u) = secondRowLabel h1 u := by
-  rw [Equiv.symm_apply_eq, labelTabloidEquiv_apply, labelTabloid_def,
-    tabloid_eq_iff_secondRowLabel_eq h1 h2]
-  simp
+    (u : YoungTableau μ) :
+    (labelTabloidEquiv h1 h2).symm (tabloid u) = secondRowLabel h1 u := by
+  rw [Equiv.symm_apply_eq, labelTabloidEquiv_apply, labelTabloid_eq_tabloid_relabel h1 h2 u,
+    tabloid_eq_iff_secondRowLabel_eq h1 h2, secondRowLabel_relabel_swap]
 
 /-- **The Young permutation module of a shape `(m, 1)` is the permutation module on the labels.** -/
-noncomputable def labelTabloidRepresentationEquiv (h1 : μ.rowLen 1 = 1) (h2 : μ.rowLen 2 = 0)
-    (t : YoungTableau μ) :
+noncomputable def labelTabloidRepresentationEquiv (h1 : μ.rowLen 1 = 1) (h2 : μ.rowLen 2 = 0) :
     (Representation.ofMulAction ℚ (Equiv.Perm (Fin μ.card)) (Fin μ.card)).Equiv
       (permutationModule (shapePartition μ)).ρ :=
-  ofMulActionEquivCongr ℚ (labelTabloidEquiv h1 h2 t) fun g k => by
+  ofMulActionEquivCongr ℚ (labelTabloidEquiv h1 h2) fun g k => by
     rw [labelTabloidEquiv_apply, labelTabloidEquiv_apply]
-    exact labelTabloid_smul h1 h2 t g k
+    exact labelTabloid_smul h1 h2 g k
 
 @[simp]
 theorem labelTabloidRepresentationEquiv_apply_single (h1 : μ.rowLen 1 = 1) (h2 : μ.rowLen 2 = 0)
-    (t : YoungTableau μ) (k : Fin μ.card) (r : ℚ) :
-    labelTabloidRepresentationEquiv h1 h2 t (MonoidAlgebra.single k r) =
-      MonoidAlgebra.single (labelTabloid h1 t k) r := by
+    (k : Fin μ.card) (r : ℚ) :
+    labelTabloidRepresentationEquiv h1 h2 (MonoidAlgebra.single k r) =
+      MonoidAlgebra.single (labelTabloid h1 k) r := by
   rw [labelTabloidRepresentationEquiv, ofMulActionEquivCongr_apply_single, labelTabloidEquiv_apply]
 
 /-- The transport of `ℚ[Fin μ.card]` onto the Young permutation module carries the augmentation
 subrepresentation of the labels onto the Specht module of the shape. -/
-private theorem map_augmentationSubrepresentation (h1 : μ.rowLen 1 = 1) (h2 : μ.rowLen 2 = 0)
-    (t : YoungTableau μ) :
+private theorem map_augmentationSubrepresentation (h1 : μ.rowLen 1 = 1) (h2 : μ.rowLen 2 = 0) :
     Submodule.map
-        ((labelTabloidRepresentationEquiv h1 h2 t).toLinearEquiv :
+        ((labelTabloidRepresentationEquiv h1 h2).toLinearEquiv :
           MonoidAlgebra ℚ (Fin μ.card) →ₗ[ℚ] (permutationModule (shapePartition μ)).V)
         (augmentationSubrepresentation ℚ (Equiv.Perm (Fin μ.card)) (Fin μ.card)).toSubmodule =
       (spechtSubrepresentation μ).toSubmodule := by
   have hsingle : ∀ (k : Fin μ.card) (r : ℚ),
-      ((labelTabloidRepresentationEquiv h1 h2 t).toLinearEquiv :
+      ((labelTabloidRepresentationEquiv h1 h2).toLinearEquiv :
           MonoidAlgebra ℚ (Fin μ.card) →ₗ[ℚ] (permutationModule (shapePartition μ)).V)
-        (MonoidAlgebra.single k r) = MonoidAlgebra.single (labelTabloid h1 t k) r :=
-    fun k r => labelTabloidRepresentationEquiv_apply_single h1 h2 t k r
+        (MonoidAlgebra.single k r) = MonoidAlgebra.single (labelTabloid h1 k) r :=
+    fun k r => labelTabloidRepresentationEquiv_apply_single h1 h2 k r
   have hsum : (MonoidAlgebra.basis
         (Equiv.Perm (Fin μ.card) ⧸ youngSubgroup (shapePartition μ)) ℚ).sumCoords ∘ₗ
-        ((labelTabloidRepresentationEquiv h1 h2 t).toLinearEquiv :
+        ((labelTabloidRepresentationEquiv h1 h2).toLinearEquiv :
           MonoidAlgebra ℚ (Fin μ.card) →ₗ[ℚ] (permutationModule (shapePartition μ)).V) =
       (MonoidAlgebra.basis (Fin μ.card) ℚ).sumCoords :=
     Module.Basis.ext (MonoidAlgebra.basis (Fin μ.card) ℚ) fun k => by
@@ -530,7 +553,7 @@ private theorem map_augmentationSubrepresentation (h1 : μ.rowLen 1 = 1) (h2 : �
     toSubmodule_augmentationSubrepresentation, toSubmodule_augmentationSubrepresentation,
     ← hsum, LinearMap.ker_comp]
   exact Submodule.map_comap_eq_of_surjective
-    (labelTabloidRepresentationEquiv h1 h2 t).toLinearEquiv.surjective _
+    (labelTabloidRepresentationEquiv h1 h2).toLinearEquiv.surjective _
 
 /-- **The Specht module of a shape `(m, 1)` is the standard representation.**  Naming the tabloids
 by the labels of their short rows carries `ℚ[Fin μ.card]` onto the Young permutation module and its
@@ -542,27 +565,27 @@ This is the third of the named small irreducibles of `Sₙ`, beside the trivial 
 `S^{(n)}` and the sign representation `S^{(1ⁿ)}` of
 `TauCeti.RepresentationTheory.Symmetric.Specht.Extremes`. -/
 noncomputable def standardRepresentationEquivSpechtSubrepresentation (h1 : μ.rowLen 1 = 1)
-    (h2 : μ.rowLen 2 = 0) (t : YoungTableau μ) :
+    (h2 : μ.rowLen 2 = 0) :
     (standardRepresentation ℚ (Fin μ.card)).Equiv (spechtSubrepresentation μ).toRepresentation :=
   Representation.Equiv.mk
-    (LinearEquiv.ofSubmodules (labelTabloidRepresentationEquiv h1 h2 t).toLinearEquiv _ _
-      (map_augmentationSubrepresentation h1 h2 t))
+    (LinearEquiv.ofSubmodules (labelTabloidRepresentationEquiv h1 h2).toLinearEquiv _ _
+      (map_augmentationSubrepresentation h1 h2))
     fun g => LinearMap.ext fun v => Subtype.ext <| by
       simp only [← toRepresentation_augmentationSubrepresentation, LinearMap.comp_apply,
         LinearEquiv.coe_coe, LinearEquiv.ofSubmodules_apply,
         Subrepresentation.toRepresentation_apply, LinearMap.coe_restrict_apply,
         Representation.Equiv.toLinearEquiv_apply]
       exact Representation.IntertwiningMap.isIntertwining _ _
-        (labelTabloidRepresentationEquiv h1 h2 t).toIntertwiningMap g v
+        (labelTabloidRepresentationEquiv h1 h2).toIntertwiningMap g v
 
 /-- The underlying equivalence of the identification is the transport of the tabloids. -/
 @[simp]
 theorem coe_standardRepresentationEquivSpechtSubrepresentation_apply (h1 : μ.rowLen 1 = 1)
-    (h2 : μ.rowLen 2 = 0) (t : YoungTableau μ)
+    (h2 : μ.rowLen 2 = 0)
     (v : (augmentationSubrepresentation ℚ (Equiv.Perm (Fin μ.card)) (Fin μ.card)).toSubmodule) :
-    (standardRepresentationEquivSpechtSubrepresentation h1 h2 t v :
+    (standardRepresentationEquivSpechtSubrepresentation h1 h2 v :
         (permutationModule (shapePartition μ)).V) =
-      labelTabloidRepresentationEquiv h1 h2 t (v : MonoidAlgebra ℚ (Fin μ.card)) :=
+      labelTabloidRepresentationEquiv h1 h2 (v : MonoidAlgebra ℚ (Fin μ.card)) :=
   -- `(rfl)`, not `rfl`: the body of the equivalence is not `@[expose]`d.
   (rfl)
 
@@ -571,19 +594,19 @@ along an identification `μ.card = N` of the labels.  This is the shape in which
 partition-indexed `TauCeti.spechtModule`, which relabels the symmetric group along
 `TauCeti.card_diagramOf`, consumes it. -/
 private noncomputable def standardRepresentationEquivSpechtSubrepresentationOfCard {N : ℕ}
-    (h1 : μ.rowLen 1 = 1) (h2 : μ.rowLen 2 = 0) (t : YoungTableau μ) (hN : μ.card = N) :
+    (h1 : μ.rowLen 1 = 1) (h2 : μ.rowLen 2 = 0) (hN : μ.card = N) :
     (standardRepresentation ℚ (Fin N)).Equiv
       ((spechtSubrepresentation μ).toRepresentation.comp
         (finCongr hN.symm).permCongrHom.toMonoidHom) := by
   subst hN
-  exact standardRepresentationEquivSpechtSubrepresentation h1 h2 t
+  exact standardRepresentationEquivSpechtSubrepresentation h1 h2
 
 private theorem coe_standardRepresentationEquivSpechtSubrepresentationOfCard_apply {N : ℕ}
-    (h1 : μ.rowLen 1 = 1) (h2 : μ.rowLen 2 = 0) (t : YoungTableau μ) (hN : μ.card = N)
+    (h1 : μ.rowLen 1 = 1) (h2 : μ.rowLen 2 = 0) (hN : μ.card = N)
     (v : (augmentationSubrepresentation ℚ (Equiv.Perm (Fin N)) (Fin N)).toSubmodule) :
-    (standardRepresentationEquivSpechtSubrepresentationOfCard h1 h2 t hN v :
+    (standardRepresentationEquivSpechtSubrepresentationOfCard h1 h2 hN v :
         (permutationModule (shapePartition μ)).V) =
-      labelTabloidRepresentationEquiv h1 h2 t
+      labelTabloidRepresentationEquiv h1 h2
         (MonoidAlgebra.mapDomainLinearEquiv ℚ ℚ (finCongr hN.symm)
           (v : MonoidAlgebra ℚ (Fin N))) := by
   subst hN
@@ -593,15 +616,14 @@ private theorem coe_standardRepresentationEquivSpechtSubrepresentationOfCard_app
       (v : MonoidAlgebra ℚ (Fin μ.card)) = (v : MonoidAlgebra ℚ (Fin μ.card)) := by
     simp [MonoidAlgebra.mapDomainLinearEquiv]
   rw [hrefl]
-  exact coe_standardRepresentationEquivSpechtSubrepresentation_apply h1 h2 t v
+  exact coe_standardRepresentationEquivSpechtSubrepresentation_apply h1 h2 v
 
 /-- **The Specht module of a shape `(m, 1)` has dimension one less than the number of labels**:
 the standard representation of the symmetric group on `μ.card` labels has dimension
 `μ.card - 1`. -/
 theorem finrank_spechtSubrepresentation_of_rowLen (h1 : μ.rowLen 1 = 1) (h2 : μ.rowLen 2 = 0) :
     Module.finrank ℚ (spechtSubrepresentation μ).toSubmodule = μ.card - 1 := by
-  obtain ⟨t⟩ := YoungTableau.nonempty μ
-  rw [← (standardRepresentationEquivSpechtSubrepresentation h1 h2 t).toLinearEquiv.finrank_eq,
+  rw [← (standardRepresentationEquivSpechtSubrepresentation h1 h2).toLinearEquiv.finrank_eq,
     finrank_augmentationSubrepresentation, Fintype.card_fin]
 
 /-! ## The shape `(n+1, 1)` -/
@@ -620,28 +642,26 @@ theorem finrank_spechtModule_singletonSecondRow (n : ℕ) :
 `TauCeti.standardRepresentationEquivSpechtSubrepresentation` for the shape `(n+1, 1)`, with the
 symmetric group on the labels of the diagram identified with `S_{n+2}` along
 `TauCeti.card_diagramOf`, the relabelling `TauCeti.spechtModule` is defined by. -/
-noncomputable def standardRepresentationEquivSpechtModuleSingletonSecondRow (n : ℕ)
-    (t : YoungTableau (diagramOf (Nat.Partition.singletonSecondRow n))) :
+noncomputable def standardRepresentationEquivSpechtModuleSingletonSecondRow (n : ℕ) :
     (standardRepresentation ℚ (Fin (n + 2))).Equiv
       (spechtModule (Nat.Partition.singletonSecondRow n)).ρ :=
   standardRepresentationEquivSpechtSubrepresentationOfCard
-    (rowLen_diagramOf_singletonSecondRow_one n) (rowLen_diagramOf_singletonSecondRow_two n) t
+    (rowLen_diagramOf_singletonSecondRow_one n) (rowLen_diagramOf_singletonSecondRow_two n)
     (card_diagramOf _)
 
 /-- The identification of `S^{(n+1,1)}` with the standard representation is the transport of the
 tabloids, read on the labels of the diagram along `TauCeti.card_diagramOf`. -/
 @[simp]
 theorem coe_standardRepresentationEquivSpechtModuleSingletonSecondRow_apply (n : ℕ)
-    (t : YoungTableau (diagramOf (Nat.Partition.singletonSecondRow n)))
     (v : (augmentationSubrepresentation ℚ (Equiv.Perm (Fin (n + 2))) (Fin (n + 2))).toSubmodule) :
-    (standardRepresentationEquivSpechtModuleSingletonSecondRow n t v :
+    (standardRepresentationEquivSpechtModuleSingletonSecondRow n v :
         (permutationModule
           (shapePartition (diagramOf (Nat.Partition.singletonSecondRow n)))).V) =
       labelTabloidRepresentationEquiv (rowLen_diagramOf_singletonSecondRow_one n)
-        (rowLen_diagramOf_singletonSecondRow_two n) t
+        (rowLen_diagramOf_singletonSecondRow_two n)
         (MonoidAlgebra.mapDomainLinearEquiv ℚ ℚ
           (finCongr (card_diagramOf (Nat.Partition.singletonSecondRow n)).symm)
           (v : MonoidAlgebra ℚ (Fin (n + 2)))) :=
-  coe_standardRepresentationEquivSpechtSubrepresentationOfCard_apply _ _ t _ v
+  coe_standardRepresentationEquivSpechtSubrepresentationOfCard_apply _ _ _ v
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/Symmetric/Standard.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Standard.lean
@@ -119,10 +119,12 @@ the vectors of `k[α]` whose coefficients sum to zero.  No hypothesis on `k` or 
 here; when `α` is finite and `(Fintype.card α : k) ≠ 0` it is a complement of the invariant line in
 the permutation representation `k[α]`, by
 `isCompl_invariantLine_augmentationSubrepresentation`, whereas when `(Fintype.card α : k) = 0` the
-invariant line lies inside it instead.  Over `ℚ` it is the Specht module of the shape
-`(|α|-1, 1)`, by
+invariant line lies inside it instead.  Over `ℚ` and on the labels `α = Fin μ.card` of a Young
+diagram `μ` whose second row is a single cell and which has no third row -- a shape `(m, 1)` -- it
+is the Specht module `S^μ`, by
 `TauCeti.standardRepresentationEquivSpechtSubrepresentation` of
-`TauCeti.RepresentationTheory.Symmetric.Specht.SingletonSecondRow`. -/
+`TauCeti.RepresentationTheory.Symmetric.Specht.SingletonSecondRow`; for the partition `(n+1, 1)`
+of `n+2` that reads, on `α = Fin (n+2)`, as `S^{(n-1,1)} = standard`. -/
 noncomputable def standardRepresentation :
     Representation k (Equiv.Perm α)
       (augmentationSubrepresentation k (Equiv.Perm α) α).toSubmodule :=

--- a/TauCeti/RepresentationTheory/Symmetric/Standard.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Standard.lean
@@ -124,7 +124,7 @@ diagram `μ` whose second row is a single cell and which has no third row -- a s
 is the Specht module `S^μ`, by
 `TauCeti.standardRepresentationEquivSpechtSubrepresentation` of
 `TauCeti.RepresentationTheory.Symmetric.Specht.SingletonSecondRow`; for the partition `(n+1, 1)`
-of `n+2` that reads, on `α = Fin (n+2)`, as `S^{(n-1,1)} = standard`. -/
+of `n+2` that reads, on `α = Fin (n+2)`, as `S^{(n+1,1)} = standard`. -/
 noncomputable def standardRepresentation :
     Representation k (Equiv.Perm α)
       (augmentationSubrepresentation k (Equiv.Perm α) α).toSubmodule :=

--- a/TauCeti/RepresentationTheory/Symmetric/Standard.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Standard.lean
@@ -119,9 +119,10 @@ the vectors of `k[α]` whose coefficients sum to zero.  No hypothesis on `k` or 
 here; when `α` is finite and `(Fintype.card α : k) ≠ 0` it is a complement of the invariant line in
 the permutation representation `k[α]`, by
 `isCompl_invariantLine_augmentationSubrepresentation`, whereas when `(Fintype.card α : k) = 0` the
-invariant line lies inside it instead.  Identifying it with the Specht module of the shape
-`(|α|-1, 1)` is an aim for later: the polytabloid presentation needed to state that equivalence is
-not yet in the repository. -/
+invariant line lies inside it instead.  Over `ℚ` it is the Specht module of the shape
+`(|α|-1, 1)`, by
+`TauCeti.standardRepresentationEquivSpechtSubrepresentation` of
+`TauCeti.RepresentationTheory.Symmetric.Specht.SingletonSecondRow`. -/
 noncomputable def standardRepresentation :
     Representation k (Equiv.Perm α)
       (augmentationSubrepresentation k (Equiv.Perm α) α).toSubmodule :=


### PR DESCRIPTION
This PR proves that the Specht module of the shape `(n-1, 1)` is the standard representation, the third of the named small irreducible representations of `Sₙ`. It adds `TauCeti/RepresentationTheory/Symmetric/Specht/SingletonSecondRow.lean` and refreshes two docstrings that flagged the identification as not yet available, and adds the two row lengths of the diagram of `(n+1, 1)` to `TauCeti/Combinatorics/Young/Partitions.lean`, beside the existing facts about the diagrams of `Nat.Partition.ones` and `Nat.Partition.indiscrete`.

The target is `TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md`, Layer 4, the bullet "**The named small irreducibles.** `S^{(n)}` is the trivial representation, `S^{(1ⁿ)}` is the sign representation `Perm.sign`, and `S^{(n-1,1)}` is the `(n-1)`-dimensional standard representation (`M^{(n-1,1)} = triv ⊕ standard`). Prove these identifications." The first two identifications are `TauCeti/RepresentationTheory/Symmetric/Specht/Extremes.lean` and the parenthesised one is `TauCeti/RepresentationTheory/Symmetric/PermutationModule/SingletonSecondRow.lean`; the third was the outstanding one, and both of those files say so in their own docstrings.

Everything is stated on the Young diagram, where the polytabloids live, and pinned by two row lengths: `μ.rowLen 1 = 1` says the second row is a single cell and `μ.rowLen 2 = 0` says there is no third row, so `μ` is a shape `(m, 1)`; both hold for `diagramOf (Nat.Partition.singletonSecondRow n)`. Three elementary facts follow — the second row holds one label (`YoungTableau.secondRowLabel`), the first column holds exactly that one and `YoungTableau.firstColumnLabel`, and every other column holds exactly one — so the column group of a tableau is `{1, (a b)}` (`YoungTableau.mem_colSubgroup_iff`) and its row group is the stabilizer of the short-row label (`YoungTableau.rowSubgroup_eq_stabilizer`). The antisymmetrization defining the polytabloid therefore has two terms of opposite sign, and `e_t = {t} - (a b) · {t}` is a difference of two tabloid basis vectors (`YoungTableau.polytabloid_eq_single_sub_single`).

Such differences span the vectors whose coefficients sum to zero, and conversely every such difference is a polytabloid: a tableau can be relabelled, without moving the label of its short row, so that the top of its first column carries any prescribed other label (`single_sub_single_mem_spechtSubrepresentation`). So the Specht module is the augmentation subrepresentation of the Young permutation module (`spechtSubrepresentation_eq_augmentationSubrepresentation`), which is what `TauCeti.standardRepresentation` is by definition. To read that on the labels rather than the tabloids, the file also names the tabloids by the labels of their short rows, equivariantly (`labelTabloidEquiv`, `labelTabloid_smul`); transporting `ℚ[Fin μ.card]` along that naming gives `standardRepresentationEquivSpechtSubrepresentation`, and `finrank_spechtSubrepresentation_of_rowLen` reads off the dimension `μ.card - 1`, specialized to `finrank_spechtModule_singletonSecondRow : finrank ℚ (spechtModule (singletonSecondRow n)) = n + 1`. Relabelling the labels along `card_diagramOf`, the relabelling `spechtModule` is defined by, states the identification itself for the partition-indexed Specht module too, as `standardRepresentationEquivSpechtModuleSingletonSecondRow : (standardRepresentation ℚ (Fin (n + 2))).Equiv (spechtModule (singletonSecondRow n)).ρ`, with its characteristic application lemma.

Nothing is vendored from Mathlib; the file consumes `Representation.ofMulAction`, `Module.Basis.sumCoords`, `LinearEquiv.ofSubmodules` and `Representation.Equiv` as they stand, together with the repository's existing polytabloid, augmentation and `ofMulActionEquivCongr` API. The two docstring edits are in `Symmetric/Standard.lean`, whose `standardRepresentation` said the polytabloid presentation needed to state this equivalence was "not yet in the repository" — it now is — and in `Specht/Extremes.lean`, which said the standard representation was "not treated here either"; both now point at the new module.

Verified locally against the pinned Mathlib: `lake build` compiles the new module and the two edited ones, and a targeted audit over the new module's 63 declarations reports only `propext`, `Classical.choice` and `Quot.sound`. `scripts/lint-style.sh` and `scripts/lint-dot-notation.py` pass (`0 new`), and the environment-linter set of `scripts/lint-env.sh` reports `0 errors` over `TauCeti` from the new module's import closure. Fourteen modules unrelated to this change (under `Analysis/`, `KnotTheory/`, `NumberTheory/`, `Topology/` and `LinearAlgebra/QuadraticForm/`) already fail to compile on this checkout of `main` before any of these edits, which is why the repository-wide `lake exe axioms` could not be run here; none of them is in the import closure of anything this PR touches.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"specht-module-n-1-1-is-standard-representation"}-->

🤖 Prepared with Claude Code

