### PR TITLE
feat: prove proper discontinuity for Fuchsian groups

### DIFF
--- a/TauCeti/Analysis/Complex/Fuchsian/ProperAction.lean
+++ b/TauCeti/Analysis/Complex/Fuchsian/ProperAction.lean
@@ -1,0 +1,88 @@
+/-
+Copyright (c) 2026 The Tau Ceti authors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti authors
+-/
+module
+
+public import Mathlib.Analysis.Complex.UpperHalfPlane.ProperAction
+public import TauCeti.Analysis.Complex.UpperHalfPlane.PSLAction
+
+import Mathlib.RingTheory.RootsOfUnity.Basic
+
+/-!
+# Proper action of `PSL(2, ℝ)` on the upper half-plane
+
+The Möbius action of `PSL(2, ℝ)` on the upper half-plane is continuous and proper. The
+properness is descended from Mathlib's proper `SL(2, ℝ)` action using the surjective quotient
+map `SL(2, ℝ) → PSL(2, ℝ)`. Consequently, every discrete subgroup of `PSL(2, ℝ)` acts
+properly discontinuously on the upper half-plane.
+
+This supplies the proper-discontinuity input needed to construct Hausdorff orbit quotients and
+to control stabilizers of Fuchsian groups.
+-/
+
+public section
+
+noncomputable section
+
+open scoped MatrixGroups
+
+open Matrix.SpecialLinearGroup UpperHalfPlane
+
+namespace TauCeti
+
+/-- The projective special linear group `PSL(2, ℝ)` is Hausdorff. -/
+instance : T2Space PSL(2, ℝ) := by
+  let _ : NeZero (max (Fintype.card (Fin 2)) 1) := ⟨by simp⟩
+  let _ : Finite (Subgroup.center SL(2, ℝ)) :=
+    Finite.of_equiv (rootsOfUnity (max (Fintype.card (Fin 2)) 1) ℝ)
+      (Matrix.SpecialLinearGroup.center_equiv_rootsOfUnity (n := Fin 2) (R := ℝ)).symm
+  let _ : IsClosed ((Subgroup.center SL(2, ℝ) : Subgroup SL(2, ℝ)) : Set SL(2, ℝ)) :=
+    Set.toFinite _ |>.isClosed
+  infer_instance
+
+/-- The effective `PSL(2, ℝ)` action on the upper half-plane is jointly continuous. -/
+instance : ContinuousSMul PSL(2, ℝ) ℍ where
+  continuous_smul := by
+    rw [← (QuotientGroup.isOpenQuotientMap_mk.prodMap IsOpenQuotientMap.id).continuous_comp_iff]
+    have hfun :
+        (fun p : PSL(2, ℝ) × ℍ ↦ p.1 • p.2) ∘
+            Prod.map (QuotientGroup.mk : SL(2, ℝ) → PSL(2, ℝ)) id =
+          fun p : SL(2, ℝ) × ℍ ↦ p.1 • p.2 := by
+      funext p
+      exact UpperHalfPlane.pslMk_smul p.1 p.2
+    rw [hfun]
+    exact continuous_smul
+
+/-- The effective `PSL(2, ℝ)` action on the upper half-plane is transitive. -/
+instance : MulAction.IsPretransitive PSL(2, ℝ) ℍ where
+  exists_smul_eq x y := by
+    obtain ⟨g, hg⟩ := MulAction.exists_smul_eq SL(2, ℝ) x y
+    exact ⟨(g : PSL(2, ℝ)), by simpa only [UpperHalfPlane.pslMk_smul] using hg⟩
+
+/-- The orbit map at `I` for the effective `PSL(2, ℝ)` action is proper. -/
+theorem isProperMap_psl_smul_I : IsProperMap fun g : PSL(2, ℝ) ↦ g • I := by
+  apply isProperMap_of_comp_of_surj QuotientGroup.continuous_mk (by fun_prop)
+  · have hfun :
+        (fun g : PSL(2, ℝ) ↦ g • I) ∘
+            (QuotientGroup.mk : SL(2, ℝ) → PSL(2, ℝ)) =
+          fun g : SL(2, ℝ) ↦ g • I := by
+      funext g
+      exact UpperHalfPlane.pslMk_smul g I
+    rw [hfun]
+    exact isProperMap_smul_I
+  · exact QuotientGroup.mk_surjective
+
+/-- The effective `PSL(2, ℝ)` action on the upper half-plane is proper. -/
+instance : ProperSMul PSL(2, ℝ) ℍ :=
+  MulAction.properSMul_of_proper_orbitMap isProperMap_psl_smul_I
+
+/-- Every discrete subgroup of `PSL(2, ℝ)` acts properly discontinuously on the upper
+half-plane. -/
+instance (G : Subgroup PSL(2, ℝ)) [DiscreteTopology G] : ProperlyDiscontinuousSMul G ℍ := by
+  have : IsClosed (G : Set PSL(2, ℝ)) := Subgroup.isClosed_of_discrete
+  rw [properlyDiscontinuousSMul_iff_properSMul]
+  infer_instance
+
+end TauCeti

