### PR TITLE
feat: majorize the CAR occupation weights

### DIFF
--- a/TauCeti/Algebra/Lie/GeneralLinear/CAR/Occupation.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/CAR/Occupation.lean
@@ -34,6 +34,8 @@ off-diagonal zero-one operators used to calculate weights in the left regular CA
 * `TauCeti.carOccupationElement_mul_self`: the corresponding multiplication normal form.
 * `TauCeti.commute_carOccupationElement`: all occupation elements commute.
 * `TauCeti.glCliffordHom_single_self_eq_sum_occupation`: `Fᵢᵢ = ∑ k, pᵢₖ`.
+* `TauCeti.sum_glCliffordHom_single_self_eq_cut_occupation`: summing the diagonal lifts over a
+  subset leaves a scalar internal contribution and the occupation elements crossing its cut.
 
 ## References
 
@@ -215,6 +217,75 @@ theorem glCliffordHom_single_self_eq_sum_positive_occupation
   split_ifs with hki
   · exact eq_sub_iff_add_eq.mpr (carOccupationElement_add_swap (K := K) i k)
   · rfl
+
+private theorem sum_carOccupationElement_internal (s : Finset n) :
+    (∑ i ∈ s, ∑ j ∈ s, carOccupationElement (K := K) i j) =
+      ((s.card : K) ^ 2 / 2) • (1 : CliffordAlgebra (traceQuadraticForm K n)) := by
+  let P : CliffordAlgebra (traceQuadraticForm K n) :=
+    ∑ i ∈ s, ∑ j ∈ s, carOccupationElement (K := K) i j
+  have htranspose :
+      (∑ i ∈ s, ∑ j ∈ s, carOccupationElement (K := K) j i) = P := by
+    simp only [P]
+    rw [Finset.sum_comm]
+  have htwo : P + P =
+      (s.card : K) ^ 2 • (1 : CliffordAlgebra (traceQuadraticForm K n)) := by
+    calc
+      P + P = P + ∑ i ∈ s, ∑ j ∈ s, carOccupationElement (K := K) j i := by
+        rw [htranspose]
+      _ = ∑ i ∈ s, ∑ j ∈ s,
+          (carOccupationElement (K := K) i j + carOccupationElement (K := K) j i) := by
+        simp only [P, Finset.sum_add_distrib]
+      _ = (s.card : K) ^ 2 •
+          (1 : CliffordAlgebra (traceQuadraticForm K n)) := by
+        simp only [carOccupationElement_add_swap, Finset.sum_const, nsmul_eq_mul]
+        simp [pow_two, Algebra.smul_def]
+  change P = _
+  calc
+    P = (2 : K)⁻¹ • ((2 : K) • P) := by
+      rw [smul_smul]
+      simp
+    _ = (2 : K)⁻¹ • (P + P) := by rw [two_smul]
+    _ = (2 : K)⁻¹ •
+        ((s.card : K) ^ 2 • (1 : CliffordAlgebra (traceQuadraticForm K n))) := by rw [htwo]
+    _ = ((s.card : K) ^ 2 / 2) •
+        (1 : CliffordAlgebra (traceQuadraticForm K n)) := by
+      rw [smul_smul]
+      congr 1
+      rw [div_eq_mul_inv]
+      ring
+
+/-- Summing the diagonal normal-ordered lifts over `s` leaves the scalar contribution from pairs
+with both indices in `s`, together with the occupation elements whose first index lies in `s` and
+whose second index lies outside it. The scalar is `|s|² / 2`, including the diagonal halves. -/
+theorem sum_glCliffordHom_single_self_eq_cut_occupation (s : Finset n) :
+    (∑ i ∈ s, glCliffordHom (K := K) (n := n) (Matrix.single i i 1)) =
+      ((s.card : K) ^ 2 / 2) • (1 : CliffordAlgebra (traceQuadraticForm K n)) +
+        ∑ ij ∈ s.product (Finset.univ \ s),
+          carOccupationElement (K := K) ij.1 ij.2 := by
+  calc
+    (∑ i ∈ s, glCliffordHom (K := K) (n := n) (Matrix.single i i 1)) =
+        ∑ i ∈ s, ∑ j : n, carOccupationElement (K := K) i j := by
+      apply Finset.sum_congr rfl
+      intro i hi
+      exact glCliffordHom_single_self_eq_sum_occupation i
+    _ = ∑ i ∈ s, ((∑ j ∈ s, carOccupationElement (K := K) i j) +
+          ∑ j ∈ Finset.univ \ s, carOccupationElement (K := K) i j) := by
+      apply Finset.sum_congr rfl
+      intro i hi
+      rw [← Finset.sum_sdiff (Finset.subset_univ s), add_comm]
+    _ = (∑ i ∈ s, ∑ j ∈ s, carOccupationElement (K := K) i j) +
+          ∑ i ∈ s, ∑ j ∈ Finset.univ \ s,
+            carOccupationElement (K := K) i j := by
+      rw [Finset.sum_add_distrib]
+    _ = ((s.card : K) ^ 2 / 2) •
+          (1 : CliffordAlgebra (traceQuadraticForm K n)) +
+          ∑ i ∈ s, ∑ j ∈ Finset.univ \ s,
+            carOccupationElement (K := K) i j := by
+      rw [sum_carOccupationElement_internal]
+    _ = _ := by
+      congr 1
+      exact (Finset.sum_product s (Finset.univ \ s)
+        (fun ij => carOccupationElement (K := K) ij.1 ij.2)).symm
 
 end Diagonal
 

--- a/TauCeti/Algebra/Lie/GeneralLinear/CAR/Occupation.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/CAR/Occupation.lean
@@ -239,9 +239,9 @@ private theorem sum_carOccupationElement_internal (s : Finset n) :
           (1 : CliffordAlgebra (traceQuadraticForm K n)) := by
         simp only [carOccupationElement_add_swap, Finset.sum_const, nsmul_eq_mul]
         simp [pow_two, Algebra.smul_def]
-  change P = _
   calc
-    P = (2 : K)⁻¹ • ((2 : K) • P) := by
+    (∑ i ∈ s, ∑ j ∈ s, carOccupationElement (K := K) i j) = P := rfl
+    _ = (2 : K)⁻¹ • ((2 : K) • P) := by
       rw [smul_smul]
       simp
     _ = (2 : K)⁻¹ • (P + P) := by rw [two_smul]

