### PR TITLE
feat: the degree-one finite-quotient colimit of continuous cohomology

### DIFF
--- a/TauCeti/RepresentationTheory/Homological/ContCohomology/FiniteQuotient/Colimit.lean
+++ b/TauCeti/RepresentationTheory/Homological/ContCohomology/FiniteQuotient/Colimit.lean
@@ -177,7 +177,7 @@ variable (G M)
 /-- The degree-one comparison maps into `H¹(G, M)`: inflation along `G → G ⧸ U`, assembled into
 the leg family of a cocone. They are named because the colimit theorem below says that *these*
 maps are universal, not that some isomorphism exists. -/
-@[expose] noncomputable def explicitFiniteQuotientComparison1 :
+noncomputable def explicitFiniteQuotientComparison1 :
     explicitFiniteQuotientSystem1 G M ⟶
       (Functor.const ((OpenNormalSubgroup G)ᵒᵖ)).obj (AddCommGrpCat.of (H1 G M)) where
   app U := AddCommGrpCat.ofHom (explicitInfl1 G M U.unop.toSubgroup)
@@ -189,10 +189,14 @@ maps are universal, not that some isomorphism exists. -/
 @[simp]
 theorem explicitFiniteQuotientComparison1_app (U : OpenNormalSubgroup G) :
     (explicitFiniteQuotientComparison1 G M).app (Opposite.op U) =
-      AddCommGrpCat.ofHom (explicitInfl1 G M U.toSubgroup) :=
-  rfl
+      AddCommGrpCat.ofHom (explicitInfl1 G M U.toSubgroup) := by
+  rw [explicitFiniteQuotientComparison1]
 
 /-- The degree-one finite-quotient cocone, whose point is `H¹(G, M)` itself. -/
+-- The body is exposed because the apex is a dependent object type: the legs and every map out of
+-- the cocone, `explicitFiniteQuotientColimit1.desc` included, are typed by `pt`, so it has to
+-- reduce outside this module.  The comparison transformation above is sealed instead, its
+-- components being recovered from `explicitFiniteQuotientComparison1_app`.
 @[expose] noncomputable def explicitFiniteQuotientCocone1 :
     Cocone (explicitFiniteQuotientSystem1 G M) where
   pt := AddCommGrpCat.of (H1 G M)

--- a/TauCeti/RepresentationTheory/Homological/ContCohomology/FiniteQuotient/Colimit.lean
+++ b/TauCeti/RepresentationTheory/Homological/ContCohomology/FiniteQuotient/Colimit.lean
@@ -68,10 +68,9 @@ normal subgroups a neighbourhood basis of `1`.
 * L. Ribes and P. Zalesskii, *Profinite Groups*, Cor. 6.5.6(a).
 -/
 
--- Provenance: the human-authored roadmap `TauCetiRoadmap/ProfiniteCohomology`, whose `README.md`
--- section "the finite-quotient colimit description" asks for the colimit theorem as universality
--- of the named comparison cocone rather than as a bare isomorphism, and whose `Suggested.lean`
--- writes down the signatures of the comparison, the cocone and the colimit followed here.
+-- Provenance: the statements follow the human-authored roadmap
+-- `TauCetiRoadmap/ProfiniteCohomology`, whose `README.md` and `Suggested.lean` fix the names and
+-- the signatures used here.
 
 public section
 
