### PR TITLE
feat: package the Spin cover of the spinor-norm kernel

### DIFF
--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Real/Basic.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Real/Basic.lean
@@ -7,7 +7,7 @@ module
 
 public import TauCeti.LinearAlgebra.CliffordAlgebra.RealForm
 public import TauCeti.LinearAlgebra.CliffordAlgebra.Spin.DoubleCover
-public import TauCeti.LinearAlgebra.CliffordAlgebra.Spin.SpinorNorm
+public import TauCeti.LinearAlgebra.CliffordAlgebra.Spin.SpinorNorm.Basic
 import Mathlib.Analysis.Real.Sqrt
 
 /-!

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/SpinorNorm/Basic.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/SpinorNorm/Basic.lean
@@ -378,6 +378,7 @@ theorem coe_spinToSpinorNormKernel_apply
   by rw [spinToSpinorNormKernel, MonoidHom.codRestrict_apply]
 
 /-- Corestricting the Spin action to the spinor-norm kernel does not change its kernel. -/
+@[simp]
 theorem ker_spinToSpinorNormKernel
     (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) :
     MonoidHom.ker (spinToSpinorNormKernel Q hQ) =
@@ -388,13 +389,9 @@ theorem ker_spinToSpinorNormKernel
 theorem spinToSpinorNormKernel_surjective
     (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) :
     Function.Surjective (spinToSpinorNormKernel Q hQ) := by
-  intro g
-  have hg : (g : QuadraticMap.specialOrthogonalGroup Q) ∈
-      MonoidHom.range (spinToSpecialOrthogonal Q) := by
-    rw [range_spinToSpecialOrthogonal_eq_ker_spinorNorm Q hQ]
-    exact g.2
-  obtain ⟨x, hx⟩ := hg
-  exact ⟨x, Subtype.ext hx⟩
+  apply (Set.surjective_codRestrict fun x ↦
+    MonoidHom.mem_ker.mpr (spinorNorm_spinToSpecialOrthogonal Q hQ x)).2
+  rw [← MonoidHom.coe_range, range_spinToSpecialOrthogonal_eq_ker_spinorNorm Q hQ]
 
 /-- If every value of a finite-dimensional nondegenerate quadratic form is a square, the Spin
 action on its special orthogonal group is surjective. This differs from

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/SpinorNorm/Basic.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/SpinorNorm/Basic.lean
@@ -32,6 +32,8 @@ Spin group.
   hypothesis makes the Spin action surjective.
 * `CliffordAlgebra.range_spinToSpecialOrthogonal_eq_ker_spinorNorm`: the Spin image is
   the kernel of the spinor norm.
+* `CliffordAlgebra.spinToSpinorNormKernel`: the Spin action corestricted to that kernel.
+* `CliffordAlgebra.spinToSpinorNormKernel_surjective`: the corestricted action is surjective.
 
 ## References
 
@@ -358,6 +360,41 @@ theorem range_spinToSpecialOrthogonal_eq_ker_spinorNorm
     have hv := congrArg (fun z : QuadraticMap.orthogonalGroup Q => ((z : V ≃ₗ[K] V) v)) horth
     rw [coe_spinToOrthogonal_apply] at hv
     exact hv