--- a/TauCeti/Analysis/Complex/Fuchsian/ProperAction.lean
+++ b/TauCeti/Analysis/Complex/Fuchsian/ProperAction.lean
@@ -5,18 +5,14 @@ Authors: The Tau Ceti authors
 -/
 module
 
-public import Mathlib.Analysis.Complex.UpperHalfPlane.ProperAction
-public import TauCeti.Analysis.Complex.UpperHalfPlane.PSLAction
-
-import Mathlib.RingTheory.RootsOfUnity.Basic
+public import TauCeti.Analysis.Complex.UpperHalfPlane.ProperAction
 
 /-!
-# Proper action of `PSL(2, ℝ)` on the upper half-plane
+# Properly discontinuous actions of Fuchsian groups
 
-The Möbius action of `PSL(2, ℝ)` on the upper half-plane is continuous and proper. The
-properness is descended from Mathlib's proper `SL(2, ℝ)` action using the surjective quotient
-map `SL(2, ℝ) → PSL(2, ℝ)`. Consequently, every discrete subgroup of `PSL(2, ℝ)` acts
-properly discontinuously on the upper half-plane.
+Every discrete subgroup of `PSL(2, ℝ)` acts properly discontinuously on the upper half-plane,
+as a consequence of the proper projective action constructed in
+`TauCeti.Analysis.Complex.UpperHalfPlane.ProperAction`.
 
 This supplies the proper-discontinuity input needed to construct Hausdorff orbit quotients and
 to control stabilizers of Fuchsian groups.
@@ -28,55 +24,9 @@ noncomputable section
 
 open scoped MatrixGroups
 
-open Matrix.SpecialLinearGroup UpperHalfPlane
+open UpperHalfPlane
 
 namespace TauCeti
