### PR TITLE
feat(Isogeny): every rational point lies in the kernel of 1 - π

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Frobenius/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Frobenius/Basic.lean
@@ -30,6 +30,9 @@ on it. The instance Mathlib's map needs is installed locally where it is require
 
 ## Main results
 
+* `AlgHom.comp_fieldPullback_frobeniusIsogeny`: an algebra homomorphism between function fields
+  commutes with the Frobenius pullbacks.
+
 * `TauCeti.Isogeny.fieldPullback_frobeniusIsogeny`: the induced map of function fields is the
   `q`-power map `FiniteField.frobeniusAlgHom F W.FunctionField`.
 * `TauCeti.Isogeny.fieldPullback_frobeniusIsogeny_apply`: the same result pointwise, with no
@@ -66,6 +69,7 @@ original.
 ## References
 
 * [J. Silverman, *The Arithmetic of Elliptic Curves*][silverman2009], II.2.
+
 -/
 
 public section
@@ -163,6 +167,13 @@ theorem separableDegree_frobeniusIsogeny : (frobeniusIsogeny W).separableDegree 
 theorem inseparableDegree_frobeniusIsogeny :
     (frobeniusIsogeny W).inseparableDegree = Nat.card F := by
   rw [inseparableDegree_eq_degree_of_isPurelyInseparable, degree_frobeniusIsogeny]
