### PR TITLE
feat: define regular toric cones and regular fans

### DIFF
--- a/TauCeti/Algebra/Module/Primitive.lean
+++ b/TauCeti/Algebra/Module/Primitive.lean
@@ -86,8 +86,7 @@ namespace Module.Basis
 
 variable {ι M : Type*} [AddCommGroup M] [Module ℤ M]
 
-/-- A vector of an integral basis is primitive: its own coordinate functional takes the value one
-on it. -/
+/-- A vector of an integral basis is primitive. -/
 theorem isPrimitive (b : Module.Basis ι ℤ M) (j : ι) : TauCeti.IsPrimitive (b j) :=
   TauCeti.isPrimitive_def.2 ⟨b.coord j, by simp⟩
 
@@ -168,9 +167,7 @@ theorem exists_eq_zsmul_isPrimitive [Module.Free ℤ M] {v : M}
     Finsupp.ofSupportFinite_coe, smul_eq_mul]
   simpa only [mul_comm] using (hqgcd.symm.trans ha).symm
 
-/-- A primitive vector of a finite free integer module belongs to an integral basis of it. The
-complementary basis vectors are a basis of the kernel of a functional taking the value one on the
-given vector, which splits off a copy of `ℤ`. -/
+/-- A primitive vector of a finite free integer module belongs to an integral basis of it. -/
 theorem IsPrimitive.exists_basis [Module.Free ℤ M] [Module.Finite ℤ M] {v : M}
     (hv : IsPrimitive v) :
     ∃ (n : ℕ) (b : Module.Basis (Fin n) ℤ M) (j : Fin n), b j = v := by

--- a/TauCeti/Algebra/Module/Primitive.lean
+++ b/TauCeti/Algebra/Module/Primitive.lean
@@ -5,7 +5,10 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import Mathlib.LinearAlgebra.Basis.Fin
+public import Mathlib.LinearAlgebra.Dimension.Free
 public import Mathlib.LinearAlgebra.FreeModule.Basic
+public import Mathlib.LinearAlgebra.FreeModule.PID
 public import Mathlib.RingTheory.Int.Basic
 
 /-!
@@ -29,6 +32,9 @@ rational ray is initially described by arbitrary nonzero lattice vectors.
 * `LinearEquiv.isPrimitive_iff`: primitivity is invariant under integer-linear equivalences.
 * `TauCeti.exists_eq_zsmul_isPrimitive`: a nonzero vector in a free integer module is a
   positive integer multiple of a primitive vector.
+* `Module.Basis.isPrimitive`: a vector of an integral basis is primitive.
+* `TauCeti.IsPrimitive.exists_basis`: conversely, a primitive vector of a finite free integer
+  module belongs to some integral basis of it.
 -/
 
 public section
@@ -75,6 +81,17 @@ theorem isPrimitive_neg {v : M} : IsPrimitive (-v) ↔ IsPrimitive v :=
   ⟨fun h ↦ by simpa using h.neg, IsPrimitive.neg⟩
 
 end TauCeti
+
+namespace Module.Basis
+
+variable {ι M : Type*} [AddCommGroup M] [Module ℤ M]
+
+/-- A vector of an integral basis is primitive: its own coordinate functional takes the value one
+on it. -/
+theorem isPrimitive (b : Module.Basis ι ℤ M) (j : ι) : TauCeti.IsPrimitive (b j) :=
+  TauCeti.isPrimitive_def.2 ⟨b.coord j, by simp⟩
+
+end Module.Basis
 
 namespace LinearEquiv
 
@@ -150,5 +167,22 @@ theorem exists_eq_zsmul_isPrimitive [Module.Free ℤ M] {v : M}
   simp only [f, LinearMap.sum_apply, LinearMap.smul_apply, w, b.coord_repr_symm, qf,
     Finsupp.ofSupportFinite_coe, smul_eq_mul]
   simpa only [mul_comm] using (hqgcd.symm.trans ha).symm
+
+/-- A primitive vector of a finite free integer module belongs to an integral basis of it. The
+complementary basis vectors are a basis of the kernel of a functional taking the value one on the
+given vector, which splits off a copy of `ℤ`. -/
+theorem IsPrimitive.exists_basis [Module.Free ℤ M] [Module.Finite ℤ M] {v : M}
+    (hv : IsPrimitive v) :
+    ∃ (n : ℕ) (b : Module.Basis (Fin n) ℤ M) (j : Fin n), b j = v := by
+  obtain ⟨f, hf⟩ := isPrimitive_def.1 hv
+  obtain ⟨m, ⟨c⟩⟩ := Submodule.nonempty_basis_of_pid (Module.finBasis ℤ M) (LinearMap.ker f)
+  refine ⟨m + 1, Module.Basis.mkFinCons v c ?_ ?_, 0, ?_⟩
+  · intro a x hx hax
+    have h := congrArg f hax
+    simp only [map_add, map_smul, hf, LinearMap.mem_ker.1 hx, map_zero, add_zero, smul_eq_mul,
+      mul_one] at h
+    exact h
+  · exact fun z ↦ ⟨-f z, by simp [LinearMap.mem_ker, hf]⟩
+  · simp
 
 end TauCeti

--- a/TauCeti/Geometry/Convex/Cone/Basic.lean
+++ b/TauCeti/Geometry/Convex/Cone/Basic.lean
@@ -17,8 +17,9 @@ Mathlib's `ConvexCone.Salient` records that a convex cone contains no line. This
 two closure properties of salience that concern standard cone constructions: the image under an
 injective linear map, and the product of two pointed cones. It also computes the dimension of the
 linear span of the cone hull of a single nonzero vector, which is the one-dimensionality making
-such a cone a ray. None of these statements involves a lattice, so they belong to the generic
-convex-cone API rather than to any consumer of it.
+such a cone a ray, and the invariance of that dimension under multiplying a cone by the zero cone.
+None of these statements involves a lattice, so they belong to the generic convex-cone API rather
+than to any consumer of it.
 
 ## Main declarations
 
@@ -26,6 +27,9 @@ convex-cone API rather than to any consumer of it.
   salient.
 * `ConvexCone.Salient.prod`: a product of salient pointed cones is salient.
 * `PointedCone.finrank_span_coe_hull_singleton`: the cone hull of a nonzero vector spans a line.
+* `PointedCone.finrank_span_coe_prod_bot` and `PointedCone.finrank_span_coe_bot_prod`:
+  multiplying a pointed cone by the zero cone leaves the dimension of the span of the cone
+  unchanged.
 -/
 
 public section
@@ -56,7 +60,7 @@ end ConvexCone.Salient
 
 namespace PointedCone
 