+
+/-- The Spin action with codomain restricted to the kernel of the spinor norm. -/
+noncomputable def spinToSpinorNormKernel
+    (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) :
+    spinGroup Q →* MonoidHom.ker (spinorNorm Q hQ) :=
+  (spinToSpecialOrthogonal Q).codRestrict _ fun x ↦
+    MonoidHom.mem_ker.mpr (spinorNorm_spinToSpecialOrthogonal Q hQ x)
+
+/-- After inclusion into the special orthogonal group, `spinToSpinorNormKernel` is the usual Spin
+action. -/
+@[simp]
+theorem coe_spinToSpinorNormKernel_apply
+    (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) (x : spinGroup Q) :
+    ((spinToSpinorNormKernel Q hQ x : MonoidHom.ker (spinorNorm Q hQ)) :
+      QuadraticMap.specialOrthogonalGroup Q) = spinToSpecialOrthogonal Q x :=
+  by rw [spinToSpinorNormKernel, MonoidHom.codRestrict_apply]
+
+/-- Corestricting the Spin action to the spinor-norm kernel does not change its kernel. -/
+theorem ker_spinToSpinorNormKernel
+    (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) :
+    MonoidHom.ker (spinToSpinorNormKernel Q hQ) =
+      MonoidHom.ker (spinToSpecialOrthogonal Q) := by
+  rw [spinToSpinorNormKernel, MonoidHom.ker_codRestrict]
+
+/-- The Spin action is surjective onto the kernel of the spinor norm. -/
+theorem spinToSpinorNormKernel_surjective
+    (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) :
+    Function.Surjective (spinToSpinorNormKernel Q hQ) := by
+  intro g
+  have hg : (g : QuadraticMap.specialOrthogonalGroup Q) ∈
+      MonoidHom.range (spinToSpecialOrthogonal Q) := by
+    rw [range_spinToSpecialOrthogonal_eq_ker_spinorNorm Q hQ]
+    exact g.2
+  obtain ⟨x, hx⟩ := hg
+  exact ⟨x, Subtype.ext hx⟩
 
 /-- If every value of a finite-dimensional nondegenerate quadratic form is a square, the Spin
 action on its special orthogonal group is surjective. This differs from

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/SpinorNorm/DoubleCover.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/SpinorNorm/DoubleCover.lean
@@ -6,7 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.LinearAlgebra.CliffordAlgebra.Spin.DoubleCover
-public import TauCeti.LinearAlgebra.CliffordAlgebra.Spin.SpinorNorm
+public import TauCeti.LinearAlgebra.CliffordAlgebra.Spin.SpinorNorm.Basic
 
 /-!
 # The Spin cover of the spinor-norm kernel
@@ -17,17 +17,16 @@ that kernel and packages the resulting short exact sequence as a group extension
 
 ## Main definitions and results
 
-* `CliffordAlgebra.spinToSpinorNormKernel` is the Spin action with codomain restricted to the
-  spinor-norm kernel.
-* `CliffordAlgebra.spinToSpinorNormKernel_surjective` proves that this restricted action is
-  surjective.
 * `CliffordAlgebra.spinDoubleCoverSpinorNormKernel` packages the short exact sequence with kernel
   `Multiplicative (ZMod 2)`.
+* `CliffordAlgebra.spinDoubleCoverSpinorNormKernel_inl_ofAdd_one` and
+  `CliffordAlgebra.spinDoubleCoverSpinorNormKernel_rightHom` identify its two maps.
 
 ## References
 
-See H. B. Lawson and M.-L. Michelsohn, *Spin Geometry* (1989), Chapter I §2. The extension API
-and proof structure are adapted from `TauCeti.LinearAlgebra.CliffordAlgebra.Spin.DoubleCover`.
+See H. B. Lawson and M.-L. Michelsohn, *Spin Geometry* (1989), Chapter I §2. This is the
+spinor-norm-kernel analogue of the Spin extension in
+`TauCeti.LinearAlgebra.CliffordAlgebra.Spin.DoubleCover`.
 -/
 
 public section
@@ -43,34 +42,6 @@ universe u v
 variable {K : Type u} {V : Type v} [Field K] [AddCommGroup V] [Module K V]
   [FiniteDimensional K V] [Invertible (2 : K)]
 
