### PR TITLE
feat: the hook-length formula for the dimension of a Specht module

### DIFF
--- a/TauCeti/Combinatorics/Young/HookLength/Basic.lean
+++ b/TauCeti/Combinatorics/Young/HookLength/Basic.lean
@@ -173,6 +173,11 @@ theorem card_hook : (hook μ c).card = hookLength μ c := by
 
 theorem hookLength_pos : 0 < hookLength μ c := Nat.succ_pos _
 
+/-- Every hook length is positive, so the product of the hook lengths of a diagram is positive.
+This is what makes the quotient form of the hook-length formula meaningful. -/
+theorem prod_hookLength_pos : 0 < ∏ d ∈ μ.cells, hookLength μ d :=
+  Finset.prod_pos fun d _ => hookLength_pos μ d
+
 variable {μ c}
 
 /-- A cell of the diagram has hook length at most the size of the diagram. -/

--- a/TauCeti/Combinatorics/Young/HookLength/Formula.lean
+++ b/TauCeti/Combinatorics/Young/HookLength/Formula.lean
@@ -22,8 +22,8 @@ number of standard Young tableaux. This file proves the **multiplicative hook-le
 (`TauCeti.standardCount_mul_prod_hookLength`), the milestone of Layer 5 of the Schur--Weyl
 roadmap. It carries no division obligation. The familiar quotient form `f^μ = n ! / ∏ hooks` is
 derived from it at the end of the file, over `ℕ` in
-`TauCeti.standardCount_eq_factorial_div_prod_hookLength` and over a field of characteristic zero
-in `TauCeti.cast_standardCount_eq_factorial_div_prod_hookLength`; the `ℕ`-division is exact
+`TauCeti.standardCount_eq_factorial_div_prod_hookLength` and over a semifield of characteristic
+zero in `TauCeti.cast_standardCount_eq_factorial_div_prod_hookLength`; the `ℕ`-division is exact
 because the product of the hook lengths divides `n !`
 (`YoungDiagram.prod_hookLength_dvd_factorial`), with `f^μ` as cofactor.
 
