### PR TITLE
feat: extend skew-zigzag scalars

### DIFF
--- a/TauCeti/RepresentationTheory/Quiver/PathAlgebra/BaseChange.lean
+++ b/TauCeti/RepresentationTheory/Quiver/PathAlgebra/BaseChange.lean
@@ -16,11 +16,7 @@ algebra while leaving its paths fixed.  More generally, if an `l`-algebra homomo
 `kQ`, where the target is regarded as a `k`-algebra through `f`.
 
 The construction packages the common path-algebra step in base-change maps for relation
-quotients.  A companion extensionality theorem says that ring homomorphisms out of any quotient
-of a path algebra are determined by scalars and path classes.
-
-This is the path-algebra scaffolding used by the scalar-extension clauses of Layers 1 and 4 of
-`TauCetiRoadmap/ZigzagPreprojective/README.md`.
+quotients.
 -/
 
 public section
@@ -115,30 +111,5 @@ theorem smul_def_baseChange (f : k →+* l) (a : k) (x : B) :
   rw [RingHom.comp_apply]
 
 end BaseChange
-
-section Ext
-
-variable {k : Type w} {Q : Type u} {A B : Type*}
-  [CommSemiring k] [Quiver.{v} Q] [Finite Q]
-  [Semiring A] [Algebra k A] [Semiring B]
-
-/-- Two ring homomorphisms out of a quotient of a path algebra are equal if they agree on
-coefficients and on the images of all paths. -/
-theorem ringHom_ext_of_surjective (q : pathAlgebra k Q →ₐ[k] A) (hq : Function.Surjective q)
-    {g h : A →+* B}
-    (hscalar : ∀ r : k, g (algebraMap k A r) = h (algebraMap k A r))
-    (hpath : ∀ x : Quiver.TotalPath Q, g (q (ofPath x)) = h (q (ofPath x))) :
-    g = h := by
-  apply RingHom.ext
-  intro y
-  obtain ⟨x, rfl⟩ := hq y
-  induction x using induction_linear with
-  | zero => simp
-  | add x y hx hy => simp only [map_add, hx, hy]
-  | single x a =>
-      rw [single_eq_smul_ofPath, map_smul]
-      simp only [Algebra.smul_def, map_mul, hscalar, hpath]
-
-end Ext
 
 end TauCeti.PathAlgebra