-/-- The Spin action with codomain restricted to the kernel of the spinor norm. -/
-noncomputable def spinToSpinorNormKernel
-    (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) :
-    spinGroup Q →* MonoidHom.ker (spinorNorm Q hQ) :=
-  (spinToSpecialOrthogonal Q).codRestrict _ fun x ↦
-    MonoidHom.mem_ker.mpr (spinorNorm_spinToSpecialOrthogonal Q hQ x)
-
-/-- After inclusion into the special orthogonal group, `spinToSpinorNormKernel` is the usual Spin
-action. -/
-@[simp]
-theorem coe_spinToSpinorNormKernel_apply
-    (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) (x : spinGroup Q) :
-    ((spinToSpinorNormKernel Q hQ x : MonoidHom.ker (spinorNorm Q hQ)) :
-      QuadraticMap.specialOrthogonalGroup Q) = spinToSpecialOrthogonal Q x :=
-  by rw [spinToSpinorNormKernel, MonoidHom.codRestrict_apply]
-
-/-- The Spin action is surjective onto the kernel of the spinor norm. -/
-theorem spinToSpinorNormKernel_surjective
-    (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) :
-    Function.Surjective (spinToSpinorNormKernel Q hQ) := by
-  intro g
-  have hg : (g : QuadraticMap.specialOrthogonalGroup Q) ∈
-      MonoidHom.range (spinToSpecialOrthogonal Q) := by
-    rw [range_spinToSpecialOrthogonal_eq_ker_spinorNorm Q hQ]
-    exact g.2
-  obtain ⟨x, hx⟩ := hg
-  exact ⟨x, Subtype.ext hx⟩
-
 /-- For a positive-dimensional finite nondegenerate quadratic space over a field in which `2` is
 invertible, the Spin group is an extension of the spinor-norm kernel by `ZMod 2`. -/
 noncomputable def spinDoubleCoverSpinorNormKernel [Nontrivial V]
@@ -80,11 +51,7 @@ noncomputable def spinDoubleCoverSpinorNormKernel [Nontrivial V]
   GroupExtension.ofMulEquivKer
     (spinToSpinorNormKernel_surjective Q hQ)
     ((zmodTwoMulEquivKerSpinToSpecialOrthogonal Q hQ).trans <|
-      MulEquiv.subgroupCongr
-        (MonoidHom.ker_codRestrict (spinToSpecialOrthogonal Q)
-          (MonoidHom.ker (spinorNorm Q hQ))
-          (fun x ↦ MonoidHom.mem_ker.mpr
-            (spinorNorm_spinToSpecialOrthogonal Q hQ x))).symm)
+      MulEquiv.subgroupCongr (ker_spinToSpinorNormKernel Q hQ).symm)
 
 /-- The inclusion in the Spin cover of the spinor-norm kernel sends the generator to the scalar
 `-1`. -/
@@ -95,6 +62,11 @@ theorem spinDoubleCoverSpinorNormKernel_inl_ofAdd_one [Nontrivial V]
       spinGroup.negOne Q hQ.ne_zero := by
   rw [spinDoubleCoverSpinorNormKernel, GroupExtension.ofMulEquivKer_inl,
     MonoidHom.comp_apply]
+  change ((((zmodTwoMulEquivKerSpinToSpecialOrthogonal Q hQ).trans <|
+    MulEquiv.subgroupCongr (ker_spinToSpinorNormKernel Q hQ).symm)
+      (Multiplicative.ofAdd 1) : MonoidHom.ker (spinToSpinorNormKernel Q hQ)) :
+        spinGroup Q) = spinGroup.negOne Q hQ.ne_zero
+  rw [MulEquiv.trans_apply, MulEquiv.subgroupCongr_apply]
   exact congrArg Subtype.val
     (zmodTwoMulEquivKerSpinToSpecialOrthogonal_apply_ofAdd_one Q hQ)
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/SpinorNorm/DoubleCover.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/SpinorNorm/DoubleCover.lean
@@ -12,8 +12,8 @@ public import TauCeti.LinearAlgebra.CliffordAlgebra.Spin.SpinorNorm.Basic
 # The Spin cover of the spinor-norm kernel
 
 Over a general field, the Spin action need not be surjective onto the whole special orthogonal
-group. Its image is exactly the kernel of the spinor norm. This file corestricts the action to
-that kernel and packages the resulting short exact sequence as a group extension.
+group. Its image is exactly the kernel of the spinor norm. `SpinorNorm.Basic` corestricts the
+action to that kernel; this file packages the resulting short exact sequence as a group extension.
 
 ## Main definitions and results
 