-
-/-- The projective special linear group `PSL(2, ℝ)` is Hausdorff. -/
-instance : T2Space PSL(2, ℝ) := by
-  let _ : NeZero (max (Fintype.card (Fin 2)) 1) := ⟨by simp⟩
-  let _ : Finite (Subgroup.center SL(2, ℝ)) :=
-    Finite.of_equiv (rootsOfUnity (max (Fintype.card (Fin 2)) 1) ℝ)
-      (Matrix.SpecialLinearGroup.center_equiv_rootsOfUnity (n := Fin 2) (R := ℝ)).symm
-  let _ : IsClosed ((Subgroup.center SL(2, ℝ) : Subgroup SL(2, ℝ)) : Set SL(2, ℝ)) :=
-    Set.toFinite _ |>.isClosed
-  infer_instance
-
-/-- The effective `PSL(2, ℝ)` action on the upper half-plane is jointly continuous. -/
-instance : ContinuousSMul PSL(2, ℝ) ℍ where
-  continuous_smul := by
-    rw [← (QuotientGroup.isOpenQuotientMap_mk.prodMap IsOpenQuotientMap.id).continuous_comp_iff]
-    have hfun :
-        (fun p : PSL(2, ℝ) × ℍ ↦ p.1 • p.2) ∘
-            Prod.map (QuotientGroup.mk : SL(2, ℝ) → PSL(2, ℝ)) id =
-          fun p : SL(2, ℝ) × ℍ ↦ p.1 • p.2 := by
-      funext p
-      exact UpperHalfPlane.pslMk_smul p.1 p.2
-    rw [hfun]
-    exact continuous_smul
-
-/-- The effective `PSL(2, ℝ)` action on the upper half-plane is transitive. -/
-instance : MulAction.IsPretransitive PSL(2, ℝ) ℍ where
-  exists_smul_eq x y := by
-    obtain ⟨g, hg⟩ := MulAction.exists_smul_eq SL(2, ℝ) x y
-    exact ⟨(g : PSL(2, ℝ)), by simpa only [UpperHalfPlane.pslMk_smul] using hg⟩
-
-/-- The orbit map at `I` for the effective `PSL(2, ℝ)` action is proper. -/
-theorem isProperMap_psl_smul_I : IsProperMap fun g : PSL(2, ℝ) ↦ g • I := by
-  apply isProperMap_of_comp_of_surj QuotientGroup.continuous_mk (by fun_prop)
-  · have hfun :
-        (fun g : PSL(2, ℝ) ↦ g • I) ∘
-            (QuotientGroup.mk : SL(2, ℝ) → PSL(2, ℝ)) =
-          fun g : SL(2, ℝ) ↦ g • I := by
-      funext g
-      exact UpperHalfPlane.pslMk_smul g I
-    rw [hfun]
-    exact isProperMap_smul_I
-  · exact QuotientGroup.mk_surjective
-
-/-- The effective `PSL(2, ℝ)` action on the upper half-plane is proper. -/
-instance : ProperSMul PSL(2, ℝ) ℍ :=
-  MulAction.properSMul_of_proper_orbitMap isProperMap_psl_smul_I
 
 /-- Every discrete subgroup of `PSL(2, ℝ)` acts properly discontinuously on the upper
 half-plane. -/

--- a/TauCeti/Analysis/Complex/UpperHalfPlane/PSLAction.lean
+++ b/TauCeti/Analysis/Complex/UpperHalfPlane/PSLAction.lean
@@ -5,9 +5,7 @@ Authors: Chris Birkbeck
 -/
 module
 
-public import Mathlib.Analysis.Complex.UpperHalfPlane.Manifold
 public import Mathlib.Analysis.Complex.UpperHalfPlane.Measure
-public import Mathlib.Geometry.Manifold.Algebra.SMul
 public import TauCeti.LinearAlgebra.Matrix.ProjectiveSpecialLinearGroup
 -- supplies the `FaithfulSMul PGL(2, ℝ) ℍ` instance behind the projective faithfulness
 import Mathlib.Analysis.Complex.UpperHalfPlane.FixedPoints
@@ -31,8 +29,6 @@ Mathlib's `GL(2, ℝ)`-invariance).
 * `UpperHalfPlane.instMulActionPSL2` — the `PSL(2, R)`-action for any coefficients mapping
   to `ℝ`, descending the `SL(2, R)`-action along the central quotient, with the
   representative compatibility `pslMk_smul`.
