### PR TITLE
feat: identify the CAR staircase weight

### DIFF
--- a/TauCeti/Algebra/Lie/GeneralLinear/CAR/WeightUniqueness.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/CAR/WeightUniqueness.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Algebra.Lie.GeneralLinear.HighestWeight
 public import TauCeti.Combinatorics.Majorization
 
 import Mathlib.Tactic
@@ -16,13 +15,11 @@ import Mathlib.Tactic
 The half-integral weights arising from the CAR model have the form `a i + 1 / 2`, where `a` is a
 tuple of natural-number occupation counts. This file specializes the integer staircase criterion
 from `TauCeti.Combinatorics.Majorization` to the finite natural-number tuples produced by that
-model. The scalar normal form
-`TauCeti.natCast_fin_rev_add_one_div_two_eq_glHalfStaircase` then identifies the recovered tuple
-with the existing half-staircase weight.
+model.
 
 ## Main results
 
-* `TauCeti.eq_fin_rev_of_antitone_of_prefix_sum_le_of_sum_eq_of_casimir_eq`: a natural occupation
+* `TauCeti.eq_finRev_of_antitone_of_prefix_sum_le_of_sum_eq_of_casimir_eq`: a natural occupation
   tuple dominated by `Fin.rev`, with the same total and quadratic sum, is `Fin.rev`.
 
 ## References
@@ -47,7 +44,7 @@ sums are equal. If the two tuples also have the same value under
 
 then `a` is the reverse-index tuple. For CAR highest weights this is the integral form of the
 trace-form `gl_N` Casimir polynomial after a common half-unit shift. -/