+
+/-- **An algebra homomorphism between function fields commutes with the Frobenius pullbacks.** -/
+theorem _root_.AlgHom.comp_fieldPullback_frobeniusIsogeny {W₁ W₂ : WeierstrassCurve.Affine F}
+    (σ : W₁.FunctionField →ₐ[F] W₂.FunctionField) :
+    σ.comp (frobeniusIsogeny W₁).fieldPullback = (frobeniusIsogeny W₂).fieldPullback.comp σ :=
+  AlgHom.ext fun z ↦ by
+    simp only [AlgHom.comp_apply, fieldPullback_frobeniusIsogeny_apply, map_pow]
 
 end Isogeny
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Frobenius/Translation.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Frobenius/Translation.lean
@@ -1,0 +1,47 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Affine.FunctionField.Translation.Basic
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.Frobenius.Basic
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.GenericPoint
+
+/-!
+# Translation moves the tautological point of Frobenius by the translating point
+
+Translating by a rational point `P` sends the generic point `g` to `g + P`. The tautological point
+of the Frobenius isogeny is `g` pushed along the `q`-power map, and that map commutes with
+translation and fixes `P`, whose coordinates lie in the base field. So the tautological point of
+Frobenius moves by `P` as well.
+
+## Main results
+
+* `TauCeti.Isogeny.map_translation_tautologicalPoint_frobeniusIsogeny`: translation by `P` adds
+  `P` to the tautological point of Frobenius.
+-/
+
+public section
+
+namespace TauCeti.Isogeny
+
+open WeierstrassCurve.Affine
+
+variable {F : Type*} [Field F] [Finite F] [DecidableEq F] (W : WeierstrassCurve.Affine F)
+  [W.IsElliptic]
+
+/-- **Translation by a rational point adds that point to the tautological point of Frobenius**,
+exactly as it does to the generic point. -/
+theorem map_translation_tautologicalPoint_frobeniusIsogeny (P : (W⁄F).toAffine.Point) :
+    Point.map (translation W P).toAlgHom (frobeniusIsogeny W).pullback.tautologicalPoint =
+      (frobeniusIsogeny W).pullback.tautologicalPoint +
+        Point.baseChange (W' := W) F W.FunctionField P := by
+  rw [tautologicalPoint_eq_map_genericPoint, Point.map_map,
+    AlgHom.comp_fieldPullback_frobeniusIsogeny, ← Point.map_map]
+  simp [map_translation_genericPoint, translatedGenericPoint_def, Point.map_baseChange]
+
+end TauCeti.Isogeny
+
+end

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/OneSubFrobenius/Kernel.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/OneSubFrobenius/Kernel.lean
@@ -1,0 +1,96 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.Frobenius.Translation
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.Kernel
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.OneSubFrobenius.TautologicalPoint
+public import TauCeti.AlgebraicGeometry.EllipticCurve.PointCount
+
+/-!
+# Every rational point lies in the kernel of `1 − π`
+
+Over a finite field the isogeny `1 − π_q` kills every `F`-rational point, so its kernel is all of
+them. The reason is the one behind the classical count: `π_q` fixes the rational points, so
+`(1 − π_q)(X + P) = (1 − π_q)(X)` for rational `P`, and a function pulled back along `1 − π_q` is
+unmoved by translating by `P`.
+
+An isogeny here has no point map, so the argument is carried out on tautological points. A kernel
+element is a point whose translation fixes the pulled-back field; translation acts on a pullback by
+post-composition, and a pullback is fixed by such an endomorphism exactly when its tautological
+point is. The tautological point of `1 − π_q` is `g − π_q(g)`, and translation moves both terms by
+the same rational point, so their difference does not move at all.
+
+## Main results
+
+* `TauCeti.Isogeny.ker_oneSubFrobeniusIsogeny`: the kernel of `1 − π_q` is everything.
+* `TauCeti.Isogeny.card_ker_oneSubFrobeniusIsogeny`: so its kernel has exactly as many elements
+  as there are rational points.
+* `TauCeti.Isogeny.pointCount_le_degree_oneSubFrobeniusIsogeny`: consequently `deg (1 − π_q)`
+  bounds `pointCount` above.
+
+This is the lower half of `deg (1 − π_q) = #E(𝔽_q)`. The upper half asks in addition that the
+kernel cut out the pulled-back field exactly, and is not proved here.
+
+## References
+
+* [J. Silverman, *The Arithmetic of Elliptic Curves*][silverman2009], III.4, V.1.
+* The AINTLIB `HasseWeil` project (Chris Birkbeck, Apache 2.0, commit
+  `513e83879e2f8cbc626eb9e04d660e92be16ccba`) states the two headline results in
+  `Hasse/PointFix.lean` as `kernel_eq_top_of_hom_eq_id_sub_frobenius` and
+  `card_kernel_eq_pointCount_of_kernel_eq_top`. Its isogenies carry a point map independent of the
+  function-field pullback, and its Frobenius declares that map to be the identity, so there the
+  first reduces to `sub_self`. The kernel here is defined from the pullback, so the proof is the
+  tautological-point argument above instead.
+-/
+
+public section
+
+namespace TauCeti.Isogeny
+
+open WeierstrassCurve.Affine
+
+variable {F : Type*} [Field F] [Finite F] [DecidableEq F] (W : WeierstrassCurve.Affine F)
+  [W.IsElliptic]
+
+/-- **The kernel of `1 − π_q` is every rational point.** -/
+@[simp]
+theorem ker_oneSubFrobeniusIsogeny : (oneSubFrobeniusIsogeny W).ker = ⊤ := by
+  refine eq_top_iff.2 fun P _ ↦ mem_ker_iff.2 ?_
+  -- it is enough that translation fixes the coordinate pullback, the function field being its
+  -- fraction field
+  have hcoord : (translation W P).toAlgHom.comp (oneSubFrobeniusIsogeny W).pullback =
+      (oneSubFrobeniusIsogeny W).pullback := by
+    refine CoordinatePullback.tautologicalPoint_injective ?_
+    rw [CoordinatePullback.tautologicalPoint_comp,
+      tautologicalPoint_oneSubFrobeniusIsogeny, map_sub, map_translation_genericPoint,
+      translatedGenericPoint_def, map_translation_tautologicalPoint_frobeniusIsogeny]
+    abel
+  have hfield : (translation W P).toAlgHom.comp (oneSubFrobeniusIsogeny W).fieldPullback =
+      (oneSubFrobeniusIsogeny W).fieldPullback :=
+    fieldPullback_unique _ _ fun x ↦ by
+      rw [AlgHom.comp_apply, fieldPullback_algebraMap, ← AlgHom.comp_apply, hcoord]
+  rintro _ ⟨z, rfl⟩
+  simpa using DFunLike.congr_fun hfield z
+
+/-- **The rational points are exactly the kernel of `1 − π_q`**, as a cardinality. -/
+theorem card_ker_oneSubFrobeniusIsogeny :
+    Nat.card (oneSubFrobeniusIsogeny W).ker = Nat.card (W⁄F).toAffine.Point := by
+  rw [ker_oneSubFrobeniusIsogeny, AddSubgroup.card_top]
+
+omit [DecidableEq F] in
+/-- **The degree of `1 − π_q` bounds the point count above.** This is the lower half of
+`deg (1 − π_q) = #E(𝔽_q)`; the upper half asks in addition that the kernel cut out the pulled-back
+field exactly, and is not proved here. -/
+theorem pointCount_le_degree_oneSubFrobeniusIsogeny :
+    W.pointCount ≤ (oneSubFrobeniusIsogeny W).degree := by
+  classical
+  rw [WeierstrassCurve.pointCount_eq_card_point]
+  exact (card_ker_oneSubFrobeniusIsogeny W).symm.trans_le (card_ker_le_degree _)
+
+end TauCeti.Isogeny
+
+end

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/OneSubFrobenius/TautologicalPoint.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/OneSubFrobenius/TautologicalPoint.lean
@@ -1,0 +1,43 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.GenericPoint
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.OneSubFrobenius.Basic
+
+/-!
+# The tautological point of `1 − π`
+
+The tautological point is additive on morphisms, and the identity's is the generic point, so the
+tautological point of `1 − π_q` is the generic point minus that of Frobenius.
+
+## Main results
+
+* `TauCeti.Isogeny.tautologicalPoint_oneSubFrobeniusIsogeny`: the tautological point of
+  `1 − π_q` is `g − π_q(g)`.
+-/
+
+public section
+
+namespace TauCeti.Isogeny
+
+open WeierstrassCurve.Affine
+
+variable {F : Type*} [Field F] [Finite F] (W : WeierstrassCurve.Affine F) [W.IsElliptic]
+
+-- Not `@[simp]`: `tautologicalPoint_eq_map_genericPoint` already rewrites this left-hand side to
+-- `Point.map (oneSubFrobeniusIsogeny W).fieldPullback (genericPoint W)`, so the annotation puts
+-- the lemma out of simp-normal form.
+/-- **The tautological point of `1 − π_q` is the generic point minus that of Frobenius.** -/
+theorem tautologicalPoint_oneSubFrobeniusIsogeny :
+    (oneSubFrobeniusIsogeny W).pullback.tautologicalPoint =
+      genericPoint W - (frobeniusIsogeny W).pullback.tautologicalPoint := by
+  rw [← Hom.tautologicalPoint_ofIsogeny, ofIsogeny_oneSubFrobeniusIsogeny]
+  simp [Hom.one_def, Hom.id_def]
+
+end TauCeti.Isogeny
+
+end


### PR DESCRIPTION
Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"EllipticCurves/Suggested.lean:layer1:ker-one-sub-frobenius"}-->

