### PR TITLE
feat: package the Cholesky equivalence

### DIFF
--- a/TauCeti/LinearAlgebra/Matrix/Cholesky/Equiv.lean
+++ b/TauCeti/LinearAlgebra/Matrix/Cholesky/Equiv.lean
@@ -1,0 +1,75 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.LinearAlgebra.Matrix.Cholesky.Basic
+import TauCeti.LinearAlgebra.Matrix.Triangular
+
+/-!
+# The Cholesky equivalence
+
+This file proves uniqueness of positive-diagonal lower-triangular Gram factors. Together with the
+Cholesky construction, this packages Cholesky factorization and reconstruction as an equivalence
+between positive-definite symmetric matrices and positive-diagonal lower-triangular matrices.
+
+## Main results
+
+* `TauCeti.cholesky_unique` identifies any positive-diagonal lower-triangular Gram factor with the
+  Cholesky factor.
+* `TauCeti.cholesky_choleskyReconstruction` is the inverse identity from factors to matrices.
+* `TauCeti.choleskyEquiv` is the resulting equivalence.
+
+## References
+
+* R. A. Horn and C. R. Johnson, *Matrix Analysis*, second edition, Cambridge University Press,
+  2013, Section 7.2.
+-/
+
+public section
+
+noncomputable section
+
+open scoped Matrix
+
+namespace TauCeti
+
+/-- A positive-diagonal lower-triangular square root of a positive-definite matrix is its
+Cholesky factor. -/
+theorem cholesky_unique {p : ℕ} (A : PosDefMatrix p) (L : PosDiagLowerTriangular p)
+    (hL : L.1 * L.1ᵀ = (A.1 : Matrix (Fin p) (Fin p) ℝ)) : L = cholesky A := by
+  apply Subtype.ext
+  exact L.2.1.eq_of_mul_transpose_self_eq (cholesky A).2.1 L.2.2 (cholesky A).2.2
+    (hL.trans (cholesky_mul_transpose A).symm)
+
+/-- Taking the Cholesky factor after reconstructing a matrix from a positive-diagonal
+lower-triangular factor returns that factor. -/
+@[simp]
+theorem cholesky_choleskyReconstruction {p : ℕ} (L : PosDiagLowerTriangular p) :
+    cholesky (choleskyReconstruction L) = L :=
+  (cholesky_unique (choleskyReconstruction L) L (choleskyReconstruction_coe L).symm).symm
+
+/-- Cholesky factorization is an equivalence between positive-definite symmetric matrices and
+positive-diagonal lower-triangular matrices. -/
+noncomputable def choleskyEquiv {p : ℕ} :
+    PosDefMatrix p ≃ PosDiagLowerTriangular p where
+  toFun := cholesky
+  invFun := choleskyReconstruction
+  left_inv := choleskyReconstruction_cholesky
+  right_inv := cholesky_choleskyReconstruction
+
+/-- The forward map of `choleskyEquiv` is `cholesky`. -/
+@[simp]
+theorem choleskyEquiv_apply {p : ℕ} (A : PosDefMatrix p) :
+    choleskyEquiv A = cholesky A :=
+  (rfl)
+
+/-- The inverse map of `choleskyEquiv` is `choleskyReconstruction`. -/
+@[simp]
+theorem choleskyEquiv_symm_apply {p : ℕ} (L : PosDiagLowerTriangular p) :
+    choleskyEquiv.symm L = choleskyReconstruction L :=
+  (rfl)
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/Matrix/Cholesky/Equiv.lean
+++ b/TauCeti/LinearAlgebra/Matrix/Cholesky/Equiv.lean
@@ -17,8 +17,8 @@ between positive-definite symmetric matrices and positive-diagonal lower-triangu
 
 ## Main results
 
-* `TauCeti.cholesky_unique` identifies any positive-diagonal lower-triangular Gram factor with the
-  Cholesky factor.
+* `TauCeti.eq_cholesky_of_mul_transpose_self_eq` identifies any positive-diagonal lower-triangular
+  Gram factor with the Cholesky factor.
 * `TauCeti.cholesky_choleskyReconstruction` is the inverse identity from factors to matrices.
 * `TauCeti.choleskyEquiv` is the resulting equivalence.
 
