### PR TITLE
refactor(Algebra): state `extendOfIsLattice` over a domain and its fraction field

### DIFF
--- a/TauCeti/Algebra/Module/Lattice.lean
+++ b/TauCeti/Algebra/Module/Lattice.lean
@@ -102,52 +102,53 @@ end
 
 namespace LinearEquiv
 
-variable {V : Type u} {W : Type v}
-variable [AddCommGroup V] [Module ℚ V]
-variable [AddCommGroup W] [Module ℚ W]
+variable {R : Type*} {K : Type*} {V : Type u} {W : Type v}
+variable [CommRing R] [Field K] [Algebra R K] [IsFractionRing R K]
+variable [AddCommGroup V] [Module R V] [Module K V] [IsScalarTower R K V]
+variable [AddCommGroup W] [Module R W] [Module K W] [IsScalarTower R K W]
 
-/-- Extend an integral linear equivalence between full submodules uniquely to their rational
-ambient spaces. -/
-noncomputable def extendOfIsLattice {S : Submodule ℤ V} {T : Submodule ℤ W}
-    [S.IsLattice ℚ] [T.IsLattice ℚ] (e : S ≃ₗ[ℤ] T) : V ≃ₗ[ℚ] W :=
-  let b := Module.Free.chooseBasis ℤ S
-  (b.extendOfIsLattice ℚ).equiv ((b.map e).extendOfIsLattice ℚ) (Equiv.refl _)
+/-- Extend an `R`-linear equivalence between full submodules uniquely to their ambient
+`K`-vector spaces. -/
+noncomputable def extendOfIsLattice {S : Submodule R V} {T : Submodule R W}
+    [S.IsLattice K] [T.IsLattice K] [Module.Free R S] (e : S ≃ₗ[R] T) : V ≃ₗ[K] W :=
+  let b := Module.Free.chooseBasis R S
+  (b.extendOfIsLattice K).equiv ((b.map e).extendOfIsLattice K) (Equiv.refl _)
 
-/-- The rational extension of a full-submodule equivalence agrees with it on the submodule. -/
+/-- The ambient extension of a full-submodule equivalence agrees with it on the submodule. -/
 @[simp]
-theorem extendOfIsLattice_apply {S : Submodule ℤ V} {T : Submodule ℤ W}
-    [S.IsLattice ℚ] [T.IsLattice ℚ] (e : S ≃ₗ[ℤ] T) (x : S) :
+theorem extendOfIsLattice_apply {S : Submodule R V} {T : Submodule R W}
+    [S.IsLattice K] [T.IsLattice K] [Module.Free R S] (e : S ≃ₗ[R] T) (x : S) :
     extendOfIsLattice e (x : V) = (e x : W) := by
-  let b := Module.Free.chooseBasis ℤ S
-  have h : (extendOfIsLattice e).toLinearMap.restrictScalars ℤ ∘ₗ S.subtype =
+  let b := Module.Free.chooseBasis R S
+  have h : (extendOfIsLattice e).toLinearMap.restrictScalars R ∘ₗ S.subtype =
       T.subtype ∘ₗ e.toLinearMap := by
     apply b.ext
     intro i
     dsimp only [b]
     simp only [LinearMap.comp_apply, LinearMap.restrictScalars_apply, Submodule.subtype_apply,
       LinearEquiv.coe_toLinearMap]
-    rw [← Basis.extendOfIsLattice_apply ℚ (Module.Free.chooseBasis ℤ S) i]
+    rw [← Basis.extendOfIsLattice_apply K (Module.Free.chooseBasis R S) i]
     -- Expose the constructed basis equivalence so `Basis.equiv_apply` can identify its values.
     unfold extendOfIsLattice
     rw [Basis.equiv_apply, Basis.extendOfIsLattice_apply, Basis.map_apply, Equiv.refl_apply]
   exact LinearMap.congr_fun h x
 
-/-- A rational linear equivalence extending a given equivalence of full submodules is the
+/-- A `K`-linear equivalence extending a given equivalence of full submodules is the
 canonical extension. -/
