### PR TITLE
refactor(LinearAlgebra): state `congrAut` at the semilinear generality

### DIFF
--- a/TauCeti/LinearAlgebra/BilinearForm/Isometry.lean
+++ b/TauCeti/LinearAlgebra/BilinearForm/Isometry.lean
@@ -193,26 +193,26 @@ section Congr
 
 /-- Conjugation by `e` carries `Aut(M, B)` onto `Aut(M', B ∘ e⁻¹)`. -/
 private theorem map_isometryGroup (B : BilinForm R M) (e : M ≃ₗ[R] M') :
-    (isometryGroup B).map (LinearEquiv.congrAut e : _ →* _)
+    (isometryGroup B).map (LinearEquiv.autCongr e : _ →* _)
       = isometryGroup (LinearMap.BilinForm.congr e B) := by
   ext g
   simp only [Subgroup.mem_map, MonoidHom.coe_coe, mem_isometryGroup_iff]
   constructor
   · rintro ⟨a, ha, rfl⟩ x y
-    simp only [LinearEquiv.congrAut_apply, LinearMap.BilinForm.congr_apply,
+    simp only [LinearEquiv.autCongr_apply_apply, LinearMap.BilinForm.congr_apply,
       LinearEquiv.symm_apply_apply]
     exact ha _ _
-  · refine fun hg => ⟨(LinearEquiv.congrAut e).symm g, fun x y => ?_,
-      (LinearEquiv.congrAut e).apply_symm_apply g⟩
+  · refine fun hg => ⟨(LinearEquiv.autCongr e).symm g, fun x y => ?_,
+      (LinearEquiv.autCongr e).apply_symm_apply g⟩
     have := hg (e x) (e y)
-    simpa only [LinearEquiv.congrAut_symm_apply, LinearMap.BilinForm.congr_apply,
+    simpa only [LinearEquiv.autCongr_symm_apply_apply, LinearMap.BilinForm.congr_apply,
       LinearEquiv.symm_apply_apply] using this
 
 /-- Transporting a bilinear form along a linear equivalence transports its isometry group:
 conjugation by `e : M ≃ₗ[R] M'` carries `Aut(M, B)` onto `Aut(M', B ∘ e⁻¹)`. -/
 def isometryGroupCongr (B : BilinForm R M) (e : M ≃ₗ[R] M') :
     isometryGroup B ≃* isometryGroup (LinearMap.BilinForm.congr e B) :=
-  ((LinearEquiv.congrAut e).subgroupMap _).trans
+  ((LinearEquiv.autCongr e).subgroupMap _).trans
     (MulEquiv.subgroupCongr (map_isometryGroup B e))
 
 @[simp]

--- a/TauCeti/LinearAlgebra/BilinearForm/Isometry.lean
+++ b/TauCeti/LinearAlgebra/BilinearForm/Isometry.lean
@@ -193,26 +193,26 @@ section Congr
 
 /-- Conjugation by `e` carries `Aut(M, B)` onto `Aut(M', B ∘ e⁻¹)`. -/
 private theorem map_isometryGroup (B : BilinForm R M) (e : M ≃ₗ[R] M') :
-    (isometryGroup B).map (LinearEquiv.autCongr e : _ →* _)
+    (isometryGroup B).map (LinearEquiv.congrAut e : _ →* _)
       = isometryGroup (LinearMap.BilinForm.congr e B) := by
   ext g
   simp only [Subgroup.mem_map, MonoidHom.coe_coe, mem_isometryGroup_iff]
   constructor
   · rintro ⟨a, ha, rfl⟩ x y
-    simp only [LinearEquiv.autCongr_apply_apply, LinearMap.BilinForm.congr_apply,
+    simp only [LinearEquiv.congrAut_apply, LinearMap.BilinForm.congr_apply,
       LinearEquiv.symm_apply_apply]
     exact ha _ _
-  · refine fun hg => ⟨(LinearEquiv.autCongr e).symm g, fun x y => ?_,
-      (LinearEquiv.autCongr e).apply_symm_apply g⟩
+  · refine fun hg => ⟨(LinearEquiv.congrAut e).symm g, fun x y => ?_,
+      (LinearEquiv.congrAut e).apply_symm_apply g⟩
     have := hg (e x) (e y)
-    simpa only [LinearEquiv.autCongr_symm_apply_apply, LinearMap.BilinForm.congr_apply,
+    simpa only [LinearEquiv.congrAut_symm_apply, LinearMap.BilinForm.congr_apply,
       LinearEquiv.symm_apply_apply] using this
 
 /-- Transporting a bilinear form along a linear equivalence transports its isometry group:
 conjugation by `e : M ≃ₗ[R] M'` carries `Aut(M, B)` onto `Aut(M', B ∘ e⁻¹)`. -/
 def isometryGroupCongr (B : BilinForm R M) (e : M ≃ₗ[R] M') :
     isometryGroup B ≃* isometryGroup (LinearMap.BilinForm.congr e B) :=
-  ((LinearEquiv.autCongr e).subgroupMap _).trans
+  ((LinearEquiv.congrAut e).subgroupMap _).trans
     (MulEquiv.subgroupCongr (map_isometryGroup B e))
 
 @[simp]

--- a/TauCeti/LinearAlgebra/GeneralLinearGroup/Congr.lean
+++ b/TauCeti/LinearAlgebra/GeneralLinearGroup/Congr.lean
@@ -15,7 +15,7 @@ Mathlib conjugates general linear groups with
 the automorphisms `M ≃ₗ[R] M` through `LinearMap.GeneralLinearGroup.generalLinearEquiv`. Groups of
 linear automorphisms cut out by a structure they preserve — an orthogonal group, an isometry
 group — are subgroups of `M ≃ₗ[R] M` rather than of `GL R M`, so what they need is the composite of
-those two, which this file records as `TauCeti.LinearEquiv.congrAut`.
+those two, which this file records as `LinearEquiv.autCongr`.
 
 Conjugation needs no more than a semilinear equivalence, which is the generality
 `congrLinearEquiv` already supplies: `e : M₁ ≃ₛₗ[σ₁₂] M₂` carries `R₁`-automorphisms of `M₁` to
@@ -25,8 +25,15 @@ identity on `R₂` — and it is the latter that makes the conjugate `R₂`-line
 
 ## Main definitions
 
-* `TauCeti.LinearEquiv.congrAut`: conjugation by `e : M₁ ≃ₛₗ[σ₁₂] M₂`, as an isomorphism
+* `LinearEquiv.autCongr`: conjugation by `e : M₁ ≃ₛₗ[σ₁₂] M₂`, as an isomorphism
   `(M₁ ≃ₗ[R₁] M₁) ≃* (M₂ ≃ₗ[R₂] M₂)`.
+
+## Main statements
+
+* `LinearEquiv.autCongr_apply` and `LinearEquiv.autCongr_symm_apply`: conjugation and its inverse
+  as equalities of linear equivalences, for consumers that read the conjugate as a map rather than
+  at a point. The pointwise `autCongr_apply_apply` and `autCongr_symm_apply_apply` are the same
+  facts evaluated at `m`.
 -/
 
 public section
@@ -46,7 +53,7 @@ variable {R M : Type*} [Semiring R] [AddCommMonoid M] [Module R M]
 
 Mathlib records how `generalLinearEquiv` computes on coercions (`coeFn_generalLinearEquiv`,
 `coe_toLinearEquiv`) rather than at the level of `M ≃ₗ[R] M`, so both evaluation lemmas for
-`congrAut` below need this bridge; it is stated once here. -/
+`autCongr` below need this bridge; it is stated once here. -/
 private theorem toLinearEquiv_generalLinearEquiv_symm (f : M ≃ₗ[R] M) :
     ((generalLinearEquiv R M).symm f).toLinearEquiv = f := by
   ext m
@@ -66,25 +73,46 @@ groups: Mathlib's `LinearMap.GeneralLinearGroup.congrLinearEquiv` read through
 `LinearMap.GeneralLinearGroup.generalLinearEquiv`.
 
 The two evaluation lemmas below are its characteristic API. -/
-def congrAut (e : M₁ ≃ₛₗ[σ₁₂] M₂) : (M₁ ≃ₗ[R₁] M₁) ≃* (M₂ ≃ₗ[R₂] M₂) :=
+def _root_.LinearEquiv.autCongr (e : M₁ ≃ₛₗ[σ₁₂] M₂) : (M₁ ≃ₗ[R₁] M₁) ≃* (M₂ ≃ₗ[R₂] M₂) :=
   ((generalLinearEquiv R₁ M₁).symm.trans (congrLinearEquiv e)).trans (generalLinearEquiv R₂ M₂)
 
 /-- Conjugating `f` by `e` sends `m` to `e (f (e.symm m))`. -/
 @[simp]
-theorem congrAut_apply (e : M₁ ≃ₛₗ[σ₁₂] M₂) (f : M₁ ≃ₗ[R₁] M₁) (m : M₂) :
-    congrAut e f m = e (f (e.symm m)) := by
-  rw [congrAut, MulEquiv.trans_apply, MulEquiv.trans_apply]
+theorem _root_.LinearEquiv.autCongr_apply_apply (e : M₁ ≃ₛₗ[σ₁₂] M₂) (f : M₁ ≃ₗ[R₁] M₁) (m : M₂) :
+    LinearEquiv.autCongr e f m = e (f (e.symm m)) := by
+  rw [LinearEquiv.autCongr, MulEquiv.trans_apply, MulEquiv.trans_apply]
   simp only [congrLinearEquiv_apply, coeFn_generalLinearEquiv, coe_ofLinearEquiv,
     LinearEquiv.trans_apply, toLinearEquiv_generalLinearEquiv_symm]
 
 /-- Inverse conjugation by `e` sends `m` to `e.symm (g (e m))`. -/
 @[simp]
-theorem congrAut_symm_apply (e : M₁ ≃ₛₗ[σ₁₂] M₂) (g : M₂ ≃ₗ[R₂] M₂) (m : M₁) :
-    (congrAut e).symm g m = e.symm (g (e m)) := by
-  rw [congrAut, MulEquiv.symm_trans_apply, MulEquiv.symm_trans_apply, congrLinearEquiv_symm]
+theorem _root_.LinearEquiv.autCongr_symm_apply_apply (e : M₁ ≃ₛₗ[σ₁₂] M₂) (g : M₂ ≃ₗ[R₂] M₂)
+    (m : M₁) :
+    (LinearEquiv.autCongr e).symm g m = e.symm (g (e m)) := by
+  rw [LinearEquiv.autCongr, MulEquiv.symm_trans_apply, MulEquiv.symm_trans_apply,
+    congrLinearEquiv_symm]
   simp only [congrLinearEquiv_apply, MulEquiv.symm_symm, coeFn_generalLinearEquiv,
     coe_ofLinearEquiv, LinearEquiv.symm_symm, LinearEquiv.trans_apply,
     toLinearEquiv_generalLinearEquiv_symm]
+
+/-- Conjugation by `e`, as an equality of linear equivalences: `autCongr e f` is `f` precomposed
+with `e.symm` and postcomposed with `e`. Structural consumers — determinants, traces, anything
+reading the conjugate as a map rather than at a point — want this form. -/
+-- Not `@[simp]`: the pointwise `autCongr_apply_apply` is the simp normal form here, and rewriting
+-- `autCongr e f` to the composite first would leave that lemma unable to fire.
+theorem _root_.LinearEquiv.autCongr_apply (e : M₁ ≃ₛₗ[σ₁₂] M₂) (f : M₁ ≃ₗ[R₁] M₁) :
+    LinearEquiv.autCongr e f = (e.symm.trans f).trans e :=
+  LinearEquiv.ext fun m ↦ LinearEquiv.autCongr_apply_apply e f m
+
+/-- Inverse conjugation by `e`, as an equality of linear equivalences.
+
+Proved by characterising the inverse rather than by unfolding `autCongr` a second time: applying
+`autCongr e` to both sides reduces it to `autCongr_apply`, so the coercion transport across
+`toLinearEquiv` happens once, in `autCongr_apply_apply`, and not again here. -/
+theorem _root_.LinearEquiv.autCongr_symm_apply (e : M₁ ≃ₛₗ[σ₁₂] M₂) (g : M₂ ≃ₗ[R₂] M₂) :
+    (LinearEquiv.autCongr e).symm g = (e.trans g).trans e.symm := by
+  rw [MulEquiv.symm_apply_eq, LinearEquiv.autCongr_apply]
+  exact LinearEquiv.ext fun m ↦ by simp
 
 end Semilinear
 

--- a/TauCeti/LinearAlgebra/GeneralLinearGroup/Congr.lean
+++ b/TauCeti/LinearAlgebra/GeneralLinearGroup/Congr.lean
@@ -104,11 +104,11 @@ theorem _root_.LinearEquiv.autCongr_apply (e : M₁ ≃ₛₗ[σ₁₂] M₂) (f
     LinearEquiv.autCongr e f = (e.symm.trans f).trans e :=
   LinearEquiv.ext fun m ↦ LinearEquiv.autCongr_apply_apply e f m
 
-/-- Inverse conjugation by `e`, as an equality of linear equivalences.
-
-Proved by characterising the inverse rather than by unfolding `autCongr` a second time: applying
-`autCongr e` to both sides reduces it to `autCongr_apply`, so the coercion transport across
-`toLinearEquiv` happens once, in `autCongr_apply_apply`, and not again here. -/
+/-- Inverse conjugation by `e`, as an equality of linear equivalences: `(autCongr e).symm g` is `g`
+precomposed with `e` and postcomposed with `e.symm`. -/
+-- Proved by characterising the inverse rather than unfolding `autCongr` a second time: applying
+-- `autCongr e` to both sides reduces it to `autCongr_apply`, so the coercion transport across
+-- `toLinearEquiv` happens once, in `autCongr_apply_apply`, and not again here.
 theorem _root_.LinearEquiv.autCongr_symm_apply (e : M₁ ≃ₛₗ[σ₁₂] M₂) (g : M₂ ≃ₗ[R₂] M₂) :
     (LinearEquiv.autCongr e).symm g = (e.trans g).trans e.symm := by
   rw [MulEquiv.symm_apply_eq, LinearEquiv.autCongr_apply]

--- a/TauCeti/LinearAlgebra/GeneralLinearGroup/Congr.lean
+++ b/TauCeti/LinearAlgebra/GeneralLinearGroup/Congr.lean
@@ -8,19 +8,25 @@ module
 public import Mathlib.LinearAlgebra.GeneralLinearGroup.Basic
 
 /-!
-# Conjugating automorphism groups along a linear equivalence
+# Conjugating automorphism groups along a semilinear equivalence
 
 Mathlib conjugates general linear groups with
-`LinearMap.GeneralLinearGroup.congrLinearEquiv : GL R M₁ ≃* GL R M₂`, and identifies `GL R M` with
+`LinearMap.GeneralLinearGroup.congrLinearEquiv : GL R₁ M₁ ≃* GL R₂ M₂`, and identifies `GL R M` with
 the automorphisms `M ≃ₗ[R] M` through `LinearMap.GeneralLinearGroup.generalLinearEquiv`. Groups of
 linear automorphisms cut out by a structure they preserve — an orthogonal group, an isometry
 group — are subgroups of `M ≃ₗ[R] M` rather than of `GL R M`, so what they need is the composite of
 those two, which this file records as `TauCeti.LinearEquiv.congrAut`.
 
+Conjugation needs no more than a semilinear equivalence, which is the generality
+`congrLinearEquiv` already supplies: `e : M₁ ≃ₛₗ[σ₁₂] M₂` carries `R₁`-automorphisms of `M₁` to
+`R₂`-automorphisms of `M₂`, the scalars travelling along `σ₁₂`. The two inverse-pair assumptions
+give a round trip on each scalar ring — `σ₂₁ ∘ σ₁₂` is the identity on `R₁` and `σ₁₂ ∘ σ₂₁` the
+identity on `R₂` — and it is the latter that makes the conjugate `R₂`-linear.
+
 ## Main definitions
 
-* `TauCeti.LinearEquiv.congrAut`: conjugation by `e : M₁ ≃ₗ[R] M₂`, as an isomorphism
-  `(M₁ ≃ₗ[R] M₁) ≃* (M₂ ≃ₗ[R] M₂)`.
+* `TauCeti.LinearEquiv.congrAut`: conjugation by `e : M₁ ≃ₛₗ[σ₁₂] M₂`, as an isomorphism
+  `(M₁ ≃ₗ[R₁] M₁) ≃* (M₂ ≃ₗ[R₂] M₂)`.
 -/
 
 public section
@@ -31,8 +37,9 @@ namespace LinearEquiv
 
 open LinearMap.GeneralLinearGroup
 
-variable {R M M₁ M₂ : Type*} [Semiring R] [AddCommMonoid M] [Module R M] [AddCommMonoid M₁]
-  [Module R M₁] [AddCommMonoid M₂] [Module R M₂]
+section Bridge
+
+variable {R M : Type*} [Semiring R] [AddCommMonoid M] [Module R M]
 
 /-- The linear automorphism underlying the general linear group element
 `(generalLinearEquiv R M).symm f` is `f` itself.
@@ -46,17 +53,25 @@ private theorem toLinearEquiv_generalLinearEquiv_symm (f : M ≃ₗ[R] M) :
   rw [coe_toLinearEquiv, ← coeFn_generalLinearEquiv]
   exact DFunLike.congr_fun ((generalLinearEquiv R M).apply_symm_apply f) m
 
-/-- Conjugation by a linear equivalence `e : M₁ ≃ₗ[R] M₂`, as an isomorphism of automorphism
+end Bridge
+
+section Semilinear
+
+variable {R₁ R₂ M₁ M₂ : Type*} [Semiring R₁] [Semiring R₂]
+  [AddCommMonoid M₁] [Module R₁ M₁] [AddCommMonoid M₂] [Module R₂ M₂]
+  {σ₁₂ : R₁ →+* R₂} {σ₂₁ : R₂ →+* R₁} [RingHomInvPair σ₁₂ σ₂₁] [RingHomInvPair σ₂₁ σ₁₂]
+
+/-- Conjugation by a semilinear equivalence `e : M₁ ≃ₛₗ[σ₁₂] M₂`, as an isomorphism of automorphism
 groups: Mathlib's `LinearMap.GeneralLinearGroup.congrLinearEquiv` read through
 `LinearMap.GeneralLinearGroup.generalLinearEquiv`.
 
 The two evaluation lemmas below are its characteristic API. -/
-def congrAut (e : M₁ ≃ₗ[R] M₂) : (M₁ ≃ₗ[R] M₁) ≃* (M₂ ≃ₗ[R] M₂) :=
-  ((generalLinearEquiv R M₁).symm.trans (congrLinearEquiv e)).trans (generalLinearEquiv R M₂)
+def congrAut (e : M₁ ≃ₛₗ[σ₁₂] M₂) : (M₁ ≃ₗ[R₁] M₁) ≃* (M₂ ≃ₗ[R₂] M₂) :=
+  ((generalLinearEquiv R₁ M₁).symm.trans (congrLinearEquiv e)).trans (generalLinearEquiv R₂ M₂)
 
 /-- Conjugating `f` by `e` sends `m` to `e (f (e.symm m))`. -/
 @[simp]
-theorem congrAut_apply (e : M₁ ≃ₗ[R] M₂) (f : M₁ ≃ₗ[R] M₁) (m : M₂) :
+theorem congrAut_apply (e : M₁ ≃ₛₗ[σ₁₂] M₂) (f : M₁ ≃ₗ[R₁] M₁) (m : M₂) :
     congrAut e f m = e (f (e.symm m)) := by
   rw [congrAut, MulEquiv.trans_apply, MulEquiv.trans_apply]
   simp only [congrLinearEquiv_apply, coeFn_generalLinearEquiv, coe_ofLinearEquiv,
@@ -64,12 +79,14 @@ theorem congrAut_apply (e : M₁ ≃ₗ[R] M₂) (f : M₁ ≃ₗ[R] M₁) (m : 
 
 /-- Inverse conjugation by `e` sends `m` to `e.symm (g (e m))`. -/
 @[simp]
-theorem congrAut_symm_apply (e : M₁ ≃ₗ[R] M₂) (g : M₂ ≃ₗ[R] M₂) (m : M₁) :
+theorem congrAut_symm_apply (e : M₁ ≃ₛₗ[σ₁₂] M₂) (g : M₂ ≃ₗ[R₂] M₂) (m : M₁) :
     (congrAut e).symm g m = e.symm (g (e m)) := by
   rw [congrAut, MulEquiv.symm_trans_apply, MulEquiv.symm_trans_apply, congrLinearEquiv_symm]
   simp only [congrLinearEquiv_apply, MulEquiv.symm_symm, coeFn_generalLinearEquiv,
     coe_ofLinearEquiv, LinearEquiv.symm_symm, LinearEquiv.trans_apply,
     toLinearEquiv_generalLinearEquiv_symm]
+
+end Semilinear
 
 end LinearEquiv
 

--- a/TauCeti/LinearAlgebra/GeneralLinearGroup/Congr.lean
+++ b/TauCeti/LinearAlgebra/GeneralLinearGroup/Congr.lean
@@ -15,7 +15,7 @@ Mathlib conjugates general linear groups with
 the automorphisms `M ≃ₗ[R] M` through `LinearMap.GeneralLinearGroup.generalLinearEquiv`. Groups of
 linear automorphisms cut out by a structure they preserve — an orthogonal group, an isometry
 group — are subgroups of `M ≃ₗ[R] M` rather than of `GL R M`, so what they need is the composite of
-those two, which this file records as `TauCeti.LinearEquiv.autCongr`.
+those two, which this file records as `TauCeti.LinearEquiv.congrAut`.
 
 Conjugation needs no more than a semilinear equivalence, which is the generality
 `congrLinearEquiv` already supplies: `e : M₁ ≃ₛₗ[σ₁₂] M₂` carries `R₁`-automorphisms of `M₁` to
@@ -25,7 +25,7 @@ identity on `R₂` — and it is the latter that makes the conjugate `R₂`-line
 
 ## Main definitions
 
-* `TauCeti.LinearEquiv.autCongr`: conjugation by `e : M₁ ≃ₛₗ[σ₁₂] M₂`, as an isomorphism
+* `TauCeti.LinearEquiv.congrAut`: conjugation by `e : M₁ ≃ₛₗ[σ₁₂] M₂`, as an isomorphism
   `(M₁ ≃ₗ[R₁] M₁) ≃* (M₂ ≃ₗ[R₂] M₂)`.
 -/
 
@@ -46,7 +46,7 @@ variable {R M : Type*} [Semiring R] [AddCommMonoid M] [Module R M]
 
 Mathlib records how `generalLinearEquiv` computes on coercions (`coeFn_generalLinearEquiv`,
 `coe_toLinearEquiv`) rather than at the level of `M ≃ₗ[R] M`, so both evaluation lemmas for
-`autCongr` below need this bridge; it is stated once here. -/
+`congrAut` below need this bridge; it is stated once here. -/
 private theorem toLinearEquiv_generalLinearEquiv_symm (f : M ≃ₗ[R] M) :
     ((generalLinearEquiv R M).symm f).toLinearEquiv = f := by
   ext m
@@ -66,22 +66,22 @@ groups: Mathlib's `LinearMap.GeneralLinearGroup.congrLinearEquiv` read through
 `LinearMap.GeneralLinearGroup.generalLinearEquiv`.
 
 The two evaluation lemmas below are its characteristic API. -/
-def autCongr (e : M₁ ≃ₛₗ[σ₁₂] M₂) : (M₁ ≃ₗ[R₁] M₁) ≃* (M₂ ≃ₗ[R₂] M₂) :=
+def congrAut (e : M₁ ≃ₛₗ[σ₁₂] M₂) : (M₁ ≃ₗ[R₁] M₁) ≃* (M₂ ≃ₗ[R₂] M₂) :=
   ((generalLinearEquiv R₁ M₁).symm.trans (congrLinearEquiv e)).trans (generalLinearEquiv R₂ M₂)
 
 /-- Conjugating `f` by `e` sends `m` to `e (f (e.symm m))`. -/
 @[simp]
-theorem autCongr_apply_apply (e : M₁ ≃ₛₗ[σ₁₂] M₂) (f : M₁ ≃ₗ[R₁] M₁) (m : M₂) :
-    autCongr e f m = e (f (e.symm m)) := by
-  rw [autCongr, MulEquiv.trans_apply, MulEquiv.trans_apply]
+theorem congrAut_apply (e : M₁ ≃ₛₗ[σ₁₂] M₂) (f : M₁ ≃ₗ[R₁] M₁) (m : M₂) :
+    congrAut e f m = e (f (e.symm m)) := by
+  rw [congrAut, MulEquiv.trans_apply, MulEquiv.trans_apply]
   simp only [congrLinearEquiv_apply, coeFn_generalLinearEquiv, coe_ofLinearEquiv,
     LinearEquiv.trans_apply, toLinearEquiv_generalLinearEquiv_symm]
 
 /-- Inverse conjugation by `e` sends `m` to `e.symm (g (e m))`. -/
 @[simp]
-theorem autCongr_symm_apply_apply (e : M₁ ≃ₛₗ[σ₁₂] M₂) (g : M₂ ≃ₗ[R₂] M₂) (m : M₁) :
-    (autCongr e).symm g m = e.symm (g (e m)) := by
-  rw [autCongr, MulEquiv.symm_trans_apply, MulEquiv.symm_trans_apply, congrLinearEquiv_symm]
+theorem congrAut_symm_apply (e : M₁ ≃ₛₗ[σ₁₂] M₂) (g : M₂ ≃ₗ[R₂] M₂) (m : M₁) :
+    (congrAut e).symm g m = e.symm (g (e m)) := by
+  rw [congrAut, MulEquiv.symm_trans_apply, MulEquiv.symm_trans_apply, congrLinearEquiv_symm]
   simp only [congrLinearEquiv_apply, MulEquiv.symm_symm, coeFn_generalLinearEquiv,
     coe_ofLinearEquiv, LinearEquiv.symm_symm, LinearEquiv.trans_apply,
     toLinearEquiv_generalLinearEquiv_symm]

--- a/TauCeti/LinearAlgebra/GeneralLinearGroup/Congr.lean
+++ b/TauCeti/LinearAlgebra/GeneralLinearGroup/Congr.lean
@@ -15,7 +15,7 @@ Mathlib conjugates general linear groups with
 the automorphisms `M ≃ₗ[R] M` through `LinearMap.GeneralLinearGroup.generalLinearEquiv`. Groups of
 linear automorphisms cut out by a structure they preserve — an orthogonal group, an isometry
 group — are subgroups of `M ≃ₗ[R] M` rather than of `GL R M`, so what they need is the composite of
-those two, which this file records as `TauCeti.LinearEquiv.congrAut`.
+those two, which this file records as `TauCeti.LinearEquiv.autCongr`.
 
 Conjugation needs no more than a semilinear equivalence, which is the generality
 `congrLinearEquiv` already supplies: `e : M₁ ≃ₛₗ[σ₁₂] M₂` carries `R₁`-automorphisms of `M₁` to
@@ -25,7 +25,7 @@ identity on `R₂` — and it is the latter that makes the conjugate `R₂`-line
 
 ## Main definitions
 
-* `TauCeti.LinearEquiv.congrAut`: conjugation by `e : M₁ ≃ₛₗ[σ₁₂] M₂`, as an isomorphism
+* `TauCeti.LinearEquiv.autCongr`: conjugation by `e : M₁ ≃ₛₗ[σ₁₂] M₂`, as an isomorphism
   `(M₁ ≃ₗ[R₁] M₁) ≃* (M₂ ≃ₗ[R₂] M₂)`.
 -/
 
@@ -46,7 +46,7 @@ variable {R M : Type*} [Semiring R] [AddCommMonoid M] [Module R M]
 
 Mathlib records how `generalLinearEquiv` computes on coercions (`coeFn_generalLinearEquiv`,
 `coe_toLinearEquiv`) rather than at the level of `M ≃ₗ[R] M`, so both evaluation lemmas for
-`congrAut` below need this bridge; it is stated once here. -/
+`autCongr` below need this bridge; it is stated once here. -/
 private theorem toLinearEquiv_generalLinearEquiv_symm (f : M ≃ₗ[R] M) :
     ((generalLinearEquiv R M).symm f).toLinearEquiv = f := by
   ext m
@@ -66,22 +66,22 @@ groups: Mathlib's `LinearMap.GeneralLinearGroup.congrLinearEquiv` read through
 `LinearMap.GeneralLinearGroup.generalLinearEquiv`.
 
 The two evaluation lemmas below are its characteristic API. -/
-def congrAut (e : M₁ ≃ₛₗ[σ₁₂] M₂) : (M₁ ≃ₗ[R₁] M₁) ≃* (M₂ ≃ₗ[R₂] M₂) :=
+def autCongr (e : M₁ ≃ₛₗ[σ₁₂] M₂) : (M₁ ≃ₗ[R₁] M₁) ≃* (M₂ ≃ₗ[R₂] M₂) :=
   ((generalLinearEquiv R₁ M₁).symm.trans (congrLinearEquiv e)).trans (generalLinearEquiv R₂ M₂)
 
 /-- Conjugating `f` by `e` sends `m` to `e (f (e.symm m))`. -/
 @[simp]
-theorem congrAut_apply (e : M₁ ≃ₛₗ[σ₁₂] M₂) (f : M₁ ≃ₗ[R₁] M₁) (m : M₂) :
-    congrAut e f m = e (f (e.symm m)) := by
-  rw [congrAut, MulEquiv.trans_apply, MulEquiv.trans_apply]
+theorem autCongr_apply_apply (e : M₁ ≃ₛₗ[σ₁₂] M₂) (f : M₁ ≃ₗ[R₁] M₁) (m : M₂) :
+    autCongr e f m = e (f (e.symm m)) := by
+  rw [autCongr, MulEquiv.trans_apply, MulEquiv.trans_apply]
   simp only [congrLinearEquiv_apply, coeFn_generalLinearEquiv, coe_ofLinearEquiv,
     LinearEquiv.trans_apply, toLinearEquiv_generalLinearEquiv_symm]
 
 /-- Inverse conjugation by `e` sends `m` to `e.symm (g (e m))`. -/
 @[simp]
-theorem congrAut_symm_apply (e : M₁ ≃ₛₗ[σ₁₂] M₂) (g : M₂ ≃ₗ[R₂] M₂) (m : M₁) :
-    (congrAut e).symm g m = e.symm (g (e m)) := by
-  rw [congrAut, MulEquiv.symm_trans_apply, MulEquiv.symm_trans_apply, congrLinearEquiv_symm]
+theorem autCongr_symm_apply_apply (e : M₁ ≃ₛₗ[σ₁₂] M₂) (g : M₂ ≃ₗ[R₂] M₂) (m : M₁) :
+    (autCongr e).symm g m = e.symm (g (e m)) := by
+  rw [autCongr, MulEquiv.symm_trans_apply, MulEquiv.symm_trans_apply, congrLinearEquiv_symm]
   simp only [congrLinearEquiv_apply, MulEquiv.symm_symm, coeFn_generalLinearEquiv,
     coe_ofLinearEquiv, LinearEquiv.symm_symm, LinearEquiv.trans_apply,
     toLinearEquiv_generalLinearEquiv_symm]

--- a/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
@@ -183,7 +183,7 @@ variable {M₁ : Type*} {M₂ : Type*} [AddCommMonoid M₁] [Module R M₁] [Add
 
 /-- Conjugation by an isometric equivalence carries `O(Q₁)` onto `O(Q₂)`. -/
 private theorem map_orthogonalGroup (e : Q₁.IsometryEquiv Q₂) :
-    (orthogonalGroup Q₁).map (LinearEquiv.autCongr e.toLinearEquiv : _ →* _)
+    (orthogonalGroup Q₁).map (LinearEquiv.congrAut e.toLinearEquiv : _ →* _)
       = orthogonalGroup Q₂ := by
   have key : ∀ x : M₁, Q₂ (e.toLinearEquiv x) = Q₁ x := e.map_app
   have key' : ∀ x : M₂, Q₁ (e.toLinearEquiv.symm x) = Q₂ x := fun x => by
@@ -192,10 +192,10 @@ private theorem map_orthogonalGroup (e : Q₁.IsometryEquiv Q₂) :
   simp only [Subgroup.mem_map, MonoidHom.coe_coe, mem_orthogonalGroup_iff]
   constructor
   · rintro ⟨f, hf, rfl⟩ m
-    rw [LinearEquiv.autCongr_apply_apply, key, hf, key']
-  · refine fun hg => ⟨(LinearEquiv.autCongr e.toLinearEquiv).symm g, fun m => ?_,
-      (LinearEquiv.autCongr e.toLinearEquiv).apply_symm_apply g⟩
-    rw [LinearEquiv.autCongr_symm_apply_apply, key', hg, key]
+    rw [LinearEquiv.congrAut_apply, key, hf, key']
+  · refine fun hg => ⟨(LinearEquiv.congrAut e.toLinearEquiv).symm g, fun m => ?_,
+      (LinearEquiv.congrAut e.toLinearEquiv).apply_symm_apply g⟩
+    rw [LinearEquiv.congrAut_symm_apply, key', hg, key]
 
 /-- Isometric quadratic maps have isomorphic orthogonal groups: conjugation by an isometric
 equivalence `e : Q₁ ≃qᵢ Q₂` carries `O(Q₁)` onto `O(Q₂)`.
@@ -204,20 +204,20 @@ Over an algebraically closed field every nondegenerate quadratic form of a given
 to every other, so this is what makes `O(Q)` depend on the rank alone. -/
 def orthogonalGroupCongr (e : Q₁.IsometryEquiv Q₂) :
     orthogonalGroup Q₁ ≃* orthogonalGroup Q₂ :=
-  ((LinearEquiv.autCongr e.toLinearEquiv).subgroupMap _).trans
+  ((LinearEquiv.congrAut e.toLinearEquiv).subgroupMap _).trans
     (MulEquiv.subgroupCongr (map_orthogonalGroup e))
 
 @[simp]
 theorem coe_orthogonalGroupCongr_apply (e : Q₁.IsometryEquiv Q₂) (f : orthogonalGroup Q₁) (m : M₂) :
     (orthogonalGroupCongr e f : M₂ ≃ₗ[R] M₂) m
       = e.toLinearEquiv ((f : M₁ ≃ₗ[R] M₁) (e.toLinearEquiv.symm m)) := by
-  simp [orthogonalGroupCongr, LinearEquiv.autCongr_apply_apply]
+  simp [orthogonalGroupCongr, LinearEquiv.congrAut_apply]
 
 @[simp]
 theorem coe_orthogonalGroupCongr_symm_apply (e : Q₁.IsometryEquiv Q₂) (g : orthogonalGroup Q₂)
     (m : M₁) : ((orthogonalGroupCongr e).symm g : M₁ ≃ₗ[R] M₁) m
       = e.toLinearEquiv.symm ((g : M₂ ≃ₗ[R] M₂) (e.toLinearEquiv m)) := by
-  simp [orthogonalGroupCongr, LinearEquiv.autCongr_symm_apply_apply]
+  simp [orthogonalGroupCongr, LinearEquiv.congrAut_symm_apply]
 
 end Congr
 
@@ -310,7 +310,7 @@ variable {M₁ : Type*} {M₂ : Type*} [AddCommGroup M₁] [Module R M₁]
 
 /-- Conjugation by an isometric equivalence carries `SO(Q₁)` onto `SO(Q₂)`. -/
 private theorem map_specialOrthogonalGroup (e : Q₁.IsometryEquiv Q₂) :
-    (specialOrthogonalGroup Q₁).map (LinearEquiv.autCongr e.toLinearEquiv : _ →* _) =
+    (specialOrthogonalGroup Q₁).map (LinearEquiv.congrAut e.toLinearEquiv : _ →* _) =
       specialOrthogonalGroup Q₂ := by
   ext g
   simp only [Subgroup.mem_map, MonoidHom.coe_coe, mem_specialOrthogonalGroup_iff]
@@ -318,22 +318,22 @@ private theorem map_specialOrthogonalGroup (e : Q₁.IsometryEquiv Q₂) :
   · rintro ⟨f, hf, rfl⟩
     constructor
     · exact (orthogonalGroupCongr e ⟨f, hf.1⟩).2
-    · -- Restate `autCongr` through Mathlib's special-linear congruence.
-      rw [show (LinearEquiv.autCongr e.toLinearEquiv) f =
+    · -- Restate `congrAut` through Mathlib's special-linear congruence.
+      rw [show (LinearEquiv.congrAut e.toLinearEquiv) f =
           (e.toLinearEquiv.symm.trans f).trans e.toLinearEquiv by
         ext m
-        exact LinearEquiv.autCongr_apply_apply e.toLinearEquiv f m]
+        exact LinearEquiv.congrAut_apply e.toLinearEquiv f m]
       exact (SpecialLinearGroup.congr_linearEquiv e.toLinearEquiv ⟨f, hf.2⟩).prop
   · intro hg
-    refine ⟨(LinearEquiv.autCongr e.toLinearEquiv).symm g, ?_,
-      (LinearEquiv.autCongr e.toLinearEquiv).apply_symm_apply g⟩
+    refine ⟨(LinearEquiv.congrAut e.toLinearEquiv).symm g, ?_,
+      (LinearEquiv.congrAut e.toLinearEquiv).apply_symm_apply g⟩
     constructor
     · exact ((orthogonalGroupCongr e).symm ⟨g, hg.1⟩).2
-    · -- Restate inverse `autCongr` through Mathlib's special-linear congruence.
-      rw [show (LinearEquiv.autCongr e.toLinearEquiv).symm g =
+    · -- Restate inverse `congrAut` through Mathlib's special-linear congruence.
+      rw [show (LinearEquiv.congrAut e.toLinearEquiv).symm g =
           (e.toLinearEquiv.trans g).trans e.toLinearEquiv.symm by
         ext m
-        exact LinearEquiv.autCongr_symm_apply_apply e.toLinearEquiv g m]
+        exact LinearEquiv.congrAut_symm_apply e.toLinearEquiv g m]
       exact (SpecialLinearGroup.congr_linearEquiv e.toLinearEquiv.symm ⟨g, hg.2⟩).prop
 
 /-- Isometric quadratic maps have isomorphic special orthogonal groups: conjugation by an
@@ -341,7 +341,7 @@ isometric equivalence `e : Q₁ ≃qᵢ Q₂` carries `SO(Q₁)` onto `SO(Q₂)`
 noncomputable def _root_.QuadraticMap.IsometryEquiv.specialOrthogonalGroupCongr
     (e : Q₁.IsometryEquiv Q₂) :
     specialOrthogonalGroup Q₁ ≃* specialOrthogonalGroup Q₂ :=
-  Subgroup.congrOfMapEq (LinearEquiv.autCongr e.toLinearEquiv)
+  Subgroup.congrOfMapEq (LinearEquiv.congrAut e.toLinearEquiv)
     (map_specialOrthogonalGroup e)
 
 /-- Evaluating special-orthogonal transport is conjugation by the isometry `e`. -/
@@ -352,7 +352,7 @@ theorem _root_.QuadraticMap.IsometryEquiv.coe_specialOrthogonalGroupCongr_apply
       e ((f : M₁ ≃ₗ[R] M₁) (e.symm m)) := by
   simp only [QuadraticMap.IsometryEquiv.specialOrthogonalGroupCongr,
     Subgroup.coe_congrOfMapEq_apply,
-    LinearEquiv.autCongr_apply_apply]
+    LinearEquiv.congrAut_apply]
   rfl
 
 /-- Evaluating inverse special-orthogonal transport is conjugation by the inverse isometry
@@ -364,7 +364,7 @@ theorem _root_.QuadraticMap.IsometryEquiv.coe_specialOrthogonalGroupCongr_symm_a
       e.symm ((g : M₂ ≃ₗ[R] M₂) (e m)) := by
   simp only [QuadraticMap.IsometryEquiv.specialOrthogonalGroupCongr,
     Subgroup.coe_congrOfMapEq_symm_apply,
-    LinearEquiv.autCongr_symm_apply_apply]
+    LinearEquiv.congrAut_symm_apply]
   rfl
 
 end SpecialCongr

--- a/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
@@ -183,7 +183,7 @@ variable {M₁ : Type*} {M₂ : Type*} [AddCommMonoid M₁] [Module R M₁] [Add
 
 /-- Conjugation by an isometric equivalence carries `O(Q₁)` onto `O(Q₂)`. -/
 private theorem map_orthogonalGroup (e : Q₁.IsometryEquiv Q₂) :
-    (orthogonalGroup Q₁).map (LinearEquiv.congrAut e.toLinearEquiv : _ →* _)
+    (orthogonalGroup Q₁).map (LinearEquiv.autCongr e.toLinearEquiv : _ →* _)
       = orthogonalGroup Q₂ := by
   have key : ∀ x : M₁, Q₂ (e.toLinearEquiv x) = Q₁ x := e.map_app
   have key' : ∀ x : M₂, Q₁ (e.toLinearEquiv.symm x) = Q₂ x := fun x => by
@@ -192,10 +192,10 @@ private theorem map_orthogonalGroup (e : Q₁.IsometryEquiv Q₂) :
   simp only [Subgroup.mem_map, MonoidHom.coe_coe, mem_orthogonalGroup_iff]
   constructor
   · rintro ⟨f, hf, rfl⟩ m
-    rw [LinearEquiv.congrAut_apply, key, hf, key']
-  · refine fun hg => ⟨(LinearEquiv.congrAut e.toLinearEquiv).symm g, fun m => ?_,
-      (LinearEquiv.congrAut e.toLinearEquiv).apply_symm_apply g⟩
-    rw [LinearEquiv.congrAut_symm_apply, key', hg, key]
+    rw [LinearEquiv.autCongr_apply_apply, key, hf, key']
+  · refine fun hg => ⟨(LinearEquiv.autCongr e.toLinearEquiv).symm g, fun m => ?_,
+      (LinearEquiv.autCongr e.toLinearEquiv).apply_symm_apply g⟩
+    rw [LinearEquiv.autCongr_symm_apply_apply, key', hg, key]
 
 /-- Isometric quadratic maps have isomorphic orthogonal groups: conjugation by an isometric
 equivalence `e : Q₁ ≃qᵢ Q₂` carries `O(Q₁)` onto `O(Q₂)`.
@@ -204,20 +204,20 @@ Over an algebraically closed field every nondegenerate quadratic form of a given
 to every other, so this is what makes `O(Q)` depend on the rank alone. -/
 def orthogonalGroupCongr (e : Q₁.IsometryEquiv Q₂) :
     orthogonalGroup Q₁ ≃* orthogonalGroup Q₂ :=
-  ((LinearEquiv.congrAut e.toLinearEquiv).subgroupMap _).trans
+  ((LinearEquiv.autCongr e.toLinearEquiv).subgroupMap _).trans
     (MulEquiv.subgroupCongr (map_orthogonalGroup e))
 
 @[simp]
 theorem coe_orthogonalGroupCongr_apply (e : Q₁.IsometryEquiv Q₂) (f : orthogonalGroup Q₁) (m : M₂) :
     (orthogonalGroupCongr e f : M₂ ≃ₗ[R] M₂) m
       = e.toLinearEquiv ((f : M₁ ≃ₗ[R] M₁) (e.toLinearEquiv.symm m)) := by
-  simp [orthogonalGroupCongr, LinearEquiv.congrAut_apply]
+  simp [orthogonalGroupCongr, LinearEquiv.autCongr_apply_apply]
 
 @[simp]
 theorem coe_orthogonalGroupCongr_symm_apply (e : Q₁.IsometryEquiv Q₂) (g : orthogonalGroup Q₂)
     (m : M₁) : ((orthogonalGroupCongr e).symm g : M₁ ≃ₗ[R] M₁) m
       = e.toLinearEquiv.symm ((g : M₂ ≃ₗ[R] M₂) (e.toLinearEquiv m)) := by
-  simp [orthogonalGroupCongr, LinearEquiv.congrAut_symm_apply]
+  simp [orthogonalGroupCongr, LinearEquiv.autCongr_symm_apply_apply]
 
 end Congr
 
@@ -310,7 +310,7 @@ variable {M₁ : Type*} {M₂ : Type*} [AddCommGroup M₁] [Module R M₁]
 
 /-- Conjugation by an isometric equivalence carries `SO(Q₁)` onto `SO(Q₂)`. -/
 private theorem map_specialOrthogonalGroup (e : Q₁.IsometryEquiv Q₂) :
-    (specialOrthogonalGroup Q₁).map (LinearEquiv.congrAut e.toLinearEquiv : _ →* _) =
+    (specialOrthogonalGroup Q₁).map (LinearEquiv.autCongr e.toLinearEquiv : _ →* _) =
       specialOrthogonalGroup Q₂ := by
   ext g
   simp only [Subgroup.mem_map, MonoidHom.coe_coe, mem_specialOrthogonalGroup_iff]
@@ -318,22 +318,22 @@ private theorem map_specialOrthogonalGroup (e : Q₁.IsometryEquiv Q₂) :
   · rintro ⟨f, hf, rfl⟩
     constructor
     · exact (orthogonalGroupCongr e ⟨f, hf.1⟩).2
-    · -- Restate `congrAut` through Mathlib's special-linear congruence.
-      rw [show (LinearEquiv.congrAut e.toLinearEquiv) f =
+    · -- Restate `autCongr` through Mathlib's special-linear congruence.
+      rw [show (LinearEquiv.autCongr e.toLinearEquiv) f =
           (e.toLinearEquiv.symm.trans f).trans e.toLinearEquiv by
         ext m
-        exact LinearEquiv.congrAut_apply e.toLinearEquiv f m]
+        exact LinearEquiv.autCongr_apply_apply e.toLinearEquiv f m]
       exact (SpecialLinearGroup.congr_linearEquiv e.toLinearEquiv ⟨f, hf.2⟩).prop
   · intro hg
-    refine ⟨(LinearEquiv.congrAut e.toLinearEquiv).symm g, ?_,
-      (LinearEquiv.congrAut e.toLinearEquiv).apply_symm_apply g⟩
+    refine ⟨(LinearEquiv.autCongr e.toLinearEquiv).symm g, ?_,
+      (LinearEquiv.autCongr e.toLinearEquiv).apply_symm_apply g⟩
     constructor
     · exact ((orthogonalGroupCongr e).symm ⟨g, hg.1⟩).2
-    · -- Restate inverse `congrAut` through Mathlib's special-linear congruence.
-      rw [show (LinearEquiv.congrAut e.toLinearEquiv).symm g =
+    · -- Restate inverse `autCongr` through Mathlib's special-linear congruence.
+      rw [show (LinearEquiv.autCongr e.toLinearEquiv).symm g =
           (e.toLinearEquiv.trans g).trans e.toLinearEquiv.symm by
         ext m
-        exact LinearEquiv.congrAut_symm_apply e.toLinearEquiv g m]
+        exact LinearEquiv.autCongr_symm_apply_apply e.toLinearEquiv g m]
       exact (SpecialLinearGroup.congr_linearEquiv e.toLinearEquiv.symm ⟨g, hg.2⟩).prop
 
 /-- Isometric quadratic maps have isomorphic special orthogonal groups: conjugation by an
@@ -341,7 +341,7 @@ isometric equivalence `e : Q₁ ≃qᵢ Q₂` carries `SO(Q₁)` onto `SO(Q₂)`
 noncomputable def _root_.QuadraticMap.IsometryEquiv.specialOrthogonalGroupCongr
     (e : Q₁.IsometryEquiv Q₂) :
     specialOrthogonalGroup Q₁ ≃* specialOrthogonalGroup Q₂ :=
-  Subgroup.congrOfMapEq (LinearEquiv.congrAut e.toLinearEquiv)
+  Subgroup.congrOfMapEq (LinearEquiv.autCongr e.toLinearEquiv)
     (map_specialOrthogonalGroup e)
 
 /-- Evaluating special-orthogonal transport is conjugation by the isometry `e`. -/
@@ -352,7 +352,7 @@ theorem _root_.QuadraticMap.IsometryEquiv.coe_specialOrthogonalGroupCongr_apply
       e ((f : M₁ ≃ₗ[R] M₁) (e.symm m)) := by
   simp only [QuadraticMap.IsometryEquiv.specialOrthogonalGroupCongr,
     Subgroup.coe_congrOfMapEq_apply,
-    LinearEquiv.congrAut_apply]
+    LinearEquiv.autCongr_apply_apply]
   rfl
 
 /-- Evaluating inverse special-orthogonal transport is conjugation by the inverse isometry
@@ -364,7 +364,7 @@ theorem _root_.QuadraticMap.IsometryEquiv.coe_specialOrthogonalGroupCongr_symm_a
       e.symm ((g : M₂ ≃ₗ[R] M₂) (e m)) := by
   simp only [QuadraticMap.IsometryEquiv.specialOrthogonalGroupCongr,
     Subgroup.coe_congrOfMapEq_symm_apply,
-    LinearEquiv.congrAut_symm_apply]
+    LinearEquiv.autCongr_symm_apply_apply]
   rfl
 
 end SpecialCongr

--- a/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
@@ -319,10 +319,7 @@ private theorem map_specialOrthogonalGroup (e : Q₁.IsometryEquiv Q₂) :
     constructor
     · exact (orthogonalGroupCongr e ⟨f, hf.1⟩).2
     · -- Restate `autCongr` through Mathlib's special-linear congruence.
-      rw [show (LinearEquiv.autCongr e.toLinearEquiv) f =
-          (e.toLinearEquiv.symm.trans f).trans e.toLinearEquiv by
-        ext m
-        exact LinearEquiv.autCongr_apply_apply e.toLinearEquiv f m]
+      rw [LinearEquiv.autCongr_apply]
       exact (SpecialLinearGroup.congr_linearEquiv e.toLinearEquiv ⟨f, hf.2⟩).prop
   · intro hg
     refine ⟨(LinearEquiv.autCongr e.toLinearEquiv).symm g, ?_,
@@ -330,10 +327,7 @@ private theorem map_specialOrthogonalGroup (e : Q₁.IsometryEquiv Q₂) :
     constructor
     · exact ((orthogonalGroupCongr e).symm ⟨g, hg.1⟩).2
     · -- Restate inverse `autCongr` through Mathlib's special-linear congruence.
-      rw [show (LinearEquiv.autCongr e.toLinearEquiv).symm g =
-          (e.toLinearEquiv.trans g).trans e.toLinearEquiv.symm by
-        ext m
-        exact LinearEquiv.autCongr_symm_apply_apply e.toLinearEquiv g m]
+      rw [LinearEquiv.autCongr_symm_apply]
       exact (SpecialLinearGroup.congr_linearEquiv e.toLinearEquiv.symm ⟨g, hg.2⟩).prop
 
 /-- Isometric quadratic maps have isomorphic special orthogonal groups: conjugation by an


### PR DESCRIPTION
`LinearMap.GeneralLinearGroup.congrLinearEquiv` already takes a semilinear equivalence
`e₁₂ : M₁ ≃ₛₗ[σ₁₂] M₂` and produces `GL R₁ M₁ ≃* GL R₂ M₂`. `congrAut` was the only thing narrowing
that to a single semiring, so it is restated — along with its two evaluation lemmas — for a
semilinear equivalence.

`RingHomInvPair.triples₂` supplies `RingHomCompTriple σ₂₁ σ₁₂ (RingHom.id R₂)`, that is
`σ₁₂ ∘ σ₂₁ = id` on `R₂`, which is what makes the conjugate `R₂`-linear. (The other round trip,
`σ₂₁ ∘ σ₁₂`, is the identity on `R₁`.) Existing call sites in
`LinearAlgebra/BilinearForm/Isometry.lean` and `LinearAlgebra/QuadraticForm/OrthogonalGroup.lean`
pass plain linear equivalences, which are `≃ₛₗ[RingHom.id R]`, and are unaffected.

The private `toLinearEquiv_generalLinearEquiv_symm` bridge is unchanged. It now sits in its own
`section`, so the semilinear variables are not auto-included into a declaration that does not use
them.

No new declarations, and no mathematics changes: each existing declaration keeps its proof.

### Rooted and renamed, because the ratchet couples them

`origin/main` is merged in — the branch had fallen 25 commits behind.

Following `naming`, the three declarations move to root `LinearEquiv` and take Mathlib's word order:

```
TauCeti.LinearEquiv.congrAut            → LinearEquiv.autCongr
TauCeti.LinearEquiv.congrAut_apply      → LinearEquiv.autCongr_apply_apply
TauCeti.LinearEquiv.congrAut_symm_apply → LinearEquiv.autCongr_symm_apply_apply
```

`AlgEquiv.autCongr` is the same construction one structure up, and the sibling pair
`LinearEquiv.conj_apply` / `conj_apply_apply` fixes `_apply_apply` for a statement applied twice.

The two halves had to land together. Renaming alone was tried and is red:
`scripts/lint-dot-notation-baseline.txt` grandfathers violations **by declaration name**, so
renaming in place un-grandfathers all three at once (`3 new`, "baseline entries no longer found").
Rooted, they are not flagged at all and the rename costs nothing. `lint-dot-notation`: **759 → 756,
0 new.**

Following `api-design`, the structural equalities now that root `LinearEquiv` is a lint-clean
namespace for them:

```lean
autCongr_apply      : autCongr e f = (e.symm.trans f).trans e
autCongr_symm_apply : (autCongr e).symm g = (e.trans g).trans e.symm
```

The inverse is proved by characterising it rather than unfolding `autCongr` twice:
`MulEquiv.symm_apply_eq` turns the goal into an application, which `autCongr_apply` discharges.
Neither is `@[simp]` — the pointwise forms are the simp normal form and both call-site files name
them.

These are the names and statements #6188 gives the same API, so the branches agree and whichever
lands second sees its own work already applied.

### The gate rows this produces

* `decldiff` pairs three VANISHED names with five APPEARED ones: three are the rename, two are the
  new structural lemmas. No rooting explains a rename, which is what that check means.
* `rootsurplus` reports all five as rooted-but-unflagged. The linter flags them under their **old**
  names; there is no `TauCeti.LinearEquiv.autCongr` for it to have flagged.
* `nsslice` reports `LinearEquiv` half-rooted: four declarations remain in `TauCeti.LinearEquiv`, all
  in `Algebra/Module/Lattice.lean` — the `extendOfIsLattice` family. **#6188 roots exactly those
  four**, so the namespace is split only while both PRs are open, and by whichever merges second it
  is empty.
* `slice` reports `Congr.lean` rooted 3 of 4 flagged. The fourth is
  `private toLinearEquiv_generalLinearEquiv_symm`: nothing outside the module can name it, so its
  namespace is not part of any interface — the reading `naming` accepted on #6093 and #6418 for
  private helpers.

### Provenance, and what is deliberately not here

Split out of #6188 at the request of its `scope` block: that PR carried a namespace relocation plus
two unrelated generalisations, and is now the relocation alone.

`api-design` on #6188 also asked for the structural forms (`autCongr_apply` / `autCongr_symm_apply`
there, `congrAut_eq` / `congrAut_symm_eq` in the wording of this PR's own `api-design` finding).
They are **not** in this PR. Adding them to `namespace TauCeti.LinearEquiv` introduces two new
`lint-dot-notation` violations, because their first explicit argument is a `LinearEquiv` and that
namespace is not rooted yet — #6188 is the PR that roots it. They belong in a follow-up on top of
#6188, where they can be declared in the root namespace from the start rather than added flagged and
rooted later.

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GadULQ4gpsVAZfpvs2htNt



