### PR TITLE
feat(EllipticCurve): the kernel counts the degree once every automorphism is a translation

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/Translation/FixedField.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/Translation/FixedField.lean
@@ -63,6 +63,9 @@ arbitrary finite subgroup of points, no isogeny being needed to state or prove t
   subgroup fixing an intermediate field of finite degree divides the separable degree above it.
 * `WeierstrassCurve.Affine.card_translationFixingSubgroup_eq_finrank_iff`: that order is the full
   degree exactly when the subgroup cuts the field back out.
+* `card_translationFixingSubgroup_eq_finrank_iff_isGalois_and_forall_exists_translation`:
+  equivalently, the extension is Galois and every automorphism over the field is a translation, so
+  neither condition can be weakened.
 
 ## References
 
@@ -301,5 +304,49 @@ theorem card_translationFixingSubgroup_eq_finrank_iff (L : IntermediateField F W
   rw [← finrank_translationFixedField W (translationFixingSubgroup W L), eq_comm,
     ← IntermediateField.eq_iff_finrank_eq_of_le' hle]
   exact ⟨fun h ↦ h.ge, le_antisymm hle⟩
+
+/-- **If `K(W)` is finite Galois over `L` and every automorphism fixing `L` is a translation, then
+`L` is cut out by exactly as many translations as its degree.** With
+`card_translationFixingSubgroup_eq_finrank_iff` this is the reverse inclusion, so it reduces a
+field-theoretic question to a group-theoretic one: given that the extension is Galois, are there
+automorphisms over `L` beyond the translations? -/
+theorem card_translationFixingSubgroup_eq_finrank_of_forall_exists_translation
+    (L : IntermediateField F W.FunctionField) [FiniteDimensional L W.FunctionField]
+    [IsGalois L W.FunctionField]
+    (h : ∀ σ ∈ L.fixingSubgroup, ∃ P : (W⁄F).toAffine.Point, translation W P = σ) :
+    Nat.card (translationFixingSubgroup W L) = Module.finrank L W.FunctionField := by
+  have hsurj : Function.Surjective (toFixingSubgroup W L) := fun σ ↦ by
+    obtain ⟨P, hP⟩ := h σ σ.2
+    exact ⟨⟨P, (mem_translationFixingSubgroup_iff W).2 fun z hz ↦ by
+      rw [hP]; exact (IntermediateField.mem_fixingSubgroup_iff L _).1 σ.2 z hz⟩,
+      Subtype.ext hP⟩
+  -- `IsGalois.card_fixingSubgroup_eq_finrank` counts a fixing subgroup inside a Galois extension
+  -- of the *base*; here `K(W)` is transcendental over `F` and only `K(W)/L` is Galois, so the count
+  -- goes through the automorphism group over `L`
+  rw [Nat.card_congr (Equiv.ofBijective _ ⟨toFixingSubgroup_injective W L, hsurj⟩),
+    Nat.card_congr (IntermediateField.fixingSubgroupEquiv L).toEquiv,
+    IsGalois.card_aut_eq_finrank]
+
+/-- **The fixing subgroup of `L` has order the degree exactly when `K(W)` is Galois over `L` and
+every automorphism over `L` is a translation.** Both hypotheses of
+`card_translationFixingSubgroup_eq_finrank_of_forall_exists_translation` are therefore necessary as
+well as sufficient, so nothing weaker will do. -/
+theorem card_translationFixingSubgroup_eq_finrank_iff_isGalois_and_forall_exists_translation
+    (L : IntermediateField F W.FunctionField) [FiniteDimensional L W.FunctionField] :
+    Nat.card (translationFixingSubgroup W L) = Module.finrank L W.FunctionField ↔
+      IsGalois L W.FunctionField ∧
+        ∀ σ ∈ L.fixingSubgroup, ∃ P : (W⁄F).toAffine.Point, translation W P = σ := by
+  refine ⟨fun h ↦ ?_, fun ⟨hgal, h⟩ ↦
+    card_translationFixingSubgroup_eq_finrank_of_forall_exists_translation W L h⟩
+  -- the count forces the subgroup to cut `L` back out, and then both halves are the Galois
+  -- correspondence for the translation action, which the file already has for a finite subgroup
+  have hfix : translationFixedField W (translationFixingSubgroup W L) = L :=
+    le_antisymm ((card_translationFixingSubgroup_eq_finrank_iff W L).1 h)
+      (le_translationFixedField_translationFixingSubgroup W L)
+  refine ⟨hfix ▸ isGalois_translationFixedField W (translationFixingSubgroup W L), fun σ hσ ↦ ?_⟩
+  rw [← hfix, fixingSubgroup_translationFixedField W (translationFixingSubgroup W L),
+    mem_translationSubgroup_iff] at hσ
+  obtain ⟨P, _, hP⟩ := hσ
+  exact ⟨P, hP⟩
 
 end WeierstrassCurve.Affine

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/Translation/FixedField.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/Translation/FixedField.lean
@@ -59,6 +59,10 @@ arbitrary finite subgroup of points, no isogeny being needed to state or prove t
 * `WeierstrassCurve.Affine.card_translationFixingSubgroup_le` and
   `WeierstrassCurve.Affine.finite_of_finiteDimensional_translationFixedField`: a degree bounds the
   translations that fix it.
+* `WeierstrassCurve.Affine.card_translationFixingSubgroup_dvd_finSepDegree`: the order of the
+  subgroup fixing an intermediate field of finite degree divides the separable degree above it.
+* `WeierstrassCurve.Affine.card_translationFixingSubgroup_eq_finrank_iff`: that order is the full
+  degree exactly when the subgroup cuts the field back out.
 
 ## References
 
@@ -258,5 +262,44 @@ theorem eq_of_translationFixedField_eq [Finite Φ]
   have : Finite Ψ := finite_of_finiteDimensional_translationFixedField W Ψ
   rw [← translationFixingSubgroup_translationFixedField W Φ, h,
     translationFixingSubgroup_translationFixedField W Ψ]
+
+/-- **The order of the fixing subgroup of `L` divides the separable degree of `K(W)` over `L`.**
+The field the subgroup cuts out is Galois over `L`, hence separable, so its degree — the order of
+the subgroup — is one factor of the separable degree of the whole extension. -/
+theorem card_translationFixingSubgroup_dvd_finSepDegree (L : IntermediateField F W.FunctionField)
+    [FiniteDimensional L W.FunctionField] :
+    Nat.card (translationFixingSubgroup W L) ∣ Field.finSepDegree L W.FunctionField := by
+  have hle := le_translationFixedField_translationFixingSubgroup W L
+  -- `extendScalars hle` is `translationFixedField W (translationFixingSubgroup W L)` with its base
+  -- enlarged from `F` to `L`. It is the same subfield of `K(W)`, so it sits under `K(W)` in the
+  -- same way; the `change`s name that identification where it is used
+  have hsep : Algebra.IsSeparable (IntermediateField.extendScalars hle) W.FunctionField := by
+    change Algebra.IsSeparable (translationFixedField W (translationFixingSubgroup W L))
+      W.FunctionField
+    infer_instance
+  have hrk : Module.finrank (IntermediateField.extendScalars hle) W.FunctionField =
+      Nat.card (translationFixingSubgroup W L) := by
+    change Module.finrank (translationFixedField W (translationFixingSubgroup W L))
+      W.FunctionField = _
+    exact finrank_translationFixedField W _
+  have htop : Field.finSepDegree (IntermediateField.extendScalars hle) W.FunctionField =
+      Nat.card (translationFixingSubgroup W L) := by
+    rw [Field.finSepDegree_eq_finrank_of_isSeparable, hrk]
+  rw [← Field.finSepDegree_mul_finSepDegree_of_isAlgebraic L
+    (IntermediateField.extendScalars hle) W.FunctionField, htop]
+  exact Dvd.intro_left _ rfl
+
+/-- **The fixing subgroup of `L` has order the degree of `K(W)` over `L` exactly when it cuts `L`
+back out.** One inclusion holds for every `L`, so the cardinality statement and the reverse
+inclusion are two names for the same thing: a single field-theoretic statement to aim at in place
+of a cardinality one. -/
+theorem card_translationFixingSubgroup_eq_finrank_iff (L : IntermediateField F W.FunctionField)
+    [FiniteDimensional L W.FunctionField] :
+    Nat.card (translationFixingSubgroup W L) = Module.finrank L W.FunctionField ↔
+      translationFixedField W (translationFixingSubgroup W L) ≤ L := by
+  have hle := le_translationFixedField_translationFixingSubgroup W L
+  rw [← finrank_translationFixedField W (translationFixingSubgroup W L), eq_comm,
+    ← IntermediateField.eq_iff_finrank_eq_of_le' hle]
+  exact ⟨fun h ↦ h.ge, le_antisymm hle⟩
 
 end WeierstrassCurve.Affine

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/Translation/FixedField.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/Translation/FixedField.lean
@@ -264,8 +264,8 @@ theorem eq_of_translationFixedField_eq [Finite Φ]
     translationFixingSubgroup_translationFixedField W Ψ]
 
 /-- **The order of the fixing subgroup of `L` divides the separable degree of `K(W)` over `L`.**
-The field the subgroup cuts out is Galois over `L`, hence separable, so its degree — the order of
-the subgroup — is one factor of the separable degree of the whole extension. -/
+`K(W)` is Galois, hence separable, over the field the subgroup cuts out, and that relative degree is
+the order of the subgroup; it is therefore one factor of the separable degree over `L`. -/
 theorem card_translationFixingSubgroup_dvd_finSepDegree (L : IntermediateField F W.FunctionField)
     [FiniteDimensional L W.FunctionField] :
     Nat.card (translationFixingSubgroup W L) ∣ Field.finSepDegree L W.FunctionField := by

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Kernel.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Kernel.lean
@@ -37,6 +37,10 @@ is proved here.
   to be trivial, as for Frobenius.
 * `TauCeti.Isogeny.card_ker_eq_degree_iff`: the cardinality statement is *equivalent* to the
   reverse fixed-field inclusion.
+* `TauCeti.Isogeny.card_ker_eq_degree_of_forall_exists_translation` and
+  `card_ker_eq_degree_iff_isGalois_and_forall_exists_translation`: it holds exactly when the
+  function field is Galois over the pulled-back field and every automorphism over that field is a
+  translation, so those two conditions are what remains of the identity.
 * `TauCeti.Isogeny.card_ker_dvd_separableDegree` and `card_ker_le_separableDegree`: the kernel
   order divides, so is bounded by, the separable degree.
 
@@ -132,6 +136,33 @@ theorem card_ker_eq_degree_iff (φ : Isogeny W₁ W₂) :
   have := φ.finiteDimensional
   rw [ker_def, degree_def]
   exact card_translationFixingSubgroup_eq_finrank_iff W₁ _
+
+/-- **The kernel counts the degree as soon as `K(W₁)` is Galois over the pulled-back field and
+every automorphism over that field is a translation.** This is the shape the point count needs:
+given the Galois hypothesis, what is left of `deg φ = #ker φ` is a statement about automorphisms,
+not about fields — are there automorphisms of `K(W₁)` over `φ^*K(W₂)` beyond the translations by
+kernel points? -/
+theorem card_ker_eq_degree_of_forall_exists_translation (φ : Isogeny W₁ W₂)
+    [IsGalois φ.fieldPullback.fieldRange W₁.FunctionField]
+    (h : ∀ σ ∈ φ.fieldPullback.fieldRange.fixingSubgroup,
+      ∃ P : (W₁⁄F).toAffine.Point, translation W₁ P = σ) :
+    Nat.card φ.ker = φ.degree := by
+  have := φ.finiteDimensional
+  rw [ker_def, degree_def]
+  exact card_translationFixingSubgroup_eq_finrank_of_forall_exists_translation W₁ _ h
+
+/-- **The kernel counts the degree exactly when `K(W₁)` is Galois over the pulled-back field and
+every automorphism over it is a translation.** So the two hypotheses of
+`card_ker_eq_degree_of_forall_exists_translation` are necessary as well as sufficient: this is the
+whole of what is left of `deg φ = #ker φ`, and nothing weaker will give it. -/
+theorem card_ker_eq_degree_iff_isGalois_and_forall_exists_translation (φ : Isogeny W₁ W₂) :
+    Nat.card φ.ker = φ.degree ↔
+      IsGalois φ.fieldPullback.fieldRange W₁.FunctionField ∧
+        ∀ σ ∈ φ.fieldPullback.fieldRange.fixingSubgroup,
+          ∃ P : (W₁⁄F).toAffine.Point, translation W₁ P = σ := by
+  have := φ.finiteDimensional
+  rw [ker_def, degree_def]
+  exact card_translationFixingSubgroup_eq_finrank_iff_isGalois_and_forall_exists_translation W₁ _
 
 /-- **The identity isogeny has trivial kernel.** -/
 @[simp]

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Kernel.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Kernel.lean
@@ -31,6 +31,8 @@ is proved here.
 
 ## Main results
 
+* `TauCeti.Isogeny.fieldPullback_fieldRange_le_translationFixedField_ker`: the pulled-back field is
+  fixed by the kernel.
 * `TauCeti.Isogeny.card_ker_le_degree`: the kernel has at most `deg φ` elements.
 * `TauCeti.Isogeny.ker_le_ker_comp`: postcomposition can only enlarge the kernel.
 * `TauCeti.Isogeny.ker_eq_bot_of_separableDegree_eq_one`: separable degree one forces this kernel
@@ -39,8 +41,6 @@ is proved here.
   reverse fixed-field inclusion.
 * `TauCeti.Isogeny.card_ker_dvd_separableDegree` and `card_ker_le_separableDegree`: the kernel
   order divides, so is bounded by, the separable degree.
-* `TauCeti.Isogeny.fieldPullback_fieldRange_le_translationFixedField_ker`: the pulled-back field is
-  fixed by the kernel.
 
 ## Provenance
 
@@ -92,36 +92,20 @@ theorem ker_le_ker_comp {W₃ : WeierstrassCurve.Affine F} (ψ : Isogeny W₂ W�
   rintro _ ⟨z, rfl⟩
   exact AlgHom.mem_fieldRange.2 ⟨ψ.fieldPullback z, by rw [comp_fieldPullback]; rfl⟩
 
-/-- **The pulled-back field is fixed by the kernel.** The kernel's interaction with the fixed-field
-operation, so that a consumer can use `ker` without unfolding it to a fixing subgroup. This is the
-inclusion that holds for every isogeny; the reverse one is the content of
+/-- **The pulled-back field is fixed by the kernel**, the kernel's interaction with the fixed-field
+operation. This is the inclusion that holds for every isogeny; the reverse one is the content of
 `card_ker_eq_degree_iff`. -/
 theorem fieldPullback_fieldRange_le_translationFixedField_ker (φ : Isogeny W₁ W₂) :
     φ.fieldPullback.fieldRange ≤ translationFixedField W₁ φ.ker := by
   rw [ker_def]; exact le_translationFixedField_translationFixingSubgroup W₁ _
 
-/-- **The kernel order divides the separable degree.** The extension cut out by the kernel is
-Galois, hence separable, so its degree — the order of the kernel — is one factor of the separable
-degree of the whole extension.
-
-This is the general form of the identity a point count needs: the separable degree is what the
-kernel can see, and the missing factor is the separable degree of the pulled-back field inside the
-field the kernel cuts out. -/
+/-- **The kernel order divides the separable degree**, the kernel being the subgroup of
+translations fixing the pulled-back field and that field having finite degree. -/
 theorem card_ker_dvd_separableDegree (φ : Isogeny W₁ W₂) :
     Nat.card φ.ker ∣ φ.separableDegree := by
-  have hle := φ.fieldPullback_fieldRange_le_translationFixedField_ker
-  -- `extendScalars hle` is the same subfield seen over `φ^*K(W₂)`; the two share a carrier, so
-  -- these transport definitionally, which instance search does not see through
-  have hsep : Algebra.IsSeparable (IntermediateField.extendScalars hle) W₁.FunctionField :=
-    inferInstanceAs (Algebra.IsSeparable (translationFixedField W₁ φ.ker) W₁.FunctionField)
-  have hrk : Module.finrank (IntermediateField.extendScalars hle) W₁.FunctionField =
-      Nat.card φ.ker := finrank_translationFixedField W₁ φ.ker
-  have htop : Field.finSepDegree (IntermediateField.extendScalars hle) W₁.FunctionField =
-      Nat.card φ.ker := by
-    rw [Field.finSepDegree_eq_finrank_of_isSeparable, hrk]
-  rw [separableDegree_def, ← Field.finSepDegree_mul_finSepDegree_of_isAlgebraic
-    φ.fieldPullback.fieldRange (IntermediateField.extendScalars hle) W₁.FunctionField, htop]
-  exact Dvd.intro_left _ rfl
+  have := φ.finiteDimensional
+  rw [ker_def, separableDegree_def]
+  exact card_translationFixingSubgroup_dvd_finSepDegree W₁ _
 
 /-- **The separable degree bounds the kernel**, sharpening the bound by the degree. -/
 theorem card_ker_le_separableDegree (φ : Isogeny W₁ W₂) :
@@ -149,8 +133,7 @@ theorem ker_eq_bot_of_degree_eq_one {φ : Isogeny W₁ W₂} (h : φ.degree = 1)
 
 /-- **The kernel counts the degree exactly when it cuts out the pulled-back field.** This is a
 *reduction*, not the separable-locus theorem: one inclusion holds for free, so the cardinality
-statement and the reverse inclusion are two names for the same thing. What it buys is a single
-field-theoretic statement to aim at in place of a cardinality one.
+statement and the reverse inclusion are two names for the same thing.
 
 That inclusion is where separability enters, and over a base field that is not separably closed it
 can fail: the kernel here consists of the rational points, while the extension is cut out by the
@@ -159,15 +142,9 @@ here. -/
 theorem card_ker_eq_degree_iff (φ : Isogeny W₁ W₂) :
     Nat.card φ.ker = φ.degree ↔
       translationFixedField W₁ φ.ker ≤ φ.fieldPullback.fieldRange := by
-  have hle := φ.fieldPullback_fieldRange_le_translationFixedField_ker
-  have htower := IntermediateField.relfinrank_mul_finrank_top hle
-  rw [finrank_translationFixedField W₁ φ.ker, ← degree_def] at htower
-  refine ⟨fun hcard ↦ ?_, fun h ↦ ?_⟩
-  · refine IntermediateField.relfinrank_eq_one_iff.1 ?_
-    rw [hcard] at htower
-    exact Nat.eq_of_mul_eq_mul_right φ.degree_pos (htower.trans (one_mul _).symm)
-  · have hfield : translationFixedField W₁ φ.ker = φ.fieldPullback.fieldRange := le_antisymm h hle
-    rw [← finrank_translationFixedField W₁ φ.ker, hfield, ← degree_def]
+  have := φ.finiteDimensional
+  rw [ker_def, degree_def]
+  exact card_translationFixingSubgroup_eq_finrank_iff W₁ _
 
 /-- **The identity isogeny has trivial kernel.** -/
 @[simp]

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Kernel.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Kernel.lean
@@ -31,8 +31,6 @@ is proved here.
 
 ## Main results
 
-* `TauCeti.Isogeny.fieldPullback_fieldRange_le_translationFixedField_ker`: the pulled-back field is
-  fixed by the kernel.
 * `TauCeti.Isogeny.card_ker_le_degree`: the kernel has at most `deg φ` elements.
 * `TauCeti.Isogeny.ker_le_ker_comp`: postcomposition can only enlarge the kernel.
 * `TauCeti.Isogeny.ker_eq_bot_of_separableDegree_eq_one`: separable degree one forces this kernel
@@ -91,13 +89,6 @@ theorem ker_le_ker_comp {W₃ : WeierstrassCurve.Affine F} (ψ : Isogeny W₂ W�
   refine translationFixingSubgroup_antitone W₁ ?_
   rintro _ ⟨z, rfl⟩
   exact AlgHom.mem_fieldRange.2 ⟨ψ.fieldPullback z, by rw [comp_fieldPullback]; rfl⟩
-
-/-- **The pulled-back field is fixed by the kernel**, the kernel's interaction with the fixed-field
-operation. This is the inclusion that holds for every isogeny; the reverse one is the content of
-`card_ker_eq_degree_iff`. -/
-theorem fieldPullback_fieldRange_le_translationFixedField_ker (φ : Isogeny W₁ W₂) :
-    φ.fieldPullback.fieldRange ≤ translationFixedField W₁ φ.ker := by
-  rw [ker_def]; exact le_translationFixedField_translationFixingSubgroup W₁ _
 
 /-- **The kernel order divides the separable degree**, the kernel being the subgroup of
 translations fixing the pulled-back field and that field having finite degree. -/

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Kernel.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Kernel.lean
@@ -127,10 +127,6 @@ theorem ker_eq_bot_of_separableDegree_eq_one {φ : Isogeny W₁ W₂} (h : φ.se
     φ.ker = ⊥ :=
   φ.ker.eq_bot_of_card_le (h ▸ φ.card_ker_le_separableDegree)
 
-/-- **An isogeny of degree one has trivial kernel.** -/
-theorem ker_eq_bot_of_degree_eq_one {φ : Isogeny W₁ W₂} (h : φ.degree = 1) : φ.ker = ⊥ :=
-  φ.ker.eq_bot_of_card_le (h ▸ φ.card_ker_le_degree)
-
 /-- **The kernel counts the degree exactly when it cuts out the pulled-back field.** This is a
 *reduction*, not the separable-locus theorem: one inclusion holds for free, so the cardinality
 statement and the reverse inclusion are two names for the same thing.
@@ -149,7 +145,7 @@ theorem card_ker_eq_degree_iff (φ : Isogeny W₁ W₂) :
 /-- **The identity isogeny has trivial kernel.** -/
 @[simp]
 theorem ker_id (W : WeierstrassCurve.Affine F) [W.IsElliptic] : (id W).ker = ⊥ :=
-  ker_eq_bot_of_degree_eq_one (degree_id W)
+  ker_eq_bot_of_separableDegree_eq_one (separableDegree_id W)
 
 end TauCeti.Isogeny
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Kernel.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Kernel.lean
@@ -6,7 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.AlgebraicGeometry.EllipticCurve.Affine.FunctionField.Translation.FixedField
-public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.Degree
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.Separability
 
 /-!
 # The kernel of an isogeny
@@ -20,9 +20,10 @@ for every isogeny over every field, with no separability or rationality hypothes
 The degree bounds the kernel: a pulled-back field of degree `d` is fixed by at most `d`
 translations. The bound is often strict, because these are the `F`-rational points only: a
 separable isogeny whose geometric kernel is not rational has fewer of them than its degree.
-Equality needs separability *and* rationality of the whole geometric kernel, which is what the
-point count `deg (1 − π_q) = #E(𝔽_q)` supplies for `1 − π` over a finite field; neither that
-identity nor the general equality is proved here.
+Equality needs separability *and* rationality of the whole geometric kernel. For `1 − π_q` over a
+finite field both hold, its geometric kernel being the `𝔽_q`-rational points, and the point count
+`deg (1 − π_q) = #E(𝔽_q)` is what they then yield; neither that identity nor the general equality
+is proved here.
 
 ## Main definitions
 
@@ -32,7 +33,23 @@ identity nor the general equality is proved here.
 
 * `TauCeti.Isogeny.card_ker_le_degree`: the kernel has at most `deg φ` elements.
 * `TauCeti.Isogeny.ker_le_ker_comp`: postcomposition can only enlarge the kernel.
-* `TauCeti.Isogeny.ker_eq_bot_of_degree_eq_one`: degree one forces a trivial kernel.
+* `TauCeti.Isogeny.ker_eq_bot_of_separableDegree_eq_one`: separable degree one forces this kernel
+  to be trivial, as for Frobenius.
+* `TauCeti.Isogeny.card_ker_eq_degree_iff`: the cardinality statement is *equivalent* to the
+  reverse fixed-field inclusion.
+* `TauCeti.Isogeny.card_ker_dvd_separableDegree` and `card_ker_le_separableDegree`: the kernel
+  order divides, so is bounded by, the separable degree.
+* `TauCeti.Isogeny.fieldPullback_fieldRange_le_translationFixedField_ker`: the pulled-back field is
+  fixed by the kernel.
+
+## Provenance
+
+The AINTLIB `HasseWeil` project (Chris Birkbeck, Apache 2.0, commit
+`513e83879e2f8cbc626eb9e04d660e92be16ccba`) proves the corresponding cardinality statement in
+`EC/SeparableKernelTorsor.lean` as `card_kernel_eq_degree_of_separable_isogeny`, parametric on two
+witnesses. The second exists only because its isogeny carries a point map independent of the
+function-field pullback, so separability and the kernel are a priori unrelated there. The kernel
+here is defined from the pullback, so that witness has no counterpart.
 
 ## References
 
@@ -59,18 +76,12 @@ theorem ker_def (φ : Isogeny W₁ W₂) :
 itself.** -/
 @[simp]
 theorem mem_ker_iff {φ : Isogeny W₁ W₂} {P : (W₁⁄F).toAffine.Point} :
-    P ∈ φ.ker ↔ ∀ z ∈ φ.fieldPullback.fieldRange, translation W₁ P z = z :=
-  mem_translationFixingSubgroup_iff W₁
+    P ∈ φ.ker ↔ ∀ z ∈ φ.fieldPullback.fieldRange, translation W₁ P z = z := by
+  rw [ker_def]; exact mem_translationFixingSubgroup_iff W₁
 
 /-- **The kernel is finite**, the pulled-back field being of finite index. -/
 instance finite_ker (φ : Isogeny W₁ W₂) : Finite φ.ker :=
-  finite_translationFixingSubgroup W₁ φ.fieldPullback.fieldRange
-
-/-- **The degree bounds the kernel**: an isogeny of degree `d` is fixed by at most `d`
-translations. The bound is often strict, this being the rational kernel: equality needs the
-isogeny to be separable and its geometric kernel to be rational. -/
-theorem card_ker_le_degree (φ : Isogeny W₁ W₂) : Nat.card φ.ker ≤ φ.degree :=
-  (card_translationFixingSubgroup_le W₁ φ.fieldPullback.fieldRange).trans_eq (φ.degree_def).symm
+  φ.ker_def ▸ finite_translationFixingSubgroup W₁ φ.fieldPullback.fieldRange
 
 /-- **Postcomposition can only enlarge the kernel**: a function pulled back from `W₃` arrives
 through `W₂`, so a translation fixing everything from `W₂` fixes it too. -/
@@ -81,9 +92,82 @@ theorem ker_le_ker_comp {W₃ : WeierstrassCurve.Affine F} (ψ : Isogeny W₂ W�
   rintro _ ⟨z, rfl⟩
   exact AlgHom.mem_fieldRange.2 ⟨ψ.fieldPullback z, by rw [comp_fieldPullback]; rfl⟩
 
-/-- **An isogeny of degree one has trivial kernel**, the bound leaving no room. -/
+/-- **The pulled-back field is fixed by the kernel.** The kernel's interaction with the fixed-field
+operation, so that a consumer can use `ker` without unfolding it to a fixing subgroup. This is the
+inclusion that holds for every isogeny; the reverse one is the content of
+`card_ker_eq_degree_iff`. -/
+theorem fieldPullback_fieldRange_le_translationFixedField_ker (φ : Isogeny W₁ W₂) :
+    φ.fieldPullback.fieldRange ≤ translationFixedField W₁ φ.ker := by
+  rw [ker_def]; exact le_translationFixedField_translationFixingSubgroup W₁ _
+
+/-- **The kernel order divides the separable degree.** The extension cut out by the kernel is
+Galois, hence separable, so its degree — the order of the kernel — is one factor of the separable
+degree of the whole extension.
+
+This is the general form of the identity a point count needs: the separable degree is what the
+kernel can see, and the missing factor is the separable degree of the pulled-back field inside the
+field the kernel cuts out. -/
+theorem card_ker_dvd_separableDegree (φ : Isogeny W₁ W₂) :
+    Nat.card φ.ker ∣ φ.separableDegree := by
+  have hle := φ.fieldPullback_fieldRange_le_translationFixedField_ker
+  -- `extendScalars hle` is the same subfield seen over `φ^*K(W₂)`; the two share a carrier, so
+  -- these transport definitionally, which instance search does not see through
+  have hsep : Algebra.IsSeparable (IntermediateField.extendScalars hle) W₁.FunctionField :=
+    inferInstanceAs (Algebra.IsSeparable (translationFixedField W₁ φ.ker) W₁.FunctionField)
+  have hrk : Module.finrank (IntermediateField.extendScalars hle) W₁.FunctionField =
+      Nat.card φ.ker := finrank_translationFixedField W₁ φ.ker
+  have htop : Field.finSepDegree (IntermediateField.extendScalars hle) W₁.FunctionField =
+      Nat.card φ.ker := by
+    rw [Field.finSepDegree_eq_finrank_of_isSeparable, hrk]
+  rw [separableDegree_def, ← Field.finSepDegree_mul_finSepDegree_of_isAlgebraic
+    φ.fieldPullback.fieldRange (IntermediateField.extendScalars hle) W₁.FunctionField, htop]
+  exact Dvd.intro_left _ rfl
+
+/-- **The separable degree bounds the kernel**, sharpening the bound by the degree. -/
+theorem card_ker_le_separableDegree (φ : Isogeny W₁ W₂) :
+    Nat.card φ.ker ≤ φ.separableDegree :=
+  Nat.le_of_dvd φ.separableDegree_pos φ.card_ker_dvd_separableDegree
+
+/-- **The degree bounds the kernel**, the separable degree being at most the degree. The bound is
+often strict, this being the rational kernel: equality needs the isogeny to be separable and its
+geometric kernel to be rational. -/
+theorem card_ker_le_degree (φ : Isogeny W₁ W₂) : Nat.card φ.ker ≤ φ.degree :=
+  φ.card_ker_le_separableDegree.trans <| by
+    rw [separableDegree_def, degree_def]; exact Field.finSepDegree_le_finrank _ _
+
+/-- **An isogeny of separable degree one has a trivial kernel here**, the bound leaving no room.
+This is the right hypothesis: a purely inseparable isogeny such as Frobenius has separable degree
+one, so its kernel in this point-valued sense is trivial whatever its degree — its scheme-theoretic
+kernel, which this file does not model, is not. -/
+theorem ker_eq_bot_of_separableDegree_eq_one {φ : Isogeny W₁ W₂} (h : φ.separableDegree = 1) :
+    φ.ker = ⊥ :=
+  φ.ker.eq_bot_of_card_le (h ▸ φ.card_ker_le_separableDegree)
+
+/-- **An isogeny of degree one has trivial kernel.** -/
 theorem ker_eq_bot_of_degree_eq_one {φ : Isogeny W₁ W₂} (h : φ.degree = 1) : φ.ker = ⊥ :=
   φ.ker.eq_bot_of_card_le (h ▸ φ.card_ker_le_degree)
+
+/-- **The kernel counts the degree exactly when it cuts out the pulled-back field.** This is a
+*reduction*, not the separable-locus theorem: one inclusion holds for free, so the cardinality
+statement and the reverse inclusion are two names for the same thing. What it buys is a single
+field-theoretic statement to aim at in place of a cardinality one.
+
+That inclusion is where separability enters, and over a base field that is not separably closed it
+can fail: the kernel here consists of the rational points, while the extension is cut out by the
+geometric ones. Deriving it from separability and rationality of the geometric kernel is not done
+here. -/
+theorem card_ker_eq_degree_iff (φ : Isogeny W₁ W₂) :
+    Nat.card φ.ker = φ.degree ↔
+      translationFixedField W₁ φ.ker ≤ φ.fieldPullback.fieldRange := by
+  have hle := φ.fieldPullback_fieldRange_le_translationFixedField_ker
+  have htower := IntermediateField.relfinrank_mul_finrank_top hle
+  rw [finrank_translationFixedField W₁ φ.ker, ← degree_def] at htower
+  refine ⟨fun hcard ↦ ?_, fun h ↦ ?_⟩
+  · refine IntermediateField.relfinrank_eq_one_iff.1 ?_
+    rw [hcard] at htower
+    exact Nat.eq_of_mul_eq_mul_right φ.degree_pos (htower.trans (one_mul _).symm)
+  · have hfield : translationFixedField W₁ φ.ker = φ.fieldPullback.fieldRange := le_antisymm h hle
+    rw [← finrank_translationFixedField W₁ φ.ker, hfield, ← degree_def]
 
 /-- **The identity isogeny has trivial kernel.** -/
 @[simp]


### PR DESCRIPTION
Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"EllipticCurves/README.md:layer1:kernel-card-eq-degree"}-->

Provenance: original. The AINTLIB `HasseWeil` project (Chris Birkbeck, Apache-2.0, `513e83879e2f8cbc626eb9e04d660e92be16ccba`) reaches the corresponding statement from the other side, as `GapSpines.emb_le_card_kernel`: a point-level torsor assembly over `AlgebraicClosure K(E)`, where each embedding gives a point, differences are Frobenius-fixed and descend, and the resulting map is injective. That needs points over the algebraic closure of the function field, which TauCeti does not have; the reduction here needs none.

## What this adds

- `WeierstrassCurve.Affine.card_translationFixingSubgroup_eq_finrank_of_forall_exists_translation`: for an intermediate field `L` with `K(W)/L` finite and Galois, if every automorphism fixing `L` pointwise is a translation, then `L` is fixed by exactly `[K(W) : L]` translations.
- `TauCeti.Isogeny.card_ker_eq_degree_of_forall_exists_translation`: consequently `Nat.card φ.ker = φ.degree` for any isogeny whose pulled-back field is Galois below `K(W₁)` and has no automorphisms over it beyond translations.
- `card_translationFixingSubgroup_eq_finrank_iff_isGalois_and_forall_exists_translation` and `Isogeny.card_ker_eq_degree_iff_isGalois_and_forall_exists_translation`: the converse, so the two hypotheses are necessary as well as sufficient.

## Why this is the step worth taking

`card_ker_eq_degree_iff` already reduces `deg φ = #ker φ` to a fixed-field inclusion. That inclusion is still a statement about fields, and there is nothing in it to attack directly. This converts it into a statement about automorphisms — *are there any over `φ^*K(W₂)` besides the translations?* — which is the form every classical proof of Silverman III.4.10(c) actually establishes, and the form AINTLIB establishes too.

The proof is short because the surjectivity half of the Galois correspondence for the translation action is already on `main` as `fixingSubgroup_translationFixedField`. Translation into the fixing subgroup is injective (`translation_injective`); the hypothesis makes it surjective; `IntermediateField.fixingSubgroupEquiv` and `IsGalois.card_aut_eq_finrank` then supply the count.

## The hypotheses are exactly right

The converse says the two conditions are not merely sufficient but equivalent to the conclusion, so nothing weaker can prove `deg φ = #ker φ`. It costs four lines, because the Galois correspondence for the translation action is already on `main` for a finite subgroup: the count forces the subgroup to cut `L` back out, and `isGalois_translationFixedField` and `fixingSubgroup_translationFixedField` then give the two halves. That fixes the shape of the remaining work rather than leaving it open-ended.

## Scope

Neither hypothesis is discharged here. For `1 − π_q` over a finite field both are expected to hold, and `isSeparable_oneSubFrobeniusIsogeny` is already on `main` as the separability half of the Galois condition; normality and the translation-exhaustion statement are the remaining work, and the docstrings say so.

This PR sits on top of #6362, which adds the `card_translationFixingSubgroup_eq_finrank_iff` this pairs with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