--- a/TauCeti/Algebra/Lie/GeneralLinear/CAR/WeightSpectrum.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/CAR/WeightSpectrum.lean
@@ -34,9 +34,9 @@ and fixes the total sum.
   a CAR highest weight has the form `m + 1/2` with `m < n`.
 * `TauCeti.exists_occupationCutCount_of_lie_single_self_eq_smul`: occupation counts on a subset
   have the form `choose |s| 2 + m`, with `m` bounded by the size of the cut.
-* `TauCeti.exists_sum_eq_natCast_add_card_sq_div_two_of_lie_single_self_eq_smul`: without any
-  characteristic assumption, the sum of the diagonal eigenvalues is a bounded natural cast plus
-  `|s|² / 2`.
+* `TauCeti.exists_sum_eq_natCast_add_card_sq_div_two_of_lie_single_self_eq_smul`: without a
+  `CharZero` assumption, but with two invertible, the sum of the diagonal eigenvalues is a bounded
+  natural cast plus `|s|² / 2`.
 * `TauCeti.IsGlHighestWeightVector.sum_occupationCounts_le`: every subset of the occupation counts
   of a CAR highest-weight vector satisfies the cut bound.
 * `TauCeti.IsGlHighestWeightVector.sum_occupationCounts_univ_eq_choose_two`: the total occupation
@@ -101,7 +101,7 @@ theorem exists_eq_natCast_add_inv_two_of_lie_single_self_eq_smul {μ : K}
 number of ordered pairs crossing from `s` to its complement.
 
 The natural number is the eigenvalue of the sum of the commuting cut occupation projections. No
-characteristic, finite-dimensionality, or splitting hypothesis is needed. -/
+`CharZero`, finite-dimensionality, or splitting hypothesis is needed, but two must be invertible. -/
 theorem exists_sum_eq_natCast_add_card_sq_div_two_of_lie_single_self_eq_smul
     {μ : n → K} {v : CliffordAlgebra (traceQuadraticForm K n)} (s : Finset n) (hv : v ≠ 0)
     (hdiag : ∀ i ∈ s, ⁅Matrix.single i i (1 : K), v⁆ = μ i • v) :

--- a/TauCeti/Algebra/Lie/GeneralLinear/CAR/WeightSpectrum.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/CAR/WeightSpectrum.lean
@@ -37,10 +37,6 @@ and fixes the total sum.
 * `TauCeti.exists_sum_eq_natCast_add_card_sq_div_two_of_lie_single_self_eq_smul`: without a
   `CharZero` assumption, but with two invertible, the sum of the diagonal eigenvalues is a bounded
   natural cast plus `|s|² / 2`.
-* `TauCeti.IsGlHighestWeightVector.sum_occupationCounts_le`: every subset of the occupation counts
-  of a CAR highest-weight vector satisfies the cut bound.
-* `TauCeti.IsGlHighestWeightVector.sum_occupationCounts_univ_eq_choose_two`: the total occupation
-  count is `choose n 2`.
 
 ## References
 
@@ -67,34 +63,6 @@ variable [h2 : Invertible (2 : K)]
 section Diagonal
 
 variable [decEq : DecidableEq n]
-
-/-- Every eigenvalue of a diagonal matrix unit on a nonzero vector in the left regular CAR module
-is a natural number less than the matrix size, shifted by `1/2`. -/
-theorem exists_eq_natCast_add_inv_two_of_lie_single_self_eq_smul {μ : K}
-    {v : CliffordAlgebra (traceQuadraticForm K n)} {i : n} (hv : v ≠ 0)
-    (hdiag : ⁅Matrix.single i i (1 : K), v⁆ = μ • v) :
-    ∃ m : ℕ, m < Fintype.card n ∧ μ = (m : K) + (2 : K)⁻¹ := by
-  cases Subsingleton.elim decEq (Classical.decEq n)
-  classical
-  let s := Finset.univ.erase i
-  have hsum : (∑ k ∈ s, carOccupationElement (K := K) i k) • v =
-      (μ - (2 : K)⁻¹) • v := by
-    rw [smul_eq_mul]
-    rw [car_lie_def,
-      @glCliffordHom_single_self_eq_sum_occupation K n inferInstance inferInstance h2 i] at hdiag
-    rw [← Finset.sum_erase_add _ _ (Finset.mem_univ i), add_mul,
-      carOccupationElement_self, smul_mul_assoc, one_mul] at hdiag
-    rw [sub_smul]
-    exact eq_sub_of_add_eq hdiag
-  obtain ⟨m, hm, hμ⟩ := s.exists_eq_natCast_of_sum_smul_eq_smul
-    (carOccupationElement (K := K) i)
-    (fun k hk => isIdempotentElem_carOccupationElement (Finset.ne_of_mem_erase hk).symm)
-    (fun _ _ _ _ _ => commute_carOccupationElement (K := K)) hv hsum
-  refine ⟨m, ?_, eq_add_of_sub_eq hμ⟩
-  have hcard : 0 < Fintype.card n := Fintype.card_pos_iff.mpr ⟨i⟩
-  have hm' : m ≤ Fintype.card n - 1 := by
-    simpa only [s, Finset.card_erase_of_mem (Finset.mem_univ i), Finset.card_univ] using hm
-  omega
 
 /-- If a nonzero vector is a simultaneous eigenvector for the diagonal matrix units indexed by
 `s`, the sum of their eigenvalues is `m + |s|² / 2`, where `m` is a natural number bounded by the
@@ -140,6 +108,27 @@ theorem exists_sum_eq_natCast_add_card_sq_div_two_of_lie_single_self_eq_smul
   rw [Finset.card_product, Finset.card_sdiff, Finset.inter_univ,
     Finset.card_univ] at hm
   exact hm
