### PR TITLE
feat(Isogeny): the kernel order divides the separable degree

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/Translation/FixedField.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/Translation/FixedField.lean
@@ -59,6 +59,10 @@ arbitrary finite subgroup of points, no isogeny being needed to state or prove t
 * `WeierstrassCurve.Affine.card_translationFixingSubgroup_le` and
   `WeierstrassCurve.Affine.finite_of_finiteDimensional_translationFixedField`: a degree bounds the
   translations that fix it.
+* `WeierstrassCurve.Affine.card_translationFixingSubgroup_dvd_finSepDegree`: the order of the
+  subgroup fixing an intermediate field of finite degree divides the separable degree above it.
+* `WeierstrassCurve.Affine.card_translationFixingSubgroup_eq_finrank_iff`: that order is the full
+  degree exactly when the subgroup cuts the field back out.
 
 ## References
 
@@ -258,5 +262,44 @@ theorem eq_of_translationFixedField_eq [Finite Φ]
   have : Finite Ψ := finite_of_finiteDimensional_translationFixedField W Ψ
   rw [← translationFixingSubgroup_translationFixedField W Φ, h,
     translationFixingSubgroup_translationFixedField W Ψ]
+
+/-- **The order of the fixing subgroup of `L` divides the separable degree of `K(W)` over `L`.**
+The field the subgroup cuts out is Galois over `L`, hence separable, so its degree — the order of
+the subgroup — is one factor of the separable degree of the whole extension. -/
+theorem card_translationFixingSubgroup_dvd_finSepDegree (L : IntermediateField F W.FunctionField)
+    [FiniteDimensional L W.FunctionField] :
+    Nat.card (translationFixingSubgroup W L) ∣ Field.finSepDegree L W.FunctionField := by
+  have hle := le_translationFixedField_translationFixingSubgroup W L
+  -- `extendScalars hle` is `translationFixedField W (translationFixingSubgroup W L)` with its base
+  -- enlarged from `F` to `L`. It is the same subfield of `K(W)`, so it sits under `K(W)` in the
+  -- same way; the `change`s name that identification where it is used
+  have hsep : Algebra.IsSeparable (IntermediateField.extendScalars hle) W.FunctionField := by
+    change Algebra.IsSeparable (translationFixedField W (translationFixingSubgroup W L))
+      W.FunctionField
+    infer_instance
+  have hrk : Module.finrank (IntermediateField.extendScalars hle) W.FunctionField =
+      Nat.card (translationFixingSubgroup W L) := by
+    change Module.finrank (translationFixedField W (translationFixingSubgroup W L))
+      W.FunctionField = _
+    exact finrank_translationFixedField W _
+  have htop : Field.finSepDegree (IntermediateField.extendScalars hle) W.FunctionField =
+      Nat.card (translationFixingSubgroup W L) := by
+    rw [Field.finSepDegree_eq_finrank_of_isSeparable, hrk]
+  rw [← Field.finSepDegree_mul_finSepDegree_of_isAlgebraic L
+    (IntermediateField.extendScalars hle) W.FunctionField, htop]
+  exact Dvd.intro_left _ rfl
+
+/-- **The fixing subgroup of `L` has order the degree of `K(W)` over `L` exactly when it cuts `L`
+back out.** One inclusion holds for every `L`, so the cardinality statement and the reverse
+inclusion are two names for the same thing: a single field-theoretic statement to aim at in place
+of a cardinality one. -/
+theorem card_translationFixingSubgroup_eq_finrank_iff (L : IntermediateField F W.FunctionField)
+    [FiniteDimensional L W.FunctionField] :
+    Nat.card (translationFixingSubgroup W L) = Module.finrank L W.FunctionField ↔
+      translationFixedField W (translationFixingSubgroup W L) ≤ L := by
+  have hle := le_translationFixedField_translationFixingSubgroup W L
+  rw [← finrank_translationFixedField W (translationFixingSubgroup W L), eq_comm,
+    ← IntermediateField.eq_iff_finrank_eq_of_le' hle]
+  exact ⟨fun h ↦ h.ge, le_antisymm hle⟩
 
 end WeierstrassCurve.Affine

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/Translation/FixedField.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/Translation/FixedField.lean
@@ -264,8 +264,8 @@ theorem eq_of_translationFixedField_eq [Finite Φ]
     translationFixingSubgroup_translationFixedField W Ψ]
 
 /-- **The order of the fixing subgroup of `L` divides the separable degree of `K(W)` over `L`.**
