### PR TITLE
feat: finite-dimensionality of a path algebra is acyclicity of the quiver

### DIFF
--- a/TauCeti/Combinatorics/Quiver/LoopPower.lean
+++ b/TauCeti/Combinatorics/Quiver/LoopPower.lean
@@ -1,0 +1,118 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Combinatorics.Quiver.Path
+public import Mathlib.Data.Fintype.EquivFin
+
+/-!
+# Powers of a closed path
+
+A closed path `p : Quiver.Path a a` can be concatenated with itself, so it has powers
+`TauCeti.Quiver.loopPow p n`, the path that runs around `p` exactly `n` times. Their lengths are
+the multiples `n * p.length` of the length of `p`, so a *nontrivial* closed path has pairwise
+distinct powers and the type of closed paths at `a` is infinite.
+
+That last statement is the source of every "an oriented cycle makes something infinite" argument.
+In `TauCeti.RepresentationTheory.Quiver.Acyclic.FinitePaths` it is what turns finiteness of the
+path space into acyclicity, and through the path basis it is what makes the path algebra of a
+quiver with an oriented cycle infinite-dimensional.
+
+## Main definitions
+
+* `TauCeti.Quiver.loopPow`: the `n`-th power of a closed path, `p` concatenated with itself `n`
+  times; the empty concatenation is `Quiver.Path.nil`.
+
+## Main results
+
+* `TauCeti.Quiver.length_loopPow`: the `n`-th power of `p` has length `n * p.length`, and
+  `TauCeti.Quiver.loopPow_add` adds exponents, which is what makes `loopPow` a power.
+* `TauCeti.Quiver.loopPow_injective`: the powers of a closed path of positive length are pairwise
+  distinct.
+* `TauCeti.Quiver.infinite_path_self_of_ne_nil`: **a nontrivial closed path forces infinitely many
+  closed paths**, and `TauCeti.Quiver.eq_nil_of_finite_path_self` is the contrapositive: at a
+  vertex carrying finitely many closed paths, the trivial path is the only one.
+
+## Implementation notes
+
+The powers are stated for a closed path rather than for a general `p : Quiver.Path a b`, since
+concatenating `p` with itself is what needs `a = b`. They are not packaged as a `Monoid` structure
+on `Quiver.Path a a`: nothing here needs one, and it would put a multiplication on a type whose
+elements already compose partially, as arbitrary paths.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace Quiver
+
+universe u v
+
+variable {V : Type u} [_root_.Quiver.{v} V] {a : V}
+
+/-- The `n`-th power of a closed path: `p` concatenated with itself `n` times, with the empty
+concatenation the trivial path. -/
+def loopPow (p : _root_.Quiver.Path a a) : ℕ → _root_.Quiver.Path a a
+  | 0 => _root_.Quiver.Path.nil
+  | n + 1 => (loopPow p n).comp p
+
+@[simp]
+theorem loopPow_zero (p : _root_.Quiver.Path a a) : loopPow p 0 = _root_.Quiver.Path.nil :=
+  (rfl)
+
+/-- The recursion `loopPow` is defined by: one more turn around `p` is one more concatenation. -/
+theorem loopPow_succ (p : _root_.Quiver.Path a a) (n : ℕ) :
+    loopPow p (n + 1) = (loopPow p n).comp p :=
+  (rfl)
+
+@[simp]
+theorem loopPow_one (p : _root_.Quiver.Path a a) : loopPow p 1 = p := by
+  rw [loopPow_succ, loopPow_zero, _root_.Quiver.Path.nil_comp]
+
+@[simp]
+theorem length_loopPow (p : _root_.Quiver.Path a a) (n : ℕ) :
+    (loopPow p n).length = n * p.length := by
+  induction n with
+  | zero => rw [loopPow_zero, _root_.Quiver.Path.length_nil, Nat.zero_mul]
+  | succ n ih =>
+    rw [loopPow_succ, _root_.Quiver.Path.length_comp, ih, Nat.add_mul, Nat.one_mul]
+
+/-- **The powers of a closed path add exponents.** With `TauCeti.Quiver.loopPow_zero` this says
+that `n ↦ loopPow p n` is a monoid homomorphism from `(ℕ, +)` into the closed paths at `a` under
+concatenation. -/
+theorem loopPow_add (p : _root_.Quiver.Path a a) (m n : ℕ) :
+    loopPow p (m + n) = (loopPow p m).comp (loopPow p n) := by
+  induction n with
+  | zero => rw [Nat.add_zero, loopPow_zero, _root_.Quiver.Path.comp_nil]
+  | succ n ih =>
+    rw [← Nat.add_assoc, loopPow_succ, ih, loopPow_succ, _root_.Quiver.Path.comp_assoc]
+
+/-- **The powers of a closed path of positive length are pairwise distinct**, because their
+lengths are the distinct multiples of `p.length`. -/
+theorem loopPow_injective {p : _root_.Quiver.Path a a} (hp : 0 < p.length) :
+    Function.Injective (loopPow p) := by
+  intro m n hmn
+  have hlen := congrArg _root_.Quiver.Path.length hmn
+  rw [length_loopPow, length_loopPow] at hlen
+  exact Nat.eq_of_mul_eq_mul_right hp hlen
+
+/-- **A nontrivial closed path forces infinitely many closed paths**, namely its powers. -/
+theorem infinite_path_self_of_ne_nil {p : _root_.Quiver.Path a a}
+    (hp : p ≠ _root_.Quiver.Path.nil) : Infinite (_root_.Quiver.Path a a) :=
+  Infinite.of_injective _ <| loopPow_injective <|
+    Nat.pos_of_ne_zero fun h => hp (p.eq_nil_of_length_zero h)
+
+/-- **Finitely many closed paths at a vertex leave only the trivial one**, the contrapositive of
+`TauCeti.Quiver.infinite_path_self_of_ne_nil`. -/
+theorem eq_nil_of_finite_path_self [Finite (_root_.Quiver.Path a a)]
+    (p : _root_.Quiver.Path a a) : p = _root_.Quiver.Path.nil := by
+  by_contra hp
+  exact (infinite_path_self_of_ne_nil hp).false
+
+end Quiver
+
+end TauCeti

