### PR TITLE
feat(EllipticCurve): the Frobenius trace of a Weierstrass model over a finite field

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/PointCount.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/PointCount.lean
@@ -32,12 +32,16 @@ through.
 
 * `WeierstrassCurve.pointCount`: the `Nat.card` count of the projective Weierstrass model's
   `F`-points.
+* `WeierstrassCurve.frobeniusTrace`: over a finite field, the defect `q + 1 − #W(F)` of that
+  count from `q + 1`.
 
 ## Main results
 
 * `WeierstrassCurve.pointCount_eq_card_point`: on an elliptic model whose affine solutions form a
   finite type — a finite base being one case of that — it is the cardinality of Mathlib's point
   type.
+* `WeierstrassCurve.frobeniusTrace_eq_card_point`: over a finite field, on an elliptic model the
+  trace is `q + 1` minus the cardinality of Mathlib's point type, which is the classical `a_q`.
 
 ## Provenance
 
@@ -81,6 +85,32 @@ theorem _root_.WeierstrassCurve.pointCount_eq_card_point
   rw [WeierstrassCurve.pointCount_def, Nat.card_congr W.toAffine.pointEquiv]
   -- `WithZero` is the `Option` the cardinality lemma is stated for
   exact Finite.card_option.symm
+
+/-- **The Frobenius trace** `a_q = q + 1 − #W(F)` of a Weierstrass model over a finite field of
+`q` elements, measured against `pointCount`.
+
+Taken against that count the formula returns the classical local invariant at *every* Weierstrass
+model: `a_q` at an elliptic one, and `1`, `−1`, `0` at split multiplicative, nonsplit
+multiplicative and additive reduction. That is why it carries no ellipticity hypothesis. It is
+elliptic-specific only in its reading as a *trace*, which rests on the identity
+`deg (1 − π_q) = #E(𝔽_q)`. -/
+noncomputable def _root_.WeierstrassCurve.frobeniusTrace [Finite F] : ℤ :=
+  -- `q` is a number only because the base is finite, so the count is taken through that
+  -- finiteness; `frobeniusTrace_def` restates it with `Nat.card`, the form the API is phrased in
+  have : Fintype F := Fintype.ofFinite F
+  (Fintype.card F : ℤ) + 1 - W.pointCount
+
+/-- The defining equation of `frobeniusTrace`. -/
+@[simp]
+theorem _root_.WeierstrassCurve.frobeniusTrace_def [Finite F] :
+    W.frobeniusTrace = (Nat.card F : ℤ) + 1 - W.pointCount := by
+  simp only [WeierstrassCurve.frobeniusTrace, @Nat.card_eq_fintype_card F (Fintype.ofFinite F)]
+
+/-- **Over a finite field, on an elliptic model the trace is measured against Mathlib's point
+type**, which is the classical `a_q`. -/
+theorem _root_.WeierstrassCurve.frobeniusTrace_eq_card_point [Finite F] [W.IsElliptic] :
+    W.frobeniusTrace = (Nat.card F : ℤ) + 1 - Nat.card W.toAffine.Point := by
+  rw [WeierstrassCurve.frobeniusTrace_def, WeierstrassCurve.pointCount_eq_card_point]
 
 end TauCeti
 


### PR DESCRIPTION
Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"EllipticCurves/Suggested.lean:layer3:frobeniusTrace"}-->

Provenance: original. The AINTLIB `HasseWeil` project has no Frobenius trace; its `pointCount` is the nonsingular-locus count and the defect is written inline where needed.

## What this adds

Three declarations in `Isogeny`-adjacent `EllipticCurve/PointCount.lean`, continuing the module #6340 started:

- `WeierstrassCurve.frobeniusTrace`: `q + 1 − #W(F)`, measured against `pointCount`, with `frobeniusTrace_def`.
- `WeierstrassCurve.frobeniusTrace_eq_card_point`: over a finite field, on an elliptic model, the trace is `q + 1` minus the cardinality of Mathlib's point type — the classical `a_q`.

## Why this shape

- **No ellipticity hypothesis.** Taken against `pointCount`, which includes the singular point when there is one, the formula returns the classical local invariant at *every* Weierstrass model: `a_q` at an elliptic one, and `1`, `−1`, `0` at split multiplicative, nonsplit multiplicative and additive reduction. Restricting it would lose exactly that.
- **Finiteness is a hypothesis on the trace, not a convention.** `q` is a number only over a finite base, so all three declarations take `[Finite F]`, and the definition counts *through* that finiteness (`Fintype.ofFinite`) rather than leaving the hypothesis inert. `frobeniusTrace_def` restates the value with `Nat.card`, which is the form the rest of the API is phrased in, so the `Fintype` never escapes the definition. `pointCount` keeps no finiteness hypothesis: it is a count, and `Nat.card` makes it the honest one wherever the solutions are finite.
- **It is elliptic-specific only in its reading as a trace**, which rests on `deg (1 − π_q) = #E(𝔽_q)`; that identity is not claimed here.

## Roadmap

`TauCetiRoadmap/EllipticCurves/Suggested.lean`, Layer 3, seeds `frobeniusTrace` and says it is "defined outright: a convention to pin, not a milestone", named rather than left inline because the Hasse bound, the zeta strand and the ordinary-endomorphism-ring theorem all quantify over it. It was deferred from #6340 so that the point-count convention could settle first.