+
+/-- Every eigenvalue of a diagonal matrix unit on a nonzero vector in the left regular CAR module
+is a natural number less than the matrix size, shifted by `1/2`. -/
+theorem exists_eq_natCast_add_inv_two_of_lie_single_self_eq_smul {μ : K}
+    {v : CliffordAlgebra (traceQuadraticForm K n)} {i : n} (hv : v ≠ 0)
+    (hdiag : ⁅Matrix.single i i (1 : K), v⁆ = μ • v) :
+    ∃ m : ℕ, m < Fintype.card n ∧ μ = (m : K) + (2 : K)⁻¹ := by
+  let μ' : n → K := fun _ => μ
+  obtain ⟨m, hm, hμ⟩ :=
+    exists_sum_eq_natCast_add_card_sq_div_two_of_lie_single_self_eq_smul
+      (μ := μ') ({i} : Finset n) hv (by
+        intro j hj
+        have hji : j = i := Finset.mem_singleton.mp hj
+        subst j
+        exact hdiag)
+  refine ⟨m, ?_, ?_⟩
+  · have hcard : 0 < Fintype.card n := Fintype.card_pos_iff.mpr ⟨i⟩
+    have hm' : m ≤ Fintype.card n - 1 := by
+      simpa only [Finset.card_singleton, one_mul] using hm
+    omega
+  · simpa [μ', div_eq_mul_inv] using hμ
 
 /-- Let a nonzero vector be a simultaneous eigenvector for the diagonal matrix units, with each
 eigenvalue written as a natural occupation count plus `1/2`. On a subset `s`, the sum of the
@@ -232,27 +221,6 @@ theorem exists_occupationCounts [DecidableEq n] {μ : n → K}
       (hv.lie_single_self_eq_smul i)
   let a : n → ℕ := fun i => (hcoord i).choose
   exact ⟨a, fun i => (hcoord i).choose_spec⟩
-
-/-- Every subset of a half-shifted natural occupation-count tuple for a CAR highest-weight vector
-satisfies the cut bound. For an initial segment of `Fin N`, the right side is the corresponding
-prefix sum of the reverse tuple. -/
-theorem sum_occupationCounts_le [CharZero K] [DecidableEq n] {μ : n → K} {a : n → ℕ}
-    {v : CliffordAlgebra (traceQuadraticForm K n)}
-    (hv : IsGlHighestWeightVector μ v)
-    (hμ : ∀ i, μ i = (a i : K) + (2 : K)⁻¹) (s : Finset n) :
-    (∑ i ∈ s, a i) ≤ s.card.choose 2 + s.card * (Fintype.card n - s.card) := by
-  exact sum_occupationCounts_le_of_lie_single_self_eq_smul s hv.ne_zero
-    (fun i _ => hv.lie_single_self_eq_smul i) (fun i _ => hμ i)
-
-/-- The total of a half-shifted natural occupation-count tuple for a CAR highest-weight vector is
-`choose n 2`. -/
-theorem sum_occupationCounts_univ_eq_choose_two [CharZero K] [DecidableEq n]
-    {μ : n → K} {a : n → ℕ} {v : CliffordAlgebra (traceQuadraticForm K n)}
-    (hv : IsGlHighestWeightVector μ v)
-    (hμ : ∀ i, μ i = (a i : K) + (2 : K)⁻¹) :
-    (∑ i : n, a i) = (Fintype.card n).choose 2 := by
-  exact sum_occupationCounts_univ_eq_choose_two_of_lie_single_self_eq_smul hv.ne_zero
-    hv.lie_single_self_eq_smul hμ
 
 end IsGlHighestWeightVector
 

--- a/TauCeti/Algebra/Lie/GeneralLinear/CAR/WeightSpectrum.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/CAR/WeightSpectrum.lean
@@ -34,6 +34,9 @@ and fixes the total sum.
   a CAR highest weight has the form `m + 1/2` with `m < n`.
 * `TauCeti.exists_occupationCutCount_of_lie_single_self_eq_smul`: occupation counts on a subset
   have the form `choose |s| 2 + m`, with `m` bounded by the size of the cut.
+* `TauCeti.exists_sum_eq_natCast_add_card_sq_div_two_of_lie_single_self_eq_smul`: without any
+  characteristic assumption, the sum of the diagonal eigenvalues is a bounded natural cast plus
+  `|s|² / 2`.
 * `TauCeti.IsGlHighestWeightVector.sum_occupationCounts_le`: every subset of the occupation counts
   of a CAR highest-weight vector satisfies the cut bound.
 * `TauCeti.IsGlHighestWeightVector.sum_occupationCounts_univ_eq_choose_two`: the total occupation
@@ -55,12 +58,15 @@ namespace TauCeti
 
 noncomputable section
 
-attribute [local instance] Classical.decEq
 attribute [local instance 100] LieRing.ofAssociativeRing
 
 variable {K n : Type*} [Field K] [Fintype n]
 
 variable [h2 : Invertible (2 : K)]
+
+section Diagonal
+
+variable [decEq : DecidableEq n]
 
 /-- Every eigenvalue of a diagonal matrix unit on a nonzero vector in the left regular CAR module
 is a natural number less than the matrix size, shifted by `1/2`. -/
@@ -68,6 +74,8 @@ theorem exists_eq_natCast_add_inv_two_of_lie_single_self_eq_smul {μ : K}
     {v : CliffordAlgebra (traceQuadraticForm K n)} {i : n} (hv : v ≠ 0)
     (hdiag : ⁅Matrix.single i i (1 : K), v⁆ = μ • v) :
     ∃ m : ℕ, m < Fintype.card n ∧ μ = (m : K) + (2 : K)⁻¹ := by
+  cases Subsingleton.elim decEq (Classical.decEq n)
+  classical
   let s := Finset.univ.erase i
   have hsum : (∑ k ∈ s, carOccupationElement (K := K) i k) • v =
       (μ - (2 : K)⁻¹) • v := by
@@ -88,20 +96,19 @@ theorem exists_eq_natCast_add_inv_two_of_lie_single_self_eq_smul {μ : K}
     simpa only [s, Finset.card_erase_of_mem (Finset.mem_univ i), Finset.card_univ] using hm
   omega
 
-/-- Let a nonzero vector be a simultaneous eigenvector for the diagonal matrix units, with each
-eigenvalue written as a natural occupation count plus `1/2`. On a subset `s`, the sum of the
-counts is `choose |s| 2 + m`, where `m` is bounded by the number of ordered pairs crossing from
-`s` to its complement.
+/-- If a nonzero vector is a simultaneous eigenvector for the diagonal matrix units indexed by
+`s`, the sum of their eigenvalues is `m + |s|² / 2`, where `m` is a natural number bounded by the
+number of ordered pairs crossing from `s` to its complement.
 
-The natural number `m` is the eigenvalue of the sum of the commuting cut occupation projections.
-No finite-dimensionality or splitting hypothesis is needed. -/
-theorem exists_occupationCutCount_of_lie_single_self_eq_smul [CharZero K]
-    {μ : n → K} {a : n → ℕ} {v : CliffordAlgebra (traceQuadraticForm K n)}
-    (s : Finset n) (hv : v ≠ 0)
-    (hdiag : ∀ i ∈ s, ⁅Matrix.single i i (1 : K), v⁆ = μ i • v)
-    (hμ : ∀ i ∈ s, μ i = (a i : K) + (2 : K)⁻¹) :
+The natural number is the eigenvalue of the sum of the commuting cut occupation projections. No
+characteristic, finite-dimensionality, or splitting hypothesis is needed. -/
+theorem exists_sum_eq_natCast_add_card_sq_div_two_of_lie_single_self_eq_smul
+    {μ : n → K} {v : CliffordAlgebra (traceQuadraticForm K n)} (s : Finset n) (hv : v ≠ 0)
+    (hdiag : ∀ i ∈ s, ⁅Matrix.single i i (1 : K), v⁆ = μ i • v) :
     ∃ m : ℕ, m ≤ s.card * (Fintype.card n - s.card) ∧
-      (∑ i ∈ s, a i) = s.card.choose 2 + m := by
+      (∑ i ∈ s, μ i) = (m : K) + (s.card : K) ^ 2 / 2 := by
+  cases Subsingleton.elim decEq (Classical.decEq n)
+  classical
   let t := s.product (Finset.univ \ s)
   let p : n × n → CliffordAlgebra (traceQuadraticForm K n) :=
     fun ij => carOccupationElement (K := K) ij.1 ij.2
@@ -120,7 +127,7 @@ theorem exists_occupationCutCount_of_lie_single_self_eq_smul [CharZero K]
       one_mul] at hsumdiag
     rw [sub_smul]
     exact eq_sub_of_add_eq' hsumdiag
