### PR TITLE
feat: the sampling laws of a graphon form an exchangeable graph law

### DIFF
--- a/TauCeti/Combinatorics/DenseGraphLimits/ExchangeableGraphLaw/Defs.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/ExchangeableGraphLaw/Defs.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.Combinatorics.SimpleGraph.Measurable
 public import Mathlib.MeasureTheory.Measure.Typeclasses.Probability
+import Mathlib.MeasureTheory.Measure.Dirac.Basic
 
 /-!
 # Exchangeable graph laws
@@ -21,7 +22,10 @@ finite-dimensional distributions of one random graph.
 The observable through which a graph parameter reads off such a law is the **upper mass** of a
 finite pattern `F`: the probability `P(F ≤ ·)` that the level-`k` sample contains `F`. Upper
 masses take values in `[0, 1]`, take the value `1` at the edgeless pattern, and are unchanged by
-relabelling a pattern along an injection — the consistency hypothesis seen on upper events.
+relabelling a pattern along an injection — the consistency hypothesis seen on upper events. They
+are a complete observable: an upper mass is the total probability of the graphs above the pattern,
+so downward induction along the finite lattice of graphs recovers the probability of an individual
+graph, and hence the whole law, from the upper masses.
 
 The label set is always a finite `Fin k`, so its graphs form a finite measurable space and every
 set of them is measurable; no measurability side conditions appear below.
@@ -37,11 +41,15 @@ set of them is measurable; no measurability side conditions appear below.
 
 * `TauCeti.DenseGraphLimits.ExchangeableGraphLaw.upperMass_map` — upper masses are unchanged by
   relabelling the pattern along an injection;
-* `TauCeti.DenseGraphLimits.ExchangeableGraphLaw.upperMass_anti` — a stronger pattern has a
+* `TauCeti.DenseGraphLimits.ExchangeableGraphLaw.upperMass_antitone` — a stronger pattern has a
   smaller upper mass;
 * `TauCeti.DenseGraphLimits.ExchangeableGraphLaw.upperMass_bot`,
   `TauCeti.DenseGraphLimits.ExchangeableGraphLaw.upperMass_nonneg` and
-  `TauCeti.DenseGraphLimits.ExchangeableGraphLaw.upperMass_le_one` — the range of an upper mass.
+  `TauCeti.DenseGraphLimits.ExchangeableGraphLaw.upperMass_le_one` — the range of an upper mass;
+* `TauCeti.DenseGraphLimits.ExchangeableGraphLaw.upperMass_eq_sum` — an upper mass is the total
+  probability of the graphs containing the pattern;
+* `TauCeti.DenseGraphLimits.ExchangeableGraphLaw.ext_upperMass` — the upper masses determine the
+  law.
 
 ## References
 
@@ -74,6 +82,9 @@ structure ExchangeableGraphLaw where
   /-- Consistency under restriction along every injection of labels. -/
   consistent : ∀ {k l : ℕ} (f : Fin k ↪ Fin l),
     (law l).map (SimpleGraph.comap ⇑f) = law k
+
+-- Restricting a marginal along an injection of labels is the canonical reduction step.
+attribute [simp] ExchangeableGraphLaw.consistent
 
 namespace ExchangeableGraphLaw
 
@@ -109,7 +120,7 @@ theorem upperMass_le_one (F : SimpleGraph (Fin k)) : L.upperMass F ≤ 1 := by
   exact ENNReal.toReal_mono ENNReal.one_ne_top prob_le_one
 
 /-- Strengthening a pattern shrinks its upper event, so upper masses are antitone. -/
-theorem upperMass_anti : Antitone (L.upperMass (k := k)) := fun _ _ h =>
+theorem upperMass_antitone : Antitone (L.upperMass (k := k)) := fun _ _ h =>
   ENNReal.toReal_mono (measure_ne_top _ _) (measure_mono fun _ hG => h.trans hG)
 
 /-- Every graph contains the edgeless pattern, so its upper mass is `1`. -/
@@ -130,6 +141,50 @@ theorem upperMass_map (F : SimpleGraph (Fin k)) (f : Fin k ↪ Fin l) :
   rw [upperMass_def, upperMass_def, hset,
     ← Measure.map_apply (SimpleGraph.measurable_comap ⇑f) MeasurableSet.of_discrete,
     L.consistent f]