-theorem eq_fin_rev_of_antitone_of_prefix_sum_le_of_sum_eq_of_casimir_eq
+theorem eq_finRev_of_antitone_of_prefix_sum_le_of_sum_eq_of_casimir_eq
     {N : ℕ} (a : Fin N → ℕ) (ha : Antitone a)
     (hmajor : ∀ (k : ℕ) (hk : k < N),
       (∑ i : Fin k, (a (Fin.castLE hk.le i) : ℤ)) ≤

--- a/TauCeti/Algebra/Lie/GeneralLinear/CAR/WeightUniqueness.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/CAR/WeightUniqueness.lean
@@ -1,0 +1,221 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Lie.GeneralLinear.Casimir
+
+import Mathlib.Algebra.BigOperators.Module
+import Mathlib.Tactic
+
+/-!
+# Uniqueness of the staircase occupation weight
+
+The half-integral weights arising from the CAR model have the form `a i + 1 / 2`, where `a` is a
+tuple of natural-number occupation counts. This file isolates the finite inequality which
+identifies `a`: if it is antitone, is majorized by the reverse-index tuple, has the same total sum,
+and gives the same trace-form Casimir polynomial, then it is the reverse-index tuple.
+
+The proof uses discrete summation by parts. For the target `t i = N - (i + 1)`, put
+
+`D k = ∑ i < k, (t i - a i)` and `q i = t i + a i + N - 2i`.
+
+The total-sum hypothesis says `D N = 0`, while the Casimir equality and summation by parts give
+
+`0 = ∑ k < N - 1, D (k + 1) * (q k - q (k + 1))`.
+
+Majorization makes every `D (k + 1)` nonnegative. Antitonicity of `a` makes every other factor
+positive, since `q k - q (k + 1) = 3 + a k - a (k + 1)`. Thus all partial deficits vanish, which
+recovers every coordinate of `a`.
+
+## Main result
+
+* `TauCeti.eq_fin_rev_of_antitone_of_prefix_sum_le_of_sum_eq_of_casimir_eq`: the reverse-index
+  tuple is uniquely determined by dominance, its prefix sums, its total sum, and the trace-form
+  Casimir polynomial.
+
+## References
+
+* G. H. Hardy, J. E. Littlewood, G. Pólya, *Inequalities*, Cambridge University Press (1952),
+  Chapter 2, for majorization and summation by parts.
+* D. Panyushev, *The exterior algebra and "spin" of an orthogonal g-module*, Transform. Groups 6
+  (2001), 371–396, Proposition 2.4 and Example 2.5(1), for the CAR staircase-weight application.
+-/
+
+public section
+
+namespace TauCeti
+
+open scoped BigOperators
+
+/-- Discrete summation by parts, written using initial sums of `d`.
+
+The separate final term makes the statement valid without assuming that the total sum of `d`
+vanishes. This is the algebraic identity used in the staircase uniqueness proof below. -/
+private theorem sum_range_mul_eq_sum_range_partialSum_mul_sub_add
+    (d q : ℕ → ℤ) : ∀ n : ℕ,
+    (∑ i ∈ Finset.range n, d i * q i) =
+      (∑ k ∈ Finset.range (n - 1), (∑ i ∈ Finset.range (k + 1), d i) *
+        (q k - q (k + 1))) + (∑ i ∈ Finset.range n, d i) * q (n - 1) := by
+  intro n
+  have h := Finset.sum_range_by_parts q d n
+  simp only [smul_eq_mul] at h
+  calc
+    _ = ∑ i ∈ Finset.range n, q i * d i := by
+      apply Finset.sum_congr rfl
+      intro i _
+      ring
+    _ = q (n - 1) * (∑ i ∈ Finset.range n, d i) -
+        ∑ k ∈ Finset.range (n - 1),
+          (q (k + 1) - q k) * (∑ i ∈ Finset.range (k + 1), d i) := h
+    _ = _ := by
+      have hneg : -(∑ k ∈ Finset.range (n - 1),
+          (q (k + 1) - q k) * (∑ i ∈ Finset.range (k + 1), d i)) =
+          ∑ k ∈ Finset.range (n - 1),
+            (∑ i ∈ Finset.range (k + 1), d i) * (q k - q (k + 1)) := by
+        rw [← Finset.sum_neg_distrib]
+        apply Finset.sum_congr rfl
+        intro k _
+        ring
+      rw [sub_eq_add_neg, hneg]
+      ring
+
+/-- The natural-number sequence form of staircase uniqueness.
+
+This form lets the proof use ordinary range sums. The public `Fin N` statement below is the API
+for callers. -/
+private theorem eq_staircase_of_antitone_of_prefix_sum_le_of_sum_eq_of_casimir_eq
+    {N : ℕ} (a : ℕ → ℕ) (ha : ∀ i, i + 1 < N → a (i + 1) ≤ a i)
+    (hmajor : ∀ (k : ℕ), k < N →
+      (∑ i ∈ Finset.range k, (a i : ℤ)) ≤
+        ∑ i ∈ Finset.range k, ((N - (i + 1) : ℕ) : ℤ))
+    (hsum : (∑ i ∈ Finset.range N, (a i : ℤ)) =
+      ∑ i ∈ Finset.range N, ((N - (i + 1) : ℕ) : ℤ))
+    (hcasimir :
+      (∑ i ∈ Finset.range N,
+        (a i : ℤ) * ((a i : ℤ) + (N : ℤ) - 2 * i)) =
+      ∑ i ∈ Finset.range N, ((N - (i + 1) : ℕ) : ℤ) *
+        (((N - (i + 1) : ℕ) : ℤ) + (N : ℤ) - 2 * i)) :
+    ∀ i, i < N → a i = N - (i + 1) := by
+  let t : ℕ → ℤ := fun i => ((N - (i + 1) : ℕ) : ℤ)
+  let d : ℕ → ℤ := fun i => t i - a i
+  let q : ℕ → ℤ := fun i => t i + a i + N - 2 * i
+  have hsum_range : (∑ i ∈ Finset.range N, d i) = 0 := by
+    rw [Finset.sum_sub_distrib, sub_eq_zero]
+    exact hsum.symm
+  have hcasimir_range : (∑ i ∈ Finset.range N, d i * q i) = 0 := by
+    rw [show (∑ i ∈ Finset.range N, d i * q i) =
+        (∑ i ∈ Finset.range N,
+          (t i * (t i + N - 2 * i) - (a i : ℤ) * ((a i : ℤ) + N - 2 * i))) by
+      apply Finset.sum_congr rfl
+      intro i _
+      simp only [d, q]
+      ring]
+    rw [Finset.sum_sub_distrib, sub_eq_zero]
+    exact hcasimir.symm
+  have hpartial_nonneg (k : ℕ) (hk : k < N) :
+      0 ≤ ∑ i ∈ Finset.range k, d i := by
+    rw [Finset.sum_sub_distrib]
+    exact sub_nonneg.mpr (hmajor k hk)
+  have hqdiff (k : ℕ) (hk : k + 1 < N) : 0 < q k - q (k + 1) := by
+    have hak := ha k hk
+    simp only [q, t]
+    push_cast at hak ⊢
+    omega
+  have hdecomp := sum_range_mul_eq_sum_range_partialSum_mul_sub_add d q N
+  rw [hcasimir_range, hsum_range, zero_mul, add_zero] at hdecomp
+  have hterms_nonneg : ∀ k ∈ Finset.range (N - 1),
+      0 ≤ (∑ i ∈ Finset.range (k + 1), d i) * (q k - q (k + 1)) := by
+    intro k hk
+    simp only [Finset.mem_range] at hk
+    have hkN : k + 1 < N := by omega
+    exact mul_nonneg (hpartial_nonneg (k + 1) hkN) (le_of_lt (hqdiff k hkN))
+  have hterm_zero : ∀ k ∈ Finset.range (N - 1),
+      (∑ i ∈ Finset.range (k + 1), d i) * (q k - q (k + 1)) = 0 :=
+    (Finset.sum_eq_zero_iff_of_nonneg hterms_nonneg).mp hdecomp.symm
+  have hpartial_zero (k : ℕ) (hk : k ≤ N) :
+      (∑ i ∈ Finset.range k, d i) = 0 := by
+    rcases eq_or_lt_of_le hk with rfl | hkN
+    · exact hsum_range
+    rcases k with _ | k
+    · simp
+    · have hprod := hterm_zero k (by simp only [Finset.mem_range]; omega)
+      exact (mul_eq_zero.mp hprod).resolve_right (ne_of_gt (hqdiff k (by omega)))
+  intro i hiN
+  have hdi : d i = 0 := by
+    have hnext := hpartial_zero (i + 1) (by omega)
+    rw [Finset.sum_range_succ, hpartial_zero i (by omega), zero_add] at hnext
+    exact hnext
+  have hz : ((a i : ℕ) : ℤ) = ((N - (i + 1) : ℕ) : ℤ) := by
+    change t i - (a i : ℤ) = 0 at hdi
+    simpa only [t] using (sub_eq_zero.mp hdi).symm
+  exact_mod_cast hz
+
+/-- **A majorized occupation weight with the staircase Casimir value is the staircase.**
+
+Let `a : Fin N → ℕ` be weakly decreasing. Suppose every initial sum of `a` is at most the
+corresponding initial sum of the reverse-index tuple `i ↦ N - 1 - i`, and suppose the total sums
+are equal. If the two tuples also have the same value under the integral form
+
+`a ↦ ∑ i, a i * (a i + N - 2i)`
+
+of the trace-form `gl_N` Casimir polynomial after a common half-unit shift, then `a` is the
+reverse-index tuple. The prefix inequalities and total equality are the majorization condition;
+the Casimir equality makes it strict enough to determine every coordinate. -/
+theorem eq_fin_rev_of_antitone_of_prefix_sum_le_of_sum_eq_of_casimir_eq
+    {N : ℕ} (a : Fin N → ℕ) (ha : Antitone a)
+    (hmajor : ∀ (k : ℕ) (hk : k < N),
+      (∑ i : Fin k, (a (Fin.castLE hk.le i) : ℤ)) ≤
+        ∑ i : Fin k, ((Fin.rev (Fin.castLE hk.le i) : ℕ) : ℤ))
+    (hsum : (∑ i : Fin N, (a i : ℤ)) =
+      ∑ i : Fin N, ((Fin.rev i : ℕ) : ℤ))
+    (hcasimir :
+      (∑ i : Fin N, (a i : ℤ) * ((a i : ℤ) + (N : ℤ) - 2 * (i : ℕ))) =
+        ∑ i : Fin N, ((Fin.rev i : ℕ) : ℤ) *
+          (((Fin.rev i : ℕ) : ℤ) + (N : ℤ) - 2 * (i : ℕ))) :
+    a = fun i => (Fin.rev i : ℕ) := by
+  let aN : ℕ → ℕ := fun i => if hi : i < N then a ⟨i, hi⟩ else 0
+  have haN : ∀ i, i + 1 < N → aN (i + 1) ≤ aN i := by
+    intro i hi
+    have hi' : i < N := by omega
+    simpa only [aN, dite_eq_left hi, dite_eq_left hi'] using
+      ha (Fin.mk_le_mk.mpr (Nat.le_succ i) : (⟨i, hi'⟩ : Fin N) ≤ ⟨i + 1, hi⟩)
+  have hmajorN : ∀ (k : ℕ), k < N →
+      (∑ i ∈ Finset.range k, (aN i : ℤ)) ≤
+        ∑ i ∈ Finset.range k, ((N - (i + 1) : ℕ) : ℤ) := by
+    intro k hk
+    rw [← Fin.sum_univ_eq_sum_range (fun i => (aN i : ℤ)) k,
+      ← Fin.sum_univ_eq_sum_range (fun i => ((N - (i + 1) : ℕ) : ℤ)) k]
+    convert hmajor k hk using 1 <;> apply Finset.sum_congr rfl <;> intro i hi
+    · have hiN : i < N := lt_trans i.isLt hk
+      simp only [aN, dite_eq_left hiN]
+      congr 1
+    · rfl
+  have hsumN : (∑ i ∈ Finset.range N, (aN i : ℤ)) =
+      ∑ i ∈ Finset.range N, ((N - (i + 1) : ℕ) : ℤ) := by
+    rw [← Fin.sum_univ_eq_sum_range (fun i => (aN i : ℤ)) N,
+      ← Fin.sum_univ_eq_sum_range (fun i => ((N - (i + 1) : ℕ) : ℤ)) N]
+    convert hsum using 1 <;> apply Finset.sum_congr rfl <;> intro i hi
+    · simp [aN, i.isLt]
+    · rfl
+  have hcasimirN :
+      (∑ i ∈ Finset.range N,
+        (aN i : ℤ) * ((aN i : ℤ) + (N : ℤ) - 2 * i)) =
+      ∑ i ∈ Finset.range N, ((N - (i + 1) : ℕ) : ℤ) *
+        (((N - (i + 1) : ℕ) : ℤ) + (N : ℤ) - 2 * i) := by
+    rw [← Fin.sum_univ_eq_sum_range
+        (fun i => (aN i : ℤ) * ((aN i : ℤ) + (N : ℤ) - 2 * i)) N,
+      ← Fin.sum_univ_eq_sum_range
+        (fun i => ((N - (i + 1) : ℕ) : ℤ) *
+          (((N - (i + 1) : ℕ) : ℤ) + (N : ℤ) - 2 * i)) N]
+    convert hcasimir using 1 <;> apply Finset.sum_congr rfl <;> intro i hi
+    · simp [aN, i.isLt]
+    · rfl
+  funext i
+  have h := eq_staircase_of_antitone_of_prefix_sum_le_of_sum_eq_of_casimir_eq
+    aN haN hmajorN hsumN hcasimirN i i.isLt
+  simpa [aN, i.isLt, Fin.rev] using h
+
+end TauCeti

--- a/TauCeti/Algebra/Lie/GeneralLinear/CAR/WeightUniqueness.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/CAR/WeightUniqueness.lean
@@ -5,41 +5,28 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Algebra.Lie.GeneralLinear.Casimir
+public import TauCeti.Algebra.Lie.GeneralLinear.HighestWeight
+public import TauCeti.Combinatorics.Majorization
 
-import Mathlib.Algebra.BigOperators.Module
 import Mathlib.Tactic
 
 /-!
-# Uniqueness of the staircase occupation weight
+# Uniqueness of the CAR staircase occupation weight
 
 The half-integral weights arising from the CAR model have the form `a i + 1 / 2`, where `a` is a
-tuple of natural-number occupation counts. This file isolates the finite inequality which
-identifies `a`: if it is antitone, is majorized by the reverse-index tuple, has the same total sum,
-and gives the same trace-form Casimir polynomial, then it is the reverse-index tuple.
+tuple of natural-number occupation counts. This file specializes the integer staircase criterion
+from `TauCeti.Combinatorics.Majorization` to the finite natural-number tuples produced by that
+model. The scalar normal form
+`TauCeti.natCast_fin_rev_add_one_div_two_eq_glHalfStaircase` then identifies the recovered tuple
+with the existing half-staircase weight.
 
-The proof uses discrete summation by parts. For the target `t i = N - (i + 1)`, put
+## Main results
 
-`D k = ∑ i < k, (t i - a i)` and `q i = t i + a i + N - 2i`.
-
-The total-sum hypothesis says `D N = 0`, while the Casimir equality and summation by parts give
-
-`0 = ∑ k < N - 1, D (k + 1) * (q k - q (k + 1))`.
-
-Majorization makes every `D (k + 1)` nonnegative. Antitonicity of `a` makes every other factor
-positive, since `q k - q (k + 1) = 3 + a k - a (k + 1)`. Thus all partial deficits vanish, which
-recovers every coordinate of `a`.
-
-## Main result
-
-* `TauCeti.eq_fin_rev_of_antitone_of_prefix_sum_le_of_sum_eq_of_casimir_eq`: the reverse-index
-  tuple is uniquely determined by dominance, its prefix sums, its total sum, and the trace-form
-  Casimir polynomial.
+* `TauCeti.eq_fin_rev_of_antitone_of_prefix_sum_le_of_sum_eq_of_casimir_eq`: a natural occupation
+  tuple dominated by `Fin.rev`, with the same total and quadratic sum, is `Fin.rev`.
 
 ## References
 
-* G. H. Hardy, J. E. Littlewood, G. Pólya, *Inequalities*, Cambridge University Press (1952),
-  Chapter 2, for majorization and summation by parts.
 * D. Panyushev, *The exterior algebra and "spin" of an orthogonal g-module*, Transform. Groups 6
   (2001), 371–396, Proposition 2.4 and Example 2.5(1), for the CAR staircase-weight application.
 -/
@@ -50,120 +37,16 @@ namespace TauCeti
 
 open scoped BigOperators
 
-/-- Discrete summation by parts, written using initial sums of `d`.
+/-- **A majorized occupation weight with the staircase quadratic value is the staircase.**
 
-The separate final term makes the statement valid without assuming that the total sum of `d`
-vanishes. This is the algebraic identity used in the staircase uniqueness proof below. -/
-private theorem sum_range_mul_eq_sum_range_partialSum_mul_sub_add
-    (d q : ℕ → ℤ) : ∀ n : ℕ,
-    (∑ i ∈ Finset.range n, d i * q i) =
-      (∑ k ∈ Finset.range (n - 1), (∑ i ∈ Finset.range (k + 1), d i) *
-        (q k - q (k + 1))) + (∑ i ∈ Finset.range n, d i) * q (n - 1) := by
-  intro n
-  have h := Finset.sum_range_by_parts q d n
-  simp only [smul_eq_mul] at h
-  calc
-    _ = ∑ i ∈ Finset.range n, q i * d i := by
-      apply Finset.sum_congr rfl
-      intro i _
-      ring
-    _ = q (n - 1) * (∑ i ∈ Finset.range n, d i) -
-        ∑ k ∈ Finset.range (n - 1),
-          (q (k + 1) - q k) * (∑ i ∈ Finset.range (k + 1), d i) := h
-    _ = _ := by
-      have hneg : -(∑ k ∈ Finset.range (n - 1),
-          (q (k + 1) - q k) * (∑ i ∈ Finset.range (k + 1), d i)) =
-          ∑ k ∈ Finset.range (n - 1),
-            (∑ i ∈ Finset.range (k + 1), d i) * (q k - q (k + 1)) := by
-        rw [← Finset.sum_neg_distrib]
-        apply Finset.sum_congr rfl
-        intro k _
-        ring
-      rw [sub_eq_add_neg, hneg]
-      ring
+Let `a : Fin N → ℕ` be weakly decreasing. Suppose every proper initial sum of `a` is at most
+the corresponding initial sum of the reverse-index tuple `i ↦ N - 1 - i`, and suppose the total
+sums are equal. If the two tuples also have the same value under
 
-/-- The natural-number sequence form of staircase uniqueness.
+`a ↦ ∑ i, a i * (a i + N - 2i)`,
 
-This form lets the proof use ordinary range sums. The public `Fin N` statement below is the API
-for callers. -/
-private theorem eq_staircase_of_antitone_of_prefix_sum_le_of_sum_eq_of_casimir_eq
-    {N : ℕ} (a : ℕ → ℕ) (ha : ∀ i, i + 1 < N → a (i + 1) ≤ a i)
-    (hmajor : ∀ (k : ℕ), k < N →
-      (∑ i ∈ Finset.range k, (a i : ℤ)) ≤
-        ∑ i ∈ Finset.range k, ((N - (i + 1) : ℕ) : ℤ))
-    (hsum : (∑ i ∈ Finset.range N, (a i : ℤ)) =
-      ∑ i ∈ Finset.range N, ((N - (i + 1) : ℕ) : ℤ))
-    (hcasimir :
-      (∑ i ∈ Finset.range N,
-        (a i : ℤ) * ((a i : ℤ) + (N : ℤ) - 2 * i)) =
-      ∑ i ∈ Finset.range N, ((N - (i + 1) : ℕ) : ℤ) *
-        (((N - (i + 1) : ℕ) : ℤ) + (N : ℤ) - 2 * i)) :
-    ∀ i, i < N → a i = N - (i + 1) := by
-  let t : ℕ → ℤ := fun i => ((N - (i + 1) : ℕ) : ℤ)
-  let d : ℕ → ℤ := fun i => t i - a i
-  let q : ℕ → ℤ := fun i => t i + a i + N - 2 * i
-  have hsum_range : (∑ i ∈ Finset.range N, d i) = 0 := by
-    rw [Finset.sum_sub_distrib, sub_eq_zero]
-    exact hsum.symm
-  have hcasimir_range : (∑ i ∈ Finset.range N, d i * q i) = 0 := by
-    rw [show (∑ i ∈ Finset.range N, d i * q i) =
-        (∑ i ∈ Finset.range N,
-          (t i * (t i + N - 2 * i) - (a i : ℤ) * ((a i : ℤ) + N - 2 * i))) by
-      apply Finset.sum_congr rfl
-      intro i _
-      simp only [d, q]
-      ring]
-    rw [Finset.sum_sub_distrib, sub_eq_zero]
-    exact hcasimir.symm
-  have hpartial_nonneg (k : ℕ) (hk : k < N) :
-      0 ≤ ∑ i ∈ Finset.range k, d i := by
-    rw [Finset.sum_sub_distrib]
-    exact sub_nonneg.mpr (hmajor k hk)
-  have hqdiff (k : ℕ) (hk : k + 1 < N) : 0 < q k - q (k + 1) := by
-    have hak := ha k hk
-    simp only [q, t]
-    push_cast at hak ⊢
-    omega
-  have hdecomp := sum_range_mul_eq_sum_range_partialSum_mul_sub_add d q N
-  rw [hcasimir_range, hsum_range, zero_mul, add_zero] at hdecomp
-  have hterms_nonneg : ∀ k ∈ Finset.range (N - 1),
-      0 ≤ (∑ i ∈ Finset.range (k + 1), d i) * (q k - q (k + 1)) := by
-    intro k hk
-    simp only [Finset.mem_range] at hk
-    have hkN : k + 1 < N := by omega
-    exact mul_nonneg (hpartial_nonneg (k + 1) hkN) (le_of_lt (hqdiff k hkN))
-  have hterm_zero : ∀ k ∈ Finset.range (N - 1),
-      (∑ i ∈ Finset.range (k + 1), d i) * (q k - q (k + 1)) = 0 :=
-    (Finset.sum_eq_zero_iff_of_nonneg hterms_nonneg).mp hdecomp.symm
-  have hpartial_zero (k : ℕ) (hk : k ≤ N) :
-      (∑ i ∈ Finset.range k, d i) = 0 := by
-    rcases eq_or_lt_of_le hk with rfl | hkN
-    · exact hsum_range
-    rcases k with _ | k
-    · simp
-    · have hprod := hterm_zero k (by simp only [Finset.mem_range]; omega)
-      exact (mul_eq_zero.mp hprod).resolve_right (ne_of_gt (hqdiff k (by omega)))
-  intro i hiN
-  have hdi : d i = 0 := by
-    have hnext := hpartial_zero (i + 1) (by omega)
-    rw [Finset.sum_range_succ, hpartial_zero i (by omega), zero_add] at hnext
-    exact hnext
-  have hz : ((a i : ℕ) : ℤ) = ((N - (i + 1) : ℕ) : ℤ) := by
-    change t i - (a i : ℤ) = 0 at hdi
-    simpa only [t] using (sub_eq_zero.mp hdi).symm
-  exact_mod_cast hz
-
-/-- **A majorized occupation weight with the staircase Casimir value is the staircase.**
-
-Let `a : Fin N → ℕ` be weakly decreasing. Suppose every initial sum of `a` is at most the
-corresponding initial sum of the reverse-index tuple `i ↦ N - 1 - i`, and suppose the total sums
-are equal. If the two tuples also have the same value under the integral form
-
-`a ↦ ∑ i, a i * (a i + N - 2i)`
-
-of the trace-form `gl_N` Casimir polynomial after a common half-unit shift, then `a` is the
-reverse-index tuple. The prefix inequalities and total equality are the majorization condition;
-the Casimir equality makes it strict enough to determine every coordinate. -/
+then `a` is the reverse-index tuple. For CAR highest weights this is the integral form of the
+trace-form `gl_N` Casimir polynomial after a common half-unit shift. -/
 theorem eq_fin_rev_of_antitone_of_prefix_sum_le_of_sum_eq_of_casimir_eq
     {N : ℕ} (a : Fin N → ℕ) (ha : Antitone a)
     (hmajor : ∀ (k : ℕ) (hk : k < N),
@@ -176,46 +59,47 @@ theorem eq_fin_rev_of_antitone_of_prefix_sum_le_of_sum_eq_of_casimir_eq
         ∑ i : Fin N, ((Fin.rev i : ℕ) : ℤ) *
           (((Fin.rev i : ℕ) : ℤ) + (N : ℤ) - 2 * (i : ℕ))) :
     a = fun i => (Fin.rev i : ℕ) := by
-  let aN : ℕ → ℕ := fun i => if hi : i < N then a ⟨i, hi⟩ else 0
-  have haN : ∀ i, i + 1 < N → aN (i + 1) ≤ aN i := by
+  let aZ : ℕ → ℤ := fun i => if hi : i < N then a ⟨i, hi⟩ else 0
+  have haZ : ∀ i, i + 1 < N → aZ (i + 1) ≤ aZ i := by
     intro i hi
     have hi' : i < N := by omega
-    simpa only [aN, dite_eq_left hi, dite_eq_left hi'] using
-      ha (Fin.mk_le_mk.mpr (Nat.le_succ i) : (⟨i, hi'⟩ : Fin N) ≤ ⟨i + 1, hi⟩)
-  have hmajorN : ∀ (k : ℕ), k < N →
-      (∑ i ∈ Finset.range k, (aN i : ℤ)) ≤
+    simpa only [aZ, dite_eq_left hi, dite_eq_left hi'] using
+      mod_cast ha (Fin.mk_le_mk.mpr (Nat.le_succ i) : (⟨i, hi'⟩ : Fin N) ≤ ⟨i + 1, hi⟩)
+  have hmajorZ : ∀ (k : ℕ), k < N →
+      (∑ i ∈ Finset.range k, aZ i) ≤
         ∑ i ∈ Finset.range k, ((N - (i + 1) : ℕ) : ℤ) := by
     intro k hk
-    rw [← Fin.sum_univ_eq_sum_range (fun i => (aN i : ℤ)) k,
+    rw [← Fin.sum_univ_eq_sum_range aZ k,
       ← Fin.sum_univ_eq_sum_range (fun i => ((N - (i + 1) : ℕ) : ℤ)) k]
     convert hmajor k hk using 1 <;> apply Finset.sum_congr rfl <;> intro i hi
     · have hiN : i < N := lt_trans i.isLt hk
-      simp only [aN, dite_eq_left hiN]
+      simp only [aZ, dite_eq_left hiN]
       congr 1
     · rfl
-  have hsumN : (∑ i ∈ Finset.range N, (aN i : ℤ)) =
+  have hsumZ : (∑ i ∈ Finset.range N, aZ i) =
       ∑ i ∈ Finset.range N, ((N - (i + 1) : ℕ) : ℤ) := by
-    rw [← Fin.sum_univ_eq_sum_range (fun i => (aN i : ℤ)) N,
+    rw [← Fin.sum_univ_eq_sum_range aZ N,
       ← Fin.sum_univ_eq_sum_range (fun i => ((N - (i + 1) : ℕ) : ℤ)) N]
     convert hsum using 1 <;> apply Finset.sum_congr rfl <;> intro i hi
-    · simp [aN, i.isLt]
+    · simp [aZ, i.isLt]
     · rfl
-  have hcasimirN :
-      (∑ i ∈ Finset.range N,
-        (aN i : ℤ) * ((aN i : ℤ) + (N : ℤ) - 2 * i)) =
+  have hcasimirZ :
+      (∑ i ∈ Finset.range N, aZ i * (aZ i + (N : ℤ) - 2 * i)) =
       ∑ i ∈ Finset.range N, ((N - (i + 1) : ℕ) : ℤ) *
         (((N - (i + 1) : ℕ) : ℤ) + (N : ℤ) - 2 * i) := by
     rw [← Fin.sum_univ_eq_sum_range
-        (fun i => (aN i : ℤ) * ((aN i : ℤ) + (N : ℤ) - 2 * i)) N,
+        (fun i => aZ i * (aZ i + (N : ℤ) - 2 * i)) N,
       ← Fin.sum_univ_eq_sum_range
         (fun i => ((N - (i + 1) : ℕ) : ℤ) *
           (((N - (i + 1) : ℕ) : ℤ) + (N : ℤ) - 2 * i)) N]
     convert hcasimir using 1 <;> apply Finset.sum_congr rfl <;> intro i hi
-    · simp [aN, i.isLt]
+    · simp [aZ, i.isLt]
     · rfl
   funext i
   have h := eq_staircase_of_antitone_of_prefix_sum_le_of_sum_eq_of_casimir_eq
-    aN haN hmajorN hsumN hcasimirN i i.isLt
-  simpa [aN, i.isLt, Fin.rev] using h
+    aZ haZ hmajorZ hsumZ hcasimirZ i i.isLt
+  have hcast : ((a i : ℕ) : ℤ) = ((Fin.rev i : ℕ) : ℤ) := by
+    simpa [aZ, i.isLt, Fin.rev] using h
+  exact_mod_cast hcast
 
 end TauCeti

--- a/TauCeti/Algebra/Lie/GeneralLinear/HighestWeight.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/HighestWeight.lean
@@ -289,6 +289,7 @@ namespace Fin
 
 /-- Casting a reverse finite index and adding the half-unit shift gives the corresponding entry of
 the half-shifted staircase. -/
+@[simp↓]
 theorem natCast_rev_add_one_div_two_eq_glHalfStaircase
     {F : Type*} [Field F] [Invertible (2 : F)] {N : ℕ} (i : Fin N) :
     (((Fin.rev i : ℕ) : F) + 1 / 2) = TauCeti.glHalfStaircase F N i := by

--- a/TauCeti/Algebra/Lie/GeneralLinear/HighestWeight.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/HighestWeight.lean
@@ -46,6 +46,8 @@ and the whole of `𝔫⁺` annihilates (`TauCeti.isGlHighestWeightVector_iff_for
 * `TauCeti.glStaircase N`: the staircase tuple `(N - 1/2, N - 3/2, …, 1/2) : Fin N → ℚ`.
 * `TauCeti.glHalfStaircase F N`: the formula `N - 1/2 - i` over any field; when two is
   invertible, this is the same half-shifted staircase.
+* `TauCeti.natCast_fin_rev_add_one_div_two_eq_glHalfStaircase`: the reverse finite index, cast to
+  a field and shifted by one half, is the corresponding half-staircase entry.
 * `TauCeti.IsGlHighestWeightVector μ v`: `v` is nonzero, the diagonal matrix unit `Eᵢᵢ` acts on it
   by `μ i`, and every raising matrix unit `Eᵢⱼ` with `i < j` annihilates it.
 
@@ -278,6 +280,18 @@ def glHalfStaircase (F : Type*) [Field F] (N : ℕ) : Fin N → F :=
 @[simp]
 theorem glHalfStaircase_apply {F : Type*} [Field F] (N : ℕ) (i : Fin N) :
     glHalfStaircase F N i = (N : F) - 1 / 2 - (i : ℕ) := (rfl)
+
+/-- Casting a reverse finite index and adding the half-unit shift gives the corresponding entry of
+the half-shifted staircase. -/
+theorem natCast_fin_rev_add_one_div_two_eq_glHalfStaircase
+    {F : Type*} [Field F] [Invertible (2 : F)] {N : ℕ} (i : Fin N) :
+    (((Fin.rev i : ℕ) : F) + 1 / 2) = glHalfStaircase F N i := by
+  rw [glHalfStaircase_apply]
+  simp only [Fin.rev, Fin.val_mk]
+  rw [Nat.cast_sub (by omega : (i : ℕ) + 1 ≤ N)]
+  push_cast
+  field_simp [Invertible.ne_zero (2 : F)]
+  ring
 
 /-- The entries of the half-shifted staircase over a field in which two is invertible sum to
 `N² / 2`. -/

--- a/TauCeti/Algebra/Lie/GeneralLinear/HighestWeight.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/HighestWeight.lean
@@ -46,7 +46,7 @@ and the whole of `𝔫⁺` annihilates (`TauCeti.isGlHighestWeightVector_iff_for
 * `TauCeti.glStaircase N`: the staircase tuple `(N - 1/2, N - 3/2, …, 1/2) : Fin N → ℚ`.
 * `TauCeti.glHalfStaircase F N`: the formula `N - 1/2 - i` over any field; when two is
   invertible, this is the same half-shifted staircase.
-* `TauCeti.natCast_fin_rev_add_one_div_two_eq_glHalfStaircase`: the reverse finite index, cast to
+* `Fin.natCast_rev_add_one_div_two_eq_glHalfStaircase`: the reverse finite index, cast to
   a field and shifted by one half, is the corresponding half-staircase entry.
 * `TauCeti.IsGlHighestWeightVector μ v`: `v` is nonzero, the diagonal matrix unit `Eᵢᵢ` acts on it
   by `μ i`, and every raising matrix unit `Eᵢⱼ` with `i < j` annihilates it.
@@ -281,17 +281,33 @@ def glHalfStaircase (F : Type*) [Field F] (N : ℕ) : Fin N → F :=
 theorem glHalfStaircase_apply {F : Type*} [Field F] (N : ℕ) (i : Fin N) :
     glHalfStaircase F N i = (N : F) - 1 / 2 - (i : ℕ) := (rfl)
 
+end Dominant
+
+end TauCeti
+
+namespace Fin
+
 /-- Casting a reverse finite index and adding the half-unit shift gives the corresponding entry of
 the half-shifted staircase. -/
-theorem natCast_fin_rev_add_one_div_two_eq_glHalfStaircase
+theorem natCast_rev_add_one_div_two_eq_glHalfStaircase
     {F : Type*} [Field F] [Invertible (2 : F)] {N : ℕ} (i : Fin N) :
-    (((Fin.rev i : ℕ) : F) + 1 / 2) = glHalfStaircase F N i := by
-  rw [glHalfStaircase_apply]
+    (((Fin.rev i : ℕ) : F) + 1 / 2) = TauCeti.glHalfStaircase F N i := by
+  rw [TauCeti.glHalfStaircase_apply]
   simp only [Fin.rev, Fin.val_mk]
   rw [Nat.cast_sub (by omega : (i : ℕ) + 1 ≤ N)]
   push_cast
   field_simp [Invertible.ne_zero (2 : F)]
   ring
+
+end Fin
+
+namespace TauCeti
+
+open Matrix
+
+attribute [local instance 100] LieRing.ofAssociativeRing
+
+section Dominant
 
 /-- The entries of the half-shifted staircase over a field in which two is invertible sum to
 `N² / 2`. -/

--- a/TauCeti/Combinatorics/Majorization.lean
+++ b/TauCeti/Combinatorics/Majorization.lean
@@ -1,0 +1,160 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.BigOperators.Module
+
+import Mathlib.Tactic
+
+/-!
+# A strict majorization criterion for staircase sequences
+
+This file identifies an integer sequence from three numerical properties: it is antitone, it is
+majorized by the finite staircase `N - 1, ..., 0`, and it has the same value as that staircase
+under a particular quadratic weighted sum.
+
+The proof uses discrete summation by parts. For the target `t i = N - (i + 1)`, put
+
+`D k = ∑ i < k, (t i - a i)` and `q i = t i + a i + N - 2i`.
+
+The total-sum hypothesis says `D N = 0`, while equality of the quadratic sums and summation by
+parts give
+
+`0 = ∑ k < N - 1, D (k + 1) * (q k - q (k + 1))`.
+
+Majorization makes every `D (k + 1)` nonnegative. Antitonicity of `a` makes every other factor
+positive, since `q k - q (k + 1) = 3 + a k - a (k + 1)`. Thus all partial deficits vanish, which
+recovers every coordinate of `a`.
+
+## Main result
+
+* `TauCeti.eq_staircase_of_antitone_of_prefix_sum_le_of_sum_eq_of_casimir_eq`: an antitone
+  integer sequence satisfying the staircase prefix, total, and quadratic-sum conditions agrees
+  with the staircase throughout the prescribed range.
+
+## References
+
+* G. H. Hardy, J. E. Littlewood, G. Pólya, *Inequalities*, Cambridge University Press (1952),
+  Chapter 2, for majorization and summation by parts.
+-/
+
+public section
+
+namespace TauCeti
+
+open scoped BigOperators
+
+/-- Discrete summation by parts, written using initial sums of `d`.
+
+The separate final term makes the statement valid without assuming that the total sum of `d`
+vanishes. This is the algebraic identity used in the staircase uniqueness proof below. -/
+private theorem sum_range_mul_eq_sum_range_partialSum_mul_sub_add
+    (d q : ℕ → ℤ) : ∀ n : ℕ,
+    (∑ i ∈ Finset.range n, d i * q i) =
+      (∑ k ∈ Finset.range (n - 1), (∑ i ∈ Finset.range (k + 1), d i) *
+        (q k - q (k + 1))) + (∑ i ∈ Finset.range n, d i) * q (n - 1) := by
+  intro n
+  have h := Finset.sum_range_by_parts q d n
+  simp only [smul_eq_mul] at h
+  calc
+    _ = ∑ i ∈ Finset.range n, q i * d i := by
+      apply Finset.sum_congr rfl
+      intro i _
+      ring
+    _ = q (n - 1) * (∑ i ∈ Finset.range n, d i) -
+        ∑ k ∈ Finset.range (n - 1),
+          (q (k + 1) - q k) * (∑ i ∈ Finset.range (k + 1), d i) := h
+    _ = _ := by
+      have hneg : -(∑ k ∈ Finset.range (n - 1),
+          (q (k + 1) - q k) * (∑ i ∈ Finset.range (k + 1), d i)) =
+          ∑ k ∈ Finset.range (n - 1),
+            (∑ i ∈ Finset.range (k + 1), d i) * (q k - q (k + 1)) := by
+        rw [← Finset.sum_neg_distrib]
+        apply Finset.sum_congr rfl
+        intro k _
+        ring
+      rw [sub_eq_add_neg, hneg]
+      ring
+
+/-- **A sequence majorized by the finite staircase and having its quadratic sum is that
+staircase.**
+
+Let `a : ℕ → ℤ` be weakly decreasing through the first `N` entries. Suppose every proper
+initial sum of `a` is at most that of `i ↦ N - (i + 1)`, and suppose their total sums agree. If
+they also have the same value under
+
+`a ↦ ∑ i < N, a i * (a i + N - 2i)`,
+
+then their first `N` entries agree. No sign condition on `a` is needed. -/
+theorem eq_staircase_of_antitone_of_prefix_sum_le_of_sum_eq_of_casimir_eq
+    {N : ℕ} (a : ℕ → ℤ) (ha : ∀ i, i + 1 < N → a (i + 1) ≤ a i)
+    (hmajor : ∀ (k : ℕ), k < N →
+      (∑ i ∈ Finset.range k, a i) ≤
+        ∑ i ∈ Finset.range k, ((N - (i + 1) : ℕ) : ℤ))
+    (hsum : (∑ i ∈ Finset.range N, a i) =
+      ∑ i ∈ Finset.range N, ((N - (i + 1) : ℕ) : ℤ))
+    (hcasimir :
+      (∑ i ∈ Finset.range N, a i * (a i + (N : ℤ) - 2 * i)) =
+      ∑ i ∈ Finset.range N, ((N - (i + 1) : ℕ) : ℤ) *
+        (((N - (i + 1) : ℕ) : ℤ) + (N : ℤ) - 2 * i)) :
+    ∀ i, i < N → a i = ((N - (i + 1) : ℕ) : ℤ) := by
+  let t : ℕ → ℤ := fun i => ((N - (i + 1) : ℕ) : ℤ)
+  let d : ℕ → ℤ := fun i => t i - a i
+  let q : ℕ → ℤ := fun i => t i + a i + N - 2 * i
+  have hsum_range : (∑ i ∈ Finset.range N, d i) = 0 := by
+    rw [Finset.sum_sub_distrib, sub_eq_zero]
+    exact hsum.symm
+  have hdq (i : ℕ) :
+      d i * q i = t i * (t i + N - 2 * i) - a i * (a i + N - 2 * i) := by
+    simp only [d, q]
+    ring
+  have hcasimir_range : (∑ i ∈ Finset.range N, d i * q i) = 0 := by
+    calc
+      _ = ∑ i ∈ Finset.range N,
+          (t i * (t i + N - 2 * i) - a i * (a i + N - 2 * i)) := by
+        apply Finset.sum_congr rfl
+        intro i _
+        exact hdq i
+      _ = (∑ i ∈ Finset.range N, t i * (t i + N - 2 * i)) -
+          ∑ i ∈ Finset.range N, a i * (a i + N - 2 * i) :=
+        by rw [Finset.sum_sub_distrib]
+      _ = 0 := sub_eq_zero.mpr hcasimir.symm
+  have hpartial_nonneg (k : ℕ) (hk : k < N) :
+      0 ≤ ∑ i ∈ Finset.range k, d i := by
+    rw [Finset.sum_sub_distrib]
+    exact sub_nonneg.mpr (hmajor k hk)
+  have hqdiff (k : ℕ) (hk : k + 1 < N) : 0 < q k - q (k + 1) := by
+    have hak := ha k hk
+    simp only [q, t]
+    omega
+  have hdecomp := sum_range_mul_eq_sum_range_partialSum_mul_sub_add d q N
+  rw [hcasimir_range, hsum_range, zero_mul, add_zero] at hdecomp
+  have hterms_nonneg : ∀ k ∈ Finset.range (N - 1),
+      0 ≤ (∑ i ∈ Finset.range (k + 1), d i) * (q k - q (k + 1)) := by
+    intro k hk
+    simp only [Finset.mem_range] at hk
+    have hkN : k + 1 < N := by omega
+    exact mul_nonneg (hpartial_nonneg (k + 1) hkN) (le_of_lt (hqdiff k hkN))
+  have hterm_zero : ∀ k ∈ Finset.range (N - 1),
+      (∑ i ∈ Finset.range (k + 1), d i) * (q k - q (k + 1)) = 0 :=
+    (Finset.sum_eq_zero_iff_of_nonneg hterms_nonneg).mp hdecomp.symm
+  have hpartial_zero (k : ℕ) (hk : k ≤ N) :
+      (∑ i ∈ Finset.range k, d i) = 0 := by
+    rcases eq_or_lt_of_le hk with rfl | hkN
+    · exact hsum_range
+    rcases k with _ | k
+    · simp
+    · have hprod := hterm_zero k (by simp only [Finset.mem_range]; omega)
+      exact (mul_eq_zero.mp hprod).resolve_right (ne_of_gt (hqdiff k (by omega)))
+  intro i hiN
+  have hdi : d i = 0 := by
+    have hnext := hpartial_zero (i + 1) (by omega)
+    rw [Finset.sum_range_succ, hpartial_zero i (by omega), zero_add] at hnext
+    exact hnext
+  have hti : t i - a i = 0 := by simpa only [d] using hdi
+  simpa only [t] using (sub_eq_zero.mp hti).symm
+
+end TauCeti

--- a/TauCeti/Combinatorics/Majorization.lean
+++ b/TauCeti/Combinatorics/Majorization.lean
@@ -16,18 +16,10 @@ This file identifies an integer sequence from three numerical properties: it is 
 majorized by the finite staircase `N - 1, ..., 0`, and it has the same value as that staircase
 under a particular quadratic weighted sum.
 
-The proof uses discrete summation by parts. For the target `t i = N - (i + 1)`, put
-
-`D k = ∑ i < k, (t i - a i)` and `q i = t i + a i + N - 2i`.
-
-The total-sum hypothesis says `D N = 0`, while equality of the quadratic sums and summation by
-parts give
-
-`0 = ∑ k < N - 1, D (k + 1) * (q k - q (k + 1))`.
-
-Majorization makes every `D (k + 1)` nonnegative. Antitonicity of `a` makes every other factor
-positive, since `q k - q (k + 1) = 3 + a k - a (k + 1)`. Thus all partial deficits vanish, which
-recovers every coordinate of `a`.
+The criterion is intended for uniqueness arguments in which prefix inequalities alone leave many
+possible sequences, but equality of a strictly convex statistic forces the extremal staircase.
+Its integer-valued statement applies directly to occupation-number tuples after passing between
+finite indices and natural-number ranges.
 
 ## Main result
 
@@ -46,38 +38,6 @@ public section
 namespace TauCeti
 
 open scoped BigOperators
-
-/-- Discrete summation by parts, written using initial sums of `d`.
-
-The separate final term makes the statement valid without assuming that the total sum of `d`
-vanishes. This is the algebraic identity used in the staircase uniqueness proof below. -/
-private theorem sum_range_mul_eq_sum_range_partialSum_mul_sub_add
-    (d q : ℕ → ℤ) : ∀ n : ℕ,
-    (∑ i ∈ Finset.range n, d i * q i) =
-      (∑ k ∈ Finset.range (n - 1), (∑ i ∈ Finset.range (k + 1), d i) *
-        (q k - q (k + 1))) + (∑ i ∈ Finset.range n, d i) * q (n - 1) := by
-  intro n
-  have h := Finset.sum_range_by_parts q d n
-  simp only [smul_eq_mul] at h
-  calc
-    _ = ∑ i ∈ Finset.range n, q i * d i := by
-      apply Finset.sum_congr rfl
-      intro i _
-      ring
-    _ = q (n - 1) * (∑ i ∈ Finset.range n, d i) -
-        ∑ k ∈ Finset.range (n - 1),
-          (q (k + 1) - q k) * (∑ i ∈ Finset.range (k + 1), d i) := h
-    _ = _ := by
-      have hneg : -(∑ k ∈ Finset.range (n - 1),
-          (q (k + 1) - q k) * (∑ i ∈ Finset.range (k + 1), d i)) =
-          ∑ k ∈ Finset.range (n - 1),
-            (∑ i ∈ Finset.range (k + 1), d i) * (q k - q (k + 1)) := by
-        rw [← Finset.sum_neg_distrib]
-        apply Finset.sum_congr rfl
-        intro k _
-        ring
-      rw [sub_eq_add_neg, hneg]
-      ring
 
 /-- **A sequence majorized by the finite staircase and having its quadratic sum is that
 staircase.**
@@ -130,8 +90,28 @@ theorem eq_staircase_of_antitone_of_prefix_sum_le_of_sum_eq_of_casimir_eq
     have hak := ha k hk
     simp only [q, t]
     omega
-  have hdecomp := sum_range_mul_eq_sum_range_partialSum_mul_sub_add d q N
-  rw [hcasimir_range, hsum_range, zero_mul, add_zero] at hdecomp
+  have hparts := Finset.sum_range_by_parts q d N
+  simp only [smul_eq_mul] at hparts
+  have hdecomp :
+      (∑ k ∈ Finset.range (N - 1), (∑ i ∈ Finset.range (k + 1), d i) *
+        (q k - q (k + 1))) = 0 := by
+    calc
+      _ = -(∑ k ∈ Finset.range (N - 1),
+          (q (k + 1) - q k) * (∑ i ∈ Finset.range (k + 1), d i)) := by
+        rw [← Finset.sum_neg_distrib]
+        apply Finset.sum_congr rfl
+        intro k _
+        ring
+      _ = q (N - 1) * (∑ i ∈ Finset.range N, d i) -
+          ∑ k ∈ Finset.range (N - 1),
+            (q (k + 1) - q k) * (∑ i ∈ Finset.range (k + 1), d i) := by
+        rw [hsum_range, mul_zero, zero_sub]
+      _ = ∑ i ∈ Finset.range N, q i * d i := hparts.symm
+      _ = ∑ i ∈ Finset.range N, d i * q i := by
+        apply Finset.sum_congr rfl
+        intro i _
+        ring
+      _ = 0 := hcasimir_range
   have hterms_nonneg : ∀ k ∈ Finset.range (N - 1),
       0 ≤ (∑ i ∈ Finset.range (k + 1), d i) * (q k - q (k + 1)) := by
     intro k hk
@@ -140,7 +120,7 @@ theorem eq_staircase_of_antitone_of_prefix_sum_le_of_sum_eq_of_casimir_eq
     exact mul_nonneg (hpartial_nonneg (k + 1) hkN) (le_of_lt (hqdiff k hkN))
   have hterm_zero : ∀ k ∈ Finset.range (N - 1),
       (∑ i ∈ Finset.range (k + 1), d i) * (q k - q (k + 1)) = 0 :=
-    (Finset.sum_eq_zero_iff_of_nonneg hterms_nonneg).mp hdecomp.symm
+    (Finset.sum_eq_zero_iff_of_nonneg hterms_nonneg).mp hdecomp
   have hpartial_zero (k : ℕ) (hk : k ≤ N) :
       (∑ i ∈ Finset.range k, d i) = 0 := by
     rcases eq_or_lt_of_le hk with rfl | hkN


### PR DESCRIPTION
This PR establishes the reusable majorization-and-Casimir uniqueness step for the CAR staircase occupation weight in the SpinRepresentations worked `gl_N`-on-`M_N` milestone.

Roadmap: RepresentationTheory

## Summary

Export an integer-valued staircase uniqueness theorem from a generic combinatorics module, then derive the `Fin N` natural occupation-count specialization needed by the CAR model. The proof specializes Mathlib's `Finset.sum_range_by_parts` directly: all prefix deficits are nonnegative, while their adjacent quadratic coefficients are strictly positive, so equality of the weighted sums forces every deficit to vanish. Add the canonical `Fin`-namespaced bridge from `Fin.rev + 1/2` to the existing `glHalfStaircase` weight for the downstream highest-weight consumer. Mark that bridge with the pre-order `@[simp↓]` attribute so it normalizes before the existing `Fin.rev` and cast simp rules rewrite its subterms. This is the next independent route-aware step after the merged CAR Casimir scalar and coordinate-spectrum calculation.

## Roadmap target

This advances `RepresentationTheory/SpinRepresentations/README.md`, Layer 9's worked instance “`gl_N` on `M_N(C)` (the CAR algebra),” specifically the identification of every irreducible constituent's highest weight with `nu = (N - 1/2, ..., 1/2)`. After this PR, the CAR proper-prefix occupation bounds and central total-sum bridge remain to instantiate this theorem; the merged `gl_N` isotypy criterion can then prove isotypy and the dimension calculation can determine the multiplicity.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"car-weight-majorization-uniqueness"}-->

## Verification

- Exact head: `3f7a8ccbb59e0b8f51a8a394c0b9f2f85a8ba8a4`
- Local Lean build: `lake exe cache get` and `lake build` — PASS (`11156` jobs)
- Axiom audit: `lake exe axioms` — PASS (`111583` declarations; allowlist only)
- Lint: repository-wide Mathlib environment lint and a focused bare-`simp`/`simpNF` consumer probe — PASS (no new violations)
- Proof golf: `ut-lean-golf` structural/reuse audit — PASS; deleted the one-use summation-by-parts restatement and applied Mathlib's `Finset.sum_range_by_parts` directly
- Public CI: pending on the updated head

## Scale and generality

The generic result is uniform in every natural rank `N`, including ranks zero and one, and permits arbitrary integer-valued coordinates; no sign condition is used. The CAR specialization retains natural occupation coordinates and ordered integer sums, avoiding unnecessary field or characteristic hypotheses. Both results ask for majorization only on proper prefixes because the separate total-sum equality supplies the full-prefix boundary.

## Scope

- **Consumes:** `Fin.rev`, `Antitone`, Mathlib's `Finset.sum_range_by_parts`, and the integral polynomial obtained by shifting the existing trace-form `gl_N` Casimir eigenvalue formula by one half
- **Provides:** the integer-valued `TauCeti.eq_staircase_of_antitone_of_prefix_sum_le_of_sum_eq_of_casimir_eq` in `TauCeti/Combinatorics/Majorization.lean`, its natural `Fin N` specialization `TauCeti.eq_finRev_of_antitone_of_prefix_sum_le_of_sum_eq_of_casimir_eq` in `TauCeti/Algebra/Lie/GeneralLinear/CAR/WeightUniqueness.lean`, and the simp-normal pre-order bridge `Fin.natCast_rev_add_one_div_two_eq_glHalfStaircase` beside the canonical weight in `TauCeti/Algebra/Lie/GeneralLinear/HighestWeight.lean`
- **Fits:** turns CAR occupation majorization, total weight, and the merged Casimir scalar into the unique staircase weight required by the existing `gl_N` isotypy criterion
- **Boundary:** does not reprove the merged coordinate spectrum or yet prove the CAR prefix bounds, central total-sum bridge, final isotypy theorem, or multiplicity formula

<sub>🤖 GPT-5.6 Sol high · TauCetiWorker @ [7518d4150b846c4524423341570c031027a1d92c](https://github.com/utensil/TauCetiWorker/commit/7518d4150b846c4524423341570c031027a1d92c) · rubrics @ [afb424eda89e8ac96d9eb69f6a88972055a4cd1b](https://github.com/utensil/TauCetiReview/commit/afb424eda89e8ac96d9eb69f6a88972055a4cd1b) · local review @ [b533e561b6d44df071c31335ed4a63ae647507d2](https://github.com/utensil/formal-land/commit/b533e561b6d44df071c31335ed4a63ae647507d2) · fixed: api-design, documentation, generality, naming, placement, proof-quality, reuse, ut-aggregate-reuse, ut-consumer-contract</sub>