@@ -62,13 +62,9 @@ theorem spinDoubleCoverSpinorNormKernel_inl_ofAdd_one [Nontrivial V]
       spinGroup.negOne Q hQ.ne_zero := by
   rw [spinDoubleCoverSpinorNormKernel, GroupExtension.ofMulEquivKer_inl,
     MonoidHom.comp_apply]
-  change ((((zmodTwoMulEquivKerSpinToSpecialOrthogonal Q hQ).trans <|
-    MulEquiv.subgroupCongr (ker_spinToSpinorNormKernel Q hQ).symm)
-      (Multiplicative.ofAdd 1) : MonoidHom.ker (spinToSpinorNormKernel Q hQ)) :
-        spinGroup Q) = spinGroup.negOne Q hQ.ne_zero
-  rw [MulEquiv.trans_apply, MulEquiv.subgroupCongr_apply]
-  exact congrArg Subtype.val
-    (zmodTwoMulEquivKerSpinToSpecialOrthogonal_apply_ofAdd_one Q hQ)
+  simpa only [MulEquiv.coe_toMonoidHom, MulEquiv.trans_apply, MulEquiv.subgroupCongr_apply,
+    Subgroup.subtype_apply] using congrArg Subtype.val
+      (zmodTwoMulEquivKerSpinToSpecialOrthogonal_apply_ofAdd_one Q hQ)
 
 /-- The projection in the Spin cover of the spinor-norm kernel is the corestricted Spin action. -/
 @[simp]

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/SpinorNormDoubleCover.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/SpinorNormDoubleCover.lean
@@ -1,0 +1,107 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.LinearAlgebra.CliffordAlgebra.Spin.DoubleCover
+public import TauCeti.LinearAlgebra.CliffordAlgebra.Spin.SpinorNorm
+
+/-!
+# The Spin cover of the spinor-norm kernel
+
+Over a general field, the Spin action need not be surjective onto the whole special orthogonal
+group. Its image is exactly the kernel of the spinor norm. This file corestricts the action to
+that kernel and packages the resulting short exact sequence as a group extension.
+
+## Main definitions and results
+
+* `CliffordAlgebra.spinToSpinorNormKernel` is the Spin action with codomain restricted to the
+  spinor-norm kernel.
+* `CliffordAlgebra.spinToSpinorNormKernel_surjective` proves that this restricted action is
+  surjective.
+* `CliffordAlgebra.spinDoubleCoverSpinorNormKernel` packages the short exact sequence with kernel
+  `Multiplicative (ZMod 2)`.
+
+## References
+
+See H. B. Lawson and M.-L. Michelsohn, *Spin Geometry* (1989), Chapter I §2.
+-/
+
+public section
+
+open QuadraticMap
+
+namespace CliffordAlgebra
+
+open TauCeti
+
+universe u v
+
+variable {K : Type u} {V : Type v} [Field K] [AddCommGroup V] [Module K V]
+  [FiniteDimensional K V] [Invertible (2 : K)]
+
+/-- The Spin action with codomain restricted to the kernel of the spinor norm. -/
+noncomputable def spinToSpinorNormKernel
+    (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) :
+    spinGroup Q →* MonoidHom.ker (spinorNorm Q hQ) :=
+  (spinToSpecialOrthogonal Q).codRestrict _ fun x ↦
+    MonoidHom.mem_ker.mpr (spinorNorm_spinToSpecialOrthogonal Q hQ x)
+
+/-- After inclusion into the special orthogonal group, `spinToSpinorNormKernel` is the usual Spin
+action. -/
+@[simp]
+theorem coe_spinToSpinorNormKernel_apply
+    (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) (x : spinGroup Q) :
+    ((spinToSpinorNormKernel Q hQ x : MonoidHom.ker (spinorNorm Q hQ)) :
+      QuadraticMap.specialOrthogonalGroup Q) = spinToSpecialOrthogonal Q x :=
+  by rw [spinToSpinorNormKernel, MonoidHom.codRestrict_apply]
+
+/-- The Spin action is surjective onto the kernel of the spinor norm. -/
+theorem spinToSpinorNormKernel_surjective
+    (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) :
+    Function.Surjective (spinToSpinorNormKernel Q hQ) := by
+  intro g
+  have hg : (g : QuadraticMap.specialOrthogonalGroup Q) ∈
+      MonoidHom.range (spinToSpecialOrthogonal Q) := by
+    rw [range_spinToSpecialOrthogonal_eq_ker_spinorNorm Q hQ]
+    exact g.2
+  obtain ⟨x, hx⟩ := hg
+  exact ⟨x, Subtype.ext hx⟩
+
+/-- For a positive-dimensional finite nondegenerate quadratic space over a field in which `2` is
+invertible, the Spin group is an extension of the spinor-norm kernel by `ZMod 2`. -/
+noncomputable def spinDoubleCoverSpinorNormKernel [Nontrivial V]
+    (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) :
+    GroupExtension (Multiplicative (ZMod 2)) (spinGroup Q)
+      (MonoidHom.ker (spinorNorm Q hQ)) :=
+  GroupExtension.ofMulEquivKer
+    (spinToSpinorNormKernel_surjective Q hQ)
+    ((zmodTwoMulEquivKerSpinToSpecialOrthogonal Q hQ).trans <|
+      MulEquiv.subgroupCongr
+        (MonoidHom.ker_codRestrict (spinToSpecialOrthogonal Q)
+          (MonoidHom.ker (spinorNorm Q hQ))
+          (fun x ↦ MonoidHom.mem_ker.mpr
+            (spinorNorm_spinToSpecialOrthogonal Q hQ x))).symm)
+
+/-- The inclusion in the Spin cover of the spinor-norm kernel sends the generator to the scalar
+`-1`. -/
+@[simp]
+theorem spinDoubleCoverSpinorNormKernel_inl_ofAdd_one [Nontrivial V]
+    (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) :
+    (spinDoubleCoverSpinorNormKernel Q hQ).inl (Multiplicative.ofAdd 1) =
+      spinGroup.negOne Q hQ.ne_zero := by
+  rw [spinDoubleCoverSpinorNormKernel, GroupExtension.ofMulEquivKer_inl,
+    MonoidHom.comp_apply]
+  exact congrArg Subtype.val
+    (zmodTwoMulEquivKerSpinToSpecialOrthogonal_apply_ofAdd_one Q hQ)
+
+/-- The projection in the Spin cover of the spinor-norm kernel is the corestricted Spin action. -/
+@[simp]
+theorem spinDoubleCoverSpinorNormKernel_rightHom [Nontrivial V]
+    (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) :
+    (spinDoubleCoverSpinorNormKernel Q hQ).rightHom = spinToSpinorNormKernel Q hQ := by
+  rw [spinDoubleCoverSpinorNormKernel, GroupExtension.ofMulEquivKer_rightHom]
+
+end CliffordAlgebra

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/SpinorNormDoubleCover.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/SpinorNormDoubleCover.lean
@@ -26,7 +26,8 @@ that kernel and packages the resulting short exact sequence as a group extension
 
 ## References
 