@@ -96,7 +95,8 @@ theorem explicitInfl1_comp_explicitFiniteQuotientTransition1 (U V : OpenNormalSu
     (hVU : V ≤ U) :
     (explicitInfl1 G M V.toSubgroup).comp (explicitFiniteQuotientTransition1 G M U V hVU) =
       explicitInfl1 G M U.toSubgroup := by
-  -- The two composable compatible pairs compose to the pair defining `explicitInfl1` at `U`.
+  -- Both maps are compatible-pair pullbacks, so the composite is the pullback along the composite
+  -- pair by `explicitMap1_comp`, and that pair is the one defining `explicitInfl1` at `U`.
   have hquot : (continuousFiniteQuotientMap G hVU).comp
       (ContinuousMonoidHom.quotientMk V.toSubgroup) =
       ContinuousMonoidHom.quotientMk U.toSubgroup := by
@@ -107,67 +107,13 @@ theorem explicitInfl1_comp_explicitFiniteQuotientTransition1 (U V : OpenNormalSu
         FixedPoints.addSubgroup V.toSubgroup M) =
       (FixedPoints.addSubgroup U.toSubgroup M).subtype :=
     AddMonoidHom.ext fun m => coe_fixedPointsInclusion hVU m
-  have hcomp : ∀ (g : G) (m : FixedPoints.addSubgroup U.toSubgroup M),
-      (((FixedPoints.addSubgroup V.toSubgroup M).subtype).comp
-          (fixedPointsInclusion hVU : FixedPoints.addSubgroup U.toSubgroup M →+
-            FixedPoints.addSubgroup V.toSubgroup M))
-        (((continuousFiniteQuotientMap G hVU).comp
-          (ContinuousMonoidHom.quotientMk V.toSubgroup)) g • m) =
-      g • (((FixedPoints.addSubgroup V.toSubgroup M).subtype).comp
-          (fixedPointsInclusion hVU : FixedPoints.addSubgroup U.toSubgroup M →+
-            FixedPoints.addSubgroup V.toSubgroup M)) m := by
-    intro g m
-    rw [hquot, hincl]
-    exact subtype_quotientMk_smul G M U.toSubgroup g m
-  refine AddMonoidHom.ext fun x => ?_
-  induction x using QuotientAddGroup.induction_on with
-  | _ c =>
-    have htrans : explicitFiniteQuotientTransition1 G M U V hVU
-        (c : H1 (G ⧸ U.toSubgroup) (FixedPoints.addSubgroup U.toSubgroup M)) =
-        H1pi (G ⧸ V.toSubgroup) (FixedPoints.addSubgroup V.toSubgroup M)
-          (cocyclesMap1 (G ⧸ U.toSubgroup) (FixedPoints.addSubgroup U.toSubgroup M)
-            (G ⧸ V.toSubgroup) (FixedPoints.addSubgroup V.toSubgroup M)
-            (continuousFiniteQuotientMap G hVU) (fixedPointsInclusion hVU)
-            continuous_of_discreteTopology
-            (fixedPointsInclusion_continuousFiniteQuotientMap_smul G M hVU) c) :=
-      explicitFiniteQuotientTransition1_mk G M hVU c
-    refine (congrArg (explicitInfl1 G M V.toSubgroup) htrans).trans ?_
-    refine (explicitInfl1_mk G M V.toSubgroup _).trans ?_
-    refine Eq.trans ?_ (explicitInfl1_mk G M U.toSubgroup c).symm
-    refine congrArg (fun w : Z1 G M => (w : H1 G M)) ?_
-    -- Functoriality of the cocycle pullback is `cocyclesMap1_comp`; only the identification of the
-    -- composite pair with the inflation pair at `U` is left.
-    have hfunct := DFunLike.congr_fun (cocyclesMap1_comp
-      (G ⧸ U.toSubgroup) (FixedPoints.addSubgroup U.toSubgroup M)
-      (G ⧸ V.toSubgroup) (FixedPoints.addSubgroup V.toSubgroup M)
-      (continuousFiniteQuotientMap G hVU)
-      (fixedPointsInclusion hVU : FixedPoints.addSubgroup U.toSubgroup M →+
-        FixedPoints.addSubgroup V.toSubgroup M)
-      continuous_of_discreteTopology
-      (fixedPointsInclusion_continuousFiniteQuotientMap_smul G M hVU) G M
-      (ContinuousMonoidHom.quotientMk V.toSubgroup)
-      (FixedPoints.addSubgroup V.toSubgroup M).subtype
-      (continuous_fixedPoints_addSubgroup_subtype G M V.toSubgroup)
-      (subtype_quotientMk_smul G M V.toSubgroup) hcomp) c
-    rw [AddMonoidHom.comp_apply] at hfunct
-    refine hfunct.symm.trans (Subtype.ext (funext fun g => ?_))
-    -- The two evaluations are spelled with all their arguments because the coefficient map of a
-    -- transition is `fixedPointsInclusion`, stated on `FixedPoints.addSubmonoid`, so the cocycle
-    -- below does not unify with the pattern of `cocyclesMap1_apply` at reducible transparency.
-    have hA := cocyclesMap1_apply (G ⧸ U.toSubgroup) (FixedPoints.addSubgroup U.toSubgroup M) G M
-      ((continuousFiniteQuotientMap G hVU).comp (ContinuousMonoidHom.quotientMk V.toSubgroup))
-      (((FixedPoints.addSubgroup V.toSubgroup M).subtype).comp
-        (fixedPointsInclusion hVU : FixedPoints.addSubgroup U.toSubgroup M →+
-          FixedPoints.addSubgroup V.toSubgroup M))
-      ((continuous_fixedPoints_addSubgroup_subtype G M V.toSubgroup).comp
-        continuous_of_discreteTopology) hcomp c g
-    have hB := cocyclesMap1_apply (G ⧸ U.toSubgroup) (FixedPoints.addSubgroup U.toSubgroup M) G M
-      (ContinuousMonoidHom.quotientMk U.toSubgroup)
-      (FixedPoints.addSubgroup U.toSubgroup M).subtype
-      (continuous_fixedPoints_addSubgroup_subtype G M U.toSubgroup)
-      (subtype_quotientMk_smul G M U.toSubgroup) c g
-    rw [hA, hB, hquot]
-    exact coe_fixedPointsInclusion hVU _
+  rw [explicitInfl1_eq_explicitMap1, explicitFiniteQuotientTransition1_eq_explicitMap1,
+    explicitInfl1_eq_explicitMap1]
+  refine (explicitMap1_comp _ _ _ _ _ _ _ _ _ _ _ _ _ _ ?_).symm.trans
+    (explicitMap1_congr_of_eq _ _ _ _ _ _ _ _ hquot hincl)
+  exact fun g m => comp_apply_smul _ _ _ _
+    (fixedPointsInclusion_continuousFiniteQuotientMap_smul G M hVU)
+    (subtype_quotientMk_smul G M V.toSubgroup) g m
 
 /-- Inflating a class from a level to a deeper one does not change it: the elementwise form of
 `TauCeti.ContCohomology.explicitInfl1_comp_explicitFiniteQuotientTransition1`. -/

--- a/TauCeti/RepresentationTheory/Homological/ContCohomology/FiniteQuotient/Colimit.lean
+++ b/TauCeti/RepresentationTheory/Homological/ContCohomology/FiniteQuotient/Colimit.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Topology.Algebra.ClopenNhdofOne
 public import TauCeti.RepresentationTheory.Homological.ContCohomology.FiniteQuotient.Explicit
 public import TauCeti.RepresentationTheory.Homological.ContCohomology.Inflation
 
@@ -63,11 +62,6 @@ Compactness and total disconnectedness of `G` are used only for that open normal
 discreteness of `M` makes the zero set open, and the two topological hypotheses make the open
 normal subgroups a neighbourhood basis of `1`.
 
-This implements the degree-one part of the "colimit theorem" milestone of Layer 4 of the
-human-authored roadmap at `TauCetiRoadmap/ProfiniteCohomology/README.md`, whose `Suggested.lean`
-fixes the names `explicitFiniteQuotientComparison1`, `explicitFiniteQuotientCocone1` and
-`explicitFiniteQuotientColimit1`.
-
 ## References
 
 * J. Neukirch, A. Schmidt, K. Wingberg, *Cohomology of Number Fields*, 2nd ed., (1.2.5).
@@ -97,6 +91,29 @@ theorem explicitInfl1_comp_explicitFiniteQuotientTransition1 (U V : OpenNormalSu
     (hVU : V ≤ U) :
     (explicitInfl1 G M V.toSubgroup).comp (explicitFiniteQuotientTransition1 G M U V hVU) =
       explicitInfl1 G M U.toSubgroup := by
+  -- The two composable compatible pairs compose to the pair defining `explicitInfl1` at `U`.
+  have hquot : (continuousFiniteQuotientMap G hVU).comp
+      (ContinuousMonoidHom.quotientMk V.toSubgroup) =
+      ContinuousMonoidHom.quotientMk U.toSubgroup := by
+    ext g
+    simp
+  have hincl : ((FixedPoints.addSubgroup V.toSubgroup M).subtype).comp
+      (fixedPointsInclusion hVU : FixedPoints.addSubgroup U.toSubgroup M →+
+        FixedPoints.addSubgroup V.toSubgroup M) =
+      (FixedPoints.addSubgroup U.toSubgroup M).subtype :=
+    AddMonoidHom.ext fun m => coe_fixedPointsInclusion hVU m
+  have hcomp : ∀ (g : G) (m : FixedPoints.addSubgroup U.toSubgroup M),
+      (((FixedPoints.addSubgroup V.toSubgroup M).subtype).comp
+          (fixedPointsInclusion hVU : FixedPoints.addSubgroup U.toSubgroup M →+
+            FixedPoints.addSubgroup V.toSubgroup M))
+        (((continuousFiniteQuotientMap G hVU).comp
+          (ContinuousMonoidHom.quotientMk V.toSubgroup)) g • m) =
+      g • (((FixedPoints.addSubgroup V.toSubgroup M).subtype).comp
+          (fixedPointsInclusion hVU : FixedPoints.addSubgroup U.toSubgroup M →+
+            FixedPoints.addSubgroup V.toSubgroup M)) m := by
+    intro g m
+    rw [hquot, hincl]
+    exact subtype_quotientMk_smul G M U.toSubgroup g m
   refine AddMonoidHom.ext fun x => ?_
   induction x using QuotientAddGroup.induction_on with
   | _ c =>
@@ -112,33 +129,39 @@ theorem explicitInfl1_comp_explicitFiniteQuotientTransition1 (U V : OpenNormalSu
     refine (congrArg (explicitInfl1 G M V.toSubgroup) htrans).trans ?_
     refine (explicitInfl1_mk G M V.toSubgroup _).trans ?_
     refine Eq.trans ?_ (explicitInfl1_mk G M U.toSubgroup c).symm
-    refine congrArg (fun w : Z1 G M => (w : H1 G M)) (Subtype.ext (funext fun g => ?_))
-    -- The three evaluations are spelled with all their arguments because the coefficient map of a
-    -- transition is `fixedPointsInclusion`, stated on `FixedPoints.addSubmonoid`, so the cocycle
-    -- below does not unify with the pattern of `cocyclesMap1_apply` at reducible transparency.
-    have hA := cocyclesMap1_apply (G ⧸ V.toSubgroup) (FixedPoints.addSubgroup V.toSubgroup M) G M
+    refine congrArg (fun w : Z1 G M => (w : H1 G M)) ?_
+    -- Functoriality of the cocycle pullback is `cocyclesMap1_comp`; only the identification of the
+    -- composite pair with the inflation pair at `U` is left.
+    have hfunct := DFunLike.congr_fun (cocyclesMap1_comp
+      (G ⧸ U.toSubgroup) (FixedPoints.addSubgroup U.toSubgroup M)
+      (G ⧸ V.toSubgroup) (FixedPoints.addSubgroup V.toSubgroup M)
+      (continuousFiniteQuotientMap G hVU)
+      (fixedPointsInclusion hVU : FixedPoints.addSubgroup U.toSubgroup M →+
+        FixedPoints.addSubgroup V.toSubgroup M)
+      continuous_of_discreteTopology
+      (fixedPointsInclusion_continuousFiniteQuotientMap_smul G M hVU) G M
       (ContinuousMonoidHom.quotientMk V.toSubgroup)
       (FixedPoints.addSubgroup V.toSubgroup M).subtype
       (continuous_fixedPoints_addSubgroup_subtype G M V.toSubgroup)
-      (subtype_quotientMk_smul G M V.toSubgroup)
-      (cocyclesMap1 (G ⧸ U.toSubgroup) (FixedPoints.addSubgroup U.toSubgroup M)
-        (G ⧸ V.toSubgroup) (FixedPoints.addSubgroup V.toSubgroup M)
-        (continuousFiniteQuotientMap G hVU) (fixedPointsInclusion hVU)
-        continuous_of_discreteTopology
-        (fixedPointsInclusion_continuousFiniteQuotientMap_smul G M hVU) c) g
-    have hB := cocyclesMap1_apply (G ⧸ U.toSubgroup) (FixedPoints.addSubgroup U.toSubgroup M)
-      (G ⧸ V.toSubgroup) (FixedPoints.addSubgroup V.toSubgroup M)
-      (continuousFiniteQuotientMap G hVU) (fixedPointsInclusion hVU)
-      continuous_of_discreteTopology
-      (fixedPointsInclusion_continuousFiniteQuotientMap_smul G M hVU) c
-      (ContinuousMonoidHom.quotientMk V.toSubgroup g)
-    have hC := cocyclesMap1_apply (G ⧸ U.toSubgroup) (FixedPoints.addSubgroup U.toSubgroup M) G M
+      (subtype_quotientMk_smul G M V.toSubgroup) hcomp) c
+    rw [AddMonoidHom.comp_apply] at hfunct
+    refine hfunct.symm.trans (Subtype.ext (funext fun g => ?_))
+    -- The two evaluations are spelled with all their arguments because the coefficient map of a
+    -- transition is `fixedPointsInclusion`, stated on `FixedPoints.addSubmonoid`, so the cocycle
+    -- below does not unify with the pattern of `cocyclesMap1_apply` at reducible transparency.
+    have hA := cocyclesMap1_apply (G ⧸ U.toSubgroup) (FixedPoints.addSubgroup U.toSubgroup M) G M
+      ((continuousFiniteQuotientMap G hVU).comp (ContinuousMonoidHom.quotientMk V.toSubgroup))
+      (((FixedPoints.addSubgroup V.toSubgroup M).subtype).comp
+        (fixedPointsInclusion hVU : FixedPoints.addSubgroup U.toSubgroup M →+
+          FixedPoints.addSubgroup V.toSubgroup M))
+      ((continuous_fixedPoints_addSubgroup_subtype G M V.toSubgroup).comp
+        continuous_of_discreteTopology) hcomp c g
+    have hB := cocyclesMap1_apply (G ⧸ U.toSubgroup) (FixedPoints.addSubgroup U.toSubgroup M) G M
       (ContinuousMonoidHom.quotientMk U.toSubgroup)
       (FixedPoints.addSubgroup U.toSubgroup M).subtype
       (continuous_fixedPoints_addSubgroup_subtype G M U.toSubgroup)
       (subtype_quotientMk_smul G M U.toSubgroup) c g
-    rw [hA, hB, hC]
-    simp only [ContinuousMonoidHom.quotientMk_apply, continuousFiniteQuotientMap_mk]
+    rw [hA, hB, hquot]
     exact coe_fixedPointsInclusion hVU _
 
 /-- Inflating a class from a level to a deeper one does not change it: the elementwise form of

--- a/TauCeti/RepresentationTheory/Homological/ContCohomology/FiniteQuotient/Colimit.lean
+++ b/TauCeti/RepresentationTheory/Homological/ContCohomology/FiniteQuotient/Colimit.lean
@@ -68,6 +68,11 @@ normal subgroups a neighbourhood basis of `1`.
 * L. Ribes and P. Zalesskii, *Profinite Groups*, Cor. 6.5.6(a).
 -/
 
+-- Provenance: the human-authored roadmap `TauCetiRoadmap/ProfiniteCohomology`, whose `README.md`
+-- section "the finite-quotient colimit description" asks for the colimit theorem as universality
+-- of the named comparison cocone rather than as a bare isomorphism, and whose `Suggested.lean`
+-- writes down the signatures of the comparison, the cocone and the colimit followed here.
+
 public section
 
 namespace TauCeti.ContCohomology

--- a/TauCeti/RepresentationTheory/Homological/ContCohomology/FiniteQuotient/Colimit.lean
+++ b/TauCeti/RepresentationTheory/Homological/ContCohomology/FiniteQuotient/Colimit.lean
@@ -1,0 +1,327 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Topology.Algebra.ClopenNhdofOne
+public import TauCeti.RepresentationTheory.Homological.ContCohomology.FiniteQuotient.Explicit
+public import TauCeti.RepresentationTheory.Homological.ContCohomology.Inflation
+
+/-!
+# The degree-one finite-quotient colimit
+
+For a profinite group `G` acting continuously on a discrete module `M`, the first continuous
+cohomology group is the colimit of the finite-level groups over the open normal subgroups:
+
+```text
+H¹(G, M) = colim_U H¹(G ⧸ U, M^U).
+```
+
+This file names the comparison maps into `H¹(G, M)`, assembles them into a cocone on the system
+`TauCeti.ContCohomology.explicitFiniteQuotientSystem1`, and proves that the cocone is colimiting.
+The statement is universality of those named maps, not a bare isomorphism.
+
+## Main definitions
+
+* `TauCeti.ContCohomology.explicitFiniteQuotientComparison1`: the leg family, inflation along
+  `G → G ⧸ U`.
+* `TauCeti.ContCohomology.explicitFiniteQuotientCocone1`: the cocone those legs form, with apex
+  `H¹(G, M)`.
+* `TauCeti.ContCohomology.explicitFiniteQuotientColimit1`: that cocone is colimiting.
+
+## Main statements
+
+* `TauCeti.ContCohomology.explicitInfl1_comp_explicitFiniteQuotientTransition1` and its
+  elementwise form `explicitInfl1_explicitFiniteQuotientTransition1`: inflating through a deeper
+  level is inflating directly, which is the cocone condition.
+* `TauCeti.ContCohomology.exists_openNormalSubgroup_apply_eq_zero`: a continuous `1`-cocycle of a
+  profinite group with discrete coefficients vanishes on an open normal subgroup.
+* `TauCeti.ContCohomology.exists_explicitInfl1_eq`: every class in `H¹(G, M)` is inflated from a
+  finite level.
+* `TauCeti.ContCohomology.subsingleton_H1_of_forall_openNormalSubgroup`: if every finite layer has
+  trivial first cohomology, so does `H¹(G, M)`.
+
+## Implementation notes
+
+The comparison map from the `U`-level is inflation along `G → G ⧸ U`, already built as
+`TauCeti.ContCohomology.explicitInfl1`; it is used under that name, and
+`explicitFiniteQuotientComparison1` is the natural transformation assembling those maps, not a
+second name for a single one.
+
+Surjectivity of the comparison is *strict*. The zero set of a continuous `1`-cocycle is an open
+neighbourhood of `1`, so `ProfiniteGrp.exist_openNormalSubgroup_sub_open_nhds_of_one` puts an open
+normal subgroup `U` inside it, and the cocycle is then the inflation of its descent to `G ⧸ U`
+(`TauCeti.ContCohomology.explicitInfl1_descendZ1`): no coboundary is subtracted. Injectivity of
+each comparison map is `TauCeti.ContCohomology.explicitInfl1_injective`, which holds for an
+arbitrary normal subgroup and needs neither compactness nor discreteness, so the colimit is a
+directed union and the descent of an arbitrary cocone is defined by choosing any level a class
+comes from.
+
+Compactness and total disconnectedness of `G` are used only for that open normal subgroup:
+discreteness of `M` makes the zero set open, and the two topological hypotheses make the open
+normal subgroups a neighbourhood basis of `1`.
+
+This implements the degree-one part of the "colimit theorem" milestone of Layer 4 of the
+human-authored roadmap at `TauCetiRoadmap/ProfiniteCohomology/README.md`, whose `Suggested.lean`
+fixes the names `explicitFiniteQuotientComparison1`, `explicitFiniteQuotientCocone1` and
+`explicitFiniteQuotientColimit1`.
+
+## References
+
+* J. Neukirch, A. Schmidt, K. Wingberg, *Cohomology of Number Fields*, 2nd ed., (1.2.5).
+* L. Ribes and P. Zalesskii, *Profinite Groups*, Cor. 6.5.6(a).
+-/
+
+public section
+
+namespace TauCeti.ContCohomology
+
+open CategoryTheory CategoryTheory.Limits
+
+universe u v
+
+variable (G : Type u) [Group G] [TopologicalSpace G] [IsTopologicalGroup G]
+  (M : Type v) [AddCommGroup M] [TopologicalSpace M] [IsTopologicalAddGroup M]
+  [DiscreteTopology M] [DistribMulAction G M] [ContinuousSMul G M]
+
+section Cocone
+
+variable {G M}
+
+/-- Inflating from the `U`-level through the `V`-level, for `V ≤ U`, is inflating from the
+`U`-level directly. This is the cocone condition for
+`TauCeti.ContCohomology.explicitFiniteQuotientCocone1`. -/
+theorem explicitInfl1_comp_explicitFiniteQuotientTransition1 (U V : OpenNormalSubgroup G)
+    (hVU : V ≤ U) :
+    (explicitInfl1 G M V.toSubgroup).comp (explicitFiniteQuotientTransition1 G M U V hVU) =
+      explicitInfl1 G M U.toSubgroup := by
+  refine AddMonoidHom.ext fun x => ?_
+  induction x using QuotientAddGroup.induction_on with
+  | _ c =>
+    have htrans : explicitFiniteQuotientTransition1 G M U V hVU
+        (c : H1 (G ⧸ U.toSubgroup) (FixedPoints.addSubgroup U.toSubgroup M)) =
+        H1pi (G ⧸ V.toSubgroup) (FixedPoints.addSubgroup V.toSubgroup M)
+          (cocyclesMap1 (G ⧸ U.toSubgroup) (FixedPoints.addSubgroup U.toSubgroup M)
+            (G ⧸ V.toSubgroup) (FixedPoints.addSubgroup V.toSubgroup M)
+            (continuousFiniteQuotientMap G hVU) (fixedPointsInclusion hVU)
+            continuous_of_discreteTopology
+            (fixedPointsInclusion_continuousFiniteQuotientMap_smul G M hVU) c) :=
+      explicitFiniteQuotientTransition1_mk G M hVU c
+    refine (congrArg (explicitInfl1 G M V.toSubgroup) htrans).trans ?_
+    refine (explicitInfl1_mk G M V.toSubgroup _).trans ?_
+    refine Eq.trans ?_ (explicitInfl1_mk G M U.toSubgroup c).symm
+    refine congrArg (fun w : Z1 G M => (w : H1 G M)) (Subtype.ext (funext fun g => ?_))
+    -- The three evaluations are spelled with all their arguments because the coefficient map of a
+    -- transition is `fixedPointsInclusion`, stated on `FixedPoints.addSubmonoid`, so the cocycle
+    -- below does not unify with the pattern of `cocyclesMap1_apply` at reducible transparency.
+    have hA := cocyclesMap1_apply (G ⧸ V.toSubgroup) (FixedPoints.addSubgroup V.toSubgroup M) G M
+      (ContinuousMonoidHom.quotientMk V.toSubgroup)
+      (FixedPoints.addSubgroup V.toSubgroup M).subtype
+      (continuous_fixedPoints_addSubgroup_subtype G M V.toSubgroup)
+      (subtype_quotientMk_smul G M V.toSubgroup)
+      (cocyclesMap1 (G ⧸ U.toSubgroup) (FixedPoints.addSubgroup U.toSubgroup M)
+        (G ⧸ V.toSubgroup) (FixedPoints.addSubgroup V.toSubgroup M)
+        (continuousFiniteQuotientMap G hVU) (fixedPointsInclusion hVU)
+        continuous_of_discreteTopology
+        (fixedPointsInclusion_continuousFiniteQuotientMap_smul G M hVU) c) g
+    have hB := cocyclesMap1_apply (G ⧸ U.toSubgroup) (FixedPoints.addSubgroup U.toSubgroup M)
+      (G ⧸ V.toSubgroup) (FixedPoints.addSubgroup V.toSubgroup M)
+      (continuousFiniteQuotientMap G hVU) (fixedPointsInclusion hVU)
+      continuous_of_discreteTopology
+      (fixedPointsInclusion_continuousFiniteQuotientMap_smul G M hVU) c
+      (ContinuousMonoidHom.quotientMk V.toSubgroup g)
+    have hC := cocyclesMap1_apply (G ⧸ U.toSubgroup) (FixedPoints.addSubgroup U.toSubgroup M) G M
+      (ContinuousMonoidHom.quotientMk U.toSubgroup)
+      (FixedPoints.addSubgroup U.toSubgroup M).subtype
+      (continuous_fixedPoints_addSubgroup_subtype G M U.toSubgroup)
+      (subtype_quotientMk_smul G M U.toSubgroup) c g
+    rw [hA, hB, hC]
+    simp only [ContinuousMonoidHom.quotientMk_apply, continuousFiniteQuotientMap_mk]
+    exact coe_fixedPointsInclusion hVU _
+
+/-- Inflating a class from a level to a deeper one does not change it: the elementwise form of
+`TauCeti.ContCohomology.explicitInfl1_comp_explicitFiniteQuotientTransition1`. -/
+theorem explicitInfl1_explicitFiniteQuotientTransition1 {U V : OpenNormalSubgroup G} (hVU : V ≤ U)
+    (y : H1 (G ⧸ U.toSubgroup) (FixedPoints.addSubgroup U.toSubgroup M)) :
+    explicitInfl1 G M V.toSubgroup (explicitFiniteQuotientTransition1 G M U V hVU y) =
+      explicitInfl1 G M U.toSubgroup y := by
+  rw [← AddMonoidHom.comp_apply, explicitInfl1_comp_explicitFiniteQuotientTransition1]
+
+variable (G M)
+
+/-- The degree-one comparison maps into `H¹(G, M)`: inflation along `G → G ⧸ U`, assembled into
+the leg family of a cocone. They are named because the colimit theorem below says that *these*
+maps are universal, not that some isomorphism exists. -/
+@[expose] noncomputable def explicitFiniteQuotientComparison1 :
+    explicitFiniteQuotientSystem1 G M ⟶
+      (Functor.const ((OpenNormalSubgroup G)ᵒᵖ)).obj (AddCommGrpCat.of (H1 G M)) where
+  app U := AddCommGrpCat.ofHom (explicitInfl1 G M U.unop.toSubgroup)
+  naturality U V f :=
+    AddCommGrpCat.hom_ext (explicitInfl1_comp_explicitFiniteQuotientTransition1
+      U.unop V.unop (leOfHom f.unop))
+
+/-- The degree-one comparison map at `U` is inflation along `G → G ⧸ U`. -/
+@[simp]
+theorem explicitFiniteQuotientComparison1_app (U : OpenNormalSubgroup G) :
+    (explicitFiniteQuotientComparison1 G M).app (Opposite.op U) =
+      AddCommGrpCat.ofHom (explicitInfl1 G M U.toSubgroup) :=
+  rfl
+
+/-- The degree-one finite-quotient cocone, whose point is `H¹(G, M)` itself. -/
+@[expose] noncomputable def explicitFiniteQuotientCocone1 :
+    Cocone (explicitFiniteQuotientSystem1 G M) where
+  pt := AddCommGrpCat.of (H1 G M)
+  ι := explicitFiniteQuotientComparison1 G M
+
+/-- The apex of the degree-one finite-quotient cocone is `H¹(G, M)`. -/
+@[simp]
+theorem explicitFiniteQuotientCocone1_pt :
+    (explicitFiniteQuotientCocone1 G M).pt = AddCommGrpCat.of (H1 G M) :=
+  rfl
+
+/-- The legs of the degree-one finite-quotient cocone are the comparison maps. -/
+@[simp]
+theorem explicitFiniteQuotientCocone1_ι :
+    (explicitFiniteQuotientCocone1 G M).ι = explicitFiniteQuotientComparison1 G M :=
+  rfl
+
+end Cocone
+
+section Colimit
+
+variable [CompactSpace G] [TotallyDisconnectedSpace G]
+
+omit [ContinuousSMul G M] in
+/-- A continuous `1`-cocycle of a profinite group with discrete coefficients vanishes on an open
+normal subgroup: its zero set is open and contains `1`. -/
+theorem exists_openNormalSubgroup_apply_eq_zero (z : Z1 G M) :
+    ∃ U : OpenNormalSubgroup G, ∀ g ∈ U, (z : G → M) g = 0 := by
+  have hopen : IsOpen ((z : G → M) ⁻¹' {0}) :=
+    ((mem_Z1_iff.1 z.2).1).isOpen_preimage _ (isOpen_discrete _)
+  have hone : (1 : G) ∈ (z : G → M) ⁻¹' {0} := map_one_of_mem_Z1 z.2
+  obtain ⟨U, hU⟩ :=
+    ProfiniteGrp.exist_openNormalSubgroup_sub_open_nhds_of_one hopen hone
+  exact ⟨U, fun g hg => hU hg⟩
+
+variable {G M}
+
+/-- **Strict surjectivity of the comparison maps**: every class in `H¹(G, M)` is inflated from a
+finite level. The representing cocycle itself vanishes on an open normal subgroup `U`, so it *is*
+the inflation of its descent to `G ⧸ U` and no coboundary is subtracted. -/
+theorem exists_explicitInfl1_eq (x : H1 G M) :
+    ∃ (U : OpenNormalSubgroup G)
+      (y : H1 (G ⧸ U.toSubgroup) (FixedPoints.addSubgroup U.toSubgroup M)),
+      explicitInfl1 G M U.toSubgroup y = x := by
+  induction x using QuotientAddGroup.induction_on with
+  | _ z =>
+    obtain ⟨U, hU⟩ := exists_openNormalSubgroup_apply_eq_zero G M z
+    exact ⟨U, descendZ1 z fun n => hU (n : G) n.2, explicitInfl1_descendZ1 z _⟩
+
+omit [CompactSpace G] [TotallyDisconnectedSpace G] in
+/-- Restricting a cocone leg through a transition map gives the leg one level up. This is the
+naturality of the cocone, read on elements. -/
+private theorem cocone_ι_explicitFiniteQuotientTransition1
+    (s : Cocone (explicitFiniteQuotientSystem1 G M)) {U V : OpenNormalSubgroup G} (hVU : V ≤ U)
+    (y : H1 (G ⧸ U.toSubgroup) (FixedPoints.addSubgroup U.toSubgroup M)) :
+    (s.ι.app (Opposite.op V)).hom (explicitFiniteQuotientTransition1 G M U V hVU y) =
+      (s.ι.app (Opposite.op U)).hom y :=
+  congrArg (fun w : (explicitFiniteQuotientSystem1 G M).obj (Opposite.op U) ⟶ s.pt => w.hom y)
+    ((s.ι.naturality (homOfLE hVU).op).trans (Category.comp_id _))
+
+omit [CompactSpace G] [TotallyDisconnectedSpace G] in
+/-- Two finite-level classes with the same inflation have the same image under every cocone: they
+already agree at the intersection of the two levels, where inflation is injective. -/
+private theorem cocone_ι_eq_of_explicitInfl1_eq
+    (s : Cocone (explicitFiniteQuotientSystem1 G M)) {U V : OpenNormalSubgroup G}
+    (y : H1 (G ⧸ U.toSubgroup) (FixedPoints.addSubgroup U.toSubgroup M))
+    (y' : H1 (G ⧸ V.toSubgroup) (FixedPoints.addSubgroup V.toSubgroup M))
+    (h : explicitInfl1 G M U.toSubgroup y = explicitInfl1 G M V.toSubgroup y') :
+    (s.ι.app (Opposite.op U)).hom y = (s.ι.app (Opposite.op V)).hom y' := by
+  have hkey : explicitFiniteQuotientTransition1 G M U (U ⊓ V) inf_le_left y =
+      explicitFiniteQuotientTransition1 G M V (U ⊓ V) inf_le_right y' := by
+    refine explicitInfl1_injective G M (U ⊓ V).toSubgroup ?_
+    rw [← AddMonoidHom.comp_apply, explicitInfl1_comp_explicitFiniteQuotientTransition1,
+      ← AddMonoidHom.comp_apply, explicitInfl1_comp_explicitFiniteQuotientTransition1]
+    exact h
+  rw [← cocone_ι_explicitFiniteQuotientTransition1 s (inf_le_left : U ⊓ V ≤ U) y,
+    ← cocone_ι_explicitFiniteQuotientTransition1 s (inf_le_right : U ⊓ V ≤ V) y', hkey]
+
+/-- The descent of a cocone to `H¹(G, M)`, as a bare function: a class is inflated from some
+finite level, and its value is the cocone leg applied to any such witness. -/
+private noncomputable def coconeDescFun (s : Cocone (explicitFiniteQuotientSystem1 G M))
+    (x : H1 G M) : s.pt :=
+  (s.ι.app (Opposite.op (exists_explicitInfl1_eq x).choose)).hom
+    (exists_explicitInfl1_eq x).choose_spec.choose
+
+/-- The descent of a cocone is computed by any level a class is inflated from. -/
+private theorem coconeDescFun_explicitInfl1 (s : Cocone (explicitFiniteQuotientSystem1 G M))
+    (U : OpenNormalSubgroup G)
+    (y : H1 (G ⧸ U.toSubgroup) (FixedPoints.addSubgroup U.toSubgroup M)) :
+    coconeDescFun s (explicitInfl1 G M U.toSubgroup y) = (s.ι.app (Opposite.op U)).hom y :=
+  cocone_ι_eq_of_explicitInfl1_eq s _ y
+    (exists_explicitInfl1_eq (explicitInfl1 G M U.toSubgroup y)).choose_spec.choose_spec
+
+/-- The descent of a cocone is additive: two classes are inflated from a common level. -/
+private theorem coconeDescFun_add (s : Cocone (explicitFiniteQuotientSystem1 G M))
+    (x x' : H1 G M) :
+    coconeDescFun s (x + x') = coconeDescFun s x + coconeDescFun s x' := by
+  obtain ⟨U, y, rfl⟩ := exists_explicitInfl1_eq x
+  obtain ⟨V, y', rfl⟩ := exists_explicitInfl1_eq x'
+  rw [← explicitInfl1_explicitFiniteQuotientTransition1 (inf_le_left : U ⊓ V ≤ U) y,
+    ← explicitInfl1_explicitFiniteQuotientTransition1 (inf_le_right : U ⊓ V ≤ V) y', ← map_add,
+    coconeDescFun_explicitInfl1, coconeDescFun_explicitInfl1, coconeDescFun_explicitInfl1]
+  exact map_add _ _ _
+
+/-- The descent of a cocone to `H¹(G, M)`, as an additive homomorphism. -/
+private noncomputable def coconeDesc (s : Cocone (explicitFiniteQuotientSystem1 G M)) :
+    H1 G M →+ s.pt :=
+  AddMonoidHom.mk' (coconeDescFun s) (coconeDescFun_add s)
+
+/-- The homomorphism form of the descent is still computed by any level a class is inflated
+from. -/
+private theorem coconeDesc_explicitInfl1 (s : Cocone (explicitFiniteQuotientSystem1 G M))
+    (U : OpenNormalSubgroup G)
+    (y : H1 (G ⧸ U.toSubgroup) (FixedPoints.addSubgroup U.toSubgroup M)) :
+    coconeDesc s (explicitInfl1 G M U.toSubgroup y) = (s.ι.app (Opposite.op U)).hom y :=
+  coconeDescFun_explicitInfl1 s U y
+
+variable (G M)
+
+/-- **The degree-one finite-quotient colimit theorem**: `H¹(G, M)` is the colimit of the
+finite-level first cohomology groups `H¹(G ⧸ U, M^U)`, through the inflation maps. -/
+noncomputable def explicitFiniteQuotientColimit1 :
+    IsColimit (explicitFiniteQuotientCocone1 G M) where
+  desc s := AddCommGrpCat.ofHom (coconeDesc s)
+  fac s U := by
+    refine AddCommGrpCat.hom_ext (AddMonoidHom.ext fun y => ?_)
+    exact coconeDesc_explicitInfl1 s U.unop y
+  uniq s m hm := by
+    refine AddCommGrpCat.hom_ext (AddMonoidHom.ext fun x => ?_)
+    obtain ⟨U, y, rfl⟩ := exists_explicitInfl1_eq x
+    refine Eq.trans ?_ (coconeDesc_explicitInfl1 s U y).symm
+    exact congrArg
+      (fun w : (explicitFiniteQuotientSystem1 G M).obj (Opposite.op U) ⟶ s.pt => w.hom y)
+      (hm (Opposite.op U))
+
+variable {G M}
+
+/-- **Vanishing descends from the finite levels**: if every finite layer has trivial first
+cohomology, so does `H¹(G, M)`. Every class comes from a finite level, and two classes are
+compared at the intersection of their levels. This is the form in which Hilbert 90 and the Kummer
+isomorphism pass from finite Galois layers to the absolute Galois group. -/
+theorem subsingleton_H1_of_forall_openNormalSubgroup
+    (h : ∀ U : OpenNormalSubgroup G,
+      Subsingleton (H1 (G ⧸ U.toSubgroup) (FixedPoints.addSubgroup U.toSubgroup M))) :
+    Subsingleton (H1 G M) := by
+  refine ⟨fun x x' => ?_⟩
+  obtain ⟨U, y, rfl⟩ := exists_explicitInfl1_eq x
+  obtain ⟨V, y', rfl⟩ := exists_explicitInfl1_eq x'
+  rw [← explicitInfl1_explicitFiniteQuotientTransition1 (inf_le_left : U ⊓ V ≤ U) y,
+    ← explicitInfl1_explicitFiniteQuotientTransition1 (inf_le_right : U ⊓ V ≤ V) y']
+  exact congrArg _ (@Subsingleton.elim _ (h (U ⊓ V)) _ _)
+
+end Colimit
+
+end TauCeti.ContCohomology

--- a/TauCeti/RepresentationTheory/Homological/ContCohomology/FiniteQuotient/Explicit.lean
+++ b/TauCeti/RepresentationTheory/Homological/ContCohomology/FiniteQuotient/Explicit.lean
@@ -44,13 +44,6 @@ It is the source diagram for the explicit degree-one finite-quotient colimit the
 * `explicitFiniteQuotientSystem1_obj` and `explicitFiniteQuotientSystem1_map` identify the
   objects and arrows of the packaged functor.
 
-## Implementation notes
-
-The body of `explicitFiniteQuotientSystem1` is exposed: a cocone on the system is written with
-`H¹(G ⧸ U, M^U)` for its source objects and `explicitFiniteQuotientTransition1` for its arrows, so
-both fields have to reduce outside this module.  Sealing it makes the cocone legs, and the
-object- and arrow-level lemmas below, fail to typecheck.
-
 ## References
 
 * J. Neukirch, A. Schmidt and K. Wingberg, *Cohomology of Number Fields*, (1.2.5).
@@ -199,6 +192,9 @@ section System
 /-- The explicit degree-one finite-quotient system of a discrete module.  It sends an open normal
 subgroup `U` to `H¹(G ⧸ U, M^U)` and an inclusion `V ≤ U` to the direct explicit transition from
 the `U`-level to the `V`-level. -/
+-- The body is exposed because a cocone on this system is written with `H¹(G ⧸ U, M^U)` for its
+-- source objects and `explicitFiniteQuotientTransition1` for its arrows, so both fields have to
+-- reduce outside this module.
 @[expose] noncomputable def explicitFiniteQuotientSystem1 :
     (OpenNormalSubgroup G)ᵒᵖ ⥤ AddCommGrpCat.{max u v} where
   obj U :=

--- a/TauCeti/RepresentationTheory/Homological/ContCohomology/FiniteQuotient/Explicit.lean
+++ b/TauCeti/RepresentationTheory/Homological/ContCohomology/FiniteQuotient/Explicit.lean
@@ -191,8 +191,12 @@ section System
 
 /-- The explicit degree-one finite-quotient system of a discrete module.  It sends an open normal
 subgroup `U` to `H¹(G ⧸ U, M^U)` and an inclusion `V ≤ U` to the direct explicit transition from
-the `U`-level to the `V`-level. -/
-noncomputable def explicitFiniteQuotientSystem1 :
+the `U`-level to the `V`-level.
+
+The body is exposed because a cocone on this system has to be written with `H¹(G ⧸ U, M^U)` for
+its source objects and `explicitFiniteQuotientTransition1` for its arrows, which needs the two
+fields to reduce outside this module. -/
+@[expose] noncomputable def explicitFiniteQuotientSystem1 :
     (OpenNormalSubgroup G)ᵒᵖ ⥤ AddCommGrpCat.{max u v} where
   obj U :=
     AddCommGrpCat.of

--- a/TauCeti/RepresentationTheory/Homological/ContCohomology/FiniteQuotient/Explicit.lean
+++ b/TauCeti/RepresentationTheory/Homological/ContCohomology/FiniteQuotient/Explicit.lean
@@ -44,6 +44,13 @@ It is the source diagram for the explicit degree-one finite-quotient colimit the
 * `explicitFiniteQuotientSystem1_obj` and `explicitFiniteQuotientSystem1_map` identify the
   objects and arrows of the packaged functor.
 
+## Implementation notes
+
+The body of `explicitFiniteQuotientSystem1` is exposed: a cocone on the system is written with
+`H¹(G ⧸ U, M^U)` for its source objects and `explicitFiniteQuotientTransition1` for its arrows, so
+both fields have to reduce outside this module.  Sealing it makes the cocone legs, and the
+object- and arrow-level lemmas below, fail to typecheck.
+
 ## References
 
 * J. Neukirch, A. Schmidt and K. Wingberg, *Cohomology of Number Fields*, (1.2.5).
@@ -191,11 +198,7 @@ section System
 
 /-- The explicit degree-one finite-quotient system of a discrete module.  It sends an open normal
 subgroup `U` to `H¹(G ⧸ U, M^U)` and an inclusion `V ≤ U` to the direct explicit transition from
-the `U`-level to the `V`-level.
-
-The body is exposed because a cocone on this system has to be written with `H¹(G ⧸ U, M^U)` for
-its source objects and `explicitFiniteQuotientTransition1` for its arrows, which needs the two
-fields to reduce outside this module. -/
+the `U`-level to the `V`-level. -/
 @[expose] noncomputable def explicitFiniteQuotientSystem1 :
     (OpenNormalSubgroup G)ᵒᵖ ⥤ AddCommGrpCat.{max u v} where
   obj U :=

--- a/TauCeti/RepresentationTheory/Homological/ContCohomology/FiniteQuotient/Explicit.lean
+++ b/TauCeti/RepresentationTheory/Homological/ContCohomology/FiniteQuotient/Explicit.lean
@@ -39,6 +39,8 @@ It is the source diagram for the explicit degree-one finite-quotient colimit the
 
 ## Main statements
 
+* `explicitFiniteQuotientTransition1_eq_explicitMap1` identifies a transition map with the
+  compatible-pair pullback it is built from.
 * `explicitFiniteQuotientTransition1_id` and `explicitFiniteQuotientTransition1_comp` are the
   identity and composition laws for the transition maps.
 * `explicitFiniteQuotientSystem1_obj` and `explicitFiniteQuotientSystem1_map` identify the
@@ -94,6 +96,27 @@ theorem explicitFiniteQuotientTransition1_mk (hVU : V ≤ U)
         continuous_of_discreteTopology
           (fixedPointsInclusion_continuousFiniteQuotientMap_smul G M hVU) c) :=
   explicitMap1_mk _ _ _ _ _ _ _ _ c
+
+omit [ContinuousSMul G M] in
+/-- A degree-one finite-quotient transition is the compatible-pair pullback along the quotient
+homomorphism `G ⧸ V → G ⧸ U` and the inclusion of invariant coefficients `M ^ U → M ^ V`. -/
+-- The pullback is ascribed its type because `fixedPointsInclusion` is stated on
+-- `FixedPoints.addSubmonoid`, so the coefficient instances of the right-hand side are fixed by the
+-- left-hand side rather than synthesized on their own.
+theorem explicitFiniteQuotientTransition1_eq_explicitMap1 (hVU : V ≤ U) :
+    explicitFiniteQuotientTransition1 G M U V hVU =
+      (explicitMap1 (G ⧸ U.toSubgroup) (FixedPoints.addSubgroup U.toSubgroup M)
+        (G ⧸ V.toSubgroup) (FixedPoints.addSubgroup V.toSubgroup M)
+        (continuousFiniteQuotientMap G hVU) (fixedPointsInclusion hVU)
+        continuous_of_discreteTopology
+          (fixedPointsInclusion_continuousFiniteQuotientMap_smul G M hVU) :
+        H1 (G ⧸ U.toSubgroup) (FixedPoints.addSubgroup U.toSubgroup M) →+
+          H1 (G ⧸ V.toSubgroup) (FixedPoints.addSubgroup V.toSubgroup M)) := by
+  refine AddMonoidHom.ext fun x => ?_
+  induction x using QuotientAddGroup.induction_on with
+  | _ c =>
+    exact (explicitFiniteQuotientTransition1_mk G M hVU c).trans
+      (explicitMap1_mk _ _ _ _ _ _ _ _ c).symm
 
 omit [ContinuousSMul G M] in
 /-- The transition from an open normal subgroup to itself is the identity. -/

--- a/TauCeti/RepresentationTheory/Homological/ContCohomology/Inflation.lean
+++ b/TauCeti/RepresentationTheory/Homological/ContCohomology/Inflation.lean
@@ -35,6 +35,8 @@ at its two nodes.
 * `TauCeti.ContCohomology.explicitRes1_comp_explicitInfl1` and
   `TauCeti.ContCohomology.explicitRes2_comp_explicitInfl2`: restricting an inflated class back to
   `N` gives zero.
+* `TauCeti.ContCohomology.explicitInfl1_eq_explicitMap1`: inflation in degree `1` is the
+  compatible-pair pullback along `G → G ⧸ N`.
 * `TauCeti.ContCohomology.explicitInfl1_injective`: inflation is injective in degree `1`.
 * `TauCeti.ContCohomology.explicitInfRes_exact`: the image of inflation is exactly the kernel of
   restriction in degree `1`.
@@ -164,6 +166,15 @@ theorem explicitInfl1_mk (c : Z1 (G ⧸ N) (FixedPoints.addSubgroup N M)) :
         (FixedPoints.addSubgroup N M).subtype (continuous_fixedPoints_addSubgroup_subtype G M N)
         (subtype_quotientMk_smul G M N) c : H1 G M) :=
   explicitMap1_mk _ _ _ _ _ _ _ _ c
+
+/-- Inflation in degree one is the compatible-pair pullback along the quotient homomorphism
+`G → G ⧸ N` and the inclusion of the invariants `M ^ N` into `M`. -/
+theorem explicitInfl1_eq_explicitMap1 :
+    explicitInfl1 G M N =
+      explicitMap1 (G ⧸ N) (FixedPoints.addSubgroup N M) G M (ContinuousMonoidHom.quotientMk N)
+        (FixedPoints.addSubgroup N M).subtype (continuous_fixedPoints_addSubgroup_subtype G M N)
+        (subtype_quotientMk_smul G M N) := by
+  rw [explicitInfl1]
 
 /-- **Restriction to `N` kills inflation in degree one**, the first half of the
 inflation-restriction sequence: the inflation of a cocycle restricts to the zero cochain on `N`,

--- a/TauCeti/RepresentationTheory/Homological/ContCohomology/Inflation.lean
+++ b/TauCeti/RepresentationTheory/Homological/ContCohomology/Inflation.lean
@@ -38,6 +38,8 @@ at its two nodes.
 * `TauCeti.ContCohomology.explicitInfl1_injective`: inflation is injective in degree `1`.
 * `TauCeti.ContCohomology.explicitInfRes_exact`: the image of inflation is exactly the kernel of
   restriction in degree `1`.
+* `TauCeti.ContCohomology.coe_descendZ1_apply_mk`: the descent of a cocycle takes on the coset of
+  `g` the value the cocycle takes at `g`.
 * `TauCeti.ContCohomology.explicitInfl1_descendZ1`: a cocycle vanishing on `N` is the inflation of
   its descent.
 
@@ -256,12 +258,13 @@ def descendZ1 (z : Z1 G M) (hz : ∀ n : N, (z : G → M) (n : G) = 0) :
 
 omit [ContinuousSMul G M] [ContinuousSMul (G ⧸ N) (FixedPoints.addSubgroup N M)] in
 /-- The descent takes on the coset of `g` the value the original cocycle takes at `g`. This is the
-computation rule of `Quotient.liftOn'` at a representative, so it is a `rfl`; isolating it here is
-what lets `explicitInfl1_descendZ1` below be a rewrite rather than a definitional unfolding. -/
-private theorem coe_descendZ1_apply_mk (z : Z1 G M) (hz : ∀ n : N, (z : G → M) (n : G) = 0)
+computation rule that characterises `TauCeti.ContCohomology.descendZ1`. -/
+@[simp]
+theorem coe_descendZ1_apply_mk (z : Z1 G M) (hz : ∀ n : N, (z : G → M) (n : G) = 0)
     (g : G) :
     ((descendZ1 z hz : (G ⧸ N) → FixedPoints.addSubgroup N M) (g : G ⧸ N) : M) =
-      (z : G → M) g :=
+      (z : G → M) g := by
+  rw [descendZ1]
   rfl
 
 /-- Inflating the descent of a continuous `1`-cocycle vanishing on `N` returns its class. -/

--- a/TauCeti/RepresentationTheory/Homological/ContCohomology/Inflation.lean
+++ b/TauCeti/RepresentationTheory/Homological/ContCohomology/Inflation.lean
@@ -27,6 +27,8 @@ at its two nodes.
 
 * `TauCeti.ContCohomology.explicitInfl0`, `explicitInfl1`, and `explicitInfl2`: inflation on the
   explicit model in degrees `0`, `1`, and `2`.
+* `TauCeti.ContCohomology.descendZ1`: the descent to `G ⧸ N` of a continuous `1`-cocycle vanishing
+  on `N`.
 
 ## Main statements
 
@@ -36,6 +38,8 @@ at its two nodes.
 * `TauCeti.ContCohomology.explicitInfl1_injective`: inflation is injective in degree `1`.
 * `TauCeti.ContCohomology.explicitInfRes_exact`: the image of inflation is exactly the kernel of
   restriction in degree `1`.
+* `TauCeti.ContCohomology.explicitInfl1_descendZ1`: a cocycle vanishing on `N` is the inflation of
+  its descent.
 
 ## Implementation notes
 
@@ -228,8 +232,9 @@ private theorem smul_apply_eq_self_of_vanishing {z : Z1 G M}
 /-- The descent to `G ⧸ N` of a continuous `1`-cocycle vanishing on `N`. It is well defined by
 `apply_mul_eq_self_of_vanishing`, takes its values in `M ^ N` by
 `smul_apply_eq_self_of_vanishing`, and is continuous because `G ⧸ N` carries the quotient
-topology. -/
-private def descendZ1 (z : Z1 G M) (hz : ∀ n : N, (z : G → M) (n : G) = 0) :
+topology. Together with `TauCeti.ContCohomology.explicitInfl1_descendZ1` it says that a cocycle
+vanishing on `N` is *itself* inflated, with no coboundary subtracted. -/
+def descendZ1 (z : Z1 G M) (hz : ∀ n : N, (z : G → M) (n : G) = 0) :
     Z1 (G ⧸ N) (FixedPoints.addSubgroup N M) :=
   ⟨fun q => Quotient.liftOn' q
       (fun g => (⟨(z : G → M) g,
@@ -260,7 +265,7 @@ private theorem coe_descendZ1_apply_mk (z : Z1 G M) (hz : ∀ n : N, (z : G → 
   rfl
 
 /-- Inflating the descent of a continuous `1`-cocycle vanishing on `N` returns its class. -/
-private theorem explicitInfl1_descendZ1 (z : Z1 G M) (hz : ∀ n : N, (z : G → M) (n : G) = 0) :
+theorem explicitInfl1_descendZ1 (z : Z1 G M) (hz : ∀ n : N, (z : G → M) (n : G) = 0) :
     explicitInfl1 G M N (descendZ1 z hz : H1 (G ⧸ N) (FixedPoints.addSubgroup N M)) =
       (z : H1 G M) := by
   rw [explicitInfl1_mk]


### PR DESCRIPTION
This PR proves the degree-one finite-quotient colimit theorem of continuous cohomology: for a profinite group `G` acting continuously on a discrete module `M`, the first continuous cohomology group `H¹(G, M)` is the colimit of the finite-level groups `H¹(G ⧸ U, M^U)` over the open normal subgroups, through inflation. The statement is universality of the *named* comparison maps, not a bare isomorphism: `explicitFiniteQuotientComparison1` is the natural transformation whose component at `U` is `explicitInfl1`, `explicitFiniteQuotientCocone1` is the cocone it forms on the system `explicitFiniteQuotientSystem1` with apex `H¹(G, M)`, and `explicitFiniteQuotientColimit1` says that cocone is colimiting.

The roadmap target is `ProfiniteCohomology`, `README.md` §5, Layer 4 ("the finite-quotient colimit description"), whose colimit-theorem milestone asks for `explicitFiniteQuotientSystem0/1/2`, `explicitFiniteQuotientComparison0/1/2`, `explicitFiniteQuotientCocone0/1/2` and `explicitFiniteQuotientColimit0/1/2`, stated "as universality of the **named** comparison cocone rather than as a bare isomorphism". The degree-one system and its transitions are already on `main`; this PR supplies the degree-one comparison, cocone and colimit. After it, Layer 4 still owes degrees 0 and 2 — which first need `explicitFiniteQuotientTransition0/2` and `explicitFiniteQuotientSystem0/2`, neither of which exists yet — together with the coefficient colimits and the Layer 4 "first consequences".

The designated roadmap is `ClassFieldTheory`, and this is the prerequisite its README sends to `ProfiniteCohomology`. `ClassFieldTheory` §1 "Consumed, not redefined" assigns "continuous cohomology of profinite groups, continuous cup products, Kummer theory, degree casts, and **the finite-quotient colimit**" to `ProfiniteCohomology`, and Layer 5 ("local coefficients, the Brauer group, the local invariant, and duality") lists `ProfiniteCohomology` among its prerequisites. The consuming declaration is Layer 5's `localSymbol`, the cohomological local Hilbert symbol, which §1 item 7 says is "defined here from Kummer classes, the continuous cup product, and the local invariant map". Those Kummer classes are `ProfiniteCohomology` Layer 9's `kummerIso`, and Layer 4's own API section names its consumers: "Layer 9's Hilbert 90, Layer 10's all-degree colimit, Layer 11's dévissage". `hilbert90` and `kummerIso` are exactly the two declarations that need the colimit to pass from finite Galois layers to the absolute Galois group, which is why `subsingleton_H1_of_forall_openNormalSubgroup` is stated here: it is the vanishing criterion Hilbert 90 descends through. The edge is therefore `ClassFieldTheory` Layer 5 `localSymbol` ← `ProfiniteCohomology` Layer 9 `kummerIso`/`hilbert90` ← Layer 4 `explicitFiniteQuotientColimit1`.

Surjectivity of the comparison is strict, as the roadmap requires. A continuous `1`-cocycle vanishes at `1` and takes values in a discrete module, so its zero set is an open neighbourhood of `1`; `ProfiniteGrp.exist_openNormalSubgroup_sub_open_nhds_of_one` puts an open normal subgroup `U` inside it (`exists_openNormalSubgroup_apply_eq_zero`), and the cocycle is then *itself* the inflation of its descent to `G ⧸ U`, with no coboundary subtracted (`exists_explicitInfl1_eq`). Injectivity of each comparison map is the `explicitInfl1_injective` already on `main`, which holds for an arbitrary normal subgroup and uses neither compactness nor discreteness; so the colimit is a directed union, and the descent of an arbitrary cocone is well defined by choosing any level a class comes from, two choices being compared at the intersection of their levels. Compactness and total disconnectedness of `G` are used only to produce that open normal subgroup.

Two supporting changes to existing modules make this possible and are part of the same topic. The body of `explicitFiniteQuotientSystem1` is exposed, because a cocone on it has to be written with `H¹(G ⧸ U, M^U)` for its source objects and `explicitFiniteQuotientTransition1` for its arrows, and those two fields have to reduce outside the module defining them. `descendZ1` and `explicitInfl1_descendZ1` in `Inflation.lean`, previously private helpers of the inflation-restriction proof, become public: they are what makes surjectivity strict, and re-deriving the descent here would duplicate them.

Nothing is vendored. The cocone condition is the compatible-pair functoriality already in `ExplicitFunctoriality.lean`, the open normal subgroup comes from Mathlib's `ProfiniteGrp.exist_openNormalSubgroup_sub_open_nhds_of_one`, and the finite levels are filtered because `OpenNormalSubgroup G` is a `SemilatticeInf`.

New file: `TauCeti/RepresentationTheory/Homological/ContCohomology/FiniteQuotient/Colimit.lean` (327 lines).

Roadmap: ProfiniteCohomology

Consumer roadmap: ClassFieldTheory

Provenance: statements follow `TauCetiProject/TauCetiRoadmap`, `ProfiniteCohomology/README.md` §5 Layer 4 and the `FiniteQuotientColimit` section of `ProfiniteCohomology/Suggested.lean`, which fixes the names used here; the mathematics is J. Neukirch, A. Schmidt and K. Wingberg, *Cohomology of Number Fields*, 2nd ed., (1.2.5), and L. Ribes and P. Zalesskii, *Profinite Groups*, Cor. 6.5.6(a). No code was ported from any other repository.

<!--tauceti-target:v1 {"focus":"ProfiniteCohomology","id":"explicitfinitequotientcolimit1"}-->

🤖 Prepared with Claude Code
