### PR TITLE
refactor(Sheaf): root the `SheafOfModules.LocalGeneratorsData` subtree

### DIFF
--- a/TauCeti/Algebra/Category/ModuleCat/Sheaf/FinitePresentation.lean
+++ b/TauCeti/Algebra/Category/ModuleCat/Sheaf/FinitePresentation.lean
@@ -15,7 +15,7 @@ finitely presented. Locally free data gives presentations with the chosen bases 
 and no relations, so finiteness of the local bases is enough.
 
 The main result is
-`TauCeti.SheafOfModules.LocalGeneratorsData.IsLocallyFreeData.isFinitePresentation`.
+`SheafOfModules.LocalGeneratorsData.IsLocallyFreeData.isFinitePresentation`.
 
 This advances `TauCetiRoadmap/JacobianChallenge/README.md`, Layer B, item "Coherent sheaves and
 cohomology `Hⁱ(X, ℱ)`". No formalization is vendored. The proof reuses Mathlib's
@@ -44,7 +44,7 @@ variable {C : Type u₁} [Category.{v₁} C] {J : GrothendieckTopology C}
 
 Mathlib's presentation associated to locally free data uses the local bases as generators and
 has no relations. -/
-theorem LocalGeneratorsData.IsLocallyFreeData.isFinitePresentation
+theorem _root_.SheafOfModules.LocalGeneratorsData.IsLocallyFreeData.isFinitePresentation
     {q : _root_.SheafOfModules.LocalGeneratorsData.{u₁} M} (hfree : q.IsLocallyFreeData)
     (hfinite : q.IsFiniteType) :
     M.IsFinitePresentation := by

--- a/TauCeti/Algebra/Category/ModuleCat/Sheaf/Invertible/Basic.lean
+++ b/TauCeti/Algebra/Category/ModuleCat/Sheaf/Invertible/Basic.lean
@@ -18,11 +18,11 @@ arbitrary site.
 
 ## Main declarations
 
-* `TauCeti.SheafOfModules.LocalGeneratorsData.IsInvertible q` says that every presentation
+* `SheafOfModules.LocalGeneratorsData.IsInvertible q` says that every presentation
   `free (q.generators i).I ⟶ M.over (q.X i)` is an isomorphism and that each indexing type is
   nonempty and a subsingleton;
 * `TauCeti.SheafOfModules.IsInvertible M` says that such data exists for the sheaf of modules `M`;
-* `TauCeti.SheafOfModules.LocalGeneratorsData.ofIso` transports local generator data along an
+* `SheafOfModules.LocalGeneratorsData.ofIso` transports local generator data along an
   isomorphism of sheaves of modules, and `TauCeti.SheafOfModules.IsInvertible.of_iso` transports
   invertibility along one.
 
