### PR TITLE
refactor(Probability): drop two unused hypotheses from cond_eq_of_extreme_iidMixture

### DIFF
--- a/TauCeti/Probability/Exchangeability/PathSpace/Law/Extreme.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/Law/Extreme.lean
@@ -101,9 +101,9 @@ theorem ergodic_shift_infinitePi_const (P : ProbabilityMeasure α) :
   · exact Or.inr (ae_iff.mpr (by simpa using hzero))
   · exact Or.inl ((_root_.MeasureTheory.mem_ae_iff_prob_eq_one hs).2 hone)
 
-private theorem cond_eq_of_extreme_iidMixture [StandardBorelSpace α]
+private theorem cond_eq_of_extreme_iidMixture
     {p : Measure (ProbabilityMeasure α)} [IsProbabilityMeasure p]
-    {ρ : Measure (ℕ → α)} [IsProbabilityMeasure ρ]
+    {ρ : Measure (ℕ → α)}
     (hρ : ρ ∈ extremePoints ℝ≥0∞
       {ν : Measure (ℕ → α) | ExchangeableLaw ν ∧ IsProbabilityMeasure ν})
     (hrepr : ρ = deFinettiBarycenter p)


### PR DESCRIPTION
refactor(Probability): drop two unused hypotheses from cond_eq_of_extreme_iidMixture

`cond_eq_of_extreme_iidMixture` bound `[StandardBorelSpace α]` and
`[IsProbabilityMeasure ρ]` and used neither. Mathlib's `unusedArguments` linter reports
both; the entry sits in `scripts/lint-baseline.txt`, so CI was green and nothing nagged.

Neither is idle bookkeeping.

`[StandardBorelSpace α]` is the standing hypothesis of the surrounding de Finetti
development, so it reads as part of the setting rather than as something this step asks
for. It is not: the file's only section variable is `{α : Type*} [MeasurableSpace α]`, so
the instance really was a binder on this declaration, and the argument — split `p` along
`s` and `sᶜ`, push both pieces through `deFinettiBarycenter`, and use extremality of `ρ`
— goes through over an arbitrary measurable space. Dropping it is a genuine
generalisation, not tidying.

`[IsProbabilityMeasure ρ]` was redundant with the hypotheses rather than unnecessary:
`hρ` places `ρ` in the extreme points of
`{ν | ExchangeableLaw ν ∧ IsProbabilityMeasure ν}`, so `ρ` is a probability measure
already. The proof never appeals to either form.

No cascade: re-running the linter afterwards reports the same declarations as before
minus this one, and nothing new. Worth checking rather than assuming — dropping a
hypothesis can free a consumer that held its own instance only to discharge this one,
and `unusedArguments` is an unbaselined violation, so a freed consumer would turn CI red.

    find TauCeti -type f -name '*.lean' | LC_ALL=C sort \
      | sed 's#/#.#g; s#\.lean$##; s#^#import #' > UnusedArgs.lean
    echo '#lint only unusedArguments in TauCeti' >> UnusedArgs.lean
    lake env lean UnusedArgs.lean

The lemma is `private`, so there is no API change; the sole call site is in the same
file and instance arguments are implicit, so it is unchanged.

`scripts/lint-baseline.txt` now carries one stale entry,
`TauCeti.Probability.cond_eq_of_extreme_iidMixture`. `scripts/` is human-owned, so this
PR leaves it alone; `lint-env.sh` prints a stale entry as a ratchet reminder without
failing.

Verified locally: `lake build` (11185 jobs), `lake exe axioms` (112105 declarations,
allowlist clean), `scripts/lint-style.sh`, `scripts/lint-dot-notation.py` (761 total, 0
new — unchanged from main).

Roadmap: Exchangeability



🤖 Generated with [Claude Code](https://claude.com/claude-code)
