### PR TITLE
feat: globalize smoothness of group homomorphisms

### DIFF
--- a/TauCeti/Geometry/Manifold/Algebra/Monoid.lean
+++ b/TauCeti/Geometry/Manifold/Algebra/Monoid.lean
@@ -11,7 +11,7 @@ public import Mathlib.Geometry.Manifold.Algebra.Monoid
 # Smooth monoid morphisms
 
 Identity, composition, and their laws for bundled smooth multiplicative and additive monoid
-morphisms.
+morphisms. It also characterizes smooth group homomorphisms by their regularity at the identity.
 -/
 
 public section
@@ -92,3 +92,39 @@ theorem comp_assoc
   rfl
 
 end ContMDiffMonoidMorphism
+
+namespace TauCeti
+
+variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+  {H : Type*} [TopologicalSpace H] {I : ModelWithCorners 𝕜 E H}
+  {E' : Type*} [NormedAddCommGroup E'] [NormedSpace 𝕜 E']
+  {H' : Type*} [TopologicalSpace H'] {I' : ModelWithCorners 𝕜 E' H'}
+  {G : Type*} [Group G] [TopologicalSpace G] [ChartedSpace H G]
+  {G' : Type*} [Monoid G'] [TopologicalSpace G'] [ChartedSpace H' G']
+  {F : Type*} [FunLike F G G'] [MonoidHomClass F G G']
+  {n : ℕ∞ω} [ContMDiffMul I n G] [ContMDiffMul I' n G']
+
+/-- A group homomorphism that is `C^n` at the identity is `C^n` everywhere.
+
+This only requires smooth multiplication: inverses occur at fixed group elements, so the
+inversion operation itself need not be smooth. -/
+@[to_additive
+  /-- An additive group homomorphism that is `C^n` at zero is `C^n` everywhere. -/]
+theorem contMDiff_of_contMDiffAt_one (f : F)
+    (hf : ContMDiffAt I I' n f 1) : ContMDiff I I' n f := by
+  intro x
+  have htranslate : ContMDiffAt I I n (fun y : G ↦ x⁻¹ * y) x :=
+    contMDiffAt_const.mul contMDiffAt_id
+  have hcomp : ContMDiffAt I I' n (fun y : G ↦ f (x⁻¹ * y)) x := by
+    -- `comp_of_eq` exposes its composition explicitly, unlike the displayed translated germ.
+    change ContMDiffAt I I' n (f ∘ fun y : G ↦ x⁻¹ * y) x
+    exact hf.comp_of_eq htranslate (by simp)
+  have hmul : ContMDiffAt I I' n (fun y : G ↦ f x * f (x⁻¹ * y)) x :=
+    contMDiffAt_const.mul hcomp
+  convert hmul using 1
+  funext y
+  rw [← map_mul]
+  simp
+
+end TauCeti

--- a/TauCeti/Geometry/Manifold/Algebra/Monoid.lean
+++ b/TauCeti/Geometry/Manifold/Algebra/Monoid.lean
@@ -107,6 +107,8 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
 
 /-- A group homomorphism that is `C^n` at the identity is `C^n` everywhere.
 
+This is the smooth analogue of Mathlib's `continuous_of_continuousAt_one`.
+
 This only requires smooth multiplication: inverses occur at fixed group elements, so the
 inversion operation itself need not be smooth. -/
 @[to_additive

--- a/TauCeti/Geometry/Manifold/Algebra/Monoid.lean
+++ b/TauCeti/Geometry/Manifold/Algebra/Monoid.lean
@@ -101,7 +101,7 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
   {E' : Type*} [NormedAddCommGroup E'] [NormedSpace 𝕜 E']
   {H' : Type*} [TopologicalSpace H'] {I' : ModelWithCorners 𝕜 E' H'}
   {G : Type*} [Group G] [TopologicalSpace G] [ChartedSpace H G]
-  {G' : Type*} [Monoid G'] [TopologicalSpace G'] [ChartedSpace H' G']
+  {G' : Type*} [MulOneClass G'] [TopologicalSpace G'] [ChartedSpace H' G']
   {F : Type*} [FunLike F G G'] [MonoidHomClass F G G']
   {n : ℕ∞ω} [ContMDiffMul I n G] [ContMDiffMul I' n G']
 
@@ -114,12 +114,10 @@ inversion operation itself need not be smooth. -/
 theorem contMDiff_of_contMDiffAt_one (f : F)
     (hf : ContMDiffAt I I' n f 1) : ContMDiff I I' n f := by
   intro x
-  have htranslate : ContMDiffAt I I n (fun y : G ↦ x⁻¹ * y) x :=
-    contMDiffAt_const.mul contMDiffAt_id
   have hcomp : ContMDiffAt I I' n (fun y : G ↦ f (x⁻¹ * y)) x := by
     -- `comp_of_eq` exposes its composition explicitly, unlike the displayed translated germ.
     change ContMDiffAt I I' n (f ∘ fun y : G ↦ x⁻¹ * y) x
-    exact hf.comp_of_eq htranslate (by simp)
+    exact hf.comp_of_eq contMDiffAt_mul_left (by simp)
   have hmul : ContMDiffAt I I' n (fun y : G ↦ f x * f (x⁻¹ * y)) x :=
     contMDiffAt_const.mul hcomp
   convert hmul using 1


### PR DESCRIPTION
This PR globalizes `C^n` regularity of a group homomorphism from the identity to every source point for the LieGroups Layer 2 automatic-smoothness path.

Roadmap: RepresentationTheory

## Summary

Add `TauCeti.contMDiff_of_contMDiffAt_one`: for any bundled morphism satisfying `MonoidHomClass`, from a group manifold to a smoothly multiplicative `MulOneClass` manifold, smoothness at the identity implies smoothness everywhere. Left translation moves the identity germ to an arbitrary point and the homomorphism law identifies the translated expression with the original map. `to_additive` supplies the zero-based additive analogue. The theorem documentation credits Mathlib's structurally analogous `continuous_of_continuousAt_one`.

This is the local-to-global boundary used after a closed-graph argument establishes smoothness at the identity. The statement keeps arbitrary differentiability order, field, and source/target models; it assumes neither finite dimensionality nor smooth inversion. No Mathlib source is vendored. The API uses Mathlib's `ContMDiffAt.comp_of_eq`, `MonoidHomClass`, and smooth multiplication, at the same structural generality as the adjacent continuous theorem `continuous_of_continuousAt_one`.

## Roadmap target

This advances `RepresentationTheory/LieGroups/README.md`, Layer 2, “the closed-subgroup (Cartan) theorem,” specifically Cartan's automatic-smoothness corollary for continuous homomorphisms. Its downstream consumer is `RepresentationTheory/SpinRepresentations/README.md`, Layer 3, “the differential of the double cover”: the abstract Spin and special-orthogonal group homomorphism must become smooth before `lieMap` can identify its differential. After this PR, the LieGroups milestone still needs the product chart and subgroup atlas, the embedded subgroup structure and graph-local smoothness argument, and the concrete Spin/SO Lie structures.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"monoid-hom-contmdiff-at-one"}-->

## Verification

- Exact head: `f80c298a33b350b5270a56c125056b88935e9771`
- Local Lean build: `spinrep-validate run -- lake build` — passed (`11176` jobs)
- Axiom audit: `spinrep-validate run -- lake exe axioms` — passed (`111943` TauCeti declarations; only `propext`, `Classical.choice`, and `Quot.sound`)
- Lint: aggregate `git diff --check` — passed
- Public CI: passed on the prior published head; pending for this repair head

## Scale and generality

The aggregate changes one existing file by 37 added lines and one module-docstring line replacement. It adds one multiplicative theorem and its generated additive counterpart, for arbitrary `n : ℕ∞ω`, a common nontrivially normed field, unrelated source and target models, a group source, a `MulOneClass` target, and any bundled morphism implementing `MonoidHomClass`. The proof uses only smooth multiplication; the inverse is a fixed source element.

## Scope

- **Consumes:** `ContMDiffAt.comp_of_eq`, smooth pointwise multiplication, `MonoidHomClass.map_mul`, and group cancellation
- **Provides:** `contMDiff_of_contMDiffAt_one` and its `to_additive` zero-based counterpart
- **Fits:** isolates the final translation step in automatic smoothness, which supplies smooth homomorphisms to `lieMap` and ultimately the Spin/SO double-cover differential
- **Boundary:** no subgroup chart, embedded-manifold structure, closed-graph theorem, automatic-smoothness endpoint, concrete Spin/SO Lie structure, or differential is asserted

<sub>🤖 GPT-5.6 Sol high · TauCetiWorker @ [7518d4150b846c4524423341570c031027a1d92c](https://github.com/utensil/TauCetiWorker/commit/7518d4150b846c4524423341570c031027a1d92c) · rubrics @ [afb424eda89e8ac96d9eb69f6a88972055a4cd1b](https://github.com/utensil/TauCetiReview/commit/afb424eda89e8ac96d9eb69f6a88972055a4cd1b) · local review @ [b533e561b6d44df071c31335ed4a63ae647507d2](https://github.com/utensil/formal-land/commit/b533e561b6d44df071c31335ed4a63ae647507d2) · fixed: attribution, generality, reuse</sub>