### PR TITLE
refactor(AlgebraicGroup): drop the unused semiring instance on mapDomain_transport

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Map.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Map.lean
@@ -105,7 +105,7 @@ lemma tangentKerMap_id :
 touch the coefficients, and the two indexings share the carrier `B` with the same
 `inferInstanceAs` instances. Recorded once as an explicit transport lemma, analogous to
 `fst_transport`. -/
-private lemma mapDomain_transport {A'' : Type*} [CommSemiring A'']
+private lemma mapDomain_transport {A'' : Type*}
     (φ : A' →ₐc[R] A)
     (ψ : WithConv (A →ₐ[R] DualNumber (Bialgebra.CounitAlgebra R A B))) :
     AlgHom.mapDomain (A := DualNumber (Bialgebra.CounitAlgebra R A'' B)) φ ψ =


### PR DESCRIPTION
refactor(AlgebraicGroup): drop the unused semiring instance on mapDomain_transport

`mapDomain_transport` bound `[CommSemiring A'']` and never used it. The lemma says that
`AlgHom.mapDomain φ ψ` agrees at the two counit coefficient indexings
`DualNumber (Bialgebra.CounitAlgebra R A'' B)` and
`DualNumber (Bialgebra.CounitAlgebra R A' B)`, and it holds by `rfl`: precomposition does
not touch the coefficients. `A''` occurs in the statement, but only as the index of a
coefficient algebra that `CounitAlgebra` builds from `R` and `B`, so nothing about `A''`
itself is needed — neither to elaborate the statement nor to prove it.

Mathlib's `unusedArguments` linter reports it; the entry sits in
`scripts/lint-baseline.txt`, so CI was green and nothing nagged.

The only call site, `tangentKerMap_comp`, keeps its own `[CommSemiring A'']` and
`[HopfAlgebra R A'']`, which it genuinely needs; instance arguments are implicit, so it
is unchanged.

No cascade: re-running the linter after the change reports the same seven declarations
as before minus this one, and nothing new. That is not automatic — dropping a hypothesis
can free a consumer that held its own instance only to discharge this one, and
`unusedArguments` is an unbaselined violation, so a freed consumer would turn CI red.
Checked with

    find TauCeti -type f -name '*.lean' | LC_ALL=C sort \
      | sed 's#/#.#g; s#\.lean$##; s#^#import #' > UnusedArgs.lean
    echo '#lint only unusedArguments in TauCeti' >> UnusedArgs.lean
    lake env lean UnusedArgs.lean

`scripts/lint-baseline.txt` now carries one stale entry,
`TauCeti.mapDomain_transport`. `scripts/` is human-owned, so this PR leaves it alone;
`lint-env.sh` prints a stale entry as a ratchet reminder without failing.

Verified locally: `lake build` (11185 jobs), `lake exe axioms` (112105 declarations,
allowlist clean), `scripts/lint-style.sh`, `scripts/lint-dot-notation.py` (761 total, 0
new — unchanged from main).

Roadmap: ReductiveGroups



🤖 Generated with [Claude Code](https://claude.com/claude-code)