--- a/TauCeti/Combinatorics/Quiver/LoopPower.lean
+++ b/TauCeti/Combinatorics/Quiver/LoopPower.lean
@@ -12,9 +12,9 @@ public import Mathlib.Data.Fintype.EquivFin
 # Powers of a closed path
 
 A closed path `p : Quiver.Path a a` can be concatenated with itself, so it has powers
-`TauCeti.Quiver.loopPow p n`, the path that runs around `p` exactly `n` times. Their lengths are
-the multiples `n * p.length` of the length of `p`, so a *nontrivial* closed path has pairwise
-distinct powers and the type of closed paths at `a` is infinite.
+`p.loopPow n`, the path that runs around `p` exactly `n` times. Their lengths are the multiples
+`n * p.length` of the length of `p`, so a *nontrivial* closed path has pairwise distinct powers
+and the type of closed paths at `a` is infinite.
 
 That last statement is the source of every "an oriented cycle makes something infinite" argument.
 In `TauCeti.RepresentationTheory.Quiver.Acyclic.FinitePaths` it is what turns finiteness of the
@@ -23,18 +23,18 @@ quiver with an oriented cycle infinite-dimensional.
 
 ## Main definitions
 
-* `TauCeti.Quiver.loopPow`: the `n`-th power of a closed path, `p` concatenated with itself `n`
+* `Quiver.Path.loopPow`: the `n`-th power of a closed path, `p` concatenated with itself `n`
   times; the empty concatenation is `Quiver.Path.nil`.
 
 ## Main results
 
-* `TauCeti.Quiver.length_loopPow`: the `n`-th power of `p` has length `n * p.length`, and
-  `TauCeti.Quiver.loopPow_add` adds exponents, which is what makes `loopPow` a power.
-* `TauCeti.Quiver.loopPow_injective`: the powers of a closed path of positive length are pairwise
+* `Quiver.Path.length_loopPow`: the `n`-th power of `p` has length `n * p.length`, and
+  `Quiver.Path.loopPow_add` adds exponents, which is what makes `loopPow` a power.
+* `Quiver.Path.loopPow_injective`: the powers of a closed path of positive length are pairwise
   distinct.
-* `TauCeti.Quiver.infinite_path_self_of_ne_nil`: **a nontrivial closed path forces infinitely many
-  closed paths**, and `TauCeti.Quiver.eq_nil_of_finite_path_self` is the contrapositive: at a
-  vertex carrying finitely many closed paths, the trivial path is the only one.
+* `Quiver.Path.infinite_of_ne_nil`: **a nontrivial closed path forces infinitely many closed
+  paths**, and `Quiver.Path.eq_nil_of_finite` is the contrapositive: at a vertex carrying finitely
+  many closed paths, the trivial path is the only one.
 
 ## Implementation notes
 
@@ -48,71 +48,83 @@ public section
 
 namespace TauCeti
 
-namespace Quiver
-
 universe u v
 
-variable {V : Type u} [_root_.Quiver.{v} V] {a : V}
+variable {V : Type u} [Quiver.{v} V] {a : V}
 
 /-- The `n`-th power of a closed path: `p` concatenated with itself `n` times, with the empty
 concatenation the trivial path. -/
-def loopPow (p : _root_.Quiver.Path a a) : ℕ → _root_.Quiver.Path a a
-  | 0 => _root_.Quiver.Path.nil
-  | n + 1 => (loopPow p n).comp p
+def _root_.Quiver.Path.loopPow (p : Quiver.Path a a) : ℕ → Quiver.Path a a
+  | 0 => Quiver.Path.nil
+  | n + 1 => (p.loopPow n).comp p
 
 @[simp]
