### PR TITLE
refactor(Exchangeability): share the block swap and cylinder approximation

### DIFF
--- a/TauCeti/Algebra/GroupAction/FiniteSupportPerm.lean
+++ b/TauCeti/Algebra/GroupAction/FiniteSupportPerm.lean
@@ -12,6 +12,7 @@ public import Mathlib.Data.Set.Countable
 public import Mathlib.Data.Set.Finite.Lattice
 public import Mathlib.Order.Interval.Finset.Nat
 public import Mathlib.Logic.Equiv.Fintype
+public import Mathlib.Logic.Equiv.Fin.Basic
 public import Mathlib.Logic.Embedding.Set
 import Mathlib.Algebra.Group.Pointwise.Set.Finite
 -- Non-public: `Finset.countable`, the index of the covering used for countability of `finitary`.
@@ -30,7 +31,9 @@ intersections (Mathlib's `CountableInterFilter`), such as the a.e. filter of a m
 
 The file also supplies `Equiv.Perm.exists_prodCongrRight_mem_finitary_apply_eq_on_finset`:
 finitely many values of an arbitrary family of permutations can be matched by a family whose
-induced permutation of the product moves only finitely many indexed points altogether.
+induced permutation of the product moves only finitely many indexed points altogether; and the
+**block swap** `blockSwap N`, the finitely supported permutation of `ℕ` exchanging `[0, N)` with
+`[N, 2N)`, which carries any finite index set inside `[0, N)` onto a disjoint copy.
 -/
 
 public section
@@ -67,6 +70,45 @@ theorem finite_compl_fixedBy_iff_eventually_eq_self {π : Equiv.Perm ℕ} :
 theorem finite_compl_fixedBy_conj {G α : Type*} [Group G] [MulAction G α] {g h : G}
     (hh : (MulAction.fixedBy α h)ᶜ.Finite) : (MulAction.fixedBy α (g⁻¹ * h * g))ᶜ.Finite := by
   simpa [Set.smul_set_compl, MulAction.smul_fixedBy] using hh.smul_set (a := g⁻¹)
+
+/-! ## The block swap -/
+
+/-- The finitely supported permutation of `ℕ` that swaps the block `[0, N)` with `[N, 2N)`
+pointwise and fixes everything from `2 * N` on: Mathlib's half-swap `finAddFlip` on `Fin (N + N)`,
+transported to `ℕ` along the value embedding. -/
+def blockSwap (N : ℕ) : Equiv.Perm ℕ :=
+  Equiv.Perm.viaFintypeEmbedding (finAddFlip (m := N) (n := N)) ⟨Fin.val, Fin.val_injective⟩
+
+/-- On `[0, N)`, `blockSwap N` shifts by `N`. -/
+theorem blockSwap_apply_of_lt {N i : ℕ} (hi : i < N) : blockSwap N i = N + i := by
+  have h : (⟨Fin.val, Fin.val_injective⟩ : Fin (N + N) ↪ ℕ)
+      (Fin.castAdd N ⟨i, hi⟩) = i := rfl
+  rw [blockSwap, ← h, Equiv.Perm.viaFintypeEmbedding_apply_image, finAddFlip_apply_castAdd]
+  rfl
+
+/-- From `2 * N` on, `blockSwap N` is the identity. -/
+theorem blockSwap_apply_of_le {N n : ℕ} (hn : N + N ≤ n) : blockSwap N n = n := by
+  refine Equiv.Perm.viaFintypeEmbedding_apply_notMem_range _ _ ?_
+  rintro ⟨j, rfl⟩
+  exact absurd j.isLt (not_lt.mpr hn)
+
+/-- `blockSwap N` carries any index set inside `[0, N)` off itself: the moved copy lands in
+`[N, 2N)`. -/
+theorem disjoint_map_blockSwap {N : ℕ} {F : Finset ℕ} (hF : F ⊆ Finset.range N) :
+    Disjoint F (F.map (Equiv.toEmbedding (blockSwap N))) := by
+  rw [Finset.disjoint_left]
+  intro a haF hamem
+  obtain ⟨b, hbF, hb⟩ := Finset.mem_map.mp hamem
+  have hbN : b < N := Finset.mem_range.mp (hF hbF)
+  have haN : a < N := Finset.mem_range.mp (hF haF)
+  rw [Equiv.coe_toEmbedding, blockSwap_apply_of_lt hbN] at hb
+  omega
+
+/-- `blockSwap N` is finitely supported. -/
+theorem blockSwap_finite_support (N : ℕ) :
+    (MulAction.fixedBy ℕ (blockSwap N))ᶜ.Finite :=
+  finite_compl_fixedBy_of_eventually_eq_self ⟨N + N, fun _ hn => blockSwap_apply_of_le hn⟩
+
 
 /-- The self-maps of a countable type that move only finitely many points form a countable set:
 such a map is determined by the finite set it moves together with its values there. -/

--- a/TauCeti/Algebra/GroupAction/FiniteSupportPerm.lean
+++ b/TauCeti/Algebra/GroupAction/FiniteSupportPerm.lean
@@ -12,9 +12,9 @@ public import Mathlib.Data.Set.Countable
 public import Mathlib.Data.Set.Finite.Lattice
 public import Mathlib.Order.Interval.Finset.Nat
 public import Mathlib.Logic.Equiv.Fintype
-public import Mathlib.Logic.Equiv.Fin.Basic
 public import Mathlib.Logic.Embedding.Set
 import Mathlib.Algebra.Group.Pointwise.Set.Finite
+import Mathlib.Logic.Equiv.Fin.Basic
 -- Non-public: `Finset.countable`, the index of the covering used for countability of `finitary`.
 import Mathlib.Logic.Equiv.List
 
@@ -80,13 +80,23 @@ def blockSwap (N : ℕ) : Equiv.Perm ℕ :=
   Equiv.Perm.viaFintypeEmbedding (finAddFlip (m := N) (n := N)) ⟨Fin.val, Fin.val_injective⟩
 
 /-- On `[0, N)`, `blockSwap N` shifts by `N`. -/
+@[simp]
 theorem blockSwap_apply_of_lt {N i : ℕ} (hi : i < N) : blockSwap N i = N + i := by
   have h : (⟨Fin.val, Fin.val_injective⟩ : Fin (N + N) ↪ ℕ)
       (Fin.castAdd N ⟨i, hi⟩) = i := rfl
   rw [blockSwap, ← h, Equiv.Perm.viaFintypeEmbedding_apply_image, finAddFlip_apply_castAdd]
   rfl
 
+/-- On `[N, 2N)`, `blockSwap N` shifts back by `N`. -/
+@[simp]
+theorem blockSwap_apply_add_of_lt {N i : ℕ} (hi : i < N) : blockSwap N (N + i) = i := by
+  have h : (⟨Fin.val, Fin.val_injective⟩ : Fin (N + N) ↪ ℕ)
+      (Fin.natAdd N ⟨i, hi⟩) = N + i := rfl
+  rw [blockSwap, ← h, Equiv.Perm.viaFintypeEmbedding_apply_image, finAddFlip_apply_natAdd]
+  rfl
+
 /-- From `2 * N` on, `blockSwap N` is the identity. -/
+@[simp]
 theorem blockSwap_apply_of_le {N n : ℕ} (hn : N + N ≤ n) : blockSwap N n = n := by
   refine Equiv.Perm.viaFintypeEmbedding_apply_notMem_range _ _ ?_
   rintro ⟨j, rfl⟩
@@ -105,7 +115,7 @@ theorem disjoint_map_blockSwap {N : ℕ} {F : Finset ℕ} (hF : F ⊆ Finset.ran
   omega
 
 /-- `blockSwap N` is finitely supported. -/
-theorem blockSwap_finite_support (N : ℕ) :
+theorem finite_compl_fixedBy_blockSwap (N : ℕ) :
     (MulAction.fixedBy ℕ (blockSwap N))ᶜ.Finite :=
   finite_compl_fixedBy_of_eventually_eq_self ⟨N + N, fun _ hn => blockSwap_apply_of_le hn⟩
 

--- a/TauCeti/Algebra/GroupAction/FiniteSupportPerm.lean
+++ b/TauCeti/Algebra/GroupAction/FiniteSupportPerm.lean
@@ -32,7 +32,7 @@ intersections (Mathlib's `CountableInterFilter`), such as the a.e. filter of a m
 The file also supplies `Equiv.Perm.exists_prodCongrRight_mem_finitary_apply_eq_on_finset`:
 finitely many values of an arbitrary family of permutations can be matched by a family whose
 induced permutation of the product moves only finitely many indexed points altogether; and the
-**block swap** `blockSwap N`, the finitely supported permutation of `ℕ` exchanging `[0, N)` with
+**block swap** `Nat.blockSwap N`, the finitely supported permutation of `ℕ` exchanging `[0, N)` with
 `[N, 2N)`, which carries any finite index set inside `[0, N)` onto a disjoint copy.
 -/
 
@@ -76,48 +76,65 @@ theorem finite_compl_fixedBy_conj {G α : Type*} [Group G] [MulAction G α] {g h
 /-- The finitely supported permutation of `ℕ` that swaps the block `[0, N)` with `[N, 2N)`
 pointwise and fixes everything from `2 * N` on: Mathlib's half-swap `finAddFlip` on `Fin (N + N)`,
 transported to `ℕ` along the value embedding. -/
-def blockSwap (N : ℕ) : Equiv.Perm ℕ :=
+def _root_.Nat.blockSwap (N : ℕ) : Equiv.Perm ℕ :=
   Equiv.Perm.viaFintypeEmbedding (finAddFlip (m := N) (n := N)) ⟨Fin.val, Fin.val_injective⟩
 
-/-- On `[0, N)`, `blockSwap N` shifts by `N`. -/
+/-- On `[0, N)`, `N.blockSwap` shifts by `N`. -/
 @[simp]
-theorem blockSwap_apply_of_lt {N i : ℕ} (hi : i < N) : blockSwap N i = N + i := by
+theorem _root_.Nat.blockSwap_apply_of_lt {N i : ℕ} (hi : i < N) : N.blockSwap i = N + i := by
   have h : (⟨Fin.val, Fin.val_injective⟩ : Fin (N + N) ↪ ℕ)
       (Fin.castAdd N ⟨i, hi⟩) = i := rfl
-  rw [blockSwap, ← h, Equiv.Perm.viaFintypeEmbedding_apply_image, finAddFlip_apply_castAdd]
+  rw [Nat.blockSwap, ← h, Equiv.Perm.viaFintypeEmbedding_apply_image, finAddFlip_apply_castAdd]
   rfl
 
-/-- On `[N, 2N)`, `blockSwap N` shifts back by `N`. -/
+/-- On `[N, 2N)`, `N.blockSwap` shifts back by `N`. -/
 @[simp]
-theorem blockSwap_apply_add_of_lt {N i : ℕ} (hi : i < N) : blockSwap N (N + i) = i := by
+theorem _root_.Nat.blockSwap_apply_add_of_lt {N i : ℕ} (hi : i < N) : N.blockSwap (N + i) = i := by
   have h : (⟨Fin.val, Fin.val_injective⟩ : Fin (N + N) ↪ ℕ)
       (Fin.natAdd N ⟨i, hi⟩) = N + i := rfl
-  rw [blockSwap, ← h, Equiv.Perm.viaFintypeEmbedding_apply_image, finAddFlip_apply_natAdd]
+  rw [Nat.blockSwap, ← h, Equiv.Perm.viaFintypeEmbedding_apply_image, finAddFlip_apply_natAdd]
   rfl
 
-/-- From `2 * N` on, `blockSwap N` is the identity. -/
+/-- From `2 * N` on, `N.blockSwap` is the identity. -/
 @[simp]
-theorem blockSwap_apply_of_le {N n : ℕ} (hn : N + N ≤ n) : blockSwap N n = n := by
+theorem _root_.Nat.blockSwap_apply_of_le {N n : ℕ} (hn : N + N ≤ n) : N.blockSwap n = n := by
   refine Equiv.Perm.viaFintypeEmbedding_apply_notMem_range _ _ ?_
   rintro ⟨j, rfl⟩
   exact absurd j.isLt (not_lt.mpr hn)
 
-/-- `blockSwap N` carries any index set inside `[0, N)` off itself: the moved copy lands in
+/-- `N.blockSwap` carries any index set inside `[0, N)` off itself: the moved copy lands in
 `[N, 2N)`. -/
-theorem disjoint_map_blockSwap {N : ℕ} {F : Finset ℕ} (hF : F ⊆ Finset.range N) :
-    Disjoint F (F.map (Equiv.toEmbedding (blockSwap N))) := by
+theorem _root_.Nat.disjoint_map_blockSwap {N : ℕ} {F : Finset ℕ} (hF : F ⊆ Finset.range N) :
+    Disjoint F (F.map (Equiv.toEmbedding (N.blockSwap))) := by
   rw [Finset.disjoint_left]
   intro a haF hamem
   obtain ⟨b, hbF, hb⟩ := Finset.mem_map.mp hamem
   have hbN : b < N := Finset.mem_range.mp (hF hbF)
   have haN : a < N := Finset.mem_range.mp (hF haF)
-  rw [Equiv.coe_toEmbedding, blockSwap_apply_of_lt hbN] at hb
+  rw [Equiv.coe_toEmbedding, Nat.blockSwap_apply_of_lt hbN] at hb
   omega
 
-/-- `blockSwap N` is finitely supported. -/
-theorem finite_compl_fixedBy_blockSwap (N : ℕ) :
-    (MulAction.fixedBy ℕ (blockSwap N))ᶜ.Finite :=
-  finite_compl_fixedBy_of_eventually_eq_self ⟨N + N, fun _ hn => blockSwap_apply_of_le hn⟩
+/-- `N.blockSwap` is finitely supported. -/
+theorem _root_.Nat.finite_compl_fixedBy_blockSwap (N : ℕ) :
+    (MulAction.fixedBy ℕ (N.blockSwap))ᶜ.Finite :=
+  finite_compl_fixedBy_of_eventually_eq_self ⟨N + N, fun _ hn => Nat.blockSwap_apply_of_le hn⟩
+
+/-- `blockSwap N` is an involution: two swaps restore every index. -/
+@[simp]
+theorem _root_.Nat.blockSwap_blockSwap (N i : ℕ) : N.blockSwap (N.blockSwap i) = i := by
+  rcases lt_or_ge i N with hi | hi
+  · rw [Nat.blockSwap_apply_of_lt hi, Nat.blockSwap_apply_add_of_lt hi]
+  rcases lt_or_ge i (N + N) with hi2 | hi2
+  · obtain ⟨j, hj, rfl⟩ : ∃ j, j < N ∧ i = N + j := ⟨i - N, by omega, by omega⟩
+    rw [Nat.blockSwap_apply_add_of_lt hj, Nat.blockSwap_apply_of_lt hj]
+  · rw [Nat.blockSwap_apply_of_le hi2, Nat.blockSwap_apply_of_le hi2]
+
+/-- `blockSwap N` is its own inverse. -/
+@[simp]
+theorem _root_.Nat.blockSwap_symm (N : ℕ) : N.blockSwap.symm = N.blockSwap :=
+  Equiv.ext fun i => by
+    rw [Equiv.symm_apply_eq]
+    exact (Nat.blockSwap_blockSwap N i).symm
 
 
 /-- The self-maps of a countable type that move only finitely many points form a countable set:

--- a/TauCeti/MeasureTheory/Constructions/CylinderApproximation.lean
+++ b/TauCeti/MeasureTheory/Constructions/CylinderApproximation.lean
@@ -1,0 +1,57 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.MeasureTheory.Constructions.Cylinders
+public import Mathlib.MeasureTheory.Measure.Typeclasses.Finite
+import Mathlib.MeasureTheory.Measure.MeasuredSets
+import Mathlib.MeasureTheory.Constructions.ProjectiveFamilyContent
+
+/-!
+# Approximation of product-space events by measurable cylinders
+
+Under a finite measure on a product space `∀ i, α i`, every measurable event is approximated in
+measure by a measurable cylinder over finitely many coordinates. This is Mathlib's density theorem
+for a generating set ring, `exists_measure_symmDiff_lt_of_generateFrom_isSetRing`, applied to the
+ring of measurable cylinders, which generates the product σ-algebra.
+
+## Main result
+
+* `TauCeti.MeasureTheory.exists_cylinder_measure_symmDiff_lt`
+-/
+
+public section
+
+open MeasureTheory Set
+
+open scoped ENNReal symmDiff
+
+namespace TauCeti
+
+namespace MeasureTheory
+
+variable {ι : Type*} {α : ι → Type*} [∀ i, MeasurableSpace (α i)]
+
+/-- Every measurable event of a product space is approximated, in measure under a finite measure,
+by a measurable cylinder over a finite set of coordinates. -/
+theorem exists_cylinder_measure_symmDiff_lt {ρ : Measure (∀ i, α i)} [IsFiniteMeasure ρ]
+    {s : Set (∀ i, α i)} (hs : MeasurableSet s) {ε : ℝ≥0∞} (hε : 0 < ε) :
+    ∃ (F : Finset ι) (S : Set (∀ i : F, α i)),
+      MeasurableSet S ∧ ρ (symmDiff (cylinder F S) s) < ε := by
+  have hcov : ∃ D : Set (Set (∀ i, α i)), D.Countable ∧
+      D ⊆ measurableCylinders α ∧ ρ (⋃₀ D)ᶜ = 0 := by
+    refine ⟨{Set.univ}, Set.countable_singleton _, ?_, ?_⟩
+    · rintro u (rfl : u = Set.univ)
+      exact univ_mem_measurableCylinders α
+    · simp
+  obtain ⟨t, ht_mem, ht⟩ := exists_measure_symmDiff_lt_of_generateFrom_isSetRing (μ := ρ)
+    isSetRing_measurableCylinders hcov generateFrom_measurableCylinders.symm hs hε
+  obtain ⟨F, S, hS, rfl⟩ := (mem_measurableCylinders t).mp ht_mem
+  exact ⟨F, S, hS, ht⟩
+
+end MeasureTheory
+
+end TauCeti

--- a/TauCeti/Probability/Exchangeability/PathSpace/HewittSavage.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/HewittSavage.lean
@@ -202,7 +202,7 @@ theorem measure_eq_zero_or_one_of_exchangeableSigma {ρ : Measure (ℕ → α)} 
   have ht'_cyl : t' = cylinder (α := fun _ : ℕ => α) (F.map (Equiv.toEmbedding π))
       (pullMoved π F α ⁻¹' S) := preimage_permReindex_cylinder π F S
   have hs_inv : permReindex (α := α) π ⁻¹' s = s :=
-    MeasurableSet.preimage_permReindex_eq_of_exchangeableSigma hs (blockSwap_finite_support N)
+    MeasurableSet.preimage_permReindex_eq_of_exchangeableSigma hs (finite_compl_fixedBy_blockSwap N)
   have ht'_symm : ρ (symmDiff t' s) = ρ (symmDiff t s) :=
     measure_symmDiff_preimage_permReindex hexch π ht_null hs_null hs_inv
   have h1 : ρ.real (symmDiff t s) < ε := ENNReal.toReal_lt_of_lt_ofReal hFS

--- a/TauCeti/Probability/Exchangeability/PathSpace/HewittSavage.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/HewittSavage.lean
@@ -11,8 +11,8 @@ public import TauCeti.Probability.Exchangeability.IID
 -- Public: `cylinder` appears in the hypothesis of `measure_eq_zero_or_one_of_exchangeableSigma`.
 public import Mathlib.MeasureTheory.Constructions.Cylinders
 -- Non-public: used only inside proofs.
-import Mathlib.MeasureTheory.Measure.MeasuredSets
-import Mathlib.MeasureTheory.Constructions.ProjectiveFamilyContent
+import TauCeti.MeasureTheory.Constructions.CylinderApproximation
+import TauCeti.Algebra.GroupAction.FiniteSupportPerm
 import Mathlib.Probability.Independence.InfinitePi
 import TauCeti.MeasureTheory.Measure.ZeroOne
 
@@ -97,39 +97,6 @@ namespace TauCeti
 
 namespace Probability
 
-/-- The finitely supported permutation of `ℕ` that swaps the block `[0, N)` with `[N, 2N)`
-pointwise and fixes everything from `2 * N` on: Mathlib's half-swap `finAddFlip` on `Fin (N + N)`,
-transported to `ℕ` along the value embedding. -/
-private def blockSwap (N : ℕ) : Equiv.Perm ℕ :=
-  Equiv.Perm.viaFintypeEmbedding (finAddFlip (m := N) (n := N)) ⟨Fin.val, Fin.val_injective⟩
-
-private theorem blockSwap_apply_of_lt {N i : ℕ} (hi : i < N) : blockSwap N i = N + i := by
-  have h : (⟨Fin.val, Fin.val_injective⟩ : Fin (N + N) ↪ ℕ)
-      (Fin.castAdd N ⟨i, hi⟩) = i := rfl
-  rw [blockSwap, ← h, Equiv.Perm.viaFintypeEmbedding_apply_image, finAddFlip_apply_castAdd]
-  rfl
-
-private theorem blockSwap_apply_of_le {N n : ℕ} (hn : N + N ≤ n) : blockSwap N n = n := by
-  refine Equiv.Perm.viaFintypeEmbedding_apply_notMem_range _ _ ?_
-  rintro ⟨j, rfl⟩
-  exact absurd j.isLt (not_lt.mpr hn)
-
-/-- `blockSwap N` carries any index block inside `[0, N)` off itself: the moved copy lands in
-`[N, 2N)`. This is the disjointness the independence step consumes. -/
-private theorem disjoint_map_blockSwap {N : ℕ} {F : Finset ℕ} (hF : F ⊆ Finset.range N) :
-    Disjoint F (F.map (Equiv.toEmbedding (blockSwap N))) := by
-  rw [Finset.disjoint_left]
-  intro a haF hamem
-  obtain ⟨b, hbF, hb⟩ := Finset.mem_map.mp hamem
-  have hbN : b < N := Finset.mem_range.mp (hF hbF)
-  have haN : a < N := Finset.mem_range.mp (hF haF)
-  rw [Equiv.coe_toEmbedding, blockSwap_apply_of_lt hbN] at hb
-  omega
-
-private theorem blockSwap_finite_support (N : ℕ) :
-    (MulAction.fixedBy ℕ (blockSwap N))ᶜ.Finite :=
-  finite_compl_fixedBy_of_eventually_eq_self ⟨N + N, fun _ hn => blockSwap_apply_of_le hn⟩
-
 section Cylinder
 
 variable {α : Type*}
@@ -157,23 +124,6 @@ private theorem preimage_permReindex_cylinder (π : Equiv.Perm ℕ) (F : Finset 
 private theorem measurable_pullMoved [MeasurableSpace α] (π : Equiv.Perm ℕ) (F : Finset ℕ) :
     Measurable (pullMoved π F α) :=
   Measurable.of_eval fun _ => measurable_pi_apply _
-
-/-- Every measurable path-space event is approximated, in measure, by a measurable cylinder over a
-finite index set. -/
-private theorem exists_cylinder_measure_symmDiff_lt [MeasurableSpace α] {ρ : Measure (ℕ → α)}
-    [IsFiniteMeasure ρ] {s : Set (ℕ → α)} (hs : MeasurableSet s) {ε : ℝ≥0∞} (hε : 0 < ε) :
-    ∃ (F : Finset ℕ) (S : Set (∀ _i : F, α)),
-      MeasurableSet S ∧ ρ (symmDiff (cylinder F S) s) < ε := by
-  have hcov : ∃ D : Set (Set (ℕ → α)), D.Countable ∧
-      D ⊆ measurableCylinders (fun _ : ℕ => α) ∧ ρ (⋃₀ D)ᶜ = 0 := by
-    refine ⟨{Set.univ}, Set.countable_singleton _, ?_, ?_⟩
-    · rintro u (rfl : u = Set.univ)
-      exact univ_mem_measurableCylinders (fun _ : ℕ => α)
-    · simp
-  obtain ⟨t, ht_mem, ht⟩ := exists_measure_symmDiff_lt_of_generateFrom_isSetRing (μ := ρ)
-    isSetRing_measurableCylinders hcov generateFrom_measurableCylinders.symm hs hε
-  obtain ⟨F, S, hS, rfl⟩ := (mem_measurableCylinders t).mp ht_mem
-  exact ⟨F, S, hS, ht⟩
 
 end Cylinder
 
@@ -237,7 +187,8 @@ theorem measure_eq_zero_or_one_of_exchangeableSigma {ρ : Measure (ℕ → α)} 
   refine TauCeti.MeasureTheory.measure_eq_zero_or_one_of_forall_exists_symmDiff_lt_inter_eq_mul
     hs_meas.nullMeasurableSet ?_
   intro ε hε
-  obtain ⟨F, S, hS, hFS⟩ := exists_cylinder_measure_symmDiff_lt (ρ := ρ) hs_meas
+  obtain ⟨F, S, hS, hFS⟩ :=
+    TauCeti.MeasureTheory.exists_cylinder_measure_symmDiff_lt (ρ := ρ) hs_meas
     (ε := ENNReal.ofReal ε) (ENNReal.ofReal_pos.mpr hε)
   obtain ⟨N, hN⟩ := Finset.exists_nat_subset_range F
   set π := blockSwap N with hπ

--- a/TauCeti/Probability/Exchangeability/PathSpace/HewittSavage.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/HewittSavage.lean
@@ -59,7 +59,7 @@ formula. The final approximation squeeze — arbitrarily close factoring approxi
 ## The argument
 
 Approximate an exchangeable event by a cylinder over `[0, N)`, then move that cylinder onto the
-disjoint block `[N, 2N)`. The mover is `blockSwap N`, the half-swap of `Fin (N + N)` transported
+disjoint block `[N, 2N)`. The mover is `Nat.blockSwap N`, the half-swap of `Fin (N + N)` transported
 to `ℕ`: it is finitely supported, hence admissible for `exchangeableSigma`, so it fixes the event
 while preserving the law. Independence then factors the event against its own moved copy, and
 letting the approximation tighten gives `q = q²`.
@@ -132,7 +132,7 @@ section Independence
 variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
 
 /-- Cylinders over **disjoint** index blocks are independent events under the path law of an
-independent family. This is the step that turns the disjointness produced by `blockSwap` into a
+independent family. This is the step that turns the disjointness produced by `Nat.blockSwap` into a
 product formula. -/
 private theorem measure_pathLaw_inter_cylinder_of_disjoint {μ : Measure Ω}
     {X : ℕ → Ω → α} (hX : ∀ n, AEMeasurable (X n) μ)
@@ -191,7 +191,7 @@ theorem measure_eq_zero_or_one_of_exchangeableSigma {ρ : Measure (ℕ → α)} 
     TauCeti.MeasureTheory.exists_cylinder_measure_symmDiff_lt (ρ := ρ) hs_meas
     (ε := ENNReal.ofReal ε) (ENNReal.ofReal_pos.mpr hε)
   obtain ⟨N, hN⟩ := Finset.exists_nat_subset_range F
-  set π := blockSwap N with hπ
+  set π := N.blockSwap with hπ
   set t := cylinder (α := fun _ : ℕ => α) F S with ht
   have ht_meas : MeasurableSet t := MeasurableSet.cylinder (α := fun _ : ℕ => α) F hS
   set t' := permReindex (α := α) π ⁻¹' t with ht'
@@ -202,7 +202,8 @@ theorem measure_eq_zero_or_one_of_exchangeableSigma {ρ : Measure (ℕ → α)} 
   have ht'_cyl : t' = cylinder (α := fun _ : ℕ => α) (F.map (Equiv.toEmbedding π))
       (pullMoved π F α ⁻¹' S) := preimage_permReindex_cylinder π F S
   have hs_inv : permReindex (α := α) π ⁻¹' s = s :=
-    MeasurableSet.preimage_permReindex_eq_of_exchangeableSigma hs (finite_compl_fixedBy_blockSwap N)
+    MeasurableSet.preimage_permReindex_eq_of_exchangeableSigma hs
+      (Nat.finite_compl_fixedBy_blockSwap N)
   have ht'_symm : ρ (symmDiff t' s) = ρ (symmDiff t s) :=
     measure_symmDiff_preimage_permReindex hexch π ht_null hs_null hs_inv
   have h1 : ρ.real (symmDiff t s) < ε := ENNReal.toReal_lt_of_lt_ofReal hFS
@@ -210,7 +211,7 @@ theorem measure_eq_zero_or_one_of_exchangeableSigma {ρ : Measure (ℕ → α)} 
     ENNReal.toReal_lt_of_lt_ofReal (ht'_symm ▸ hFS)
   have hinter : ρ.real (t ∩ t') = ρ.real t * ρ.real t' := by
     rw [Measure.real, Measure.real, Measure.real, ht'_cyl, ht,
-      hprod (disjoint_map_blockSwap hN) hS (hS.preimage (measurable_pullMoved π F)),
+      hprod (Nat.disjoint_map_blockSwap hN) hS (hS.preimage (measurable_pullMoved π F)),
       ENNReal.toReal_mul]
   exact ⟨t, t', ht_null, ht'_null, h1, h2, hinter⟩
 


### PR DESCRIPTION
Two pieces of proof infrastructure in `PathSpace/HewittSavage.lean` were private, and the joint-array ergodicity theorem (#6361) needs both verbatim at a second index type. This gives each one home and makes Hewitt–Savage its first consumer; no statement changes.

- **The block swap.** `blockSwap N`, the finitely supported permutation of `ℕ` exchanging `[0, N)` with `[N, 2N)`, with its four lemmas (`blockSwap_apply_of_lt`, `blockSwap_apply_of_le`, `disjoint_map_blockSwap`, `blockSwap_finite_support`), moves to `Algebra/GroupAction/FiniteSupportPerm.lean`, beside the other finitary-permutation facts it is built from.
- **Cylinder approximation.** `exists_cylinder_measure_symmDiff_lt` — under a finite measure, every measurable event of a product space is within `ε` in measure of a measurable cylinder over finitely many coordinates — is stated for an arbitrary product `∀ i, α i` in a new `MeasureTheory/Constructions/CylinderApproximation.lean`. It is Mathlib's density theorem for a generating set ring applied to the ring of measurable cylinders; Hewitt–Savage instantiates it at `ℕ → α`, and #6361 will at `ℕ × ℕ → α`.

`HewittSavage.lean` loses its two private copies and two Mathlib imports it reached them through, and gains the two TauCeti imports.

## Roadmap

Roadmap: Exchangeability

A de-privatisation of existing code for a second consumer, shipped ahead of it as its own PR. No roadmap target is claimed.

🤖 Directed by Cameron Freer, drafted by Claude
