### PR TITLE
feat(Isogeny): the point count divides the degree of 1 - π

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/OneSubFrobenius/Kernel.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/OneSubFrobenius/Kernel.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.Frobenius.Translation
 public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.Kernel
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.OneSubFrobenius.Separable
 public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.OneSubFrobenius.TautologicalPoint
 public import TauCeti.AlgebraicGeometry.EllipticCurve.PointCount
 
@@ -31,6 +32,8 @@ the same rational point, so their difference does not move at all.
   as there are rational points.
 * `TauCeti.Isogeny.pointCount_le_degree_oneSubFrobeniusIsogeny`: consequently `deg (1 − π_q)`
   bounds `pointCount` above.
+* `TauCeti.Isogeny.pointCount_dvd_degree_oneSubFrobeniusIsogeny`: and, `1 − π_q` being
+  separable, `pointCount` divides `deg (1 − π_q)`.
 
 This is the lower half of `deg (1 − π_q) = #E(𝔽_q)`. The upper half asks in addition that the
 kernel cut out the pulled-back field exactly, and is not proved here.
@@ -90,6 +93,19 @@ theorem pointCount_le_degree_oneSubFrobeniusIsogeny :
   classical
   rw [WeierstrassCurve.pointCount_eq_card_point]
   exact (card_ker_oneSubFrobeniusIsogeny W).symm.trans_le (card_ker_le_degree _)
+
+omit [DecidableEq F] in
+/-- **The point count divides the degree of `1 − π_q`.** The kernel order always divides the
+separable degree, and `1 − π_q` is separable, so the bound above is a divisibility. Equality is
+the upper half, which is not proved here. -/
+theorem pointCount_dvd_degree_oneSubFrobeniusIsogeny :
+    W.pointCount ∣ (oneSubFrobeniusIsogeny W).degree := by
+  classical
+  have := isSeparable_oneSubFrobeniusIsogeny W
+  have h := card_ker_dvd_separableDegree (oneSubFrobeniusIsogeny W)
+  rw [separableDegree_eq_degree_of_isSeparable, card_ker_oneSubFrobeniusIsogeny] at h
+  rw [WeierstrassCurve.pointCount_eq_card_point]
+  exact h
 
 end TauCeti.Isogeny
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/OneSubFrobenius/Kernel.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/OneSubFrobenius/Kernel.lean
@@ -7,7 +7,7 @@ module
 
 public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.Frobenius.Translation
 public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.Kernel
-public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.OneSubFrobenius.Separable
+import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.OneSubFrobenius.Separable
 public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.OneSubFrobenius.TautologicalPoint
 public import TauCeti.AlgebraicGeometry.EllipticCurve.PointCount
 


### PR DESCRIPTION
Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"EllipticCurves/README.md:layer1:kernel-order-bounds"}-->

Provenance: no port. Every ingredient is already on `main`; this is the four-line consequence they were built for. AINTLIB's `HasseWeil` has no divisibility statement of this shape — its `Hasse/PointFix.lean` goes straight for the equality, and in an encoding that asserts rather than earns it (its `Isogeny` carries `pullback` and `toAddMonoidHom` as independent fields, and its Frobenius declares the point map to be the identity).

## What this adds

One theorem, in the existing `Isogeny/OneSubFrobenius/Kernel.lean`:

- `Isogeny.pointCount_dvd_degree_oneSubFrobeniusIsogeny`: `W.pointCount ∣ deg (1 − π_q)`.

It sits directly beneath `pointCount_le_degree_oneSubFrobeniusIsogeny`, which it sharpens from a bound to a divisibility.

## The argument

Three facts, all on `main`:

1. `card_ker_dvd_separableDegree` — the kernel order divides the separable degree, for every isogeny.
2. `ker_oneSubFrobeniusIsogeny` — the kernel of `1 − π_q` is every rational point, so `card_ker_oneSubFrobeniusIsogeny` identifies its order with `pointCount`.
3. `isSeparable_oneSubFrobeniusIsogeny` — `1 − π_q` is separable, so `separableDegree_eq_degree_of_isSeparable` turns the separable degree into the degree.

The only new import is `OneSubFrobenius.Separable`, for (3); `Kernel.lean` and `Separable.lean` were previously independent siblings, and this is the first result needing both.

## Scope

Still the lower half of `deg (1 − π_q) = #E(𝔽_q)`, now in its sharpest available form. The upper half is the reverse fixed-field inclusion, which #6411 pins to exactly two conditions — `K(W₁)` Galois over the pulled-back field, and every automorphism over it a translation — and is not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
