### PR TITLE
feat: package graphs of continuous homomorphisms

### DIFF
--- a/TauCeti/Topology/Algebra/Group/Graph.lean
+++ b/TauCeti/Topology/Algebra/Group/Graph.lean
@@ -17,20 +17,18 @@ as a subgroup of a product. The source is continuously multiplicatively equivale
 and the graph is closed when the codomain is Hausdorff.
 -/
 
-@[expose] public section
+public section
 
-namespace TauCeti
-
-variable {G H : Type*} [Group G] [Group H] [TopologicalSpace G] [TopologicalSpace H]
-
-namespace ContinuousMonoidHom
+variable {G H F : Type*} [Group G] [Group H] [TopologicalSpace G] [TopologicalSpace H]
+  [FunLike F G H] [MonoidHomClass F G H] [ContinuousMapClass F G H]
 
 /-- A group is continuously multiplicatively equivalent to the graph of a continuous
 homomorphism out of it. -/
-@[to_additive ContinuousAddMonoidHom.graphEquiv
+@[to_additive
   /-- An additive group is continuously additively equivalent to the graph of a continuous
   homomorphism out of it. -/]
-def graphEquiv (f : G →ₜ* H) : G ≃ₜ* (f : G →* H).graph where
+def MonoidHomClass.graphEquiv (f : F) :
+    G ≃ₜ* (MonoidHomClass.toMonoidHom f).graph where
   toFun g := ⟨(g, f g), rfl⟩
   invFun x := x.1.1
   left_inv _ := rfl
@@ -40,33 +38,26 @@ def graphEquiv (f : G →ₜ* H) : G ≃ₜ* (f : G →* H).graph where
     · rfl
     · exact x.property
   map_mul' x y := by
-    apply Subtype.ext
-    change (x * y, f (x * y)) = (x * y, f x * f y)
-    simp
-  continuous_toFun := (continuous_id.prodMk f.continuous).subtype_mk _
+    ext <;> simp
+  continuous_toFun := (continuous_id.prodMk (map_continuous f)).subtype_mk _
   continuous_invFun := continuous_fst.comp continuous_subtype_val
 
 /-- The graph equivalence sends an element to the corresponding point of the graph. -/
-@[to_additive (attr := simp) ContinuousAddMonoidHom.coe_graphEquiv_apply
+@[to_additive (attr := simp)
   /-- The additive graph equivalence sends an element to the corresponding point of the graph. -/]
-theorem coe_graphEquiv_apply (f : G →ₜ* H) (g : G) :
-    (graphEquiv f g : G × H) = (g, f g) :=
-  rfl
+theorem MonoidHomClass.coe_graphEquiv_apply (f : F) (g : G) :
+    (MonoidHomClass.graphEquiv f g : G × H) = (g, f g) := (rfl)
 
 /-- The inverse graph equivalence is the first projection. -/
-@[to_additive (attr := simp) ContinuousAddMonoidHom.graphEquiv_symm_apply
+@[to_additive (attr := simp)
   /-- The inverse additive graph equivalence is the first projection. -/]
-theorem graphEquiv_symm_apply (f : G →ₜ* H) (x : (f : G →* H).graph) :
-    (graphEquiv f).symm x = x.1.1 :=
-  rfl
+theorem MonoidHomClass.graphEquiv_symm_apply (f : F)
+    (x : (MonoidHomClass.toMonoidHom f).graph) :
+    (MonoidHomClass.graphEquiv f).symm x = x.1.1 := (rfl)
 
 /-- The graph of a continuous homomorphism into a Hausdorff group is closed. -/
-@[to_additive ContinuousAddMonoidHom.isClosed_graph
+@[to_additive
   /-- The graph of a continuous additive homomorphism into a Hausdorff additive group is closed. -/]
-theorem isClosed_graph [T2Space H] (f : G →ₜ* H) :
-    IsClosed ((f : G →* H).graph : Set (G × H)) := by
-  exact isClosed_eq (f.continuous.comp continuous_fst) continuous_snd
-
-end ContinuousMonoidHom
-
-end TauCeti
+theorem MonoidHomClass.isClosed_graph [T2Space H] (f : F) :
+    IsClosed ((MonoidHomClass.toMonoidHom f).graph : Set (G × H)) := by
+  exact isClosed_eq ((map_continuous f).comp continuous_fst) continuous_snd

--- a/TauCeti/Topology/Algebra/Group/Graph.lean
+++ b/TauCeti/Topology/Algebra/Group/Graph.lean
@@ -10,25 +10,30 @@ public import Mathlib.Topology.Algebra.ContinuousMonoidHom
 public import Mathlib.Topology.Separation.Hausdorff
 
 /-!
-# Graphs of continuous group homomorphisms
+# Graphs of continuous monoid homomorphisms
 
-This file equips the graph of a continuous group homomorphism with the topology needed to use it
-as a subgroup of a product. The source is continuously multiplicatively equivalent to the graph,
-and the graph is closed when the codomain is Hausdorff.
+This file studies the graph of a continuous monoid homomorphism with its inherited subtype topology.
+The source is continuously multiplicatively equivalent to the graph, and the graph is closed when
+the codomain is Hausdorff. For groups, these results specialize from submonoid graphs to subgroup
+graphs.
 -/
 
 public section
 
-variable {G H F : Type*} [Group G] [Group H] [TopologicalSpace G] [TopologicalSpace H]
-  [FunLike F G H] [MonoidHomClass F G H] [ContinuousMapClass F G H]
+variable {G H F : Type*} [TopologicalSpace G] [TopologicalSpace H]
 
-/-- A group is continuously multiplicatively equivalent to the graph of a continuous
+section Monoid
+
+variable [Monoid G] [Monoid H] [FunLike F G H] [MonoidHomClass F G H]
+  [ContinuousMapClass F G H]
+
+/-- A monoid is continuously multiplicatively equivalent to the submonoid graph of a continuous
 homomorphism out of it. -/
 @[to_additive
-  /-- An additive group is continuously additively equivalent to the graph of a continuous
-  homomorphism out of it. -/]
-def MonoidHomClass.graphEquiv (f : F) :
-    G ≃ₜ* (MonoidHomClass.toMonoidHom f).graph where
+  /-- An additive monoid is continuously additively equivalent to the submonoid graph of a
+  continuous homomorphism out of it. -/]
+def MonoidHomClass.mgraphEquiv (f : F) :
+    G ≃ₜ* (MonoidHomClass.toMonoidHom f).mgraph where
   toFun g := ⟨(g, f g), rfl⟩
   invFun x := x.1.1
   left_inv _ := rfl
@@ -42,15 +47,59 @@ def MonoidHomClass.graphEquiv (f : F) :
   continuous_toFun := (continuous_id.prodMk (map_continuous f)).subtype_mk _
   continuous_invFun := continuous_fst.comp continuous_subtype_val
 
-/-- The graph equivalence sends an element to the corresponding point of the graph. -/
+/-- The submonoid graph equivalence sends an element to the corresponding point of the graph. -/
 @[to_additive (attr := simp)
-  /-- The additive graph equivalence sends an element to the corresponding point of the graph. -/]
+  /-- The additive submonoid graph equivalence sends an element to the corresponding point of the
+  graph. -/]
+theorem MonoidHomClass.coe_mgraphEquiv_apply (f : F) (g : G) :
+    (MonoidHomClass.mgraphEquiv f g : G × H) = (g, f g) := (rfl)
+
+/-- The inverse submonoid graph equivalence is the first projection. -/
+@[to_additive (attr := simp)
+  /-- The inverse additive submonoid graph equivalence is the first projection. -/]
+theorem MonoidHomClass.mgraphEquiv_symm_apply (f : F)
+    (x : (MonoidHomClass.toMonoidHom f).mgraph) :
+    (MonoidHomClass.mgraphEquiv f).symm x = x.1.1 := (rfl)
+
+/-- The submonoid graph of a continuous homomorphism into a Hausdorff monoid is closed. -/
+@[to_additive
+  /-- The additive submonoid graph of a continuous additive homomorphism into a Hausdorff additive
+  monoid is closed. -/]
+theorem MonoidHomClass.isClosed_mgraph [T2Space H] (f : F) :
+    IsClosed ((MonoidHomClass.toMonoidHom f).mgraph : Set (G × H)) := by
+  have hgraph :
+      ((MonoidHomClass.toMonoidHom f).mgraph : Set (G × H)) = {x | f x.1 = x.2} := by
+    ext x
+    exact MonoidHom.mem_mgraph
+  rw [hgraph]
+  exact isClosed_eq ((map_continuous f).comp continuous_fst) continuous_snd
+
+end Monoid
+
+section Group
+
+variable [Group G] [Group H] [FunLike F G H] [MonoidHomClass F G H]
+  [ContinuousMapClass F G H]
+
+/-- A group is continuously multiplicatively equivalent to the subgroup graph of a continuous
+homomorphism out of it. -/
+@[to_additive
+  /-- An additive group is continuously additively equivalent to the subgroup graph of a continuous
+  homomorphism out of it. -/]
+def MonoidHomClass.graphEquiv (f : F) :
+    G ≃ₜ* (MonoidHomClass.toMonoidHom f).graph :=
+  MonoidHomClass.mgraphEquiv f
+
+/-- The subgroup graph equivalence sends an element to the corresponding point of the graph. -/
+@[to_additive (attr := simp)
+  /-- The additive subgroup graph equivalence sends an element to the corresponding point of the
+  graph. -/]
 theorem MonoidHomClass.coe_graphEquiv_apply (f : F) (g : G) :
     (MonoidHomClass.graphEquiv f g : G × H) = (g, f g) := (rfl)
 
-/-- The inverse graph equivalence is the first projection. -/
+/-- The inverse subgroup graph equivalence is the first projection. -/
 @[to_additive (attr := simp)
-  /-- The inverse additive graph equivalence is the first projection. -/]
+  /-- The inverse additive subgroup graph equivalence is the first projection. -/]
 theorem MonoidHomClass.graphEquiv_symm_apply (f : F)
     (x : (MonoidHomClass.toMonoidHom f).graph) :
     (MonoidHomClass.graphEquiv f).symm x = x.1.1 := (rfl)
@@ -60,4 +109,6 @@ theorem MonoidHomClass.graphEquiv_symm_apply (f : F)
   /-- The graph of a continuous additive homomorphism into a Hausdorff additive group is closed. -/]
 theorem MonoidHomClass.isClosed_graph [T2Space H] (f : F) :
     IsClosed ((MonoidHomClass.toMonoidHom f).graph : Set (G × H)) := by
