### PR TITLE
refactor: state the scheme-presentation API in simp-normal form

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/Scheme.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/Scheme.lean
@@ -226,7 +226,7 @@ lemma groupScheme_inv_left :
     ι[(groupScheme R).X].left =
       eqToHom (groupScheme_X_left R) ≫
         Spec.map (CommRingCat.ofHom
-          (HopfAlgebra.antipodeAlgHom R (SymmetricAlgebra R R)).toRingHom) ≫
+          (HopfAlgebra.antipodeAlgHom R (SymmetricAlgebra R R))) ≫
         eqToHom (groupScheme_X_left R).symm := by
   unfold groupScheme
   convert hopfSpec_obj_inv_left R (coordinateHopfAlgebra R) using 1
@@ -317,7 +317,7 @@ noncomputable def groupSchemePointMulEquiv :
 lemma groupSchemePointMulEquiv_apply_left
     (f : WithConv (SymmetricAlgebra R R →ₐ[R] A)) :
     (groupSchemePointMulEquiv A f).left =
-      Spec.map (CommRingCat.ofHom f.ofConv.toRingHom) ≫
+      Spec.map (CommRingCat.ofHom f.ofConv) ≫
         eqToHom (groupScheme_X_left R).symm := by
   simpa only [groupSchemePointMulEquiv] using
     CommHopfAlgCat.mapMulEquivOfPresentation_apply_left

--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/SchemePoints.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/SchemePoints.lean
@@ -80,7 +80,7 @@ lemma mapMulEquiv_left
     {S T : Type u} [CommRing S] [CommRing T] [Bialgebra R S] [Algebra R T]
     (f : WithConv (S →ₐ[R] T)) :
     (AlgebraicGeometry.Spec.mapMulEquiv f).left =
-      Spec.map (CommRingCat.ofHom f.ofConv.toRingHom) :=
+      Spec.map (CommRingCat.ofHom f.ofConv) :=
   rfl
 
 /-- Mathlib's spectrum-points equivalence is contravariantly natural in the coordinate
@@ -319,7 +319,7 @@ private theorem mapMulEquivOfPresentation_apply_left_comp
     (f : WithConv (H →ₐ[R] A)) :
     (mapMulEquivOfPresentation H A hG f).left ≫
         eqToHom hX =
-      Spec.map (CommRingCat.ofHom f.ofConv.toRingHom) := by
+      Spec.map (CommRingCat.ofHom f.ofConv) := by
   subst G
   rfl
 
@@ -334,7 +334,7 @@ theorem mapMulEquivOfPresentation_apply_left
     (hX : G.X.left = Spec (CommRingCat.of H))
     (f : WithConv (H →ₐ[R] A)) :
     (mapMulEquivOfPresentation H A hG f).left =
-      Spec.map (CommRingCat.ofHom f.ofConv.toRingHom) ≫
+      Spec.map (CommRingCat.ofHom f.ofConv) ≫
         eqToHom hX.symm := by
   apply (cancel_mono (eqToHom hX)).1
   subst G