-See H. B. Lawson and M.-L. Michelsohn, *Spin Geometry* (1989), Chapter I §2.
+See H. B. Lawson and M.-L. Michelsohn, *Spin Geometry* (1989), Chapter I §2. The extension API
+and proof structure are adapted from `TauCeti.LinearAlgebra.CliffordAlgebra.Spin.DoubleCover`.
 -/
 
 public section


### PR DESCRIPTION
This PR packages the general-field Spin action as a double cover of the spinor-norm kernel for the SpinRepresentations double-cover milestone and its real-Spin consumer.

Roadmap: RepresentationTheory
Consumer roadmap: RepresentationTheory

## Summary

Corestrict `spinToSpecialOrthogonal Q` to `MonoidHom.ker (spinorNorm Q hQ)`, prove the resulting homomorphism surjective from the existing image theorem, transport the canonical two-element Spin kernel across that corestriction, and package the result as a `GroupExtension`. The projection and distinguished-generator equations make the extension immediately usable without unfolding transported structures.

The spinor-norm theory now uses the canonical `SpinorNorm/Basic.lean` and `SpinorNorm/DoubleCover.lean` layout. The reusable corestricted action and its kernel and surjectivity laws live beside the spinor-norm image theorem, while the extension module contains only the group-extension package and its structural equations. The surjectivity proof uses Mathlib's generic `Set.surjective_codRestrict`, and the kernel normalization is available to the simplifier.