-theorem loopPow_zero (p : _root_.Quiver.Path a a) : loopPow p 0 = _root_.Quiver.Path.nil :=
+theorem _root_.Quiver.Path.loopPow_zero (p : Quiver.Path a a) : p.loopPow 0 = Quiver.Path.nil :=
   (rfl)
 
-/-- The recursion `loopPow` is defined by: one more turn around `p` is one more concatenation. -/
-theorem loopPow_succ (p : _root_.Quiver.Path a a) (n : ℕ) :
-    loopPow p (n + 1) = (loopPow p n).comp p :=
+/-- **One more turn around `p` is one more concatenation**, the recursion `loopPow` is defined
+by. -/
+@[simp]
+theorem _root_.Quiver.Path.loopPow_succ (p : Quiver.Path a a) (n : ℕ) :
+    p.loopPow (n + 1) = (p.loopPow n).comp p :=
   (rfl)
 
-@[simp]
-theorem loopPow_one (p : _root_.Quiver.Path a a) : loopPow p 1 = p := by
-  rw [loopPow_succ, loopPow_zero, _root_.Quiver.Path.nil_comp]
+/-- **The first power of a closed path is the path itself.** This is not `@[simp]`: with
+`Quiver.Path.loopPow_succ` and `Quiver.Path.loopPow_zero` tagged, `simp` already reduces
+`p.loopPow 1`. -/
+theorem _root_.Quiver.Path.loopPow_one (p : Quiver.Path a a) : p.loopPow 1 = p := by
+  rw [Quiver.Path.loopPow_succ, Quiver.Path.loopPow_zero, Quiver.Path.nil_comp]
 
+/-- **Every power of the trivial path is trivial**: running around a path of no arrows changes
+nothing. -/
 @[simp]
-theorem length_loopPow (p : _root_.Quiver.Path a a) (n : ℕ) :
-    (loopPow p n).length = n * p.length := by
+theorem _root_.Quiver.Path.loopPow_nil (n : ℕ) :
+    (Quiver.Path.nil : Quiver.Path a a).loopPow n = Quiver.Path.nil := by
   induction n with
-  | zero => rw [loopPow_zero, _root_.Quiver.Path.length_nil, Nat.zero_mul]
-  | succ n ih =>
-    rw [loopPow_succ, _root_.Quiver.Path.length_comp, ih, Nat.add_mul, Nat.one_mul]
+  | zero => rw [Quiver.Path.loopPow_zero]
+  | succ n ih => rw [Quiver.Path.loopPow_succ, ih, Quiver.Path.comp_nil]
 
-/-- **The powers of a closed path add exponents.** With `TauCeti.Quiver.loopPow_zero` this says
-that `n ↦ loopPow p n` is a monoid homomorphism from `(ℕ, +)` into the closed paths at `a` under
+/-- **The `n`-th power of a closed path has length `n * p.length`**: each of the `n` turns
+contributes the arrows of `p` once. -/
+@[simp]
+theorem _root_.Quiver.Path.length_loopPow (p : Quiver.Path a a) (n : ℕ) :
+    (p.loopPow n).length = n * p.length := by
+  induction n with
+  | zero => rw [Quiver.Path.loopPow_zero, Quiver.Path.length_nil, Nat.zero_mul]
+  | succ n ih =>
+    rw [Quiver.Path.loopPow_succ, Quiver.Path.length_comp, ih, Nat.add_mul, Nat.one_mul]
+
+/-- **The powers of a closed path add exponents.** With `Quiver.Path.loopPow_zero` this says that
+`n ↦ p.loopPow n` is a monoid homomorphism from `(ℕ, +)` into the closed paths at `a` under
 concatenation. -/
-theorem loopPow_add (p : _root_.Quiver.Path a a) (m n : ℕ) :
-    loopPow p (m + n) = (loopPow p m).comp (loopPow p n) := by
+theorem _root_.Quiver.Path.loopPow_add (p : Quiver.Path a a) (m n : ℕ) :
+    p.loopPow (m + n) = (p.loopPow m).comp (p.loopPow n) := by
   induction n with
-  | zero => rw [Nat.add_zero, loopPow_zero, _root_.Quiver.Path.comp_nil]
+  | zero => rw [Nat.add_zero, Quiver.Path.loopPow_zero, Quiver.Path.comp_nil]
   | succ n ih =>
-    rw [← Nat.add_assoc, loopPow_succ, ih, loopPow_succ, _root_.Quiver.Path.comp_assoc]
+    rw [← Nat.add_assoc, Quiver.Path.loopPow_succ, ih, Quiver.Path.loopPow_succ,
+      Quiver.Path.comp_assoc]
 
 /-- **The powers of a closed path of positive length are pairwise distinct**, because their
 lengths are the distinct multiples of `p.length`. -/
-theorem loopPow_injective {p : _root_.Quiver.Path a a} (hp : 0 < p.length) :
-    Function.Injective (loopPow p) := by
+theorem _root_.Quiver.Path.loopPow_injective {p : Quiver.Path a a} (hp : 0 < p.length) :
+    Function.Injective p.loopPow := by
   intro m n hmn
