### PR TITLE
feat: contain pro-p subgroups in Sylow pro-p subgroups

### DIFF
--- a/TauCeti/GroupTheory/QuotientGroup/Map.lean
+++ b/TauCeti/GroupTheory/QuotientGroup/Map.lean
@@ -31,14 +31,16 @@ rewritable.
   is what characterizes it.
 * `TauCeti.QuotientGroup.mapOfLE_refl` and `TauCeti.QuotientGroup.mapOfLE_comp`: the two functor
   laws.
+* `TauCeti.QuotientGroup.mapOfLE_comp_mk'`: composing it with the quotient map of `G` modulo
+  `V` gives the quotient map of `G` modulo `U`.
 * `TauCeti.QuotientGroup.mapOfLE_surjective`: the map is surjective.
 
 ## Usage
 
-Work with `mapOfLE` through the four lemmas above: `mapOfLE_mk` evaluates it on classes,
-`mapOfLE_refl` and `mapOfLE_comp` simplify identities and composites, and `mapOfLE_surjective`
-feeds constructions that need a surjection, such as `Sylow.mapSurjective`. To identify
-`mapOfLE hVU` with another homomorphism out of `G ⧸ V`, compare the two on classes with
+Work with `mapOfLE` through the five lemmas above: `mapOfLE_mk` evaluates it on classes,
+`mapOfLE_refl`, `mapOfLE_comp` and `mapOfLE_comp_mk'` simplify identities and composites, and
+`mapOfLE_surjective` feeds constructions that need a surjection, such as `Sylow.mapSurjective`.
+To identify `mapOfLE hVU` with another homomorphism out of `G ⧸ V`, compare the two on classes with
 `QuotientGroup.induction_on` and `mapOfLE_mk`.
 -/
 
@@ -75,6 +77,13 @@ for `W ≤ U`. -/
 theorem mapOfLE_comp [U.Normal] [V.Normal] [W.Normal] (hWV : W ≤ V) (hVU : V ≤ U) :
     (mapOfLE hVU).comp (mapOfLE hWV) = mapOfLE (hWV.trans hVU) :=
   _root_.QuotientGroup.map_comp_map W V U (.id G) (.id G) _ _ _