--- a/TauCeti/RepresentationTheory/Quiver/PathAlgebra/BaseChange.lean
+++ b/TauCeti/RepresentationTheory/Quiver/PathAlgebra/BaseChange.lean
@@ -89,18 +89,18 @@ theorem baseChangeAlgHom_ofPath (f : k →+* l) (g : pathAlgebra l Q →ₐ[l] B
   exact liftAlgHom_ofPath k _ (baseChangeAlgHom_hcomp g)
     (baseChangeAlgHom_hzero g) (baseChangeAlgHom_hone g) x
 
-/-- Changing coefficients and applying `g` transports a scalar through `f`. -/
+/-- In the `k`-algebra structure induced through `f`, the algebra map applies `f` before the
+original `l`-algebra map. -/
 @[simp]
-theorem baseChangeAlgHom_algebraMap (f : k →+* l) (g : pathAlgebra l Q →ₐ[l] B)
-    (a : k) :
+theorem algebraMap_baseChange (f : k →+* l) (a : k) :
     letI : Algebra k B := ((algebraMap l B).comp f).toAlgebra'
       (fun b y ↦ Algebra.commutes (R := l) (A := B) (f b) y)
-    baseChangeAlgHom f g (algebraMap k (pathAlgebra k Q) a) = algebraMap l B (f a) := by
+    algebraMap k B a = algebraMap l B (f a) := by
   let _ : Algebra k B := ((algebraMap l B).comp f).toAlgebra'
     (fun b y ↦ Algebra.commutes (R := l) (A := B) (f b) y)
   -- `toAlgebra'` makes the target's `k`-algebra map the displayed composite.
-  rw [← RingHom.comp_apply]
-  exact (baseChangeAlgHom f g).commutes a
+  change ((algebraMap l B).comp f) a = algebraMap l B (f a)
+  rw [RingHom.comp_apply]
 
 /-- In the algebra structure induced through `f`, the scalar action of `k` is the scalar action
 of `l` after applying `f`. -/

--- a/TauCeti/RepresentationTheory/Quiver/PathAlgebra/BaseChange.lean
+++ b/TauCeti/RepresentationTheory/Quiver/PathAlgebra/BaseChange.lean
@@ -90,6 +90,7 @@ theorem baseChangeAlgHom_ofPath (f : k →+* l) (g : pathAlgebra l Q →ₐ[l] B
     (baseChangeAlgHom_hzero g) (baseChangeAlgHom_hone g) x
 
 /-- Changing coefficients and applying `g` transports a scalar through `f`. -/
+@[simp]
 theorem baseChangeAlgHom_algebraMap (f : k →+* l) (g : pathAlgebra l Q →ₐ[l] B)
     (a : k) :
     letI : Algebra k B := ((algebraMap l B).comp f).toAlgebra'
@@ -97,8 +98,8 @@ theorem baseChangeAlgHom_algebraMap (f : k →+* l) (g : pathAlgebra l Q →ₐ[
     baseChangeAlgHom f g (algebraMap k (pathAlgebra k Q) a) = algebraMap l B (f a) := by
   let _ : Algebra k B := ((algebraMap l B).comp f).toAlgebra'
     (fun b y ↦ Algebra.commutes (R := l) (A := B) (f b) y)
-  change baseChangeAlgHom f g (algebraMap k (pathAlgebra k Q) a) =
-    ((algebraMap l B).comp f) a
+  -- `toAlgebra'` makes the target's `k`-algebra map the displayed composite.
+  rw [← RingHom.comp_apply]
   exact (baseChangeAlgHom f g).commutes a
 
 /-- In the algebra structure induced through `f`, the scalar action of `k` is the scalar action
@@ -108,7 +109,9 @@ theorem smul_def_baseChange (f : k →+* l) (a : k) (x : B) :
       (fun b y ↦ Algebra.commutes (R := l) (A := B) (f b) y)
     a • x = f a • x := by
   simp only [Algebra.smul_def]
-  rfl
+  -- Expose the coefficient map supplied by `toAlgebra'` before evaluating the composite.
+  change ((algebraMap l B).comp f) a * x = algebraMap l B (f a) * x
+  rw [RingHom.comp_apply]
 
 end BaseChange
 

--- a/TauCeti/RepresentationTheory/Quiver/PathAlgebra/BaseChange.lean
+++ b/TauCeti/RepresentationTheory/Quiver/PathAlgebra/BaseChange.lean
@@ -104,6 +104,7 @@ theorem algebraMap_baseChange (f : k →+* l) (a : k) :
 
 /-- In the algebra structure induced through `f`, the scalar action of `k` is the scalar action
 of `l` after applying `f`. -/
+@[simp]
 theorem smul_def_baseChange (f : k →+* l) (a : k) (x : B) :
     letI : Algebra k B := ((algebraMap l B).comp f).toAlgebra'
       (fun b y ↦ Algebra.commutes (R := l) (A := B) (f b) y)

--- a/TauCeti/RepresentationTheory/Quiver/PathAlgebra/BaseChange.lean
+++ b/TauCeti/RepresentationTheory/Quiver/PathAlgebra/BaseChange.lean
@@ -1,0 +1,140 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.RepresentationTheory.Quiver.PathAlgebra.Basic
+
+/-!
+# Changing coefficients in a path algebra
+
+A homomorphism of commutative semirings `f : k →+* l` transports the coefficients of a path
+algebra while leaving its paths fixed.  More generally, if an `l`-algebra homomorphism out of
+`lQ` assigns values to the paths, those same values induce a `k`-algebra homomorphism out of
+`kQ`, where the target is regarded as a `k`-algebra through `f`.
+
+The construction packages the common path-algebra step in base-change maps for relation
+quotients.  A companion extensionality theorem says that ring homomorphisms out of any quotient
+of a path algebra are determined by scalars and path classes.
+
+This is the path-algebra scaffolding used by the scalar-extension clauses of Layers 1 and 4 of
+`TauCetiRoadmap/ZigzagPreprojective/README.md`.
+-/
+
+public section
+
+namespace TauCeti.PathAlgebra
+
+open _root_.Quiver
+
+universe u v w z
+
+section BaseChange
+
+variable {k : Type w} {l : Type z} {Q : Type u} {B : Type*}
+  [CommSemiring k] [CommSemiring l] [Quiver.{v} Q] [Finite Q]
+  [Semiring B] [Algebra l B]
+
+private theorem baseChangeAlgHom_hcomp (g : pathAlgebra l Q →ₐ[l] B)
+    {a b c : Q} (p : Path a b) (q : Path c a) :
+    g (ofPath ⟨a, b, p⟩) * g (ofPath ⟨c, a, q⟩) = g (ofPath ⟨c, b, q.comp p⟩) := by
+  rw [← map_mul, ofPath_mul_ofPath_of_comp]
+
+private theorem baseChangeAlgHom_hzero (g : pathAlgebra l Q →ₐ[l] B)
+    {x y : Quiver.TotalPath Q} (h : y.2.1 ≠ x.1) :
+    g (ofPath x) * g (ofPath y) = 0 := by
+  rw [← map_mul, ofPath_mul_ofPath_of_not_composable h, map_zero]
+
+private theorem baseChangeAlgHom_hone (g : pathAlgebra l Q →ₐ[l] B) :
+    letI := Fintype.ofFinite Q
+    ∑ x : Q, g (ofPath ⟨x, x, Path.nil⟩) = 1 := by
+  let _ := Fintype.ofFinite Q
+  calc
+    (∑ x : Q, g (ofPath ⟨x, x, Path.nil⟩)) =
+        g (∑ x : Q, (ofPath ⟨x, x, Path.nil⟩ : pathAlgebra l Q)) := by
+      rw [map_sum]
+    _ = g (∑ x : Q, vertexIdempotent l x) := by
+      congr 1
+      apply Finset.sum_congr rfl
+      intro x hx
+      rw [vertexIdempotent_eq_ofPath]
+    _ = g 1 := by rw [one_def]
+    _ = 1 := g.map_one
+
+/-- Change the coefficients in a path algebra and then apply an algebra homomorphism, leaving
+every path fixed.  The target is regarded as a `k`-algebra through the composite coefficient
+map. -/
+noncomputable def baseChangeAlgHom (f : k →+* l) (g : pathAlgebra l Q →ₐ[l] B) :
+    letI : Algebra k B := ((algebraMap l B).comp f).toAlgebra'
+      (fun a x ↦ Algebra.commutes (R := l) (A := B) (f a) x)
+    pathAlgebra k Q →ₐ[k] B := by
+  let _ : Algebra k B := ((algebraMap l B).comp f).toAlgebra'
+    (fun a x ↦ Algebra.commutes (R := l) (A := B) (f a) x)
+  exact liftAlgHom k (fun x ↦ g (ofPath x)) (baseChangeAlgHom_hcomp g)
+    (baseChangeAlgHom_hzero g) (baseChangeAlgHom_hone g)
+
+/-- Changing coefficients and applying `g` sends a path over the source ring to the value under
+`g` of the same path over the target ring. -/
+@[simp]
+theorem baseChangeAlgHom_ofPath (f : k →+* l) (g : pathAlgebra l Q →ₐ[l] B)
+    (x : Quiver.TotalPath Q) :
+    letI : Algebra k B := ((algebraMap l B).comp f).toAlgebra'
+      (fun a y ↦ Algebra.commutes (R := l) (A := B) (f a) y)
+    baseChangeAlgHom f g (ofPath x) = g (ofPath x) := by
+  let _ : Algebra k B := ((algebraMap l B).comp f).toAlgebra'
+    (fun a y ↦ Algebra.commutes (R := l) (A := B) (f a) y)
+  rw [baseChangeAlgHom]
+  exact liftAlgHom_ofPath k _ (baseChangeAlgHom_hcomp g)
+    (baseChangeAlgHom_hzero g) (baseChangeAlgHom_hone g) x
+
+/-- Changing coefficients and applying `g` transports a scalar through `f`. -/
+theorem baseChangeAlgHom_algebraMap (f : k →+* l) (g : pathAlgebra l Q →ₐ[l] B)
+    (a : k) :
+    letI : Algebra k B := ((algebraMap l B).comp f).toAlgebra'
+      (fun b y ↦ Algebra.commutes (R := l) (A := B) (f b) y)
+    baseChangeAlgHom f g (algebraMap k (pathAlgebra k Q) a) = algebraMap l B (f a) := by
+  let _ : Algebra k B := ((algebraMap l B).comp f).toAlgebra'
+    (fun b y ↦ Algebra.commutes (R := l) (A := B) (f b) y)
+  change baseChangeAlgHom f g (algebraMap k (pathAlgebra k Q) a) =
+    ((algebraMap l B).comp f) a
+  exact (baseChangeAlgHom f g).commutes a
+
+/-- In the algebra structure induced through `f`, the scalar action of `k` is the scalar action
+of `l` after applying `f`. -/
+theorem smul_def_baseChange (f : k →+* l) (a : k) (x : B) :
+    letI : Algebra k B := ((algebraMap l B).comp f).toAlgebra'
+      (fun b y ↦ Algebra.commutes (R := l) (A := B) (f b) y)
+    a • x = f a • x := by
+  simp only [Algebra.smul_def]
+  rfl
+
+end BaseChange
+
+section Ext
+
+variable {k : Type w} {Q : Type u} {A B : Type*}
+  [CommSemiring k] [Quiver.{v} Q] [Finite Q]
+  [Semiring A] [Algebra k A] [Semiring B]
+
+/-- Two ring homomorphisms out of a quotient of a path algebra are equal if they agree on
+coefficients and on the images of all paths. -/
+theorem ringHom_ext_of_surjective (q : pathAlgebra k Q →ₐ[k] A) (hq : Function.Surjective q)
+    {g h : A →+* B}
+    (hscalar : ∀ r : k, g (algebraMap k A r) = h (algebraMap k A r))
+    (hpath : ∀ x : Quiver.TotalPath Q, g (q (ofPath x)) = h (q (ofPath x))) :
+    g = h := by
+  apply RingHom.ext
+  intro y
+  obtain ⟨x, rfl⟩ := hq y
+  induction x using induction_linear with
+  | zero => simp
+  | add x y hx hy => simp only [map_add, hx, hy]
+  | single x a =>
+      rw [single_eq_smul_ofPath, map_smul]
+      simp only [Algebra.smul_def, map_mul, hscalar, hpath]
+
+end Ext
+
+end TauCeti.PathAlgebra

--- a/TauCeti/RepresentationTheory/Quiver/PathAlgebra/BaseChange.lean
+++ b/TauCeti/RepresentationTheory/Quiver/PathAlgebra/BaseChange.lean
@@ -16,7 +16,8 @@ algebra while leaving its paths fixed.  More generally, if an `l`-algebra homomo
 `kQ`, where the target is regarded as a `k`-algebra through `f`.
 
 The construction packages the common path-algebra step in base-change maps for relation
-quotients.
+quotients.  The construction `baseChangeAlgHom` was generalized from
+`TauCeti.RepresentationTheory.Quiver.Preprojective.BaseChange`.
 -/
 
 public section
@@ -84,31 +85,6 @@ theorem baseChangeAlgHom_ofPath (f : k →+* l) (g : pathAlgebra l Q →ₐ[l] B
   rw [baseChangeAlgHom]
   exact liftAlgHom_ofPath k _ (baseChangeAlgHom_hcomp g)
     (baseChangeAlgHom_hzero g) (baseChangeAlgHom_hone g) x
-
-/-- In the `k`-algebra structure induced through `f`, the algebra map applies `f` before the
-original `l`-algebra map. -/
-@[simp]
-theorem algebraMap_baseChange (f : k →+* l) (a : k) :
-    letI : Algebra k B := ((algebraMap l B).comp f).toAlgebra'
-      (fun b y ↦ Algebra.commutes (R := l) (A := B) (f b) y)
-    algebraMap k B a = algebraMap l B (f a) := by
-  let _ : Algebra k B := ((algebraMap l B).comp f).toAlgebra'
-    (fun b y ↦ Algebra.commutes (R := l) (A := B) (f b) y)
-  -- `toAlgebra'` makes the target's `k`-algebra map the displayed composite.
-  change ((algebraMap l B).comp f) a = algebraMap l B (f a)
-  rw [RingHom.comp_apply]
-
-/-- In the algebra structure induced through `f`, the scalar action of `k` is the scalar action
-of `l` after applying `f`. -/
-@[simp]
-theorem smul_def_baseChange (f : k →+* l) (a : k) (x : B) :
-    letI : Algebra k B := ((algebraMap l B).comp f).toAlgebra'
-      (fun b y ↦ Algebra.commutes (R := l) (A := B) (f b) y)
-    a • x = f a • x := by
-  simp only [Algebra.smul_def]
-  -- Expose the coefficient map supplied by `toAlgebra'` before evaluating the composite.
-  change ((algebraMap l B).comp f) a * x = algebraMap l B (f a) * x
-  rw [RingHom.comp_apply]
 
 end BaseChange
 

--- a/TauCeti/RepresentationTheory/Quiver/PathAlgebra/Basic.lean
+++ b/TauCeti/RepresentationTheory/Quiver/PathAlgebra/Basic.lean
@@ -842,6 +842,31 @@ theorem algEquiv_ext ⦃f g : pathAlgebra k Q ≃ₐ[k] B⦄
 
 end Lift
 
+section Ext
+
+variable {k : Type w} {Q : Type u} {A B : Type*}
+  [CommSemiring k] [Quiver.{v} Q] [Finite Q]
+  [Semiring A] [Algebra k A] [Semiring B]
+
+/-- Two ring homomorphisms out of a quotient of a path algebra are equal if they agree on
+coefficients and on the images of all paths. -/
+theorem ringHom_ext_of_surjective (q : pathAlgebra k Q →ₐ[k] A) (hq : Function.Surjective q)
+    {g h : A →+* B}
+    (hscalar : ∀ r : k, g (algebraMap k A r) = h (algebraMap k A r))
+    (hpath : ∀ x : Quiver.TotalPath Q, g (q (ofPath x)) = h (q (ofPath x))) :
+    g = h := by
+  apply RingHom.ext
+  intro y
+  obtain ⟨x, rfl⟩ := hq y
+  induction x using induction_linear with
+  | zero => simp
+  | add x y hx hy => simp only [map_add, hx, hy]
+  | single x a =>
+      rw [single_eq_smul_ofPath, map_smul]
+      simp only [Algebra.smul_def, map_mul, hscalar, hpath]
+
+end Ext
+
 end PathAlgebra
 
 section DivisionRing

--- a/TauCeti/RepresentationTheory/Quiver/PathAlgebra/Basic.lean
+++ b/TauCeti/RepresentationTheory/Quiver/PathAlgebra/Basic.lean
@@ -848,8 +848,8 @@ variable {k : Type w} {Q : Type u} {A B : Type*}
   [CommSemiring k] [Quiver.{v} Q] [Finite Q]
   [Semiring A] [Algebra k A] [Semiring B]
 
-/-- Two ring homomorphisms out of a quotient of a path algebra are equal if they agree on
-coefficients and on the images of all paths. -/
+/-- Two ring homomorphisms out of an algebra admitting a surjective map from a path algebra are
+equal if they agree on coefficients and on the images of all paths. -/
 theorem ringHom_ext_of_surjective (q : pathAlgebra k Q →ₐ[k] A) (hq : Function.Surjective q)
     {g h : A →+* B}
     (hscalar : ∀ r : k, g (algebraMap k A r) = h (algebraMap k A r))

--- a/TauCeti/RepresentationTheory/Quiver/Preprojective/BaseChange.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Preprojective/BaseChange.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.RepresentationTheory.Quiver.PathAlgebra.BaseChange
 public import TauCeti.RepresentationTheory.Quiver.Preprojective.Basic
 
 /-!
@@ -47,42 +48,6 @@ variable {k : Type w} {l : Type z} {Q : Type u}
   [CommRing k] [CommRing l] [Quiver.{v + 1} Q] [Fintype Q]
   [∀ i j : Q, Fintype (i ⟶ j)]
 
-/-! ### The path-algebra map behind the quotient map -/
-
-private theorem preprojectiveBaseChangePathAlgHom_hcomp
-    {a b c : Symmetrify Q} (p : Path a b) (q : Path c a) :
-    (preprojectiveMk l Q (ofPath ⟨a, b, p⟩) : preprojectiveAlgebra l Q) *
-        preprojectiveMk l Q (ofPath ⟨c, a, q⟩) =
-      preprojectiveMk l Q (ofPath ⟨c, b, q.comp p⟩) := by
-  rw [← map_mul, ofPath_mul_ofPath_of_comp]
-
-private theorem preprojectiveBaseChangePathAlgHom_hzero
-    {x y : Quiver.TotalPath (Symmetrify Q)} (h : y.2.1 ≠ x.1) :
-    (preprojectiveMk l Q (ofPath x) : preprojectiveAlgebra l Q) *
-        preprojectiveMk l Q (ofPath y) = 0 := by
-  rw [← map_mul, ofPath_mul_ofPath_of_not_composable h, map_zero]
-
-private theorem preprojectiveBaseChangePathAlgHom_hone :
-    letI : Fintype (Symmetrify Q) := Fintype.ofFinite _
-    (∑ v : Symmetrify Q,
-        (preprojectiveMk l Q
-          (ofPath ⟨v, v, Path.nil⟩) : preprojectiveAlgebra l Q)) = 1 := by
-  let _ := Fintype.ofFinite (Symmetrify Q)
-  calc
-    (∑ v : Symmetrify Q,
-        (preprojectiveMk l Q
-          (ofPath ⟨v, v, Path.nil⟩) : preprojectiveAlgebra l Q)) =
-        preprojectiveMk l Q (∑ v : Symmetrify Q,
-          (ofPath ⟨v, v, Path.nil⟩ : pathAlgebra l (Symmetrify Q))) := by
-      rw [map_sum]
-    _ = preprojectiveMk l Q (∑ v : Symmetrify Q, vertexIdempotent l v) := by
-      congr 1
-      apply Finset.sum_congr rfl
-      intro v hv
-      rw [vertexIdempotent_eq_ofPath]
-    _ = preprojectiveMk l Q 1 := by rw [one_def]
-    _ = 1 := (preprojectiveMk l Q).map_one
-
 private noncomputable def preprojectiveBaseChangePathAlgHom (f : k →+* l) :
     letI : Algebra k (preprojectiveAlgebra l Q) :=
       ((algebraMap l (preprojectiveAlgebra l Q)).comp f).toAlgebra'
@@ -91,11 +56,7 @@ private noncomputable def preprojectiveBaseChangePathAlgHom (f : k →+* l) :
   let _ : Algebra k (preprojectiveAlgebra l Q) :=
     ((algebraMap l (preprojectiveAlgebra l Q)).comp f).toAlgebra'
       (fun c x => Algebra.commutes (R := l) (A := preprojectiveAlgebra l Q) (f c) x)
-  exact PathAlgebra.liftAlgHom k
-    (fun x => preprojectiveMk l Q (ofPath x))
-    preprojectiveBaseChangePathAlgHom_hcomp
-    preprojectiveBaseChangePathAlgHom_hzero
-    preprojectiveBaseChangePathAlgHom_hone
+  exact PathAlgebra.baseChangeAlgHom f (preprojectiveMk l Q)
 
 private theorem preprojectiveBaseChangePathAlgHom_ofPath (f : k →+* l)
     (x : Quiver.TotalPath (Symmetrify Q)) :
@@ -106,8 +67,7 @@ private theorem preprojectiveBaseChangePathAlgHom_ofPath (f : k →+* l)
   let _ : Algebra k (preprojectiveAlgebra l Q) :=
     ((algebraMap l (preprojectiveAlgebra l Q)).comp f).toAlgebra'
       (fun c x => Algebra.commutes (R := l) (A := preprojectiveAlgebra l Q) (f c) x)
-  rw [preprojectiveBaseChangePathAlgHom]
-  exact PathAlgebra.liftAlgHom_ofPath k _ _ _ _ x
+  exact PathAlgebra.baseChangeAlgHom_ofPath f (preprojectiveMk l Q) x
 
 private theorem preprojectiveBaseChangePathAlgHom_headBacktrackElem (f : k →+* l)
     {i j : Q} (a : i ⟶ j) :

--- a/TauCeti/RepresentationTheory/Quiver/Preprojective/BaseChange.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Preprojective/BaseChange.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.RepresentationTheory.Quiver.PathAlgebra.BaseChange
 public import TauCeti.RepresentationTheory.Quiver.Preprojective.Basic
 
 /-!
@@ -48,6 +47,42 @@ variable {k : Type w} {l : Type z} {Q : Type u}
   [CommRing k] [CommRing l] [Quiver.{v + 1} Q] [Fintype Q]
   [∀ i j : Q, Fintype (i ⟶ j)]
 
+/-! ### The path-algebra map behind the quotient map -/
+
+private theorem preprojectiveBaseChangePathAlgHom_hcomp
+    {a b c : Symmetrify Q} (p : Path a b) (q : Path c a) :
+    (preprojectiveMk l Q (ofPath ⟨a, b, p⟩) : preprojectiveAlgebra l Q) *
+        preprojectiveMk l Q (ofPath ⟨c, a, q⟩) =
+      preprojectiveMk l Q (ofPath ⟨c, b, q.comp p⟩) := by
+  rw [← map_mul, ofPath_mul_ofPath_of_comp]
+
+private theorem preprojectiveBaseChangePathAlgHom_hzero
+    {x y : Quiver.TotalPath (Symmetrify Q)} (h : y.2.1 ≠ x.1) :
+    (preprojectiveMk l Q (ofPath x) : preprojectiveAlgebra l Q) *
+        preprojectiveMk l Q (ofPath y) = 0 := by
+  rw [← map_mul, ofPath_mul_ofPath_of_not_composable h, map_zero]
+
+private theorem preprojectiveBaseChangePathAlgHom_hone :
+    letI : Fintype (Symmetrify Q) := Fintype.ofFinite _
+    (∑ v : Symmetrify Q,
+        (preprojectiveMk l Q
+          (ofPath ⟨v, v, Path.nil⟩) : preprojectiveAlgebra l Q)) = 1 := by
+  let _ := Fintype.ofFinite (Symmetrify Q)
+  calc
+    (∑ v : Symmetrify Q,
+        (preprojectiveMk l Q
+          (ofPath ⟨v, v, Path.nil⟩) : preprojectiveAlgebra l Q)) =
+        preprojectiveMk l Q (∑ v : Symmetrify Q,
+          (ofPath ⟨v, v, Path.nil⟩ : pathAlgebra l (Symmetrify Q))) := by
+      rw [map_sum]
+    _ = preprojectiveMk l Q (∑ v : Symmetrify Q, vertexIdempotent l v) := by
+      congr 1
+      apply Finset.sum_congr rfl
+      intro v hv
+      rw [vertexIdempotent_eq_ofPath]
+    _ = preprojectiveMk l Q 1 := by rw [one_def]
+    _ = 1 := (preprojectiveMk l Q).map_one
+
 private noncomputable def preprojectiveBaseChangePathAlgHom (f : k →+* l) :
     letI : Algebra k (preprojectiveAlgebra l Q) :=
       ((algebraMap l (preprojectiveAlgebra l Q)).comp f).toAlgebra'
@@ -56,7 +91,11 @@ private noncomputable def preprojectiveBaseChangePathAlgHom (f : k →+* l) :
   let _ : Algebra k (preprojectiveAlgebra l Q) :=
     ((algebraMap l (preprojectiveAlgebra l Q)).comp f).toAlgebra'
       (fun c x => Algebra.commutes (R := l) (A := preprojectiveAlgebra l Q) (f c) x)
-  exact PathAlgebra.baseChangeAlgHom f (preprojectiveMk l Q)
+  exact PathAlgebra.liftAlgHom k
+    (fun x => preprojectiveMk l Q (ofPath x))
+    preprojectiveBaseChangePathAlgHom_hcomp
+    preprojectiveBaseChangePathAlgHom_hzero
+    preprojectiveBaseChangePathAlgHom_hone
 
 private theorem preprojectiveBaseChangePathAlgHom_ofPath (f : k →+* l)
     (x : Quiver.TotalPath (Symmetrify Q)) :
@@ -67,7 +106,8 @@ private theorem preprojectiveBaseChangePathAlgHom_ofPath (f : k →+* l)
   let _ : Algebra k (preprojectiveAlgebra l Q) :=
     ((algebraMap l (preprojectiveAlgebra l Q)).comp f).toAlgebra'
       (fun c x => Algebra.commutes (R := l) (A := preprojectiveAlgebra l Q) (f c) x)
-  exact PathAlgebra.baseChangeAlgHom_ofPath f (preprojectiveMk l Q) x
+  rw [preprojectiveBaseChangePathAlgHom]
+  exact PathAlgebra.liftAlgHom_ofPath k _ _ _ _ x
 
 private theorem preprojectiveBaseChangePathAlgHom_headBacktrackElem (f : k →+* l)
     {i j : Q} (a : i ⟶ j) :
@@ -169,8 +209,7 @@ theorem preprojectiveBaseChange_algebraMap (f : k →+* l) (r : k) :
 @[simp]
 theorem preprojectiveBaseChange_id :
     preprojectiveBaseChange (RingHom.id k) = RingHom.id (preprojectiveAlgebra k Q) := by
-  apply PathAlgebra.ringHom_ext_of_surjective (preprojectiveMk k Q)
-    (preprojectiveMk_surjective k Q)
+  apply preprojectiveAlgebra_ringHom_ext
   · intro r
     simp
   · intro x
@@ -182,8 +221,7 @@ maps. -/
 theorem preprojectiveBaseChange_comp {m : Type*} [CommRing m] (f : k →+* l) (g : l →+* m) :
     preprojectiveBaseChange (Q := Q) (g.comp f) =
       (preprojectiveBaseChange (Q := Q) g).comp (preprojectiveBaseChange (Q := Q) f) := by
-  apply PathAlgebra.ringHom_ext_of_surjective (preprojectiveMk k Q)
-    (preprojectiveMk_surjective k Q)
+  apply preprojectiveAlgebra_ringHom_ext
   · intro r
     simp
   · intro x

--- a/TauCeti/RepresentationTheory/Quiver/Preprojective/BaseChange.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Preprojective/BaseChange.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.RepresentationTheory.Quiver.PathAlgebra.BaseChange
 public import TauCeti.RepresentationTheory.Quiver.Preprojective.Basic
 
 /-!
@@ -47,42 +48,6 @@ variable {k : Type w} {l : Type z} {Q : Type u}
   [CommRing k] [CommRing l] [Quiver.{v + 1} Q] [Fintype Q]
   [∀ i j : Q, Fintype (i ⟶ j)]
 
-/-! ### The path-algebra map behind the quotient map -/
-
-private theorem preprojectiveBaseChangePathAlgHom_hcomp
-    {a b c : Symmetrify Q} (p : Path a b) (q : Path c a) :
-    (preprojectiveMk l Q (ofPath ⟨a, b, p⟩) : preprojectiveAlgebra l Q) *
-        preprojectiveMk l Q (ofPath ⟨c, a, q⟩) =
-      preprojectiveMk l Q (ofPath ⟨c, b, q.comp p⟩) := by
-  rw [← map_mul, ofPath_mul_ofPath_of_comp]
-
-private theorem preprojectiveBaseChangePathAlgHom_hzero
-    {x y : Quiver.TotalPath (Symmetrify Q)} (h : y.2.1 ≠ x.1) :
-    (preprojectiveMk l Q (ofPath x) : preprojectiveAlgebra l Q) *
-        preprojectiveMk l Q (ofPath y) = 0 := by
-  rw [← map_mul, ofPath_mul_ofPath_of_not_composable h, map_zero]
-
-private theorem preprojectiveBaseChangePathAlgHom_hone :
-    letI : Fintype (Symmetrify Q) := Fintype.ofFinite _
-    (∑ v : Symmetrify Q,
-        (preprojectiveMk l Q
-          (ofPath ⟨v, v, Path.nil⟩) : preprojectiveAlgebra l Q)) = 1 := by
-  let _ := Fintype.ofFinite (Symmetrify Q)
-  calc
-    (∑ v : Symmetrify Q,
-        (preprojectiveMk l Q
-          (ofPath ⟨v, v, Path.nil⟩) : preprojectiveAlgebra l Q)) =
-        preprojectiveMk l Q (∑ v : Symmetrify Q,
-          (ofPath ⟨v, v, Path.nil⟩ : pathAlgebra l (Symmetrify Q))) := by
-      rw [map_sum]
-    _ = preprojectiveMk l Q (∑ v : Symmetrify Q, vertexIdempotent l v) := by
-      congr 1
-      apply Finset.sum_congr rfl
-      intro v hv
-      rw [vertexIdempotent_eq_ofPath]
-    _ = preprojectiveMk l Q 1 := by rw [one_def]
-    _ = 1 := (preprojectiveMk l Q).map_one
-
 private noncomputable def preprojectiveBaseChangePathAlgHom (f : k →+* l) :
     letI : Algebra k (preprojectiveAlgebra l Q) :=
       ((algebraMap l (preprojectiveAlgebra l Q)).comp f).toAlgebra'
@@ -91,11 +56,7 @@ private noncomputable def preprojectiveBaseChangePathAlgHom (f : k →+* l) :
   let _ : Algebra k (preprojectiveAlgebra l Q) :=
     ((algebraMap l (preprojectiveAlgebra l Q)).comp f).toAlgebra'
       (fun c x => Algebra.commutes (R := l) (A := preprojectiveAlgebra l Q) (f c) x)
-  exact PathAlgebra.liftAlgHom k
-    (fun x => preprojectiveMk l Q (ofPath x))
-    preprojectiveBaseChangePathAlgHom_hcomp
-    preprojectiveBaseChangePathAlgHom_hzero
-    preprojectiveBaseChangePathAlgHom_hone
+  exact PathAlgebra.baseChangeAlgHom f (preprojectiveMk l Q)
 
 private theorem preprojectiveBaseChangePathAlgHom_ofPath (f : k →+* l)
     (x : Quiver.TotalPath (Symmetrify Q)) :
@@ -106,8 +67,7 @@ private theorem preprojectiveBaseChangePathAlgHom_ofPath (f : k →+* l)
   let _ : Algebra k (preprojectiveAlgebra l Q) :=
     ((algebraMap l (preprojectiveAlgebra l Q)).comp f).toAlgebra'
       (fun c x => Algebra.commutes (R := l) (A := preprojectiveAlgebra l Q) (f c) x)
-  rw [preprojectiveBaseChangePathAlgHom]
-  exact PathAlgebra.liftAlgHom_ofPath k _ _ _ _ x
+  exact PathAlgebra.baseChangeAlgHom_ofPath f (preprojectiveMk l Q) x
 
 private theorem preprojectiveBaseChangePathAlgHom_headBacktrackElem (f : k →+* l)
     {i j : Q} (a : i ⟶ j) :
@@ -209,7 +169,8 @@ theorem preprojectiveBaseChange_algebraMap (f : k →+* l) (r : k) :
 @[simp]
 theorem preprojectiveBaseChange_id :
     preprojectiveBaseChange (RingHom.id k) = RingHom.id (preprojectiveAlgebra k Q) := by
-  apply preprojectiveAlgebra_ringHom_ext
+  apply PathAlgebra.ringHom_ext_of_surjective (preprojectiveMk k Q)
+    (preprojectiveMk_surjective k Q)
   · intro r
     simp
   · intro x
@@ -221,7 +182,8 @@ maps. -/
 theorem preprojectiveBaseChange_comp {m : Type*} [CommRing m] (f : k →+* l) (g : l →+* m) :
     preprojectiveBaseChange (Q := Q) (g.comp f) =
       (preprojectiveBaseChange (Q := Q) g).comp (preprojectiveBaseChange (Q := Q) f) := by
-  apply preprojectiveAlgebra_ringHom_ext
+  apply PathAlgebra.ringHom_ext_of_surjective (preprojectiveMk k Q)
+    (preprojectiveMk_surjective k Q)
   · intro r
     simp
   · intro x

--- a/TauCeti/RepresentationTheory/Quiver/Preprojective/Basic.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Preprojective/Basic.lean
@@ -523,6 +523,26 @@ theorem preprojectiveMk_apply (f : pathAlgebra k (Symmetrify Q)) :
 theorem preprojectiveMk_surjective : Function.Surjective (preprojectiveMk k Q) :=
   Ideal.Quotient.mk_surjective
 
+/-- Two ring homomorphisms out of a preprojective algebra are equal if they agree on coefficients
+and on the classes of all doubled paths. -/
+theorem preprojectiveAlgebra_ringHom_ext {B : Type*} [Semiring B]
+    {g h : preprojectiveAlgebra k Q →+* B}
+    (hscalar : ∀ r : k,
+      g (algebraMap k (preprojectiveAlgebra k Q) r) =
+        h (algebraMap k (preprojectiveAlgebra k Q) r))
+    (hpath : ∀ x : Quiver.TotalPath (Symmetrify Q),
+      g (preprojectiveMk k Q (ofPath x)) = h (preprojectiveMk k Q (ofPath x))) :
+    g = h := by
+  apply RingHom.ext
+  intro y
+  obtain ⟨x, rfl⟩ := preprojectiveMk_surjective k Q y
+  induction x using PathAlgebra.induction_linear with
+  | zero => simp
+  | add x y hx hy => simp only [map_add, hx, hy]
+  | single x c =>
+      rw [single_eq_smul_ofPath, map_smul]
+      simp only [Algebra.smul_def, map_mul, hscalar, hpath]
+
 @[simp]
 theorem preprojectiveMk_eq_zero_iff {f : pathAlgebra k (Symmetrify Q)} :
     preprojectiveMk k Q f = 0 ↔ f ∈ preprojectiveIdeal k Q := by

--- a/TauCeti/RepresentationTheory/Quiver/Preprojective/Basic.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Preprojective/Basic.lean
@@ -523,26 +523,6 @@ theorem preprojectiveMk_apply (f : pathAlgebra k (Symmetrify Q)) :
 theorem preprojectiveMk_surjective : Function.Surjective (preprojectiveMk k Q) :=
   Ideal.Quotient.mk_surjective
 
-/-- Two ring homomorphisms out of a preprojective algebra are equal if they agree on coefficients
-and on the classes of all doubled paths. -/
-theorem preprojectiveAlgebra_ringHom_ext {B : Type*} [Semiring B]
-    {g h : preprojectiveAlgebra k Q →+* B}
-    (hscalar : ∀ r : k,
-      g (algebraMap k (preprojectiveAlgebra k Q) r) =
-        h (algebraMap k (preprojectiveAlgebra k Q) r))
-    (hpath : ∀ x : Quiver.TotalPath (Symmetrify Q),
-      g (preprojectiveMk k Q (ofPath x)) = h (preprojectiveMk k Q (ofPath x))) :
-    g = h := by
-  apply RingHom.ext
-  intro y
-  obtain ⟨x, rfl⟩ := preprojectiveMk_surjective k Q y
-  induction x using PathAlgebra.induction_linear with
-  | zero => simp
-  | add x y hx hy => simp only [map_add, hx, hy]
-  | single x c =>
-      rw [single_eq_smul_ofPath, map_smul]
-      simp only [Algebra.smul_def, map_mul, hscalar, hpath]
-
 @[simp]
 theorem preprojectiveMk_eq_zero_iff {f : pathAlgebra k (Symmetrify Q)} :
     preprojectiveMk k Q f = 0 ↔ f ∈ preprojectiveIdeal k Q := by

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/BaseChange.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/BaseChange.lean
@@ -200,9 +200,12 @@ theorem skewZigzagIdeal_map_comp {m : Type*} [CommRing m]
     (f : k →+* l) (g : l →+* m) (c : SkewZigzagParameter k G) :
     (skewZigzagIdeal m G (c.map (g.comp f : k →* m))).asIdeal =
       (skewZigzagIdeal m G ((c.map (f : k →* l)).map (g : l →* m))).asIdeal :=
-  congrArg (fun d : SkewZigzagParameter m G => (skewZigzagIdeal m G d).asIdeal) (by
-    ext i j j' h h'
-    simp)
+  congrArg (fun d : SkewZigzagParameter m G => (skewZigzagIdeal m G d).asIdeal)
+    (by
+      rw [show (g.comp f : k →* m) = (g : l →* m).comp (f : k →* l) by
+        ext x
+        rfl]
+      exact SkewZigzagParameter.map_comp (f : k →* l) (g : l →* m) c)
 
 /-- Scalar extension along the identity coefficient homomorphism is the identity map. -/
 @[simp]

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/BaseChange.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/BaseChange.lean
@@ -187,7 +187,7 @@ theorem skewZigzagBaseChange_algebraMap
 
 /-- Mapping a skew-zigzag parameter along the identity homomorphism leaves its relation ideal
 unchanged. -/
-theorem skewZigzagIdeal_map_id (c : SkewZigzagParameter k G) :
+private theorem skewZigzagIdeal_map_id (c : SkewZigzagParameter k G) :
     (skewZigzagIdeal k G (c.map (RingHom.id k : k →* k))).asIdeal =
       (skewZigzagIdeal k G c).asIdeal :=
   congrArg (fun d : SkewZigzagParameter k G => (skewZigzagIdeal k G d).asIdeal) (by
@@ -196,7 +196,7 @@ theorem skewZigzagIdeal_map_id (c : SkewZigzagParameter k G) :
 
 /-- Mapping a skew-zigzag parameter along a composite or successively gives the same relation
 ideal. -/
-theorem skewZigzagIdeal_map_comp {m : Type*} [CommRing m]
+private theorem skewZigzagIdeal_map_comp {m : Type*} [CommRing m]
     (f : k →+* l) (g : l →+* m) (c : SkewZigzagParameter k G) :
     (skewZigzagIdeal m G (c.map (g.comp f : k →* m))).asIdeal =
       (skewZigzagIdeal m G ((c.map (f : k →* l)).map (g : l →* m))).asIdeal :=
@@ -214,7 +214,10 @@ theorem skewZigzagIdeal_map_comp {m : Type*} [CommRing m]
 theorem skewZigzagBaseChange_id (c : SkewZigzagParameter k G) :
     (Ideal.quotientEquivAlgOfEq k
       (I := (skewZigzagIdeal k G (c.map (RingHom.id k : k →* k))).asIdeal)
-      (J := (skewZigzagIdeal k G c).asIdeal) (skewZigzagIdeal_map_id G c)).toRingHom.comp
+      (J := (skewZigzagIdeal k G c).asIdeal)
+      (congrArg (fun d : SkewZigzagParameter k G => (skewZigzagIdeal k G d).asIdeal) (by
+        simpa only [RingHom.toMonoidHom_eq_coe, RingHom.coe_monoidHom_id] using
+          SkewZigzagParameter.map_id c))).toRingHom.comp
         (skewZigzagBaseChange G (RingHom.id k) c) =
       RingHom.id (skewZigzagQuotient k G c) := by
   apply PathAlgebra.ringHom_ext_of_surjective (skewZigzagMk k G c)
@@ -235,7 +238,12 @@ scalar-extension maps. -/
 @[simp]
 theorem skewZigzagBaseChange_comp {m : Type*} [CommRing m]
     (f : k →+* l) (g : l →+* m) (c : SkewZigzagParameter k G) :
-    (Ideal.Quotient.factor (le_of_eq (skewZigzagIdeal_map_comp G f g c))).comp
+    (Ideal.Quotient.factor (le_of_eq
+      (congrArg (fun d : SkewZigzagParameter m G => (skewZigzagIdeal m G d).asIdeal) (by
+        rw [show (g.comp f : k →* m) = (g : l →* m).comp (f : k →* l) by
+          ext x
+          rfl]
+        exact SkewZigzagParameter.map_comp (f : k →* l) (g : l →* m) c)))).comp
         (skewZigzagBaseChange G (g.comp f) c) =
       (skewZigzagBaseChange G g (c.map (f : k →* l))).comp
         (skewZigzagBaseChange G f c) := by

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/BaseChange.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/BaseChange.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.RepresentationTheory.Quiver.PathAlgebra.BaseChange
 public import TauCeti.RepresentationTheory.Quiver.Zigzag.Gauge
 
 /-!
@@ -22,9 +23,8 @@ presentation-level scalar-extension map; it does not identify the target with a 
 The parameter construction is functorial in the coefficient homomorphism and is compatible with
 gauge transforms, so gauge-equivalent parameters remain gauge equivalent after scalar extension.
 
-The parameter construction only needs a monoid homomorphism.  Injectivity is stated only when the
-homomorphism itself is injective, since extending coefficients need not distinguish units without
-that hypothesis.
+The parameter construction only needs a monoid homomorphism.  Injectivity is stated exactly when
+the induced map on units is injective, since the parameters only record unit-valued ratios.
 
 ## Main definitions
 
@@ -40,10 +40,13 @@ that hypothesis.
 * `TauCeti.skewZigzagBaseChange_skewZigzagMk_ofPath`: scalar extension fixes every doubled path.
 * `TauCeti.skewZigzagBaseChange_algebraMap`: scalar coefficients are transported by the given
   ring homomorphism.
+* `TauCeti.skewZigzagBaseChange_id` and `TauCeti.skewZigzagBaseChange_comp`: scalar extension is
+  functorial in the coefficient homomorphism.
 
 The parameter conventions follow C. Couture, *Skew-Zigzag Algebras*, Sections 3 and 4,
-https://arxiv.org/abs/1509.08405; the coefficient map is induced directly from the presented
-relations.
+https://arxiv.org/abs/1509.08405.  The coefficient-map construction follows
+`TauCeti.RepresentationTheory.Quiver.Preprojective.BaseChange` and implements the scalar-extension
+clause of Layer 1 of `TauCetiRoadmap/ZigzagPreprojective/README.md`.
 -/
 
 public section
@@ -101,14 +104,13 @@ theorem map_comp {m : Type*} [Monoid m] (f : k →* l) (g : l →* m)
   ext i j j' h h'
   simp [Units.map_comp]
 
-/-- An injective coefficient homomorphism induces an injective map on skew-zigzag parameters. -/
-theorem map_injective (f : k →* l) (hf : Function.Injective f) :
+/-- Injectivity on units induces an injective map on skew-zigzag parameters. -/
+theorem map_injective (f : k →* l) (hf : Function.Injective (Units.map f)) :
     Function.Injective (map (G := G) f) := by
   intro c c' h
   apply SkewZigzagParameter.ext
   funext i j j' hi hj
-  apply Units.map_injective hf
-  exact congrArg (fun d : SkewZigzagParameter l G => d.ratio hi hj) h
+  exact hf (congrArg (fun d : SkewZigzagParameter l G => d.ratio hi hj) h)
 
 end Map
 
@@ -148,140 +150,93 @@ section Quotient
 variable {k : Type w} {l : Type z} {V : Type u}
   [CommRing k] [CommRing l] (G : SimpleGraph V) [Finite V]
 
-private theorem skewZigzagBaseChangePathAlgHom_hcomp
-    (f : k →+* l) (c : SkewZigzagParameter k G) {a b d : DoubledQuiver G}
-    (p : Path a b) (q : Path d a) :
-    (skewZigzagMk l G (c.map f.toMonoidHom) (ofPath ⟨a, b, p⟩) :
-        skewZigzagQuotient l G (c.map f.toMonoidHom)) *
-      skewZigzagMk l G (c.map f.toMonoidHom)
-          (ofPath ⟨d, a, q⟩) =
-        skewZigzagMk l G (c.map f.toMonoidHom)
-          (ofPath ⟨d, b, q.comp p⟩) := by
-  rw [← map_mul, ofPath_mul_ofPath_of_comp]
-
-private theorem skewZigzagBaseChangePathAlgHom_hzero
-    (f : k →+* l) (c : SkewZigzagParameter k G)
-    {x y : Quiver.TotalPath (DoubledQuiver G)} (h : y.2.1 ≠ x.1) :
-    (skewZigzagMk l G (c.map f.toMonoidHom) (ofPath x) :
-        skewZigzagQuotient l G (c.map f.toMonoidHom)) *
-      skewZigzagMk l G (c.map f.toMonoidHom) (ofPath y) = 0 := by
-  rw [← map_mul, ofPath_mul_ofPath_of_not_composable h, map_zero]
-
-private theorem skewZigzagBaseChangePathAlgHom_hone
-    (f : k →+* l) (c : SkewZigzagParameter k G) :
-    letI : Fintype (DoubledQuiver G) := Fintype.ofFinite _
-    (∑ v : DoubledQuiver G,
-        (skewZigzagMk l G (c.map f.toMonoidHom)
-          (ofPath ⟨v, v, Path.nil⟩) : skewZigzagQuotient l G (c.map f.toMonoidHom))) = 1 := by
-  let _ := Fintype.ofFinite (DoubledQuiver G)
-  calc
-    (∑ v : DoubledQuiver G,
-        (skewZigzagMk l G (c.map f.toMonoidHom)
-          (ofPath ⟨v, v, Path.nil⟩) : skewZigzagQuotient l G (c.map f.toMonoidHom))) =
-        skewZigzagMk l G (c.map f.toMonoidHom)
-          (∑ v : DoubledQuiver G, (ofPath ⟨v, v, Path.nil⟩ :
-            pathAlgebra l (DoubledQuiver G))) := by
-      rw [map_sum]
-    _ = skewZigzagMk l G (c.map f.toMonoidHom)
-        (∑ v : DoubledQuiver G, vertexIdempotent l v) := by
-      congr 1
-      apply Finset.sum_congr rfl
-      intro v hv
-      rw [vertexIdempotent_eq_ofPath]
-    _ = skewZigzagMk l G (c.map f.toMonoidHom) 1 := by rw [one_def]
-    _ = 1 := (skewZigzagMk l G (c.map f.toMonoidHom)).map_one
-
 private noncomputable def skewZigzagBaseChangePathAlgHom
     (f : k →+* l) (c : SkewZigzagParameter k G) :
-    letI : Algebra k (skewZigzagQuotient l G (c.map f.toMonoidHom)) :=
-      ((algebraMap l (skewZigzagQuotient l G (c.map f.toMonoidHom))).comp f).toAlgebra'
+    letI : Algebra k (skewZigzagQuotient l G (c.map (f : k →* l))) :=
+      ((algebraMap l (skewZigzagQuotient l G (c.map (f : k →* l)))).comp f).toAlgebra'
         (fun a x => Algebra.commutes (R := l)
-          (A := skewZigzagQuotient l G (c.map f.toMonoidHom)) (f a) x)
-    pathAlgebra k (DoubledQuiver G) →ₐ[k] skewZigzagQuotient l G (c.map f.toMonoidHom) := by
-  let _ : Algebra k (skewZigzagQuotient l G (c.map f.toMonoidHom)) :=
-    ((algebraMap l (skewZigzagQuotient l G (c.map f.toMonoidHom))).comp f).toAlgebra'
+          (A := skewZigzagQuotient l G (c.map (f : k →* l))) (f a) x)
+    pathAlgebra k (DoubledQuiver G) →ₐ[k] skewZigzagQuotient l G (c.map (f : k →* l)) := by
+  let _ : Algebra k (skewZigzagQuotient l G (c.map (f : k →* l))) :=
+    ((algebraMap l (skewZigzagQuotient l G (c.map (f : k →* l)))).comp f).toAlgebra'
       (fun a x => Algebra.commutes (R := l)
-        (A := skewZigzagQuotient l G (c.map f.toMonoidHom)) (f a) x)
-  exact PathAlgebra.liftAlgHom k
-    (fun x => skewZigzagMk l G (c.map f.toMonoidHom) (ofPath x))
-    (skewZigzagBaseChangePathAlgHom_hcomp G f c)
-    (skewZigzagBaseChangePathAlgHom_hzero G f c)
-    (skewZigzagBaseChangePathAlgHom_hone G f c)
+        (A := skewZigzagQuotient l G (c.map (f : k →* l))) (f a) x)
+  exact PathAlgebra.baseChangeAlgHom f (skewZigzagMk l G (c.map (f : k →* l)))
 
 private theorem skewZigzagBaseChangePathAlgHom_ofPath
     (f : k →+* l) (c : SkewZigzagParameter k G)
     (x : Quiver.TotalPath (DoubledQuiver G)) :
-    letI : Algebra k (skewZigzagQuotient l G (c.map f.toMonoidHom)) :=
-      ((algebraMap l (skewZigzagQuotient l G (c.map f.toMonoidHom))).comp f).toAlgebra'
+    letI : Algebra k (skewZigzagQuotient l G (c.map (f : k →* l))) :=
+      ((algebraMap l (skewZigzagQuotient l G (c.map (f : k →* l)))).comp f).toAlgebra'
         (fun a y => Algebra.commutes (R := l)
-          (A := skewZigzagQuotient l G (c.map f.toMonoidHom)) (f a) y)
+          (A := skewZigzagQuotient l G (c.map (f : k →* l))) (f a) y)
     skewZigzagBaseChangePathAlgHom G f c (ofPath x) =
-      skewZigzagMk l G (c.map f.toMonoidHom) (ofPath x) := by
-  let _ : Algebra k (skewZigzagQuotient l G (c.map f.toMonoidHom)) :=
-    ((algebraMap l (skewZigzagQuotient l G (c.map f.toMonoidHom))).comp f).toAlgebra'
+      skewZigzagMk l G (c.map (f : k →* l)) (ofPath x) := by
+  let _ : Algebra k (skewZigzagQuotient l G (c.map (f : k →* l))) :=
+    ((algebraMap l (skewZigzagQuotient l G (c.map (f : k →* l)))).comp f).toAlgebra'
       (fun a y => Algebra.commutes (R := l)
-        (A := skewZigzagQuotient l G (c.map f.toMonoidHom)) (f a) y)
-  rw [skewZigzagBaseChangePathAlgHom]
-  exact PathAlgebra.liftAlgHom_ofPath k _ _ _ _ x
+        (A := skewZigzagQuotient l G (c.map (f : k →* l))) (f a) y)
+  exact PathAlgebra.baseChangeAlgHom_ofPath f
+    (skewZigzagMk l G (c.map (f : k →* l))) x
 
 private theorem skewZigzagBaseChangePathAlgHom_backtrackElem
     (f : k →+* l) (c : SkewZigzagParameter k G) {i j : V} (h : G.Adj i j) :
-    letI : Algebra k (skewZigzagQuotient l G (c.map f.toMonoidHom)) :=
-      ((algebraMap l (skewZigzagQuotient l G (c.map f.toMonoidHom))).comp f).toAlgebra'
+    letI : Algebra k (skewZigzagQuotient l G (c.map (f : k →* l))) :=
+      ((algebraMap l (skewZigzagQuotient l G (c.map (f : k →* l)))).comp f).toAlgebra'
         (fun a y => Algebra.commutes (R := l)
-          (A := skewZigzagQuotient l G (c.map f.toMonoidHom)) (f a) y)
+          (A := skewZigzagQuotient l G (c.map (f : k →* l))) (f a) y)
     skewZigzagBaseChangePathAlgHom G f c (backtrackElem G k h) =