-  have hlen := congrArg _root_.Quiver.Path.length hmn
-  rw [length_loopPow, length_loopPow] at hlen
+  have hlen := congrArg Quiver.Path.length hmn
+  rw [Quiver.Path.length_loopPow, Quiver.Path.length_loopPow] at hlen
   exact Nat.eq_of_mul_eq_mul_right hp hlen
 
 /-- **A nontrivial closed path forces infinitely many closed paths**, namely its powers. -/
-theorem infinite_path_self_of_ne_nil {p : _root_.Quiver.Path a a}
-    (hp : p ≠ _root_.Quiver.Path.nil) : Infinite (_root_.Quiver.Path a a) :=
-  Infinite.of_injective _ <| loopPow_injective <|
+theorem _root_.Quiver.Path.infinite_of_ne_nil {p : Quiver.Path a a} (hp : p ≠ Quiver.Path.nil) :
+    Infinite (Quiver.Path a a) :=
+  Infinite.of_injective _ <| Quiver.Path.loopPow_injective <|
     Nat.pos_of_ne_zero fun h => hp (p.eq_nil_of_length_zero h)
 
 /-- **Finitely many closed paths at a vertex leave only the trivial one**, the contrapositive of
-`TauCeti.Quiver.infinite_path_self_of_ne_nil`. -/
-theorem eq_nil_of_finite_path_self [Finite (_root_.Quiver.Path a a)]
-    (p : _root_.Quiver.Path a a) : p = _root_.Quiver.Path.nil := by
+`Quiver.Path.infinite_of_ne_nil`. -/
+theorem _root_.Quiver.Path.eq_nil_of_finite [Finite (Quiver.Path a a)] (p : Quiver.Path a a) :
+    p = Quiver.Path.nil := by
   by_contra hp
-  exact (infinite_path_self_of_ne_nil hp).false
-
-end Quiver
+  exact (Quiver.Path.infinite_of_ne_nil hp).false
 
 end TauCeti

--- a/TauCeti/Combinatorics/Quiver/LoopPower.lean
+++ b/TauCeti/Combinatorics/Quiver/LoopPower.lean
@@ -69,16 +69,10 @@ theorem _root_.Quiver.Path.loopPow_succ (p : Quiver.Path a a) (n : ℕ) :
     p.loopPow (n + 1) = (p.loopPow n).comp p :=
   (rfl)
 
-/-- **The first power of a closed path is the path itself.** This is not `@[simp]`: with
-`Quiver.Path.loopPow_succ` and `Quiver.Path.loopPow_zero` tagged, `simp` already reduces
-`p.loopPow 1`. -/
-theorem _root_.Quiver.Path.loopPow_one (p : Quiver.Path a a) : p.loopPow 1 = p := by
-  rw [Quiver.Path.loopPow_succ, Quiver.Path.loopPow_zero, Quiver.Path.nil_comp]
-
 /-- **Every power of the trivial path is trivial**: running around a path of no arrows changes
 nothing. -/
 @[simp]
-theorem _root_.Quiver.Path.loopPow_nil (n : ℕ) :
+theorem _root_.Quiver.Path.nil_loopPow (n : ℕ) :
     (Quiver.Path.nil : Quiver.Path a a).loopPow n = Quiver.Path.nil := by
   induction n with
   | zero => rw [Quiver.Path.loopPow_zero]

--- a/TauCeti/RepresentationTheory/Quiver/Acyclic/FinitePaths.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Acyclic/FinitePaths.lean
@@ -6,21 +6,35 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Combinatorics.Quiver.BoundedPaths
+public import TauCeti.Combinatorics.Quiver.LoopPower
 public import TauCeti.RepresentationTheory.Quiver.Acyclic.Basic
 
 /-!
 # Finite paths in acyclic quivers
 
 This file proves that a finite quiver with finitely many arrows between any two vertices has only
-finitely many paths when it is acyclic. The result supplies the finiteness hypothesis needed for
-the finite-dimensionality of its path algebra. The bound that makes the count finite is the
-acyclic one: every path has length below the number of vertices, so the count reduces to the
-bounded-length count of `TauCeti.Combinatorics.Quiver.BoundedPaths`.
+finitely many paths **exactly when** it is acyclic. The forward half supplies the finiteness
+hypothesis needed for the finite-dimensionality of its path algebra. The bound that makes the
+count finite is the acyclic one: every path has length below the number of vertices, so the count
+reduces to the bounded-length count of `TauCeti.Combinatorics.Quiver.BoundedPaths`.
+
+The converse needs no finiteness of the quiver at all: an oriented cycle has infinitely many
+powers (`TauCeti.Quiver.eq_nil_of_finite_path_self`), so a quiver with finitely many paths has
+none.
+
+## Main results
+
+* `TauCeti.finite_paths_of_isAcyclic`: a finite acyclic quiver with finite arrow types has
+  finitely many paths.
+* `TauCeti.isAcyclic_of_finite_paths`: **a quiver with finitely many paths is acyclic.**
+* `TauCeti.isAcyclic_iff_finite_paths`: the two together, the extensional form of acyclicity that
+  the finite-dimensionality of the path algebra is read off.
 
 ## References
 
 This file implements the `finite_paths_of_isAcyclic` part of Layer 0, “Acyclicity, as a