@@ -68,7 +68,7 @@ lengths sum to `n` and the shifts `r - 1 - i` are a reflection of `0, 1, …, r 
 * `YoungDiagram.prod_hookLength_dvd_factorial`: the product of the hook lengths divides `n !`.
 * `TauCeti.standardCount_eq_factorial_div_prod_hookLength` and
   `TauCeti.cast_standardCount_eq_factorial_div_prod_hookLength`: **the hook-length formula in
-  quotient form**, over `ℕ` and over a field of characteristic zero.
+  quotient form**, over `ℕ` and over a semifield of characteristic zero.
 
 ## References
 
@@ -303,14 +303,9 @@ theorem standardCount_eq_factorial_div_prod_hookLength (μ : YoungDiagram) :
   (Nat.div_eq_of_eq_mul_left μ.prod_hookLength_pos
     (standardCount_mul_prod_hookLength μ).symm).symm
 
-/-- The number of standard Young tableaux of a shape divides the factorial of its number of
-cells, the cofactor being the product of the hook lengths. -/
-theorem standardCount_dvd_factorial (μ : YoungDiagram) : standardCount μ ∣ μ.card ! :=
-  ⟨∏ c ∈ μ.cells, YoungDiagram.hookLength μ c, (standardCount_mul_prod_hookLength μ).symm⟩
-
-/-- **The hook-length formula over a field of characteristic zero**, in the familiar quotient form
-`f^μ = n ! / ∏ hooks`.  The denominator is nonzero because every hook length is positive. -/
-theorem cast_standardCount_eq_factorial_div_prod_hookLength {K : Type*} [Field K] [CharZero K]
+/-- **The hook-length formula over a semifield of characteristic zero**, in the familiar quotient
+form `f^μ = n ! / ∏ hooks`.  The denominator is nonzero because every hook length is positive. -/
+theorem cast_standardCount_eq_factorial_div_prod_hookLength {K : Type*} [Semifield K] [CharZero K]
     (μ : YoungDiagram) :
     (standardCount μ : K) = (μ.card ! : K) / ∏ c ∈ μ.cells, (YoungDiagram.hookLength μ c : K) := by
   have hp : (∏ c ∈ μ.cells, (YoungDiagram.hookLength μ c : K)) ≠ 0 := by

--- a/TauCeti/Combinatorics/Young/HookLength/Formula.lean
+++ b/TauCeti/Combinatorics/Young/HookLength/Formula.lean
@@ -295,9 +295,8 @@ theorem standardCount_mul_prod_hookLength (μ : YoungDiagram) :
 /-- **The hook-length formula in quotient form**: the number of standard Young tableaux of shape
 `μ` is `μ.card !` divided by the product of the hook lengths.
 
-The division is exact, by `YoungDiagram.prod_hookLength_dvd_factorial`; the multiplicative form
-`TauCeti.standardCount_mul_prod_hookLength` is the primary statement, and this one is read off it
-together with the positivity `YoungDiagram.prod_hookLength_pos`. -/
+The division is exact: the product of the hook lengths divides `μ.card !`, by
+`YoungDiagram.prod_hookLength_dvd_factorial`. -/
 theorem standardCount_eq_factorial_div_prod_hookLength (μ : YoungDiagram) :
     standardCount μ = μ.card ! / ∏ c ∈ μ.cells, YoungDiagram.hookLength μ c :=
   (Nat.div_eq_of_eq_mul_left μ.prod_hookLength_pos

--- a/TauCeti/Combinatorics/Young/HookLength/Formula.lean
+++ b/TauCeti/Combinatorics/Young/HookLength/Formula.lean
@@ -20,8 +20,12 @@ number of standard Young tableaux. This file proves the **multiplicative hook-le
 `f^μ * ∏ c ∈ μ.cells, hookLength μ c = n !`
 
 (`TauCeti.standardCount_mul_prod_hookLength`), the milestone of Layer 5 of the Schur--Weyl
-roadmap. It carries no division obligation, and the quotient form `f^μ = n ! / ∏ hooks`, which
-follows from it because the hook lengths are positive, is simply not stated here.
+roadmap. It carries no division obligation. The familiar quotient form `f^μ = n ! / ∏ hooks` is
+derived from it at the end of the file, over `ℕ` in
+`TauCeti.standardCount_eq_factorial_div_prod_hookLength` and over a field of characteristic zero
+in `TauCeti.cast_standardCount_eq_factorial_div_prod_hookLength`; the `ℕ`-division is exact
+because the product of the hook lengths divides `n !`
+(`YoungDiagram.prod_hookLength_dvd_factorial`), with `f^μ` as cofactor.
 
 ## The route
 
@@ -61,6 +65,10 @@ lengths sum to `n` and the shifts `r - 1 - i` are a reflection of `0, 1, …, r 
 
 * `TauCeti.standardCount_mul_prod_factorial_betaNumber`: **the Frobenius determinant formula.**
 * `TauCeti.standardCount_mul_prod_hookLength`: **the multiplicative hook-length formula.**
+* `YoungDiagram.prod_hookLength_dvd_factorial`: the product of the hook lengths divides `n !`.
+* `TauCeti.standardCount_eq_factorial_div_prod_hookLength` and
+  `TauCeti.cast_standardCount_eq_factorial_div_prod_hookLength`: **the hook-length formula in
+  quotient form**, over `ℕ` and over a field of characteristic zero.
 
 ## References
 