-      skewZigzagMk l G (c.map f.toMonoidHom) (backtrackElem G l h) := by
-  let _ : Algebra k (skewZigzagQuotient l G (c.map f.toMonoidHom)) :=
-    ((algebraMap l (skewZigzagQuotient l G (c.map f.toMonoidHom))).comp f).toAlgebra'
+      skewZigzagMk l G (c.map (f : k →* l)) (backtrackElem G l h) := by
+  let _ : Algebra k (skewZigzagQuotient l G (c.map (f : k →* l))) :=
+    ((algebraMap l (skewZigzagQuotient l G (c.map (f : k →* l)))).comp f).toAlgebra'
       (fun a y => Algebra.commutes (R := l)
-        (A := skewZigzagQuotient l G (c.map f.toMonoidHom)) (f a) y)
+        (A := skewZigzagQuotient l G (c.map (f : k →* l))) (f a) y)
   rw [backtrackElem_eq_ofPath, skewZigzagBaseChangePathAlgHom_ofPath,
     backtrackElem_eq_ofPath]
 
 private theorem skewZigzagBaseChangePathAlgHom_relator
     (f : k →+* l) (c : SkewZigzagParameter k G)
     (x : pathAlgebra k (DoubledQuiver G)) (hx : IsSkewZigzagRelator k G c x) :