-predicate”, in `TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md`.
+predicate”, in `TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md`, whose
+statement is that for a finite quiver acyclicity *is* finiteness of the path space.
 -/
 
 public section
@@ -70,6 +84,25 @@ end Quiver.IsAcyclic
 theorem finite_paths_of_isAcyclic [Finite V] [∀ a b : V, Finite (a ⟶ b)]
     (h : Quiver.IsAcyclic V) : Finite (Σ a b : V, _root_.Quiver.Path a b) :=
   h.finite_paths
+
+/-- **A quiver with finitely many paths is acyclic**: the powers of an oriented cycle are already
+infinitely many paths. No finiteness of the vertices or of the arrows is needed. -/
+theorem isAcyclic_of_finite_paths (h : Finite (Σ a b : V, _root_.Quiver.Path a b)) :
+    Quiver.IsAcyclic V := by
+  have := h
+  refine Quiver.isAcyclic_def.mpr fun a p => ?_
+  have : Finite (_root_.Quiver.Path a a) :=
+    Finite.of_injective
+      (fun q : _root_.Quiver.Path a a => (⟨a, a, q⟩ : Σ a b : V, _root_.Quiver.Path a b))
+      fun _ _ hxy => by simpa using hxy
+  exact Quiver.eq_nil_of_finite_path_self p
+
+/-- **For a finite quiver with finite arrow types, acyclicity is finiteness of the path space.**
+This is the extensional form of acyclicity, the hypothesis under which the path algebra is a
+finite module. -/
+theorem isAcyclic_iff_finite_paths [Finite V] [∀ a b : V, Finite (a ⟶ b)] :
+    Quiver.IsAcyclic V ↔ Finite (Σ a b : V, _root_.Quiver.Path a b) :=
+  ⟨finite_paths_of_isAcyclic, isAcyclic_of_finite_paths⟩
 
 end
 

--- a/TauCeti/RepresentationTheory/Quiver/Acyclic/FinitePaths.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Acyclic/FinitePaths.lean
@@ -19,7 +19,8 @@ count finite is the acyclic one: every path has length below the number of verti
 reduces to the bounded-length count of `TauCeti.Combinatorics.Quiver.BoundedPaths`.
 
 The converse needs no finiteness of the quiver at all: an oriented cycle has infinitely many
-powers (`Quiver.Path.eq_nil_of_finite`), so a quiver with finitely many paths has none.
+powers (`Quiver.Path.infinite_of_ne_nil`), so a quiver with finitely many paths has none — the
+form the proof uses is the contrapositive `Quiver.Path.eq_nil_of_finite`.
 
 ## Main results
 
@@ -28,6 +29,11 @@ powers (`Quiver.Path.eq_nil_of_finite`), so a quiver with finitely many paths ha
 * `TauCeti.isAcyclic_of_finite_paths`: **a quiver with finitely many paths is acyclic.**
 * `TauCeti.isAcyclic_iff_finite_paths`: the two together, the extensional form of acyclicity that
   the finite-dimensionality of the path algebra is read off.
+
+## References
+
+See Assem--Simson--Skowroński, *Elements of the Representation Theory of Associative Algebras I*,
+Ch. II.
 -/
 
 public section

--- a/TauCeti/RepresentationTheory/Quiver/Acyclic/FinitePaths.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Acyclic/FinitePaths.lean
@@ -19,8 +19,7 @@ count finite is the acyclic one: every path has length below the number of verti
 reduces to the bounded-length count of `TauCeti.Combinatorics.Quiver.BoundedPaths`.
 
 The converse needs no finiteness of the quiver at all: an oriented cycle has infinitely many
-powers (`TauCeti.Quiver.eq_nil_of_finite_path_self`), so a quiver with finitely many paths has
-none.
+powers (`Quiver.Path.eq_nil_of_finite`), so a quiver with finitely many paths has none.
 
 ## Main results
 
@@ -29,12 +28,6 @@ none.
 * `TauCeti.isAcyclic_of_finite_paths`: **a quiver with finitely many paths is acyclic.**
 * `TauCeti.isAcyclic_iff_finite_paths`: the two together, the extensional form of acyclicity that
   the finite-dimensionality of the path algebra is read off.
-
-## References
-
-This file implements the `finite_paths_of_isAcyclic` part of Layer 0, “Acyclicity, as a
-predicate”, in `TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md`, whose
-statement is that for a finite quiver acyclicity *is* finiteness of the path space.
 -/
 
 public section