+
+open Classical in
+/-- An upper mass is the total probability of the individual graphs containing the pattern: the
+label set is finite, so the upper event is a finite union of singletons. -/
+theorem upperMass_eq_sum (F : SimpleGraph (Fin k)) :
+    L.upperMass F = ∑ G ∈ Finset.univ.filter (F ≤ ·), (L.law k {G}).toReal := by
+  have hset : {G : SimpleGraph (Fin k) | F ≤ G} = ↑(Finset.univ.filter (F ≤ ·)) := by
+    ext G
+    simp
+  rw [upperMass_def, hset, ← sum_measure_singleton,
+    ENNReal.toReal_sum fun G _ => measure_ne_top _ _]
+
+open Classical in
+/-- **The upper masses determine the law.** The upper mass of a pattern is the probability of the
+pattern itself plus the upper masses contributed by the strictly larger patterns, so downward
+induction along the finite lattice of graphs recovers every marginal from the upper masses. -/
+theorem ext_upperMass {L L' : ExchangeableGraphLaw}
+    (h : ∀ (k : ℕ) (F : SimpleGraph (Fin k)), L.upperMass F = L'.upperMass F) : L = L' := by
+  have key : ∀ (k : ℕ) (G : SimpleGraph (Fin k)),
+      (L.law k {G}).toReal = (L'.law k {G}).toReal := by
+    intro k G
+    induction G using WellFoundedGT.induction with
+    | ind G ih =>
+      -- The graphs containing `G` are `G` itself together with the ones strictly above it.
+      have hins : Finset.univ.filter (G ≤ ·) =
+          insert G (Finset.univ.filter (fun H : SimpleGraph (Fin k) => G < H)) := by
+        ext H
+        simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_insert]
+        exact ⟨fun hle => hle.lt_or_eq.symm.imp Eq.symm id, fun h => h.elim ge_of_eq le_of_lt⟩
+      have hG : G ∉ Finset.univ.filter (fun H : SimpleGraph (Fin k) => G < H) := by simp
+      have hsplit : ∀ M : ExchangeableGraphLaw, M.upperMass G = (M.law k {G}).toReal +
+          ∑ H ∈ Finset.univ.filter (fun H : SimpleGraph (Fin k) => G < H),
+            (M.law k {H}).toReal := fun M => by
+        rw [M.upperMass_eq_sum G, hins, Finset.sum_insert hG]
+      -- The strictly larger patterns contribute the same to both laws, so the rest does too.
+      have htail : ∑ H ∈ Finset.univ.filter (fun H : SimpleGraph (Fin k) => G < H),
+            (L.law k {H}).toReal =
+          ∑ H ∈ Finset.univ.filter (fun H : SimpleGraph (Fin k) => G < H),
+            (L'.law k {H}).toReal :=
+        Finset.sum_congr rfl fun H hH => ih H (Finset.mem_filter.1 hH).2
+      have hadd := ((hsplit L).symm.trans (h k G)).trans (hsplit L')
+      rwa [htail, add_right_cancel_iff] at hadd
+  exact ext fun k => Measure.ext_of_singleton fun G =>
+    (ENNReal.toReal_eq_toReal_iff' (measure_ne_top _ _) (measure_ne_top _ _)).1 (key k G)
 
 end ExchangeableGraphLaw
 

--- a/TauCeti/Combinatorics/DenseGraphLimits/ExchangeableGraphLaw/Defs.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/ExchangeableGraphLaw/Defs.lean
@@ -37,6 +37,8 @@ set of them is measurable; no measurability side conditions appear below.
 
 * `TauCeti.DenseGraphLimits.ExchangeableGraphLaw.upperMass_map` — upper masses are unchanged by
   relabelling the pattern along an injection;
+* `TauCeti.DenseGraphLimits.ExchangeableGraphLaw.upperMass_anti` — a stronger pattern has a
+  smaller upper mass;
 * `TauCeti.DenseGraphLimits.ExchangeableGraphLaw.upperMass_bot`,
   `TauCeti.DenseGraphLimits.ExchangeableGraphLaw.upperMass_nonneg` and
   `TauCeti.DenseGraphLimits.ExchangeableGraphLaw.upperMass_le_one` — the range of an upper mass.
@@ -78,6 +80,16 @@ namespace ExchangeableGraphLaw
 instance instIsProbabilityMeasureLaw (L : ExchangeableGraphLaw) (k : ℕ) :
     IsProbabilityMeasure (L.law k) := L.prob k
 
+/-- A law is determined by its marginals: the two remaining fields are propositions. -/
+@[ext]
+theorem ext {L L' : ExchangeableGraphLaw} (h : ∀ k, L.law k = L'.law k) : L = L' := by
+  cases L with
+  | mk law prob consistent =>
+    cases L' with
+    | mk law' prob' consistent' =>
+      congr 1
+      exact funext h
+
 variable (L : ExchangeableGraphLaw) {k l : ℕ}
 
 /-- The upper mass of a pattern `F`: the probability that the level-`k` sample contains `F`. -/
@@ -95,6 +107,10 @@ theorem upperMass_nonneg (F : SimpleGraph (Fin k)) : 0 ≤ L.upperMass F :=
 theorem upperMass_le_one (F : SimpleGraph (Fin k)) : L.upperMass F ≤ 1 := by
   rw [upperMass_def, ← ENNReal.toReal_one]
   exact ENNReal.toReal_mono ENNReal.one_ne_top prob_le_one
+
+/-- Strengthening a pattern shrinks its upper event, so upper masses are antitone. -/
+theorem upperMass_anti : Antitone (L.upperMass (k := k)) := fun _ _ h =>
+  ENNReal.toReal_mono (measure_ne_top _ _) (measure_mono fun _ hG => h.trans hG)
 
 /-- Every graph contains the edgeless pattern, so its upper mass is `1`. -/
 @[simp]

--- a/TauCeti/Combinatorics/DenseGraphLimits/ExchangeableGraphLaw/Defs.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/ExchangeableGraphLaw/Defs.lean
@@ -1,0 +1,122 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import TauCeti.Combinatorics.SimpleGraph.Measurable
+public import Mathlib.MeasureTheory.Measure.Typeclasses.Probability
+
+/-!
+# Exchangeable graph laws
+
+An exchangeable random graph on an unbounded label set is presented here by its finite marginals:
+a probability law on `SimpleGraph (Fin k)` for every `k`, consistent under pulling a graph back
+along every injection of labels `Fin k ↪ Fin l`. Consistency along *all* injections is a single
+hypothesis doing two jobs: the permutations of `Fin k` give invariance under relabelling, and the
+inclusions `Fin k ↪ Fin (k + 1)` give the projectivity that makes the family the
+finite-dimensional distributions of one random graph.
+
+The observable through which a graph parameter reads off such a law is the **upper mass** of a
+finite pattern `F`: the probability `P(F ≤ ·)` that the level-`k` sample contains `F`. Upper
+masses take values in `[0, 1]`, take the value `1` at the edgeless pattern, and are unchanged by
+relabelling a pattern along an injection — the consistency hypothesis seen on upper events.
+
+The label set is always a finite `Fin k`, so its graphs form a finite measurable space and every
+set of them is measurable; no measurability side conditions appear below.
+
+## Main definitions
+
+* `TauCeti.DenseGraphLimits.ExchangeableGraphLaw` — a consistent family of finite graph laws, with
+  each marginal a probability measure by instance;
+* `TauCeti.DenseGraphLimits.ExchangeableGraphLaw.upperMass` — the probability that the sample
+  contains a fixed finite pattern.
+
+## Main results
+
+* `TauCeti.DenseGraphLimits.ExchangeableGraphLaw.upperMass_map` — upper masses are unchanged by
+  relabelling the pattern along an injection;
+* `TauCeti.DenseGraphLimits.ExchangeableGraphLaw.upperMass_bot`,
+  `TauCeti.DenseGraphLimits.ExchangeableGraphLaw.upperMass_nonneg` and
+  `TauCeti.DenseGraphLimits.ExchangeableGraphLaw.upperMass_le_one` — the range of an upper mass.
+
+## References
+
+* P. Diaconis, S. Janson, *Graph limits and exchangeable random graphs*, Rend. Mat. Appl. (7) 28
+  (2008), 33--61, Section 5.
+* C. Freer, `cameronfreer/graphon` at commit
+  `6eccca5bbe5c9df46d7129bf59575b8b9b1d6699`, Apache-2.0,
+  `Graphon/ExchangeableGraphLaw.lean`. The presentation by consistent finite marginals and the
+  upper-mass observable follow its formulation.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory
+
+namespace TauCeti
+
+namespace DenseGraphLimits
+
+/-- An exchangeable random graph presented by its consistent finite marginals: a probability law
+on the graphs with labels `Fin k` for every `k`, consistent under pulling back along every
+injection of labels. -/
+structure ExchangeableGraphLaw where
+  /-- The level-`k` marginal law. -/
+  law : (k : ℕ) → Measure (SimpleGraph (Fin k))
+  /-- Every marginal is a probability measure. -/
+  prob : ∀ k, IsProbabilityMeasure (law k)
+  /-- Consistency under restriction along every injection of labels. -/
+  consistent : ∀ {k l : ℕ} (f : Fin k ↪ Fin l),
+    (law l).map (SimpleGraph.comap ⇑f) = law k
+
+namespace ExchangeableGraphLaw
+
+instance instIsProbabilityMeasureLaw (L : ExchangeableGraphLaw) (k : ℕ) :
+    IsProbabilityMeasure (L.law k) := L.prob k
+
+variable (L : ExchangeableGraphLaw) {k l : ℕ}
+
+/-- The upper mass of a pattern `F`: the probability that the level-`k` sample contains `F`. -/
+def upperMass (F : SimpleGraph (Fin k)) : ℝ := (L.law k {G | F ≤ G}).toReal
+
+/-- The defining probability of an upper mass. -/
+theorem upperMass_def (F : SimpleGraph (Fin k)) :
+    L.upperMass F = (L.law k {G | F ≤ G}).toReal := (rfl)
+
+/-- An upper mass is nonnegative. -/
+theorem upperMass_nonneg (F : SimpleGraph (Fin k)) : 0 ≤ L.upperMass F :=
+  ENNReal.toReal_nonneg
+
+/-- An upper mass is at most `1`. -/
+theorem upperMass_le_one (F : SimpleGraph (Fin k)) : L.upperMass F ≤ 1 := by
+  rw [upperMass_def, ← ENNReal.toReal_one]
+  exact ENNReal.toReal_mono ENNReal.one_ne_top prob_le_one
+
+/-- Every graph contains the edgeless pattern, so its upper mass is `1`. -/
+@[simp]
+theorem upperMass_bot : L.upperMass (⊥ : SimpleGraph (Fin k)) = 1 := by
+  have hset : {G : SimpleGraph (Fin k) | ⊥ ≤ G} = Set.univ := by simp
+  rw [upperMass_def, hset, measure_univ, ENNReal.toReal_one]
+
+/-- Upper masses are unchanged by relabelling the pattern along an injection: the event that the
+level-`l` sample contains the relabelled pattern is the event that its restriction to the window
+contains the original one. -/
+@[simp]
+theorem upperMass_map (F : SimpleGraph (Fin k)) (f : Fin k ↪ Fin l) :
+    L.upperMass (F.map ⇑f) = L.upperMass F := by
+  have hset : {G : SimpleGraph (Fin l) | F.map ⇑f ≤ G} =
+      SimpleGraph.comap ⇑f ⁻¹' {H : SimpleGraph (Fin k) | F ≤ H} :=
+    Set.ext fun G => SimpleGraph.map_le_iff_le_comap f F G
+  rw [upperMass_def, upperMass_def, hset,
+    ← Measure.map_apply (SimpleGraph.measurable_comap ⇑f) MeasurableSet.of_discrete,
+    L.consistent f]
+
+end ExchangeableGraphLaw
+
+end DenseGraphLimits
+
+end TauCeti

--- a/TauCeti/Combinatorics/DenseGraphLimits/ExchangeableGraphLaw/Defs.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/ExchangeableGraphLaw/Defs.lean
@@ -183,8 +183,7 @@ theorem ext_upperMass {L L' : ExchangeableGraphLaw}
         Finset.sum_congr rfl fun H hH => ih H (Finset.mem_filter.1 hH).2
       have hadd := ((hsplit L).symm.trans (h k G)).trans (hsplit L')
       rwa [htail, add_right_cancel_iff] at hadd
-  exact ext fun k => Measure.ext_of_singleton fun G =>
-    (ENNReal.toReal_eq_toReal_iff' (measure_ne_top _ _) (measure_ne_top _ _)).1 (key k G)
+  exact ext fun k => Measure.ext_of_measureReal_singleton (key k)
 
 end ExchangeableGraphLaw
 

--- a/TauCeti/Combinatorics/DenseGraphLimits/ExchangeableGraphLaw/Sampling.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/ExchangeableGraphLaw/Sampling.lean
@@ -6,25 +6,17 @@ Authors: Claude
 module
 
 public import TauCeti.Combinatorics.DenseGraphLimits.ExchangeableGraphLaw.Defs
+public import TauCeti.Combinatorics.DenseGraphLimits.Sampling.Consistency
 public import TauCeti.Combinatorics.DenseGraphLimits.Sampling.Unbiased
-public import TauCeti.Combinatorics.SimpleGraph.Maps
-public import TauCeti.MeasureTheory.Constructions.Pi
 
 /-!
 # The sampling laws of a graphon form an exchangeable graph law
 
 Sampling `l` independent points from a graphon and then tossing an independent coin for each
-unordered pair produces a law on `SimpleGraph (Fin l)`. Restricting such a sample to a window of
-`k` labels is the same as running the `k`-point sampling procedure from the start: the window
-reads `k` of the `l` independent points, which are again independent with the same law, and the
-coins outside the window are simply not looked at. This file proves that statement and packages
-the whole family as an exchangeable graph law.
-
-The combinatorial half is that the graphs on `Fin l` restricting to a fixed `H` along an
-injection `f` are exactly the graphs whose edges meet the window `⊤.map f` in the image of the
-edges of `H`. Summing the conditional masses over that family collapses the coins outside the
-window, leaving the conditional mass of `H` at the restricted positions. The probabilistic half is
-that restricting an independent family of positions along an injection is measure preserving.
+unordered pair produces a law on `SimpleGraph (Fin l)`. Those laws are consistent under
+restriction of the label set — that is
+`TauCeti.DenseGraphLimits.sampleGraph_map_comap` — so the whole family is an exchangeable graph
+law, which is what this file packages.
 
 The upper mass of a pattern under a sampling law is its graphon homomorphism density: the sample
 contains `F` exactly when every edge of `F` wins its coin toss, whose conditional probability at
@@ -37,16 +29,8 @@ fixed positions is the product of the edge factors of `F`.
 
 ## Main results
 
-* `TauCeti.DenseGraphLimits.sum_sampleIntegrand_comap_eq` — at fixed positions, the conditional
-  masses of the graphs restricting to `H` sum to the conditional mass of `H` at the restricted
-  positions;
-* `TauCeti.DenseGraphLimits.sum_sampleMass_comap_eq` — the same identity after integrating out
-  the positions;
-* `TauCeti.DenseGraphLimits.sampleGraph_map_comap` — the sampling laws are consistent under
-  restriction along every injection of labels;
 * `TauCeti.DenseGraphLimits.upperMass_sampleExchangeableLaw` — the upper mass of a pattern under
-  a sampling law is its homomorphism density, with the Erdős–Rényi value
-  `TauCeti.DenseGraphLimits.upperMass_sampleExchangeableLaw_const` as a check.
+  a sampling law is its homomorphism density.
 
 ## References
 
@@ -56,9 +40,9 @@ fixed positions is the product of the edge factors of `F`.
   (2008), 33--61, Section 5.
 * C. Freer, `cameronfreer/graphon` at commit
   `6eccca5bbe5c9df46d7129bf59575b8b9b1d6699`, Apache-2.0,
-  `Graphon/ExchangeableGraphLaw.lean`. The consistency statement and its packaging follow that
-  source; the proof here is written for Tau Ceti's strict graphon carrier and reduces the
-  combinatorial step to the prescribed-trace mass formula.
+  `Graphon/ExchangeableGraphLaw.lean`. The packaging of the sampling laws and the identification of
+  the upper mass with a homomorphism density follow that source, adapted to Tau Ceti's strict
+  graphon carrier.
 -/
 
 public section
@@ -73,88 +57,6 @@ namespace DenseGraphLimits
 
 variable {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω} [IsProbabilityMeasure μ]
 
-section Consistency
-
-variable {k l : ℕ} (W : Graphon Ω μ) (f : Fin k ↪ Fin l) (H : SimpleGraph (Fin k))
-
-open Classical in
-/-- At fixed vertex positions, the conditional masses of the graphs restricting to `H` along `f`
-sum to the conditional mass of `H` at the restricted positions: such a graph is prescribed on the
-window seen by `f` and free outside it, and the free coins contribute `1`. -/
-theorem sum_sampleIntegrand_comap_eq (x : Fin l → Ω) :
-    ∑ G ∈ Finset.univ.filter (fun G : SimpleGraph (Fin l) => SimpleGraph.comap ⇑f G = H),
-        sampleIntegrand W G x = sampleIntegrand W H (x ∘ ⇑f) := by
-  have hA : ((⊤ : SimpleGraph (Fin k)).map ⇑f).edgeFinset ⊆
-      (⊤ : SimpleGraph (Fin l)).edgeFinset := SimpleGraph.edgeFinset_mono le_top
-  have hBA : (H.map ⇑f).edgeFinset ⊆ ((⊤ : SimpleGraph (Fin k)).map ⇑f).edgeFinset :=
-    SimpleGraph.edgeFinset_mono (SimpleGraph.map_monotone _ le_top)
-  -- Restricting to `H` along `f` prescribes exactly the edges inside the window.
-  have hfilter :
-      Finset.univ.filter (fun G : SimpleGraph (Fin l) => SimpleGraph.comap ⇑f G = H) =
-        Finset.univ.filter (fun G : SimpleGraph (Fin l) =>
-          G.edgeFinset ∩ ((⊤ : SimpleGraph (Fin k)).map ⇑f).edgeFinset =
-            (H.map ⇑f).edgeFinset) :=
-    Finset.filter_congr fun G _ => by
-      rw [SimpleGraph.comap_eq_iff_inf_map_top, ← SimpleGraph.edgeFinset_inj,
-        SimpleGraph.edgeFinset_inf]
-  -- Inside the window the edges of the pattern are read through the injection `Sym2.map f`.
-  have hinj : Function.Injective (Sym2.map ⇑f) := Sym2.map.injective f.injective
-  have hmapTop : ((⊤ : SimpleGraph (Fin k)).map ⇑f).edgeFinset =
-      (⊤ : SimpleGraph (Fin k)).edgeFinset.image (Sym2.map ⇑f) := by
-    ext e
-    simp [SimpleGraph.edgeSet_map]
-  have hmapH : (H.map ⇑f).edgeFinset = H.edgeFinset.image (Sym2.map ⇑f) := by
-    ext e
-    simp [SimpleGraph.edgeSet_map]
-  rw [hfilter, sum_sampleIntegrand_inter_eq W _ _ hA hBA, hmapTop, hmapH,
-    ← Finset.image_sdiff _ _ hinj, Finset.prod_image fun _ _ _ _ h => hinj h,
-    Finset.prod_image fun _ _ _ _ h => hinj h, sampleIntegrand_def]
-  simp_rw [edgeFactor_map]
-
-open Classical in
-/-- The masses of the graphs restricting to `H` along `f` sum to the mass of `H`: integrating the
-conditional identity over the positions, which the restriction to the window redistributes without
-changing their law. -/
-theorem sum_sampleMass_comap_eq :
-    ∑ G ∈ Finset.univ.filter (fun G : SimpleGraph (Fin l) => SimpleGraph.comap ⇑f G = H),
-        sampleMass W G = sampleMass W H := by
-  -- Restricting an independent family of positions to the window is measure preserving.
-  have hmp : MeasurePreserving (fun x : Fin l → Ω => fun i : Fin k => x (f i))
-      (Measure.pi fun _ : Fin l => μ) (Measure.pi fun _ : Fin k => μ) :=
-    TauCeti.measurePreserving_pi_comp_embedding (fun _ : Fin l => μ) f
-  calc ∑ G ∈ Finset.univ.filter
-        (fun G : SimpleGraph (Fin l) => SimpleGraph.comap ⇑f G = H), sampleMass W G
-      = ∫ x : Fin l → Ω, ∑ G ∈ Finset.univ.filter
-            (fun G : SimpleGraph (Fin l) => SimpleGraph.comap ⇑f G = H),
-          sampleIntegrand W G x ∂Measure.pi fun _ => μ := by
-        simp_rw [sampleMass_def]
-        exact (integral_finsetSum _ fun G _ => integrable_sampleIntegrand W G).symm
-    _ = ∫ x : Fin l → Ω, sampleIntegrand W H (x ∘ ⇑f) ∂Measure.pi fun _ => μ :=
-        integral_congr_ae (Filter.Eventually.of_forall (sum_sampleIntegrand_comap_eq W f H))
-    _ = ∫ y : Fin k → Ω, sampleIntegrand W H y ∂Measure.pi fun _ => μ := by
-        rw [← hmp.map_eq, integral_map hmp.measurable.aemeasurable
-          (measurable_sampleIntegrand W H).aestronglyMeasurable]
-        rfl
-    _ = sampleMass W H := (sampleMass_def W H).symm
-
-/-- **Consistency of graphon sampling.** Restricting a sample on `Fin l` to a window of `k`
-labels has the law of a sample on `Fin k`. -/
-theorem sampleGraph_map_comap :
-    (sampleGraph W l).map (SimpleGraph.comap ⇑f) = sampleGraph W k := by
-  classical
-  refine Measure.ext_of_singleton fun H => ?_
-  have hpre : SimpleGraph.comap ⇑f ⁻¹' {H} =
-      ↑(Finset.univ.filter (fun G : SimpleGraph (Fin l) => SimpleGraph.comap ⇑f G = H)) := by
-    ext G
-    simp
-  rw [Measure.map_apply (SimpleGraph.measurable_comap ⇑f) (MeasurableSet.singleton H), hpre,
-    ← sum_measure_singleton]
-  simp_rw [sampleGraph_singleton]
-  rw [← ENNReal.ofReal_sum_of_nonneg fun G _ => sampleMass_nonneg W G,
-    sum_sampleMass_comap_eq W f H]
-
-end Consistency
-
 /-- The sampling laws of a fixed graphon, packaged as an exchangeable graph law. -/
 def sampleExchangeableLaw (W : Graphon Ω μ) : ExchangeableGraphLaw where
   law k := sampleGraph W k
@@ -168,6 +70,7 @@ theorem sampleExchangeableLaw_law (W : Graphon Ω μ) (k : ℕ) :
 open Classical in
 /-- **The sampling anchor.** The upper mass of a pattern under a graphon's sampling law is its
 homomorphism density: `P(F ≤ G(k, W)) = t(F, W)`. -/
+@[simp]
 theorem upperMass_sampleExchangeableLaw {k : ℕ} (F : SimpleGraph (Fin k)) [DecidableRel F.Adj]
     (W : Graphon Ω μ) :
     (sampleExchangeableLaw W).upperMass F = homDensity F W := by
@@ -180,14 +83,6 @@ theorem upperMass_sampleExchangeableLaw {k : ℕ} (F : SimpleGraph (Fin k)) [Dec
   rw [← ENNReal.ofReal_sum_of_nonneg fun G _ => sampleMass_nonneg W G,
     sum_sampleMass_supergraph_eq_homDensity W F,
     ENNReal.toReal_ofReal (homDensity_nonneg F W)]
-
-/-- **The Erdős–Rényi check.** Under the sampling law of the constant graphon with parameter `p`,
-each of the `e(F)` edges of `F` appears with probability `p`, independently. -/
-@[simp]
-theorem upperMass_sampleExchangeableLaw_const (p : unitInterval) {k : ℕ}
-    (F : SimpleGraph (Fin k)) [DecidableRel F.Adj] :
-    (sampleExchangeableLaw (Graphon.const μ p)).upperMass F = (p : ℝ) ^ F.edgeFinset.card := by
-  rw [upperMass_sampleExchangeableLaw, homDensity_const]
 
 end DenseGraphLimits
 

--- a/TauCeti/Combinatorics/DenseGraphLimits/ExchangeableGraphLaw/Sampling.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/ExchangeableGraphLaw/Sampling.lean
@@ -1,0 +1,194 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import TauCeti.Combinatorics.DenseGraphLimits.ExchangeableGraphLaw.Defs
+public import TauCeti.Combinatorics.DenseGraphLimits.Sampling.Unbiased
+public import TauCeti.Combinatorics.SimpleGraph.Maps
+public import TauCeti.MeasureTheory.Constructions.Pi
+
+/-!
+# The sampling laws of a graphon form an exchangeable graph law
+
+Sampling `l` independent points from a graphon and then tossing an independent coin for each
+unordered pair produces a law on `SimpleGraph (Fin l)`. Restricting such a sample to a window of
+`k` labels is the same as running the `k`-point sampling procedure from the start: the window
+reads `k` of the `l` independent points, which are again independent with the same law, and the
+coins outside the window are simply not looked at. This file proves that statement and packages
+the whole family as an exchangeable graph law.
+
+The combinatorial half is that the graphs on `Fin l` restricting to a fixed `H` along an
+injection `f` are exactly the graphs whose edges meet the window `⊤.map f` in the image of the
+edges of `H`. Summing the conditional masses over that family collapses the coins outside the
+window, leaving the conditional mass of `H` at the restricted positions. The probabilistic half is
+that restricting an independent family of positions along an injection is measure preserving.
+
+The upper mass of a pattern under a sampling law is its graphon homomorphism density: the sample
+contains `F` exactly when every edge of `F` wins its coin toss, whose conditional probability at
+fixed positions is the product of the edge factors of `F`.
+
+## Main definitions
+
+* `TauCeti.DenseGraphLimits.sampleExchangeableLaw` — the sampling laws of a graphon, packaged as
+  an exchangeable graph law.
+
+## Main results
+
+* `TauCeti.DenseGraphLimits.sum_sampleIntegrand_comap_eq` — at fixed positions, the conditional
+  masses of the graphs restricting to `H` sum to the conditional mass of `H` at the restricted
+  positions;
+* `TauCeti.DenseGraphLimits.sum_sampleMass_comap_eq` — the same identity after integrating out
+  the positions;
+* `TauCeti.DenseGraphLimits.sampleGraph_map_comap` — the sampling laws are consistent under
+  restriction along every injection of labels;
+* `TauCeti.DenseGraphLimits.upperMass_sampleExchangeableLaw` — the upper mass of a pattern under
+  a sampling law is its homomorphism density, with the Erdős–Rényi value
+  `TauCeti.DenseGraphLimits.upperMass_sampleExchangeableLaw_const` as a check.
+
+## References
+
+* L. Lovász, *Large Networks and Graph Limits*, AMS Colloquium Publications 60 (2012),
+  Section 10.1.
+* P. Diaconis, S. Janson, *Graph limits and exchangeable random graphs*, Rend. Mat. Appl. (7) 28
+  (2008), 33--61, Section 5.
+* C. Freer, `cameronfreer/graphon` at commit
+  `6eccca5bbe5c9df46d7129bf59575b8b9b1d6699`, Apache-2.0,
+  `Graphon/ExchangeableGraphLaw.lean`. The consistency statement and its packaging follow that
+  source; the proof here is written for Tau Ceti's strict graphon carrier and reduces the
+  combinatorial step to the prescribed-trace mass formula.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory
+
+namespace TauCeti
+
+namespace DenseGraphLimits
+
+variable {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω} [IsProbabilityMeasure μ]
+
+section Consistency
+
+variable {k l : ℕ} (W : Graphon Ω μ) (f : Fin k ↪ Fin l) (H : SimpleGraph (Fin k))
+
+open Classical in
+/-- At fixed vertex positions, the conditional masses of the graphs restricting to `H` along `f`
+sum to the conditional mass of `H` at the restricted positions: such a graph is prescribed on the
+window seen by `f` and free outside it, and the free coins contribute `1`. -/
+theorem sum_sampleIntegrand_comap_eq (x : Fin l → Ω) :
+    ∑ G ∈ Finset.univ.filter (fun G : SimpleGraph (Fin l) => SimpleGraph.comap ⇑f G = H),
+        sampleIntegrand W G x = sampleIntegrand W H (x ∘ ⇑f) := by
+  have hA : ((⊤ : SimpleGraph (Fin k)).map ⇑f).edgeFinset ⊆
+      (⊤ : SimpleGraph (Fin l)).edgeFinset := SimpleGraph.edgeFinset_mono le_top
+  have hBA : (H.map ⇑f).edgeFinset ⊆ ((⊤ : SimpleGraph (Fin k)).map ⇑f).edgeFinset :=
+    SimpleGraph.edgeFinset_mono (SimpleGraph.map_monotone _ le_top)
+  -- Restricting to `H` along `f` prescribes exactly the edges inside the window.
+  have hfilter :
+      Finset.univ.filter (fun G : SimpleGraph (Fin l) => SimpleGraph.comap ⇑f G = H) =
+        Finset.univ.filter (fun G : SimpleGraph (Fin l) =>
+          G.edgeFinset ∩ ((⊤ : SimpleGraph (Fin k)).map ⇑f).edgeFinset =
+            (H.map ⇑f).edgeFinset) :=
+    Finset.filter_congr fun G _ => by
+      rw [SimpleGraph.comap_eq_iff_inf_map_top, ← SimpleGraph.edgeFinset_inj,
+        SimpleGraph.edgeFinset_inf]
+  -- Inside the window the edges of the pattern are read through the injection `Sym2.map f`.
+  have hinj : Function.Injective (Sym2.map ⇑f) := Sym2.map.injective f.injective
+  have hmapTop : ((⊤ : SimpleGraph (Fin k)).map ⇑f).edgeFinset =
+      (⊤ : SimpleGraph (Fin k)).edgeFinset.image (Sym2.map ⇑f) := by
+    ext e
+    simp [SimpleGraph.edgeSet_map]
+  have hmapH : (H.map ⇑f).edgeFinset = H.edgeFinset.image (Sym2.map ⇑f) := by
+    ext e
+    simp [SimpleGraph.edgeSet_map]
+  rw [hfilter, sum_sampleIntegrand_inter_eq W _ _ hA hBA, hmapTop, hmapH,
+    ← Finset.image_sdiff _ _ hinj, Finset.prod_image fun _ _ _ _ h => hinj h,
+    Finset.prod_image fun _ _ _ _ h => hinj h, sampleIntegrand_def]
+  simp_rw [edgeFactor_map]
+
+open Classical in
+/-- The masses of the graphs restricting to `H` along `f` sum to the mass of `H`: integrating the
+conditional identity over the positions, which the restriction to the window redistributes without
+changing their law. -/
+theorem sum_sampleMass_comap_eq :
+    ∑ G ∈ Finset.univ.filter (fun G : SimpleGraph (Fin l) => SimpleGraph.comap ⇑f G = H),
+        sampleMass W G = sampleMass W H := by
+  -- Restricting an independent family of positions to the window is measure preserving.
+  have hmp : MeasurePreserving (fun x : Fin l → Ω => fun i : Fin k => x (f i))
+      (Measure.pi fun _ : Fin l => μ) (Measure.pi fun _ : Fin k => μ) :=
+    TauCeti.measurePreserving_pi_comp_embedding (fun _ : Fin l => μ) f
+  calc ∑ G ∈ Finset.univ.filter
+        (fun G : SimpleGraph (Fin l) => SimpleGraph.comap ⇑f G = H), sampleMass W G
+      = ∫ x : Fin l → Ω, ∑ G ∈ Finset.univ.filter
+            (fun G : SimpleGraph (Fin l) => SimpleGraph.comap ⇑f G = H),
+          sampleIntegrand W G x ∂Measure.pi fun _ => μ := by
+        simp_rw [sampleMass_def]
+        exact (integral_finsetSum _ fun G _ => integrable_sampleIntegrand W G).symm
+    _ = ∫ x : Fin l → Ω, sampleIntegrand W H (x ∘ ⇑f) ∂Measure.pi fun _ => μ :=
+        integral_congr_ae (Filter.Eventually.of_forall (sum_sampleIntegrand_comap_eq W f H))
+    _ = ∫ y : Fin k → Ω, sampleIntegrand W H y ∂Measure.pi fun _ => μ := by
+        rw [← hmp.map_eq, integral_map hmp.measurable.aemeasurable
+          (measurable_sampleIntegrand W H).aestronglyMeasurable]
+        rfl
+    _ = sampleMass W H := (sampleMass_def W H).symm
+
+/-- **Consistency of graphon sampling.** Restricting a sample on `Fin l` to a window of `k`
+labels has the law of a sample on `Fin k`. -/
+theorem sampleGraph_map_comap :
+    (sampleGraph W l).map (SimpleGraph.comap ⇑f) = sampleGraph W k := by
+  classical
+  refine Measure.ext_of_singleton fun H => ?_
+  have hpre : SimpleGraph.comap ⇑f ⁻¹' {H} =
+      ↑(Finset.univ.filter (fun G : SimpleGraph (Fin l) => SimpleGraph.comap ⇑f G = H)) := by
+    ext G
+    simp
+  rw [Measure.map_apply (SimpleGraph.measurable_comap ⇑f) (MeasurableSet.singleton H), hpre,
+    ← sum_measure_singleton]
+  simp_rw [sampleGraph_singleton]
+  rw [← ENNReal.ofReal_sum_of_nonneg fun G _ => sampleMass_nonneg W G,
+    sum_sampleMass_comap_eq W f H]
+
+end Consistency
+
+/-- The sampling laws of a fixed graphon, packaged as an exchangeable graph law. -/
+def sampleExchangeableLaw (W : Graphon Ω μ) : ExchangeableGraphLaw where
+  law k := sampleGraph W k
+  prob k := sampleGraph_isProbabilityMeasure W k
+  consistent f := sampleGraph_map_comap W f
+
+@[simp]
+theorem sampleExchangeableLaw_law (W : Graphon Ω μ) (k : ℕ) :
+    (sampleExchangeableLaw W).law k = sampleGraph W k := (rfl)
+
+open Classical in
+/-- **The sampling anchor.** The upper mass of a pattern under a graphon's sampling law is its
+homomorphism density: `P(F ≤ G(k, W)) = t(F, W)`. -/
+theorem upperMass_sampleExchangeableLaw {k : ℕ} (F : SimpleGraph (Fin k)) [DecidableRel F.Adj]
+    (W : Graphon Ω μ) :
+    (sampleExchangeableLaw W).upperMass F = homDensity F W := by
+  have hset : {G : SimpleGraph (Fin k) | F ≤ G} = ↑(Finset.univ.filter (F ≤ ·)) := by
+    ext G
+    simp
+  rw [ExchangeableGraphLaw.upperMass_def, sampleExchangeableLaw_law, hset,
+    ← sum_measure_singleton]
+  simp_rw [sampleGraph_singleton]
+  rw [← ENNReal.ofReal_sum_of_nonneg fun G _ => sampleMass_nonneg W G,
+    sum_sampleMass_supergraph_eq_homDensity W F,
+    ENNReal.toReal_ofReal (homDensity_nonneg F W)]
+
+/-- **The Erdős–Rényi check.** Under the sampling law of the constant graphon with parameter `p`,
+each of the `e(F)` edges of `F` appears with probability `p`, independently. -/
+@[simp]
+theorem upperMass_sampleExchangeableLaw_const (p : unitInterval) {k : ℕ}
+    (F : SimpleGraph (Fin k)) [DecidableRel F.Adj] :
+    (sampleExchangeableLaw (Graphon.const μ p)).upperMass F = (p : ℝ) ^ F.edgeFinset.card := by
+  rw [upperMass_sampleExchangeableLaw, homDensity_const]
+
+end DenseGraphLimits
+
+end TauCeti

--- a/TauCeti/Combinatorics/DenseGraphLimits/Sampling/Consistency.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/Sampling/Consistency.lean
@@ -1,0 +1,143 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import TauCeti.Combinatorics.DenseGraphLimits.Sampling.Finite
+public import TauCeti.Combinatorics.SimpleGraph.Maps
+public import TauCeti.Combinatorics.SimpleGraph.Measurable
+public import TauCeti.MeasureTheory.Constructions.Pi
+
+/-!
+# Consistency of graphon sampling under restriction of labels
+
+Sampling `l` independent points from a graphon and then tossing an independent coin for each
+unordered pair produces a law on `SimpleGraph (Fin l)`. Restricting such a sample to a window of
+`k` labels is the same as running the `k`-point sampling procedure from the start: the window
+reads `k` of the `l` independent points, which are again independent with the same law, and the
+coins outside the window are simply not looked at.
+
+The combinatorial half is that the graphs on `Fin l` restricting to a fixed `H` along an
+injection `f` are exactly the graphs whose edges meet the window `⊤.map f` in the image of the
+edges of `H`. Summing the conditional masses over that family collapses the coins outside the
+window, leaving the conditional mass of `H` at the restricted positions. The probabilistic half is
+that restricting an independent family of positions along an injection is measure preserving.
+
+## Main results
+
+* `TauCeti.DenseGraphLimits.sum_sampleIntegrand_comap_eq` — at fixed positions, the conditional
+  masses of the graphs restricting to `H` sum to the conditional mass of `H` at the restricted
+  positions;
+* `TauCeti.DenseGraphLimits.sum_sampleMass_comap_eq` — the same identity after integrating out
+  the positions;
+* `TauCeti.DenseGraphLimits.sampleGraph_map_comap` — the sampling laws are consistent under
+  restriction along every injection of labels.
+
+## References
+
+* L. Lovász, *Large Networks and Graph Limits*, AMS Colloquium Publications 60 (2012),
+  Section 10.1.
+* P. Diaconis, S. Janson, *Graph limits and exchangeable random graphs*, Rend. Mat. Appl. (7) 28
+  (2008), 33--61, Section 5.
+* C. Freer, `cameronfreer/graphon` at commit
+  `6eccca5bbe5c9df46d7129bf59575b8b9b1d6699`, Apache-2.0,
+  `Graphon/ExchangeableGraphLaw.lean`. The consistency statement follows that source; the proof
+  here is written for Tau Ceti's strict graphon carrier and reduces the combinatorial step to the
+  prescribed-trace mass formula.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory
+
+namespace TauCeti
+
+namespace DenseGraphLimits
+
+variable {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω} [IsProbabilityMeasure μ]
+variable {k l : ℕ} (W : Graphon Ω μ) (f : Fin k ↪ Fin l) (H : SimpleGraph (Fin k))
+
+open Classical in
+/-- At fixed vertex positions, the conditional masses of the graphs restricting to `H` along `f`
+sum to the conditional mass of `H` at the restricted positions: such a graph is prescribed on the
+window seen by `f` and free outside it, and the free coins contribute `1`. -/
+theorem sum_sampleIntegrand_comap_eq (x : Fin l → Ω) :
+    ∑ G ∈ Finset.univ.filter (fun G : SimpleGraph (Fin l) => SimpleGraph.comap ⇑f G = H),
+        sampleIntegrand W G x = sampleIntegrand W H (x ∘ ⇑f) := by
+  have hA : ((⊤ : SimpleGraph (Fin k)).map ⇑f).edgeFinset ⊆
+      (⊤ : SimpleGraph (Fin l)).edgeFinset := SimpleGraph.edgeFinset_mono le_top
+  have hBA : (H.map ⇑f).edgeFinset ⊆ ((⊤ : SimpleGraph (Fin k)).map ⇑f).edgeFinset :=
+    SimpleGraph.edgeFinset_mono (SimpleGraph.map_monotone _ le_top)
+  -- Restricting to `H` along `f` prescribes exactly the edges inside the window.
+  have hfilter :
+      Finset.univ.filter (fun G : SimpleGraph (Fin l) => SimpleGraph.comap ⇑f G = H) =
+        Finset.univ.filter (fun G : SimpleGraph (Fin l) =>
+          G.edgeFinset ∩ ((⊤ : SimpleGraph (Fin k)).map ⇑f).edgeFinset =
+            (H.map ⇑f).edgeFinset) :=
+    Finset.filter_congr fun G _ => by
+      rw [SimpleGraph.comap_eq_iff_inf_map_top, ← SimpleGraph.edgeFinset_inj,
+        SimpleGraph.edgeFinset_inf]
+  -- Inside the window the edges of the pattern are read through the injection `Sym2.map f`.
+  have hinj : Function.Injective (Sym2.map ⇑f) := Sym2.map.injective f.injective
+  have hmapTop : ((⊤ : SimpleGraph (Fin k)).map ⇑f).edgeFinset =
+      (⊤ : SimpleGraph (Fin k)).edgeFinset.image (Sym2.map ⇑f) := by
+    ext e
+    simp [SimpleGraph.edgeSet_map]
+  have hmapH : (H.map ⇑f).edgeFinset = H.edgeFinset.image (Sym2.map ⇑f) := by
+    ext e
+    simp [SimpleGraph.edgeSet_map]
+  rw [hfilter, sum_sampleIntegrand_inter_eq W _ _ hA hBA, hmapTop, hmapH,
+    ← Finset.image_sdiff _ _ hinj, Finset.prod_image fun _ _ _ _ h => hinj h,
+    Finset.prod_image fun _ _ _ _ h => hinj h, sampleIntegrand_def]
+  simp_rw [edgeFactor_map]
+
+open Classical in
+/-- The masses of the graphs restricting to `H` along `f` sum to the mass of `H`: integrating the
+conditional identity over the positions, which the restriction to the window redistributes without
+changing their law. -/
+theorem sum_sampleMass_comap_eq :
+    ∑ G ∈ Finset.univ.filter (fun G : SimpleGraph (Fin l) => SimpleGraph.comap ⇑f G = H),
+        sampleMass W G = sampleMass W H := by
+  -- Restricting an independent family of positions to the window is measure preserving.
+  have hmp : MeasurePreserving (fun x : Fin l → Ω => fun i : Fin k => x (f i))
+      (Measure.pi fun _ : Fin l => μ) (Measure.pi fun _ : Fin k => μ) :=
+    TauCeti.measurePreserving_pi_comp_embedding (fun _ : Fin l => μ) f
+  calc ∑ G ∈ Finset.univ.filter
+        (fun G : SimpleGraph (Fin l) => SimpleGraph.comap ⇑f G = H), sampleMass W G
+      = ∫ x : Fin l → Ω, ∑ G ∈ Finset.univ.filter
+            (fun G : SimpleGraph (Fin l) => SimpleGraph.comap ⇑f G = H),
+          sampleIntegrand W G x ∂Measure.pi fun _ => μ := by
+        simp_rw [sampleMass_def]
+        exact (integral_finsetSum _ fun G _ => integrable_sampleIntegrand W G).symm
+    _ = ∫ x : Fin l → Ω, sampleIntegrand W H (x ∘ ⇑f) ∂Measure.pi fun _ => μ :=
+        integral_congr_ae (Filter.Eventually.of_forall (sum_sampleIntegrand_comap_eq W f H))
+    _ = ∫ y : Fin k → Ω, sampleIntegrand W H y ∂Measure.pi fun _ => μ := by
+        rw [← hmp.map_eq, integral_map hmp.measurable.aemeasurable
+          (measurable_sampleIntegrand W H).aestronglyMeasurable]
+        rfl
+    _ = sampleMass W H := (sampleMass_def W H).symm
+
+/-- **Consistency of graphon sampling.** Restricting a sample on `Fin l` to a window of `k`
+labels has the law of a sample on `Fin k`. -/
+@[simp]
+theorem sampleGraph_map_comap :
+    (sampleGraph W l).map (SimpleGraph.comap ⇑f) = sampleGraph W k := by
+  classical
+  refine Measure.ext_of_singleton fun H => ?_
+  have hpre : SimpleGraph.comap ⇑f ⁻¹' {H} =
+      ↑(Finset.univ.filter (fun G : SimpleGraph (Fin l) => SimpleGraph.comap ⇑f G = H)) := by
+    ext G
+    simp
+  rw [Measure.map_apply (SimpleGraph.measurable_comap ⇑f) (MeasurableSet.singleton H), hpre,
+    ← sum_measure_singleton]
+  simp_rw [sampleGraph_singleton]
+  rw [← ENNReal.ofReal_sum_of_nonneg fun G _ => sampleMass_nonneg W G,
+    sum_sampleMass_comap_eq W f H]
+
+end DenseGraphLimits
+
+end TauCeti

--- a/TauCeti/Combinatorics/DenseGraphLimits/Sampling/Finite.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/Sampling/Finite.lean
@@ -19,9 +19,11 @@ stages and packages the resulting masses as a probability measure on finite simp
 
 The mass of a graph `G` is the integral of a finite product. Its edges contribute factors `W`,
 while its nonedges contribute factors `1 - W`. At fixed vertex positions, summing this product
-over the graphs whose edges include a fixed set expands as `∏ₑ (Wₑ + (1 - Wₑ)) = 1` over the
-remaining optional edges, leaving the factors of the fixed set. Taking that set empty gives
-normalization without imposing any extra regularity on the graphon's carrier.
+over the graphs that decide a fixed set of pairs in a prescribed way expands as
+`∏ₑ (Wₑ + (1 - Wₑ)) = 1` over the remaining undecided pairs, leaving the factors of the decided
+ones. Requiring a fixed set of edges and leaving the rest free is the special case that computes
+the mass of an upper event, and deciding nothing at all gives normalization without imposing any
+extra regularity on the graphon's carrier.
 
 ## Main definitions
 
@@ -32,8 +34,10 @@ normalization without imposing any extra regularity on the graphon's carrier.
 
 ## Main results
 
-* `sum_sampleIntegrand_superset_eq_prod_edgeFactor` computes the conditional mass of the graphs
-  containing a fixed set of edges;
+* `sum_sampleIntegrand_inter_eq` computes the conditional mass of the graphs with a prescribed
+  trace on a fixed set of pairs;
+* `sum_sampleIntegrand_superset_eq_prod_edgeFactor` specializes it to the graphs containing a
+  fixed set of edges;
 * `sampleMass_nonneg` and `sum_sampleMass_eq_one` show that the masses form a probability law;
 * `sampleGraph_singleton` computes the probability of an individual graph;
 * `sampleGraph_const` identifies sampling a constant graphon with Mathlib's binomial random graph.
@@ -45,9 +49,9 @@ normalization without imposing any extra regularity on the graphon's carrier.
 * C. Freer, `cameronfreer/graphon` at commit
   `6eccca5bbe5c9df46d7129bf59575b8b9b1d6699`, Apache-2.0,
   `Graphon/Sampling.lean`, `Graphon/SamplingLaw.lean`, and `Graphon/SamplingExamples.lean`.
-  The definitions and the Boolean-cube normalization argument, here generalized to a fixed set of
-  required edges, are adapted to Tau Ceti's strict graphon carrier; the constant-law proof reuses
-  the same reduction to Mathlib's singleton-mass formula.
+  The definitions and the Boolean-cube normalization argument, here generalized to a prescribed
+  trace on a fixed set of pairs, are adapted to Tau Ceti's strict graphon carrier; the
+  constant-law proof reuses the same reduction to Mathlib's singleton-mass formula.
 -/
 
 public section
@@ -153,6 +157,102 @@ theorem sampleMass_le_one : sampleMass W G ≤ 1 := by
   simpa using h
 
 open Classical in
+/-- At fixed vertex positions, summing the conditional masses over the graphs whose edges meet a
+fixed loop-free set `A` in a prescribed subset `B` collapses to the product of the edge factors of
+`B` against the complementary factors of `A \ B`: the edges left undecided by `A` contribute
+`∏ₑ (Wₑ + (1 - Wₑ)) = 1`. Loop-freeness of `A` is expressed as containment in the edges of the
+complete graph. -/
+theorem sum_sampleIntegrand_inter_eq (A B : Finset (Sym2 (Fin n)))
+    (hA : A ⊆ (⊤ : SimpleGraph (Fin n)).edgeFinset) (hBA : B ⊆ A) (x : Fin n → Ω) :
+    ∑ H ∈ Finset.univ.filter (fun H : SimpleGraph (Fin n) => H.edgeFinset ∩ A = B),
+        sampleIntegrand W H x =
+      (∏ e ∈ B, edgeFactor W x e) * ∏ e ∈ A \ B, (1 - edgeFactor W x e) := by
+  have hnotdiag : ∀ e ∈ (⊤ : SimpleGraph (Fin n)).edgeFinset, ¬ e.IsDiag := fun e he =>
+    (⊤ : SimpleGraph (Fin n)).not_isDiag_of_mem_edgeSet (SimpleGraph.mem_edgeFinset.mp he)
+  -- The graph built from `B` together with a set `S` of undecided edges has edge set `B ∪ S`.
+  have hedge : ∀ S ⊆ (⊤ : SimpleGraph (Fin n)).edgeFinset \ A, ∀ e,
+      e ∈ (SimpleGraph.fromEdgeSet (↑(B ∪ S) : Set (Sym2 (Fin n)))).edgeSet ↔ e ∈ B ∪ S := by
+    intro S hSsub e
+    rw [SimpleGraph.edgeSet_fromEdgeSet]
+    refine ⟨fun h => Finset.mem_coe.mp h.1, fun h => ⟨Finset.mem_coe.mpr h, ?_⟩⟩
+    rcases Finset.mem_union.mp h with h' | h'
+    · exact hnotdiag e (hA (hBA h'))
+    · exact hnotdiag e (Finset.mem_sdiff.mp (hSsub h')).1
+  have hsum : ∑ H ∈ Finset.univ.filter (fun H : SimpleGraph (Fin n) => H.edgeFinset ∩ A = B),
+        sampleIntegrand W H x =
+      ∑ S ∈ ((⊤ : SimpleGraph (Fin n)).edgeFinset \ A).powerset,
+        ((∏ e ∈ B, edgeFactor W x e) * ∏ e ∈ A \ B, (1 - edgeFactor W x e)) *
+          ((∏ e ∈ S, edgeFactor W x e) *
+            ∏ e ∈ ((⊤ : SimpleGraph (Fin n)).edgeFinset \ A) \ S, (1 - edgeFactor W x e)) := by
+    -- A graph with edge trace `B` on `A` is the same data as the set `S` of edges it uses outside
+    -- `A`, so the two maps below are mutually inverse bijections between those graphs and the
+    -- subsets of the undecided edges `E(⊤) \ A`.
+    refine Finset.sum_nbij'
+      (fun H => H.edgeFinset \ A)
+      (fun S => SimpleGraph.fromEdgeSet (↑(B ∪ S) : Set (Sym2 (Fin n))))
+      ?_ ?_ ?_ ?_ ?_
+    -- The edges a graph uses outside `A` are undecided edges.
+    · intro H hH
+      rw [Finset.mem_powerset]
+      intro e he
+      rw [Finset.mem_sdiff] at he ⊢
+      exact ⟨SimpleGraph.edgeFinset_mono le_top he.1, he.2⟩
+    -- Adding a set of undecided edges to `B` produces a graph with edge trace `B` on `A`.
+    · intro S hS
+      have hSsub := Finset.mem_powerset.mp hS
+      rw [Finset.mem_filter]
+      refine ⟨Finset.mem_univ _, ?_⟩
+      ext e
+      simp only [Finset.mem_inter, SimpleGraph.mem_edgeFinset, hedge S hSsub e, Finset.mem_union]
+      exact ⟨fun h => h.1.resolve_right fun heS => (Finset.mem_sdiff.mp (hSsub heS)).2 h.2,
+        fun h => ⟨Or.inl h, hBA h⟩⟩
+    -- Adding back the edges a graph uses outside `A` recovers that graph.
+    · intro H hH
+      rw [Finset.mem_filter] at hH
+      have hcoe : (↑(B ∪ (H.edgeFinset \ A)) : Set (Sym2 (Fin n))) = H.edgeSet := by
+        rw [← hH.2, Finset.coe_union, Finset.coe_inter, Finset.coe_sdiff,
+          SimpleGraph.coe_edgeFinset, Set.inter_union_sdiff]
+      rw [hcoe, SimpleGraph.fromEdgeSet_edgeSet]
+    -- The edges that `B ∪ S` uses outside `A` are exactly `S`, since `S` avoids `A`.
+    · intro S hS
+      have hSsub := Finset.mem_powerset.mp hS
+      ext e
+      simp only [Finset.mem_sdiff, SimpleGraph.mem_edgeFinset, hedge S hSsub e, Finset.mem_union]
+      exact ⟨fun h => h.1.resolve_left fun heB => h.2 (hBA heB),
+        fun h => ⟨Or.inr h, (Finset.mem_sdiff.mp (hSsub h)).2⟩⟩
+    -- The summands agree: the edges of `H` split as `B` together with the edges used outside `A`,
+    -- and the edges missing from `H` split as `A \ B` together with the undecided edges it skips.
+    · intro H hH
+      rw [Finset.mem_filter] at hH
+      have hmem : ∀ e, e ∈ B ↔ e ∈ H.edgeFinset ∧ e ∈ A := by
+        intro e
+        rw [← hH.2, Finset.mem_inter]
+      have hunion : B ∪ (H.edgeFinset \ A) = H.edgeFinset := by
+        ext e
+        simp only [Finset.mem_union, Finset.mem_sdiff, hmem]
+        tauto
+      have hdisj : Disjoint B (H.edgeFinset \ A) :=
+        Finset.disjoint_left.mpr fun e he hne => (Finset.mem_sdiff.mp hne).2 ((hmem e).mp he).2
+      have hcompl :
+          (⊤ : SimpleGraph (Fin n)).edgeFinset \ H.edgeFinset =
+            (A \ B) ∪ (((⊤ : SimpleGraph (Fin n)).edgeFinset \ A) \ (H.edgeFinset \ A)) := by
+        ext e
+        simp only [Finset.mem_sdiff, Finset.mem_union, hmem]
+        exact ⟨fun h => by by_cases heA : e ∈ A <;> tauto,
+          fun h => h.elim (fun h => ⟨hA h.1, fun hH => h.2 ⟨hH, h.1⟩⟩) fun h => ⟨h.1.1, by tauto⟩⟩
+      have hdisj' : Disjoint (A \ B)
+          (((⊤ : SimpleGraph (Fin n)).edgeFinset \ A) \ (H.edgeFinset \ A)) :=
+        Finset.disjoint_left.mpr fun e he hne =>
+          (Finset.mem_sdiff.mp (Finset.mem_sdiff.mp hne).1).2 (Finset.mem_sdiff.mp he).1
+      have hprod : (∏ e ∈ H.edgeFinset, edgeFactor W x e) =
+          (∏ e ∈ B, edgeFactor W x e) * ∏ e ∈ H.edgeFinset \ A, edgeFactor W x e := by
+        rw [← Finset.prod_union hdisj, hunion]
+      rw [sampleIntegrand_def, hprod, hcompl, Finset.prod_union hdisj']
+      ring
+  rw [hsum, ← Finset.mul_sum, ← Finset.prod_add]
+  simp
+
+open Classical in
 /-- At fixed vertex positions, summing the conditional masses over every graph whose edges
 include a fixed loop-free set `T` collapses to the product of the edge factors of `T`: the
 optional edges outside `T` contribute `∏ₑ (Wₑ + (1 - Wₑ)) = 1`. Loop-freeness of `T` is expressed
@@ -162,84 +262,12 @@ theorem sum_sampleIntegrand_superset_eq_prod_edgeFactor (T : Finset (Sym2 (Fin n
     ∑ H ∈ Finset.univ.filter (fun H => (T : Set (Sym2 (Fin n))) ⊆ H.edgeSet),
         sampleIntegrand W H x =
       ∏ e ∈ T, edgeFactor W x e := by
-  have hTdiag : ∀ e ∈ T, ¬ e.IsDiag := fun e he =>
-    (⊤ : SimpleGraph (Fin n)).not_isDiag_of_mem_edgeSet (SimpleGraph.mem_edgeFinset.mp (hT he))
-  have hsum : ∑ H ∈ Finset.univ.filter (fun H => (T : Set (Sym2 (Fin n))) ⊆ H.edgeSet),
-        sampleIntegrand W H x =
-      ∑ S ∈ ((⊤ : SimpleGraph (Fin n)).edgeFinset \ T).powerset,
-        (∏ e ∈ T, edgeFactor W x e) *
-          ((∏ e ∈ S, edgeFactor W x e) *
-            ∏ e ∈ ((⊤ : SimpleGraph (Fin n)).edgeFinset \ T) \ S, (1 - edgeFactor W x e)) := by
-    -- A graph containing `T` is the same data as the set `S` of edges it adds to `T`, so the two
-    -- maps below are mutually inverse bijections between those graphs and the subsets of the
-    -- optional edges `E(⊤) \ T`.
-    refine Finset.sum_nbij'
-      (fun H => H.edgeFinset \ T)
-      (fun S => SimpleGraph.fromEdgeSet (↑(T ∪ S) : Set (Sym2 (Fin n))))
-      ?_ ?_ ?_ ?_ ?_
-    -- The edges a graph adds to `T` are optional edges.
-    · intro H hH
-      rw [Finset.mem_powerset]
-      intro e he
-      rw [Finset.mem_sdiff] at he ⊢
-      exact ⟨SimpleGraph.edgeFinset_mono le_top he.1, he.2⟩
-    -- Adding a set of optional edges to `T` produces a graph containing `T`.
-    · intro S hS
-      rw [Finset.mem_filter]
-      refine ⟨Finset.mem_univ _, fun e he => ?_⟩
-      rw [SimpleGraph.edgeSet_fromEdgeSet]
-      exact ⟨Finset.mem_coe.mpr (Finset.mem_union_left _ (Finset.mem_coe.mp he)),
-        hTdiag e (Finset.mem_coe.mp he)⟩
-    -- Adding back the edges a graph adds to `T` recovers that graph.
-    · intro H hH
-      rw [Finset.mem_filter] at hH
-      have hcoe : (↑(T ∪ (H.edgeFinset \ T)) : Set (Sym2 (Fin n))) = H.edgeSet := by
-        rw [Finset.coe_union, Finset.coe_sdiff, SimpleGraph.coe_edgeFinset]
-        exact Set.union_sdiff_cancel hH.2
-      rw [hcoe, SimpleGraph.fromEdgeSet_edgeSet]
-    -- The edges that `T ∪ S` adds to `T` are exactly `S`, since `S` avoids `T`.
-    · intro S hS
-      have hSsub := Finset.mem_powerset.mp hS
-      apply Finset.coe_injective
-      rw [Finset.coe_sdiff, SimpleGraph.coe_edgeFinset, SimpleGraph.edgeSet_fromEdgeSet,
-        Finset.coe_union]
-      ext e
-      simp only [Set.mem_sdiff, Set.mem_union, Finset.mem_coe, Sym2.mem_diagSet]
-      constructor
-      · rintro ⟨⟨heT | heS, _⟩, hnT⟩
-        · exact (hnT heT).elim
-        · exact heS
-      · intro heS
-        have heSdiff := hSsub heS
-        refine ⟨⟨Or.inr heS, (⊤ : SimpleGraph (Fin n)).not_isDiag_of_mem_edgeSet
-          (SimpleGraph.mem_edgeFinset.mp (Finset.sdiff_subset heSdiff))⟩, ?_⟩
-        exact (Finset.mem_sdiff.mp heSdiff).2
-    -- The summands agree: the edges of `H` split as `T` together with the added edges, and the
-    -- optional edges missing from `H` are the optional edges outside the added ones.
-    · intro H hH
-      rw [Finset.mem_filter] at hH
-      have hsub : T ⊆ H.edgeFinset := fun e he =>
-        SimpleGraph.mem_edgeFinset.mpr (hH.2 (Finset.mem_coe.mpr he))
-      have hunion : T ∪ (H.edgeFinset \ T) = H.edgeFinset := Finset.union_sdiff_of_subset hsub
-      have hdiff :
-          (⊤ : SimpleGraph (Fin n)).edgeFinset \ H.edgeFinset =
-            ((⊤ : SimpleGraph (Fin n)).edgeFinset \ T) \ (H.edgeFinset \ T) := by
-        ext e
-        simp only [Finset.mem_sdiff]
-        tauto
-      have hprod :
-          (∏ e ∈ H.edgeFinset, edgeFactor W x e) =
-            (∏ e ∈ T, edgeFactor W x e) *
-              ∏ e ∈ H.edgeFinset \ T, edgeFactor W x e := by
-        calc
-          (∏ e ∈ H.edgeFinset, edgeFactor W x e) =
-              ∏ e ∈ T ∪ (H.edgeFinset \ T), edgeFactor W x e := by
-                exact congrArg
-                  (fun s : Finset (Sym2 (Fin n)) => ∏ e ∈ s, edgeFactor W x e) hunion.symm
-          _ = _ := Finset.prod_union Finset.disjoint_sdiff
-      rw [sampleIntegrand_def, hprod, hdiff]
-      ring
-  rw [hsum, ← Finset.mul_sum, ← Finset.prod_add]
+  have hfilter : Finset.univ.filter
+        (fun H : SimpleGraph (Fin n) => (T : Set (Sym2 (Fin n))) ⊆ H.edgeSet) =
+      Finset.univ.filter (fun H : SimpleGraph (Fin n) => H.edgeFinset ∩ T = T) :=
+    Finset.filter_congr fun H _ => by
+      rw [Finset.inter_eq_right, ← Finset.coe_subset, SimpleGraph.coe_edgeFinset]
+  rw [hfilter, sum_sampleIntegrand_inter_eq W T T hT le_rfl]
   simp
 
 open Classical in

--- a/TauCeti/Combinatorics/SimpleGraph/Maps.lean
+++ b/TauCeti/Combinatorics/SimpleGraph/Maps.lean
@@ -1,0 +1,50 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import Mathlib.Combinatorics.SimpleGraph.Maps
+
+/-!
+# Pulling a simple graph back along an embedding
+
+Pulling a simple graph back along an embedding `f : V ↪ W` forgets everything outside the window
+`f '' V`, and pushing the result forward again recovers exactly what the window sees: the
+intersection of the graph with the complete graph supported on that window. Since pushing forward
+along an embedding is injective, prescribing a pullback is therefore the same as prescribing that
+intersection — a condition on an induced subgraph turned into a condition on edges.
+
+## Main results
+
+* `SimpleGraph.map_comap_eq_inf_map_top` — pushing a pullback forward cuts the graph down to the
+  window;
+* `SimpleGraph.comap_eq_iff_inf_map_top` — prescribing a pullback is prescribing that
+  intersection.
+-/
+
+public section
+
+namespace SimpleGraph
+
+variable {V W : Type*}
+
+/-- Pushing a pullback forward again cuts the graph down to the window seen by the embedding. -/
+theorem map_comap_eq_inf_map_top (f : V ↪ W) (G : SimpleGraph W) :
+    (G.comap ⇑f).map ⇑f = G ⊓ (⊤ : SimpleGraph V).map ⇑f := by
+  ext u v
+  simp only [map_adj, comap_adj, inf_adj, top_adj]
+  constructor
+  · rintro ⟨a, b, hab, rfl, rfl⟩
+    exact ⟨hab, a, b, fun h => hab.ne (congrArg f h), rfl, rfl⟩
+  · rintro ⟨hG, a, b, -, rfl, rfl⟩
+    exact ⟨a, b, hG, rfl, rfl⟩
+
+/-- A pullback along an embedding is prescribed exactly by prescribing the intersection of the
+graph with the window seen by the embedding. -/
+theorem comap_eq_iff_inf_map_top (f : V ↪ W) (G : SimpleGraph W) (H : SimpleGraph V) :
+    G.comap ⇑f = H ↔ G ⊓ (⊤ : SimpleGraph V).map ⇑f = H.map ⇑f := by
+  rw [← (map_injective f).eq_iff, map_comap_eq_inf_map_top]
+
+end SimpleGraph

--- a/TauCeti/Combinatorics/SimpleGraph/Maps.lean
+++ b/TauCeti/Combinatorics/SimpleGraph/Maps.lean
@@ -31,6 +31,7 @@ namespace SimpleGraph
 variable {V W : Type*}
 
 /-- Pushing a pullback forward again cuts the graph down to the window seen by the embedding. -/
+@[simp]
 theorem map_comap_eq_inf_map_top (f : V ↪ W) (G : SimpleGraph W) :
     (G.comap ⇑f).map ⇑f = G ⊓ (⊤ : SimpleGraph V).map ⇑f := by
   ext u v

--- a/TauCeti/Combinatorics/SimpleGraph/Measurable.lean
+++ b/TauCeti/Combinatorics/SimpleGraph/Measurable.lean
@@ -5,19 +5,25 @@ Authors: Codex
 -/
 module
 
+public import Mathlib.Combinatorics.SimpleGraph.Maps
 public import Mathlib.MeasureTheory.Constructions.SimpleGraph
 
 /-!
-# Measurability of individual simple graphs
+# Measurability of individual simple graphs and of relabelling
 
 Mathlib equips `SimpleGraph V` with the sigma-algebra induced by all adjacency coordinates. When
 `V` is countable, an individual graph is measurable because its edge set is a measurable point in
 the countable product space. This supplies the discrete integration API for finite random graphs.
 
-## Main result
+Pulling a graph back along a map of vertex types reads finitely many adjacency coordinates of the
+source graph, so it is measurable with no hypothesis on either vertex type. This is what lets a
+random graph be restricted to a window of labels.
+
+## Main results
 
 * `SimpleGraph.instMeasurableSingletonClass` — singletons of graphs on a countable vertex type are
-  measurable.
+  measurable;
+* `SimpleGraph.measurable_comap` — pulling back along a map of vertex types is measurable.
 
 ## Reference
 
@@ -40,5 +46,14 @@ instance instMeasurableSingletonClass [Countable V] :
   measurableSet_singleton G := by
     rw [← measurableEmbedding_edgeSet.measurableSet_image, Set.image_singleton]
     exact MeasurableSet.singleton _
+
+variable {W : Type*}
+
+/-- Pulling a simple graph back along a map of vertex types is measurable: each adjacency
+coordinate of the pullback is an adjacency coordinate of the source. -/
+@[fun_prop]
+theorem measurable_comap (f : V → W) :
+    Measurable (SimpleGraph.comap f : SimpleGraph W → SimpleGraph V) :=
+  measurable_iff_adj.2 fun u v => measurable_iff_adj.1 measurable_id (f u) (f v)
 
 end SimpleGraph

--- a/TauCeti/Combinatorics/SimpleGraph/Measurable.lean
+++ b/TauCeti/Combinatorics/SimpleGraph/Measurable.lean
@@ -15,9 +15,9 @@ Mathlib equips `SimpleGraph V` with the sigma-algebra induced by all adjacency c
 `V` is countable, an individual graph is measurable because its edge set is a measurable point in
 the countable product space. This supplies the discrete integration API for finite random graphs.
 
-Pulling a graph back along a map of vertex types reads finitely many adjacency coordinates of the
-source graph, so it is measurable with no hypothesis on either vertex type. This is what lets a
-random graph be restricted to a window of labels.
+Each adjacency coordinate of a graph pulled back along a map of vertex types is a single
+adjacency coordinate of the source graph, so the pullback is measurable with no hypothesis on
+either vertex type. This is what lets a random graph be restricted to a window of labels.
 
 ## Main results
 


### PR DESCRIPTION
This PR introduces the exchangeable graph law — a random graph on an unbounded label set presented by its consistent finite marginals — and proves that the `W`-random graph laws of a graphon are one of them. `ExchangeableGraphLaw` bundles a probability law on `SimpleGraph (Fin k)` for every `k` with consistency under pulling a graph back along *every* injection `Fin k ↪ Fin l`; that single hypothesis supplies both invariance under relabelling (the permutations) and projectivity (the inclusions). Its observable is `ExchangeableGraphLaw.upperMass F`, the probability `P(F ≤ ·)` that the level-`k` sample contains `F`, shown to lie in `[0, 1]`, to equal `1` at the edgeless pattern, and to be unchanged by relabelling the pattern along an injection. That observable is complete: `upperMass_eq_sum` writes an upper mass as the total probability of the graphs above the pattern, and `ext_upperMass` inverts this by downward induction along the finite lattice of graphs, so the upper masses determine the law. The main theorem `sampleGraph_map_comap` says restricting a graphon sample on `Fin l` to a window of `k` labels has the law of a sample on `Fin k`, so `sampleExchangeableLaw W` is well formed, and the sampling anchor `upperMass_sampleExchangeableLaw` identifies `P(F ≤ G(k, W))` with the homomorphism density `t(F, W)`.

Roadmap: DenseGraphLimits

<!--tauceti-target:v1 {"focus":"DenseGraphLimits","id":"uppermass-sampleexchangeablelaw"}-->

The milestone is Layer 9b, the exchangeable graph laws and their graphon-mixture representation; its first four named targets — `ExchangeableGraphLaw`, `sampleGraph_map_comap`, `sampleExchangeableLaw`, `upperMass` with `upperMass_sampleExchangeableLaw` — are what this PR lands. It is the next step on that layer because Layer 9a's sampling objects, which Layer 9b consumes, arrived with `sampleGraph` (TauCeti#6012) and the unbiasedness anchor (TauCeti#6266), and because the ordering section puts Layer 9b before the Layer-8b representability spine, which consumes exactly `ExchangeableGraphLaw`, `upperMass` and `IsDissociated`. What remains on the layer after this PR: `IsDissociated` with `isDissociated_sampleExchangeableLaw` and the bridge `isDissociated_iff_upperMass_mul`, then the infinite form and the empirical-mixing existence spine, whose compactness extraction still waits on Layer 4.

The proof runs in two halves. Combinatorially, the graphs on `Fin l` that restrict to a fixed `H` along `f` are exactly those whose edges meet the window `⊤.map f` in the image of the edges of `H`; summing the conditional masses over that family collapses the coins outside the window to `∏ₑ (Wₑ + (1 − Wₑ)) = 1` and leaves the conditional mass of `H` at the restricted positions. Probabilistically, restricting an independent family of positions to the window is measure preserving, which is the already-available `TauCeti.measurePreserving_pi_comp_embedding`.

Three supporting pieces make that argument possible. `sum_sampleIntegrand_inter_eq` generalizes the existing `sum_sampleIntegrand_superset_eq_prod_edgeFactor` from "these edges are required" to "this set of pairs is decided in this way", with the old statement re-derived from it in three lines; the same Boolean-cube expansion proves both, and only the general form computes the mass of a prescribed restriction. `SimpleGraph.map_comap_eq_inf_map_top` and `SimpleGraph.comap_eq_iff_inf_map_top` record that pushing a pullback forward cuts a graph down to the window seen by the embedding, so prescribing a pullback is prescribing an intersection — the step that turns a condition on an induced subgraph into a condition on edges. `SimpleGraph.measurable_comap` joins the existing measurable-graph module, since the pushforward is along that map.

New modules: `TauCeti/Combinatorics/DenseGraphLimits/ExchangeableGraphLaw/Defs.lean`, `TauCeti/Combinatorics/DenseGraphLimits/Sampling/Consistency.lean`, `TauCeti/Combinatorics/DenseGraphLimits/ExchangeableGraphLaw/Sampling.lean` and `TauCeti/Combinatorics/SimpleGraph/Maps.lean`; `TauCeti/Combinatorics/DenseGraphLimits/Sampling/Finite.lean` and `TauCeti/Combinatorics/SimpleGraph/Measurable.lean` are extended. The sampling-consistency results live in `Sampling/Consistency.lean` because they are statements about `sampleGraph` alone; `ExchangeableGraphLaw/Sampling.lean` imports them and only does the packaging.

Proof routes and the shape of `ExchangeableGraphLaw`, `sampleGraph_map_comap` and `upperMass` follow `cameronfreer/graphon` at commit `6eccca5bbe5c9df46d7129bf59575b8b9b1d6699` (Apache-2.0), `Graphon/ExchangeableGraphLaw.lean`, adapted to Tau Ceti's strict graphon carrier; no code is vendored. Attribution is recorded in the module docstrings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
