### PR TITLE
feat: identify scalar extension of invariant group algebras

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/GroupAlgebra/Galois/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GroupAlgebra/Galois/BaseChange.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.Algebra.AlgebraicGroup.GroupAlgebra.Galois.Invariants
 import TauCeti.RepresentationTheory.GaloisDescent.Span
+import TauCeti.RepresentationTheory.GaloisDescent.Injective
 
 /-!
 # Scalar extension of an invariant group algebra
@@ -17,10 +18,10 @@ exponents, with the latter specified by an integral representation on the abelia
 The scalar-extension map is Mathlib's `AlgHom.liftEquiv` applied to the invariant-subalgebra
 inclusion; it sends `a ⊗ x` to `a • x`.
 
-This supplies the surjectivity part of the coordinate descent for groups of multiplicative
-type, including non-split tori. Identifying the scalar extension with the split coordinate
-algebra additionally requires injectivity; transporting the Hopf structure requires the analogous
-identification on tensor squares.
+For a finite Galois extension this map is an algebra equivalence. This identifies the scalar
+extension of the descended coordinate algebra with the split group algebra, as needed for
+groups of multiplicative type and non-split tori. Transporting the Hopf structure additionally
+requires the analogous identification on tensor squares.
 
 ## References
 
@@ -63,5 +64,60 @@ theorem liftEquiv_groupAlgebraInvariants_surjective
   intro x hx
   exact ⟨1 ⊗ₜ[k] (⟨x, hx⟩ : groupAlgebraInvariants rho), by
     simp [f]⟩