@@ -56,7 +56,8 @@ variable {C : Type u₁} [Category.{v₁} C] {J : GrothendieckTopology C} {R : S
 
 /-- Local generators exhibit a sheaf of modules as invertible when they freely generate it
 on a cover and every local generating type has exactly one element. -/
-structure LocalGeneratorsData.IsInvertible (q : SheafOfModules.LocalGeneratorsData M) : Prop where
+structure _root_.SheafOfModules.LocalGeneratorsData.IsInvertible
+    (q : SheafOfModules.LocalGeneratorsData M) : Prop where
   /-- The local generators freely generate the restricted sheaf. -/
   isLocallyFreeData : q.IsLocallyFreeData
   /-- Every local free basis has at least one element. -/
@@ -83,7 +84,8 @@ instance IsInvertible.isLocallyFree (M : SheafOfModules.{u} R) [h : IsInvertible
 /-- Transport local generator data along an isomorphism of sheaves of modules: the same cover, with
 each family of local generators pushed forward along the restricted isomorphism. -/
 @[expose, simps]
-def LocalGeneratorsData.ofIso (q : SheafOfModules.LocalGeneratorsData M) (e : M ≅ N) :
+def _root_.SheafOfModules.LocalGeneratorsData.ofIso (q : SheafOfModules.LocalGeneratorsData M)
+    (e : M ≅ N) :
     SheafOfModules.LocalGeneratorsData N where
   I := q.I
   X := q.X
@@ -91,7 +93,8 @@ def LocalGeneratorsData.ofIso (q : SheafOfModules.LocalGeneratorsData M) (e : M 
   generators i := (q.generators i).ofEpi ((SheafOfModules.overFunctor R (q.X i)).mapIso e).hom
 
 /-- Rank-one local generator data stays rank one after transport along an isomorphism. -/
-theorem LocalGeneratorsData.IsInvertible.ofIso {q : SheafOfModules.LocalGeneratorsData M}
+theorem _root_.SheafOfModules.LocalGeneratorsData.IsInvertible.ofIso
+    {q : SheafOfModules.LocalGeneratorsData M}
     (hq : LocalGeneratorsData.IsInvertible q) (e : M ≅ N) :
     LocalGeneratorsData.IsInvertible (LocalGeneratorsData.ofIso q e) where
   isLocallyFreeData :=

--- a/TauCeti/Algebra/Category/ModuleCat/Sheaf/Invertible/Basic.lean
+++ b/TauCeti/Algebra/Category/ModuleCat/Sheaf/Invertible/Basic.lean
@@ -72,7 +72,8 @@ exactly one element. -/
 class IsInvertible : Prop where
   /-- A rank-one local trivialization of the sheaf. -/
   exists_isInvertible :
-    ∃ q : SheafOfModules.LocalGeneratorsData.{u₁} M, LocalGeneratorsData.IsInvertible q
+    ∃ q : SheafOfModules.LocalGeneratorsData.{u₁} M,
+      SheafOfModules.LocalGeneratorsData.IsInvertible q
 
 /-- An invertible sheaf is locally free. -/
 instance IsInvertible.isLocallyFree (M : SheafOfModules.{u} R) [h : IsInvertible M] :
@@ -95,8 +96,9 @@ def _root_.SheafOfModules.LocalGeneratorsData.ofIso (q : SheafOfModules.LocalGen
 /-- Rank-one local generator data stays rank one after transport along an isomorphism. -/
 theorem _root_.SheafOfModules.LocalGeneratorsData.IsInvertible.ofIso
     {q : SheafOfModules.LocalGeneratorsData M}
-    (hq : LocalGeneratorsData.IsInvertible q) (e : M ≅ N) :
-    LocalGeneratorsData.IsInvertible (LocalGeneratorsData.ofIso q e) where
+    (hq : SheafOfModules.LocalGeneratorsData.IsInvertible q) (e : M ≅ N) :
+    SheafOfModules.LocalGeneratorsData.IsInvertible
+      (SheafOfModules.LocalGeneratorsData.ofIso q e) where
   isLocallyFreeData :=
     { isIso := by
         -- `ofIso` leaves the index type of the cover untouched, so the index may be taken in
@@ -118,7 +120,7 @@ theorem _root_.SheafOfModules.LocalGeneratorsData.IsInvertible.ofIso
 /-- Invertibility transports along an isomorphism of sheaves of modules. -/
 theorem IsInvertible.of_iso (e : M ≅ N) [h : IsInvertible M] : IsInvertible N := by
   obtain ⟨q, hq⟩ := h.exists_isInvertible
-  exact ⟨LocalGeneratorsData.ofIso q e, hq.ofIso e⟩
+  exact ⟨SheafOfModules.LocalGeneratorsData.ofIso q e, hq.ofIso e⟩
 
 section
 

--- a/TauCeti/Algebra/Category/ModuleCat/Sheaf/Invertible/FinitePresentation.lean
+++ b/TauCeti/Algebra/Category/ModuleCat/Sheaf/Invertible/FinitePresentation.lean
@@ -51,7 +51,8 @@ The rank-one local bases give finite generating families, and the locally free p
 have no relations. -/
 instance IsInvertible.isFinitePresentation [hM : IsInvertible M] : M.IsFinitePresentation := by
   obtain ⟨q, hq⟩ := hM.exists_isInvertible
-  apply LocalGeneratorsData.IsLocallyFreeData.isFinitePresentation hq.isLocallyFreeData
+  apply SheafOfModules.LocalGeneratorsData.IsLocallyFreeData.isFinitePresentation
+    hq.isLocallyFreeData
   exact ⟨fun i ↦ by
     let : Subsingleton (q.generators i).I := hq.basisSubsingleton i
     exact ⟨Finite.of_subsingleton⟩⟩

--- a/TauCeti/Algebra/Category/ModuleCat/Sheaf/Invertible/LocalTriviality.lean
+++ b/TauCeti/Algebra/Category/ModuleCat/Sheaf/Invertible/LocalTriviality.lean
@@ -18,8 +18,8 @@ on `PUnit`.
 The structure `SheafOfModules.LocalTrivializations M` records such a cover and its
 trivializing isomorphisms. The two formulations are equivalent:
 
-* `LocalGeneratorsData.IsInvertible.trivializationIso` standardizes each rank-one free
-  presentation;
+* `SheafOfModules.LocalGeneratorsData.IsInvertible.trivializationIso` standardizes each
+  rank-one free presentation;
 * `LocalTrivializations.ofIso` transports a local trivialization atlas along an isomorphism;
 * `LocalTrivializations.isInvertible` recovers the local-generator formulation;
 * `LocalTrivializations.ofIsInvertible` constructs local trivializations from an invertible
@@ -72,7 +72,7 @@ structure LocalTrivializations (M : SheafOfModules.{u} R) where
 the free sheaf on `PUnit`. -/
 def _root_.SheafOfModules.LocalGeneratorsData.IsInvertible.trivializationIso
     {q : SheafOfModules.LocalGeneratorsData M}
-    (hq : LocalGeneratorsData.IsInvertible q) (i : q.I) :
+    (hq : SheafOfModules.LocalGeneratorsData.IsInvertible q) (i : q.I) :
     _root_.SheafOfModules.free (R := R.over (q.X i)) PUnit ≅ M.over (q.X i) := by
   letI : Nonempty (q.generators i).I := hq.basisNonempty i
   letI : Subsingleton (q.generators i).I := hq.basisSubsingleton i
@@ -86,7 +86,8 @@ followed by the original local free presentation. -/
 @[simp]
 lemma _root_.SheafOfModules.LocalGeneratorsData.IsInvertible.trivializationIso_hom
     {q : SheafOfModules.LocalGeneratorsData M}
-    (hq : LocalGeneratorsData.IsInvertible q) (i : q.I) : (hq.trivializationIso i).hom =
+    (hq : SheafOfModules.LocalGeneratorsData.IsInvertible q) (i : q.I) :
+    (hq.trivializationIso i).hom =
       (_root_.SheafOfModules.freeFunctor (R := R.over (q.X i))).map
         (@Equiv.punitOfNonemptyOfSubsingleton (q.generators i).I
           (hq.basisNonempty i) (hq.basisSubsingleton i)).symm.toIso.hom ≫

--- a/TauCeti/Algebra/Category/ModuleCat/Sheaf/Invertible/LocalTriviality.lean
+++ b/TauCeti/Algebra/Category/ModuleCat/Sheaf/Invertible/LocalTriviality.lean
@@ -67,11 +67,11 @@ structure LocalTrivializations (M : SheafOfModules.{u} R) where
   iso (i : I) :
     _root_.SheafOfModules.free (R := R.over (X i)) PUnit ≅ M.over (X i)
 
-namespace LocalGeneratorsData.IsInvertible
 
 /-- A rank-one free presentation on a member of a cover, standardized to an isomorphism from
 the free sheaf on `PUnit`. -/
-def trivializationIso {q : SheafOfModules.LocalGeneratorsData M}
+def _root_.SheafOfModules.LocalGeneratorsData.IsInvertible.trivializationIso
+    {q : SheafOfModules.LocalGeneratorsData M}
     (hq : LocalGeneratorsData.IsInvertible q) (i : q.I) :
     _root_.SheafOfModules.free (R := R.over (q.X i)) PUnit ≅ M.over (q.X i) := by
   letI : Nonempty (q.generators i).I := hq.basisNonempty i
@@ -84,20 +84,21 @@ def trivializationIso {q : SheafOfModules.LocalGeneratorsData M}
 /-- The forward map of the standardized trivialization is the relabelling of the free basis,
 followed by the original local free presentation. -/
 @[simp]
-lemma trivializationIso_hom {q : SheafOfModules.LocalGeneratorsData M}
+lemma _root_.SheafOfModules.LocalGeneratorsData.IsInvertible.trivializationIso_hom
+    {q : SheafOfModules.LocalGeneratorsData M}
     (hq : LocalGeneratorsData.IsInvertible q) (i : q.I) : (hq.trivializationIso i).hom =
       (_root_.SheafOfModules.freeFunctor (R := R.over (q.X i))).map
         (@Equiv.punitOfNonemptyOfSubsingleton (q.generators i).I
           (hq.basisNonempty i) (hq.basisSubsingleton i)).symm.toIso.hom ≫
         (q.generators i).π :=
   by
-    simp only [trivializationIso, Iso.trans_hom, Functor.mapIso_hom]
+    simp only [SheafOfModules.LocalGeneratorsData.IsInvertible.trivializationIso, Iso.trans_hom,
+      Functor.mapIso_hom]
     -- the residual goal is `(asIso (q.generators i).π).hom = (q.generators i).π`; `asIso_hom`
     -- no longer rewrites under the composition after the bump, and `asIso` stores its `hom`
     -- field as the given morphism, so this is definitional.
     rfl
 
-end LocalGeneratorsData.IsInvertible
 
 namespace LocalTrivializations
 


### PR DESCRIPTION
Six declarations of the `SheafOfModules.LocalGeneratorsData` subtree move from `namespace TauCeti`
to Mathlib's root namespace, so that dot notation on a `SheafOfModules.LocalGeneratorsData` reaches
them:

| file | declarations |
|---|---|
| `Invertible/Basic.lean` | `IsInvertible`, `ofIso`, `IsInvertible.ofIso` |
| `Invertible/LocalTriviality.lean` | `IsInvertible.trivializationIso`, `trivializationIso_hom` |
| `FinitePresentation.lean` | `IsLocallyFreeData.isFinitePresentation` |

The subtree moves as a unit, including the `IsInvertible` child namespace whose API lives in
`LocalTriviality.lean`. Rooting the parent alone would split one class's API between the root and
`TauCeti.`, which is the defect the `nsslice` screen exists to catch.

`lint-dot-notation`: **761 → 759**, no new findings. No mathematics changes: every declaration keeps
its statement and its proof.

### What stays nested, and why

`Invertible/Basic.lean` and `Invertible/LocalTriviality.lean` each keep declarations in
`TauCeti.SheafOfModules` after this change — `IsInvertible` (the class on a `SheafOfModules`, not the
structure on `LocalGeneratorsData`), `IsInvertible.isLocallyFree`, `IsInvertible.of_iso`,
`free_isInvertible`, and the `LocalTrivializations` structure with its namespace.

That is deliberate, and the two `IsInvertible`s are genuinely different notions: this PR roots
`SheafOfModules.LocalGeneratorsData.IsInvertible`, a structure whose receiver is Mathlib's
`LocalGeneratorsData`, while `TauCeti.SheafOfModules.IsInvertible` is a Tau Ceti class whose receiver
is the sheaf itself. `lint-dot-notation` flags **none** of the declarations left behind: rooting them
would not fix a dot-notation failure, it would place Tau Ceti's own notions into Mathlib's
`SheafOfModules` namespace on this PR's authority. If that is wanted it is its own change, with its
own argument.

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GadULQ4gpsVAZfpvs2htNt
