### PR TITLE
feat: Tate cohomology along an isomorphism of finite groups

### DIFF
--- a/TauCeti/RepresentationTheory/Homological/TateCohomology/Functoriality.lean
+++ b/TauCeti/RepresentationTheory/Homological/TateCohomology/Functoriality.lean
@@ -1,0 +1,321 @@
+/-
+Copyright (c) 2026 Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import Mathlib.RepresentationTheory.Homological.TateCohomology.Basic
+
+/-!
+# Tate cohomology along an isomorphism of finite groups
+
+Mathlib's Tate cohomology of a finite group is functorial in the coefficient representation, but
+the group is fixed throughout. This file supplies the missing variance in the group for the case
+of an isomorphism. A **compatible pair** consists of a group isomorphism `e : G ≃* H` and a
+linear map `φ` between the coefficient modules of `M : Rep R G` and `N : Rep R H` satisfying
+
+`φ ∘ ρ g = σ (e g) ∘ φ`.
+
+Such a pair induces a map of Tate complexes, hence a map
+`tateCohomology M n ⟶ tateCohomology N n` in every integer degree, and that map is an
+isomorphism as soon as `φ` is.
+
+The construction connects the two halves of the Tate complex: on the chain half it is Mathlib's
+`groupHomology.chainsMap` along `e`, on the cochain half it is `groupCohomology.cochainsMap`
+along `e.symm`, and the two agree on the Tate norm because `e` permutes the group, so the norm
+`∑ g, ρ g` is carried to `∑ h, σ h`. In the degrees where Mathlib identifies Tate cohomology
+with ordinary group cohomology or homology, the construction is the ordinary change-of-group map
+of that theory.
+
+The main application is conjugation: for an element of a group acting on a normal layer of a
+class formation, conjugation is an isomorphism of finite Galois groups covered by an isomorphism
+of coefficient modules, and the class-formation axioms compare the invariants of a layer with the
+invariants of its conjugate through the resulting map in degree two.
+
+## Main definitions
+
+* `TauCeti.TateCohomology.IsCompatible`: the compatibility relation between a group isomorphism
+  and a map of coefficient modules.
+* `TauCeti.TateCohomology.IsCompatible.complexMap`: the induced map of Tate complexes.
+* `TauCeti.TateCohomology.map`: the induced map in a single integer degree.
+* `TauCeti.TateCohomology.mapIso`: the induced isomorphism, for `φ` a linear equivalence.
+* `TauCeti.TateCohomology.resIso`: the packaged natural isomorphism
+  `Res(e) ⋙ tateCohomologyFunctor n ≅ tateCohomologyFunctor n`.
+
+## Main results
+
+* `TauCeti.TateCohomology.IsCompatible.complexMap_refl`: along the identity isomorphism the
+  construction is Mathlib's coefficient functoriality.
+* `TauCeti.TateCohomology.map_id` and `TauCeti.TateCohomology.map_comp`: functoriality in the
+  compatible pair.
+* `TauCeti.TateCohomology.map_comp_isoGroupCohomology_hom`: in positive degrees the construction
+  is `groupCohomology.map` along `e.symm`.
+* `TauCeti.TateCohomology.map_comp_isoGroupHomology_hom`: in degrees at most `-2` it is
+  `groupHomology.map` along `e`.
+
+## References
+
+* E. Artin and J. Tate, *Class Field Theory*, Chapter XIV, §4.
+* J. Neukirch, A. Schmidt and K. Wingberg, *Cohomology of Number Fields*, Chapter I, §5.
+-/
+
+@[expose] public noncomputable section
+
+universe u
+
+open CategoryTheory
+
+namespace TauCeti.TateCohomology
+
+variable {R G H K : Type u} [CommRing R] [Group G] [Group H] [Group K]
+  {M : Rep R G} {N : Rep R H} {P : Rep R K}
+
+/-- A group isomorphism `e : G ≃* H` and a linear map `φ` between the coefficient modules of
+`M : Rep R G` and `N : Rep R H` are **compatible** when `φ ∘ ρ g = σ (e g) ∘ φ` for every `g`.
+Such a pair is what carries the Tate cohomology of `M` to that of `N`. -/
+def IsCompatible (e : G ≃* H) (φ : M.V →ₗ[R] N.V) : Prop :=
+  ∀ g, φ ∘ₗ M.ρ g = N.ρ (e g) ∘ₗ φ
+
+namespace IsCompatible
+
+variable {e : G ≃* H} {φ : M.V →ₗ[R] N.V}
+
+/-- A compatible pair read as a morphism `M ⟶ Res(e)(N)` of `G`-representations. This is the
+datum that `groupHomology.chainsMap` consumes. -/
+def toRes (hφ : IsCompatible e φ) : M ⟶ Rep.res (e : G →* H) N := Rep.ofHom ⟨φ, hφ⟩
+
+/-- A compatible pair read as a morphism `Res(e⁻¹)(M) ⟶ N` of `H`-representations. This is the
+datum that `groupCohomology.cochainsMap` consumes. -/
+def ofRes (hφ : IsCompatible e φ) : Rep.res (e.symm : H →* G) M ⟶ N :=
+  Rep.ofHom ⟨φ, fun h ↦ by simpa using hφ (e.symm h)⟩
+
+@[simp] theorem toRes_hom_toLinearMap (hφ : IsCompatible e φ) :
+    hφ.toRes.hom.toLinearMap = φ := rfl
+
+@[simp] theorem ofRes_hom_toLinearMap (hφ : IsCompatible e φ) :
+    hφ.ofRes.hom.toLinearMap = φ := rfl
+
+/-- **Compatible pairs compose.** -/
+theorem trans (hφ : IsCompatible e φ) {e₂ : H ≃* K} {ψ : N.V →ₗ[R] P.V}
+    (hψ : IsCompatible e₂ ψ) : IsCompatible (e.trans e₂) (ψ ∘ₗ φ) := fun g ↦ by
+  rw [LinearMap.comp_assoc, hφ g, ← LinearMap.comp_assoc, hψ (e g), LinearMap.comp_assoc]
+  rfl
+
+/-- **The inverse of a compatible pair whose linear part is an equivalence is compatible.** -/
+theorem symm {e' : M.V ≃ₗ[R] N.V} (he : IsCompatible e (e' : M.V →ₗ[R] N.V)) :
+    IsCompatible e.symm (e'.symm : N.V →ₗ[R] M.V) := fun h ↦ by
+  rw [e'.toLinearMap_symm_comp_eq, ← LinearMap.comp_assoc, he (e.symm h)]
+  ext x
+  simp
+
+end IsCompatible
+
+/-- The identity of a representation is compatible with the identity of its group. -/
+theorem isCompatible_id :
+    IsCompatible (MulEquiv.refl G) (LinearMap.id : M.V →ₗ[R] M.V) := fun g ↦ by simp
+
+/-- Restricting the coefficients along `e` and comparing back by the identity is a compatible
+pair. -/
+theorem isCompatible_res (e : G ≃* H) (N : Rep R H) :
+    IsCompatible (M := Rep.res (e : G →* H) N) e
+      ((LinearEquiv.refl R N.V : N.V →ₗ[R] N.V) :
+        (Rep.res (e : G →* H) N).V →ₗ[R] N.V) := fun g ↦ by
+  ext x
+  simp
+
+section Complex
+
+variable [Fintype G] [Fintype H] {e : G ≃* H} {φ : M.V →ₗ[R] N.V}
+
+namespace IsCompatible
+
+/-- **A compatible pair intertwines the two norm maps.** The group isomorphism permutes the
+summands of `∑ g, ρ g`. -/
+theorem comp_norm (hφ : IsCompatible e φ) : φ ∘ₗ M.ρ.norm = N.ρ.norm ∘ₗ φ := by
+  ext x
+  simpa [Representation.norm] using
+    Fintype.sum_equiv e.toEquiv (fun g ↦ φ (M.ρ g x)) (fun h ↦ N.ρ h (φ x))
+      fun g ↦ congr($(hφ g) x)
+
+/-- The square joining the chain half of the Tate complex to its cochain half commutes for a
+compatible pair: this is `IsCompatible.comp_norm` in degree zero. -/
+theorem chainsMap_comp_d₀ (hφ : IsCompatible e φ) :
+    (groupHomology.chainsMap (e : G →* H) hφ.toRes).f 0 ≫ (tateComplexConnectData N).d₀ =
+      (tateComplexConnectData M).d₀ ≫
+        (groupCohomology.cochainsMap (e.symm : H →* G) hφ.ofRes).f 0 := by
+  simp only [tateComplexConnectData_d₀]
+  ext x m y
+  simp only [groupHomology.lsingle_comp_chainsMap_f_assoc, MonoidHom.coe_coe, ModuleCat.ofHom_comp,
+    Category.assoc, ModuleCat.hom_comp, ConcreteCategory.hom_ofHom, LinearMap.coe_comp,
+    Function.comp_apply, Finsupp.lsingle_apply, Rep.tateNorm_eq, groupCohomology.cochainsMap_f,
+    toRes, ofRes, Finsupp.lsum_single, LinearMap.pi_apply, LinearMap.compLeft_apply,
+    LinearMap.funLeft_apply]
+  exact congr($(hφ.comp_norm) m).symm
+
+/-- **The map of Tate complexes attached to a compatible pair.** On the chain half it is
+`groupHomology.chainsMap` along `e`, on the cochain half `groupCohomology.cochainsMap` along
+`e.symm`. -/
+def complexMap (hφ : IsCompatible e φ) : tateComplex M ⟶ tateComplex N :=
+  (tateComplexConnectData M).map (tateComplexConnectData N)
+    (groupHomology.chainsMap (e : G →* H) hφ.toRes)
+    (groupCohomology.cochainsMap (e.symm : H →* G) hφ.ofRes)
+    hφ.chainsMap_comp_d₀
+
+end IsCompatible
+
+end Complex
+
+section Degrees
+
+variable [Fintype G] [Fintype H] [Fintype K]
+
+namespace IsCompatible
+
+/-- The map of Tate complexes depends only on the compatible pair, not on the compatibility
+proof. -/
+theorem complexMap_congr {e₁ e₂ : G ≃* H} {φ₁ φ₂ : M.V →ₗ[R] N.V}
+    {h₁ : IsCompatible e₁ φ₁} {h₂ : IsCompatible e₂ φ₂} (he : e₁ = e₂) (hφ : φ₁ = φ₂) :
+    h₁.complexMap = h₂.complexMap := by
+  subst he; subst hφ; rfl
+
+/-- **Along the identity isomorphism the construction is Mathlib's coefficient
+functoriality.** -/
+theorem complexMap_refl {M N : Rep R G} {φ : M.V →ₗ[R] N.V}
+    (hφ : IsCompatible (MulEquiv.refl G) φ) :
+    hφ.complexMap = tateComplex.map (Rep.ofHom ⟨φ, hφ⟩) := rfl
+
+/-- The identity compatible pair induces the identity of Tate complexes. -/
+theorem complexMap_id : (isCompatible_id (M := M)).complexMap = 𝟙 (tateComplex M) :=
+  (tateComplexFunctor R G).map_id M
+
+/-- **The construction is functorial in the compatible pair.** -/
+theorem complexMap_trans {e₁ : G ≃* H} {e₂ : H ≃* K} {φ : M.V →ₗ[R] N.V}
+    (hφ : IsCompatible e₁ φ) {ψ : N.V →ₗ[R] P.V} (hψ : IsCompatible e₂ ψ) :
+    hφ.complexMap ≫ hψ.complexMap = (hφ.trans hψ).complexMap := by
+  refine (CochainComplex.ConnectData.map_comp_map ..).trans ?_
+  congr 1
+  exact (groupHomology.chainsMap_comp _ _ _ _).symm
+
+end IsCompatible
+
+/-- **The isomorphism of Tate complexes attached to a compatible pair whose linear part is an
+equivalence.** -/
+def complexMapIso {e : G ≃* H} {e' : M.V ≃ₗ[R] N.V}
+    (he : IsCompatible e (e' : M.V →ₗ[R] N.V)) : tateComplex M ≅ tateComplex N where
+  hom := he.complexMap
+  inv := he.symm.complexMap
+  hom_inv_id := (IsCompatible.complexMap_trans ..).trans
+    ((IsCompatible.complexMap_congr (by simp) (by ext x; simp)).trans
+      IsCompatible.complexMap_id)
+  inv_hom_id := (IsCompatible.complexMap_trans ..).trans
+    ((IsCompatible.complexMap_congr (by simp) (by ext x; simp)).trans
+      IsCompatible.complexMap_id)
+
+/-- **Tate cohomology along a compatible pair**, in a single integer degree. -/
+def map {e : G ≃* H} {φ : M.V →ₗ[R] N.V} (hφ : IsCompatible e φ) (n : ℤ) :
+    tateCohomology M n ⟶ tateCohomology N n :=
+  HomologicalComplex.homologyMap hφ.complexMap n
+
+/-- **Tate cohomology along a compatible pair whose linear part is an equivalence** is an
+isomorphism in every integer degree. -/
+def mapIso {e : G ≃* H} {e' : M.V ≃ₗ[R] N.V} (he : IsCompatible e (e' : M.V →ₗ[R] N.V))
+    (n : ℤ) : tateCohomology M n ≅ tateCohomology N n :=
+  HomologicalComplex.homologyMapIso (complexMapIso he) n
+
+@[simp] theorem mapIso_hom {e : G ≃* H} {e' : M.V ≃ₗ[R] N.V}
+    (he : IsCompatible e (e' : M.V →ₗ[R] N.V)) (n : ℤ) :
+    (mapIso he n).hom = map he n := rfl
+
+@[simp] theorem mapIso_inv {e : G ≃* H} {e' : M.V ≃ₗ[R] N.V}
+    (he : IsCompatible e (e' : M.V →ₗ[R] N.V)) (n : ℤ) :
+    (mapIso he n).inv = map he.symm n := rfl
+
+/-- Tate cohomology in a fixed degree depends only on the compatible pair. -/
+theorem map_congr {e₁ e₂ : G ≃* H} {φ₁ φ₂ : M.V →ₗ[R] N.V} {h₁ : IsCompatible e₁ φ₁}
+    {h₂ : IsCompatible e₂ φ₂} (he : e₁ = e₂) (hφ : φ₁ = φ₂) (n : ℤ) :
+    map h₁ n = map h₂ n := by
+  rw [map, map, IsCompatible.complexMap_congr he hφ]
+
+/-- Along the identity isomorphism, Tate cohomology of a compatible pair is Mathlib's coefficient
+functoriality. -/
+theorem map_refl {M N : Rep R G} {φ : M.V →ₗ[R] N.V} (hφ : IsCompatible (MulEquiv.refl G) φ)
+    (n : ℤ) :
+    map hφ n = (tateCohomologyFunctor n).map (Rep.ofHom ⟨φ, hφ⟩) := rfl
+
+/-- The identity compatible pair induces the identity in every degree. -/
+theorem map_id (n : ℤ) :
+    map (isCompatible_id (M := M)) n = 𝟙 (tateCohomology M n) := by
+  rw [map, IsCompatible.complexMap_id]
+  exact HomologicalComplex.homologyMap_id _ _
+
+/-- **Tate cohomology is functorial in the compatible pair**, in every degree. -/
+theorem map_trans {e₁ : G ≃* H} {e₂ : H ≃* K} {φ : M.V →ₗ[R] N.V} (hφ : IsCompatible e₁ φ)
+    {ψ : N.V →ₗ[R] P.V} (hψ : IsCompatible e₂ ψ) (n : ℤ) :
+    map hφ n ≫ map hψ n = map (hφ.trans hψ) n := by
+  rw [map, map, map, ← IsCompatible.complexMap_trans hφ hψ, HomologicalComplex.homologyMap_comp]
+  rfl
+
+/-- **In positive degrees the construction is the ordinary cohomological change-of-group map**
+along `e.symm`, read through Mathlib's comparison between Tate and group cohomology. -/
+theorem map_comp_isoGroupCohomology_hom {e : G ≃* H} {φ : M.V →ₗ[R] N.V}
+    (hφ : IsCompatible e φ) (n : ℕ) [NeZero n] :
+    map hφ (n : ℤ) ≫ (_root_.TateCohomology.isoGroupCohomology n).hom.app N =
+      (_root_.TateCohomology.isoGroupCohomology n).hom.app M ≫
+        groupCohomology.map (e.symm : H →* G) hφ.ofRes n := by
+  have key : HomologicalComplex.homologyMap hφ.complexMap (n : ℤ) ≫
+      ((tateComplexConnectData N).homologyIsoPos n (n : ℤ) rfl).hom =
+        ((tateComplexConnectData M).homologyIsoPos n (n : ℤ) rfl).hom ≫
+          HomologicalComplex.homologyMap
+            (groupCohomology.cochainsMap (e.symm : H →* G) hφ.ofRes) n := by
+    rw [IsCompatible.complexMap, CochainComplex.ConnectData.homologyMap_map_of_eq_succ
+      (n := n) (m := (n : ℤ)) (hmn := rfl)]
+    simp
+  exact key
+
+/-- **In degrees at most `-2` the construction is the ordinary homological change-of-group map**
+along `e`, read through Mathlib's comparison between Tate cohomology and group homology. -/
+theorem map_comp_isoGroupHomology_hom {e : G ≃* H} {φ : M.V →ₗ[R] N.V} (hφ : IsCompatible e φ)
+    (m : ℤ) (n : ℕ) (hmn : m = -(n + 1)) [NeZero n] :
+    map hφ m ≫ (_root_.TateCohomology.isoGroupHomology m n hmn).hom.app N =
+      (_root_.TateCohomology.isoGroupHomology m n hmn).hom.app M ≫
+        groupHomology.map (e : G →* H) hφ.toRes n := by
+  have key : HomologicalComplex.homologyMap hφ.complexMap m ≫
+      ((tateComplexConnectData N).homologyIsoNeg n m hmn).hom =
+        ((tateComplexConnectData M).homologyIsoNeg n m hmn).hom ≫
+          HomologicalComplex.homologyMap (groupHomology.chainsMap (e : G →* H) hφ.toRes) n := by
+    rw [IsCompatible.complexMap, CochainComplex.ConnectData.homologyMap_map_of_eq_neg_succ
+      (n := n) (m := m) (hmn := hmn)]
+    simp
+  exact key
+
+/-- **Restricting the coefficients along an isomorphism of finite groups does not change Tate
+cohomology**, naturally in the coefficients. -/
+def resIso (e : G ≃* H) (n : ℤ) :
+    Rep.resFunctor (e : G →* H) ⋙ tateCohomologyFunctor (R := R) (G := G) n ≅
+      tateCohomologyFunctor n :=
+  NatIso.ofComponents (fun N ↦ mapIso (isCompatible_res e N) n)
+    fun {N N'} ψ ↦ by
+      have hψ : IsCompatible (MulEquiv.refl H) ψ.hom.toLinearMap := ψ.hom.isIntertwining'
+      have hres : IsCompatible (M := Rep.res (e : G →* H) N) (N := Rep.res (e : G →* H) N')
+          (MulEquiv.refl G)
+          (ψ.hom.toLinearMap : (Rep.res (e : G →* H) N).V →ₗ[R] (Rep.res (e : G →* H) N').V) :=
+        fun g ↦ hψ (e g)
+      have key : map hres n ≫ map (isCompatible_res e N') n =
+          map (isCompatible_res e N) n ≫ map hψ n := by
+        rw [map_trans, map_trans]
+        exact map_congr (by ext x; rfl) (by ext x; rfl) n
+      exact key
+
+/-- Tate cohomology groups matched by a compatible pair whose linear part is an equivalence have
+the same cardinality. -/
+theorem natCard_tateCohomology_eq {e : G ≃* H} {e' : M.V ≃ₗ[R] N.V}
+    (he : IsCompatible e (e' : M.V →ₗ[R] N.V)) (n : ℤ) :
+    Nat.card (tateCohomology M n) = Nat.card (tateCohomology N n) :=
+  Nat.card_congr (mapIso he n).toLinearEquiv.toEquiv
+
+end Degrees
+
+end TateCohomology
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Homological/TateCohomology/Functoriality.lean
+++ b/TauCeti/RepresentationTheory/Homological/TateCohomology/Functoriality.lean
@@ -59,7 +59,6 @@ invariants of its conjugate through the resulting map in degree two.
 
 ## References
 
-* `TauCetiRoadmap/ClassFieldTheory/README.md`, §4, Layers 0–1.
 * E. Artin and J. Tate, *Class Field Theory*, Chapter XIV, §4.
 * J. Neukirch, A. Schmidt and K. Wingberg, *Cohomology of Number Fields*, Chapter I, §5.
 -/
@@ -68,7 +67,7 @@ public noncomputable section
 
 universe u
 
-open CategoryTheory TauCeti.Representation
+open CategoryTheory Representation
 
 namespace TauCeti.TateCohomology
 

--- a/TauCeti/RepresentationTheory/Homological/TateCohomology/Functoriality.lean
+++ b/TauCeti/RepresentationTheory/Homological/TateCohomology/Functoriality.lean
@@ -134,16 +134,22 @@ theorem complexMap_refl {M N : Rep R G} {φ : M.V →ₗ[R] N.V}
 
 /-- The identity compatible pair induces the identity of Tate complexes. -/
 @[simp] theorem complexMap_id :
-    complexMap (e := MulEquiv.refl G) (φ := LinearMap.id) (isIntertwiningMap_id M) =
+    complexMap (e := MulEquiv.refl G) (φ := LinearMap.id) (Rep.isIntertwiningMap_id M) =
       𝟙 (tateComplex M) :=
   (tateComplexFunctor R G).map_id M
 
 /-- **The construction is functorial in the compatible pair.** -/
+-- The underlying monoid homomorphism of `e₁.trans e₂` is only extensionally equal to the
+-- `MonoidHom.comp` in `IsIntertwiningMap.trans`, so the right-hand side transports across that
+-- equality.
 @[reassoc]
 theorem complexMap_comp {e₁ : G ≃* H} {e₂ : H ≃* K} {φ : M.V →ₗ[R] N.V}
     (hφ : M.ρ.IsIntertwiningMap (N.ρ.comp (e₁ : G →* H)) φ) {ψ : N.V →ₗ[R] P.V}
     (hψ : N.ρ.IsIntertwiningMap (P.ρ.comp (e₂ : H →* K)) ψ) :
-    complexMap hφ ≫ complexMap hψ = complexMap (IsIntertwiningMap.trans hφ hψ) := by
+    complexMap hφ ≫ complexMap hψ = complexMap (e := e₁.trans e₂) (φ := ψ ∘ₗ φ) (by
+      convert IsIntertwiningMap.trans hφ hψ using 1
+      ext x
+      rfl) := by
   refine (CochainComplex.ConnectData.map_comp_map ..).trans ?_
   congr 1
   exact (groupHomology.chainsMap_comp _ _ _ _).symm
@@ -224,17 +230,22 @@ theorem map_refl {M N : Rep R G} {φ : M.V →ₗ[R] N.V}
 
 /-- The identity compatible pair induces the identity in every degree. -/
 @[simp] theorem map_id (n : ℤ) :
-    map (e := MulEquiv.refl G) (φ := LinearMap.id) (isIntertwiningMap_id M) n =
+    map (e := MulEquiv.refl G) (φ := LinearMap.id) (Rep.isIntertwiningMap_id M) n =
       𝟙 (tateCohomology M n) := by
   rw [map_def, complexMap_id]
   exact HomologicalComplex.homologyMap_id _ _
 
 /-- **Tate cohomology is functorial in the compatible pair**, in every degree. -/
+-- As in `complexMap_comp`, the right-hand side transports the generalized composition theorem
+-- across the extensional equality of the two underlying monoid homomorphisms.
 @[reassoc]
 theorem map_comp {e₁ : G ≃* H} {e₂ : H ≃* K} {φ : M.V →ₗ[R] N.V}
     (hφ : M.ρ.IsIntertwiningMap (N.ρ.comp (e₁ : G →* H)) φ) {ψ : N.V →ₗ[R] P.V}
     (hψ : N.ρ.IsIntertwiningMap (P.ρ.comp (e₂ : H →* K)) ψ) (n : ℤ) :
-    map hφ n ≫ map hψ n = map (IsIntertwiningMap.trans hφ hψ) n := by
+    map hφ n ≫ map hψ n = map (e := e₁.trans e₂) (φ := ψ ∘ₗ φ) (by
+      convert IsIntertwiningMap.trans hφ hψ using 1
+      ext x
+      rfl) n := by
   rw [map_def, map_def, map_def, ← complexMap_comp hφ hψ,
     HomologicalComplex.homologyMap_comp]
   rfl
@@ -288,7 +299,7 @@ cohomology**, naturally in the coefficients. -/
 def resIso (e : G ≃* H) (n : ℤ) :
     Rep.resFunctor (e : G →* H) ⋙ tateCohomologyFunctor (R := R) (G := G) n ≅
       tateCohomologyFunctor n :=
-  NatIso.ofComponents (fun N ↦ mapIso (isIntertwiningMap_res (e : G →* H) N) n)
+  NatIso.ofComponents (fun N ↦ mapIso (Rep.isIntertwiningMap_res N (e : G →* H)) n)
     fun {N N'} ψ ↦ by
       have hψ : N.ρ.IsIntertwiningMap
           (N'.ρ.comp ((MulEquiv.refl H : H ≃* H) : H →* H)) ψ.hom.toLinearMap :=
@@ -299,21 +310,23 @@ def resIso (e : G ≃* H) (n : ℤ) :
           (ψ.hom.toLinearMap :
             (Rep.res (e : G →* H) N).V →ₗ[R] (Rep.res (e : G →* H) N').V) :=
         ⟨fun g v ↦ congr($(ψ.hom.isIntertwining' (e g)) v)⟩
-      have key : map (e := MulEquiv.refl G) hres n ≫ map (isIntertwiningMap_res (e : G →* H) N') n =
-          map (isIntertwiningMap_res (e : G →* H) N) n ≫ map (e := MulEquiv.refl H) hψ n := by
+      have key : map (e := MulEquiv.refl G) hres n ≫
+          map (Rep.isIntertwiningMap_res N' (e : G →* H)) n =
+          map (Rep.isIntertwiningMap_res N (e : G →* H)) n ≫
+            map (e := MulEquiv.refl H) hψ n := by
         rw [map_comp, map_comp]
         exact map_congr (by ext x; rfl) (by ext x; rfl) n
       exact key
 
 @[simp] theorem resIso_hom_app (e : G ≃* H) (n : ℤ) (N : Rep R H) :
-    (resIso e n).hom.app N = (mapIso (isIntertwiningMap_res (e : G →* H) N) n).hom := by
+    (resIso e n).hom.app N = (mapIso (Rep.isIntertwiningMap_res N (e : G →* H)) n).hom := by
   rw [resIso]
   -- `NatIso.ofComponents_hom_app` is not usable as a rewrite here: its motive is ill-typed at
   -- `implicit` transparency, because `tateCohomologyFunctor` is a semireducible `def`.
   rfl
 
 @[simp] theorem resIso_inv_app (e : G ≃* H) (n : ℤ) (N : Rep R H) :
-    (resIso e n).inv.app N = (mapIso (isIntertwiningMap_res (e : G →* H) N) n).inv := by
+    (resIso e n).inv.app N = (mapIso (Rep.isIntertwiningMap_res N (e : G →* H)) n).inv := by
   rw [resIso]
   -- As above for `NatIso.ofComponents_inv_app`.
   rfl

--- a/TauCeti/RepresentationTheory/Homological/TateCohomology/Functoriality.lean
+++ b/TauCeti/RepresentationTheory/Homological/TateCohomology/Functoriality.lean
@@ -111,9 +111,7 @@ theorem trans (hφ : IsCompatible e φ) {e₂ : H ≃* K} {ψ : N.V →ₗ[R] P.
 /-- **The inverse of a compatible pair whose linear part is an equivalence is compatible.** -/
 theorem symm {e' : M.V ≃ₗ[R] N.V} (he : IsCompatible e (e' : M.V →ₗ[R] N.V)) :
     IsCompatible e.symm (e'.symm : N.V →ₗ[R] M.V) := fun h ↦ by
-  rw [e'.toLinearMap_symm_comp_eq, ← LinearMap.comp_assoc, he (e.symm h)]
-  ext x
-  simp
+  simpa using e'.isIntertwining_symm_isIntertwining (σ := N.ρ.comp (e : G →* H)) he (e.symm h)
 
 end IsCompatible
 

--- a/TauCeti/RepresentationTheory/Homological/TateCohomology/Functoriality.lean
+++ b/TauCeti/RepresentationTheory/Homological/TateCohomology/Functoriality.lean
@@ -35,8 +35,6 @@ invariants of its conjugate through the resulting map in degree two.
 
 ## Main definitions
 
-* `TauCeti.TateCohomology.IsCompatible`: the compatibility relation between a group isomorphism
-  and a map of coefficient modules.
 * `TauCeti.TateCohomology.IsCompatible.complexMap`: the induced map of Tate complexes.
 * `TauCeti.TateCohomology.map`: the induced map in a single integer degree.
 * `TauCeti.TateCohomology.mapIso`: the induced isomorphism, for `φ` a linear equivalence.
@@ -56,6 +54,7 @@ invariants of its conjugate through the resulting map in degree two.
 
 ## References
 
+* `TauCetiRoadmap/ClassFieldTheory/README.md`, §4, Layers 0–1.
 * E. Artin and J. Tate, *Class Field Theory*, Chapter XIV, §4.
 * J. Neukirch, A. Schmidt and K. Wingberg, *Cohomology of Number Fields*, Chapter I, §5.
 -/
@@ -71,62 +70,68 @@ namespace TauCeti.TateCohomology
 variable {R G H K : Type u} [CommRing R] [Group G] [Group H] [Group K]
   {M : Rep R G} {N : Rep R H} {P : Rep R K}
 
-/-- A group isomorphism `e : G ≃* H` and a linear map `φ` between the coefficient modules of
-`M : Rep R G` and `N : Rep R H` are **compatible** when `φ ∘ ρ g = σ (e g) ∘ φ` for every `g`.
-Such a pair is what carries the Tate cohomology of `M` to that of `N`.
-
-Use `TauCeti.TateCohomology.isCompatible_iff` to build or to destructure such a pair. -/
-def IsCompatible (e : G ≃* H) (φ : M.V →ₗ[R] N.V) : Prop :=
-  ∀ g, φ ∘ₗ M.ρ g = N.ρ (e g) ∘ₗ φ
-
-/-- The defining intertwining condition of a compatible pair. -/
-theorem isCompatible_iff {e : G ≃* H} {φ : M.V →ₗ[R] N.V} :
-    IsCompatible e φ ↔ ∀ g, φ ∘ₗ M.ρ g = N.ρ (e g) ∘ₗ φ := Iff.rfl
-
 namespace IsCompatible
 
 variable {e : G ≃* H} {φ : M.V →ₗ[R] N.V}
 
 /-- A compatible pair read as a morphism `M ⟶ Res(e)(N)` of `G`-representations. This is the
 datum that `groupHomology.chainsMap` consumes. -/
-def toRes (hφ : IsCompatible e φ) : M ⟶ Rep.res (e : G →* H) N := Rep.ofHom ⟨φ, hφ⟩
+def toRes (hφ : M.ρ.IsIntertwiningMap (N.ρ.comp (e : G →* H)) φ) :
+    M ⟶ Rep.res (e : G →* H) N :=
+  Rep.ofHom ⟨φ, fun g ↦ by ext v; exact hφ.isIntertwining g v⟩
 
 /-- A compatible pair read as a morphism `Res(e⁻¹)(M) ⟶ N` of `H`-representations. This is the
 datum that `groupCohomology.cochainsMap` consumes. -/
-def ofRes (hφ : IsCompatible e φ) : Rep.res (e.symm : H →* G) M ⟶ N :=
-  Rep.ofHom ⟨φ, fun h ↦ by simpa using hφ (e.symm h)⟩
+def ofRes (hφ : M.ρ.IsIntertwiningMap (N.ρ.comp (e : G →* H)) φ) :
+    Rep.res (e.symm : H →* G) M ⟶ N :=
+  Rep.ofHom ⟨φ, fun h ↦ by ext v; simpa using hφ.isIntertwining (e.symm h) v⟩
 
-@[simp] theorem toRes_hom_toLinearMap (hφ : IsCompatible e φ) :
-    hφ.toRes.hom.toLinearMap = φ := by simp [toRes]
+@[simp] theorem toRes_hom_toLinearMap
+    (hφ : M.ρ.IsIntertwiningMap (N.ρ.comp (e : G →* H)) φ) :
+    (toRes hφ).hom.toLinearMap = φ := by simp [toRes]
 
-@[simp] theorem ofRes_hom_toLinearMap (hφ : IsCompatible e φ) :
-    hφ.ofRes.hom.toLinearMap = φ := by simp [ofRes]
+@[simp] theorem ofRes_hom_toLinearMap
+    (hφ : M.ρ.IsIntertwiningMap (N.ρ.comp (e : G →* H)) φ) :
+    (ofRes hφ).hom.toLinearMap = φ := by simp [ofRes]
 
 /-- **Compatible pairs compose.** -/
-theorem trans (hφ : IsCompatible e φ) {e₂ : H ≃* K} {ψ : N.V →ₗ[R] P.V}
-    (hψ : IsCompatible e₂ ψ) : IsCompatible (e.trans e₂) (ψ ∘ₗ φ) := fun g ↦ by
-  rw [LinearMap.comp_assoc, hφ g, ← LinearMap.comp_assoc, hψ (e g), LinearMap.comp_assoc]
-  rfl
+theorem trans (hφ : M.ρ.IsIntertwiningMap (N.ρ.comp (e : G →* H)) φ)
+    {e₂ : H ≃* K} {ψ : N.V →ₗ[R] P.V}
+    (hψ : N.ρ.IsIntertwiningMap (P.ρ.comp (e₂ : H →* K)) ψ) :
+    M.ρ.IsIntertwiningMap (P.ρ.comp (e.trans e₂ : G →* K)) (ψ ∘ₗ φ) :=
+  ⟨fun g v ↦ by
+    have hφ' : φ (M.ρ g v) = N.ρ (e g) (φ v) := by
+      simpa using hφ.isIntertwining g v
+    have hψ' : ψ (N.ρ (e g) (φ v)) = P.ρ (e₂ (e g)) (ψ (φ v)) := by
+      simpa using hψ.isIntertwining (e g) (φ v)
+    change ψ (φ (M.ρ g v)) = P.ρ (e₂ (e g)) (ψ (φ v))
+    rw [hφ', hψ']⟩
 
 /-- **The inverse of a compatible pair whose linear part is an equivalence is compatible.** -/
-theorem symm {e' : M.V ≃ₗ[R] N.V} (he : IsCompatible e (e' : M.V →ₗ[R] N.V)) :
-    IsCompatible e.symm (e'.symm : N.V →ₗ[R] M.V) := fun h ↦ by
-  simpa using e'.isIntertwining_symm_isIntertwining (σ := N.ρ.comp (e : G →* H)) he (e.symm h)
+theorem symm {e' : M.V ≃ₗ[R] N.V}
+    (he : M.ρ.IsIntertwiningMap (N.ρ.comp (e : G →* H)) (e' : M.V →ₗ[R] N.V)) :
+    N.ρ.IsIntertwiningMap (M.ρ.comp (e.symm : H →* G))
+      (e'.symm : N.V →ₗ[R] M.V) :=
+  ⟨fun h v ↦ by
+    have he' : ∀ g, (e' : M.V →ₗ[R] N.V) ∘ₗ M.ρ g =
+        N.ρ (e g) ∘ₗ (e' : M.V →ₗ[R] N.V) :=
+      fun g ↦ by ext x; exact he.isIntertwining g x
+    simpa using congr($(e'.isIntertwining_symm_isIntertwining
+      (σ := N.ρ.comp (e : G →* H)) he' (e.symm h)) v)⟩
 
 end IsCompatible
 
 /-- The identity of a representation is compatible with the identity of its group. -/
 theorem isCompatible_id :
-    IsCompatible (MulEquiv.refl G) (LinearMap.id : M.V →ₗ[R] M.V) := fun g ↦ by simp
+    M.ρ.IsIntertwiningMap (M.ρ.comp ((MulEquiv.refl G : G ≃* G) : G →* G))
+      (LinearMap.id : M.V →ₗ[R] M.V) := ⟨fun g v ↦ by simp⟩
 
 /-- Restricting the coefficients along `e` and comparing back by the identity is a compatible
 pair. -/
 theorem isCompatible_res (e : G ≃* H) (N : Rep R H) :
-    IsCompatible (M := Rep.res (e : G →* H) N) e
+    (Rep.res (e : G →* H) N).ρ.IsIntertwiningMap (N.ρ.comp (e : G →* H))
       ((LinearEquiv.refl R N.V : N.V →ₗ[R] N.V) :
-        (Rep.res (e : G →* H) N).V →ₗ[R] N.V) := fun g ↦ by
-  ext x
-  simp
+        (Rep.res (e : G →* H) N).V →ₗ[R] N.V) := ⟨fun g v ↦ by simp⟩
 
 section Complex
 
@@ -136,18 +141,21 @@ namespace IsCompatible
 
 /-- **A compatible pair intertwines the two norm maps.** The group isomorphism permutes the
 summands of `∑ g, ρ g`. -/
-theorem comp_norm (hφ : IsCompatible e φ) : φ ∘ₗ M.ρ.norm = N.ρ.norm ∘ₗ φ := by
+theorem comp_norm (hφ : M.ρ.IsIntertwiningMap (N.ρ.comp (e : G →* H)) φ) :
+    φ ∘ₗ M.ρ.norm = N.ρ.norm ∘ₗ φ := by
   ext x
   simpa [Representation.norm] using
     Fintype.sum_equiv e.toEquiv (fun g ↦ φ (M.ρ g x)) (fun h ↦ N.ρ h (φ x))
-      fun g ↦ congr($(hφ g) x)
+      fun g ↦ hφ.isIntertwining g x
 
 /-- The square joining the chain half of the Tate complex to its cochain half commutes for a
 compatible pair: this is `IsCompatible.comp_norm` in degree zero. -/
-theorem chainsMap_comp_d₀ (hφ : IsCompatible e φ) :
-    (groupHomology.chainsMap (e : G →* H) hφ.toRes).f 0 ≫ (tateComplexConnectData N).d₀ =
+theorem chainsMap_comp_d₀
+    (hφ : M.ρ.IsIntertwiningMap (N.ρ.comp (e : G →* H)) φ) :
+    (groupHomology.chainsMap (e : G →* H) (toRes hφ)).f 0 ≫
+      (tateComplexConnectData N).d₀ =
       (tateComplexConnectData M).d₀ ≫
-        (groupCohomology.cochainsMap (e.symm : H →* G) hφ.ofRes).f 0 := by
+        (groupCohomology.cochainsMap (e.symm : H →* G) (ofRes hφ)).f 0 := by
   simp only [tateComplexConnectData_d₀]
   ext x m y
   simp only [groupHomology.lsingle_comp_chainsMap_f_assoc, MonoidHom.coe_coe, ModuleCat.ofHom_comp,
@@ -155,16 +163,17 @@ theorem chainsMap_comp_d₀ (hφ : IsCompatible e φ) :
     Function.comp_apply, Finsupp.lsingle_apply, Rep.tateNorm_eq, groupCohomology.cochainsMap_f,
     toRes, ofRes, Finsupp.lsum_single, LinearMap.pi_apply, LinearMap.compLeft_apply,
     LinearMap.funLeft_apply]
-  exact congr($(hφ.comp_norm) m).symm
+  exact congr($(comp_norm hφ) m).symm
 
 /-- **The map of Tate complexes attached to a compatible pair.** On the chain half it is
 `groupHomology.chainsMap` along `e`, on the cochain half `groupCohomology.cochainsMap` along
 `e.symm`. -/
-def complexMap (hφ : IsCompatible e φ) : tateComplex M ⟶ tateComplex N :=
+def complexMap (hφ : M.ρ.IsIntertwiningMap (N.ρ.comp (e : G →* H)) φ) :
+    tateComplex M ⟶ tateComplex N :=
   (tateComplexConnectData M).map (tateComplexConnectData N)
-    (groupHomology.chainsMap (e : G →* H) hφ.toRes)
-    (groupCohomology.cochainsMap (e.symm : H →* G) hφ.ofRes)
-    hφ.chainsMap_comp_d₀
+    (groupHomology.chainsMap (e : G →* H) (toRes hφ))
+    (groupCohomology.cochainsMap (e.symm : H →* G) (ofRes hφ))
+    (chainsMap_comp_d₀ hφ)
 
 end IsCompatible
 
@@ -179,8 +188,9 @@ namespace IsCompatible
 /-- The map of Tate complexes depends only on the compatible pair, not on the compatibility
 proof. -/
 theorem complexMap_congr {e₁ e₂ : G ≃* H} {φ₁ φ₂ : M.V →ₗ[R] N.V}
-    {h₁ : IsCompatible e₁ φ₁} {h₂ : IsCompatible e₂ φ₂} (he : e₁ = e₂) (hφ : φ₁ = φ₂) :
-    h₁.complexMap = h₂.complexMap := by
+    {h₁ : M.ρ.IsIntertwiningMap (N.ρ.comp (e₁ : G →* H)) φ₁}
+    {h₂ : M.ρ.IsIntertwiningMap (N.ρ.comp (e₂ : G →* H)) φ₂}
+    (he : e₁ = e₂) (hφ : φ₁ = φ₂) : complexMap h₁ = complexMap h₂ := by
   subst he; subst hφ; rfl
 
 /-- **Along the identity isomorphism the construction is Mathlib's coefficient
@@ -189,19 +199,25 @@ functoriality.** -/
 -- `IsCompatible.complexMap_id`, and its right-hand side is a dead end for `simp`, which has no
 -- lemma carrying `tateComplex.map (𝟙 M)` back to `𝟙 (tateComplex M)`.
 theorem complexMap_refl {M N : Rep R G} {φ : M.V →ₗ[R] N.V}
-    (hφ : IsCompatible (MulEquiv.refl G) φ) :
-    hφ.complexMap = tateComplex.map (Rep.ofHom ⟨φ, isCompatible_iff.mp hφ⟩) := by
+    (hφ : M.ρ.IsIntertwiningMap
+      (N.ρ.comp ((MulEquiv.refl G : G ≃* G) : G →* G)) φ) :
+    complexMap hφ = tateComplex.map
+      (Rep.ofHom ⟨φ, fun g ↦ by ext v; simpa using hφ.isIntertwining g v⟩ : M ⟶ N) := by
   rw [complexMap]
   rfl
 
 /-- The identity compatible pair induces the identity of Tate complexes. -/
-@[simp] theorem complexMap_id : (isCompatible_id (M := M)).complexMap = 𝟙 (tateComplex M) :=
+@[simp] theorem complexMap_id :
+    complexMap (e := MulEquiv.refl G) (φ := LinearMap.id) (isCompatible_id (M := M)) =
+      𝟙 (tateComplex M) :=
   (tateComplexFunctor R G).map_id M
 
 /-- **The construction is functorial in the compatible pair.** -/
+@[reassoc]
 theorem complexMap_comp {e₁ : G ≃* H} {e₂ : H ≃* K} {φ : M.V →ₗ[R] N.V}
-    (hφ : IsCompatible e₁ φ) {ψ : N.V →ₗ[R] P.V} (hψ : IsCompatible e₂ ψ) :
-    hφ.complexMap ≫ hψ.complexMap = (hφ.trans hψ).complexMap := by
+    (hφ : M.ρ.IsIntertwiningMap (N.ρ.comp (e₁ : G →* H)) φ) {ψ : N.V →ₗ[R] P.V}
+    (hψ : N.ρ.IsIntertwiningMap (P.ρ.comp (e₂ : H →* K)) ψ) :
+    complexMap hφ ≫ complexMap hψ = complexMap (trans hφ hψ) := by
   refine (CochainComplex.ConnectData.map_comp_map ..).trans ?_
   congr 1
   exact (groupHomology.chainsMap_comp _ _ _ _).symm
@@ -211,9 +227,10 @@ end IsCompatible
 /-- **The isomorphism of Tate complexes attached to a compatible pair whose linear part is an
 equivalence.** -/
 def complexMapIso {e : G ≃* H} {e' : M.V ≃ₗ[R] N.V}
-    (he : IsCompatible e (e' : M.V →ₗ[R] N.V)) : tateComplex M ≅ tateComplex N where
-  hom := he.complexMap
-  inv := he.symm.complexMap
+    (he : M.ρ.IsIntertwiningMap (N.ρ.comp (e : G →* H)) (e' : M.V →ₗ[R] N.V)) :
+    tateComplex M ≅ tateComplex N where
+  hom := IsCompatible.complexMap he
+  inv := IsCompatible.complexMap (IsCompatible.symm he)
   hom_inv_id := (IsCompatible.complexMap_comp ..).trans
     ((IsCompatible.complexMap_congr (by simp) (by ext x; simp)).trans
       IsCompatible.complexMap_id)
@@ -222,43 +239,49 @@ def complexMapIso {e : G ≃* H} {e' : M.V ≃ₗ[R] N.V}
       IsCompatible.complexMap_id)
 
 @[simp] theorem complexMapIso_hom {e : G ≃* H} {e' : M.V ≃ₗ[R] N.V}
-    (he : IsCompatible e (e' : M.V →ₗ[R] N.V)) : (complexMapIso he).hom = he.complexMap := by
+    (he : M.ρ.IsIntertwiningMap (N.ρ.comp (e : G →* H)) (e' : M.V →ₗ[R] N.V)) :
+    (complexMapIso he).hom = IsCompatible.complexMap he := by
   rw [complexMapIso]
 
 @[simp] theorem complexMapIso_inv {e : G ≃* H} {e' : M.V ≃ₗ[R] N.V}
-    (he : IsCompatible e (e' : M.V →ₗ[R] N.V)) :
-    (complexMapIso he).inv = he.symm.complexMap := by
+    (he : M.ρ.IsIntertwiningMap (N.ρ.comp (e : G →* H)) (e' : M.V →ₗ[R] N.V)) :
+    (complexMapIso he).inv = IsCompatible.complexMap (IsCompatible.symm he) := by
   rw [complexMapIso]
 
 /-- **Tate cohomology along a compatible pair**, in a single integer degree. -/
-def map {e : G ≃* H} {φ : M.V →ₗ[R] N.V} (hφ : IsCompatible e φ) (n : ℤ) :
+def map {e : G ≃* H} {φ : M.V →ₗ[R] N.V}
+    (hφ : M.ρ.IsIntertwiningMap (N.ρ.comp (e : G →* H)) φ) (n : ℤ) :
     tateCohomology M n ⟶ tateCohomology N n :=
-  HomologicalComplex.homologyMap hφ.complexMap n
+  HomologicalComplex.homologyMap (IsCompatible.complexMap hφ) n
 
 /-- `TauCeti.TateCohomology.map` is the homology map of `IsCompatible.complexMap`. This records
 the body of `map`, whose definition is not exported. -/
-theorem map_def {e : G ≃* H} {φ : M.V →ₗ[R] N.V} (hφ : IsCompatible e φ) (n : ℤ) :
-    map hφ n = HomologicalComplex.homologyMap hφ.complexMap n := by rw [map]
+theorem map_def {e : G ≃* H} {φ : M.V →ₗ[R] N.V}
+    (hφ : M.ρ.IsIntertwiningMap (N.ρ.comp (e : G →* H)) φ) (n : ℤ) :
+    map hφ n = HomologicalComplex.homologyMap (IsCompatible.complexMap hφ) n := by rw [map]
 
 /-- **Tate cohomology along a compatible pair whose linear part is an equivalence** is an
 isomorphism in every integer degree. -/
-def mapIso {e : G ≃* H} {e' : M.V ≃ₗ[R] N.V} (he : IsCompatible e (e' : M.V →ₗ[R] N.V))
-    (n : ℤ) : tateCohomology M n ≅ tateCohomology N n :=
+def mapIso {e : G ≃* H} {e' : M.V ≃ₗ[R] N.V}
+    (he : M.ρ.IsIntertwiningMap (N.ρ.comp (e : G →* H)) (e' : M.V →ₗ[R] N.V)) (n : ℤ) :
+    tateCohomology M n ≅ tateCohomology N n :=
   HomologicalComplex.homologyMapIso (complexMapIso he) n
 
 @[simp] theorem mapIso_hom {e : G ≃* H} {e' : M.V ≃ₗ[R] N.V}
-    (he : IsCompatible e (e' : M.V →ₗ[R] N.V)) (n : ℤ) :
+    (he : M.ρ.IsIntertwiningMap (N.ρ.comp (e : G →* H)) (e' : M.V →ₗ[R] N.V)) (n : ℤ) :
     (mapIso he n).hom = map he n := by
   rw [mapIso, HomologicalComplex.homologyMapIso_hom, complexMapIso_hom, map_def]
 
 @[simp] theorem mapIso_inv {e : G ≃* H} {e' : M.V ≃ₗ[R] N.V}
-    (he : IsCompatible e (e' : M.V →ₗ[R] N.V)) (n : ℤ) :
-    (mapIso he n).inv = map he.symm n := by
+    (he : M.ρ.IsIntertwiningMap (N.ρ.comp (e : G →* H)) (e' : M.V →ₗ[R] N.V)) (n : ℤ) :
+    (mapIso he n).inv = map (IsCompatible.symm he) n := by
   rw [mapIso, HomologicalComplex.homologyMapIso_inv, complexMapIso_inv, map_def]
 
 /-- Tate cohomology in a fixed degree depends only on the compatible pair. -/
-theorem map_congr {e₁ e₂ : G ≃* H} {φ₁ φ₂ : M.V →ₗ[R] N.V} {h₁ : IsCompatible e₁ φ₁}
-    {h₂ : IsCompatible e₂ φ₂} (he : e₁ = e₂) (hφ : φ₁ = φ₂) (n : ℤ) :
+theorem map_congr {e₁ e₂ : G ≃* H} {φ₁ φ₂ : M.V →ₗ[R] N.V}
+    {h₁ : M.ρ.IsIntertwiningMap (N.ρ.comp (e₁ : G →* H)) φ₁}
+    {h₂ : M.ρ.IsIntertwiningMap (N.ρ.comp (e₂ : G →* H)) φ₂}
+    (he : e₁ = e₂) (hφ : φ₁ = φ₂) (n : ℤ) :
     map h₁ n = map h₂ n := by
   rw [map_def, map_def, IsCompatible.complexMap_congr he hφ]
 
@@ -267,22 +290,27 @@ functoriality. -/
 -- As for `IsCompatible.complexMap_refl`, deliberately not a `simp` lemma: it would subsume the
 -- `@[simp]` `map_id` and leave `simp` stuck on the identity, since `Rep.ofHom ⟨LinearMap.id, _⟩`
 -- has no `simp` route to `𝟙 M`.
-theorem map_refl {M N : Rep R G} {φ : M.V →ₗ[R] N.V} (hφ : IsCompatible (MulEquiv.refl G) φ)
-    (n : ℤ) :
-    map hφ n = (tateCohomologyFunctor n).map (Rep.ofHom ⟨φ, isCompatible_iff.mp hφ⟩) := by
+theorem map_refl {M N : Rep R G} {φ : M.V →ₗ[R] N.V}
+    (hφ : M.ρ.IsIntertwiningMap
+      (N.ρ.comp ((MulEquiv.refl G : G ≃* G) : G →* G)) φ) (n : ℤ) :
+    map hφ n = (tateCohomologyFunctor n).map
+      (Rep.ofHom ⟨φ, fun g ↦ by ext v; simpa using hφ.isIntertwining g v⟩ : M ⟶ N) := by
   rw [map_def, IsCompatible.complexMap_refl]
   exact (HomologicalComplex.homologyFunctor_map (ModuleCat R) (ComplexShape.up ℤ) n _).symm
 
 /-- The identity compatible pair induces the identity in every degree. -/
 @[simp] theorem map_id (n : ℤ) :
-    map (isCompatible_id (M := M)) n = 𝟙 (tateCohomology M n) := by
+    map (e := MulEquiv.refl G) (φ := LinearMap.id) (isCompatible_id (M := M)) n =
+      𝟙 (tateCohomology M n) := by
   rw [map_def, IsCompatible.complexMap_id]
   exact HomologicalComplex.homologyMap_id _ _
 
 /-- **Tate cohomology is functorial in the compatible pair**, in every degree. -/
-theorem map_comp {e₁ : G ≃* H} {e₂ : H ≃* K} {φ : M.V →ₗ[R] N.V} (hφ : IsCompatible e₁ φ)
-    {ψ : N.V →ₗ[R] P.V} (hψ : IsCompatible e₂ ψ) (n : ℤ) :
-    map hφ n ≫ map hψ n = map (hφ.trans hψ) n := by
+@[reassoc]
+theorem map_comp {e₁ : G ≃* H} {e₂ : H ≃* K} {φ : M.V →ₗ[R] N.V}
+    (hφ : M.ρ.IsIntertwiningMap (N.ρ.comp (e₁ : G →* H)) φ) {ψ : N.V →ₗ[R] P.V}
+    (hψ : N.ρ.IsIntertwiningMap (P.ρ.comp (e₂ : H →* K)) ψ) (n : ℤ) :
+    map hφ n ≫ map hψ n = map (IsCompatible.trans hφ hψ) n := by
   rw [map_def, map_def, map_def, ← IsCompatible.complexMap_comp hφ hψ,
     HomologicalComplex.homologyMap_comp]
   rfl
@@ -290,15 +318,15 @@ theorem map_comp {e₁ : G ≃* H} {e₂ : H ≃* K} {φ : M.V →ₗ[R] N.V} (h
 /-- **In positive degrees the construction is the ordinary cohomological change-of-group map**
 along `e.symm`, read through Mathlib's comparison between Tate and group cohomology. -/
 theorem map_comp_isoGroupCohomology_hom {e : G ≃* H} {φ : M.V →ₗ[R] N.V}
-    (hφ : IsCompatible e φ) (n : ℕ) [NeZero n] :
+    (hφ : M.ρ.IsIntertwiningMap (N.ρ.comp (e : G →* H)) φ) (n : ℕ) [NeZero n] :
     map hφ (n : ℤ) ≫ (_root_.TateCohomology.isoGroupCohomology n).hom.app N =
       (_root_.TateCohomology.isoGroupCohomology n).hom.app M ≫
-        groupCohomology.map (e.symm : H →* G) hφ.ofRes n := by
-  have key : HomologicalComplex.homologyMap hφ.complexMap (n : ℤ) ≫
+        groupCohomology.map (e.symm : H →* G) (IsCompatible.ofRes hφ) n := by
+  have key : HomologicalComplex.homologyMap (IsCompatible.complexMap hφ) (n : ℤ) ≫
       ((tateComplexConnectData N).homologyIsoPos n (n : ℤ) rfl).hom =
         ((tateComplexConnectData M).homologyIsoPos n (n : ℤ) rfl).hom ≫
           HomologicalComplex.homologyMap
-            (groupCohomology.cochainsMap (e.symm : H →* G) hφ.ofRes) n := by
+            (groupCohomology.cochainsMap (e.symm : H →* G) (IsCompatible.ofRes hφ)) n := by
     rw [IsCompatible.complexMap, CochainComplex.ConnectData.homologyMap_map_of_eq_succ
       (n := n) (m := (n : ℤ)) (hmn := rfl)]
     simp
@@ -312,15 +340,17 @@ theorem map_comp_isoGroupCohomology_hom {e : G ≃* H} {φ : M.V →ₗ[R] N.V}
 
 /-- **In degrees at most `-2` the construction is the ordinary homological change-of-group map**
 along `e`, read through Mathlib's comparison between Tate cohomology and group homology. -/
-theorem map_comp_isoGroupHomology_hom {e : G ≃* H} {φ : M.V →ₗ[R] N.V} (hφ : IsCompatible e φ)
+theorem map_comp_isoGroupHomology_hom {e : G ≃* H} {φ : M.V →ₗ[R] N.V}
+    (hφ : M.ρ.IsIntertwiningMap (N.ρ.comp (e : G →* H)) φ)
     (m : ℤ) (n : ℕ) (hmn : m = -(n + 1)) [NeZero n] :
     map hφ m ≫ (_root_.TateCohomology.isoGroupHomology m n hmn).hom.app N =
       (_root_.TateCohomology.isoGroupHomology m n hmn).hom.app M ≫
-        groupHomology.map (e : G →* H) hφ.toRes n := by
-  have key : HomologicalComplex.homologyMap hφ.complexMap m ≫
+        groupHomology.map (e : G →* H) (IsCompatible.toRes hφ) n := by
+  have key : HomologicalComplex.homologyMap (IsCompatible.complexMap hφ) m ≫
       ((tateComplexConnectData N).homologyIsoNeg n m hmn).hom =
         ((tateComplexConnectData M).homologyIsoNeg n m hmn).hom ≫
-          HomologicalComplex.homologyMap (groupHomology.chainsMap (e : G →* H) hφ.toRes) n := by
+          HomologicalComplex.homologyMap
+            (groupHomology.chainsMap (e : G →* H) (IsCompatible.toRes hφ)) n := by
     rw [IsCompatible.complexMap, CochainComplex.ConnectData.homologyMap_map_of_eq_neg_succ
       (n := n) (m := m) (hmn := hmn)]
     simp
@@ -336,13 +366,17 @@ def resIso (e : G ≃* H) (n : ℤ) :
       tateCohomologyFunctor n :=
   NatIso.ofComponents (fun N ↦ mapIso (isCompatible_res e N) n)
     fun {N N'} ψ ↦ by
-      have hψ : IsCompatible (MulEquiv.refl H) ψ.hom.toLinearMap := ψ.hom.isIntertwining'
-      have hres : IsCompatible (M := Rep.res (e : G →* H) N) (N := Rep.res (e : G →* H) N')
-          (MulEquiv.refl G)
-          (ψ.hom.toLinearMap : (Rep.res (e : G →* H) N).V →ₗ[R] (Rep.res (e : G →* H) N').V) :=
-        fun g ↦ hψ (e g)
-      have key : map hres n ≫ map (isCompatible_res e N') n =
-          map (isCompatible_res e N) n ≫ map hψ n := by
+      have hψ : N.ρ.IsIntertwiningMap
+          (N'.ρ.comp ((MulEquiv.refl H : H ≃* H) : H →* H)) ψ.hom.toLinearMap :=
+        ⟨fun g v ↦ congr($(ψ.hom.isIntertwining' g) v)⟩
+      have hres : (Rep.res (e : G →* H) N).ρ.IsIntertwiningMap
+          ((Rep.res (e : G →* H) N').ρ.comp
+            ((MulEquiv.refl G : G ≃* G) : G →* G))
+          (ψ.hom.toLinearMap :
+            (Rep.res (e : G →* H) N).V →ₗ[R] (Rep.res (e : G →* H) N').V) :=
+        ⟨fun g v ↦ congr($(ψ.hom.isIntertwining' (e g)) v)⟩
+      have key : map (e := MulEquiv.refl G) hres n ≫ map (isCompatible_res e N') n =
+          map (isCompatible_res e N) n ≫ map (e := MulEquiv.refl H) hψ n := by
         rw [map_comp, map_comp]
         exact map_congr (by ext x; rfl) (by ext x; rfl) n
       exact key
@@ -363,7 +397,7 @@ def resIso (e : G ≃* H) (n : ℤ) :
 /-- Tate cohomology groups matched by a compatible pair whose linear part is an equivalence have
 the same cardinality. -/
 theorem natCard_tateCohomology_eq {e : G ≃* H} {e' : M.V ≃ₗ[R] N.V}
-    (he : IsCompatible e (e' : M.V →ₗ[R] N.V)) (n : ℤ) :
+    (he : M.ρ.IsIntertwiningMap (N.ρ.comp (e : G →* H)) (e' : M.V →ₗ[R] N.V)) (n : ℤ) :
     Nat.card (tateCohomology M n) = Nat.card (tateCohomology N n) :=
   Nat.card_congr (mapIso he n).toLinearEquiv.toEquiv
 

--- a/TauCeti/RepresentationTheory/Homological/TateCohomology/Functoriality.lean
+++ b/TauCeti/RepresentationTheory/Homological/TateCohomology/Functoriality.lean
@@ -60,7 +60,7 @@ invariants of its conjugate through the resulting map in degree two.
 * J. Neukirch, A. Schmidt and K. Wingberg, *Cohomology of Number Fields*, Chapter I, §5.
 -/
 
-@[expose] public noncomputable section
+public noncomputable section
 
 universe u
 
@@ -73,8 +73,11 @@ variable {R G H K : Type u} [CommRing R] [Group G] [Group H] [Group K]
 
 /-- A group isomorphism `e : G ≃* H` and a linear map `φ` between the coefficient modules of
 `M : Rep R G` and `N : Rep R H` are **compatible** when `φ ∘ ρ g = σ (e g) ∘ φ` for every `g`.
-Such a pair is what carries the Tate cohomology of `M` to that of `N`. -/
-def IsCompatible (e : G ≃* H) (φ : M.V →ₗ[R] N.V) : Prop :=
+Such a pair is what carries the Tate cohomology of `M` to that of `N`.
+
+The body is exposed because this is a specification: a caller supplies a compatible pair by
+proving the displayed identity, which needs the definition to unfold. -/
+@[expose] def IsCompatible (e : G ≃* H) (φ : M.V →ₗ[R] N.V) : Prop :=
   ∀ g, φ ∘ₗ M.ρ g = N.ρ (e g) ∘ₗ φ
 
 namespace IsCompatible
@@ -91,10 +94,10 @@ def ofRes (hφ : IsCompatible e φ) : Rep.res (e.symm : H →* G) M ⟶ N :=
   Rep.ofHom ⟨φ, fun h ↦ by simpa using hφ (e.symm h)⟩
 
 @[simp] theorem toRes_hom_toLinearMap (hφ : IsCompatible e φ) :
-    hφ.toRes.hom.toLinearMap = φ := rfl
+    hφ.toRes.hom.toLinearMap = φ := by simp [toRes]
 
 @[simp] theorem ofRes_hom_toLinearMap (hφ : IsCompatible e φ) :
-    hφ.ofRes.hom.toLinearMap = φ := rfl
+    hφ.ofRes.hom.toLinearMap = φ := by simp [ofRes]
 
 /-- **Compatible pairs compose.** -/
 theorem trans (hφ : IsCompatible e φ) {e₂ : H ≃* K} {ψ : N.V →ₗ[R] P.V}
@@ -183,14 +186,16 @@ theorem complexMap_congr {e₁ e₂ : G ≃* H} {φ₁ φ₂ : M.V →ₗ[R] N.V
 functoriality.** -/
 theorem complexMap_refl {M N : Rep R G} {φ : M.V →ₗ[R] N.V}
     (hφ : IsCompatible (MulEquiv.refl G) φ) :
-    hφ.complexMap = tateComplex.map (Rep.ofHom ⟨φ, hφ⟩) := rfl
+    hφ.complexMap = tateComplex.map (Rep.ofHom ⟨φ, hφ⟩) := by
+  rw [complexMap]
+  rfl
 
 /-- The identity compatible pair induces the identity of Tate complexes. -/
-theorem complexMap_id : (isCompatible_id (M := M)).complexMap = 𝟙 (tateComplex M) :=
+@[simp] theorem complexMap_id : (isCompatible_id (M := M)).complexMap = 𝟙 (tateComplex M) :=
   (tateComplexFunctor R G).map_id M
 
 /-- **The construction is functorial in the compatible pair.** -/
-theorem complexMap_trans {e₁ : G ≃* H} {e₂ : H ≃* K} {φ : M.V →ₗ[R] N.V}
+theorem complexMap_comp {e₁ : G ≃* H} {e₂ : H ≃* K} {φ : M.V →ₗ[R] N.V}
     (hφ : IsCompatible e₁ φ) {ψ : N.V →ₗ[R] P.V} (hψ : IsCompatible e₂ ψ) :
     hφ.complexMap ≫ hψ.complexMap = (hφ.trans hψ).complexMap := by
   refine (CochainComplex.ConnectData.map_comp_map ..).trans ?_
@@ -205,17 +210,31 @@ def complexMapIso {e : G ≃* H} {e' : M.V ≃ₗ[R] N.V}
     (he : IsCompatible e (e' : M.V →ₗ[R] N.V)) : tateComplex M ≅ tateComplex N where
   hom := he.complexMap
   inv := he.symm.complexMap
-  hom_inv_id := (IsCompatible.complexMap_trans ..).trans
+  hom_inv_id := (IsCompatible.complexMap_comp ..).trans
     ((IsCompatible.complexMap_congr (by simp) (by ext x; simp)).trans
       IsCompatible.complexMap_id)
-  inv_hom_id := (IsCompatible.complexMap_trans ..).trans
+  inv_hom_id := (IsCompatible.complexMap_comp ..).trans
     ((IsCompatible.complexMap_congr (by simp) (by ext x; simp)).trans
       IsCompatible.complexMap_id)
+
+@[simp] theorem complexMapIso_hom {e : G ≃* H} {e' : M.V ≃ₗ[R] N.V}
+    (he : IsCompatible e (e' : M.V →ₗ[R] N.V)) : (complexMapIso he).hom = he.complexMap := by
+  rw [complexMapIso]
+
+@[simp] theorem complexMapIso_inv {e : G ≃* H} {e' : M.V ≃ₗ[R] N.V}
+    (he : IsCompatible e (e' : M.V →ₗ[R] N.V)) :
+    (complexMapIso he).inv = he.symm.complexMap := by
+  rw [complexMapIso]
 
 /-- **Tate cohomology along a compatible pair**, in a single integer degree. -/
 def map {e : G ≃* H} {φ : M.V →ₗ[R] N.V} (hφ : IsCompatible e φ) (n : ℤ) :
     tateCohomology M n ⟶ tateCohomology N n :=
   HomologicalComplex.homologyMap hφ.complexMap n
+
+/-- `TauCeti.TateCohomology.map` is the homology map of `IsCompatible.complexMap`. This records
+the body of `map`, whose definition is not exported. -/
+theorem map_def {e : G ≃* H} {φ : M.V →ₗ[R] N.V} (hφ : IsCompatible e φ) (n : ℤ) :
+    map hφ n = HomologicalComplex.homologyMap hφ.complexMap n := by rw [map]
 
 /-- **Tate cohomology along a compatible pair whose linear part is an equivalence** is an
 isomorphism in every integer degree. -/
@@ -225,35 +244,40 @@ def mapIso {e : G ≃* H} {e' : M.V ≃ₗ[R] N.V} (he : IsCompatible e (e' : M.
 
 @[simp] theorem mapIso_hom {e : G ≃* H} {e' : M.V ≃ₗ[R] N.V}
     (he : IsCompatible e (e' : M.V →ₗ[R] N.V)) (n : ℤ) :
-    (mapIso he n).hom = map he n := rfl
+    (mapIso he n).hom = map he n := by
+  rw [mapIso, HomologicalComplex.homologyMapIso_hom, complexMapIso_hom, map_def]
 
 @[simp] theorem mapIso_inv {e : G ≃* H} {e' : M.V ≃ₗ[R] N.V}
     (he : IsCompatible e (e' : M.V →ₗ[R] N.V)) (n : ℤ) :
-    (mapIso he n).inv = map he.symm n := rfl
+    (mapIso he n).inv = map he.symm n := by
+  rw [mapIso, HomologicalComplex.homologyMapIso_inv, complexMapIso_inv, map_def]
 
 /-- Tate cohomology in a fixed degree depends only on the compatible pair. -/
 theorem map_congr {e₁ e₂ : G ≃* H} {φ₁ φ₂ : M.V →ₗ[R] N.V} {h₁ : IsCompatible e₁ φ₁}
     {h₂ : IsCompatible e₂ φ₂} (he : e₁ = e₂) (hφ : φ₁ = φ₂) (n : ℤ) :
     map h₁ n = map h₂ n := by
-  rw [map, map, IsCompatible.complexMap_congr he hφ]
+  rw [map_def, map_def, IsCompatible.complexMap_congr he hφ]
 
 /-- Along the identity isomorphism, Tate cohomology of a compatible pair is Mathlib's coefficient
 functoriality. -/
 theorem map_refl {M N : Rep R G} {φ : M.V →ₗ[R] N.V} (hφ : IsCompatible (MulEquiv.refl G) φ)
     (n : ℤ) :
-    map hφ n = (tateCohomologyFunctor n).map (Rep.ofHom ⟨φ, hφ⟩) := rfl
+    map hφ n = (tateCohomologyFunctor n).map (Rep.ofHom ⟨φ, hφ⟩) := by
+  rw [map_def, IsCompatible.complexMap_refl]
+  exact (HomologicalComplex.homologyFunctor_map (ModuleCat R) (ComplexShape.up ℤ) n _).symm
 
 /-- The identity compatible pair induces the identity in every degree. -/
-theorem map_id (n : ℤ) :
+@[simp] theorem map_id (n : ℤ) :
     map (isCompatible_id (M := M)) n = 𝟙 (tateCohomology M n) := by
-  rw [map, IsCompatible.complexMap_id]
+  rw [map_def, IsCompatible.complexMap_id]
   exact HomologicalComplex.homologyMap_id _ _
 
 /-- **Tate cohomology is functorial in the compatible pair**, in every degree. -/
-theorem map_trans {e₁ : G ≃* H} {e₂ : H ≃* K} {φ : M.V →ₗ[R] N.V} (hφ : IsCompatible e₁ φ)
+theorem map_comp {e₁ : G ≃* H} {e₂ : H ≃* K} {φ : M.V →ₗ[R] N.V} (hφ : IsCompatible e₁ φ)
     {ψ : N.V →ₗ[R] P.V} (hψ : IsCompatible e₂ ψ) (n : ℤ) :
     map hφ n ≫ map hψ n = map (hφ.trans hψ) n := by
-  rw [map, map, map, ← IsCompatible.complexMap_trans hφ hψ, HomologicalComplex.homologyMap_comp]
+  rw [map_def, map_def, map_def, ← IsCompatible.complexMap_comp hφ hψ,
+    HomologicalComplex.homologyMap_comp]
   rfl
 
 /-- **In positive degrees the construction is the ordinary cohomological change-of-group map**
@@ -271,6 +295,12 @@ theorem map_comp_isoGroupCohomology_hom {e : G ≃* H} {φ : M.V →ₗ[R] N.V}
     rw [IsCompatible.complexMap, CochainComplex.ConnectData.homologyMap_map_of_eq_succ
       (n := n) (m := (n : ℤ)) (hmn := rfl)]
     simp
+  rw [map_def]
+  -- What is left is Mathlib's own unfoldings, all of which cross `tateCohomologyFunctor`, a
+  -- semireducible `def`: `isoGroupCohomology` is `homologyIsoPos` componentwise,
+  -- `groupCohomology.map` is `homologyMap` of `cochainsMap`, and `tateCohomology M n` is the
+  -- homology of `tateComplex M`.
+  -- `rw`/`simp` cannot cross them, because their motives are ill-typed at `implicit` transparency.
   exact key
 
 /-- **In degrees at most `-2` the construction is the ordinary homological change-of-group map**
@@ -287,6 +317,9 @@ theorem map_comp_isoGroupHomology_hom {e : G ≃* H} {φ : M.V →ₗ[R] N.V} (h
     rw [IsCompatible.complexMap, CochainComplex.ConnectData.homologyMap_map_of_eq_neg_succ
       (n := n) (m := m) (hmn := hmn)]
     simp
+  rw [map_def]
+  -- As above: `isoGroupHomology` is `homologyIsoNeg` componentwise, `groupHomology.map` is
+  -- `homologyMap` of `chainsMap`, and `tateCohomology M m` is the homology of `tateComplex M`.
   exact key
 
 /-- **Restricting the coefficients along an isomorphism of finite groups does not change Tate
@@ -303,7 +336,7 @@ def resIso (e : G ≃* H) (n : ℤ) :
         fun g ↦ hψ (e g)
       have key : map hres n ≫ map (isCompatible_res e N') n =
           map (isCompatible_res e N) n ≫ map hψ n := by
-        rw [map_trans, map_trans]
+        rw [map_comp, map_comp]
         exact map_congr (by ext x; rfl) (by ext x; rfl) n
       exact key
 

--- a/TauCeti/RepresentationTheory/Homological/TateCohomology/Functoriality.lean
+++ b/TauCeti/RepresentationTheory/Homological/TateCohomology/Functoriality.lean
@@ -75,10 +75,13 @@ variable {R G H K : Type u} [CommRing R] [Group G] [Group H] [Group K]
 `M : Rep R G` and `N : Rep R H` are **compatible** when `φ ∘ ρ g = σ (e g) ∘ φ` for every `g`.
 Such a pair is what carries the Tate cohomology of `M` to that of `N`.
 
-The body is exposed because this is a specification: a caller supplies a compatible pair by
-proving the displayed identity, which needs the definition to unfold. -/
-@[expose] def IsCompatible (e : G ≃* H) (φ : M.V →ₗ[R] N.V) : Prop :=
+Use `TauCeti.TateCohomology.isCompatible_iff` to build or to destructure such a pair. -/
+def IsCompatible (e : G ≃* H) (φ : M.V →ₗ[R] N.V) : Prop :=
   ∀ g, φ ∘ₗ M.ρ g = N.ρ (e g) ∘ₗ φ
+
+/-- The defining intertwining condition of a compatible pair. -/
+theorem isCompatible_iff {e : G ≃* H} {φ : M.V →ₗ[R] N.V} :
+    IsCompatible e φ ↔ ∀ g, φ ∘ₗ M.ρ g = N.ρ (e g) ∘ₗ φ := Iff.rfl
 
 namespace IsCompatible
 
@@ -186,7 +189,7 @@ theorem complexMap_congr {e₁ e₂ : G ≃* H} {φ₁ φ₂ : M.V →ₗ[R] N.V
 functoriality.** -/
 theorem complexMap_refl {M N : Rep R G} {φ : M.V →ₗ[R] N.V}
     (hφ : IsCompatible (MulEquiv.refl G) φ) :
-    hφ.complexMap = tateComplex.map (Rep.ofHom ⟨φ, hφ⟩) := by
+    hφ.complexMap = tateComplex.map (Rep.ofHom ⟨φ, isCompatible_iff.mp hφ⟩) := by
   rw [complexMap]
   rfl
 
@@ -262,7 +265,7 @@ theorem map_congr {e₁ e₂ : G ≃* H} {φ₁ φ₂ : M.V →ₗ[R] N.V} {h₁
 functoriality. -/
 theorem map_refl {M N : Rep R G} {φ : M.V →ₗ[R] N.V} (hφ : IsCompatible (MulEquiv.refl G) φ)
     (n : ℤ) :
-    map hφ n = (tateCohomologyFunctor n).map (Rep.ofHom ⟨φ, hφ⟩) := by
+    map hφ n = (tateCohomologyFunctor n).map (Rep.ofHom ⟨φ, isCompatible_iff.mp hφ⟩) := by
   rw [map_def, IsCompatible.complexMap_refl]
   exact (HomologicalComplex.homologyFunctor_map (ModuleCat R) (ComplexShape.up ℤ) n _).symm
 
@@ -339,6 +342,19 @@ def resIso (e : G ≃* H) (n : ℤ) :
         rw [map_comp, map_comp]
         exact map_congr (by ext x; rfl) (by ext x; rfl) n
       exact key
+
+@[simp] theorem resIso_hom_app (e : G ≃* H) (n : ℤ) (N : Rep R H) :
+    (resIso e n).hom.app N = (mapIso (isCompatible_res e N) n).hom := by
+  rw [resIso]
+  -- `NatIso.ofComponents_hom_app` is not usable as a rewrite here: its motive is ill-typed at
+  -- `implicit` transparency, because `tateCohomologyFunctor` is a semireducible `def`.
+  rfl
+
+@[simp] theorem resIso_inv_app (e : G ≃* H) (n : ℤ) (N : Rep R H) :
+    (resIso e n).inv.app N = (mapIso (isCompatible_res e N) n).inv := by
+  rw [resIso]
+  -- As above for `NatIso.ofComponents_inv_app`.
+  rfl
 
 /-- Tate cohomology groups matched by a compatible pair whose linear part is an equivalence have
 the same cardinality. -/

--- a/TauCeti/RepresentationTheory/Homological/TateCohomology/Functoriality.lean
+++ b/TauCeti/RepresentationTheory/Homological/TateCohomology/Functoriality.lean
@@ -184,9 +184,10 @@ theorem complexMap_congr {e₁ e₂ : G ≃* H} {φ₁ φ₂ : M.V →ₗ[R] N.V
   subst he; subst hφ; rfl
 
 /-- **Along the identity isomorphism the construction is Mathlib's coefficient
-functoriality.** This is deliberately not a `simp` lemma: its left-hand side subsumes that of the
-`@[simp]` `IsCompatible.complexMap_id`, and its right-hand side is a dead end for `simp`, which
-has no lemma carrying `tateComplex.map (𝟙 M)` back to `𝟙 (tateComplex M)`. -/
+functoriality.** -/
+-- Deliberately not a `simp` lemma: its left-hand side subsumes that of the `@[simp]`
+-- `IsCompatible.complexMap_id`, and its right-hand side is a dead end for `simp`, which has no
+-- lemma carrying `tateComplex.map (𝟙 M)` back to `𝟙 (tateComplex M)`.
 theorem complexMap_refl {M N : Rep R G} {φ : M.V →ₗ[R] N.V}
     (hφ : IsCompatible (MulEquiv.refl G) φ) :
     hφ.complexMap = tateComplex.map (Rep.ofHom ⟨φ, isCompatible_iff.mp hφ⟩) := by
@@ -262,9 +263,10 @@ theorem map_congr {e₁ e₂ : G ≃* H} {φ₁ φ₂ : M.V →ₗ[R] N.V} {h₁
   rw [map_def, map_def, IsCompatible.complexMap_congr he hφ]
 
 /-- Along the identity isomorphism, Tate cohomology of a compatible pair is Mathlib's coefficient
-functoriality. As for `IsCompatible.complexMap_refl`, this is deliberately not a `simp` lemma: it
-would subsume the `@[simp]` `map_id` and leave `simp` stuck on the identity, since
-`Rep.ofHom ⟨LinearMap.id, _⟩` has no `simp` route to `𝟙 M`. -/
+functoriality. -/
+-- As for `IsCompatible.complexMap_refl`, deliberately not a `simp` lemma: it would subsume the
+-- `@[simp]` `map_id` and leave `simp` stuck on the identity, since `Rep.ofHom ⟨LinearMap.id, _⟩`
+-- has no `simp` route to `𝟙 M`.
 theorem map_refl {M N : Rep R G} {φ : M.V →ₗ[R] N.V} (hφ : IsCompatible (MulEquiv.refl G) φ)
     (n : ℤ) :
     map hφ n = (tateCohomologyFunctor n).map (Rep.ofHom ⟨φ, isCompatible_iff.mp hφ⟩) := by

--- a/TauCeti/RepresentationTheory/Homological/TateCohomology/Functoriality.lean
+++ b/TauCeti/RepresentationTheory/Homological/TateCohomology/Functoriality.lean
@@ -186,7 +186,9 @@ theorem complexMap_congr {e₁ e₂ : G ≃* H} {φ₁ φ₂ : M.V →ₗ[R] N.V
   subst he; subst hφ; rfl
 
 /-- **Along the identity isomorphism the construction is Mathlib's coefficient
-functoriality.** -/
+functoriality.** This is deliberately not a `simp` lemma: its left-hand side subsumes that of the
+`@[simp]` `IsCompatible.complexMap_id`, and its right-hand side is a dead end for `simp`, which
+has no lemma carrying `tateComplex.map (𝟙 M)` back to `𝟙 (tateComplex M)`. -/
 theorem complexMap_refl {M N : Rep R G} {φ : M.V →ₗ[R] N.V}
     (hφ : IsCompatible (MulEquiv.refl G) φ) :
     hφ.complexMap = tateComplex.map (Rep.ofHom ⟨φ, isCompatible_iff.mp hφ⟩) := by
@@ -262,7 +264,9 @@ theorem map_congr {e₁ e₂ : G ≃* H} {φ₁ φ₂ : M.V →ₗ[R] N.V} {h₁
   rw [map_def, map_def, IsCompatible.complexMap_congr he hφ]
 
 /-- Along the identity isomorphism, Tate cohomology of a compatible pair is Mathlib's coefficient
-functoriality. -/
+functoriality. As for `IsCompatible.complexMap_refl`, this is deliberately not a `simp` lemma: it
+would subsume the `@[simp]` `map_id` and leave `simp` stuck on the identity, since
+`Rep.ofHom ⟨LinearMap.id, _⟩` has no `simp` route to `𝟙 M`. -/
 theorem map_refl {M N : Rep R G} {φ : M.V →ₗ[R] N.V} (hφ : IsCompatible (MulEquiv.refl G) φ)
     (n : ℤ) :
     map hφ n = (tateCohomologyFunctor n).map (Rep.ofHom ⟨φ, isCompatible_iff.mp hφ⟩) := by

--- a/TauCeti/RepresentationTheory/Homological/TateCohomology/Functoriality.lean
+++ b/TauCeti/RepresentationTheory/Homological/TateCohomology/Functoriality.lean
@@ -6,6 +6,7 @@ Authors: Claude
 module
 
 public import Mathlib.RepresentationTheory.Homological.TateCohomology.Basic
+public import TauCeti.RepresentationTheory.Rep.ChangeOfGroup
 
 /-!
 # Tate cohomology along an isomorphism of finite groups
@@ -15,7 +16,11 @@ the group is fixed throughout. This file supplies the missing variance in the gr
 of an isomorphism. A **compatible pair** consists of a group isomorphism `e : G ≃* H` and a
 linear map `φ` between the coefficient modules of `M : Rep R G` and `N : Rep R H` satisfying
 
-`φ ∘ ρ g = σ (e g) ∘ φ`.
+`φ ∘ ρ g = σ (e g) ∘ φ`,
+
+which is Mathlib's `Representation.IsIntertwiningMap M.ρ (N.ρ.comp e) φ`; the general
+representation-theoretic API of such a map lives in
+`TauCeti.RepresentationTheory.Rep.ChangeOfGroup`.
 
 Such a pair induces a map of Tate complexes, hence a map
 `tateCohomology M n ⟶ tateCohomology N n` in every integer degree, and that map is an
@@ -35,7 +40,7 @@ invariants of its conjugate through the resulting map in degree two.
 
 ## Main definitions
 
-* `TauCeti.TateCohomology.IsCompatible.complexMap`: the induced map of Tate complexes.
+* `TauCeti.TateCohomology.complexMap`: the induced map of Tate complexes.
 * `TauCeti.TateCohomology.map`: the induced map in a single integer degree.
 * `TauCeti.TateCohomology.mapIso`: the induced isomorphism, for `φ` a linear equivalence.
 * `TauCeti.TateCohomology.resIso`: the packaged natural isomorphism
@@ -43,7 +48,7 @@ invariants of its conjugate through the resulting map in degree two.
 
 ## Main results
 
-* `TauCeti.TateCohomology.IsCompatible.complexMap_refl`: along the identity isomorphism the
+* `TauCeti.TateCohomology.complexMap_refl`: along the identity isomorphism the
   construction is Mathlib's coefficient functoriality.
 * `TauCeti.TateCohomology.map_id` and `TauCeti.TateCohomology.map_comp`: functoriality in the
   compatible pair.
@@ -63,107 +68,33 @@ public noncomputable section
 
 universe u
 
-open CategoryTheory
+open CategoryTheory TauCeti.Representation
 
 namespace TauCeti.TateCohomology
 
 variable {R G H K : Type u} [CommRing R] [Group G] [Group H] [Group K]
   {M : Rep R G} {N : Rep R H} {P : Rep R K}
 
-namespace IsCompatible
-
-variable {e : G ≃* H} {φ : M.V →ₗ[R] N.V}
-
-/-- A compatible pair read as a morphism `M ⟶ Res(e)(N)` of `G`-representations. This is the
-datum that `groupHomology.chainsMap` consumes. -/
-def toRes (hφ : M.ρ.IsIntertwiningMap (N.ρ.comp (e : G →* H)) φ) :
-    M ⟶ Rep.res (e : G →* H) N :=
-  Rep.ofHom ⟨φ, fun g ↦ by ext v; exact hφ.isIntertwining g v⟩
-
-/-- A compatible pair read as a morphism `Res(e⁻¹)(M) ⟶ N` of `H`-representations. This is the
-datum that `groupCohomology.cochainsMap` consumes. -/
-def ofRes (hφ : M.ρ.IsIntertwiningMap (N.ρ.comp (e : G →* H)) φ) :
-    Rep.res (e.symm : H →* G) M ⟶ N :=
-  Rep.ofHom ⟨φ, fun h ↦ by ext v; simpa using hφ.isIntertwining (e.symm h) v⟩
-
-@[simp] theorem toRes_hom_toLinearMap
-    (hφ : M.ρ.IsIntertwiningMap (N.ρ.comp (e : G →* H)) φ) :
-    (toRes hφ).hom.toLinearMap = φ := by simp [toRes]
-
-@[simp] theorem ofRes_hom_toLinearMap
-    (hφ : M.ρ.IsIntertwiningMap (N.ρ.comp (e : G →* H)) φ) :
-    (ofRes hφ).hom.toLinearMap = φ := by simp [ofRes]
-
-/-- **Compatible pairs compose.** -/
-theorem trans (hφ : M.ρ.IsIntertwiningMap (N.ρ.comp (e : G →* H)) φ)
-    {e₂ : H ≃* K} {ψ : N.V →ₗ[R] P.V}
-    (hψ : N.ρ.IsIntertwiningMap (P.ρ.comp (e₂ : H →* K)) ψ) :
-    M.ρ.IsIntertwiningMap (P.ρ.comp (e.trans e₂ : G →* K)) (ψ ∘ₗ φ) :=
-  ⟨fun g v ↦ by
-    have hφ' : φ (M.ρ g v) = N.ρ (e g) (φ v) := by
-      simpa using hφ.isIntertwining g v
-    have hψ' : ψ (N.ρ (e g) (φ v)) = P.ρ (e₂ (e g)) (ψ (φ v)) := by
-      simpa using hψ.isIntertwining (e g) (φ v)
-    change ψ (φ (M.ρ g v)) = P.ρ (e₂ (e g)) (ψ (φ v))
-    rw [hφ', hψ']⟩
-
-/-- **The inverse of a compatible pair whose linear part is an equivalence is compatible.** -/
-theorem symm {e' : M.V ≃ₗ[R] N.V}
-    (he : M.ρ.IsIntertwiningMap (N.ρ.comp (e : G →* H)) (e' : M.V →ₗ[R] N.V)) :
-    N.ρ.IsIntertwiningMap (M.ρ.comp (e.symm : H →* G))
-      (e'.symm : N.V →ₗ[R] M.V) :=
-  ⟨fun h v ↦ by
-    have he' : ∀ g, (e' : M.V →ₗ[R] N.V) ∘ₗ M.ρ g =
-        N.ρ (e g) ∘ₗ (e' : M.V →ₗ[R] N.V) :=
-      fun g ↦ by ext x; exact he.isIntertwining g x
-    simpa using congr($(e'.isIntertwining_symm_isIntertwining
-      (σ := N.ρ.comp (e : G →* H)) he' (e.symm h)) v)⟩
-
-end IsCompatible
-
-/-- The identity of a representation is compatible with the identity of its group. -/
-theorem isCompatible_id :
-    M.ρ.IsIntertwiningMap (M.ρ.comp ((MulEquiv.refl G : G ≃* G) : G →* G))
-      (LinearMap.id : M.V →ₗ[R] M.V) := ⟨fun g v ↦ by simp⟩
-
-/-- Restricting the coefficients along `e` and comparing back by the identity is a compatible
-pair. -/
-theorem isCompatible_res (e : G ≃* H) (N : Rep R H) :
-    (Rep.res (e : G →* H) N).ρ.IsIntertwiningMap (N.ρ.comp (e : G →* H))
-      ((LinearEquiv.refl R N.V : N.V →ₗ[R] N.V) :
-        (Rep.res (e : G →* H) N).V →ₗ[R] N.V) := ⟨fun g v ↦ by simp⟩
-
 section Complex
 
 variable [Fintype G] [Fintype H] {e : G ≃* H} {φ : M.V →ₗ[R] N.V}
 
-namespace IsCompatible
-
-/-- **A compatible pair intertwines the two norm maps.** The group isomorphism permutes the
-summands of `∑ g, ρ g`. -/
-theorem comp_norm (hφ : M.ρ.IsIntertwiningMap (N.ρ.comp (e : G →* H)) φ) :
-    φ ∘ₗ M.ρ.norm = N.ρ.norm ∘ₗ φ := by
-  ext x
-  simpa [Representation.norm] using
-    Fintype.sum_equiv e.toEquiv (fun g ↦ φ (M.ρ g x)) (fun h ↦ N.ρ h (φ x))
-      fun g ↦ hφ.isIntertwining g x
-
 /-- The square joining the chain half of the Tate complex to its cochain half commutes for a
-compatible pair: this is `IsCompatible.comp_norm` in degree zero. -/
+compatible pair: this is `IsIntertwiningMap.comp_norm` in degree zero. -/
 theorem chainsMap_comp_d₀
     (hφ : M.ρ.IsIntertwiningMap (N.ρ.comp (e : G →* H)) φ) :
-    (groupHomology.chainsMap (e : G →* H) (toRes hφ)).f 0 ≫
+    (groupHomology.chainsMap (e : G →* H) (IsIntertwiningMap.toRes hφ)).f 0 ≫
       (tateComplexConnectData N).d₀ =
       (tateComplexConnectData M).d₀ ≫
-        (groupCohomology.cochainsMap (e.symm : H →* G) (ofRes hφ)).f 0 := by
+        (groupCohomology.cochainsMap (e.symm : H →* G) (IsIntertwiningMap.ofRes hφ)).f 0 := by
   simp only [tateComplexConnectData_d₀]
   ext x m y
   simp only [groupHomology.lsingle_comp_chainsMap_f_assoc, MonoidHom.coe_coe, ModuleCat.ofHom_comp,
     Category.assoc, ModuleCat.hom_comp, ConcreteCategory.hom_ofHom, LinearMap.coe_comp,
     Function.comp_apply, Finsupp.lsingle_apply, Rep.tateNorm_eq, groupCohomology.cochainsMap_f,
-    toRes, ofRes, Finsupp.lsum_single, LinearMap.pi_apply, LinearMap.compLeft_apply,
-    LinearMap.funLeft_apply]
-  exact congr($(comp_norm hφ) m).symm
+    IsIntertwiningMap.toRes_hom_toLinearMap, IsIntertwiningMap.ofRes_hom_toLinearMap,
+    Finsupp.lsum_single, LinearMap.pi_apply, LinearMap.compLeft_apply, LinearMap.funLeft_apply]
+  exact congr($(IsIntertwiningMap.comp_norm hφ) m).symm
 
 /-- **The map of Tate complexes attached to a compatible pair.** On the chain half it is
 `groupHomology.chainsMap` along `e`, on the cochain half `groupCohomology.cochainsMap` along
@@ -171,19 +102,15 @@ theorem chainsMap_comp_d₀
 def complexMap (hφ : M.ρ.IsIntertwiningMap (N.ρ.comp (e : G →* H)) φ) :
     tateComplex M ⟶ tateComplex N :=
   (tateComplexConnectData M).map (tateComplexConnectData N)
-    (groupHomology.chainsMap (e : G →* H) (toRes hφ))
-    (groupCohomology.cochainsMap (e.symm : H →* G) (ofRes hφ))
+    (groupHomology.chainsMap (e : G →* H) (IsIntertwiningMap.toRes hφ))
+    (groupCohomology.cochainsMap (e.symm : H →* G) (IsIntertwiningMap.ofRes hφ))
     (chainsMap_comp_d₀ hφ)
-
-end IsCompatible
 
 end Complex
 
 section Degrees
 
 variable [Fintype G] [Fintype H] [Fintype K]
-
-namespace IsCompatible
 
 /-- The map of Tate complexes depends only on the compatible pair, not on the compatibility
 proof. -/
@@ -196,8 +123,8 @@ theorem complexMap_congr {e₁ e₂ : G ≃* H} {φ₁ φ₂ : M.V →ₗ[R] N.V
 /-- **Along the identity isomorphism the construction is Mathlib's coefficient
 functoriality.** -/
 -- Deliberately not a `simp` lemma: its left-hand side subsumes that of the `@[simp]`
--- `IsCompatible.complexMap_id`, and its right-hand side is a dead end for `simp`, which has no
--- lemma carrying `tateComplex.map (𝟙 M)` back to `𝟙 (tateComplex M)`.
+-- `complexMap_id`, and its right-hand side is a dead end for `simp`, which has no lemma carrying
+-- `tateComplex.map (𝟙 M)` back to `𝟙 (tateComplex M)`.
 theorem complexMap_refl {M N : Rep R G} {φ : M.V →ₗ[R] N.V}
     (hφ : M.ρ.IsIntertwiningMap
       (N.ρ.comp ((MulEquiv.refl G : G ≃* G) : G →* G)) φ) :
@@ -208,7 +135,7 @@ theorem complexMap_refl {M N : Rep R G} {φ : M.V →ₗ[R] N.V}
 
 /-- The identity compatible pair induces the identity of Tate complexes. -/
 @[simp] theorem complexMap_id :
-    complexMap (e := MulEquiv.refl G) (φ := LinearMap.id) (isCompatible_id (M := M)) =
+    complexMap (e := MulEquiv.refl G) (φ := LinearMap.id) (isIntertwiningMap_id M) =
       𝟙 (tateComplex M) :=
   (tateComplexFunctor R G).map_id M
 
@@ -217,48 +144,46 @@ theorem complexMap_refl {M N : Rep R G} {φ : M.V →ₗ[R] N.V}
 theorem complexMap_comp {e₁ : G ≃* H} {e₂ : H ≃* K} {φ : M.V →ₗ[R] N.V}
     (hφ : M.ρ.IsIntertwiningMap (N.ρ.comp (e₁ : G →* H)) φ) {ψ : N.V →ₗ[R] P.V}
     (hψ : N.ρ.IsIntertwiningMap (P.ρ.comp (e₂ : H →* K)) ψ) :
-    complexMap hφ ≫ complexMap hψ = complexMap (trans hφ hψ) := by
+    complexMap hφ ≫ complexMap hψ = complexMap (IsIntertwiningMap.trans hφ hψ) := by
   refine (CochainComplex.ConnectData.map_comp_map ..).trans ?_
   congr 1
   exact (groupHomology.chainsMap_comp _ _ _ _).symm
-
-end IsCompatible
 
 /-- **The isomorphism of Tate complexes attached to a compatible pair whose linear part is an
 equivalence.** -/
 def complexMapIso {e : G ≃* H} {e' : M.V ≃ₗ[R] N.V}
     (he : M.ρ.IsIntertwiningMap (N.ρ.comp (e : G →* H)) (e' : M.V →ₗ[R] N.V)) :
     tateComplex M ≅ tateComplex N where
-  hom := IsCompatible.complexMap he
-  inv := IsCompatible.complexMap (IsCompatible.symm he)
-  hom_inv_id := (IsCompatible.complexMap_comp ..).trans
-    ((IsCompatible.complexMap_congr (by simp) (by ext x; simp)).trans
-      IsCompatible.complexMap_id)
-  inv_hom_id := (IsCompatible.complexMap_comp ..).trans
-    ((IsCompatible.complexMap_congr (by simp) (by ext x; simp)).trans
-      IsCompatible.complexMap_id)
+  hom := complexMap he
+  inv := complexMap (IsIntertwiningMap.symm he)
+  hom_inv_id := (complexMap_comp ..).trans
+    ((complexMap_congr (by simp) (by ext x; simp)).trans
+      complexMap_id)
+  inv_hom_id := (complexMap_comp ..).trans
+    ((complexMap_congr (by simp) (by ext x; simp)).trans
+      complexMap_id)
 
 @[simp] theorem complexMapIso_hom {e : G ≃* H} {e' : M.V ≃ₗ[R] N.V}
     (he : M.ρ.IsIntertwiningMap (N.ρ.comp (e : G →* H)) (e' : M.V →ₗ[R] N.V)) :
-    (complexMapIso he).hom = IsCompatible.complexMap he := by
+    (complexMapIso he).hom = complexMap he := by
   rw [complexMapIso]
 
 @[simp] theorem complexMapIso_inv {e : G ≃* H} {e' : M.V ≃ₗ[R] N.V}
     (he : M.ρ.IsIntertwiningMap (N.ρ.comp (e : G →* H)) (e' : M.V →ₗ[R] N.V)) :
-    (complexMapIso he).inv = IsCompatible.complexMap (IsCompatible.symm he) := by
+    (complexMapIso he).inv = complexMap (IsIntertwiningMap.symm he) := by
   rw [complexMapIso]
 
 /-- **Tate cohomology along a compatible pair**, in a single integer degree. -/
 def map {e : G ≃* H} {φ : M.V →ₗ[R] N.V}
     (hφ : M.ρ.IsIntertwiningMap (N.ρ.comp (e : G →* H)) φ) (n : ℤ) :
     tateCohomology M n ⟶ tateCohomology N n :=
-  HomologicalComplex.homologyMap (IsCompatible.complexMap hφ) n
+  HomologicalComplex.homologyMap (complexMap hφ) n
 
-/-- `TauCeti.TateCohomology.map` is the homology map of `IsCompatible.complexMap`. This records
-the body of `map`, whose definition is not exported. -/
+/-- `TauCeti.TateCohomology.map` is the homology map of `complexMap`. This records the body of
+`map`, whose definition is not exported. -/
 theorem map_def {e : G ≃* H} {φ : M.V →ₗ[R] N.V}
     (hφ : M.ρ.IsIntertwiningMap (N.ρ.comp (e : G →* H)) φ) (n : ℤ) :
-    map hφ n = HomologicalComplex.homologyMap (IsCompatible.complexMap hφ) n := by rw [map]
+    map hφ n = HomologicalComplex.homologyMap (complexMap hφ) n := by rw [map]
 
 /-- **Tate cohomology along a compatible pair whose linear part is an equivalence** is an
 isomorphism in every integer degree. -/
@@ -274,7 +199,7 @@ def mapIso {e : G ≃* H} {e' : M.V ≃ₗ[R] N.V}
 
 @[simp] theorem mapIso_inv {e : G ≃* H} {e' : M.V ≃ₗ[R] N.V}
     (he : M.ρ.IsIntertwiningMap (N.ρ.comp (e : G →* H)) (e' : M.V →ₗ[R] N.V)) (n : ℤ) :
-    (mapIso he n).inv = map (IsCompatible.symm he) n := by
+    (mapIso he n).inv = map (IsIntertwiningMap.symm he) n := by
   rw [mapIso, HomologicalComplex.homologyMapIso_inv, complexMapIso_inv, map_def]
 
 /-- Tate cohomology in a fixed degree depends only on the compatible pair. -/
@@ -283,11 +208,11 @@ theorem map_congr {e₁ e₂ : G ≃* H} {φ₁ φ₂ : M.V →ₗ[R] N.V}
     {h₂ : M.ρ.IsIntertwiningMap (N.ρ.comp (e₂ : G →* H)) φ₂}
     (he : e₁ = e₂) (hφ : φ₁ = φ₂) (n : ℤ) :
     map h₁ n = map h₂ n := by
-  rw [map_def, map_def, IsCompatible.complexMap_congr he hφ]
+  rw [map_def, map_def, complexMap_congr he hφ]
 
 /-- Along the identity isomorphism, Tate cohomology of a compatible pair is Mathlib's coefficient
 functoriality. -/
--- As for `IsCompatible.complexMap_refl`, deliberately not a `simp` lemma: it would subsume the
+-- As for `complexMap_refl`, deliberately not a `simp` lemma: it would subsume the
 -- `@[simp]` `map_id` and leave `simp` stuck on the identity, since `Rep.ofHom ⟨LinearMap.id, _⟩`
 -- has no `simp` route to `𝟙 M`.
 theorem map_refl {M N : Rep R G} {φ : M.V →ₗ[R] N.V}
@@ -295,14 +220,14 @@ theorem map_refl {M N : Rep R G} {φ : M.V →ₗ[R] N.V}
       (N.ρ.comp ((MulEquiv.refl G : G ≃* G) : G →* G)) φ) (n : ℤ) :
     map hφ n = (tateCohomologyFunctor n).map
       (Rep.ofHom ⟨φ, fun g ↦ by ext v; simpa using hφ.isIntertwining g v⟩ : M ⟶ N) := by
-  rw [map_def, IsCompatible.complexMap_refl]
+  rw [map_def, complexMap_refl]
   exact (HomologicalComplex.homologyFunctor_map (ModuleCat R) (ComplexShape.up ℤ) n _).symm
 
 /-- The identity compatible pair induces the identity in every degree. -/
 @[simp] theorem map_id (n : ℤ) :
-    map (e := MulEquiv.refl G) (φ := LinearMap.id) (isCompatible_id (M := M)) n =
+    map (e := MulEquiv.refl G) (φ := LinearMap.id) (isIntertwiningMap_id M) n =
       𝟙 (tateCohomology M n) := by
-  rw [map_def, IsCompatible.complexMap_id]
+  rw [map_def, complexMap_id]
   exact HomologicalComplex.homologyMap_id _ _
 
 /-- **Tate cohomology is functorial in the compatible pair**, in every degree. -/
@@ -310,8 +235,8 @@ theorem map_refl {M N : Rep R G} {φ : M.V →ₗ[R] N.V}
 theorem map_comp {e₁ : G ≃* H} {e₂ : H ≃* K} {φ : M.V →ₗ[R] N.V}
     (hφ : M.ρ.IsIntertwiningMap (N.ρ.comp (e₁ : G →* H)) φ) {ψ : N.V →ₗ[R] P.V}
     (hψ : N.ρ.IsIntertwiningMap (P.ρ.comp (e₂ : H →* K)) ψ) (n : ℤ) :
-    map hφ n ≫ map hψ n = map (IsCompatible.trans hφ hψ) n := by
-  rw [map_def, map_def, map_def, ← IsCompatible.complexMap_comp hφ hψ,
+    map hφ n ≫ map hψ n = map (IsIntertwiningMap.trans hφ hψ) n := by
+  rw [map_def, map_def, map_def, ← complexMap_comp hφ hψ,
     HomologicalComplex.homologyMap_comp]
   rfl
 
@@ -321,13 +246,13 @@ theorem map_comp_isoGroupCohomology_hom {e : G ≃* H} {φ : M.V →ₗ[R] N.V}
     (hφ : M.ρ.IsIntertwiningMap (N.ρ.comp (e : G →* H)) φ) (n : ℕ) [NeZero n] :
     map hφ (n : ℤ) ≫ (_root_.TateCohomology.isoGroupCohomology n).hom.app N =
       (_root_.TateCohomology.isoGroupCohomology n).hom.app M ≫
-        groupCohomology.map (e.symm : H →* G) (IsCompatible.ofRes hφ) n := by
-  have key : HomologicalComplex.homologyMap (IsCompatible.complexMap hφ) (n : ℤ) ≫
+        groupCohomology.map (e.symm : H →* G) (IsIntertwiningMap.ofRes hφ) n := by
+  have key : HomologicalComplex.homologyMap (complexMap hφ) (n : ℤ) ≫
       ((tateComplexConnectData N).homologyIsoPos n (n : ℤ) rfl).hom =
         ((tateComplexConnectData M).homologyIsoPos n (n : ℤ) rfl).hom ≫
           HomologicalComplex.homologyMap
-            (groupCohomology.cochainsMap (e.symm : H →* G) (IsCompatible.ofRes hφ)) n := by
-    rw [IsCompatible.complexMap, CochainComplex.ConnectData.homologyMap_map_of_eq_succ
+            (groupCohomology.cochainsMap (e.symm : H →* G) (IsIntertwiningMap.ofRes hφ)) n := by
+    rw [complexMap, CochainComplex.ConnectData.homologyMap_map_of_eq_succ
       (n := n) (m := (n : ℤ)) (hmn := rfl)]
     simp
   rw [map_def]
@@ -345,13 +270,13 @@ theorem map_comp_isoGroupHomology_hom {e : G ≃* H} {φ : M.V →ₗ[R] N.V}
     (m : ℤ) (n : ℕ) (hmn : m = -(n + 1)) [NeZero n] :
     map hφ m ≫ (_root_.TateCohomology.isoGroupHomology m n hmn).hom.app N =
       (_root_.TateCohomology.isoGroupHomology m n hmn).hom.app M ≫
-        groupHomology.map (e : G →* H) (IsCompatible.toRes hφ) n := by
-  have key : HomologicalComplex.homologyMap (IsCompatible.complexMap hφ) m ≫
+        groupHomology.map (e : G →* H) (IsIntertwiningMap.toRes hφ) n := by
+  have key : HomologicalComplex.homologyMap (complexMap hφ) m ≫
       ((tateComplexConnectData N).homologyIsoNeg n m hmn).hom =
         ((tateComplexConnectData M).homologyIsoNeg n m hmn).hom ≫
           HomologicalComplex.homologyMap
-            (groupHomology.chainsMap (e : G →* H) (IsCompatible.toRes hφ)) n := by
-    rw [IsCompatible.complexMap, CochainComplex.ConnectData.homologyMap_map_of_eq_neg_succ
+            (groupHomology.chainsMap (e : G →* H) (IsIntertwiningMap.toRes hφ)) n := by
+    rw [complexMap, CochainComplex.ConnectData.homologyMap_map_of_eq_neg_succ
       (n := n) (m := m) (hmn := hmn)]
     simp
   rw [map_def]
@@ -364,7 +289,7 @@ cohomology**, naturally in the coefficients. -/
 def resIso (e : G ≃* H) (n : ℤ) :
     Rep.resFunctor (e : G →* H) ⋙ tateCohomologyFunctor (R := R) (G := G) n ≅
       tateCohomologyFunctor n :=
-  NatIso.ofComponents (fun N ↦ mapIso (isCompatible_res e N) n)
+  NatIso.ofComponents (fun N ↦ mapIso (isIntertwiningMap_res (e : G →* H) N) n)
     fun {N N'} ψ ↦ by
       have hψ : N.ρ.IsIntertwiningMap
           (N'.ρ.comp ((MulEquiv.refl H : H ≃* H) : H →* H)) ψ.hom.toLinearMap :=
@@ -375,21 +300,21 @@ def resIso (e : G ≃* H) (n : ℤ) :
           (ψ.hom.toLinearMap :
             (Rep.res (e : G →* H) N).V →ₗ[R] (Rep.res (e : G →* H) N').V) :=
         ⟨fun g v ↦ congr($(ψ.hom.isIntertwining' (e g)) v)⟩
-      have key : map (e := MulEquiv.refl G) hres n ≫ map (isCompatible_res e N') n =
-          map (isCompatible_res e N) n ≫ map (e := MulEquiv.refl H) hψ n := by
+      have key : map (e := MulEquiv.refl G) hres n ≫ map (isIntertwiningMap_res (e : G →* H) N') n =
+          map (isIntertwiningMap_res (e : G →* H) N) n ≫ map (e := MulEquiv.refl H) hψ n := by
         rw [map_comp, map_comp]
         exact map_congr (by ext x; rfl) (by ext x; rfl) n
       exact key
 
 @[simp] theorem resIso_hom_app (e : G ≃* H) (n : ℤ) (N : Rep R H) :
-    (resIso e n).hom.app N = (mapIso (isCompatible_res e N) n).hom := by
+    (resIso e n).hom.app N = (mapIso (isIntertwiningMap_res (e : G →* H) N) n).hom := by
   rw [resIso]
   -- `NatIso.ofComponents_hom_app` is not usable as a rewrite here: its motive is ill-typed at
   -- `implicit` transparency, because `tateCohomologyFunctor` is a semireducible `def`.
   rfl
 
 @[simp] theorem resIso_inv_app (e : G ≃* H) (n : ℤ) (N : Rep R H) :
-    (resIso e n).inv.app N = (mapIso (isCompatible_res e N) n).inv := by
+    (resIso e n).inv.app N = (mapIso (isIntertwiningMap_res (e : G →* H) N) n).inv := by
   rw [resIso]
   -- As above for `NatIso.ofComponents_inv_app`.
   rfl

--- a/TauCeti/RepresentationTheory/Homological/TateCohomology/Functoriality.lean
+++ b/TauCeti/RepresentationTheory/Homological/TateCohomology/Functoriality.lean
@@ -130,13 +130,16 @@ theorem complexMap_refl {M N : Rep R G} {φ : M.V →ₗ[R] N.V}
     complexMap hφ = tateComplex.map
       (Rep.ofHom ⟨φ, fun g ↦ by ext v; simpa using hφ.isIntertwining g v⟩ : M ⟶ N) := by
   rw [complexMap]
-  rfl
+  congr 1
+  · exact groupHomology.chainsMap_congr rfl (IsIntertwiningMap.toRes_hom_toLinearMap hφ)
+  · exact groupCohomology.cochainsMap_congr rfl (IsIntertwiningMap.ofRes_hom_toLinearMap hφ)
 
 /-- The identity compatible pair induces the identity of Tate complexes. -/
 @[simp] theorem complexMap_id :
     complexMap (e := MulEquiv.refl G) (φ := LinearMap.id) (Rep.isIntertwiningMap_id M) =
-      𝟙 (tateComplex M) :=
-  (tateComplexFunctor R G).map_id M
+      𝟙 (tateComplex M) := by
+  rw [complexMap_refl]
+  exact (tateComplexFunctor R G).map_id M
 
 /-- **The construction is functorial in the compatible pair.** -/
 -- The underlying monoid homomorphism of `e₁.trans e₂` is only extensionally equal to the
@@ -152,7 +155,14 @@ theorem complexMap_comp {e₁ : G ≃* H} {e₂ : H ≃* K} {φ : M.V →ₗ[R] 
       rfl) := by
   refine (CochainComplex.ConnectData.map_comp_map ..).trans ?_
   congr 1
-  exact (groupHomology.chainsMap_comp _ _ _ _).symm
+  · refine (groupHomology.chainsMap_comp _ _ _ _).symm.trans
+      (groupHomology.chainsMap_congr (by ext x; rfl) ?_)
+    rw [IsIntertwiningMap.toRes_hom_toLinearMap]
+    simp
+  · refine (groupCohomology.cochainsMap_comp _ _ _ _).symm.trans
+      (groupCohomology.cochainsMap_congr (by ext x; rfl) ?_)
+    rw [IsIntertwiningMap.ofRes_hom_toLinearMap]
+    simp
 
 /-- **The isomorphism of Tate complexes attached to a compatible pair whose linear part is an
 equivalence.** -/
@@ -316,6 +326,11 @@ def resIso (e : G ≃* H) (n : ℤ) :
             map (e := MulEquiv.refl H) hψ n := by
         rw [map_comp, map_comp]
         exact map_congr (by ext x; rfl) (by ext x; rfl) n
+      have hsrc : (Rep.resFunctor (e : G →* H) ⋙ tateCohomologyFunctor (R := R) (G := G) n).map ψ =
+          map (e := MulEquiv.refl G) hres n := (map_refl hres n).symm
+      have htgt : (tateCohomologyFunctor n).map ψ = map (e := MulEquiv.refl H) hψ n :=
+        (map_refl hψ n).symm
+      rw [hsrc, htgt, mapIso_hom, mapIso_hom]
       exact key
 
 @[simp] theorem resIso_hom_app (e : G ≃* H) (n : ℤ) (N : Rep R H) :

--- a/TauCeti/RepresentationTheory/Rep/ChangeOfGroup.lean
+++ b/TauCeti/RepresentationTheory/Rep/ChangeOfGroup.lean
@@ -136,14 +136,12 @@ namespace IsIntertwiningMap
 
 /-- An intertwining map along `f : G →* H` read as a morphism `M ⟶ Res(f)(N)` of
 `G`-representations. This is the datum that `groupHomology.chainsMap` consumes. -/
--- Exposed, like Mathlib's `Rep.resMap`, because the comparison of a change-of-group map along
--- the identity isomorphism with the coefficient functoriality of a fixed group is definitional.
-@[expose] def toRes {f : G →* H} (hφ : M.ρ.IsIntertwiningMap (N.ρ.comp f) φ) : M ⟶ Rep.res f N :=
+def toRes {f : G →* H} (hφ : M.ρ.IsIntertwiningMap (N.ρ.comp f) φ) : M ⟶ Rep.res f N :=
   Rep.ofHom ⟨φ, fun g ↦ by ext v; exact hφ.isIntertwining g v⟩
 
 /-- An intertwining map along an isomorphism `e : G ≃* H` read as a morphism `Res(e⁻¹)(M) ⟶ N` of
 `H`-representations. This is the datum that `groupCohomology.cochainsMap` consumes. -/
-@[expose] def ofRes {e : G ≃* H} (hφ : M.ρ.IsIntertwiningMap (N.ρ.comp (e : G →* H)) φ) :
+def ofRes {e : G ≃* H} (hφ : M.ρ.IsIntertwiningMap (N.ρ.comp (e : G →* H)) φ) :
     Rep.res (e.symm : H →* G) M ⟶ N :=
   Rep.ofHom ⟨φ, fun h ↦ by ext v; simpa using hφ.isIntertwining (e.symm h) v⟩
 

--- a/TauCeti/RepresentationTheory/Rep/ChangeOfGroup.lean
+++ b/TauCeti/RepresentationTheory/Rep/ChangeOfGroup.lean
@@ -32,11 +32,11 @@ and cohomology: `groupHomology.chainsMap` consumes the first adapter and
 ## Main results
 
 * `Representation.IsIntertwiningMap.trans` and `Representation.IsIntertwiningMap.symm`:
-  intertwining maps along an isomorphism of monoids compose, and invert when their linear part is
-  an equivalence.
+  intertwining maps along homomorphisms of monoids compose, and invert along an isomorphism when
+  their linear part is an equivalence.
 * `Representation.IsIntertwiningMap.comp_norm`: an intertwining map along an isomorphism of
   finite groups intertwines the two norms.
-* `Representation.isIntertwiningMap_id` and `Representation.isIntertwiningMap_res`: the identity
+* `Rep.isIntertwiningMap_id` and `Rep.isIntertwiningMap_res`: the identity
   map is intertwining along the identity isomorphism of the monoid, and along `f` between a
   restricted representation and the representation it restricts.
 -/
@@ -57,20 +57,20 @@ variable {R : Type u} {G : Type uG} {H : Type uH} {K : Type uK}
 namespace IsIntertwiningMap
 
 variable {ρ : Representation R G V} {σ : Representation R H W} {τ : Representation R K U}
-  {e : G ≃* H} {φ : V →ₗ[R] W}
+  {f : G →* H} {e : G ≃* H} {φ : V →ₗ[R] W}
 
-/-- **Intertwining maps along isomorphisms of monoids compose.** -/
-theorem trans (hφ : ρ.IsIntertwiningMap (σ.comp (e : G →* H)) φ)
-    {e₂ : H ≃* K} {ψ : W →ₗ[R] U}
-    (hψ : σ.IsIntertwiningMap (τ.comp (e₂ : H →* K)) ψ) :
-    ρ.IsIntertwiningMap (τ.comp (e.trans e₂ : G →* K)) (ψ ∘ₗ φ) :=
-  ⟨fun g v ↦ by
-    have hφ' : φ (ρ g v) = σ (e g) (φ v) := by
-      simpa using hφ.isIntertwining g v
-    have hψ' : ψ (σ (e g) (φ v)) = τ (e₂ (e g)) (ψ (φ v)) := by
-      simpa using hψ.isIntertwining (e g) (φ v)
-    simp only [LinearMap.comp_apply, MonoidHom.coe_comp, MonoidHom.coe_coe, Function.comp_apply,
-      MulEquiv.coe_trans, hφ', hψ']⟩
+/-- **Intertwining maps along homomorphisms of monoids compose.** -/
+theorem trans (hφ : ρ.IsIntertwiningMap (σ.comp f) φ)
+    {g : H →* K} {ψ : W →ₗ[R] U}
+    (hψ : σ.IsIntertwiningMap (τ.comp g) ψ) :
+    ρ.IsIntertwiningMap (τ.comp (g.comp f)) (ψ ∘ₗ φ) :=
+  ⟨fun x v ↦ by
+    have hφ' : φ (ρ x v) = σ (f x) (φ v) := by
+      simpa using hφ.isIntertwining x v
+    have hψ' : ψ (σ (f x) (φ v)) = τ (g (f x)) (ψ (φ v)) := by
+      simpa using hψ.isIntertwining (f x) (φ v)
+    simp only [LinearMap.comp_apply, MonoidHom.coe_comp, Function.comp_apply,
+      hφ', hψ']⟩
 
 /-- **The inverse of an intertwining map along an isomorphism of monoids is intertwining**, when
 its linear part is an equivalence. -/
@@ -105,9 +105,13 @@ theorem IsIntertwiningMap.comp_norm {ρ : Representation R G V} {σ : Representa
 
 end Norm
 
+end Representation
+
 section RepMorphisms
 
 variable {R : Type u} {G : Type uG} {H : Type uH} [Semiring R] [Monoid G] [Monoid H]
+
+namespace Rep
 
 /-- The identity map of a representation is intertwining along the identity isomorphism of its
 monoid. -/
@@ -117,12 +121,16 @@ theorem isIntertwiningMap_id (M : Rep.{uV} R G) :
 
 /-- Restricting the coefficients along `f` and comparing back by the identity is an intertwining
 map along `f`. -/
-theorem isIntertwiningMap_res (f : G →* H) (N : Rep.{uV} R H) :
+theorem isIntertwiningMap_res (N : Rep.{uV} R H) (f : G →* H) :
     (Rep.res f N).ρ.IsIntertwiningMap (N.ρ.comp f)
       ((LinearEquiv.refl R N.V : N.V →ₗ[R] N.V) : (Rep.res f N).V →ₗ[R] N.V) :=
   ⟨fun g v ↦ by simp⟩
 
+end Rep
+
 variable {M : Rep.{uV} R G} {N : Rep.{uV} R H} {φ : M.V →ₗ[R] N.V}
+
+namespace Representation
 
 namespace IsIntertwiningMap
 
@@ -149,6 +157,6 @@ namespace IsIntertwiningMap
 
 end IsIntertwiningMap
 
-end RepMorphisms
-
 end Representation
+
+end RepMorphisms

--- a/TauCeti/RepresentationTheory/Rep/ChangeOfGroup.lean
+++ b/TauCeti/RepresentationTheory/Rep/ChangeOfGroup.lean
@@ -1,0 +1,139 @@
+/-
+Copyright (c) 2026 Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import Mathlib.RepresentationTheory.Rep.Res
+
+/-!
+# Intertwining maps along a homomorphism of groups
+
+Mathlib's `Representation.IsIntertwiningMap` compares two representations of one and the same
+group. For a homomorphism `f : G →* H`, a linear map intertwining `ρ : Representation R G V` with
+`σ.comp f`, for `σ : Representation R H W`, is the same datum as a morphism of `G`-representations
+`M ⟶ Res(f)(N)`, and, when `f` is an isomorphism, also as a morphism `Res(f⁻¹)(M) ⟶ N` of
+`H`-representations. This file supplies those two adapters, the identity, composition and
+inversion lemmas for intertwining maps along a homomorphism of groups, and the compatibility of
+such a map with the norm `∑ g, ρ g` of a finite group.
+
+These are the general representation-theoretic inputs of a change-of-group map in group homology
+and cohomology: `groupHomology.chainsMap` consumes the first adapter and
+`groupCohomology.cochainsMap` the second.
+
+## Main definitions
+
+* `TauCeti.Representation.IsIntertwiningMap.toRes`: an intertwining map along `f : G →* H` read as
+  a morphism `M ⟶ Res(f)(N)` of `G`-representations.
+* `TauCeti.Representation.IsIntertwiningMap.ofRes`: an intertwining map along an isomorphism
+  `e : G ≃* H` read as a morphism `Res(e⁻¹)(M) ⟶ N` of `H`-representations.
+
+## Main results
+
+* `TauCeti.Representation.IsIntertwiningMap.trans` and
+  `TauCeti.Representation.IsIntertwiningMap.symm`: intertwining maps along an isomorphism of groups
+  compose, and invert when their linear part is an equivalence.
+* `TauCeti.Representation.IsIntertwiningMap.comp_norm`: an intertwining map along an isomorphism of
+  finite groups intertwines the two norms.
+* `TauCeti.Representation.isIntertwiningMap_id` and
+  `TauCeti.Representation.isIntertwiningMap_res`: the identity map is intertwining along the
+  identity isomorphism of the group, and along `f` between a restricted representation and the
+  representation it restricts.
+-/
+
+public noncomputable section
+
+universe u
+
+namespace TauCeti.Representation
+
+variable {R G H K V W U : Type u} [CommRing R] [Group G] [Group H] [Group K]
+  [AddCommGroup V] [Module R V] [AddCommGroup W] [Module R W] [AddCommGroup U] [Module R U]
+
+namespace IsIntertwiningMap
+
+variable {ρ : Representation R G V} {σ : Representation R H W} {τ : Representation R K U}
+  {e : G ≃* H} {φ : V →ₗ[R] W}
+
+/-- **Intertwining maps along isomorphisms of groups compose.** -/
+theorem trans (hφ : ρ.IsIntertwiningMap (σ.comp (e : G →* H)) φ)
+    {e₂ : H ≃* K} {ψ : W →ₗ[R] U}
+    (hψ : σ.IsIntertwiningMap (τ.comp (e₂ : H →* K)) ψ) :
+    ρ.IsIntertwiningMap (τ.comp (e.trans e₂ : G →* K)) (ψ ∘ₗ φ) :=
+  ⟨fun g v ↦ by
+    have hφ' : φ (ρ g v) = σ (e g) (φ v) := by
+      simpa using hφ.isIntertwining g v
+    have hψ' : ψ (σ (e g) (φ v)) = τ (e₂ (e g)) (ψ (φ v)) := by
+      simpa using hψ.isIntertwining (e g) (φ v)
+    change ψ (φ (ρ g v)) = τ (e₂ (e g)) (ψ (φ v))
+    rw [hφ', hψ']⟩
+
+/-- **The inverse of an intertwining map along an isomorphism of groups is intertwining**, when
+its linear part is an equivalence. -/
+theorem symm {e' : V ≃ₗ[R] W}
+    (he : ρ.IsIntertwiningMap (σ.comp (e : G →* H)) (e' : V →ₗ[R] W)) :
+    σ.IsIntertwiningMap (ρ.comp (e.symm : H →* G)) (e'.symm : W →ₗ[R] V) :=
+  ⟨fun h v ↦ by
+    have he' : ∀ g, (e' : V →ₗ[R] W) ∘ₗ ρ g = σ (e g) ∘ₗ (e' : V →ₗ[R] W) :=
+      fun g ↦ by ext x; exact he.isIntertwining g x
+    simpa using congr($(e'.isIntertwining_symm_isIntertwining
+      (σ := σ.comp (e : G →* H)) he' (e.symm h)) v)⟩
+
+/-- **An intertwining map along an isomorphism of finite groups intertwines the two norms.** The
+group isomorphism permutes the summands of `∑ g, ρ g`. -/
+theorem comp_norm [Fintype G] [Fintype H]
+    (hφ : ρ.IsIntertwiningMap (σ.comp (e : G →* H)) φ) :
+    φ ∘ₗ ρ.norm = σ.norm ∘ₗ φ := by
+  ext x
+  simpa [_root_.Representation.norm] using
+    Fintype.sum_equiv e.toEquiv (fun g ↦ φ (ρ g x)) (fun h ↦ σ h (φ x))
+      fun g ↦ hφ.isIntertwining g x
+
+end IsIntertwiningMap
+
+section RepMorphisms
+
+/-- The identity map of a representation is intertwining along the identity isomorphism of its
+group. -/
+theorem isIntertwiningMap_id (M : Rep R G) :
+    M.ρ.IsIntertwiningMap (M.ρ.comp ((MulEquiv.refl G : G ≃* G) : G →* G))
+      (LinearMap.id : M.V →ₗ[R] M.V) := ⟨fun g v ↦ by simp⟩
+
+/-- Restricting the coefficients along `f` and comparing back by the identity is an intertwining
+map along `f`. -/
+theorem isIntertwiningMap_res (f : G →* H) (N : Rep R H) :
+    (Rep.res f N).ρ.IsIntertwiningMap (N.ρ.comp f)
+      ((LinearEquiv.refl R N.V : N.V →ₗ[R] N.V) : (Rep.res f N).V →ₗ[R] N.V) :=
+  ⟨fun g v ↦ by simp⟩
+
+variable {M : Rep R G} {N : Rep R H} {φ : M.V →ₗ[R] N.V}
+
+namespace IsIntertwiningMap
+
+/-- An intertwining map along `f : G →* H` read as a morphism `M ⟶ Res(f)(N)` of
+`G`-representations. This is the datum that `groupHomology.chainsMap` consumes. -/
+-- Exposed, like Mathlib's `Rep.resMap`, because the comparison of a change-of-group map along
+-- the identity isomorphism with the coefficient functoriality of a fixed group is definitional.
+@[expose] def toRes {f : G →* H} (hφ : M.ρ.IsIntertwiningMap (N.ρ.comp f) φ) : M ⟶ Rep.res f N :=
+  Rep.ofHom ⟨φ, fun g ↦ by ext v; exact hφ.isIntertwining g v⟩
+
+/-- An intertwining map along an isomorphism `e : G ≃* H` read as a morphism `Res(e⁻¹)(M) ⟶ N` of
+`H`-representations. This is the datum that `groupCohomology.cochainsMap` consumes. -/
+@[expose] def ofRes {e : G ≃* H} (hφ : M.ρ.IsIntertwiningMap (N.ρ.comp (e : G →* H)) φ) :
+    Rep.res (e.symm : H →* G) M ⟶ N :=
+  Rep.ofHom ⟨φ, fun h ↦ by ext v; simpa using hφ.isIntertwining (e.symm h) v⟩
+
+@[simp] theorem toRes_hom_toLinearMap {f : G →* H}
+    (hφ : M.ρ.IsIntertwiningMap (N.ρ.comp f) φ) :
+    (toRes hφ).hom.toLinearMap = φ := by simp [toRes]
+
+@[simp] theorem ofRes_hom_toLinearMap {e : G ≃* H}
+    (hφ : M.ρ.IsIntertwiningMap (N.ρ.comp (e : G →* H)) φ) :
+    (ofRes hφ).hom.toLinearMap = φ := by simp [ofRes]
+
+end IsIntertwiningMap
+
+end RepMorphisms
+
+end TauCeti.Representation

--- a/TauCeti/RepresentationTheory/Rep/ChangeOfGroup.lean
+++ b/TauCeti/RepresentationTheory/Rep/ChangeOfGroup.lean
@@ -8,14 +8,14 @@ module
 public import Mathlib.RepresentationTheory.Rep.Res
 
 /-!
-# Intertwining maps along a homomorphism of groups
+# Intertwining maps along a homomorphism of monoids
 
 Mathlib's `Representation.IsIntertwiningMap` compares two representations of one and the same
-group. For a homomorphism `f : G →* H`, a linear map intertwining `ρ : Representation R G V` with
+monoid. For a homomorphism `f : G →* H`, a linear map intertwining `ρ : Representation R G V` with
 `σ.comp f`, for `σ : Representation R H W`, is the same datum as a morphism of `G`-representations
 `M ⟶ Res(f)(N)`, and, when `f` is an isomorphism, also as a morphism `Res(f⁻¹)(M) ⟶ N` of
 `H`-representations. This file supplies those two adapters, the identity, composition and
-inversion lemmas for intertwining maps along a homomorphism of groups, and the compatibility of
+inversion lemmas for intertwining maps along a homomorphism of monoids, and the compatibility of
 such a map with the norm `∑ g, ρ g` of a finite group.
 
 These are the general representation-theoretic inputs of a change-of-group map in group homology
@@ -24,39 +24,42 @@ and cohomology: `groupHomology.chainsMap` consumes the first adapter and
 
 ## Main definitions
 
-* `TauCeti.Representation.IsIntertwiningMap.toRes`: an intertwining map along `f : G →* H` read as
+* `Representation.IsIntertwiningMap.toRes`: an intertwining map along `f : G →* H` read as
   a morphism `M ⟶ Res(f)(N)` of `G`-representations.
-* `TauCeti.Representation.IsIntertwiningMap.ofRes`: an intertwining map along an isomorphism
+* `Representation.IsIntertwiningMap.ofRes`: an intertwining map along an isomorphism
   `e : G ≃* H` read as a morphism `Res(e⁻¹)(M) ⟶ N` of `H`-representations.
 
 ## Main results
 
-* `TauCeti.Representation.IsIntertwiningMap.trans` and
-  `TauCeti.Representation.IsIntertwiningMap.symm`: intertwining maps along an isomorphism of groups
-  compose, and invert when their linear part is an equivalence.
-* `TauCeti.Representation.IsIntertwiningMap.comp_norm`: an intertwining map along an isomorphism of
+* `Representation.IsIntertwiningMap.trans` and `Representation.IsIntertwiningMap.symm`:
+  intertwining maps along an isomorphism of monoids compose, and invert when their linear part is
+  an equivalence.
+* `Representation.IsIntertwiningMap.comp_norm`: an intertwining map along an isomorphism of
   finite groups intertwines the two norms.
-* `TauCeti.Representation.isIntertwiningMap_id` and
-  `TauCeti.Representation.isIntertwiningMap_res`: the identity map is intertwining along the
-  identity isomorphism of the group, and along `f` between a restricted representation and the
-  representation it restricts.
+* `Representation.isIntertwiningMap_id` and `Representation.isIntertwiningMap_res`: the identity
+  map is intertwining along the identity isomorphism of the monoid, and along `f` between a
+  restricted representation and the representation it restricts.
 -/
 
 public noncomputable section
 
-universe u
+universe u uG uH uK uV uW uU
 
-namespace TauCeti.Representation
+namespace Representation
 
-variable {R G H K V W U : Type u} [CommRing R] [Group G] [Group H] [Group K]
-  [AddCommGroup V] [Module R V] [AddCommGroup W] [Module R W] [AddCommGroup U] [Module R U]
+section Monoid
+
+variable {R : Type u} {G : Type uG} {H : Type uH} {K : Type uK}
+  {V : Type uV} {W : Type uW} {U : Type uU}
+  [Semiring R] [Monoid G] [Monoid H] [Monoid K]
+  [AddCommMonoid V] [Module R V] [AddCommMonoid W] [Module R W] [AddCommMonoid U] [Module R U]
 
 namespace IsIntertwiningMap
 
 variable {ρ : Representation R G V} {σ : Representation R H W} {τ : Representation R K U}
   {e : G ≃* H} {φ : V →ₗ[R] W}
 
-/-- **Intertwining maps along isomorphisms of groups compose.** -/
+/-- **Intertwining maps along isomorphisms of monoids compose.** -/
 theorem trans (hφ : ρ.IsIntertwiningMap (σ.comp (e : G →* H)) φ)
     {e₂ : H ≃* K} {ψ : W →ₗ[R] U}
     (hψ : σ.IsIntertwiningMap (τ.comp (e₂ : H →* K)) ψ) :
@@ -66,10 +69,10 @@ theorem trans (hφ : ρ.IsIntertwiningMap (σ.comp (e : G →* H)) φ)
       simpa using hφ.isIntertwining g v
     have hψ' : ψ (σ (e g) (φ v)) = τ (e₂ (e g)) (ψ (φ v)) := by
       simpa using hψ.isIntertwining (e g) (φ v)
-    change ψ (φ (ρ g v)) = τ (e₂ (e g)) (ψ (φ v))
-    rw [hφ', hψ']⟩
+    simp only [LinearMap.comp_apply, MonoidHom.coe_comp, MonoidHom.coe_coe, Function.comp_apply,
+      MulEquiv.coe_trans, hφ', hψ']⟩
 
-/-- **The inverse of an intertwining map along an isomorphism of groups is intertwining**, when
+/-- **The inverse of an intertwining map along an isomorphism of monoids is intertwining**, when
 its linear part is an equivalence. -/
 theorem symm {e' : V ≃ₗ[R] W}
     (he : ρ.IsIntertwiningMap (σ.comp (e : G →* H)) (e' : V →ₗ[R] W)) :
@@ -80,34 +83,46 @@ theorem symm {e' : V ≃ₗ[R] W}
     simpa using congr($(e'.isIntertwining_symm_isIntertwining
       (σ := σ.comp (e : G →* H)) he' (e.symm h)) v)⟩
 
+end IsIntertwiningMap
+
+end Monoid
+
+section Norm
+
+variable {R : Type u} {G : Type uG} {H : Type uH} {V : Type uV} {W : Type uW}
+  [Semiring R] [Group G] [Group H] [Fintype G] [Fintype H]
+  [AddCommMonoid V] [Module R V] [AddCommMonoid W] [Module R W]
+
 /-- **An intertwining map along an isomorphism of finite groups intertwines the two norms.** The
 group isomorphism permutes the summands of `∑ g, ρ g`. -/
-theorem comp_norm [Fintype G] [Fintype H]
-    (hφ : ρ.IsIntertwiningMap (σ.comp (e : G →* H)) φ) :
+theorem IsIntertwiningMap.comp_norm {ρ : Representation R G V} {σ : Representation R H W}
+    {e : G ≃* H} {φ : V →ₗ[R] W} (hφ : ρ.IsIntertwiningMap (σ.comp (e : G →* H)) φ) :
     φ ∘ₗ ρ.norm = σ.norm ∘ₗ φ := by
   ext x
-  simpa [_root_.Representation.norm] using
+  simpa [Representation.norm] using
     Fintype.sum_equiv e.toEquiv (fun g ↦ φ (ρ g x)) (fun h ↦ σ h (φ x))
       fun g ↦ hφ.isIntertwining g x
 
-end IsIntertwiningMap
+end Norm
 
 section RepMorphisms
 
+variable {R : Type u} {G : Type uG} {H : Type uH} [Semiring R] [Monoid G] [Monoid H]
+
 /-- The identity map of a representation is intertwining along the identity isomorphism of its
-group. -/
-theorem isIntertwiningMap_id (M : Rep R G) :
+monoid. -/
+theorem isIntertwiningMap_id (M : Rep.{uV} R G) :
     M.ρ.IsIntertwiningMap (M.ρ.comp ((MulEquiv.refl G : G ≃* G) : G →* G))
       (LinearMap.id : M.V →ₗ[R] M.V) := ⟨fun g v ↦ by simp⟩
 
 /-- Restricting the coefficients along `f` and comparing back by the identity is an intertwining
 map along `f`. -/
-theorem isIntertwiningMap_res (f : G →* H) (N : Rep R H) :
+theorem isIntertwiningMap_res (f : G →* H) (N : Rep.{uV} R H) :
     (Rep.res f N).ρ.IsIntertwiningMap (N.ρ.comp f)
       ((LinearEquiv.refl R N.V : N.V →ₗ[R] N.V) : (Rep.res f N).V →ₗ[R] N.V) :=
   ⟨fun g v ↦ by simp⟩
 
-variable {M : Rep R G} {N : Rep R H} {φ : M.V →ₗ[R] N.V}
+variable {M : Rep.{uV} R G} {N : Rep.{uV} R H} {φ : M.V →ₗ[R] N.V}
 
 namespace IsIntertwiningMap
 
@@ -136,4 +151,4 @@ end IsIntertwiningMap
 
 end RepMorphisms
 
-end TauCeti.Representation
+end Representation


### PR DESCRIPTION
This PR adds the variance in the **group** that Mathlib's Tate cohomology is missing. Mathlib's `tateCohomology` is functorial in the coefficient representation, but the finite group is fixed throughout; here a **compatible pair** — a group isomorphism `e : G ≃* H` together with a linear map `φ` between the coefficient modules of `M : Rep R G` and `N : Rep R H` satisfying `φ ∘ ρ g = σ (e g) ∘ φ` (Mathlib's `Representation.IsIntertwiningMap`) — induces a map of Tate complexes (`complexMap`), hence a map `tateCohomology M n ⟶ tateCohomology N n` in every integer degree (`map`), which is an isomorphism as soon as `φ` is (`mapIso`). The chain half of the Tate complex is carried by `groupHomology.chainsMap` along `e`, the cochain half by `groupCohomology.cochainsMap` along `e.symm`, and the two agree on the connecting Tate norm because `e` permutes the group, so `∑ g, ρ g` is carried to `∑ h, σ h` (`Representation.IsIntertwiningMap.comp_norm`, `chainsMap_comp_d₀`).

The construction is pinned down, not merely asserted to exist. Compatible pairs compose and invert (`Representation.IsIntertwiningMap.trans`, `Representation.IsIntertwiningMap.symm`), the induced maps compose and are the identity on the identity pair (`map_comp`, `map_id`), along the identity isomorphism the map *is* Mathlib's coefficient functoriality (`complexMap_refl`, `map_refl`), and in the degrees where Mathlib compares Tate cohomology with ordinary theory the map is the ordinary change-of-group map: `groupCohomology.map` along `e.symm` in positive degrees (`map_comp_isoGroupCohomology_hom`) and `groupHomology.map` along `e` in degrees at most `-2` (`map_comp_isoGroupHomology_hom`). Restriction of coefficients along `e` is packaged as a natural isomorphism `Res(e) ⋙ tateCohomologyFunctor n ≅ tateCohomologyFunctor n` (`resIso`), and `natCard_tateCohomology_eq` records the cardinality corollary the class-formation axioms consume.

The roadmap target is `ClassFieldTheory`, `README.md` §4, Layer 0 ("audit and complete the cohomology suppliers"), whose item 4 asks the generic supplier for the missing change-of-group maps in every Tate degree; §1 directs such material to the generic supplier in a Mathlib-facing namespace rather than to a class-field-theory directory, which is why this file joins `TauCeti/RepresentationTheory/Homological/TateCohomology/` beside `Inflation.lean`, `LowDegree.lean` and `Periodic.lean`. The consumer is Layer 1, which requires "conjugation adapters between layer representations, on ordinary and **Tate** cohomology": the open PR #6349 builds `conjugateLayer` and `layerCohomologyConj` and states explicitly that its Tate-degree companion `layerTateConj` "needs the functoriality of Mathlib's `tateCohomology` along a group isomorphism, which is a Layer 0 supplier item that does not exist yet". Conjugation by a group element is exactly a compatible pair, so `layerTateConj` is now `mapIso` applied to `conjGalEquiv` and `conjRepIso`; downstream, the `ClassFormation` axiom `inv_conj` of Layer 2 and the formula `fundamentalClass_conj` of Layer 3 are stated against it. After this PR, Layer 0 still owes restriction and corestriction in every Tate degree with `cor ∘ res = [G : H]`, the Tate cup product in all bidegrees, and Tate's cup-product criterion.

Nothing is vendored. `complexMap` is Mathlib's `CochainComplex.ConnectData.map` applied to `groupHomology.chainsMap` and `groupCohomology.cochainsMap`, its functoriality comes from `ConnectData.map_id` and `ConnectData.map_comp_map`, and the two comparison theorems are `ConnectData.homologyMap_map_of_eq_succ` and `homologyMap_map_of_eq_neg_succ` read through Mathlib's `TateCohomology.isoGroupCohomology` and `isoGroupHomology`. The norm identity is `Fintype.sum_equiv` along `e`. The shape of the definitions mirrors Mathlib's own `groupCohomology.mapIso` and `groupHomology.mapIso`, which handle the same situation for ordinary cohomology and homology.

New files: `TauCeti/RepresentationTheory/Homological/TateCohomology/Functoriality.lean` and `TauCeti/RepresentationTheory/Rep/ChangeOfGroup.lean`. The second holds the general representation-theoretic half of the construction — the adapters `Representation.IsIntertwiningMap.toRes` and `ofRes` that turn an intertwining map along a group homomorphism into a morphism to, or from, a restricted representation, together with `trans`, `symm`, `comp_norm`, `isIntertwiningMap_id` and `isIntertwiningMap_res` — none of which is about Tate cohomology.

Roadmap: ClassFieldTheory

Provenance: statements follow `TauCetiProject/TauCetiRoadmap`, `ClassFieldTheory/README.md` §4 Layer 0 and §4 Layer 1; the compatible-pair formalism for change-of-group maps is Neukirch–Schmidt–Wingberg, *Cohomology of Number Fields*, Chapter I §5, and the Tate-degree statement is Artin–Tate, *Class Field Theory*, Chapter XIV §4. No code was ported from any other repository.

<!--tauceti-target:v1 {"focus":"ClassFieldTheory","id":"tate-cohomology-map-along-group-isomorphism"}-->

🤖 Prepared with Claude Code