-The field the subgroup cuts out is Galois over `L`, hence separable, so its degree — the order of
-the subgroup — is one factor of the separable degree of the whole extension. -/
+`K(W)` is Galois, hence separable, over the field the subgroup cuts out, and that relative degree is
+the order of the subgroup; it is therefore one factor of the separable degree over `L`. -/
 theorem card_translationFixingSubgroup_dvd_finSepDegree (L : IntermediateField F W.FunctionField)
     [FiniteDimensional L W.FunctionField] :
     Nat.card (translationFixingSubgroup W L) ∣ Field.finSepDegree L W.FunctionField := by

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Kernel.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Kernel.lean
@@ -31,6 +31,8 @@ is proved here.
 
 ## Main results
 
+* `TauCeti.Isogeny.fieldPullback_fieldRange_le_translationFixedField_ker`: the pulled-back field is
+  fixed by the kernel.
 * `TauCeti.Isogeny.card_ker_le_degree`: the kernel has at most `deg φ` elements.
 * `TauCeti.Isogeny.ker_le_ker_comp`: postcomposition can only enlarge the kernel.
 * `TauCeti.Isogeny.ker_eq_bot_of_separableDegree_eq_one`: separable degree one forces this kernel
@@ -39,8 +41,6 @@ is proved here.
   reverse fixed-field inclusion.
 * `TauCeti.Isogeny.card_ker_dvd_separableDegree` and `card_ker_le_separableDegree`: the kernel
   order divides, so is bounded by, the separable degree.
-* `TauCeti.Isogeny.fieldPullback_fieldRange_le_translationFixedField_ker`: the pulled-back field is
-  fixed by the kernel.
 
 ## Provenance
 
