### PR TITLE
refactor(Spa): ask Lemma 8.1's target for a topological ring, not a nonarchimedean one

### DIFF
--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Localization/UniversalProperty.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Localization/UniversalProperty.lean
@@ -81,6 +81,12 @@ field. `[IsHuberRing B]` is not a restriction added to make the proof go
 through: Wedhorn states Lemma 8.1 for a
 continuous homomorphism into a *complete affinoid ring*, and an affinoid ring is a Huber pair.
 
+Nonarchimedean-ness of `B` is used throughout but is not assumed: with `[IsHuberRing B]` already
+present, `TauCeti.Huber.IsHuberRing.toNonarchimedeanRing` derives it from `[IsTopologicalRing B]`.
+The target is therefore presented the same way as the source `A` in the same signature —
+`[IsTopologicalRing _]` carrying the topology and `[IsHuberRing _]` (or a pair of definition)
+carrying the Huber structure.
+
 ## References
 
 * [T. Wedhorn, *Adic Spaces*][wedhorn_adic] (arXiv:1910.05934v1), Lemma 8.1, whose statement and
@@ -187,7 +193,7 @@ theorem existsUnique_continuous_ringHom_of_isUnit_of_forall_comap_mem_rationalSu
     [IsTopologicalRing A]
     (P : PairOfDefinition A) (Aplus : Subring A) (T : Finset A) (s : A) (S : Type*) [CommRing S]
     [Algebra A S] [IsLocalization.Away s S] (hden : HasDenominatorPower P T s S)
-    {B : Type*} [CommRing B] [UniformSpace B] [IsUniformAddGroup B] [NonarchimedeanRing B]
+    {B : Type*} [CommRing B] [UniformSpace B] [IsUniformAddGroup B] [IsTopologicalRing B]
     [IsHuberRing B] [CompleteSpace B] [T0Space B] (Bplus : Subring B)
     (hB : IsRingOfIntegralElements Bplus) {φ : A →+* B} (hφ : ContinuousAt φ 0)
     (hs : IsUnit (φ s))
@@ -211,7 +217,7 @@ unit `φ s` is not assumed but derived from the factorisation, which is step 1. 
 theorem existsUnique_continuous_ringHom_of_forall_comap_mem_rationalSubset [IsTopologicalRing A]
     (P : PairOfDefinition A) (Aplus : Subring A) (T : Finset A) (s : A) (S : Type*) [CommRing S]
     [Algebra A S] [IsLocalization.Away s S] (hden : HasDenominatorPower P T s S)
-    {B : Type*} [CommRing B] [UniformSpace B] [IsUniformAddGroup B] [NonarchimedeanRing B]
+    {B : Type*} [CommRing B] [UniformSpace B] [IsUniformAddGroup B] [IsTopologicalRing B]
     [IsHuberRing B] [CompleteSpace B] [T0Space B] (Bplus : Subring B)
     (hB : IsRingOfIntegralElements Bplus) {φ : A →+* B} (hφ : ContinuousAt φ 0)
     (hfac : ∀ w ∈ spa Bplus, comap φ w ∈ rationalSubset Aplus T s) :


### PR DESCRIPTION
Wedhorn's Lemma 8.1 — `existsUnique_continuous_ringHom_of_forall_comap_mem_rationalSubset` — and
its `isUnit` variant presented their target `B` as

```lean
[CommRing B] [UniformSpace B] [IsUniformAddGroup B] [NonarchimedeanRing B]
[IsHuberRing B] [CompleteSpace B] [T0Space B]
```

while presenting the *source* `A`, in the same signature, as `[IsTopologicalRing A]` together
with a `PairOfDefinition A`. The two idioms carry the same content:
`TauCeti.Huber.IsHuberRing.toNonarchimedeanRing` derives `NonarchimedeanRing B` from
`[IsTopologicalRing B]` and `[IsHuberRing B]`, both of which the signature already has. So
`[NonarchimedeanRing B]` is a consequence of the other hypotheses rather than an assumption,
and stating it makes the target's presentation differ from the source's for no reason.

This weakens it to `[IsTopologicalRing B]` at both sites. `IsTopologicalRing` is strictly weaker
than `NonarchimedeanRing`, and it is what the topology is actually needed for; nonarchimedean-ness
is then recovered by instance resolution wherever the proofs use it, so no proof body changes.

The module docstring's `## What this file consumes` section already accounted for the target's
hypotheses as `IsRingOfIntegralElements Bplus` plus `[IsHuberRing B]`, and never mentioned
`[NonarchimedeanRing B]` — because it was not one of them. A short paragraph now records where
nonarchimedean-ness comes from.

Verified: `IsHuberRing B` + `IsTopologicalRing B` ⊢ `NonarchimedeanRing B` by `infer_instance`
(compiled probe); 2190-job build green with zero Mathlib compilation; `runLinter` clean on the
module; the one importer, `Spa/Localization/PresentationIndependence.lean`, builds unchanged.

Roadmap: AdicSpaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XG8YChDNLwcvvVGgqG5dL7
