### PR TITLE
feat(ModularForms): the factor dichotomy of the coprime sieve (Miyake 4.6.8, case split)

### DIFF
--- a/TauCeti/NumberTheory/DirichletCharacter/Basic.lean
+++ b/TauCeti/NumberTheory/DirichletCharacter/Basic.lean
@@ -32,8 +32,6 @@ case the descent uses is `d = L N / p` with `p ∣ N` coprime to `L`, where the 
   lift to a multiple level through `d` descends to a factorisation of `χ` through `gcd (N, d)`,
   and `DirichletCharacter.factorsThrough_div_of_changeLevel_factorsThrough`: its arithmetic
   specialisation, from `L N / p` to `N / p`.
-* `DirichletCharacter.exists_comp_unitsMap_of_factorsThrough`: a factorisation of `MulChar.ofUnitHom
-  χ` through `d`, read back as `χ = χ₀ ∘ ZMod.unitsMap` on unit homomorphisms.
 
 ## Provenance
 
@@ -106,21 +104,5 @@ theorem factorsThrough_div_of_changeLevel_factorsThrough {R : Type*} [CommMonoid
       _ = N / p := by rw [hpL.gcd_eq_one, one_mul]
   rw [← hgcd]
   exact factorsThrough_gcd_of_changeLevel_factorsThrough _ hfac
-
-/-- **A factorisation, read on unit homomorphisms.** If the Dirichlet character `MulChar.ofUnitHom
-χ` factors through `d ∣ N`, then the unit homomorphism `χ` itself is a composition
-`χ₀ ∘ ZMod.unitsMap` with a unit homomorphism modulo `d` — the form in which a lowered nebentypus
-is consumed. -/
-theorem exists_comp_unitsMap_of_factorsThrough {R : Type*} [CommMonoidWithZero R] {N d : ℕ}
-    (hd : d ∣ N) {χ : (ZMod N)ˣ →* Rˣ}
-    (hfac : FactorsThrough (MulChar.ofUnitHom χ : DirichletCharacter R N) d) :
-    ∃ χ₀ : (ZMod d)ˣ →* Rˣ, χ = χ₀.comp (ZMod.unitsMap hd) := by
-  refine ⟨hfac.χ₀.toUnitHom, ?_⟩
-  -- forwards, by applying `toUnitHom` to `eq_changeLevel`: `hfac.χ₀` mentions `χ` through the
-  -- type of `hfac`, so rewriting `χ` in the goal would break the motive
-  have hχ : MulChar.toUnitHom (MulChar.ofUnitHom χ : DirichletCharacter R N) = χ :=
-    MulChar.equivToUnitHom.apply_symm_apply χ
-  have h := congrArg MulChar.toUnitHom hfac.eq_changeLevel
-  rwa [DirichletCharacter.changeLevel_toUnitHom, hχ] at h
 
 end DirichletCharacter

--- a/TauCeti/NumberTheory/DirichletCharacter/Basic.lean
+++ b/TauCeti/NumberTheory/DirichletCharacter/Basic.lean
@@ -40,6 +40,17 @@ Adapted from the AINTLIB `LeanModularForms` project (Chris Birkbeck,
 intermediate shift form (`exists_kernel_unit_with_char_shift`, :646) and a separate
 non-factorisation witness (`exists_unit_of_not_factorsThrough`, :542); each is a one-line
 consequence of the other, so only this form is ported and the extraction is done inline.
+
+`factorsThrough_div_of_changeLevel_factorsThrough` is extracted from the same project at commit
+`eb9621e7bcb0ce220ad53983ec45d987cb5b9002`, file
+`projects/LeanModularForms/LeanModularForms/StrongMultiplicityOne/InductiveStep.lean`: the
+conductor step inside the proof of `miyake_4_6_8_factor_dichotomy`, which the source carries as
+the private lemmas `conductor_dvd_of_factorsThrough`, `factorsThrough_of_conductor_dvd` and
+`conductor_changeLevel` specialised to `L N / p`. Here those three are Mathlib's
+`conductor_dvd_of_mem_conductorSet`, `mem_conductorSet_iff_conductor_dvd` and
+`conductor_changeLevel`, so what is ported is the arithmetic of the descent — the conductor
+divides `gcd (N, L N / p) = N / p` — stated once for characters valued in any
+`CommMonoidWithZero`.
 -/
 
 public section

--- a/TauCeti/NumberTheory/DirichletCharacter/Basic.lean
+++ b/TauCeti/NumberTheory/DirichletCharacter/Basic.lean
@@ -110,16 +110,14 @@ theorem factorsThrough_div_of_changeLevel_factorsThrough {R : Type*} [CommMonoid
 /-- **A factorisation, read on unit homomorphisms.** If the Dirichlet character `MulChar.ofUnitHom
 χ` factors through `d ∣ N`, then the unit homomorphism `χ` itself is a composition
 `χ₀ ∘ ZMod.unitsMap` with a unit homomorphism modulo `d` — the form in which a lowered nebentypus
-is consumed.
-
-The conversion is the forward one, applying `MulChar.toUnitHom` to
-`DirichletCharacter.FactorsThrough.eq_changeLevel`: the lowered character `hfac.χ₀` mentions `χ`
-through the type of `hfac`, so rewriting `χ` in the goal would break the motive. -/
+is consumed. -/
 theorem exists_comp_unitsMap_of_factorsThrough {R : Type*} [CommMonoidWithZero R] {N d : ℕ}
     (hd : d ∣ N) {χ : (ZMod N)ˣ →* Rˣ}
     (hfac : FactorsThrough (MulChar.ofUnitHom χ : DirichletCharacter R N) d) :
     ∃ χ₀ : (ZMod d)ˣ →* Rˣ, χ = χ₀.comp (ZMod.unitsMap hd) := by
   refine ⟨hfac.χ₀.toUnitHom, ?_⟩
+  -- forwards, by applying `toUnitHom` to `eq_changeLevel`: `hfac.χ₀` mentions `χ` through the
+  -- type of `hfac`, so rewriting `χ` in the goal would break the motive
   have hχ : MulChar.toUnitHom (MulChar.ofUnitHom χ : DirichletCharacter R N) = χ :=
     MulChar.equivToUnitHom.apply_symm_apply χ
   have h := congrArg MulChar.toUnitHom hfac.eq_changeLevel

--- a/TauCeti/NumberTheory/DirichletCharacter/Basic.lean
+++ b/TauCeti/NumberTheory/DirichletCharacter/Basic.lean
@@ -19,17 +19,19 @@ determine its character value: every unit has a partner in the same fibre of `ZM
 which `χ` takes a different value. This is the form the level-lowering argument for the
 conductor theorem consumes.
 
-If the lift of `χ` to a level `L N` factors through `L N / p` for some `p ∣ N` coprime to `L`,
-then `χ` itself factors through `N / p`: `changeLevel` preserves the conductor, which then
-divides `gcd (N, L N / p) = N / p`. This is how a factorisation found at an auxiliary level is
-brought back to the level of `χ`.
+If the lift of `χ` to a multiple level factors through `d`, then `χ` itself factors through
+`gcd (N, d)`: `changeLevel` preserves the conductor, which then divides both. This is how a
+factorisation found at an auxiliary level is brought back to the level of `χ`; the arithmetic
+case the descent uses is `d = L N / p` with `p ∣ N` coprime to `L`, where the gcd is `N / p`.
 
 ## Main results
 
 * `DirichletCharacter.exists_alt_unit_in_coset_with_char_separation`: character separation within
   a fibre of the reduction map.
-* `DirichletCharacter.factorsThrough_div_of_changeLevel_factorsThrough`: a factorisation of the
-  lift through `L N / p` descends to a factorisation of `χ` through `N / p`.
+* `DirichletCharacter.factorsThrough_gcd_of_changeLevel_factorsThrough`: a factorisation of the
+  lift to a multiple level through `d` descends to a factorisation of `χ` through `gcd (N, d)`,
+  and `DirichletCharacter.factorsThrough_div_of_changeLevel_factorsThrough`: its arithmetic
+  specialisation, from `L N / p` to `N / p`.
 
 ## Provenance
 
@@ -72,22 +74,35 @@ theorem exists_alt_unit_in_coset_with_char_separation {R : Type*} [CommMonoidWit
   exact ⟨u * v, by rw [map_mul, hv_ker', mul_one],
     by rw [map_mul, Ne, mul_eq_left]; exact hv_chi'⟩
 
+/-- **A factorisation found at a multiple level descends to the gcd.** If the lift of `ψ` mod `N`
+to a multiple level `M` factors through `d`, then `ψ` factors through `gcd (N, d)`:
+`changeLevel` preserves the conductor, which then divides both the level `N` and `d`. -/
+theorem factorsThrough_gcd_of_changeLevel_factorsThrough {R : Type*} [CommMonoidWithZero R]
+    {N M d : ℕ} [NeZero N] [NeZero M] (hNM : N ∣ M) {ψ : DirichletCharacter R N}
+    (hfac : (changeLevel hNM ψ).FactorsThrough d) : ψ.FactorsThrough (Nat.gcd N d) := by
+  have hc : ψ.conductor ∣ d := by
+    have := conductor_dvd_of_mem_conductorSet _ hfac
+    rwa [conductor_changeLevel] at this
+  exact (mem_conductorSet_iff_conductor_dvd _ (Nat.gcd_dvd_left N d)).mpr
+    (Nat.dvd_gcd ψ.conductor_dvd_level hc)
+
 /-- **A factorisation found at an auxiliary level descends.** If the lift of `ψ` mod `N` to level
-`L N` factors through `L N / p`, for `p ∣ N` coprime to `L`, then `ψ` factors through `N / p`:
-`changeLevel` preserves the conductor, which then divides `gcd (N, L N / p) = N / p`. -/
+`L N` factors through `L N / p`, for `p ∣ N` coprime to `L`, then `ψ` factors through `N / p`.
+This is `factorsThrough_gcd_of_changeLevel_factorsThrough` at the gcd
+`gcd (N, L N / p) = gcd (p, L) · (N / p) = N / p`. -/
 theorem factorsThrough_div_of_changeLevel_factorsThrough {R : Type*} [CommMonoidWithZero R]
     {N p L : ℕ} [NeZero N] [NeZero L] (hpN : p ∣ N) (hpL : Nat.Coprime p L)
     {ψ : DirichletCharacter R N}
     (hfac : (changeLevel (Nat.dvd_mul_left N L) ψ).FactorsThrough (L * N / p)) :
     ψ.FactorsThrough (N / p) := by
   have : NeZero (L * N) := ⟨mul_ne_zero (NeZero.ne L) (NeZero.ne N)⟩
-  have hN : N = p * (N / p) := (Nat.mul_div_cancel' hpN).symm
-  have hc : ψ.conductor ∣ L * (N / p) := by
-    have := conductor_dvd_of_mem_conductorSet _ hfac
-    rwa [conductor_changeLevel, Nat.mul_div_assoc L hpN] at this
-  have hgcd : Nat.gcd (p * (N / p)) (L * (N / p)) = N / p := by
-    rw [Nat.gcd_mul_right, hpL.gcd_eq_one, one_mul]
-  exact (mem_conductorSet_iff_conductor_dvd _ (Nat.div_dvd_of_dvd hpN)).mpr
-    (hgcd ▸ Nat.dvd_gcd (hN ▸ ψ.conductor_dvd_level) hc)
+  have hgcd : Nat.gcd N (L * N / p) = N / p := by
+    rw [Nat.mul_div_assoc L hpN]
+    calc Nat.gcd N (L * (N / p)) = Nat.gcd (p * (N / p)) (L * (N / p)) := by
+          rw [Nat.mul_div_cancel' hpN]
+      _ = Nat.gcd p L * (N / p) := Nat.gcd_mul_right p (N / p) L
+      _ = N / p := by rw [hpL.gcd_eq_one, one_mul]
+  rw [← hgcd]
+  exact factorsThrough_gcd_of_changeLevel_factorsThrough _ hfac
 
 end DirichletCharacter

--- a/TauCeti/NumberTheory/DirichletCharacter/Basic.lean
+++ b/TauCeti/NumberTheory/DirichletCharacter/Basic.lean
@@ -8,19 +8,28 @@ module
 public import Mathlib.NumberTheory.DirichletCharacter.Basic
 
 /-!
-# A character that does not factor is not a function of the reduction
+# Factoring a Dirichlet character through a divisor
 
-If `χ` mod `N` does not factor through `d ∣ N`, then knowing a unit's reduction modulo `d` does
-not determine its character value: every unit has a partner in the same fibre of
-`ZMod.unitsMap` on which `χ` takes a different value. This is the form the level-lowering
-argument for the conductor theorem consumes, and it is stated for characters valued in any
-`CommMonoidWithZero`, which is the generality of
-`DirichletCharacter.factorsThrough_iff_ker_unitsMap`.
+Two facts about when a Dirichlet character `χ` mod `N` factors through a divisor of `N`, both
+stated for characters valued in any `CommMonoidWithZero`, which is the generality of
+`DirichletCharacter.factorsThrough_iff_ker_unitsMap` and of the conductor.
+
+If `χ` does not factor through `d ∣ N`, then knowing a unit's reduction modulo `d` does not
+determine its character value: every unit has a partner in the same fibre of `ZMod.unitsMap` on
+which `χ` takes a different value. This is the form the level-lowering argument for the
+conductor theorem consumes.
+
+If the lift of `χ` to a level `L N` factors through `L N / p` for some `p ∣ N` coprime to `L`,
+then `χ` itself factors through `N / p`: `changeLevel` preserves the conductor, which then
+divides `gcd (N, L N / p) = N / p`. This is how a factorisation found at an auxiliary level is
+brought back to the level of `χ`.
 
 ## Main results
 
 * `DirichletCharacter.exists_alt_unit_in_coset_with_char_separation`: character separation within
   a fibre of the reduction map.
+* `DirichletCharacter.factorsThrough_div_of_changeLevel_factorsThrough`: a factorisation of the
+  lift through `L N / p` descends to a factorisation of `χ` through `N / p`.
 
 ## Provenance
 
@@ -51,5 +60,23 @@ theorem exists_alt_unit_in_coset_with_char_separation {R : Type*} [CommMonoidWit
   have hv_chi' : χ.toUnitHom v ≠ 1 := hv_chi ∘ MonoidHom.mem_ker.mpr
   exact ⟨u * v, by rw [map_mul, hv_ker', mul_one],
     by rw [map_mul, Ne, mul_eq_left]; exact hv_chi'⟩
+
+/-- **A factorisation found at an auxiliary level descends.** If the lift of `ψ` mod `N` to level
+`L N` factors through `L N / p`, for `p ∣ N` coprime to `L`, then `ψ` factors through `N / p`:
+`changeLevel` preserves the conductor, which then divides `gcd (N, L N / p) = N / p`. -/
+theorem factorsThrough_div_of_changeLevel_factorsThrough {R : Type*} [CommMonoidWithZero R]
+    {N p L : ℕ} [NeZero N] [NeZero L] (hpN : p ∣ N) (hpL : Nat.Coprime p L)
+    {ψ : DirichletCharacter R N}
+    (hfac : (changeLevel (Nat.dvd_mul_left N L) ψ).FactorsThrough (L * N / p)) :
+    ψ.FactorsThrough (N / p) := by
+  have : NeZero (L * N) := ⟨mul_ne_zero (NeZero.ne L) (NeZero.ne N)⟩
+  have hN : N = p * (N / p) := (Nat.mul_div_cancel' hpN).symm
+  have hc : ψ.conductor ∣ L * (N / p) := by
+    have := conductor_dvd_of_mem_conductorSet _ hfac
+    rwa [conductor_changeLevel, Nat.mul_div_assoc L hpN] at this
+  have hgcd : Nat.gcd (p * (N / p)) (L * (N / p)) = N / p := by
+    rw [Nat.gcd_mul_right, hpL.gcd_eq_one, one_mul]
+  exact (mem_conductorSet_iff_conductor_dvd _ (Nat.div_dvd_of_dvd hpN)).mpr
+    (hgcd ▸ Nat.dvd_gcd (hN ▸ ψ.conductor_dvd_level) hc)
 
 end DirichletCharacter

--- a/TauCeti/NumberTheory/DirichletCharacter/Basic.lean
+++ b/TauCeti/NumberTheory/DirichletCharacter/Basic.lean
@@ -32,6 +32,8 @@ case the descent uses is `d = L N / p` with `p ∣ N` coprime to `L`, where the 
   lift to a multiple level through `d` descends to a factorisation of `χ` through `gcd (N, d)`,
   and `DirichletCharacter.factorsThrough_div_of_changeLevel_factorsThrough`: its arithmetic
   specialisation, from `L N / p` to `N / p`.
+* `DirichletCharacter.exists_comp_unitsMap_of_factorsThrough`: a factorisation of `MulChar.ofUnitHom
+  χ` through `d`, read back as `χ = χ₀ ∘ ZMod.unitsMap` on unit homomorphisms.
 
 ## Provenance
 
@@ -104,5 +106,23 @@ theorem factorsThrough_div_of_changeLevel_factorsThrough {R : Type*} [CommMonoid
       _ = N / p := by rw [hpL.gcd_eq_one, one_mul]
   rw [← hgcd]
   exact factorsThrough_gcd_of_changeLevel_factorsThrough _ hfac
+
+/-- **A factorisation, read on unit homomorphisms.** If the Dirichlet character `MulChar.ofUnitHom
+χ` factors through `d ∣ N`, then the unit homomorphism `χ` itself is a composition
+`χ₀ ∘ ZMod.unitsMap` with a unit homomorphism modulo `d` — the form in which a lowered nebentypus
+is consumed.
+
+The conversion is the forward one, applying `MulChar.toUnitHom` to
+`DirichletCharacter.FactorsThrough.eq_changeLevel`: the lowered character `hfac.χ₀` mentions `χ`
+through the type of `hfac`, so rewriting `χ` in the goal would break the motive. -/
+theorem exists_comp_unitsMap_of_factorsThrough {R : Type*} [CommMonoidWithZero R] {N d : ℕ}
+    (hd : d ∣ N) {χ : (ZMod N)ˣ →* Rˣ}
+    (hfac : FactorsThrough (MulChar.ofUnitHom χ : DirichletCharacter R N) d) :
+    ∃ χ₀ : (ZMod d)ˣ →* Rˣ, χ = χ₀.comp (ZMod.unitsMap hd) := by
+  refine ⟨hfac.χ₀.toUnitHom, ?_⟩
+  have hχ : MulChar.toUnitHom (MulChar.ofUnitHom χ : DirichletCharacter R N) = χ :=
+    MulChar.equivToUnitHom.apply_symm_apply χ
+  have h := congrArg MulChar.toUnitHom hfac.eq_changeLevel
+  rwa [DirichletCharacter.changeLevel_toUnitHom, hχ] at h
 
 end DirichletCharacter

--- a/TauCeti/NumberTheory/ModularForms/Newforms/CoprimeFilter/Dichotomy.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/CoprimeFilter/Dichotomy.lean
@@ -54,6 +54,23 @@ namespace TauCeti
 
 variable {N : ℕ} [NeZero N] {k : ℤ}
 
+/-- A character modulo `N` whose lift to level `L N` factors through `L N / p`, for `p ∣ N`
+prime and `L` coprime to `p`, factors through `N / p`: `changeLevel` preserves the conductor,
+which then divides `gcd (N, L N / p) = N / p`. -/
+private theorem factorsThrough_div_of_changeLevel_factorsThrough {p L : ℕ} [NeZero (L * N)]
+    (hpN : p ∣ N) (hpL : Nat.Coprime p L) {ψ : DirichletCharacter ℂ N}
+    (hfac : (DirichletCharacter.changeLevel (Nat.dvd_mul_left N L) ψ).FactorsThrough
+      (L * N / p)) :
+    ψ.FactorsThrough (N / p) := by
+  have hN : N = p * (N / p) := (Nat.mul_div_cancel' hpN).symm
+  have hc : ψ.conductor ∣ L * (N / p) := by
+    have := DirichletCharacter.conductor_dvd_of_mem_conductorSet _ hfac
+    rwa [DirichletCharacter.conductor_changeLevel, Nat.mul_div_assoc L hpN] at this
+  have hgcd : Nat.gcd (p * (N / p)) (L * (N / p)) = N / p := by
+    rw [Nat.gcd_mul_right, hpL.gcd_eq_one, one_mul]
+  exact (DirichletCharacter.mem_conductorSet_iff_conductor_dvd _ (Nat.div_dvd_of_dvd hpN)).mpr
+    (hgcd ▸ Nat.dvd_gcd (hN ▸ ψ.conductor_dvd_level) hc)
+
 /-- **The factor dichotomy.** For `f ∈ S_k(Γ₁(N), χ)` vanishing at every index coprime to `p L`,
 with `p ∣ N` prime and `L` squarefree, coprime to `p`, with primes dividing `N`: either `f`
 vanishes at every index coprime to `L`, or `χ` is the pull-back of a character modulo `N / p`. -/
@@ -78,17 +95,9 @@ theorem qExpansion_coeff_eq_zero_of_coprime_or_exists_eq_comp_unitsMap (χ : (ZM
     rwa [DirichletCharacter.changeLevel_toUnitHom, hψχ]
   rcases exists_cuspForm_mem_cuspFormCharSpace_or_eq_zero hpLN k _ φ G hGψ hGφ hφT with
     ⟨hfac, -, -, -⟩ | hφ0
-  · -- `χ` lifted to level `L N` factors through `L N / p`, so its conductor divides `N / p`
+  · -- `χ` lifted to level `L N` factors through `L N / p`, so `χ` factors through `N / p`
     right
-    have hN : N = p * (N / p) := (Nat.mul_div_cancel' hpN).symm
-    have hc : ψ.conductor ∣ L * (N / p) := by
-      have := DirichletCharacter.conductor_dvd_of_mem_conductorSet _ hfac
-      rwa [DirichletCharacter.conductor_changeLevel, Nat.mul_div_assoc L hpN] at this
-    have hgcd : Nat.gcd (p * (N / p)) (L * (N / p)) = N / p := by
-      rw [Nat.gcd_mul_right, hpL.gcd_eq_one, one_mul]
-    have hfac' : ψ.FactorsThrough (N / p) :=
-      (DirichletCharacter.mem_conductorSet_iff_conductor_dvd _ (Nat.div_dvd_of_dvd hpN)).mpr
-        (hgcd ▸ Nat.dvd_gcd (hN ▸ ψ.conductor_dvd_level) hc)
+    have hfac' := factorsThrough_div_of_changeLevel_factorsThrough hpN hpL hfac
     refine ⟨hfac'.χ₀.toUnitHom, ?_⟩
     rw [← hψχ]
     conv_lhs => rw [hfac'.eq_changeLevel]

--- a/TauCeti/NumberTheory/ModularForms/Newforms/CoprimeFilter/Dichotomy.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/CoprimeFilter/Dichotomy.lean
@@ -8,22 +8,26 @@ module
 public import TauCeti.NumberTheory.ModularForms.ConductorDichotomy
 public import TauCeti.NumberTheory.ModularForms.Newforms.CoprimeFilter.Basic
 public import TauCeti.NumberTheory.ModularForms.Newforms.Descent.Basic
+import TauCeti.NumberTheory.DirichletCharacter.Basic
 
 /-!
 # The factor dichotomy of the coprime sieve
 
 Let `f ∈ S_k(Γ₁(N), χ)` vanish at every index coprime to `p L`, for a prime `p ∣ N` and a
-squarefree `L` coprime to `p` whose primes divide `N`. Either `f` already vanishes at every index
+nonzero `L` coprime to `p` whose primes divide `N`. Either `f` already vanishes at every index
 coprime to `L`, or the nebentypus `χ` is the pull-back of a character modulo `N / p`. This is
 the case split of Miyake's proof of Lemma 4.6.8 (the Main Lemma of Diamond–Shurman §5.7, per
-character): in the second case the descent along `p` produces a form of level `N / p`, and in
-the first the prime `p` needs no descent at all.
+character): the second case is what a later descent along `p` needs, and in the first the prime
+`p` needs no descent at all.
 
-The coprime filter of `f` (`Newforms/CoprimeFilter/Basic.lean`) is a form `G` of level `L N`
-carrying the coefficients of `f` at the indices coprime to `L` and supported on the multiples of
-`p`; the level-lowering dichotomy (`ConductorDichotomy.lean`) either finds `G` to be a
-level-raise from `L N / p`, so that the pulled-back character factors through `L N / p` and, by
-the conductor, `χ` factors through `N / p`, or forces `G = 0`, which is the vanishing of `f`.
+The coprime filter of `f` (`Newforms/CoprimeFilter/Basic.lean`) is a form `G` of level `L' N`,
+`L'` the product of the primes of `L`, carrying the coefficients of `f` at the indices coprime
+to `L` and supported on the multiples of `p`; the level-lowering dichotomy
+(`ConductorDichotomy.lean`) either finds `G` to be a level-raise from `L' N / p`, so that the
+pulled-back character factors through `L' N / p` and, by the conductor
+(`DirichletCharacter.factorsThrough_div_of_changeLevel_factorsThrough`), `χ` factors through
+`N / p`, or forces `G = 0`, which is the required vanishing of the coefficients of `f` at the
+indices coprime to `L`.
 
 ## Main results
 
@@ -37,7 +41,8 @@ Adapted from the AINTLIB `LeanModularForms` project (Chris Birkbeck, Apache-2.0,
 `miyake_4_6_8_factor_dichotomy`. The source's private conductor lemmas
 (`conductor_dvd_of_factorsThrough`, `factorsThrough_of_conductor_dvd`, `conductor_changeLevel`)
 are Mathlib's `DirichletCharacter.conductor_dvd_of_mem_conductorSet`,
-`mem_conductorSet_iff_conductor_dvd` and `conductor_changeLevel`.
+`mem_conductorSet_iff_conductor_dvd` and `conductor_changeLevel`; the source assumes `L`
+squarefree, which the filter at the radical of `L` makes unnecessary.
 
 ## References
 
@@ -54,38 +59,24 @@ namespace TauCeti
 
 variable {N : ℕ} [NeZero N] {k : ℤ}
 
-/-- A character modulo `N` whose lift to level `L N` factors through `L N / p`, for `p ∣ N`
-prime and `L` coprime to `p`, factors through `N / p`: `changeLevel` preserves the conductor,
-which then divides `gcd (N, L N / p) = N / p`. -/
-private theorem factorsThrough_div_of_changeLevel_factorsThrough {p L : ℕ} [NeZero (L * N)]
-    (hpN : p ∣ N) (hpL : Nat.Coprime p L) {ψ : DirichletCharacter ℂ N}
-    (hfac : (DirichletCharacter.changeLevel (Nat.dvd_mul_left N L) ψ).FactorsThrough
-      (L * N / p)) :
-    ψ.FactorsThrough (N / p) := by
-  have hN : N = p * (N / p) := (Nat.mul_div_cancel' hpN).symm
-  have hc : ψ.conductor ∣ L * (N / p) := by
-    have := DirichletCharacter.conductor_dvd_of_mem_conductorSet _ hfac
-    rwa [DirichletCharacter.conductor_changeLevel, Nat.mul_div_assoc L hpN] at this
-  have hgcd : Nat.gcd (p * (N / p)) (L * (N / p)) = N / p := by
-    rw [Nat.gcd_mul_right, hpL.gcd_eq_one, one_mul]
-  exact (DirichletCharacter.mem_conductorSet_iff_conductor_dvd _ (Nat.div_dvd_of_dvd hpN)).mpr
-    (hgcd ▸ Nat.dvd_gcd (hN ▸ ψ.conductor_dvd_level) hc)
-
 /-- **The factor dichotomy.** For `f ∈ S_k(Γ₁(N), χ)` vanishing at every index coprime to `p L`,
-with `p ∣ N` prime and `L` squarefree, coprime to `p`, with primes dividing `N`: either `f`
-vanishes at every index coprime to `L`, or `χ` is the pull-back of a character modulo `N / p`. -/
+with `p ∣ N` prime and `L ≠ 0` coprime to `p` with primes dividing `N`: either `f` vanishes at
+every index coprime to `L`, or `χ` is the pull-back of a character modulo `N / p`. -/
 theorem qExpansion_coeff_eq_zero_of_coprime_or_exists_eq_comp_unitsMap (χ : (ZMod N)ˣ →* ℂˣ)
     {f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k} (hf : f ∈ cuspFormCharSpace k χ) {p L : ℕ}
-    (hp : p.Prime) (hpN : p ∣ N) (hL : Squarefree L) (hLN : L.primeFactors ⊆ N.primeFactors)
+    [NeZero L] (hp : p.Prime) (hpN : p ∣ N) (hLN : L.primeFactors ⊆ N.primeFactors)
     (hpL : Nat.Coprime p L) (hvan : ∀ n, Nat.Coprime n (p * L) → (qExpansion 1 f).coeff n = 0) :
     (∀ n, Nat.Coprime n L → (qExpansion 1 f).coeff n = 0) ∨
       ∃ χ₀ : (ZMod (N / p))ˣ →* ℂˣ, χ = χ₀.comp (ZMod.unitsMap (Nat.div_dvd_of_dvd hpN)) := by
   have : NeZero p := ⟨hp.ne_zero⟩
-  have : NeZero (L * N) := ⟨Nat.mul_ne_zero hL.ne_zero (NeZero.ne N)⟩
-  have hpLN : p ∣ L * N := dvd_mul_of_dvd_right hpN L
-  have hNLN : N ∣ L * N := Nat.dvd_mul_left N L
+  -- the filter lives at the level `L' N`, `L'` the radical of `L`
   obtain ⟨G, hGχ, hGsupp, hGcoeff⟩ :=
-    exists_mem_cuspFormCharSpace_qExpansionSupportedOnDvd_of_squarefree χ hf hp hL hLN hvan
+    exists_mem_cuspFormCharSpace_qExpansionSupportedOnDvd χ hf hp hLN hvan
+  have hL'L : L.primeFactors.prod id ∣ L := Nat.prod_primeFactors_dvd L
+  have : NeZero (L.primeFactors.prod id) := ⟨ne_zero_of_dvd_ne_zero (NeZero.ne L) hL'L⟩
+  have hpL' : Nat.Coprime p (L.primeFactors.prod id) := hpL.coprime_dvd_right hL'L
+  have hpLN : p ∣ L.primeFactors.prod id * N := dvd_mul_of_dvd_right hpN _
+  have hNLN : N ∣ L.primeFactors.prod id * N := Nat.dvd_mul_left N _
   obtain ⟨φ, hGφ, hφT⟩ :=
     CuspForm.exists_eq_smul_slash_scaleGL_and_slash_T_eq_of_qExpansionSupportedOnDvd G hGsupp
   -- the nebentypus of `G` is the level-`L N` lift of `χ`, as a Dirichlet character
@@ -97,7 +88,7 @@ theorem qExpansion_coeff_eq_zero_of_coprime_or_exists_eq_comp_unitsMap (χ : (ZM
     ⟨hfac, -, -, -⟩ | hφ0
   · -- `χ` lifted to level `L N` factors through `L N / p`, so `χ` factors through `N / p`
     right
-    have hfac' := factorsThrough_div_of_changeLevel_factorsThrough hpN hpL hfac
+    have hfac' := DirichletCharacter.factorsThrough_div_of_changeLevel_factorsThrough hpN hpL' hfac
     refine ⟨hfac'.χ₀.toUnitHom, ?_⟩
     rw [← hψχ]
     conv_lhs => rw [hfac'.eq_changeLevel]

--- a/TauCeti/NumberTheory/ModularForms/Newforms/CoprimeFilter/Dichotomy.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/CoprimeFilter/Dichotomy.lean
@@ -65,8 +65,7 @@ every index coprime to `L`, or the nebentypus factors through `N / p`.
 
 The second branch is stated with Mathlib's `DirichletCharacter.FactorsThrough`: its `χ₀`, `dvd`
 and `eq_changeLevel` give a consumer the lowered character modulo `N / p` and the factorisation
-of `χ` through it, which is what the descent lemmas take —
-`DirichletCharacter.exists_comp_unitsMap_of_factorsThrough` packages that conversion.
+of `χ` through it, which is what the descent lemmas take.
 -/
 theorem qExpansion_coeff_eq_zero_of_coprime_or_factorsThrough (χ : (ZMod N)ˣ →* ℂˣ)
     {f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k} (hf : f ∈ cuspFormCharSpace k χ) {p L : ℕ}

--- a/TauCeti/NumberTheory/ModularForms/Newforms/CoprimeFilter/Dichotomy.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/CoprimeFilter/Dichotomy.lean
@@ -1,0 +1,104 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.NumberTheory.ModularForms.ConductorDichotomy
+public import TauCeti.NumberTheory.ModularForms.Newforms.CoprimeFilter.Basic
+public import TauCeti.NumberTheory.ModularForms.Newforms.Descent.Basic
+
+/-!
+# The factor dichotomy of the coprime sieve
+
+Let `f ∈ S_k(Γ₁(N), χ)` vanish at every index coprime to `p L`, for a prime `p ∣ N` and a
+squarefree `L` coprime to `p` whose primes divide `N`. Either `f` already vanishes at every index
+coprime to `L`, or the nebentypus `χ` is the pull-back of a character modulo `N / p`. This is
+the case split of Miyake's proof of Lemma 4.6.8 (the Main Lemma of Diamond–Shurman §5.7, per
+character): in the second case the descent along `p` produces a form of level `N / p`, and in
+the first the prime `p` needs no descent at all.
+
+The coprime filter of `f` (`Newforms/CoprimeFilter/Basic.lean`) is a form `G` of level `L N`
+carrying the coefficients of `f` at the indices coprime to `L` and supported on the multiples of
+`p`; the level-lowering dichotomy (`ConductorDichotomy.lean`) either finds `G` to be a
+level-raise from `L N / p`, so that the pulled-back character factors through `L N / p` and, by
+the conductor, `χ` factors through `N / p`, or forces `G = 0`, which is the vanishing of `f`.
+
+## Main results
+
+* `TauCeti.qExpansion_coeff_eq_zero_of_coprime_or_exists_eq_comp_unitsMap`: the dichotomy.
+
+## Provenance
+
+Adapted from the AINTLIB `LeanModularForms` project (Chris Birkbeck, Apache-2.0,
+<https://github.com/CBirkbeck/AINTLIB> @ `eb9621e7bcb0ce220ad53983ec45d987cb5b9002`),
+`projects/LeanModularForms/LeanModularForms/StrongMultiplicityOne/InductiveStep.lean`,
+`miyake_4_6_8_factor_dichotomy`. The source's private conductor lemmas
+(`conductor_dvd_of_factorsThrough`, `factorsThrough_of_conductor_dvd`, `conductor_changeLevel`)
+are Mathlib's `DirichletCharacter.conductor_dvd_of_mem_conductorSet`,
+`mem_conductorSet_iff_conductor_dvd` and `conductor_changeLevel`.
+
+## References
+
+* [T. Miyake, *Modular forms*][miyake1989], Lemma 4.6.8.
+-/
+
+public section
+
+open Matrix.SpecialLinearGroup UpperHalfPlane CongruenceSubgroup
+
+open scoped MatrixGroups ModularForm
+
+namespace TauCeti
+
+variable {N : ℕ} [NeZero N] {k : ℤ}
+
+/-- **The factor dichotomy.** For `f ∈ S_k(Γ₁(N), χ)` vanishing at every index coprime to `p L`,
+with `p ∣ N` prime and `L` squarefree, coprime to `p`, with primes dividing `N`: either `f`
+vanishes at every index coprime to `L`, or `χ` is the pull-back of a character modulo `N / p`. -/
+theorem qExpansion_coeff_eq_zero_of_coprime_or_exists_eq_comp_unitsMap (χ : (ZMod N)ˣ →* ℂˣ)
+    {f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k} (hf : f ∈ cuspFormCharSpace k χ) {p L : ℕ}
+    (hp : p.Prime) (hpN : p ∣ N) (hL : Squarefree L) (hLN : L.primeFactors ⊆ N.primeFactors)
+    (hpL : Nat.Coprime p L) (hvan : ∀ n, Nat.Coprime n (p * L) → (qExpansion 1 f).coeff n = 0) :
+    (∀ n, Nat.Coprime n L → (qExpansion 1 f).coeff n = 0) ∨
+      ∃ χ₀ : (ZMod (N / p))ˣ →* ℂˣ, χ = χ₀.comp (ZMod.unitsMap (Nat.div_dvd_of_dvd hpN)) := by
+  have : NeZero p := ⟨hp.ne_zero⟩
+  have : NeZero (L * N) := ⟨Nat.mul_ne_zero hL.ne_zero (NeZero.ne N)⟩
+  have hpLN : p ∣ L * N := dvd_mul_of_dvd_right hpN L
+  have hNLN : N ∣ L * N := Nat.dvd_mul_left N L
+  obtain ⟨G, hGχ, hGsupp, hGcoeff⟩ :=
+    exists_mem_cuspFormCharSpace_qExpansionSupportedOnDvd_of_squarefree χ hf hp hL hLN hvan
+  obtain ⟨φ, hGφ, hφT⟩ :=
+    CuspForm.exists_eq_smul_slash_scaleGL_and_slash_T_eq_of_qExpansionSupportedOnDvd G hGsupp
+  -- the nebentypus of `G` is the level-`L N` lift of `χ`, as a Dirichlet character
+  set ψ : DirichletCharacter ℂ N := MulChar.ofUnitHom χ with hψ
+  have hψχ : ψ.toUnitHom = χ := MulChar.equivToUnitHom.apply_symm_apply χ
+  have hGψ : G ∈ cuspFormCharSpace k (DirichletCharacter.changeLevel hNLN ψ).toUnitHom := by
+    rwa [DirichletCharacter.changeLevel_toUnitHom, hψχ]
+  rcases exists_cuspForm_mem_cuspFormCharSpace_or_eq_zero hpLN k _ φ G hGψ hGφ hφT with
+    ⟨hfac, -, -, -⟩ | hφ0
+  · -- `χ` lifted to level `L N` factors through `L N / p`, so its conductor divides `N / p`
+    right
+    have hN : N = p * (N / p) := (Nat.mul_div_cancel' hpN).symm
+    have hc : ψ.conductor ∣ L * (N / p) := by
+      have := DirichletCharacter.conductor_dvd_of_mem_conductorSet _ hfac
+      rwa [DirichletCharacter.conductor_changeLevel, Nat.mul_div_assoc L hpN] at this
+    have hgcd : Nat.gcd (p * (N / p)) (L * (N / p)) = N / p := by
+      rw [Nat.gcd_mul_right, hpL.gcd_eq_one, one_mul]
+    have hfac' : ψ.FactorsThrough (N / p) :=
+      (DirichletCharacter.mem_conductorSet_iff_conductor_dvd _ (Nat.div_dvd_of_dvd hpN)).mpr
+        (hgcd ▸ Nat.dvd_gcd (hN ▸ ψ.conductor_dvd_level) hc)
+    refine ⟨hfac'.χ₀.toUnitHom, ?_⟩
+    rw [← hψχ]
+    conv_lhs => rw [hfac'.eq_changeLevel]
+    rw [DirichletCharacter.changeLevel_toUnitHom]
+  · -- `G = 0`: the coefficients of `f` at the indices coprime to `L` are those of `G`
+    left
+    intro n hn
+    have hG0 : (⇑G : ℍ → ℂ) = 0 := by rw [hGφ, hφ0, SlashAction.zero_slash, smul_zero]
+    have h := hGcoeff n
+    rw [hG0, qExpansion_zero, map_zero, ite_eq_left hn] at h
+    exact h.symm
+
+end TauCeti

--- a/TauCeti/NumberTheory/ModularForms/Newforms/CoprimeFilter/Dichotomy.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/CoprimeFilter/Dichotomy.lean
@@ -64,10 +64,18 @@ with `p ∣ N` prime and `L` coprime to `p` with primes dividing `N`: either `f`
 every index coprime to `L`, or the nebentypus factors through `N / p`.
 
 The second branch is stated with Mathlib's `DirichletCharacter.FactorsThrough`, whose `χ₀` and
-`eq_changeLevel` give back the lowered unit homomorphism `χ₀` and the factorisation
-`χ = χ₀ ∘ unitsMap` that the descent lemmas consume:
-`⟨hfac.χ₀.toUnitHom, by rw [← MulChar.equivToUnitHom.apply_symm_apply χ];
-conv_lhs => rw [hfac.eq_changeLevel]; rw [DirichletCharacter.changeLevel_toUnitHom]⟩`. -/
+`eq_changeLevel` give back the lowered unit homomorphism and the factorisation
+`χ = χ₀ ∘ unitsMap` that the descent lemmas consume. Note that `hfac.χ₀` mentions `χ` through
+the type of `hfac`, so the conversion goes forwards, by applying `MulChar.toUnitHom` to
+`eq_changeLevel` rather than by rewriting `χ` in the goal:
+
+```text
+have hψχ : (MulChar.ofUnitHom χ).toUnitHom = χ := MulChar.equivToUnitHom.apply_symm_apply χ
+have hcomp : χ = (hfac.χ₀).toUnitHom.comp (ZMod.unitsMap (Nat.div_dvd_of_dvd hpN)) := by
+  have h := congrArg MulChar.toUnitHom hfac.eq_changeLevel
+  rwa [DirichletCharacter.changeLevel_toUnitHom, hψχ] at h
+```
+-/
 theorem qExpansion_coeff_eq_zero_of_coprime_or_factorsThrough (χ : (ZMod N)ˣ →* ℂˣ)
     {f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k} (hf : f ∈ cuspFormCharSpace k χ) {p L : ℕ}
     (hp : p.Prime) (hpN : p ∣ N) (hLN : L.primeFactors ⊆ N.primeFactors)

--- a/TauCeti/NumberTheory/ModularForms/Newforms/CoprimeFilter/Dichotomy.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/CoprimeFilter/Dichotomy.lean
@@ -63,18 +63,9 @@ variable {N : ℕ} [NeZero N] {k : ℤ}
 with `p ∣ N` prime and `L` coprime to `p` with primes dividing `N`: either `f` vanishes at
 every index coprime to `L`, or the nebentypus factors through `N / p`.
 
-The second branch is stated with Mathlib's `DirichletCharacter.FactorsThrough`, whose `χ₀` and
-`eq_changeLevel` give back the lowered unit homomorphism and the factorisation
-`χ = χ₀ ∘ unitsMap` that the descent lemmas consume. Note that `hfac.χ₀` mentions `χ` through
-the type of `hfac`, so the conversion goes forwards, by applying `MulChar.toUnitHom` to
-`eq_changeLevel` rather than by rewriting `χ` in the goal:
-
-```text
-have hψχ : (MulChar.ofUnitHom χ).toUnitHom = χ := MulChar.equivToUnitHom.apply_symm_apply χ
-have hcomp : χ = (hfac.χ₀).toUnitHom.comp (ZMod.unitsMap (Nat.div_dvd_of_dvd hpN)) := by
-  have h := congrArg MulChar.toUnitHom hfac.eq_changeLevel
-  rwa [DirichletCharacter.changeLevel_toUnitHom, hψχ] at h
-```
+The second branch is stated with Mathlib's `DirichletCharacter.FactorsThrough`: its `χ₀`, `dvd`
+and `eq_changeLevel` give a consumer the lowered character modulo `N / p` and the factorisation
+of `χ` through it, which is what the descent lemmas take.
 -/
 theorem qExpansion_coeff_eq_zero_of_coprime_or_factorsThrough (χ : (ZMod N)ˣ →* ℂˣ)
     {f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k} (hf : f ∈ cuspFormCharSpace k χ) {p L : ℕ}

--- a/TauCeti/NumberTheory/ModularForms/Newforms/CoprimeFilter/Dichotomy.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/CoprimeFilter/Dichotomy.lean
@@ -5,16 +5,15 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.NumberTheory.ModularForms.ConductorDichotomy
 public import TauCeti.NumberTheory.ModularForms.Newforms.CoprimeFilter.Basic
-public import TauCeti.NumberTheory.ModularForms.Newforms.Descent.Basic
-import TauCeti.NumberTheory.DirichletCharacter.Basic
+import TauCeti.NumberTheory.ModularForms.ConductorDichotomy
+import TauCeti.NumberTheory.ModularForms.Newforms.Descent.Basic
 
 /-!
 # The factor dichotomy of the coprime sieve
 
-Let `f ∈ S_k(Γ₁(N), χ)` vanish at every index coprime to `p L`, for a prime `p ∣ N` and a
-nonzero `L` coprime to `p` whose primes divide `N`. Either `f` already vanishes at every index
+Let `f ∈ S_k(Γ₁(N), χ)` vanish at every index coprime to `p L`, for a prime `p ∣ N` and an
+`L` coprime to `p` (so `L ≠ 0`) whose primes divide `N`. Either `f` already vanishes at every index
 coprime to `L`, or the nebentypus `χ` is the pull-back of a character modulo `N / p`. This is
 the case split of Miyake's proof of Lemma 4.6.8 (the Main Lemma of Diamond–Shurman §5.7, per
 character): the second case is what a later descent along `p` needs, and in the first the prime
@@ -60,15 +59,17 @@ namespace TauCeti
 variable {N : ℕ} [NeZero N] {k : ℤ}
 
 /-- **The factor dichotomy.** For `f ∈ S_k(Γ₁(N), χ)` vanishing at every index coprime to `p L`,
-with `p ∣ N` prime and `L ≠ 0` coprime to `p` with primes dividing `N`: either `f` vanishes at
+with `p ∣ N` prime and `L` coprime to `p` with primes dividing `N`: either `f` vanishes at
 every index coprime to `L`, or `χ` is the pull-back of a character modulo `N / p`. -/
 theorem qExpansion_coeff_eq_zero_of_coprime_or_exists_eq_comp_unitsMap (χ : (ZMod N)ˣ →* ℂˣ)
     {f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k} (hf : f ∈ cuspFormCharSpace k χ) {p L : ℕ}
-    [NeZero L] (hp : p.Prime) (hpN : p ∣ N) (hLN : L.primeFactors ⊆ N.primeFactors)
+    (hp : p.Prime) (hpN : p ∣ N) (hLN : L.primeFactors ⊆ N.primeFactors)
     (hpL : Nat.Coprime p L) (hvan : ∀ n, Nat.Coprime n (p * L) → (qExpansion 1 f).coeff n = 0) :
     (∀ n, Nat.Coprime n L → (qExpansion 1 f).coeff n = 0) ∨
       ∃ χ₀ : (ZMod (N / p))ˣ →* ℂˣ, χ = χ₀.comp (ZMod.unitsMap (Nat.div_dvd_of_dvd hpN)) := by
   have : NeZero p := ⟨hp.ne_zero⟩
+  -- `L ≠ 0`: a prime is not coprime to `0`
+  have : NeZero L := ⟨by rintro rfl; exact hp.ne_one ((Nat.coprime_zero_right p).mp hpL)⟩
   -- the filter lives at the level `L' N`, `L'` the radical of `L`
   obtain ⟨G, hGχ, hGsupp, hGcoeff⟩ :=
     exists_mem_cuspFormCharSpace_qExpansionSupportedOnDvd χ hf hp hLN hvan

--- a/TauCeti/NumberTheory/ModularForms/Newforms/CoprimeFilter/Dichotomy.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/CoprimeFilter/Dichotomy.lean
@@ -65,7 +65,8 @@ every index coprime to `L`, or the nebentypus factors through `N / p`.
 
 The second branch is stated with Mathlib's `DirichletCharacter.FactorsThrough`: its `χ₀`, `dvd`
 and `eq_changeLevel` give a consumer the lowered character modulo `N / p` and the factorisation
-of `χ` through it, which is what the descent lemmas take.
+of `χ` through it, which is what the descent lemmas take —
+`DirichletCharacter.exists_comp_unitsMap_of_factorsThrough` packages that conversion.
 -/
 theorem qExpansion_coeff_eq_zero_of_coprime_or_factorsThrough (χ : (ZMod N)ˣ →* ℂˣ)
     {f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k} (hf : f ∈ cuspFormCharSpace k χ) {p L : ℕ}

--- a/TauCeti/NumberTheory/ModularForms/Newforms/CoprimeFilter/Dichotomy.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/CoprimeFilter/Dichotomy.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import Mathlib.NumberTheory.DirichletCharacter.Basic
 public import TauCeti.NumberTheory.ModularForms.Newforms.CoprimeFilter.Basic
 import TauCeti.NumberTheory.ModularForms.ConductorDichotomy
 import TauCeti.NumberTheory.ModularForms.Newforms.Descent.Basic
@@ -14,7 +15,7 @@ import TauCeti.NumberTheory.ModularForms.Newforms.Descent.Basic
 
 Let `f ∈ S_k(Γ₁(N), χ)` vanish at every index coprime to `p L`, for a prime `p ∣ N` and an
 `L` coprime to `p` (so `L ≠ 0`) whose primes divide `N`. Either `f` already vanishes at every index
-coprime to `L`, or the nebentypus `χ` is the pull-back of a character modulo `N / p`. This is
+coprime to `L`, or the nebentypus `χ` factors through `N / p`. This is
 the case split of Miyake's proof of Lemma 4.6.8 (the Main Lemma of Diamond–Shurman §5.7, per
 character): the second case is what a later descent along `p` needs, and in the first the prime
 `p` needs no descent at all.
@@ -30,7 +31,7 @@ indices coprime to `L`.
 
 ## Main results
 
-* `TauCeti.qExpansion_coeff_eq_zero_of_coprime_or_exists_eq_comp_unitsMap`: the dichotomy.
+* `TauCeti.qExpansion_coeff_eq_zero_of_coprime_or_factorsThrough`: the dichotomy.
 
 ## Provenance
 
@@ -60,13 +61,19 @@ variable {N : ℕ} [NeZero N] {k : ℤ}
 
 /-- **The factor dichotomy.** For `f ∈ S_k(Γ₁(N), χ)` vanishing at every index coprime to `p L`,
 with `p ∣ N` prime and `L` coprime to `p` with primes dividing `N`: either `f` vanishes at
-every index coprime to `L`, or `χ` is the pull-back of a character modulo `N / p`. -/
-theorem qExpansion_coeff_eq_zero_of_coprime_or_exists_eq_comp_unitsMap (χ : (ZMod N)ˣ →* ℂˣ)
+every index coprime to `L`, or the nebentypus factors through `N / p`.
+
+The second branch is stated with Mathlib's `DirichletCharacter.FactorsThrough`, whose `χ₀` and
+`eq_changeLevel` give back the lowered unit homomorphism `χ₀` and the factorisation
+`χ = χ₀ ∘ unitsMap` that the descent lemmas consume:
+`⟨hfac.χ₀.toUnitHom, by rw [← MulChar.equivToUnitHom.apply_symm_apply χ];
+conv_lhs => rw [hfac.eq_changeLevel]; rw [DirichletCharacter.changeLevel_toUnitHom]⟩`. -/
+theorem qExpansion_coeff_eq_zero_of_coprime_or_factorsThrough (χ : (ZMod N)ˣ →* ℂˣ)
     {f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k} (hf : f ∈ cuspFormCharSpace k χ) {p L : ℕ}
     (hp : p.Prime) (hpN : p ∣ N) (hLN : L.primeFactors ⊆ N.primeFactors)
     (hpL : Nat.Coprime p L) (hvan : ∀ n, Nat.Coprime n (p * L) → (qExpansion 1 f).coeff n = 0) :
     (∀ n, Nat.Coprime n L → (qExpansion 1 f).coeff n = 0) ∨
-      ∃ χ₀ : (ZMod (N / p))ˣ →* ℂˣ, χ = χ₀.comp (ZMod.unitsMap (Nat.div_dvd_of_dvd hpN)) := by
+      DirichletCharacter.FactorsThrough (MulChar.ofUnitHom χ) (N / p) := by
   have : NeZero p := ⟨hp.ne_zero⟩
   -- `L ≠ 0`: a prime is not coprime to `0`
   have : NeZero L := ⟨by rintro rfl; exact hp.ne_one ((Nat.coprime_zero_right p).mp hpL)⟩
@@ -81,22 +88,17 @@ theorem qExpansion_coeff_eq_zero_of_coprime_or_exists_eq_comp_unitsMap (χ : (ZM
   obtain ⟨φ, hGφ, hφT⟩ :=
     CuspForm.exists_eq_smul_slash_scaleGL_and_slash_T_eq_of_qExpansionSupportedOnDvd G hGsupp
   -- the nebentypus of `G` is the level-`L N` lift of `χ`, as a Dirichlet character
-  set ψ : DirichletCharacter ℂ N := MulChar.ofUnitHom χ with hψ
-  have hψχ : ψ.toUnitHom = χ := MulChar.equivToUnitHom.apply_symm_apply χ
-  have hGψ : G ∈ cuspFormCharSpace k (DirichletCharacter.changeLevel hNLN ψ).toUnitHom := by
+  have hψχ : (MulChar.ofUnitHom χ).toUnitHom = χ := MulChar.equivToUnitHom.apply_symm_apply χ
+  have hGψ : G ∈ cuspFormCharSpace k
+      (DirichletCharacter.changeLevel hNLN (MulChar.ofUnitHom χ)).toUnitHom := by
     rwa [DirichletCharacter.changeLevel_toUnitHom, hψχ]
   rcases exists_cuspForm_mem_cuspFormCharSpace_or_eq_zero hpLN k _ φ G hGψ hGφ hφT with
     ⟨hfac, -, -, -⟩ | hφ0
   · -- `χ` lifted to level `L N` factors through `L N / p`, so `χ` factors through `N / p`
-    right
-    have hfac' := DirichletCharacter.factorsThrough_div_of_changeLevel_factorsThrough hpN hpL' hfac
-    refine ⟨hfac'.χ₀.toUnitHom, ?_⟩
-    rw [← hψχ]
-    conv_lhs => rw [hfac'.eq_changeLevel]
-    rw [DirichletCharacter.changeLevel_toUnitHom]
+    exact Or.inr
+      (DirichletCharacter.factorsThrough_div_of_changeLevel_factorsThrough hpN hpL' hfac)
   · -- `G = 0`: the coefficients of `f` at the indices coprime to `L` are those of `G`
-    left
-    intro n hn
+    refine Or.inl fun n hn ↦ ?_
     have hG0 : (⇑G : ℍ → ℂ) = 0 := by rw [hGφ, hφ0, SlashAction.zero_slash, smul_zero]
     have h := hGcoeff n
     rw [hG0, qExpansion_zero, map_zero, ite_eq_left hn] at h


### PR DESCRIPTION
Miyake's proof of Lemma 4.6.8 (the Main Lemma of Diamond–Shurman §5.7, per character) descends one prime at a time, and at each prime it first asks whether the descent is needed at all. This PR is that case split.

**New file** `TauCeti/NumberTheory/ModularForms/Newforms/CoprimeFilter/Dichotomy.lean` (namespace `TauCeti`):

- `qExpansion_coeff_eq_zero_of_coprime_or_factorsThrough`: **the factor dichotomy.** For `f ∈ S_k(Γ₁(N), χ)` vanishing at every index coprime to `p L`, with `p ∣ N` prime and `L` coprime to `p` (hence nonzero) with primes dividing `N`: either `f` vanishes at every index coprime to `L`, or `χ`, as a Dirichlet character, `FactorsThrough (N / p)` — Mathlib's interface, whose `χ₀` and `eq_changeLevel` give back the lowered unit homomorphism and the factorisation `χ = χ₀ ∘ unitsMap` that the descent lemmas take (round 4). The coprime filter of `f` (`CoprimeFilter/Basic.lean`) is a form `G` of level `L' N`, `L'` the radical of `L`, supported on the multiples of `p` and carrying the coefficients of `f` at the indices coprime to `L`; the level-lowering dichotomy (`ConductorDichotomy.lean`) either finds `G` to be a level-raise from `L' N / p`, so that the lifted character `changeLevel χ` factors through `L' N / p` and, since `changeLevel` preserves the conductor, `cond χ ∣ gcd(N, L' N / p) = N / p`, or forces `G = 0`, which is the required vanishing of the coefficients of `f` at the indices coprime to `L`. (Round 1: the statement no longer assumes `L` squarefree — the filter at the radical makes that unnecessary. Round 2: nor `L ≠ 0`, which follows from `p` prime and coprime to `L`. Round 4: the conductor descent is stated at a general gcd, `DirichletCharacter.factorsThrough_gcd_of_changeLevel_factorsThrough`, with the `L N / p ↦ N / p` case derived from it.)

**Also touched** (round 1): `TauCeti/NumberTheory/DirichletCharacter/Basic.lean` gains `DirichletCharacter.factorsThrough_div_of_changeLevel_factorsThrough` — a factorisation of the lift of `ψ` mod `N` to level `L N` through `L N / p`, for `p ∣ N` coprime to `L`, descends to a factorisation of `ψ` through `N / p` — for characters valued in any `CommMonoidWithZero`. Its conductor bookkeeping is Mathlib's `DirichletCharacter.conductor_dvd_of_mem_conductorSet`, `mem_conductorSet_iff_conductor_dvd` and `conductor_changeLevel`, so nothing about conductors themselves is added.

**Consumption.** The inductive step of the Main Lemma (next PR: the descent witness of level `N / p` lifted back to level `N`, then the outer induction over the primes of `N`) branches on this dichotomy: in the second case it descends along `p`, in the first it drops `p` from the set of primes still to be handled.

Roadmap: ModularForms

No `tauceti-target:v1` marker: this is a prerequisite step for the Layer 4A Atkin–Lehner Main Lemma node (the per-character route `mainLemma_charSpace_routeB`, through Miyake's Lemma 4.6.8) rather than the node itself, and the contract asks for a deterministic identifier of the target, not a free-form slug.

Provenance: github.com/CBirkbeck/AINTLIB @ `eb9621e7bcb0ce220ad53983ec45d987cb5b9002` (Apache-2.0, Chris Birkbeck), `projects/LeanModularForms/LeanModularForms/StrongMultiplicityOne/InductiveStep.lean` — `miyake_4_6_8_factor_dichotomy`; its private conductor lemmas are Mathlib's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQieFQn95rzgvYRvNdX3hR
