### PR TITLE
feat(Huber): a change of presentation leaves the structure map into A⟨T/s⟩ alone

### DIFF
--- a/TauCeti/RingTheory/Huber/LocalizationTopology/Completion.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/Completion.lean
@@ -30,8 +30,11 @@ complete Hausdorff targets.
 * `locUniformSpace_toTopologicalSpace`: the topology `locUniformSpace` induces is `locTopology`.
   This is what a proof rewrites against, so no body in this file needs exposing.
 * `locUniformSpace_congr`: presentations sharing a ring of definition share the uniformity, so
-  the two completions `A⟨T/s⟩` are the same object. Whether the restriction maps out of them
-  agree is a further question, and is not settled here.
+  the two completions `A⟨T/s⟩` are the same object.
+* `toCompletionLoc_heq`: the two structure maps `A → A⟨T/s⟩` into them agree. This is what
+  `locUniformSpace_congr` alone does not give — it identifies only the codomains — and it is what
+  a statement about the maps *out of* `A⟨T/s⟩` needs before it can be carried between
+  presentations. The maps out of it remain a further question.
 * `isUniformAddGroup_locUniformSpace` and `isTopologicalRing_locUniformSpace`: the two companions
   of `locUniformSpace`. Since `locTopology` is not an instance, a statement about `A⟨T/s⟩` has to
   name its structures; these three declarations are what it names.
