### PR TITLE
feat(EllipticCurve): the coordinate subfield sits twice the degree below the function field

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/Finrank.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/Finrank.lean
@@ -55,6 +55,8 @@ rational function field that sits *inside* `R(W)` as an intermediate field.
   acting on `F(W)`.
 * `WeierstrassCurve.Affine.relfinrank_map_ratFuncRange_fieldRange`: mapping the pair
   `F(x) ⊆ F(W)` along a function-field embedding preserves its relative degree two.
+* `WeierstrassCurve.Affine.finrank_map_ratFuncRange`: consequently the image of `F(x)` sits twice
+  the degree of the image of `F(W)` below the target.
 
 Exporting the algebra instance is safe here for the reason Mathlib withholds it in general: the
 collision is with the identity structure on `FractionRing R[X]`, and `R(W)` is a *quadratic*
@@ -227,6 +229,18 @@ theorem relfinrank_map_ratFuncRange_fieldRange {M : Type*} [Field M] [Algebra F 
     IntermediateField.relfinrank ((ratFuncRange W).map f) f.fieldRange = 2 := by
   rw [AlgHom.fieldRange_eq_map, IntermediateField.relfinrank_map_map,
     IntermediateField.relfinrank_top_right, finrank_ratFuncRange]
+
+/-- **The image of `F(x)` sits twice the degree of the image of `F(W)` below the target**, the
+bottom step of the tower having relative degree `2`. It converts a degree over the image of `F(W)`
+into one over a rational subfield. -/
+@[simp]
+theorem finrank_map_ratFuncRange {M : Type*} [Field M] [Algebra F M]
+    (f : W.FunctionField →ₐ[F] M) :
+    Module.finrank ((ratFuncRange W).map f) M = 2 * Module.finrank f.fieldRange M := by
+  have hle : (ratFuncRange W).map f ≤ f.fieldRange := by
+    rw [AlgHom.fieldRange_eq_map]
+    exact IntermediateField.map_mono _ le_top
+  rw [← IntermediateField.relfinrank_mul_finrank_top hle, relfinrank_map_ratFuncRange_fieldRange]
 
 end Field
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Degree.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Degree.lean
@@ -50,6 +50,8 @@ degree off any algebra structure whose structure map is the pullback.
 * `TauCeti.Isogeny.degree_eq_one_iff`: degree one means the function-field pullback is onto;
   `TauCeti.Isogeny.degree_id` is the identity's case, and is the `@[simp]` normal form of a
   degree.
+* `TauCeti.Isogeny.finrank_map_ratFuncRange_fieldPullback`: the pulled-back coordinate subfield
+  sits `2 · deg φ` below the function field.
 * `TauCeti.Isogeny.degree_comp`: **the tower formula** `deg (ψ ∘ φ) = deg ψ * deg φ`.
 
 These are the `Isogeny.finiteDimensional` and `degree_pos` seeds of
@@ -63,6 +65,15 @@ map of curves finite.
 in that shared upstream development, in its function-field form, ahead of the mathlib PRs
 (`TauCetiRoadmap/EllipticCurves/README.md` §Provenance). It is built here until those land; the
 proofs below are written against the coordinate-ring form rather than ported.
+
+## Provenance
+
+`degree` and `finiteDimensional` are as described above. Separately,
+`finrank_map_ratFuncRange_fieldPullback` is an identity the AINTLIB `HasseWeil` project (Chris
+Birkbeck, Apache 2.0, commit `513e83879e2f8cbc626eb9e04d660e92be16ccba`) needs for its point count
+and assumes rather than proves: it is the hypothesis `h_tower_witness` of
+`bridgeA_intermediateField_finrank_eq_two_mul_degree_of_witness` in
+`Hasse/SepDegreeEqPointCount.lean`.
 
 ## References
 
@@ -191,6 +202,18 @@ theorem degree_comp (ψ : Isogeny W₂ W₃) (φ : Isogeny W₁ W₂) :
     (ψ.comp φ).fieldPullback.algebraMap_toAlgebra_apply
   rw [φ.degree_eq_finrank hφ, ψ.degree_eq_finrank hψ, (ψ.comp φ).degree_eq_finrank hc]
   exact (Module.finrank_mul_finrank W₃.FunctionField W₂.FunctionField W₁.FunctionField).symm
+
+/-- **The pulled-back coordinate subfield sits `2 · deg φ` below the function field**, converting
+the isogeny's degree into a degree over a rational subfield. Over a finite base that is what a
+point count is read through, but nothing here is restricted to one and no count is proved. -/
+-- Higher priority than the generic `WeierstrassCurve.Affine.finrank_map_ratFuncRange`, so that this
+-- fires first and the normal form is `2 * φ.degree` rather than `2 * finrank …fieldRange …`.
+@[simp 1100]
+theorem finrank_map_ratFuncRange_fieldPullback (φ : Isogeny W₁ W₂) :
+    Module.finrank ((WeierstrassCurve.Affine.ratFuncRange W₂).map φ.fieldPullback)
+      W₁.FunctionField = 2 * φ.degree :=
+  (WeierstrassCurve.Affine.finrank_map_ratFuncRange W₂ φ.fieldPullback).trans
+    (congrArg (2 * ·) (φ.degree_def).symm)
 
 /-- **Both factors of an identity composite have degree one.** Degree is multiplicative and the
 identity has degree one, and `1` factors in `ℕ` only as `1 * 1`. -/


### PR DESCRIPTION
Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"EllipticCurves/STATUS.md:frontier:hasse-bound:coordinate-tower"}-->

Provenance: the AINTLIB `HasseWeil` project (Chris Birkbeck, Apache-2.0, `513e83879e2f8cbc626eb9e04d660e92be16ccba`) needs this identity for its point count and does **not** prove it: `Hasse/SepDegreeEqPointCount.lean` ships it as the witness hypothesis `h_tower_witness` of `bridgeA_intermediateField_finrank_eq_two_mul_degree_of_witness`, with a comment describing the intended tower argument. The proof here is that argument, carried out with this repository's own relative-degree API.

## What this adds

Two theorems. The content is generic, so it is stated for an arbitrary function-field embedding and specialised afterwards.

`WeierstrassCurve.Affine.finrank_map_ratFuncRange`, in `Affine/FunctionField/Finrank.lean`: for any `f : W.FunctionField →ₐ[F] M`,

```
Module.finrank ((ratFuncRange W).map f) M = 2 * Module.finrank f.fieldRange M
```

The tower is `f(F(x)) ⊆ f(F(W)) ⊆ M`. The bottom step has relative degree `2`, which is the neighbouring `relfinrank_map_ratFuncRange_fieldRange`; `IntermediateField.relfinrank_mul_finrank_top` multiplies the two steps.

`TauCeti.Isogeny.finrank_map_ratFuncRange_fieldPullback`, in `Isogeny/Degree.lean`, is the isogeny-facing corollary, `@[simp]`:

```
Module.finrank ((ratFuncRange W₂).map φ.fieldPullback) W₁.FunctionField = 2 * φ.degree
```

since the degree is by definition the upper step.

## Why

This is the step that turns an isogeny's degree into a degree over a *rational* subfield, which is where places can be counted. It is the bridge the Hasse-bound point count `deg (1 − π_q) = #E(𝔽_q)` is read through, and it is the one part of that route the provenance leaves unproved.

No hypotheses are needed beyond having an embedding: no ellipticity, no separability, no finiteness of the base, and in the general form no isogeny either. Both proofs are a few lines because the two steps of the tower are already on `main`; nothing new is built here.