-    letI : Algebra k (skewZigzagQuotient l G (c.map f.toMonoidHom)) :=
-      ((algebraMap l (skewZigzagQuotient l G (c.map f.toMonoidHom))).comp f).toAlgebra'
+    letI : Algebra k (skewZigzagQuotient l G (c.map (f : k →* l))) :=
+      ((algebraMap l (skewZigzagQuotient l G (c.map (f : k →* l)))).comp f).toAlgebra'
         (fun a y => Algebra.commutes (R := l)
-          (A := skewZigzagQuotient l G (c.map f.toMonoidHom)) (f a) y)
+          (A := skewZigzagQuotient l G (c.map (f : k →* l))) (f a) y)
     skewZigzagBaseChangePathAlgHom G f c x = 0 := by
-  let _ : Algebra k (skewZigzagQuotient l G (c.map f.toMonoidHom)) :=
-    ((algebraMap l (skewZigzagQuotient l G (c.map f.toMonoidHom))).comp f).toAlgebra'
+  let _ : Algebra k (skewZigzagQuotient l G (c.map (f : k →* l))) :=
+    ((algebraMap l (skewZigzagQuotient l G (c.map (f : k →* l)))).comp f).toAlgebra'
       (fun a y => Algebra.commutes (R := l)
-        (A := skewZigzagQuotient l G (c.map f.toMonoidHom)) (f a) y)
+        (A := skewZigzagQuotient l G (c.map (f : k →* l))) (f a) y)
   cases hx with
   | nonreturn p hlen hne =>
       rw [skewZigzagBaseChangePathAlgHom_ofPath]
-      exact skewZigzagMk_ofPath_eq_zero_of_ne l G (c.map f.toMonoidHom) p hlen hne
+      exact skewZigzagMk_ofPath_eq_zero_of_ne l G (c.map (f : k →* l)) p hlen hne
   | backtrack_ratio h h' =>
       rw [map_sub, map_smul, skewZigzagBaseChangePathAlgHom_backtrackElem,
         skewZigzagBaseChangePathAlgHom_backtrackElem, sub_eq_zero]
       calc