@@ -38,7 +38,8 @@ namespace TauCeti
 
 /-- A positive-diagonal lower-triangular square root of a positive-definite matrix is its
 Cholesky factor. -/
-theorem cholesky_unique {p : ℕ} (A : PosDefMatrix p) (L : PosDiagLowerTriangular p)
+theorem eq_cholesky_of_mul_transpose_self_eq {p : ℕ} (A : PosDefMatrix p)
+    (L : PosDiagLowerTriangular p)
     (hL : L.1 * L.1ᵀ = (A.1 : Matrix (Fin p) (Fin p) ℝ)) : L = cholesky A := by
   apply Subtype.ext
   exact L.2.1.eq_of_mul_transpose_self_eq (cholesky A).2.1 L.2.2 (cholesky A).2.2
@@ -49,7 +50,8 @@ lower-triangular factor returns that factor. -/
 @[simp]
 theorem cholesky_choleskyReconstruction {p : ℕ} (L : PosDiagLowerTriangular p) :
     cholesky (choleskyReconstruction L) = L :=
-  (cholesky_unique (choleskyReconstruction L) L (choleskyReconstruction_coe L).symm).symm
+  (eq_cholesky_of_mul_transpose_self_eq (choleskyReconstruction L) L
+      (choleskyReconstruction_coe L).symm).symm
 
 /-- Cholesky factorization is an equivalence between positive-definite symmetric matrices and
 positive-diagonal lower-triangular matrices. -/

--- a/TauCeti/LinearAlgebra/Matrix/Triangular.lean
+++ b/TauCeti/LinearAlgebra/Matrix/Triangular.lean
@@ -33,6 +33,8 @@ Lie-algebra theory.
   matrices is the pointwise product of the diagonals.
 * `Matrix.mul_apply_diag_of_isLowerTriangular` — the corresponding formula for lower-triangular
   matrices.
+* `Matrix.IsLowerTriangular.eq_one_of_mul_transpose_self_eq_one` — a lower-triangular orthogonal
+  matrix with positive diagonal is the identity.
 * `Matrix.IsLowerTriangular.eq_of_mul_transpose_self_eq` — lower-triangular matrices with positive
   diagonal are determined by their product with their transpose.
 * `Matrix.pow_apply_diag_of_isUpperTriangular` — the diagonal of a power of an upper-triangular
@@ -204,6 +206,34 @@ theorem mul_apply_diag_of_isLowerTriangular (hA : A.IsLowerTriangular)
     · rw [hA hik, zero_mul]
   · exact fun h ↦ absurd (Finset.mem_univ i) h
 
