### PR TITLE
feat: prove the symplectic diagonal torus is a maximal torus

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/DiagonalTorus/Maximal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/DiagonalTorus/Maximal.lean
@@ -139,7 +139,8 @@ private theorem mkQuotient_comp_diagonalTorusCoordinateIso_hom_commHopfAlgCat :
 
 /-- The base-change isomorphism of `GL_n` coordinate Hopf algebras carries the base-changed
 diagonal-torus ideal onto the diagonal-torus ideal over the extended base. -/
-private theorem map_baseChangeHopfIdeal_diagonalTorusDefiningIdeal
+@[simp]
+theorem map_baseChangeHopfIdeal_diagonalTorusDefiningIdeal
     (K : Type u) [Field K] [Algebra k K] :
     (CommHopfAlgCat.baseChangeHopfIdeal (K := K) (diagonalTorusDefiningIdeal k n)).map
         (coordinateHopfAlgebraBaseChangeIso k K n).hom.hom =

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/DiagonalTorus/Maximal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/DiagonalTorus/Maximal.lean
@@ -138,69 +138,23 @@ private theorem mkQuotient_comp_diagonalTorusCoordinateIso_hom_commHopfAlgCat :
       diagonalTorusCoordinateMap (R := k) (N := n) at h
   exact h
 
+/-- The base-change isomorphism of `GL_n` coordinate Hopf algebras carries the base-changed
+diagonal-torus ideal onto the diagonal-torus ideal over the extended base. -/
 private theorem map_baseChangeHopfIdeal_diagonalTorusDefiningIdeal
     (K : Type u) [Field K] [Algebra k K] :
     (CommHopfAlgCat.baseChangeHopfIdeal (K := K) (diagonalTorusDefiningIdeal k n)).map
         (coordinateHopfAlgebraBaseChangeIso k K n).hom.hom =
-      diagonalTorusDefiningIdeal K n := by
-  let H := coordinateHopfAlgebra k n
-  let D := diagonalTorusDefiningIdeal k n
-  let e := coordinateHopfAlgebraBaseChangeIso k K n
-  let q := (forget₂ (FiniteTypeCommHopfAlgCat.{u, u} k)
-    (_root_.CommHopfAlgCat.{u} k)).mapIso (diagonalTorusCoordinateIso k n)
-  let t := DiagonalizableGroup.baseChangeCoordinateHopfAlgebraIso k K
-    (SplitTorus.characterGroup (ULift.{u} (Fin n)))
-  let r := CommHopfAlgCat.baseChangeMap (K := K) q.hom ≫ t.hom
-  have he : Function.Bijective e.hom.hom := ConcreteCategory.bijective_of_isIso e.hom
-  have hq : CommHopfAlgCat.mkQuotient H D ≫ q.hom =
-      diagonalTorusCoordinateMap (R := k) (N := n) :=
-    mkQuotient_comp_diagonalTorusCoordinateIso_hom_commHopfAlgCat k n
-  have hqK :
-      CommHopfAlgCat.baseChangeMap (K := K) (CommHopfAlgCat.mkQuotient H D) ≫
-          CommHopfAlgCat.baseChangeMap (K := K) q.hom =
-        CommHopfAlgCat.baseChangeMap (K := K)
-          (diagonalTorusCoordinateMap (R := k) (N := n)) := by
-    rw [← (CommHopfAlgCat.baseChangeFunctor (K := K)).map_comp]
-    exact congrArg (CommHopfAlgCat.baseChangeMap (K := K)) hq
-  have hdiag := diagonalTorusCoordinateMap_baseChange (N := n) k K
-  -- The local names `e` and `t` abbreviate exactly the isomorphisms in the preceding theorem;
-  -- exposing them is a definitional conversion, with no propositional equality to rewrite.
-  change e.inv ≫
-      CommHopfAlgCat.baseChangeMap (K := K)
-        (diagonalTorusCoordinateMap (R := k) (N := n)) ≫ t.hom =
-    diagonalTorusCoordinateMap (R := K) (N := n) at hdiag
-  have hcomm :
-      CommHopfAlgCat.baseChangeMap (K := K) (CommHopfAlgCat.mkQuotient H D) ≫ r =
-        e.hom ≫ diagonalTorusCoordinateMap (R := K) (N := n) := by
-    dsimp only [r]
-    rw [← Category.assoc, hqK, ← hdiag]
-    simp
-  have hr : Function.Injective r.hom := by
-    dsimp only [r]
-    exact (ConcreteCategory.bijective_of_isIso
-      ((CommHopfAlgCat.baseChangeFunctor (K := K)).mapIso q ≪≫ t).hom).1
-  have hzero (y : CommHopfAlgCat.baseChange (K := K) H) :
-      (CommHopfAlgCat.baseChangeMap (K := K)
-          (CommHopfAlgCat.mkQuotient H D)).hom y = 0 ↔
-        (diagonalTorusCoordinateMap (R := K) (N := n)).hom (e.hom.hom y) = 0 := by
-    have hy := congrArg (fun f ↦ f.hom y) hcomm
-    simp only [_root_.CommHopfAlgCat.hom_comp, BialgHom.comp_apply] at hy
-    rw [← hy]
-    exact ⟨fun hy0 ↦ by rw [hy0, map_zero], fun hy0 ↦ hr (by simpa using hy0)⟩
-  ext x
-  rw [HopfIdeal.mem_map_iff_of_surjective he.2]
-  have hmemx : x ∈ diagonalTorusDefiningIdeal K n ↔
-      (diagonalTorusCoordinateMap (R := K) (N := n)).hom x = 0 := by
-    rw [diagonalTorusDefiningIdeal, HopfIdeal.mem_kerOfSurjective]
-  rw [hmemx]
-  constructor
-  · rintro ⟨y, hy, rfl⟩
-    exact (hzero y).mp ((CommHopfAlgCat.mem_baseChangeHopfIdeal_iff D y).mp hy)
-  · intro hx
-    refine ⟨e.inv.hom x, ?_, _root_.CommHopfAlgCat.hom_inv_apply e x⟩
-    rw [CommHopfAlgCat.mem_baseChangeHopfIdeal_iff]
-    apply (hzero _).mpr
-    rwa [_root_.CommHopfAlgCat.hom_inv_apply]
+      diagonalTorusDefiningIdeal K n :=
+  CommHopfAlgCat.map_baseChangeHopfIdeal_of_quotientIso
+    (diagonalTorusDefiningIdeal k n) (diagonalTorusDefiningIdeal K n)
+    (coordinateHopfAlgebraBaseChangeIso k K n)
+    (DiagonalizableGroup.baseChangeCoordinateHopfAlgebraIso k K
+      (SplitTorus.characterGroup (ULift.{u} (Fin n))))
+    ((forget₂ (FiniteTypeCommHopfAlgCat.{u, u} k)
+      (_root_.CommHopfAlgCat.{u} k)).mapIso (diagonalTorusCoordinateIso k n))
+    (mkQuotient_comp_diagonalTorusCoordinateIso_hom_commHopfAlgCat k n)
+    (diagonalTorusCoordinateMap_baseChange (N := n) k K)
+    (fun _ ↦ HopfIdeal.mem_kerOfSurjective _ _)
 
 /-- The quotient coordinate Hopf algebra of the diagonal torus is a split torus of rank `n`. -/
 theorem splitTorusCommHopfAlgProperty_quotient_diagonalTorusDefiningIdeal :
@@ -376,53 +330,13 @@ applies, and then descended using faithful flatness. -/
 @[grind =>]
 theorem isMaximalTorus_diagonalTorusDefiningIdeal :
     HopfIdeal.IsMaximalTorus k (coordinateHopfAlgebra k n)
-      (diagonalTorusDefiningIdeal k n) := by
-  rw [HopfIdeal.isMaximalTorus_iff]
-  refine ⟨torusCommHopfAlgProperty_quotient_diagonalTorusDefiningIdeal k n, ?_⟩
-  intro I hI hID
-  let K := AlgebraicClosure k
-  let H := coordinateHopfAlgebra k n
-  let HK := coordinateHopfAlgebra K n
-  let Hft : FiniteTypeCommHopfAlgCat k :=
-    ⟨H, (finiteTypeCommHopfAlgProperty_iff _).2 inferInstance⟩
-  let HKft : FiniteTypeCommHopfAlgCat K :=
-    ⟨HK, (finiteTypeCommHopfAlgProperty_iff _).2 inferInstance⟩
-  let e := coordinateHopfAlgebraBaseChangeIso k K n
-  let IK := (CommHopfAlgCat.baseChangeHopfIdeal (K := K) I).map e.hom.hom
-  have hmapI :
-      (CommHopfAlgCat.baseChangeHopfIdeal (K := K) I).map e.hom.hom = IK := rfl
-  let qIso : FiniteTypeCommHopfAlgCat.baseChange (K := K)
-        (FiniteTypeCommHopfAlgCat.quotient Hft I) ≅
-      FiniteTypeCommHopfAlgCat.quotient HKft IK :=
-    ObjectProperty.isoMk _
-      (CommHopfAlgCat.quotientBaseChangeIsoOfMapEq I IK e hmapI)
-  have hsplit : splitTorusCommHopfAlgProperty K
-      (FiniteTypeCommHopfAlgCat.baseChange (K := K)
-        (FiniteTypeCommHopfAlgCat.quotient Hft I)) := by
-    rw [splitTorusCommHopfAlgProperty_iff]
-    rw [torusCommHopfAlgProperty_iff] at hI
-    simpa only [Hft] using hI
-  have hIK : torusCommHopfAlgProperty K
-      (FiniteTypeCommHopfAlgCat.quotient HKft IK) :=
-    ((splitTorusCommHopfAlgProperty K).prop_of_iso qIso hsplit).torus K _
-  have hIKD : IK ≤ diagonalTorusDefiningIdeal K n := by
-    rw [← map_baseChangeHopfIdeal_diagonalTorusDefiningIdeal k n K]
-    exact HopfIdeal.map_mono e.hom.hom
-      (CommHopfAlgCat.baseChangeHopfIdeal_mono hID)
-  have hmaxK := isMaximalTorus_diagonalTorusDefiningIdeal_of_isAlgClosed K n
-  rw [HopfIdeal.isMaximalTorus_iff] at hmaxK
-  have hDIK : diagonalTorusDefiningIdeal K n ≤ IK := hmaxK.2 IK hIK hIKD
-  have he : Function.Bijective e.hom.hom := ConcreteCategory.bijective_of_isIso e.hom
-  have hbase :
-      CommHopfAlgCat.baseChangeHopfIdeal (K := K) (diagonalTorusDefiningIdeal k n) ≤
-        CommHopfAlgCat.baseChangeHopfIdeal (K := K) I := by
-    have hcomap := HopfIdeal.comapOfSurjective_mono e.hom.hom he.2 hDIK
-    rw [← map_baseChangeHopfIdeal_diagonalTorusDefiningIdeal k n K,
-      HopfIdeal.comapOfSurjective_map_of_bijective _ _ he,
-      HopfIdeal.comapOfSurjective_map_of_bijective _ _ he] at hcomap
-    exact hcomap
-  exact (CommHopfAlgCat.baseChangeHopfIdeal_le_iff
-    (algebraMap k K).injective).mp hbase
+      (diagonalTorusDefiningIdeal k n) :=
+  HopfIdeal.isMaximalTorus_of_baseChange (diagonalTorusDefiningIdeal k n)
+    (diagonalTorusDefiningIdeal (AlgebraicClosure k) n)
+    (coordinateHopfAlgebraBaseChangeIso k (AlgebraicClosure k) n)
+    (torusCommHopfAlgProperty_quotient_diagonalTorusDefiningIdeal k n)
+    (map_baseChangeHopfIdeal_diagonalTorusDefiningIdeal k n (AlgebraicClosure k))
+    (isMaximalTorus_diagonalTorusDefiningIdeal_of_isAlgClosed (AlgebraicClosure k) n)
 
 end
 

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/DiagonalTorus/Maximal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/DiagonalTorus/Maximal.lean
@@ -10,7 +10,6 @@ public import TauCeti.Algebra.AlgebraicGroup.Hopf.KernelPoints
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Points.Separation
 public import TauCeti.Algebra.AlgebraicGroup.Torus.Maximal
 import TauCeti.Algebra.AlgebraicGroup.Torus.SmoothConnected