-        skewZigzagMk l G (c.map f.toMonoidHom) (backtrackElem G l h) =
-            ((c.map f.toMonoidHom).ratio h h' : l) •
-              skewZigzagMk l G (c.map f.toMonoidHom) (backtrackElem G l h') :=
-          skewZigzagMk_backtrackElem_eq_smul l G (c.map f.toMonoidHom) h h'
+        skewZigzagMk l G (c.map (f : k →* l)) (backtrackElem G l h) =
+            ((c.map (f : k →* l)).ratio h h' : l) •
+              skewZigzagMk l G (c.map (f : k →* l)) (backtrackElem G l h') :=
+          skewZigzagMk_backtrackElem_eq_smul l G (c.map (f : k →* l)) h h'
         _ = (c.ratio h h' : k) •
-              skewZigzagMk l G (c.map f.toMonoidHom) (backtrackElem G l h') := by
-          simp only [Algebra.smul_def, SkewZigzagParameter.map_ratio, Units.coe_map]
-          rfl
+              skewZigzagMk l G (c.map (f : k →* l)) (backtrackElem G l h') := by
+          rw [PathAlgebra.smul_def_baseChange]
+          simp
   | long_path y h3 =>
       rw [skewZigzagBaseChangePathAlgHom_ofPath]
-      exact skewZigzagMk_ofPath_eq_zero_of_three_le l G (c.map f.toMonoidHom) y h3
+      exact skewZigzagMk_ofPath_eq_zero_of_three_le l G (c.map (f : k →* l)) y h3
 
 private noncomputable def skewZigzagBaseChangeAlgHom
     (f : k →+* l) (c : SkewZigzagParameter k G) :
-    letI : Algebra k (skewZigzagQuotient l G (c.map f.toMonoidHom)) :=
-      ((algebraMap l (skewZigzagQuotient l G (c.map f.toMonoidHom))).comp f).toAlgebra'
+    letI : Algebra k (skewZigzagQuotient l G (c.map (f : k →* l))) :=
+      ((algebraMap l (skewZigzagQuotient l G (c.map (f : k →* l)))).comp f).toAlgebra'
         (fun a y => Algebra.commutes (R := l)
-          (A := skewZigzagQuotient l G (c.map f.toMonoidHom)) (f a) y)
-    skewZigzagQuotient k G c →ₐ[k] skewZigzagQuotient l G (c.map f.toMonoidHom) := by
-  let _ : Algebra k (skewZigzagQuotient l G (c.map f.toMonoidHom)) :=
-    ((algebraMap l (skewZigzagQuotient l G (c.map f.toMonoidHom))).comp f).toAlgebra'
+          (A := skewZigzagQuotient l G (c.map (f : k →* l))) (f a) y)
+    skewZigzagQuotient k G c →ₐ[k] skewZigzagQuotient l G (c.map (f : k →* l)) := by
+  let _ : Algebra k (skewZigzagQuotient l G (c.map (f : k →* l))) :=
+    ((algebraMap l (skewZigzagQuotient l G (c.map (f : k →* l)))).comp f).toAlgebra'
       (fun a y => Algebra.commutes (R := l)
-        (A := skewZigzagQuotient l G (c.map f.toMonoidHom)) (f a) y)
+        (A := skewZigzagQuotient l G (c.map (f : k →* l))) (f a) y)
   exact skewZigzagLift k G c (skewZigzagBaseChangePathAlgHom G f c)
     (skewZigzagBaseChangePathAlgHom_relator G f c)
 
@@ -291,10 +246,10 @@ It fixes every doubled path and applies `f` to scalar coefficients.  The codomai
 parameter obtained by applying `f` to every unit-valued ratio. -/
 noncomputable def skewZigzagBaseChange (f : k →+* l) (c : SkewZigzagParameter k G) :
     skewZigzagQuotient k G c →+* skewZigzagQuotient l G (c.map (f : k →* l)) := by
-  let _ : Algebra k (skewZigzagQuotient l G (c.map f.toMonoidHom)) :=
-    ((algebraMap l (skewZigzagQuotient l G (c.map f.toMonoidHom))).comp f).toAlgebra'
+  let _ : Algebra k (skewZigzagQuotient l G (c.map (f : k →* l))) :=
+    ((algebraMap l (skewZigzagQuotient l G (c.map (f : k →* l)))).comp f).toAlgebra'
       (fun a y => Algebra.commutes (R := l)
-        (A := skewZigzagQuotient l G (c.map f.toMonoidHom)) (f a) y)
+        (A := skewZigzagQuotient l G (c.map (f : k →* l))) (f a) y)
   exact (skewZigzagBaseChangeAlgHom G f c).toRingHom
 
 /-- Scalar extension sends the class of every doubled path to the class of the same path over the
@@ -305,15 +260,14 @@ theorem skewZigzagBaseChange_skewZigzagMk_ofPath
     (x : Quiver.TotalPath (DoubledQuiver G)) :
     skewZigzagBaseChange G f c (skewZigzagMk k G c (ofPath x)) =
       skewZigzagMk l G (c.map (f : k →* l)) (ofPath x) := by
-  let _ : Algebra k (skewZigzagQuotient l G (c.map f.toMonoidHom)) :=
-    ((algebraMap l (skewZigzagQuotient l G (c.map f.toMonoidHom))).comp f).toAlgebra'
+  let _ : Algebra k (skewZigzagQuotient l G (c.map (f : k →* l))) :=
+    ((algebraMap l (skewZigzagQuotient l G (c.map (f : k →* l)))).comp f).toAlgebra'
       (fun a y => Algebra.commutes (R := l)
-        (A := skewZigzagQuotient l G (c.map f.toMonoidHom)) (f a) y)
+        (A := skewZigzagQuotient l G (c.map (f : k →* l))) (f a) y)
   -- The public map is the underlying ring map of the quotient lift.
   change skewZigzagBaseChangeAlgHom G f c (skewZigzagMk k G c (ofPath x)) = _
   rw [skewZigzagBaseChangeAlgHom, skewZigzagLift_skewZigzagMk,
     skewZigzagBaseChangePathAlgHom_ofPath]
-  rfl
 
 /-- Scalar extension carries the source scalar action to the target scalar action through the
 coefficient homomorphism. -/
@@ -322,14 +276,67 @@ theorem skewZigzagBaseChange_algebraMap
     (f : k →+* l) (c : SkewZigzagParameter k G) (a : k) :
     skewZigzagBaseChange G f c (algebraMap k (skewZigzagQuotient k G c) a) =
       algebraMap l (skewZigzagQuotient l G (c.map (f : k →* l))) (f a) := by
-  let _ : Algebra k (skewZigzagQuotient l G (c.map f.toMonoidHom)) :=
-    ((algebraMap l (skewZigzagQuotient l G (c.map f.toMonoidHom))).comp f).toAlgebra'
+  let _ : Algebra k (skewZigzagQuotient l G (c.map (f : k →* l))) :=
+    ((algebraMap l (skewZigzagQuotient l G (c.map (f : k →* l)))).comp f).toAlgebra'
       (fun b y => Algebra.commutes (R := l)
-        (A := skewZigzagQuotient l G (c.map f.toMonoidHom)) (f b) y)
+        (A := skewZigzagQuotient l G (c.map (f : k →* l))) (f b) y)
   -- The target is a `k`-algebra via the composite coefficient map.
   change skewZigzagBaseChangeAlgHom G f c (algebraMap k (skewZigzagQuotient k G c) a) =
-    ((algebraMap l (skewZigzagQuotient l G (c.map f.toMonoidHom))).comp f) a
+    ((algebraMap l (skewZigzagQuotient l G (c.map (f : k →* l)))).comp f) a
   exact (skewZigzagBaseChangeAlgHom G f c).commutes a
+
+/-- Scalar extension along the identity coefficient homomorphism is the identity map. -/
+@[simp]
+theorem skewZigzagBaseChange_id (c : SkewZigzagParameter k G) :
+    (skewZigzagQuotientCongr k G (by
+      simpa only [RingHom.toMonoidHom_eq_coe, RingHom.coe_monoidHom_id] using
+        SkewZigzagParameter.map_id c)).toRingHom.comp
+        (skewZigzagBaseChange G (RingHom.id k) c) =
+      RingHom.id (skewZigzagQuotient k G c) := by
+  apply PathAlgebra.ringHom_ext_of_surjective (skewZigzagMk k G c)
+    (skewZigzagMk_surjective k G c)
+  · intro a
+    simp only [RingHom.comp_apply, skewZigzagBaseChange_algebraMap,
+      RingEquiv.toRingHom_eq_coe, AlgEquiv.toRingEquiv_toRingHom, RingHom.coe_coe,
+      AlgEquiv.commutes, RingHom.id_apply]
+  · intro x
+    simp only [RingHom.comp_apply, skewZigzagBaseChange_skewZigzagMk_ofPath,
+      RingEquiv.toRingHom_eq_coe, AlgEquiv.toRingEquiv_toRingHom, RingHom.coe_coe,
+      skewZigzagQuotientCongr_skewZigzagMk, RingHom.id_apply]
+
+/-- Scalar extension along a composite coefficient homomorphism is the composite of the two
+scalar-extension maps. -/
+@[simp]
+theorem skewZigzagBaseChange_comp {m : Type*} [CommRing m]
+    (f : k →+* l) (g : l →+* m) (c : SkewZigzagParameter k G) :
+    ((↑(skewZigzagQuotientCongr m G
+      (c := c.map (g.comp f : k →* m))
+      (c' := (c.map (f : k →* l)).map (g : l →* m))
+      (by
+        ext i j j' h h'
+        simp)) :
+      skewZigzagQuotient m G (c.map (g.comp f : k →* m)) →+*
+        skewZigzagQuotient m G ((c.map (f : k →* l)).map (g : l →* m))).comp
+        (skewZigzagBaseChange G (g.comp f) c)) =
+      (skewZigzagBaseChange G g (c.map (f : k →* l))).comp
+        (skewZigzagBaseChange G f c) := by
+  apply PathAlgebra.ringHom_ext_of_surjective (skewZigzagMk k G c)
+    (skewZigzagMk_surjective k G c)
+  · intro a
+    simp only [RingHom.comp_apply]
+    rw [skewZigzagBaseChange_algebraMap, skewZigzagBaseChange_algebraMap,
+      skewZigzagBaseChange_algebraMap]
+    exact (skewZigzagQuotientCongr m G (by
+      ext i j j' h h'
+      simp)).commutes (g (f a))
+  · intro x
+    simp only [RingHom.comp_apply]
+    rw [skewZigzagBaseChange_skewZigzagMk_ofPath,
+      skewZigzagBaseChange_skewZigzagMk_ofPath,
+      skewZigzagBaseChange_skewZigzagMk_ofPath]
+    exact skewZigzagQuotientCongr_skewZigzagMk m G (by
+      ext i j j' h h'
+      simp) (ofPath x)
 
 end Quotient
 

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/BaseChange.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/BaseChange.lean
@@ -239,11 +239,7 @@ scalar-extension maps. -/
 theorem skewZigzagBaseChange_comp {m : Type*} [CommRing m]
     (f : k →+* l) (g : l →+* m) (c : SkewZigzagParameter k G) :
     (Ideal.Quotient.factor (le_of_eq
-      (congrArg (fun d : SkewZigzagParameter m G => (skewZigzagIdeal m G d).asIdeal) (by
-        rw [show (g.comp f : k →* m) = (g : l →* m).comp (f : k →* l) by
-          ext x
-          rfl]
-        exact SkewZigzagParameter.map_comp (f : k →* l) (g : l →* m) c)))).comp
+      (by exact skewZigzagIdeal_map_comp G f g c))).comp
         (skewZigzagBaseChange G (g.comp f) c) =
       (skewZigzagBaseChange G g (c.map (f : k →* l))).comp
         (skewZigzagBaseChange G f c) := by

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/BaseChange.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/BaseChange.lean
@@ -215,9 +215,7 @@ theorem skewZigzagBaseChange_id (c : SkewZigzagParameter k G) :
     (Ideal.quotientEquivAlgOfEq k
       (I := (skewZigzagIdeal k G (c.map (RingHom.id k : k →* k))).asIdeal)
       (J := (skewZigzagIdeal k G c).asIdeal)
-      (congrArg (fun d : SkewZigzagParameter k G => (skewZigzagIdeal k G d).asIdeal) (by
-        simpa only [RingHom.toMonoidHom_eq_coe, RingHom.coe_monoidHom_id] using
-          SkewZigzagParameter.map_id c))).toRingHom.comp
+      (by exact skewZigzagIdeal_map_id G c)).toRingHom.comp
         (skewZigzagBaseChange G (RingHom.id k) c) =
       RingHom.id (skewZigzagQuotient k G c) := by
   apply PathAlgebra.ringHom_ext_of_surjective (skewZigzagMk k G c)

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/BaseChange.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/BaseChange.lean
@@ -202,6 +202,8 @@ theorem skewZigzagIdeal_map_comp {m : Type*} [CommRing m]
       (skewZigzagIdeal m G ((c.map (f : k →* l)).map (g : l →* m))).asIdeal :=
   congrArg (fun d : SkewZigzagParameter m G => (skewZigzagIdeal m G d).asIdeal)
     (by
+      -- Expose that coercing a composite ring hom to a monoid hom gives the composite of the
+      -- coerced monoid homs, so `map_comp` applies.
       rw [show (g.comp f : k →* m) = (g : l →* m).comp (f : k →* l) by
         ext x
         rfl]

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/BaseChange.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/BaseChange.lean
@@ -288,9 +288,12 @@ theorem skewZigzagBaseChange_algebraMap
 /-- Scalar extension along the identity coefficient homomorphism is the identity map. -/
 @[simp]
 theorem skewZigzagBaseChange_id (c : SkewZigzagParameter k G) :
-    (skewZigzagQuotientCongr k G (by
-      simpa only [RingHom.toMonoidHom_eq_coe, RingHom.coe_monoidHom_id] using
-        SkewZigzagParameter.map_id c)).toRingHom.comp
+    (Ideal.quotientEquivAlgOfEq k
+      (I := (skewZigzagIdeal k G (c.map (RingHom.id k : k →* k))).asIdeal)
+      (J := (skewZigzagIdeal k G c).asIdeal) (congrArg
+      (fun d : SkewZigzagParameter k G => (skewZigzagIdeal k G d).asIdeal) (by
+        simpa only [RingHom.toMonoidHom_eq_coe, RingHom.coe_monoidHom_id] using
+          SkewZigzagParameter.map_id c))).toRingHom.comp
         (skewZigzagBaseChange G (RingHom.id k) c) =
       RingHom.id (skewZigzagQuotient k G c) := by
   apply PathAlgebra.ringHom_ext_of_surjective (skewZigzagMk k G c)
@@ -300,24 +303,25 @@ theorem skewZigzagBaseChange_id (c : SkewZigzagParameter k G) :
       RingEquiv.toRingHom_eq_coe, AlgEquiv.toRingEquiv_toRingHom, RingHom.coe_coe,
       AlgEquiv.commutes, RingHom.id_apply]
   · intro x
-    simp only [RingHom.comp_apply, skewZigzagBaseChange_skewZigzagMk_ofPath,
-      RingEquiv.toRingHom_eq_coe, AlgEquiv.toRingEquiv_toRingHom, RingHom.coe_coe,
-      skewZigzagQuotientCongr_skewZigzagMk, RingHom.id_apply]
+    rw [RingHom.comp_apply, skewZigzagBaseChange_skewZigzagMk_ofPath,
+      skewZigzagMk_apply, skewZigzagMk_apply, RingHom.id_apply]
+    simpa only [RingEquiv.toRingHom_eq_coe, AlgEquiv.toRingEquiv_toRingHom,
+      RingHom.coe_coe] using
+        (Ideal.quotientEquivAlgOfEq_mk k (congrArg
+          (fun d : SkewZigzagParameter k G => (skewZigzagIdeal k G d).asIdeal) (by
+            simpa only [RingHom.toMonoidHom_eq_coe, RingHom.coe_monoidHom_id] using
+              SkewZigzagParameter.map_id c)) (ofPath x))
 
 /-- Scalar extension along a composite coefficient homomorphism is the composite of the two
 scalar-extension maps. -/
 @[simp]
 theorem skewZigzagBaseChange_comp {m : Type*} [CommRing m]
     (f : k →+* l) (g : l →+* m) (c : SkewZigzagParameter k G) :
