### PR TITLE
feat: package the compact Spin double cover topologically

### DIFF
--- a/TauCeti/GroupTheory/GroupExtension/Basic.lean
+++ b/TauCeti/GroupTheory/GroupExtension/Basic.lean
@@ -14,6 +14,8 @@ This file provides operations on an existing group extension.
 
 ## Main definitions and results
 
+* `GroupExtension.card_fiber_rightHom`: every fiber of the projection has the cardinality of the
+  kernel term.
 * `GroupExtension.relabelKer`: relabels the kernel term of a group extension.
 
 The construction is mirrored for additive groups by `to_additive`.
@@ -26,6 +28,19 @@ universe u v w
 namespace GroupExtension
 
 variable {N : Type u} {E : Type v} {G : Type w} [Group N] [Group E] [Group G]
+
+/-- Every fiber of the projection in a group extension has the cardinality of its kernel term. -/
+@[to_additive
+  /-- Every fiber of the projection in an additive group extension has the cardinality of its
+  kernel term. -/]
+theorem card_fiber_rightHom (S : GroupExtension N E G) (g : G) :
+    Nat.card (S.rightHom ⁻¹' {g}) = Nat.card N := by
+  calc
+    Nat.card (S.rightHom ⁻¹' {g}) = Nat.card S.rightHom.ker :=
+      Nat.card_congr (MonoidHom.fiberEquivKerOfSurjective S.rightHom_surjective g)
+    _ = Nat.card S.inl.range := by rw [S.range_inl_eq_ker_rightHom]
+    _ = Nat.card N :=
+      (Nat.card_congr (Equiv.ofInjective S.inl S.inl_injective)).symm
 
 /-- Relabel the kernel term of a group extension along a multiplicative equivalence. -/
 @[to_additive /-- Relabel the kernel term of an additive group extension along an additive

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Real/Basic.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Real/Basic.lean
@@ -30,7 +30,7 @@ separate.
 * `CliffordAlgebra.realCliffordSpinGroup` names the real Spin groups by signature.
 * `CliffordAlgebra.realCliffordSpinGroupZero` names the compact real Spin group.
 * `CliffordAlgebra.realCliffordSpinDoubleCoverZero` packages its double cover in positive dimension.
-* `CliffordAlgebra.natCard_fiber_realCliffordSpinDoubleCoverZero_rightHom` proves that every fiber
+* `CliffordAlgebra.card_fiber_realCliffordSpinDoubleCoverZero_rightHom` proves that every fiber
   of the double cover contains exactly two points.
 
 ## References
@@ -102,19 +102,10 @@ theorem realCliffordSpinDoubleCoverZero_rightHom (n : ℕ) [NeZero n] :
   rw [realCliffordSpinDoubleCoverZero, spinDoubleCoverOfSurjective_rightHom]
 
 /-- Every fiber of the compact real Spin double cover has exactly two elements. -/
-theorem natCard_fiber_realCliffordSpinDoubleCoverZero_rightHom
+theorem card_fiber_realCliffordSpinDoubleCoverZero_rightHom
     (n : ℕ) [NeZero n]
     (g : QuadraticMap.specialOrthogonalGroup (realCliffordForm n 0)) :
     Nat.card ((realCliffordSpinDoubleCoverZero n).rightHom ⁻¹' {g}) = 2 := by
-  let S := realCliffordSpinDoubleCoverZero n
-  calc
-    Nat.card (S.rightHom ⁻¹' {g}) = Nat.card S.rightHom.ker :=
-      Nat.card_congr (MonoidHom.fiberEquivKerOfSurjective S.rightHom_surjective g)
-    _ = Nat.card (MonoidHom.ker
-        (spinToSpecialOrthogonal (realCliffordForm n 0))) := by
-      rw [realCliffordSpinDoubleCoverZero_rightHom]
-    _ = 2 := card_ker_spinToSpecialOrthogonal (K := ℝ) (M := Fin (n + 0) → ℝ)
-      (by simpa using Nat.pos_of_ne_zero (NeZero.ne n)) _
-      (nondegenerate_realCliffordForm n 0)
+  simpa using (realCliffordSpinDoubleCoverZero n).card_fiber_rightHom g
 
 end CliffordAlgebra

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Real/Basic.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Real/Basic.lean
@@ -30,6 +30,8 @@ separate.
 * `CliffordAlgebra.realCliffordSpinGroup` names the real Spin groups by signature.
 * `CliffordAlgebra.realCliffordSpinGroupZero` names the compact real Spin group.
 * `CliffordAlgebra.realCliffordSpinDoubleCoverZero` packages its double cover in positive dimension.
+* `CliffordAlgebra.natCard_fiber_realCliffordSpinDoubleCoverZero_rightHom` proves that every fiber
+  of the double cover contains exactly two points.
 
 ## References
 
@@ -98,5 +100,21 @@ theorem realCliffordSpinDoubleCoverZero_rightHom (n : ℕ) [NeZero n] :
     (realCliffordSpinDoubleCoverZero n).rightHom =
       spinToSpecialOrthogonal (realCliffordForm n 0) := by
   rw [realCliffordSpinDoubleCoverZero, spinDoubleCoverOfSurjective_rightHom]
+
+/-- Every fiber of the compact real Spin double cover has exactly two elements. -/
+theorem natCard_fiber_realCliffordSpinDoubleCoverZero_rightHom
+    (n : ℕ) [NeZero n]
+    (g : QuadraticMap.specialOrthogonalGroup (realCliffordForm n 0)) :
+    Nat.card ((realCliffordSpinDoubleCoverZero n).rightHom ⁻¹' {g}) = 2 := by
+  let S := realCliffordSpinDoubleCoverZero n
+  calc
+    Nat.card (S.rightHom ⁻¹' {g}) = Nat.card S.rightHom.ker :=
+      Nat.card_congr (MonoidHom.fiberEquivKerOfSurjective S.rightHom_surjective g)
+    _ = Nat.card (MonoidHom.ker
+        (spinToSpecialOrthogonal (realCliffordForm n 0))) := by
+      rw [realCliffordSpinDoubleCoverZero_rightHom]
+    _ = 2 := card_ker_spinToSpecialOrthogonal (K := ℝ) (M := Fin (n + 0) → ℝ)
+      (by simpa using Nat.pos_of_ne_zero (NeZero.ne n)) _
+      (nondegenerate_realCliffordForm n 0)
 
 end CliffordAlgebra

--- a/TauCeti/Topology/Algebra/CliffordAlgebra/Spin/Covering.lean
+++ b/TauCeti/Topology/Algebra/CliffordAlgebra/Spin/Covering.lean
@@ -1,0 +1,81 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Topology.Algebra.CliffordAlgebra.Spin.Basic
+public import Mathlib.Topology.Covering.Quotient
+
+/-!
+# The compact real Spin double cover
+
+The projection from the compact real Spin group to the special orthogonal group is a covering map
+whenever its domain is compact. Indeed, the projection is a continuous surjection from a compact
+space to a Hausdorff space, hence a quotient map. Its kernel is the finite image of the included
+group `Multiplicative (ZMod 2)`, so the standard quotient-covering construction applies.
+
+Every fiber of the projection is equivalent to its kernel. Combining this equivalence with the
+known cardinality of the Spin kernel shows that the covering has exactly two sheets.
+
+## Main results
+
+* `CliffordAlgebra.isQuotientCoveringMap_realCliffordSpinDoubleCoverZero_rightHom` packages the
+  compact real Spin projection as a quotient covering map by its kernel.
+* `CliffordAlgebra.isCoveringMap_realCliffordSpinDoubleCoverZero_rightHom` packages the projection
+  as an ordinary covering map.
+* `CliffordAlgebra.natCard_fiber_realCliffordSpinDoubleCoverZero_rightHom` proves that every fiber
+  contains exactly two points.
+
+## References
+
+* H. B. Lawson and M.-L. Michelsohn, *Spin Geometry* (1989), Chapter I, Section 2.
+-/
+
+public section
+
+namespace CliffordAlgebra
+
+open TauCeti
+
+/-- The compact real Spin projection is a quotient covering map by its kernel. -/
+theorem isQuotientCoveringMap_realCliffordSpinDoubleCoverZero_rightHom
+    (n : ℕ) [NeZero n] [CompactSpace (realCliffordSpinGroupZero n)] :
+    IsQuotientCoveringMap (realCliffordSpinDoubleCoverZero n).rightHom
+      (realCliffordSpinDoubleCoverZero n).rightHom.ker := by
+  let S := realCliffordSpinDoubleCoverZero n
+  have hquot : Topology.IsQuotientMap S.rightHom :=
+    Topology.IsQuotientMap.of_surjective_continuous S.rightHom_surjective
+      (continuous_realCliffordSpinDoubleCoverZero_rightHom n)
+  apply hquot.isQuotientCoveringMap_of_isDiscrete_ker_monoidHom
+  rw [← S.range_inl_eq_ker_rightHom]
+  exact (Set.finite_range S.inl).isDiscrete
+
+/-- The projection from the compact real Spin group to the special orthogonal group is a covering
+map. -/
+theorem isCoveringMap_realCliffordSpinDoubleCoverZero_rightHom
+    (n : ℕ) [NeZero n] [CompactSpace (realCliffordSpinGroupZero n)] :
+    IsCoveringMap (realCliffordSpinDoubleCoverZero n).rightHom :=
+  (isQuotientCoveringMap_realCliffordSpinDoubleCoverZero_rightHom n).isCoveringMap
+
+/-- Every fiber of the compact real Spin projection has exactly two elements. -/
+theorem natCard_fiber_realCliffordSpinDoubleCoverZero_rightHom
+    (n : ℕ) [NeZero n] [CompactSpace (realCliffordSpinGroupZero n)]
+    (g : QuadraticMap.specialOrthogonalGroup (realCliffordForm n 0)) :
+    Nat.card ((realCliffordSpinDoubleCoverZero n).rightHom ⁻¹' {g}) = 2 := by
+  let S := realCliffordSpinDoubleCoverZero n
+  obtain ⟨x, hx⟩ := S.rightHom_surjective g
+  calc
+    Nat.card (S.rightHom ⁻¹' {g}) = Nat.card S.rightHom.ker :=
+      Nat.card_congr
+        ((isQuotientCoveringMap_realCliffordSpinDoubleCoverZero_rightHom n).fiberEquivGroup
+          ⟨x, hx⟩)
+    _ = Nat.card (MonoidHom.ker
+        (spinToSpecialOrthogonal (realCliffordForm n 0))) := by
+      rw [realCliffordSpinDoubleCoverZero_rightHom]
+    _ = 2 := card_ker_spinToSpecialOrthogonal (K := ℝ) (M := Fin (n + 0) → ℝ)
+      (by simpa using Nat.pos_of_ne_zero (NeZero.ne n)) _
+      (nondegenerate_realCliffordForm n 0)
+
+end CliffordAlgebra

--- a/TauCeti/Topology/Algebra/CliffordAlgebra/Spin/Covering.lean
+++ b/TauCeti/Topology/Algebra/CliffordAlgebra/Spin/Covering.lean
@@ -16,17 +16,12 @@ whenever its domain is compact. Indeed, the projection is a continuous surjectio
 space to a Hausdorff space, hence a quotient map. Its kernel is the finite image of the included
 group `Multiplicative (ZMod 2)`, so the standard quotient-covering construction applies.
 
-Every fiber of the projection is equivalent to its kernel. Combining this equivalence with the
-known cardinality of the Spin kernel shows that the covering has exactly two sheets.
-
 ## Main results
 
 * `CliffordAlgebra.isQuotientCoveringMap_realCliffordSpinDoubleCoverZero_rightHom` packages the
   compact real Spin projection as a quotient covering map by its kernel.
 * `CliffordAlgebra.isCoveringMap_realCliffordSpinDoubleCoverZero_rightHom` packages the projection
   as an ordinary covering map.
-* `CliffordAlgebra.natCard_fiber_realCliffordSpinDoubleCoverZero_rightHom` proves that every fiber
-  contains exactly two points.
 
 ## References
 
@@ -58,24 +53,5 @@ theorem isCoveringMap_realCliffordSpinDoubleCoverZero_rightHom
     (n : ℕ) [NeZero n] [CompactSpace (realCliffordSpinGroupZero n)] :
     IsCoveringMap (realCliffordSpinDoubleCoverZero n).rightHom :=
   (isQuotientCoveringMap_realCliffordSpinDoubleCoverZero_rightHom n).isCoveringMap
-
-/-- Every fiber of the compact real Spin projection has exactly two elements. -/
-theorem natCard_fiber_realCliffordSpinDoubleCoverZero_rightHom
-    (n : ℕ) [NeZero n] [CompactSpace (realCliffordSpinGroupZero n)]
-    (g : QuadraticMap.specialOrthogonalGroup (realCliffordForm n 0)) :
-    Nat.card ((realCliffordSpinDoubleCoverZero n).rightHom ⁻¹' {g}) = 2 := by
-  let S := realCliffordSpinDoubleCoverZero n
-  obtain ⟨x, hx⟩ := S.rightHom_surjective g
-  calc
-    Nat.card (S.rightHom ⁻¹' {g}) = Nat.card S.rightHom.ker :=
-      Nat.card_congr
-        ((isQuotientCoveringMap_realCliffordSpinDoubleCoverZero_rightHom n).fiberEquivGroup
-          ⟨x, hx⟩)
-    _ = Nat.card (MonoidHom.ker
-        (spinToSpecialOrthogonal (realCliffordForm n 0))) := by
-      rw [realCliffordSpinDoubleCoverZero_rightHom]
-    _ = 2 := card_ker_spinToSpecialOrthogonal (K := ℝ) (M := Fin (n + 0) → ℝ)
-      (by simpa using Nat.pos_of_ne_zero (NeZero.ne n)) _
-      (nondegenerate_realCliffordForm n 0)
 
 end CliffordAlgebra


### PR DESCRIPTION
This PR packages the compact real Spin projection as a two-sheeted covering map for the SpinRepresentations Layer 7 compact-group topology milestone.

Roadmap: RepresentationTheory

## Summary

Add the topology boundary for `Spin(n) → SO(n)`: the packaged group-extension projection is a quotient covering by its kernel, hence an ordinary covering map. Complete the double-cover API algebraically by proving every fiber has `Nat.card` two without a compactness assumption. The fiber calculation is factored through a general `GroupExtension.card_fiber_rightHom` theorem, using Mathlib's `MonoidHom.fiberEquivKerOfSurjective` and the extension's injective kernel inclusion; the covering proofs reuse Mathlib's quotient-covering infrastructure together with Tau Ceti's existing continuity and extension-kernel results.

## Roadmap target

This advances `RepresentationTheory/SpinRepresentations`, Layer 7, “for compact `Spin(n)`: prove connectedness for `n ≥ 2` and simple connectivity for `n ≥ 3`; identify it as the universal cover of `SO(n)`.” It supplies the covering-map prerequisite consumed by the simple-connectivity and universal-cover identification. The active compactness prerequisite is PR #6353: its `CompactSpace (realCliffordSpinGroupZero n)` instance discharges this PR's exact compact-domain hypothesis. After this PR, #6353 must land and the simple-connectivity theorem for `n ≥ 3` and universal-cover identification remain.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"compact-spin-double-cover"}-->

## Verification

- Exact head: `15c5a60eea00f053bbd2d7cb015e552d6160800c`
- Local Lean build: `lake build` — pass (11,188 jobs)
- Axiom audit: `lake exe axioms` — pass (112,135 declarations; only `propext`, `Classical.choice`, and `Quot.sound`)
- Lint: `lake exe module-system`, `bash scripts/lint-env.sh`, `python3 scripts/lint-dot-notation.py`, `bash scripts/lint-style.sh`, and `git diff --check` with GNU Bash/GNU sed on `PATH` — pass, no new violations
- Public CI: pending on the exact head

## Scale and generality

The change adds 81 lines across three modules. The fiber-cardinality calculation is stated for every multiplicative or additive group extension, including infinite groups, and the compact Spin result is a direct two-element-kernel specialization. Only the two covering-map theorems assume compactness of the Spin domain—the hypothesis used to turn the existing continuous surjection into a quotient map. No result imposes connectedness or the later `n ≥ 3` simple-connectivity bound.

## Scope

- **Consumes:** `realCliffordSpinDoubleCoverZero`, continuity and surjectivity of its right homomorphism, `GroupExtension.range_inl_eq_ker_rightHom`, `MonoidHom.fiberEquivKerOfSurjective`, and Mathlib's quotient-covering infrastructure
- **Provides:** generic multiplicative and additive `card_fiber_rightHom` theorems, `card_fiber_realCliffordSpinDoubleCoverZero_rightHom`, `isQuotientCoveringMap_realCliffordSpinDoubleCoverZero_rightHom`, and `isCoveringMap_realCliffordSpinDoubleCoverZero_rightHom`
- **Fits:** closes the two-sheeted covering-space packaging boundary needed by the remaining compact Spin simple-connectivity and universal-cover work
- **Boundary:** does not prove compactness, simple connectivity, or the universal-cover universal property

<sub>🤖 GPT-5.6 Sol high · TauCetiWorker @ [7518d4150b846c4524423341570c031027a1d92c](https://github.com/utensil/TauCetiWorker/commit/7518d4150b846c4524423341570c031027a1d92c) · rubrics @ [afb424eda89e8ac96d9eb69f6a88972055a4cd1b](https://github.com/utensil/TauCetiReview/commit/afb424eda89e8ac96d9eb69f6a88972055a4cd1b) · local review @ [b533e561b6d44df071c31335ed4a63ae647507d2](https://github.com/utensil/formal-land/commit/b533e561b6d44df071c31335ed4a63ae647507d2) · fixed: api-design, generality, naming, placement, reuse, ut-consumer-contract, ut-aggregate-reuse</sub>