@@ -95,7 +88,7 @@ theorem isAcyclic_of_finite_paths (h : Finite (Σ a b : V, _root_.Quiver.Path a 
     Finite.of_injective
       (fun q : _root_.Quiver.Path a a => (⟨a, a, q⟩ : Σ a b : V, _root_.Quiver.Path a b))
       fun _ _ hxy => by simpa using hxy
-  exact Quiver.eq_nil_of_finite_path_self p
+  exact p.eq_nil_of_finite
 
 /-- **For a finite quiver with finite arrow types, acyclicity is finiteness of the path space.**
 This is the extensional form of acyclicity, the hypothesis under which the path algebra is a

--- a/TauCeti/RepresentationTheory/Quiver/Acyclic/PathAlgebra.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Acyclic/PathAlgebra.lean
@@ -19,7 +19,8 @@ Acyclicity is not merely sufficient but **necessary**: an oriented cycle contrib
 many powers to the path basis, so a path algebra that is a finite module over a nonzero base ring
 has no oriented cycle, whatever the quiver. For a finite quiver with finite arrow types the two
 conditions therefore agree, and finite-dimensionality of `kQ` *is* acyclicity of `Q`. The loop
-quiver is the boundary case, where the path algebra is the polynomial ring and
+quiver is the boundary case, where the path algebra is the additive monoid algebra of `ℕ` — the
+polynomial ring, over a commutative base — and
 `TauCeti.not_finiteDimensional_pathAlgebra_oneLoop` records the failure directly.
 
 This is the only place the generic path algebra of
@@ -32,8 +33,9 @@ module of its own: the path algebra itself needs nothing from the theory of acyc
   quiver with finite arrow types is finite-dimensional.
 * `TauCeti.isAcyclic_of_module_finite_pathAlgebra`: **a path algebra that is a finite module over
   a nonzero base ring comes from an acyclic quiver**, with no finiteness assumed of the quiver.
-* `TauCeti.finiteDimensional_pathAlgebra_iff_isAcyclic`: the two together, for a finite quiver
-  with finite arrow types over a division ring.
+* `TauCeti.module_finite_pathAlgebra_iff_isAcyclic`: the two together, for a finite quiver with
+  finite arrow types over a nonzero base semiring, and
+  `TauCeti.finiteDimensional_pathAlgebra_iff_isAcyclic` its reading over a division ring.
 
 ## References
 
@@ -65,12 +67,19 @@ theorem isAcyclic_of_module_finite_pathAlgebra (k : Type w) (Q : Type u) [Semiri
     Quiver.IsAcyclic Q :=
   isAcyclic_of_finite_paths ((module_finite_pathAlgebra_iff k Q).mp h)
 
-/-- **Finite-dimensionality of the path algebra is acyclicity of the quiver**, for a finite quiver
-with finite arrow types over a division ring.  This is the extensional reading of "no oriented
-cycle" that the finite-dimensional-algebra theory of a quiver runs on. -/
+/-- **Finiteness of the path algebra as a module is acyclicity of the quiver**, for a finite quiver
+with finite arrow types over a nonzero base semiring.  This is the extensional reading of "no
+oriented cycle" that the finite-dimensional-algebra theory of a quiver runs on. -/
+theorem module_finite_pathAlgebra_iff_isAcyclic (k : Type w) (Q : Type u) [Semiring k]
+    [Nontrivial k] [Quiver.{v} Q] [Finite Q] [∀ a b : Q, Finite (a ⟶ b)] :
+    Module.Finite k (pathAlgebra k Q) ↔ Quiver.IsAcyclic Q :=
+  (module_finite_pathAlgebra_iff k Q).trans isAcyclic_iff_finite_paths.symm
+
+/-- **Finite-dimensionality of the path algebra is acyclicity of the quiver**, the reading of
+`TauCeti.module_finite_pathAlgebra_iff_isAcyclic` over a division ring. -/
 theorem finiteDimensional_pathAlgebra_iff_isAcyclic (k : Type w) (Q : Type u) [DivisionRing k]
     [Quiver.{v} Q] [Finite Q] [∀ a b : Q, Finite (a ⟶ b)] :
     FiniteDimensional k (pathAlgebra k Q) ↔ Quiver.IsAcyclic Q :=
-  ⟨isAcyclic_of_module_finite_pathAlgebra k Q, finiteDimensional_pathAlgebra_of_isAcyclic k Q⟩
+  module_finite_pathAlgebra_iff_isAcyclic k Q
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/Quiver/Acyclic/PathAlgebra.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Acyclic/PathAlgebra.lean
@@ -37,11 +37,8 @@ module of its own: the path algebra itself needs nothing from the theory of acyc
 
 ## References
 
-This file implements the finite-dimensionality part of Layer 0 of
-`TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md`, whose statement is that
-`kQ` is finite-dimensional exactly when `Q` has finitely many paths, the extensional form of
-being finite and acyclic. See Assem--Simson--Skowroński, *Elements of the Representation Theory of
-Associative Algebras I*, Ch. II.
+See Assem--Simson--Skowroński, *Elements of the Representation Theory of Associative Algebras I*,
+Ch. II.
 -/
 
 public section

--- a/TauCeti/RepresentationTheory/Quiver/Acyclic/PathAlgebra.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Acyclic/PathAlgebra.lean
@@ -15,6 +15,13 @@ A finite quiver with finitely many arrows between any two vertices has finitely 
 is acyclic, and the paths are a basis of its path algebra; so the path algebra of such a quiver is
 finite-dimensional over a division ring.
 
+Acyclicity is not merely sufficient but **necessary**: an oriented cycle contributes its infinitely
+many powers to the path basis, so a path algebra that is a finite module over a nonzero base ring
+has no oriented cycle, whatever the quiver. For a finite quiver with finite arrow types the two
+conditions therefore agree, and finite-dimensionality of `kQ` *is* acyclicity of `Q`. The loop
+quiver is the boundary case, where the path algebra is the polynomial ring and
+`TauCeti.not_finiteDimensional_pathAlgebra_oneLoop` records the failure directly.
+
 This is the only place the generic path algebra of
 `TauCeti.RepresentationTheory.Quiver.PathAlgebra.Basic` meets acyclicity, which is why it is a
 module of its own: the path algebra itself needs nothing from the theory of acyclic quivers.
@@ -23,12 +30,18 @@ module of its own: the path algebra itself needs nothing from the theory of acyc
 
 * `TauCeti.finiteDimensional_pathAlgebra_of_isAcyclic`: the path algebra of a finite acyclic
   quiver with finite arrow types is finite-dimensional.
+* `TauCeti.isAcyclic_of_module_finite_pathAlgebra`: **a path algebra that is a finite module over
+  a nonzero base ring comes from an acyclic quiver**, with no finiteness assumed of the quiver.
+* `TauCeti.finiteDimensional_pathAlgebra_iff_isAcyclic`: the two together, for a finite quiver
+  with finite arrow types over a division ring.
 
 ## References
 
-This file implements the finite-dimensionality half of the path-algebra part of Layer 0 of
-`TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md`. See Assem--Simson--
-Skowroński, *Elements of the Representation Theory of Associative Algebras I*, Ch. II.
+This file implements the finite-dimensionality part of Layer 0 of
+`TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md`, whose statement is that
+`kQ` is finite-dimensional exactly when `Q` has finitely many paths, the extensional form of
+being finite and acyclic. See Assem--Simson--Skowroński, *Elements of the Representation Theory of
+Associative Algebras I*, Ch. II.
 -/
 
 public section
@@ -45,5 +58,22 @@ theorem finiteDimensional_pathAlgebra_of_isAcyclic (k : Type w) (Q : Type u) [Di
     FiniteDimensional k (pathAlgebra k Q) :=
   letI := finite_paths_of_isAcyclic h
   module_finite_pathAlgebra k Q
+
+/-- **A finite path algebra comes from an acyclic quiver.**  Over a nonzero base ring the paths are
+a basis, so finitely many of them are available; an oriented cycle would already contribute its
+infinitely many powers.  Neither the vertices nor the arrows are assumed finite: it is the path
+algebra that carries the finiteness. -/
+theorem isAcyclic_of_module_finite_pathAlgebra (k : Type w) (Q : Type u) [Semiring k]
+    [Nontrivial k] [Quiver.{v} Q] (h : Module.Finite k (pathAlgebra k Q)) :
+    Quiver.IsAcyclic Q :=
+  isAcyclic_of_finite_paths ((module_finite_pathAlgebra_iff k Q).mp h)
+
+/-- **Finite-dimensionality of the path algebra is acyclicity of the quiver**, for a finite quiver
+with finite arrow types over a division ring.  This is the extensional reading of "no oriented
+cycle" that the finite-dimensional-algebra theory of a quiver runs on. -/
+theorem finiteDimensional_pathAlgebra_iff_isAcyclic (k : Type w) (Q : Type u) [DivisionRing k]
+    [Quiver.{v} Q] [Finite Q] [∀ a b : Q, Finite (a ⟶ b)] :
+    FiniteDimensional k (pathAlgebra k Q) ↔ Quiver.IsAcyclic Q :=
+  ⟨isAcyclic_of_module_finite_pathAlgebra k Q, finiteDimensional_pathAlgebra_of_isAcyclic k Q⟩
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/Quiver/PathAlgebra/Basic.lean
+++ b/TauCeti/RepresentationTheory/Quiver/PathAlgebra/Basic.lean
@@ -52,7 +52,8 @@ idempotents `e`, so left multiplication by `α` carries the `i`-component of a l
 * `TauCeti.module_finite_pathAlgebra` and `TauCeti.finrank_pathAlgebra`: `kQ` is a free module of
   rank the number of paths of `Q`, with `TauCeti.pathAlgebraBasis_repr_single` reading off the
   coordinates of a basis path and `TauCeti.linearIndependent_ofPath` recording that any
-  subfamily of the path basis stays linearly independent. The specialization to a finite acyclic
+  subfamily of the path basis stays linearly independent. Over a nonzero `k` the finiteness is an
+  equivalence, `TauCeti.module_finite_pathAlgebra_iff`; the specialization to a finite acyclic
   quiver, whose paths are finite, is `TauCeti.finiteDimensional_pathAlgebra_of_isAcyclic` in
   `TauCeti.RepresentationTheory.Quiver.Acyclic.PathAlgebra`.
 * `TauCeti.vertexIdempotent_mul_mul_vertexIdempotent`: when the trivial path is the only path from
@@ -668,6 +669,16 @@ theorem coe_pathAlgebraBasis :
 theorem module_finite_pathAlgebra [Finite (Quiver.TotalPath Q)] :
     Module.Finite k (pathAlgebra k Q) :=
   Module.Finite.of_basis (pathAlgebraBasis k Q)
+
+/-- **The path algebra is a finite module exactly when the quiver has finitely many paths**: the
+paths are a basis of it, and a free module is finite exactly when one — hence any — of its bases
+is. Over a nonzero base ring only; over the zero ring the path algebra is the zero module however
+many paths `Q` has. -/
+theorem module_finite_pathAlgebra_iff [Nontrivial k] :
+    Module.Finite k (pathAlgebra k Q) ↔ Finite (Quiver.TotalPath Q) := by
+  refine ⟨fun _ => Module.Finite.finite_basis (pathAlgebraBasis k Q), fun h => ?_⟩
+  have := h
+  exact module_finite_pathAlgebra k Q
 
 /-- **Any subfamily of the path basis is linearly independent**: the paths satisfying a predicate
 `p`, indexed by the subtype they cut out, are `k`-linearly independent in the path algebra. -/


### PR DESCRIPTION
This PR completes the finite-dimensionality item of Layer 0 of the quiver-representations
roadmap: prove that the path algebra of a quiver is a finite module exactly when the quiver is
acyclic, so far available only in the sufficient direction. The cited target is
`TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md`, Layer 0, the bullets
"Acyclicity, as a predicate" ("For a finite quiver it is equivalent to
`Finite (Σ a b : Q, Quiver.Path a b)`") and "Finite dimension"; the companion `Suggested.lean`
states the same equivalence for `finiteDimensional_pathAlgebra` ("`kQ` is finite-dimensional
exactly when there are finitely many paths, the extensional form of finite and acyclic").
`TauCeti.finite_paths_of_isAcyclic` and `TauCeti.finiteDimensional_pathAlgebra_of_isAcyclic`
already supply the forward halves; the converses are what is added here.

The mechanism is the powers of an oriented cycle. A new module
`TauCeti/Combinatorics/Quiver/LoopPower.lean` introduces `Quiver.Path.loopPow`, so that
`p.loopPow n` is the closed path that runs `n` times around a closed path `p`, with
`length_loopPow` computing its length as `n * p.length` and `loopPow_add` adding exponents. A
closed path of positive length therefore has pairwise distinct powers (`loopPow_injective`), so a
nontrivial closed path forces `Infinite (Quiver.Path a a)`
(`Quiver.Path.infinite_of_ne_nil`), and contrapositively a vertex with finitely many closed paths
carries only the trivial one (`Quiver.Path.eq_nil_of_finite`). Nothing here needs the quiver to be
finite. The loop-power API lives in Mathlib's `Quiver.Path` namespace so that it reads as dot
notation on the path, following `TauCeti/Combinatorics/Quiver/Prefunctor.lean`.

On top of that, `TauCeti.isAcyclic_of_finite_paths` says a quiver with finitely many paths is
acyclic, and `TauCeti.isAcyclic_iff_finite_paths` packages it with the existing forward direction
into the equivalence the roadmap states. Transporting it through the path basis,
`TauCeti.module_finite_pathAlgebra_iff` records that `kQ` is a finite `k`-module exactly when `Q`
has finitely many paths (over a nonzero `k`: over the zero ring `kQ` is the zero module whatever
`Q` is), `TauCeti.isAcyclic_of_module_finite_pathAlgebra` reads acyclicity off a finite path
algebra with no finiteness assumed of the quiver. The packaged equivalence is
`TauCeti.module_finite_pathAlgebra_iff_isAcyclic`, over a nonzero base semiring, and the headline
`TauCeti.finiteDimensional_pathAlgebra_iff_isAcyclic` over a division ring is read off it. The loop quiver remains the boundary case already recorded by
`TauCeti.not_finiteDimensional_pathAlgebra_oneLoop`.

No Mathlib infrastructure was vendored. The converse consumes Mathlib's
`Module.not_finite_of_infinite_basis` / `Module.Finite.finite_basis` against the existing
`TauCeti.pathAlgebraBasis`, and `Quiver.Path.eq_nil_of_length_zero`, `Quiver.Path.length_comp` and
`Quiver.Path.comp_assoc` for the powers; the three touched files gain only the new statements and
the matching module-docstring lines.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"finitedimensional-pathalgebra-iff-isacyclic"}-->

🤖 Prepared with Claude Code