-  exact isClosed_eq ((map_continuous f).comp continuous_fst) continuous_snd
+  exact MonoidHomClass.isClosed_mgraph f
+
+end Group

--- a/TauCeti/Topology/Algebra/Group/Graph.lean
+++ b/TauCeti/Topology/Algebra/Group/Graph.lean
@@ -1,0 +1,72 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Group.Graph
+public import Mathlib.Topology.Algebra.ContinuousMonoidHom
+public import Mathlib.Topology.Separation.Hausdorff
+
+/-!
+# Graphs of continuous group homomorphisms
+
+This file equips the graph of a continuous group homomorphism with the topology needed to use it
+as a subgroup of a product. The source is continuously multiplicatively equivalent to the graph,
+and the graph is closed when the codomain is Hausdorff.
+-/
+
+@[expose] public section
+
+namespace TauCeti
+
+variable {G H : Type*} [Group G] [Group H] [TopologicalSpace G] [TopologicalSpace H]
+
+namespace ContinuousMonoidHom
+
+/-- A group is continuously multiplicatively equivalent to the graph of a continuous
+homomorphism out of it. -/
+@[to_additive ContinuousAddMonoidHom.graphEquiv
+  /-- An additive group is continuously additively equivalent to the graph of a continuous
+  homomorphism out of it. -/]
+def graphEquiv (f : G →ₜ* H) : G ≃ₜ* (f : G →* H).graph where
+  toFun g := ⟨(g, f g), rfl⟩
+  invFun x := x.1.1
+  left_inv _ := rfl
+  right_inv x := by
+    apply Subtype.ext
+    apply Prod.ext
+    · rfl
+    · exact x.property
+  map_mul' x y := by
+    apply Subtype.ext
+    change (x * y, f (x * y)) = (x * y, f x * f y)
+    simp
+  continuous_toFun := (continuous_id.prodMk f.continuous).subtype_mk _
+  continuous_invFun := continuous_fst.comp continuous_subtype_val
+
+/-- The graph equivalence sends an element to the corresponding point of the graph. -/
+@[to_additive (attr := simp) ContinuousAddMonoidHom.coe_graphEquiv_apply
+  /-- The additive graph equivalence sends an element to the corresponding point of the graph. -/]
+theorem coe_graphEquiv_apply (f : G →ₜ* H) (g : G) :
+    (graphEquiv f g : G × H) = (g, f g) :=
+  rfl
+
+/-- The inverse graph equivalence is the first projection. -/
+@[to_additive (attr := simp) ContinuousAddMonoidHom.graphEquiv_symm_apply
+  /-- The inverse additive graph equivalence is the first projection. -/]
+theorem graphEquiv_symm_apply (f : G →ₜ* H) (x : (f : G →* H).graph) :
+    (graphEquiv f).symm x = x.1.1 :=
+  rfl
+
+/-- The graph of a continuous homomorphism into a Hausdorff group is closed. -/
+@[to_additive ContinuousAddMonoidHom.isClosed_graph
+  /-- The graph of a continuous additive homomorphism into a Hausdorff additive group is closed. -/]
+theorem isClosed_graph [T2Space H] (f : G →ₜ* H) :
+    IsClosed ((f : G →* H).graph : Set (G × H)) := by
+  exact isClosed_eq (f.continuous.comp continuous_fst) continuous_snd
+
+end ContinuousMonoidHom
+
+end TauCeti