-    ((↑(skewZigzagQuotientCongr m G
-      (c := c.map (g.comp f : k →* m))
-      (c' := (c.map (f : k →* l)).map (g : l →* m))
-      (by
+    (Ideal.Quotient.factor (le_of_eq (congrArg
+      (fun d : SkewZigzagParameter m G => (skewZigzagIdeal m G d).asIdeal) (by
         ext i j j' h h'
-        simp)) :
-      skewZigzagQuotient m G (c.map (g.comp f : k →* m)) →+*
-        skewZigzagQuotient m G ((c.map (f : k →* l)).map (g : l →* m))).comp
-        (skewZigzagBaseChange G (g.comp f) c)) =
+        simp)))).comp
+        (skewZigzagBaseChange G (g.comp f) c) =
       (skewZigzagBaseChange G g (c.map (f : k →* l))).comp
         (skewZigzagBaseChange G f c) := by
   apply PathAlgebra.ringHom_ext_of_surjective (skewZigzagMk k G c)
@@ -326,17 +330,26 @@ theorem skewZigzagBaseChange_comp {m : Type*} [CommRing m]
     simp only [RingHom.comp_apply]
     rw [skewZigzagBaseChange_algebraMap, skewZigzagBaseChange_algebraMap,
       skewZigzagBaseChange_algebraMap]
-    exact (skewZigzagQuotientCongr m G (by
-      ext i j j' h h'
-      simp)).commutes (g (f a))
+    exact (Ideal.quotientEquivAlgOfEq m
+      (I := (skewZigzagIdeal m G (c.map (g.comp f : k →* m))).asIdeal)
+      (J := (skewZigzagIdeal m G ((c.map (f : k →* l)).map (g : l →* m))).asIdeal)
+      (congrArg
+      (fun d : SkewZigzagParameter m G => (skewZigzagIdeal m G d).asIdeal) (by
+        ext i j j' h h'
+        simp))).commutes (g (f a))
   · intro x
     simp only [RingHom.comp_apply]
     rw [skewZigzagBaseChange_skewZigzagMk_ofPath,
       skewZigzagBaseChange_skewZigzagMk_ofPath,
-      skewZigzagBaseChange_skewZigzagMk_ofPath]
-    exact skewZigzagQuotientCongr_skewZigzagMk m G (by
-      ext i j j' h h'
-      simp) (ofPath x)
+      skewZigzagBaseChange_skewZigzagMk_ofPath, skewZigzagMk_apply,
+      skewZigzagMk_apply]
+    exact Ideal.quotientEquivAlgOfEq_mk m
+      (I := (skewZigzagIdeal m G (c.map (g.comp f : k →* m))).asIdeal)
+      (J := (skewZigzagIdeal m G ((c.map (f : k →* l)).map (g : l →* m))).asIdeal)
+      (congrArg
+      (fun d : SkewZigzagParameter m G => (skewZigzagIdeal m G d).asIdeal) (by
+        ext i j j' h h'
+        simp)) (ofPath x)
 
 end Quotient
 

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/BaseChange.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/BaseChange.lean
@@ -1,0 +1,336 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.RepresentationTheory.Quiver.Zigzag.Gauge
+
+/-!
+# Scalar extension of skew-zigzag parameters
+
+A homomorphism of coefficient rings sends every unit-valued ratio of a skew-zigzag parameter to
+a unit-valued ratio over the target.  The resulting parameter has a canonical coefficient map
+
+```text
+Z_k(G,c) → Z_l(G,c.map f)
+```
+
+which fixes the doubled paths and applies `f : k →+* l` to their coefficients.  This is the
+presentation-level scalar-extension map; it does not identify the target with a tensor product.
+The parameter construction is functorial in the coefficient homomorphism and is compatible with
+gauge transforms, so gauge-equivalent parameters remain gauge equivalent after scalar extension.
+
+The parameter construction only needs a monoid homomorphism.  Injectivity is stated only when the
+homomorphism itself is injective, since extending coefficients need not distinguish units without
+that hypothesis.
+
+## Main definitions
+
+* `TauCeti.SkewZigzagParameter.map`: apply a monoid homomorphism to every parameter ratio.
+* `TauCeti.skewZigzagBaseChange`: the induced coefficient map between relation quotients.
+
+## Main results
+
+* `TauCeti.SkewZigzagParameter.map_injective`: an injective coefficient map distinguishes
+  parameters.
+* `TauCeti.SkewZigzagParameter.IsGaugeEquivalent.map`: scalar extension preserves gauge
+  equivalence.
+* `TauCeti.skewZigzagBaseChange_skewZigzagMk_ofPath`: scalar extension fixes every doubled path.
+* `TauCeti.skewZigzagBaseChange_algebraMap`: scalar coefficients are transported by the given
+  ring homomorphism.
+
+The parameter conventions follow C. Couture, *Skew-Zigzag Algebras*, Sections 3 and 4,
+https://arxiv.org/abs/1509.08405; the coefficient map is induced directly from the presented
+relations.
+-/
+
+public section
+
+namespace TauCeti
+
+open _root_.Quiver PathAlgebra DoubledQuiver
+
+universe u w z
+
+namespace SkewZigzagParameter
+
+section Map
+
+variable {k : Type w} {l : Type z} [Monoid k] [Monoid l]
+  {V : Type u} {G : SimpleGraph V}
+
+/-- Apply a monoid homomorphism to every ratio of a skew-zigzag parameter. -/
+def map (f : k →* l) (c : SkewZigzagParameter k G) : SkewZigzagParameter l G where
+  ratio _ _ _ h h' := Units.map f (c.ratio h h')
+  ratio_self := by intro i j h; simp
+  ratio_inv := by
+    intro i j j' h h'
+    rw [← map_mul, c.ratio_inv]
+    exact map_one (Units.map f)
+  ratio_cocycle := by
+    intro i j j' j'' h h' h''
+    rw [← map_mul, ← map_mul, c.ratio_cocycle]
+    exact map_one (Units.map f)
+
+/-- Scalar extension applies the coefficient homomorphism to a parameter ratio. -/
+@[simp]
+theorem map_ratio (f : k →* l) (c : SkewZigzagParameter k G)
+    {i j j' : V} (h : G.Adj i j) (h' : G.Adj i j') :
+    (c.map f).ratio h h' = Units.map f (c.ratio h h') := (rfl)
+
+/-- The constant parameter remains constant after scalar extension. -/
+@[simp]
+theorem map_one (f : k →* l) :
+    map f (1 : SkewZigzagParameter k G) = 1 := by
+  ext i j j' h h'
+  simp
+
+/-- Mapping a parameter along the identity homomorphism changes nothing. -/
+@[simp]
+theorem map_id (c : SkewZigzagParameter k G) : c.map (MonoidHom.id k) = c := by
+  ext i j j' h h'
+  simp
+
+/-- Mapping a parameter along a composite is successive scalar extension. -/
+@[simp]
+theorem map_comp {m : Type*} [Monoid m] (f : k →* l) (g : l →* m)
+    (c : SkewZigzagParameter k G) :
+    c.map (g.comp f) = (c.map f).map g := by
+  ext i j j' h h'
+  simp [Units.map_comp]
+
+/-- An injective coefficient homomorphism induces an injective map on skew-zigzag parameters. -/
+theorem map_injective (f : k →* l) (hf : Function.Injective f) :
+    Function.Injective (map (G := G) f) := by
+  intro c c' h
+  apply SkewZigzagParameter.ext
+  funext i j j' hi hj
+  apply Units.map_injective hf
+  exact congrArg (fun d : SkewZigzagParameter l G => d.ratio hi hj) h
+
+end Map
+
+section Gauge
+
+variable {k : Type w} {l : Type z} [CommMonoid k] [CommMonoid l]
+  {V : Type u} {G : SimpleGraph V}
+
+/-- Scalar extension commutes with a gauge transform when the arrow labels are extended by the
+same coefficient homomorphism. -/
+theorem map_gauge (f : k →* l) (c : SkewZigzagParameter k G)
+    (a : ∀ ⦃x y : DoubledQuiver G⦄, (x ⟶ y) → kˣ) :
+    (c.gauge a).map f =
+      (c.map f).gauge (fun _ _ b ↦ Units.map f (a b)) := by
+  have hscale {i j : V} (h : G.Adj i j) :
+      backtrackScale G (fun _ _ b ↦ Units.map f (a b)) h =
+        Units.map f (backtrackScale G a h) := by
+    rw [backtrackScale_apply, backtrackScale_apply, map_mul]
+  ext i j j' h h'
+  rw [map_ratio, gauge_ratio, gauge_ratio, hscale, hscale, map_mul, map_div]
+  rfl
+
+/-- Gauge-equivalent skew-zigzag parameters remain gauge equivalent after scalar extension. -/
+theorem IsGaugeEquivalent.map (f : k →* l) {c c' : SkewZigzagParameter k G}
+    (h : c.IsGaugeEquivalent c') :
+    (c.map f).IsGaugeEquivalent (c'.map f) := by
+  obtain ⟨a, rfl⟩ := isGaugeEquivalent_iff.mp h
+  rw [map_gauge]
+  exact isGaugeEquivalent_iff.mpr ⟨_, rfl⟩
+
+end Gauge
+
+end SkewZigzagParameter
+
+section Quotient
+
+variable {k : Type w} {l : Type z} {V : Type u}
+  [CommRing k] [CommRing l] (G : SimpleGraph V) [Finite V]
+
+private theorem skewZigzagBaseChangePathAlgHom_hcomp
+    (f : k →+* l) (c : SkewZigzagParameter k G) {a b d : DoubledQuiver G}
+    (p : Path a b) (q : Path d a) :
+    (skewZigzagMk l G (c.map f.toMonoidHom) (ofPath ⟨a, b, p⟩) :
+        skewZigzagQuotient l G (c.map f.toMonoidHom)) *
+      skewZigzagMk l G (c.map f.toMonoidHom)
+          (ofPath ⟨d, a, q⟩) =
+        skewZigzagMk l G (c.map f.toMonoidHom)
+          (ofPath ⟨d, b, q.comp p⟩) := by
+  rw [← map_mul, ofPath_mul_ofPath_of_comp]
+
+private theorem skewZigzagBaseChangePathAlgHom_hzero
+    (f : k →+* l) (c : SkewZigzagParameter k G)
+    {x y : Quiver.TotalPath (DoubledQuiver G)} (h : y.2.1 ≠ x.1) :
+    (skewZigzagMk l G (c.map f.toMonoidHom) (ofPath x) :
+        skewZigzagQuotient l G (c.map f.toMonoidHom)) *
+      skewZigzagMk l G (c.map f.toMonoidHom) (ofPath y) = 0 := by
+  rw [← map_mul, ofPath_mul_ofPath_of_not_composable h, map_zero]
+
+private theorem skewZigzagBaseChangePathAlgHom_hone
+    (f : k →+* l) (c : SkewZigzagParameter k G) :
+    letI : Fintype (DoubledQuiver G) := Fintype.ofFinite _
+    (∑ v : DoubledQuiver G,
+        (skewZigzagMk l G (c.map f.toMonoidHom)
+          (ofPath ⟨v, v, Path.nil⟩) : skewZigzagQuotient l G (c.map f.toMonoidHom))) = 1 := by
+  let _ := Fintype.ofFinite (DoubledQuiver G)
+  calc
+    (∑ v : DoubledQuiver G,
+        (skewZigzagMk l G (c.map f.toMonoidHom)
+          (ofPath ⟨v, v, Path.nil⟩) : skewZigzagQuotient l G (c.map f.toMonoidHom))) =
+        skewZigzagMk l G (c.map f.toMonoidHom)
+          (∑ v : DoubledQuiver G, (ofPath ⟨v, v, Path.nil⟩ :
+            pathAlgebra l (DoubledQuiver G))) := by
+      rw [map_sum]
+    _ = skewZigzagMk l G (c.map f.toMonoidHom)
+        (∑ v : DoubledQuiver G, vertexIdempotent l v) := by
+      congr 1
+      apply Finset.sum_congr rfl
+      intro v hv
+      rw [vertexIdempotent_eq_ofPath]
+    _ = skewZigzagMk l G (c.map f.toMonoidHom) 1 := by rw [one_def]
+    _ = 1 := (skewZigzagMk l G (c.map f.toMonoidHom)).map_one
+
+private noncomputable def skewZigzagBaseChangePathAlgHom
+    (f : k →+* l) (c : SkewZigzagParameter k G) :
+    letI : Algebra k (skewZigzagQuotient l G (c.map f.toMonoidHom)) :=
+      ((algebraMap l (skewZigzagQuotient l G (c.map f.toMonoidHom))).comp f).toAlgebra'
+        (fun a x => Algebra.commutes (R := l)
+          (A := skewZigzagQuotient l G (c.map f.toMonoidHom)) (f a) x)
+    pathAlgebra k (DoubledQuiver G) →ₐ[k] skewZigzagQuotient l G (c.map f.toMonoidHom) := by
+  let _ : Algebra k (skewZigzagQuotient l G (c.map f.toMonoidHom)) :=
+    ((algebraMap l (skewZigzagQuotient l G (c.map f.toMonoidHom))).comp f).toAlgebra'
+      (fun a x => Algebra.commutes (R := l)
+        (A := skewZigzagQuotient l G (c.map f.toMonoidHom)) (f a) x)
+  exact PathAlgebra.liftAlgHom k
+    (fun x => skewZigzagMk l G (c.map f.toMonoidHom) (ofPath x))
+    (skewZigzagBaseChangePathAlgHom_hcomp G f c)
+    (skewZigzagBaseChangePathAlgHom_hzero G f c)
+    (skewZigzagBaseChangePathAlgHom_hone G f c)
+
+private theorem skewZigzagBaseChangePathAlgHom_ofPath
+    (f : k →+* l) (c : SkewZigzagParameter k G)
+    (x : Quiver.TotalPath (DoubledQuiver G)) :
+    letI : Algebra k (skewZigzagQuotient l G (c.map f.toMonoidHom)) :=
+      ((algebraMap l (skewZigzagQuotient l G (c.map f.toMonoidHom))).comp f).toAlgebra'
+        (fun a y => Algebra.commutes (R := l)
+          (A := skewZigzagQuotient l G (c.map f.toMonoidHom)) (f a) y)
+    skewZigzagBaseChangePathAlgHom G f c (ofPath x) =
+      skewZigzagMk l G (c.map f.toMonoidHom) (ofPath x) := by
+  let _ : Algebra k (skewZigzagQuotient l G (c.map f.toMonoidHom)) :=
+    ((algebraMap l (skewZigzagQuotient l G (c.map f.toMonoidHom))).comp f).toAlgebra'
+      (fun a y => Algebra.commutes (R := l)
+        (A := skewZigzagQuotient l G (c.map f.toMonoidHom)) (f a) y)
+  rw [skewZigzagBaseChangePathAlgHom]
+  exact PathAlgebra.liftAlgHom_ofPath k _ _ _ _ x
+
+private theorem skewZigzagBaseChangePathAlgHom_backtrackElem
+    (f : k →+* l) (c : SkewZigzagParameter k G) {i j : V} (h : G.Adj i j) :
+    letI : Algebra k (skewZigzagQuotient l G (c.map f.toMonoidHom)) :=
+      ((algebraMap l (skewZigzagQuotient l G (c.map f.toMonoidHom))).comp f).toAlgebra'
+        (fun a y => Algebra.commutes (R := l)
+          (A := skewZigzagQuotient l G (c.map f.toMonoidHom)) (f a) y)
+    skewZigzagBaseChangePathAlgHom G f c (backtrackElem G k h) =
+      skewZigzagMk l G (c.map f.toMonoidHom) (backtrackElem G l h) := by
+  let _ : Algebra k (skewZigzagQuotient l G (c.map f.toMonoidHom)) :=
+    ((algebraMap l (skewZigzagQuotient l G (c.map f.toMonoidHom))).comp f).toAlgebra'
+      (fun a y => Algebra.commutes (R := l)
+        (A := skewZigzagQuotient l G (c.map f.toMonoidHom)) (f a) y)
+  rw [backtrackElem_eq_ofPath, skewZigzagBaseChangePathAlgHom_ofPath,
+    backtrackElem_eq_ofPath]
+
+private theorem skewZigzagBaseChangePathAlgHom_relator
+    (f : k →+* l) (c : SkewZigzagParameter k G)
+    (x : pathAlgebra k (DoubledQuiver G)) (hx : IsSkewZigzagRelator k G c x) :
+    letI : Algebra k (skewZigzagQuotient l G (c.map f.toMonoidHom)) :=
+      ((algebraMap l (skewZigzagQuotient l G (c.map f.toMonoidHom))).comp f).toAlgebra'
+        (fun a y => Algebra.commutes (R := l)
+          (A := skewZigzagQuotient l G (c.map f.toMonoidHom)) (f a) y)
+    skewZigzagBaseChangePathAlgHom G f c x = 0 := by
+  let _ : Algebra k (skewZigzagQuotient l G (c.map f.toMonoidHom)) :=
+    ((algebraMap l (skewZigzagQuotient l G (c.map f.toMonoidHom))).comp f).toAlgebra'
+      (fun a y => Algebra.commutes (R := l)
+        (A := skewZigzagQuotient l G (c.map f.toMonoidHom)) (f a) y)
+  cases hx with
+  | nonreturn p hlen hne =>
+      rw [skewZigzagBaseChangePathAlgHom_ofPath]
+      exact skewZigzagMk_ofPath_eq_zero_of_ne l G (c.map f.toMonoidHom) p hlen hne
+  | backtrack_ratio h h' =>
+      rw [map_sub, map_smul, skewZigzagBaseChangePathAlgHom_backtrackElem,
+        skewZigzagBaseChangePathAlgHom_backtrackElem, sub_eq_zero]
+      calc
+        skewZigzagMk l G (c.map f.toMonoidHom) (backtrackElem G l h) =
+            ((c.map f.toMonoidHom).ratio h h' : l) •
+              skewZigzagMk l G (c.map f.toMonoidHom) (backtrackElem G l h') :=
+          skewZigzagMk_backtrackElem_eq_smul l G (c.map f.toMonoidHom) h h'
+        _ = (c.ratio h h' : k) •
+              skewZigzagMk l G (c.map f.toMonoidHom) (backtrackElem G l h') := by
+          simp only [Algebra.smul_def, SkewZigzagParameter.map_ratio, Units.coe_map]
+          rfl
+  | long_path y h3 =>
+      rw [skewZigzagBaseChangePathAlgHom_ofPath]
+      exact skewZigzagMk_ofPath_eq_zero_of_three_le l G (c.map f.toMonoidHom) y h3
+
+private noncomputable def skewZigzagBaseChangeAlgHom
+    (f : k →+* l) (c : SkewZigzagParameter k G) :
+    letI : Algebra k (skewZigzagQuotient l G (c.map f.toMonoidHom)) :=
+      ((algebraMap l (skewZigzagQuotient l G (c.map f.toMonoidHom))).comp f).toAlgebra'
+        (fun a y => Algebra.commutes (R := l)
+          (A := skewZigzagQuotient l G (c.map f.toMonoidHom)) (f a) y)
+    skewZigzagQuotient k G c →ₐ[k] skewZigzagQuotient l G (c.map f.toMonoidHom) := by
+  let _ : Algebra k (skewZigzagQuotient l G (c.map f.toMonoidHom)) :=
+    ((algebraMap l (skewZigzagQuotient l G (c.map f.toMonoidHom))).comp f).toAlgebra'
+      (fun a y => Algebra.commutes (R := l)
+        (A := skewZigzagQuotient l G (c.map f.toMonoidHom)) (f a) y)
+  exact skewZigzagLift k G c (skewZigzagBaseChangePathAlgHom G f c)
+    (skewZigzagBaseChangePathAlgHom_relator G f c)
+
+/-- The coefficient map on a skew-zigzag relation quotient.
+
+It fixes every doubled path and applies `f` to scalar coefficients.  The codomain carries the
+parameter obtained by applying `f` to every unit-valued ratio. -/
+noncomputable def skewZigzagBaseChange (f : k →+* l) (c : SkewZigzagParameter k G) :
+    skewZigzagQuotient k G c →+* skewZigzagQuotient l G (c.map (f : k →* l)) := by
+  let _ : Algebra k (skewZigzagQuotient l G (c.map f.toMonoidHom)) :=
+    ((algebraMap l (skewZigzagQuotient l G (c.map f.toMonoidHom))).comp f).toAlgebra'
+      (fun a y => Algebra.commutes (R := l)
+        (A := skewZigzagQuotient l G (c.map f.toMonoidHom)) (f a) y)
+  exact (skewZigzagBaseChangeAlgHom G f c).toRingHom
+
+/-- Scalar extension sends the class of every doubled path to the class of the same path over the
+target coefficient ring. -/
+@[simp]
+theorem skewZigzagBaseChange_skewZigzagMk_ofPath
+    (f : k →+* l) (c : SkewZigzagParameter k G)
+    (x : Quiver.TotalPath (DoubledQuiver G)) :
+    skewZigzagBaseChange G f c (skewZigzagMk k G c (ofPath x)) =
+      skewZigzagMk l G (c.map (f : k →* l)) (ofPath x) := by
+  let _ : Algebra k (skewZigzagQuotient l G (c.map f.toMonoidHom)) :=
+    ((algebraMap l (skewZigzagQuotient l G (c.map f.toMonoidHom))).comp f).toAlgebra'
+      (fun a y => Algebra.commutes (R := l)
+        (A := skewZigzagQuotient l G (c.map f.toMonoidHom)) (f a) y)
+  -- The public map is the underlying ring map of the quotient lift.
+  change skewZigzagBaseChangeAlgHom G f c (skewZigzagMk k G c (ofPath x)) = _
+  rw [skewZigzagBaseChangeAlgHom, skewZigzagLift_skewZigzagMk,
+    skewZigzagBaseChangePathAlgHom_ofPath]
+  rfl
+
+/-- Scalar extension carries the source scalar action to the target scalar action through the
+coefficient homomorphism. -/
+@[simp]
+theorem skewZigzagBaseChange_algebraMap
+    (f : k →+* l) (c : SkewZigzagParameter k G) (a : k) :
+    skewZigzagBaseChange G f c (algebraMap k (skewZigzagQuotient k G c) a) =
+      algebraMap l (skewZigzagQuotient l G (c.map (f : k →* l))) (f a) := by
+  let _ : Algebra k (skewZigzagQuotient l G (c.map f.toMonoidHom)) :=
+    ((algebraMap l (skewZigzagQuotient l G (c.map f.toMonoidHom))).comp f).toAlgebra'
+      (fun b y => Algebra.commutes (R := l)
+        (A := skewZigzagQuotient l G (c.map f.toMonoidHom)) (f b) y)
+  -- The target is a `k`-algebra via the composite coefficient map.
+  change skewZigzagBaseChangeAlgHom G f c (algebraMap k (skewZigzagQuotient k G c) a) =
+    ((algebraMap l (skewZigzagQuotient l G (c.map f.toMonoidHom))).comp f) a
+  exact (skewZigzagBaseChangeAlgHom G f c).commutes a
+
+end Quotient
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/BaseChange.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/BaseChange.lean
@@ -113,8 +113,9 @@ private theorem skewZigzagBaseChangePathAlgHom_relator
           skewZigzagMk_backtrackElem_eq_smul l G (c.map (f : k →* l)) h h'
         _ = (c.ratio h h' : k) •
               skewZigzagMk l G (c.map (f : k →* l)) (backtrackElem G l h') := by
-          rw [PathAlgebra.smul_def_baseChange]
-          simp
+          rw [RingHom.smul_toAlgebra', RingHom.comp_apply]
+          simp only [SkewZigzagParameter.map_ratio, Units.coe_map, MonoidHom.coe_coe]
+          rw [Algebra.smul_def]
         _ = (c.ratio h h' : k) •
               skewZigzagBaseChangePathAlgHom G f c (backtrackElem G k h') := by
           congr 1
@@ -184,15 +185,31 @@ theorem skewZigzagBaseChange_algebraMap
     ((algebraMap l (skewZigzagQuotient l G (c.map (f : k →* l)))).comp f) a
   exact (skewZigzagBaseChangeAlgHom G f c).commutes a
 
+/-- Mapping a skew-zigzag parameter along the identity homomorphism leaves its relation ideal
+unchanged. -/
+theorem skewZigzagIdeal_map_id (c : SkewZigzagParameter k G) :
+    (skewZigzagIdeal k G (c.map (RingHom.id k : k →* k))).asIdeal =
+      (skewZigzagIdeal k G c).asIdeal :=
+  congrArg (fun d : SkewZigzagParameter k G => (skewZigzagIdeal k G d).asIdeal) (by
+    simpa only [RingHom.toMonoidHom_eq_coe, RingHom.coe_monoidHom_id] using
+      SkewZigzagParameter.map_id c)
+
+/-- Mapping a skew-zigzag parameter along a composite or successively gives the same relation
+ideal. -/
+theorem skewZigzagIdeal_map_comp {m : Type*} [CommRing m]
+    (f : k →+* l) (g : l →+* m) (c : SkewZigzagParameter k G) :
+    (skewZigzagIdeal m G (c.map (g.comp f : k →* m))).asIdeal =
+      (skewZigzagIdeal m G ((c.map (f : k →* l)).map (g : l →* m))).asIdeal :=
+  congrArg (fun d : SkewZigzagParameter m G => (skewZigzagIdeal m G d).asIdeal) (by
+    ext i j j' h h'
+    simp)
+
 /-- Scalar extension along the identity coefficient homomorphism is the identity map. -/
 @[simp]
 theorem skewZigzagBaseChange_id (c : SkewZigzagParameter k G) :
     (Ideal.quotientEquivAlgOfEq k
       (I := (skewZigzagIdeal k G (c.map (RingHom.id k : k →* k))).asIdeal)
-      (J := (skewZigzagIdeal k G c).asIdeal) (congrArg
-      (fun d : SkewZigzagParameter k G => (skewZigzagIdeal k G d).asIdeal) (by
-        simpa only [RingHom.toMonoidHom_eq_coe, RingHom.coe_monoidHom_id] using
-          SkewZigzagParameter.map_id c))).toRingHom.comp
+      (J := (skewZigzagIdeal k G c).asIdeal) (skewZigzagIdeal_map_id G c)).toRingHom.comp
         (skewZigzagBaseChange G (RingHom.id k) c) =
       RingHom.id (skewZigzagQuotient k G c) := by
   apply PathAlgebra.ringHom_ext_of_surjective (skewZigzagMk k G c)
@@ -206,20 +223,14 @@ theorem skewZigzagBaseChange_id (c : SkewZigzagParameter k G) :
       skewZigzagMk_apply, skewZigzagMk_apply, RingHom.id_apply]
     simpa only [RingEquiv.toRingHom_eq_coe, AlgEquiv.toRingEquiv_toRingHom,
       RingHom.coe_coe] using
-        (Ideal.quotientEquivAlgOfEq_mk k (congrArg
-          (fun d : SkewZigzagParameter k G => (skewZigzagIdeal k G d).asIdeal) (by
-            simpa only [RingHom.toMonoidHom_eq_coe, RingHom.coe_monoidHom_id] using
-              SkewZigzagParameter.map_id c)) (ofPath x))
+        (Ideal.quotientEquivAlgOfEq_mk k (skewZigzagIdeal_map_id G c) (ofPath x))
 
 /-- Scalar extension along a composite coefficient homomorphism is the composite of the two
 scalar-extension maps. -/
 @[simp]
 theorem skewZigzagBaseChange_comp {m : Type*} [CommRing m]
     (f : k →+* l) (g : l →+* m) (c : SkewZigzagParameter k G) :
-    (Ideal.Quotient.factor (le_of_eq (congrArg
-      (fun d : SkewZigzagParameter m G => (skewZigzagIdeal m G d).asIdeal) (by
-        ext i j j' h h'
-        simp)))).comp
+    (Ideal.Quotient.factor (le_of_eq (skewZigzagIdeal_map_comp G f g c))).comp
         (skewZigzagBaseChange G (g.comp f) c) =
       (skewZigzagBaseChange G g (c.map (f : k →* l))).comp
         (skewZigzagBaseChange G f c) := by
@@ -232,10 +243,7 @@ theorem skewZigzagBaseChange_comp {m : Type*} [CommRing m]
     exact (Ideal.quotientEquivAlgOfEq m
       (I := (skewZigzagIdeal m G (c.map (g.comp f : k →* m))).asIdeal)
       (J := (skewZigzagIdeal m G ((c.map (f : k →* l)).map (g : l →* m))).asIdeal)
-      (congrArg
-      (fun d : SkewZigzagParameter m G => (skewZigzagIdeal m G d).asIdeal) (by
-        ext i j j' h h'
-        simp))).commutes (g (f a))
+      (skewZigzagIdeal_map_comp G f g c)).commutes (g (f a))
   · intro x
     simp only [RingHom.comp_apply]
     rw [skewZigzagBaseChange_skewZigzagMk_ofPath,
@@ -245,10 +253,7 @@ theorem skewZigzagBaseChange_comp {m : Type*} [CommRing m]
     exact Ideal.quotientEquivAlgOfEq_mk m
       (I := (skewZigzagIdeal m G (c.map (g.comp f : k →* m))).asIdeal)
       (J := (skewZigzagIdeal m G ((c.map (f : k →* l)).map (g : l →* m))).asIdeal)
-      (congrArg
-      (fun d : SkewZigzagParameter m G => (skewZigzagIdeal m G d).asIdeal) (by
-        ext i j j' h h'
-        simp)) (ofPath x)
+      (skewZigzagIdeal_map_comp G f g c) (ofPath x)
 
 end Quotient
 

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/BaseChange.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/BaseChange.lean
@@ -6,10 +6,10 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.RepresentationTheory.Quiver.PathAlgebra.BaseChange
-public import TauCeti.RepresentationTheory.Quiver.Zigzag.Gauge
+public import TauCeti.RepresentationTheory.Quiver.Zigzag.Skew
 
 /-!
-# Scalar extension of skew-zigzag parameters
+# Scalar extension of skew-zigzag relation quotients
 
 A homomorphism of coefficient rings sends every unit-valued ratio of a skew-zigzag parameter to
 a unit-valued ratio over the target.  The resulting parameter has a canonical coefficient map
@@ -20,23 +20,17 @@ Z_k(G,c) → Z_l(G,c.map f)
 
 which fixes the doubled paths and applies `f : k →+* l` to their coefficients.  This is the
 presentation-level scalar-extension map; it does not identify the target with a tensor product.
-The parameter construction is functorial in the coefficient homomorphism and is compatible with
-gauge transforms, so gauge-equivalent parameters remain gauge equivalent after scalar extension.
+The parameter construction is functorial in the coefficient homomorphism.
 
 The parameter construction only needs a monoid homomorphism.  Injectivity is stated exactly when
 the induced map on units is injective, since the parameters only record unit-valued ratios.
 
 ## Main definitions
 
-* `TauCeti.SkewZigzagParameter.map`: apply a monoid homomorphism to every parameter ratio.
 * `TauCeti.skewZigzagBaseChange`: the induced coefficient map between relation quotients.
 
 ## Main results
 
-* `TauCeti.SkewZigzagParameter.map_injective`: an injective coefficient map distinguishes
-  parameters.
-* `TauCeti.SkewZigzagParameter.IsGaugeEquivalent.map`: scalar extension preserves gauge
-  equivalence.
 * `TauCeti.skewZigzagBaseChange_skewZigzagMk_ofPath`: scalar extension fixes every doubled path.
 * `TauCeti.skewZigzagBaseChange_algebraMap`: scalar coefficients are transported by the given
   ring homomorphism.
@@ -45,8 +39,7 @@ the induced map on units is injective, since the parameters only record unit-val
 
 The parameter conventions follow C. Couture, *Skew-Zigzag Algebras*, Sections 3 and 4,
 https://arxiv.org/abs/1509.08405.  The coefficient-map construction follows
-`TauCeti.RepresentationTheory.Quiver.Preprojective.BaseChange` and implements the scalar-extension
-clause of Layer 1 of `TauCetiRoadmap/ZigzagPreprojective/README.md`.
+`TauCeti.RepresentationTheory.Quiver.Preprojective.BaseChange`.
 -/
 
 public section
@@ -56,94 +49,6 @@ namespace TauCeti
 open _root_.Quiver PathAlgebra DoubledQuiver
 
 universe u w z
-
-namespace SkewZigzagParameter
-
-section Map
-
-variable {k : Type w} {l : Type z} [Monoid k] [Monoid l]
-  {V : Type u} {G : SimpleGraph V}
-
-/-- Apply a monoid homomorphism to every ratio of a skew-zigzag parameter. -/
-def map (f : k →* l) (c : SkewZigzagParameter k G) : SkewZigzagParameter l G where
-  ratio _ _ _ h h' := Units.map f (c.ratio h h')
-  ratio_self := by intro i j h; simp
-  ratio_inv := by
-    intro i j j' h h'
-    rw [← map_mul, c.ratio_inv]
-    exact map_one (Units.map f)
-  ratio_cocycle := by
-    intro i j j' j'' h h' h''
-    rw [← map_mul, ← map_mul, c.ratio_cocycle]
-    exact map_one (Units.map f)
-
-/-- Scalar extension applies the coefficient homomorphism to a parameter ratio. -/
-@[simp]
-theorem map_ratio (f : k →* l) (c : SkewZigzagParameter k G)
-    {i j j' : V} (h : G.Adj i j) (h' : G.Adj i j') :
-    (c.map f).ratio h h' = Units.map f (c.ratio h h') := (rfl)
-
-/-- The constant parameter remains constant after scalar extension. -/
-@[simp]
-theorem map_one (f : k →* l) :
-    map f (1 : SkewZigzagParameter k G) = 1 := by
-  ext i j j' h h'
-  simp
-
-/-- Mapping a parameter along the identity homomorphism changes nothing. -/
-@[simp]
-theorem map_id (c : SkewZigzagParameter k G) : c.map (MonoidHom.id k) = c := by
-  ext i j j' h h'
-  simp
-
-/-- Mapping a parameter along a composite is successive scalar extension. -/
-@[simp]
-theorem map_comp {m : Type*} [Monoid m] (f : k →* l) (g : l →* m)
-    (c : SkewZigzagParameter k G) :
-    c.map (g.comp f) = (c.map f).map g := by
-  ext i j j' h h'
-  simp [Units.map_comp]
-
-/-- Injectivity on units induces an injective map on skew-zigzag parameters. -/
-theorem map_injective (f : k →* l) (hf : Function.Injective (Units.map f)) :
-    Function.Injective (map (G := G) f) := by
-  intro c c' h
-  apply SkewZigzagParameter.ext
-  funext i j j' hi hj
-  exact hf (congrArg (fun d : SkewZigzagParameter l G => d.ratio hi hj) h)
-
-end Map
-
-section Gauge
-
-variable {k : Type w} {l : Type z} [CommMonoid k] [CommMonoid l]
-  {V : Type u} {G : SimpleGraph V}
-
-/-- Scalar extension commutes with a gauge transform when the arrow labels are extended by the
-same coefficient homomorphism. -/
-theorem map_gauge (f : k →* l) (c : SkewZigzagParameter k G)
-    (a : ∀ ⦃x y : DoubledQuiver G⦄, (x ⟶ y) → kˣ) :
-    (c.gauge a).map f =
-      (c.map f).gauge (fun _ _ b ↦ Units.map f (a b)) := by
-  have hscale {i j : V} (h : G.Adj i j) :
-      backtrackScale G (fun _ _ b ↦ Units.map f (a b)) h =
-        Units.map f (backtrackScale G a h) := by
-    rw [backtrackScale_apply, backtrackScale_apply, map_mul]
-  ext i j j' h h'
-  rw [map_ratio, gauge_ratio, gauge_ratio, hscale, hscale, map_mul, map_div]
-  rfl
-
-/-- Gauge-equivalent skew-zigzag parameters remain gauge equivalent after scalar extension. -/
-theorem IsGaugeEquivalent.map (f : k →* l) {c c' : SkewZigzagParameter k G}
-    (h : c.IsGaugeEquivalent c') :
-    (c.map f).IsGaugeEquivalent (c'.map f) := by
-  obtain ⟨a, rfl⟩ := isGaugeEquivalent_iff.mp h
-  rw [map_gauge]
-  exact isGaugeEquivalent_iff.mpr ⟨_, rfl⟩
-
-end Gauge
-
-end SkewZigzagParameter
 
 section Quotient
 
@@ -179,21 +84,6 @@ private theorem skewZigzagBaseChangePathAlgHom_ofPath
   exact PathAlgebra.baseChangeAlgHom_ofPath f
     (skewZigzagMk l G (c.map (f : k →* l))) x
 
-private theorem skewZigzagBaseChangePathAlgHom_backtrackElem
-    (f : k →+* l) (c : SkewZigzagParameter k G) {i j : V} (h : G.Adj i j) :
-    letI : Algebra k (skewZigzagQuotient l G (c.map (f : k →* l))) :=
-      ((algebraMap l (skewZigzagQuotient l G (c.map (f : k →* l)))).comp f).toAlgebra'
-        (fun a y => Algebra.commutes (R := l)
-          (A := skewZigzagQuotient l G (c.map (f : k →* l))) (f a) y)
-    skewZigzagBaseChangePathAlgHom G f c (backtrackElem G k h) =
-      skewZigzagMk l G (c.map (f : k →* l)) (backtrackElem G l h) := by
-  let _ : Algebra k (skewZigzagQuotient l G (c.map (f : k →* l))) :=
-    ((algebraMap l (skewZigzagQuotient l G (c.map (f : k →* l)))).comp f).toAlgebra'
-      (fun a y => Algebra.commutes (R := l)
-        (A := skewZigzagQuotient l G (c.map (f : k →* l))) (f a) y)
-  rw [backtrackElem_eq_ofPath, skewZigzagBaseChangePathAlgHom_ofPath,
-    backtrackElem_eq_ofPath]
-
 private theorem skewZigzagBaseChangePathAlgHom_relator
     (f : k →+* l) (c : SkewZigzagParameter k G)
     (x : pathAlgebra k (DoubledQuiver G)) (hx : IsSkewZigzagRelator k G c x) :
@@ -211,10 +101,13 @@ private theorem skewZigzagBaseChangePathAlgHom_relator
       rw [skewZigzagBaseChangePathAlgHom_ofPath]
       exact skewZigzagMk_ofPath_eq_zero_of_ne l G (c.map (f : k →* l)) p hlen hne
   | backtrack_ratio h h' =>
-      rw [map_sub, map_smul, skewZigzagBaseChangePathAlgHom_backtrackElem,
-        skewZigzagBaseChangePathAlgHom_backtrackElem, sub_eq_zero]
+      rw [map_sub, map_smul, sub_eq_zero]
       calc
-        skewZigzagMk l G (c.map (f : k →* l)) (backtrackElem G l h) =
+        skewZigzagBaseChangePathAlgHom G f c (backtrackElem G k h) =
+            skewZigzagMk l G (c.map (f : k →* l)) (backtrackElem G l h) := by
+          rw [backtrackElem_eq_ofPath, skewZigzagBaseChangePathAlgHom_ofPath,
+            backtrackElem_eq_ofPath]
+        _ =
             ((c.map (f : k →* l)).ratio h h' : l) •
               skewZigzagMk l G (c.map (f : k →* l)) (backtrackElem G l h') :=
           skewZigzagMk_backtrackElem_eq_smul l G (c.map (f : k →* l)) h h'
@@ -222,6 +115,12 @@ private theorem skewZigzagBaseChangePathAlgHom_relator
               skewZigzagMk l G (c.map (f : k →* l)) (backtrackElem G l h') := by
           rw [PathAlgebra.smul_def_baseChange]
           simp
+        _ = (c.ratio h h' : k) •
+              skewZigzagBaseChangePathAlgHom G f c (backtrackElem G k h') := by
+          congr 1
+          symm
+          rw [backtrackElem_eq_ofPath, skewZigzagBaseChangePathAlgHom_ofPath,
+            backtrackElem_eq_ofPath]
   | long_path y h3 =>
       rw [skewZigzagBaseChangePathAlgHom_ofPath]
       exact skewZigzagMk_ofPath_eq_zero_of_three_le l G (c.map (f : k →* l)) y h3

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/Gauge.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/Gauge.lean
@@ -267,8 +267,8 @@ section Map
 
 variable {l : Type z} [CommMonoid l]
 
-/-- Scalar extension commutes with a gauge transform when the arrow labels are extended by the
-same coefficient homomorphism. -/
+/-- Mapping parameters along a monoid homomorphism commutes with gauge transforms when the arrow
+labels are mapped by the same homomorphism. -/
 theorem map_gauge (f : k →* l) (c : SkewZigzagParameter k G)
     (a : ∀ ⦃x y : DoubledQuiver G⦄, (x ⟶ y) → kˣ) :
     (c.gauge a).map f =
@@ -281,7 +281,7 @@ theorem map_gauge (f : k →* l) (c : SkewZigzagParameter k G)
   rw [map_ratio, gauge_ratio, gauge_ratio, hscale, hscale, map_mul, map_div]
   rw [map_ratio]
 
-/-- Gauge-equivalent skew-zigzag parameters remain gauge equivalent after scalar extension. -/
+/-- Mapping along a monoid homomorphism preserves gauge equivalence of skew-zigzag parameters. -/
 theorem IsGaugeEquivalent.map {c c' : SkewZigzagParameter k G}
     (h : c.IsGaugeEquivalent c') (f : k →* l) :
     (c.map f).IsGaugeEquivalent (c'.map f) := by

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/Gauge.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/Gauge.lean
@@ -69,7 +69,7 @@ namespace TauCeti
 
 open PathAlgebra DoubledQuiver
 
-universe u w
+universe u w z
 
 namespace DoubledQuiver
 
@@ -262,6 +262,34 @@ theorem IsGaugeEquivalent.trans {c c' c'' : SkewZigzagParameter k G}
 theorem IsGaugeEquivalent.equivalence :
     Equivalence (IsGaugeEquivalent (k := k) (G := G)) :=
   ⟨IsGaugeEquivalent.refl, IsGaugeEquivalent.symm, IsGaugeEquivalent.trans⟩
+
+section Map
+
+variable {l : Type z} [CommMonoid l]
+
+/-- Scalar extension commutes with a gauge transform when the arrow labels are extended by the
+same coefficient homomorphism. -/
+theorem map_gauge (f : k →* l) (c : SkewZigzagParameter k G)
+    (a : ∀ ⦃x y : DoubledQuiver G⦄, (x ⟶ y) → kˣ) :
+    (c.gauge a).map f =
+      (c.map f).gauge (fun _ _ b ↦ Units.map f (a b)) := by
+  have hscale {i j : V} (h : G.Adj i j) :
+      backtrackScale G (fun _ _ b ↦ Units.map f (a b)) h =
+        Units.map f (backtrackScale G a h) := by
+    rw [backtrackScale_apply, backtrackScale_apply, map_mul]
+  ext i j j' h h'
+  rw [map_ratio, gauge_ratio, gauge_ratio, hscale, hscale, map_mul, map_div]
+  rw [map_ratio]
+
+/-- Gauge-equivalent skew-zigzag parameters remain gauge equivalent after scalar extension. -/
+theorem IsGaugeEquivalent.map {c c' : SkewZigzagParameter k G}
+    (h : c.IsGaugeEquivalent c') (f : k →* l) :
+    (c.map f).IsGaugeEquivalent (c'.map f) := by
+  obtain ⟨a, rfl⟩ := isGaugeEquivalent_iff.mp h
+  rw [map_gauge]
+  exact isGaugeEquivalent_iff.mpr ⟨_, rfl⟩
+
+end Map
 
 end SkewZigzagParameter
 

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/Gauge.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/Gauge.lean
@@ -269,6 +269,7 @@ variable {l : Type z} [CommMonoid l]
 
 /-- Mapping parameters along a monoid homomorphism commutes with gauge transforms when the arrow
 labels are mapped by the same homomorphism. -/
+@[simp]
 theorem map_gauge (f : k →* l) (c : SkewZigzagParameter k G)
     (a : ∀ ⦃x y : DoubledQuiver G⦄, (x ⟶ y) → kˣ) :
     (c.gauge a).map f =

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/Skew.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/Skew.lean
@@ -172,22 +172,6 @@ theorem skewZigzagMk_apply (x : pathAlgebra k (DoubledQuiver G)) :
 theorem skewZigzagMk_surjective : Function.Surjective (skewZigzagMk k G c) :=
   Ideal.Quotient.mk_surjective
 
-/-- Equal skew-zigzag parameters define canonically isomorphic relation quotients. -/
-noncomputable def skewZigzagQuotientCongr {c c' : SkewZigzagParameter k G} (h : c = c') :
-    skewZigzagQuotient k G c ≃ₐ[k] skewZigzagQuotient k G c' := by
-  subst c'
-  exact AlgEquiv.refl
-
-/-- The canonical quotient isomorphism attached to an equality of parameters preserves every
-quotient class. -/
-@[simp]
-theorem skewZigzagQuotientCongr_skewZigzagMk {c c' : SkewZigzagParameter k G} (h : c = c')
-    (x : pathAlgebra k (DoubledQuiver G)) :
-    skewZigzagQuotientCongr k G h (skewZigzagMk k G c x) =
-      skewZigzagMk k G c' x := by
-  subst c'
-  rfl
-
 /-- The kernel of the skew-zigzag quotient map is its relation ideal. -/
 @[simp]
 theorem skewZigzagMk_eq_zero_iff {x : pathAlgebra k (DoubledQuiver G)} :

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/Skew.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/Skew.lean
@@ -133,13 +133,13 @@ def map (f : k →* l) (c : SkewZigzagParameter k G) : SkewZigzagParameter l G w
     rw [← map_mul, ← map_mul, c.ratio_cocycle]
     exact map_one (Units.map f)
 
-/-- Scalar extension applies the coefficient homomorphism to a parameter ratio. -/
+/-- Mapping a parameter applies the monoid homomorphism to each ratio. -/
 @[simp]
 theorem map_ratio (f : k →* l) (c : SkewZigzagParameter k G)
     {i j j' : V} (h : G.Adj i j) (h' : G.Adj i j') :
     (c.map f).ratio h h' = Units.map f (c.ratio h h') := (rfl)
 
-/-- The constant parameter remains constant after scalar extension. -/
+/-- The constant parameter remains constant after mapping along a monoid homomorphism. -/
 @[simp]
 theorem map_one (f : k →* l) :
     map f (1 : SkewZigzagParameter k G) = 1 := by
@@ -152,7 +152,7 @@ theorem map_id (c : SkewZigzagParameter k G) : c.map (MonoidHom.id k) = c := by
   ext i j j' h h'
   simp
 
-/-- Mapping a parameter along a composite is successive scalar extension. -/
+/-- Mapping a parameter along a composite is the same as successive mapping. -/
 @[simp]
 theorem map_comp {m : Type*} [Monoid m] (f : k →* l) (g : l →* m)
     (c : SkewZigzagParameter k G) :

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/Skew.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/Skew.lean
@@ -168,6 +168,30 @@ theorem skewZigzagMk_apply (x : pathAlgebra k (DoubledQuiver G)) :
     skewZigzagMk k G c x = Ideal.Quotient.mk (skewZigzagIdeal k G c).asIdeal x :=
   by rw [skewZigzagMk, Ideal.Quotient.mkₐ_eq_mk]
 
+/-- The skew-zigzag quotient map is surjective. -/
+theorem skewZigzagMk_surjective : Function.Surjective (skewZigzagMk k G c) :=
+  Ideal.Quotient.mk_surjective
+
+/-- Two ring homomorphisms out of a skew-zigzag quotient are equal if they agree on coefficients
+and on the classes of all doubled paths. -/
+theorem skewZigzagQuotient_ringHom_ext {B : Type*} [Semiring B]
+    {g h : skewZigzagQuotient k G c →+* B}
+    (hscalar : ∀ r : k,
+      g (algebraMap k (skewZigzagQuotient k G c) r) =
+        h (algebraMap k (skewZigzagQuotient k G c) r))
+    (hpath : ∀ x : Quiver.TotalPath (DoubledQuiver G),
+      g (skewZigzagMk k G c (ofPath x)) = h (skewZigzagMk k G c (ofPath x))) :
+    g = h := by
+  apply RingHom.ext
+  intro y
+  obtain ⟨x, rfl⟩ := skewZigzagMk_surjective k G c y
+  induction x using PathAlgebra.induction_linear with
+  | zero => simp
+  | add x y hx hy => simp only [map_add, hx, hy]
+  | single x a =>
+      rw [single_eq_smul_ofPath, map_smul]
+      simp only [Algebra.smul_def, map_mul, hscalar, hpath]
+
 /-- The kernel of the skew-zigzag quotient map is its relation ideal. -/
 @[simp]
 theorem skewZigzagMk_eq_zero_iff {x : pathAlgebra k (DoubledQuiver G)} :

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/Skew.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/Skew.lean
@@ -172,25 +172,21 @@ theorem skewZigzagMk_apply (x : pathAlgebra k (DoubledQuiver G)) :
 theorem skewZigzagMk_surjective : Function.Surjective (skewZigzagMk k G c) :=
   Ideal.Quotient.mk_surjective
 
-/-- Two ring homomorphisms out of a skew-zigzag quotient are equal if they agree on coefficients
-and on the classes of all doubled paths. -/
-theorem skewZigzagQuotient_ringHom_ext {B : Type*} [Semiring B]
-    {g h : skewZigzagQuotient k G c →+* B}
-    (hscalar : ∀ r : k,
-      g (algebraMap k (skewZigzagQuotient k G c) r) =
-        h (algebraMap k (skewZigzagQuotient k G c) r))
-    (hpath : ∀ x : Quiver.TotalPath (DoubledQuiver G),
-      g (skewZigzagMk k G c (ofPath x)) = h (skewZigzagMk k G c (ofPath x))) :
-    g = h := by
-  apply RingHom.ext
-  intro y
-  obtain ⟨x, rfl⟩ := skewZigzagMk_surjective k G c y
-  induction x using PathAlgebra.induction_linear with
-  | zero => simp
-  | add x y hx hy => simp only [map_add, hx, hy]
-  | single x a =>
-      rw [single_eq_smul_ofPath, map_smul]
-      simp only [Algebra.smul_def, map_mul, hscalar, hpath]
+/-- Equal skew-zigzag parameters define canonically isomorphic relation quotients. -/
+noncomputable def skewZigzagQuotientCongr {c c' : SkewZigzagParameter k G} (h : c = c') :
+    skewZigzagQuotient k G c ≃ₐ[k] skewZigzagQuotient k G c' := by
+  subst c'
+  exact AlgEquiv.refl
+
+/-- The canonical quotient isomorphism attached to an equality of parameters preserves every
+quotient class. -/
+@[simp]
+theorem skewZigzagQuotientCongr_skewZigzagMk {c c' : SkewZigzagParameter k G} (h : c = c')
+    (x : pathAlgebra k (DoubledQuiver G)) :
+    skewZigzagQuotientCongr k G h (skewZigzagMk k G c x) =
+      skewZigzagMk k G c' x := by
+  subst c'
+  rfl
 
 /-- The kernel of the skew-zigzag quotient map is its relation ideal. -/
 @[simp]

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/Skew.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/Skew.lean
@@ -56,7 +56,7 @@ namespace TauCeti
 
 open PathAlgebra DoubledQuiver
 
-universe u w
+universe u w z
 
 /-- A skew-zigzag parameter assigns a unit-valued, hence invertible, scalar ratio to every ordered
 pair of adjacencies with a common source.  The units make invertibility part of the type, and the
@@ -114,6 +114,61 @@ theorem one_ratio {i j j' : V} (h : G.Adj i j) (h' : G.Adj i j') :
     (1 : SkewZigzagParameter k G).ratio h h' = 1 := (rfl)
 
 end One
+
+section Map
+
+variable {k : Type w} {l : Type z} [Monoid k] [Monoid l]
+  {V : Type u} {G : SimpleGraph V}
+
+/-- Apply a monoid homomorphism to every ratio of a skew-zigzag parameter. -/
+def map (f : k →* l) (c : SkewZigzagParameter k G) : SkewZigzagParameter l G where
+  ratio _ _ _ h h' := Units.map f (c.ratio h h')
+  ratio_self := by intro i j h; simp
+  ratio_inv := by
+    intro i j j' h h'
+    rw [← map_mul, c.ratio_inv]
+    exact map_one (Units.map f)
+  ratio_cocycle := by
+    intro i j j' j'' h h' h''
+    rw [← map_mul, ← map_mul, c.ratio_cocycle]
+    exact map_one (Units.map f)
+
+/-- Scalar extension applies the coefficient homomorphism to a parameter ratio. -/
+@[simp]
+theorem map_ratio (f : k →* l) (c : SkewZigzagParameter k G)
+    {i j j' : V} (h : G.Adj i j) (h' : G.Adj i j') :
+    (c.map f).ratio h h' = Units.map f (c.ratio h h') := (rfl)
+
+/-- The constant parameter remains constant after scalar extension. -/
+@[simp]
+theorem map_one (f : k →* l) :
+    map f (1 : SkewZigzagParameter k G) = 1 := by
+  ext i j j' h h'
+  simp
+
+/-- Mapping a parameter along the identity homomorphism changes nothing. -/
+@[simp]
+theorem map_id (c : SkewZigzagParameter k G) : c.map (MonoidHom.id k) = c := by
+  ext i j j' h h'
+  simp
+
+/-- Mapping a parameter along a composite is successive scalar extension. -/
+@[simp]
+theorem map_comp {m : Type*} [Monoid m] (f : k →* l) (g : l →* m)
+    (c : SkewZigzagParameter k G) :
+    c.map (g.comp f) = (c.map f).map g := by
+  ext i j j' h h'
+  simp [Units.map_comp]
+
+/-- Injectivity on units induces an injective map on skew-zigzag parameters. -/
+theorem map_injective (f : k →* l) (hf : Function.Injective (Units.map f)) :
+    Function.Injective (map (G := G) f) := by
+  intro c c' h
+  apply SkewZigzagParameter.ext
+  funext i j j' hi hj
+  exact hf (congrArg (fun d : SkewZigzagParameter l G => d.ratio hi hj) h)
+
+end Map
 
 variable {k : Type w} [MonoidWithZero k] [Nontrivial k] {V : Type u} {G : SimpleGraph V}
 


### PR DESCRIPTION
This PR extends every skew-zigzag parameter along a coefficient homomorphism, proves that the extension is functorial and injective under an injective map on coefficients, carries gauge equivalence through scalar extension, and descends the coefficient map to the skew-zigzag relation quotient while fixing every doubled path.

The exact target is `ZigzagPreprojective/README.md`, Layer 1 “strict ordinary and skew zigzag algebras,” specifically “For a specified field homomorphism, extend every parameter by applying the homomorphism and construct the resulting scalar-extension comparison.” This is the most effective current step because the skew presentation, gauge action, tree trivialization, and cycle calculations are already on `main`, while the scalar-extension map is the remaining presentation-level prerequisite needed before those gauge classes can be compared over different fields. After this PR, the Layer 1 skew milestone still needs Couture’s `H¹(G,kˣ)` classification and the skew Frobenius-trace normalization; any injectivity statement for the eventual `H¹` classification must separately assume that the induced map on units has the required injectivity.

The new `TauCeti/RepresentationTheory/Quiver/Zigzag/BaseChange.lean` contains 336 lines. `TauCeti/RepresentationTheory/Quiver/Zigzag/Skew.lean` gains 24 lines exposing quotient-map surjectivity and ring-homomorphism extensionality, the characteristic API used to prove coefficient-map uniqueness without unfolding the quotient.

The parameter conventions follow C. Couture, *Skew-Zigzag Algebras*, Sections 3 and 4, as cited in the module documentation. The quotient construction reuses `Units.map`, `PathAlgebra.liftAlgHom`, and the existing skew-zigzag universal property, following the presentation-level coefficient-map pattern already used by `TauCeti.RepresentationTheory.Quiver.Preprojective.BaseChange`; no Mathlib implementation is vendored.

Roadmap: ZigzagPreprojective

<!--tauceti-target:v1 {"focus":"ZigzagPreprojective","id":"skew-zigzag-scalar-extension"}-->

🤖 Prepared with Codex