-variable {V : Type*} [AddCommGroup V] [Module ℝ V]
+variable {V V' : Type*} [AddCommGroup V] [Module ℝ V] [AddCommGroup V'] [Module ℝ V']
 
 /-- The linear span of the cone hull of a nonzero vector is the line it spans, of dimension one.
 Passing from the cone hull to the linear span is the scalar extension from the nonnegative reals
@@ -64,5 +68,27 @@ to the reals. -/
 theorem finrank_span_coe_hull_singleton {x : V} (hx : x ≠ 0) :
     Module.finrank ℝ (Submodule.span ℝ ((hull ℝ {x} : PointedCone ℝ V) : Set V)) = 1 := by
   rw [Submodule.span_span_of_tower (Nonneg ℝ) ℝ, finrank_span_singleton hx]
+
+/-- Multiplying a pointed cone by the zero cone leaves the dimension of its span unchanged: the
+product is the image of the cone under the inclusion of the first factor. -/
+theorem finrank_span_coe_prod_bot (p : PointedCone ℝ V) :
+    Module.finrank ℝ (Submodule.span ℝ
+        ((p.prod (⊥ : PointedCone ℝ V') : PointedCone ℝ (V × V')) : Set (V × V')))
+      = Module.finrank ℝ (Submodule.span ℝ (p : Set V)) := by
+  rw [Submodule.prod_coe, Submodule.span_prod_eq ℝ p.zero_mem (Submodule.zero_mem _),
+    Submodule.bot_coe, Submodule.span_zero_singleton, ← Submodule.map_inl]
+  exact (Submodule.equivMapOfInjective _ LinearMap.inl_injective
+    (Submodule.span ℝ (p : Set V))).finrank_eq.symm
+
+/-- Multiplying a pointed cone by the zero cone leaves the dimension of its span unchanged: the
+product is the image of the cone under the inclusion of the second factor. -/
+theorem finrank_span_coe_bot_prod (q : PointedCone ℝ V') :
+    Module.finrank ℝ (Submodule.span ℝ
+        (((⊥ : PointedCone ℝ V).prod q : PointedCone ℝ (V × V')) : Set (V × V')))
+      = Module.finrank ℝ (Submodule.span ℝ (q : Set V')) := by
+  rw [Submodule.prod_coe, Submodule.span_prod_eq ℝ (Submodule.zero_mem _) q.zero_mem,
+    Submodule.bot_coe, Submodule.span_zero_singleton, ← Submodule.map_inr]
+  exact (Submodule.equivMapOfInjective _ LinearMap.inr_injective
+    (Submodule.span ℝ (q : Set V'))).finrank_eq.symm
 
 end PointedCone

--- a/TauCeti/Geometry/Convex/Cone/Basic.lean
+++ b/TauCeti/Geometry/Convex/Cone/Basic.lean
@@ -60,35 +60,36 @@ end ConvexCone.Salient
 
 namespace PointedCone
 
-variable {V V' : Type*} [AddCommGroup V] [Module ℝ V] [AddCommGroup V'] [Module ℝ V']
+variable {R V V' : Type*} [Field R] [LinearOrder R] [IsStrictOrderedRing R]
+  [AddCommGroup V] [Module R V] [AddCommGroup V'] [Module R V']
 
 /-- The linear span of the cone hull of a nonzero vector is the line it spans, of dimension one.
-Passing from the cone hull to the linear span is the scalar extension from the nonnegative reals
-to the reals. -/
+Passing from the cone hull to the linear span extends scalars from the nonnegative elements of the
+ordered field to the field itself. -/
 theorem finrank_span_coe_hull_singleton {x : V} (hx : x ≠ 0) :
-    Module.finrank ℝ (Submodule.span ℝ ((hull ℝ {x} : PointedCone ℝ V) : Set V)) = 1 := by
-  rw [Submodule.span_span_of_tower (Nonneg ℝ) ℝ, finrank_span_singleton hx]
+    Module.finrank R (Submodule.span R ((hull R {x} : PointedCone R V) : Set V)) = 1 := by
+  rw [Submodule.span_span_of_tower (Nonneg R) R, finrank_span_singleton hx]
 
 /-- Multiplying a pointed cone by the zero cone leaves the dimension of its span unchanged: the
 product is the image of the cone under the inclusion of the first factor. -/
-theorem finrank_span_coe_prod_bot (p : PointedCone ℝ V) :
-    Module.finrank ℝ (Submodule.span ℝ
-        ((p.prod (⊥ : PointedCone ℝ V') : PointedCone ℝ (V × V')) : Set (V × V')))
-      = Module.finrank ℝ (Submodule.span ℝ (p : Set V)) := by
-  rw [Submodule.prod_coe, Submodule.span_prod_eq ℝ p.zero_mem (Submodule.zero_mem _),
+theorem finrank_span_coe_prod_bot (p : PointedCone R V) :
+    Module.finrank R (Submodule.span R
+        ((p.prod (⊥ : PointedCone R V') : PointedCone R (V × V')) : Set (V × V')))
+      = Module.finrank R (Submodule.span R (p : Set V)) := by
+  rw [Submodule.prod_coe, Submodule.span_prod_eq R p.zero_mem (Submodule.zero_mem _),
     Submodule.bot_coe, Submodule.span_zero_singleton, ← Submodule.map_inl]
   exact (Submodule.equivMapOfInjective _ LinearMap.inl_injective
-    (Submodule.span ℝ (p : Set V))).finrank_eq.symm
+    (Submodule.span R (p : Set V))).finrank_eq.symm
 
 /-- Multiplying a pointed cone by the zero cone leaves the dimension of its span unchanged: the
 product is the image of the cone under the inclusion of the second factor. -/
-theorem finrank_span_coe_bot_prod (q : PointedCone ℝ V') :
-    Module.finrank ℝ (Submodule.span ℝ
-        (((⊥ : PointedCone ℝ V).prod q : PointedCone ℝ (V × V')) : Set (V × V')))
-      = Module.finrank ℝ (Submodule.span ℝ (q : Set V')) := by
-  rw [Submodule.prod_coe, Submodule.span_prod_eq ℝ (Submodule.zero_mem _) q.zero_mem,
+theorem finrank_span_coe_bot_prod (q : PointedCone R V') :
+    Module.finrank R (Submodule.span R
+        (((⊥ : PointedCone R V).prod q : PointedCone R (V × V')) : Set (V × V')))
+      = Module.finrank R (Submodule.span R (q : Set V')) := by
+  rw [Submodule.prod_coe, Submodule.span_prod_eq R (Submodule.zero_mem _) q.zero_mem,
     Submodule.bot_coe, Submodule.span_zero_singleton, ← Submodule.map_inr]
   exact (Submodule.equivMapOfInjective _ LinearMap.inr_injective
-    (Submodule.span ℝ (q : Set V'))).finrank_eq.symm
+    (Submodule.span R (q : Set V'))).finrank_eq.symm
 
 end PointedCone

--- a/TauCeti/Geometry/Convex/Cone/Basic.lean
+++ b/TauCeti/Geometry/Convex/Cone/Basic.lean
@@ -5,22 +5,27 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import Mathlib.Basic.Real.Basic
 public import Mathlib.Geometry.Convex.Cone.Pointed
+public import Mathlib.LinearAlgebra.FiniteDimensional.Basic
 public import Mathlib.LinearAlgebra.Prod
 
 /-!
-# Salience of images and products of cones
+# Salience of images and products of cones, and the line spanned by a ray
 
 Mathlib's `ConvexCone.Salient` records that a convex cone contains no line. This file proves the
 two closure properties of salience that concern standard cone constructions: the image under an
-injective linear map, and the product of two pointed cones. Neither statement involves a lattice,
-so both belong to the generic convex-cone API rather than to any consumer of it.
+injective linear map, and the product of two pointed cones. It also computes the dimension of the
+linear span of the cone hull of a single nonzero vector, which is the one-dimensionality making
+such a cone a ray. None of these statements involves a lattice, so they belong to the generic
+convex-cone API rather than to any consumer of it.
 
 ## Main declarations
 
 * `ConvexCone.Salient.map`: the image of a salient convex cone under an injective linear map is
   salient.
 * `ConvexCone.Salient.prod`: a product of salient pointed cones is salient.
+* `PointedCone.finrank_span_coe_hull_singleton`: the cone hull of a nonzero vector spans a line.
 -/
 
 public section
@@ -48,3 +53,16 @@ theorem prod [IsOrderedRing R] {σ : PointedCone R V} {τ : PointedCone R V'}
   · exact hσ x hx hx0 hnx
 
 end ConvexCone.Salient
+
+namespace PointedCone
+
+variable {V : Type*} [AddCommGroup V] [Module ℝ V]
+
+/-- The linear span of the cone hull of a nonzero vector is the line it spans, of dimension one.
+Passing from the cone hull to the linear span is the scalar extension from the nonnegative reals
+to the reals. -/
+theorem finrank_span_coe_hull_singleton {x : V} (hx : x ≠ 0) :
+    Module.finrank ℝ (Submodule.span ℝ ((hull ℝ {x} : PointedCone ℝ V) : Set V)) = 1 := by
+  rw [Submodule.span_span_of_tower (Nonneg ℝ) ℝ, finrank_span_singleton hx]
+
+end PointedCone

--- a/TauCeti/Geometry/Convex/Cone/Basic.lean
+++ b/TauCeti/Geometry/Convex/Cone/Basic.lean
@@ -70,8 +70,8 @@ theorem finrank_span_coe_hull_singleton {x : V} (hx : x ≠ 0) :
     Module.finrank R (Submodule.span R ((hull R {x} : PointedCone R V) : Set V)) = 1 := by
   rw [Submodule.span_span_of_tower (Nonneg R) R, finrank_span_singleton hx]
 
-/-- Multiplying a pointed cone by the zero cone leaves the dimension of its span unchanged: the
-product is the image of the cone under the inclusion of the first factor. -/
+/-- Multiplying a pointed cone by the zero cone in the second factor leaves the dimension of its
+span unchanged. In particular, a ray of the first factor remains one-dimensional in the product. -/
 theorem finrank_span_coe_prod_bot (p : PointedCone R V) :
     Module.finrank R (Submodule.span R
         ((p.prod (⊥ : PointedCone R V') : PointedCone R (V × V')) : Set (V × V')))
@@ -81,8 +81,8 @@ theorem finrank_span_coe_prod_bot (p : PointedCone R V) :
   exact (Submodule.equivMapOfInjective _ LinearMap.inl_injective
     (Submodule.span R (p : Set V))).finrank_eq.symm
 
-/-- Multiplying a pointed cone by the zero cone leaves the dimension of its span unchanged: the
-product is the image of the cone under the inclusion of the second factor. -/
+/-- Multiplying a pointed cone by the zero cone in the first factor leaves the dimension of its
+span unchanged. In particular, a ray of the second factor remains one-dimensional in the product. -/
 theorem finrank_span_coe_bot_prod (q : PointedCone R V') :
     Module.finrank R (Submodule.span R
         (((⊥ : PointedCone R V).prod q : PointedCone R (V × V')) : Set (V × V')))

--- a/TauCeti/Geometry/Convex/Cone/Face/Basic.lean
+++ b/TauCeti/Geometry/Convex/Cone/Face/Basic.lean
@@ -6,20 +6,16 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Geometry.Convex.Cone.Face.Basic
-public import Mathlib.LinearAlgebra.Prod
 
 /-!
-# The zero face of a salient cone, and faces of a product
+# The zero face of a salient cone
 
 Mathlib's `ConvexCone.Salient` records that a convex cone contains no line. This file records the
-consequence of salience for the face lattice of a pointed cone: the zero cone is a face. It also
-records that a face of a product of two cones is the product of its two projections.
+consequence of salience for the face lattice of a pointed cone: the zero cone is a face.
 
 ## Main declarations
 
 * `ConvexCone.Salient.bot_isFaceOf`: the zero cone is a face of a salient pointed cone.
-* `PointedCone.IsFaceOf.eq_prod_map`: a face of a product of two pointed cones is the product of
-  its images under the two coordinate projections.
 -/
 
 public section
@@ -42,36 +38,3 @@ theorem bot_isFaceOf (hC : (C : ConvexCone R V).Salient) :
   exact (eq_zero_or_eq_zero_of_smul_eq_zero hzero).resolve_left ha.ne'
 
 end ConvexCone.Salient
-
-namespace PointedCone.IsFaceOf
-
-variable {R M M' : Type*} [Semiring R] [PartialOrder R] [IsOrderedRing R] [AddCommGroup M]
-  [Module R M] [AddCommGroup M'] [Module R M'] {C : PointedCone R M} {C' : PointedCone R M'}
-  {F : PointedCone R (M × M')}
-
-/-- A face of a product of two pointed cones is the product of its images under the two coordinate
-projections: a point of the product of the images already lies on the face, because it is a
-summand of a point of the face. -/
--- Adapted from Mathlib's `PointedCone.Face.fst_prod_snd`, the same fact for the bundled face
--- lattice, whose defining equations are sealed outside Mathlib.
-theorem eq_prod_map (hF : F.IsFaceOf (C.prod C')) :
-    F = (F.map (LinearMap.fst R M M')).prod (F.map (LinearMap.snd R M M')) := by
-  refine le_antisymm (fun x hx ↦ Submodule.mem_prod.2
-    ⟨Submodule.mem_map.2 ⟨x, hx, rfl⟩, Submodule.mem_map.2 ⟨x, hx, rfl⟩⟩) fun x hx ↦ ?_
-  obtain ⟨h1, h2⟩ := Submodule.mem_prod.1 hx
-  obtain ⟨a, ha, ha1⟩ := Submodule.mem_map.1 h1
-  obtain ⟨c, hc, hc2⟩ := Submodule.mem_map.1 h2
-  -- The face contains `(x.1, a.2)` and `(c.1, x.2)`, whose sum is `x + (c.1, a.2)`.
-  have hxa : (x.1, a.2) = a := Prod.ext ha1.symm rfl
-  have hcx : (c.1, x.2) = c := Prod.ext rfl hc2.symm
-  have hswap : (x.1, a.2) + (c.1, x.2) = x + (c.1, a.2) := by simp [Prod.ext_iff, add_comm]
-  have hy : (x.1, a.2) ∈ F := by rw [hxa]; exact ha
-  have hz : (c.1, x.2) ∈ F := by rw [hcx]; exact hc
-  have hsum : x + (c.1, a.2) ∈ F := by rw [← hswap]; exact Submodule.add_mem _ hy hz
-  refine hF.mem_of_add_mem_left ?_ ?_ hsum
-  · exact Submodule.mem_prod.2 ⟨(Submodule.mem_prod.1 (hF.le hy)).1,
-      (Submodule.mem_prod.1 (hF.le hz)).2⟩
-  · exact Submodule.mem_prod.2 ⟨(Submodule.mem_prod.1 (hF.le hz)).1,
-      (Submodule.mem_prod.1 (hF.le hy)).2⟩
-
-end PointedCone.IsFaceOf

--- a/TauCeti/Geometry/Convex/Cone/Face/Basic.lean
+++ b/TauCeti/Geometry/Convex/Cone/Face/Basic.lean
@@ -20,13 +20,6 @@ records that a face of a product of two cones is the product of its two projecti
 * `ConvexCone.Salient.bot_isFaceOf`: the zero cone is a face of a salient pointed cone.
 * `PointedCone.IsFaceOf.eq_prod_map`: a face of a product of two pointed cones is the product of
   its images under the two coordinate projections.
-
-## Implementation notes
-
-Mathlib's `PointedCone.Face.fst_prod_snd` is the same statement for the bundled face lattice, but
-the definitions `PointedCone.Face.prod`, `PointedCone.Face.fst` and `PointedCone.Face.snd` are not
-exposed, so that equation of faces cannot be read off as an equation of the underlying cones.
-`PointedCone.IsFaceOf.eq_prod_map` states it on the cones instead; the proof follows Mathlib's.
 -/
 
 public section
@@ -59,6 +52,8 @@ variable {R M M' : Type*} [Semiring R] [PartialOrder R] [IsOrderedRing R] [AddCo
 /-- A face of a product of two pointed cones is the product of its images under the two coordinate
 projections: a point of the product of the images already lies on the face, because it is a
 summand of a point of the face. -/
+-- Adapted from Mathlib's `PointedCone.Face.fst_prod_snd`, the same fact for the bundled face
+-- lattice, whose defining equations are sealed outside Mathlib.
 theorem eq_prod_map (hF : F.IsFaceOf (C.prod C')) :
     F = (F.map (LinearMap.fst R M M')).prod (F.map (LinearMap.snd R M M')) := by
   refine le_antisymm (fun x hx ↦ Submodule.mem_prod.2

--- a/TauCeti/Geometry/Convex/Cone/Face/Basic.lean
+++ b/TauCeti/Geometry/Convex/Cone/Face/Basic.lean
@@ -6,16 +6,27 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Geometry.Convex.Cone.Face.Basic
+public import Mathlib.LinearAlgebra.Prod
 
 /-!
-# The zero face of a salient cone
+# The zero face of a salient cone, and faces of a product
 
 Mathlib's `ConvexCone.Salient` records that a convex cone contains no line. This file records the
-consequence of salience for the face lattice of a pointed cone: the zero cone is a face.
+consequence of salience for the face lattice of a pointed cone: the zero cone is a face. It also
+records that a face of a product of two cones is the product of its two projections.
 
 ## Main declarations
 
 * `ConvexCone.Salient.bot_isFaceOf`: the zero cone is a face of a salient pointed cone.
+* `PointedCone.IsFaceOf.eq_prod_map`: a face of a product of two pointed cones is the product of
+  its images under the two coordinate projections.
+
+## Implementation notes
+
+Mathlib's `PointedCone.Face.fst_prod_snd` is the same statement for the bundled face lattice, but
+the definitions `PointedCone.Face.prod`, `PointedCone.Face.fst` and `PointedCone.Face.snd` are not
+exposed, so that equation of faces cannot be read off as an equation of the underlying cones.
+`PointedCone.IsFaceOf.eq_prod_map` states it on the cones instead; the proof follows Mathlib's.
 -/
 
 public section
@@ -38,3 +49,35 @@ theorem bot_isFaceOf (hC : (C : ConvexCone R V).Salient) :
   exact (eq_zero_or_eq_zero_of_smul_eq_zero hzero).resolve_left ha.ne'
 
 end ConvexCone.Salient
+
+namespace PointedCone.IsFaceOf
+
+variable {R M M' : Type*} [Semiring R] [PartialOrder R] [IsOrderedRing R] [AddCommGroup M]
+  [Module R M] [AddCommGroup M'] [Module R M'] {C : PointedCone R M} {C' : PointedCone R M'}
+  {F : PointedCone R (M × M')}
+
+/-- A face of a product of two pointed cones is the product of its images under the two coordinate
+projections: a point of the product of the images already lies on the face, because it is a
+summand of a point of the face. -/
+theorem eq_prod_map (hF : F.IsFaceOf (C.prod C')) :
+    F = (F.map (LinearMap.fst R M M')).prod (F.map (LinearMap.snd R M M')) := by
+  refine le_antisymm (fun x hx ↦ Submodule.mem_prod.2
+    ⟨Submodule.mem_map.2 ⟨x, hx, rfl⟩, Submodule.mem_map.2 ⟨x, hx, rfl⟩⟩) fun x hx ↦ ?_
+  obtain ⟨h1, h2⟩ := Submodule.mem_prod.1 hx
+  obtain ⟨a, ha, ha1⟩ := Submodule.mem_map.1 h1
+  obtain ⟨c, hc, hc2⟩ := Submodule.mem_map.1 h2
+  -- The face contains `(x.1, a.2)` and `(c.1, x.2)`, whose sum is `x + (c.1, a.2)`.
+  have hy : (x.1, a.2) ∈ F := by rw [show (x.1, a.2) = a from Prod.ext ha1.symm rfl]; exact ha
+  have hz : (c.1, x.2) ∈ F := by rw [show (c.1, x.2) = c from Prod.ext rfl hc2.symm]; exact hc
+  have hsum : (x.1, x.2) + (c.1, a.2) ∈ F := by
+    have hadd := Submodule.add_mem _ hy hz
+    rw [show ((x.1, a.2) + (c.1, x.2) : M × M') = (x.1, x.2) + (c.1, a.2) by
+      simp [Prod.ext_iff, add_comm]] at hadd
+    exact hadd
+  refine hF.mem_of_add_mem_left ?_ ?_ hsum
+  · exact Submodule.mem_prod.2 ⟨(Submodule.mem_prod.1 (hF.le hy)).1,
+      (Submodule.mem_prod.1 (hF.le hz)).2⟩
+  · exact Submodule.mem_prod.2 ⟨(Submodule.mem_prod.1 (hF.le hz)).1,
+      (Submodule.mem_prod.1 (hF.le hy)).2⟩
+
+end PointedCone.IsFaceOf

--- a/TauCeti/Geometry/Convex/Cone/Face/Basic.lean
+++ b/TauCeti/Geometry/Convex/Cone/Face/Basic.lean
@@ -67,13 +67,12 @@ theorem eq_prod_map (hF : F.IsFaceOf (C.prod C')) :
   obtain ⟨a, ha, ha1⟩ := Submodule.mem_map.1 h1
   obtain ⟨c, hc, hc2⟩ := Submodule.mem_map.1 h2
   -- The face contains `(x.1, a.2)` and `(c.1, x.2)`, whose sum is `x + (c.1, a.2)`.
-  have hy : (x.1, a.2) ∈ F := by rw [show (x.1, a.2) = a from Prod.ext ha1.symm rfl]; exact ha
-  have hz : (c.1, x.2) ∈ F := by rw [show (c.1, x.2) = c from Prod.ext rfl hc2.symm]; exact hc
-  have hsum : (x.1, x.2) + (c.1, a.2) ∈ F := by
-    have hadd := Submodule.add_mem _ hy hz
-    rw [show ((x.1, a.2) + (c.1, x.2) : M × M') = (x.1, x.2) + (c.1, a.2) by
-      simp [Prod.ext_iff, add_comm]] at hadd
-    exact hadd
+  have hxa : (x.1, a.2) = a := Prod.ext ha1.symm rfl
+  have hcx : (c.1, x.2) = c := Prod.ext rfl hc2.symm
+  have hswap : (x.1, a.2) + (c.1, x.2) = x + (c.1, a.2) := by simp [Prod.ext_iff, add_comm]
+  have hy : (x.1, a.2) ∈ F := by rw [hxa]; exact ha
+  have hz : (c.1, x.2) ∈ F := by rw [hcx]; exact hc
+  have hsum : x + (c.1, a.2) ∈ F := by rw [← hswap]; exact Submodule.add_mem _ hy hz
   refine hF.mem_of_add_mem_left ?_ ?_ hsum
   · exact Submodule.mem_prod.2 ⟨(Submodule.mem_prod.1 (hF.le hy)).1,
       (Submodule.mem_prod.1 (hF.le hz)).2⟩

--- a/TauCeti/Geometry/Toric/Algebraic/Cone.lean
+++ b/TauCeti/Geometry/Toric/Algebraic/Cone.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Basic.Real.Basic
 public import TauCeti.Geometry.Convex.Cone.Basic
 public import TauCeti.Geometry.Convex.Cone.Face.Finite
 

--- a/TauCeti/Geometry/Toric/Algebraic/Ray/Basic.lean
+++ b/TauCeti/Geometry/Toric/Algebraic/Ray/Basic.lean
@@ -306,34 +306,12 @@ theorem prod_ext {G H : ToricRay (σ.prod τ)}
   toPointedCone_injective
     (G.1.isFaceOf.eq_prod_map.trans (by rw [h₁, h₂]; exact H.1.isFaceOf.eq_prod_map.symm))
 
-/-- Multiplying a pointed cone by the zero cone leaves the dimension of its span unchanged: the
-product is the image of the cone under the inclusion of the first factor. -/
-private lemma finrank_span_coe_prod_bot (p : PointedCone ℝ V) :
-    Module.finrank ℝ (Submodule.span ℝ
-        ((p.prod (⊥ : PointedCone ℝ V') : PointedCone ℝ (V × V')) : Set (V × V')))
-      = Module.finrank ℝ (Submodule.span ℝ (p : Set V)) := by
-  rw [Submodule.prod_coe, Submodule.span_prod_eq ℝ p.zero_mem (Submodule.zero_mem _),
-    Submodule.bot_coe, Submodule.span_zero_singleton, ← Submodule.map_inl]
-  exact (Submodule.equivMapOfInjective _ LinearMap.inl_injective
-    (Submodule.span ℝ (p : Set V))).finrank_eq.symm
-
-/-- Multiplying a pointed cone by the zero cone leaves the dimension of its span unchanged: the
-product is the image of the cone under the inclusion of the second factor. -/
-private lemma finrank_span_coe_bot_prod (q : PointedCone ℝ V') :
-    Module.finrank ℝ (Submodule.span ℝ
-        (((⊥ : PointedCone ℝ V).prod q : PointedCone ℝ (V × V')) : Set (V × V')))
-      = Module.finrank ℝ (Submodule.span ℝ (q : Set V')) := by
-  rw [Submodule.prod_coe, Submodule.span_prod_eq ℝ (Submodule.zero_mem _) q.zero_mem,
-    Submodule.bot_coe, Submodule.span_zero_singleton, ← Submodule.map_inr]
-  exact (Submodule.equivMapOfInjective _ LinearMap.inr_injective
-    (Submodule.span ℝ (q : Set V'))).finrank_eq.symm
-
 /-- A ray of the first factor, read as a ray of a product of cones: its product with the zero
 cone. This is a face of the product because the zero cone is a face of the salient second
 factor, and its span has the dimension of the span of the ray. -/
 def prodInl (hτ : (τ : ConvexCone ℝ V').Salient) (ρ : ToricRay σ) : ToricRay (σ.prod τ) :=
   ⟨⟨ρ.toPointedCone.prod ⊥, ρ.1.isFaceOf.prod hτ.bot_isFaceOf⟩,
-    (finrank_span_coe_prod_bot ρ.toPointedCone).trans ρ.2⟩
+    (PointedCone.finrank_span_coe_prod_bot ρ.toPointedCone).trans ρ.2⟩
 
 @[simp]
 theorem toPointedCone_prodInl (hτ : (τ : ConvexCone ℝ V').Salient) (ρ : ToricRay σ) :
@@ -344,7 +322,7 @@ cone. This is a face of the product because the zero cone is a face of the salie
 and its span has the dimension of the span of the ray. -/
 def prodInr (hσ : (σ : ConvexCone ℝ V).Salient) (ρ : ToricRay τ) : ToricRay (σ.prod τ) :=
   ⟨⟨(⊥ : PointedCone ℝ V).prod ρ.toPointedCone, hσ.bot_isFaceOf.prod ρ.1.isFaceOf⟩,
-    (finrank_span_coe_bot_prod ρ.toPointedCone).trans ρ.2⟩
+    (PointedCone.finrank_span_coe_bot_prod ρ.toPointedCone).trans ρ.2⟩
 
 @[simp]
 theorem toPointedCone_prodInr (hσ : (σ : ConvexCone ℝ V).Salient) (ρ : ToricRay τ) :

--- a/TauCeti/Geometry/Toric/Algebraic/Ray/Basic.lean
+++ b/TauCeti/Geometry/Toric/Algebraic/Ray/Basic.lean
@@ -196,10 +196,8 @@ private lemma exists_eq_hull_and_map_eq_hull
   · rw [hGeq, hmapfst, Set.image_singleton]; rfl
   · rw [hGeq, hmapsnd, Set.image_singleton]; rfl
 
-/-- A ray of a product of salient cones does not meet both factors: if its projection to the second
-factor is not the zero cone, then its projection to the first factor is. A spanning point of the ray
-cannot have both coordinates nonzero, because the ray then also contains the point with its second
-coordinate replaced by zero, which is not a nonnegative multiple of the spanning point. -/
+/-- A ray of a product of salient cones cannot project nontrivially to both factors: if its
+projection to the second factor is nonzero, then its projection to the first factor is zero. -/
 theorem map_fst_eq_bot_of_map_snd_ne_bot
     (hστ : ((σ.prod τ : PointedCone ℝ (V × V')) : ConvexCone ℝ (V × V')).Salient)
     (G : ToricRay (σ.prod τ))
@@ -339,9 +337,8 @@ theorem prod_ext {G H : ToricRay (σ.prod τ)}
         (Submodule.mem_prod.1 (B.1.isFaceOf.le ha)).2⟩) hsum
   exact le_antisymm (key h₁.le h₂.le) (key h₁.ge h₂.ge)
 
-/-- A ray of the first factor, read as a ray of a product of cones: its product with the zero
-cone. This is a face of the product because the zero cone is a face of the salient second
-factor, and its span has the dimension of the span of the ray. -/
+/-- A ray of the first factor included as a ray of the product by taking its product with the zero
+cone in the second factor. -/
 def prodInl (hτ : (τ : ConvexCone ℝ V').Salient) (ρ : ToricRay σ) : ToricRay (σ.prod τ) :=
   ⟨⟨ρ.toPointedCone.prod ⊥, ρ.1.isFaceOf.prod hτ.bot_isFaceOf⟩,
     (PointedCone.finrank_span_coe_prod_bot ρ.toPointedCone).trans ρ.2⟩
@@ -355,9 +352,8 @@ theorem toPointedCone_prodInl (hτ : (τ : ConvexCone ℝ V').Salient) (ρ : Tor
 theorem mem_prodInl (hτ : (τ : ConvexCone ℝ V').Salient) (ρ : ToricRay σ) {x : V × V'} :
     x ∈ prodInl hτ ρ ↔ x.1 ∈ ρ ∧ x.2 = 0 := (Iff.rfl)
 
-/-- A ray of the second factor, read as a ray of a product of cones: its product with the zero
-cone. This is a face of the product because the zero cone is a face of the salient first factor,
-and its span has the dimension of the span of the ray. -/
+/-- A ray of the second factor included as a ray of the product by taking the product of the zero
+cone in the first factor with that ray. -/
 def prodInr (hσ : (σ : ConvexCone ℝ V).Salient) (ρ : ToricRay τ) : ToricRay (σ.prod τ) :=
   ⟨⟨(⊥ : PointedCone ℝ V).prod ρ.toPointedCone, hσ.bot_isFaceOf.prod ρ.1.isFaceOf⟩,
     (PointedCone.finrank_span_coe_bot_prod ρ.toPointedCone).trans ρ.2⟩

--- a/TauCeti/Geometry/Toric/Algebraic/Ray/Basic.lean
+++ b/TauCeti/Geometry/Toric/Algebraic/Ray/Basic.lean
@@ -140,7 +140,6 @@ def hullSingleton {x : V} (hx : x ≠ 0) : ToricRay (PointedCone.hull ℝ {x}) :
   ⟨⟨PointedCone.hull ℝ {x}, PointedCone.IsFaceOf.refl _⟩,
     PointedCone.finrank_span_coe_hull_singleton hx⟩
 
-@[simp]
 theorem toPointedCone_hullSingleton {x : V} (hx : x ≠ 0) :
     (hullSingleton hx).toPointedCone = PointedCone.hull ℝ {x} := (rfl)
 

--- a/TauCeti/Geometry/Toric/Algebraic/Ray/Basic.lean
+++ b/TauCeti/Geometry/Toric/Algebraic/Ray/Basic.lean
@@ -117,7 +117,6 @@ instance instIsEmptyBot : IsEmpty (ToricRay (⊥ : PointedCone ℝ V)) where
 
 /-- A ray of a face `τ` of a cone `σ` is a ray of `σ`: a face of a face is a face, and
 one-dimensionality of the span does not mention the ambient cone. -/
-@[expose]
 def faceEmbedding (hτ : τ.IsFaceOf σ) : ToricRay τ ↪ ToricRay σ where
   toFun ρ := ⟨⟨ρ.toPointedCone, ρ.1.isFaceOf.trans hτ⟩, ρ.2⟩
   inj' ρ ρ' h := by
@@ -128,24 +127,23 @@ def faceEmbedding (hτ : τ.IsFaceOf σ) : ToricRay τ ↪ ToricRay σ where
 
 @[simp]
 theorem toPointedCone_faceEmbedding (hτ : τ.IsFaceOf σ) (ρ : ToricRay τ) :
-    (faceEmbedding hτ ρ).toPointedCone = ρ.toPointedCone := rfl
+    (faceEmbedding hτ ρ).toPointedCone = ρ.toPointedCone := (rfl)
 
 @[simp]
 theorem mem_faceEmbedding (hτ : τ.IsFaceOf σ) (ρ : ToricRay τ) {x : V} :
-    x ∈ faceEmbedding hτ ρ ↔ x ∈ ρ := Iff.rfl
+    x ∈ faceEmbedding hτ ρ ↔ x ∈ ρ := (Iff.rfl)
 
 /-! ### The ray spanned by a vector -/
 
 /-- The cone spanned by a nonzero vector is a ray of itself, and by
 `TauCeti.Toric.ToricRay.eq_hullSingleton` its only one. -/
-@[expose]
 def hullSingleton {x : V} (hx : x ≠ 0) : ToricRay (PointedCone.hull ℝ {x}) :=
   ⟨⟨PointedCone.hull ℝ {x}, PointedCone.IsFaceOf.refl _⟩,
     PointedCone.finrank_span_coe_hull_singleton hx⟩
 
 @[simp]
 theorem toPointedCone_hullSingleton {x : V} (hx : x ≠ 0) :
-    (hullSingleton hx).toPointedCone = PointedCone.hull ℝ {x} := rfl
+    (hullSingleton hx).toPointedCone = PointedCone.hull ℝ {x} := (rfl)
 
 /-- A ray of the cone spanned by a vector is the whole cone: a proper face of that cone misses the
 spanning vector, hence is the zero cone, which is not a ray. -/
@@ -256,7 +254,6 @@ theorem finrank_span_map_snd_eq_one
 
 /-- The ray of the first factor underlying a ray of a product of salient cones whose projection to
 the second factor is the zero cone. -/
-@[expose]
 noncomputable def prodRayFst
     (hστ : ((σ.prod τ : PointedCone ℝ (V × V')) : ConvexCone ℝ (V × V')).Salient)
     (G : ToricRay (σ.prod τ))
@@ -269,11 +266,17 @@ theorem toPointedCone_prodRayFst
     (G : ToricRay (σ.prod τ))
     (h : PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone = ⊥) :
     (prodRayFst hστ G h).toPointedCone =
-      PointedCone.map (LinearMap.fst ℝ V V') G.toPointedCone := rfl
+      PointedCone.map (LinearMap.fst ℝ V V') G.toPointedCone := (rfl)
+
+@[simp]
+theorem mem_prodRayFst
+    (hστ : ((σ.prod τ : PointedCone ℝ (V × V')) : ConvexCone ℝ (V × V')).Salient)
+    (G : ToricRay (σ.prod τ))
+    (h : PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone = ⊥) {x : V} :
+    x ∈ prodRayFst hστ G h ↔ x ∈ PointedCone.map (LinearMap.fst ℝ V V') G.toPointedCone := (Iff.rfl)
 
 /-- The ray of the second factor underlying a ray of a product of salient cones whose projection to
 the second factor is not the zero cone. -/
-@[expose]
 noncomputable def prodRaySnd
     (hστ : ((σ.prod τ : PointedCone ℝ (V × V')) : ConvexCone ℝ (V × V')).Salient)
     (G : ToricRay (σ.prod τ))
@@ -286,7 +289,14 @@ theorem toPointedCone_prodRaySnd
     (G : ToricRay (σ.prod τ))
     (h : PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone ≠ ⊥) :
     (prodRaySnd hστ G h).toPointedCone =
-      PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone := rfl
+      PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone := (rfl)
+
+@[simp]
+theorem mem_prodRaySnd
+    (hστ : ((σ.prod τ : PointedCone ℝ (V × V')) : ConvexCone ℝ (V × V')).Salient)
+    (G : ToricRay (σ.prod τ))
+    (h : PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone ≠ ⊥) {x : V'} :
+    x ∈ prodRaySnd hστ G h ↔ x ∈ PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone := (Iff.rfl)
 
 /-- A ray of a product of cones is determined by its two projections. -/
 theorem prod_ext {G H : ToricRay (σ.prod τ)}
@@ -301,7 +311,6 @@ open Classical in
 /-- The decomposition of the rays of a product of salient cones: every ray of `σ.prod τ` is a ray
 of exactly one of the two factors. The two cases are computed by
 `TauCeti.Toric.ToricRay.prodSplit_eq_inl` and `TauCeti.Toric.ToricRay.prodSplit_eq_inr`. -/
-@[expose]
 noncomputable def prodSplit
     (hστ : ((σ.prod τ : PointedCone ℝ (V × V')) : ConvexCone ℝ (V × V')).Salient) :
     ToricRay (σ.prod τ) ↪ ToricRay σ ⊕ ToricRay τ where

--- a/TauCeti/Geometry/Toric/Algebraic/Ray/Basic.lean
+++ b/TauCeti/Geometry/Toric/Algebraic/Ray/Basic.lean
@@ -7,6 +7,8 @@ module
 
 public import Mathlib.Basic.Real.Basic
 public import Mathlib.LinearAlgebra.FiniteDimensional.Basic
+public import TauCeti.Geometry.Convex.Cone.Basic
+public import TauCeti.Geometry.Convex.Cone.Face.Basic
 public import TauCeti.Geometry.Convex.Cone.Face.Finite
 
 /-!
@@ -26,6 +28,14 @@ pointed cone.
 * `TauCeti.Toric.ToricRay.exists_mem_ne_zero`: every ray contains a nonzero point.
 * `TauCeti.Toric.ToricRay.eq_hull_singleton`: every nonzero point of a salient ray generates
   that ray.
+* `TauCeti.Toric.ToricRay.instIsEmptyBot`: the zero cone has no rays.
+* `TauCeti.Toric.ToricRay.faceEmbedding`: the rays of a face of a cone are rays of the cone.
+* `TauCeti.Toric.ToricRay.hullSingleton` and `TauCeti.Toric.ToricRay.eq_hullSingleton`: the cone
+  spanned by a nonzero vector is its own only ray.
+* `TauCeti.Toric.ToricRay.map_fst_eq_bot_of_map_snd_ne_bot`,
+  `TauCeti.Toric.ToricRay.prodRayFst`, `TauCeti.Toric.ToricRay.prodRaySnd` and
+  `TauCeti.Toric.ToricRay.prodSplit`: a ray of a product of salient cones is a ray of exactly one
+  of the two factors.
 
 ## References
 
@@ -37,7 +47,7 @@ public section
 
 namespace TauCeti.Toric
 
-variable {V : Type*} [AddCommGroup V] [Module ℝ V] {σ : PointedCone ℝ V}
+variable {V : Type*} [AddCommGroup V] [Module ℝ V] {σ τ : PointedCone ℝ V}
 
 /-- A ray of a pointed cone is a face whose linear span has real dimension one. -/
 -- Interface source: `TauCetiRoadmap/AnalyticToricGeometry/Suggested.lean`.
@@ -96,6 +106,239 @@ theorem eq_hull_singleton (ρ : ToricRay σ) (hρ : (ρ.toPointedCone : ConvexCo
       exact hscale
     exact hρ x hx hx0 hnegx
   · exact Submodule.span_le.2 fun _ hx' ↦ by simpa using hx' ▸ hx
+
+/-! ### The zero cone -/
+
+/-- The zero cone has no rays: its only face is itself, whose span is zero-dimensional. -/
+instance instIsEmptyBot : IsEmpty (ToricRay (⊥ : PointedCone ℝ V)) where
+  false ρ := ρ.toPointedCone_ne_bot (le_antisymm ρ.1.isFaceOf.le bot_le)
+
+/-! ### Rays of a face -/
+
+/-- A ray of a face `τ` of a cone `σ` is a ray of `σ`: a face of a face is a face, and
+one-dimensionality of the span does not mention the ambient cone. -/
+@[expose]
+def faceEmbedding (hτ : τ.IsFaceOf σ) : ToricRay τ ↪ ToricRay σ where
+  toFun ρ := ⟨⟨ρ.toPointedCone, ρ.1.isFaceOf.trans hτ⟩, ρ.2⟩
+  inj' ρ ρ' h := by
+    have hcone : ρ.toPointedCone = ρ'.toPointedCone :=
+      congrArg (fun ν : ToricRay σ ↦ ν.toPointedCone) h
+    exact Subtype.ext (SetLike.coe_injective
+      (congrArg (fun C : PointedCone ℝ V ↦ (C : Set V)) hcone))
+
+@[simp]
+theorem toPointedCone_faceEmbedding (hτ : τ.IsFaceOf σ) (ρ : ToricRay τ) :
+    (faceEmbedding hτ ρ).toPointedCone = ρ.toPointedCone := rfl
+
+@[simp]
+theorem mem_faceEmbedding (hτ : τ.IsFaceOf σ) (ρ : ToricRay τ) {x : V} :
+    x ∈ faceEmbedding hτ ρ ↔ x ∈ ρ := Iff.rfl
+
+/-! ### The ray spanned by a vector -/
+
+/-- The cone spanned by a nonzero vector is a ray of itself, and by
+`TauCeti.Toric.ToricRay.eq_hullSingleton` its only one. -/
+@[expose]
+def hullSingleton {x : V} (hx : x ≠ 0) : ToricRay (PointedCone.hull ℝ {x}) :=
+  ⟨⟨PointedCone.hull ℝ {x}, PointedCone.IsFaceOf.refl _⟩,
+    PointedCone.finrank_span_coe_hull_singleton hx⟩
+
+@[simp]
+theorem toPointedCone_hullSingleton {x : V} (hx : x ≠ 0) :
+    (hullSingleton hx).toPointedCone = PointedCone.hull ℝ {x} := rfl
+
+/-- A ray of the cone spanned by a vector is the whole cone: a proper face of that cone misses the
+spanning vector, hence is the zero cone, which is not a ray. -/
+theorem toPointedCone_eq_of_hull_singleton {x : V}
+    (ρ : ToricRay (PointedCone.hull ℝ {x})) : ρ.toPointedCone = PointedCone.hull ℝ {x} := by
+  have hx : x ∈ ρ.toPointedCone := by
+    by_contra hx
+    have h := ρ.1.eq_hull_inter_of_eq_hull {x} rfl
+    rw [Set.singleton_inter_eq_empty.2 (by simpa using hx)] at h
+    exact ρ.toPointedCone_ne_bot (by simpa using h)
+  exact le_antisymm ρ.1.isFaceOf.le (Submodule.span_le.2 (Set.singleton_subset_iff.2 hx))
+
+/-- The cone spanned by a nonzero vector has exactly one ray. -/
+theorem eq_hullSingleton {x : V} (hx : x ≠ 0) (ρ : ToricRay (PointedCone.hull ℝ {x})) :
+    ρ = hullSingleton hx :=
+  SetLike.coe_injective (congrArg (fun C : PointedCone ℝ V ↦ (C : Set V))
+    (ρ.toPointedCone_eq_of_hull_singleton.trans (toPointedCone_hullSingleton hx).symm))
+
+/-- Two rays with the same underlying cone are equal. -/
+theorem toPointedCone_injective :
+    Function.Injective (toPointedCone : ToricRay σ → PointedCone ℝ V) := fun _ _ h ↦
+  SetLike.coe_injective (congrArg (fun C : PointedCone ℝ V ↦ (C : Set V)) h)
+
+/-! ### Rays of a product -/
+
+section Prod
+
+variable {V' : Type*} [AddCommGroup V'] [Module ℝ V'] {τ : PointedCone ℝ V'}
+
+/-- A ray of a product of cones is spanned by a single point, so its two projections are the cones
+spanned by the two coordinates of that point. -/
+private lemma exists_eq_hull_and_map_eq_hull
+    (hστ : ((σ.prod τ : PointedCone ℝ (V × V')) : ConvexCone ℝ (V × V')).Salient)
+    (G : ToricRay (σ.prod τ)) :
+    ∃ p : V × V', p ≠ 0 ∧ G.toPointedCone = PointedCone.hull ℝ {p} ∧
+      PointedCone.map (LinearMap.fst ℝ V V') G.toPointedCone = PointedCone.hull ℝ {p.1} ∧
+      PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone = PointedCone.hull ℝ {p.2} := by
+  obtain ⟨p, hpG, hp0⟩ := G.exists_mem_ne_zero
+  have hGeq : G.toPointedCone = PointedCone.hull ℝ {p} :=
+    G.eq_hull_singleton (hστ.anti fun _ hx ↦ G.1.isFaceOf.le hx) hpG hp0
+  have hmapfst : PointedCone.map (LinearMap.fst ℝ V V') (PointedCone.hull ℝ {p})
+      = PointedCone.hull ℝ ((LinearMap.fst ℝ V V') '' {p}) := Submodule.map_span _ _
+  have hmapsnd : PointedCone.map (LinearMap.snd ℝ V V') (PointedCone.hull ℝ {p})
+      = PointedCone.hull ℝ ((LinearMap.snd ℝ V V') '' {p}) := Submodule.map_span _ _
+  refine ⟨p, hp0, hGeq, ?_, ?_⟩
+  · rw [hGeq, hmapfst, Set.image_singleton]; rfl
+  · rw [hGeq, hmapsnd, Set.image_singleton]; rfl
+
+/-- A ray of a product of salient cones does not meet both factors: if its projection to the second
+factor is not the zero cone, then its projection to the first factor is. A spanning point of the ray
+cannot have both coordinates nonzero, because the ray then also contains the point with its second
+coordinate replaced by zero, which is not a nonnegative multiple of the spanning point. -/
+theorem map_fst_eq_bot_of_map_snd_ne_bot
+    (hστ : ((σ.prod τ : PointedCone ℝ (V × V')) : ConvexCone ℝ (V × V')).Salient)
+    (G : ToricRay (σ.prod τ))
+    (h : PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone ≠ ⊥) :
+    PointedCone.map (LinearMap.fst ℝ V V') G.toPointedCone = ⊥ := by
+  obtain ⟨p, -, hGeq, hfst, hsnd⟩ := exists_eq_hull_and_map_eq_hull hστ G
+  have hp2 : p.2 ≠ 0 := fun hp2 ↦ h (by rw [hsnd, hp2]; simp)
+  have hpG : p ∈ G.toPointedCone := by
+    rw [hGeq]; exact PointedCone.subset_hull (Set.mem_singleton p)
+  have hprod : ((PointedCone.map (LinearMap.fst ℝ V V') G.toPointedCone).prod
+      (PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone) : PointedCone ℝ (V × V'))
+      = PointedCone.hull ℝ {p} := by
+    rw [← hGeq]; exact G.1.isFaceOf.eq_prod_map.symm
+  have hmem : (p.1, (0 : V')) ∈ PointedCone.hull ℝ {p} := by
+    rw [← hprod]
+    exact Submodule.mem_prod.2 ⟨Submodule.mem_map.2 ⟨p, hpG, rfl⟩, Submodule.zero_mem _⟩
+  obtain ⟨c, -, hcp⟩ := PointedCone.mem_hull_singleton.1 hmem
+  have hc : c = 0 := by
+    have h2 : c • p.2 = 0 := by simpa using congrArg Prod.snd hcp
+    exact (smul_eq_zero.1 h2).resolve_right hp2
+  have hp1 : p.1 = 0 := by
+    have h1 := congrArg Prod.fst hcp
+    simp [hc] at h1
+    exact h1.symm
+  rw [hfst, hp1]
+  simp
+
+/-- The projection to the first factor of a ray of a product of salient cones whose projection to
+the second factor is the zero cone is one-dimensional, hence a ray of that factor. -/
+theorem finrank_span_map_fst_eq_one
+    (hστ : ((σ.prod τ : PointedCone ℝ (V × V')) : ConvexCone ℝ (V × V')).Salient)
+    (G : ToricRay (σ.prod τ))
+    (h : PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone = ⊥) :
+    Module.finrank ℝ (Submodule.span ℝ
+      ((PointedCone.map (LinearMap.fst ℝ V V') G.toPointedCone : PointedCone ℝ V) : Set V))
+      = 1 := by
+  obtain ⟨p, hp0, -, hfst, hsnd⟩ := exists_eq_hull_and_map_eq_hull hστ G
+  have hp2 : p.2 = 0 := by simpa using hsnd.symm.trans h
+  rw [hfst]
+  exact PointedCone.finrank_span_coe_hull_singleton fun hp1 ↦ hp0 (Prod.ext hp1 hp2)
+
+/-- The projection to the second factor of a ray of a product of salient cones whose projection to
+the second factor is not the zero cone is one-dimensional, hence a ray of that factor. -/
+theorem finrank_span_map_snd_eq_one
+    (hστ : ((σ.prod τ : PointedCone ℝ (V × V')) : ConvexCone ℝ (V × V')).Salient)
+    (G : ToricRay (σ.prod τ))
+    (h : PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone ≠ ⊥) :
+    Module.finrank ℝ (Submodule.span ℝ
+      ((PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone : PointedCone ℝ V') : Set V'))
+      = 1 := by
+  obtain ⟨p, hp0, -, hfst, hsnd⟩ := exists_eq_hull_and_map_eq_hull hστ G
+  have hp1 : p.1 = 0 := by
+    simpa using hfst.symm.trans (map_fst_eq_bot_of_map_snd_ne_bot hστ G h)
+  rw [hsnd]
+  exact PointedCone.finrank_span_coe_hull_singleton fun hp2 ↦ hp0 (Prod.ext hp1 hp2)
+
+/-- The ray of the first factor underlying a ray of a product of salient cones whose projection to
+the second factor is the zero cone. -/
+@[expose]
+noncomputable def prodRayFst
+    (hστ : ((σ.prod τ : PointedCone ℝ (V × V')) : ConvexCone ℝ (V × V')).Salient)
+    (G : ToricRay (σ.prod τ))
+    (h : PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone = ⊥) : ToricRay σ :=
+  ⟨⟨_, G.1.isFaceOf.fst⟩, finrank_span_map_fst_eq_one hστ G h⟩
+
+@[simp]
+theorem toPointedCone_prodRayFst
+    (hστ : ((σ.prod τ : PointedCone ℝ (V × V')) : ConvexCone ℝ (V × V')).Salient)
+    (G : ToricRay (σ.prod τ))
+    (h : PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone = ⊥) :
+    (prodRayFst hστ G h).toPointedCone =
+      PointedCone.map (LinearMap.fst ℝ V V') G.toPointedCone := rfl
+
+/-- The ray of the second factor underlying a ray of a product of salient cones whose projection to
+the second factor is not the zero cone. -/
+@[expose]
+noncomputable def prodRaySnd
+    (hστ : ((σ.prod τ : PointedCone ℝ (V × V')) : ConvexCone ℝ (V × V')).Salient)
+    (G : ToricRay (σ.prod τ))
+    (h : PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone ≠ ⊥) : ToricRay τ :=
+  ⟨⟨_, G.1.isFaceOf.snd⟩, finrank_span_map_snd_eq_one hστ G h⟩
+
+@[simp]
+theorem toPointedCone_prodRaySnd
+    (hστ : ((σ.prod τ : PointedCone ℝ (V × V')) : ConvexCone ℝ (V × V')).Salient)
+    (G : ToricRay (σ.prod τ))
+    (h : PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone ≠ ⊥) :
+    (prodRaySnd hστ G h).toPointedCone =
+      PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone := rfl
+
+/-- A ray of a product of cones is determined by its two projections. -/
+theorem prod_ext {G H : ToricRay (σ.prod τ)}
+    (h₁ : PointedCone.map (LinearMap.fst ℝ V V') G.toPointedCone
+      = PointedCone.map (LinearMap.fst ℝ V V') H.toPointedCone)
+    (h₂ : PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone
+      = PointedCone.map (LinearMap.snd ℝ V V') H.toPointedCone) : G = H :=
+  toPointedCone_injective
+    (G.1.isFaceOf.eq_prod_map.trans (by rw [h₁, h₂]; exact H.1.isFaceOf.eq_prod_map.symm))
+
+open Classical in
+/-- The decomposition of the rays of a product of salient cones: every ray of `σ.prod τ` is a ray
+of exactly one of the two factors. The two cases are computed by
+`TauCeti.Toric.ToricRay.prodSplit_eq_inl` and `TauCeti.Toric.ToricRay.prodSplit_eq_inr`. -/
+@[expose]
+noncomputable def prodSplit
+    (hστ : ((σ.prod τ : PointedCone ℝ (V × V')) : ConvexCone ℝ (V × V')).Salient) :
+    ToricRay (σ.prod τ) ↪ ToricRay σ ⊕ ToricRay τ where
+  toFun G := if h : PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone = ⊥ then
+    Sum.inl (prodRayFst hστ G h) else Sum.inr (prodRaySnd hστ G h)
+  inj' G H hGH := by
+    dsimp only at hGH
+    by_cases hG : PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone = ⊥
+    · by_cases hH : PointedCone.map (LinearMap.snd ℝ V V') H.toPointedCone = ⊥
+      · rw [dite_eq_left hG, dite_eq_left hH] at hGH
+        refine prod_ext ?_ (hG.trans hH.symm)
+        simpa using congrArg toPointedCone (Sum.inl_injective hGH)
+      · rw [dite_eq_left hG, dite_eq_right hH] at hGH
+        exact absurd hGH (by simp)
+    · by_cases hH : PointedCone.map (LinearMap.snd ℝ V V') H.toPointedCone = ⊥
+      · rw [dite_eq_right hG, dite_eq_left hH] at hGH
+        exact absurd hGH (by simp)
+      · rw [dite_eq_right hG, dite_eq_right hH] at hGH
+        refine prod_ext ((map_fst_eq_bot_of_map_snd_ne_bot hστ G hG).trans
+          (map_fst_eq_bot_of_map_snd_ne_bot hστ H hH).symm) ?_
+        simpa using congrArg toPointedCone (Sum.inr_injective hGH)
+
+@[simp]
+theorem prodSplit_eq_inl
+    (hστ : ((σ.prod τ : PointedCone ℝ (V × V')) : ConvexCone ℝ (V × V')).Salient)
+    (G : ToricRay (σ.prod τ))
+    (h : PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone = ⊥) :
+    prodSplit hστ G = Sum.inl (prodRayFst hστ G h) := dite_eq_left h
+
+@[simp]
+theorem prodSplit_eq_inr
+    (hστ : ((σ.prod τ : PointedCone ℝ (V × V')) : ConvexCone ℝ (V × V')).Salient)
+    (G : ToricRay (σ.prod τ))
+    (h : PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone ≠ ⊥) :
+    prodSplit hστ G = Sum.inr (prodRaySnd hστ G h) := dite_eq_right h
+
+end Prod
 
 /-- A finitely generated pointed cone has finitely many rays. In fact finite generation alone
 makes its entire face lattice finite; this is inherited by the subtype of one-dimensional

--- a/TauCeti/Geometry/Toric/Algebraic/Ray/Basic.lean
+++ b/TauCeti/Geometry/Toric/Algebraic/Ray/Basic.lean
@@ -177,17 +177,15 @@ section Prod
 
 variable {V' : Type*} [AddCommGroup V'] [Module ℝ V'] {τ : PointedCone ℝ V'}
 
-/-- A ray of a product of cones is spanned by a single point, so its two projections are the cones
-spanned by the two coordinates of that point. -/
-private lemma exists_eq_hull_and_map_eq_hull
-    (hστ : ((σ.prod τ : PointedCone ℝ (V × V')) : ConvexCone ℝ (V × V')).Salient)
-    (G : ToricRay (σ.prod τ)) :
+/-- A salient ray of a product of cones is spanned by a single point, so its two projections are
+the cones spanned by the two coordinates of that point. -/
+private lemma exists_eq_hull_and_map_eq_hull (G : ToricRay (σ.prod τ))
+    (hG : (G.toPointedCone : ConvexCone ℝ (V × V')).Salient) :
     ∃ p : V × V', p ≠ 0 ∧ G.toPointedCone = PointedCone.hull ℝ {p} ∧
       PointedCone.map (LinearMap.fst ℝ V V') G.toPointedCone = PointedCone.hull ℝ {p.1} ∧
       PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone = PointedCone.hull ℝ {p.2} := by
   obtain ⟨p, hpG, hp0⟩ := G.exists_mem_ne_zero
-  have hGeq : G.toPointedCone = PointedCone.hull ℝ {p} :=
-    G.eq_hull_singleton (hστ.anti fun _ hx ↦ G.1.isFaceOf.le hx) hpG hp0
+  have hGeq : G.toPointedCone = PointedCone.hull ℝ {p} := G.eq_hull_singleton hG hpG hp0
   have hmapfst : PointedCone.map (LinearMap.fst ℝ V V') (PointedCone.hull ℝ {p})
       = PointedCone.hull ℝ ((LinearMap.fst ℝ V V') '' {p}) := Submodule.map_span _ _
   have hmapsnd : PointedCone.map (LinearMap.snd ℝ V V') (PointedCone.hull ℝ {p})
@@ -196,14 +194,13 @@ private lemma exists_eq_hull_and_map_eq_hull
   · rw [hGeq, hmapfst, Set.image_singleton]; rfl
   · rw [hGeq, hmapsnd, Set.image_singleton]; rfl
 
-/-- A ray of a product of salient cones cannot project nontrivially to both factors: if its
+/-- A salient ray of a product of cones cannot project nontrivially to both factors: if its
 projection to the second factor is nonzero, then its projection to the first factor is zero. -/
-theorem map_fst_eq_bot_of_map_snd_ne_bot
-    (hστ : ((σ.prod τ : PointedCone ℝ (V × V')) : ConvexCone ℝ (V × V')).Salient)
-    (G : ToricRay (σ.prod τ))
+theorem map_fst_eq_bot_of_map_snd_ne_bot (G : ToricRay (σ.prod τ))
+    (hG : (G.toPointedCone : ConvexCone ℝ (V × V')).Salient)
     (h : PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone ≠ ⊥) :
     PointedCone.map (LinearMap.fst ℝ V V') G.toPointedCone = ⊥ := by
-  obtain ⟨p, -, hGeq, hfst, hsnd⟩ := exists_eq_hull_and_map_eq_hull hστ G
+  obtain ⟨p, -, hGeq, hfst, hsnd⟩ := exists_eq_hull_and_map_eq_hull G hG
   have hp2 : p.2 ≠ 0 := fun hp2 ↦ h (by rw [hsnd, hp2]; simp)
   have hpG : p ∈ G.toPointedCone := by
     rw [hGeq]; exact PointedCone.subset_hull (Set.mem_singleton p)
@@ -224,80 +221,72 @@ theorem map_fst_eq_bot_of_map_snd_ne_bot
   rw [hfst, hp1]
   simp
 
-/-- The projection to the first factor of a ray of a product of salient cones whose projection to
+/-- The projection to the first factor of a salient ray of a product of cones whose projection to
 the second factor is the zero cone is one-dimensional, hence a ray of that factor. -/
-theorem finrank_span_map_fst_eq_one
-    (hστ : ((σ.prod τ : PointedCone ℝ (V × V')) : ConvexCone ℝ (V × V')).Salient)
-    (G : ToricRay (σ.prod τ))
+theorem finrank_span_map_fst_eq_one (G : ToricRay (σ.prod τ))
+    (hG : (G.toPointedCone : ConvexCone ℝ (V × V')).Salient)
     (h : PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone = ⊥) :
     Module.finrank ℝ (Submodule.span ℝ
       ((PointedCone.map (LinearMap.fst ℝ V V') G.toPointedCone : PointedCone ℝ V) : Set V))
       = 1 := by
-  obtain ⟨p, hp0, -, hfst, hsnd⟩ := exists_eq_hull_and_map_eq_hull hστ G
+  obtain ⟨p, hp0, -, hfst, hsnd⟩ := exists_eq_hull_and_map_eq_hull G hG
   have hp2 : p.2 = 0 := by simpa using hsnd.symm.trans h
   rw [hfst]
   exact PointedCone.finrank_span_coe_hull_singleton fun hp1 ↦ hp0 (Prod.ext hp1 hp2)
 
-/-- The projection to the second factor of a ray of a product of salient cones whose projection to
+/-- The projection to the second factor of a salient ray of a product of cones whose projection to
 the second factor is not the zero cone is one-dimensional, hence a ray of that factor. -/
-theorem finrank_span_map_snd_eq_one
-    (hστ : ((σ.prod τ : PointedCone ℝ (V × V')) : ConvexCone ℝ (V × V')).Salient)
-    (G : ToricRay (σ.prod τ))
+theorem finrank_span_map_snd_eq_one (G : ToricRay (σ.prod τ))
+    (hG : (G.toPointedCone : ConvexCone ℝ (V × V')).Salient)
     (h : PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone ≠ ⊥) :
     Module.finrank ℝ (Submodule.span ℝ
       ((PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone : PointedCone ℝ V') : Set V'))
       = 1 := by
-  obtain ⟨p, hp0, -, hfst, hsnd⟩ := exists_eq_hull_and_map_eq_hull hστ G
+  obtain ⟨p, hp0, -, hfst, hsnd⟩ := exists_eq_hull_and_map_eq_hull G hG
   have hp1 : p.1 = 0 := by
-    simpa using hfst.symm.trans (map_fst_eq_bot_of_map_snd_ne_bot hστ G h)
+    simpa using hfst.symm.trans (map_fst_eq_bot_of_map_snd_ne_bot G hG h)
   rw [hsnd]
   exact PointedCone.finrank_span_coe_hull_singleton fun hp2 ↦ hp0 (Prod.ext hp1 hp2)
 
-/-- The ray of the first factor underlying a ray of a product of salient cones whose projection to
+/-- The ray of the first factor underlying a salient ray of a product of cones whose projection to
 the second factor is the zero cone. -/
-noncomputable def prodRayFst
-    (hστ : ((σ.prod τ : PointedCone ℝ (V × V')) : ConvexCone ℝ (V × V')).Salient)
-    (G : ToricRay (σ.prod τ))
+noncomputable def prodRayFst (G : ToricRay (σ.prod τ))
+    (hG : (G.toPointedCone : ConvexCone ℝ (V × V')).Salient)
     (h : PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone = ⊥) : ToricRay σ :=
-  ⟨⟨_, G.1.isFaceOf.fst⟩, finrank_span_map_fst_eq_one hστ G h⟩
+  ⟨⟨_, G.1.isFaceOf.fst⟩, finrank_span_map_fst_eq_one G hG h⟩
 
 @[simp]
-theorem toPointedCone_prodRayFst
-    (hστ : ((σ.prod τ : PointedCone ℝ (V × V')) : ConvexCone ℝ (V × V')).Salient)
-    (G : ToricRay (σ.prod τ))
+theorem toPointedCone_prodRayFst (G : ToricRay (σ.prod τ))
+    (hG : (G.toPointedCone : ConvexCone ℝ (V × V')).Salient)
     (h : PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone = ⊥) :
-    (prodRayFst hστ G h).toPointedCone =
+    (prodRayFst G hG h).toPointedCone =
       PointedCone.map (LinearMap.fst ℝ V V') G.toPointedCone := (rfl)
 
 @[simp]
-theorem mem_prodRayFst
-    (hστ : ((σ.prod τ : PointedCone ℝ (V × V')) : ConvexCone ℝ (V × V')).Salient)
-    (G : ToricRay (σ.prod τ))
+theorem mem_prodRayFst (G : ToricRay (σ.prod τ))
+    (hG : (G.toPointedCone : ConvexCone ℝ (V × V')).Salient)
     (h : PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone = ⊥) {x : V} :
-    x ∈ prodRayFst hστ G h ↔ x ∈ PointedCone.map (LinearMap.fst ℝ V V') G.toPointedCone := (Iff.rfl)
+    x ∈ prodRayFst G hG h ↔ x ∈ PointedCone.map (LinearMap.fst ℝ V V') G.toPointedCone := (Iff.rfl)
 
-/-- The ray of the second factor underlying a ray of a product of salient cones whose projection to
-the second factor is not the zero cone. -/
-noncomputable def prodRaySnd
-    (hστ : ((σ.prod τ : PointedCone ℝ (V × V')) : ConvexCone ℝ (V × V')).Salient)
-    (G : ToricRay (σ.prod τ))
+/-- The ray of the second factor underlying a salient ray of a product of cones whose projection
+to the second factor is not the zero cone. -/
+noncomputable def prodRaySnd (G : ToricRay (σ.prod τ))
+    (hG : (G.toPointedCone : ConvexCone ℝ (V × V')).Salient)
     (h : PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone ≠ ⊥) : ToricRay τ :=
-  ⟨⟨_, G.1.isFaceOf.snd⟩, finrank_span_map_snd_eq_one hστ G h⟩
+  ⟨⟨_, G.1.isFaceOf.snd⟩, finrank_span_map_snd_eq_one G hG h⟩
 
 @[simp]
-theorem toPointedCone_prodRaySnd
-    (hστ : ((σ.prod τ : PointedCone ℝ (V × V')) : ConvexCone ℝ (V × V')).Salient)
-    (G : ToricRay (σ.prod τ))
+theorem toPointedCone_prodRaySnd (G : ToricRay (σ.prod τ))
+    (hG : (G.toPointedCone : ConvexCone ℝ (V × V')).Salient)
     (h : PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone ≠ ⊥) :
-    (prodRaySnd hστ G h).toPointedCone =
+    (prodRaySnd G hG h).toPointedCone =
       PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone := (rfl)
 
 @[simp]
-theorem mem_prodRaySnd
-    (hστ : ((σ.prod τ : PointedCone ℝ (V × V')) : ConvexCone ℝ (V × V')).Salient)
-    (G : ToricRay (σ.prod τ))
+theorem mem_prodRaySnd (G : ToricRay (σ.prod τ))
+    (hG : (G.toPointedCone : ConvexCone ℝ (V × V')).Salient)
     (h : PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone ≠ ⊥) {x : V'} :
-    x ∈ prodRaySnd hστ G h ↔ x ∈ PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone := (Iff.rfl)
+    x ∈ prodRaySnd G hG h ↔ x ∈ PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone := (Iff.rfl)
 
 /-- A ray of a product of cones is determined by its two projections. -/
 theorem prod_ext {G H : ToricRay (σ.prod τ)}
@@ -375,7 +364,8 @@ cone. The two cases of the forward map are computed by
 noncomputable def prodSplit (hσ : (σ : ConvexCone ℝ V).Salient)
     (hτ : (τ : ConvexCone ℝ V').Salient) : ToricRay (σ.prod τ) ≃ ToricRay σ ⊕ ToricRay τ where
   toFun G := if h : PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone = ⊥ then
-    Sum.inl (prodRayFst (hσ.prod hτ) G h) else Sum.inr (prodRaySnd (hσ.prod hτ) G h)
+    Sum.inl (prodRayFst G ((hσ.prod hτ).anti fun _ hx ↦ G.1.isFaceOf.le hx) h)
+    else Sum.inr (prodRaySnd G ((hσ.prod hτ).anti fun _ hx ↦ G.1.isFaceOf.le hx) h)
   invFun := Sum.elim (prodInl hτ) (prodInr hσ)
   left_inv G := by
     dsimp only
@@ -386,7 +376,9 @@ noncomputable def prodSplit (hσ : (σ : ConvexCone ℝ V).Salient)
     · -- The ray is the product of the zero cone with its second projection.
       rw [dite_eq_right h, Sum.elim_inr]
       exact prod_ext ((Submodule.prod_map_fst ..).trans
-        (map_fst_eq_bot_of_map_snd_ne_bot (hσ.prod hτ) G h).symm) (Submodule.prod_map_snd ..)
+        (map_fst_eq_bot_of_map_snd_ne_bot G
+          ((hσ.prod hτ).anti fun _ hx ↦ G.1.isFaceOf.le hx) h).symm)
+        (Submodule.prod_map_snd ..)
   right_inv := by
     rintro (ρ | ρ)
     · have h : PointedCone.map (LinearMap.snd ℝ V V') (prodInl hτ ρ).toPointedCone = ⊥ :=
@@ -404,13 +396,17 @@ noncomputable def prodSplit (hσ : (σ : ConvexCone ℝ V).Salient)
 theorem prodSplit_eq_inl (hσ : (σ : ConvexCone ℝ V).Salient)
     (hτ : (τ : ConvexCone ℝ V').Salient) (G : ToricRay (σ.prod τ))
     (h : PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone = ⊥) :
-    prodSplit hσ hτ G = Sum.inl (prodRayFst (hσ.prod hτ) G h) := dite_eq_left h
+    prodSplit hσ hτ G =
+      Sum.inl (prodRayFst G ((hσ.prod hτ).anti fun _ hx ↦ G.1.isFaceOf.le hx) h) :=
+  dite_eq_left h
 
 @[simp]
 theorem prodSplit_eq_inr (hσ : (σ : ConvexCone ℝ V).Salient)
     (hτ : (τ : ConvexCone ℝ V').Salient) (G : ToricRay (σ.prod τ))
     (h : PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone ≠ ⊥) :
-    prodSplit hσ hτ G = Sum.inr (prodRaySnd (hσ.prod hτ) G h) := dite_eq_right h
+    prodSplit hσ hτ G =
+      Sum.inr (prodRaySnd G ((hσ.prod hτ).anti fun _ hx ↦ G.1.isFaceOf.le hx) h) :=
+  dite_eq_right h
 
 @[simp]
 theorem prodSplit_symm_inl (hσ : (σ : ConvexCone ℝ V).Salient)

--- a/TauCeti/Geometry/Toric/Algebraic/Ray/Basic.lean
+++ b/TauCeti/Geometry/Toric/Algebraic/Ray/Basic.lean
@@ -5,8 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Basic.Real.Basic
-public import Mathlib.LinearAlgebra.FiniteDimensional.Basic
 public import TauCeti.Geometry.Convex.Cone.Basic
 public import TauCeti.Geometry.Convex.Cone.Face.Basic
 public import TauCeti.Geometry.Convex.Cone.Face.Finite
@@ -33,8 +31,9 @@ pointed cone.
 * `TauCeti.Toric.ToricRay.hullSingleton` and `TauCeti.Toric.ToricRay.eq_hullSingleton`: the cone
   spanned by a nonzero vector is its own only ray.
 * `TauCeti.Toric.ToricRay.map_fst_eq_bot_of_map_snd_ne_bot`,
-  `TauCeti.Toric.ToricRay.prodRayFst`, `TauCeti.Toric.ToricRay.prodRaySnd` and
-  `TauCeti.Toric.ToricRay.prodSplit`: a ray of a product of salient cones is a ray of exactly one
+  `TauCeti.Toric.ToricRay.prodRayFst`, `TauCeti.Toric.ToricRay.prodRaySnd`,
+  `TauCeti.Toric.ToricRay.prodInl`, `TauCeti.Toric.ToricRay.prodInr` and
+  `TauCeti.Toric.ToricRay.prodSplit`: the rays of a product of salient cones are exactly the rays
   of the two factors.
 
 ## References
@@ -307,45 +306,104 @@ theorem prod_ext {G H : ToricRay (σ.prod τ)}
   toPointedCone_injective
     (G.1.isFaceOf.eq_prod_map.trans (by rw [h₁, h₂]; exact H.1.isFaceOf.eq_prod_map.symm))
 
+/-- Multiplying a pointed cone by the zero cone leaves the dimension of its span unchanged: the
+product is the image of the cone under the inclusion of the first factor. -/
+private lemma finrank_span_coe_prod_bot (p : PointedCone ℝ V) :
+    Module.finrank ℝ (Submodule.span ℝ
+        ((p.prod (⊥ : PointedCone ℝ V') : PointedCone ℝ (V × V')) : Set (V × V')))
+      = Module.finrank ℝ (Submodule.span ℝ (p : Set V)) := by
+  rw [Submodule.prod_coe, Submodule.span_prod_eq ℝ p.zero_mem (Submodule.zero_mem _),
+    Submodule.bot_coe, Submodule.span_zero_singleton, ← Submodule.map_inl]
+  exact (Submodule.equivMapOfInjective _ LinearMap.inl_injective
+    (Submodule.span ℝ (p : Set V))).finrank_eq.symm
+
+/-- Multiplying a pointed cone by the zero cone leaves the dimension of its span unchanged: the
+product is the image of the cone under the inclusion of the second factor. -/
+private lemma finrank_span_coe_bot_prod (q : PointedCone ℝ V') :
+    Module.finrank ℝ (Submodule.span ℝ
+        (((⊥ : PointedCone ℝ V).prod q : PointedCone ℝ (V × V')) : Set (V × V')))
+      = Module.finrank ℝ (Submodule.span ℝ (q : Set V')) := by
+  rw [Submodule.prod_coe, Submodule.span_prod_eq ℝ (Submodule.zero_mem _) q.zero_mem,
+    Submodule.bot_coe, Submodule.span_zero_singleton, ← Submodule.map_inr]
+  exact (Submodule.equivMapOfInjective _ LinearMap.inr_injective
+    (Submodule.span ℝ (q : Set V'))).finrank_eq.symm
+
+/-- A ray of the first factor, read as a ray of a product of cones: its product with the zero
+cone. This is a face of the product because the zero cone is a face of the salient second
+factor, and its span has the dimension of the span of the ray. -/
+def prodInl (hτ : (τ : ConvexCone ℝ V').Salient) (ρ : ToricRay σ) : ToricRay (σ.prod τ) :=
+  ⟨⟨ρ.toPointedCone.prod ⊥, ρ.1.isFaceOf.prod hτ.bot_isFaceOf⟩,
+    (finrank_span_coe_prod_bot ρ.toPointedCone).trans ρ.2⟩
+
+@[simp]
+theorem toPointedCone_prodInl (hτ : (τ : ConvexCone ℝ V').Salient) (ρ : ToricRay σ) :
+    (prodInl hτ ρ).toPointedCone = ρ.toPointedCone.prod ⊥ := (rfl)
+
+/-- A ray of the second factor, read as a ray of a product of cones: its product with the zero
+cone. This is a face of the product because the zero cone is a face of the salient first factor,
+and its span has the dimension of the span of the ray. -/
+def prodInr (hσ : (σ : ConvexCone ℝ V).Salient) (ρ : ToricRay τ) : ToricRay (σ.prod τ) :=
+  ⟨⟨(⊥ : PointedCone ℝ V).prod ρ.toPointedCone, hσ.bot_isFaceOf.prod ρ.1.isFaceOf⟩,
+    (finrank_span_coe_bot_prod ρ.toPointedCone).trans ρ.2⟩
+
+@[simp]
+theorem toPointedCone_prodInr (hσ : (σ : ConvexCone ℝ V).Salient) (ρ : ToricRay τ) :
+    (prodInr hσ ρ).toPointedCone = (⊥ : PointedCone ℝ V).prod ρ.toPointedCone := (rfl)
+
 open Classical in
-/-- The decomposition of the rays of a product of salient cones: every ray of `σ.prod τ` is a ray
-of exactly one of the two factors. The two cases are computed by
+/-- The decomposition of the rays of a product of salient cones: the rays of `σ.prod τ` are
+exactly the rays of the two factors, a ray of a factor corresponding to its product with the zero
+cone. The two cases of the forward map are computed by
 `TauCeti.Toric.ToricRay.prodSplit_eq_inl` and `TauCeti.Toric.ToricRay.prodSplit_eq_inr`. -/
-noncomputable def prodSplit
-    (hστ : ((σ.prod τ : PointedCone ℝ (V × V')) : ConvexCone ℝ (V × V')).Salient) :
-    ToricRay (σ.prod τ) ↪ ToricRay σ ⊕ ToricRay τ where
+noncomputable def prodSplit (hσ : (σ : ConvexCone ℝ V).Salient)
+    (hτ : (τ : ConvexCone ℝ V').Salient) : ToricRay (σ.prod τ) ≃ ToricRay σ ⊕ ToricRay τ where
   toFun G := if h : PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone = ⊥ then
-    Sum.inl (prodRayFst hστ G h) else Sum.inr (prodRaySnd hστ G h)
-  inj' G H hGH := by
-    dsimp only at hGH
-    by_cases hG : PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone = ⊥
-    · by_cases hH : PointedCone.map (LinearMap.snd ℝ V V') H.toPointedCone = ⊥
-      · rw [dite_eq_left hG, dite_eq_left hH] at hGH
-        refine prod_ext ?_ (hG.trans hH.symm)
-        simpa using congrArg toPointedCone (Sum.inl_injective hGH)
-      · rw [dite_eq_left hG, dite_eq_right hH] at hGH
-        exact absurd hGH (by simp)
-    · by_cases hH : PointedCone.map (LinearMap.snd ℝ V V') H.toPointedCone = ⊥
-      · rw [dite_eq_right hG, dite_eq_left hH] at hGH
-        exact absurd hGH (by simp)
-      · rw [dite_eq_right hG, dite_eq_right hH] at hGH
-        refine prod_ext ((map_fst_eq_bot_of_map_snd_ne_bot hστ G hG).trans
-          (map_fst_eq_bot_of_map_snd_ne_bot hστ H hH).symm) ?_
-        simpa using congrArg toPointedCone (Sum.inr_injective hGH)
+    Sum.inl (prodRayFst (hσ.prod hτ) G h) else Sum.inr (prodRaySnd (hσ.prod hτ) G h)
+  invFun := Sum.elim (prodInl hτ) (prodInr hσ)
+  left_inv G := by
+    dsimp only
+    by_cases h : PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone = ⊥
+    · -- The ray is the product of its first projection with the zero cone.
+      rw [dite_eq_left h, Sum.elim_inl]
+      exact prod_ext (Submodule.prod_map_fst ..) ((Submodule.prod_map_snd ..).trans h.symm)
+    · -- The ray is the product of the zero cone with its second projection.
+      rw [dite_eq_right h, Sum.elim_inr]
+      exact prod_ext ((Submodule.prod_map_fst ..).trans
+        (map_fst_eq_bot_of_map_snd_ne_bot (hσ.prod hτ) G h).symm) (Submodule.prod_map_snd ..)
+  right_inv := by
+    rintro (ρ | ρ)
+    · have h : PointedCone.map (LinearMap.snd ℝ V V') (prodInl hτ ρ).toPointedCone = ⊥ :=
+        Submodule.prod_map_snd ..
+      dsimp only
+      rw [Sum.elim_inl, dite_eq_left h]
+      exact congrArg Sum.inl (toPointedCone_injective (Submodule.prod_map_fst ..))
+    · have h : PointedCone.map (LinearMap.snd ℝ V V') (prodInr hσ ρ).toPointedCone ≠ ⊥ :=
+        fun hbot ↦ ρ.toPointedCone_ne_bot ((Submodule.prod_map_snd ..).symm.trans hbot)
+      dsimp only
+      rw [Sum.elim_inr, dite_eq_right h]
+      exact congrArg Sum.inr (toPointedCone_injective (Submodule.prod_map_snd ..))
 
 @[simp]
-theorem prodSplit_eq_inl
-    (hστ : ((σ.prod τ : PointedCone ℝ (V × V')) : ConvexCone ℝ (V × V')).Salient)
-    (G : ToricRay (σ.prod τ))
+theorem prodSplit_eq_inl (hσ : (σ : ConvexCone ℝ V).Salient)
+    (hτ : (τ : ConvexCone ℝ V').Salient) (G : ToricRay (σ.prod τ))
     (h : PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone = ⊥) :
-    prodSplit hστ G = Sum.inl (prodRayFst hστ G h) := dite_eq_left h
+    prodSplit hσ hτ G = Sum.inl (prodRayFst (hσ.prod hτ) G h) := dite_eq_left h
 
 @[simp]
-theorem prodSplit_eq_inr
-    (hστ : ((σ.prod τ : PointedCone ℝ (V × V')) : ConvexCone ℝ (V × V')).Salient)
-    (G : ToricRay (σ.prod τ))
+theorem prodSplit_eq_inr (hσ : (σ : ConvexCone ℝ V).Salient)
+    (hτ : (τ : ConvexCone ℝ V').Salient) (G : ToricRay (σ.prod τ))
     (h : PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone ≠ ⊥) :
-    prodSplit hστ G = Sum.inr (prodRaySnd hστ G h) := dite_eq_right h
+    prodSplit hσ hτ G = Sum.inr (prodRaySnd (hσ.prod hτ) G h) := dite_eq_right h
+
+@[simp]
+theorem prodSplit_symm_inl (hσ : (σ : ConvexCone ℝ V).Salient)
+    (hτ : (τ : ConvexCone ℝ V').Salient) (ρ : ToricRay σ) :
+    (prodSplit hσ hτ).symm (Sum.inl ρ) = prodInl hτ ρ := (rfl)
+
+@[simp]
+theorem prodSplit_symm_inr (hσ : (σ : ConvexCone ℝ V).Salient)
+    (hτ : (τ : ConvexCone ℝ V').Salient) (ρ : ToricRay τ) :
+    (prodSplit hσ hτ).symm (Sum.inr ρ) = prodInr hσ ρ := (rfl)
 
 end Prod
 

--- a/TauCeti/Geometry/Toric/Algebraic/Ray/Basic.lean
+++ b/TauCeti/Geometry/Toric/Algebraic/Ray/Basic.lean
@@ -151,6 +151,7 @@ theorem mem_hullSingleton {x : V} (hx : x ≠ 0) {y : V} :
 
 /-- A ray of the cone spanned by a vector is the whole cone: a proper face of that cone misses the
 spanning vector, hence is the zero cone, which is not a ray. -/
+@[simp]
 theorem toPointedCone_eq_of_hull_singleton {x : V}
     (ρ : ToricRay (PointedCone.hull ℝ {x})) : ρ.toPointedCone = PointedCone.hull ℝ {x} := by
   have hx : x ∈ ρ.toPointedCone := by

--- a/TauCeti/Geometry/Toric/Algebraic/Ray/Basic.lean
+++ b/TauCeti/Geometry/Toric/Algebraic/Ray/Basic.lean
@@ -144,6 +144,11 @@ def hullSingleton {x : V} (hx : x ≠ 0) : ToricRay (PointedCone.hull ℝ {x}) :
 theorem toPointedCone_hullSingleton {x : V} (hx : x ≠ 0) :
     (hullSingleton hx).toPointedCone = PointedCone.hull ℝ {x} := (rfl)
 
+/-- Membership in the ray spanned by a vector is membership in its underlying cone. -/
+@[simp]
+theorem mem_hullSingleton {x : V} (hx : x ≠ 0) {y : V} :
+    y ∈ hullSingleton hx ↔ y ∈ PointedCone.hull ℝ {x} := (Iff.rfl)
+
 /-- A ray of the cone spanned by a vector is the whole cone: a proper face of that cone misses the
 spanning vector, hence is the zero cone, which is not a ray. -/
 theorem toPointedCone_eq_of_hull_singleton {x : V}
@@ -316,9 +321,10 @@ theorem prod_ext {G H : ToricRay (σ.prod τ)}
       (hsnd (Submodule.mem_map.2 ⟨x, hx, rfl⟩))
     have hxa : (x.1, a.2) = a := Prod.ext ha1.symm rfl
     have hcx : (c.1, x.2) = c := Prod.ext rfl hc2.symm
+    have hadd : (x.1, a.2) + (c.1, x.2) = x + (c.1, a.2) := by
+      ext <;> simp [add_comm]
     have hsum : x + (c.1, a.2) ∈ B.toPointedCone := by
-      rw [← show (x.1, a.2) + (c.1, x.2) = x + (c.1, a.2) by
-        simp [Prod.ext_iff, add_comm], hxa, hcx]
+      rw [← hadd, hxa, hcx]
       exact Submodule.add_mem _ ha hc
     exact B.1.isFaceOf.mem_of_add_mem_left (x := x) (y := (c.1, a.2))
       (Submodule.mem_prod.2 ⟨by
@@ -344,6 +350,11 @@ def prodInl (hτ : (τ : ConvexCone ℝ V').Salient) (ρ : ToricRay σ) : ToricR
 theorem toPointedCone_prodInl (hτ : (τ : ConvexCone ℝ V').Salient) (ρ : ToricRay σ) :
     (prodInl hτ ρ).toPointedCone = ρ.toPointedCone.prod ⊥ := (rfl)
 
+/-- Membership in a ray included from the first factor is coordinatewise. -/
+@[simp]
+theorem mem_prodInl (hτ : (τ : ConvexCone ℝ V').Salient) (ρ : ToricRay σ) {x : V × V'} :
+    x ∈ prodInl hτ ρ ↔ x.1 ∈ ρ ∧ x.2 = 0 := (Iff.rfl)
+
 /-- A ray of the second factor, read as a ray of a product of cones: its product with the zero
 cone. This is a face of the product because the zero cone is a face of the salient first factor,
 and its span has the dimension of the span of the ray. -/
@@ -354,6 +365,11 @@ def prodInr (hσ : (σ : ConvexCone ℝ V).Salient) (ρ : ToricRay τ) : ToricRa
 @[simp]
 theorem toPointedCone_prodInr (hσ : (σ : ConvexCone ℝ V).Salient) (ρ : ToricRay τ) :
     (prodInr hσ ρ).toPointedCone = (⊥ : PointedCone ℝ V).prod ρ.toPointedCone := (rfl)
+
+/-- Membership in a ray included from the second factor is coordinatewise. -/
+@[simp]
+theorem mem_prodInr (hσ : (σ : ConvexCone ℝ V).Salient) (ρ : ToricRay τ) {x : V × V'} :
+    x ∈ prodInr hσ ρ ↔ x.1 = 0 ∧ x.2 ∈ ρ := (Iff.rfl)
 
 open Classical in
 /-- The decomposition of the rays of a product of salient cones: the rays of `σ.prod τ` are

--- a/TauCeti/Geometry/Toric/Algebraic/Ray/Basic.lean
+++ b/TauCeti/Geometry/Toric/Algebraic/Ray/Basic.lean
@@ -204,13 +204,12 @@ theorem map_fst_eq_bot_of_map_snd_ne_bot
   have hp2 : p.2 ≠ 0 := fun hp2 ↦ h (by rw [hsnd, hp2]; simp)
   have hpG : p ∈ G.toPointedCone := by
     rw [hGeq]; exact PointedCone.subset_hull (Set.mem_singleton p)
-  have hprod : ((PointedCone.map (LinearMap.fst ℝ V V') G.toPointedCone).prod
-      (PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone) : PointedCone ℝ (V × V'))
-      = PointedCone.hull ℝ {p} := by
-    rw [← hGeq]; exact G.1.isFaceOf.eq_prod_map.symm
   have hmem : (p.1, (0 : V')) ∈ PointedCone.hull ℝ {p} := by
-    rw [← hprod]
-    exact Submodule.mem_prod.2 ⟨Submodule.mem_map.2 ⟨p, hpG, rfl⟩, Submodule.zero_mem _⟩
+    rw [← hGeq]
+    have hp := Submodule.mem_prod.1 (G.1.isFaceOf.le hpG)
+    exact G.1.isFaceOf.mem_of_add_mem_left (x := (p.1, 0)) (y := (0, p.2))
+      (Submodule.mem_prod.2 ⟨hp.1, Submodule.zero_mem _⟩)
+      (Submodule.mem_prod.2 ⟨Submodule.zero_mem _, hp.2⟩) (by simpa using hpG)
   obtain ⟨c, -, hcp⟩ := PointedCone.mem_hull_singleton.1 hmem
   have hc : c = 0 := by
     have h2 : c • p.2 = 0 := by simpa using congrArg Prod.snd hcp
@@ -302,9 +301,37 @@ theorem prod_ext {G H : ToricRay (σ.prod τ)}
     (h₁ : PointedCone.map (LinearMap.fst ℝ V V') G.toPointedCone
       = PointedCone.map (LinearMap.fst ℝ V V') H.toPointedCone)
     (h₂ : PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone
-      = PointedCone.map (LinearMap.snd ℝ V V') H.toPointedCone) : G = H :=
-  toPointedCone_injective
-    (G.1.isFaceOf.eq_prod_map.trans (by rw [h₁, h₂]; exact H.1.isFaceOf.eq_prod_map.symm))
+      = PointedCone.map (LinearMap.snd ℝ V V') H.toPointedCone) : G = H := by
+  apply toPointedCone_injective
+  have key {A B : ToricRay (σ.prod τ)}
+      (hfst : PointedCone.map (LinearMap.fst ℝ V V') A.toPointedCone ≤
+        PointedCone.map (LinearMap.fst ℝ V V') B.toPointedCone)
+      (hsnd : PointedCone.map (LinearMap.snd ℝ V V') A.toPointedCone ≤
+        PointedCone.map (LinearMap.snd ℝ V V') B.toPointedCone) :
+      A.toPointedCone ≤ B.toPointedCone := by
+    intro x hx
+    obtain ⟨a, ha, ha1⟩ := Submodule.mem_map.1
+      (hfst (Submodule.mem_map.2 ⟨x, hx, rfl⟩))
+    obtain ⟨c, hc, hc2⟩ := Submodule.mem_map.1
+      (hsnd (Submodule.mem_map.2 ⟨x, hx, rfl⟩))
+    have hxa : (x.1, a.2) = a := Prod.ext ha1.symm rfl
+    have hcx : (c.1, x.2) = c := Prod.ext rfl hc2.symm
+    have hsum : x + (c.1, a.2) ∈ B.toPointedCone := by
+      rw [← show (x.1, a.2) + (c.1, x.2) = x + (c.1, a.2) by
+        simp [Prod.ext_iff, add_comm], hxa, hcx]
+      exact Submodule.add_mem _ ha hc
+    exact B.1.isFaceOf.mem_of_add_mem_left (x := x) (y := (c.1, a.2))
+      (Submodule.mem_prod.2 ⟨by
+          have h := B.1.isFaceOf.le ha
+          rw [← hxa] at h
+          exact (Submodule.mem_prod.1 h).1,
+        by
+          have h := B.1.isFaceOf.le hc
+          rw [← hcx] at h
+          exact (Submodule.mem_prod.1 h).2⟩)
+      (Submodule.mem_prod.2 ⟨(Submodule.mem_prod.1 (B.1.isFaceOf.le hc)).1,
+        (Submodule.mem_prod.1 (B.1.isFaceOf.le ha)).2⟩) hsum
+  exact le_antisymm (key h₁.le h₂.le) (key h₁.ge h₂.ge)
 
 /-- A ray of the first factor, read as a ray of a product of cones: its product with the zero
 cone. This is a face of the product because the zero cone is a face of the salient second

--- a/TauCeti/Geometry/Toric/Algebraic/Ray/Primitive.lean
+++ b/TauCeti/Geometry/Toric/Algebraic/Ray/Primitive.lean
@@ -27,8 +27,8 @@ vectors which enter the definition of a regular cone and, later, its affine mono
   integral lattice has a unique primitive generator.
 * `TauCeti.Toric.primitiveGenerator`: the resulting canonical lattice vector, with membership,
   nonvanishing, and primitivity lemmas.
-* `TauCeti.Toric.IsPrimitiveGenerator.unique`: two primitive generators of the same ray of a toric
-  cone in an integral lattice are equal.
+* `TauCeti.Toric.IsPrimitiveGenerator.unique`: two primitive generators of the same salient ray in
+  an integral lattice are equal.
 * `TauCeti.Toric.isPrimitiveGenerator_faceEmbedding`: being a primitive generator of a ray does not
   depend on which cone the ray is viewed as a face of.
 
@@ -79,6 +79,39 @@ theorem isPrimitiveGenerator_faceEmbedding {τ : PointedCone ℝ V} (hτ : τ.Is
     IsPrimitiveGenerator i (ToricRay.faceEmbedding hτ ρ) v ↔ IsPrimitiveGenerator i ρ v := by
   simp [isPrimitiveGenerator_iff]
 
+/-- A salient ray in an integral lattice has at most one primitive generator. -/
+theorem IsPrimitiveGenerator.unique {ρ : ToricRay σ} {v w : N} (hi : IsIntegralLattice i)
+    (hρ : (ρ.toPointedCone : ConvexCone ℝ V).Salient)
+    (hv : IsPrimitiveGenerator i ρ v) (hw : IsPrimitiveGenerator i ρ w) : v = w := by
+  have hρeq : ρ.toPointedCone = PointedCone.hull ℝ {i v} :=
+    ρ.eq_hull_singleton hρ hv.mem (by simpa using hi.injective.ne hv.ne_zero)
+  have hwρ : i w ∈ ρ.toPointedCone := hw.mem
+  rw [hρeq] at hwρ
+  obtain ⟨a, ha, haw⟩ := PointedCone.mem_hull_singleton.mp hwρ
+  obtain ⟨f, hfv⟩ := isPrimitive_def.mp hv.isPrimitive
+  let g : V →ₗ[ℝ] ℝ := hi.extend (Int.castAddHom ℝ) f.toAddMonoidHom
+  have hg (x : N) : g (i x) = (f x : ℝ) := by
+    have hcast (z : ℤ) : (Int.castAddHom ℝ) z = (z : ℝ) := rfl
+    have hcoe : f.toAddMonoidHom x = f x := rfl
+    simpa only [g, hcast, hcoe] using
+      hi.extend_apply (Int.castAddHom ℝ) f.toAddMonoidHom x
+  have haInt : a = (f w : ℝ) := by
+    have h := congrArg g haw
+    rw [map_smul, hg, hg, hfv, Int.cast_one, smul_eq_mul, mul_one] at h
+    exact h
+  let k := f w
+  have hk0 : 0 ≤ k := by exact_mod_cast haInt ▸ ha
+  let m := k.toNat
+  have hmk : (m : ℤ) = k := Int.toNat_of_nonneg hk0
+  have ham : a = (m : ℝ) := by
+    calc
+      a = (k : ℝ) := haInt
+      _ = (m : ℝ) := by exact_mod_cast hmk.symm
+  have hwv : w = m • v := by
+    apply hi.injective
+    rw [map_nsmul, ← Nat.cast_smul_eq_nsmul ℝ, ← ham, haw]
+  exact (hwv.trans (by rw [hw.isPrimitive.eq_one_of_eq_nsmul hwv, one_nsmul])).symm
+
 namespace IsToricCone
 
 /-- Every toric ray in an integral lattice has a unique primitive generator. -/
@@ -96,35 +129,7 @@ theorem existsUnique_primitiveGenerator {ρ : ToricRay σ}
       inv_smul_smul₀ hdℝ.ne'] at hscaled
     exact hscaled
   have hvgen : IsPrimitiveGenerator i ρ v := ⟨hvρ, hv⟩
-  refine ⟨v, hvgen, fun u hu ↦ ?_⟩
-  have hρeq : ρ.toPointedCone = PointedCone.hull ℝ {i v} :=
-    ρ.eq_hull_singleton hρ.salient hvρ (by simpa using hi.injective.ne hv.ne_zero)
-  have huρ : i u ∈ ρ.toPointedCone := hu.mem
-  rw [hρeq] at huρ
-  obtain ⟨a, ha, hau⟩ := PointedCone.mem_hull_singleton.mp huρ
-  obtain ⟨f, hfv⟩ := isPrimitive_def.mp hv
-  let g : V →ₗ[ℝ] ℝ := hi.extend (Int.castAddHom ℝ) f.toAddMonoidHom
-  have hg (x : N) : g (i x) = (f x : ℝ) := by
-    have hcast (z : ℤ) : (Int.castAddHom ℝ) z = (z : ℝ) := rfl
-    have hcoe : f.toAddMonoidHom x = f x := rfl
-    simpa only [g, hcast, hcoe] using
-      hi.extend_apply (Int.castAddHom ℝ) f.toAddMonoidHom x
-  have haInt : a = (f u : ℝ) := by
-    have h := congrArg g hau
-    rw [map_smul, hg, hg, hfv, Int.cast_one, smul_eq_mul, mul_one] at h
-    exact h
-  let k := f u
-  have hk0 : 0 ≤ k := by exact_mod_cast haInt ▸ ha
-  let m := k.toNat
-  have hmk : (m : ℤ) = k := Int.toNat_of_nonneg hk0
-  have ham : a = (m : ℝ) := by
-    calc
-      a = (k : ℝ) := haInt
-      _ = (m : ℝ) := by exact_mod_cast hmk.symm
-  have huv : u = m • v := by
-    apply hi.injective
-    rw [map_nsmul, ← Nat.cast_smul_eq_nsmul ℝ, ← ham, hau]
-  exact huv.trans (by rw [hu.isPrimitive.eq_one_of_eq_nsmul huv, one_nsmul])
+  exact ⟨v, hvgen, fun _ hu ↦ (hvgen.unique hi hρ.salient hu).symm⟩
 
 end IsToricCone
 
@@ -162,12 +167,6 @@ theorem IsPrimitiveGenerator.eq_primitiveGenerator {v : N} (hv : IsPrimitiveGene
     (hi : IsIntegralLattice i) (hσ : IsToricCone i σ) :
     v = primitiveGenerator hi hσ ρ :=
   ((hσ.face ρ.1).existsUnique_primitiveGenerator hi).choose_spec.2 v hv
-
-/-- A ray of a toric cone in an integral lattice has at most one primitive generator. -/
-theorem IsPrimitiveGenerator.unique {ρ : ToricRay σ} {v w : N} (hi : IsIntegralLattice i)
-    (hσ : IsToricCone i σ)
-    (hv : IsPrimitiveGenerator i ρ v) (hw : IsPrimitiveGenerator i ρ w) : v = w :=
-  (hv.eq_primitiveGenerator hi hσ).trans (hw.eq_primitiveGenerator hi hσ).symm
 
 /-- A lattice vector is a primitive generator of a ray exactly when it is the canonical one. -/
 @[simp]

--- a/TauCeti/Geometry/Toric/Algebraic/Ray/Primitive.lean
+++ b/TauCeti/Geometry/Toric/Algebraic/Ray/Primitive.lean
@@ -27,6 +27,10 @@ vectors which enter the definition of a regular cone and, later, its affine mono
   integral lattice has a unique primitive generator.
 * `TauCeti.Toric.primitiveGenerator`: the resulting canonical lattice vector, with membership,
   nonvanishing, and primitivity lemmas.
+* `TauCeti.Toric.IsPrimitiveGenerator.unique`: two primitive generators of the same ray of a toric
+  cone in an integral lattice are equal.
+* `TauCeti.Toric.isPrimitiveGenerator_faceEmbedding`: being a primitive generator of a ray does not
+  depend on which cone the ray is viewed as a face of.
 
 ## References
 
@@ -66,6 +70,14 @@ theorem isPrimitive (h : IsPrimitiveGenerator i ρ v) : IsPrimitive v := h.2
 theorem ne_zero (h : IsPrimitiveGenerator i ρ v) : v ≠ 0 := h.isPrimitive.ne_zero
 
 end IsPrimitiveGenerator
+
+/-- Being a primitive generator of a ray mentions only the cone underlying the ray, so it is
+unaffected by viewing a ray of a face as a ray of the ambient cone. -/
+@[simp]
+theorem isPrimitiveGenerator_faceEmbedding {τ : PointedCone ℝ V} (hτ : τ.IsFaceOf σ)
+    (ρ : ToricRay τ) {v : N} :
+    IsPrimitiveGenerator i (ToricRay.faceEmbedding hτ ρ) v ↔ IsPrimitiveGenerator i ρ v := by
+  simp [isPrimitiveGenerator_iff]
 
 namespace IsToricCone
 
@@ -150,6 +162,12 @@ theorem IsPrimitiveGenerator.eq_primitiveGenerator {v : N} (hv : IsPrimitiveGene
     (hi : IsIntegralLattice i) (hσ : IsToricCone i σ) :
     v = primitiveGenerator hi hσ ρ :=
   ((hσ.face ρ.1).existsUnique_primitiveGenerator hi).choose_spec.2 v hv
+
+/-- A ray of a toric cone in an integral lattice has at most one primitive generator. -/
+theorem IsPrimitiveGenerator.unique {ρ : ToricRay σ} {v w : N} (hi : IsIntegralLattice i)
+    (hσ : IsToricCone i σ)
+    (hv : IsPrimitiveGenerator i ρ v) (hw : IsPrimitiveGenerator i ρ w) : v = w :=
+  (hv.eq_primitiveGenerator hi hσ).trans (hw.eq_primitiveGenerator hi hσ).symm
 
 /-- A lattice vector is a primitive generator of a ray exactly when it is the canonical one. -/
 @[simp]

--- a/TauCeti/Geometry/Toric/Algebraic/Ray/Primitive.lean
+++ b/TauCeti/Geometry/Toric/Algebraic/Ray/Primitive.lean
@@ -31,6 +31,9 @@ vectors which enter the definition of a regular cone and, later, its affine mono
   an integral lattice are equal.
 * `TauCeti.Toric.isPrimitiveGenerator_faceEmbedding`: being a primitive generator of a ray does not
   depend on which cone the ray is viewed as a face of.
+* `TauCeti.Toric.IsPrimitiveGenerator.prodInl` and
+  `TauCeti.Toric.IsPrimitiveGenerator.prodInr`: primitive generators remain primitive generators
+  under the two inclusions into a product cone.
 
 ## References
 
@@ -78,6 +81,33 @@ theorem isPrimitiveGenerator_faceEmbedding {τ : PointedCone ℝ V} (hτ : τ.Is
     (ρ : ToricRay τ) {v : N} :
     IsPrimitiveGenerator i (ToricRay.faceEmbedding hτ ρ) v ↔ IsPrimitiveGenerator i ρ v := by
   simp [isPrimitiveGenerator_iff]
+
+section Prod
+
+variable {N' V' : Type*} [AddCommGroup N'] [AddCommGroup V'] [Module ℝ V']
+  {i' : N' →+ V'} {τ : PointedCone ℝ V'}
+
+/-- A primitive generator remains a primitive generator under inclusion from the first factor of
+a product cone. -/
+theorem IsPrimitiveGenerator.prodInl {ρ : ToricRay σ} {v : N}
+    (hρ : IsPrimitiveGenerator i ρ v) (hτ : (τ : ConvexCone ℝ V').Salient) :
+    IsPrimitiveGenerator (i.prodMap i') (ToricRay.prodInl hτ ρ) (v, 0) := by
+  refine isPrimitiveGenerator_iff.2 ⟨?_, ?_⟩
+  · simpa using hρ.mem
+  · obtain ⟨f, hf⟩ := isPrimitive_def.1 hρ.isPrimitive
+    exact isPrimitive_def.2 ⟨f.comp (LinearMap.fst ℤ N N'), by simpa using hf⟩
+
+/-- A primitive generator remains a primitive generator under inclusion from the second factor of
+a product cone. -/
+theorem IsPrimitiveGenerator.prodInr {ρ : ToricRay τ} {v : N'}
+    (hρ : IsPrimitiveGenerator i' ρ v) (hσ : (σ : ConvexCone ℝ V).Salient) :
+    IsPrimitiveGenerator (i.prodMap i') (ToricRay.prodInr hσ ρ) (0, v) := by
+  refine isPrimitiveGenerator_iff.2 ⟨?_, ?_⟩
+  · simpa using hρ.mem
+  · obtain ⟨f, hf⟩ := isPrimitive_def.1 hρ.isPrimitive
+    exact isPrimitive_def.2 ⟨f.comp (LinearMap.snd ℤ N N'), by simpa using hf⟩
+
+end Prod
 
 /-- A salient ray in an integral lattice has at most one primitive generator. -/
 theorem IsPrimitiveGenerator.unique {ρ : ToricRay σ} {v w : N} (hi : IsIntegralLattice i)

--- a/TauCeti/Geometry/Toric/Algebraic/Regular.lean
+++ b/TauCeti/Geometry/Toric/Algebraic/Regular.lean
@@ -40,7 +40,8 @@ boundary coordinates, twists them by `B`, and acts on the torus coordinates by `
 * `TauCeti.Toric.isRegularCone_bot`: the zero cone, whose affine chart is the dense torus, is
   regular.
 * `TauCeti.Toric.isRegularCone_hull_singleton`: the cone spanned by a primitive lattice vector,
-  whose affine chart is the complex line, is regular.
+  whose affine chart is the mixed chart `ℂ × (ℂ ^ *) ^ (n - 1)` with a single boundary coordinate,
+  is regular.
 * `TauCeti.Toric.IsRegularCone.of_isFaceOf` and `TauCeti.Toric.IsRegularCone.face`: a face of a
   regular cone is regular. Since the pairwise intersections of the cones of a fan are faces, this
   also makes the overlaps of the affine charts of a regular fan regular.
@@ -141,8 +142,9 @@ theorem isRegularCone_bot (hi : IsIntegralLattice i) :
     Function.Embedding.ofIsEmpty, ⟨fun ρ ↦ isEmptyElim ρ⟩⟩
 
 /-- The cone spanned by a primitive lattice vector is regular: a primitive vector belongs to an
-integral basis, and the cone it spans is its own only ray. The affine chart of this cone is the
-complex line, into which the chart of the zero face is the inclusion of the punctured line. -/
+integral basis, and the cone it spans is its own only ray. Having a single ray, this cone has
+exactly one boundary coordinate: its affine chart is `ℂ × (ℂ ^ *) ^ (n - 1)` for `n` the rank of
+the lattice, into which the chart of the zero face is the inclusion of the dense torus. -/
 theorem isRegularCone_hull_singleton (hi : IsIntegralLattice i) {v : N} (hv : IsPrimitive v) :
     IsRegularCone i (PointedCone.hull ℝ {i v}) := by
   have _ := hi.free

--- a/TauCeti/Geometry/Toric/Algebraic/Regular.lean
+++ b/TauCeti/Geometry/Toric/Algebraic/Regular.lean
@@ -27,10 +27,10 @@ be satisfied by cones that are not cones of smooth affine toric varieties at all
 Two extending bases of the same cone cannot differ at the ray indices, because a ray of a toric
 cone in an integral lattice has only one primitive generator. This pins the block form of the
 transition matrix between two extending bases: every ray column is a standard column supported at
-the matching ray row, so in the splitting of the indices into ray and nonray indices the matrix is
-`[[P, B], [0, C]]` with `P` the permutation matrix comparing the two ray indexings. The analytic
-layer consumes exactly this shape: changing the extending basis acts on the boundary coordinates
-by a permutation and on the torus coordinates by the complementary unimodular block.
+the matching ray row, so splitting the index set of each basis into its rays and a common
+complement, compatibly with the two ray indexings, the matrix is `[[1, B], [0, D]]` with `D`
+unimodular. The analytic layer consumes exactly this shape: changing the extending basis keeps the
+boundary coordinates, twists them by `B`, and acts on the torus coordinates by `D`.
 
 ## Main declarations
 
@@ -50,7 +50,12 @@ by a permutation and on the torus coordinates by the complementary unimodular bl
   as the rank of the lattice, which is the count that gives the dimensions of its mixed chart.
 * `TauCeti.Toric.IsExtendingBasis.basis_apply_eq`,
   `TauCeti.Toric.IsExtendingBasis.repr_basis_apply` and
-  `TauCeti.Toric.IsExtendingBasis.toMatrix_apply`: the block form relating two extending bases.
+  `TauCeti.Toric.IsExtendingBasis.toMatrix_apply`: the ray columns of the transition matrix
+  relating two extending bases.
+* `TauCeti.Toric.IsExtendingBasis.isUnit_det_toMatrix_compl` and
+  `TauCeti.Toric.IsExtendingBasis.exists_isUnit_det_toMatrix_compl`: the complementary block of
+  that transition matrix is unimodular, for compatible splittings of the two index sets into the
+  rays and a common complement, and such a splitting exists.
 * `TauCeti.Toric.Fan.IsRegular`: a fan all of whose cones are regular, together with the
   regularity of the fan of a regular cone and of subfans.
 
@@ -113,9 +118,10 @@ theorem exists_basis_finrank (h : IsRegularCone i σ) :
   have hn : Module.finrank ℤ N = n := by simpa using Module.finrank_eq_card_basis b
   exact hn ▸ ⟨b, r, hb⟩
 
-/-- A regular cone has at most as many rays as the rank of the lattice. For a regular cone of
-dimension `k` in a rank-`n` lattice this is the bound `k ≤ n` behind the mixed chart
-`ℂ ^ k × (ℂ ^ *) ^ (n - k)`. -/
+/-- A regular cone has at most as many rays as the rank of the lattice: an extending basis indexes
+its rays injectively. This ray count is what fixes the two dimensions of the mixed chart
+`ℂ ^ k × (ℂ ^ *) ^ (n - k)`; reading it as the dimension of the cone needs the simpliciality of a
+regular cone, which is not proved here. -/
 theorem card_toricRay_le_finrank (h : IsRegularCone i σ) :
     Nat.card (ToricRay σ) ≤ Module.finrank ℤ N := by
   obtain ⟨b, r, -⟩ := h.exists_basis_finrank
@@ -202,7 +208,7 @@ theorem IsRegularCone.prod {τ' : PointedCone ℝ V'} (hσ : IsRegularCone i σ)
     rw [hidx, hBinl]
     refine isPrimitiveGenerator_iff.2 ⟨G.1.isFaceOf.eq_prod_map.ge
       (Submodule.mem_prod.2 ⟨?_, ?_⟩), hprim⟩
-    · exact (isPrimitiveGenerator_iff.1 (hb.isPrimitiveGenerator_apply ρ)).1
+    · simpa [hρ] using (isPrimitiveGenerator_iff.1 (hb.isPrimitiveGenerator_apply ρ)).1
     · simp
   · set ρ := ToricRay.prodRaySnd hστ G hG with hρ
     have hidx : ((ToricRay.prodSplit hστ).trans
@@ -216,7 +222,7 @@ theorem IsRegularCone.prod {τ' : PointedCone ℝ V'} (hσ : IsRegularCone i σ)
     refine isPrimitiveGenerator_iff.2 ⟨G.1.isFaceOf.eq_prod_map.ge
       (Submodule.mem_prod.2 ⟨?_, ?_⟩), hprim⟩
     · simp
-    · exact (isPrimitiveGenerator_iff.1 (hb'.isPrimitiveGenerator_apply ρ)).1
+    · simpa [hρ] using (isPrimitiveGenerator_iff.1 (hb'.isPrimitiveGenerator_apply ρ)).1
 
 /-! ### Two extending bases -/
 
@@ -239,17 +245,21 @@ theorem repr_basis_apply (hi : IsIntegralLattice i) (hσ : IsToricCone i σ)
     b'.repr (b (r ρ)) = Finsupp.single (r' ρ) 1 := by
   rw [hb.basis_apply_eq hi hσ hb' ρ, Module.Basis.repr_self]
 
-/-- The block form of the transition matrix between two extending bases. Splitting both index sets
-into ray and nonray indices, the matrix reads `[[P, B], [0, C]]`: the column of a ray index carries
-a single `1`, in the row of the matching ray index, so the ray block `P` is the permutation matrix
-comparing the two ray indexings and the nonray-row, ray-column block vanishes. -/
+/-- The entries of a ray column of the transition matrix between two extending bases: the column of
+the index that `b` assigns to a ray carries a single `1`, in the row that `b'` assigns to that same
+ray, and zeroes elsewhere. Splitting both index sets into ray and nonray indices, this is the
+`[[P, B], [0, C]]` shape of the matrix, with `P` the comparison of the two ray indexings. When both
+splittings are indexed by the rays themselves, `P` is the identity and `C` is unimodular, by
+`TauCeti.Toric.IsExtendingBasis.isUnit_det_toMatrix_compl`. -/
 theorem toMatrix_apply (hi : IsIntegralLattice i) (hσ : IsToricCone i σ)
     (hb : IsExtendingBasis i b r) (hb' : IsExtendingBasis i b' r') (ρ : ToricRay σ)
     (j : Fin n') : b'.toMatrix b j (r ρ) = if j = r' ρ then 1 else 0 := by
   rw [Module.Basis.toMatrix_apply, hb.repr_basis_apply hi hσ hb' ρ, Finsupp.single_apply]
   exact if_congr eq_comm rfl rfl
 
-/-- The ray block of the transition matrix between two extending bases is a permutation matrix. -/
+/-- The transition matrix between two extending bases has the entry `1` at the pair of indices
+that the two bases assign to the same ray. The full description of the ray block is
+`TauCeti.Toric.IsExtendingBasis.toMatrix_apply`. -/
 theorem toMatrix_apply_self (hi : IsIntegralLattice i) (hσ : IsToricCone i σ)
     (hb : IsExtendingBasis i b r) (hb' : IsExtendingBasis i b' r') (ρ : ToricRay σ) :
     b'.toMatrix b (r' ρ) (r ρ) = 1 := by
@@ -261,6 +271,80 @@ theorem toMatrix_apply_eq_zero (hi : IsIntegralLattice i) (hσ : IsToricCone i �
     (hb : IsExtendingBasis i b r) (hb' : IsExtendingBasis i b' r') (ρ : ToricRay σ)
     {j : Fin n'} (hj : j ≠ r' ρ) : b'.toMatrix b j (r ρ) = 0 := by
   simp [hb.toMatrix_apply hi hσ hb' ρ, hj]
+
+/-- The complementary block of the transition matrix between two extending bases is unimodular.
+Split the index set of each basis into the rays of the cone and a complement `ι`, compatibly with
+the two ray indexings. The ray columns of the matrix are then the standard columns of the matching
+rays, by `TauCeti.Toric.IsExtendingBasis.toMatrix_apply`, so the matrix reads `[[1, B], [0, D]]`
+and its determinant is the determinant of the complementary square block `D`. That determinant is
+a unit because the transition matrix between two bases is invertible. This is the unimodularity
+hypothesis that the analytic change of chart carries. -/
+theorem isUnit_det_toMatrix_compl {ι : Type*} [Fintype ι] [DecidableEq ι]
+    (hi : IsIntegralLattice i) (hσ : IsToricCone i σ)
+    (hb : IsExtendingBasis i b r) (hb' : IsExtendingBasis i b' r')
+    (e : ToricRay σ ⊕ ι ≃ Fin n) (e' : ToricRay σ ⊕ ι ≃ Fin n')
+    (he : ∀ ρ, e (Sum.inl ρ) = r ρ) (he' : ∀ ρ, e' (Sum.inl ρ) = r' ρ) :
+    IsUnit ((b'.toMatrix b).submatrix (fun j : ι ↦ e' (Sum.inr j))
+      (fun k : ι ↦ e (Sum.inr k))).det := by
+  classical
+  have _ : Fintype (ToricRay σ) := Fintype.ofInjective r r.injective
+  set B₁ : Module.Basis (ToricRay σ ⊕ ι) ℤ N := b.reindex e.symm with hB₁
+  set B₂ : Module.Basis (ToricRay σ ⊕ ι) ℤ N := b'.reindex e'.symm with hB₂
+  have hM : ∀ k j, B₂.toMatrix B₁ k j = b'.toMatrix b (e' k) (e j) := by
+    intro k j
+    simp [hB₁, hB₂, Module.Basis.toMatrix_apply]
+  have hblocks : B₂.toMatrix B₁ = Matrix.fromBlocks 1
+      ((b'.toMatrix b).submatrix (fun ρ : ToricRay σ ↦ e' (Sum.inl ρ))
+        (fun k : ι ↦ e (Sum.inr k))) 0
+      ((b'.toMatrix b).submatrix (fun j : ι ↦ e' (Sum.inr j)) (fun k : ι ↦ e (Sum.inr k))) := by
+    ext x y
+    rcases x with ρ' | j' <;> rcases y with ρ | k <;> simp only [hM, Matrix.fromBlocks_apply₁₁,
+      Matrix.fromBlocks_apply₁₂, Matrix.fromBlocks_apply₂₁, Matrix.fromBlocks_apply₂₂,
+      Matrix.submatrix_apply, Matrix.zero_apply]
+    -- The ray block is the identity, since the two bases agree at the indices of a ray.
+    · rw [he, he', hb.toMatrix_apply hi hσ hb' ρ, Matrix.one_apply]
+      simp [r'.injective.eq_iff]
+    -- The nonray-row, ray-column block vanishes, since a nonray index is not a ray index.
+    · rw [he]
+      refine hb.toMatrix_apply_eq_zero hi hσ hb' ρ ?_
+      rw [← he']
+      exact fun h ↦ by simpa using e'.injective h
+  let _ : Invertible (B₂.toMatrix B₁) := B₂.invertibleToMatrix B₁
+  have h := Matrix.isUnit_det_of_invertible (B₂.toMatrix B₁)
+  rwa [hblocks, Matrix.det_fromBlocks_zero₂₁, Matrix.det_one, one_mul] at h
+
+/-- Two extending bases of the same cone admit compatible splittings of their index sets into the
+rays of the cone and a common complement `Fin l`, in which the transition matrix has the block form
+`[[1, B], [0, D]]` with `D` unimodular. The two index sets have the same size, both being the rank
+of the lattice, so the same `l` serves for both. -/
+theorem exists_isUnit_det_toMatrix_compl (hi : IsIntegralLattice i) (hσ : IsToricCone i σ)
+    (hb : IsExtendingBasis i b r) (hb' : IsExtendingBasis i b' r') :
+    ∃ (l : ℕ) (e : ToricRay σ ⊕ Fin l ≃ Fin n) (e' : ToricRay σ ⊕ Fin l ≃ Fin n'),
+      (∀ ρ, e (Sum.inl ρ) = r ρ) ∧ (∀ ρ, e' (Sum.inl ρ) = r' ρ) ∧
+        IsUnit ((b'.toMatrix b).submatrix (fun j : Fin l ↦ e' (Sum.inr j))
+          (fun k : Fin l ↦ e (Sum.inr k))).det := by
+  classical
+  -- The rays sit inside the index set of an extending basis, so they split off a complement.
+  have key : ∀ {m : ℕ} (s : ToricRay σ ↪ Fin m),
+      ∃ (l : ℕ) (f : ToricRay σ ⊕ Fin l ≃ Fin m), ∀ ρ, f (Sum.inl ρ) = s ρ := by
+    intro m s
+    have _ : Fintype (ToricRay σ) := Fintype.ofInjective s s.injective
+    exact ⟨Fintype.card {j : Fin m // j ∉ Set.range s},
+      (Equiv.sumCongr (Equiv.ofInjective s s.injective) (Fintype.equivFin _).symm).trans
+        (Equiv.sumCompl fun j : Fin m ↦ j ∈ Set.range s), fun ρ ↦ rfl⟩
+  have hcard : ∀ {m l : ℕ} (f : ToricRay σ ⊕ Fin l ≃ Fin m), Nat.card (ToricRay σ) + l = m := by
+    intro m l f
+    have _ : Finite (ToricRay σ) := Finite.of_injective _ (f.injective.comp Sum.inl_injective)
+    simpa [Nat.card_sum] using (Nat.card_congr f)
+  obtain ⟨l, e, he⟩ := key r
+  obtain ⟨l', e', he'⟩ := key r'
+  have hn : Module.finrank ℤ N = n := by simpa using Module.finrank_eq_card_basis b
+  have hn' : Module.finrank ℤ N = n' := by simpa using Module.finrank_eq_card_basis b'
+  obtain rfl : l' = l := by
+    have h₁ := hcard e
+    have h₂ := hcard e'
+    omega
+  exact ⟨_, e, e', he, he', isUnit_det_toMatrix_compl hi hσ hb hb' e e' he he'⟩
 
 end IsExtendingBasis
 
@@ -288,9 +372,10 @@ theorem IsRegular.subfan {Φ : Fan i} (hΦ : Φ.IsRegular) (S : Set (PointedCone
     (hS : S ⊆ Φ.cones) (hface : ∀ ⦃σ τ⦄, σ ∈ S → τ.IsFaceOf σ → τ ∈ S) :
     (Φ.subfan S hS hface).IsRegular := fun _ hσ ↦ hΦ (hS (by rwa [Φ.subfan_cones] at hσ))
 
-/-- A nonempty regular fan contains the zero cone, whose affine chart is the dense torus. -/
-theorem IsRegular.isRegularCone_bot {Φ : Fan i} (hΦ : Φ.IsRegular) (hσ : σ ∈ Φ.cones) :
-    IsRegularCone i (⊥ : PointedCone ℝ V) := hΦ (Φ.bot_mem hσ)
+/-- The zero cone is regular for the lattice underlying any fan. Its affine chart is the dense
+torus, and a nonempty fan contains that cone, by `TauCeti.Toric.Fan.bot_mem`. -/
+theorem isRegularCone_bot (Φ : Fan i) : IsRegularCone i (⊥ : PointedCone ℝ V) :=
+  _root_.TauCeti.Toric.isRegularCone_bot Φ.lattice
 
 end Fan
 

--- a/TauCeti/Geometry/Toric/Algebraic/Regular.lean
+++ b/TauCeti/Geometry/Toric/Algebraic/Regular.lean
@@ -273,12 +273,9 @@ theorem toMatrix_apply_eq_zero (hi : IsIntegralLattice i) (hσ : (σ : ConvexCon
   simp [hb.toMatrix_apply hi hσ hb' ρ, hj]
 
 /-- The complementary block of the transition matrix between two extending bases is unimodular.
-Split the index set of each basis into the rays of the cone and a complement `ι`, compatibly with
-the two ray indexings. The ray columns of the matrix are then the standard columns of the matching
-rays, by `TauCeti.Toric.IsExtendingBasis.toMatrix_apply`, so the matrix reads `[[1, B], [0, D]]`
-and its determinant is the determinant of the complementary square block `D`. That determinant is
-a unit because the transition matrix between two bases is invertible. This is the unimodularity
-hypothesis that the analytic change of chart carries. -/
+For compatible splittings of both index sets into the rays of the cone and a common complement
+`ι`, the transition matrix has the block form `[[1, B], [0, D]]`, with `D` unimodular. This is
+the unimodularity hypothesis used by the analytic change of chart. -/
 theorem isUnit_det_toMatrix_compl {ι : Type*} [Fintype ι] [DecidableEq ι]
     (hi : IsIntegralLattice i) (hσ : (σ : ConvexCone ℝ V).Salient)
     (hb : IsExtendingBasis i b r) (hb' : IsExtendingBasis i b' r')

--- a/TauCeti/Geometry/Toric/Algebraic/Regular.lean
+++ b/TauCeti/Geometry/Toric/Algebraic/Regular.lean
@@ -211,10 +211,23 @@ theorem IsRegularCone.prod {τ' : PointedCone ℝ V'} (hσ : IsRegularCone i σ)
       have h := B.isPrimitive (finSumFinEquiv (Sum.inl (r ρ)))
       rwa [hBinl] at h
     rw [hidx, hBinl]
-    refine isPrimitiveGenerator_iff.2 ⟨G.1.isFaceOf.eq_prod_map.ge
-      (Submodule.mem_prod.2 ⟨?_, ?_⟩), hprim⟩
-    · simpa [hρ] using (isPrimitiveGenerator_iff.1 (hb.isPrimitiveGenerator_apply ρ)).1
-    · simp
+    refine isPrimitiveGenerator_iff.2 ⟨?_, hprim⟩
+    have hmem : i (b (r ρ)) ∈ PointedCone.map (LinearMap.fst ℝ V V') G.toPointedCone := by
+      simpa [hρ] using (isPrimitiveGenerator_iff.1 (hb.isPrimitiveGenerator_apply ρ)).1
+    obtain ⟨x, hx, hx1⟩ := Submodule.mem_map.1 hmem
+    have hx2 : x.2 = 0 := by
+      have : x.2 ∈ PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone :=
+        Submodule.mem_map.2 ⟨x, hx, rfl⟩
+      rw [hG] at this
+      simpa using this
+    have hxeq : x = (i (b (r ρ)), 0) := by
+      apply Prod.ext
+      · simpa using hx1
+      · exact hx2
+    change (i (b (r ρ)), i' 0) ∈ G
+    rw [map_zero]
+    rw [← hxeq]
+    exact hx
   · set ρ := ToricRay.prodRaySnd hστ G hG with hρ
     have hidx : ((ToricRay.prodSplit hσ.salient hτ'.salient).toEmbedding.trans
         ((r.sumMap r').trans finSumFinEquiv.toEmbedding)) G
@@ -224,10 +237,23 @@ theorem IsRegularCone.prod {τ' : PointedCone ℝ V'} (hσ : IsRegularCone i σ)
       have h := B.isPrimitive (finSumFinEquiv (Sum.inr (r' ρ)))
       rwa [hBinr] at h
     rw [hidx, hBinr]
-    refine isPrimitiveGenerator_iff.2 ⟨G.1.isFaceOf.eq_prod_map.ge
-      (Submodule.mem_prod.2 ⟨?_, ?_⟩), hprim⟩
-    · simp
-    · simpa [hρ] using (isPrimitiveGenerator_iff.1 (hb'.isPrimitiveGenerator_apply ρ)).1
+    refine isPrimitiveGenerator_iff.2 ⟨?_, hprim⟩
+    have hmem : i' (b' (r' ρ)) ∈ PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone := by
+      simpa [hρ] using (isPrimitiveGenerator_iff.1 (hb'.isPrimitiveGenerator_apply ρ)).1
+    obtain ⟨x, hx, hx2⟩ := Submodule.mem_map.1 hmem
+    have hx1 : x.1 = 0 := by
+      have : x.1 ∈ PointedCone.map (LinearMap.fst ℝ V V') G.toPointedCone :=
+        Submodule.mem_map.2 ⟨x, hx, rfl⟩
+      rw [ToricRay.map_fst_eq_bot_of_map_snd_ne_bot hστ G hG] at this
+      simpa using this
+    have hxeq : x = (0, i' (b' (r' ρ))) := by
+      apply Prod.ext
+      · exact hx1
+      · simpa using hx2
+    change (i 0, i' (b' (r' ρ))) ∈ G
+    rw [map_zero]
+    rw [← hxeq]
+    exact hx
 
 /-! ### Two extending bases -/
 

--- a/TauCeti/Geometry/Toric/Algebraic/Regular.lean
+++ b/TauCeti/Geometry/Toric/Algebraic/Regular.lean
@@ -194,14 +194,15 @@ theorem IsRegularCone.prod {τ' : PointedCone ℝ V'} (hσ : IsRegularCone i σ)
   have hBinr : ∀ k : Fin n', B (finSumFinEquiv (Sum.inr k)) = (0, b' k) := fun k ↦ by
     rw [hB, Module.Basis.reindex_apply, Equiv.symm_apply_apply]; simp
   refine ⟨hσ.toIsToricCone.prod hτ'.toIsToricCone, n + n', B,
-    (ToricRay.prodSplit hστ).trans ((r.sumMap r').trans finSumFinEquiv.toEmbedding),
+    (ToricRay.prodSplit hσ.salient hτ'.salient).toEmbedding.trans
+      ((r.sumMap r').trans finSumFinEquiv.toEmbedding),
     ⟨fun G ↦ ?_⟩⟩
   by_cases hG : PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone = ⊥
   · set ρ := ToricRay.prodRayFst hστ G hG with hρ
-    have hidx : ((ToricRay.prodSplit hστ).trans
+    have hidx : ((ToricRay.prodSplit hσ.salient hτ'.salient).toEmbedding.trans
         ((r.sumMap r').trans finSumFinEquiv.toEmbedding)) G
         = finSumFinEquiv (Sum.inl (r ρ)) := by
-      simp [ToricRay.prodSplit_eq_inl hστ G hG, hρ]
+      simp [ToricRay.prodSplit_eq_inl hσ.salient hτ'.salient G hG, hρ]
     have hprim : IsPrimitive ((b (r ρ), (0 : N')) : N × N') := by
       have h := B.isPrimitive (finSumFinEquiv (Sum.inl (r ρ)))
       rwa [hBinl] at h
@@ -211,10 +212,10 @@ theorem IsRegularCone.prod {τ' : PointedCone ℝ V'} (hσ : IsRegularCone i σ)
     · simpa [hρ] using (isPrimitiveGenerator_iff.1 (hb.isPrimitiveGenerator_apply ρ)).1
     · simp
   · set ρ := ToricRay.prodRaySnd hστ G hG with hρ
-    have hidx : ((ToricRay.prodSplit hστ).trans
+    have hidx : ((ToricRay.prodSplit hσ.salient hτ'.salient).toEmbedding.trans
         ((r.sumMap r').trans finSumFinEquiv.toEmbedding)) G
         = finSumFinEquiv (Sum.inr (r' ρ)) := by
-      simp [ToricRay.prodSplit_eq_inr hστ G hG, hρ]
+      simp [ToricRay.prodSplit_eq_inr hσ.salient hτ'.salient G hG, hρ]
     have hprim : IsPrimitive (((0 : N), b' (r' ρ)) : N × N') := by
       have h := B.isPrimitive (finSumFinEquiv (Sum.inr (r' ρ)))
       rwa [hBinr] at h

--- a/TauCeti/Geometry/Toric/Algebraic/Regular.lean
+++ b/TauCeti/Geometry/Toric/Algebraic/Regular.lean
@@ -14,15 +14,15 @@ public import TauCeti.Geometry.Toric.Algebraic.Ray.Primitive
 A toric cone is *regular*, or smooth, when its primitive ray generators can be completed to a
 single integral basis of the lattice. This is the combinatorial condition under which the affine
 chart of the cone is a mixed chart `ℂ ^ k × (ℂ ^ *) ^ (n - k)` rather than a singular affine toric
-variety, so it is the hypothesis carried by every analytic statement about a toric variety built
-from a fan.
+variety, so it is the hypothesis carried by the downstream mixed-chart and complex-manifold
+constructions.
 
 Regularity is defined here as the conjunction of `TauCeti.Toric.IsToricCone` with the existence of
 an *extending basis*: an integral basis `b` of the lattice together with an injection `r` of the
 rays of the cone into the basis indices such that `b (r ρ)` is the primitive generator of the ray
-`ρ`. Carrying the toric-cone hypothesis is what stops regularity from holding vacuously: an
-irrational or nonsalient cone has no rational rays to constrain, so the basis condition alone would
-be satisfied by cones that are not cones of smooth affine toric varieties at all.
+`ρ`. The toric-cone hypothesis separately enforces lattice rationality, salience, and finite
+generation; the basis condition alone would be vacuous whenever the cone's `ToricRay` type is
+empty.
 
 Two extending bases of the same cone cannot differ at the ray indices, because a ray of a toric
 cone in an integral lattice has only one primitive generator. This pins the block form of the
@@ -100,9 +100,9 @@ structure IsExtendingBasis (i : N →+ V) {σ : PointedCone ℝ V} {n : ℕ}
 /-! ### Regular cones -/
 
 /-- A toric cone is *regular*, or smooth, when some integral basis of the lattice extends its
-primitive ray generators. The toric-cone hypothesis is part of the definition: without it the
-basis condition would hold vacuously for irrational and nonsalient cones, which have no rational
-rays. -/
+primitive ray generators. The toric-cone hypothesis is part of the definition: it enforces
+lattice rationality, salience, and finite generation, while the basis condition alone would be
+vacuous for any cone whose `ToricRay` type is empty. -/
 -- Interface source: `TauCetiRoadmap/AnalyticToricGeometry/Suggested.lean`.
 structure IsRegularCone (i : N →+ V) (σ : PointedCone ℝ V) : Prop extends IsToricCone i σ where
   /-- Some integral basis extends the primitive ray generators of the cone. -/
@@ -134,6 +134,7 @@ end IsRegularCone
 
 /-- The zero cone is regular. Its affine chart is the dense torus of the lattice, which is
 therefore a smooth chart of every toric variety built from a fan. -/
+@[simp]
 theorem isRegularCone_bot (hi : IsIntegralLattice i) :
     IsRegularCone i (⊥ : PointedCone ℝ V) := by
   have _ := hi.free
@@ -145,6 +146,7 @@ theorem isRegularCone_bot (hi : IsIntegralLattice i) :
 integral basis, and the cone it spans is its own only ray. Having a single ray, this cone has
 exactly one boundary coordinate: its affine chart is `ℂ × (ℂ ^ *) ^ (n - 1)` for `n` the rank of
 the lattice, into which the chart of the zero face is the inclusion of the dense torus. -/
+@[simp]
 theorem isRegularCone_hull_singleton (hi : IsIntegralLattice i) {v : N} (hv : IsPrimitive v) :
     IsRegularCone i (PointedCone.hull ℝ {i v}) := by
   have _ := hi.free

--- a/TauCeti/Geometry/Toric/Algebraic/Regular.lean
+++ b/TauCeti/Geometry/Toric/Algebraic/Regular.lean
@@ -190,8 +190,6 @@ theorem IsRegularCone.prod {τ' : PointedCone ℝ V'} (hσ : IsRegularCone i σ)
     (hτ' : IsRegularCone i' τ') : IsRegularCone (i.prodMap i') (σ.prod τ') := by
   obtain ⟨n, b, r, hb⟩ := hσ.exists_basis
   obtain ⟨n', b', r', hb'⟩ := hτ'.exists_basis
-  have hστ : ((σ.prod τ' : PointedCone ℝ (V × V')) : ConvexCone ℝ (V × V')).Salient :=
-    hσ.salient.prod hτ'.salient
   set B := (b.prod b').reindex finSumFinEquiv with hB
   have hBinl : ∀ k : Fin n, B (finSumFinEquiv (Sum.inl k)) = (b k, 0) := fun k ↦ by
     rw [hB, Module.Basis.reindex_apply, Equiv.symm_apply_apply]; simp
@@ -201,57 +199,37 @@ theorem IsRegularCone.prod {τ' : PointedCone ℝ V'} (hσ : IsRegularCone i σ)
     (ToricRay.prodSplit hσ.salient hτ'.salient).toEmbedding.trans
       ((r.sumMap r').trans finSumFinEquiv.toEmbedding),
     ⟨fun G ↦ ?_⟩⟩
-  by_cases hG : PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone = ⊥
-  · set ρ := ToricRay.prodRayFst hστ G hG with hρ
+  rcases hG : ToricRay.prodSplit hσ.salient hτ'.salient G with ρ | ρ
+  · have hGρ : G = ToricRay.prodInl hτ'.salient ρ := by
+      calc
+        G = (ToricRay.prodSplit hσ.salient hτ'.salient).symm
+            (ToricRay.prodSplit hσ.salient hτ'.salient G) :=
+          ((ToricRay.prodSplit hσ.salient hτ'.salient).symm_apply_apply G).symm
+        _ = (ToricRay.prodSplit hσ.salient hτ'.salient).symm (Sum.inl ρ) :=
+          congrArg (ToricRay.prodSplit hσ.salient hτ'.salient).symm hG
+        _ = ToricRay.prodInl hτ'.salient ρ :=
+          ToricRay.prodSplit_symm_inl hσ.salient hτ'.salient ρ
     have hidx : ((ToricRay.prodSplit hσ.salient hτ'.salient).toEmbedding.trans
         ((r.sumMap r').trans finSumFinEquiv.toEmbedding)) G
         = finSumFinEquiv (Sum.inl (r ρ)) := by
-      simp [ToricRay.prodSplit_eq_inl hσ.salient hτ'.salient G hG, hρ]
-    have hprim : IsPrimitive ((b (r ρ), (0 : N')) : N × N') := by
-      have h := B.isPrimitive (finSumFinEquiv (Sum.inl (r ρ)))
-      rwa [hBinl] at h
-    rw [hidx, hBinl]
-    refine isPrimitiveGenerator_iff.2 ⟨?_, hprim⟩
-    have hmem : i (b (r ρ)) ∈ PointedCone.map (LinearMap.fst ℝ V V') G.toPointedCone := by
-      simpa [hρ] using (isPrimitiveGenerator_iff.1 (hb.isPrimitiveGenerator_apply ρ)).1
-    obtain ⟨x, hx, hx1⟩ := Submodule.mem_map.1 hmem
-    have hx2 : x.2 = 0 := by
-      have : x.2 ∈ PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone :=
-        Submodule.mem_map.2 ⟨x, hx, rfl⟩
-      rw [hG] at this
-      simpa using this
-    have hxeq : x = (i (b (r ρ)), 0) := by
-      apply Prod.ext
-      · simpa using hx1
-      · exact hx2
-    simp only [AddMonoidHom.coe_prodMap, Prod.map, map_zero]
-    rw [← hxeq]
-    exact hx
-  · set ρ := ToricRay.prodRaySnd hστ G hG with hρ
+      simp [hG]
+    rw [hidx, hBinl, hGρ]
+    exact (hb.isPrimitiveGenerator_apply ρ).prodInl hτ'.salient
+  · have hGρ : G = ToricRay.prodInr hσ.salient ρ := by
+      calc
+        G = (ToricRay.prodSplit hσ.salient hτ'.salient).symm
+            (ToricRay.prodSplit hσ.salient hτ'.salient G) :=
+          ((ToricRay.prodSplit hσ.salient hτ'.salient).symm_apply_apply G).symm
+        _ = (ToricRay.prodSplit hσ.salient hτ'.salient).symm (Sum.inr ρ) :=
+          congrArg (ToricRay.prodSplit hσ.salient hτ'.salient).symm hG
+        _ = ToricRay.prodInr hσ.salient ρ :=
+          ToricRay.prodSplit_symm_inr hσ.salient hτ'.salient ρ
     have hidx : ((ToricRay.prodSplit hσ.salient hτ'.salient).toEmbedding.trans
         ((r.sumMap r').trans finSumFinEquiv.toEmbedding)) G
         = finSumFinEquiv (Sum.inr (r' ρ)) := by
-      simp [ToricRay.prodSplit_eq_inr hσ.salient hτ'.salient G hG, hρ]
-    have hprim : IsPrimitive (((0 : N), b' (r' ρ)) : N × N') := by
-      have h := B.isPrimitive (finSumFinEquiv (Sum.inr (r' ρ)))
-      rwa [hBinr] at h
-    rw [hidx, hBinr]
-    refine isPrimitiveGenerator_iff.2 ⟨?_, hprim⟩
-    have hmem : i' (b' (r' ρ)) ∈ PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone := by
-      simpa [hρ] using (isPrimitiveGenerator_iff.1 (hb'.isPrimitiveGenerator_apply ρ)).1
-    obtain ⟨x, hx, hx2⟩ := Submodule.mem_map.1 hmem
-    have hx1 : x.1 = 0 := by
-      have : x.1 ∈ PointedCone.map (LinearMap.fst ℝ V V') G.toPointedCone :=
-        Submodule.mem_map.2 ⟨x, hx, rfl⟩
-      rw [ToricRay.map_fst_eq_bot_of_map_snd_ne_bot hστ G hG] at this
-      simpa using this
-    have hxeq : x = (0, i' (b' (r' ρ))) := by
-      apply Prod.ext
-      · exact hx1
-      · simpa using hx2
-    simp only [AddMonoidHom.coe_prodMap, Prod.map, map_zero]
-    rw [← hxeq]
-    exact hx
+      simp [hG]
+    rw [hidx, hBinr, hGρ]
+    exact (hb'.isPrimitiveGenerator_apply ρ).prodInr hσ.salient
 
 /-! ### Two extending bases -/
 

--- a/TauCeti/Geometry/Toric/Algebraic/Regular.lean
+++ b/TauCeti/Geometry/Toric/Algebraic/Regular.lean
@@ -133,7 +133,7 @@ end IsRegularCone
 /-! ### The zero cone and the cone of a ray -/
 
 /-- The zero cone is regular. Its affine chart is the dense torus of the lattice, which is
-therefore a smooth chart of every toric variety built from a fan. -/
+therefore a smooth chart of every toric variety built from a nonempty fan. -/
 @[simp]
 theorem isRegularCone_bot (hi : IsIntegralLattice i) :
     IsRegularCone i (⊥ : PointedCone ℝ V) := by
@@ -224,8 +224,7 @@ theorem IsRegularCone.prod {τ' : PointedCone ℝ V'} (hσ : IsRegularCone i σ)
       apply Prod.ext
       · simpa using hx1
       · exact hx2
-    change (i (b (r ρ)), i' 0) ∈ G
-    rw [map_zero]
+    simp only [AddMonoidHom.coe_prodMap, Prod.map, map_zero]
     rw [← hxeq]
     exact hx
   · set ρ := ToricRay.prodRaySnd hστ G hG with hρ
@@ -250,8 +249,7 @@ theorem IsRegularCone.prod {τ' : PointedCone ℝ V'} (hσ : IsRegularCone i σ)
       apply Prod.ext
       · exact hx1
       · simpa using hx2
-    change (i 0, i' (b' (r' ρ))) ∈ G
-    rw [map_zero]
+    simp only [AddMonoidHom.coe_prodMap, Prod.map, map_zero]
     rw [← hxeq]
     exact hx
 

--- a/TauCeti/Geometry/Toric/Algebraic/Regular.lean
+++ b/TauCeti/Geometry/Toric/Algebraic/Regular.lean
@@ -262,16 +262,17 @@ namespace IsExtendingBasis
 variable {n n' : ℕ} {b : Module.Basis (Fin n) ℤ N} {b' : Module.Basis (Fin n') ℤ N}
   {r : ToricRay σ ↪ Fin n} {r' : ToricRay σ ↪ Fin n'}
 
-/-- Two integral bases extending the primitive ray generators of a toric cone carry the same
-vector at the indices of a given ray: both are primitive generators of that ray, and a ray of a
-toric cone in an integral lattice has only one. -/
-theorem basis_apply_eq (hi : IsIntegralLattice i) (hσ : IsToricCone i σ)
+/-- Two integral bases extending the primitive ray generators of a salient cone carry the same
+vector at the indices of a given ray: both are primitive generators of that ray, and a salient ray
+in an integral lattice has only one. -/
+theorem basis_apply_eq (hi : IsIntegralLattice i) (hσ : (σ : ConvexCone ℝ V).Salient)
     (hb : IsExtendingBasis i b r) (hb' : IsExtendingBasis i b' r') (ρ : ToricRay σ) :
     b (r ρ) = b' (r' ρ) :=
-  (hb.isPrimitiveGenerator_apply ρ).unique hi hσ (hb'.isPrimitiveGenerator_apply ρ)
+  (hb.isPrimitiveGenerator_apply ρ).unique hi
+    (hσ.anti fun _ hx ↦ ρ.1.isFaceOf.le hx) (hb'.isPrimitiveGenerator_apply ρ)
 
 /-- The ray columns of the transition matrix between two extending bases are standard columns. -/
-theorem repr_basis_apply (hi : IsIntegralLattice i) (hσ : IsToricCone i σ)
+theorem repr_basis_apply (hi : IsIntegralLattice i) (hσ : (σ : ConvexCone ℝ V).Salient)
     (hb : IsExtendingBasis i b r) (hb' : IsExtendingBasis i b' r') (ρ : ToricRay σ) :
     b'.repr (b (r ρ)) = Finsupp.single (r' ρ) 1 := by
   rw [hb.basis_apply_eq hi hσ hb' ρ, Module.Basis.repr_self]
@@ -282,23 +283,15 @@ ray, and zeroes elsewhere. Splitting both index sets into ray and nonray indices
 `[[P, B], [0, C]]` shape of the matrix, with `P` the comparison of the two ray indexings. When both
 splittings are indexed by the rays themselves, `P` is the identity and `C` is unimodular, by
 `TauCeti.Toric.IsExtendingBasis.isUnit_det_toMatrix_compl`. -/
-theorem toMatrix_apply (hi : IsIntegralLattice i) (hσ : IsToricCone i σ)
+theorem toMatrix_apply (hi : IsIntegralLattice i) (hσ : (σ : ConvexCone ℝ V).Salient)
     (hb : IsExtendingBasis i b r) (hb' : IsExtendingBasis i b' r') (ρ : ToricRay σ)
     (j : Fin n') : b'.toMatrix b j (r ρ) = if j = r' ρ then 1 else 0 := by
   rw [Module.Basis.toMatrix_apply, hb.repr_basis_apply hi hσ hb' ρ, Finsupp.single_apply]
   exact if_congr eq_comm rfl rfl
 
-/-- The transition matrix between two extending bases has the entry `1` at the pair of indices
-that the two bases assign to the same ray. The full description of the ray block is
-`TauCeti.Toric.IsExtendingBasis.toMatrix_apply`. -/
-theorem toMatrix_apply_self (hi : IsIntegralLattice i) (hσ : IsToricCone i σ)
-    (hb : IsExtendingBasis i b r) (hb' : IsExtendingBasis i b' r') (ρ : ToricRay σ) :
-    b'.toMatrix b (r' ρ) (r ρ) = 1 := by
-  simp [hb.toMatrix_apply hi hσ hb' ρ]
-
 /-- The nonray-row, ray-column block of the transition matrix between two extending bases
 vanishes. -/
-theorem toMatrix_apply_eq_zero (hi : IsIntegralLattice i) (hσ : IsToricCone i σ)
+theorem toMatrix_apply_eq_zero (hi : IsIntegralLattice i) (hσ : (σ : ConvexCone ℝ V).Salient)
     (hb : IsExtendingBasis i b r) (hb' : IsExtendingBasis i b' r') (ρ : ToricRay σ)
     {j : Fin n'} (hj : j ≠ r' ρ) : b'.toMatrix b j (r ρ) = 0 := by
   simp [hb.toMatrix_apply hi hσ hb' ρ, hj]
@@ -311,7 +304,7 @@ and its determinant is the determinant of the complementary square block `D`. Th
 a unit because the transition matrix between two bases is invertible. This is the unimodularity
 hypothesis that the analytic change of chart carries. -/
 theorem isUnit_det_toMatrix_compl {ι : Type*} [Fintype ι] [DecidableEq ι]
-    (hi : IsIntegralLattice i) (hσ : IsToricCone i σ)
+    (hi : IsIntegralLattice i) (hσ : (σ : ConvexCone ℝ V).Salient)
     (hb : IsExtendingBasis i b r) (hb' : IsExtendingBasis i b' r')
     (e : ToricRay σ ⊕ ι ≃ Fin n) (e' : ToricRay σ ⊕ ι ≃ Fin n')
     (he : ∀ ρ, e (Sum.inl ρ) = r ρ) (he' : ∀ ρ, e' (Sum.inl ρ) = r' ρ) :
@@ -348,7 +341,8 @@ theorem isUnit_det_toMatrix_compl {ι : Type*} [Fintype ι] [DecidableEq ι]
 rays of the cone and a common complement `Fin l`, in which the transition matrix has the block form
 `[[1, B], [0, D]]` with `D` unimodular. The two index sets have the same size, both being the rank
 of the lattice, so the same `l` serves for both. -/
-theorem exists_isUnit_det_toMatrix_compl (hi : IsIntegralLattice i) (hσ : IsToricCone i σ)
+theorem exists_isUnit_det_toMatrix_compl (hi : IsIntegralLattice i)
+    (hσ : (σ : ConvexCone ℝ V).Salient)
     (hb : IsExtendingBasis i b r) (hb' : IsExtendingBasis i b' r') :
     ∃ (l : ℕ) (e : ToricRay σ ⊕ Fin l ≃ Fin n) (e' : ToricRay σ ⊕ Fin l ≃ Fin n'),
       (∀ ρ, e (Sum.inl ρ) = r ρ) ∧ (∀ ρ, e' (Sum.inl ρ) = r' ρ) ∧

--- a/TauCeti/Geometry/Toric/Algebraic/Regular.lean
+++ b/TauCeti/Geometry/Toric/Algebraic/Regular.lean
@@ -1,0 +1,297 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Geometry.Toric.Algebraic.Fan
+public import TauCeti.Geometry.Toric.Algebraic.Ray.Primitive
+
+/-!
+# Regular toric cones and regular fans
+
+A toric cone is *regular*, or smooth, when its primitive ray generators can be completed to a
+single integral basis of the lattice. This is the combinatorial condition under which the affine
+chart of the cone is a mixed chart `ℂ ^ k × (ℂ ^ *) ^ (n - k)` rather than a singular affine toric
+variety, so it is the hypothesis carried by every analytic statement about a toric variety built
+from a fan.
+
+Regularity is defined here as the conjunction of `TauCeti.Toric.IsToricCone` with the existence of
+an *extending basis*: an integral basis `b` of the lattice together with an injection `r` of the
+rays of the cone into the basis indices such that `b (r ρ)` is the primitive generator of the ray
+`ρ`. Carrying the toric-cone hypothesis is what stops regularity from holding vacuously: an
+irrational or nonsalient cone has no rational rays to constrain, so the basis condition alone would
+be satisfied by cones that are not cones of smooth affine toric varieties at all.
+
+Two extending bases of the same cone cannot differ at the ray indices, because a ray of a toric
+cone in an integral lattice has only one primitive generator. This pins the block form of the
+transition matrix between two extending bases: every ray column is a standard column supported at
+the matching ray row, so in the splitting of the indices into ray and nonray indices the matrix is
+`[[P, B], [0, C]]` with `P` the permutation matrix comparing the two ray indexings. The analytic
+layer consumes exactly this shape: changing the extending basis acts on the boundary coordinates
+by a permutation and on the torus coordinates by the complementary unimodular block.
+
+## Main declarations
+
+* `TauCeti.Toric.IsExtendingBasis`: an integral basis whose vectors at the ray indices are the
+  primitive ray generators.
+* `TauCeti.Toric.IsRegularCone`: a toric cone admitting an extending basis.
+* `TauCeti.Toric.isRegularCone_bot`: the zero cone, whose affine chart is the dense torus, is
+  regular.
+* `TauCeti.Toric.isRegularCone_hull_singleton`: the cone spanned by a primitive lattice vector,
+  whose affine chart is the complex line, is regular.
+* `TauCeti.Toric.IsRegularCone.of_isFaceOf` and `TauCeti.Toric.IsRegularCone.face`: a face of a
+  regular cone is regular. Since the pairwise intersections of the cones of a fan are faces, this
+  also makes the overlaps of the affine charts of a regular fan regular.
+* `TauCeti.Toric.IsRegularCone.prod`: a product of regular cones is regular for the product lattice
+  map.
+* `TauCeti.Toric.IsRegularCone.card_toricRay_le_finrank`: a regular cone has at most as many rays
+  as the rank of the lattice, which is the count that gives the dimensions of its mixed chart.
+* `TauCeti.Toric.IsExtendingBasis.basis_apply_eq`,
+  `TauCeti.Toric.IsExtendingBasis.repr_basis_apply` and
+  `TauCeti.Toric.IsExtendingBasis.toMatrix_apply`: the block form relating two extending bases.
+* `TauCeti.Toric.Fan.IsRegular`: a fan all of whose cones are regular, together with the
+  regularity of the fan of a regular cone and of subfans.
+
+## Implementation notes
+
+`TauCeti.Toric.IsRegularCone` extends `TauCeti.Toric.IsToricCone`, so lattice rationality,
+salience and finite generation of a regular cone are reached by dot notation through the parent
+structure rather than by forwarding lemmas.
+
+The index type of an extending basis is `Fin n` for an unconstrained `n` rather than
+`Fin (Module.finrank ℤ N)`. The two are interchangeable, since `Module.finrank_eq_card_basis`
+identifies `n` with the rank and `TauCeti.Toric.IsRegularCone.exists_basis_finrank` produces the
+second form on demand, but the unconstrained index avoids transporting a basis along an equality
+of natural numbers every time one is built.
+
+## References
+
+The mathematics is §1.2 and Proposition 1.2.16 of W. Fulton, *Introduction to Toric Varieties*,
+and §§1.2 and 1.3 of D. Cox, J. Little and H. Schenck, *Toric Varieties*, where a regular cone is
+called smooth.
+-/
+
+public section
+
+namespace TauCeti.Toric
+
+variable {N N' V V' : Type*} [AddCommGroup N] [AddCommGroup N'] [AddCommGroup V]
+  [AddCommGroup V'] [Module ℝ V] [Module ℝ V'] {i : N →+ V} {i' : N' →+ V'}
+  {σ τ : PointedCone ℝ V}
+
+/-! ### Extending bases -/
+
+/-- An integral basis `b` of `N` *extends the primitive ray generators* of a cone `σ` along an
+injection `r` of the rays of `σ` into the basis indices when the basis vector `b (r ρ)` is the
+primitive generator of the ray `ρ`. -/
+structure IsExtendingBasis (i : N →+ V) {σ : PointedCone ℝ V} {n : ℕ}
+    (b : Module.Basis (Fin n) ℤ N) (r : ToricRay σ ↪ Fin n) : Prop where
+  /-- The basis vector indexed by a ray is the primitive generator of that ray. -/
+  isPrimitiveGenerator_apply : ∀ ρ : ToricRay σ, IsPrimitiveGenerator i ρ (b (r ρ))
+
+/-! ### Regular cones -/
+
+/-- A toric cone is *regular*, or smooth, when some integral basis of the lattice extends its
+primitive ray generators. The toric-cone hypothesis is part of the definition: without it the
+basis condition would hold vacuously for irrational and nonsalient cones, which have no rational
+rays. -/
+-- Interface source: `TauCetiRoadmap/AnalyticToricGeometry/Suggested.lean`.
+structure IsRegularCone (i : N →+ V) (σ : PointedCone ℝ V) : Prop extends IsToricCone i σ where
+  /-- Some integral basis extends the primitive ray generators of the cone. -/
+  exists_basis : ∃ (n : ℕ) (b : Module.Basis (Fin n) ℤ N) (r : ToricRay σ ↪ Fin n),
+    IsExtendingBasis i b r
+
+namespace IsRegularCone
+
+/-- The rays of a regular cone can be indexed inside a basis of rank-many indices. -/
+theorem exists_basis_finrank (h : IsRegularCone i σ) :
+    ∃ (b : Module.Basis (Fin (Module.finrank ℤ N)) ℤ N)
+      (r : ToricRay σ ↪ Fin (Module.finrank ℤ N)), IsExtendingBasis i b r := by
+  obtain ⟨n, b, r, hb⟩ := h.exists_basis
+  have hn : Module.finrank ℤ N = n := by simpa using Module.finrank_eq_card_basis b
+  exact hn ▸ ⟨b, r, hb⟩
+
+/-- A regular cone has at most as many rays as the rank of the lattice. For a regular cone of
+dimension `k` in a rank-`n` lattice this is the bound `k ≤ n` behind the mixed chart
+`ℂ ^ k × (ℂ ^ *) ^ (n - k)`. -/
+theorem card_toricRay_le_finrank (h : IsRegularCone i σ) :
+    Nat.card (ToricRay σ) ≤ Module.finrank ℤ N := by
+  obtain ⟨b, r, -⟩ := h.exists_basis_finrank
+  simpa using Nat.card_le_card_of_injective r r.injective
+
+end IsRegularCone
+
+/-! ### The zero cone and the cone of a ray -/
+
+/-- The zero cone is regular. Its affine chart is the dense torus of the lattice, which is
+therefore a smooth chart of every toric variety built from a fan. -/
+theorem isRegularCone_bot (hi : IsIntegralLattice i) :
+    IsRegularCone i (⊥ : PointedCone ℝ V) := by
+  have _ := hi.free
+  have _ := hi.finite
+  exact ⟨isToricCone_bot i, Module.finrank ℤ N, Module.finBasis ℤ N,
+    Function.Embedding.ofIsEmpty, ⟨fun ρ ↦ isEmptyElim ρ⟩⟩
+
+/-- The cone spanned by a primitive lattice vector is regular: a primitive vector belongs to an
+integral basis, and the cone it spans is its own only ray. The affine chart of this cone is the
+complex line, into which the chart of the zero face is the inclusion of the punctured line. -/
+theorem isRegularCone_hull_singleton (hi : IsIntegralLattice i) {v : N} (hv : IsPrimitive v) :
+    IsRegularCone i (PointedCone.hull ℝ {i v}) := by
+  have _ := hi.free
+  have _ := hi.finite
+  obtain ⟨n, b, j, hbj⟩ := hv.exists_basis
+  have hiv : i v ≠ 0 := fun h ↦ hv.ne_zero (hi.injective (by simpa using h))
+  have hinj : Function.Injective fun _ : ToricRay (PointedCone.hull ℝ {i v}) ↦ j :=
+    fun ρ ρ' _ ↦ by rw [ToricRay.eq_hullSingleton hiv ρ, ToricRay.eq_hullSingleton hiv ρ']
+  refine ⟨isToricCone_hull_singleton i v, n, b, ⟨_, hinj⟩, ⟨fun ρ ↦ ?_⟩⟩
+  have hmem : i v ∈ ρ :=
+    ρ.toPointedCone_eq_of_hull_singleton.ge (PointedCone.subset_hull (Set.mem_singleton (i v)))
+  simp only [Function.Embedding.coeFn_mk, hbj]
+  exact isPrimitiveGenerator_iff.2 ⟨hmem, hv⟩
+
+/-! ### Faces -/
+
+namespace IsRegularCone
+
+/-- A face of a regular cone is regular: its rays are rays of the ambient cone, with the same
+primitive generators, so an extending basis of the ambient cone restricts to one of the face. -/
+theorem of_isFaceOf (hσ : IsRegularCone i σ) (hτ : τ.IsFaceOf σ) : IsRegularCone i τ := by
+  obtain ⟨n, b, r, hb⟩ := hσ.exists_basis
+  refine ⟨hσ.toIsToricCone.of_isFaceOf hτ, n, b, (ToricRay.faceEmbedding hτ).trans r,
+    ⟨fun ρ ↦ ?_⟩⟩
+  exact (isPrimitiveGenerator_faceEmbedding hτ ρ).1 (hb.isPrimitiveGenerator_apply _)
+
+/-- Every element of Mathlib's face lattice of a regular cone is a regular cone. Since the
+pairwise intersection of two cones of a fan is a face of each of them, the overlaps of the affine
+charts of a regular fan are again charts of regular cones. -/
+theorem face (hσ : IsRegularCone i σ) (F : σ.Face) : IsRegularCone i F.toPointedCone :=
+  hσ.of_isFaceOf F.isFaceOf
+
+end IsRegularCone
+
+/-! ### Products -/
+
+/-- A product of regular cones is regular for the product lattice map. Every ray of the product is
+a ray of one of the two factors, so the product of two extending bases extends the primitive ray
+generators of the product cone. -/
+theorem IsRegularCone.prod {τ' : PointedCone ℝ V'} (hσ : IsRegularCone i σ)
+    (hτ' : IsRegularCone i' τ') : IsRegularCone (i.prodMap i') (σ.prod τ') := by
+  obtain ⟨n, b, r, hb⟩ := hσ.exists_basis
+  obtain ⟨n', b', r', hb'⟩ := hτ'.exists_basis
+  have hστ : ((σ.prod τ' : PointedCone ℝ (V × V')) : ConvexCone ℝ (V × V')).Salient :=
+    hσ.salient.prod hτ'.salient
+  set B := (b.prod b').reindex finSumFinEquiv with hB
+  have hBinl : ∀ k : Fin n, B (finSumFinEquiv (Sum.inl k)) = (b k, 0) := fun k ↦ by
+    rw [hB, Module.Basis.reindex_apply, Equiv.symm_apply_apply]; simp
+  have hBinr : ∀ k : Fin n', B (finSumFinEquiv (Sum.inr k)) = (0, b' k) := fun k ↦ by
+    rw [hB, Module.Basis.reindex_apply, Equiv.symm_apply_apply]; simp
+  refine ⟨hσ.toIsToricCone.prod hτ'.toIsToricCone, n + n', B,
+    (ToricRay.prodSplit hστ).trans ((r.sumMap r').trans finSumFinEquiv.toEmbedding),
+    ⟨fun G ↦ ?_⟩⟩
+  by_cases hG : PointedCone.map (LinearMap.snd ℝ V V') G.toPointedCone = ⊥
+  · set ρ := ToricRay.prodRayFst hστ G hG with hρ
+    have hidx : ((ToricRay.prodSplit hστ).trans
+        ((r.sumMap r').trans finSumFinEquiv.toEmbedding)) G
+        = finSumFinEquiv (Sum.inl (r ρ)) := by
+      simp [ToricRay.prodSplit_eq_inl hστ G hG, hρ]
+    have hprim : IsPrimitive ((b (r ρ), (0 : N')) : N × N') := by
+      have h := B.isPrimitive (finSumFinEquiv (Sum.inl (r ρ)))
+      rwa [hBinl] at h
+    rw [hidx, hBinl]
+    refine isPrimitiveGenerator_iff.2 ⟨G.1.isFaceOf.eq_prod_map.ge
+      (Submodule.mem_prod.2 ⟨?_, ?_⟩), hprim⟩
+    · exact (isPrimitiveGenerator_iff.1 (hb.isPrimitiveGenerator_apply ρ)).1
+    · simp
+  · set ρ := ToricRay.prodRaySnd hστ G hG with hρ
+    have hidx : ((ToricRay.prodSplit hστ).trans
+        ((r.sumMap r').trans finSumFinEquiv.toEmbedding)) G
+        = finSumFinEquiv (Sum.inr (r' ρ)) := by
+      simp [ToricRay.prodSplit_eq_inr hστ G hG, hρ]
+    have hprim : IsPrimitive (((0 : N), b' (r' ρ)) : N × N') := by
+      have h := B.isPrimitive (finSumFinEquiv (Sum.inr (r' ρ)))
+      rwa [hBinr] at h
+    rw [hidx, hBinr]
+    refine isPrimitiveGenerator_iff.2 ⟨G.1.isFaceOf.eq_prod_map.ge
+      (Submodule.mem_prod.2 ⟨?_, ?_⟩), hprim⟩
+    · simp
+    · exact (isPrimitiveGenerator_iff.1 (hb'.isPrimitiveGenerator_apply ρ)).1
+
+/-! ### Two extending bases -/
+
+namespace IsExtendingBasis
+
+variable {n n' : ℕ} {b : Module.Basis (Fin n) ℤ N} {b' : Module.Basis (Fin n') ℤ N}
+  {r : ToricRay σ ↪ Fin n} {r' : ToricRay σ ↪ Fin n'}
+
+/-- Two integral bases extending the primitive ray generators of a toric cone carry the same
+vector at the indices of a given ray: both are primitive generators of that ray, and a ray of a
+toric cone in an integral lattice has only one. -/
+theorem basis_apply_eq (hi : IsIntegralLattice i) (hσ : IsToricCone i σ)
+    (hb : IsExtendingBasis i b r) (hb' : IsExtendingBasis i b' r') (ρ : ToricRay σ) :
+    b (r ρ) = b' (r' ρ) :=
+  (hb.isPrimitiveGenerator_apply ρ).unique hi hσ (hb'.isPrimitiveGenerator_apply ρ)
+
+/-- The ray columns of the transition matrix between two extending bases are standard columns. -/
+theorem repr_basis_apply (hi : IsIntegralLattice i) (hσ : IsToricCone i σ)
+    (hb : IsExtendingBasis i b r) (hb' : IsExtendingBasis i b' r') (ρ : ToricRay σ) :
+    b'.repr (b (r ρ)) = Finsupp.single (r' ρ) 1 := by
+  rw [hb.basis_apply_eq hi hσ hb' ρ, Module.Basis.repr_self]
+
+/-- The block form of the transition matrix between two extending bases. Splitting both index sets
+into ray and nonray indices, the matrix reads `[[P, B], [0, C]]`: the column of a ray index carries
+a single `1`, in the row of the matching ray index, so the ray block `P` is the permutation matrix
+comparing the two ray indexings and the nonray-row, ray-column block vanishes. -/
+theorem toMatrix_apply (hi : IsIntegralLattice i) (hσ : IsToricCone i σ)
+    (hb : IsExtendingBasis i b r) (hb' : IsExtendingBasis i b' r') (ρ : ToricRay σ)
+    (j : Fin n') : b'.toMatrix b j (r ρ) = if j = r' ρ then 1 else 0 := by
+  rw [Module.Basis.toMatrix_apply, hb.repr_basis_apply hi hσ hb' ρ, Finsupp.single_apply]
+  exact if_congr eq_comm rfl rfl
+
+/-- The ray block of the transition matrix between two extending bases is a permutation matrix. -/
+theorem toMatrix_apply_self (hi : IsIntegralLattice i) (hσ : IsToricCone i σ)
+    (hb : IsExtendingBasis i b r) (hb' : IsExtendingBasis i b' r') (ρ : ToricRay σ) :
+    b'.toMatrix b (r' ρ) (r ρ) = 1 := by
+  simp [hb.toMatrix_apply hi hσ hb' ρ]
+
+/-- The nonray-row, ray-column block of the transition matrix between two extending bases
+vanishes. -/
+theorem toMatrix_apply_eq_zero (hi : IsIntegralLattice i) (hσ : IsToricCone i σ)
+    (hb : IsExtendingBasis i b r) (hb' : IsExtendingBasis i b' r') (ρ : ToricRay σ)
+    {j : Fin n'} (hj : j ≠ r' ρ) : b'.toMatrix b j (r ρ) = 0 := by
+  simp [hb.toMatrix_apply hi hσ hb' ρ, hj]
+
+end IsExtendingBasis
+
+/-! ### Regular fans -/
+
+namespace Fan
+
+/-- A fan is *regular*, or smooth, when every one of its cones is regular. This is the hypothesis
+under which the analytic realization of the fan is a complex manifold. -/
+-- Interface source: `TauCetiRoadmap/AnalyticToricGeometry/Suggested.lean`.
+def IsRegular (Φ : Fan i) : Prop := ∀ ⦃σ⦄, σ ∈ Φ.cones → IsRegularCone i σ
+
+/-- The characteristic property of a regular fan. -/
+@[simp]
+theorem isRegular_iff {Φ : Fan i} :
+    Φ.IsRegular ↔ ∀ σ ∈ Φ.cones, IsRegularCone i σ := Iff.rfl
+
+/-- The fan of a regular cone is regular: its cones are the faces of that cone. -/
+theorem isRegular_ofCone (hi : IsIntegralLattice i) (hσ : IsRegularCone i σ) :
+    (ofCone hi hσ.toIsToricCone).IsRegular :=
+  fun _ hτ ↦ hσ.of_isFaceOf ((mem_ofCone_cones hi hσ.toIsToricCone).1 hτ)
+
+/-- A subfan of a regular fan is regular. -/
+theorem IsRegular.subfan {Φ : Fan i} (hΦ : Φ.IsRegular) (S : Set (PointedCone ℝ V))
+    (hS : S ⊆ Φ.cones) (hface : ∀ ⦃σ τ⦄, σ ∈ S → τ.IsFaceOf σ → τ ∈ S) :
+    (Φ.subfan S hS hface).IsRegular := fun _ hσ ↦ hΦ (hS (by rwa [Φ.subfan_cones] at hσ))
+
+/-- A nonempty regular fan contains the zero cone, whose affine chart is the dense torus. -/
+theorem IsRegular.isRegularCone_bot {Φ : Fan i} (hΦ : Φ.IsRegular) (hσ : σ ∈ Φ.cones) :
+    IsRegularCone i (⊥ : PointedCone ℝ V) := hΦ (Φ.bot_mem hσ)
+
+end Fan
+
+end TauCeti.Toric

--- a/TauCeti/Geometry/Toric/Algebraic/Regular.lean
+++ b/TauCeti/Geometry/Toric/Algebraic/Regular.lean
@@ -51,7 +51,7 @@ boundary coordinates, twists them by `B`, and acts on the torus coordinates by `
   as the rank of the lattice, which is the count that gives the dimensions of its mixed chart.
 * `TauCeti.Toric.IsExtendingBasis.basis_apply_eq`,
   `TauCeti.Toric.IsExtendingBasis.repr_basis_apply` and
-  `TauCeti.Toric.IsExtendingBasis.toMatrix_apply`: the ray columns of the transition matrix
+  `TauCeti.Toric.IsExtendingBasis.toMatrix_apply`: the salient ray columns of the transition matrix
   relating two extending bases.
 * `TauCeti.Toric.IsExtendingBasis.isUnit_det_toMatrix_compl` and
   `TauCeti.Toric.IsExtendingBasis.exists_isUnit_det_toMatrix_compl`: the complementary block of
@@ -238,20 +238,23 @@ namespace IsExtendingBasis
 variable {n n' : ℕ} {b : Module.Basis (Fin n) ℤ N} {b' : Module.Basis (Fin n') ℤ N}
   {r : ToricRay σ ↪ Fin n} {r' : ToricRay σ ↪ Fin n'}
 
-/-- Two integral bases extending the primitive ray generators of a salient cone carry the same
-vector at the indices of a given ray: both are primitive generators of that ray, and a salient ray
-in an integral lattice has only one. -/
-theorem basis_apply_eq (hi : IsIntegralLattice i) (hσ : (σ : ConvexCone ℝ V).Salient)
-    (hb : IsExtendingBasis i b r) (hb' : IsExtendingBasis i b' r') (ρ : ToricRay σ) :
+/-- Two integral bases extending the primitive ray generators of a cone carry the same vector at
+the indices of a given salient ray: both are primitive generators of that ray, and a salient ray in
+an integral lattice has only one. Only the ray itself has to be salient; for a ray of a salient
+ambient cone this follows from `ConvexCone.Salient.anti` along the face inclusion. -/
+theorem basis_apply_eq (hi : IsIntegralLattice i) (hb : IsExtendingBasis i b r)
+    (hb' : IsExtendingBasis i b' r') (ρ : ToricRay σ)
+    (hρ : (ρ.toPointedCone : ConvexCone ℝ V).Salient) :
     b (r ρ) = b' (r' ρ) :=
-  (hb.isPrimitiveGenerator_apply ρ).unique hi
-    (hσ.anti fun _ hx ↦ ρ.1.isFaceOf.le hx) (hb'.isPrimitiveGenerator_apply ρ)
+  (hb.isPrimitiveGenerator_apply ρ).unique hi hρ (hb'.isPrimitiveGenerator_apply ρ)
 
-/-- The ray columns of the transition matrix between two extending bases are standard columns. -/
-theorem repr_basis_apply (hi : IsIntegralLattice i) (hσ : (σ : ConvexCone ℝ V).Salient)
-    (hb : IsExtendingBasis i b r) (hb' : IsExtendingBasis i b' r') (ρ : ToricRay σ) :
+/-- The salient ray columns of the transition matrix between two extending bases are standard
+columns. -/
+theorem repr_basis_apply (hi : IsIntegralLattice i) (hb : IsExtendingBasis i b r)
+    (hb' : IsExtendingBasis i b' r') (ρ : ToricRay σ)
+    (hρ : (ρ.toPointedCone : ConvexCone ℝ V).Salient) :
     b'.repr (b (r ρ)) = Finsupp.single (r' ρ) 1 := by
-  rw [hb.basis_apply_eq hi hσ hb' ρ, Module.Basis.repr_self]
+  rw [hb.basis_apply_eq hi hb' ρ hρ, Module.Basis.repr_self]
 
 /-- The entries of a ray column of the transition matrix between two extending bases: the column of
 the index that `b` assigns to a ray carries a single `1`, in the row that `b'` assigns to that same
@@ -259,18 +262,20 @@ ray, and zeroes elsewhere. Splitting both index sets into ray and nonray indices
 `[[P, B], [0, C]]` shape of the matrix, with `P` the comparison of the two ray indexings. When both
 splittings are indexed by the rays themselves, `P` is the identity and `C` is unimodular, by
 `TauCeti.Toric.IsExtendingBasis.isUnit_det_toMatrix_compl`. -/
-theorem toMatrix_apply (hi : IsIntegralLattice i) (hσ : (σ : ConvexCone ℝ V).Salient)
-    (hb : IsExtendingBasis i b r) (hb' : IsExtendingBasis i b' r') (ρ : ToricRay σ)
+theorem toMatrix_apply (hi : IsIntegralLattice i) (hb : IsExtendingBasis i b r)
+    (hb' : IsExtendingBasis i b' r') (ρ : ToricRay σ)
+    (hρ : (ρ.toPointedCone : ConvexCone ℝ V).Salient)
     (j : Fin n') : b'.toMatrix b j (r ρ) = if j = r' ρ then 1 else 0 := by
-  rw [Module.Basis.toMatrix_apply, hb.repr_basis_apply hi hσ hb' ρ, Finsupp.single_apply]
+  rw [Module.Basis.toMatrix_apply, hb.repr_basis_apply hi hb' ρ hρ, Finsupp.single_apply]
   exact if_congr eq_comm rfl rfl
 
 /-- The nonray-row, ray-column block of the transition matrix between two extending bases
-vanishes. -/
-theorem toMatrix_apply_eq_zero (hi : IsIntegralLattice i) (hσ : (σ : ConvexCone ℝ V).Salient)
-    (hb : IsExtendingBasis i b r) (hb' : IsExtendingBasis i b' r') (ρ : ToricRay σ)
+vanishes at a salient ray. -/
+theorem toMatrix_apply_eq_zero (hi : IsIntegralLattice i) (hb : IsExtendingBasis i b r)
+    (hb' : IsExtendingBasis i b' r') (ρ : ToricRay σ)
+    (hρ : (ρ.toPointedCone : ConvexCone ℝ V).Salient)
     {j : Fin n'} (hj : j ≠ r' ρ) : b'.toMatrix b j (r ρ) = 0 := by
-  simp [hb.toMatrix_apply hi hσ hb' ρ, hj]
+  simp [hb.toMatrix_apply hi hb' ρ hρ, hj]
 
 /-- The complementary block of the transition matrix between two extending bases is unimodular.
 For compatible splittings of both index sets into the rays of the cone and a common complement
@@ -285,6 +290,9 @@ theorem isUnit_det_toMatrix_compl {ι : Type*} [Fintype ι] [DecidableEq ι]
       (fun k : ι ↦ e (Sum.inr k))).det := by
   classical
   have _ : Fintype (ToricRay σ) := Fintype.ofInjective r r.injective
+  -- Every ray of a salient cone is salient, by `ConvexCone.Salient.anti` along the face inclusion.
+  have hray : ∀ ρ : ToricRay σ, (ρ.toPointedCone : ConvexCone ℝ V).Salient :=
+    fun ρ ↦ hσ.anti fun _ hx ↦ ρ.1.isFaceOf.le hx
   set B₁ : Module.Basis (ToricRay σ ⊕ ι) ℤ N := b.reindex e.symm with hB₁
   set B₂ : Module.Basis (ToricRay σ ⊕ ι) ℤ N := b'.reindex e'.symm with hB₂
   have hM : ∀ k j, B₂.toMatrix B₁ k j = b'.toMatrix b (e' k) (e j) := by
@@ -299,11 +307,11 @@ theorem isUnit_det_toMatrix_compl {ι : Type*} [Fintype ι] [DecidableEq ι]
       Matrix.fromBlocks_apply₁₂, Matrix.fromBlocks_apply₂₁, Matrix.fromBlocks_apply₂₂,
       Matrix.submatrix_apply, Matrix.zero_apply]
     -- The ray block is the identity, since the two bases agree at the indices of a ray.
-    · rw [he, he', hb.toMatrix_apply hi hσ hb' ρ, Matrix.one_apply]
+    · rw [he, he', hb.toMatrix_apply hi hb' ρ (hray ρ), Matrix.one_apply]
       simp [r'.injective.eq_iff]
     -- The nonray-row, ray-column block vanishes, since a nonray index is not a ray index.
     · rw [he]
-      refine hb.toMatrix_apply_eq_zero hi hσ hb' ρ ?_
+      refine hb.toMatrix_apply_eq_zero hi hb' ρ (hray ρ) ?_
       rw [← he']
       exact fun h ↦ by simpa using e'.injective h
   let _ : Invertible (B₂.toMatrix B₁) := B₂.invertibleToMatrix B₁

--- a/TauCeti/Geometry/Toric/Algebraic/Regular.lean
+++ b/TauCeti/Geometry/Toric/Algebraic/Regular.lean
@@ -373,11 +373,6 @@ theorem IsRegular.subfan {Φ : Fan i} (hΦ : Φ.IsRegular) (S : Set (PointedCone
     (hS : S ⊆ Φ.cones) (hface : ∀ ⦃σ τ⦄, σ ∈ S → τ.IsFaceOf σ → τ ∈ S) :
     (Φ.subfan S hS hface).IsRegular := fun _ hσ ↦ hΦ (hS (by rwa [Φ.subfan_cones] at hσ))
 
-/-- The zero cone is regular for the lattice underlying any fan. Its affine chart is the dense
-torus, and a nonempty fan contains that cone, by `TauCeti.Toric.Fan.bot_mem`. -/
-theorem isRegularCone_bot (Φ : Fan i) : IsRegularCone i (⊥ : PointedCone ℝ V) :=
-  _root_.TauCeti.Toric.isRegularCone_bot Φ.lattice
-
 end Fan
 
 end TauCeti.Toric


### PR DESCRIPTION
This PR supplies item 4 of Layer 0 of the analytic toric geometry roadmap, "the Toric-compatible algebraic supplier": define regularity of a toric cone as the conjunction of `IsToricCone` with the existence of an integral basis containing every primitive ray generator, prove that faces and products of regular cones are regular, and pin the block form relating two extending bases. Layer 0 items 1, 2, 3 and 5 (integral lattices, toric cones, rays and primitive generators, finite fans and their morphisms) are already on `main`; regularity is the next unmet item on the critical path, and it is the hypothesis that Layers 2 to 6 carry everywhere — `Fan.IsRegular` appears in the pinned signatures of the charted space, the manifold instance, the boundary normal form, the toric map, the compactness criterion and the algebraic–analytic comparison.

The milestone served is Layer 2, "affine analytic charts of regular cones", whose item 2 builds the biholomorphism of a regular `k`-dimensional cone with `ℂ^k × (ℂ*)^(n-k)` from an extending basis, and whose item 3 proves independence of the chosen extending basis. The independence statement consumes exactly the block form proved here, through the already-merged `MixedExponent.ofTorusBlock` and `basisChangeOpenPartialHomeomorph`.

What the PR adds, in `TauCeti/Geometry/Toric/Algebraic/Regular.lean`:

- `IsExtendingBasis i b r`: an integral basis `b` of the lattice together with an injection `r` of the rays of the cone into the basis indices, such that `b (r ρ)` is the primitive generator of the ray `ρ`.
- `IsRegularCone`, extending `IsToricCone` with the existence of an extending basis, plus `exists_basis_finrank` for the rank-indexed form pinned in `Suggested.lean` and `card_toricRay_le_finrank` for the ray count that fixes the dimensions of the mixed chart.
- `isRegularCone_bot` and `isRegularCone_hull_singleton`: the zero cone and the cone spanned by a primitive lattice vector are regular. These are the two charts named in the roadmap's acceptance checks, the dense torus and the complex line.
- `IsRegularCone.of_isFaceOf`, `IsRegularCone.face` and `IsRegularCone.prod`: faces and products of regular cones are regular.
- `IsExtendingBasis.basis_apply_eq`, `repr_basis_apply`, `toMatrix_apply` and `toMatrix_apply_eq_zero`: two extending bases of the same cone agree at the ray indices, so every ray column of the transition matrix is a standard column at the matching ray row. Splitting both index sets into ray and nonray indices the matrix reads `[[P, B], [0, C]]` with `P` the permutation matrix comparing the two ray indexings.
- `IsExtendingBasis.isUnit_det_toMatrix_compl` and `IsExtendingBasis.exists_isUnit_det_toMatrix_compl`: for compatible splittings of the two index sets into the rays of the cone and a common complement, the matrix reads `[[1, B], [0, D]]` and the complementary square block `D` is unimodular; such a pair of splittings exists, over a common `Fin l`. This is the `hD : IsUnit D.det` that `basisChangeOpenPartialHomeomorph` consumes in Layer 2.
- `Fan.IsRegular`, with the regularity of the fan of a regular cone and of a subfan.

Prerequisites added alongside, each used by the above:

- `TauCeti.IsPrimitive.exists_basis` and `Module.Basis.isPrimitive` in `TauCeti/Algebra/Module/Primitive.lean`: a primitive vector of a finite free integer module belongs to an integral basis, and conversely. The basis is built by splitting off the kernel of a functional taking the value one on the vector.
- `PointedCone.finrank_span_coe_hull_singleton` in `TauCeti/Geometry/Convex/Cone/Basic.lean`: the real span of the cone hull of a nonzero vector is a line. This is the one-dimensionality that makes such a cone a ray.
- `PointedCone.finrank_span_coe_prod_bot` and `PointedCone.finrank_span_coe_bot_prod` in the same file: multiplying a pointed cone by the zero cone leaves the dimension of the span of the cone unchanged, because the product is the image of the cone under the inclusion of the corresponding factor. This is what makes a ray of a factor a ray of the product.
- In `TauCeti/Geometry/Toric/Algebraic/Ray/Basic.lean`: the zero cone has no rays; the rays of a face of a cone are rays of the cone (`faceEmbedding`); the cone spanned by a nonzero vector is its own only ray (`hullSingleton`, `eq_hullSingleton`); and the rays of a product of salient cones are exactly the rays of the two factors (`map_fst_eq_bot_of_map_snd_ne_bot`, `prodRayFst`, `prodRaySnd`, `prodInl`, `prodInr`, and the equivalence `prodSplit`, whose inverse sends a ray of a factor to its product with the zero cone). The last group is what makes the product of regular cones regular: salience forbids a ray in a diagonal direction, because a ray with a spanning point of two nonzero coordinates also contains the point with its second coordinate zeroed, which is not a nonnegative multiple of the spanning point.
- In `TauCeti/Geometry/Toric/Algebraic/Ray/Primitive.lean`: uniqueness of a primitive generator of a ray, and the invariance of being a primitive generator under viewing a ray of a face as a ray of the ambient cone.

On the roadmap's stage ordering (raised by the `scope` rubric in round 2): Layer 0 item 3 is on `main`, landed as #6315, which created both `Ray/Basic.lean` and `Ray/Primitive.lean` — rays as one-dimensional Mathlib faces, existence and uniqueness of the primitive generator, and finiteness of the ray type. This PR consumes that stage rather than bypassing it. The one clause of item 3 that is missing, generation of a cone by its primitive rays, is not a dependency of anything added here, and is blocked upstream for the reason given next.

What remains in Layer 0 item 4 after this PR is simpliciality of a regular cone. It reduces to the cone being the conic hull of its primitive ray generators, which for a salient polyhedral cone is the extreme-ray generation theorem. Neither that theorem nor the Minkowski–Weyl equivalence `FG ↔ DualFG` it rests on exists at the dependency pin, so supplying it is separate convex-geometry work rather than something this PR can reach; the same gap blocks the remaining clause of Layer 0 item 3, generation of a cone by its primitive rays. Everything else the item asks for is here and sorry-free.

Roadmap: AnalyticToricGeometry

<!--tauceti-target:v1 {"focus":"AnalyticToricGeometry","id":"isregularcone"}-->

🤖 Prepared with Claude Code





