### PR TITLE
feat: identify root stabilizers with relative Galois groups

### DIFF
--- a/TauCeti/FieldTheory/Galois/FixedField.lean
+++ b/TauCeti/FieldTheory/Galois/FixedField.lean
@@ -124,6 +124,12 @@ theorem card_fixingSubgroup_le (E : IntermediateField K M) [FiniteDimensional E 
   rw [Nat.card_congr (fixingSubgroupEquiv E).toEquiv, Nat.card_eq_fintype_card]
   exact AlgEquiv.card_le
 
+-- The subgroup extensionality argument below, reducing membership of `K⟮x⟯.fixingSubgroup` to
+-- `IntermediateField.forall_mem_adjoin_smul_eq_self_iff` at the singleton `{x}`, is adapted from
+-- the proof of `stabilizer_isOpen_of_isIntegral` in `Mathlib/FieldTheory/KrullTopology.lean`,
+-- which uses it there to identify a point stabilizer with the fixing subgroup of a finite
+-- intermediate field. Here it is recorded as a statement in its own right, with no integrality
+-- hypothesis.
 /-- **The fixing subgroup of a simple extension is the stabilizer of its generator.** A
 `K`-automorphism of `M` is determined on `K⟮x⟯` by its value at `x`, so fixing `K⟮x⟯` pointwise is
 fixing `x`; no hypothesis on `M / K` is needed, and `x` need not be algebraic.

--- a/TauCeti/FieldTheory/Galois/FixedField.lean
+++ b/TauCeti/FieldTheory/Galois/FixedField.lean
@@ -32,6 +32,11 @@ cyclic group of automorphisms has `M` cyclic over it, and for `⟨σ⟩` there i
 over the fixed field — `AlgEquiv.toFixedFieldAlgEquiv σ` acts on `M` as `σ` does, and generates
 once `⟨σ⟩` is finite.
 
+A simple extension `K⟮x⟯` is fixed pointwise by exactly those automorphisms that fix `x`, so
+its fixing subgroup is the stabilizer of `x`; this needs no hypothesis on `M / K` at all. For a
+finite Galois extension the correspondence is an order isomorphism onto the dual of the subgroup
+lattice, so an intermediate field is an atom exactly when its fixing subgroup is a coatom.
+
 Neither `M / K` Galois nor `M / K` finite is needed, and neither is faithfulness of the action:
 `FixedPoints.toAlgAut_surjective` asks only that the group be finite, and cyclicity passes along
 its surjection. The fixed-point subfield it produces is the one underlying
@@ -44,6 +49,9 @@ its surjection. The fixed-point subfield it produces is the one underlying
 * `IntermediateField.fixingSubgroup_fixedField_of_finite`
 * `IntermediateField.finite_of_finiteDimensional_fixedField`
 * `IntermediateField.card_fixingSubgroup_le`
+* `IntermediateField.mem_fixingSubgroup_adjoin_simple_iff`,
+  `IntermediateField.fixingSubgroup_adjoin_simple`
+* `IntermediateField.isCoatom_fixingSubgroup_iff_isAtom`
 * `FixedPoints.isCyclic_algEquiv`
 * `AlgEquiv.toFixedFieldAlgEquiv`, with `AlgEquiv.zpowers_toFixedFieldAlgEquiv_eq_top`
 -/
@@ -119,6 +127,42 @@ theorem card_fixingSubgroup_le (E : IntermediateField K M) [FiniteDimensional E 
     Nat.card (fixingSubgroup E) ≤ Module.finrank E M := by
   rw [Nat.card_congr (fixingSubgroupEquiv E).toEquiv, Nat.card_eq_fintype_card]
   exact AlgEquiv.card_le
+
+/-- **Fixing a simple extension pointwise is fixing its generator.** A `K`-automorphism of `M`
+is determined on `K⟮x⟯` by its value at `x`, so the two conditions coincide; no hypothesis on
+`M / K` is needed, and `x` need not be algebraic.
+
+Mathlib's `IntermediateField.mem_fixingSubgroup_iff` leaves a quantifier over the whole
+intermediate field; this is the form that a point stabilizer of an action on a set of generators
+matches. -/
+theorem mem_fixingSubgroup_adjoin_simple_iff {x : M} {σ : M ≃ₐ[K] M} :
+    σ ∈ K⟮x⟯.fixingSubgroup ↔ σ x = x := by
+  rw [mem_fixingSubgroup_iff]
+  refine ⟨fun h => h x (mem_adjoin_simple_self K x), fun h y hy => ?_⟩
+  have hσ : Subgroup.zpowers σ ≤ MulAction.stabilizer (M ≃ₐ[K] M) x := Subgroup.zpowers_le.mpr h
+  have hx : x ∈ fixedField (Subgroup.zpowers σ) := fun g => hσ g.2
+  exact (mem_fixedField_iff _ _).mp (adjoin_simple_le_iff.mpr hx hy) σ (Subgroup.mem_zpowers σ)
+
+/-- **The fixing subgroup of a simple extension is the stabilizer of its generator.** This is the
+subgroup form of `IntermediateField.mem_fixingSubgroup_adjoin_simple_iff`, and it is what turns a
+statement about the action of `Gal(M/K)` on a set of elements of `M` into a statement about the
+Galois correspondence. -/
+theorem fixingSubgroup_adjoin_simple (x : M) :
+    K⟮x⟯.fixingSubgroup = MulAction.stabilizer (M ≃ₐ[K] M) x :=
+  Subgroup.ext fun _ => mem_fixingSubgroup_adjoin_simple_iff
+
+/-- **The Galois correspondence carries atoms to coatoms.** For a finite Galois extension an
+intermediate field is an atom — that is, it is not `K` and has no intermediate field strictly
+between `K` and it — exactly when its fixing subgroup is a maximal proper subgroup of
+`Gal(M/K)`.
+
+The correspondence `IsGalois.intermediateFieldEquivSubgroup` is an order isomorphism onto the
+*dual* of the subgroup lattice, so an atom on the field side is an atom of the dual order, which
+is a coatom of the subgroup lattice. -/
+theorem isCoatom_fixingSubgroup_iff_isAtom [FiniteDimensional K M] [IsGalois K M]
+    (E : IntermediateField K M) : IsCoatom E.fixingSubgroup ↔ IsAtom E := by
+  rw [← isAtom_dual_iff_isCoatom]
+  exact IsGalois.intermediateFieldEquivSubgroup.isAtom_iff E
 
 end IntermediateField
 

--- a/TauCeti/FieldTheory/Galois/FixedField.lean
+++ b/TauCeti/FieldTheory/Galois/FixedField.lean
@@ -32,15 +32,13 @@ cyclic group of automorphisms has `M` cyclic over it, and for `⟨σ⟩` there i
 over the fixed field — `AlgEquiv.toFixedFieldAlgEquiv σ` acts on `M` as `σ` does, and generates
 once `⟨σ⟩` is finite.
 
-A simple extension `K⟮x⟯` is fixed pointwise by exactly those automorphisms that fix `x`, so
-its fixing subgroup is the stabilizer of `x`; this needs no hypothesis on `M / K` at all. For a
-finite Galois extension the correspondence is an order isomorphism onto the dual of the subgroup
-lattice, so an intermediate field is an atom exactly when its fixing subgroup is a coatom.
-
 Neither `M / K` Galois nor `M / K` finite is needed, and neither is faithfulness of the action:
 `FixedPoints.toAlgAut_surjective` asks only that the group be finite, and cyclicity passes along
 its surjection. The fixed-point subfield it produces is the one underlying
 `IntermediateField.fixedField`.
+
+A simple extension `K⟮x⟯` is fixed pointwise by exactly those automorphisms that fix `x`, so
+its fixing subgroup is the stabilizer of `x`; this too needs no hypothesis on `M / K` at all.
 
 ## Main results
 
@@ -50,7 +48,6 @@ its surjection. The fixed-point subfield it produces is the one underlying
 * `IntermediateField.finite_of_finiteDimensional_fixedField`
 * `IntermediateField.card_fixingSubgroup_le`
 * `IntermediateField.fixingSubgroup_adjoin_simple`
-* `IntermediateField.isCoatom_fixingSubgroup_iff_isAtom`
 * `FixedPoints.isCyclic_algEquiv`
 * `AlgEquiv.toFixedFieldAlgEquiv`, with `AlgEquiv.zpowers_toFixedFieldAlgEquiv_eq_top`
 -/
@@ -139,19 +136,6 @@ theorem fixingSubgroup_adjoin_simple (x : M) :
   ext σ
   rw [mem_fixingSubgroup_iff, MulAction.mem_stabilizer_iff]
   simpa using forall_mem_adjoin_smul_eq_self_iff K (S := {x}) σ
-
-/-- **The Galois correspondence carries atoms to coatoms.** For a finite Galois extension an
-intermediate field is an atom — that is, it is not `K` and has no intermediate field strictly
-between `K` and it — exactly when its fixing subgroup is a maximal proper subgroup of
-`Gal(M/K)`.
-
-The correspondence `IsGalois.intermediateFieldEquivSubgroup` is an order isomorphism onto the
-*dual* of the subgroup lattice, so an atom on the field side is an atom of the dual order, which
-is a coatom of the subgroup lattice. -/
-theorem isCoatom_fixingSubgroup_iff_isAtom [FiniteDimensional K M] [IsGalois K M]
-    (E : IntermediateField K M) : IsCoatom E.fixingSubgroup ↔ IsAtom E := by
-  rw [← isAtom_dual_iff_isCoatom]
-  exact IsGalois.intermediateFieldEquivSubgroup.isAtom_iff E
 
 end IntermediateField
 

--- a/TauCeti/FieldTheory/Galois/FixedField.lean
+++ b/TauCeti/FieldTheory/Galois/FixedField.lean
@@ -49,8 +49,7 @@ its surjection. The fixed-point subfield it produces is the one underlying
 * `IntermediateField.fixingSubgroup_fixedField_of_finite`
 * `IntermediateField.finite_of_finiteDimensional_fixedField`
 * `IntermediateField.card_fixingSubgroup_le`
-* `IntermediateField.mem_fixingSubgroup_adjoin_simple_iff`,
-  `IntermediateField.fixingSubgroup_adjoin_simple`
+* `IntermediateField.fixingSubgroup_adjoin_simple`
 * `IntermediateField.isCoatom_fixingSubgroup_iff_isAtom`
 * `FixedPoints.isCyclic_algEquiv`
 * `AlgEquiv.toFixedFieldAlgEquiv`, with `AlgEquiv.zpowers_toFixedFieldAlgEquiv_eq_top`
@@ -128,28 +127,18 @@ theorem card_fixingSubgroup_le (E : IntermediateField K M) [FiniteDimensional E 
   rw [Nat.card_congr (fixingSubgroupEquiv E).toEquiv, Nat.card_eq_fintype_card]
   exact AlgEquiv.card_le
 
-/-- **Fixing a simple extension pointwise is fixing its generator.** A `K`-automorphism of `M`
-is determined on `K⟮x⟯` by its value at `x`, so the two conditions coincide; no hypothesis on
-`M / K` is needed, and `x` need not be algebraic.
+/-- **The fixing subgroup of a simple extension is the stabilizer of its generator.** A
+`K`-automorphism of `M` is determined on `K⟮x⟯` by its value at `x`, so fixing `K⟮x⟯` pointwise is
+fixing `x`; no hypothesis on `M / K` is needed, and `x` need not be algebraic.
 
-Mathlib's `IntermediateField.mem_fixingSubgroup_iff` leaves a quantifier over the whole
-intermediate field; this is the form that a point stabilizer of an action on a set of generators
-matches. -/
-theorem mem_fixingSubgroup_adjoin_simple_iff {x : M} {σ : M ≃ₐ[K] M} :
-    σ ∈ K⟮x⟯.fixingSubgroup ↔ σ x = x := by
-  rw [mem_fixingSubgroup_iff]
-  refine ⟨fun h => h x (mem_adjoin_simple_self K x), fun h y hy => ?_⟩
-  have hσ : Subgroup.zpowers σ ≤ MulAction.stabilizer (M ≃ₐ[K] M) x := Subgroup.zpowers_le.mpr h
-  have hx : x ∈ fixedField (Subgroup.zpowers σ) := fun g => hσ g.2
-  exact (mem_fixedField_iff _ _).mp (adjoin_simple_le_iff.mpr hx hy) σ (Subgroup.mem_zpowers σ)
-
-/-- **The fixing subgroup of a simple extension is the stabilizer of its generator.** This is the
-subgroup form of `IntermediateField.mem_fixingSubgroup_adjoin_simple_iff`, and it is what turns a
-statement about the action of `Gal(M/K)` on a set of elements of `M` into a statement about the
-Galois correspondence. -/
+This is what turns a statement about the action of `Gal(M/K)` on a set of elements of `M` into a
+statement about the Galois correspondence. -/
+@[simp]
 theorem fixingSubgroup_adjoin_simple (x : M) :
-    K⟮x⟯.fixingSubgroup = MulAction.stabilizer (M ≃ₐ[K] M) x :=
-  Subgroup.ext fun _ => mem_fixingSubgroup_adjoin_simple_iff
+    K⟮x⟯.fixingSubgroup = MulAction.stabilizer (M ≃ₐ[K] M) x := by
+  ext σ
+  rw [mem_fixingSubgroup_iff, MulAction.mem_stabilizer_iff]
+  simpa using forall_mem_adjoin_smul_eq_self_iff K (S := {x}) σ
 
 /-- **The Galois correspondence carries atoms to coatoms.** For a finite Galois extension an
 intermediate field is an atom — that is, it is not `K` and has no intermediate field strictly

--- a/TauCeti/FieldTheory/GaloisGroups/Orbits.lean
+++ b/TauCeti/FieldTheory/GaloisGroups/Orbits.lean
@@ -24,8 +24,8 @@ the members of `Polynomial.Factors p`.
 
 The dictionary also identifies transitivity of the root action with irreducibility for a
 separable polynomial of positive degree, and records what the orbit count says about the action
-inside the splitting field itself: an irreducible polynomial acts transitively there, and when
-its degree is prime it acts primitively.
+inside the splitting field itself: an irreducible polynomial acts transitively there, and an
+irreducible separable polynomial of prime degree acts primitively.
 
 ## Main results
 
@@ -41,9 +41,10 @@ its degree is prime it acts primitively.
   `TauCeti.image_val_orbit_eq_rootSet_minpoly_splittingField`,
   `TauCeti.natCard_orbit_eq_natDegree_minpoly_splittingField`: the same three descriptions of an
   orbit for the intrinsic action on the roots in the splitting field.
-* `TauCeti.isPretransitive_of_irreducible`, `TauCeti.isPreprimitive_of_prime_natDegree`: inside
-  the splitting field, an irreducible polynomial has a transitive root action, and an irreducible
-  separable polynomial of prime degree a primitive one.
+* `TauCeti.isPretransitive_of_irreducible`,
+  `TauCeti.isPreprimitive_of_irreducible_of_separable_of_prime_natDegree`: inside the splitting
+  field, an irreducible polynomial has a transitive root action, and an irreducible separable
+  polynomial of prime degree a primitive one.
 * `TauCeti.orbitQuotientEquivFactors`: the orbit quotient is in bijection with the
   monic irreducible factors of `p`, the orbit of a root going to its minimal polynomial.
 * `TauCeti.natCard_orbit_eq_natDegree_factor`: along that bijection, a separable
@@ -205,6 +206,12 @@ here; the orbit descriptions are obtained by feeding the intrinsic orbit criteri
 proofs as above, and transitivity is proved directly rather than read off
 `TauCeti.isPretransitive_iff_irreducible` or `Polynomial.Gal.galAction_isPretransitive`. -/
 
+/-- The Galois action on the roots in the splitting field is the action by evaluation. -/
+@[simp]
+theorem _root_.Polynomial.Gal.coe_smul (g : p.Gal) (x : p.rootSet p.SplittingField) :
+    ((g • x : p.rootSet p.SplittingField) : p.SplittingField) = g x :=
+  rfl
+
 /-- Two roots of `p` in the splitting field lie in the same Galois orbit exactly when their
 minimal polynomials over the base field agree.
 
@@ -216,6 +223,15 @@ theorem mem_orbit_iff_minpoly_eq_splittingField {x y : p.rootSet p.SplittingFiel
       minpoly F (x : p.SplittingField) = minpoly F (y : p.SplittingField) := by
   rw [Normal.minpoly_eq_iff_mem_orbit p.SplittingField]
   exact ⟨fun ⟨g, hg⟩ => ⟨g, congrArg Subtype.val hg⟩, fun ⟨g, hg⟩ => ⟨g, Subtype.ext hg⟩⟩
+
+/-- The orbit of a root of `p` in the splitting field consists of the roots of its minimal
+polynomial.
+
+This is `TauCeti.orbit_eq_preimage_rootSet_minpoly` for the intrinsic action. -/
+theorem orbit_eq_preimage_rootSet_minpoly_splittingField (x : p.rootSet p.SplittingField) :
+    MulAction.orbit p.Gal x =
+      Subtype.val ⁻¹' (minpoly F (x : p.SplittingField)).rootSet p.SplittingField :=
+  orbit_eq_preimage_rootSet_minpoly_aux (fun _ _ => mem_orbit_iff_minpoly_eq_splittingField) x
 
 /-- Read inside the splitting field, the orbit of a root of `p` is exactly the root set of its
 minimal polynomial.
@@ -256,9 +272,13 @@ theorem isPretransitive_of_irreducible (hp : Irreducible p) :
 
 /-- **An irreducible separable polynomial of prime degree has a primitive root action.** A
 transitive action on a set of prime cardinality is primitive, and the roots of a separable
-polynomial number its degree. -/
-theorem isPreprimitive_of_prime_natDegree (hp : Irreducible p) (hsep : p.Separable)
-    (hprime : p.natDegree.Prime) :
+polynomial number its degree.
+
+This is the corollary of the milestone "Primitivity and intermediate fields" in Layer 2 of
+`TauCetiRoadmap/PolynomialGaloisGroups/README.md` that the roadmap records as "also available
+from `IsPreprimitive.of_prime_card`". -/
+theorem isPreprimitive_of_irreducible_of_separable_of_prime_natDegree (hp : Irreducible p)
+    (hsep : p.Separable) (hprime : p.natDegree.Prime) :
     MulAction.IsPreprimitive p.Gal (p.rootSet p.SplittingField) := by
   have htr : MulAction.IsPretransitive p.Gal (p.rootSet p.SplittingField) :=
     isPretransitive_of_irreducible hp

--- a/TauCeti/FieldTheory/GaloisGroups/Orbits.lean
+++ b/TauCeti/FieldTheory/GaloisGroups/Orbits.lean
@@ -272,11 +272,7 @@ theorem isPretransitive_of_irreducible (hp : Irreducible p) :
 
 /-- **An irreducible separable polynomial of prime degree has a primitive root action.** A
 transitive action on a set of prime cardinality is primitive, and the roots of a separable
-polynomial number its degree.
-
-This is the corollary of the milestone "Primitivity and intermediate fields" in Layer 2 of
-`TauCetiRoadmap/PolynomialGaloisGroups/README.md` that the roadmap records as "also available
-from `IsPreprimitive.of_prime_card`". -/
+polynomial number its degree. -/
 theorem isPreprimitive_of_irreducible_of_separable_of_prime_natDegree (hp : Irreducible p)
     (hsep : p.Separable) (hprime : p.natDegree.Prime) :
     MulAction.IsPreprimitive p.Gal (p.rootSet p.SplittingField) := by

--- a/TauCeti/FieldTheory/GaloisGroups/Orbits.lean
+++ b/TauCeti/FieldTheory/GaloisGroups/Orbits.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.FieldTheory.PolynomialGaloisGroup
-public import Mathlib.GroupTheory.GroupAction.Primitive
 public import TauCeti.RingTheory.Polynomial.Factors
 
 /-!
@@ -23,9 +22,8 @@ turns this into a bijection with the distinct monic irreducible factors of `p`, 
 the members of `Polynomial.Factors p`.
 
 The dictionary also identifies transitivity of the root action with irreducibility for a
-separable polynomial of positive degree, and records what the orbit count says about the action
-inside the splitting field itself: an irreducible polynomial acts transitively there, and an
-irreducible separable polynomial of prime degree acts primitively.
+separable polynomial of positive degree, and records the same descriptions for the action inside
+the splitting field itself, where an irreducible polynomial acts transitively.
 
 ## Main results
 
@@ -41,19 +39,13 @@ irreducible separable polynomial of prime degree acts primitively.
   `TauCeti.image_val_orbit_eq_rootSet_minpoly_splittingField`,
   `TauCeti.natCard_orbit_eq_natDegree_minpoly_splittingField`: the same three descriptions of an
   orbit for the intrinsic action on the roots in the splitting field.
-* `TauCeti.isPretransitive_of_irreducible`,
-  `TauCeti.isPreprimitive_of_irreducible_of_separable_of_prime_natDegree`: inside the splitting
-  field, an irreducible polynomial has a transitive root action, and an irreducible separable
-  polynomial of prime degree a primitive one.
+* `TauCeti.isPretransitive_of_irreducible`: inside the splitting field, an irreducible
+  polynomial has a transitive root action.
 * `TauCeti.orbitQuotientEquivFactors`: the orbit quotient is in bijection with the
   monic irreducible factors of `p`, the orbit of a root going to its minimal polynomial.
 * `TauCeti.natCard_orbit_eq_natDegree_factor`: along that bijection, a separable
   factor has as many roots in the matching orbit as its degree.
 -/
-
--- Source. The primitivity of the root action of an irreducible separable polynomial of prime
--- degree is asked for by the Tau Ceti `PolynomialGaloisGroups` roadmap, `README.md`, section
--- "Primitivity and intermediate fields".
 
 public section
 
@@ -273,18 +265,6 @@ theorem isPretransitive_of_irreducible (hp : Irreducible p) :
   have hy := minpoly.eq_of_irreducible hp (aeval_eq_zero_of_mem_rootSet y.2)
   obtain ⟨g, hg⟩ := (Normal.minpoly_eq_iff_mem_orbit p.SplittingField).mp (hy.symm.trans hx)
   exact ⟨g, Subtype.ext hg⟩
-
-/-- **An irreducible separable polynomial of prime degree has a primitive root action.** A
-transitive action on a set of prime cardinality is primitive, and the roots of a separable
-polynomial number its degree. -/
-theorem isPreprimitive_of_irreducible_of_separable_of_prime_natDegree (hp : Irreducible p)
-    (hsep : p.Separable) (hprime : p.natDegree.Prime) :
-    MulAction.IsPreprimitive p.Gal (p.rootSet p.SplittingField) := by
-  have htr : MulAction.IsPretransitive p.Gal (p.rootSet p.SplittingField) :=
-    isPretransitive_of_irreducible hp
-  refine MulAction.IsPreprimitive.of_prime_card ?_
-  rwa [Nat.card_eq_fintype_card,
-    card_rootSet_eq_natDegree hsep (IsSplittingField.splits p.SplittingField p)]
 
 /-! ## Orbits and monic irreducible factors -/
 

--- a/TauCeti/FieldTheory/GaloisGroups/Orbits.lean
+++ b/TauCeti/FieldTheory/GaloisGroups/Orbits.lean
@@ -37,6 +37,10 @@ its degree is prime it acts primitively.
   separable, an orbit has as many elements as its degree.
 * `TauCeti.isPretransitive_iff_irreducible`: for separable `p` of positive degree, transitivity
   of the root action is equivalent to irreducibility of `p`.
+* `TauCeti.mem_orbit_iff_minpoly_eq_splittingField`,
+  `TauCeti.image_val_orbit_eq_rootSet_minpoly_splittingField`,
+  `TauCeti.natCard_orbit_eq_natDegree_minpoly_splittingField`: the same three descriptions of an
+  orbit for the intrinsic action on the roots in the splitting field.
 * `TauCeti.isPretransitive_of_irreducible`, `TauCeti.isPreprimitive_of_prime_natDegree`: inside
   the splitting field, an irreducible polynomial has a transitive root action, and an irreducible
   separable polynomial of prime degree a primitive one.
@@ -104,28 +108,52 @@ theorem mem_orbit_iff_minpoly_eq {x y : p.rootSet E} :
 
 /-! ## The orbit of a root -/
 
-/-- The orbit of a root of `p` consists of the roots of its minimal polynomial. -/
-theorem orbit_eq_preimage_rootSet_minpoly (x : p.rootSet E) :
-    MulAction.orbit p.Gal x = Subtype.val ⁻¹' (minpoly F (x : E)).rootSet E := by
-  have hint : IsIntegral F (x : E) := (isAlgebraic_of_mem_rootSet x.2).isIntegral
+/- The two descriptions of an orbit below use nothing about the action beyond its orbits being
+the fibres of `minpoly F`, so they are proved once for an arbitrary action of `p.Gal` on a root
+set and then applied twice: to `Polynomial.Gal.galAction` on a general splitting extension here,
+and to `Polynomial.Gal.galActionAux` on the splitting field itself in the section on the action
+inside the splitting field below. -/
+
+-- The preimage description, from the minimal polynomial as an orbit invariant.
+private theorem orbit_eq_preimage_rootSet_minpoly_aux {L : Type w} [Field L] [Algebra F L]
+    [MulAction p.Gal (p.rootSet L)]
+    (horbit : ∀ x y : p.rootSet L,
+      x ∈ MulAction.orbit p.Gal y ↔ minpoly F (x : L) = minpoly F (y : L))
+    (x : p.rootSet L) :
+    MulAction.orbit p.Gal x = Subtype.val ⁻¹' (minpoly F (x : L)).rootSet L := by
+  have hint : IsIntegral F (x : L) := (isAlgebraic_of_mem_rootSet x.2).isIntegral
   ext y
-  rw [Set.mem_preimage, mem_rootSet, mem_orbit_iff_minpoly_eq]
-  refine ⟨fun h => ⟨minpoly.ne_zero hint, h ▸ minpoly.aeval F (y : E)⟩, fun h => ?_⟩
+  rw [Set.mem_preimage, mem_rootSet, horbit y x]
+  refine ⟨fun h => ⟨minpoly.ne_zero hint, h ▸ minpoly.aeval F (y : L)⟩, fun h => ?_⟩
   exact (minpoly.eq_of_irreducible_of_monic (minpoly.irreducible hint) h.2
     (minpoly.monic hint)).symm
+
+-- The image description, from the preimage one and `minpoly F x ∣ p`.
+private theorem image_val_orbit_eq_rootSet_minpoly_aux {L : Type w} [Field L] [Algebra F L]
+    [MulAction p.Gal (p.rootSet L)]
+    (horbit : ∀ x y : p.rootSet L,
+      x ∈ MulAction.orbit p.Gal y ↔ minpoly F (x : L) = minpoly F (y : L))
+    (x : p.rootSet L) :
+    Subtype.val '' MulAction.orbit p.Gal x = (minpoly F (x : L)).rootSet L := by
+  have hdvd : minpoly F (x : L) ∣ p := minpoly.dvd F _ (aeval_eq_zero_of_mem_rootSet x.2)
+  refine Set.Subset.antisymm ?_ fun z hz => ?_
+  · rintro _ ⟨y, hy, rfl⟩
+    exact (orbit_eq_preimage_rootSet_minpoly_aux horbit x).le hy
+  · have hzp : z ∈ p.rootSet L := mem_rootSet.mpr ⟨ne_zero_of_mem_rootSet x.2,
+      aeval_eq_zero_of_dvd_aeval_eq_zero hdvd (aeval_eq_zero_of_mem_rootSet hz)⟩
+    exact ⟨⟨z, hzp⟩, (orbit_eq_preimage_rootSet_minpoly_aux horbit x).ge hz, rfl⟩
+
+/-- The orbit of a root of `p` consists of the roots of its minimal polynomial. -/
+theorem orbit_eq_preimage_rootSet_minpoly (x : p.rootSet E) :
+    MulAction.orbit p.Gal x = Subtype.val ⁻¹' (minpoly F (x : E)).rootSet E :=
+  orbit_eq_preimage_rootSet_minpoly_aux (fun _ _ => mem_orbit_iff_minpoly_eq E) x
 
 /-- Read inside the ambient field, the orbit of a root of `p` is exactly the root set of its
 minimal polynomial. -/
 @[simp]
 theorem image_val_orbit_eq_rootSet_minpoly (x : p.rootSet E) :
-    Subtype.val '' MulAction.orbit p.Gal x = (minpoly F (x : E)).rootSet E := by
-  have hdvd : minpoly F (x : E) ∣ p := minpoly.dvd F _ (aeval_eq_zero_of_mem_rootSet x.2)
-  refine Set.Subset.antisymm ?_ fun z hz => ?_
-  · rintro _ ⟨y, hy, rfl⟩
-    exact (orbit_eq_preimage_rootSet_minpoly E x).le hy
-  · have hzp : z ∈ p.rootSet E := mem_rootSet.mpr ⟨ne_zero_of_mem_rootSet x.2,
-      aeval_eq_zero_of_dvd_aeval_eq_zero hdvd (aeval_eq_zero_of_mem_rootSet hz)⟩
-    exact ⟨⟨z, hzp⟩, (orbit_eq_preimage_rootSet_minpoly E x).ge hz, rfl⟩
+    Subtype.val '' MulAction.orbit p.Gal x = (minpoly F (x : E)).rootSet E :=
+  image_val_orbit_eq_rootSet_minpoly_aux (fun _ _ => mem_orbit_iff_minpoly_eq E) x
 
 /-- When the minimal polynomial of a root is separable, its orbit has as many elements as the
 degree of that minimal polynomial. -/
@@ -167,14 +195,48 @@ theorem isPretransitive_iff_irreducible (hsep : p.Separable) (hdeg : 0 < p.natDe
 
 /-! ## The action inside the splitting field -/
 
-/- The two results below are about `p.rootSet p.SplittingField` carrying Mathlib's
+/- The results below are about `p.rootSet p.SplittingField` carrying Mathlib's
 `Polynomial.Gal.galActionAux`, the intrinsic action for which `↑(g • x)` is literally `g ↑x`.
 That is not the instance `E := p.SplittingField` gives the results above: those use
 `Polynomial.Gal.galAction`, the transport of `galActionAux` along `Gal.rootsEquivRoots`, which
 goes through the `Algebra p.SplittingField p.SplittingField` instance built from
 `IsSplittingField.lift` rather than through the identity. So no `Fact` instance is introduced
-here, and transitivity is proved directly rather than read off
+here; the orbit descriptions are obtained by feeding the intrinsic orbit criterion to the same
+proofs as above, and transitivity is proved directly rather than read off
 `TauCeti.isPretransitive_iff_irreducible` or `Polynomial.Gal.galAction_isPretransitive`. -/
+
+/-- Two roots of `p` in the splitting field lie in the same Galois orbit exactly when their
+minimal polynomials over the base field agree.
+
+This is `TauCeti.mem_orbit_iff_minpoly_eq` for the intrinsic action; see the note above for why
+that instance is not the one the general statement carries. -/
+theorem mem_orbit_iff_minpoly_eq_splittingField {x y : p.rootSet p.SplittingField} :
+    x ∈ MulAction.orbit p.Gal y ↔
+      minpoly F (x : p.SplittingField) = minpoly F (y : p.SplittingField) := by
+  rw [Normal.minpoly_eq_iff_mem_orbit p.SplittingField]
+  exact ⟨fun ⟨g, hg⟩ => ⟨g, congrArg Subtype.val hg⟩, fun ⟨g, hg⟩ => ⟨g, Subtype.ext hg⟩⟩
+
+/-- Read inside the splitting field, the orbit of a root of `p` is exactly the root set of its
+minimal polynomial.
+
+This is `TauCeti.image_val_orbit_eq_rootSet_minpoly` for the intrinsic action. -/
+theorem image_val_orbit_eq_rootSet_minpoly_splittingField (x : p.rootSet p.SplittingField) :
+    Subtype.val '' MulAction.orbit p.Gal x =
+      (minpoly F (x : p.SplittingField)).rootSet p.SplittingField :=
+  image_val_orbit_eq_rootSet_minpoly_aux (fun _ _ => mem_orbit_iff_minpoly_eq_splittingField) x
+
+/-- When the minimal polynomial of a root is separable, its orbit in the splitting field has as
+many elements as the degree of that minimal polynomial.
+
+This is `TauCeti.natCard_orbit_eq_natDegree_minpoly` for the intrinsic action; the minimal
+polynomial splits because the splitting field is normal over `F`. -/
+theorem natCard_orbit_eq_natDegree_minpoly_splittingField (x : p.rootSet p.SplittingField)
+    (hsep : (minpoly F (x : p.SplittingField)).Separable) :
+    Nat.card (MulAction.orbit p.Gal x) = (minpoly F (x : p.SplittingField)).natDegree := by
+  rw [Nat.card_congr (Equiv.Set.image _ _ Subtype.val_injective),
+    image_val_orbit_eq_rootSet_minpoly_splittingField, Nat.card_eq_fintype_card,
+    card_rootSet_eq_natDegree hsep
+      (Normal.splits (SplittingField.instNormal p) (x : p.SplittingField))]
 
 /-- **The root action of an irreducible polynomial is transitive.** Two roots of an irreducible
 polynomial have the same minimal polynomial, and a normal extension moves one to the other.

--- a/TauCeti/FieldTheory/GaloisGroups/Orbits.lean
+++ b/TauCeti/FieldTheory/GaloisGroups/Orbits.lean
@@ -27,6 +27,9 @@ separable polynomial of positive degree, and records what the orbit count says a
 inside the splitting field itself: an irreducible polynomial acts transitively there, and an
 irreducible separable polynomial of prime degree acts primitively.
 
+The prime-degree statement is the corollary recorded in the “Primitivity and intermediate
+fields” milestone of `TauCetiRoadmap/PolynomialGaloisGroups/README.md`, Layer 2.
+
 ## Main results
 
 * `TauCeti.mem_orbit_iff_minpoly_eq`: two roots of `p` are in the same Galois orbit exactly when

--- a/TauCeti/FieldTheory/GaloisGroups/Orbits.lean
+++ b/TauCeti/FieldTheory/GaloisGroups/Orbits.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.FieldTheory.PolynomialGaloisGroup
+public import Mathlib.GroupTheory.GroupAction.Primitive
 public import TauCeti.RingTheory.Polynomial.Factors
 
 /-!
@@ -22,7 +23,9 @@ turns this into a bijection with the distinct monic irreducible factors of `p`, 
 the members of `Polynomial.Factors p`.
 
 The dictionary also identifies transitivity of the root action with irreducibility for a
-separable polynomial of positive degree.
+separable polynomial of positive degree, and records what the orbit count says about the action
+inside the splitting field itself: an irreducible polynomial acts transitively there, and when
+its degree is prime it acts primitively.
 
 ## Main results
 
@@ -34,6 +37,9 @@ separable polynomial of positive degree.
   separable, an orbit has as many elements as its degree.
 * `TauCeti.isPretransitive_iff_irreducible`: for separable `p` of positive degree, transitivity
   of the root action is equivalent to irreducibility of `p`.
+* `TauCeti.isPretransitive_of_irreducible`, `TauCeti.isPreprimitive_of_prime_natDegree`: inside
+  the splitting field, an irreducible polynomial has a transitive root action, and an irreducible
+  separable polynomial of prime degree a primitive one.
 * `TauCeti.orbitQuotientEquivFactors`: the orbit quotient is in bijection with the
   monic irreducible factors of `p`, the orbit of a root going to its minimal polynomial.
 * `TauCeti.natCard_orbit_eq_natDegree_factor`: along that bijection, a separable
@@ -158,6 +164,43 @@ theorem isPretransitive_iff_irreducible (hsep : p.Separable) (hdeg : 0 < p.natDe
   rw [eq_leadingCoeff_mul_of_monic_of_dvd_of_natDegree_le (minpoly.monic hint) hdvd hdegle,
     irreducible_isUnit_mul hunit]
   exact minpoly.irreducible hint
+
+/-! ## The action inside the splitting field -/
+
+/- The two results below are about `p.rootSet p.SplittingField` carrying Mathlib's
+`Polynomial.Gal.galActionAux`, the intrinsic action for which `↑(g • x)` is literally `g ↑x`.
+That is not the instance `E := p.SplittingField` gives the results above: those use
+`Polynomial.Gal.galAction`, the transport of `galActionAux` along `Gal.rootsEquivRoots`, which
+goes through the `Algebra p.SplittingField p.SplittingField` instance built from
+`IsSplittingField.lift` rather than through the identity. So no `Fact` instance is introduced
+here, and transitivity is proved directly rather than read off
+`TauCeti.isPretransitive_iff_irreducible` or `Polynomial.Gal.galAction_isPretransitive`. -/
+
+/-- **The root action of an irreducible polynomial is transitive.** Two roots of an irreducible
+polynomial have the same minimal polynomial, and a normal extension moves one to the other.
+
+This is `Polynomial.Gal.galAction_isPretransitive` for the intrinsic action on the roots in the
+splitting field; see the note above for why that instance is not the one Mathlib's statement
+carries. -/
+theorem isPretransitive_of_irreducible (hp : Irreducible p) :
+    MulAction.IsPretransitive p.Gal (p.rootSet p.SplittingField) := by
+  refine ⟨fun x y => ?_⟩
+  have hx := minpoly.eq_of_irreducible hp (aeval_eq_zero_of_mem_rootSet x.2)
+  have hy := minpoly.eq_of_irreducible hp (aeval_eq_zero_of_mem_rootSet y.2)
+  obtain ⟨g, hg⟩ := (Normal.minpoly_eq_iff_mem_orbit p.SplittingField).mp (hy.symm.trans hx)
+  exact ⟨g, Subtype.ext hg⟩
+
+/-- **An irreducible separable polynomial of prime degree has a primitive root action.** A
+transitive action on a set of prime cardinality is primitive, and the roots of a separable
+polynomial number its degree. -/
+theorem isPreprimitive_of_prime_natDegree (hp : Irreducible p) (hsep : p.Separable)
+    (hprime : p.natDegree.Prime) :
+    MulAction.IsPreprimitive p.Gal (p.rootSet p.SplittingField) := by
+  have htr : MulAction.IsPretransitive p.Gal (p.rootSet p.SplittingField) :=
+    isPretransitive_of_irreducible hp
+  refine MulAction.IsPreprimitive.of_prime_card ?_
+  rwa [Nat.card_eq_fintype_card,
+    card_rootSet_eq_natDegree hsep (IsSplittingField.splits p.SplittingField p)]
 
 /-! ## Orbits and monic irreducible factors -/
 

--- a/TauCeti/FieldTheory/GaloisGroups/Orbits.lean
+++ b/TauCeti/FieldTheory/GaloisGroups/Orbits.lean
@@ -27,9 +27,6 @@ separable polynomial of positive degree, and records what the orbit count says a
 inside the splitting field itself: an irreducible polynomial acts transitively there, and an
 irreducible separable polynomial of prime degree acts primitively.
 
-The prime-degree statement is the corollary recorded in the “Primitivity and intermediate
-fields” milestone of `TauCetiRoadmap/PolynomialGaloisGroups/README.md`, Layer 2.
-
 ## Main results
 
 * `TauCeti.mem_orbit_iff_minpoly_eq`: two roots of `p` are in the same Galois orbit exactly when
@@ -53,6 +50,10 @@ fields” milestone of `TauCetiRoadmap/PolynomialGaloisGroups/README.md`, Layer 
 * `TauCeti.natCard_orbit_eq_natDegree_factor`: along that bijection, a separable
   factor has as many roots in the matching orbit as its degree.
 -/
+
+-- Source. The primitivity of the root action of an irreducible separable polynomial of prime
+-- degree is asked for by the Tau Ceti `PolynomialGaloisGroups` roadmap, `README.md`, section
+-- "Primitivity and intermediate fields".
 
 public section
 

--- a/TauCeti/FieldTheory/GaloisGroups/Orbits.lean
+++ b/TauCeti/FieldTheory/GaloisGroups/Orbits.lean
@@ -210,6 +210,7 @@ minimal polynomials over the base field agree.
 
 This is `TauCeti.mem_orbit_iff_minpoly_eq` for the intrinsic action; see the note above for why
 that instance is not the one the general statement carries. -/
+@[simp]
 theorem mem_orbit_iff_minpoly_eq_splittingField {x y : p.rootSet p.SplittingField} :
     x ∈ MulAction.orbit p.Gal y ↔
       minpoly F (x : p.SplittingField) = minpoly F (y : p.SplittingField) := by

--- a/TauCeti/FieldTheory/GaloisGroups/Orbits.lean
+++ b/TauCeti/FieldTheory/GaloisGroups/Orbits.lean
@@ -220,6 +220,7 @@ theorem mem_orbit_iff_minpoly_eq_splittingField {x y : p.rootSet p.SplittingFiel
 minimal polynomial.
 
 This is `TauCeti.image_val_orbit_eq_rootSet_minpoly` for the intrinsic action. -/
+@[simp]
 theorem image_val_orbit_eq_rootSet_minpoly_splittingField (x : p.rootSet p.SplittingField) :
     Subtype.val '' MulAction.orbit p.Gal x =
       (minpoly F (x : p.SplittingField)).rootSet p.SplittingField :=

--- a/TauCeti/FieldTheory/GaloisGroups/Stabilizer.lean
+++ b/TauCeti/FieldTheory/GaloisGroups/Stabilizer.lean
@@ -18,10 +18,12 @@ with a relative Galois group: it is the subgroup of `p.Gal` fixing the simple ex
 pointwise. Every further reading of the action against the Galois correspondence goes through
 that identification.
 
-Three consequences follow at once. The fixed field of the stabilizer is `F⟮x⟯` again, so the
-correspondence loses nothing. The index of the stabilizer is `[F⟮x⟯ : F]`, which for irreducible
-`p` is `p.natDegree`. And the action is primitive exactly when `F⟮x⟯` is an atom, that is,
-exactly when `F⟮x⟯ / F` has no intermediate field other than its two ends.
+Three consequences follow, each with the hypothesis it needs. For separable `p` the splitting
+field is Galois over `F`, so the fixed field of the stabilizer is `F⟮x⟯` again and the
+correspondence loses nothing; the index of the stabilizer is then `[F⟮x⟯ : F]`, which for
+irreducible `p` is `p.natDegree`. For `p` irreducible and separable of degree greater than one,
+the action is primitive exactly when `F⟮x⟯` is an atom, that is, exactly when `F⟮x⟯ / F` has no
+intermediate field other than its two ends.
 
 ## Main results
 
@@ -52,10 +54,6 @@ the same instance, and only the intrinsic one has stabilizers that the Galois co
 reads directly. No `Fact` instance is introduced below, so `galActionAux` is the only candidate
 and no ambiguity arises. For the same reason `TauCeti.isPretransitive_of_irreducible` is proved
 here rather than taken from `Polynomial.Gal.galAction_isPretransitive`.
-
-This supplies the first milestone of Layer 2 of
-`TauCetiRoadmap/PolynomialGaloisGroups/README.md`, "Stabilizers are relative Galois groups",
-together with the primitivity reading that the same layer asks for.
 -/
 
 public section
@@ -83,8 +81,9 @@ about the polynomial. -/
 theorem stabilizer_eq_fixingSubgroup_adjoin (x : p.rootSet p.SplittingField) :
     stabilizer p.Gal x = F⟮(x : p.SplittingField)⟯.fixingSubgroup := by
   ext σ
-  rw [MulAction.mem_stabilizer_iff, Subtype.ext_iff, Polynomial.Gal.coe_smul]
-  exact mem_fixingSubgroup_adjoin_simple_iff.symm
+  rw [MulAction.mem_stabilizer_iff, Subtype.ext_iff, Polynomial.Gal.coe_smul,
+    IntermediateField.fixingSubgroup_adjoin_simple]
+  exact Iff.rfl
 
 /-- **The field a root generates is recovered from its stabilizer.** For separable `p` the
 splitting field is Galois over `F`, so the fixed field of the stabilizer of `x` is `F⟮x⟯`. -/

--- a/TauCeti/FieldTheory/GaloisGroups/Stabilizer.lean
+++ b/TauCeti/FieldTheory/GaloisGroups/Stabilizer.lean
@@ -17,6 +17,9 @@ with a relative Galois group: it is the subgroup of `p.Gal` fixing the simple ex
 pointwise. The fixed-field and endpoint readings of the action against the Galois correspondence
 go through that identification.
 
+This is the “Stabilizers are relative Galois groups” milestone of
+`TauCetiRoadmap/PolynomialGaloisGroups/README.md`, Layer 2.
+
 The identification itself needs no hypothesis on `p`. Recovering the fixed field and the two
 ends of the Galois correspondence needs `IsGalois F L`. The index, however, is an
 orbit-stabilizer calculation: it only needs the minimal polynomial of the chosen root to be

--- a/TauCeti/FieldTheory/GaloisGroups/Stabilizer.lean
+++ b/TauCeti/FieldTheory/GaloisGroups/Stabilizer.lean
@@ -58,10 +58,6 @@ variable {F : Type*} [Field F] {p : F[X]}
 
 /-! ### The stabilizer of a root -/
 
--- Source. Both the identification of the point stabilizer with the subgroup fixing the field
--- the root generates and the index of that stabilizer are the statements specified by
--- `TauCetiRoadmap/PolynomialGaloisGroups/README.md`, section "Stabilizers are relative Galois
--- groups".
 /-- **The stabilizer of a root is a relative Galois group.** An automorphism of the splitting
 field fixes a root `x` exactly when it fixes the subfield `F⟮x⟯` pointwise, so the point
 stabilizer of the root action is the fixing subgroup of that subfield.

--- a/TauCeti/FieldTheory/GaloisGroups/Stabilizer.lean
+++ b/TauCeti/FieldTheory/GaloisGroups/Stabilizer.lean
@@ -18,27 +18,26 @@ with a relative Galois group: it is the subgroup of `p.Gal` fixing the simple ex
 pointwise. Every further reading of the action against the Galois correspondence goes through
 that identification.
 
-Three consequences follow, each with the hypothesis it needs. For separable `p` the splitting
-field is Galois over `F`, so the fixed field of the stabilizer is `F⟮x⟯` again and the
-correspondence loses nothing; the index of the stabilizer is then `[F⟮x⟯ : F]`, which for
-irreducible `p` is `p.natDegree`. For `p` irreducible and separable of degree greater than one,
-the action is primitive exactly when `F⟮x⟯` is an atom, that is, exactly when `F⟮x⟯ / F` has no
-intermediate field other than its two ends.
+The consequences each carry the hypothesis they need. For separable `p` the splitting field is
+Galois over `F`, so the fixed field of the stabilizer is `F⟮x⟯` again and the correspondence
+loses nothing; the index of the stabilizer is then `[F⟮x⟯ : F]`, which for irreducible separable
+`p` is `p.natDegree`. For irreducible `p` the action on the roots is transitive, and when the
+degree is prime it is primitive.
 
 ## Main results
 
 * `TauCeti.stabilizer_eq_fixingSubgroup_adjoin`: the stabilizer of a root is the fixing subgroup
   of the field the root generates.
 * `TauCeti.fixedField_stabilizer`: for separable `p`, the field it fixes is that same field.
-* `TauCeti.index_stabilizer`, `TauCeti.index_stabilizer_eq_natDegree`: the index of the
-  stabilizer is the degree of the minimal polynomial of the root, so for irreducible `p` it is
-  `p.natDegree`.
+* `TauCeti.index_stabilizer`, `TauCeti.index_stabilizer_eq_natDegree`: for separable `p` the
+  index of the stabilizer is the degree of the minimal polynomial of the root, so for
+  irreducible separable `p` it is `p.natDegree`.
 * `TauCeti.stabilizer_eq_bot_iff_adjoin_eq_top`,
-  `TauCeti.stabilizer_eq_top_iff_adjoin_eq_bot`: the two ends of the correspondence, a root that
-  generates the whole splitting field and a root that lies in the base field.
-* `TauCeti.isPreprimitive_iff_isAtom_adjoin`: for irreducible separable `p` of degree greater
-  than one, the root action is primitive exactly when `F⟮x⟯` admits no proper intermediate
-  field.
+  `TauCeti.stabilizer_eq_top_iff_adjoin_eq_bot`: for separable `p`, the two ends of the
+  correspondence, a root that generates the whole splitting field and a root that lies in the
+  base field.
+* `TauCeti.isPretransitive_of_irreducible`: the root action of an irreducible polynomial is
+  transitive.
 * `TauCeti.isPreprimitive_of_prime_natDegree`: an irreducible separable polynomial of prime
   degree has a primitive root action.
 
@@ -94,9 +93,10 @@ theorem fixedField_stabilizer (hsep : p.Separable) (x : p.rootSet p.SplittingFie
 
 /-! ### The index of a point stabilizer -/
 
-/-- **The index of a point stabilizer is the degree of the minimal polynomial of the point.** The
-index of the fixing subgroup of an intermediate field is the degree of that field over the base,
-and `F⟮x⟯` has the degree of the minimal polynomial of `x`. -/
+/-- **For separable `p`, the index of a point stabilizer is the degree of the minimal polynomial
+of the point.** The index of the fixing subgroup of an intermediate field is the degree of that
+field over the base, and `F⟮x⟯` has the degree of the minimal polynomial of `x`; separability is
+what makes the splitting field Galois over `F`, so that the correspondence applies. -/
 theorem index_stabilizer (hsep : p.Separable) (x : p.rootSet p.SplittingField) :
     (stabilizer p.Gal x).index = (minpoly F (x : p.SplittingField)).natDegree := by
   have : IsGalois F p.SplittingField := IsGalois.of_separable_splitting_field hsep
@@ -104,9 +104,10 @@ theorem index_stabilizer (hsep : p.Separable) (x : p.rootSet p.SplittingField) :
     ← IntermediateField.adjoin.finrank (IsIntegral.of_finite F (x : p.SplittingField))]
   exact (IntermediateField.finrank_eq_fixingSubgroup_index _ F⟮(x : p.SplittingField)⟯).symm
 
-/-- **For an irreducible polynomial every point stabilizer has index the degree.** This is the
-form the permutation representation uses: a transitive subgroup of degree `n` has point
-stabilizers of index `n`. -/
+/-- **For an irreducible separable polynomial every point stabilizer has index the degree.** This
+is the form the permutation representation uses: a transitive subgroup of degree `n` has point
+stabilizers of index `n`. Separability is needed for `TauCeti.index_stabilizer`, and without it
+an irreducible polynomial can have fewer roots than its degree. -/
 theorem index_stabilizer_eq_natDegree (hp : Irreducible p) (hsep : p.Separable)
     (x : p.rootSet p.SplittingField) : (stabilizer p.Gal x).index = p.natDegree := by
   have hmin : (minpoly F (x : p.SplittingField)).natDegree = p.natDegree := by
@@ -116,9 +117,9 @@ theorem index_stabilizer_eq_natDegree (hp : Irreducible p) (hsep : p.Separable)
 
 /-! ### The two ends of the correspondence -/
 
-/-- **A root with trivial stabilizer is a primitive element**, and conversely. Together with
-`TauCeti.stabilizer_eq_top_iff_adjoin_eq_bot` this pins the orientation of the correspondence:
-the stabilizer shrinks as the field the root generates grows. -/
+/-- **For separable `p`, a root with trivial stabilizer is a primitive element**, and conversely.
+Together with `TauCeti.stabilizer_eq_top_iff_adjoin_eq_bot` this pins the orientation of the
+correspondence: the stabilizer shrinks as the field the root generates grows. -/
 theorem stabilizer_eq_bot_iff_adjoin_eq_top (hsep : p.Separable)
     (x : p.rootSet p.SplittingField) :
     stabilizer p.Gal x = ⊥ ↔ F⟮(x : p.SplittingField)⟯ = ⊤ := by
@@ -129,7 +130,9 @@ theorem stabilizer_eq_bot_iff_adjoin_eq_top (hsep : p.Separable)
   · rw [stabilizer_eq_fixingSubgroup_adjoin, h]
     exact IntermediateField.fixingSubgroup_top
 
-/-- **A root fixed by the whole Galois group lies in the base field**, and conversely. -/
+/-- **For separable `p`, a root fixed by the whole Galois group lies in the base field**, and
+conversely. Separability is what makes the fixed field of the whole group `F` itself; over an
+inseparable extension a root outside `F` can be fixed by every automorphism. -/
 theorem stabilizer_eq_top_iff_adjoin_eq_bot (hsep : p.Separable)
     (x : p.rootSet p.SplittingField) :
     stabilizer p.Gal x = ⊤ ↔ F⟮(x : p.SplittingField)⟯ = ⊥ := by
@@ -155,30 +158,6 @@ theorem isPretransitive_of_irreducible (hp : Irreducible p) :
   have hy := minpoly.eq_of_irreducible hp (aeval_eq_zero_of_mem_rootSet y.2)
   obtain ⟨g, hg⟩ := (Normal.minpoly_eq_iff_mem_orbit p.SplittingField).mp (hy.symm.trans hx)
   exact ⟨g, Subtype.ext hg⟩
-
-/-- **Primitivity of the root action is the absence of intermediate fields.** For an irreducible
-separable `p` of degree greater than one, the action of `p.Gal` on the roots is primitive exactly
-when `F⟮x⟯` is an atom, that is, exactly when no field lies strictly between `F` and `F⟮x⟯`.
-
-The degree hypothesis cannot be dropped. For linear `p` the root set is a single point, on which
-every action is primitive, while `F⟮x⟯ = ⊥` is not an atom. It is the hypothesis that Mathlib's
-`MulAction.isCoatom_stabilizer_iff_preprimitive` carries as `[Nontrivial X]`.
-
-The conclusion does not depend on the chosen root, since the action is transitive; `x` appears on
-the right only to name a field. -/
-theorem isPreprimitive_iff_isAtom_adjoin (hp : Irreducible p) (hsep : p.Separable)
-    (hdeg : 1 < p.natDegree) (x : p.rootSet p.SplittingField) :
-    IsPreprimitive p.Gal (p.rootSet p.SplittingField) ↔
-      IsAtom F⟮(x : p.SplittingField)⟯ := by
-  have hgal : IsGalois F p.SplittingField := IsGalois.of_separable_splitting_field hsep
-  have htr : IsPretransitive p.Gal (p.rootSet p.SplittingField) :=
-    isPretransitive_of_irreducible hp
-  have hcard : Fintype.card (p.rootSet p.SplittingField) = p.natDegree :=
-    Polynomial.card_rootSet_eq_natDegree hsep (IsSplittingField.splits p.SplittingField p)
-  have hnt : Nontrivial (p.rootSet p.SplittingField) :=
-    Fintype.one_lt_card_iff_nontrivial.mp (by omega)
-  rw [← isCoatom_stabilizer_iff_preprimitive p.Gal x, stabilizer_eq_fixingSubgroup_adjoin]
-  exact IntermediateField.isCoatom_fixingSubgroup_iff_isAtom F⟮(x : p.SplittingField)⟯
 
 /-- **An irreducible separable polynomial of prime degree has a primitive root action.** A
 transitive action on a set of prime cardinality is primitive, and the roots of a separable

--- a/TauCeti/FieldTheory/GaloisGroups/Stabilizer.lean
+++ b/TauCeti/FieldTheory/GaloisGroups/Stabilizer.lean
@@ -48,11 +48,6 @@ reads directly. No `Fact` instance is introduced below, so `galActionAux` is the
 and no ambiguity arises.
 -/
 
--- Source. The identification of the point stabilizer of the root action with the subgroup
--- fixing the field the root generates, and its index, are asked for by the Tau Ceti
--- `PolynomialGaloisGroups` roadmap, `README.md`, section "Stabilizers are relative Galois
--- groups".
-
 public section
 
 namespace TauCeti
@@ -63,6 +58,10 @@ variable {F : Type*} [Field F] {p : F[X]}
 
 /-! ### The stabilizer of a root -/
 
+-- Source. Both the identification of the point stabilizer with the subgroup fixing the field
+-- the root generates and the index of that stabilizer are the statements specified by
+-- `TauCetiRoadmap/PolynomialGaloisGroups/README.md`, section "Stabilizers are relative Galois
+-- groups".
 /-- **The stabilizer of a root is a relative Galois group.** An automorphism of the splitting
 field fixes a root `x` exactly when it fixes the subfield `F⟮x⟯` pointwise, so the point
 stabilizer of the root action is the fixing subgroup of that subfield.

--- a/TauCeti/FieldTheory/GaloisGroups/Stabilizer.lean
+++ b/TauCeti/FieldTheory/GaloisGroups/Stabilizer.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.FieldTheory.PolynomialGaloisGroup
-public import Mathlib.GroupTheory.GroupAction.Primitive
 public import TauCeti.FieldTheory.Galois.FixedField
 
 /-!
@@ -18,28 +17,25 @@ with a relative Galois group: it is the subgroup of `p.Gal` fixing the simple ex
 pointwise. Every further reading of the action against the Galois correspondence goes through
 that identification.
 
-The consequences each carry the hypothesis they need. For separable `p` the splitting field is
-Galois over `F`, so the fixed field of the stabilizer is `F⟮x⟯` again and the correspondence
-loses nothing; the index of the stabilizer is then `[F⟮x⟯ : F]`, which for irreducible separable
-`p` is `p.natDegree`. For irreducible `p` the action on the roots is transitive, and when the
-degree is prime it is primitive.
+The identification itself needs no hypothesis on `p`. Reading it back through the Galois
+correspondence needs one, and the hypothesis it needs is `IsGalois F L`: that is what makes the
+fixed field of the stabilizer `F⟮x⟯` again, and its index `[F⟮x⟯ : F]`, which for irreducible `p`
+is `p.natDegree`. Separability of `p` supplies that instance through
+`IsGalois.of_separable_splitting_field`, but it is not the weakest hypothesis that does: a power
+of a separable irreducible polynomial is inseparable and still has a Galois splitting field.
 
 ## Main results
 
 * `TauCeti.stabilizer_eq_fixingSubgroup_adjoin`: the stabilizer of a root is the fixing subgroup
   of the field the root generates.
-* `TauCeti.fixedField_stabilizer`: for separable `p`, the field it fixes is that same field.
-* `TauCeti.index_stabilizer`, `TauCeti.index_stabilizer_eq_natDegree`: for separable `p` the
-  index of the stabilizer is the degree of the minimal polynomial of the root, so for
-  irreducible separable `p` it is `p.natDegree`.
+* `TauCeti.fixedField_stabilizer`: for a Galois splitting field, the field the stabilizer fixes
+  is that same field.
+* `TauCeti.index_stabilizer_eq_minpoly_natDegree`,
+  `TauCeti.index_stabilizer_eq_natDegree`: the index of the stabilizer is the degree of the
+  minimal polynomial of the root, so for irreducible `p` it is `p.natDegree`.
 * `TauCeti.stabilizer_eq_bot_iff_adjoin_eq_top`,
-  `TauCeti.stabilizer_eq_top_iff_adjoin_eq_bot`: for separable `p`, the two ends of the
-  correspondence, a root that generates the whole splitting field and a root that lies in the
-  base field.
-* `TauCeti.isPretransitive_of_irreducible`: the root action of an irreducible polynomial is
-  transitive.
-* `TauCeti.isPreprimitive_of_prime_natDegree`: an irreducible separable polynomial of prime
-  degree has a primitive root action.
+  `TauCeti.stabilizer_eq_top_iff_adjoin_eq_bot`: the two ends of the correspondence, a root that
+  generates the whole splitting field and a root that lies in the base field.
 
 ## Implementation notes
 
@@ -51,8 +47,7 @@ which goes through the `Algebra p.SplittingField p.SplittingField` instance buil
 `IsSplittingField.lift` rather than through the identity. The two actions are isomorphic but not
 the same instance, and only the intrinsic one has stabilizers that the Galois correspondence
 reads directly. No `Fact` instance is introduced below, so `galActionAux` is the only candidate
-and no ambiguity arises. For the same reason `TauCeti.isPretransitive_of_irreducible` is proved
-here rather than taken from `Polynomial.Gal.galAction_isPretransitive`.
+and no ambiguity arises.
 -/
 
 public section
@@ -84,90 +79,63 @@ theorem stabilizer_eq_fixingSubgroup_adjoin (x : p.rootSet p.SplittingField) :
     IntermediateField.fixingSubgroup_adjoin_simple]
   exact Iff.rfl
 
-/-- **The field a root generates is recovered from its stabilizer.** For separable `p` the
-splitting field is Galois over `F`, so the fixed field of the stabilizer of `x` is `F⟮x⟯`. -/
-theorem fixedField_stabilizer (hsep : p.Separable) (x : p.rootSet p.SplittingField) :
+/-- **The field a root generates is recovered from its stabilizer.** When the splitting field is
+Galois over `F` the fixed field of the stabilizer of `x` is `F⟮x⟯`. -/
+theorem fixedField_stabilizer [IsGalois F p.SplittingField] (x : p.rootSet p.SplittingField) :
     IntermediateField.fixedField (stabilizer p.Gal x) = F⟮(x : p.SplittingField)⟯ := by
-  have : IsGalois F p.SplittingField := IsGalois.of_separable_splitting_field hsep
   rw [stabilizer_eq_fixingSubgroup_adjoin, IsGalois.fixedField_fixingSubgroup]
 
 /-! ### The index of a point stabilizer -/
 
-/-- **For separable `p`, the index of a point stabilizer is the degree of the minimal polynomial
-of the point.** The index of the fixing subgroup of an intermediate field is the degree of that
-field over the base, and `F⟮x⟯` has the degree of the minimal polynomial of `x`; separability is
-what makes the splitting field Galois over `F`, so that the correspondence applies. -/
-theorem index_stabilizer (hsep : p.Separable) (x : p.rootSet p.SplittingField) :
+/-- **The index of a point stabilizer is the degree of the minimal polynomial of the point.** The
+index of the fixing subgroup of an intermediate field is the degree of that field over the base,
+and `F⟮x⟯` has the degree of the minimal polynomial of `x`; the splitting field being Galois over
+`F` is what makes the correspondence apply. -/
+theorem index_stabilizer_eq_minpoly_natDegree [IsGalois F p.SplittingField]
+    (x : p.rootSet p.SplittingField) :
     (stabilizer p.Gal x).index = (minpoly F (x : p.SplittingField)).natDegree := by
-  have : IsGalois F p.SplittingField := IsGalois.of_separable_splitting_field hsep
   rw [stabilizer_eq_fixingSubgroup_adjoin,
     ← IntermediateField.adjoin.finrank (IsIntegral.of_finite F (x : p.SplittingField))]
   exact (IntermediateField.finrank_eq_fixingSubgroup_index _ F⟮(x : p.SplittingField)⟯).symm
 
-/-- **For an irreducible separable polynomial every point stabilizer has index the degree.** This
-is the form the permutation representation uses: a transitive subgroup of degree `n` has point
-stabilizers of index `n`. Separability is needed for `TauCeti.index_stabilizer`, and without it
-an irreducible polynomial can have fewer roots than its degree. -/
-theorem index_stabilizer_eq_natDegree (hp : Irreducible p) (hsep : p.Separable)
+/-- **For an irreducible polynomial every point stabilizer has index the degree.** This is the
+form the permutation representation uses: a transitive subgroup of degree `n` has point
+stabilizers of index `n`.
+
+An irreducible `p` whose splitting field is Galois over `F` is separable, and an inseparable
+irreducible polynomial has fewer roots than its degree; so the hypotheses here are the same as
+irreducibility together with `p.Separable`, stated in the form the Galois correspondence uses. -/
+theorem index_stabilizer_eq_natDegree [IsGalois F p.SplittingField] (hp : Irreducible p)
     (x : p.rootSet p.SplittingField) : (stabilizer p.Gal x).index = p.natDegree := by
   have hmin : (minpoly F (x : p.SplittingField)).natDegree = p.natDegree := by
     rw [← minpoly.eq_of_irreducible hp (aeval_eq_zero_of_mem_rootSet x.2)]
     exact natDegree_mul_C (inv_ne_zero (leadingCoeff_ne_zero.mpr hp.ne_zero))
-  rw [index_stabilizer hsep, hmin]
+  rw [index_stabilizer_eq_minpoly_natDegree x, hmin]
 
 /-! ### The two ends of the correspondence -/
 
-/-- **For separable `p`, a root with trivial stabilizer is a primitive element**, and conversely.
-Together with `TauCeti.stabilizer_eq_top_iff_adjoin_eq_bot` this pins the orientation of the
-correspondence: the stabilizer shrinks as the field the root generates grows. -/
-theorem stabilizer_eq_bot_iff_adjoin_eq_top (hsep : p.Separable)
+/-- **A root with trivial stabilizer is a primitive element**, and conversely. Together with
+`TauCeti.stabilizer_eq_top_iff_adjoin_eq_bot` this pins the orientation of the correspondence:
+the stabilizer shrinks as the field the root generates grows. -/
+theorem stabilizer_eq_bot_iff_adjoin_eq_top [IsGalois F p.SplittingField]
     (x : p.rootSet p.SplittingField) :
     stabilizer p.Gal x = ⊥ ↔ F⟮(x : p.SplittingField)⟯ = ⊤ := by
-  have : IsGalois F p.SplittingField := IsGalois.of_separable_splitting_field hsep
   refine ⟨fun h => ?_, fun h => ?_⟩
-  · rw [← fixedField_stabilizer hsep x, h]
+  · rw [← fixedField_stabilizer x, h]
     exact IntermediateField.fixedField_bot
   · rw [stabilizer_eq_fixingSubgroup_adjoin, h]
     exact IntermediateField.fixingSubgroup_top
 
-/-- **For separable `p`, a root fixed by the whole Galois group lies in the base field**, and
-conversely. Separability is what makes the fixed field of the whole group `F` itself; over an
-inseparable extension a root outside `F` can be fixed by every automorphism. -/
-theorem stabilizer_eq_top_iff_adjoin_eq_bot (hsep : p.Separable)
+/-- **A root fixed by the whole Galois group lies in the base field**, and conversely. The
+splitting field being Galois over `F` is what makes the fixed field of the whole group `F`
+itself; over an inseparable extension a root outside `F` can be fixed by every automorphism. -/
+theorem stabilizer_eq_top_iff_adjoin_eq_bot [IsGalois F p.SplittingField]
     (x : p.rootSet p.SplittingField) :
     stabilizer p.Gal x = ⊤ ↔ F⟮(x : p.SplittingField)⟯ = ⊥ := by
-  have : IsGalois F p.SplittingField := IsGalois.of_separable_splitting_field hsep
   refine ⟨fun h => ?_, fun h => ?_⟩
-  · rw [← fixedField_stabilizer hsep x, h]
+  · rw [← fixedField_stabilizer x, h]
     exact IsGalois.fixedField_top
   · rw [stabilizer_eq_fixingSubgroup_adjoin, h]
     exact IntermediateField.fixingSubgroup_bot
-
-/-! ### Transitivity and primitivity -/
-
-/-- **The root action of an irreducible polynomial is transitive.** Two roots of an irreducible
-polynomial have the same minimal polynomial, and a normal extension moves one to the other.
-
-This is `Polynomial.Gal.galAction_isPretransitive` for the intrinsic action on the roots in the
-splitting field; see the implementation notes for why that instance is not the one Mathlib's
-statement carries. -/
-theorem isPretransitive_of_irreducible (hp : Irreducible p) :
-    IsPretransitive p.Gal (p.rootSet p.SplittingField) := by
-  refine ⟨fun x y => ?_⟩
-  have hx := minpoly.eq_of_irreducible hp (aeval_eq_zero_of_mem_rootSet x.2)
-  have hy := minpoly.eq_of_irreducible hp (aeval_eq_zero_of_mem_rootSet y.2)
-  obtain ⟨g, hg⟩ := (Normal.minpoly_eq_iff_mem_orbit p.SplittingField).mp (hy.symm.trans hx)
-  exact ⟨g, Subtype.ext hg⟩
-
-/-- **An irreducible separable polynomial of prime degree has a primitive root action.** A
-transitive action on a set of prime cardinality is primitive, and the roots of a separable
-polynomial number its degree. -/
-theorem isPreprimitive_of_prime_natDegree (hp : Irreducible p) (hsep : p.Separable)
-    (hprime : p.natDegree.Prime) : IsPreprimitive p.Gal (p.rootSet p.SplittingField) := by
-  have htr : IsPretransitive p.Gal (p.rootSet p.SplittingField) :=
-    isPretransitive_of_irreducible hp
-  refine IsPreprimitive.of_prime_card ?_
-  rwa [Nat.card_eq_fintype_card,
-    Polynomial.card_rootSet_eq_natDegree hsep (IsSplittingField.splits p.SplittingField p)]
 
 end TauCeti

--- a/TauCeti/FieldTheory/GaloisGroups/Stabilizer.lean
+++ b/TauCeti/FieldTheory/GaloisGroups/Stabilizer.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.FieldTheory.PolynomialGaloisGroup
 public import TauCeti.FieldTheory.Galois.FixedField
+public import TauCeti.FieldTheory.GaloisGroups.Orbits
 
 /-!
 # Point stabilizers of the Galois action on the roots
@@ -87,47 +88,13 @@ theorem fixedField_stabilizer [IsGalois F p.SplittingField] (x : p.rootSet p.Spl
 
 /-- **The index of a point stabilizer is the degree of the minimal polynomial of the point.** The
 orbit of `x` consists of all roots of its minimal polynomial in the normal splitting field, and
-separability makes their number its degree. -/
+separability makes their number its degree, so this is orbit-stabilizer applied to
+`TauCeti.natCard_orbit_eq_natDegree_minpoly_splittingField`. -/
 theorem index_stabilizer_eq_minpoly_natDegree (x : p.rootSet p.SplittingField)
     (hsep : (minpoly F (x : p.SplittingField)).Separable) :
     (stabilizer p.Gal x).index = (minpoly F (x : p.SplittingField)).natDegree := by
-  rw [MulAction.index_stabilizer]
-  have hint : IsIntegral F (x : p.SplittingField) :=
-    (isAlgebraic_of_mem_rootSet x.2).isIntegral
-  have hdvd : minpoly F (x : p.SplittingField) ∣ p :=
-    minpoly.dvd F _ (aeval_eq_zero_of_mem_rootSet x.2)
-  have horbit :
-      Subtype.val '' MulAction.orbit p.Gal x =
-        (minpoly F (x : p.SplittingField)).rootSet p.SplittingField := by
-    ext y
-    constructor
-    · rintro ⟨z, hz, rfl⟩
-      obtain ⟨g, rfl⟩ := hz
-      rw [mem_rootSet]
-      refine ⟨minpoly.ne_zero hint, ?_⟩
-      rw [← minpoly.algEquiv_eq g (x : p.SplittingField)]
-      exact minpoly.aeval F (g (x : p.SplittingField))
-    · intro hy
-      have hp0 : p ≠ 0 := ne_zero_of_mem_rootSet x.2
-      have hyp : y ∈ p.rootSet p.SplittingField :=
-        mem_rootSet.mpr ⟨hp0, aeval_eq_zero_of_dvd_aeval_eq_zero hdvd
-          (aeval_eq_zero_of_mem_rootSet hy)⟩
-      have hmin : minpoly F y = minpoly F (x : p.SplittingField) :=
-        (minpoly.eq_of_irreducible_of_monic (minpoly.irreducible hint)
-          (aeval_eq_zero_of_mem_rootSet hy) (minpoly.monic hint)).symm
-      obtain ⟨g, hg⟩ :=
-        (Normal.minpoly_eq_iff_mem_orbit p.SplittingField).mp hmin
-      exact ⟨⟨y, hyp⟩, ⟨g, Subtype.ext hg⟩, rfl⟩
-  calc
-    (MulAction.orbit p.Gal x).ncard =
-        (Subtype.val '' MulAction.orbit p.Gal x).ncard :=
-      (Set.ncard_image_of_injective _ Subtype.val_injective).symm
-    _ = ((minpoly F (x : p.SplittingField)).rootSet p.SplittingField).ncard :=
-      congrArg Set.ncard horbit
-    _ = (minpoly F (x : p.SplittingField)).natDegree := by
-      rw [← Nat.card_coe_set_eq, Nat.card_eq_fintype_card,
-        card_rootSet_eq_natDegree hsep
-          (Normal.splits (SplittingField.instNormal p) (x : p.SplittingField))]
+  rw [MulAction.index_stabilizer, ← Nat.card_coe_set_eq,
+    natCard_orbit_eq_natDegree_minpoly_splittingField x hsep]
 
 /-- **For an irreducible separable polynomial every point stabilizer has index the degree.** This
 is the form the permutation representation uses: a transitive subgroup of degree `n` has point

--- a/TauCeti/FieldTheory/GaloisGroups/Stabilizer.lean
+++ b/TauCeti/FieldTheory/GaloisGroups/Stabilizer.lean
@@ -17,9 +17,6 @@ with a relative Galois group: it is the subgroup of `p.Gal` fixing the simple ex
 pointwise. The fixed-field and endpoint readings of the action against the Galois correspondence
 go through that identification.
 
-This is the “Stabilizers are relative Galois groups” milestone of
-`TauCetiRoadmap/PolynomialGaloisGroups/README.md`, Layer 2.
-
 The identification itself needs no hypothesis on `p`. Recovering the fixed field and the two
 ends of the Galois correspondence needs `IsGalois F L`. The index, however, is an
 orbit-stabilizer calculation: it only needs the minimal polynomial of the chosen root to be
@@ -50,6 +47,11 @@ the same instance, and only the intrinsic one has stabilizers that the Galois co
 reads directly. No `Fact` instance is introduced below, so `galActionAux` is the only candidate
 and no ambiguity arises.
 -/
+
+-- Source. The identification of the point stabilizer of the root action with the subgroup
+-- fixing the field the root generates, and its index, are asked for by the Tau Ceti
+-- `PolynomialGaloisGroups` roadmap, `README.md`, section "Stabilizers are relative Galois
+-- groups".
 
 public section
 

--- a/TauCeti/FieldTheory/GaloisGroups/Stabilizer.lean
+++ b/TauCeti/FieldTheory/GaloisGroups/Stabilizer.lean
@@ -1,0 +1,195 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.FieldTheory.PolynomialGaloisGroup
+public import Mathlib.GroupTheory.GroupAction.Primitive
+public import TauCeti.FieldTheory.Galois.FixedField
+
+/-!
+# Point stabilizers of the Galois action on the roots
+
+Let `p` be a polynomial over a field `F` and let `L = p.SplittingField`. The Galois group
+`Polynomial.Gal p` acts on `p.rootSet L`, and this file identifies the stabilizer of a root `x`
+with a relative Galois group: it is the subgroup of `p.Gal` fixing the simple extension `F⟮x⟯`
+pointwise. Every further reading of the action against the Galois correspondence goes through
+that identification.
+
+Three consequences follow at once. The fixed field of the stabilizer is `F⟮x⟯` again, so the
+correspondence loses nothing. The index of the stabilizer is `[F⟮x⟯ : F]`, which for irreducible
+`p` is `p.natDegree`. And the action is primitive exactly when `F⟮x⟯` is an atom, that is,
+exactly when `F⟮x⟯ / F` has no intermediate field other than its two ends.
+
+## Main results
+
+* `TauCeti.stabilizer_eq_fixingSubgroup_adjoin`: the stabilizer of a root is the fixing subgroup
+  of the field the root generates.
+* `TauCeti.fixedField_stabilizer`: for separable `p`, the field it fixes is that same field.
+* `TauCeti.index_stabilizer`, `TauCeti.index_stabilizer_eq_natDegree`: the index of the
+  stabilizer is the degree of the minimal polynomial of the root, so for irreducible `p` it is
+  `p.natDegree`.
+* `TauCeti.stabilizer_eq_bot_iff_adjoin_eq_top`,
+  `TauCeti.stabilizer_eq_top_iff_adjoin_eq_bot`: the two ends of the correspondence, a root that
+  generates the whole splitting field and a root that lies in the base field.
+* `TauCeti.isPreprimitive_iff_isAtom_adjoin`: for irreducible separable `p` of degree greater
+  than one, the root action is primitive exactly when `F⟮x⟯` admits no proper intermediate
+  field.
+* `TauCeti.isPreprimitive_of_prime_natDegree`: an irreducible separable polynomial of prime
+  degree has a primitive root action.
+
+## Implementation notes
+
+The action used here is Mathlib's `Polynomial.Gal.galActionAux`, the intrinsic action on
+`p.rootSet p.SplittingField`, for which `↑(g • x)` is literally `g ↑x`. Mathlib also has
+`Polynomial.Gal.galAction` on `p.rootSet E` for a splitting extension `E`, but its instance for
+`E = p.SplittingField` is the transport of `galActionAux` along `Polynomial.Gal.rootsEquivRoots`,
+which goes through the `Algebra p.SplittingField p.SplittingField` instance built from
+`IsSplittingField.lift` rather than through the identity. The two actions are isomorphic but not
+the same instance, and only the intrinsic one has stabilizers that the Galois correspondence
+reads directly. No `Fact` instance is introduced below, so `galActionAux` is the only candidate
+and no ambiguity arises. For the same reason `TauCeti.isPretransitive_of_irreducible` is proved
+here rather than taken from `Polynomial.Gal.galAction_isPretransitive`.
+
+This supplies the first milestone of Layer 2 of
+`TauCetiRoadmap/PolynomialGaloisGroups/README.md`, "Stabilizers are relative Galois groups",
+together with the primitivity reading that the same layer asks for.
+-/
+
+public section
+
+namespace TauCeti
+
+open Polynomial IntermediateField MulAction
+
+variable {F : Type*} [Field F] {p : F[X]}
+
+/-! ### The stabilizer of a root -/
+
+/-- The Galois action on the roots in the splitting field is the action by evaluation. -/
+@[simp]
+theorem _root_.Polynomial.Gal.coe_smul (g : p.Gal) (x : p.rootSet p.SplittingField) :
+    ((g • x : p.rootSet p.SplittingField) : p.SplittingField) = g x :=
+  rfl
+
+/-- **The stabilizer of a root is a relative Galois group.** An automorphism of the splitting
+field fixes a root `x` exactly when it fixes the subfield `F⟮x⟯` pointwise, so the point
+stabilizer of the root action is the fixing subgroup of that subfield.
+
+No hypothesis on `p` is needed: the statement is about one root and the field it generates, not
+about the polynomial. -/
+theorem stabilizer_eq_fixingSubgroup_adjoin (x : p.rootSet p.SplittingField) :
+    stabilizer p.Gal x = F⟮(x : p.SplittingField)⟯.fixingSubgroup := by
+  ext σ
+  rw [MulAction.mem_stabilizer_iff, Subtype.ext_iff, Polynomial.Gal.coe_smul]
+  exact mem_fixingSubgroup_adjoin_simple_iff.symm
+
+/-- **The field a root generates is recovered from its stabilizer.** For separable `p` the
+splitting field is Galois over `F`, so the fixed field of the stabilizer of `x` is `F⟮x⟯`. -/
+theorem fixedField_stabilizer (hsep : p.Separable) (x : p.rootSet p.SplittingField) :
+    IntermediateField.fixedField (stabilizer p.Gal x) = F⟮(x : p.SplittingField)⟯ := by
+  have : IsGalois F p.SplittingField := IsGalois.of_separable_splitting_field hsep
+  rw [stabilizer_eq_fixingSubgroup_adjoin, IsGalois.fixedField_fixingSubgroup]
+
+/-! ### The index of a point stabilizer -/
+
+/-- **The index of a point stabilizer is the degree of the minimal polynomial of the point.** The
+index of the fixing subgroup of an intermediate field is the degree of that field over the base,
+and `F⟮x⟯` has the degree of the minimal polynomial of `x`. -/
+theorem index_stabilizer (hsep : p.Separable) (x : p.rootSet p.SplittingField) :
+    (stabilizer p.Gal x).index = (minpoly F (x : p.SplittingField)).natDegree := by
+  have : IsGalois F p.SplittingField := IsGalois.of_separable_splitting_field hsep
+  rw [stabilizer_eq_fixingSubgroup_adjoin,
+    ← IntermediateField.adjoin.finrank (IsIntegral.of_finite F (x : p.SplittingField))]
+  exact (IntermediateField.finrank_eq_fixingSubgroup_index _ F⟮(x : p.SplittingField)⟯).symm
+
+/-- **For an irreducible polynomial every point stabilizer has index the degree.** This is the
+form the permutation representation uses: a transitive subgroup of degree `n` has point
+stabilizers of index `n`. -/
+theorem index_stabilizer_eq_natDegree (hp : Irreducible p) (hsep : p.Separable)
+    (x : p.rootSet p.SplittingField) : (stabilizer p.Gal x).index = p.natDegree := by
+  have hmin : (minpoly F (x : p.SplittingField)).natDegree = p.natDegree := by
+    rw [← minpoly.eq_of_irreducible hp (aeval_eq_zero_of_mem_rootSet x.2)]
+    exact natDegree_mul_C (inv_ne_zero (leadingCoeff_ne_zero.mpr hp.ne_zero))
+  rw [index_stabilizer hsep, hmin]
+
+/-! ### The two ends of the correspondence -/
+
+/-- **A root with trivial stabilizer is a primitive element**, and conversely. Together with
+`TauCeti.stabilizer_eq_top_iff_adjoin_eq_bot` this pins the orientation of the correspondence:
+the stabilizer shrinks as the field the root generates grows. -/
+theorem stabilizer_eq_bot_iff_adjoin_eq_top (hsep : p.Separable)
+    (x : p.rootSet p.SplittingField) :
+    stabilizer p.Gal x = ⊥ ↔ F⟮(x : p.SplittingField)⟯ = ⊤ := by
+  have : IsGalois F p.SplittingField := IsGalois.of_separable_splitting_field hsep
+  refine ⟨fun h => ?_, fun h => ?_⟩
+  · rw [← fixedField_stabilizer hsep x, h]
+    exact IntermediateField.fixedField_bot
+  · rw [stabilizer_eq_fixingSubgroup_adjoin, h]
+    exact IntermediateField.fixingSubgroup_top
+
+/-- **A root fixed by the whole Galois group lies in the base field**, and conversely. -/
+theorem stabilizer_eq_top_iff_adjoin_eq_bot (hsep : p.Separable)
+    (x : p.rootSet p.SplittingField) :
+    stabilizer p.Gal x = ⊤ ↔ F⟮(x : p.SplittingField)⟯ = ⊥ := by
+  have : IsGalois F p.SplittingField := IsGalois.of_separable_splitting_field hsep
+  refine ⟨fun h => ?_, fun h => ?_⟩
+  · rw [← fixedField_stabilizer hsep x, h]
+    exact IsGalois.fixedField_top
+  · rw [stabilizer_eq_fixingSubgroup_adjoin, h]
+    exact IntermediateField.fixingSubgroup_bot
+
+/-! ### Transitivity and primitivity -/
+
+/-- **The root action of an irreducible polynomial is transitive.** Two roots of an irreducible
+polynomial have the same minimal polynomial, and a normal extension moves one to the other.
+
+This is `Polynomial.Gal.galAction_isPretransitive` for the intrinsic action on the roots in the
+splitting field; see the implementation notes for why that instance is not the one Mathlib's
+statement carries. -/
+theorem isPretransitive_of_irreducible (hp : Irreducible p) :
+    IsPretransitive p.Gal (p.rootSet p.SplittingField) := by
+  refine ⟨fun x y => ?_⟩
+  have hx := minpoly.eq_of_irreducible hp (aeval_eq_zero_of_mem_rootSet x.2)
+  have hy := minpoly.eq_of_irreducible hp (aeval_eq_zero_of_mem_rootSet y.2)
+  obtain ⟨g, hg⟩ := (Normal.minpoly_eq_iff_mem_orbit p.SplittingField).mp (hy.symm.trans hx)
+  exact ⟨g, Subtype.ext hg⟩
+
+/-- **Primitivity of the root action is the absence of intermediate fields.** For an irreducible
+separable `p` of degree greater than one, the action of `p.Gal` on the roots is primitive exactly
+when `F⟮x⟯` is an atom, that is, exactly when no field lies strictly between `F` and `F⟮x⟯`.
+
+The degree hypothesis cannot be dropped. For linear `p` the root set is a single point, on which
+every action is primitive, while `F⟮x⟯ = ⊥` is not an atom. It is the hypothesis that Mathlib's
+`MulAction.isCoatom_stabilizer_iff_preprimitive` carries as `[Nontrivial X]`.
+
+The conclusion does not depend on the chosen root, since the action is transitive; `x` appears on
+the right only to name a field. -/
+theorem isPreprimitive_iff_isAtom_adjoin (hp : Irreducible p) (hsep : p.Separable)
+    (hdeg : 1 < p.natDegree) (x : p.rootSet p.SplittingField) :
+    IsPreprimitive p.Gal (p.rootSet p.SplittingField) ↔
+      IsAtom F⟮(x : p.SplittingField)⟯ := by
+  have hgal : IsGalois F p.SplittingField := IsGalois.of_separable_splitting_field hsep
+  have htr : IsPretransitive p.Gal (p.rootSet p.SplittingField) :=
+    isPretransitive_of_irreducible hp
+  have hcard : Fintype.card (p.rootSet p.SplittingField) = p.natDegree :=
+    Polynomial.card_rootSet_eq_natDegree hsep (IsSplittingField.splits p.SplittingField p)
+  have hnt : Nontrivial (p.rootSet p.SplittingField) :=
+    Fintype.one_lt_card_iff_nontrivial.mp (by omega)
+  rw [← isCoatom_stabilizer_iff_preprimitive p.Gal x, stabilizer_eq_fixingSubgroup_adjoin]
+  exact IntermediateField.isCoatom_fixingSubgroup_iff_isAtom F⟮(x : p.SplittingField)⟯
+
+/-- **An irreducible separable polynomial of prime degree has a primitive root action.** A
+transitive action on a set of prime cardinality is primitive, and the roots of a separable
+polynomial number its degree. -/
+theorem isPreprimitive_of_prime_natDegree (hp : Irreducible p) (hsep : p.Separable)
+    (hprime : p.natDegree.Prime) : IsPreprimitive p.Gal (p.rootSet p.SplittingField) := by
+  have htr : IsPretransitive p.Gal (p.rootSet p.SplittingField) :=
+    isPretransitive_of_irreducible hp
+  refine IsPreprimitive.of_prime_card ?_
+  rwa [Nat.card_eq_fintype_card,
+    Polynomial.card_rootSet_eq_natDegree hsep (IsSplittingField.splits p.SplittingField p)]
+
+end TauCeti

--- a/TauCeti/FieldTheory/GaloisGroups/Stabilizer.lean
+++ b/TauCeti/FieldTheory/GaloisGroups/Stabilizer.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.FieldTheory.PolynomialGaloisGroup
 public import TauCeti.FieldTheory.Galois.FixedField
 public import TauCeti.FieldTheory.GaloisGroups.Orbits
 
@@ -36,6 +35,18 @@ separable, and for irreducible `p` this follows from `p.Separable`.
   `TauCeti.stabilizer_eq_top_iff_adjoin_simple_eq_bot`: the two ends of the correspondence, a
   root that generates the whole splitting field and a root that lies in the base field.
 
+## Roadmap
+
+This is the milestone "Stabilizers are relative Galois groups" of Layer 2,
+"the dictionary between Galois theory and permutations", of
+`TauCetiRoadmap/PolynomialGaloisGroups/README.md`, which asks for
+`stabilizer p.Gal α = (IntermediateField.adjoin F {α}).fixingSubgroup` of index `natDegree p`.
+The prime-degree corollary of that layer's "Primitivity and intermediate fields" milestone, which
+the roadmap records as "also available from `IsPreprimitive.of_prime_card`", is
+`TauCeti.isPreprimitive_of_irreducible_of_separable_of_prime_natDegree` of
+`TauCeti/FieldTheory/GaloisGroups/Orbits.lean`; the primitivity-as-atom equivalence itself waits
+on the block/intermediate-field correspondence the milestone lists as its prerequisite.
+
 ## Implementation notes
 
 The action used here is Mathlib's `Polynomial.Gal.galActionAux`, the intrinsic action on
@@ -58,12 +69,6 @@ open Polynomial IntermediateField MulAction
 variable {F : Type*} [Field F] {p : F[X]}
 
 /-! ### The stabilizer of a root -/
-
-/-- The Galois action on the roots in the splitting field is the action by evaluation. -/
-@[simp]
-theorem _root_.Polynomial.Gal.coe_smul (g : p.Gal) (x : p.rootSet p.SplittingField) :
-    ((g • x : p.rootSet p.SplittingField) : p.SplittingField) = g x :=
-  rfl
 
 /-- **The stabilizer of a root is a relative Galois group.** An automorphism of the splitting
 field fixes a root `x` exactly when it fixes the subfield `F⟮x⟯` pointwise, so the point
@@ -104,11 +109,9 @@ Separability cannot be dropped: an inseparable irreducible polynomial has fewer 
 degree. -/
 theorem index_stabilizer_eq_natDegree (hp : Irreducible p) (hsep : p.Separable)
     (x : p.rootSet p.SplittingField) : (stabilizer p.Gal x).index = p.natDegree := by
-  have hmin : (minpoly F (x : p.SplittingField)).natDegree = p.natDegree := by
-    rw [← minpoly.eq_of_irreducible hp (aeval_eq_zero_of_mem_rootSet x.2)]
-    exact natDegree_mul_C (inv_ne_zero (leadingCoeff_ne_zero.mpr hp.ne_zero))
-  rw [index_stabilizer_eq_minpoly_natDegree x
-    (hsep.of_dvd (minpoly.dvd F _ (aeval_eq_zero_of_mem_rootSet x.2))), hmin]
+  have := isPretransitive_of_irreducible hp
+  rw [MulAction.index_stabilizer_of_transitive, Nat.card_eq_fintype_card,
+    card_rootSet_eq_natDegree hsep (IsSplittingField.splits p.SplittingField p)]
 
 /-! ### The two ends of the correspondence -/
 

--- a/TauCeti/FieldTheory/GaloisGroups/Stabilizer.lean
+++ b/TauCeti/FieldTheory/GaloisGroups/Stabilizer.lean
@@ -28,24 +28,12 @@ separable, and for irreducible `p` this follows from `p.Separable`.
   subgroup of the field the root generates.
 * `TauCeti.fixedField_stabilizer`: for a Galois splitting field, the field the stabilizer fixes
   is that same field.
-* `TauCeti.index_stabilizer_eq_minpoly_natDegree`,
+* `TauCeti.index_stabilizer_eq_natDegree_minpoly`,
   `TauCeti.index_stabilizer_eq_natDegree`: the index of the stabilizer is the degree of the
   minimal polynomial of the root, so for irreducible separable `p` it is `p.natDegree`.
 * `TauCeti.stabilizer_eq_bot_iff_adjoin_simple_eq_top`,
   `TauCeti.stabilizer_eq_top_iff_adjoin_simple_eq_bot`: the two ends of the correspondence, a
   root that generates the whole splitting field and a root that lies in the base field.
-
-## Roadmap
-
-This is the milestone "Stabilizers are relative Galois groups" of Layer 2,
-"the dictionary between Galois theory and permutations", of
-`TauCetiRoadmap/PolynomialGaloisGroups/README.md`, which asks for
-`stabilizer p.Gal α = (IntermediateField.adjoin F {α}).fixingSubgroup` of index `natDegree p`.
-The prime-degree corollary of that layer's "Primitivity and intermediate fields" milestone, which
-the roadmap records as "also available from `IsPreprimitive.of_prime_card`", is
-`TauCeti.isPreprimitive_of_irreducible_of_separable_of_prime_natDegree` of
-`TauCeti/FieldTheory/GaloisGroups/Orbits.lean`; the primitivity-as-atom equivalence itself waits
-on the block/intermediate-field correspondence the milestone lists as its prerequisite.
 
 ## Implementation notes
 
@@ -95,7 +83,7 @@ theorem fixedField_stabilizer [IsGalois F p.SplittingField] (x : p.rootSet p.Spl
 orbit of `x` consists of all roots of its minimal polynomial in the normal splitting field, and
 separability makes their number its degree, so this is orbit-stabilizer applied to
 `TauCeti.natCard_orbit_eq_natDegree_minpoly_splittingField`. -/
-theorem index_stabilizer_eq_minpoly_natDegree (x : p.rootSet p.SplittingField)
+theorem index_stabilizer_eq_natDegree_minpoly (x : p.rootSet p.SplittingField)
     (hsep : (minpoly F (x : p.SplittingField)).Separable) :
     (stabilizer p.Gal x).index = (minpoly F (x : p.SplittingField)).natDegree := by
   rw [MulAction.index_stabilizer, ← Nat.card_coe_set_eq,

--- a/TauCeti/FieldTheory/GaloisGroups/Stabilizer.lean
+++ b/TauCeti/FieldTheory/GaloisGroups/Stabilizer.lean
@@ -14,28 +14,26 @@ public import TauCeti.FieldTheory.Galois.FixedField
 Let `p` be a polynomial over a field `F` and let `L = p.SplittingField`. The Galois group
 `Polynomial.Gal p` acts on `p.rootSet L`, and this file identifies the stabilizer of a root `x`
 with a relative Galois group: it is the subgroup of `p.Gal` fixing the simple extension `F⟮x⟯`
-pointwise. Every further reading of the action against the Galois correspondence goes through
-that identification.
+pointwise. The fixed-field and endpoint readings of the action against the Galois correspondence
+go through that identification.
 
-The identification itself needs no hypothesis on `p`. Reading it back through the Galois
-correspondence needs one, and the hypothesis it needs is `IsGalois F L`: that is what makes the
-fixed field of the stabilizer `F⟮x⟯` again, and its index `[F⟮x⟯ : F]`, which for irreducible `p`
-is `p.natDegree`. Separability of `p` supplies that instance through
-`IsGalois.of_separable_splitting_field`, but it is not the weakest hypothesis that does: a power
-of a separable irreducible polynomial is inseparable and still has a Galois splitting field.
+The identification itself needs no hypothesis on `p`. Recovering the fixed field and the two
+ends of the Galois correspondence needs `IsGalois F L`. The index, however, is an
+orbit-stabilizer calculation: it only needs the minimal polynomial of the chosen root to be
+separable, and for irreducible `p` this follows from `p.Separable`.
 
 ## Main results
 
-* `TauCeti.stabilizer_eq_fixingSubgroup_adjoin`: the stabilizer of a root is the fixing subgroup
-  of the field the root generates.
+* `TauCeti.stabilizer_eq_fixingSubgroup_adjoin_simple`: the stabilizer of a root is the fixing
+  subgroup of the field the root generates.
 * `TauCeti.fixedField_stabilizer`: for a Galois splitting field, the field the stabilizer fixes
   is that same field.
 * `TauCeti.index_stabilizer_eq_minpoly_natDegree`,
   `TauCeti.index_stabilizer_eq_natDegree`: the index of the stabilizer is the degree of the
-  minimal polynomial of the root, so for irreducible `p` it is `p.natDegree`.
-* `TauCeti.stabilizer_eq_bot_iff_adjoin_eq_top`,
-  `TauCeti.stabilizer_eq_top_iff_adjoin_eq_bot`: the two ends of the correspondence, a root that
-  generates the whole splitting field and a root that lies in the base field.
+  minimal polynomial of the root, so for irreducible separable `p` it is `p.natDegree`.
+* `TauCeti.stabilizer_eq_bot_iff_adjoin_simple_eq_top`,
+  `TauCeti.stabilizer_eq_top_iff_adjoin_simple_eq_bot`: the two ends of the correspondence, a
+  root that generates the whole splitting field and a root that lies in the base field.
 
 ## Implementation notes
 
@@ -72,7 +70,7 @@ stabilizer of the root action is the fixing subgroup of that subfield.
 
 No hypothesis on `p` is needed: the statement is about one root and the field it generates, not
 about the polynomial. -/
-theorem stabilizer_eq_fixingSubgroup_adjoin (x : p.rootSet p.SplittingField) :
+theorem stabilizer_eq_fixingSubgroup_adjoin_simple (x : p.rootSet p.SplittingField) :
     stabilizer p.Gal x = F⟮(x : p.SplittingField)⟯.fixingSubgroup := by
   ext σ
   rw [MulAction.mem_stabilizer_iff, Subtype.ext_iff, Polynomial.Gal.coe_smul,
@@ -83,59 +81,92 @@ theorem stabilizer_eq_fixingSubgroup_adjoin (x : p.rootSet p.SplittingField) :
 Galois over `F` the fixed field of the stabilizer of `x` is `F⟮x⟯`. -/
 theorem fixedField_stabilizer [IsGalois F p.SplittingField] (x : p.rootSet p.SplittingField) :
     IntermediateField.fixedField (stabilizer p.Gal x) = F⟮(x : p.SplittingField)⟯ := by
-  rw [stabilizer_eq_fixingSubgroup_adjoin, IsGalois.fixedField_fixingSubgroup]
+  rw [stabilizer_eq_fixingSubgroup_adjoin_simple, IsGalois.fixedField_fixingSubgroup]
 
 /-! ### The index of a point stabilizer -/
 
 /-- **The index of a point stabilizer is the degree of the minimal polynomial of the point.** The
-index of the fixing subgroup of an intermediate field is the degree of that field over the base,
-and `F⟮x⟯` has the degree of the minimal polynomial of `x`; the splitting field being Galois over
-`F` is what makes the correspondence apply. -/
-theorem index_stabilizer_eq_minpoly_natDegree [IsGalois F p.SplittingField]
-    (x : p.rootSet p.SplittingField) :
+orbit of `x` consists of all roots of its minimal polynomial in the normal splitting field, and
+separability makes their number its degree. -/
+theorem index_stabilizer_eq_minpoly_natDegree (x : p.rootSet p.SplittingField)
+    (hsep : (minpoly F (x : p.SplittingField)).Separable) :
     (stabilizer p.Gal x).index = (minpoly F (x : p.SplittingField)).natDegree := by
-  rw [stabilizer_eq_fixingSubgroup_adjoin,
-    ← IntermediateField.adjoin.finrank (IsIntegral.of_finite F (x : p.SplittingField))]
-  exact (IntermediateField.finrank_eq_fixingSubgroup_index _ F⟮(x : p.SplittingField)⟯).symm
+  rw [MulAction.index_stabilizer]
+  have hint : IsIntegral F (x : p.SplittingField) :=
+    (isAlgebraic_of_mem_rootSet x.2).isIntegral
+  have hdvd : minpoly F (x : p.SplittingField) ∣ p :=
+    minpoly.dvd F _ (aeval_eq_zero_of_mem_rootSet x.2)
+  have horbit :
+      Subtype.val '' MulAction.orbit p.Gal x =
+        (minpoly F (x : p.SplittingField)).rootSet p.SplittingField := by
+    ext y
+    constructor
+    · rintro ⟨z, hz, rfl⟩
+      obtain ⟨g, rfl⟩ := hz
+      rw [mem_rootSet]
+      refine ⟨minpoly.ne_zero hint, ?_⟩
+      rw [← minpoly.algEquiv_eq g (x : p.SplittingField)]
+      exact minpoly.aeval F (g (x : p.SplittingField))
+    · intro hy
+      have hp0 : p ≠ 0 := ne_zero_of_mem_rootSet x.2
+      have hyp : y ∈ p.rootSet p.SplittingField :=
+        mem_rootSet.mpr ⟨hp0, aeval_eq_zero_of_dvd_aeval_eq_zero hdvd
+          (aeval_eq_zero_of_mem_rootSet hy)⟩
+      have hmin : minpoly F y = minpoly F (x : p.SplittingField) :=
+        (minpoly.eq_of_irreducible_of_monic (minpoly.irreducible hint)
+          (aeval_eq_zero_of_mem_rootSet hy) (minpoly.monic hint)).symm
+      obtain ⟨g, hg⟩ :=
+        (Normal.minpoly_eq_iff_mem_orbit p.SplittingField).mp hmin
+      exact ⟨⟨y, hyp⟩, ⟨g, Subtype.ext hg⟩, rfl⟩
+  calc
+    (MulAction.orbit p.Gal x).ncard =
+        (Subtype.val '' MulAction.orbit p.Gal x).ncard :=
+      (Set.ncard_image_of_injective _ Subtype.val_injective).symm
+    _ = ((minpoly F (x : p.SplittingField)).rootSet p.SplittingField).ncard :=
+      congrArg Set.ncard horbit
+    _ = (minpoly F (x : p.SplittingField)).natDegree := by
+      rw [← Nat.card_coe_set_eq, Nat.card_eq_fintype_card,
+        card_rootSet_eq_natDegree hsep
+          (Normal.splits (SplittingField.instNormal p) (x : p.SplittingField))]
 
-/-- **For an irreducible polynomial every point stabilizer has index the degree.** This is the
-form the permutation representation uses: a transitive subgroup of degree `n` has point
+/-- **For an irreducible separable polynomial every point stabilizer has index the degree.** This
+is the form the permutation representation uses: a transitive subgroup of degree `n` has point
 stabilizers of index `n`.
 
-An irreducible `p` whose splitting field is Galois over `F` is separable, and an inseparable
-irreducible polynomial has fewer roots than its degree; so the hypotheses here are the same as
-irreducibility together with `p.Separable`, stated in the form the Galois correspondence uses. -/
-theorem index_stabilizer_eq_natDegree [IsGalois F p.SplittingField] (hp : Irreducible p)
+Separability cannot be dropped: an inseparable irreducible polynomial has fewer roots than its
+degree. -/
+theorem index_stabilizer_eq_natDegree (hp : Irreducible p) (hsep : p.Separable)
     (x : p.rootSet p.SplittingField) : (stabilizer p.Gal x).index = p.natDegree := by
   have hmin : (minpoly F (x : p.SplittingField)).natDegree = p.natDegree := by
     rw [← minpoly.eq_of_irreducible hp (aeval_eq_zero_of_mem_rootSet x.2)]
     exact natDegree_mul_C (inv_ne_zero (leadingCoeff_ne_zero.mpr hp.ne_zero))
-  rw [index_stabilizer_eq_minpoly_natDegree x, hmin]
+  rw [index_stabilizer_eq_minpoly_natDegree x
+    (hsep.of_dvd (minpoly.dvd F _ (aeval_eq_zero_of_mem_rootSet x.2))), hmin]
 
 /-! ### The two ends of the correspondence -/
 
 /-- **A root with trivial stabilizer is a primitive element**, and conversely. Together with
-`TauCeti.stabilizer_eq_top_iff_adjoin_eq_bot` this pins the orientation of the correspondence:
-the stabilizer shrinks as the field the root generates grows. -/
-theorem stabilizer_eq_bot_iff_adjoin_eq_top [IsGalois F p.SplittingField]
+`TauCeti.stabilizer_eq_top_iff_adjoin_simple_eq_bot` this pins the orientation of the
+correspondence: the stabilizer shrinks as the field the root generates grows. -/
+theorem stabilizer_eq_bot_iff_adjoin_simple_eq_top [IsGalois F p.SplittingField]
     (x : p.rootSet p.SplittingField) :
     stabilizer p.Gal x = ⊥ ↔ F⟮(x : p.SplittingField)⟯ = ⊤ := by
   refine ⟨fun h => ?_, fun h => ?_⟩
   · rw [← fixedField_stabilizer x, h]
     exact IntermediateField.fixedField_bot
-  · rw [stabilizer_eq_fixingSubgroup_adjoin, h]
+  · rw [stabilizer_eq_fixingSubgroup_adjoin_simple, h]
     exact IntermediateField.fixingSubgroup_top
 
 /-- **A root fixed by the whole Galois group lies in the base field**, and conversely. The
 splitting field being Galois over `F` is what makes the fixed field of the whole group `F`
 itself; over an inseparable extension a root outside `F` can be fixed by every automorphism. -/
-theorem stabilizer_eq_top_iff_adjoin_eq_bot [IsGalois F p.SplittingField]
+theorem stabilizer_eq_top_iff_adjoin_simple_eq_bot [IsGalois F p.SplittingField]
     (x : p.rootSet p.SplittingField) :
     stabilizer p.Gal x = ⊤ ↔ F⟮(x : p.SplittingField)⟯ = ⊥ := by
   refine ⟨fun h => ?_, fun h => ?_⟩
   · rw [← fixedField_stabilizer x, h]
     exact IsGalois.fixedField_top
-  · rw [stabilizer_eq_fixingSubgroup_adjoin, h]
+  · rw [stabilizer_eq_fixingSubgroup_adjoin_simple, h]
     exact IntermediateField.fixingSubgroup_bot
 
 end TauCeti


### PR DESCRIPTION
This PR proves that the stabilizer of a root in the Galois action on `p.rootSet p.SplittingField` is the subgroup of `Polynomial.Gal p` fixing the simple extension `F⟮x⟯` pointwise, and reads the Galois correspondence off that identification. This is the first milestone of Layer 2 of `TauCetiRoadmap/PolynomialGaloisGroups/README.md`, "Stabilizers are relative Galois groups", which asks for `stabilizer p.Gal α = (IntermediateField.adjoin F {α}).fixingSubgroup` of index `natDegree p`. Nothing from that layer's "Primitivity and intermediate fields" milestone is claimed here: the `scope` rubric asked for it to ship on its own, so both the prime-degree corollary and the atom equivalence are left to the PR for that milestone.

`TauCeti/FieldTheory/GaloisGroups/Stabilizer.lean` is new. `TauCeti.stabilizer_eq_fixingSubgroup_adjoin_simple` needs no hypothesis on `p`. The two fixed-field readings of it take `[IsGalois F p.SplittingField]`, which is the hypothesis their proofs use; separability of `p` gives that instance through `IsGalois.of_separable_splitting_field`, but is strictly stronger, since a power of a separable irreducible polynomial is inseparable and still has a Galois splitting field. The index is an orbit-stabilizer count instead, so it asks only for the minimal polynomial of the chosen root to be separable. From the identification: `TauCeti.fixedField_stabilizer` recovers `F⟮x⟯` as the fixed field; `TauCeti.index_stabilizer_eq_minpoly_natDegree` gives the index as `(minpoly F x).natDegree` and `TauCeti.index_stabilizer_eq_natDegree` gives `p.natDegree` for irreducible separable `p`; `TauCeti.stabilizer_eq_bot_iff_adjoin_simple_eq_top` and `TauCeti.stabilizer_eq_top_iff_adjoin_simple_eq_bot` pin the orientation at the two ends.

`TauCeti/FieldTheory/GaloisGroups/Orbits.lean`, whose subject is already the root action and its orbits, gains the readings of the action inside the splitting field: the orbit of a root there (`TauCeti.mem_orbit_iff_minpoly_eq_splittingField`, `TauCeti.image_val_orbit_eq_rootSet_minpoly_splittingField`, `TauCeti.natCard_orbit_eq_natDegree_minpoly_splittingField`), which is what the index of a stabilizer counts, and `TauCeti.isPretransitive_of_irreducible`, which the index computation is proved from. The descriptions of an orbit use nothing about the action beyond its orbits being the fibres of `minpoly F`, so they are proved once in that generality and applied twice: to `Polynomial.Gal.galAction` on a general splitting extension, and to `Polynomial.Gal.galActionAux` on the splitting field.

One general lemma that mentions no polynomial goes to `TauCeti/FieldTheory/Galois/FixedField.lean`, whose subject is already fixed fields and fixing subgroups: `IntermediateField.fixingSubgroup_adjoin_simple` holds for an arbitrary extension with no algebraicity hypothesis and is proved from Mathlib's `IntermediateField.forall_mem_adjoin_smul_eq_self_iff` by subgroup extensionality. That argument is adapted from the proof of `stabilizer_isOpen_of_isIntegral` in `Mathlib/FieldTheory/KrullTopology.lean`, and a comment above the declaration says so.

The action used is Mathlib's `Polynomial.Gal.galActionAux`, the intrinsic action on the roots in the splitting field, for which `↑(g • x)` is `g ↑x`. Mathlib's `Polynomial.Gal.galAction` on a splitting extension `E` instantiates at `E = p.SplittingField` to the transport of `galActionAux` along an `Algebra p.SplittingField p.SplittingField` instance built from `IsSplittingField.lift` rather than from the identity, so it is a different instance whose stabilizers the Galois correspondence does not read directly. No `Fact` instance is introduced, so only the intrinsic action is in scope. That is also why `TauCeti.isPretransitive_of_irreducible` is proved from `Normal.minpoly_eq_iff_mem_orbit` instead of being taken from `Polynomial.Gal.galAction_isPretransitive`, and why the transitivity criterion already in `Orbits.lean`, which is stated for a general splitting extension, does not apply on the nose.

What remains in Layer 2 after this: the whole "Primitivity and intermediate fields" milestone, that is the order anti-isomorphism between the blocks containing a root and the intermediate fields of `F⟮x⟯ / F`, the primitivity-as-atom equivalence and the prime-degree corollary; the 2-transitivity criterion for `p / (X - α)`; and the description of `restrictProd` as a fibre product.

No Mathlib source was vendored.

Roadmap: PolynomialGaloisGroups

<!--tauceti-target:v1 {"focus":"PolynomialGaloisGroups","id":"stabilizer-eq-fixingsubgroup-adjoin"}-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)