@@ -267,8 +275,8 @@ theorem standardCount_mul_prod_factorial_betaNumber (μ : YoungDiagram) {r : ℕ
 /-- **The multiplicative hook-length formula.** The number of standard Young tableaux of shape `μ`,
 times the product of the hook lengths of the cells of `μ`, is the factorial of the number of cells.
 
-The quotient form `f^μ = μ.card ! / ∏ hooks`, which follows from this one because the hook lengths
-are positive, is not stated here. -/
+The quotient form `f^μ = μ.card ! / ∏ hooks` is derived from it below, in
+`TauCeti.standardCount_eq_factorial_div_prod_hookLength`. -/
 theorem standardCount_mul_prod_hookLength (μ : YoungDiagram) :
     standardCount μ * ∏ c ∈ μ.cells, YoungDiagram.hookLength μ c = μ.card ! := by
   obtain ⟨r, hr⟩ : ∃ r, μ.colLen 0 ≤ r := ⟨μ.colLen 0, le_rfl⟩
@@ -282,4 +290,46 @@ theorem standardCount_mul_prod_hookLength (μ : YoungDiagram) :
   rw [mul_assoc, hhook]
   exact standardCount_mul_prod_factorial_betaNumber μ hr
 
+/-! ### The quotient form -/
+
+/-- **The hook-length formula in quotient form**: the number of standard Young tableaux of shape
+`μ` is `μ.card !` divided by the product of the hook lengths.
+
+The division is exact, by `YoungDiagram.prod_hookLength_dvd_factorial`; the multiplicative form
+`TauCeti.standardCount_mul_prod_hookLength` is the primary statement, and this one is read off it
+together with the positivity `YoungDiagram.prod_hookLength_pos`. -/
+theorem standardCount_eq_factorial_div_prod_hookLength (μ : YoungDiagram) :
+    standardCount μ = μ.card ! / ∏ c ∈ μ.cells, YoungDiagram.hookLength μ c :=
+  (Nat.div_eq_of_eq_mul_left μ.prod_hookLength_pos
+    (standardCount_mul_prod_hookLength μ).symm).symm
+
+/-- The number of standard Young tableaux of a shape divides the factorial of its number of
+cells, the cofactor being the product of the hook lengths. -/
+theorem standardCount_dvd_factorial (μ : YoungDiagram) : standardCount μ ∣ μ.card ! :=
+  ⟨∏ c ∈ μ.cells, YoungDiagram.hookLength μ c, (standardCount_mul_prod_hookLength μ).symm⟩
+
+/-- **The hook-length formula over a field of characteristic zero**, in the familiar quotient form
+`f^μ = n ! / ∏ hooks`.  The denominator is nonzero because every hook length is positive. -/
+theorem cast_standardCount_eq_factorial_div_prod_hookLength {K : Type*} [Field K] [CharZero K]
+    (μ : YoungDiagram) :
+    (standardCount μ : K) = (μ.card ! : K) / ∏ c ∈ μ.cells, (YoungDiagram.hookLength μ c : K) := by
+  have hp : (∏ c ∈ μ.cells, (YoungDiagram.hookLength μ c : K)) ≠ 0 := by
+    rw [← Nat.cast_prod]
+    exact_mod_cast μ.prod_hookLength_pos.ne'
+  rw [eq_div_iff hp, ← Nat.cast_prod, ← Nat.cast_mul, standardCount_mul_prod_hookLength]
+
 end TauCeti
+
+namespace YoungDiagram
+
+open Finset Nat
+
+/-- **The product of the hook lengths divides `n !`**, the cofactor being the number `f^μ` of
+standard Young tableaux of the shape.  This is the divisibility that makes the quotient form
+`TauCeti.standardCount_eq_factorial_div_prod_hookLength` of the hook-length formula an exact
+identity rather than a truncated one. -/
+theorem prod_hookLength_dvd_factorial (μ : YoungDiagram) :
+    (∏ c ∈ μ.cells, hookLength μ c) ∣ μ.card ! :=
+  ⟨TauCeti.standardCount μ, by rw [← TauCeti.standardCount_mul_prod_hookLength μ, mul_comm]⟩
+
+end YoungDiagram

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/HookLength.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/HookLength.lean
@@ -53,9 +53,8 @@ variable {n : ℕ} (μ : n.Partition)
 irreducible rational representation `S^μ` of `Sₙ`, times the product of the hook lengths of the
 shape `μ`, is `n !`.
 
-This is `TauCeti.standardCount_mul_prod_hookLength` read through
-`TauCeti.finrank_spechtModule`, the standard polytabloids being a basis of `S^μ`. It carries no
-division obligation; the quotient form is
+Equivalently, the degree of `S^μ` is the number of standard Young tableaux of shape `μ`. The
+quotient form `dim_ℚ S^μ = n ! / ∏ hooks` is
 `TauCeti.finrank_spechtModule_eq_factorial_div_prod_hookLength`. -/
 theorem finrank_spechtModule_mul_prod_hookLength :
     finrank ℚ (spechtModule μ) * ∏ c ∈ (diagramOf μ).cells, (diagramOf μ).hookLength c = n ! := by

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/HookLength.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/HookLength.lean
@@ -1,0 +1,103 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Combinatorics.Young.HookLength.Formula
+public import TauCeti.RepresentationTheory.Symmetric.Specht.Character
+public import TauCeti.RepresentationTheory.Symmetric.Specht.StandardBasis
+
+/-!
+# The hook-length formula for the degrees of the irreducible representations of `Sₙ`
+
+The Specht modules `S^μ` are the irreducible rational representations of `Sₙ`, and the standard
+polytabloids are a basis of `S^μ`, so `dim_ℚ S^μ` is the number `f^μ` of standard Young tableaux
+of shape `μ` (`TauCeti.finrank_spechtModule`).  The hook-length formula
+(`TauCeti.standardCount_mul_prod_hookLength`) computes that number from the shape alone.  This
+file transports the combinatorial statement to the representation it counts:
+
+`dim_ℚ S^μ · ∏_{c ∈ μ} hookLength μ c = n !`,
+
+and reads off the quotient form `dim_ℚ S^μ = n ! / ∏ hooks`, over `ℕ` and over `ℚ`.  Since the
+identity column of the character table of `Sₙ` holds the degrees
+(`TauCeti.symmetricCharacterTable_one`), the same identity computes that column.
+
+Nothing new is proved about Specht modules here; the content is the identification of the two
+sides, which needs `TauCeti.card_diagramOf` to see the Young diagram of a partition of `n` as a
+diagram with `n` cells.  The shapes are written as `TauCeti.diagramOf μ` throughout, matching
+`TauCeti.finrank_spechtModule`, because the hook lengths are attached to the diagram and not to
+the partition.
+
+## Main results
+
+* `TauCeti.finrank_spechtModule_mul_prod_hookLength`: **the hook-length formula for the dimension
+  of a Specht module**, in multiplicative form.
+* `TauCeti.finrank_spechtModule_eq_factorial_div_prod_hookLength` and
+  `TauCeti.cast_finrank_spechtModule_eq_factorial_div_prod_hookLength`: its quotient form, over
+  `ℕ` and over `ℚ`.
+* `TauCeti.spechtChar_one_mul_prod_hookLength` and
+  `TauCeti.symmetricCharacterTable_one_mul_prod_hookLength`: the same identity for the degree
+  `χ^μ(1)` and for the identity column of the character table of `Sₙ`.
+
+## References
+
+* [G. D. James, *The Representation Theory of the Symmetric Groups*][james1978], Chapter 20.
+* [B. E. Sagan, *The Symmetric Group*][sagan2001], Section 3.10.
+* [Schur--Weyl roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md),
+  Layer 5, whose quotient form `finrank ℚ (spechtModule μ) = n ! / ∏ hooks` this supplies.
+-/
+
+public section
+
+open Finset Module Nat
+
+namespace TauCeti
+
+variable {n : ℕ} (μ : n.Partition)
+
+/-- **The hook-length formula for the dimension of a Specht module.** The degree of the
+irreducible rational representation `S^μ` of `Sₙ`, times the product of the hook lengths of the
+shape `μ`, is `n !`.
+
+This is `TauCeti.standardCount_mul_prod_hookLength` read through
+`TauCeti.finrank_spechtModule`, the standard polytabloids being a basis of `S^μ`. It carries no
+division obligation; the quotient form is
+`TauCeti.finrank_spechtModule_eq_factorial_div_prod_hookLength`. -/
+theorem finrank_spechtModule_mul_prod_hookLength :
+    finrank ℚ (spechtModule μ) * ∏ c ∈ (diagramOf μ).cells, (diagramOf μ).hookLength c = n ! := by
+  rw [finrank_spechtModule, standardCount_mul_prod_hookLength, card_diagramOf]
+
+/-- **The hook-length formula in quotient form**: the degree of `S^μ` is `n !` divided by the
+product of the hook lengths of the shape `μ`. The division is exact, by
+`YoungDiagram.prod_hookLength_dvd_factorial` at the shape `TauCeti.diagramOf μ`, which has `n`
+cells. -/
+theorem finrank_spechtModule_eq_factorial_div_prod_hookLength :
+    finrank ℚ (spechtModule μ)
+      = n ! / ∏ c ∈ (diagramOf μ).cells, (diagramOf μ).hookLength c := by
+  rw [finrank_spechtModule, standardCount_eq_factorial_div_prod_hookLength, card_diagramOf]
+
+/-- **The hook-length formula in quotient form over `ℚ`**, the field the Specht modules live
+over. -/
+theorem cast_finrank_spechtModule_eq_factorial_div_prod_hookLength :
+    (finrank ℚ (spechtModule μ) : ℚ)
+      = (n ! : ℚ) / ∏ c ∈ (diagramOf μ).cells, ((diagramOf μ).hookLength c : ℚ) := by
+  rw [finrank_spechtModule, cast_standardCount_eq_factorial_div_prod_hookLength, card_diagramOf]
+
+/-- The hook-length formula for the degree `χ^μ(1)` of the irreducible character of `Sₙ` indexed
+by `μ`, the character being `ℤ`-valued. -/
+theorem spechtChar_one_mul_prod_hookLength :
+    spechtChar μ 1 * ∏ c ∈ (diagramOf μ).cells, ((diagramOf μ).hookLength c : ℤ) = (n ! : ℤ) := by
+  rw [spechtChar_one, ← Nat.cast_prod, ← Nat.cast_mul,
+    finrank_spechtModule_mul_prod_hookLength]
+
+/-- **The identity column of the character table of `Sₙ` is computed by the hook-length
+formula**: its entry at `μ`, times the product of the hook lengths of the shape `μ`, is `n !`. -/
+theorem symmetricCharacterTable_one_mul_prod_hookLength :
+    symmetricCharacterTable n μ ((partitionEquivConjClasses n).symm (ConjClasses.mk 1)) *
+        ∏ c ∈ (diagramOf μ).cells, ((diagramOf μ).hookLength c : ℤ) = (n ! : ℤ) := by
+  rw [symmetricCharacterTable_one, ← Nat.cast_prod, ← Nat.cast_mul,
+    finrank_spechtModule_mul_prod_hookLength]
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/HookLength.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/HookLength.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Combinatorics.Young.HookLength.Formula
-public import TauCeti.RepresentationTheory.Symmetric.Specht.Character
 public import TauCeti.RepresentationTheory.Symmetric.Specht.StandardBasis
 
 /-!
@@ -20,9 +19,7 @@ file transports the combinatorial statement to the representation it counts:
 
 `dim_ℚ S^μ · ∏_{c ∈ μ} hookLength μ c = n !`,
 
-and reads off the quotient form `dim_ℚ S^μ = n ! / ∏ hooks`, over `ℕ` and over `ℚ`.  Since the
-identity column of the character table of `Sₙ` holds the degrees
-(`TauCeti.symmetricCharacterTable_one`), the same identity computes that column.
+and reads off the quotient form `dim_ℚ S^μ = n ! / ∏ hooks`, over `ℕ` and over `ℚ`.
 
 Nothing new is proved about Specht modules here; the content is the identification of the two
 sides, which needs `TauCeti.card_diagramOf` to see the Young diagram of a partition of `n` as a
@@ -37,16 +34,11 @@ the partition.
 * `TauCeti.finrank_spechtModule_eq_factorial_div_prod_hookLength` and
   `TauCeti.cast_finrank_spechtModule_eq_factorial_div_prod_hookLength`: its quotient form, over
   `ℕ` and over `ℚ`.
-* `TauCeti.spechtChar_one_mul_prod_hookLength` and
-  `TauCeti.symmetricCharacterTable_one_mul_prod_hookLength`: the same identity for the degree
-  `χ^μ(1)` and for the identity column of the character table of `Sₙ`.
 
 ## References
 
 * [G. D. James, *The Representation Theory of the Symmetric Groups*][james1978], Chapter 20.
 * [B. E. Sagan, *The Symmetric Group*][sagan2001], Section 3.10.
-* [Schur--Weyl roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md),
-  Layer 5, whose quotient form `finrank ℚ (spechtModule μ) = n ! / ∏ hooks` this supplies.
 -/
 
 public section
@@ -84,20 +76,5 @@ theorem cast_finrank_spechtModule_eq_factorial_div_prod_hookLength :
     (finrank ℚ (spechtModule μ) : ℚ)
       = (n ! : ℚ) / ∏ c ∈ (diagramOf μ).cells, ((diagramOf μ).hookLength c : ℚ) := by
   rw [finrank_spechtModule, cast_standardCount_eq_factorial_div_prod_hookLength, card_diagramOf]
-
-/-- The hook-length formula for the degree `χ^μ(1)` of the irreducible character of `Sₙ` indexed
-by `μ`, the character being `ℤ`-valued. -/
-theorem spechtChar_one_mul_prod_hookLength :
-    spechtChar μ 1 * ∏ c ∈ (diagramOf μ).cells, ((diagramOf μ).hookLength c : ℤ) = (n ! : ℤ) := by
-  rw [spechtChar_one, ← Nat.cast_prod, ← Nat.cast_mul,
-    finrank_spechtModule_mul_prod_hookLength]
-
-/-- **The identity column of the character table of `Sₙ` is computed by the hook-length
-formula**: its entry at `μ`, times the product of the hook lengths of the shape `μ`, is `n !`. -/
-theorem symmetricCharacterTable_one_mul_prod_hookLength :
-    symmetricCharacterTable n μ ((partitionEquivConjClasses n).symm (ConjClasses.mk 1)) *
-        ∏ c ∈ (diagramOf μ).cells, ((diagramOf μ).hookLength c : ℤ) = (n ! : ℤ) := by
-  rw [symmetricCharacterTable_one, ← Nat.cast_prod, ← Nat.cast_mul,
-    finrank_spechtModule_mul_prod_hookLength]
 
 end TauCeti


### PR DESCRIPTION
This PR derives the quotient form of the hook-length formula and transports it to the degrees of the irreducible rational representations of the symmetric group. `TauCeti/Combinatorics/Young/HookLength/Formula.lean` already proves the multiplicative hook-length formula `f^μ · ∏_{c ∈ μ} hookLength μ c = n !`, and its header says outright that the familiar quotient form "follows from it because the hook lengths are positive, is simply not stated here". That deferred corollary is exactly what `TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md`, Layer 5 ("The standard basis and the hook-length formula"), asks for in its "Hook lengths and the formula" bullet: "The quotient form `finrank ℚ (spechtModule μ) = n ! / ∏ hooks` is a **derived** corollary, obtained only after the separate divisibility lemma `∏_c hookLength μ c ∣ n!`."

Three declarations close that in the combinatorial file: `YoungDiagram.prod_hookLength_pos` (in `HookLength/Basic.lean`, beside `hookLength_pos`), `YoungDiagram.prod_hookLength_dvd_factorial` — the roadmap's named divisibility lemma, with `f^μ` as the cofactor — and `TauCeti.standardCount_eq_factorial_div_prod_hookLength`, with `TauCeti.cast_standardCount_eq_factorial_div_prod_hookLength` giving the same identity over a semifield of characteristic zero, where the denominator is genuinely invertible rather than a truncated `ℕ`-division. The file header and its "Main results" list are updated, so the sentence that announced the omission is replaced by a pointer to what now discharges it.

The new module `TauCeti/RepresentationTheory/Symmetric/Specht/HookLength.lean` reads those statements on the representation they count. Because the standard polytabloids are a basis of `S^μ` (`TauCeti.finrank_spechtModule`), `TauCeti.finrank_spechtModule_mul_prod_hookLength` says `dim_ℚ S^μ · ∏ hooks = n !`, with the quotient forms `TauCeti.finrank_spechtModule_eq_factorial_div_prod_hookLength` over `ℕ` and `TauCeti.cast_finrank_spechtModule_eq_factorial_div_prod_hookLength` over `ℚ`. The only mathematical friction is the indexing: hook lengths live on a `YoungDiagram`, so every statement is phrased at `TauCeti.diagramOf μ` and translated back through `TauCeti.card_diagramOf`.

No Mathlib infrastructure was vendored; Mathlib has neither hook lengths nor the count of standard Young tableaux, and the whole hook-length development is already in this repository.

`lake build` and `lake exe axioms` are green, `scripts/lint-style.sh`, `scripts/lint-dot-notation.py` and `scripts/lint-env.sh` all pass with no new violations.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"hook-length-formula-specht-module-dimension"}-->

🤖 Prepared with Claude Code