+
+variable [FiniteDimensional k L] [IsGalois k L]
+
+/-- Over a finite Galois extension, scalar extension of the invariant group-algebra inclusion
+is injective. The exponent group need not be finitely generated. -/
+theorem liftEquiv_groupAlgebraInvariants_injective
+    (rho : Representation ℤ (L ≃ₐ[k] L) M) :
+    Function.Injective
+      (AlgHom.liftEquiv k L (groupAlgebraInvariants rho)
+        (MonoidAlgebra L (Multiplicative M)) (groupAlgebraInvariants rho).val) := by
+  let ρ : Representation k (L ≃ₐ[k] L) (MonoidAlgebra L (Multiplicative M)) :=
+    { toFun := fun σ ↦ (groupAlgebraAction rho σ).toLinearMap
+      map_one' := by ext x; simp
+      map_mul' := by intros; ext x; simp }
+  let f := (groupAlgebraInvariants rho).val
+  have h := liftBaseChange_injective_of_invariant (ρ := ρ)
+    (groupAlgebraAction_smul rho) f.toLinearMap Subtype.val_injective
+    (fun σ x ↦ (mem_groupAlgebraInvariants_iff rho x).mp x.property σ)
+  have heq : (AlgHom.liftEquiv k L _ _ f).toLinearMap =
+      f.toLinearMap.liftBaseChange L := by
+    apply TensorProduct.AlgebraTensorModule.ext
+    intro a x
+    simp
+  rw [← heq] at h
+  exact h
+
+/-- The invariant group algebra descends the split coordinate algebra along a finite Galois
+extension: extending its scalars recovers the original group algebra. -/
+noncomputable def groupAlgebraInvariantsBaseChangeEquiv
+    (rho : Representation ℤ (L ≃ₐ[k] L) M) :
+    L ⊗[k] groupAlgebraInvariants rho ≃ₐ[L] MonoidAlgebra L (Multiplicative M) :=
+  AlgEquiv.ofBijective
+    (AlgHom.liftEquiv k L (groupAlgebraInvariants rho)
+      (MonoidAlgebra L (Multiplicative M)) (groupAlgebraInvariants rho).val)
+    ⟨liftEquiv_groupAlgebraInvariants_injective rho,
+      liftEquiv_groupAlgebraInvariants_surjective rho⟩
+
+/-- The descent equivalence is scalar multiplication on pure tensors. -/
+@[simp]
+theorem groupAlgebraInvariantsBaseChangeEquiv_tmul
+    (rho : Representation ℤ (L ≃ₐ[k] L) M)
+    (a : L) (x : groupAlgebraInvariants rho) :
+    groupAlgebraInvariantsBaseChangeEquiv rho (a ⊗ₜ[k] x) =
+      a • (x : MonoidAlgebra L (Multiplicative M)) := by
+  exact (AlgEquiv.ofBijective_apply _ _ _).trans (AlgHom.liftEquiv_tmul _ a x)
+
+/-- The inverse descent equivalence sends an invariant element to its tensor with one. -/
+@[simp]
+theorem groupAlgebraInvariantsBaseChangeEquiv_symm_apply_coe
+    (rho : Representation ℤ (L ≃ₐ[k] L) M)
+    (x : groupAlgebraInvariants rho) :
+    (groupAlgebraInvariantsBaseChangeEquiv rho).symm
+      (x : MonoidAlgebra L (Multiplicative M)) = 1 ⊗ₜ[k] x := by
+  apply (groupAlgebraInvariantsBaseChangeEquiv rho).injective
+  simp
 
 end TauCeti.GaloisDescent

--- a/TauCeti/Algebra/AlgebraicGroup/GroupAlgebra/Galois/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GroupAlgebra/Galois/BaseChange.lean
@@ -79,8 +79,8 @@ theorem liftEquiv_groupAlgebraInvariants_injective
       map_one' := by ext x; simp
       map_mul' := by intros; ext x; simp }
   let f := (groupAlgebraInvariants rho).val
-  have h := liftBaseChange_injective_of_invariant (ρ := ρ)
-    f.toLinearMap Subtype.val_injective (fun σ a x ↦ by
+  have h := liftBaseChange_injective_of_invariant (ρ := ρ) (f := f.toLinearMap)
+    Subtype.val_injective (fun σ a x ↦ by
       -- Expand the local representation and inclusion to apply the action's scalar law.
       change groupAlgebraAction rho σ (a • x.val) = σ a • x.val
       rw [groupAlgebraAction_smul,

--- a/TauCeti/Algebra/AlgebraicGroup/GroupAlgebra/Galois/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GroupAlgebra/Galois/BaseChange.lean
@@ -80,8 +80,11 @@ theorem liftEquiv_groupAlgebraInvariants_injective
       map_mul' := by intros; ext x; simp }
   let f := (groupAlgebraInvariants rho).val
   have h := liftBaseChange_injective_of_invariant (ρ := ρ)
-    (groupAlgebraAction_smul rho) f.toLinearMap Subtype.val_injective
-    (fun σ x ↦ (mem_groupAlgebraInvariants_iff rho x).mp x.property σ)
+    f.toLinearMap Subtype.val_injective (fun σ a x ↦ by
+      -- Expand the local representation and inclusion to apply the action's scalar law.
+      change groupAlgebraAction rho σ (a • x.val) = σ a • x.val
+      rw [groupAlgebraAction_smul,
+        (mem_groupAlgebraInvariants_iff rho x).mp x.property σ])
   have heq : (AlgHom.liftEquiv k L _ _ f).toLinearMap =
       f.toLinearMap.liftBaseChange L := by
     apply TensorProduct.AlgebraTensorModule.ext
@@ -112,7 +115,7 @@ theorem groupAlgebraInvariantsBaseChangeEquiv_tmul
 
 /-- The inverse descent equivalence sends an invariant element to its tensor with one. -/
 @[simp]
-theorem groupAlgebraInvariantsBaseChangeEquiv_symm_apply_coe
+theorem groupAlgebraInvariantsBaseChangeEquiv_symm_apply
     (rho : Representation ℤ (L ≃ₐ[k] L) M)
     (x : groupAlgebraInvariants rho) :
     (groupAlgebraInvariantsBaseChangeEquiv rho).symm

--- a/TauCeti/RepresentationTheory/GaloisDescent/Injective.lean
+++ b/TauCeti/RepresentationTheory/GaloisDescent/Injective.lean
@@ -41,7 +41,7 @@ injective after scalar extension. Semilinearity is only required on scalar multi
 image of the map. No dimension restriction is imposed on either module. -/
 theorem liftBaseChange_injective_of_invariant
     {ρ : Representation k (L ≃ₐ[k] L) V}
-    (f : W →ₗ[k] V) (hf : Function.Injective f)
+    {f : W →ₗ[k] V} (hf : Function.Injective f)
     (hsemi : ∀ (σ : L ≃ₐ[k] L) (a : L) (w : W),
       ρ σ (a • f w) = σ a • f w) :
     Function.Injective (f.liftBaseChange L) := by

--- a/TauCeti/RepresentationTheory/GaloisDescent/Injective.lean
+++ b/TauCeti/RepresentationTheory/GaloisDescent/Injective.lean
@@ -1,0 +1,76 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import Mathlib.FieldTheory.Galois.Basic
+public import Mathlib.RepresentationTheory.Basic
+public import Mathlib.RingTheory.TensorProduct.Basic
+import Mathlib.RingTheory.Flat.Basic
+import Mathlib.RingTheory.Trace.Basic
+
+/-!
+# Injectivity in semilinear Galois descent
+
+Over a finite Galois extension `L/k`, an injective `k`-linear map into the invariant vectors
+of a semilinear representation stays injective after extending scalars to `L`. Together with
+the spanning theorem for invariant vectors, this identifies a semilinear representation with
+the scalar extension of its invariants. The result applies to infinite-dimensional vector
+spaces and does not require the Galois group order to be invertible.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Appendix A.64 (Galois descent).
+-/
+
+public section
+
+open scoped TensorProduct
+
+namespace TauCeti.GaloisDescent
+
+variable {k L V W : Type*} [Field k] [Field L] [Algebra k L]
+variable [AddCommGroup V] [Module k V] [Module L V] [IsScalarTower k L V]
+variable [AddCommGroup W] [Module k W]
+variable [FiniteDimensional k L] [IsGalois k L]
+
+/-- An injective map into invariant vectors of a semilinear Galois representation remains
+injective after scalar extension. No dimension restriction is imposed on either module. -/
+theorem liftBaseChange_injective_of_invariant
+    {ρ : Representation k (L ≃ₐ[k] L) V}
+    (hsemi : ∀ (σ : L ≃ₐ[k] L) (a : L) (v : V),
+      ρ σ (a • v) = σ a • ρ σ v)
+    (f : W →ₗ[k] V) (hf : Function.Injective f)
+    (hfix : ∀ (σ : L ≃ₐ[k] L) (w : W), ρ σ (f w) = f w) :
+    Function.Injective (f.liftBaseChange L) := by
+  classical
+  let b := Module.finBasis k L
+  -- The trace-dual basis extracts each coefficient of a tensor by an orbit sum.
+  have hnorm (a : L) (w : W) :
+      ρ.norm (a • f w) = Algebra.trace k L a • f w := by
+    simp only [Representation.norm, LinearMap.sum_apply, hsemi, hfix]
+    rw [← Finset.sum_smul, ← trace_eq_sum_automorphisms,
+      IsScalarTower.algebraMap_smul]
+  let p : V →ₗ[k] L ⊗[k] V := ∑ i,
+    (TensorProduct.mk k L V (b i)).comp
+      (ρ.norm.comp ((LinearMap.lsmul L V (b.traceDual i)).restrictScalars k))
+  have hp : p.comp ((f.liftBaseChange L).restrictScalars k) = f.lTensor L := by
+    apply TensorProduct.ext'
+    intro a w
+    simp only [LinearMap.comp_apply, LinearMap.restrictScalars_apply,
+      LinearMap.liftBaseChange_tmul, LinearMap.lTensor_tmul, p,
+      LinearMap.sum_apply, LinearMap.lsmul_apply, smul_smul, hnorm,
+      TensorProduct.mk_apply]
+    have hcoeff (i) : Algebra.trace k L (b.traceDual i * a) = b.repr a i := by
+      rw [← b.traceDual_traceDual, Module.Basis.traceDual_repr_apply]
+      simp [Algebra.traceForm, mul_comm]
+    simp only [hcoeff, ← TensorProduct.smul_tmul]
+    rw [← TensorProduct.sum_tmul, b.sum_repr]
+  intro x y h
+  apply Module.Flat.lTensor_preserves_injective_linearMap (M := L) f hf
+  have h' := congrArg p h
+  simpa only [← hp, LinearMap.comp_apply, LinearMap.restrictScalars_apply] using h'
+
+end TauCeti.GaloisDescent

--- a/TauCeti/RepresentationTheory/GaloisDescent/Injective.lean
+++ b/TauCeti/RepresentationTheory/GaloisDescent/Injective.lean
@@ -37,20 +37,20 @@ variable [AddCommGroup W] [Module k W]
 variable [FiniteDimensional k L] [IsGalois k L]
 
 /-- An injective map into invariant vectors of a semilinear Galois representation remains
-injective after scalar extension. No dimension restriction is imposed on either module. -/
+injective after scalar extension. Semilinearity is only required on scalar multiples of the
+image of the map. No dimension restriction is imposed on either module. -/
 theorem liftBaseChange_injective_of_invariant
     {ρ : Representation k (L ≃ₐ[k] L) V}
-    (hsemi : ∀ (σ : L ≃ₐ[k] L) (a : L) (v : V),
-      ρ σ (a • v) = σ a • ρ σ v)
     (f : W →ₗ[k] V) (hf : Function.Injective f)
-    (hfix : ∀ (σ : L ≃ₐ[k] L) (w : W), ρ σ (f w) = f w) :
+    (hsemi : ∀ (σ : L ≃ₐ[k] L) (a : L) (w : W),
+      ρ σ (a • f w) = σ a • f w) :
     Function.Injective (f.liftBaseChange L) := by
   classical
   let b := Module.finBasis k L
   -- The trace-dual basis extracts each coefficient of a tensor by an orbit sum.
   have hnorm (a : L) (w : W) :
       ρ.norm (a • f w) = Algebra.trace k L a • f w := by
-    simp only [Representation.norm, LinearMap.sum_apply, hsemi, hfix]
+    simp only [Representation.norm, LinearMap.sum_apply, hsemi]
     rw [← Finset.sum_smul, ← trace_eq_sum_automorphisms,
       IsScalarTower.algebraMap_smul]
   let p : V →ₗ[k] L ⊗[k] V := ∑ i,


### PR DESCRIPTION
This PR proves that scalar extension of a Galois-invariant group algebra is isomorphic to the original split group algebra, advancing [ReductiveGroups/README.md, Layer 4, “Tori: split and non-split”](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/ReductiveGroups/README.md#layer-4-jordan-decomposition-diagonalizable-groups-tori). The new `groupAlgebraInvariantsBaseChangeEquiv` identifies `L ⊗[k] groupAlgebraInvariants rho` with `L[Multiplicative M]` for every finite Galois extension `L/k`, with simplification formulas on pure tensors and for the inverse on invariant elements.

This supplies exactly the injectivity missing after merged PR #6341, and reuses its surjectivity theorem to complete the algebra comparison. The immediate next consumer is descent of `groupAlgebraInvariantsComul`: its current target is the invariant tensor square, which must be identified with the tensor square of the invariant algebra. After this PR, the milestone still needs that tensor comparison, assembly of the descended Hopf algebra, and the torus–Galois-lattice anti-equivalence.

The general theorem `GaloisDescent.liftBaseChange_injective_of_invariant` applies to any injective linear map whose image is fixed by a semilinear Galois representation. A trace-dual basis extracts tensor coefficients by orbit sums; ordinary tensoring preserves injectivity over the base field. Neither representation module needs to be finite-dimensional, the exponent group need not be finitely generated, and there is no characteristic restriction.

Add `TauCeti/RepresentationTheory/GaloisDescent/Injective.lean` (76 lines) and extend `TauCeti/Algebra/AlgebraicGroup/GroupAlgebra/Galois/BaseChange.lean` to 123 lines: 136 insertions and 4 deletions in total. The proof reuses Mathlib's `Module.Basis.traceDual`, `trace_eq_sum_automorphisms`, `Representation.norm`, `Module.Flat.lTensor_preserves_injective_linearMap`, and `AlgHom.liftEquiv`. No Mathlib infrastructure or external formalization is vendored. The mathematical reference is Milne, [Algebraic Groups (2017)](https://www.jmilne.org/math/Books/iAG2017.pdf), Appendix A.64 and Theorem 12.23, cited in the modules.

Self-review against API design, reuse, and generality found no duplicate result or excess mathematical hypothesis. It narrowed the general module's representation import and replaced unfolding with explicit application lemmas. Both changed modules pass their targeted `lake build`. The changed-module axiom audit accepts all 16 declarations, and `git diff --cached --check` passes. The prescribed lint wrapper stops at its stale default-set guard because it omits `tacticAlt`; a temporary copy adding exactly that linter, matching the approved set on current main, passes both changed modules with zero violations and zero grandfathered findings. No repository scripts or linter configuration are changed.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"groupalgebrainvariantsbasechangeequiv"}-->

🤖 Prepared with Codex