@@ -140,7 +143,9 @@ theorem isTopologicalRing_locUniformSpace [IsTopologicalRing A] (P : PairOfDefin
 
 /-- **A change of presentation with the same ring of definition leaves `locUniformSpace` alone.**
 `restrictionRingHomOfSubset` is stated under `locUniformSpace`, so this identifies the rings such
-a map runs between. Identifying the maps themselves needs more than this. -/
+a map runs between. It does not by itself identify any map; the structure maps *into* those rings
+are identified by `toCompletionLoc_heq` below, and the restriction maps out of them are still
+open. -/
 theorem locUniformSpace_congr [IsTopologicalRing A] (P : PairOfDefinition A) (T T' : Finset A)
     (s s' : A) (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
     [IsLocalization.Away s' S] (hden : HasDenominatorPower P T s S)
@@ -215,6 +220,35 @@ theorem toCompletionLoc_apply [IsTopologicalRing A] (P : PairOfDefinition A) (T 
     letI := isUniformAddGroup_locUniformSpace P T s S hden
     letI := isTopologicalRing_locUniformSpace P T s S hden
     toCompletionLoc P T s S hden a = (algebraMap A S a : UniformSpace.Completion S) := (rfl)
+
+/-- `UniformSpace.Completion.coeRingHom` composed with a fixed map depends on the uniformity only
+through the instance, so equal uniformities give heterogeneously equal composites. Substituting
+the equation is what makes this provable: the two sides are then the same term, the remaining
+`IsTopologicalRing` and `IsUniformAddGroup` arguments being proofs. -/
+private theorem coeRingHom_comp_heq {R S : Type*} [CommRing R] [CommRing S] (f : R →+* S)
+    {u₁ u₂ : UniformSpace S} (hu : u₁ = u₂)
+    (t₁ : @IsTopologicalRing S u₁.toTopologicalSpace _)
+    (t₂ : @IsTopologicalRing S u₂.toTopologicalSpace _)
+    (g₁ : @IsUniformAddGroup S u₁ _) (g₂ : @IsUniformAddGroup S u₂ _) :
+    HEq ((@UniformSpace.Completion.coeRingHom S _ u₁ t₁ g₁).comp f)
+      ((@UniformSpace.Completion.coeRingHom S _ u₂ t₂ g₂).comp f) := by
+  subst hu
+  rfl
+
+/-- **A change of presentation with the same ring of definition leaves the structure map alone.**
+`locUniformSpace_congr` identifies the two completions; this identifies the two structure maps
+`A → A⟨T/s⟩` into them, which is what a statement about maps out of `A⟨T/s⟩` needs before it can
+be carried between presentations.
+
+The conclusion is `HEq` rather than `=` because the type `UniformSpace.Completion S` mentions the
+uniformity on `S`: the two structure maps do not share a codomain until `locUniformSpace_congr` is
+applied. -/
+theorem toCompletionLoc_heq [IsTopologicalRing A] (P : PairOfDefinition A) (T T' : Finset A)
+    (s s' : A) (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
+    [IsLocalization.Away s' S] (hden : HasDenominatorPower P T s S)
+    (hden' : HasDenominatorPower P T' s' S) (h : locSubring P T' s' S = locSubring P T s S) :
+    HEq (toCompletionLoc P T' s' S hden') (toCompletionLoc P T s S hden) :=
+  coeRingHom_comp_heq (algebraMap A S) (locUniformSpace_congr P T T' s s' S hden hden' h) _ _ _ _
 
 
 /-- The localisation pair `localization`, transported along `locUniformSpace_toTopologicalSpace`

--- a/TauCeti/RingTheory/Huber/LocalizationTopology/Completion.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/Completion.lean
@@ -8,6 +8,7 @@ module
 public import TauCeti.RingTheory.Huber.LocalizationTopology.UniversalProperty
 public import TauCeti.RingTheory.Huber.Completion
 public import TauCeti.RingTheory.Localization.Completion
+public import TauCeti.Topology.Algebra.UniformRing
 
 /-!
 # The completion `A⟨T/s⟩`
@@ -221,20 +222,6 @@ theorem toCompletionLoc_apply [IsTopologicalRing A] (P : PairOfDefinition A) (T 
     letI := isTopologicalRing_locUniformSpace P T s S hden
     toCompletionLoc P T s S hden a = (algebraMap A S a : UniformSpace.Completion S) := (rfl)
 
-/-- `UniformSpace.Completion.coeRingHom` composed with a fixed map depends on the uniformity only
-through the instance, so equal uniformities give heterogeneously equal composites. Substituting
-the equation is what makes this provable: the two sides are then the same term, the remaining
-`IsTopologicalRing` and `IsUniformAddGroup` arguments being proofs. -/
-private theorem coeRingHom_comp_heq {R S : Type*} [CommRing R] [CommRing S] (f : R →+* S)
-    {u₁ u₂ : UniformSpace S} (hu : u₁ = u₂)
-    (t₁ : @IsTopologicalRing S u₁.toTopologicalSpace _)
-    (t₂ : @IsTopologicalRing S u₂.toTopologicalSpace _)
-    (g₁ : @IsUniformAddGroup S u₁ _) (g₂ : @IsUniformAddGroup S u₂ _) :
-    HEq ((@UniformSpace.Completion.coeRingHom S _ u₁ t₁ g₁).comp f)
-      ((@UniformSpace.Completion.coeRingHom S _ u₂ t₂ g₂).comp f) := by
-  subst hu
-  rfl
-
 /-- **A change of presentation with the same ring of definition leaves the structure map alone.**
 `locUniformSpace_congr` identifies the two completions; this identifies the two structure maps
 `A → A⟨T/s⟩` into them, which is what a statement about maps out of `A⟨T/s⟩` needs before it can
@@ -248,7 +235,8 @@ theorem toCompletionLoc_heq [IsTopologicalRing A] (P : PairOfDefinition A) (T T'
     [IsLocalization.Away s' S] (hden : HasDenominatorPower P T s S)
     (hden' : HasDenominatorPower P T' s' S) (h : locSubring P T' s' S = locSubring P T s S) :
     HEq (toCompletionLoc P T' s' S hden') (toCompletionLoc P T s S hden) :=
-  coeRingHom_comp_heq (algebraMap A S) (locUniformSpace_congr P T T' s s' S hden hden' h) _ _ _ _
+  UniformSpace.Completion.coeRingHom_comp_heq (algebraMap A S)
+    (locUniformSpace_congr P T T' s s' S hden hden' h) _ _ _ _
 
 
 /-- The localisation pair `localization`, transported along `locUniformSpace_toTopologicalSpace`

--- a/TauCeti/RingTheory/Huber/LocalizationTopology/Completion.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/Completion.lean
@@ -235,7 +235,7 @@ theorem toCompletionLoc_heq [IsTopologicalRing A] (P : PairOfDefinition A) (T T'
     [IsLocalization.Away s' S] (hden : HasDenominatorPower P T s S)
     (hden' : HasDenominatorPower P T' s' S) (h : locSubring P T' s' S = locSubring P T s S) :
     HEq (toCompletionLoc P T' s' S hden') (toCompletionLoc P T s S hden) :=
-  UniformSpace.Completion.coeRingHom_comp_heq (algebraMap A S)
+  (algebraMap A S).completionCoe_comp_heq
     (locUniformSpace_congr P T T' s s' S hden hden' h) _ _ _ _
 
 

--- a/TauCeti/Topology/Algebra/UniformRing.lean
+++ b/TauCeti/Topology/Algebra/UniformRing.lean
@@ -10,8 +10,10 @@ public import Mathlib.Topology.Algebra.UniformRing
 /-!
 # Ring homomorphisms out of a completion
 
-Two results about `UniformSpace.Completion` as a *ring*, both in the root
-`UniformSpace.Completion` namespace they extend.
+Results about `UniformSpace.Completion` as a *ring*. Those about the completion itself live in
+the root `UniformSpace.Completion` namespace they extend; `RingHom.completionCoe_comp_heq`, whose
+subject is the homomorphism being followed by the coercion, lives in `RingHom` so that it is
+available by dot notation on that map.
 
 `UniformSpace.Completion.ringHom_ext_of_continuous` is `UniformSpace.Completion.ext` for ring
 homomorphisms: two continuous ring homomorphisms out of `Completion R` that agree after composing
@@ -42,10 +44,10 @@ what `UniformSpace.Completion.algebra` requires.
 The declarations live in the root `UniformSpace.Completion` namespace they extend, following
 this repository's convention for lemmas about external types.
 
-`UniformSpace.Completion.coeRingHom_comp_heq` compares the coercion for two *equal* uniformities
-on the same ring: following a fixed map by the coercion gives heterogeneously equal composites.
-It is stated here rather than where it is consumed because nothing in it is specific to any
-particular ring being completed.
+`RingHom.completionCoe_comp_heq` compares the coercion for two *equal* uniformities on the same
+ring: following a fixed map by the coercion gives heterogeneously equal composites. It is stated
+here rather than where it is consumed because nothing in it is specific to any particular ring
+being completed.
 
 ## Main definitions
 
@@ -56,6 +58,9 @@ particular ring being completed.
   uniformly continuous (`UniformContinuousConstSMul R S`).
 
 ## Main results
+
+* `RingHom.completionCoe_comp_heq`: equal uniformities on the codomain give heterogeneously equal
+  composites with the coercion into the completion.
 
 * `UniformSpace.Completion.ringHom_ext_of_continuous`: two continuous ring homomorphisms out of
   a completion that agree on the image of the coercion are equal.
@@ -80,7 +85,8 @@ through the instance.** For two equal uniformities on `S`, the composites
 The conclusion is `HEq` rather than `=` because the type `UniformSpace.Completion S` mentions the
 uniformity on `S`, so the two composites do not share a codomain. A caller holding an equation
 between uniformities — rather than a defeq — is the intended consumer. -/
-theorem coeRingHom_comp_heq {R S : Type*} [Ring R] [Ring S] (f : R →+* S)
+theorem _root_.RingHom.completionCoe_comp_heq {R S : Type*} [NonAssocSemiring R] [Ring S]
+    (f : R →+* S)
     {u₁ u₂ : UniformSpace S} (hu : u₁ = u₂)
     (t₁ : @IsTopologicalRing S u₁.toTopologicalSpace _)
     (t₂ : @IsTopologicalRing S u₂.toTopologicalSpace _)

--- a/TauCeti/Topology/Algebra/UniformRing.lean
+++ b/TauCeti/Topology/Algebra/UniformRing.lean
@@ -42,6 +42,11 @@ what `UniformSpace.Completion.algebra` requires.
 The declarations live in the root `UniformSpace.Completion` namespace they extend, following
 this repository's convention for lemmas about external types.
 
+`UniformSpace.Completion.coeRingHom_comp_heq` compares the coercion for two *equal* uniformities
+on the same ring: following a fixed map by the coercion gives heterogeneously equal composites.
+It is stated here rather than where it is consumed because nothing in it is specific to any
+particular ring being completed.
+
 ## Main definitions
 
 * `UniformSpace.Completion.completeRingEquivSelf`: the ring isomorphism
@@ -65,6 +70,26 @@ this repository's convention for lemmas about external types.
 public section
 
 namespace UniformSpace.Completion
+
+section Congr
+
+/-- **Following a fixed map by the coercion into a completion depends on the uniformity only
+through the instance.** For two equal uniformities on `S`, the composites
+`R →+* S → UniformSpace.Completion S` agree.
+
+The conclusion is `HEq` rather than `=` because the type `UniformSpace.Completion S` mentions the
+uniformity on `S`, so the two composites do not share a codomain. A caller holding an equation
+between uniformities — rather than a defeq — is the intended consumer. -/
+theorem coeRingHom_comp_heq {R S : Type*} [CommRing R] [CommRing S] (f : R →+* S)
+    {u₁ u₂ : UniformSpace S} (hu : u₁ = u₂)
+    (t₁ : @IsTopologicalRing S u₁.toTopologicalSpace _)
+    (t₂ : @IsTopologicalRing S u₂.toTopologicalSpace _)
+    (g₁ : @IsUniformAddGroup S u₁ _) (g₂ : @IsUniformAddGroup S u₂ _) :
+    HEq ((@coeRingHom S _ u₁ t₁ g₁).comp f) ((@coeRingHom S _ u₂ t₂ g₂).comp f) := by
+  subst hu
+  rfl
+
+end Congr
 
 section Ext
 

--- a/TauCeti/Topology/Algebra/UniformRing.lean
+++ b/TauCeti/Topology/Algebra/UniformRing.lean
@@ -80,7 +80,7 @@ through the instance.** For two equal uniformities on `S`, the composites
 The conclusion is `HEq` rather than `=` because the type `UniformSpace.Completion S` mentions the
 uniformity on `S`, so the two composites do not share a codomain. A caller holding an equation
 between uniformities — rather than a defeq — is the intended consumer. -/
-theorem coeRingHom_comp_heq {R S : Type*} [CommRing R] [CommRing S] (f : R →+* S)
+theorem coeRingHom_comp_heq {R S : Type*} [Ring R] [Ring S] (f : R →+* S)
     {u₁ u₂ : UniformSpace S} (hu : u₁ = u₂)
     (t₁ : @IsTopologicalRing S u₁.toTopologicalSpace _)
     (t₂ : @IsTopologicalRing S u₂.toTopologicalSpace _)


### PR DESCRIPTION
#6351 landed `locUniformSpace_congr`: two presentations of a rational subset that share a ring of
definition give the same uniformity on `Aₛ`, hence literally the same completion `A⟨T/s⟩`. Its
docstring was explicit about what that does *not* give — it identifies the **codomain** of a map,
not any map. This adds the map into it.

```lean
theorem toCompletionLoc_heq (P : PairOfDefinition A) (T T' : Finset A) (s s' : A) (S : Type*)
    … (h : locSubring P T' s' S = locSubring P T s S) :
    HEq (toCompletionLoc P T' s' S hden') (toCompletionLoc P T s S hden)
```

So a shared ring of definition pins down the coordinate ring **and** its structure map from `A`,
with no further hypotheses — in particular without going through Lemma 8.1, which the comparison
route in `Spa/Localization/PresentationIndependence.lean` needs and which carries two hypotheses
Wedhorn does not impose.

`HEq` and not `=` because `UniformSpace.Completion S` mentions the uniformity on `S`: the two maps
share no codomain until `locUniformSpace_congr` is applied.

**What the proof turns on.** Stated directly at the two `locUniformSpace` terms there is nothing to
substitute, and that is the wall earlier attempts hit — `rw` reports *motive is not type correct*
(the ideal powers carry an `IsScalarTower` over the subring) and `congr` reduces the goal to the
false `T' = T`. The fix is to abstract the uniformity into a variable first. `toCompletionLoc` is
`Completion.coeRingHom` composed with `algebraMap A S`, and only the first factor sees the
uniformity, so a private lemma quantified over `u₁ u₂ : UniformSpace S` lets `subst` fire on
`locUniformSpace_congr`; afterwards the two sides are the same term and `rfl` closes it. The
`IsTopologicalRing` and `IsUniformAddGroup` arguments that still differ are proofs, absorbed by
proof irrelevance.

**Scope.** This is a prerequisite step, and the module docstring now says exactly how far it goes:
the objects are identified (#6351), the structure maps *into* them are identified here, and the
restriction maps *out* of them are still open. That last one is what Proposition 8.30 without
`hnil` needs, and it is not claimed here.

Verified: module builds in 2.2s, `runLinter` clean, all lines ≤ 100 codepoints, no name
collisions with Mathlib or TauCeti.

Roadmap: AdicSpaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XG8YChDNLwcvvVGgqG5dL7