@@ -404,7 +404,7 @@ private lemma transportedHopfSpecMap_left
         (AlgebraicGeometry.hopfSpec (CommRingCat.of R)).map φ.op ≫
         eqToHom hG.symm).hom.hom.left =
       eqToHom (congrArg (fun K : Grp (Over (Spec (CommRingCat.of R))) ↦ K.X.left) hH') ≫
-        Spec.map (CommRingCat.ofHom φ.hom.toAlgHom.toRingHom) ≫
+        Spec.map (CommRingCat.ofHom (φ.hom.toAlgHom : H →+* K)) ≫
         eqToHom (congrArg (fun K : Grp (Over (Spec (CommRingCat.of R))) ↦ K.X.left) hG).symm := by
   subst G
   subst H'
@@ -425,10 +425,10 @@ theorem pointMulEquivOfPresentation_mapDomain
     (eH' : WithConv (K →ₐ[R] A) ≃*
       ((Spec (CommRingCat.of A)).asOver (Spec (CommRingCat.of R)) ⟶ H'.X))
     (eG_apply_left : ∀ f, (eG f).left =
-      Spec.map (CommRingCat.ofHom f.ofConv.toRingHom) ≫
+      Spec.map (CommRingCat.ofHom (f.ofConv : H →+* A)) ≫
         eqToHom (congrArg (fun K : Grp (Over (Spec (CommRingCat.of R))) ↦ K.X.left) hG).symm)
     (eH'_apply_left : ∀ f, (eH' f).left =
-      Spec.map (CommRingCat.ofHom f.ofConv.toRingHom) ≫
+      Spec.map (CommRingCat.ofHom (f.ofConv : K →+* A)) ≫
         eqToHom (congrArg (fun K : Grp (Over (Spec (CommRingCat.of R))) ↦ K.X.left) hH').symm)
     (φ : H ⟶ K) (p : HopfAlgebra.points (R := R) (H := K) (CommAlgCat.of R A)) :
     eH' p ≫
@@ -446,11 +446,11 @@ theorem pointMulEquivOfPresentation_mapDomain
     transportedHopfSpecMap_left hG hH' φ, eG_apply_left]
   -- The public computations expose the same spectrum maps behind differently wrapped `Over`
   -- sources; restate them explicitly so the two presentation transports can cancel.
-  change (Spec.map (CommRingCat.ofHom p.ofConv.toRingHom) ≫ eqToHom hH'X.symm) ≫
-      eqToHom hH'X ≫ Spec.map (CommRingCat.ofHom φ.hom.toAlgHom.toRingHom) ≫
+  change (Spec.map (CommRingCat.ofHom (p.ofConv : K →+* A)) ≫ eqToHom hH'X.symm) ≫
+      eqToHom hH'X ≫ Spec.map (CommRingCat.ofHom (φ.hom.toAlgHom : H →+* K)) ≫
         eqToHom hGX.symm =
     Spec.map (CommRingCat.ofHom
-      (((mapPointsFunctor φ).app (CommAlgCat.of R A) p).ofConv.toRingHom)) ≫
+      (((mapPointsFunctor φ).app (CommAlgCat.of R A) p).ofConv : H →+* A)) ≫
         eqToHom hGX.symm
   rw [mapPointsFunctor_app_apply, WithConv.ofConv_toConv]
   simp only [Category.assoc, eqToHom_trans_assoc, eqToHom_refl, Category.id_comp]

--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/SchemePoints.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/SchemePoints.lean
@@ -80,7 +80,10 @@ lemma mapMulEquiv_left
     {S T : Type u} [CommRing S] [CommRing T] [Bialgebra R S] [Algebra R T]
     (f : WithConv (S →ₐ[R] T)) :
     (AlgebraicGeometry.Spec.mapMulEquiv f).left =
-      Spec.map (CommRingCat.ofHom f.ofConv) :=
+      Spec.map (CommRingCat.ofHom f.ofConv) := by
+  rw [← AlgHom.toRingHom_eq_coe]
+  -- `rfl` then closes Mathlib's `Spec.mapMulEquiv` wrapper, as it did before the coercion
+  -- step was named.
   rfl
 
 /-- Mathlib's spectrum-points equivalence is contravariantly natural in the coordinate
@@ -321,6 +324,7 @@ private theorem mapMulEquivOfPresentation_apply_left_comp
         eqToHom hX =
       Spec.map (CommRingCat.ofHom f.ofConv) := by
   subst G
+  rw [← AlgHom.toRingHom_eq_coe]
   rfl
 
 /-- The underlying scheme map of the spectrum point transported across a named presentation.
@@ -338,6 +342,7 @@ theorem mapMulEquivOfPresentation_apply_left
         eqToHom hX.symm := by
   apply (cancel_mono (eqToHom hX)).1
   subst G
+  rw [← AlgHom.toRingHom_eq_coe]
   rfl
 
 /-- Mathlib's spectrum-points equivalence is natural in the value algebra. Postcomposing
@@ -408,6 +413,7 @@ private lemma transportedHopfSpecMap_left
         eqToHom (congrArg (fun K : Grp (Over (Spec (CommRingCat.of R))) ↦ K.X.left) hG).symm := by
   subst G
   subst H'
+  rw [← AlgHom.toRingHom_eq_coe]
   rfl
 
 /-- Contravariant naturality in the coordinate Hopf algebra for named point equivalences.

--- a/TauCeti/Algebra/AlgebraicGroup/ConstantGroup/Scheme.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/ConstantGroup/Scheme.lean
@@ -118,7 +118,7 @@ coordinate functions along `f`. -/
 theorem groupSchemeMap_hom_left {H : Type u} [Group H] [Finite H] (f : G →* H) :
     (groupSchemeMap R f).hom.hom.left =
       eqToHom (groupScheme_X_left R G) ≫
-        Spec.map (CommRingCat.ofHom (coordinateMap R G H f).toRingHom) ≫
+        Spec.map (CommRingCat.ofHom (coordinateMap R G H f)) ≫
         eqToHom (groupScheme_X_left R H).symm := by
   apply (conj_eqToHom_iff_heq _ _
     (groupScheme_X_left R G) (groupScheme_X_left R H)).2
@@ -191,7 +191,7 @@ noncomputable def groupSchemePointMulEquiv (A : Type u) [CommRing A] [Algebra R 
 theorem groupSchemePointMulEquiv_apply_left (A : Type u) [CommRing A] [Algebra R A]
     (p : WithConv (coordinateRing R G →ₐ[R] A)) :
     (groupSchemePointMulEquiv R G A p).left =
-      Spec.map (CommRingCat.ofHom p.ofConv.toRingHom) ≫
+      Spec.map (CommRingCat.ofHom p.ofConv) ≫
         eqToHom (groupScheme_X_left R G).symm := by
   exact CommHopfAlgCat.mapMulEquivOfPresentation_apply_left
     (CommHopfAlgCat.of R (coordinateRing R G)) A (groupScheme_def R G)

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Scheme/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Scheme/Basic.lean
@@ -155,7 +155,7 @@ lemma groupScheme_inv_left (G : FGCommGrpCat.{u}) :
     ι[(groupScheme R G).X].left =
       eqToHom (groupScheme_X_left R G) ≫
       Spec.map (CommRingCat.ofHom
-        (HopfAlgebra.antipodeAlgHom R (MonoidAlgebra R G)).toRingHom) ≫
+        (HopfAlgebra.antipodeAlgHom R (MonoidAlgebra R G))) ≫
       eqToHom (groupScheme_X_left R G).symm := by
   unfold groupScheme
   convert hopfSpec_obj_inv_left R (coordinateRing R G).obj using 1
@@ -186,7 +186,7 @@ lemma groupSchemeMap_hom_left {G H : FGCommGrpCat.{u}} (f : G ⟶ H) :
     (groupSchemeMap R f).hom.hom.left =
       eqToHom (groupScheme_X_left R H) ≫
         Spec.map (CommRingCat.ofHom
-          (FiniteTypeCommHopfAlgCat.toBialgHom (coordinateMap R f)).toAlgHom.toRingHom) ≫
+          (FiniteTypeCommHopfAlgCat.toBialgHom (coordinateMap R f)).toAlgHom) ≫
         eqToHom (groupScheme_X_left R G).symm := by
   apply (conj_eqToHom_iff_heq _ _
     (groupScheme_X_left R H) (groupScheme_X_left R G)).2

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Scheme/Points.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Scheme/Points.lean
@@ -178,14 +178,14 @@ transported to the named diagonalizable group scheme. -/
 lemma groupSchemePointsMulEquiv_symm_apply_left (G : FGCommGrpCat.{u})
     (f : WithConv (MonoidAlgebra R G →ₐ[R] A)) :
     ((groupSchemePointsMulEquiv (R := R) (A := A) G).symm f).left =
-      Spec.map (CommRingCat.ofHom f.ofConv.toRingHom) ≫
+      Spec.map (CommRingCat.ofHom f.ofConv) ≫
         eqToHom (groupScheme_X_left R G).symm := by
   apply (cancel_mono (eqToHom (groupScheme_X_left R G))).1
   rw [groupSchemePointsMulEquiv_apply_left_comp, MulEquiv.apply_symm_apply,
     CommHopfAlgCat.mapMulEquiv_left]
   -- Normalize the `Over.left` source and the proof-irrelevant equality witnesses.
-  change Spec.map (CommRingCat.ofHom f.ofConv.toRingHom) =
-    (Spec.map (CommRingCat.ofHom f.ofConv.toRingHom) ≫
+  change Spec.map (CommRingCat.ofHom (f.ofConv : MonoidAlgebra R G →+* A)) =
+    (Spec.map (CommRingCat.ofHom (f.ofConv : MonoidAlgebra R G →+* A)) ≫
       eqToHom (groupScheme_X_left R G).symm) ≫ eqToHom (groupScheme_X_left R G)
   simp
 

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Scheme.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Scheme.lean
@@ -271,7 +271,7 @@ private lemma groupScheme_inv_left_bundled :
     ι[(groupScheme R n).X].left =
       eqToHom (groupScheme_X_left R n) ≫
         Spec.map (CommRingCat.ofHom
-          (HopfAlgebra.antipodeAlgHom R (coordinateHopfAlgebra R n)).toRingHom) ≫
+          (HopfAlgebra.antipodeAlgHom R (coordinateHopfAlgebra R n))) ≫
         eqToHom (groupScheme_X_left R n).symm := by
   unfold groupScheme
   convert hopfSpec_obj_inv_left R (coordinateHopfAlgebra R n) using 1
@@ -280,7 +280,7 @@ private lemma groupScheme_inv_left_bundled :
 @[simp]
 lemma groupScheme_one_left :
     η[(groupScheme R n).X].left =
-      Spec.map (CommRingCat.ofHom (counit R n).toRingHom) ≫
+      Spec.map (CommRingCat.ofHom (counit R n)) ≫
         (groupSchemeSpecIso R n).inv := by
   rw [groupScheme_one_left_bundled, groupSchemeSpecIso]
   simp only [Iso.trans_inv, eqToIso.inv,
@@ -292,7 +292,8 @@ lemma groupScheme_one_left :
   rw [Spec.map_inj]
   rw [← CommRingCat.ofHom_comp]
   exact congrArg (fun f : coordinateHopfAlgebra R n →ₐ[R] R ↦
-    CommRingCat.ofHom f.toRingHom) (coordinateHopfAlgebra_counitAlgHom R n)
+    CommRingCat.ofHom (f : coordinateHopfAlgebra R n →+* R))
+    (coordinateHopfAlgebra_counitAlgHom R n)
 
 /-- Multiplication on the general linear group scheme is induced by the raw matrix-multiplication
 comultiplication. The source presentation fixes the tensor-factor order representing ordinary
@@ -301,7 +302,7 @@ matrix multiplication. -/
 lemma groupScheme_mul_left :
     μ[(groupScheme R n).X].left =
       (groupSchemeMulSourceIso R n).hom ≫
-        Spec.map (CommRingCat.ofHom (comul R n).toRingHom) ≫
+        Spec.map (CommRingCat.ofHom (comul R n)) ≫
         (groupSchemeSpecIso R n).inv := by
   rw [groupScheme_mul_left_bundled, groupSchemeMulSourceIso, groupSchemeSpecIso]
   simp only [Iso.trans_hom, eqToIso.hom, Functor.mapIso_hom, Iso.op_hom,
@@ -320,14 +321,16 @@ lemma groupScheme_mul_left :
   exact congrArg
     (fun f : coordinateHopfAlgebra R n →ₐ[R]
       coordinateHopfAlgebra R n ⊗[R] coordinateHopfAlgebra R n ↦
-        CommRingCat.ofHom f.toRingHom) (coordinateHopfAlgebra_comulAlgHom R n)
+        CommRingCat.ofHom (f : coordinateHopfAlgebra R n →+*
+          coordinateHopfAlgebra R n ⊗[R] coordinateHopfAlgebra R n))
+    (coordinateHopfAlgebra_comulAlgHom R n)
 
 /-- Inversion on the general linear group scheme is induced by the raw inverse-matrix antipode. -/
 @[simp]
 lemma groupScheme_inv_left :
     ι[(groupScheme R n).X].left =
       (groupSchemeSpecIso R n).hom ≫
-        Spec.map (CommRingCat.ofHom (antipode R n).toRingHom) ≫
+        Spec.map (CommRingCat.ofHom (antipode R n)) ≫
         (groupSchemeSpecIso R n).inv := by
   rw [groupScheme_inv_left_bundled, groupSchemeSpecIso]
   simp only [Iso.trans_hom, eqToIso.hom, Functor.mapIso_hom, Iso.op_hom,
@@ -342,7 +345,8 @@ lemma groupScheme_inv_left :
   rw [← CommRingCat.ofHom_comp, ← CommRingCat.ofHom_comp]
   exact congrArg
     (fun f : coordinateHopfAlgebra R n →ₐ[R] coordinateHopfAlgebra R n ↦
-      CommRingCat.ofHom f.toRingHom) (coordinateHopfAlgebra_antipodeAlgHom R n)
+      CommRingCat.ofHom (f : coordinateHopfAlgebra R n →+* coordinateHopfAlgebra R n))
+    (coordinateHopfAlgebra_antipodeAlgHom R n)
 
 /-- The general linear group scheme is affine. -/
 instance isAffine_groupScheme : IsAffine (groupScheme R n).X.left := by
@@ -381,7 +385,7 @@ noncomputable def groupSchemePointMulEquiv :
 lemma groupSchemePointMulEquiv_apply_left
     (f : WithConv (coordinateHopfAlgebra R n →ₐ[R] A)) :
     (groupSchemePointMulEquiv n A f).left =
-      Spec.map (CommRingCat.ofHom f.ofConv.toRingHom) ≫
+      Spec.map (CommRingCat.ofHom f.ofConv) ≫
         eqToHom (groupScheme_X_left R n).symm := by
   simpa only [groupSchemePointMulEquiv] using
     CommHopfAlgCat.mapMulEquivOfPresentation_apply_left

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Scheme.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Scheme.lean
@@ -149,7 +149,7 @@ point. -/
 lemma groupSchemePointMulEquiv_apply_left
     (f : WithConv (coordinateHopfAlgebra R n →ₐ[R] A)) :
     (groupSchemePointMulEquiv n A f).left =
-      Spec.map (CommRingCat.ofHom f.ofConv.toRingHom) ≫
+      Spec.map (CommRingCat.ofHom f.ofConv) ≫
         eqToHom (groupScheme_X_left R n).symm := by
   simpa only [groupSchemePointMulEquiv] using
     CommHopfAlgCat.mapMulEquivOfPresentation_apply_left

--- a/TauCeti/Algebra/AlgebraicGroup/Symplectic/Scheme.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Symplectic/Scheme.lean
@@ -62,7 +62,7 @@ noncomputable def groupSchemePointMulEquiv :
 lemma groupSchemePointMulEquiv_apply_left
     (f : WithConv (coordinateHopfAlgebra R m →ₐ[R] A)) :
     (groupSchemePointMulEquiv m A f).left =
-      Spec.map (CommRingCat.ofHom f.ofConv.toRingHom) ≫
+      Spec.map (CommRingCat.ofHom f.ofConv) ≫
         eqToHom (groupScheme_X_left R m).symm := by
   simpa only [groupSchemePointMulEquiv] using
     CommHopfAlgCat.mapMulEquivOfPresentation_apply_left

--- a/TauCeti/Algebra/AlgebraicGroup/UpperUnitriangular/Scheme.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/UpperUnitriangular/Scheme.lean
@@ -313,7 +313,7 @@ noncomputable def groupSchemePointMulEquiv :
 theorem groupSchemePointMulEquiv_apply_left
     (f : WithConv (coordinateHopfAlgebra R m →ₐ[R] A)) :
     (groupSchemePointMulEquiv m A f).left =
-      AlgebraicGeometry.Spec.map (CommRingCat.ofHom f.ofConv.toRingHom) ≫
+      AlgebraicGeometry.Spec.map (CommRingCat.ofHom f.ofConv) ≫
         eqToHom (groupScheme_X_left R m).symm := by
   simpa only [groupSchemePointMulEquiv] using
     CommHopfAlgCat.mapMulEquivOfPresentation_apply_left

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/GraphAutomorphism.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/GraphAutomorphism.lean
@@ -446,7 +446,7 @@ private noncomputable def groupSchemePointMulEquiv (A : Type) [CommRing A] :
 private theorem groupSchemePointMulEquiv_apply_left {A : Type} [CommRing A]
     (q : WithConv (carrierCoordinateHopfAlgebra r →ₐ[ℤ] A)) :
     (groupSchemePointMulEquiv r A q).left =
-      Spec.map (CommRingCat.ofHom q.ofConv.toRingHom) ≫
+      Spec.map (CommRingCat.ofHom (q.ofConv : carrierCoordinateHopfAlgebra r →+* A)) ≫
         eqToHom (congrArg
           (fun K : Grp (Over (Spec (CommRingCat.of ℤ))) => K.X.left)
           (groupScheme_eq_hopfSpec r)).symm := by

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/ToralClosure/NumberedSymmetry.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/ToralClosure/NumberedSymmetry.lean
@@ -569,7 +569,9 @@ private theorem kostantToralSchemePointMulEquiv_apply_left (A : Type) [CommRing 
     (q : WithConv (CommHopfAlgCat.quotient (GeneralLinear.coordinateHopfAlgebra ℤ n)
       (kostantToralDefiningIdeal e h ρ M hM hnil b wt) →ₐ[ℤ] A)) :
     (kostantToralSchemePointMulEquiv e h ρ M hM hnil b wt A q).left =
-      Spec.map (CommRingCat.ofHom q.ofConv.toRingHom) ≫
+      Spec.map (CommRingCat.ofHom (q.ofConv :
+        CommHopfAlgCat.quotient (GeneralLinear.coordinateHopfAlgebra ℤ n)
+          (kostantToralDefiningIdeal e h ρ M hM hnil b wt) →+* A)) ≫
         eqToHom (congrArg (fun K : Grp (Over (Spec (CommRingCat.of ℤ))) => K.X.left)
           (kostantToralGroupScheme_eq_hopfSpec e h ρ M hM hnil b wt)).symm := by
   simpa only [kostantToralSchemePointMulEquiv] using

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/HopfSpec.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/HopfSpec.lean
@@ -192,7 +192,7 @@ lemma algSpec_map_left_ofAlgHom {A B : Type u} [CommRing A] [CommRing B]
     ((AlgebraicGeometry.algSpec (CommRingCat.of R)).map
       (CommAlgCat.ofHom f).op).left =
         Spec.map (CommRingCat.ofHom f) := by
-  rw [AlgebraicGeometry.algSpec_map_left]
+  rw [AlgebraicGeometry.algSpec_map_left, ← AlgHom.toRingHom_eq_coe]
   rfl
 
 /-- Mathlib's `hopfSpec` object is the group object on the ordinary spectrum.

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/HopfSpec.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/HopfSpec.lean
@@ -191,7 +191,7 @@ lemma algSpec_map_left_ofAlgHom {A B : Type u} [CommRing A] [CommRing B]
     [Algebra R A] [Algebra R B] (f : A →ₐ[R] B) :
     ((AlgebraicGeometry.algSpec (CommRingCat.of R)).map
       (CommAlgCat.ofHom f).op).left =
-        Spec.map (CommRingCat.ofHom f.toRingHom) := by
+        Spec.map (CommRingCat.ofHom f) := by
   rw [AlgebraicGeometry.algSpec_map_left]
   rfl
 
@@ -249,8 +249,7 @@ lemma hopfSpec_obj_inv_left (H : CommHopfAlgCat.{u} R) :
     ι[((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).obj
       (Opposite.op H)).X].left =
       eqToHom (hopfSpec_obj_X_left R H) ≫
-        Spec.map (CommRingCat.ofHom
-          (HopfAlgebra.antipodeAlgHom R H).toRingHom) ≫
+        Spec.map (CommRingCat.ofHom (HopfAlgebra.antipodeAlgHom R H)) ≫
         eqToHom (hopfSpec_obj_X_left R H).symm := by
   apply (conj_eqToHom_iff_heq _ _
     (hopfSpec_obj_X_left R H) (hopfSpec_obj_X_left R H)).2


### PR DESCRIPTION
refactor: state the scheme-presentation API in simp-normal form

Mathlib makes the coercion the simp-normal form of `AlgHom.toRingHom`
(`AlgHom.toRingHom_eq_coe`, whose source comment reads "make the coercion the
simp-normal form"). A `@[simp]` lemma whose right-hand side says `.toRingHom` is
therefore rewritten again the moment it fires, so every caller lands one rewrite
short of normal form. #6317 fixed this across the general-linear points API and
left the scheme-presentation family, which says
`Spec.map (CommRingCat.ofHom f.ofConv.toRingHom)`, as the follow-up. This is that
follow-up.

* `AffineGroupScheme/HopfSpec.lean`: the `@[simp↓]` hub `algSpec_map_left_ofAlgHom`
  and `hopfSpec_obj_inv_left`. The latter was the odd one out of the three group-law
  lemmas in that file: `hopfSpec_obj_one_left` and `hopfSpec_obj_mul_left` already
  said `CommRingCat.ofHom (Bialgebra.counitAlgHom R H)`.
* `CommHopfAlgCat/SchemePoints.lean`: the points hub `mapMulEquiv_left`,
  `mapMulEquivOfPresentation_apply_left` and its private `_comp` companion, plus the
  `eG_apply_left` / `eH'_apply_left` hypotheses of
  `pointMulEquivOfPresentation_mapDomain`, which the carrier lemmas below are passed
  to directly, and `transportedHopfSpecMap_left`.
* The carrier `@[simp]` statements that go through those hubs:
  `groupSchemePointMulEquiv_apply_left` for AdditiveGroup, ConstantGroup,
  GeneralLinear, SpecialLinear, Symplectic and UpperUnitriangular;
  `groupScheme_one_left`, `groupScheme_mul_left` and `groupScheme_inv_left`;
  `groupSchemeMap_hom_left`; and the DiagonalizableGroup and Lie-side siblings.

Every proof that consumes a restated statement is restated with it, so that no
declaration closes across the gap between the two spellings. `CommRingCat.ofHom ↑f`
and `CommRingCat.ofHom f.toRingHom` are definitionally equal but *not* reducibly so
(`with_reducible rfl` rejects them), and leaving a proof arguing in the old spelling
against a statement in the new one would be exactly the silent coercion-defeq
reliance #6317 was praised for removing. This covers the three `congrArg` motives in
`GeneralLinear/Scheme.lean` and the `change` blocks in
`DiagonalizableGroup/Scheme/Points.lean` and `CommHopfAlgCat/SchemePoints.lean`.

Four statements keep the coercion but pin its type by hand — `(f.ofConv : H →+* A)`
and friends, five ascriptions in all, since `pointMulEquivOfPresentation_mapDomain`
carries one in each of its two hypotheses. Their expected ring-hom type is the `commHopfAlgCatEquivCogrpCommAlgCat`
carrier expression, which is defeq to `↑H` but not syntactically an algebra-hom
domain, so the coercion has nothing to elaborate against. The ascription leaves no
trace in the elaborated term, so these still match the unascribed statements exactly;
the idiom is already used in `AffineGroupScheme/Image.lean`.

Three kinds of `.toRingHom` deliberately remain.

* Under `.asOver`. Mathlib's `IsOver` instance
  (`Mathlib/AlgebraicGeometry/Group/Affine.lean`) is stated for
  `Spec.map (CommRingCat.ofHom f.toRingHom)` and instance search will not see through
  the coercion, so dropping `.toRingHom` there fails to synthesize
  `Scheme.Hom.IsOver`. This is upstream's spelling, which Tau Ceti follows. Anyone
  attempting the tidy-up and meeting an unexplained `IsOver` synthesis failure is
  hitting this; the instance, not the call site, is what would have to change.
* Proof steps that convert a presentation by raw defeq rather than by citing a
  restated lemma: the near-clone `change` blocks in
  `Kostant/RootSubgroup/Scheme/Torus.lean` and `GeneralLinear/DiagonalTorus/Basic.lean`.
  In both, an earlier `change` has already pushed the goal back to
  `(Spec.mapMulEquiv _).left`, so by the time those steps run neither side carries a
  `CommRingCat.ofHom` at all and the step is unfolding Mathlib's `Spec.mapMulEquiv`,
  whose `toFun` is itself written with `.toRingHom`. `.toRingHom` is the faithful
  spelling there; both files are untouched.
* `private` statements and definition types in a different API: the `IsPullback`
  square in `HopfIdeal/Scheme/Kernel.lean`, and the morphism-property lemmas in
  `AffineGroupScheme/{Image,ClosedImmersion}.lean` and
  `AffineGroupScheme/BaseChange/Coordinate.lean`. These are not reached by the hub
  change and pin no ring-hom type of their own, so converting them would mean an
  ascription at every site for no normal-form benefit — `Kernel.lean` has no `@[simp]`
  lemma among them at all. No public, non-`.asOver` statement in the
  scheme-presentation family is left unconverted.

Verified locally against this base: `lake build` (11143 jobs), `lake exe axioms`
(111295 declarations, allowlist clean), `scripts/lint-style.sh`, and
`scripts/lint-dot-notation.py` (761 total, 0 new — byte-identical to main).
`scripts/lint-env.sh` fails identically on unmodified main in this checkout (a known
issue with an open PR), so it was not run as a gate.

Roadmap: ReductiveGroups



🤖 Generated with [Claude Code](https://claude.com/claude-code)