@@ -92,36 +92,20 @@ theorem ker_le_ker_comp {W₃ : WeierstrassCurve.Affine F} (ψ : Isogeny W₂ W�
   rintro _ ⟨z, rfl⟩
   exact AlgHom.mem_fieldRange.2 ⟨ψ.fieldPullback z, by rw [comp_fieldPullback]; rfl⟩
 
-/-- **The pulled-back field is fixed by the kernel.** The kernel's interaction with the fixed-field
-operation, so that a consumer can use `ker` without unfolding it to a fixing subgroup. This is the
-inclusion that holds for every isogeny; the reverse one is the content of
+/-- **The pulled-back field is fixed by the kernel**, the kernel's interaction with the fixed-field
+operation. This is the inclusion that holds for every isogeny; the reverse one is the content of
 `card_ker_eq_degree_iff`. -/
 theorem fieldPullback_fieldRange_le_translationFixedField_ker (φ : Isogeny W₁ W₂) :
     φ.fieldPullback.fieldRange ≤ translationFixedField W₁ φ.ker := by
   rw [ker_def]; exact le_translationFixedField_translationFixingSubgroup W₁ _
 
-/-- **The kernel order divides the separable degree.** The extension cut out by the kernel is
-Galois, hence separable, so its degree — the order of the kernel — is one factor of the separable
-degree of the whole extension.
-
-This is the general form of the identity a point count needs: the separable degree is what the
-kernel can see, and the missing factor is the separable degree of the pulled-back field inside the
-field the kernel cuts out. -/
+/-- **The kernel order divides the separable degree**, the kernel being the subgroup of
+translations fixing the pulled-back field and that field having finite degree. -/
 theorem card_ker_dvd_separableDegree (φ : Isogeny W₁ W₂) :
     Nat.card φ.ker ∣ φ.separableDegree := by
-  have hle := φ.fieldPullback_fieldRange_le_translationFixedField_ker
-  -- `extendScalars hle` is the same subfield seen over `φ^*K(W₂)`; the two share a carrier, so
-  -- these transport definitionally, which instance search does not see through
-  have hsep : Algebra.IsSeparable (IntermediateField.extendScalars hle) W₁.FunctionField :=
-    inferInstanceAs (Algebra.IsSeparable (translationFixedField W₁ φ.ker) W₁.FunctionField)
-  have hrk : Module.finrank (IntermediateField.extendScalars hle) W₁.FunctionField =
-      Nat.card φ.ker := finrank_translationFixedField W₁ φ.ker
-  have htop : Field.finSepDegree (IntermediateField.extendScalars hle) W₁.FunctionField =
-      Nat.card φ.ker := by
-    rw [Field.finSepDegree_eq_finrank_of_isSeparable, hrk]
-  rw [separableDegree_def, ← Field.finSepDegree_mul_finSepDegree_of_isAlgebraic
-    φ.fieldPullback.fieldRange (IntermediateField.extendScalars hle) W₁.FunctionField, htop]
-  exact Dvd.intro_left _ rfl
+  have := φ.finiteDimensional
+  rw [ker_def, separableDegree_def]
+  exact card_translationFixingSubgroup_dvd_finSepDegree W₁ _
 
 /-- **The separable degree bounds the kernel**, sharpening the bound by the degree. -/
 theorem card_ker_le_separableDegree (φ : Isogeny W₁ W₂) :
@@ -149,8 +133,7 @@ theorem ker_eq_bot_of_degree_eq_one {φ : Isogeny W₁ W₂} (h : φ.degree = 1)
 
 /-- **The kernel counts the degree exactly when it cuts out the pulled-back field.** This is a
 *reduction*, not the separable-locus theorem: one inclusion holds for free, so the cardinality
-statement and the reverse inclusion are two names for the same thing. What it buys is a single
-field-theoretic statement to aim at in place of a cardinality one.
+statement and the reverse inclusion are two names for the same thing.
 
 That inclusion is where separability enters, and over a base field that is not separably closed it
 can fail: the kernel here consists of the rational points, while the extension is cut out by the
@@ -159,15 +142,9 @@ here. -/
 theorem card_ker_eq_degree_iff (φ : Isogeny W₁ W₂) :
     Nat.card φ.ker = φ.degree ↔
       translationFixedField W₁ φ.ker ≤ φ.fieldPullback.fieldRange := by
-  have hle := φ.fieldPullback_fieldRange_le_translationFixedField_ker
-  have htower := IntermediateField.relfinrank_mul_finrank_top hle
-  rw [finrank_translationFixedField W₁ φ.ker, ← degree_def] at htower
-  refine ⟨fun hcard ↦ ?_, fun h ↦ ?_⟩
-  · refine IntermediateField.relfinrank_eq_one_iff.1 ?_
-    rw [hcard] at htower
-    exact Nat.eq_of_mul_eq_mul_right φ.degree_pos (htower.trans (one_mul _).symm)
-  · have hfield : translationFixedField W₁ φ.ker = φ.fieldPullback.fieldRange := le_antisymm h hle
-    rw [← finrank_translationFixedField W₁ φ.ker, hfield, ← degree_def]
+  have := φ.finiteDimensional
+  rw [ker_def, degree_def]
+  exact card_translationFixingSubgroup_eq_finrank_iff W₁ _
 
 /-- **The identity isogeny has trivial kernel.** -/
 @[simp]

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Kernel.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Kernel.lean
@@ -31,8 +31,6 @@ is proved here.
 
 ## Main results
 
-* `TauCeti.Isogeny.fieldPullback_fieldRange_le_translationFixedField_ker`: the pulled-back field is
-  fixed by the kernel.
 * `TauCeti.Isogeny.card_ker_le_degree`: the kernel has at most `deg φ` elements.
 * `TauCeti.Isogeny.ker_le_ker_comp`: postcomposition can only enlarge the kernel.
 * `TauCeti.Isogeny.ker_eq_bot_of_separableDegree_eq_one`: separable degree one forces this kernel
@@ -91,13 +89,6 @@ theorem ker_le_ker_comp {W₃ : WeierstrassCurve.Affine F} (ψ : Isogeny W₂ W�
   refine translationFixingSubgroup_antitone W₁ ?_
   rintro _ ⟨z, rfl⟩
   exact AlgHom.mem_fieldRange.2 ⟨ψ.fieldPullback z, by rw [comp_fieldPullback]; rfl⟩
-
-/-- **The pulled-back field is fixed by the kernel**, the kernel's interaction with the fixed-field
-operation. This is the inclusion that holds for every isogeny; the reverse one is the content of
-`card_ker_eq_degree_iff`. -/
-theorem fieldPullback_fieldRange_le_translationFixedField_ker (φ : Isogeny W₁ W₂) :
-    φ.fieldPullback.fieldRange ≤ translationFixedField W₁ φ.ker := by
-  rw [ker_def]; exact le_translationFixedField_translationFixingSubgroup W₁ _
 
 /-- **The kernel order divides the separable degree**, the kernel being the subgroup of
 translations fixing the pulled-back field and that field having finite degree. -/

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Kernel.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Kernel.lean
@@ -127,10 +127,6 @@ theorem ker_eq_bot_of_separableDegree_eq_one {φ : Isogeny W₁ W₂} (h : φ.se
     φ.ker = ⊥ :=
   φ.ker.eq_bot_of_card_le (h ▸ φ.card_ker_le_separableDegree)
 
-/-- **An isogeny of degree one has trivial kernel.** -/
-theorem ker_eq_bot_of_degree_eq_one {φ : Isogeny W₁ W₂} (h : φ.degree = 1) : φ.ker = ⊥ :=
-  φ.ker.eq_bot_of_card_le (h ▸ φ.card_ker_le_degree)
-
 /-- **The kernel counts the degree exactly when it cuts out the pulled-back field.** This is a
 *reduction*, not the separable-locus theorem: one inclusion holds for free, so the cardinality
 statement and the reverse inclusion are two names for the same thing.
@@ -149,7 +145,7 @@ theorem card_ker_eq_degree_iff (φ : Isogeny W₁ W₂) :
 /-- **The identity isogeny has trivial kernel.** -/
 @[simp]
 theorem ker_id (W : WeierstrassCurve.Affine F) [W.IsElliptic] : (id W).ker = ⊥ :=
-  ker_eq_bot_of_degree_eq_one (degree_id W)
+  ker_eq_bot_of_separableDegree_eq_one (separableDegree_id W)
 
 end TauCeti.Isogeny
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Kernel.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Kernel.lean
@@ -6,7 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.AlgebraicGeometry.EllipticCurve.Affine.FunctionField.Translation.FixedField
-public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.Degree
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.Separability
 
 /-!
 # The kernel of an isogeny
@@ -20,9 +20,10 @@ for every isogeny over every field, with no separability or rationality hypothes
 The degree bounds the kernel: a pulled-back field of degree `d` is fixed by at most `d`
 translations. The bound is often strict, because these are the `F`-rational points only: a
 separable isogeny whose geometric kernel is not rational has fewer of them than its degree.
-Equality needs separability *and* rationality of the whole geometric kernel, which is what the
-point count `deg (1 − π_q) = #E(𝔽_q)` supplies for `1 − π` over a finite field; neither that
-identity nor the general equality is proved here.
+Equality needs separability *and* rationality of the whole geometric kernel. For `1 − π_q` over a
+finite field both hold, its geometric kernel being the `𝔽_q`-rational points, and the point count
+`deg (1 − π_q) = #E(𝔽_q)` is what they then yield; neither that identity nor the general equality
+is proved here.
 
 ## Main definitions
 
@@ -32,7 +33,23 @@ identity nor the general equality is proved here.
 
 * `TauCeti.Isogeny.card_ker_le_degree`: the kernel has at most `deg φ` elements.
 * `TauCeti.Isogeny.ker_le_ker_comp`: postcomposition can only enlarge the kernel.
-* `TauCeti.Isogeny.ker_eq_bot_of_degree_eq_one`: degree one forces a trivial kernel.
+* `TauCeti.Isogeny.ker_eq_bot_of_separableDegree_eq_one`: separable degree one forces this kernel
+  to be trivial, as for Frobenius.
+* `TauCeti.Isogeny.card_ker_eq_degree_iff`: the cardinality statement is *equivalent* to the
+  reverse fixed-field inclusion.
+* `TauCeti.Isogeny.card_ker_dvd_separableDegree` and `card_ker_le_separableDegree`: the kernel
+  order divides, so is bounded by, the separable degree.
+* `TauCeti.Isogeny.fieldPullback_fieldRange_le_translationFixedField_ker`: the pulled-back field is
+  fixed by the kernel.
+
+## Provenance
+
+The AINTLIB `HasseWeil` project (Chris Birkbeck, Apache 2.0, commit
+`513e83879e2f8cbc626eb9e04d660e92be16ccba`) proves the corresponding cardinality statement in
+`EC/SeparableKernelTorsor.lean` as `card_kernel_eq_degree_of_separable_isogeny`, parametric on two
+witnesses. The second exists only because its isogeny carries a point map independent of the
+function-field pullback, so separability and the kernel are a priori unrelated there. The kernel
+here is defined from the pullback, so that witness has no counterpart.
 
 ## References
 
@@ -59,18 +76,12 @@ theorem ker_def (φ : Isogeny W₁ W₂) :
 itself.** -/
 @[simp]
 theorem mem_ker_iff {φ : Isogeny W₁ W₂} {P : (W₁⁄F).toAffine.Point} :
-    P ∈ φ.ker ↔ ∀ z ∈ φ.fieldPullback.fieldRange, translation W₁ P z = z :=
-  mem_translationFixingSubgroup_iff W₁
+    P ∈ φ.ker ↔ ∀ z ∈ φ.fieldPullback.fieldRange, translation W₁ P z = z := by
+  rw [ker_def]; exact mem_translationFixingSubgroup_iff W₁
 
 /-- **The kernel is finite**, the pulled-back field being of finite index. -/
 instance finite_ker (φ : Isogeny W₁ W₂) : Finite φ.ker :=
-  finite_translationFixingSubgroup W₁ φ.fieldPullback.fieldRange
-
-/-- **The degree bounds the kernel**: an isogeny of degree `d` is fixed by at most `d`
-translations. The bound is often strict, this being the rational kernel: equality needs the
-isogeny to be separable and its geometric kernel to be rational. -/
-theorem card_ker_le_degree (φ : Isogeny W₁ W₂) : Nat.card φ.ker ≤ φ.degree :=
-  (card_translationFixingSubgroup_le W₁ φ.fieldPullback.fieldRange).trans_eq (φ.degree_def).symm
+  φ.ker_def ▸ finite_translationFixingSubgroup W₁ φ.fieldPullback.fieldRange
 
 /-- **Postcomposition can only enlarge the kernel**: a function pulled back from `W₃` arrives
 through `W₂`, so a translation fixing everything from `W₂` fixes it too. -/
@@ -81,9 +92,82 @@ theorem ker_le_ker_comp {W₃ : WeierstrassCurve.Affine F} (ψ : Isogeny W₂ W�
   rintro _ ⟨z, rfl⟩
   exact AlgHom.mem_fieldRange.2 ⟨ψ.fieldPullback z, by rw [comp_fieldPullback]; rfl⟩
 
-/-- **An isogeny of degree one has trivial kernel**, the bound leaving no room. -/
+/-- **The pulled-back field is fixed by the kernel.** The kernel's interaction with the fixed-field
+operation, so that a consumer can use `ker` without unfolding it to a fixing subgroup. This is the
+inclusion that holds for every isogeny; the reverse one is the content of
+`card_ker_eq_degree_iff`. -/
+theorem fieldPullback_fieldRange_le_translationFixedField_ker (φ : Isogeny W₁ W₂) :
+    φ.fieldPullback.fieldRange ≤ translationFixedField W₁ φ.ker := by
+  rw [ker_def]; exact le_translationFixedField_translationFixingSubgroup W₁ _
+
+/-- **The kernel order divides the separable degree.** The extension cut out by the kernel is
+Galois, hence separable, so its degree — the order of the kernel — is one factor of the separable
+degree of the whole extension.
+
+This is the general form of the identity a point count needs: the separable degree is what the
+kernel can see, and the missing factor is the separable degree of the pulled-back field inside the
+field the kernel cuts out. -/
+theorem card_ker_dvd_separableDegree (φ : Isogeny W₁ W₂) :
+    Nat.card φ.ker ∣ φ.separableDegree := by
+  have hle := φ.fieldPullback_fieldRange_le_translationFixedField_ker
+  -- `extendScalars hle` is the same subfield seen over `φ^*K(W₂)`; the two share a carrier, so
+  -- these transport definitionally, which instance search does not see through
+  have hsep : Algebra.IsSeparable (IntermediateField.extendScalars hle) W₁.FunctionField :=
+    inferInstanceAs (Algebra.IsSeparable (translationFixedField W₁ φ.ker) W₁.FunctionField)
+  have hrk : Module.finrank (IntermediateField.extendScalars hle) W₁.FunctionField =
+      Nat.card φ.ker := finrank_translationFixedField W₁ φ.ker
+  have htop : Field.finSepDegree (IntermediateField.extendScalars hle) W₁.FunctionField =
+      Nat.card φ.ker := by
+    rw [Field.finSepDegree_eq_finrank_of_isSeparable, hrk]
+  rw [separableDegree_def, ← Field.finSepDegree_mul_finSepDegree_of_isAlgebraic
+    φ.fieldPullback.fieldRange (IntermediateField.extendScalars hle) W₁.FunctionField, htop]
+  exact Dvd.intro_left _ rfl
+
+/-- **The separable degree bounds the kernel**, sharpening the bound by the degree. -/
+theorem card_ker_le_separableDegree (φ : Isogeny W₁ W₂) :
+    Nat.card φ.ker ≤ φ.separableDegree :=
+  Nat.le_of_dvd φ.separableDegree_pos φ.card_ker_dvd_separableDegree
+
+/-- **The degree bounds the kernel**, the separable degree being at most the degree. The bound is
+often strict, this being the rational kernel: equality needs the isogeny to be separable and its
+geometric kernel to be rational. -/
+theorem card_ker_le_degree (φ : Isogeny W₁ W₂) : Nat.card φ.ker ≤ φ.degree :=
+  φ.card_ker_le_separableDegree.trans <| by
+    rw [separableDegree_def, degree_def]; exact Field.finSepDegree_le_finrank _ _
+
+/-- **An isogeny of separable degree one has a trivial kernel here**, the bound leaving no room.
+This is the right hypothesis: a purely inseparable isogeny such as Frobenius has separable degree
+one, so its kernel in this point-valued sense is trivial whatever its degree — its scheme-theoretic
+kernel, which this file does not model, is not. -/
+theorem ker_eq_bot_of_separableDegree_eq_one {φ : Isogeny W₁ W₂} (h : φ.separableDegree = 1) :
+    φ.ker = ⊥ :=
+  φ.ker.eq_bot_of_card_le (h ▸ φ.card_ker_le_separableDegree)
+
+/-- **An isogeny of degree one has trivial kernel.** -/
 theorem ker_eq_bot_of_degree_eq_one {φ : Isogeny W₁ W₂} (h : φ.degree = 1) : φ.ker = ⊥ :=
   φ.ker.eq_bot_of_card_le (h ▸ φ.card_ker_le_degree)
+
+/-- **The kernel counts the degree exactly when it cuts out the pulled-back field.** This is a
+*reduction*, not the separable-locus theorem: one inclusion holds for free, so the cardinality
+statement and the reverse inclusion are two names for the same thing. What it buys is a single
+field-theoretic statement to aim at in place of a cardinality one.
+
+That inclusion is where separability enters, and over a base field that is not separably closed it
+can fail: the kernel here consists of the rational points, while the extension is cut out by the
+geometric ones. Deriving it from separability and rationality of the geometric kernel is not done
+here. -/
+theorem card_ker_eq_degree_iff (φ : Isogeny W₁ W₂) :
+    Nat.card φ.ker = φ.degree ↔
+      translationFixedField W₁ φ.ker ≤ φ.fieldPullback.fieldRange := by
+  have hle := φ.fieldPullback_fieldRange_le_translationFixedField_ker
+  have htower := IntermediateField.relfinrank_mul_finrank_top hle
+  rw [finrank_translationFixedField W₁ φ.ker, ← degree_def] at htower
+  refine ⟨fun hcard ↦ ?_, fun h ↦ ?_⟩
+  · refine IntermediateField.relfinrank_eq_one_iff.1 ?_
+    rw [hcard] at htower
+    exact Nat.eq_of_mul_eq_mul_right φ.degree_pos (htower.trans (one_mul _).symm)
+  · have hfield : translationFixedField W₁ φ.ker = φ.fieldPullback.fieldRange := le_antisymm h hle
+    rw [← finrank_translationFixedField W₁ φ.ker, hfield, ← degree_def]
 
 /-- **The identity isogeny has trivial kernel.** -/
 @[simp]


### PR DESCRIPTION
Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"EllipticCurves/README.md:layer1:kernel-order-bounds"}-->

Provenance: the AINTLIB `HasseWeil` project (Chris Birkbeck, Apache-2.0, `513e83879e2f8cbc626eb9e04d660e92be16ccba`) proves the corresponding statement in `EC/SeparableKernelTorsor.lean` as `card_kernel_eq_degree_of_separable_isogeny`, parametric on **two** witnesses. Its own docstring explains why two are needed: its `Isogeny` bundles the function-field pullback and the point map as independent fields, so separability, which is driven by the pullback, and the kernel, which is driven by the point map, are a priori unrelated — it gives the example `{pullback := id, toAddMonoidHom := 0}`. Here the kernel *is* defined from the pullback, so the coherence witness is unnecessary and only the field-theoretic one remains.

## What this adds

Two general theorems in `Affine/FunctionField/Translation/FixedField.lean`, about an arbitrary intermediate field `L` of finite degree below `K(W)`:

- `card_translationFixingSubgroup_dvd_finSepDegree`: the order of the subgroup of translations fixing `L` divides `[K(W) : L]_s`. The field that subgroup cuts out is Galois over `L`, hence separable, so its degree is one factor of the separable degree of the whole extension.
- `card_translationFixingSubgroup_eq_finrank_iff`: that order is `[K(W) : L]` exactly when the subgroup cuts `L` back out.

Neither mentions isogenies; both use only that `L` has finite degree. The isogeny statements in `Isogeny/Kernel.lean` are then four-line corollaries:

- **`Isogeny.card_ker_dvd_separableDegree`**, with `card_ker_le_separableDegree`: the kernel order divides the separable degree, with no hypothesis. This sharpens the degree bound already on `main`, and it is the shape the point count wants, the separable degree being what a kernel can see.
- `Isogeny.card_ker_eq_degree_iff`: a **reduction**, not the separable-locus theorem. One inclusion holds for free, so `Nat.card φ.ker = φ.degree` and the reverse inclusion are equivalent. What it buys is a single field-theoretic statement to aim at in place of a cardinality one. Deriving that inclusion from separability and rationality of the geometric kernel is not attempted here, and the docstring says so.
- `card_ker_le_degree` (already on `main` from #6350) is now derived from the separable bound rather than proved independently.

`Isogeny.ker_eq_bot_of_separableDegree_eq_one` is the trivial-kernel criterion; separable degree is the right hypothesis, since a purely inseparable isogeny such as Frobenius has separable degree one and so a trivial point-valued kernel whatever its degree.

## On the roadmap target

An earlier revision of this description claimed the `kernel-card-eq-degree` target. It should not have: this PR proves the divisibility bound and reduces the equality to a fixed-field inclusion, and does not prove the equality itself. The target marker now names what is delivered, the kernel-order bounds. The equality under explicit hypotheses is the follow-up, on `elliptic/translation-galois`, which turns the remaining inclusion into the question of whether any automorphism over the pulled-back field fails to be a translation.

## On the lemma that was contested here

Earlier revisions also exported `Isogeny.fieldPullback_fieldRange_le_translationFixedField_ker`, and `reuse` and `api-design` disagreed about it across several rounds: one called it a thin restatement of the generic inclusion after unfolding `ker`, the other wanted it as the kernel's principal fixed-field interaction.

Moving the substance to `FixedField.lean` settles that without a ruling. The generic inclusion is now used inside the general proofs, where it belongs, and no consumer unfolds `ker` to reach it, because the corollaries are stated about `ker` directly. The lemma is deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