-theorem eq_extendOfIsLattice {S : Submodule ℤ V} {T : Submodule ℤ W}
-    [S.IsLattice ℚ] [T.IsLattice ℚ] (e : S ≃ₗ[ℤ] T) (f : V ≃ₗ[ℚ] W)
+theorem eq_extendOfIsLattice {S : Submodule R V} {T : Submodule R W}
+    [S.IsLattice K] [T.IsLattice K] [Module.Free R S] (e : S ≃ₗ[R] T) (f : V ≃ₗ[K] W)
     (h : ∀ x : S, f (x : V) = (e x : W)) : f = extendOfIsLattice e := by
   apply LinearEquiv.toLinearMap_injective
-  apply (Module.Free.chooseBasis ℤ S).extendOfIsLattice ℚ |>.ext
+  apply (Module.Free.chooseBasis R S).extendOfIsLattice K |>.ext
   intro i
   rw [Basis.extendOfIsLattice_apply]
-  exact (h (Module.Free.chooseBasis ℤ S i)).trans
-    (extendOfIsLattice_apply e (Module.Free.chooseBasis ℤ S i)).symm
+  exact (h (Module.Free.chooseBasis R S i)).trans
+    (extendOfIsLattice_apply e (Module.Free.chooseBasis R S i)).symm
 
-/-- The rational extension maps the source full submodule onto the target full submodule. -/
-theorem extendOfIsLattice_map {S : Submodule ℤ V} {T : Submodule ℤ W}
-    [S.IsLattice ℚ] [T.IsLattice ℚ] (e : S ≃ₗ[ℤ] T) :
-    S.map ((extendOfIsLattice e).restrictScalars ℤ).toLinearMap = T := by
+/-- The ambient extension maps the source full submodule onto the target full submodule. -/
+theorem extendOfIsLattice_map {S : Submodule R V} {T : Submodule R W}
+    [S.IsLattice K] [T.IsLattice K] [Module.Free R S] (e : S ≃ₗ[R] T) :
+    S.map ((extendOfIsLattice e).restrictScalars R).toLinearMap = T := by
   apply le_antisymm
   · rintro _ ⟨x, hx, rfl⟩
     have hmem : (e (⟨x, hx⟩ : S) : W) ∈ T := (e ⟨x, hx⟩).2


### PR DESCRIPTION
The four `LinearEquiv.extendOfIsLattice` declarations hard-coded `Submodule ℤ` and `Module ℚ`.
Nothing in the construction needs them, and every ingredient is already stated at the general level:

* Mathlib's `Submodule.IsLattice` is a class on `{R} [CommRing R]` and `(A) [CommRing A] [Algebra R A]`;
* Mathlib's `Basis.extendOfIsLattice` takes `[IsFractionRing R K]` and produces a `K`-basis of the
  ambient space from an `R`-basis of a lattice;
* this file's own `Basis.span_range_extendOfIsLattice` and `Submodule.IsLattice.finrank_eq_finrank`
  already carry exactly the variable block used here.

Only this section was specialised, so the change is a restatement rather than new mathematics: each
declaration keeps its proof.

### The freeness assumption is the real content

`Module.Free R S` becomes an explicit instance argument. Over `ℤ` it is found by instance search —
which is why the existing proofs can call `Module.Free.chooseBasis` with no hypothesis at all — but
over a general domain a lattice need not be free, and the construction begins by choosing a basis.

`IsDomain R` is deliberately **absent**: the section never uses it. Choosing the basis needs
`Module.Free R S`, and Mathlib's `Basis.extendOfIsLattice` needs `IsFractionRing R K`; neither
requires a domain.

The `ℤ`/`ℚ` uses in `TauCeti/LinearAlgebra/IntegralLattice/` are unchanged and obtain the old
statements by specialisation.

### Provenance

Split out of #6188 at the request of its `scope` block. That PR carried a namespace relocation plus
two unrelated generalisations; it is now the relocation alone, and this is one of the two pieces
removed from it.

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GadULQ4gpsVAZfpvs2htNt