-import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.BaseChange
 
 /-!
 # Maximality of the diagonal torus in the general linear group

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/BaseChange.lean
@@ -52,6 +52,9 @@ along `h ↦ 1 ⊗ h`.
   by a base-changed family sits inside the base change of the subgroup it generates.
 * `TauCeti.CommHopfAlgCat.quotientBaseChangeIso`: the identification
   `(K ⊗[k] H) ⧸ J_K ≅ K ⊗[k] (H ⧸ J)`.
+* `TauCeti.CommHopfAlgCat.map_baseChangeHopfIdeal_of_quotientIso`: an ambient base-change
+  isomorphism carries a base-changed Hopf ideal onto a target ideal presented as the kernel of
+  the base change of the quotient morphism.
 * `TauCeti.CommHopfAlgCat.quotientBaseChangeIsoOfMapEq`: transport of this identification
   across an ambient base-change isomorphism carrying the base-changed ideal to a target ideal.
 * `TauCeti.CommHopfAlgCat.mkQuotient_comp_quotientBaseChangeIso_hom`: the identification is
@@ -403,6 +406,48 @@ theorem map_baseChangeHopfIdeal_of_toIdeal_eq_span
   simpa only [Algebra.TensorProduct.includeRight_apply, BialgHom.coe_toAlgHom,
     AlgHom.toRingHom_eq_coe, RingHom.coe_coe] using
     Iff.of_eq (congrArg (fun T => x ∈ Ideal.span T) h)
