### PR TITLE
refactor(Probability): drop the duplicate `tail_le_exchangeableSigma`

### DIFF
--- a/TauCeti/Probability/DeFinetti/JointRectangle.lean
+++ b/TauCeti/Probability/DeFinetti/JointRectangle.lean
@@ -155,7 +155,7 @@ private theorem measure_inter_blockCylinder_eq_setLIntegral_of_injective
       (directingProbabilityMeasure μ (fun j (x : ℕ → α) => x j) ⁻¹' S)
       = directingProbabilityMeasure μ (fun j (x : ℕ → α) => x j) ⁻¹' S := by
     rw [← Set.preimage_comp, comp_permReindex_eq_of_measurable_exchangeableSigma
-      (measurable_tailProcess_directingProbabilityMeasure.mono tail_le_exchangeableSigma le_rfl)
+      (measurable_tailProcess_directingProbabilityMeasure.mono pathTail_le_exchangeableSigma le_rfl)
       hπfin]
   have hcyl := blockCylinder_eq_preimage_permReindex (B := B) hπval
   have hmp : MeasurePreserving (permReindex (α := α) π) μ μ :=

--- a/TauCeti/Probability/Exchangeability/PathSpace/Exchangeable/Sigma.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/Exchangeable/Sigma.lean
@@ -163,11 +163,6 @@ theorem pathTail_le_exchangeableSigma :
     exact preimage_permReindex_eq_of_measurable_tailFamily
       ((pathTail_le_tailFamily (α := α) N) s hs) hN
 
-/-- The path-space tail σ-algebra is contained in the exchangeable σ-algebra. -/
-theorem tail_le_exchangeableSigma :
-    pathTail α ≤ exchangeableSigma α :=
-  pathTail_le_exchangeableSigma
-
 end Probability
 
 end TauCeti

--- a/TauCeti/Probability/Exchangeability/PathSpace/HewittSavage.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/HewittSavage.lean
@@ -31,7 +31,7 @@ invariant under modification of finitely many coordinates. The qualification mat
 `B = ∅` or `B = Set.univ`, or a one-point coordinate space, the event collapses to `∅` or
 `Set.univ` and is a tail event after all.
 
-`tail_le_exchangeableSigma` records the inclusion of the two σ-algebras formally; its strictness
+`pathTail_le_exchangeableSigma` records the inclusion of the two σ-algebras formally; its strictness
 is not formalized here.
 
 Identical distribution enters only as the route to exchangeability of the path law: it is what


### PR DESCRIPTION
`TauCeti.tail_le_exchangeableSigma` is a duplicate: its statement is identical to
`pathTail_le_exchangeableSigma` in the same file and its proof is that theorem verbatim.

```lean
/-- The path-space tail σ-algebra is contained in the exchangeable σ-algebra. -/
theorem tail_le_exchangeableSigma :
    pathTail α ≤ exchangeableSigma α :=
  pathTail_le_exchangeableSigma
```

The project does not preserve backwards compatibility and does not keep duplicate theorem names, so
the alias is deleted rather than deprecated. Its two uses — one proof step in
`DeFinetti/JointRectangle.lean` and one module-docstring reference in `HewittSavage.lean` — move to
`pathTail_le_exchangeableSigma`, which is the name the other six call sites across five files already
use.

No mathematics changes: the surviving theorem keeps its statement and its proof, and nothing else in
the diff is touched.

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GadULQ4gpsVAZfpvs2htNt