+
+/-- The quotient homomorphism `G ⧸ V →* G ⧸ U` is the quotient map of `G` modulo `U`, read
+through the quotient map of `G` modulo `V`. -/
+@[simp]
+theorem mapOfLE_comp_mk' [U.Normal] [V.Normal] (hVU : V ≤ U) :
+    (mapOfLE hVU).comp (_root_.QuotientGroup.mk' V) = _root_.QuotientGroup.mk' U :=
+  MonoidHom.ext fun g ↦ mapOfLE_mk hVU g
 
 /-- The quotient homomorphism `G ⧸ V →* G ⧸ U` is surjective. -/
 theorem mapOfLE_surjective [U.Normal] [V.Normal] (hVU : V ≤ U) :

--- a/TauCeti/Topology/Algebra/Group/Profinite/ProP/Basic.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/ProP/Basic.lean
@@ -30,6 +30,7 @@ separate topological fact is supplied by `QuotientGroup.instTotallyDisconnectedS
 * `isProP_iff_isPGroup`: for a discrete topology, pro-`p` agrees with `IsPGroup`.
 * `IsProP.of_surjective`: a continuous surjective image of a pro-`p` group is pro-`p`.
 * `IsProP.quotient`: a quotient of a pro-`p` group by a normal subgroup is pro-`p`.
+* `IsProP.top`: the top subgroup of a pro-`p` group is pro-`p`.
 * `IsProP.isPGroup_range`: a continuous homomorphism from a pro-`p` group to a discrete group
   has a `p`-group as its range.
 * `IsProP.isPGroup_map_mk'`: the image of a pro-`p` subgroup in the quotient by an open normal
@@ -112,6 +113,11 @@ Hausdorff and profinite, not whether its open-normal quotients are `p`-groups. -
 theorem quotient (hG : IsProP p G) (N : Subgroup G) [N.Normal] : IsProP p (G ⧸ N) :=
   hG.of_surjective (QuotientGroup.mk' N) QuotientGroup.continuous_mk
     (QuotientGroup.mk'_surjective N)
+
+/-- The top subgroup of a pro-`p` group, with its subspace topology, is pro-`p`. -/
+theorem top (hG : IsProP p G) : IsProP p (⊤ : Subgroup G) :=
+  hG.of_surjective (Subgroup.topEquiv (G := G)).symm.toMonoidHom
+    (continuous_induced_rng.mpr continuous_id) (Subgroup.topEquiv (G := G)).symm.surjective
 
 /-- A topological group isomorphism carries the pro-`p` property to its target. -/
 theorem of_equiv (hG : IsProP p G) (e : G ≃ₜ* H) : IsProP p H :=

--- a/TauCeti/Topology/Algebra/Group/Profinite/Sylow/Basic.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Sylow/Basic.lean
@@ -28,6 +28,7 @@ a separate compatible inverse-limit argument.
 * `IsProPSylow`: the predicate for a Sylow pro-`p` subgroup.
 * `IsProPSylow.map_continuousMulEquiv`, `IsProPSylow.map_conj`: the predicate is preserved by
   isomorphisms of topological groups, in particular by conjugation.
+* `IsProP.isProPSylow_top`: a pro-`p` group is its own Sylow pro-`p` subgroup.
 * `isProPSylow_iff_isClosed_and_isProP_and_not_dvd_profiniteIndex`: its
   supernatural-index formulation.
 * `isProPSylow_iff_isPGroup_and_not_dvd_index`: its specialization to a discrete group.
@@ -119,6 +120,18 @@ theorem map_conj [IsTopologicalGroup G] (hP : IsProPSylow p P) (g : G) :
         rw [inv_inv]; exact (MulAut.conj_symm_apply g x).symm }
 
 end IsProPSylow
+
+/-- A pro-`p` topological group is its own Sylow pro-`p` subgroup: the top subgroup is closed,
+is pro-`p`, and its image in every quotient by an open normal subgroup is everything, hence of
+index `1`. -/
+theorem IsProP.isProPSylow_top [Fact p.Prime] (hG : IsProP p G) :
+    IsProPSylow p (⊤ : Subgroup G) := by
+  refine isProPSylow_iff.mpr ⟨?_, hG.top, fun U ↦ ?_⟩
+  · rw [Subgroup.coe_top]
+    exact isClosed_univ
+  · rw [Subgroup.map_top_of_surjective _ (QuotientGroup.mk'_surjective U.toSubgroup),
+      Subgroup.index_top, Nat.dvd_one]
+    exact (Fact.out : p.Prime).ne_one
 
 section ProfiniteIndex
 

--- a/TauCeti/Topology/Algebra/Group/Profinite/Sylow/Conjugacy.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Sylow/Conjugacy.lean
@@ -5,18 +5,15 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Topology.Algebra.Group.Profinite.Sylow.Basic
-import TauCeti.Algebra.Group.Subgroup.Map
-import TauCeti.GroupTheory.QuotientGroup.Map
+public import TauCeti.Topology.Algebra.Group.Profinite.Sylow.Containment
 
 /-!
 # Conjugacy of Sylow subgroups in profinite groups
 
-Any two Sylow pro-`p` subgroups of a profinite group are conjugate. At every finite continuous
-quotient their images are ordinary Sylow subgroups, so finite Sylow theory supplies a nonempty
-set of conjugators. The inverse images of these finite sets form a downward-directed family of
-closed subsets of the ambient compact group. An element of their intersection conjugates the
-two closed subgroups in every finite quotient, and hence conjugates the subgroups themselves.
+Any two Sylow pro-`p` subgroups of a profinite group are conjugate. This is containment read
+against maximality: a Sylow pro-`p` subgroup lies in a conjugate of any other by
+`IsProP.exists_le_map_conj`, and a conjugate of a Sylow pro-`p` subgroup is again Sylow pro-`p`,
+so `IsProPSylow.eq_of_le` upgrades that containment to an equality.
 
 ## Main results
 
@@ -44,56 +41,8 @@ namespace IsProPSylow
 /-- Any two Sylow pro-`p` subgroups of a profinite group are conjugate. -/
 theorem exists_map_conj_eq (hP : IsProPSylow p P) (hQ : IsProPSylow p Q) :
     ∃ g : G, P.map (MulAut.conj g).toMonoidHom = Q := by
-  let PSylow (U : OpenNormalSubgroup G) : Sylow p (G ⧸ U.toSubgroup) :=
-    (hP.isProP.isPGroup_map_mk' U).toSylow (hP.not_dvd_index U)
-  let QSylow (U : OpenNormalSubgroup G) : Sylow p (G ⧸ U.toSubgroup) :=
-    (hQ.isProP.isPGroup_map_mk' U).toSylow (hQ.not_dvd_index U)
-  let conjugators (U : OpenNormalSubgroup G) : Set (G ⧸ U.toSubgroup) :=
-    {x | x • PSylow U = QSylow U}
-  let t (U : OpenNormalSubgroup G) : Set G :=
-    (QuotientGroup.mk' U.toSubgroup) ⁻¹' conjugators U
-  have mem_t {U : OpenNormalSubgroup G} {g : G} : g ∈ t U ↔
-      (P.map (QuotientGroup.mk' U.toSubgroup)).map
-          (MulAut.conj (g : G ⧸ U.toSubgroup)).toMonoidHom =
-        Q.map (QuotientGroup.mk' U.toSubgroup) := by
-    simp only [t, conjugators, PSylow, QSylow, Set.mem_preimage, Set.mem_ofPred_eq,
-      Sylow.ext_iff, Sylow.coe_subgroup_smul, IsPGroup.toSylow_coe]
-    -- Mathlib defines the pointwise `MulAut` action on subgroups as `Subgroup.map`
-    -- (`Subgroup.pointwise_smul_def` is `rfl`) and provides no rewrite lemma to `toMonoidHom`.
-    exact Iff.rfl
-  have ht_nonempty (U : OpenNormalSubgroup G) : (t U).Nonempty := by
-    obtain ⟨x, hx⟩ := MulAction.exists_smul_eq (G ⧸ U.toSubgroup) (PSylow U) (QSylow U)
-    obtain ⟨g, rfl⟩ := QuotientGroup.mk'_surjective U.toSubgroup x
-    exact ⟨g, hx⟩
-  have ht_closed (U : OpenNormalSubgroup G) : IsClosed (t U) :=
-    (isClosed_discrete (conjugators U)).preimage QuotientGroup.continuous_mk
-  have ht_mono {U V : OpenNormalSubgroup G} (hVU : V ≤ U) : t V ⊆ t U := by
-    intro g hg
-    have hVU' : V.toSubgroup ≤ U.toSubgroup := fun _ hx ↦ hVU hx
-    have hmap (R : Subgroup G) :
-        (R.map (QuotientGroup.mk' V.toSubgroup)).map (QuotientGroup.mapOfLE hVU') =
-          R.map (QuotientGroup.mk' U.toSubgroup) := by
-      rw [Subgroup.map_map, QuotientGroup.mapOfLE_comp_mk']
-    rw [mem_t] at hg ⊢
-    rw [← hmap Q, ← hg, Subgroup.map_conj_map, hmap P, QuotientGroup.mapOfLE_mk]
-  have ht_directed : Directed (· ⊇ ·) t := by
-    intro U V
-    exact ⟨U ⊓ V, ht_mono inf_le_left, ht_mono inf_le_right⟩
-  let _ : Nonempty (OpenNormalSubgroup G) :=
-    ⟨{ toOpenSubgroup := ⊤, isNormal' := Subgroup.normal_top }⟩
-  obtain ⟨g, hg⟩ := IsCompact.nonempty_iInter_of_directed_nonempty_isCompact_isClosed t
-    ht_directed ht_nonempty (fun U ↦ (ht_closed U).isCompact) ht_closed
-  refine ⟨g, ?_⟩
-  rw [Subgroup.eq_iInf_sup_openNormalSubgroup Q hQ.isClosed,
-    Subgroup.eq_iInf_sup_openNormalSubgroup _ (hP.map_conj g).isClosed]
-  congr 1
-  funext U
-  have himages : (P.map (MulAut.conj g).toMonoidHom).map (QuotientGroup.mk' U.toSubgroup) =
-      Q.map (QuotientGroup.mk' U.toSubgroup) := by
-    rw [Subgroup.map_conj_map, QuotientGroup.mk'_apply]
-    exact mem_t.mp (Set.mem_iInter.mp hg U)
-  have hcomap := congrArg (Subgroup.comap (QuotientGroup.mk' U.toSubgroup)) himages
-  simpa only [Subgroup.comap_map_eq, QuotientGroup.ker_mk'] using hcomap
+  obtain ⟨g, hg⟩ := hQ.isProP.exists_le_map_conj hP
+  exact ⟨g, (hQ.eq_of_le (hP.map_conj g).isProP hg).symm⟩
 
 /-- A normal Sylow pro-`p` subgroup is the unique Sylow pro-`p` subgroup. -/
 theorem eq_of_normal (p : ℕ) [Fact p.Prime] (G : Type u) [Group G] [TopologicalSpace G]

--- a/TauCeti/Topology/Algebra/Group/Profinite/Sylow/Conjugacy.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Sylow/Conjugacy.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.Topology.Algebra.Group.Profinite.Sylow.Basic
 import TauCeti.Algebra.Group.Subgroup.Map
+import TauCeti.GroupTheory.QuotientGroup.Map
 
 /-!
 # Conjugacy of Sylow subgroups in profinite groups
@@ -69,12 +70,12 @@ theorem exists_map_conj_eq (hP : IsProPSylow p P) (hQ : IsProPSylow p Q) :
   have ht_mono {U V : OpenNormalSubgroup G} (hVU : V ≤ U) : t V ⊆ t U := by
     intro g hg
     have hVU' : V.toSubgroup ≤ U.toSubgroup := fun _ hx ↦ hVU hx
-    have hmap (R : Subgroup G) : (R.map (QuotientGroup.mk' V.toSubgroup)).map
-        (QuotientGroup.map V.toSubgroup U.toSubgroup (.id G) (by simpa using hVU')) =
+    have hmap (R : Subgroup G) :
+        (R.map (QuotientGroup.mk' V.toSubgroup)).map (QuotientGroup.mapOfLE hVU') =
           R.map (QuotientGroup.mk' U.toSubgroup) := by
-      rw [Subgroup.map_mk'_map_quotientGroupMap, Subgroup.map_id]
+      rw [Subgroup.map_map, QuotientGroup.mapOfLE_comp_mk']
     rw [mem_t] at hg ⊢
-    rw [← hmap Q, ← hg, Subgroup.map_conj_map, hmap P, QuotientGroup.map_mk, MonoidHom.id_apply]
+    rw [← hmap Q, ← hg, Subgroup.map_conj_map, hmap P, QuotientGroup.mapOfLE_mk]
   have ht_directed : Directed (· ⊇ ·) t := by
     intro U V
     exact ⟨U ⊓ V, ht_mono inf_le_left, ht_mono inf_le_right⟩

--- a/TauCeti/Topology/Algebra/Group/Profinite/Sylow/Containment.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Sylow/Containment.lean
@@ -1,0 +1,172 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Topology.Algebra.Group.Profinite.Sylow.Existence
+import TauCeti.Algebra.Group.Subgroup.Map
+import TauCeti.GroupTheory.QuotientGroup.Map
+
+/-!
+# Sylow subgroups and the poset of pro-`p` subgroups
+
+Every pro-`p` subgroup of a profinite group is contained in a Sylow pro-`p` subgroup, and the
+Sylow pro-`p` subgroups are exactly the maximal ones. The containment statement is proved in the
+sharper conjugacy form: given one Sylow pro-`p` subgroup `P`, every pro-`p` subgroup `Q` lies in
+a conjugate of `P`. At each finite continuous quotient the image of `Q` is a `p`-group and the
+image of `P` is a Sylow subgroup, so finite Sylow theory supplies a nonempty set of elements
+conjugating `P` past `Q`; these sets are closed and downward directed, and a point of their
+intersection conjugates `P` past `Q` in every finite quotient, hence past `Q` itself.
+
+Maximality runs the same finite-level comparison without compactness: a pro-`p` subgroup
+containing a Sylow pro-`p` subgroup has the same image in every finite quotient, and a Sylow
+pro-`p` subgroup is closed, so the two subgroups agree. Together with containment this
+identifies the Sylow pro-`p` subgroups with the maximal pro-`p` subgroups, and shows that a
+pro-`p` group is its own unique Sylow pro-`p` subgroup.
+
+## Main results
+
+* `IsProP.exists_le_map_conj`: a pro-`p` subgroup lies in a conjugate of any given Sylow
+  pro-`p` subgroup.
+* `IsProP.exists_le_isProPSylow`: a pro-`p` subgroup lies in a Sylow pro-`p` subgroup.
+* `IsProPSylow.eq_of_le`: a Sylow pro-`p` subgroup is maximal among the pro-`p`
+  subgroups.
+* `isProPSylow_iff_isProP_and_maximal`: the Sylow pro-`p` subgroups are exactly the
+  maximal pro-`p` subgroups.
+* `IsProPSylow.eq_top` and `IsProP.isProPSylow_top`: a profinite group is
+  pro-`p` exactly when it is its own Sylow pro-`p` subgroup.
+
+## References
+
+* L. Ribes and P. Zalesskii, *Profinite Groups*, Section 2.3.
+-/
+
+public section
+
+namespace TauCeti
+
+universe u
+
+variable {p : ℕ} [Fact p.Prime]
+variable {G : Type u} [Group G] [TopologicalSpace G] [IsTopologicalGroup G]
+  [CompactSpace G] [TotallyDisconnectedSpace G]
+variable {P Q : Subgroup G}
+
+/-- **Containment in a conjugate.** A pro-`p` subgroup of a profinite group is contained in a
+conjugate of any given Sylow pro-`p` subgroup. -/
+theorem IsProP.exists_le_map_conj (hQ : IsProP p Q) (hP : IsProPSylow p P) :
+    ∃ g : G, Q ≤ P.map (MulAut.conj g).toMonoidHom := by
+  -- At each finite level the image of `P` is an ordinary Sylow subgroup.
+  let PSylow (U : OpenNormalSubgroup G) : Sylow p (G ⧸ U.toSubgroup) :=
+    (hP.isProP.isPGroup_map_mk' U).toSylow (hP.not_dvd_index U)
+  have hPSylow (U : OpenNormalSubgroup G) :
+      (PSylow U : Subgroup (G ⧸ U.toSubgroup)) = P.map (QuotientGroup.mk' U.toSubgroup) :=
+    IsPGroup.toSylow_coe _ _
+  -- The elements that conjugate `P` past `Q` in the quotient by `U`.
+  let conjugators (U : OpenNormalSubgroup G) : Set (G ⧸ U.toSubgroup) :=
+    {x | Q.map (QuotientGroup.mk' U.toSubgroup) ≤ (x • PSylow U : Sylow p (G ⧸ U.toSubgroup))}
+  let t (U : OpenNormalSubgroup G) : Set G := QuotientGroup.mk' U.toSubgroup ⁻¹' conjugators U
+  have mem_t {U : OpenNormalSubgroup G} {g : G} : g ∈ t U ↔
+      Q.map (QuotientGroup.mk' U.toSubgroup) ≤
+        (P.map (MulAut.conj g).toMonoidHom).map (QuotientGroup.mk' U.toSubgroup) := by
+    simp only [t, conjugators, Set.mem_preimage, Set.mem_ofPred_eq, Sylow.coe_subgroup_smul,
+      QuotientGroup.mk'_apply, Subgroup.map_conj_map, hPSylow]
+    -- Mathlib defines the pointwise `MulAut` action on subgroups as `Subgroup.map`
+    -- (`Subgroup.pointwise_smul_def` is `rfl`) and provides no rewrite lemma to `toMonoidHom`.
+    exact Iff.rfl
+  have ht_nonempty (U : OpenNormalSubgroup G) : (t U).Nonempty := by
+    obtain ⟨S, hS⟩ := (hQ.isPGroup_map_mk' U).exists_le_sylow
+    obtain ⟨x, hx⟩ := MulAction.exists_smul_eq (G ⧸ U.toSubgroup) (PSylow U) S
+    obtain ⟨g, rfl⟩ := QuotientGroup.mk'_surjective U.toSubgroup x
+    refine ⟨g, ?_⟩
+    simp only [t, conjugators, Set.mem_preimage, Set.mem_ofPred_eq, hx]
+    exact hS
+  have ht_closed (U : OpenNormalSubgroup G) : IsClosed (t U) :=
+    (isClosed_discrete (conjugators U)).preimage QuotientGroup.continuous_mk
+  have ht_mono {U V : OpenNormalSubgroup G} (hVU : V ≤ U) : t V ⊆ t U := by
+    intro g hg
+    have hVU' : V.toSubgroup ≤ U.toSubgroup := fun _ hx ↦ hVU hx
+    have hmap (R : Subgroup G) :
+        (R.map (QuotientGroup.mk' V.toSubgroup)).map (QuotientGroup.mapOfLE hVU') =
+          R.map (QuotientGroup.mk' U.toSubgroup) := by
+      rw [Subgroup.map_map, QuotientGroup.mapOfLE_comp_mk']
+    rw [mem_t] at hg ⊢
+    rw [← hmap Q, ← hmap (P.map (MulAut.conj g).toMonoidHom)]
+    exact Subgroup.map_mono hg
+  have ht_directed : Directed (· ⊇ ·) t := fun U V ↦
+    ⟨U ⊓ V, ht_mono inf_le_left, ht_mono inf_le_right⟩
+  let _ : Nonempty (OpenNormalSubgroup G) :=
+    ⟨{ toOpenSubgroup := ⊤, isNormal' := Subgroup.normal_top }⟩
+  obtain ⟨g, hg⟩ := IsCompact.nonempty_iInter_of_directed_nonempty_isCompact_isClosed t
+    ht_directed ht_nonempty (fun U ↦ (ht_closed U).isCompact) ht_closed
+  -- A conjugate of a Sylow pro-`p` subgroup is closed, so it is the infimum of its joins with
+  -- the open normal subgroups, and each join contains `Q` by the finite-level containment.
+  refine ⟨g, ?_⟩
+  rw [Subgroup.eq_iInf_sup_openNormalSubgroup _ (hP.map_conj g).isClosed]
+  refine le_iInf fun U ↦ ?_
+  calc Q ≤ (Q.map (QuotientGroup.mk' U.toSubgroup)).comap (QuotientGroup.mk' U.toSubgroup) :=
+        Subgroup.le_comap_map _ _
+    _ ≤ ((P.map (MulAut.conj g).toMonoidHom).map (QuotientGroup.mk' U.toSubgroup)).comap
+          (QuotientGroup.mk' U.toSubgroup) :=
+        Subgroup.comap_mono (mem_t.mp (Set.mem_iInter.mp hg U))
+    _ = P.map (MulAut.conj g).toMonoidHom ⊔ U.toSubgroup := by
+        rw [Subgroup.comap_map_eq, QuotientGroup.ker_mk']
+
+/-- **Containment.** Every pro-`p` subgroup of a profinite group is contained in a Sylow pro-`p`
+subgroup. -/
+theorem IsProP.exists_le_isProPSylow (hQ : IsProP p Q) :
+    ∃ P : Subgroup G, IsProPSylow p P ∧ Q ≤ P := by
+  obtain ⟨P, hP⟩ := exists_isProPSylow p G
+  obtain ⟨g, hg⟩ := hQ.exists_le_map_conj hP
+  exact ⟨_, hP.map_conj g, hg⟩
+
+/-- **Maximality.** A pro-`p` subgroup of a profinite group that contains a Sylow pro-`p`
+subgroup is equal to it. Equivalently, a closed pro-`p` subgroup of index prime to `p` is
+maximal among the pro-`p` subgroups. -/
+theorem IsProPSylow.eq_of_le (hP : IsProPSylow p P) (hQ : IsProP p Q) (hPQ : P ≤ Q) : P = Q := by
+  refine le_antisymm hPQ ?_
+  rw [Subgroup.eq_iInf_sup_openNormalSubgroup P hP.isClosed]
+  refine le_iInf fun U ↦ ?_
+  -- The image of `P` in `G ⧸ U` is a Sylow subgroup, so the `p`-group above it is no bigger.
+  have hPU : ((hP.isProP.isPGroup_map_mk' U).toSylow (hP.not_dvd_index U) :
+      Subgroup (G ⧸ U.toSubgroup)) = P.map (QuotientGroup.mk' U.toSubgroup) :=
+    IsPGroup.toSylow_coe _ _
+  have himage : Q.map (QuotientGroup.mk' U.toSubgroup) =
+      P.map (QuotientGroup.mk' U.toSubgroup) := by
+    have hle : ((hP.isProP.isPGroup_map_mk' U).toSylow (hP.not_dvd_index U) :
+        Subgroup (G ⧸ U.toSubgroup)) ≤ Q.map (QuotientGroup.mk' U.toSubgroup) := by
+      rw [hPU]
+      exact Subgroup.map_mono hPQ
+    have hmax := ((hP.isProP.isPGroup_map_mk' U).toSylow (hP.not_dvd_index U)).is_maximal'
+      (hQ.isPGroup_map_mk' U) hle
+    rwa [hPU] at hmax
+  calc Q ≤ (Q.map (QuotientGroup.mk' U.toSubgroup)).comap (QuotientGroup.mk' U.toSubgroup) :=
+        Subgroup.le_comap_map _ _
+    _ = P ⊔ U.toSubgroup := by
+        rw [himage, Subgroup.comap_map_eq, QuotientGroup.ker_mk']
+
+/-- A maximal pro-`p` subgroup of a profinite group is a Sylow pro-`p` subgroup. -/
+theorem isProPSylow_of_maximal (hQ : IsProP p Q)
+    (hmax : ∀ R : Subgroup G, IsProP p R → Q ≤ R → R ≤ Q) : IsProPSylow p Q := by
+  obtain ⟨P, hP, hQP⟩ := hQ.exists_le_isProPSylow
+  exact le_antisymm hQP (hmax P hP.isProP hQP) ▸ hP
+
+/-- **The Sylow pro-`p` subgroups are the maximal pro-`p` subgroups.** Closedness is not part of
+the right-hand side: a maximal pro-`p` subgroup is closed because it is Sylow. -/
+theorem isProPSylow_iff_isProP_and_maximal :
+    IsProPSylow p P ↔ IsProP p P ∧ ∀ R : Subgroup G, IsProP p R → P ≤ R → R ≤ P :=
+  ⟨fun hP ↦ ⟨hP.isProP, fun _ hR hPR ↦ (hP.eq_of_le hR hPR).ge⟩,
+    fun hP ↦ isProPSylow_of_maximal hP.1 hP.2⟩
+
+/-- A Sylow pro-`p` subgroup of a pro-`p` group is the whole group. -/
+theorem IsProPSylow.eq_top (hP : IsProPSylow p P) (hG : IsProP p G) : P = ⊤ :=
+  hP.eq_of_le hG.top le_top
+
+/-- A pro-`p` profinite group is its own Sylow pro-`p` subgroup. -/
+theorem IsProP.isProPSylow_top (hG : IsProP p G) : IsProPSylow p (⊤ : Subgroup G) := by
+  obtain ⟨P, hP⟩ := exists_isProPSylow p G
+  exact hP.eq_top hG ▸ hP
+
+end TauCeti

--- a/TauCeti/Topology/Algebra/Group/Profinite/Sylow/Containment.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Sylow/Containment.lean
@@ -35,8 +35,9 @@ pro-`p` group is its own unique Sylow pro-`p` subgroup.
   subgroups.
 * `isProPSylow_iff_isProP_and_maximal`: the Sylow pro-`p` subgroups are exactly the
   maximal pro-`p` subgroups.
-* `IsProPSylow.eq_top` and `IsProP.isProPSylow_top`: a profinite group is
-  pro-`p` exactly when it is its own Sylow pro-`p` subgroup.
+* `IsProPSylow.eq_top`: a Sylow pro-`p` subgroup of a pro-`p` profinite group is the whole
+  group. Together with `IsProP.isProPSylow_top` this says that a pro-`p` profinite group is its
+  own unique Sylow pro-`p` subgroup.
 
 ## References
 
@@ -163,10 +164,5 @@ theorem isProPSylow_iff_isProP_and_maximal :
 /-- A Sylow pro-`p` subgroup of a pro-`p` group is the whole group. -/
 theorem IsProPSylow.eq_top (hP : IsProPSylow p P) (hG : IsProP p G) : P = ⊤ :=
   hP.eq_of_le hG.top le_top
-
-/-- A pro-`p` profinite group is its own Sylow pro-`p` subgroup. -/
-theorem IsProP.isProPSylow_top (hG : IsProP p G) : IsProPSylow p (⊤ : Subgroup G) := by
-  obtain ⟨P, hP⟩ := exists_isProPSylow p G
-  exact hP.eq_top hG ▸ hP
 
 end TauCeti


### PR DESCRIPTION
This PR closes the containment and maximality half of the "Conjugacy and the poset" milestone in
Layer 2 of the `ProfiniteProPGroups` roadmap, which asks for "Every closed pro-`p` subgroup lies
in a `p`-Sylow subgroup. A pro-`p` subgroup of index prime to `p` is maximal pro-`p`, and a
maximal closed pro-`p` subgroup is `p`-Sylow." It supplies the frozen export
`IsProP.exists_le_isProPSylow`, the last one of that milestone still missing after
`exists_isProPSylow` (#6239) and `IsProPSylow.eq_of_normal` (#6278).

Containment is proved in the sharper conjugacy form `IsProP.exists_le_map_conj`: given one Sylow
pro-`p` subgroup `P`, every pro-`p` subgroup `Q` lies in a conjugate of `P`. At each quotient by
an open normal subgroup the image of `Q` is a `p`-group and the image of `P` is an ordinary Sylow
subgroup, so `IsPGroup.exists_le_sylow` together with conjugacy of finite Sylow subgroups makes
the set of elements conjugating `P` past `Q` nonempty; those sets are closed, because the
condition only depends on the class modulo the open normal subgroup, and downward directed, so a
point of their intersection conjugates `P` past `Q` in every finite quotient. Since a conjugate
of a Sylow pro-`p` subgroup is closed, it is the infimum of its joins with the open normal
subgroups, and the finite-level containments assemble into `Q ≤ P.map (MulAut.conj g)`.
Combining this with `exists_isProPSylow` gives the frozen statement. The closedness hypothesis
that `Suggested.lean` puts on `Q` is not used and is therefore dropped: only the image of `Q` in
each finite quotient enters the argument.

Maximality, `IsProPSylow.eq_of_le`, needs no compactness: a pro-`p` subgroup `Q` above a Sylow
pro-`p` subgroup `P` has the same image as `P` in every finite quotient, by maximality of a
finite Sylow subgroup, so `Q ≤ P ⊔ U` for every open normal `U`, and `P` is closed. Read
together, containment and maximality give `isProPSylow_iff_isProP_and_maximal`: the Sylow
pro-`p` subgroups are exactly the maximal pro-`p` subgroups, with closedness dropping out of the
right-hand side rather than being assumed. They also give the roadmap's worked example for the
predicate, `P = ⊤` when `G` is pro-`p`, as `IsProPSylow.eq_top`.

The existing conjugacy theorem `IsProPSylow.exists_map_conj_eq` is exactly containment read
against maximality — a Sylow pro-`p` subgroup lies in a conjugate of any other, and that
conjugate is Sylow pro-`p`, hence equal to it — so `Sylow/Conjugacy.lean` now imports
`Sylow/Containment.lean` and its own copy of the conjugator-set and compact-intersection
construction goes away, leaving a two-line proof.

Three supporting declarations land outside the new module. `QuotientGroup.mapOfLE_comp_mk'`
records that the transition map `G ⧸ V →* G ⧸ U` composed with the quotient map of `G` modulo
`V` is the quotient map modulo `U`; it is the directedness step of the containment proof.
`IsProP.top` says the top subgroup of a pro-`p` group is pro-`p` in its subspace topology, which
belongs with the rest of the `IsProP` covariance API and is what turns maximality into the `⊤`
statement. `IsProP.isProPSylow_top`, the converse direction of that worked example, needs neither
compactness nor total disconnectedness nor the existence theorem, so it sits beside the predicate
in `Sylow/Basic.lean`: the top subgroup is closed, is pro-`p`, and its image in every quotient by
an open normal subgroup is everything, hence of index `1`. No Mathlib source was vendored.

New file: `TauCeti/Topology/Algebra/Group/Profinite/Sylow/Containment.lean` (168 lines), plus
thirteen lines in `Sylow/Basic.lean`, six in `ProP/Basic.lean`, five in
`GroupTheory/QuotientGroup/Map.lean` and a net deletion of 61 lines from `Sylow/Conjugacy.lean`.

What remains on Layer 2 after this PR: the functoriality milestone — the image of a Sylow pro-`p`
subgroup under a continuous surjection is Sylow pro-`p` (`IsProPSylow.map_of_surjective`), and the
Sylow subgroup of an inverse limit as the inverse limit of Sylow subgroups — together with the
`ℤ̂` worked instance, which the roadmap defers to Layer 4.

Roadmap: ProfiniteProPGroups

<!--tauceti-target:v1 {"focus":"ProfiniteProPGroups","id":"isprop-exists-le-ispropsylow"}-->

🤖 Prepared with Claude Code