+
+/-- An ambient base-change isomorphism carries a base-changed Hopf ideal onto a target Hopf
+ideal, when both are presented as vanishing ideals of morphisms matched by base change: `J` is
+the kernel of `f`, which factors through the quotient by `J` via the isomorphism `q`, and `f'`
+is the base change of `f` read through `e` and `t`.
+
+This is the kernel-presented companion of
+`TauCeti.CommHopfAlgCat.map_baseChangeHopfIdeal_of_toIdeal_eq_span`, for ideals that come with a
+quotient presentation rather than with generating sets. -/
+theorem map_baseChangeHopfIdeal_of_quotientIso
+    {T : _root_.CommHopfAlgCat.{v} k} {H' T' : _root_.CommHopfAlgCat.{max w v} K}
+    (J : HopfIdeal k H) (J' : HopfIdeal K H')
+    (e : baseChange (K := K) H ≅ H') (t : baseChange (K := K) T ≅ T')
+    (q : quotient H J ≅ T) {f : H ⟶ T} {f' : H' ⟶ T'}
+    (hq : mkQuotient H J ≫ q.hom = f)
+    (hf' : e.inv ≫ baseChangeMap (K := K) f ≫ t.hom = f')
+    (hJ' : ∀ x, x ∈ J' ↔ f'.hom x = 0) :
+    (baseChangeHopfIdeal (K := K) J).map e.hom.hom = J' := by
+  have he : Function.Bijective e.hom.hom := ConcreteCategory.bijective_of_isIso e.hom
+  have hcomm : baseChangeMap (K := K) (mkQuotient H J) ≫
+      (baseChangeMap (K := K) q.hom ≫ t.hom) = e.hom ≫ f' := by
+    rw [← Category.assoc, ← (baseChangeFunctor (K := K)).map_comp, hq, ← hf']
+    simp
+  have hr : Function.Injective (baseChangeMap (K := K) q.hom ≫ t.hom).hom :=
+    (ConcreteCategory.bijective_of_isIso
+      ((baseChangeFunctor (K := K)).mapIso q ≪≫ t).hom).1
+  have hzero (y : baseChange (K := K) H) :
+      (baseChangeMap (K := K) (mkQuotient H J)).hom y = 0 ↔ f'.hom (e.hom.hom y) = 0 := by
+    have hy := congrArg (fun g ↦ g.hom y) hcomm
+    simp only [_root_.CommHopfAlgCat.hom_comp, BialgHom.comp_apply] at hy
+    rw [← hy]
+    exact ⟨fun hy0 ↦ by rw [hy0]; simp, fun hy0 ↦ hr (by simpa using hy0)⟩
+  ext x
+  rw [HopfIdeal.mem_map_iff_of_surjective he.2, hJ' x]
+  constructor
+  · rintro ⟨y, hy, rfl⟩
+    exact (hzero y).mp ((mem_baseChangeHopfIdeal_iff J y).mp hy)
+  · intro hx
+    refine ⟨e.inv.hom x, ?_, _root_.CommHopfAlgCat.hom_inv_apply e x⟩
+    rw [mem_baseChangeHopfIdeal_iff]
+    apply (hzero _).mpr
+    rwa [_root_.CommHopfAlgCat.hom_inv_apply]
 
 /-- Pulling a target Hopf ideal back along an ambient isomorphism which is its image recovers
 the original ideal. -/

--- a/TauCeti/Algebra/AlgebraicGroup/Symplectic/DiagonalTorus/ClosedImmersion.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Symplectic/DiagonalTorus/ClosedImmersion.lean
@@ -15,8 +15,9 @@ import TauCeti.CategoryTheory.Comma.Over
 
 Over every commutative ring, the diagonal map from the rank-`m` split torus to `Sp₂ₘ` is a
 closed immersion. Its defining Hopf ideal is the kernel of restriction to diagonal coordinates,
-and the quotient is isomorphic to the split-torus coordinate Hopf algebra. These constructions
-make the diagonal torus available as a closed subgroup when studying maximal tori and pinnings.
+the quotient is isomorphic to the split-torus coordinate Hopf algebra, and the ideal is
+compatible with scalar extension. These constructions make the diagonal torus available as a
+closed subgroup when studying maximal tori and pinnings.
 -/
 
 public section
@@ -120,6 +121,44 @@ theorem splitTorusCommHopfAlgProperty_quotient_diagonalTorusDefiningIdeal :
 
 grind_pattern splitTorusCommHopfAlgProperty_quotient_diagonalTorusDefiningIdeal =>
   diagonalTorusDefiningIdeal R m
+
+private theorem mkQuotient_comp_diagonalTorusCoordinateIso_hom_commHopfAlgCat :
+    CommHopfAlgCat.mkQuotient (coordinateHopfAlgebra R m) (diagonalTorusDefiningIdeal R m) ≫
+        ((forget₂ (FiniteTypeCommHopfAlgCat.{u, u} R)
+          (_root_.CommHopfAlgCat.{u} R)).mapIso (diagonalTorusCoordinateIso R m)).hom =
+      diagonalTorusCoordinateMap (R := R) (m := m) := by
+  have h := congrArg
+    (fun f ↦ (forget₂ (FiniteTypeCommHopfAlgCat.{u, u} R)
+      (_root_.CommHopfAlgCat.{u} R)).map f)
+    (mkQuotient_comp_diagonalTorusCoordinateIso_hom R m)
+  rw [Functor.map_comp] at h
+  -- A morphism in an `ObjectProperty.FullSubcategory` is definitionally its underlying
+  -- morphism, so applying the forgetful functor changes only the wrapper. There is no
+  -- propositional rewrite lemma for this reducible coercion.
+  change CommHopfAlgCat.mkQuotient (coordinateHopfAlgebra R m)
+      (diagonalTorusDefiningIdeal R m) ≫
+        ((forget₂ (FiniteTypeCommHopfAlgCat.{u, u} R)
+          (_root_.CommHopfAlgCat.{u} R)).mapIso (diagonalTorusCoordinateIso R m)).hom =
+      diagonalTorusCoordinateMap (R := R) (m := m) at h
+  exact h
+
+/-- The base-change isomorphism of symplectic coordinate Hopf algebras carries the base-changed
+diagonal-torus ideal onto the diagonal-torus ideal over the extended base. -/
+theorem map_baseChangeHopfIdeal_diagonalTorusDefiningIdeal
+    (K : Type u) [CommRing K] [Algebra R K] :
+    (CommHopfAlgCat.baseChangeHopfIdeal (K := K) (diagonalTorusDefiningIdeal R m)).map
+        (coordinateHopfAlgebraBaseChangeIso R K m).hom.hom =
+      diagonalTorusDefiningIdeal K m :=
+  CommHopfAlgCat.map_baseChangeHopfIdeal_of_quotientIso
+    (diagonalTorusDefiningIdeal R m) (diagonalTorusDefiningIdeal K m)
+    (coordinateHopfAlgebraBaseChangeIso R K m)
+    (DiagonalizableGroup.baseChangeCoordinateHopfAlgebraIso R K
+      (SplitTorus.characterGroup (ULift.{u} (Fin m))))
+    ((forget₂ (FiniteTypeCommHopfAlgCat.{u, u} R)
+      (_root_.CommHopfAlgCat.{u} R)).mapIso (diagonalTorusCoordinateIso R m))
+    (mkQuotient_comp_diagonalTorusCoordinateIso_hom_commHopfAlgCat R m)
+    (diagonalTorusCoordinateMap_baseChange (m := m) R K)
+    (fun x ↦ mem_diagonalTorusDefiningIdeal K m x)
 
 /-- Over a field, the coordinate quotient defining the symplectic diagonal torus is a torus. -/
 theorem torusCommHopfAlgProperty_quotient_diagonalTorusDefiningIdeal

--- a/TauCeti/Algebra/AlgebraicGroup/Symplectic/DiagonalTorus/ClosedImmersion.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Symplectic/DiagonalTorus/ClosedImmersion.lean
@@ -144,6 +144,7 @@ private theorem mkQuotient_comp_diagonalTorusCoordinateIso_hom_commHopfAlgCat :
 
 /-- The base-change isomorphism of symplectic coordinate Hopf algebras carries the base-changed
 diagonal-torus ideal onto the diagonal-torus ideal over the extended base. -/
+@[simp]
 theorem map_baseChangeHopfIdeal_diagonalTorusDefiningIdeal
     (K : Type u) [CommRing K] [Algebra R K] :
     (CommHopfAlgCat.baseChangeHopfIdeal (K := K) (diagonalTorusDefiningIdeal R m)).map

--- a/TauCeti/Algebra/AlgebraicGroup/Symplectic/DiagonalTorus/Maximal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Symplectic/DiagonalTorus/Maximal.lean
@@ -37,9 +37,11 @@ diagonal torus in `TauCeti.Algebra.AlgebraicGroup.Symplectic.DiagonalTorus.Close
 
 * J. S. Milne, *Algebraic Groups* (2017), §17 and §23.
 * J. E. Humphreys, *Linear Algebraic Groups* (1975), §16.1 and §26.3.
-* The Hopf-ideal organization, the point-subgroup comparison and the base-change descent of
-  maximality follow the formal template in
-  `TauCeti.Algebra.AlgebraicGroup.GeneralLinear.DiagonalTorus.Maximal`.
+* The Hopf-ideal organization and the point-subgroup comparison follow the formal template in
+  `TauCeti.Algebra.AlgebraicGroup.GeneralLinear.DiagonalTorus.Maximal`, with which this module
+  shares the base-change transport lemma
+  `TauCeti.CommHopfAlgCat.map_baseChangeHopfIdeal_of_quotientIso` and the maximality descent
+  lemma `TauCeti.HopfIdeal.isMaximalTorus_of_baseChange`.
 * The matrix centralizer input is
   `TauCeti.GLSymplecticFin.centralizer_diagonalTorus`.
 -/
@@ -110,61 +112,17 @@ private theorem map_baseChangeHopfIdeal_diagonalTorusDefiningIdeal
     (K : Type u) [Field K] [Algebra k K] :
     (CommHopfAlgCat.baseChangeHopfIdeal (K := K) (diagonalTorusDefiningIdeal k m)).map
         (coordinateHopfAlgebraBaseChangeIso k K m).hom.hom =
-      diagonalTorusDefiningIdeal K m := by
-  let H := coordinateHopfAlgebra k m
-  let D := diagonalTorusDefiningIdeal k m
-  let e := coordinateHopfAlgebraBaseChangeIso k K m
-  let q := (forget₂ (FiniteTypeCommHopfAlgCat.{u, u} k)
-    (_root_.CommHopfAlgCat.{u} k)).mapIso (diagonalTorusCoordinateIso k m)
-  let t := DiagonalizableGroup.baseChangeCoordinateHopfAlgebraIso k K
-    (SplitTorus.characterGroup (ULift.{u} (Fin m)))
-  let r := CommHopfAlgCat.baseChangeMap (K := K) q.hom ≫ t.hom
-  have he : Function.Bijective e.hom.hom := ConcreteCategory.bijective_of_isIso e.hom
-  have hq : CommHopfAlgCat.mkQuotient H D ≫ q.hom =
-      diagonalTorusCoordinateMap (R := k) (m := m) :=
-    mkQuotient_comp_diagonalTorusCoordinateIso_hom_commHopfAlgCat k m
-  have hqK :
-      CommHopfAlgCat.baseChangeMap (K := K) (CommHopfAlgCat.mkQuotient H D) ≫
-          CommHopfAlgCat.baseChangeMap (K := K) q.hom =
-        CommHopfAlgCat.baseChangeMap (K := K)
-          (diagonalTorusCoordinateMap (R := k) (m := m)) := by
-    rw [← (CommHopfAlgCat.baseChangeFunctor (K := K)).map_comp]
-    exact congrArg (CommHopfAlgCat.baseChangeMap (K := K)) hq
-  have hdiag := diagonalTorusCoordinateMap_baseChange (m := m) k K
-  -- The local names `e` and `t` abbreviate exactly the isomorphisms appearing in that statement;
-  -- exposing them is a definitional conversion, with no propositional equality to rewrite.
-  change e.inv ≫
-      CommHopfAlgCat.baseChangeMap (K := K)
-        (diagonalTorusCoordinateMap (R := k) (m := m)) ≫ t.hom =
-    diagonalTorusCoordinateMap (R := K) (m := m) at hdiag
-  have hcomm :
-      CommHopfAlgCat.baseChangeMap (K := K) (CommHopfAlgCat.mkQuotient H D) ≫ r =
-        e.hom ≫ diagonalTorusCoordinateMap (R := K) (m := m) := by
-    dsimp only [r]
-    rw [← Category.assoc, hqK, ← hdiag]
-    simp
-  have hr : Function.Injective r.hom := by
-    dsimp only [r]
-    exact (ConcreteCategory.bijective_of_isIso
-      ((CommHopfAlgCat.baseChangeFunctor (K := K)).mapIso q ≪≫ t).hom).1
-  have hzero (y : CommHopfAlgCat.baseChange (K := K) H) :
-      (CommHopfAlgCat.baseChangeMap (K := K)
-          (CommHopfAlgCat.mkQuotient H D)).hom y = 0 ↔
-        (diagonalTorusCoordinateMap (R := K) (m := m)).hom (e.hom.hom y) = 0 := by
-    have hy := congrArg (fun f ↦ f.hom y) hcomm
-    simp only [_root_.CommHopfAlgCat.hom_comp, BialgHom.comp_apply] at hy
-    rw [← hy]
-    exact ⟨fun hy0 ↦ by rw [hy0, map_zero], fun hy0 ↦ hr (by simpa using hy0)⟩
-  ext x
-  rw [HopfIdeal.mem_map_iff_of_surjective he.2, mem_diagonalTorusDefiningIdeal]
-  constructor
-  · rintro ⟨y, hy, rfl⟩
-    exact (hzero y).mp ((CommHopfAlgCat.mem_baseChangeHopfIdeal_iff D y).mp hy)
-  · intro hx
-    refine ⟨e.inv.hom x, ?_, _root_.CommHopfAlgCat.hom_inv_apply e x⟩
-    rw [CommHopfAlgCat.mem_baseChangeHopfIdeal_iff]
-    apply (hzero _).mpr
-    rwa [_root_.CommHopfAlgCat.hom_inv_apply]
+      diagonalTorusDefiningIdeal K m :=
+  CommHopfAlgCat.map_baseChangeHopfIdeal_of_quotientIso
+    (diagonalTorusDefiningIdeal k m) (diagonalTorusDefiningIdeal K m)
+    (coordinateHopfAlgebraBaseChangeIso k K m)
+    (DiagonalizableGroup.baseChangeCoordinateHopfAlgebraIso k K
+      (SplitTorus.characterGroup (ULift.{u} (Fin m))))
+    ((forget₂ (FiniteTypeCommHopfAlgCat.{u, u} k)
+      (_root_.CommHopfAlgCat.{u} k)).mapIso (diagonalTorusCoordinateIso k m))
+    (mkQuotient_comp_diagonalTorusCoordinateIso_hom_commHopfAlgCat k m)
+    (diagonalTorusCoordinateMap_baseChange (m := m) k K)
+    (fun x ↦ mem_diagonalTorusDefiningIdeal K m x)
 
 private theorem isReduced_quotient_diagonalTorusDefiningIdeal :
     IsReduced (CommHopfAlgCat.quotient (coordinateHopfAlgebra k m)
@@ -277,54 +235,15 @@ omit [IsAlgClosed k] in
 @[grind =>]
 theorem isMaximalTorus_diagonalTorusDefiningIdeal :
     HopfIdeal.IsMaximalTorus k (coordinateHopfAlgebra k m)
-      (diagonalTorusDefiningIdeal k m) := by
+      (diagonalTorusDefiningIdeal k m) :=
   -- Maximality is checked after base change to an algebraic closure, where the stronger
   -- pointwise maximality theorem applies, and descended along the faithfully flat extension.
-  rw [HopfIdeal.isMaximalTorus_iff]
-  refine ⟨torusCommHopfAlgProperty_quotient_diagonalTorusDefiningIdeal k m, ?_⟩
-  intro I hI hID
-  let K := AlgebraicClosure k
-  let H := coordinateHopfAlgebra k m
-  let HK := coordinateHopfAlgebra K m
-  let Hft : FiniteTypeCommHopfAlgCat k :=
-    ⟨H, (finiteTypeCommHopfAlgProperty_iff _).2 inferInstance⟩
-  let HKft : FiniteTypeCommHopfAlgCat K :=
-    ⟨HK, (finiteTypeCommHopfAlgProperty_iff _).2 inferInstance⟩
-  let e := coordinateHopfAlgebraBaseChangeIso k K m
-  let IK := (CommHopfAlgCat.baseChangeHopfIdeal (K := K) I).map e.hom.hom
-  have hmapI :
-      (CommHopfAlgCat.baseChangeHopfIdeal (K := K) I).map e.hom.hom = IK := rfl
-  let qIso : FiniteTypeCommHopfAlgCat.baseChange (K := K)
-        (FiniteTypeCommHopfAlgCat.quotient Hft I) ≅
-      FiniteTypeCommHopfAlgCat.quotient HKft IK :=
-    ObjectProperty.isoMk _
-      (CommHopfAlgCat.quotientBaseChangeIsoOfMapEq I IK e hmapI)
-  have hsplit : splitTorusCommHopfAlgProperty K
-      (FiniteTypeCommHopfAlgCat.baseChange (K := K)
-        (FiniteTypeCommHopfAlgCat.quotient Hft I)) := by
-    rw [splitTorusCommHopfAlgProperty_iff]
-    rw [torusCommHopfAlgProperty_iff] at hI
-    simpa only [Hft] using hI
-  have hIK : torusCommHopfAlgProperty K
-      (FiniteTypeCommHopfAlgCat.quotient HKft IK) :=
-    ((splitTorusCommHopfAlgProperty K).prop_of_iso qIso hsplit).torus K _
-  have hIKD : IK ≤ diagonalTorusDefiningIdeal K m := by
-    rw [← map_baseChangeHopfIdeal_diagonalTorusDefiningIdeal k m K]
-    exact HopfIdeal.map_mono e.hom.hom (CommHopfAlgCat.baseChangeHopfIdeal_mono hID)
-  have hmaxK := isMaximalTorus_diagonalTorusDefiningIdeal_of_isAlgClosed K m
-  rw [HopfIdeal.isMaximalTorus_iff] at hmaxK
-  have hDIK : diagonalTorusDefiningIdeal K m ≤ IK := hmaxK.2 IK hIK hIKD
-  have he : Function.Bijective e.hom.hom := ConcreteCategory.bijective_of_isIso e.hom
-  have hbase :
-      CommHopfAlgCat.baseChangeHopfIdeal (K := K) (diagonalTorusDefiningIdeal k m) ≤
-        CommHopfAlgCat.baseChangeHopfIdeal (K := K) I := by
-    have hcomap := HopfIdeal.comapOfSurjective_mono e.hom.hom he.2 hDIK
-    rw [← map_baseChangeHopfIdeal_diagonalTorusDefiningIdeal k m K,
-      HopfIdeal.comapOfSurjective_map_of_bijective _ _ he,
-      HopfIdeal.comapOfSurjective_map_of_bijective _ _ he] at hcomap
-    exact hcomap
-  exact (CommHopfAlgCat.baseChangeHopfIdeal_le_iff
-    (algebraMap k K).injective).mp hbase
+  HopfIdeal.isMaximalTorus_of_baseChange (diagonalTorusDefiningIdeal k m)
+    (diagonalTorusDefiningIdeal (AlgebraicClosure k) m)
+    (coordinateHopfAlgebraBaseChangeIso k (AlgebraicClosure k) m)
+    (torusCommHopfAlgProperty_quotient_diagonalTorusDefiningIdeal k m)
+    (map_baseChangeHopfIdeal_diagonalTorusDefiningIdeal k m (AlgebraicClosure k))
+    (isMaximalTorus_diagonalTorusDefiningIdeal_of_isAlgClosed (AlgebraicClosure k) m)
 
 end
 

--- a/TauCeti/Algebra/AlgebraicGroup/Symplectic/DiagonalTorus/Maximal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Symplectic/DiagonalTorus/Maximal.lean
@@ -1,0 +1,338 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Hopf.KernelPoints
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Points.Separation
+public import TauCeti.Algebra.AlgebraicGroup.Symplectic.DiagonalTorus.ClosedImmersion
+public import TauCeti.Algebra.AlgebraicGroup.Torus.Maximal
+public import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Symplectic.Diagonal.Centralizer
+import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.BaseChange
+import TauCeti.Algebra.AlgebraicGroup.Torus.SmoothConnected
+
+/-!
+# Maximality of the diagonal torus in the symplectic group
+
+Over any field, the paired diagonal torus of `Sp₂ₘ` is a maximal torus. Over an algebraically
+closed field it is more: no reduced commutative closed subgroup scheme properly contains it. That
+is stronger than maximality among tori, because a competing subgroup here need not be a torus, or
+even connected.
+
+The proof compares points over an algebraic closure. A reduced commutative closed subgroup
+containing the diagonal torus gives a commutative subgroup of `Sp₂ₘ(k)` containing every paired
+diagonal matrix, and the matrix centralizer calculation of
+`TauCeti.GLSymplecticFin.centralizer_diagonalTorus` says that such a subgroup is the diagonal
+torus itself. Point separation for reduced finite-type Hopf algebras then upgrades the equality of
+point subgroups to an equality of defining Hopf ideals. Over a general field, maximality is
+checked after base change to an algebraic closure and descended along the faithfully flat
+extension.
+
+The defining Hopf ideal and its split-torus quotient are the ones already attached to the
+diagonal torus in `TauCeti.Algebra.AlgebraicGroup.Symplectic.DiagonalTorus.ClosedImmersion`.
+
+## Main declarations
+
+* `TauCeti.Symplectic.quotientPointsSubgroup_diagonalTorusDefiningIdeal`: the points cut out by
+  the diagonal-torus ideal are the range of the diagonal-torus point morphism.
+* `TauCeti.Symplectic.eq_diagonalTorusDefiningIdeal_of_le_of_isCocomm`: over an algebraically
+  closed field, no larger reduced commutative closed subgroup contains the diagonal torus.
+* `TauCeti.Symplectic.isMaximalTorus_diagonalTorusDefiningIdeal`: **the diagonal torus of `Sp₂ₘ`
+  is a maximal torus**, over every field.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), §17 and §23.
+* J. E. Humphreys, *Linear Algebraic Groups* (1975), §16.1 and §26.3.
+* The Hopf-ideal organization, the point-subgroup comparison and the base-change descent of
+  maximality follow the formal template in
+  `TauCeti.Algebra.AlgebraicGroup.GeneralLinear.DiagonalTorus.Maximal`.
+
+This supplies the maximal torus of the `Sp₂ₘ` worked example asked for by Layer 7, "Borel
+subgroups, maximal tori", of the ReductiveGroups roadmap: together with reductivity of `Sp₂ₘ`, it
+makes the diagonal torus the split maximal torus of a split reductive pair. The root datum of
+type `Cₘ` attached to that pair, and conjugacy of maximal tori, remain separate milestones.
+-/
+
+public section
+
+open CategoryTheory WithConv
+
+namespace TauCeti.Symplectic
+
+universe u
+
+noncomputable section
+
+variable (k : Type u) [Field k] (m : ℕ)
+
+private theorem diagonalTorusDefiningIdeal_eq_ker :
+    diagonalTorusDefiningIdeal k m =
+      HopfIdeal.kerOfSurjective (diagonalTorusCoordinateMap (R := k) (m := m)).hom
+        (diagonalTorusCoordinateMap_surjective (R := k) (m := m)) := by
+  ext x
+  rw [mem_diagonalTorusDefiningIdeal, HopfIdeal.mem_kerOfSurjective]
+
+private theorem mkQuotient_comp_diagonalTorusCoordinateIso_hom_commHopfAlgCat :
+    CommHopfAlgCat.mkQuotient (coordinateHopfAlgebra k m) (diagonalTorusDefiningIdeal k m) ≫
+        ((forget₂ (FiniteTypeCommHopfAlgCat.{u, u} k)
+          (_root_.CommHopfAlgCat.{u} k)).mapIso (diagonalTorusCoordinateIso k m)).hom =
+      diagonalTorusCoordinateMap (R := k) (m := m) := by
+  have h := congrArg
+    (fun f ↦ (forget₂ (FiniteTypeCommHopfAlgCat.{u, u} k)
+      (_root_.CommHopfAlgCat.{u} k)).map f)
+    (mkQuotient_comp_diagonalTorusCoordinateIso_hom k m)
+  rw [Functor.map_comp] at h
+  -- A morphism in an `ObjectProperty.FullSubcategory` is definitionally its underlying
+  -- morphism, so applying the forgetful functor changes only the wrapper. There is no
+  -- propositional rewrite lemma for this reducible coercion.
+  change CommHopfAlgCat.mkQuotient (coordinateHopfAlgebra k m)
+      (diagonalTorusDefiningIdeal k m) ≫
+        ((forget₂ (FiniteTypeCommHopfAlgCat.{u, u} k)
+          (_root_.CommHopfAlgCat.{u} k)).mapIso (diagonalTorusCoordinateIso k m)).hom =
+      diagonalTorusCoordinateMap (R := k) (m := m) at h
+  exact h
+
+/-- The base-change isomorphism of symplectic coordinate Hopf algebras carries the base-changed
+diagonal-torus ideal onto the diagonal-torus ideal over the extended base. -/
+private theorem map_baseChangeHopfIdeal_diagonalTorusDefiningIdeal
+    (K : Type u) [Field K] [Algebra k K] :
+    (CommHopfAlgCat.baseChangeHopfIdeal (K := K) (diagonalTorusDefiningIdeal k m)).map
+        (coordinateHopfAlgebraBaseChangeIso k K m).hom.hom =
+      diagonalTorusDefiningIdeal K m := by
+  let H := coordinateHopfAlgebra k m
+  let D := diagonalTorusDefiningIdeal k m
+  let e := coordinateHopfAlgebraBaseChangeIso k K m
+  let q := (forget₂ (FiniteTypeCommHopfAlgCat.{u, u} k)
+    (_root_.CommHopfAlgCat.{u} k)).mapIso (diagonalTorusCoordinateIso k m)
+  let t := DiagonalizableGroup.baseChangeCoordinateHopfAlgebraIso k K
+    (SplitTorus.characterGroup (ULift.{u} (Fin m)))
+  let r := CommHopfAlgCat.baseChangeMap (K := K) q.hom ≫ t.hom
+  have he : Function.Bijective e.hom.hom := ConcreteCategory.bijective_of_isIso e.hom
+  have hq : CommHopfAlgCat.mkQuotient H D ≫ q.hom =
+      diagonalTorusCoordinateMap (R := k) (m := m) :=
+    mkQuotient_comp_diagonalTorusCoordinateIso_hom_commHopfAlgCat k m
+  have hqK :
+      CommHopfAlgCat.baseChangeMap (K := K) (CommHopfAlgCat.mkQuotient H D) ≫
+          CommHopfAlgCat.baseChangeMap (K := K) q.hom =
+        CommHopfAlgCat.baseChangeMap (K := K)
+          (diagonalTorusCoordinateMap (R := k) (m := m)) := by
+    rw [← (CommHopfAlgCat.baseChangeFunctor (K := K)).map_comp]
+    exact congrArg (CommHopfAlgCat.baseChangeMap (K := K)) hq
+  have hdiag := diagonalTorusCoordinateMap_baseChange (m := m) k K
+  -- The local names `e` and `t` abbreviate exactly the isomorphisms appearing in that statement;
+  -- exposing them is a definitional conversion, with no propositional equality to rewrite.
+  change e.inv ≫
+      CommHopfAlgCat.baseChangeMap (K := K)
+        (diagonalTorusCoordinateMap (R := k) (m := m)) ≫ t.hom =
+    diagonalTorusCoordinateMap (R := K) (m := m) at hdiag
+  have hcomm :
+      CommHopfAlgCat.baseChangeMap (K := K) (CommHopfAlgCat.mkQuotient H D) ≫ r =
+        e.hom ≫ diagonalTorusCoordinateMap (R := K) (m := m) := by
+    dsimp only [r]
+    rw [← Category.assoc, hqK, ← hdiag]
+    simp
+  have hr : Function.Injective r.hom := by
+    dsimp only [r]
+    exact (ConcreteCategory.bijective_of_isIso
+      ((CommHopfAlgCat.baseChangeFunctor (K := K)).mapIso q ≪≫ t).hom).1
+  have hzero (y : CommHopfAlgCat.baseChange (K := K) H) :
+      (CommHopfAlgCat.baseChangeMap (K := K)
+          (CommHopfAlgCat.mkQuotient H D)).hom y = 0 ↔
+        (diagonalTorusCoordinateMap (R := K) (m := m)).hom (e.hom.hom y) = 0 := by
+    have hy := congrArg (fun f ↦ f.hom y) hcomm
+    simp only [_root_.CommHopfAlgCat.hom_comp, BialgHom.comp_apply] at hy
+    rw [← hy]
+    exact ⟨fun hy0 ↦ by rw [hy0, map_zero], fun hy0 ↦ hr (by simpa using hy0)⟩
+  ext x
+  rw [HopfIdeal.mem_map_iff_of_surjective he.2, mem_diagonalTorusDefiningIdeal]
+  constructor
+  · rintro ⟨y, hy, rfl⟩
+    exact (hzero y).mp ((CommHopfAlgCat.mem_baseChangeHopfIdeal_iff D y).mp hy)
+  · intro hx
+    refine ⟨e.inv.hom x, ?_, _root_.CommHopfAlgCat.hom_inv_apply e x⟩
+    rw [CommHopfAlgCat.mem_baseChangeHopfIdeal_iff]
+    apply (hzero _).mpr
+    rwa [_root_.CommHopfAlgCat.hom_inv_apply]
+
+/-- The points cut out by `diagonalTorusDefiningIdeal` are exactly the diagonal-torus points. -/
+theorem quotientPointsSubgroup_diagonalTorusDefiningIdeal (A : CommAlgCat.{u} k) :
+    CommHopfAlgCat.quotientPointsSubgroup (coordinateHopfAlgebra k m)
+        (diagonalTorusDefiningIdeal k m) A =
+      ((CommHopfAlgCat.mapPointsFunctor
+        (diagonalTorusCoordinateMap (R := k) (m := m))).app A).hom.range := by
+  rw [diagonalTorusDefiningIdeal_eq_ker,
+    HopfIdeal.quotientPointsSubgroup_kerOfSurjective_eq_range]
+  apply congrArg MonoidHom.range
+  apply MonoidHom.ext
+  intro q
+  rw [AlgHom.mapDomain_apply]
+  exact (CommHopfAlgCat.mapPointsFunctor_app_apply
+    (diagonalTorusCoordinateMap (R := k) (m := m)) A q).symm
+
+private theorem isReduced_quotient_diagonalTorusDefiningIdeal :
+    IsReduced (CommHopfAlgCat.quotient (coordinateHopfAlgebra k m)
+      (diagonalTorusDefiningIdeal k m)) := by
+  rw [diagonalTorusDefiningIdeal_eq_ker]
+  let f := (diagonalTorusCoordinateMap (R := k) (m := m)).hom
+  let hf : Function.Surjective f := diagonalTorusCoordinateMap_surjective (R := k) (m := m)
+  let e := HopfIdeal.kerLiftBialgEquiv f hf
+  exact isReduced_of_injective e.toAlgEquiv.toRingEquiv.toRingHom e.injective
+
+/-- A rational point of the split torus, read through the symplectic point equivalence, is the
+paired diagonal matrix of its coordinates. -/
+private theorem pointsMulEquiv_diagonalTorusPoints_symm (t : Fin m → kˣ) :
+    pointsMulEquiv (R := k) (A := k) m
+        (diagonalTorusPoints
+          ((SplitTorus.pointsMulEquiv (R := k) (A := k)).symm
+            (fun i : ULift.{u} (Fin m) ↦ t i.down))) =
+      GLSymplecticFin.diagonal t := by
+  rw [pointsMulEquiv_diagonalTorusPoints]
+  congr 1
+  funext i
+  rw [GeneralLinear.diagonalTorusCoordinates_apply]
+  exact congrFun
+    ((SplitTorus.pointsMulEquiv (R := k) (A := k)).apply_symm_apply
+      (fun j : ULift.{u} (Fin m) ↦ t j.down)) (ULift.up i)
+
+variable [IsAlgClosed k]
+
+/-- **The diagonal torus of `Sp₂ₘ` is maximal among reduced commutative closed subgroup schemes
+over an algebraically closed field.**
+
+If `I` cuts out a reduced commutative closed subgroup containing the diagonal torus, then `I` is
+the diagonal-torus defining ideal. Containment is written contravariantly as
+`I ≤ diagonalTorusDefiningIdeal k m`; commutativity is the cocommutativity of the quotient
+coordinate Hopf algebra. -/
+theorem eq_diagonalTorusDefiningIdeal_of_le_of_isCocomm
+    (I : HopfIdeal k (coordinateHopfAlgebra k m))
+    [IsReduced (CommHopfAlgCat.quotient (coordinateHopfAlgebra k m) I)]
+    [Coalgebra.IsCocomm k (CommHopfAlgCat.quotient (coordinateHopfAlgebra k m) I)]
+    (hI : I ≤ diagonalTorusDefiningIdeal k m) :
+    I = diagonalTorusDefiningIdeal k m := by
+  let H := coordinateHopfAlgebra k m
+  let D := diagonalTorusDefiningIdeal k m
+  let A := CommAlgCat.of k k
+  let GI := CommHopfAlgCat.quotientPointsSubgroup H I A
+  let GD := CommHopfAlgCat.quotientPointsSubgroup H D A
+  let e := pointsMulEquiv (R := k) (A := k) m
+  let P : Subgroup (GLSymplecticFin m k) := GI.map e.toMonoidHom
+  let _ : IsMulCommutative GI :=
+    CommHopfAlgCat.instIsMulCommutativeQuotientPointsSubgroup
+      (coordinateHopfAlgebra k m) I (CommAlgCat.of k k)
+  let _ : IsMulCommutative P := Subgroup.map_isMulCommutative GI e.toMonoidHom
+  have hDG : GD ≤ GI :=
+    CommHopfAlgCat.quotientPointsSubgroup_le_of_le H hI A
+  have hdiagonalP : GLSymplecticFin.diagonalTorus k m ≤ P := by
+    intro g hg
+    obtain ⟨t, rfl⟩ := GLSymplecticFin.mem_diagonalTorus_iff_exists_diagonal.mp hg
+    let s : ULift.{u} (Fin m) → kˣ := fun i ↦ t i.down
+    let q : WithConv
+        (MonoidAlgebra k (Multiplicative (ULift.{u} (Fin m) →₀ ℤ)) →ₐ[k] k) :=
+      (SplitTorus.pointsMulEquiv (R := k) (A := k)).symm s
+    let d := diagonalTorusPoints (R := k) (m := m) (A := k) q
+    have hdD : d ∈ GD := by
+      dsimp only [GD, D]
+      rw [quotientPointsSubgroup_diagonalTorusDefiningIdeal]
+      exact ⟨q, mapPointsFunctor_diagonalTorusCoordinateMap_app A q⟩
+    refine ⟨d, hDG hdD, ?_⟩
+    -- Unfold the `e.toMonoidHom` coercion introduced by `Subgroup.map` to the coercion of `e`.
+    change e d = GLSymplecticFin.diagonal t
+    simpa only [e, d, q, s] using pointsMulEquiv_diagonalTorusPoints_symm k m t
+  have hP : P = GLSymplecticFin.diagonalTorus k m :=
+    GLSymplecticFin.eq_diagonalTorus_of_le_of_isMulCommutative_of_infinite P hdiagonalP
+  have hpoints : GI = GD := by
+    refine le_antisymm (fun g hg ↦ ?_) hDG
+    have hegD : e g ∈ GLSymplecticFin.diagonalTorus k m := hP ▸ ⟨g, hg, rfl⟩
+    obtain ⟨t, ht⟩ := GLSymplecticFin.mem_diagonalTorus_iff_exists_diagonal.mp hegD
+    let s : ULift.{u} (Fin m) → kˣ := fun i ↦ t i.down
+    let q : WithConv
+        (MonoidAlgebra k (Multiplicative (ULift.{u} (Fin m) →₀ ℤ)) →ₐ[k] k) :=
+      (SplitTorus.pointsMulEquiv (R := k) (A := k)).symm s
+    have hdiag : e (diagonalTorusPoints (R := k) (m := m) (A := k) q) =
+        GLSymplecticFin.diagonal t := by
+      simpa only [e, q, s] using pointsMulEquiv_diagonalTorusPoints_symm k m t
+    dsimp only [GD, D]
+    rw [quotientPointsSubgroup_diagonalTorusDefiningIdeal]
+    refine ⟨q, e.injective ?_⟩
+    rw [mapPointsFunctor_diagonalTorusCoordinateMap_app]
+    exact hdiag.trans ht
+  let _ : IsReduced (CommHopfAlgCat.quotient H D) :=
+    isReduced_quotient_diagonalTorusDefiningIdeal k m
+  exact HopfIdeal.eq_of_quotientPointsSubgroup_eq hpoints
+
+/-- The diagonal torus of `Sp₂ₘ` is a maximal torus over an algebraically closed field. This
+packages the stronger statement above into the general Hopf-ideal maximal-torus predicate. -/
+private theorem isMaximalTorus_diagonalTorusDefiningIdeal_of_isAlgClosed :
+    HopfIdeal.IsMaximalTorus k (coordinateHopfAlgebra k m)
+      (diagonalTorusDefiningIdeal k m) := by
+  rw [HopfIdeal.isMaximalTorus_iff]
+  refine ⟨torusCommHopfAlgProperty_quotient_diagonalTorusDefiningIdeal k m, ?_⟩
+  intro I hI hID
+  let _ : IsReduced (CommHopfAlgCat.quotient (coordinateHopfAlgebra k m) I) :=
+    hI.geometricallyReduced.isReduced
+  let _ : Coalgebra.IsCocomm k (CommHopfAlgCat.quotient (coordinateHopfAlgebra k m) I) :=
+    hI.isCocomm k _
+  have hEq := eq_diagonalTorusDefiningIdeal_of_le_of_isCocomm k m I hID
+  subst I
+  exact le_rfl
+
+omit [IsAlgClosed k] in
+/-- **The diagonal torus of `Sp₂ₘ` is a maximal torus over every field.** Maximality is checked
+after base change to an algebraic closure, where the stronger pointwise maximality theorem
+applies, and then descended using faithful flatness. -/
+@[grind =>]
+theorem isMaximalTorus_diagonalTorusDefiningIdeal :
+    HopfIdeal.IsMaximalTorus k (coordinateHopfAlgebra k m)
+      (diagonalTorusDefiningIdeal k m) := by
+  rw [HopfIdeal.isMaximalTorus_iff]
+  refine ⟨torusCommHopfAlgProperty_quotient_diagonalTorusDefiningIdeal k m, ?_⟩
+  intro I hI hID
+  let K := AlgebraicClosure k
+  let H := coordinateHopfAlgebra k m
+  let HK := coordinateHopfAlgebra K m
+  let Hft : FiniteTypeCommHopfAlgCat k :=
+    ⟨H, (finiteTypeCommHopfAlgProperty_iff _).2 inferInstance⟩
+  let HKft : FiniteTypeCommHopfAlgCat K :=
+    ⟨HK, (finiteTypeCommHopfAlgProperty_iff _).2 inferInstance⟩
+  let e := coordinateHopfAlgebraBaseChangeIso k K m
+  let IK := (CommHopfAlgCat.baseChangeHopfIdeal (K := K) I).map e.hom.hom
+  have hmapI :
+      (CommHopfAlgCat.baseChangeHopfIdeal (K := K) I).map e.hom.hom = IK := rfl
+  let qIso : FiniteTypeCommHopfAlgCat.baseChange (K := K)
+        (FiniteTypeCommHopfAlgCat.quotient Hft I) ≅
+      FiniteTypeCommHopfAlgCat.quotient HKft IK :=
+    ObjectProperty.isoMk _
+      (CommHopfAlgCat.quotientBaseChangeIsoOfMapEq I IK e hmapI)
+  have hsplit : splitTorusCommHopfAlgProperty K
+      (FiniteTypeCommHopfAlgCat.baseChange (K := K)
+        (FiniteTypeCommHopfAlgCat.quotient Hft I)) := by
+    rw [splitTorusCommHopfAlgProperty_iff]
+    rw [torusCommHopfAlgProperty_iff] at hI
+    simpa only [Hft] using hI
+  have hIK : torusCommHopfAlgProperty K
+      (FiniteTypeCommHopfAlgCat.quotient HKft IK) :=
+    ((splitTorusCommHopfAlgProperty K).prop_of_iso qIso hsplit).torus K _
+  have hIKD : IK ≤ diagonalTorusDefiningIdeal K m := by
+    rw [← map_baseChangeHopfIdeal_diagonalTorusDefiningIdeal k m K]
+    exact HopfIdeal.map_mono e.hom.hom (CommHopfAlgCat.baseChangeHopfIdeal_mono hID)
+  have hmaxK := isMaximalTorus_diagonalTorusDefiningIdeal_of_isAlgClosed K m
+  rw [HopfIdeal.isMaximalTorus_iff] at hmaxK
+  have hDIK : diagonalTorusDefiningIdeal K m ≤ IK := hmaxK.2 IK hIK hIKD
+  have he : Function.Bijective e.hom.hom := ConcreteCategory.bijective_of_isIso e.hom
+  have hbase :
+      CommHopfAlgCat.baseChangeHopfIdeal (K := K) (diagonalTorusDefiningIdeal k m) ≤
+        CommHopfAlgCat.baseChangeHopfIdeal (K := K) I := by
+    have hcomap := HopfIdeal.comapOfSurjective_mono e.hom.hom he.2 hDIK
+    rw [← map_baseChangeHopfIdeal_diagonalTorusDefiningIdeal k m K,
+      HopfIdeal.comapOfSurjective_map_of_bijective _ _ he,
+      HopfIdeal.comapOfSurjective_map_of_bijective _ _ he] at hcomap
+    exact hcomap
+  exact (CommHopfAlgCat.baseChangeHopfIdeal_le_iff
+    (algebraMap k K).injective).mp hbase
+
+end
+
+end TauCeti.Symplectic

--- a/TauCeti/Algebra/AlgebraicGroup/Symplectic/DiagonalTorus/Maximal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Symplectic/DiagonalTorus/Maximal.lean
@@ -8,7 +8,6 @@ module
 public import TauCeti.Algebra.AlgebraicGroup.Hopf.KernelPoints
 public import TauCeti.Algebra.AlgebraicGroup.Symplectic.DiagonalTorus.ClosedImmersion
 public import TauCeti.Algebra.AlgebraicGroup.Torus.Maximal
-import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.BaseChange
 import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Points.Separation
 import TauCeti.Algebra.AlgebraicGroup.Torus.SmoothConnected
 import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Symplectic.Diagonal.Centralizer

--- a/TauCeti/Algebra/AlgebraicGroup/Symplectic/DiagonalTorus/Maximal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Symplectic/DiagonalTorus/Maximal.lean
@@ -67,6 +67,7 @@ private theorem diagonalTorusDefiningIdeal_eq_ker :
   rw [mem_diagonalTorusDefiningIdeal, HopfIdeal.mem_kerOfSurjective]
 
 /-- The points cut out by `diagonalTorusDefiningIdeal` are exactly the diagonal-torus points. -/
+@[simp]
 theorem quotientPointsSubgroup_diagonalTorusDefiningIdeal (A : CommAlgCat.{u} R) :
     CommHopfAlgCat.quotientPointsSubgroup (coordinateHopfAlgebra R m)
         (diagonalTorusDefiningIdeal R m) A =

--- a/TauCeti/Algebra/AlgebraicGroup/Symplectic/DiagonalTorus/Maximal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Symplectic/DiagonalTorus/Maximal.lean
@@ -38,9 +38,7 @@ diagonal torus in `TauCeti.Algebra.AlgebraicGroup.Symplectic.DiagonalTorus.Close
 * J. E. Humphreys, *Linear Algebraic Groups* (1975), §16.1 and §26.3.
 * The Hopf-ideal organization and the point-subgroup comparison follow the formal template in
   `TauCeti.Algebra.AlgebraicGroup.GeneralLinear.DiagonalTorus.Maximal`, with which this module
-  shares the base-change transport lemma
-  `TauCeti.CommHopfAlgCat.map_baseChangeHopfIdeal_of_quotientIso` and the maximality descent
-  lemma `TauCeti.HopfIdeal.isMaximalTorus_of_baseChange`.
+  shares the maximality descent lemma `TauCeti.HopfIdeal.isMaximalTorus_of_baseChange`.
 * The matrix centralizer input is
   `TauCeti.GLSymplecticFin.centralizer_diagonalTorus`.
 -/
@@ -59,6 +57,8 @@ section CommRing
 
 variable (R : Type u) [CommRing R] (m : ℕ)
 
+-- The body of `diagonalTorusDefiningIdeal` is not exposed outside its defining module, so the
+-- kernel presentation it is given there is recovered here from the public membership lemma.
 private theorem diagonalTorusDefiningIdeal_eq_ker :
     diagonalTorusDefiningIdeal R m =
       HopfIdeal.kerOfSurjective (diagonalTorusCoordinateMap (R := R) (m := m)).hom
@@ -84,44 +84,6 @@ theorem quotientPointsSubgroup_diagonalTorusDefiningIdeal (A : CommAlgCat.{u} R)
 end CommRing
 
 variable (k : Type u) [Field k] (m : ℕ)
-
-private theorem mkQuotient_comp_diagonalTorusCoordinateIso_hom_commHopfAlgCat :
-    CommHopfAlgCat.mkQuotient (coordinateHopfAlgebra k m) (diagonalTorusDefiningIdeal k m) ≫
-        ((forget₂ (FiniteTypeCommHopfAlgCat.{u, u} k)
-          (_root_.CommHopfAlgCat.{u} k)).mapIso (diagonalTorusCoordinateIso k m)).hom =
-      diagonalTorusCoordinateMap (R := k) (m := m) := by
-  have h := congrArg
-    (fun f ↦ (forget₂ (FiniteTypeCommHopfAlgCat.{u, u} k)
-      (_root_.CommHopfAlgCat.{u} k)).map f)
-    (mkQuotient_comp_diagonalTorusCoordinateIso_hom k m)
-  rw [Functor.map_comp] at h
-  -- A morphism in an `ObjectProperty.FullSubcategory` is definitionally its underlying
-  -- morphism, so applying the forgetful functor changes only the wrapper. There is no
-  -- propositional rewrite lemma for this reducible coercion.
-  change CommHopfAlgCat.mkQuotient (coordinateHopfAlgebra k m)
-      (diagonalTorusDefiningIdeal k m) ≫
-        ((forget₂ (FiniteTypeCommHopfAlgCat.{u, u} k)
-          (_root_.CommHopfAlgCat.{u} k)).mapIso (diagonalTorusCoordinateIso k m)).hom =
-      diagonalTorusCoordinateMap (R := k) (m := m) at h
-  exact h
-
-/-- The base-change isomorphism of symplectic coordinate Hopf algebras carries the base-changed
-diagonal-torus ideal onto the diagonal-torus ideal over the extended base. -/
-private theorem map_baseChangeHopfIdeal_diagonalTorusDefiningIdeal
-    (K : Type u) [Field K] [Algebra k K] :
-    (CommHopfAlgCat.baseChangeHopfIdeal (K := K) (diagonalTorusDefiningIdeal k m)).map
-        (coordinateHopfAlgebraBaseChangeIso k K m).hom.hom =
-      diagonalTorusDefiningIdeal K m :=
-  CommHopfAlgCat.map_baseChangeHopfIdeal_of_quotientIso
-    (diagonalTorusDefiningIdeal k m) (diagonalTorusDefiningIdeal K m)
-    (coordinateHopfAlgebraBaseChangeIso k K m)
-    (DiagonalizableGroup.baseChangeCoordinateHopfAlgebraIso k K
-      (SplitTorus.characterGroup (ULift.{u} (Fin m))))
-    ((forget₂ (FiniteTypeCommHopfAlgCat.{u, u} k)
-      (_root_.CommHopfAlgCat.{u} k)).mapIso (diagonalTorusCoordinateIso k m))
-    (mkQuotient_comp_diagonalTorusCoordinateIso_hom_commHopfAlgCat k m)
-    (diagonalTorusCoordinateMap_baseChange (m := m) k K)
-    (fun x ↦ mem_diagonalTorusDefiningIdeal K m x)
 
 private theorem isReduced_quotient_diagonalTorusDefiningIdeal :
     IsReduced (CommHopfAlgCat.quotient (coordinateHopfAlgebra k m)

--- a/TauCeti/Algebra/AlgebraicGroup/Symplectic/DiagonalTorus/Maximal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Symplectic/DiagonalTorus/Maximal.lean
@@ -6,12 +6,12 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.Hopf.KernelPoints
-public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Points.Separation
 public import TauCeti.Algebra.AlgebraicGroup.Symplectic.DiagonalTorus.ClosedImmersion
 public import TauCeti.Algebra.AlgebraicGroup.Torus.Maximal
-public import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Symplectic.Diagonal.Centralizer
 import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.BaseChange
+import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Points.Separation
 import TauCeti.Algebra.AlgebraicGroup.Torus.SmoothConnected
+import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Symplectic.Diagonal.Centralizer
 
 /-!
 # Maximality of the diagonal torus in the symplectic group
@@ -20,15 +20,6 @@ Over any field, the paired diagonal torus of `Sp₂ₘ` is a maximal torus. Over
 closed field it is more: no reduced commutative closed subgroup scheme properly contains it. That
 is stronger than maximality among tori, because a competing subgroup here need not be a torus, or
 even connected.
-
-The proof compares points over an algebraic closure. A reduced commutative closed subgroup
-containing the diagonal torus gives a commutative subgroup of `Sp₂ₘ(k)` containing every paired
-diagonal matrix, and the matrix centralizer calculation of
-`TauCeti.GLSymplecticFin.centralizer_diagonalTorus` says that such a subgroup is the diagonal
-torus itself. Point separation for reduced finite-type Hopf algebras then upgrades the equality of
-point subgroups to an equality of defining Hopf ideals. Over a general field, maximality is
-checked after base change to an algebraic closure and descended along the faithfully flat
-extension.
 
 The defining Hopf ideal and its split-torus quotient are the ones already attached to the
 diagonal torus in `TauCeti.Algebra.AlgebraicGroup.Symplectic.DiagonalTorus.ClosedImmersion`.
@@ -49,11 +40,8 @@ diagonal torus in `TauCeti.Algebra.AlgebraicGroup.Symplectic.DiagonalTorus.Close
 * The Hopf-ideal organization, the point-subgroup comparison and the base-change descent of
   maximality follow the formal template in
   `TauCeti.Algebra.AlgebraicGroup.GeneralLinear.DiagonalTorus.Maximal`.
-
-This supplies the maximal torus of the `Sp₂ₘ` worked example asked for by Layer 7, "Borel
-subgroups, maximal tori", of the ReductiveGroups roadmap: together with reductivity of `Sp₂ₘ`, it
-makes the diagonal torus the split maximal torus of a split reductive pair. The root datum of
-type `Cₘ` attached to that pair, and conjugacy of maximal tori, remain separate milestones.
+* The matrix centralizer input is
+  `TauCeti.GLSymplecticFin.centralizer_diagonalTorus`.
 -/
 
 public section
@@ -66,14 +54,35 @@ universe u
 
 noncomputable section
 
-variable (k : Type u) [Field k] (m : ℕ)
+section CommRing
+
+variable (R : Type u) [CommRing R] (m : ℕ)
 
 private theorem diagonalTorusDefiningIdeal_eq_ker :
-    diagonalTorusDefiningIdeal k m =
-      HopfIdeal.kerOfSurjective (diagonalTorusCoordinateMap (R := k) (m := m)).hom
-        (diagonalTorusCoordinateMap_surjective (R := k) (m := m)) := by
+    diagonalTorusDefiningIdeal R m =
+      HopfIdeal.kerOfSurjective (diagonalTorusCoordinateMap (R := R) (m := m)).hom
+        (diagonalTorusCoordinateMap_surjective (R := R) (m := m)) := by
   ext x
   rw [mem_diagonalTorusDefiningIdeal, HopfIdeal.mem_kerOfSurjective]
+
+/-- The points cut out by `diagonalTorusDefiningIdeal` are exactly the diagonal-torus points. -/
+theorem quotientPointsSubgroup_diagonalTorusDefiningIdeal (A : CommAlgCat.{u} R) :
+    CommHopfAlgCat.quotientPointsSubgroup (coordinateHopfAlgebra R m)
+        (diagonalTorusDefiningIdeal R m) A =
+      ((CommHopfAlgCat.mapPointsFunctor
+        (diagonalTorusCoordinateMap (R := R) (m := m))).app A).hom.range := by
+  rw [diagonalTorusDefiningIdeal_eq_ker,
+    HopfIdeal.quotientPointsSubgroup_kerOfSurjective_eq_range]
+  apply congrArg MonoidHom.range
+  apply MonoidHom.ext
+  intro q
+  rw [AlgHom.mapDomain_apply]
+  exact (CommHopfAlgCat.mapPointsFunctor_app_apply
+    (diagonalTorusCoordinateMap (R := R) (m := m)) A q).symm
+
+end CommRing
+
+variable (k : Type u) [Field k] (m : ℕ)
 
 private theorem mkQuotient_comp_diagonalTorusCoordinateIso_hom_commHopfAlgCat :
     CommHopfAlgCat.mkQuotient (coordinateHopfAlgebra k m) (diagonalTorusDefiningIdeal k m) ≫
@@ -156,21 +165,6 @@ private theorem map_baseChangeHopfIdeal_diagonalTorusDefiningIdeal
     rw [CommHopfAlgCat.mem_baseChangeHopfIdeal_iff]
     apply (hzero _).mpr
     rwa [_root_.CommHopfAlgCat.hom_inv_apply]
-
-/-- The points cut out by `diagonalTorusDefiningIdeal` are exactly the diagonal-torus points. -/
-theorem quotientPointsSubgroup_diagonalTorusDefiningIdeal (A : CommAlgCat.{u} k) :
-    CommHopfAlgCat.quotientPointsSubgroup (coordinateHopfAlgebra k m)
-        (diagonalTorusDefiningIdeal k m) A =
-      ((CommHopfAlgCat.mapPointsFunctor
-        (diagonalTorusCoordinateMap (R := k) (m := m))).app A).hom.range := by
-  rw [diagonalTorusDefiningIdeal_eq_ker,
-    HopfIdeal.quotientPointsSubgroup_kerOfSurjective_eq_range]
-  apply congrArg MonoidHom.range
-  apply MonoidHom.ext
-  intro q
-  rw [AlgHom.mapDomain_apply]
-  exact (CommHopfAlgCat.mapPointsFunctor_app_apply
-    (diagonalTorusCoordinateMap (R := k) (m := m)) A q).symm
 
 private theorem isReduced_quotient_diagonalTorusDefiningIdeal :
     IsReduced (CommHopfAlgCat.quotient (coordinateHopfAlgebra k m)
@@ -263,8 +257,7 @@ theorem eq_diagonalTorusDefiningIdeal_of_le_of_isCocomm
     isReduced_quotient_diagonalTorusDefiningIdeal k m
   exact HopfIdeal.eq_of_quotientPointsSubgroup_eq hpoints
 
-/-- The diagonal torus of `Sp₂ₘ` is a maximal torus over an algebraically closed field. This
-packages the stronger statement above into the general Hopf-ideal maximal-torus predicate. -/
+/-- The diagonal torus of `Sp₂ₘ` is a maximal torus over an algebraically closed field. -/
 private theorem isMaximalTorus_diagonalTorusDefiningIdeal_of_isAlgClosed :
     HopfIdeal.IsMaximalTorus k (coordinateHopfAlgebra k m)
       (diagonalTorusDefiningIdeal k m) := by
@@ -280,13 +273,13 @@ private theorem isMaximalTorus_diagonalTorusDefiningIdeal_of_isAlgClosed :
   exact le_rfl
 
 omit [IsAlgClosed k] in
-/-- **The diagonal torus of `Sp₂ₘ` is a maximal torus over every field.** Maximality is checked
-after base change to an algebraic closure, where the stronger pointwise maximality theorem
-applies, and then descended using faithful flatness. -/
+/-- **The diagonal torus of `Sp₂ₘ` is a maximal torus over every field.** -/
 @[grind =>]
 theorem isMaximalTorus_diagonalTorusDefiningIdeal :
     HopfIdeal.IsMaximalTorus k (coordinateHopfAlgebra k m)
       (diagonalTorusDefiningIdeal k m) := by
+  -- Maximality is checked after base change to an algebraic closure, where the stronger
+  -- pointwise maximality theorem applies, and descended along the faithfully flat extension.
   rw [HopfIdeal.isMaximalTorus_iff]
   refine ⟨torusCommHopfAlgProperty_quotient_diagonalTorusDefiningIdeal k m, ?_⟩
   intro I hI hID

--- a/TauCeti/Algebra/AlgebraicGroup/Torus/Maximal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Torus/Maximal.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.BaseChange
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Basic
 public import TauCeti.Algebra.AlgebraicGroup.Torus.Basic
 
@@ -19,6 +20,8 @@ then `I = J`.
 ## Main declarations
 
 * `TauCeti.HopfIdeal.IsMaximalTorus`: maximality among torus Hopf ideals.
+* `TauCeti.HopfIdeal.isMaximalTorus_of_baseChange`: maximality descends from an algebraic
+  closure along a base-change isomorphism of the ambient coordinate Hopf algebra.
 
 ## References
 
@@ -120,6 +123,63 @@ theorem comapOfIso_iff (e : H ≅ K) (I : HopfIdeal k K.obj) :
   · exact fun hI ↦ hI.comapOfIso e
 
 end IsMaximalTorus
+
+/-- **Maximality of a torus descends from an algebraic closure.** If `I` cuts out a torus over
+`k` and its base change, transported along an isomorphism `e` of the base-changed ambient
+coordinate Hopf algebra, is a maximal torus over the algebraic closure, then `I` is a maximal
+torus over `k`. -/
+theorem isMaximalTorus_of_baseChange {k : Type u} [Field k]
+    {H : _root_.CommHopfAlgCat.{u} k} [Algebra.FiniteType k H]
+    {H' : _root_.CommHopfAlgCat.{u} (AlgebraicClosure k)}
+    [Algebra.FiniteType (AlgebraicClosure k) H']
+    (I : HopfIdeal k H) (I' : HopfIdeal (AlgebraicClosure k) H')
+    (e : CommHopfAlgCat.baseChange (K := AlgebraicClosure k) H ≅ H')
+    (hI : torusCommHopfAlgProperty k
+      (FiniteTypeCommHopfAlgCat.quotient
+        ⟨H, (finiteTypeCommHopfAlgProperty_iff H).2 inferInstance⟩ I))
+    (hmap : (CommHopfAlgCat.baseChangeHopfIdeal (K := AlgebraicClosure k) I).map e.hom.hom = I')
+    (hmax : IsMaximalTorus (AlgebraicClosure k) H' I') :
+    IsMaximalTorus k H I := by
+  -- A competing torus is base-changed, compared over the algebraic closure, and the resulting
+  -- containment is descended along the faithfully flat extension `k → AlgebraicClosure k`.
+  rw [isMaximalTorus_iff]
+  refine ⟨hI, ?_⟩
+  intro J hJ hJI
+  let K := AlgebraicClosure k
+  let Hft : FiniteTypeCommHopfAlgCat k :=
+    ⟨H, (finiteTypeCommHopfAlgProperty_iff H).2 inferInstance⟩
+  let H'ft : FiniteTypeCommHopfAlgCat K :=
+    ⟨H', (finiteTypeCommHopfAlgProperty_iff H').2 inferInstance⟩
+  let JK := (CommHopfAlgCat.baseChangeHopfIdeal (K := K) J).map e.hom.hom
+  have hmapJ : (CommHopfAlgCat.baseChangeHopfIdeal (K := K) J).map e.hom.hom = JK := rfl
+  let qIso : FiniteTypeCommHopfAlgCat.baseChange (K := K)
+        (FiniteTypeCommHopfAlgCat.quotient Hft J) ≅
+      FiniteTypeCommHopfAlgCat.quotient H'ft JK :=
+    ObjectProperty.isoMk _
+      (CommHopfAlgCat.quotientBaseChangeIsoOfMapEq J JK e hmapJ)
+  have hsplit : splitTorusCommHopfAlgProperty K
+      (FiniteTypeCommHopfAlgCat.baseChange (K := K)
+        (FiniteTypeCommHopfAlgCat.quotient Hft J)) := by
+    rw [splitTorusCommHopfAlgProperty_iff]
+    rw [torusCommHopfAlgProperty_iff] at hJ
+    simpa only [Hft] using hJ
+  have hJK : torusCommHopfAlgProperty K
+      (FiniteTypeCommHopfAlgCat.quotient H'ft JK) :=
+    ((splitTorusCommHopfAlgProperty K).prop_of_iso qIso hsplit).torus K _
+  have hJKI : JK ≤ I' := by
+    rw [← hmap]
+    exact HopfIdeal.map_mono e.hom.hom (CommHopfAlgCat.baseChangeHopfIdeal_mono hJI)
+  rw [isMaximalTorus_iff] at hmax
+  have hIJK : I' ≤ JK := hmax.2 JK hJK hJKI
+  have he : Function.Bijective e.hom.hom := ConcreteCategory.bijective_of_isIso e.hom
+  have hbase :
+      CommHopfAlgCat.baseChangeHopfIdeal (K := K) I ≤
+        CommHopfAlgCat.baseChangeHopfIdeal (K := K) J := by
+    have hcomap := HopfIdeal.comapOfSurjective_mono e.hom.hom he.2 hIJK
+    rw [← hmap, HopfIdeal.comapOfSurjective_map_of_bijective _ _ he,
+      HopfIdeal.comapOfSurjective_map_of_bijective _ _ he] at hcomap
+    exact hcomap
+  exact (CommHopfAlgCat.baseChangeHopfIdeal_le_iff (algebraMap k K).injective).mp hbase
 
 end HopfIdeal
 

--- a/TauCeti/Algebra/AlgebraicGroup/Torus/Maximal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Torus/Maximal.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.BaseChange
-public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Basic
 public import TauCeti.Algebra.AlgebraicGroup.Torus.Basic
 
 /-!


### PR DESCRIPTION
This PR proves that the paired diagonal torus of `Sp₂ₘ` is a maximal torus, over every field, and that over an algebraically closed field no reduced commutative closed subgroup scheme properly contains it. It advances Layer 7 of `TauCetiRoadmap/ReductiveGroups/README.md`, "Borel subgroups, maximal tori, and their conjugacy", on the `Sp₂ₙ` entry of that roadmap's "Worked examples" list; together with the already-merged reductivity of `Sp₂ₘ` it makes the diagonal torus the split maximal torus of a split reductive pair, which is what the Layer 7 root datum `(X*(T), Φ, X_*(T), Φ^∨)` and the Layer 9 pinning are both stated against. After this PR the `Cₘ` milestone still needs the adjoint weight decomposition of the Lie algebra of `Sp₂ₘ` under this torus and the root datum read off it.

The new module is `TauCeti/Algebra/AlgebraicGroup/Symplectic/DiagonalTorus/Maximal.lean` (338 lines). Its main result is `TauCeti.Symplectic.isMaximalTorus_diagonalTorusDefiningIdeal`, and the sharper algebraically closed statement is `TauCeti.Symplectic.eq_diagonalTorusDefiningIdeal_of_le_of_isCocomm`: if a Hopf ideal `I` with reduced cocommutative quotient satisfies `I ≤ diagonalTorusDefiningIdeal k m`, then it is equal to it. That is stronger than maximality among tori, since the competing closed subgroup need not be a torus, or even connected. Along the way the points cut out by the diagonal-torus ideal are identified with the range of the diagonal-torus point morphism.

The proof compares points over an algebraic closure. A reduced commutative closed subgroup containing the diagonal torus gives a commutative subgroup of `Sp₂ₘ(k)` containing every paired diagonal matrix; the matrix centralizer calculation `TauCeti.GLSymplecticFin.centralizer_diagonalTorus`, merged in TauCetiProject/TauCeti#6204 for exactly this purpose, says that such a subgroup is the diagonal torus itself. Point separation for reduced finite-type Hopf algebras upgrades that equality of point subgroups to an equality of defining Hopf ideals, and over a general field maximality is checked after base change to an algebraic closure and descended along the faithfully flat extension. The Hopf ideal, its split-torus quotient isomorphism and the split-torus and torus properties of that quotient are not rebuilt here: they are the ones already attached to the diagonal torus in `Symplectic/DiagonalTorus/ClosedImmersion.lean`, and only the base-change transport of that ideal is new. No Mathlib infrastructure was vendored. The Hopf-ideal organization, the point-subgroup comparison and the base-change descent of maximality follow the formal template of `GeneralLinear/DiagonalTorus/Maximal.lean`, which is credited in the module's references.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"symplectic-diagonal-torus-maximal-torus"}-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Prepared with Claude Code
