### PR TITLE
refactor(RepresentationTheory): root the `TauCeti.FDRep` character API

### DIFF
--- a/TauCeti/RepresentationTheory/CharacterTable/Degree.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Degree.lean
@@ -30,7 +30,7 @@ rational algebraic integer is an integer, so `χ(1)` divides `|G|`.
 
 * `TauCeti.Representation.finrank_mul_sum_centralCharacter_eq_card`: the division-free identity
   `χ(1) · ∑_C ωᵪ(K_C) χ(g_C⁻¹) = |G|`.
-* `TauCeti.Representation.finrank_dvd_card` and `TauCeti.FDRep.finrank_dvd_card`: the degree of an
+* `TauCeti.Representation.finrank_dvd_card` and `FDRep.finrank_dvd_card`: the degree of an
   irreducible representation divides the order of the group.
 
 ## Implementation notes

--- a/TauCeti/RepresentationTheory/CharacterTable/Degree.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Degree.lean
@@ -140,7 +140,7 @@ variable {k G : Type*} [Field k] [IsAlgClosed k] [CharZero k] [Group G] [Finite 
 
 /-- **The degree of an irreducible character divides the order of the group**, for a bundled
 finite-dimensional representation. -/
-theorem finrank_dvd_card (X : FDRep k G) [_root_.Representation.IsIrreducible X.ρ] :
+theorem _root_.FDRep.finrank_dvd_card (X : FDRep k G) [_root_.Representation.IsIrreducible X.ρ] :
     finrank k X ∣ Nat.card G :=
   Representation.finrank_dvd_card X.ρ
 

--- a/TauCeti/RepresentationTheory/CharacterTable/FrobeniusSchur/Basic.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/FrobeniusSchur/Basic.lean
@@ -214,15 +214,15 @@ variable [Field k] [Group G] [Fintype G]
 
 /-- **The Frobenius-Schur indicator** of a finite-dimensional representation presented as an
 object of `FDRep k G`: the indicator `|G|⁻¹ ∑_g χ(g²)` of the underlying representation `V.ρ`. -/
-noncomputable def frobeniusSchurIndicator (V : FDRep k G) : k :=
+noncomputable def _root_.FDRep.frobeniusSchurIndicator (V : FDRep k G) : k :=
   Representation.frobeniusSchurIndicator V.ρ
 
 /-- The two forms of the indicator agree: the `FDRep`-level indicator of `V` is the indicator of
 the underlying representation `V.ρ`. It is a `simp` lemma, so results proved on the module spine
 apply to the `FDRep`-level indicator automatically. -/
 @[simp]
-theorem frobeniusSchurIndicator_def (V : FDRep k G) :
-    frobeniusSchurIndicator V = Representation.frobeniusSchurIndicator V.ρ :=
+theorem _root_.FDRep.frobeniusSchurIndicator_def (V : FDRep k G) :
+    FDRep.frobeniusSchurIndicator V = Representation.frobeniusSchurIndicator V.ρ :=
   (rfl)
 
 end FDRep

--- a/TauCeti/RepresentationTheory/CharacterTable/FrobeniusSchur/Basic.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/FrobeniusSchur/Basic.lean
@@ -39,7 +39,7 @@ agreement with this one are at the end of the file.
 ## Main definitions
 
 * `TauCeti.Representation.frobeniusSchurIndicator`: `ν₂(ρ) = |G|⁻¹ ∑_g χ(g²)`.
-* `TauCeti.FDRep.frobeniusSchurIndicator`: the same indicator, for a `V : FDRep k G`.
+* `FDRep.frobeniusSchurIndicator`: the same indicator, for a `V : FDRep k G`.
 
 ## Main results
 
@@ -51,7 +51,7 @@ agreement with this one are at the end of the file.
   in characteristic zero.
 * `TauCeti.Representation.frobeniusSchurIndicator_eq_intCast`: in characteristic zero the indicator
   is the integer `dim (Sym²V)ᴳ - dim (Λ²V)ᴳ`.
-* `TauCeti.FDRep.frobeniusSchurIndicator_def`: the `FDRep`-level indicator is the indicator of the
+* `FDRep.frobeniusSchurIndicator_def`: the `FDRep`-level indicator is the indicator of the
   underlying representation.
 
 ## Implementation notes
@@ -61,7 +61,7 @@ not of the object. The two statements that do not mention the indicator ask only
 and build the `Fintype` they average over inside their proofs.
 
 The `FDRep`-level indicator is the module-level one applied to `V.ρ` rather than a second copy of
-the average, so `TauCeti.FDRep.frobeniusSchurIndicator_def` unfolds that one definition and nothing
+the average, so `FDRep.frobeniusSchurIndicator_def` unfolds that one definition and nothing
 else, and every theorem about the average transfers through it. Neither definition is `@[expose]`d,
 so the two `_def` lemmas are the only route to the two averages from another module; that is what
 they are for. It is also why both are proved by a parenthesised `(rfl)`: a proof written

--- a/TauCeti/RepresentationTheory/CharacterTable/Galois.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Galois.lean
@@ -50,11 +50,11 @@ consumes once such a `σ` is in hand.
 * `TauCeti.Representation.map_ofCharacter_eq_powMap`: on a group of exponent dividing `n` the
   Galois twist `σ ∘ χ` is the power-map twist `TauCeti.ClassFunction.powMap j` of the class
   function of `χ`, so the twist is an operation on `ClassFunction k G`.
-* `TauCeti.FDRep.map_character_eq_character_pow_of_isPrimitiveRoot`: over `ℂ`, a field
+* `FDRep.map_character_eq_character_pow_of_isPrimitiveRoot`: over `ℂ`, a field
   automorphism `f` of `ℂ` sends `χ(g)` to `χ(g ^ j)`, with `j` the cyclotomic exponent
   `IsPrimitiveRoot.autToPow` attaches to `f`.
-* `TauCeti.FDRep.isConjRoot_character_pow`: `χ(g)` and `χ(g ^ j)` are conjugate over `ℚ`.
-* `TauCeti.FDRep.character_pow_eq_character_of_mem_range`: a rational character value is unchanged
+* `FDRep.isConjRoot_character_pow`: `χ(g)` and `χ(g ^ j)` are conjugate over `ℚ`.
+* `FDRep.character_pow_eq_character_of_mem_range`: a rational character value is unchanged
   by the power maps that automorphisms of `ℂ` realize.
 
 ## References

--- a/TauCeti/RepresentationTheory/CharacterTable/Galois.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Galois.lean
@@ -127,7 +127,7 @@ variable {G : Type v} [Monoid G]
 /-- **The Galois action on complex character values is by power maps.** If `g ^ n = 1` and the ring
 endomorphism `σ` of `ℂ` raises every `n`-th root of unity to the `j`-th power, then
 `σ (χ(g)) = χ(g ^ j)`. -/
-theorem map_character_eq_character_pow (X : FDRep ℂ G) {g : G} {n j : ℕ} (hn : n ≠ 0)
+theorem _root_.FDRep.map_character_eq_character_pow (X : FDRep ℂ G) {g : G} {n j : ℕ} (hn : n ≠ 0)
     (hg : g ^ n = 1) (σ : ℂ →+* ℂ) (hσ : ∀ μ : ℂ, μ ^ n = 1 → σ μ = μ ^ j) :
     σ (X.character g) = X.character (g ^ j) :=
   Representation.map_character_eq_character_pow X.ρ (Nat.cast_ne_zero.2 hn) hg σ hσ
@@ -136,7 +136,8 @@ theorem map_character_eq_character_pow (X : FDRep ℂ G) {g : G} {n j : ℕ} (hn
 the cyclotomic character `IsPrimitiveRoot.autToPow`: a field automorphism `f` of `ℂ`, which is the
 same thing as a `ℚ`-algebra automorphism, acts on the roots of unity of order dividing `n` as
 `ζ ↦ ζ ^ j` for a unique `j : (ZMod n)ˣ`, and then `f (χ(g)) = χ(g ^ j)` whenever `g ^ n = 1`. -/
-theorem map_character_eq_character_pow_of_isPrimitiveRoot (X : FDRep ℂ G) {n : ℕ} [NeZero n] {ζ : ℂ}
+theorem _root_.FDRep.map_character_eq_character_pow_of_isPrimitiveRoot (X : FDRep ℂ G) {n : ℕ}
+    [NeZero n] {ζ : ℂ}
     (hζ : IsPrimitiveRoot ζ n) {g : G} (hg : g ^ n = 1) (f : ℂ ≃ₐ[ℚ] ℂ) :
     f (X.character g) = X.character (g ^ ((hζ.autToPow ℚ f : ZMod n).val)) :=
   FDRep.map_character_eq_character_pow X (NeZero.ne n) hg f.toAlgHom.toRingHom
@@ -145,7 +146,7 @@ theorem map_character_eq_character_pow_of_isPrimitiveRoot (X : FDRep ℂ G) {n :
 /-- **A character value and its power-map twist are conjugate algebraic numbers**: `χ(g)` and
 `χ(g ^ j)` have the same minimal polynomial over `ℚ`, being images of one another under a field
 automorphism of `ℂ`. -/
-theorem isConjRoot_character_pow (X : FDRep ℂ G) {n : ℕ} [NeZero n] {ζ : ℂ}
+theorem _root_.FDRep.isConjRoot_character_pow (X : FDRep ℂ G) {n : ℕ} [NeZero n] {ζ : ℂ}
     (hζ : IsPrimitiveRoot ζ n) {g : G} (hg : g ^ n = 1) (f : ℂ ≃ₐ[ℚ] ℂ) :
     IsConjRoot ℚ (X.character g) (X.character (g ^ ((hζ.autToPow ℚ f : ZMod n).val))) := by
   rw [← FDRep.map_character_eq_character_pow_of_isPrimitiveRoot X hζ hg f]
@@ -153,7 +154,8 @@ theorem isConjRoot_character_pow (X : FDRep ℂ G) {n : ℕ} [NeZero n] {ζ : �
 
 /-- **A rational character value is fixed by the power maps that automorphisms of `ℂ` realize**: if
 `χ(g)` is rational then `χ(g ^ j) = χ(g)` for every `j` coming from a field automorphism of `ℂ`. -/
-theorem character_pow_eq_character_of_mem_range (X : FDRep ℂ G) {n : ℕ} [NeZero n] {ζ : ℂ}
+theorem _root_.FDRep.character_pow_eq_character_of_mem_range (X : FDRep ℂ G) {n : ℕ} [NeZero n]
+    {ζ : ℂ}
     (hζ : IsPrimitiveRoot ζ n) {g : G} (hg : g ^ n = 1) (f : ℂ ≃ₐ[ℚ] ℂ)
     (hχ : X.character g ∈ (algebraMap ℚ ℂ).range) :
     X.character (g ^ ((hζ.autToPow ℚ f : ZMod n).val)) = X.character g := by

--- a/TauCeti/RepresentationTheory/CharacterTable/Values.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Values.lean
@@ -244,14 +244,15 @@ variable {G : Type v} [Group G] [Finite G]
 
 /-- **Character values are algebraic integers.** For a finite group, every value of the character
 of a finite-dimensional representation over any field is integral over `ℤ`. -/
-theorem isIntegral_char {k : Type u} [Field k] (V : FDRep k G) (g : G) :
+theorem _root_.FDRep.isIntegral_char {k : Type u} [Field k] (V : FDRep k G) (g : G) :
     IsIntegral ℤ (V.character g) :=
   Representation.isIntegral_char V.ρ (isOfFinOrder_of_finite g).orderOf_pos.ne'
     (pow_orderOf_eq_one g)
 
 /-- **A rational character is integer-valued.** For a finite group, every value of the character of
 a finite-dimensional representation over `ℚ` is the cast of an integer. -/
-theorem exists_char_eq_intCast (V : FDRep ℚ G) (g : G) : ∃ m : ℤ, V.character g = (m : ℚ) :=
+theorem _root_.FDRep.exists_char_eq_intCast (V : FDRep ℚ G) (g : G) :
+    ∃ m : ℤ, V.character g = (m : ℚ) :=
   Representation.exists_char_eq_intCast V.ρ (isOfFinOrder_of_finite g).orderOf_pos.ne'
     (pow_orderOf_eq_one g)
 
@@ -263,52 +264,54 @@ integer, not extra information.
 
 Being in the `TauCeti.FDRep` namespace rather than the root one, it is not available through dot
 notation on an `FDRep ℚ G`, and is written `intCharacter V g` throughout. -/
-noncomputable def intCharacter (V : FDRep ℚ G) (g : G) : ℤ := (V.character g).num
+noncomputable def _root_.FDRep.intCharacter (V : FDRep ℚ G) (g : G) : ℤ := (V.character g).num
 
 omit [Finite G] in
 private theorem intCharacter_def (V : FDRep ℚ G) (g : G) :
-    intCharacter V g = (V.character g).num := (rfl)
+    FDRep.intCharacter V g = (V.character g).num := (rfl)
 
 /-- **The integer character casts back to the character.** -/
 @[simp]
-theorem intCharacter_cast (V : FDRep ℚ G) (g : G) : (intCharacter V g : ℚ) = V.character g := by
-  obtain ⟨m, hm⟩ := exists_char_eq_intCast V g
+theorem _root_.FDRep.intCharacter_cast (V : FDRep ℚ G) (g : G) :
+    (FDRep.intCharacter V g : ℚ) = V.character g := by
+  obtain ⟨m, hm⟩ := FDRep.exists_char_eq_intCast V g
   rw [intCharacter_def, hm, Rat.num_intCast]
 
 /-- **The integer character carries exactly the information of the rational one**: this is the
 elimination principle for `TauCeti.FDRep.intCharacter`, an integer equation between its values
 being the corresponding equation between character values. -/
 theorem intCharacter_eq_iff {V W : FDRep ℚ G} {g h : G} :
-    intCharacter V g = intCharacter W h ↔ V.character g = W.character h := by
-  rw [← Int.cast_inj (α := ℚ), intCharacter_cast, intCharacter_cast]
+    FDRep.intCharacter V g = FDRep.intCharacter W h ↔ V.character g = W.character h := by
+  rw [← Int.cast_inj (α := ℚ), FDRep.intCharacter_cast, FDRep.intCharacter_cast]
 
 /-- **The integer character is a class function.** -/
 @[simp]
-theorem intCharacter_conj (V : FDRep ℚ G) (g h : G) :
-    intCharacter V (h * g * h⁻¹) = intCharacter V g :=
+theorem _root_.FDRep.intCharacter_conj (V : FDRep ℚ G) (g h : G) :
+    FDRep.intCharacter V (h * g * h⁻¹) = FDRep.intCharacter V g :=
   intCharacter_eq_iff.2 (_root_.FDRep.char_conj V g h)
 
 /-- **The integer character of a rational representation, as a class function.** -/
-noncomputable def intClassFunction (V : FDRep ℚ G) : ClassFunction ℤ G :=
-  ⟨intCharacter V, ClassFunction.mem_iff.2 (intCharacter_conj V)⟩
+noncomputable def _root_.FDRep.intClassFunction (V : FDRep ℚ G) : ClassFunction ℤ G :=
+  ⟨FDRep.intCharacter V, ClassFunction.mem_iff.2 (FDRep.intCharacter_conj V)⟩
 
 @[simp]
-theorem intClassFunction_apply (V : FDRep ℚ G) (g : G) :
-    (intClassFunction V).1 g = intCharacter V g := (rfl)
+theorem _root_.FDRep.intClassFunction_apply (V : FDRep ℚ G) (g : G) :
+    (FDRep.intClassFunction V).1 g = FDRep.intCharacter V g := (rfl)
 
 /-- Conjugate elements have the same integer character. -/
-theorem intCharacter_eq_of_isConj (V : FDRep ℚ G) {g h : G} (hgh : IsConj g h) :
-    intCharacter V g = intCharacter V h :=
-  ClassFunction.eq_of_isConj (intClassFunction V) hgh
+theorem _root_.FDRep.intCharacter_eq_of_isConj (V : FDRep ℚ G) {g h : G} (hgh : IsConj g h) :
+    FDRep.intCharacter V g = FDRep.intCharacter V h :=
+  ClassFunction.eq_of_isConj (FDRep.intClassFunction V) hgh
 
 /-- **The integer character at the identity is the degree.** -/
 @[simp]
-theorem intCharacter_one (V : FDRep ℚ G) : intCharacter V 1 = Module.finrank ℚ V :=
+theorem _root_.FDRep.intCharacter_one (V : FDRep ℚ G) :
+    FDRep.intCharacter V 1 = Module.finrank ℚ V :=
   Int.cast_injective (α := ℚ) (by simp)
 
 /-- **Character values are cyclotomic integers.** For a finite group of exponent `e` and a
 primitive `e`-th root of unity `ζ`, every value of a complex character lies in `ℤ[ζ]`. -/
-theorem char_mem_adjoin_of_isPrimitiveRoot (V : FDRep ℂ G) {ζ : ℂ}
+theorem _root_.FDRep.char_mem_adjoin_of_isPrimitiveRoot (V : FDRep ℂ G) {ζ : ℂ}
     (hζ : IsPrimitiveRoot ζ (Monoid.exponent G)) (g : G) :
     V.character g ∈ Algebra.adjoin ℤ ({ζ} : Set ℂ) :=
   haveI : NeZero (Monoid.exponent G) := ⟨Monoid.exponent_ne_zero_of_finite⟩
@@ -316,7 +319,7 @@ theorem char_mem_adjoin_of_isPrimitiveRoot (V : FDRep ℂ G) {ζ : ℂ}
 
 /-- Over `ℂ`, a character of a finite group is bounded in absolute value by its degree,
 `‖χ(g)‖ ≤ χ(1)`. -/
-theorem norm_char_le_finrank (V : FDRep ℂ G) (g : G) : ‖V.character g‖ ≤ finrank ℂ V :=
+theorem _root_.FDRep.norm_char_le_finrank (V : FDRep ℂ G) (g : G) : ‖V.character g‖ ≤ finrank ℂ V :=
   Representation.norm_char_le_finrank V.ρ (isOfFinOrder_of_finite g).orderOf_pos.ne'
     (pow_orderOf_eq_one g)
 
@@ -332,7 +335,7 @@ theorem _root_.FDRep.exists_apply_eq_smul_of_norm_char_eq_finrank (V : FDRep ℂ
 /-- **Over `ℂ`, inversion conjugates the character values of a finite group**, so that a complex
 character is a "unitary" class function: `conj (χ g) = χ g⁻¹`. -/
 @[simp]
-theorem conj_char (V : FDRep ℂ G) (g : G) :
+theorem _root_.FDRep.conj_char (V : FDRep ℂ G) (g : G) :
     (starRingEnd ℂ) (V.character g) = V.character g⁻¹ :=
   Representation.conj_char V.ρ g
 
@@ -341,7 +344,7 @@ omit [Finite G] in
 and which every finite group satisfies in characteristic zero, then `V.ρ g` is a semisimple
 endomorphism. Over an algebraically closed field, `ℂ` for instance, this is its
 diagonalizability. -/
-theorem isSemisimple_ρ {k : Type u} [Field k] [NeZero (Nat.card G : k)] (V : FDRep k G)
+theorem _root_.FDRep.isSemisimple_ρ {k : Type u} [Field k] [NeZero (Nat.card G : k)] (V : FDRep k G)
     (g : G) : End.IsSemisimple (V.ρ g) :=
   Representation.isSemisimple_apply V.ρ (NeZero.ne _) g
 

--- a/TauCeti/RepresentationTheory/CharacterTable/Values.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Values.lean
@@ -46,8 +46,8 @@ representation of a group, from the eigenvalues alone, with no invariant inner p
   `(ρ g).charpoly` splits, a character value is a sum of `finrank` many `n`-th roots of unity. The
   variant `TauCeti.Representation.exists_multiset_rootsOfUnity_char_eq_sum` specializes it to an
   algebraically closed field.
-* `TauCeti.Representation.isIntegral_char` and `FDRep.isIntegral_char`: **character values
-  are algebraic integers**, over an arbitrary field.
+* `TauCeti.Representation.isIntegral_char`: **character values are algebraic integers**, over an
+  arbitrary field. The bundled `FDRep` form is Mathlib's `FDRep.isIntegral_character`.
 * `TauCeti.Representation.exists_char_eq_intCast` and `FDRep.exists_char_eq_intCast`:
   **a rational character is integer-valued**.
 * `FDRep.intCharacter`: the resulting `ℤ`-valued character of a rational representation of
@@ -241,13 +241,6 @@ end Representation
 namespace FDRep
 
 variable {G : Type v} [Group G] [Finite G]
-
-/-- **Character values are algebraic integers.** For a finite group, every value of the character
-of a finite-dimensional representation over any field is integral over `ℤ`. -/
-theorem _root_.FDRep.isIntegral_char {k : Type u} [Field k] (V : FDRep k G) (g : G) :
-    IsIntegral ℤ (V.character g) :=
-  Representation.isIntegral_char V.ρ (isOfFinOrder_of_finite g).orderOf_pos.ne'
-    (pow_orderOf_eq_one g)
 
 /-- **A rational character is integer-valued.** For a finite group, every value of the character of
 a finite-dimensional representation over `ℚ` is the cast of an integer. -/

--- a/TauCeti/RepresentationTheory/CharacterTable/Values.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Values.lean
@@ -255,8 +255,8 @@ that integer, extracted as the numerator of the rational value. Read it only thr
 `FDRep.intCharacter_cast`, which is what pins it down; the numerator is a way of naming the
 integer, not extra information.
 
-Being in the `TauCeti.FDRep` namespace rather than the root one, it is not available through dot
-notation on an `FDRep ℚ G`, and is written `intCharacter V g` throughout. -/
+It lives in the root `FDRep` namespace, so dot notation on an `FDRep ℚ G` reaches it: write
+`V.intCharacter g`. -/
 noncomputable def _root_.FDRep.intCharacter (V : FDRep ℚ G) (g : G) : ℤ := (V.character g).num
 
 omit [Finite G] in
@@ -273,7 +273,7 @@ theorem _root_.FDRep.intCharacter_cast (V : FDRep ℚ G) (g : G) :
 /-- **The integer character carries exactly the information of the rational one**: this is the
 elimination principle for `FDRep.intCharacter`, an integer equation between its values
 being the corresponding equation between character values. -/
-theorem intCharacter_eq_iff {V W : FDRep ℚ G} {g h : G} :
+theorem _root_.FDRep.intCharacter_eq_iff {V W : FDRep ℚ G} {g h : G} :
     FDRep.intCharacter V g = FDRep.intCharacter W h ↔ V.character g = W.character h := by
   rw [← Int.cast_inj (α := ℚ), FDRep.intCharacter_cast, FDRep.intCharacter_cast]
 
@@ -281,7 +281,7 @@ theorem intCharacter_eq_iff {V W : FDRep ℚ G} {g h : G} :
 @[simp]
 theorem _root_.FDRep.intCharacter_conj (V : FDRep ℚ G) (g h : G) :
     FDRep.intCharacter V (h * g * h⁻¹) = FDRep.intCharacter V g :=
-  intCharacter_eq_iff.2 (_root_.FDRep.char_conj V g h)
+  _root_.FDRep.intCharacter_eq_iff.2 (_root_.FDRep.char_conj V g h)
 
 /-- **The integer character of a rational representation, as a class function.** -/
 noncomputable def _root_.FDRep.intClassFunction (V : FDRep ℚ G) : ClassFunction ℤ G :=

--- a/TauCeti/RepresentationTheory/CharacterTable/Values.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Values.lean
@@ -46,23 +46,23 @@ representation of a group, from the eigenvalues alone, with no invariant inner p
   `(ρ g).charpoly` splits, a character value is a sum of `finrank` many `n`-th roots of unity. The
   variant `TauCeti.Representation.exists_multiset_rootsOfUnity_char_eq_sum` specializes it to an
   algebraically closed field.
-* `TauCeti.Representation.isIntegral_char` and `TauCeti.FDRep.isIntegral_char`: **character values
+* `TauCeti.Representation.isIntegral_char` and `FDRep.isIntegral_char`: **character values
   are algebraic integers**, over an arbitrary field.
-* `TauCeti.Representation.exists_char_eq_intCast` and `TauCeti.FDRep.exists_char_eq_intCast`:
+* `TauCeti.Representation.exists_char_eq_intCast` and `FDRep.exists_char_eq_intCast`:
   **a rational character is integer-valued**.
-* `TauCeti.FDRep.intCharacter`: the resulting `ℤ`-valued character of a rational representation of
-  a finite group, taking the degree at the identity, and `TauCeti.FDRep.intClassFunction`: the same
+* `FDRep.intCharacter`: the resulting `ℤ`-valued character of a rational representation of
+  a finite group, taking the degree at the identity, and `FDRep.intClassFunction`: the same
   character read as an element of `TauCeti.ClassFunction ℤ G`.
-* `TauCeti.FDRep.char_mem_adjoin_of_isPrimitiveRoot`: over `ℂ` they lie in `ℤ[ζ_e]`, for `ζ_e`
+* `FDRep.char_mem_adjoin_of_isPrimitiveRoot`: over `ℂ` they lie in `ℤ[ζ_e]`, for `ζ_e`
   a primitive root of unity of order the exponent of the group.
-* `TauCeti.FDRep.norm_char_le_finrank`: over `ℂ`, `‖χ(g)‖ ≤ χ(1)`.
+* `FDRep.norm_char_le_finrank`: over `ℂ`, `‖χ(g)‖ ≤ χ(1)`.
 * `Representation.exists_apply_eq_smul_of_norm_char_eq_finrank` and its bundled form
   `FDRep.exists_apply_eq_smul_of_norm_char_eq_finrank`: the equality case of that bound,
   `‖χ(g)‖ = χ(1)`, which forces `ρ g` to be a root of unity times the identity.
-* `TauCeti.FDRep.conj_char`: over `ℂ`, **inversion conjugates character values**,
+* `FDRep.conj_char`: over `ℂ`, **inversion conjugates character values**,
   `conj (χ g) = χ g⁻¹`. This is what makes the character pairing agree with the Hermitian inner
   product on complex class functions.
-* `TauCeti.Representation.isSemisimple_apply` and `TauCeti.FDRep.isSemisimple_ρ`: if the
+* `TauCeti.Representation.isSemisimple_apply` and `FDRep.isSemisimple_ρ`: if the
   characteristic of `k` does not divide `|G|`, then `ρ g` is a semisimple endomorphism; over `ℂ`
   the hypothesis is found by instance search.
 
@@ -257,9 +257,9 @@ theorem _root_.FDRep.exists_char_eq_intCast (V : FDRep ℚ G) (g : G) :
     (pow_orderOf_eq_one g)
 
 /-- **The integer character** of a rational representation of a finite group: the character value
-`V.character g` is the cast of an integer (`TauCeti.FDRep.exists_char_eq_intCast`), and this is
+`V.character g` is the cast of an integer (`FDRep.exists_char_eq_intCast`), and this is
 that integer, extracted as the numerator of the rational value. Read it only through
-`TauCeti.FDRep.intCharacter_cast`, which is what pins it down; the numerator is a way of naming the
+`FDRep.intCharacter_cast`, which is what pins it down; the numerator is a way of naming the
 integer, not extra information.
 
 Being in the `TauCeti.FDRep` namespace rather than the root one, it is not available through dot
@@ -278,7 +278,7 @@ theorem _root_.FDRep.intCharacter_cast (V : FDRep ℚ G) (g : G) :
   rw [intCharacter_def, hm, Rat.num_intCast]
 
 /-- **The integer character carries exactly the information of the rational one**: this is the
-elimination principle for `TauCeti.FDRep.intCharacter`, an integer equation between its values
+elimination principle for `FDRep.intCharacter`, an integer equation between its values
 being the corresponding equation between character values. -/
 theorem intCharacter_eq_iff {V W : FDRep ℚ G} {g h : G} :
     FDRep.intCharacter V g = FDRep.intCharacter W h ↔ V.character g = W.character h := by
@@ -325,7 +325,7 @@ theorem _root_.FDRep.norm_char_le_finrank (V : FDRep ℂ G) (g : G) : ‖V.chara
 
 /-- **The equality case of the bound on a character value**, for a finite group: if `‖χ(g)‖`
 attains the degree, then `V.ρ g` is a scalar, the scalar being a root of unity of order dividing
-that of `g`. The bound itself is `TauCeti.FDRep.norm_char_le_finrank`. -/
+that of `g`. The bound itself is `FDRep.norm_char_le_finrank`. -/
 theorem _root_.FDRep.exists_apply_eq_smul_of_norm_char_eq_finrank (V : FDRep ℂ G) {g : G}
     (h : ‖V.character g‖ = (finrank ℂ V : ℝ)) :
     ∃ μ : ℂ, μ ^ orderOf g = 1 ∧ V.ρ g = μ • 1 :=

--- a/TauCeti/RepresentationTheory/CharacterTable/VirtualCharacter.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/VirtualCharacter.lean
@@ -173,13 +173,13 @@ section Complex
 variable {G : Type v} [Group G] [Finite G]
 
 /-- **Over `ℂ`, inverting the argument conjugates the value of a virtual character** of a finite
-group: `conj (f g) = f g⁻¹`. This holds for genuine characters (`TauCeti.FDRep.conj_char`), and
+group: `conj (f g) = f g⁻¹`. This holds for genuine characters (`FDRep.conj_char`), and
 both sides are additive in `f`.
 
 This is not a `simp` lemma: `TauCeti.character_mem_virtualCharacters` and
 `TauCeti.irreducibleCharacter_mem_virtualCharacters` discharge its hypothesis, so as a conditional
 `simp` lemma it fires on the characters themselves and makes the more specific
-`TauCeti.FDRep.conj_char` and `TauCeti.conj_irreducibleCharacter` redundant, which the `simpNF`
+`FDRep.conj_char` and `TauCeti.conj_irreducibleCharacter` redundant, which the `simpNF`
 linter rejects. -/
 theorem conj_apply_of_mem_virtualCharacters {f : G → ℂ} (hf : f ∈ virtualCharacters ℂ G) (g : G) :
     (starRingEnd ℂ) (f g) = f g⁻¹ := by

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/Character.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/Character.lean
@@ -30,7 +30,7 @@ precisely the irreducible rational representations of `Sₙ`
 column of the identity holds the degrees.
 
 The general half of the argument is stated for an arbitrary rational representation of a finite
-group, as `TauCeti.FDRep.intCharacter`, and is what this file specializes. Nothing here computes
+group, as `FDRep.intCharacter`, and is what this file specializes. Nothing here computes
 an entry of the table: the recursion that does is the Murnaghan--Nakayama rule, which needs rim
 hooks and is not proved here. The comparison with the library's general
 `TauCeti.characterTable k G`, which lives over an algebraically closed field and enumerates its
@@ -76,7 +76,7 @@ variable {n : ℕ}
 /-! ## The integer character -/
 
 /-- **The integer character `χ^μ` of the Specht module** `S^μ`. The character of `S^μ` takes
-rational values, and those values are integers (`TauCeti.FDRep.intCharacter`); this is the
+rational values, and those values are integers (`FDRep.intCharacter`); this is the
 integer-valued refinement, related to the rational character by `TauCeti.spechtChar_cast`. -/
 noncomputable def spechtChar (μ : n.Partition) : Equiv.Perm (Fin n) → ℤ :=
   FDRep.intCharacter (spechtModule μ)
@@ -121,7 +121,7 @@ theorem spechtChar_one_pos (μ : n.Partition) : 0 < spechtChar μ 1 := by
 /-! ## Descent to the conjugacy classes -/
 
 /-- **The integer character as a function of the conjugacy class**, the descent
-(`TauCeti.ClassFunction.toConjClasses`) of the class function `TauCeti.FDRep.intClassFunction` of
+(`TauCeti.ClassFunction.toConjClasses`) of the class function `FDRep.intClassFunction` of
 `S^μ`. -/
 noncomputable def spechtCharConjClasses (μ : n.Partition) : ConjClasses (Equiv.Perm (Fin n)) → ℤ :=
   ClassFunction.toConjClasses (FDRep.intClassFunction (spechtModule μ))


### PR DESCRIPTION
Twenty declarations of the character API take an `FDRep k G` as their first explicit argument but
were written inside `namespace TauCeti`, so `V.intCharacter` and friends could not be reached by dot
notation. Nineteen move to Mathlib's root `FDRep` namespace, joining
`FDRep.exists_apply_eq_smul_of_norm_char_eq_finrank`, which `Values.lean` already declares there.
The twentieth turned out to be a duplicate of a Mathlib lemma and is deleted instead — see below.

| file | declarations |
|---|---|
| `CharacterTable/Values.lean` | 12, including `intCharacter`, `intClassFunction`, `conj_char`, `isSemisimple_ρ` |
| `CharacterTable/Galois.lean` | 4 |
| `CharacterTable/FrobeniusSchur/Basic.lean` | `frobeniusSchurIndicator`, `frobeniusSchurIndicator_def` |
| `CharacterTable/Degree.lean` | `finrank_dvd_card` |

Eighteen sibling references inside the surviving `namespace FDRep` blocks are qualified to match:
inside `TauCeti.FDRep`, Lean tries `TauCeti.FDRep.x`, then `TauCeti.x`, then root `x` — it never
tries `FDRep.x` — so a bare sibling reference stops resolving the moment its target is rooted.
Twenty-four docstring references to the old `TauCeti.FDRep.…` paths move with them.

`lint-dot-notation`: **761 → 741**, no new findings. No mathematics changes: every declaration keeps
its statement and its proof.

### The one declaration that is deleted, not rooted

`TauCeti.FDRep.isIntegral_char` is gone rather than rooted. Rooting it would have placed it beside
Mathlib's `FDRep.isIntegral_character`, which states the same thing at the same generality:

```lean
-- Mathlib/RepresentationTheory/Character.lean:206
theorem isIntegral_character [Finite G] (V : FDRep k G) (g : G) : IsIntegral ℤ (V.character g)
```

with `{k : Type u} [Field k]` and `{G : Type v} [Group G]` in scope — exactly the binders our
version spelled out for itself. Nested under `TauCeti` the two names coexisted harmlessly; rooted,
they would be a straight duplicate in Mathlib's own namespace.

Nothing referenced it in code — its only mention was a module-doc bullet, which now points at
Mathlib's bundled form. This is why `decldiff` reports a declaration that "no rooting explains":
the removal is deliberate, and it is the whole of the difference that check sees.

The general `TauCeti.Representation.isIntegral_char` stays. It takes the order hypotheses
explicitly rather than requiring `[Finite G]`, so it is strictly more general than Mathlib's
`Representation.isIntegral_character`, and it is what the call sites in `Degree`, `Solvable`,
`Vanishing` and `Values` use.

### `intCharacter_eq_iff` is rooted too, though the linter never asked

It takes `{V W : FDRep ℚ G}` **implicitly**, so rooting it enables no `V.intCharacter_eq_iff` —
dot notation resolves against the first *explicit* argument — and `lint-dot-notation` does not flag
it. That was the original reason for leaving it nested, and it is still true as far as it goes.

It is the wrong reason. `intCharacter_eq_iff` is the elimination principle for
`FDRep.intCharacter`, and is named as such in that definition's own docstring. Leaving it in
`TauCeti.FDRep` while its subject moved to root `FDRep` splits one characteristic API across two
unrelated namespace paths, which is what a reader has to navigate rather than what a linter can see.
It is rooted, and its single call site inside `intCharacter_conj` is qualified — a bare sibling
reference stops resolving the moment its target leaves the wrapper.

This is why `rootsurplus` reports `FDRep.intCharacter_eq_iff` as rooted-but-unflagged. The rooting
is deliberate and is not the linter's call; the declaration belongs with the definition it
characterises.

The `FDRep.intCharacter` docstring also closed by stating that the definition sits in
`TauCeti.FDRep`, is unavailable through dot notation, and is written `intCharacter V g`. The rooting
falsified all three in the same commit that wrote them; it now describes the rooted API.

### What stays in `TauCeti.FDRep`, and why

One declaration remains, so the namespace survives and these files mix rooted with nested.

* `intCharacter_def` is `private`. Nothing outside the module can name it, so its namespace is not
  part of any interface — the reading `naming` accepted on #6093 for the two private helpers in
  `Topology/Covering/Quotient.lean`. It is the only flagged declaration left behind.

`TauCeti.FDRep.simple_of_isIrreducible`, referenced from `GL2/PrincipalSeries/Irreducible.lean`, is
declared elsewhere and is untouched.

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GadULQ4gpsVAZfpvs2htNt