### PR DESCRIPTION
This PR packages the graph of a continuous monoid homomorphism for the RepresentationTheory/LieGroups Layer 2 closed-subgroup (Cartan) theorem and its automatic-smoothness corollary.

Roadmap: RepresentationTheory

## Summary

Add the canonical continuous multiplicative equivalence from a monoid to the submonoid graph of any map carrying `MonoidHomClass` and `ContinuousMapClass`, its forward and inverse coordinate simp lemmas, and the corresponding additive API. Prove that the submonoid graph is closed whenever the codomain is Hausdorff. For groups, derive the subgroup graph equivalence and closedness theorem from this monoid-level boundary, preserving the exact interface needed by the automatic-smoothness consumer. The implementation reuses Mathlib's `MonoidHom.mgraph`, `MonoidHom.graph`, `ContinuousMulEquiv`, subtype topology, `MonoidHom.mem_mgraph`, and `isClosed_eq`; no Mathlib infrastructure is vendored.

## Roadmap target

This advances [RepresentationTheory/LieGroups, Layer 2: the closed-subgroup (Cartan) theorem](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/RepresentationTheory/LieGroups/README.md#layer-2-the-closed-subgroup-cartan-theorem), specifically the stated automatic-smoothness consequence that every continuous homomorphism between Lie groups is smooth because its graph is a closed subgroup. After this PR, the complementary exponential-product chart (once its open inverse-function-theorem prerequisite lands), the embedded closed-subgroup theorem, and the graph-based smoothness argument remain before the concrete Spin/SO Lie structures and the differential of `spinToSpecialOrthogonal`.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"continuous-homomorphism-graph"}-->

## Verification

- Exact head: `280f9adce13fc1b61cb084ff9b9590726ed5be8e`
- Local Lean build: `spinrep-validate run -- lake build --iofail` — passed (11,186 jobs)
- Axiom audit: `spinrep-validate run -- lake exe axioms` — passed (112,139 TauCeti declarations; only `propext`, `Classical.choice`, and `Quot.sound`)
- Lint: module-system passed all 5,023 modules; environment lint passed with no new violations; style lint passed all 5,022 source headers
- Public CI: pending after this repair push

## Scale and generality

The 114-line module is universe-polymorphic in arbitrary monoids, arbitrary topologies, and any `FunLike` map carrying the standard homomorphism and continuity classes. The submonoid graph equivalence requires no separation or topological-monoid instances; closedness assumes only `T2Space` on the codomain. The group API is a specialization of the monoid construction, and `to_additive` generation keeps all multiplicative and additive interfaces synchronized.

## Scope

- **Consumes:** Mathlib's algebraic `MonoidHom.mgraph` and `MonoidHom.graph`, continuous homomorphism/equivalence structures, product and subtype topology, graph membership, and Hausdorff equalizer closedness
- **Provides:** monoid-level `MonoidHomClass.mgraphEquiv` and `isClosed_mgraph`, their coordinate simp lemmas, the derived group-level `graphEquiv` and `isClosed_graph` API, and generated `AddMonoidHomClass` counterparts
- **Fits:** supplies the closed graph and source/graph topology identification used by the Layer 2 automatic-smoothness route, which later makes the Spin-to-SO map differentiable for the SpinRepresentations Layer 3 milestone
- **Boundary:** does not anticipate the open inverse-function-theorem dependency, construct the closed-subgroup atlas, assert automatic smoothness, or introduce concrete Spin/SO manifold structures

<sub>🤖 GPT-5.6 Sol high · TauCetiWorker @ [cd34d76f5173995310422b13b1be93c978d16f8f](https://github.com/utensil/TauCetiWorker/commit/cd34d76f5173995310422b13b1be93c978d16f8f) · rubrics @ [afb424eda89e8ac96d9eb69f6a88972055a4cd1b](https://github.com/utensil/TauCetiReview/commit/afb424eda89e8ac96d9eb69f6a88972055a4cd1b) · local review @ [b533e561b6d44df071c31335ed4a63ae647507d2](https://github.com/utensil/formal-land/commit/b533e561b6d44df071c31335ed4a63ae647507d2) · fixed: api-design, generality, naming, proof-quality, ut-consumer-contract</sub>