+/-- A lower-triangular matrix over an ordered field with positive diagonal whose product with its
+transpose is the identity is itself the identity. -/
+theorem IsLowerTriangular.eq_one_of_mul_transpose_self_eq_one
+    {K : Type*} [Field K] [LinearOrder K] [IsStrictOrderedRing K]
+    {Q : Matrix n n K} (hQ : Q.IsLowerTriangular) (hQpos : ∀ i, 0 < Q i i)
+    (hQorth : Q * Qᵀ = 1) : Q = 1 := by
+  let _ : Invertible Q := invertibleOfRightInverse Q Qᵀ hQorth
+  have hQttri : Qᵀ.IsLowerTriangular := by
+    rw [← Matrix.inv_eq_right_inv hQorth]
+    exact Matrix.blockTriangular_inv_of_blockTriangular hQ
+  have hQupper : Q.IsUpperTriangular := by
+    intro i j hji
+    simpa only [Matrix.transpose_apply] using hQttri hji
+  ext i j
+  rcases lt_trichotomy i j with hij | rfl | hij
+  · rw [hQ hij, Matrix.one_apply_ne hij.ne]
+  · have hii : Q i i * Q i i = 1 := by
+      have hmul := Matrix.mul_apply_diag_of_isUpperTriangular hQupper hQ.transpose i
+      calc
+        Q i i * Q i i = Q i i * Qᵀ i i := by rw [Matrix.transpose_apply]
+        _ = (Q * Qᵀ) i i := hmul.symm
+        _ = 1 := by rw [hQorth, Matrix.one_apply_eq]
+    rw [Matrix.one_apply_eq]
+    nlinarith [hQpos i]
+  · have hzero : Qᵀ j i = 0 := hQttri hij
+    rw [Matrix.one_apply_ne hij.ne']
+    simpa only [Matrix.transpose_apply] using hzero
+
 /-- Lower-triangular matrices over an ordered field with positive diagonal are determined by
 their Gram matrices `L * Lᵀ`.
 
@@ -240,30 +270,8 @@ theorem IsLowerTriangular.eq_of_mul_transpose_self_eq
       _ = L⁻¹ * (L * Lᵀ) * L⁻¹ᵀ := by rw [← hgram]
       _ = (L⁻¹ * L) * (Lᵀ * L⁻¹ᵀ) := by simp only [Matrix.mul_assoc]
       _ = 1 := by rw [Matrix.nonsing_inv_mul L hLdet, hLinvt_right, one_mul]
-  let _ : Invertible (L⁻¹ * M) :=
-    invertibleOfRightInverse (L⁻¹ * M) (L⁻¹ * M)ᵀ hQorth
-  have hQttri : (L⁻¹ * M)ᵀ.IsLowerTriangular := by
-    rw [← Matrix.inv_eq_right_inv hQorth]
-    exact Matrix.blockTriangular_inv_of_blockTriangular hQtri
-  have hQupper : (L⁻¹ * M).IsUpperTriangular := by
-    intro i j hji
-    simpa only [Matrix.transpose_apply] using hQttri hji
   have hQone : L⁻¹ * M = 1 := by
-    ext i j
-    rcases lt_trichotomy i j with hij | rfl | hij
-    · rw [hQtri hij, Matrix.one_apply_ne hij.ne]
-    · have hii : (L⁻¹ * M) i i * (L⁻¹ * M) i i = 1 := by
-        have hmul := Matrix.mul_apply_diag_of_isUpperTriangular hQupper hQtri.transpose i
-        calc
-          (L⁻¹ * M) i i * (L⁻¹ * M) i i =
-              (L⁻¹ * M) i i * (L⁻¹ * M)ᵀ i i := by rw [Matrix.transpose_apply]
-          _ = ((L⁻¹ * M) * (L⁻¹ * M)ᵀ) i i := hmul.symm
-          _ = 1 := by rw [hQorth, Matrix.one_apply_eq]
-      rw [Matrix.one_apply_eq]
-      nlinarith [hQdiag i]
-    · have hzero : (L⁻¹ * M)ᵀ j i = 0 := hQttri hij
-      rw [Matrix.one_apply_ne hij.ne']
-      simpa only [Matrix.transpose_apply] using hzero
+    exact hQtri.eq_one_of_mul_transpose_self_eq_one hQdiag hQorth
   calc
     L = L * 1 := (Matrix.mul_one L).symm
     _ = L * (L⁻¹ * M) := by rw [hQone]

--- a/TauCeti/LinearAlgebra/Matrix/Triangular.lean
+++ b/TauCeti/LinearAlgebra/Matrix/Triangular.lean
@@ -14,13 +14,15 @@ import Mathlib.LinearAlgebra.Matrix.Reindex
 
 Mathlib's `Matrix.BlockTriangular` API computes determinants and inverses of triangular
 matrices, but not their individual diagonal entries. This file supplies the facts that
-consumers keep needing: on the diagonal, a product of upper-triangular matrices multiplies
+consumers keep needing: on the diagonal, a product of triangular matrices multiplies
 entrywise, because `∑ k, A i k * B k i` has a single surviving term — and consequences of
-that, such as the diagonal of an inverse. It also defines upper-unitriangular matrices and proves
-that strictly upper-triangular matrices are nilpotent.
+that, such as the diagonal of an inverse. It also proves uniqueness of a lower-triangular Gram
+factor with positive diagonal, defines upper-unitriangular matrices, and proves that strictly
+upper-triangular matrices are nilpotent.
 
-The diagonal results are stated for `Matrix.IsUpperTriangular` rather than through membership in
-the Borel subalgebra, since there is no Lie theory in them. It is
+The diagonal results are stated directly for `Matrix.IsUpperTriangular` and
+`Matrix.IsLowerTriangular` rather than through membership in the Borel subalgebra, since there is
+no Lie theory in them. It is
 `Matrix.mul_apply_diag_of_isUpperTriangular` that `TauCeti.Algebra.Lie.GeneralLinear.Borel`
 consumes in that form, and all of them are available to modules with no business importing
 Lie-algebra theory.
@@ -29,6 +31,10 @@ Lie-algebra theory.
 
 * `Matrix.mul_apply_diag_of_isUpperTriangular` — the diagonal of a product of upper-triangular
   matrices is the pointwise product of the diagonals.
+* `Matrix.mul_apply_diag_of_isLowerTriangular` — the corresponding formula for lower-triangular
+  matrices.
+* `Matrix.IsLowerTriangular.eq_of_mul_transpose_self_eq` — lower-triangular matrices with positive
+  diagonal are determined by their product with their transpose.
 * `Matrix.pow_apply_diag_of_isUpperTriangular` — the diagonal of a power of an upper-triangular
   matrix is the corresponding power of the diagonal entry.
 * `Matrix.isUpperUnitriangular_geom_sum_of_isUpperTriangular_of_diag_eq_zero` — the geometric
@@ -186,6 +192,82 @@ theorem mul_apply_diag_of_isUpperTriangular (hA : A.IsUpperTriangular)
     · rw [hA h, zero_mul]
     · rw [hB h, mul_zero]
   · exact fun h ↦ absurd (Finset.mem_univ i) h
+
+/-- The diagonal of a product of lower-triangular matrices is the pointwise product of the
+diagonals. -/
+theorem mul_apply_diag_of_isLowerTriangular (hA : A.IsLowerTriangular)
+    (hB : B.IsLowerTriangular) (i : n) : (A * B) i i = A i i * B i i := by
+  rw [Matrix.mul_apply, Finset.sum_eq_single i]
+  · intro k _ hki
+    rcases lt_or_gt_of_ne hki with hki | hik
+    · rw [hB hki, mul_zero]
+    · rw [hA hik, zero_mul]
+  · exact fun h ↦ absurd (Finset.mem_univ i) h
+
+/-- Lower-triangular matrices over an ordered field with positive diagonal are determined by
+their Gram matrices `L * Lᵀ`.
+
+Equivalently, the map `L ↦ L * Lᵀ` is injective on positive-diagonal lower-triangular matrices.
+The empty index type is included. -/
+theorem IsLowerTriangular.eq_of_mul_transpose_self_eq
+    {K : Type*} [Field K] [LinearOrder K] [IsStrictOrderedRing K]
+    {L M : Matrix n n K} (hL : L.IsLowerTriangular) (hM : M.IsLowerTriangular)
+    (hLpos : ∀ i, 0 < L i i) (hMpos : ∀ i, 0 < M i i)
+    (hgram : L * Lᵀ = M * Mᵀ) : L = M := by
+  have hLdet : IsUnit L.det := by
+    rw [Matrix.det_of_isLowerTriangular L hL, isUnit_iff_ne_zero]
+    exact Finset.prod_ne_zero_iff.mpr fun i _ ↦ (hLpos i).ne'
+  let _ : Invertible L := Matrix.invertibleOfIsUnitDet L hLdet
+  have hLinv : L⁻¹.IsLowerTriangular :=
+    Matrix.blockTriangular_inv_of_blockTriangular hL
+  have hQtri : (L⁻¹ * M).IsLowerTriangular := hLinv.mul hM
+  have hQdiag : ∀ i, 0 < (L⁻¹ * M) i i := by
+    intro i
+    rw [mul_apply_diag_of_isLowerTriangular hLinv hM]
+    apply mul_pos
+    · have hinvdiag : L⁻¹ i i * L i i = 1 := by
+        rw [← mul_apply_diag_of_isLowerTriangular hLinv hL,
+          Matrix.nonsing_inv_mul L hLdet, Matrix.one_apply_eq]
+      nlinarith [hLpos i]
+    · exact hMpos i
+  have hLinvt_right : Lᵀ * L⁻¹ᵀ = 1 := by
+    rw [← Matrix.transpose_mul, Matrix.nonsing_inv_mul L hLdet, Matrix.transpose_one]
+  have hQorth : (L⁻¹ * M) * (L⁻¹ * M)ᵀ = 1 := by
+    rw [Matrix.transpose_mul]
+    calc
+      (L⁻¹ * M) * (Mᵀ * L⁻¹ᵀ) = L⁻¹ * (M * Mᵀ) * L⁻¹ᵀ := by
+        simp only [Matrix.mul_assoc]
+      _ = L⁻¹ * (L * Lᵀ) * L⁻¹ᵀ := by rw [← hgram]
+      _ = (L⁻¹ * L) * (Lᵀ * L⁻¹ᵀ) := by simp only [Matrix.mul_assoc]
+      _ = 1 := by rw [Matrix.nonsing_inv_mul L hLdet, hLinvt_right, one_mul]
+  let _ : Invertible (L⁻¹ * M) :=
+    invertibleOfRightInverse (L⁻¹ * M) (L⁻¹ * M)ᵀ hQorth
+  have hQttri : (L⁻¹ * M)ᵀ.IsLowerTriangular := by
+    rw [← Matrix.inv_eq_right_inv hQorth]
+    exact Matrix.blockTriangular_inv_of_blockTriangular hQtri
+  have hQupper : (L⁻¹ * M).IsUpperTriangular := by
+    intro i j hji
+    simpa only [Matrix.transpose_apply] using hQttri hji
+  have hQone : L⁻¹ * M = 1 := by
+    ext i j
+    rcases lt_trichotomy i j with hij | rfl | hij
+    · rw [hQtri hij, Matrix.one_apply_ne hij.ne]
+    · have hii : (L⁻¹ * M) i i * (L⁻¹ * M) i i = 1 := by
+        have hmul := Matrix.mul_apply_diag_of_isUpperTriangular hQupper hQtri.transpose i
+        calc
+          (L⁻¹ * M) i i * (L⁻¹ * M) i i =
+              (L⁻¹ * M) i i * (L⁻¹ * M)ᵀ i i := by rw [Matrix.transpose_apply]
+          _ = ((L⁻¹ * M) * (L⁻¹ * M)ᵀ) i i := hmul.symm
+          _ = 1 := by rw [hQorth, Matrix.one_apply_eq]
+      rw [Matrix.one_apply_eq]
+      nlinarith [hQdiag i]
+    · have hzero : (L⁻¹ * M)ᵀ j i = 0 := hQttri hij
+      rw [Matrix.one_apply_ne hij.ne']
+      simpa only [Matrix.transpose_apply] using hzero
+  calc
+    L = L * 1 := (Matrix.mul_one L).symm
+    _ = L * (L⁻¹ * M) := by rw [hQone]
+    _ = M := by rw [← Matrix.mul_assoc, Matrix.mul_nonsing_inv L hLdet, Matrix.one_mul]
 
 /-- The diagonal of a power of an upper-triangular matrix is the corresponding power of the
 diagonal entry. -/

--- a/TauCeti/LinearAlgebra/Matrix/Triangular.lean
+++ b/TauCeti/LinearAlgebra/Matrix/Triangular.lean
@@ -34,7 +34,7 @@ Lie-algebra theory.
 * `Matrix.mul_apply_diag_of_isLowerTriangular` — the corresponding formula for lower-triangular
   matrices.
 * `Matrix.IsLowerTriangular.eq_one_of_mul_transpose_self_eq_one` — a lower-triangular orthogonal
-  matrix with positive diagonal is the identity.
+  matrix with nonnegative diagonal is the identity.
 * `Matrix.IsLowerTriangular.eq_of_mul_transpose_self_eq` — lower-triangular matrices with positive
   diagonal are determined by their product with their transpose.
 * `Matrix.pow_apply_diag_of_isUpperTriangular` — the diagonal of a power of an upper-triangular
@@ -206,11 +206,11 @@ theorem mul_apply_diag_of_isLowerTriangular (hA : A.IsLowerTriangular)
     · rw [hA hik, zero_mul]
   · exact fun h ↦ absurd (Finset.mem_univ i) h
 
-/-- A lower-triangular matrix over an ordered field with positive diagonal whose product with its
-transpose is the identity is itself the identity. -/
+/-- A lower-triangular matrix over an ordered field with nonnegative diagonal whose product with
+its transpose is the identity is itself the identity. -/
 theorem IsLowerTriangular.eq_one_of_mul_transpose_self_eq_one
     {K : Type*} [Field K] [LinearOrder K] [IsStrictOrderedRing K]
-    {Q : Matrix n n K} (hQ : Q.IsLowerTriangular) (hQpos : ∀ i, 0 < Q i i)
+    {Q : Matrix n n K} (hQ : Q.IsLowerTriangular) (hQnonneg : ∀ i, 0 ≤ Q i i)
     (hQorth : Q * Qᵀ = 1) : Q = 1 := by
   let _ : Invertible Q := invertibleOfRightInverse Q Qᵀ hQorth
   have hQttri : Qᵀ.IsLowerTriangular := by
@@ -229,7 +229,7 @@ theorem IsLowerTriangular.eq_one_of_mul_transpose_self_eq_one
         _ = (Q * Qᵀ) i i := hmul.symm
         _ = 1 := by rw [hQorth, Matrix.one_apply_eq]
     rw [Matrix.one_apply_eq]
-    nlinarith [hQpos i]
+    nlinarith [hQnonneg i]
   · have hzero : Qᵀ j i = 0 := hQttri hij
     rw [Matrix.one_apply_ne hij.ne']
     simpa only [Matrix.transpose_apply] using hzero
@@ -271,7 +271,7 @@ theorem IsLowerTriangular.eq_of_mul_transpose_self_eq
       _ = (L⁻¹ * L) * (Lᵀ * L⁻¹ᵀ) := by simp only [Matrix.mul_assoc]
       _ = 1 := by rw [Matrix.nonsing_inv_mul L hLdet, hLinvt_right, one_mul]
   have hQone : L⁻¹ * M = 1 := by
-    exact hQtri.eq_one_of_mul_transpose_self_eq_one hQdiag hQorth
+    exact hQtri.eq_one_of_mul_transpose_self_eq_one (fun i ↦ (hQdiag i).le) hQorth
   calc
     L = L * 1 := (Matrix.mul_one L).symm
     _ = L * (L⁻¹ * M) := by rw [hQone]


### PR DESCRIPTION
This PR proves uniqueness of positive-diagonal lower-triangular Gram factors and packages Cholesky factorization with `L ↦ L * Lᵀ` as `choleskyEquiv`. It completes the algebraic-equivalence step of StandardDistributions Layer 6, milestone 2, **Cholesky decomposition**, whose exact target is to “Package Cholesky and `L ↦ L * Lᵀ` as `choleskyEquiv` between the positive-definite symmetric matrices and the positive-diagonal lower-triangular matrices.”

At the general matrix level, this adds `Matrix.IsLowerTriangular.eq_of_mul_transpose_self_eq` over an ordered field, including the empty index type, and the lower-triangular diagonal-product formula it needs. The proof studies `L⁻¹ * M`: it is lower triangular and orthogonal, its inverse-transpose identity makes it upper triangular, and positivity forces every diagonal entry to be one. The roadmap-facing corollaries provide `cholesky_unique`, the missing inverse identity `cholesky_choleskyReconstruction`, and `[simp]` descriptions of both directions of `choleskyEquiv`.

After this PR, milestone 2 still requires continuity and measurability in both directions, the resulting homeomorphism and measurable equivalence, and the lower-coordinate Jacobian and measure-map identity.

The mathematical argument follows the standard Cholesky uniqueness proof described in Horn and Johnson, *Matrix Analysis*, second edition, Section 7.2, and reuses Mathlib's determinant, inverse, and `Matrix.BlockTriangular` infrastructure; no upstream code is vendored.

Roadmap: StandardDistributions

<!--tauceti-target:v1 {"focus":"StandardDistributions","id":"choleskyequiv"}-->

🤖 Prepared with Codex