Provenance: AINTLIB `HasseWeil` (Chris Birkbeck, Apache 2.0, commit `513e83879e2f8cbc626eb9e04d660e92be16ccba`), `Hasse/PointFix.lean`, `kernel_eq_top_of_hom_eq_id_sub_frobenius` and `card_kernel_eq_pointCount_of_kernel_eq_top`. Those are proved there, but in an encoding that asserts them: AINTLIB's `Isogeny` carries `pullback` and `toAddMonoidHom` as independent fields and its Frobenius isogeny declares its point map to be `AddMonoidHom.id`, so `ker (1 − π) = ⊤` reduces to `sub_self`. The statement is earned here instead, the kernel being defined from the pullback.

## What this adds

The kernel results, in `Isogeny/OneSubFrobenius/Kernel.lean`:

- `Isogeny.ker_oneSubFrobeniusIsogeny`: `(oneSubFrobeniusIsogeny W).ker = ⊤`.
- `Isogeny.card_ker_oneSubFrobeniusIsogeny`: so the kernel has exactly as many elements as there are rational points.
- `Isogeny.pointCount_le_degree_oneSubFrobeniusIsogeny`: hence `W.pointCount ≤ deg (1 − π_q)`, which is the roadmap's Layer 3 count against a Layer 1 degree.

Three supporting lemmas, each in its own canonical home rather than beside its consumer:

- `AlgHom.comp_fieldPullback_frobeniusIsogeny` in `Isogeny/Frobenius/Basic.lean`, in the `AlgHom` namespace per `rubrics/naming.md`'s first-explicit-argument rule: an algebra homomorphism between the function fields of any two curves commutes with the Frobenius pullbacks.
- `Isogeny.map_translation_tautologicalPoint_frobeniusIsogeny` in a new `Isogeny/Frobenius/Translation.lean`: translation by `P` adds `P` to the tautological point of Frobenius.
- `Isogeny.tautologicalPoint_pullback_oneSubFrobeniusIsogeny` in a new `Isogeny/OneSubFrobenius/TautologicalPoint.lean`: that point is `g − π_q(g)`.

Nothing new is added about tautological points in general: the existing `Isogeny.tautologicalPoint_eq_map_genericPoint` supplies the Frobenius case directly. For the same reason `tautologicalPoint_pullback_oneSubFrobeniusIsogeny` is deliberately not `@[simp]` — that existing simp lemma already rewrites its left-hand side, so the annotation puts it out of simp-normal form and `simpNF` rejects it. The source records that.

## The argument

An isogeny here has no point map, so `ker` is the points whose translation fixes the pulled-back field. The proof therefore never mentions a Frobenius action on points:

1. Translation acts on a coordinate pullback by post-composition, and a pullback is determined by its tautological point, so it is enough that translation fixes that point.
2. The tautological point of `1 − π_q` is `g − π_q(g)`, for `g` the generic point, by additivity of the tautological point on `Hom`.
3. Translation by `P` sends `g` to `g + P`. It commutes with the `q`-power map, and `Point.map_baseChange` says the `q`-power map fixes the constant point `P` — that is where `P` being rational is used.
4. So both terms move by the same `P` and the difference is unchanged.

## Scope

This is the lower half of `deg (1 − π_q) = #E(𝔽_q)`. The upper half asks in addition that the kernel cut out the pulled-back field exactly, and is not claimed here. Once #6362 lands, `card_ker_le_separableDegree` sharpens the last corollary from the degree to the separable degree; that follow-up is deliberately left out rather than made to depend on an unmerged branch.

This PR sits on top of #6369, which adds the tautological-point functoriality it uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