-  obtain ⟨m, hm, hscalar⟩ := t.exists_eq_natCast_of_sum_smul_eq_smul p
+  obtain ⟨m, hm, hμ⟩ := t.exists_eq_natCast_of_sum_smul_eq_smul p
     (fun ij hij => by
       apply isIdempotentElem_carOccupationElement
       have hi := (Finset.mem_product.mp hij).1
@@ -128,12 +135,29 @@ theorem exists_occupationCutCount_of_lie_single_self_eq_smul [CharZero K]
       intro hij'
       exact hj (hij' ▸ hi))
     (fun _ _ _ _ _ => commute_carOccupationElement (K := K)) hv hboundary
-  have hm' : m ≤ s.card * (Fintype.card n - s.card) := by
-    dsimp [t] at hm
-    rw [Finset.card_product, Finset.card_sdiff, Finset.inter_univ,
-      Finset.card_univ] at hm
-    exact hm
-  refine ⟨m, hm', Nat.cast_injective (R := K) ?_⟩
+  refine ⟨m, ?_, eq_add_of_sub_eq hμ⟩
+  dsimp [t] at hm
+  rw [Finset.card_product, Finset.card_sdiff, Finset.inter_univ,
+    Finset.card_univ] at hm
+  exact hm
+
+/-- Let a nonzero vector be a simultaneous eigenvector for the diagonal matrix units, with each
+eigenvalue written as a natural occupation count plus `1/2`. On a subset `s`, the sum of the
+counts is `choose |s| 2 + m`, where `m` is bounded by the number of ordered pairs crossing from
+`s` to its complement.
+
+The natural number `m` is the eigenvalue of the sum of the commuting cut occupation projections.
+No finite-dimensionality or splitting hypothesis is needed. -/
+theorem exists_occupationCutCount_of_lie_single_self_eq_smul [CharZero K]
+    {μ : n → K} {a : n → ℕ} {v : CliffordAlgebra (traceQuadraticForm K n)}
+    (s : Finset n) (hv : v ≠ 0)
+    (hdiag : ∀ i ∈ s, ⁅Matrix.single i i (1 : K), v⁆ = μ i • v)
+    (hμ : ∀ i ∈ s, μ i = (a i : K) + (2 : K)⁻¹) :
+    ∃ m : ℕ, m ≤ s.card * (Fintype.card n - s.card) ∧
+      (∑ i ∈ s, a i) = s.card.choose 2 + m := by
+  obtain ⟨m, hm, hscalar⟩ :=
+    exists_sum_eq_natCast_add_card_sq_div_two_of_lie_single_self_eq_smul s hv hdiag
+  refine ⟨m, hm, Nat.cast_injective (R := K) ?_⟩
   rw [Nat.cast_add, Nat.cast_choose_two]
   have hleft : ((∑ i ∈ s, a i : ℕ) : K) + (s.card : K) / 2 =
       ∑ i ∈ s, μ i := by
@@ -178,6 +202,8 @@ theorem sum_occupationCounts_univ_eq_choose_two_of_lie_single_self_eq_smul [Char
   have hm0 : m = 0 := by simpa using hm
   simpa [hm0] using hsum
 
+end Diagonal
+
 namespace IsGlHighestWeightVector
 
 variable [LinearOrder n]
@@ -187,7 +213,7 @@ than the matrix size, shifted by `1/2`.
 
 This statement supplies the coordinate restriction; it does not assert that every expression is
 attained by a given vector. -/
-theorem exists_weight_apply_eq_natCast_add_inv_two {μ : n → K}
+theorem exists_weight_apply_eq_natCast_add_inv_two [DecidableEq n] {μ : n → K}
     {v : CliffordAlgebra (traceQuadraticForm K n)}
     (hv : IsGlHighestWeightVector μ v) (i : n) :
     ∃ m : ℕ, m < Fintype.card n ∧ μ i = (m : K) + (2 : K)⁻¹ := by
@@ -195,7 +221,7 @@ theorem exists_weight_apply_eq_natCast_add_inv_two {μ : n → K}
     (hv.lie_single_self_eq_smul i)
 
 /-- Package the coordinate spectrum into one natural-valued occupation-count tuple. -/
-theorem exists_occupationCounts {μ : n → K}
+theorem exists_occupationCounts [DecidableEq n] {μ : n → K}
     {v : CliffordAlgebra (traceQuadraticForm K n)}
     (hv : IsGlHighestWeightVector μ v) :
     ∃ a : n → ℕ, ∀ i,
@@ -210,7 +236,7 @@ theorem exists_occupationCounts {μ : n → K}
 /-- Every subset of a half-shifted natural occupation-count tuple for a CAR highest-weight vector
 satisfies the cut bound. For an initial segment of `Fin N`, the right side is the corresponding
 prefix sum of the reverse tuple. -/
-theorem sum_occupationCounts_le [CharZero K] {μ : n → K} {a : n → ℕ}
+theorem sum_occupationCounts_le [CharZero K] [DecidableEq n] {μ : n → K} {a : n → ℕ}
     {v : CliffordAlgebra (traceQuadraticForm K n)}
     (hv : IsGlHighestWeightVector μ v)
     (hμ : ∀ i, μ i = (a i : K) + (2 : K)⁻¹) (s : Finset n) :
@@ -220,7 +246,7 @@ theorem sum_occupationCounts_le [CharZero K] {μ : n → K} {a : n → ℕ}
 
 /-- The total of a half-shifted natural occupation-count tuple for a CAR highest-weight vector is
 `choose n 2`. -/
-theorem sum_occupationCounts_univ_eq_choose_two [CharZero K]
+theorem sum_occupationCounts_univ_eq_choose_two [CharZero K] [DecidableEq n]
     {μ : n → K} {a : n → ℕ} {v : CliffordAlgebra (traceQuadraticForm K n)}
     (hv : IsGlHighestWeightVector μ v)
     (hμ : ∀ i, μ i = (a i : K) + (2 : K)⁻¹) :

--- a/TauCeti/Algebra/Lie/GeneralLinear/CAR/WeightSpectrum.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/CAR/WeightSpectrum.lean
@@ -32,7 +32,7 @@ and fixes the total sum.
   eigenvalue has the form `m + 1/2` with `m < n`.
 * `TauCeti.IsGlHighestWeightVector.exists_weight_apply_eq_natCast_add_inv_two`: every coordinate of
   a CAR highest weight has the form `m + 1/2` with `m < n`.
-* `TauCeti.exists_occupationCutCount_of_lie_single_self_eq_smul`: occupation counts on a subset
+* `TauCeti.exists_sum_eq_choose_two_add_of_lie_single_self_eq_smul`: occupation counts on a subset
   have the form `choose |s| 2 + m`, with `m` bounded by the size of the cut.
 * `TauCeti.exists_sum_eq_natCast_add_card_sq_div_two_of_lie_single_self_eq_smul`: without a
   `CharZero` assumption, but with two invertible, the sum of the diagonal eigenvalues is a bounded
@@ -137,7 +137,7 @@ counts is `choose |s| 2 + m`, where `m` is bounded by the number of ordered pair
 
 The natural number `m` is the eigenvalue of the sum of the commuting cut occupation projections.
 No finite-dimensionality or splitting hypothesis is needed. -/
-theorem exists_occupationCutCount_of_lie_single_self_eq_smul [CharZero K]
+theorem exists_sum_eq_choose_two_add_of_lie_single_self_eq_smul [CharZero K]
     {μ : n → K} {a : n → ℕ} {v : CliffordAlgebra (traceQuadraticForm K n)}
     (s : Finset n) (hv : v ≠ 0)
     (hdiag : ∀ i ∈ s, ⁅Matrix.single i i (1 : K), v⁆ = μ i • v)
@@ -165,7 +165,7 @@ theorem exists_occupationCutCount_of_lie_single_self_eq_smul [CharZero K]
   linear_combination hscalar
 
 /-- Under the hypotheses of
-`TauCeti.exists_occupationCutCount_of_lie_single_self_eq_smul`, the occupation-count sum on `s`
+`TauCeti.exists_sum_eq_choose_two_add_of_lie_single_self_eq_smul`, the occupation-count sum on `s`
 is bounded by `choose |s| 2 + |s| (n - |s|)`. -/
 theorem sum_occupationCounts_le_of_lie_single_self_eq_smul [CharZero K]
     {μ : n → K} {a : n → ℕ} {v : CliffordAlgebra (traceQuadraticForm K n)}
@@ -174,7 +174,7 @@ theorem sum_occupationCounts_le_of_lie_single_self_eq_smul [CharZero K]
     (hμ : ∀ i ∈ s, μ i = (a i : K) + (2 : K)⁻¹) :
     (∑ i ∈ s, a i) ≤ s.card.choose 2 + s.card * (Fintype.card n - s.card) := by
   obtain ⟨m, hm, hsum⟩ :=
-    exists_occupationCutCount_of_lie_single_self_eq_smul s hv hdiag hμ
+    exists_sum_eq_choose_two_add_of_lie_single_self_eq_smul s hv hdiag hμ
   rw [hsum]
   omega
 
@@ -186,7 +186,7 @@ theorem sum_occupationCounts_univ_eq_choose_two_of_lie_single_self_eq_smul [Char
     (hdiag : ∀ i : n, ⁅Matrix.single i i (1 : K), v⁆ = μ i • v)
     (hμ : ∀ i : n, μ i = (a i : K) + (2 : K)⁻¹) :
     (∑ i : n, a i) = (Fintype.card n).choose 2 := by
-  obtain ⟨m, hm, hsum⟩ := exists_occupationCutCount_of_lie_single_self_eq_smul
+  obtain ⟨m, hm, hsum⟩ := exists_sum_eq_choose_two_add_of_lie_single_self_eq_smul
     (Finset.univ : Finset n) hv (fun i _ => hdiag i) (fun i _ => hμ i)
   have hm0 : m = 0 := by simpa using hm
   simpa [hm0] using hsum
@@ -208,19 +208,6 @@ theorem exists_weight_apply_eq_natCast_add_inv_two [DecidableEq n] {μ : n → K
     ∃ m : ℕ, m < Fintype.card n ∧ μ i = (m : K) + (2 : K)⁻¹ := by
   exact exists_eq_natCast_add_inv_two_of_lie_single_self_eq_smul hv.ne_zero
     (hv.lie_single_self_eq_smul i)
-
-/-- Package the coordinate spectrum into one natural-valued occupation-count tuple. -/
-theorem exists_occupationCounts [DecidableEq n] {μ : n → K}
-    {v : CliffordAlgebra (traceQuadraticForm K n)}
-    (hv : IsGlHighestWeightVector μ v) :
-    ∃ a : n → ℕ, ∀ i,
-      a i < Fintype.card n ∧ μ i = (a i : K) + (2 : K)⁻¹ := by
-  have hcoord (i : n) :
-      ∃ m : ℕ, m < Fintype.card n ∧ μ i = (m : K) + (2 : K)⁻¹ := by
-    exact exists_eq_natCast_add_inv_two_of_lie_single_self_eq_smul hv.ne_zero
-      (hv.lie_single_self_eq_smul i)
-  let a : n → ℕ := fun i => (hcoord i).choose
-  exact ⟨a, fun i => (hcoord i).choose_spec⟩
 
 end IsGlHighestWeightVector
 

--- a/TauCeti/Algebra/Lie/GeneralLinear/CAR/WeightSpectrum.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/CAR/WeightSpectrum.lean
@@ -18,7 +18,13 @@ for a natural number `m < n`. In particular, this restricts every coordinate of 
 
 The diagonal lift is a sum of commuting occupation projections together with its scalar diagonal
 term. Removing the diagonal `1/2` from a diagonal eigenvector equation leaves `n - 1` commuting
-idempotents, reducing the result to the general spectrum theorem for their sum.
+idempotents, reducing the coordinate result to the general spectrum theorem for their sum.
+
+More generally, summing diagonal equations over a subset `s` leaves the commuting occupation
+projections crossing from `s` to its complement. Their eigenvalue is a natural number `m` bounded
+by `|s| (n - |s|)`. Consequently, natural occupation counts for the coordinates have subset sum
+`choose |s| 2 + m`. This gives all cut bounds at once, while the full subset has no crossing terms
+and fixes the total sum.
 
 ## Main results
 
@@ -26,6 +32,12 @@ idempotents, reducing the result to the general spectrum theorem for their sum.
   eigenvalue has the form `m + 1/2` with `m < n`.
 * `TauCeti.IsGlHighestWeightVector.exists_weight_apply_eq_natCast_add_inv_two`: every coordinate of
   a CAR highest weight has the form `m + 1/2` with `m < n`.
+* `TauCeti.exists_occupationCutCount_of_lie_single_self_eq_smul`: occupation counts on a subset
+  have the form `choose |s| 2 + m`, with `m` bounded by the size of the cut.
+* `TauCeti.IsGlHighestWeightVector.sum_occupationCounts_le`: every subset of the occupation counts
+  of a CAR highest-weight vector satisfies the cut bound.
+* `TauCeti.IsGlHighestWeightVector.sum_occupationCounts_univ_eq_choose_two`: the total occupation
+  count is `choose n 2`.
 
 ## References
 
@@ -44,6 +56,7 @@ namespace TauCeti
 noncomputable section
 
 attribute [local instance] Classical.decEq
+attribute [local instance 100] LieRing.ofAssociativeRing
 
 variable {K n : Type*} [Field K] [Fintype n]
 
@@ -75,6 +88,96 @@ theorem exists_eq_natCast_add_inv_two_of_lie_single_self_eq_smul {μ : K}
     simpa only [s, Finset.card_erase_of_mem (Finset.mem_univ i), Finset.card_univ] using hm
   omega
 
+/-- Let a nonzero vector be a simultaneous eigenvector for the diagonal matrix units, with each
+eigenvalue written as a natural occupation count plus `1/2`. On a subset `s`, the sum of the
+counts is `choose |s| 2 + m`, where `m` is bounded by the number of ordered pairs crossing from
+`s` to its complement.
+
+The natural number `m` is the eigenvalue of the sum of the commuting cut occupation projections.
+No finite-dimensionality or splitting hypothesis is needed. -/
+theorem exists_occupationCutCount_of_lie_single_self_eq_smul [CharZero K]
+    {μ : n → K} {a : n → ℕ} {v : CliffordAlgebra (traceQuadraticForm K n)}
+    (s : Finset n) (hv : v ≠ 0)
+    (hdiag : ∀ i ∈ s, ⁅Matrix.single i i (1 : K), v⁆ = μ i • v)
+    (hμ : ∀ i ∈ s, μ i = (a i : K) + (2 : K)⁻¹) :
+    ∃ m : ℕ, m ≤ s.card * (Fintype.card n - s.card) ∧
+      (∑ i ∈ s, a i) = s.card.choose 2 + m := by
+  let t := s.product (Finset.univ \ s)
+  let p : n × n → CliffordAlgebra (traceQuadraticForm K n) :=
+    fun ij => carOccupationElement (K := K) ij.1 ij.2
+  have hsumdiag :
+      (∑ i ∈ s, glCliffordHom (K := K) (n := n) (Matrix.single i i 1)) * v =
+        (∑ i ∈ s, μ i) • v := by
+    rw [Finset.sum_mul, Finset.sum_smul]
+    apply Finset.sum_congr rfl
+    intro i hi
+    rw [← car_lie_def]
+    exact hdiag i hi
+  have hboundary : (∑ ij ∈ t, p ij) • v =
+      ((∑ i ∈ s, μ i) - (s.card : K) ^ 2 / 2) • v := by
+    rw [smul_eq_mul]
+    rw [sum_glCliffordHom_single_self_eq_cut_occupation, add_mul, smul_mul_assoc,
+      one_mul] at hsumdiag
+    rw [sub_smul]
+    exact eq_sub_of_add_eq' hsumdiag
+  obtain ⟨m, hm, hscalar⟩ := t.exists_eq_natCast_of_sum_smul_eq_smul p
+    (fun ij hij => by
+      apply isIdempotentElem_carOccupationElement
+      have hi := (Finset.mem_product.mp hij).1
+      have hj := (Finset.mem_sdiff.mp (Finset.mem_product.mp hij).2).2
+      intro hij'
+      exact hj (hij' ▸ hi))
+    (fun _ _ _ _ _ => commute_carOccupationElement (K := K)) hv hboundary
+  have hm' : m ≤ s.card * (Fintype.card n - s.card) := by
+    dsimp [t] at hm
+    rw [Finset.card_product, Finset.card_sdiff, Finset.inter_univ,
+      Finset.card_univ] at hm
+    exact hm
+  refine ⟨m, hm', Nat.cast_injective (R := K) ?_⟩
+  rw [Nat.cast_add, Nat.cast_choose_two]
+  have hleft : ((∑ i ∈ s, a i : ℕ) : K) + (s.card : K) / 2 =
+      ∑ i ∈ s, μ i := by
+    rw [Nat.cast_sum]
+    calc
+      (∑ i ∈ s, (a i : K)) + (s.card : K) / 2 =
+          ∑ i ∈ s, ((a i : K) + (2 : K)⁻¹) := by
+        simp only [Finset.sum_add_distrib, Finset.sum_const, nsmul_eq_mul]
+        simp [div_eq_mul_inv]
+      _ = ∑ i ∈ s, μ i := by
+        apply Finset.sum_congr rfl
+        intro i hi
+        exact (hμ i hi).symm
+  rw [← hleft] at hscalar
+  field_simp at hscalar ⊢
+  linear_combination hscalar
+
+/-- Under the hypotheses of
+`TauCeti.exists_occupationCutCount_of_lie_single_self_eq_smul`, the occupation-count sum on `s`
+is bounded by `choose |s| 2 + |s| (n - |s|)`. -/
+theorem sum_occupationCounts_le_of_lie_single_self_eq_smul [CharZero K]
+    {μ : n → K} {a : n → ℕ} {v : CliffordAlgebra (traceQuadraticForm K n)}
+    (s : Finset n) (hv : v ≠ 0)
+    (hdiag : ∀ i ∈ s, ⁅Matrix.single i i (1 : K), v⁆ = μ i • v)
+    (hμ : ∀ i ∈ s, μ i = (a i : K) + (2 : K)⁻¹) :
+    (∑ i ∈ s, a i) ≤ s.card.choose 2 + s.card * (Fintype.card n - s.card) := by
+  obtain ⟨m, hm, hsum⟩ :=
+    exists_occupationCutCount_of_lie_single_self_eq_smul s hv hdiag hμ
+  rw [hsum]
+  omega
+
+/-- For simultaneous half-shifted natural diagonal eigenvalues, the total occupation count is
+`choose n 2`. This is the full-subset case of the cut calculation, where no projection crosses
+the boundary. -/
+theorem sum_occupationCounts_univ_eq_choose_two_of_lie_single_self_eq_smul [CharZero K]
+    {μ : n → K} {a : n → ℕ} {v : CliffordAlgebra (traceQuadraticForm K n)} (hv : v ≠ 0)
+    (hdiag : ∀ i : n, ⁅Matrix.single i i (1 : K), v⁆ = μ i • v)
+    (hμ : ∀ i : n, μ i = (a i : K) + (2 : K)⁻¹) :
+    (∑ i : n, a i) = (Fintype.card n).choose 2 := by
+  obtain ⟨m, hm, hsum⟩ := exists_occupationCutCount_of_lie_single_self_eq_smul
+    (Finset.univ : Finset n) hv (fun i _ => hdiag i) (fun i _ => hμ i)
+  have hm0 : m = 0 := by simpa using hm
+  simpa [hm0] using hsum
+
 namespace IsGlHighestWeightVector
 
 variable [LinearOrder n]
@@ -90,6 +193,40 @@ theorem exists_weight_apply_eq_natCast_add_inv_two {μ : n → K}
     ∃ m : ℕ, m < Fintype.card n ∧ μ i = (m : K) + (2 : K)⁻¹ := by
   exact exists_eq_natCast_add_inv_two_of_lie_single_self_eq_smul hv.ne_zero
     (hv.lie_single_self_eq_smul i)
+
+/-- Package the coordinate spectrum into one natural-valued occupation-count tuple. -/
+theorem exists_occupationCounts {μ : n → K}
+    {v : CliffordAlgebra (traceQuadraticForm K n)}
+    (hv : IsGlHighestWeightVector μ v) :
+    ∃ a : n → ℕ, ∀ i,
+      a i < Fintype.card n ∧ μ i = (a i : K) + (2 : K)⁻¹ := by
+  have hcoord (i : n) :
+      ∃ m : ℕ, m < Fintype.card n ∧ μ i = (m : K) + (2 : K)⁻¹ := by
+    exact exists_eq_natCast_add_inv_two_of_lie_single_self_eq_smul hv.ne_zero
+      (hv.lie_single_self_eq_smul i)
+  let a : n → ℕ := fun i => (hcoord i).choose
+  exact ⟨a, fun i => (hcoord i).choose_spec⟩
+
+/-- Every subset of a half-shifted natural occupation-count tuple for a CAR highest-weight vector
+satisfies the cut bound. For an initial segment of `Fin N`, the right side is the corresponding
+prefix sum of the reverse tuple. -/
+theorem sum_occupationCounts_le [CharZero K] {μ : n → K} {a : n → ℕ}
+    {v : CliffordAlgebra (traceQuadraticForm K n)}
+    (hv : IsGlHighestWeightVector μ v)
+    (hμ : ∀ i, μ i = (a i : K) + (2 : K)⁻¹) (s : Finset n) :
+    (∑ i ∈ s, a i) ≤ s.card.choose 2 + s.card * (Fintype.card n - s.card) := by
+  exact sum_occupationCounts_le_of_lie_single_self_eq_smul s hv.ne_zero
+    (fun i _ => hv.lie_single_self_eq_smul i) (fun i _ => hμ i)
+
+/-- The total of a half-shifted natural occupation-count tuple for a CAR highest-weight vector is
+`choose n 2`. -/
+theorem sum_occupationCounts_univ_eq_choose_two [CharZero K]
+    {μ : n → K} {a : n → ℕ} {v : CliffordAlgebra (traceQuadraticForm K n)}
+    (hv : IsGlHighestWeightVector μ v)
+    (hμ : ∀ i, μ i = (a i : K) + (2 : K)⁻¹) :
+    (∑ i : n, a i) = (Fintype.card n).choose 2 := by
+  exact sum_occupationCounts_univ_eq_choose_two_of_lie_single_self_eq_smul hv.ne_zero
+    hv.lie_single_self_eq_smul hμ
 
 end IsGlHighestWeightVector
 

--- a/TauCeti/Algebra/Lie/GeneralLinear/CAR/WeightSpectrum.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/CAR/WeightSpectrum.lean
@@ -167,7 +167,7 @@ theorem exists_sum_eq_choose_two_add_of_lie_single_self_eq_smul [CharZero K]
 /-- Under the hypotheses of
 `TauCeti.exists_sum_eq_choose_two_add_of_lie_single_self_eq_smul`, the occupation-count sum on `s`
 is bounded by `choose |s| 2 + |s| (n - |s|)`. -/
-theorem sum_occupationCounts_le_of_lie_single_self_eq_smul [CharZero K]
+theorem sum_le_choose_two_add_card_mul_sub_of_lie_single_self_eq_smul [CharZero K]
     {μ : n → K} {a : n → ℕ} {v : CliffordAlgebra (traceQuadraticForm K n)}
     (s : Finset n) (hv : v ≠ 0)
     (hdiag : ∀ i ∈ s, ⁅Matrix.single i i (1 : K), v⁆ = μ i • v)
@@ -181,7 +181,7 @@ theorem sum_occupationCounts_le_of_lie_single_self_eq_smul [CharZero K]
 /-- For simultaneous half-shifted natural diagonal eigenvalues, the total occupation count is
 `choose n 2`. This is the full-subset case of the cut calculation, where no projection crosses
 the boundary. -/
-theorem sum_occupationCounts_univ_eq_choose_two_of_lie_single_self_eq_smul [CharZero K]
+theorem sum_univ_eq_choose_two_of_lie_single_self_eq_smul [CharZero K]
     {μ : n → K} {a : n → ℕ} {v : CliffordAlgebra (traceQuadraticForm K n)} (hv : v ≠ 0)
     (hdiag : ∀ i : n, ⁅Matrix.single i i (1 : K), v⁆ = μ i • v)
     (hμ : ∀ i : n, μ i = (a i : K) + (2 : K)⁻¹) :

--- a/TauCeti/Algebra/Lie/GeneralLinear/HighestWeight.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/HighestWeight.lean
@@ -59,6 +59,8 @@ and the whole of `𝔫⁺` annihilates (`TauCeti.isGlHighestWeightVector_iff_for
 * `TauCeti.IsGlDominantIntegral.add_const`: dominance is invariant under the central direction, and
   `TauCeti.IsGlDominantIntegral.exists_antitone_natCast_add_const` is the converse decomposition:
   every dominant weight is an antitone tuple of natural numbers translated along that direction.
+  `TauCeti.IsGlDominantIntegral.antitone_of_eq_natCast_add_const` recovers antitonicity when that
+  translated tuple is prescribed.
 * `TauCeti.isGlDominantIntegral_glStaircase` and `TauCeti.glStaircase_ne_intCast`: the staircase is
   dominant and no entry of it is an integer, so dominance genuinely does not force integrality.
 * `TauCeti.sum_glStaircase`: the sum of the staircase entries after mapping to a
@@ -249,6 +251,25 @@ theorem IsGlDominantIntegral.exists_antitone_natCast_add_const (hmu : IsGlDomina
       ring
     exact Nat.le.intro (Nat.cast_injective hcast)
   · exact sub_eq_iff_eq_add.mp (key i)
+
+/-- If a dominant integral weight is already expressed as a common translate of a natural tuple,
+that tuple is antitone. This is the prescribed-tuple counterpart to
+`TauCeti.IsGlDominantIntegral.exists_antitone_natCast_add_const`. -/
+theorem IsGlDominantIntegral.antitone_of_eq_natCast_add_const
+    (hmu : IsGlDominantIntegral mu) {a : Fin n → ℕ} {c : R}
+    (h : mu = fun i => (a i : R) + c) : Antitone a := by
+  intro i j hij
+  obtain ⟨d, hd⟩ := hmu.exists_natCast_sub_of_le hij
+  have hdiff : (a i : R) - (a j : R) = (d : R) := by
+    calc
+      (a i : R) - (a j : R) = mu i - mu j := by rw [h]; ring
+      _ = (d : R) := hd
+  have hcast : ((a j + d : ℕ) : R) = (a i : R) := by
+    rw [Nat.cast_add]
+    calc
+      (a j : R) + (d : R) = (d : R) + (a j : R) := add_comm _ _
+      _ = (a i : R) := (sub_eq_iff_eq_add.mp hdiff).symm
+  exact Nat.le.intro (Nat.cast_injective hcast)
 
 /-- Over an index type with at most one element there is no consecutive pair, so every tuple is
 dominant. -/


### PR DESCRIPTION
This PR establishes arbitrary-cut majorization bounds for the CAR occupation weights needed by the Layer 9 CAR isotypy milestone.

Roadmap: RepresentationTheory

## Summary

The normal-ordered diagonal lifts now admit an arbitrary-cut identity: internal occupation terms collapse to the scalar `|s|² / 2`, while the remaining terms are commuting idempotents crossing from `s` to its complement. Applying the existing simultaneous-idempotent spectrum theorem first gives an aggregate eigenvalue formula without `CharZero` but with two invertible, then natural cut counts, the sharp subset bound, and the exact full occupation total in characteristic zero. The coordinate spectrum is derived from that arbitrary-cut result at a singleton, and the generic cut-bound and total-count declarations are directly available to highest-weight consumers through the existing highest-weight fields. A general dominance lemma recovers antitonicity from any natural tuple with a common scalar translate.

## Roadmap target

This advances the CAR-algebra worked instance in `RepresentationTheory/SpinRepresentations/README.md`, specifically the Layer 9 target identifying the highest weight of every simple summand in the left-regular Clifford representation. After this PR, the remaining weight-identification step is to combine these bounds and the exact total with the now-merged Casimir-based numerical uniqueness theorem, then apply the existing highest-weight isotypy criterion; the later explicit highest-weight vector and multiplicity decomposition remain separate targets.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"car-weight-majorization-bounds"}-->

## Verification

- Exact head: `8e202253021c265a0d6082b677362276e7d76b70`
- Local Lean build: `lake exe cache get` and `lake build` — PASS (`11164` jobs)
- Axiom audit: `lake exe axioms` — PASS (`111754` declarations; only `propext`, `Classical.choice`, and `Quot.sound`)
- Lint: `/opt/homebrew/bin/bash scripts/lint-style.sh` — PASS (all `5001` source headers conform)
- Public CI: PASS (exact-head sandboxed build and workflow-pinned audits)

## Scale and generality

The cut calculation is stated for an arbitrary finite index type and every subset, including the empty and full cases. Its operator and aggregate-spectrum layers assume only a field and invertibility of two; converting half-shifted natural coordinates back to a natural-number equality adds exactly characteristic zero. The public diagonal-spectrum boundary exposes `DecidableEq n`, so concrete `Fin N` consumers use the same matrix-unit instance without elaboration blowups. No algebraic-closure or finite-dimensionality hypothesis is introduced. The dominance bridge works over the existing characteristic-zero commutative-ring setting and an arbitrary translation constant.

## Scope

- **Consumes:** the normal-ordered diagonal identity, commuting CAR occupation projections, Mathlib's finite commuting-idempotent spectrum theorem, and the existing general-linear dominance API
- **Provides:** one reusable diagonal cut identity, an aggregate spectrum theorem assuming two invertible but not `CharZero`, its singleton coordinate specialization, cut-count existence and bound theorems, the exact full occupation total, and a prescribed-tuple dominance bridge
- **Fits:** supplies the missing majorization and total-sum inputs for the CAR staircase-weight uniqueness and ensuing isotypy argument
- **Boundary:** does not restate the merged Casimir/uniqueness calculation, construct an explicit staircase-weight vector, or prove the final decomposition and multiplicities

<sub>🤖 GPT-5.6 Sol high · TauCetiWorker @ [7518d4150b846c4524423341570c031027a1d92c](https://github.com/utensil/TauCetiWorker/commit/7518d4150b846c4524423341570c031027a1d92c) · rubrics @ [afb424eda89e8ac96d9eb69f6a88972055a4cd1b](https://github.com/utensil/TauCetiReview/commit/afb424eda89e8ac96d9eb69f6a88972055a4cd1b) · local review @ [b533e561b6d44df071c31335ed4a63ae647507d2](https://github.com/utensil/formal-land/commit/b533e561b6d44df071c31335ed4a63ae647507d2) · fixed: api-design, documentation, generality, naming, proof-quality, reuse, ut-consumer-contract</sub>