### PR TITLE
feat: descend tensor squares of invariant group algebras

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/GroupAlgebra/Galois/Tensor.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GroupAlgebra/Galois/Tensor.lean
@@ -1,0 +1,175 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.GroupAlgebra.Galois.BaseChange
+import TauCeti.Algebra.TensorProduct.BaseChange
+import TauCeti.RepresentationTheory.GaloisDescent.Range
+import Mathlib.RingTheory.Flat.Basic
+
+/-!
+# Tensor products of invariant group algebras
+
+For a finite Galois extension `L/k`, the tensor square over `k` of the invariant group algebra
+is the invariant subalgebra of the tensor square over `L` of the split group algebra. The
+comparison sends `x ⊗ y` to the tensor of their inclusions. Its inverse converts the
+invariant-valued comultiplication into a comultiplication with values in the tensor square
+of the descended algebra.
+
+There is no finite-generation assumption on the exponent group and no characteristic
+restriction. The proof uses the scalar-extension equivalence for the invariant group algebra
+and the compatibility of scalar extension with tensor products.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Theorem 12.23 and Appendix A.64.
+-/
+
+public section
+
+open scoped TensorProduct TauCeti.GaloisDescent
+
+namespace TauCeti.GaloisDescent
+
+variable {k L M : Type*} [Field k] [Field L] [Algebra k L] [AddCommGroup M]
+
+/-- The tensor of the invariant-algebra inclusions, with the ambient tensor product over `L`. -/
+private noncomputable def tensorInclusion (rho : Representation ℤ (L ≃ₐ[k] L) M) :
+    groupAlgebraInvariants rho ⊗[k] groupAlgebraInvariants rho →ₐ[k]
+      MonoidAlgebra L (Multiplicative M) ⊗[L] MonoidAlgebra L (Multiplicative M) :=
+  Algebra.TensorProduct.lift
+    (((Algebra.TensorProduct.includeLeft (R := L) (S := L)).restrictScalars k).comp
+      (groupAlgebraInvariants rho).val)
+    (((Algebra.TensorProduct.includeRight (R := L)).restrictScalars k).comp
+      (groupAlgebraInvariants rho).val)
+    (fun _ _ ↦ Commute.all _ _)
+
+@[simp]
+private theorem tensorInclusion_tmul (rho : Representation ℤ (L ≃ₐ[k] L) M)
+    (x y : groupAlgebraInvariants rho) :
+    tensorInclusion rho (x ⊗ₜ[k] y) =
+      (x : MonoidAlgebra L (Multiplicative M)) ⊗ₜ[L]
+        (y : MonoidAlgebra L (Multiplicative M)) := by
+  simp [tensorInclusion]
+
+private theorem tensorInclusion_mem (rho : Representation ℤ (L ≃ₐ[k] L) M)
+    (x : groupAlgebraInvariants rho ⊗[k] groupAlgebraInvariants rho) :
+    tensorInclusion rho x ∈ groupAlgebraTensorInvariants rho := by
+  induction x using TensorProduct.induction_on with
+  | zero => simp
+  | tmul x y =>
+      simp only [tensorInclusion_tmul, mem_groupAlgebraTensorInvariants_iff,
+        groupAlgebraTensorActionSemilinearEquiv_tmul]
+      intro σ
+      rw [(mem_groupAlgebraInvariants_iff rho x).mp x.property σ,
+        (mem_groupAlgebraInvariants_iff rho y).mp y.property σ]
+  | add x y hx hy => simpa only [map_add] using
+      (groupAlgebraTensorInvariants rho).add_mem hx hy
+
+variable [FiniteDimensional k L] [IsGalois k L]
+
+private theorem liftEquiv_tensorInclusion_bijective
+    (rho : Representation ℤ (L ≃ₐ[k] L) M) :
+    Function.Bijective (AlgHom.liftEquiv k L _ _ (tensorInclusion rho)) := by
+  let e := (Algebra.TensorProduct.baseChangeTensorAlgEquiv k L
+    (groupAlgebraInvariants rho) (groupAlgebraInvariants rho)).trans
+      (Algebra.TensorProduct.congr (groupAlgebraInvariantsBaseChangeEquiv rho)
+        (groupAlgebraInvariantsBaseChangeEquiv rho))
+  have he : AlgHom.liftEquiv k L _ _ (tensorInclusion rho) = e.toAlgHom := by
+    apply AlgHom.toLinearMap_injective
+    apply TensorProduct.AlgebraTensorModule.ext
+    intro a x
+    induction x using TensorProduct.induction_on with
+    | zero => simp
+    | tmul x y => simp [e, TensorProduct.smul_tmul']
+    | add x y hx hy => simp only [TensorProduct.tmul_add, map_add, hx, hy]
+  rw [he]
+  exact e.bijective
+
+/-- The diagonal semilinear tensor action, regarded as a `k`-linear representation. -/
+private noncomputable def tensorRepresentation
+    (rho : Representation ℤ (L ≃ₐ[k] L) M) :
+    Representation k (L ≃ₐ[k] L)
+      (MonoidAlgebra L (Multiplicative M) ⊗[L] MonoidAlgebra L (Multiplicative M)) where
+  toFun σ :=
+    { toFun := groupAlgebraTensorActionSemilinearEquiv rho σ
+      map_add' := map_add _
+      map_smul' r x := by
+        rw [← IsScalarTower.algebraMap_smul L r x,
+          groupAlgebraTensorActionSemilinearEquiv_smul, σ.commutes,
+          IsScalarTower.algebraMap_smul]
+        rfl }
+  map_one' := by ext x; exact groupAlgebraTensorActionSemilinearEquiv_one rho x
+  map_mul' σ τ := by ext x; exact groupAlgebraTensorActionSemilinearEquiv_mul rho σ τ x
+
+private theorem tensorInclusion_range (rho : Representation ℤ (L ≃ₐ[k] L) M) :
+    LinearMap.range (tensorInclusion rho).toLinearMap =
+      (groupAlgebraTensorInvariants rho).toSubmodule := by
+  have he : (AlgHom.liftEquiv k L _ _ (tensorInclusion rho)).toLinearMap =
+      (tensorInclusion rho).toLinearMap.liftBaseChange L := by
+    apply TensorProduct.AlgebraTensorModule.ext
+    intros
+    simp
+  have hf : Function.Surjective ((tensorInclusion rho).toLinearMap.liftBaseChange L) := by
+    rw [← he]
+    exact (liftEquiv_tensorInclusion_bijective rho).surjective
+  have hinv : (tensorRepresentation rho).invariants =
+      (groupAlgebraTensorInvariants rho).toSubmodule := by
+    ext x
+    simp [Representation.mem_invariants, tensorRepresentation]
+  rw [← hinv]
+  exact range_eq_invariants_of_liftBaseChange_surjective
+    (ρ := tensorRepresentation rho)
+    (groupAlgebraTensorActionSemilinearEquiv_smul rho)
+    (fun σ x ↦ (mem_groupAlgebraTensorInvariants_iff rho _).mp
+      (tensorInclusion_mem rho x) σ) hf
+
+private theorem tensorInclusion_injective (rho : Representation ℤ (L ≃ₐ[k] L) M) :
+    Function.Injective (tensorInclusion rho) := by
+  intro x y h
+  apply Algebra.TensorProduct.includeRight_injective (A := L)
+    (FaithfulSMul.algebraMap_injective k L)
+  apply (liftEquiv_tensorInclusion_bijective rho).injective
+  simpa only [Algebra.TensorProduct.includeRight_apply, AlgHom.liftEquiv_tmul, one_smul]
+    using h
+
+/-- The tensor square of the descended group algebra is the invariant subalgebra of the
+split tensor square, for the diagonal semilinear Galois action. -/
+noncomputable def groupAlgebraInvariantsTensorEquiv
+    (rho : Representation ℤ (L ≃ₐ[k] L) M) :
+    groupAlgebraInvariants rho ⊗[k] groupAlgebraInvariants rho ≃ₐ[k]
+      groupAlgebraTensorInvariants rho :=
+  AlgEquiv.ofBijective
+    ((tensorInclusion rho).codRestrict _ (tensorInclusion_mem rho))
+    ⟨(AlgHom.injective_codRestrict _ _ _).mpr (tensorInclusion_injective rho), by
+      intro x
+      obtain ⟨y, hy⟩ := (tensorInclusion_range rho).ge x.property
+      exact ⟨y, Subtype.ext hy⟩⟩
+
+/-- The tensor descent equivalence sends a pure tensor to the tensor of its inclusions. -/
+@[simp]
+theorem groupAlgebraInvariantsTensorEquiv_tmul
+    (rho : Representation ℤ (L ≃ₐ[k] L) M) (x y : groupAlgebraInvariants rho) :
+    (groupAlgebraInvariantsTensorEquiv rho (x ⊗ₜ[k] y) :
+        MonoidAlgebra L (Multiplicative M) ⊗[L] MonoidAlgebra L (Multiplicative M)) =
+      (x : MonoidAlgebra L (Multiplicative M)) ⊗ₜ[L]
+        (y : MonoidAlgebra L (Multiplicative M)) := by
+  exact (congrArg Subtype.val (AlgEquiv.ofBijective_apply _ _ _)).trans
+    ((AlgHom.coe_codRestrict _ _ _ _).trans (tensorInclusion_tmul rho x y))
+
+/-- The inverse comparison recovers the tensor of invariant elements from their ambient
+tensor, independently of the proof of invariance. -/
+@[simp]
+theorem groupAlgebraInvariantsTensorEquiv_symm_tmul
+    (rho : Representation ℤ (L ≃ₐ[k] L) M) (x y : groupAlgebraInvariants rho)
+    (h : (x : MonoidAlgebra L (Multiplicative M)) ⊗ₜ[L]
+      (y : MonoidAlgebra L (Multiplicative M)) ∈ groupAlgebraTensorInvariants rho) :
+    (groupAlgebraInvariantsTensorEquiv rho).symm ⟨_, h⟩ = x ⊗ₜ[k] y := by
+  apply (groupAlgebraInvariantsTensorEquiv rho).injective
+  apply Subtype.ext
+  simp
+
+end TauCeti.GaloisDescent

--- a/TauCeti/RepresentationTheory/GaloisDescent/Range.lean
+++ b/TauCeti/RepresentationTheory/GaloisDescent/Range.lean
@@ -1,0 +1,75 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import Mathlib.RepresentationTheory.Invariants
+import Mathlib.RingTheory.Trace.Basic
+public import Mathlib.FieldTheory.Galois.Basic
+public import Mathlib.RingTheory.TensorProduct.Basic
+
+/-!
+# Recognizing the invariant vectors by scalar extension
+
+An invariant subspace of a semilinear representation over a finite Galois extension is the
+whole space of invariants if its scalar extension surjects onto the representation. This
+criterion identifies tensor products of descended vector spaces with invariant tensors.
+It works in arbitrary characteristic, using an element of field trace one instead of dividing
+by the order of the Galois group.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Appendix A.64 (Galois descent).
+-/
+
+public section
+
+open scoped TensorProduct
+
+namespace TauCeti.GaloisDescent
+
+variable {k L V W : Type*} [Field k] [Field L] [Algebra k L]
+variable [AddCommGroup V] [Module k V] [Module L V] [IsScalarTower k L V]
+variable [AddCommGroup W] [Module k W]
+variable [FiniteDimensional k L] [IsGalois k L]
+
+/-- An invariant linear map whose scalar extension is surjective has image equal to all the
+invariant vectors. Neither vector space needs to be finite-dimensional. -/
+theorem range_eq_invariants_of_liftBaseChange_surjective
+    {ρ : Representation k (L ≃ₐ[k] L) V} {f : W →ₗ[k] V}
+    (hsemi : ∀ (σ : L ≃ₐ[k] L) (a : L) (v : V),
+      ρ σ (a • v) = σ a • ρ σ v)
+    (hinv : ∀ (σ : L ≃ₐ[k] L) (w : W), ρ σ (f w) = f w)
+    (hf : Function.Surjective (f.liftBaseChange L)) :
+    LinearMap.range f = ρ.invariants := by
+  classical
+  apply le_antisymm
+  · rintro _ ⟨w, rfl⟩
+    exact (Representation.mem_invariants _ _).mpr (fun σ ↦ hinv σ w)
+  · intro v hv
+    obtain ⟨a, ha⟩ := Algebra.trace_surjective k L 1
+    have hnorm (b : L) (w : W) :
+        ρ.norm (b • f w) = Algebra.trace k L b • f w := by
+      simp only [Representation.norm, LinearMap.sum_apply, hsemi, hinv]
+      rw [← Finset.sum_smul, ← trace_eq_sum_automorphisms,
+        IsScalarTower.algebraMap_smul]
+    have hmem (x : L ⊗[k] W) :
+        ρ.norm (a • f.liftBaseChange L x) ∈ LinearMap.range f := by
+      induction x using TensorProduct.induction_on with
+      | zero => simp
+      | tmul b w =>
+          rw [LinearMap.liftBaseChange_tmul, smul_smul, hnorm]
+          exact ⟨Algebra.trace k L (a * b) • w, f.map_smul _ _⟩
+      | add x y hx hy =>
+          simpa only [map_add, smul_add] using (LinearMap.range f).add_mem hx hy
+    obtain ⟨x, rfl⟩ := hf v
+    have hfixed := (Representation.mem_invariants _ _).mp hv
+    have hnorm_v : ρ.norm (a • f.liftBaseChange L x) = f.liftBaseChange L x := by
+      simp only [Representation.norm, LinearMap.sum_apply, hsemi, hfixed]
+      rw [← Finset.sum_smul, ← trace_eq_sum_automorphisms,
+        IsScalarTower.algebraMap_smul, ha, one_smul]
+    exact hnorm_v ▸ hmem x
+
+end TauCeti.GaloisDescent


### PR DESCRIPTION
This PR identifies the tensor square of a Galois-invariant group algebra with the invariant subalgebra of the split tensor square, advancing [ReductiveGroups/README.md, Layer 4, “Tori: split and non-split”](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/ReductiveGroups/README.md#layer-4-jordan-decomposition-diagonalizable-groups-tori). For a finite Galois extension `L/k` and any integral representation `rho` on an abelian group `M`, `groupAlgebraInvariantsTensorEquiv rho` is the algebra equivalence `(L[M])^Gal ⊗[k] (L[M])^Gal ≃ₐ[k] (L[M] ⊗[L] L[M])^Gal` for the diagonal semilinear action.

This follows the scalar-extension equivalence merged in #6356 and removes the immediate codomain obstruction to descending comultiplication. The concrete consumer is `groupAlgebraInvariantsComul`: composing it with the inverse of this equivalence gives comultiplication valued in the tensor square of the descended coordinate algebra. After this PR, the milestone still needs the descended coalgebra and Hopf axioms, compatibility of the splitting comparison with that Hopf structure, and assembly of the torus–Galois-lattice anti-equivalence.

The general theorem `GaloisDescent.range_eq_invariants_of_liftBaseChange_surjective` recognizes all invariant vectors as the image of an invariant linear map when its scalar extension is surjective. An element of field trace one supplies the projection, so there is no characteristic restriction and no assumption that the Galois group order is invertible. The tensor comparison reuses `groupAlgebraInvariantsBaseChangeEquiv`, `Algebra.TensorProduct.baseChangeTensorAlgEquiv`, Mathlib's tensor-product universal property, and flatness-based injectivity. Neither vector-space finite-dimensionality nor finite generation of the exponent group is assumed.

Add `TauCeti/RepresentationTheory/GaloisDescent/Range.lean` (75 lines) and `TauCeti/Algebra/AlgebraicGroup/GroupAlgebra/Galois/Tensor.lean` (175 lines), for 250 lines total. The mathematical reference is Milne, *Algebraic Groups* (2017), Theorem 12.23 and Appendix A.64, cited in the modules. No Mathlib infrastructure or external formalization is vendored.

Self-review against API design, reuse, and generality found no duplicated result or excess hypothesis. It replaced manual codomain-restriction injectivity with `AlgHom.injective_codRestrict` and made the comparison of the two invariant subspaces explicit through their membership API; the public tensor API consists of the equivalence and its forward and inverse pure-tensor simp lemmas, with construction helpers private and documented.

Validation: targeted `lake build` passes for both new modules, `tauceti-axioms --changed-since-merge-base origin/main` accepts all 44 declarations with only the allowed axioms, and `git diff --cached --check` passes. The prescribed `tauceti-lint-env` wrapper stops at its stale default-set guard because it omits `tacticAlt`; a temporary copy adding exactly that missing linter, matching the approved set on current main and preserving every check, passes both changed modules with zero violations and zero grandfathered findings. All three scanned definitions are documented. No repository scripts, linter configuration, or Lake pins are changed.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"groupalgebrainvariantstensorequiv"}-->

🤖 Prepared with Codex