-* `TauCeti.instContMDiffConstSMulPSL2UpperHalfPlane` — every element of `PSL(2, ℝ)`
-  acts by a biholomorphism.
 * `FaithfulSMul` instances for `PSL(2, ℤ)` and `PSL(2, ℝ)` on `ℍ`, restricting Mathlib's
   faithful `PGL(2, ℝ)`-action along the injective `toPGL` and `psl2zToPSL2R`.
 * `SMulInvariantMeasure` instances for `SL(2, R)` and `PSL(2, R)` (any coefficients
@@ -62,7 +58,7 @@ public section
 
 noncomputable section
 
-open scoped ContDiff Manifold MatrixGroups Pointwise
+open scoped MatrixGroups Pointwise
 
 open ModularGroup UpperHalfPlane Matrix.SpecialLinearGroup MeasureTheory
 
@@ -143,24 +139,6 @@ noncomputable instance : MeasurableConstSMul PSL(2, R) ℍ where
     refine QuotientGroup.induction_on g fun a ↦ ?_
     simp only [pslMk_smul]
     exact measurable_const_smul a
-
-end UpperHalfPlane
-
-namespace TauCeti
-
-/-- Every element of `PSL(2, ℝ)` acts on the upper half-plane by a biholomorphism. -/
-noncomputable instance instContMDiffConstSMulPSL2UpperHalfPlane :
-    ContMDiffConstSMul 𝓘(ℂ) ∞ PSL(2, ℝ) ℍ where
-  contMDiff_const_smul g := by
-    refine QuotientGroup.induction_on g fun a ↦ ?_
-    change CMDiff ∞ fun x : ℍ ↦ (a : SL(2, ℝ)) • x
-    exact UpperHalfPlane.contMDiff_smul (n := ∞) (g := a) (by simp)
-
-end TauCeti
-
-namespace UpperHalfPlane
-
-variable {R : Type*} [CommRing R] [Algebra R ℝ]
 
 /-- `PSL(2, R)` preserves the invariant measure on `ℍ`, descending the `SL(2, R)`
 invariance. -/

--- a/TauCeti/Analysis/Complex/UpperHalfPlane/PSLAction.lean
+++ b/TauCeti/Analysis/Complex/UpperHalfPlane/PSLAction.lean
@@ -5,7 +5,9 @@ Authors: Chris Birkbeck
 -/
 module
 
+public import Mathlib.Analysis.Complex.UpperHalfPlane.Manifold
 public import Mathlib.Analysis.Complex.UpperHalfPlane.Measure
+public import Mathlib.Geometry.Manifold.Algebra.SMul
 public import TauCeti.LinearAlgebra.Matrix.ProjectiveSpecialLinearGroup
 -- supplies the `FaithfulSMul PGL(2, ℝ) ℍ` instance behind the projective faithfulness
 import Mathlib.Analysis.Complex.UpperHalfPlane.FixedPoints
@@ -29,6 +31,8 @@ Mathlib's `GL(2, ℝ)`-invariance).
 * `UpperHalfPlane.instMulActionPSL2` — the `PSL(2, R)`-action for any coefficients mapping
   to `ℝ`, descending the `SL(2, R)`-action along the central quotient, with the
   representative compatibility `pslMk_smul`.
+* `TauCeti.instContMDiffConstSMulPSL2UpperHalfPlane` — every element of `PSL(2, ℝ)`
+  acts by a biholomorphism.
 * `FaithfulSMul` instances for `PSL(2, ℤ)` and `PSL(2, ℝ)` on `ℍ`, restricting Mathlib's
   faithful `PGL(2, ℝ)`-action along the injective `toPGL` and `psl2zToPSL2R`.
 * `SMulInvariantMeasure` instances for `SL(2, R)` and `PSL(2, R)` (any coefficients
@@ -58,7 +62,7 @@ public section
 
 noncomputable section
 
-open scoped MatrixGroups Pointwise
+open scoped ContDiff Manifold MatrixGroups Pointwise
 
 open ModularGroup UpperHalfPlane Matrix.SpecialLinearGroup MeasureTheory
 
@@ -139,6 +143,24 @@ noncomputable instance : MeasurableConstSMul PSL(2, R) ℍ where
     refine QuotientGroup.induction_on g fun a ↦ ?_
     simp only [pslMk_smul]
     exact measurable_const_smul a
+
+end UpperHalfPlane
+
+namespace TauCeti
+
+/-- Every element of `PSL(2, ℝ)` acts on the upper half-plane by a biholomorphism. -/
+noncomputable instance instContMDiffConstSMulPSL2UpperHalfPlane :
+    ContMDiffConstSMul 𝓘(ℂ) ∞ PSL(2, ℝ) ℍ where
+  contMDiff_const_smul g := by
+    refine QuotientGroup.induction_on g fun a ↦ ?_
+    change CMDiff ∞ fun x : ℍ ↦ (a : SL(2, ℝ)) • x
+    exact UpperHalfPlane.contMDiff_smul (n := ∞) (g := a) (by simp)
+
+end TauCeti
+
+namespace UpperHalfPlane
+
+variable {R : Type*} [CommRing R] [Algebra R ℝ]
 
 /-- `PSL(2, R)` preserves the invariant measure on `ℍ`, descending the `SL(2, R)`
 invariance. -/

--- a/TauCeti/Analysis/Complex/UpperHalfPlane/ProperAction.lean
+++ b/TauCeti/Analysis/Complex/UpperHalfPlane/ProperAction.lean
@@ -25,7 +25,7 @@ open scoped MatrixGroups
 
 open Matrix.SpecialLinearGroup UpperHalfPlane
 
-namespace TauCeti
+namespace TauCeti.UpperHalfPlane
 
 /-- The effective `PSL(2, ℝ)` action on the upper half-plane is jointly continuous. -/
 instance : ContinuousSMul PSL(2, ℝ) ℍ where
@@ -63,4 +63,4 @@ theorem isProperMap_psl_smul_I : IsProperMap fun g : PSL(2, ℝ) ↦ g • I := 
 instance : ProperSMul PSL(2, ℝ) ℍ :=
   MulAction.properSMul_of_proper_orbitMap isProperMap_psl_smul_I
 
-end TauCeti
+end TauCeti.UpperHalfPlane

--- a/TauCeti/Analysis/Complex/UpperHalfPlane/ProperAction.lean
+++ b/TauCeti/Analysis/Complex/UpperHalfPlane/ProperAction.lean
@@ -7,8 +7,7 @@ module
 
 public import Mathlib.Analysis.Complex.UpperHalfPlane.ProperAction
 public import TauCeti.Analysis.Complex.UpperHalfPlane.PSLAction
-
-import TauCeti.LinearAlgebra.Matrix.SpecialLinearGroup.Basic
+public import TauCeti.Topology.Algebra.Matrix.ProjectiveSpecialLinearGroup
 
 /-!
 # Proper action of `PSL(2, ℝ)` on the upper half-plane
@@ -27,14 +26,6 @@ open scoped MatrixGroups
 open Matrix.SpecialLinearGroup UpperHalfPlane
 
 namespace TauCeti
-
-/-- The projective special linear group `PSL(2, ℝ)` is Hausdorff. -/
-instance : T2Space PSL(2, ℝ) := by
-  let _ : Finite (Subgroup.center SL(2, ℝ)) :=
-    Matrix.SpecialLinearGroup.finite_center (R := ℝ)
-  let _ : IsClosed ((Subgroup.center SL(2, ℝ) : Subgroup SL(2, ℝ)) : Set SL(2, ℝ)) :=
-    Set.toFinite _ |>.isClosed
-  infer_instance
 
 /-- The effective `PSL(2, ℝ)` action on the upper half-plane is jointly continuous. -/
 instance : ContinuousSMul PSL(2, ℝ) ℍ where

--- a/TauCeti/Analysis/Complex/UpperHalfPlane/ProperAction.lean
+++ b/TauCeti/Analysis/Complex/UpperHalfPlane/ProperAction.lean
@@ -1,0 +1,75 @@
+/-
+Copyright (c) 2026 The Tau Ceti authors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti authors
+-/
+module
+
+public import Mathlib.Analysis.Complex.UpperHalfPlane.ProperAction
+public import TauCeti.Analysis.Complex.UpperHalfPlane.PSLAction
+
+import TauCeti.LinearAlgebra.Matrix.SpecialLinearGroup.Basic
+
+/-!
+# Proper action of `PSL(2, ℝ)` on the upper half-plane
+
+The Möbius action of `PSL(2, ℝ)` on the upper half-plane is continuous and proper. The
+properness is descended from Mathlib's proper `SL(2, ℝ)` action using the surjective quotient
+map `SL(2, ℝ) → PSL(2, ℝ)`.
+-/
+
+public section
+
+noncomputable section
+
+open scoped MatrixGroups
+
+open Matrix.SpecialLinearGroup UpperHalfPlane
+
+namespace TauCeti
+
+/-- The projective special linear group `PSL(2, ℝ)` is Hausdorff. -/
+instance : T2Space PSL(2, ℝ) := by
+  let _ : Finite (Subgroup.center SL(2, ℝ)) :=
+    Matrix.SpecialLinearGroup.finite_center (R := ℝ)
+  let _ : IsClosed ((Subgroup.center SL(2, ℝ) : Subgroup SL(2, ℝ)) : Set SL(2, ℝ)) :=
+    Set.toFinite _ |>.isClosed
+  infer_instance
+
+/-- The effective `PSL(2, ℝ)` action on the upper half-plane is jointly continuous. -/
+instance : ContinuousSMul PSL(2, ℝ) ℍ where
+  continuous_smul := by
+    rw [← (QuotientGroup.isOpenQuotientMap_mk.prodMap IsOpenQuotientMap.id).continuous_comp_iff]
+    have hfun :
+        (fun p : PSL(2, ℝ) × ℍ ↦ p.1 • p.2) ∘
+            Prod.map (QuotientGroup.mk : SL(2, ℝ) → PSL(2, ℝ)) id =
+          fun p : SL(2, ℝ) × ℍ ↦ p.1 • p.2 := by
+      funext p
+      exact UpperHalfPlane.pslMk_smul p.1 p.2
+    rw [hfun]
+    exact continuous_smul
+
+/-- The effective `PSL(2, ℝ)` action on the upper half-plane is transitive. -/
+instance : MulAction.IsPretransitive PSL(2, ℝ) ℍ where
+  exists_smul_eq x y := by
+    obtain ⟨g, hg⟩ := MulAction.exists_smul_eq SL(2, ℝ) x y
+    exact ⟨(g : PSL(2, ℝ)), by simpa only [UpperHalfPlane.pslMk_smul] using hg⟩
+
+/-- The orbit map at `I` for the effective `PSL(2, ℝ)` action is proper. -/
+theorem isProperMap_psl_smul_I : IsProperMap fun g : PSL(2, ℝ) ↦ g • I := by
+  apply isProperMap_of_comp_of_surj QuotientGroup.continuous_mk (by fun_prop)
+  · have hfun :
+        (fun g : PSL(2, ℝ) ↦ g • I) ∘
+            (QuotientGroup.mk : SL(2, ℝ) → PSL(2, ℝ)) =
+          fun g : SL(2, ℝ) ↦ g • I := by
+      funext g
+      exact UpperHalfPlane.pslMk_smul g I
+    rw [hfun]
+    exact isProperMap_smul_I
+  · exact QuotientGroup.mk_surjective
+
+/-- The effective `PSL(2, ℝ)` action on the upper half-plane is proper. -/
+instance : ProperSMul PSL(2, ℝ) ℍ :=
+  MulAction.properSMul_of_proper_orbitMap isProperMap_psl_smul_I
+
+end TauCeti

--- a/TauCeti/Topology/Algebra/Matrix/ProjectiveSpecialLinearGroup.lean
+++ b/TauCeti/Topology/Algebra/Matrix/ProjectiveSpecialLinearGroup.lean
@@ -1,0 +1,37 @@
+/-
+Copyright (c) 2026 The Tau Ceti authors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti authors
+-/
+module
+
+public import Mathlib.Topology.Algebra.Group.Matrix
+public import Mathlib.Topology.Algebra.ProperAction.Basic
+public import TauCeti.LinearAlgebra.Matrix.ProjectiveSpecialLinearGroup
+
+import TauCeti.LinearAlgebra.Matrix.SpecialLinearGroup.Basic
+
+/-!
+# Topology on `PSL(2, ℝ)`
+
+The quotient topology on the projective special linear group `PSL(2, ℝ)` is Hausdorff
+because the center of `SL(2, ℝ)` is finite, hence closed.
+-/
+
+public section
+
+open scoped MatrixGroups
+
+open Matrix.SpecialLinearGroup
+
+namespace TauCeti
+
+/-- The projective special linear group `PSL(2, ℝ)` is Hausdorff. -/
+instance : T2Space PSL(2, ℝ) := by
+  let _ : Finite (Subgroup.center SL(2, ℝ)) :=
+    Matrix.SpecialLinearGroup.finite_center (R := ℝ)
+  let _ : IsClosed ((Subgroup.center SL(2, ℝ) : Subgroup SL(2, ℝ)) : Set SL(2, ℝ)) :=
+    Set.toFinite _ |>.isClosed
+  infer_instance
+
+end TauCeti

--- a/TauCeti/Topology/Algebra/Matrix/ProjectiveSpecialLinearGroup.lean
+++ b/TauCeti/Topology/Algebra/Matrix/ProjectiveSpecialLinearGroup.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti authors
 module
 
 public import Mathlib.Topology.Algebra.Group.Matrix
-public import Mathlib.Topology.Algebra.ProperAction.Basic
 public import TauCeti.LinearAlgebra.Matrix.ProjectiveSpecialLinearGroup
 
 import TauCeti.LinearAlgebra.Matrix.SpecialLinearGroup.Basic


### PR DESCRIPTION
This PR establishes the Hausdorff quotient topology and continuous proper Möbius action of `PSL(2, ℝ)`, then derives proper discontinuity for every discrete projective subgroup. It descends the proper orbit map from Mathlib's `UpperHalfPlane.isProperMap_smul_I` along the surjective central quotient, so the construction makes no choice of matrix representative.

The exact target is `FuchsianOrbifolds/README.md`, Layer 0, item 3: prove that a discrete subgroup `Γ ≤ PSL(2, ℝ)` acts properly discontinuously. This advances completion milestone 1, whose effective faithful action was already on `main`; it is the most direct next step because proper discontinuity supplies the finite-stabilizer and quotient-separation input used throughout the elliptic, cusp, and compactification layers.

After this PR, Layer 0 still needs the cyclic classification and derivative order of nontrivial stabilizers, followed by the open invariant free locus and its covering/local-biholomorphism quotient.

The new 88-line module `TauCeti.Analysis.Complex.Fuchsian.ProperAction` provides the `T2Space`, `ContinuousSMul`, transitivity, and `ProperSMul` instances for the effective projective action, the proper orbit-map theorem, and the `ProperlyDiscontinuousSMul` instance for discrete subgroups. It reuses Mathlib's proper `SL(2, ℝ)` action, open quotient-map API, proper-map descent along a surjection, and equivalence between the center of `SL` and roots of unity. No Mathlib source or external formalization is vendored.

Roadmap: FuchsianOrbifolds

<!--tauceti-target:v1 {"focus":"FuchsianOrbifolds","id":"properly-discontinuous-psl-subgroup"}-->

🤖 Prepared with Codex
