### PR TITLE
refactor(Isogeny): drop the duplicated fixed-field inclusion and correct four docstrings

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/Translation/FixedField.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/Translation/FixedField.lean
@@ -65,7 +65,7 @@ arbitrary finite subgroup of points, no isogeny being needed to state or prove t
   degree exactly when the subgroup cuts the field back out.
 * `card_translationFixingSubgroup_eq_finrank_iff_isGalois_and_forall_exists_translation`:
   equivalently, the extension is Galois and every automorphism over the field is a translation, so
-  neither condition can be weakened.
+  the two conditions together are necessary as well as sufficient.
 
 ## References
 
@@ -267,8 +267,8 @@ theorem eq_of_translationFixedField_eq [Finite Φ]
     translationFixingSubgroup_translationFixedField W Ψ]
 
 /-- **The order of the fixing subgroup of `L` divides the separable degree of `K(W)` over `L`.**
-The field the subgroup cuts out is Galois over `L`, hence separable, so its degree — the order of
-the subgroup — is one factor of the separable degree of the whole extension. -/
+`K(W)` is Galois, hence separable, over the field the subgroup cuts out, and that relative degree is
+the order of the subgroup; it is therefore one factor of the separable degree over `L`. -/
 theorem card_translationFixingSubgroup_dvd_finSepDegree (L : IntermediateField F W.FunctionField)
     [FiniteDimensional L W.FunctionField] :
     Nat.card (translationFixingSubgroup W L) ∣ Field.finSepDegree L W.FunctionField := by
@@ -328,9 +328,9 @@ theorem card_translationFixingSubgroup_eq_finrank_of_forall_exists_translation
     IsGalois.card_aut_eq_finrank]
 
 /-- **The fixing subgroup of `L` has order the degree exactly when `K(W)` is Galois over `L` and
-every automorphism over `L` is a translation.** Both hypotheses of
-`card_translationFixingSubgroup_eq_finrank_of_forall_exists_translation` are therefore necessary as
-well as sufficient, so nothing weaker will do. -/
+every automorphism over `L` is a translation.** The two hypotheses of
+`card_translationFixingSubgroup_eq_finrank_of_forall_exists_translation` are therefore jointly
+necessary as well as sufficient. -/
 theorem card_translationFixingSubgroup_eq_finrank_iff_isGalois_and_forall_exists_translation
     (L : IntermediateField F W.FunctionField) [FiniteDimensional L W.FunctionField] :
     Nat.card (translationFixingSubgroup W L) = Module.finrank L W.FunctionField ↔

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Kernel.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Kernel.lean
@@ -31,8 +31,6 @@ is proved here.
 
 ## Main results
 
-* `TauCeti.Isogeny.fieldPullback_fieldRange_le_translationFixedField_ker`: the pulled-back field is
-  fixed by the kernel.
 * `TauCeti.Isogeny.card_ker_le_degree`: the kernel has at most `deg φ` elements.
 * `TauCeti.Isogeny.ker_le_ker_comp`: postcomposition can only enlarge the kernel.
 * `TauCeti.Isogeny.ker_eq_bot_of_separableDegree_eq_one`: separable degree one forces this kernel
@@ -96,13 +94,6 @@ theorem ker_le_ker_comp {W₃ : WeierstrassCurve.Affine F} (ψ : Isogeny W₂ W�
   rintro _ ⟨z, rfl⟩
   exact AlgHom.mem_fieldRange.2 ⟨ψ.fieldPullback z, by rw [comp_fieldPullback]; rfl⟩
 
-/-- **The pulled-back field is fixed by the kernel**, the kernel's interaction with the fixed-field
-operation. This is the inclusion that holds for every isogeny; the reverse one is the content of
-`card_ker_eq_degree_iff`. -/
-theorem fieldPullback_fieldRange_le_translationFixedField_ker (φ : Isogeny W₁ W₂) :
-    φ.fieldPullback.fieldRange ≤ translationFixedField W₁ φ.ker := by
-  rw [ker_def]; exact le_translationFixedField_translationFixingSubgroup W₁ _
-
 /-- **The kernel order divides the separable degree**, the kernel being the subgroup of
 translations fixing the pulled-back field and that field having finite degree. -/
 theorem card_ker_dvd_separableDegree (φ : Isogeny W₁ W₂) :
@@ -162,8 +153,8 @@ theorem card_ker_eq_degree_of_forall_exists_translation (φ : Isogeny W₁ W₂)
 
 /-- **The kernel counts the degree exactly when `K(W₁)` is Galois over the pulled-back field and
 every automorphism over it is a translation.** So the two hypotheses of
-`card_ker_eq_degree_of_forall_exists_translation` are necessary as well as sufficient: this is the
-whole of what is left of `deg φ = #ker φ`, and nothing weaker will give it. -/
+`card_ker_eq_degree_of_forall_exists_translation` are jointly necessary as well as sufficient: this
+is what is left of `deg φ = #ker φ`. -/
 theorem card_ker_eq_degree_iff_isGalois_and_forall_exists_translation (φ : Isogeny W₁ W₂) :
     Nat.card φ.ker = φ.degree ↔
       IsGalois φ.fieldPullback.fieldRange W₁.FunctionField ∧


### PR DESCRIPTION
Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"EllipticCurves/improvement:kernel-inclusion-cleanup"}-->

Provenance: improvement work on code already on `main`. No new mathematics; one declaration removed and four docstrings corrected.

## Why these are on `main`

#6411 was stacked on #6362, and the fixes below were made on #6362 after #6411's branch had been rebased under it. #6411's own hunks in `Isogeny/Kernel.lean` restored the surrounding lines, so the squash that landed #6411 (`a6cc330fb`) carried the rest of #6362 onto `main` but not these. #6362 is closed; this is the remainder, off current `main`.

## The duplicated inclusion

`Isogeny.fieldPullback_fieldRange_le_translationFixedField_ker` states `φ^*K(W₂) ≤ translationFixedField W₁ φ.ker`, which is `le_translationFixedField_translationFixingSubgroup W₁ _` after rewriting with `ker_def` — the generic statement now lives in `Translation/FixedField.lean`, so this is a second public name for one result, with no consumer.

Both rubrics asked for its removal on #6362 in the last round there: `reuse` ("merely specializes `le_translationFixedField_translationFixingSubgroup` after unfolding `ker_def`, and no added theorem consumes this wrapper") and `api-design` ("creating two public names for the same result"). Its `Main results` entry goes with it.

## The four docstrings

Three said that the Galois criterion's hypotheses cannot be weakened — `neither condition can be weakened` in `FixedField.lean`'s module summary, and `nothing weaker will do` / `nothing weaker will give it` on `card_translationFixingSubgroup_eq_finrank_iff_isGalois_and_forall_exists_translation` and `card_ker_eq_degree_iff_isGalois_and_forall_exists_translation`. Proving `A ↔ (B ∧ C)` shows `B ∧ C` is necessary and sufficient; it says nothing about whether some other, weaker or reformulated, condition is also equivalent — `A` itself is one. They now say the two conditions are jointly necessary and sufficient. `documentation` raised this on #6411 after it had merged.

The fourth, on `card_translationFixingSubgroup_dvd_finSepDegree`, had the extension the wrong way round: it claimed the field the subgroup cuts out is Galois over `L`, where the proof establishes that `K(W)` is Galois — hence separable — over that fixed field, whose relative degree is the subgroup's order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