## Roadmap target

This advances the exact [SpinRepresentations Layer 2 double-cover target](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md#layer-2-the-pin-and-spin-groups-and-the-double-covers): assemble the general-field short exact sequence whose quotient is the kernel of the spinor norm. Its immediate consumer is Layer 7's real `Spin(p,q)` milestone, where this extension specializes to the component-qualified real cover. After this PR, that real milestone still needs the explicit real-signature/component statement, while the compact route separately needs the two-sheeted topological covering after #6353, then simple connectivity and the universal-cover identification.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"spin-double-cover-spinor-norm-kernel"}-->

## Verification

- Exact head: `55024d3dd11927db1f464a82b6d5ec25de2a85eb`
- Local Lean build: `lake exe cache get` and `lake build` — pass; `Build completed successfully (11152 jobs).`
- Axiom audit: `lake exe axioms` — pass; `axioms: audited 111500 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`
- Lint: `lake exe module-system`, Bash-5/GNU-sed `scripts/lint-env.sh`, `python3 scripts/lint-dot-notation.py`, Bash-5 `scripts/lint-style.sh`, and `git diff --check` — pass; all 4990 modules use the module system, 8953 declarations are documented, there are zero new environment or dot-notation violations, and all 4989 source headers conform
- Proof golf: pinned-source survey plus `lake build TauCeti.LinearAlgebra.CliffordAlgebra.Spin.SpinorNorm.Basic` and public consumer probes — pass; the manual codomain-restriction proof was replaced by `Set.surjective_codRestrict`, with no other API or import changes
- Public CI: pending for this repair head

## Scale and generality

The aggregate changes three `TauCeti/` files: it relocates the existing spinor-norm module, adds a 76-line extension module, and updates the real-form import, for 111 insertions and one deletion relative to the merge base. It adds seven public declarations. The corestricted projection and its kernel and surjectivity laws hold for every finite-dimensional quadratic space over a field with invertible `2`, including dimension zero; only the actual `ZMod 2` double-cover extension requires `[Nontrivial V]`, exactly where the canonical Spin kernel has two distinct elements.

## Scope

- **Consumes:** `range_spinToSpecialOrthogonal_eq_ker_spinorNorm`, `zmodTwoMulEquivKerSpinToSpecialOrthogonal`, Mathlib's `Set.surjective_codRestrict` and corestriction-kernel theorem, subgroup transport, and `GroupExtension.ofMulEquivKer`
- **Provides:** `spinToSpinorNormKernel`, its kernel, surjectivity, and coercion equations, and `spinDoubleCoverSpinorNormKernel` with canonical inclusion and projection equations
- **Fits:** closes the general-field spinor-norm exact-sequence boundary and supplies the algebraic extension consumed by the real `Spin(p,q)` component-qualified cover
- **Boundary:** no duplicate all-`SO(Q)` surjectivity theorem, real-signature alias, compactness, topological covering, sphere-orbit package, simple-connectivity proof, or universal-cover assertion

<sub>🤖 GPT-5.6 Sol high · TauCetiWorker @ [7518d4150b846c4524423341570c031027a1d92c](https://github.com/utensil/TauCetiWorker/commit/7518d4150b846c4524423341570c031027a1d92c) · rubrics @ [afb424eda89e8ac96d9eb69f6a88972055a4cd1b](https://github.com/utensil/TauCetiReview/commit/afb424eda89e8ac96d9eb69f6a88972055a4cd1b) · local review @ [b533e561b6d44df071c31335ed4a63ae647507d2](https://github.com/utensil/formal-land/commit/b533e561b6d44df071c31335ed4a63ae647507d2) · fixed: placement, documentation, proof-quality, reuse, api-design</sub>