### PR TITLE
feat: state Zeeman's conjecture

### DIFF
--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Collapse/Cylinder.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Collapse/Cylinder.lean
@@ -1,0 +1,101 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicTopology.SimplicialComplex.Collapse.Cone
+public import TauCeti.AlgebraicTopology.SimplicialComplex.Product
+
+/-!
+# Collapsing ordered simplicial cylinders
+
+If a complex is a cone whose apex is the greatest vertex, then its ordered cylinder is again a
+cone: its apex is the pair of the original apex with the terminal interval vertex. Consequently a
+finite such cylinder collapses to that apex. In particular this applies to the full simplex,
+supplying a first nontrivial family for which the conclusion of Zeeman's conjecture holds and
+checking that the ordered-product convention and the collapse API fit together.
+
+The ordered cylinder is the staircase triangulation from
+`TauCeti.AlgebraicTopology.SimplicialComplex.Product`; collapse and the theorem that finite cones
+collapse are from `TauCeti.AlgebraicTopology.SimplicialComplex.Collapse.Cone`. The argument is the
+standard observation that every vertex of a full ordered simplex lies below its greatest vertex.
+
+## Main results
+
+* `AbstractSimplicialComplex.isCone_orderedCylinder_of_isCone`: taking the ordered cylinder
+  preserves a cone whose apex is greatest.
+* `AbstractSimplicialComplex.isCone_orderedCylinder_top`: the full-simplex specialization.
+* `AbstractSimplicialComplex.collapsesTo_point_orderedCylinder_top`: a finite such cylinder
+  collapses to its greatest terminal vertex.
+* `AbstractSimplicialComplex.collapsible_orderedCylinder_top`: a finite such cylinder is
+  collapsible.
+-/
+
+public section
+
+namespace AbstractSimplicialComplex
+
+variable {ι : Type*} [LinearOrder ι] [OrderTop ι]
+
+/-- The ordered cylinder of a cone whose apex is the greatest vertex is a cone with apex the pair
+of that vertex and the terminal endpoint of the interval. -/
+theorem isCone_orderedCylinder_of_isCone {K : AbstractSimplicialComplex ι}
+    (hK : PreAbstractSimplicialComplex.IsCone K.toPreAbstractSimplicialComplex ⊤) :
+    PreAbstractSimplicialComplex.IsCone
+      K.orderedCylinder.toPreAbstractSimplicialComplex (⊤, (1 : Fin 2)) := by
+  refine ⟨K.orderedCylinder.singleton_mem _, ?_⟩
+  intro σ hσ
+  rw [orderedCylinder_toPreAbstractSimplicialComplex] at hσ ⊢
+  rw [PreAbstractSimplicialComplex.mem_orderedProd_iff] at hσ ⊢
+  refine ⟨?_, ?_, ?_⟩
+  · simpa only [Finset.image_insert, Prod.fst] using hK.insert_mem hσ.1
+  · exact Finset.image_nonempty.mpr (Finset.insert_nonempty _ _)
+  · rw [Finset.coe_insert]
+    exact hσ.2.2.insert fun p _ _ ↦ Or.inr ⟨le_top, Fin.le_last p.2⟩
+
+/-- The ordered cylinder of the full abstract simplex is a cone with apex the greatest vertex at
+the terminal endpoint of the interval. -/
+theorem isCone_orderedCylinder_top :
+    PreAbstractSimplicialComplex.IsCone
+      (orderedCylinder (⊤ : AbstractSimplicialComplex ι)).toPreAbstractSimplicialComplex
+      (⊤, (1 : Fin 2)) := by
+  apply isCone_orderedCylinder_of_isCone
+  exact ⟨Finset.singleton_nonempty _, fun _ _ ↦ Finset.insert_nonempty _ _⟩
+
+/-- The ordered cylinder of a cone with greatest apex on a finite vertex type collapses to the
+corresponding terminal apex. -/
+theorem collapsesTo_point_orderedCylinder_of_isCone [Finite ι]
+    {K : AbstractSimplicialComplex ι}
+    (hK : PreAbstractSimplicialComplex.IsCone K.toPreAbstractSimplicialComplex ⊤) :
+    PreAbstractSimplicialComplex.CollapsesTo K.orderedCylinder.toPreAbstractSimplicialComplex
+      (PreAbstractSimplicialComplex.point (⊤, (1 : Fin 2))) := by
+  classical
+  let _ := Fintype.ofFinite ι
+  exact (isCone_orderedCylinder_of_isCone hK).collapsesTo_point (Set.toFinite _)
+
+/-- The ordered cylinder of a cone with greatest apex on a finite vertex type is collapsible. -/
+theorem collapsible_orderedCylinder_of_isCone [Finite ι] {K : AbstractSimplicialComplex ι}
+    (hK : PreAbstractSimplicialComplex.IsCone K.toPreAbstractSimplicialComplex ⊤) :
+    PreAbstractSimplicialComplex.Collapsible K.orderedCylinder.toPreAbstractSimplicialComplex :=
+  PreAbstractSimplicialComplex.collapsible_iff.mpr
+    ⟨(⊤, (1 : Fin 2)), collapsesTo_point_orderedCylinder_of_isCone hK⟩
+
+/-- The ordered cylinder of a full simplex on a finite vertex type collapses to its greatest
+vertex at the terminal endpoint. -/
+theorem collapsesTo_point_orderedCylinder_top [Finite ι] :
+    PreAbstractSimplicialComplex.CollapsesTo
+      (orderedCylinder (⊤ : AbstractSimplicialComplex ι)).toPreAbstractSimplicialComplex
+      (PreAbstractSimplicialComplex.point (⊤, (1 : Fin 2))) :=
+  collapsesTo_point_orderedCylinder_of_isCone
+    ⟨Finset.singleton_nonempty _, fun _ _ ↦ Finset.insert_nonempty _ _⟩
+
+/-- The ordered cylinder of a full simplex on a finite vertex type is collapsible. -/
+theorem collapsible_orderedCylinder_top [Finite ι] :
+    PreAbstractSimplicialComplex.Collapsible
+      (orderedCylinder (⊤ : AbstractSimplicialComplex ι)).toPreAbstractSimplicialComplex :=
+  collapsible_orderedCylinder_of_isCone
+    ⟨Finset.singleton_nonempty _, fun _ _ ↦ Finset.insert_nonempty _ _⟩
+
+end AbstractSimplicialComplex

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Collapse/Cylinder.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Collapse/Cylinder.lean
@@ -24,9 +24,10 @@ standard observation that every vertex of a full ordered simplex lies below its 
 
 ## Main results
 
-* `AbstractSimplicialComplex.isCone_orderedCylinder_of_isCone`: taking the ordered cylinder
-  preserves a cone whose apex is greatest.
-* `AbstractSimplicialComplex.isCone_orderedCylinder_top`: the full-simplex specialization.
+* `AbstractSimplicialComplex.collapsesTo_point_orderedCylinder_of_isCone`: a finite cone's
+  ordered cylinder collapses to its terminal apex.
+* `AbstractSimplicialComplex.collapsible_orderedCylinder_of_isCone`: a finite cone's ordered
+  cylinder is collapsible.
 * `AbstractSimplicialComplex.collapsesTo_point_orderedCylinder_top`: a finite such cylinder
   collapses to its greatest terminal vertex.
 * `AbstractSimplicialComplex.collapsible_orderedCylinder_top`: a finite such cylinder is
@@ -37,65 +38,45 @@ public section
 
 namespace AbstractSimplicialComplex
 
-variable {ι : Type*} [LinearOrder ι] [OrderTop ι]
+variable {ι : Type*} [LinearOrder ι]
 
-/-- The ordered cylinder of a cone whose apex is the greatest vertex is a cone with apex the pair
-of that vertex and the terminal endpoint of the interval. -/
-theorem isCone_orderedCylinder_of_isCone {K : AbstractSimplicialComplex ι}
-    (hK : PreAbstractSimplicialComplex.IsCone K.toPreAbstractSimplicialComplex ⊤) :
-    PreAbstractSimplicialComplex.IsCone
-      K.orderedCylinder.toPreAbstractSimplicialComplex (⊤, (1 : Fin 2)) := by
-  refine ⟨K.orderedCylinder.singleton_mem _, ?_⟩
-  intro σ hσ
-  rw [orderedCylinder_toPreAbstractSimplicialComplex] at hσ ⊢
-  rw [PreAbstractSimplicialComplex.mem_orderedProd_iff] at hσ ⊢
-  refine ⟨?_, ?_, ?_⟩
-  · simpa only [Finset.image_insert, Prod.fst] using hK.insert_mem hσ.1
-  · exact Finset.image_nonempty.mpr (Finset.insert_nonempty _ _)
-  · rw [Finset.coe_insert]
-    exact hσ.2.2.insert fun p _ _ ↦ Or.inr ⟨le_top, Fin.le_last p.2⟩
-
-/-- The ordered cylinder of the full abstract simplex is a cone with apex the greatest vertex at
-the terminal endpoint of the interval. -/
-theorem isCone_orderedCylinder_top :
-    PreAbstractSimplicialComplex.IsCone
-      (orderedCylinder (⊤ : AbstractSimplicialComplex ι)).toPreAbstractSimplicialComplex
-      (⊤, (1 : Fin 2)) := by
-  apply isCone_orderedCylinder_of_isCone
-  exact ⟨Finset.singleton_nonempty _, fun _ _ ↦ Finset.insert_nonempty _ _⟩
-
-/-- The ordered cylinder of a cone with greatest apex on a finite vertex type collapses to the
+/-- The ordered cylinder of a finite cone whose apex bounds every vertex collapses to the
 corresponding terminal apex. -/
-theorem collapsesTo_point_orderedCylinder_of_isCone [Finite ι]
+theorem collapsesTo_point_orderedCylinder_of_isCone {v : ι}
     {K : AbstractSimplicialComplex ι}
-    (hK : PreAbstractSimplicialComplex.IsCone K.toPreAbstractSimplicialComplex ⊤) :
+    (hfin : K.faces.Finite)
+    (hK : PreAbstractSimplicialComplex.IsCone K.toPreAbstractSimplicialComplex v)
+    (hv : ∀ w, ({w} : Finset ι) ∈ K → w ≤ v) :
     PreAbstractSimplicialComplex.CollapsesTo K.orderedCylinder.toPreAbstractSimplicialComplex
-      (PreAbstractSimplicialComplex.point (⊤, (1 : Fin 2))) := by
-  classical
-  let _ := Fintype.ofFinite ι
-  exact (isCone_orderedCylinder_of_isCone hK).collapsesTo_point (Set.toFinite _)
+      (PreAbstractSimplicialComplex.point (v, (1 : Fin 2))) :=
+  (isCone_orderedCylinder_of_isCone hK hv).collapsesTo_point
+    (finite_faces_orderedCylinder hfin)
 
-/-- The ordered cylinder of a cone with greatest apex on a finite vertex type is collapsible. -/
-theorem collapsible_orderedCylinder_of_isCone [Finite ι] {K : AbstractSimplicialComplex ι}
-    (hK : PreAbstractSimplicialComplex.IsCone K.toPreAbstractSimplicialComplex ⊤) :
+/-- The ordered cylinder of a finite cone whose apex bounds every vertex is collapsible. -/
+theorem collapsible_orderedCylinder_of_isCone {v : ι} {K : AbstractSimplicialComplex ι}
+    (hfin : K.faces.Finite)
+    (hK : PreAbstractSimplicialComplex.IsCone K.toPreAbstractSimplicialComplex v)
+    (hv : ∀ w, ({w} : Finset ι) ∈ K → w ≤ v) :
     PreAbstractSimplicialComplex.Collapsible K.orderedCylinder.toPreAbstractSimplicialComplex :=
-  PreAbstractSimplicialComplex.collapsible_iff.mpr
-    ⟨(⊤, (1 : Fin 2)), collapsesTo_point_orderedCylinder_of_isCone hK⟩
+  (isCone_orderedCylinder_of_isCone hK hv).collapsible (finite_faces_orderedCylinder hfin)
+
+variable [OrderTop ι]
 
 /-- The ordered cylinder of a full simplex on a finite vertex type collapses to its greatest
 vertex at the terminal endpoint. -/
 theorem collapsesTo_point_orderedCylinder_top [Finite ι] :
     PreAbstractSimplicialComplex.CollapsesTo
       (orderedCylinder (⊤ : AbstractSimplicialComplex ι)).toPreAbstractSimplicialComplex
-      (PreAbstractSimplicialComplex.point (⊤, (1 : Fin 2))) :=
-  collapsesTo_point_orderedCylinder_of_isCone
-    ⟨Finset.singleton_nonempty _, fun _ _ ↦ Finset.insert_nonempty _ _⟩
+      (PreAbstractSimplicialComplex.point (⊤, (1 : Fin 2))) := by
+  classical
+  let _ := Fintype.ofFinite ι
+  exact isCone_orderedCylinder_top.collapsesTo_point (Set.toFinite _)
 
 /-- The ordered cylinder of a full simplex on a finite vertex type is collapsible. -/
 theorem collapsible_orderedCylinder_top [Finite ι] :
     PreAbstractSimplicialComplex.Collapsible
       (orderedCylinder (⊤ : AbstractSimplicialComplex ι)).toPreAbstractSimplicialComplex :=
-  collapsible_orderedCylinder_of_isCone
-    ⟨Finset.singleton_nonempty _, fun _ _ ↦ Finset.insert_nonempty _ _⟩
+  PreAbstractSimplicialComplex.collapsible_iff.mpr
+    ⟨(⊤, (1 : Fin 2)), collapsesTo_point_orderedCylinder_top⟩
 
 end AbstractSimplicialComplex

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Product.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Product.lean
@@ -11,7 +11,7 @@ public import TauCeti.AlgebraicTopology.SimplicialComplex.Basic
 public import TauCeti.AlgebraicTopology.SimplicialComplex.IsCone
 public import TauCeti.AlgebraicTopology.SimplicialComplex.Maps
 import Mathlib.Data.Finset.Prod
-import Mathlib.Data.Fintype.Powerset
+import Mathlib.Data.Finset.Powerset
 import Mathlib.Data.Set.Finite.Lattice
 
 /-!

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Product.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Product.lean
@@ -8,7 +8,11 @@ module
 public import Mathlib.Order.Preorder.Chain
 public import Mathlib.Order.Fin.Basic
 public import TauCeti.AlgebraicTopology.SimplicialComplex.Basic
+public import TauCeti.AlgebraicTopology.SimplicialComplex.IsCone
 public import TauCeti.AlgebraicTopology.SimplicialComplex.Maps
+import Mathlib.Data.Finset.Prod
+import Mathlib.Data.Fintype.Powerset
+import Mathlib.Data.Set.Finite.Lattice
 
 /-!
 # Ordered products of abstract simplicial complexes
@@ -36,6 +40,8 @@ product is made here; identifying its realization with the product of realizatio
 * `PreAbstractSimplicialComplex.orderedProd`: the ordered product of two precomplexes.
 * `AbstractSimplicialComplex.orderedProd`: the ordered product of two complexes.
 * `AbstractSimplicialComplex.orderedCylinder`: product with the standard one-simplex.
+* `AbstractSimplicialComplex.isCone_orderedCylinder_of_isCone`: taking the ordered cylinder
+  preserves a cone whose apex is greatest.
 * `PreAbstractSimplicialComplex.SimplicialMap.orderedProdFst` and
   `orderedProdSnd`: the coordinate projections.
 * `PreAbstractSimplicialComplex.SimplicialMap.prodMkLeft` and `prodMkRight`:
@@ -377,6 +383,52 @@ theorem image_fst_mem_of_mem_orderedCylinder {σ : Finset (α × Fin 2)}
 theorem isChain_of_mem_orderedCylinder {σ : Finset (α × Fin 2)}
     (hσ : σ ∈ orderedCylinder K) : IsChain (· ≤ ·) (σ : Set (α × Fin 2)) :=
   (mem_orderedCylinder_iff.mp hσ).2
+
+/-- The ordered cylinder of a finite abstract simplicial complex has finitely many faces. -/
+theorem finite_faces_orderedCylinder (hfin : K.faces.Finite) :
+    K.orderedCylinder.faces.Finite := by
+  refine (hfin.preimage' fun τ _ ↦ ?_).subset fun σ hσ ↦
+    image_fst_mem_of_mem_orderedCylinder hσ
+  refine (Finset.finite_toSet ((τ.product Finset.univ).powerset)).subset ?_
+  intro σ hστ
+  rw [Set.mem_preimage, Set.mem_singleton_iff] at hστ
+  change σ ∈ (τ.product Finset.univ).powerset
+  rw [Finset.mem_powerset]
+  intro p hp
+  apply Finset.mem_product.mpr
+  refine ⟨?_, Finset.mem_univ _⟩
+  rw [← hστ]
+  exact Finset.mem_image.mpr ⟨p, hp, rfl⟩
+
+/-- The ordered cylinder of a cone whose apex bounds every vertex of the complex is a cone with
+apex the pair of that vertex and the terminal endpoint of the interval. -/
+theorem isCone_orderedCylinder_of_isCone {v : α}
+    (hK : PreAbstractSimplicialComplex.IsCone K.toPreAbstractSimplicialComplex v)
+    (hv : ∀ w, ({w} : Finset α) ∈ K → w ≤ v) :
+    PreAbstractSimplicialComplex.IsCone
+      K.orderedCylinder.toPreAbstractSimplicialComplex (v, (1 : Fin 2)) := by
+  refine ⟨K.orderedCylinder.singleton_mem _, ?_⟩
+  intro σ hσ
+  rw [orderedCylinder_toPreAbstractSimplicialComplex] at hσ ⊢
+  rw [PreAbstractSimplicialComplex.mem_orderedProd_iff] at hσ ⊢
+  refine ⟨?_, ?_, ?_⟩
+  · simpa only [Finset.image_insert, Prod.fst] using hK.insert_mem hσ.1
+  · exact Finset.image_nonempty.mpr (Finset.insert_nonempty _ _)
+  · rw [Finset.coe_insert]
+    exact hσ.2.2.insert fun p _ _ ↦
+      Or.inr ⟨hv p.1 (K.singleton_mem p.1), Fin.le_last p.2⟩
+
+variable [OrderTop α]
+
+/-- The ordered cylinder of the full abstract simplex is a cone with apex the greatest vertex at
+the terminal endpoint of the interval. -/
+theorem isCone_orderedCylinder_top :
+    PreAbstractSimplicialComplex.IsCone
+      (orderedCylinder (⊤ : AbstractSimplicialComplex α)).toPreAbstractSimplicialComplex
+      (⊤, (1 : Fin 2)) := by
+  apply isCone_orderedCylinder_of_isCone
+  · exact ⟨Finset.singleton_nonempty _, fun _ _ ↦ Finset.insert_nonempty _ _⟩
+  · exact fun _ _ ↦ le_top
 
 end OrderedProd
 

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Product.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Product.lean
@@ -392,8 +392,7 @@ theorem finite_faces_orderedCylinder (hfin : K.faces.Finite) :
   refine (Finset.finite_toSet ((τ.product Finset.univ).powerset)).subset ?_
   intro σ hστ
   rw [Set.mem_preimage, Set.mem_singleton_iff] at hστ
-  change σ ∈ (τ.product Finset.univ).powerset
-  rw [Finset.mem_powerset]
+  rw [Finset.mem_coe, Finset.mem_powerset]
   intro p hp
   apply Finset.mem_product.mpr
   refine ⟨?_, Finset.mem_univ _⟩

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Zeeman.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Zeeman.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Analysis.Convex.Contractible
+public import TauCeti.AlgebraicTopology.SimplicialComplex.Collapse.Cylinder
 public import TauCeti.AlgebraicTopology.SimplicialComplex.Dimension
 public import TauCeti.AlgebraicTopology.SimplicialComplex.Simplex.Realization
 
@@ -22,6 +23,11 @@ The standard one-simplex is provided as a nontrivial witness.  Its realization i
 the homeomorphism with Mathlib's convex standard simplex, so the predicate is exercised without
 assuming the desired Zeeman conclusion.
 
+The universe-polymorphic proposition `TauCeti.ZeemanConjecture` asserts that the ordered
+simplicial cylinder is collapsible for every finite contractible complex of dimension at most two.
+The conjecture remains open; the full simplex on a finite ordered type supplies a family where its
+conclusion follows from the cylinder's cone structure.
+
 ## Main definitions
 
 * `AbstractSimplicialComplex.Contractible2Complex`: finite, at-most-two-dimensional complexes
@@ -32,8 +38,10 @@ assuming the desired Zeeman conclusion.
 * `AbstractSimplicialComplex.contractible2Complex_iff`: the defining characterization.
 * `AbstractSimplicialComplex.contractible2Complex_standardOneSimplex`: the standard one-simplex
   is a non-void contractible 2-complex (the dimension bound is at most two).
+* `TauCeti.ZeemanConjecture`: the universal statement of the conjecture.
+* `TauCeti.ZeemanConjecture.collapsible_orderedCylinder`: its specialization to one complex.
 
-No claim that a product with an interval is collapsible is made here.
+The proposition is stated, not proved.
 -/
 
 public section
@@ -103,3 +111,29 @@ theorem contractible2Complex_standardOneSimplex :
       _ ≤ 2 := by norm_num
 
 end AbstractSimplicialComplex
+
+namespace TauCeti
+
+/-- **Zeeman's conjecture**: the ordered simplicial cylinder on every finite contractible
+complex of dimension at most two is collapsible.
+
+The cylinder uses the staircase triangulation fixed by `AbstractSimplicialComplex.orderedCylinder`.
+Its collapse is taken after forgetting to a pre-abstract simplicial complex, since collapse can
+remove vertices. -/
+def ZeemanConjecture.{u} : Prop :=
+  ∀ (ι : Type u) [LinearOrder ι] (K : AbstractSimplicialComplex ι),
+    K.Contractible2Complex →
+      PreAbstractSimplicialComplex.Collapsible K.orderedCylinder.toPreAbstractSimplicialComplex
+
+namespace ZeemanConjecture
+
+/-- A proof of Zeeman's conjecture makes the ordered cylinder on any contractible two-complex
+collapsible. -/
+theorem collapsible_orderedCylinder {ι : Type u} [LinearOrder ι] (h : ZeemanConjecture.{u})
+    (K : AbstractSimplicialComplex ι) (hK : K.Contractible2Complex) :
+    PreAbstractSimplicialComplex.Collapsible K.orderedCylinder.toPreAbstractSimplicialComplex :=
+  h ι K hK
+
+end ZeemanConjecture
+
+end TauCeti

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Zeeman.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Zeeman.lean
@@ -6,8 +6,9 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Analysis.Convex.Contractible
-public import TauCeti.AlgebraicTopology.SimplicialComplex.Collapse.Cylinder
+public import TauCeti.AlgebraicTopology.SimplicialComplex.Collapse.Basic
 public import TauCeti.AlgebraicTopology.SimplicialComplex.Dimension
+public import TauCeti.AlgebraicTopology.SimplicialComplex.Product
 public import TauCeti.AlgebraicTopology.SimplicialComplex.Simplex.Realization
 
 /-!
@@ -25,8 +26,8 @@ assuming the desired Zeeman conclusion.
 
 The universe-polymorphic proposition `TauCeti.ZeemanConjecture` asserts that the ordered
 simplicial cylinder is collapsible for every finite contractible complex of dimension at most two.
-The conjecture remains open; the full simplex on a finite ordered type supplies a family where its
-conclusion follows from the cylinder's cone structure.
+The conjecture remains open; the full simplex on a finite linearly ordered type with a greatest
+element supplies a family where its conclusion follows from the cylinder's cone structure.
 
 ## Main definitions
 
@@ -39,7 +40,7 @@ conclusion follows from the cylinder's cone structure.
 * `AbstractSimplicialComplex.contractible2Complex_standardOneSimplex`: the standard one-simplex
   is a non-void contractible 2-complex (the dimension bound is at most two).
 * `TauCeti.ZeemanConjecture`: the universal statement of the conjecture.
-* `TauCeti.ZeemanConjecture.collapsible_orderedCylinder`: its specialization to one complex.
+* `TauCeti.zeemanConjecture_iff`: the defining characterization.
 
 The proposition is stated, not proved.
 -/
@@ -125,15 +126,13 @@ def ZeemanConjecture.{u} : Prop :=
     K.Contractible2Complex →
       PreAbstractSimplicialComplex.Collapsible K.orderedCylinder.toPreAbstractSimplicialComplex
 
-namespace ZeemanConjecture
-
-/-- A proof of Zeeman's conjecture makes the ordered cylinder on any contractible two-complex
-collapsible. -/
-theorem collapsible_orderedCylinder {ι : Type u} [LinearOrder ι] (h : ZeemanConjecture.{u})
-    (K : AbstractSimplicialComplex ι) (hK : K.Contractible2Complex) :
-    PreAbstractSimplicialComplex.Collapsible K.orderedCylinder.toPreAbstractSimplicialComplex :=
-  h ι K hK
-
-end ZeemanConjecture
+/-- The defining characterization of Zeeman's conjecture. -/
+theorem zeemanConjecture_iff :
+    ZeemanConjecture.{u} ↔
+      ∀ (ι : Type u) [LinearOrder ι] (K : AbstractSimplicialComplex ι),
+        K.Contractible2Complex →
+          PreAbstractSimplicialComplex.Collapsible
+            K.orderedCylinder.toPreAbstractSimplicialComplex :=
+  Iff.rfl
 
 end TauCeti

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Zeeman.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Zeeman.lean
@@ -126,6 +126,17 @@ def ZeemanConjecture.{u} : Prop :=
     K.Contractible2Complex →
       PreAbstractSimplicialComplex.Collapsible K.orderedCylinder.toPreAbstractSimplicialComplex
 
+namespace ZeemanConjecture
+
+/-- A proof of Zeeman's conjecture makes the ordered cylinder on any contractible two-complex
+collapsible. -/
+theorem collapsible_orderedCylinder {ι : Type u} [LinearOrder ι] (h : ZeemanConjecture.{u})
+    (K : AbstractSimplicialComplex ι) (hK : K.Contractible2Complex) :
+    PreAbstractSimplicialComplex.Collapsible K.orderedCylinder.toPreAbstractSimplicialComplex :=
+  h ι K hK
+
+end ZeemanConjecture
+
 /-- The defining characterization of Zeeman's conjecture. -/
 theorem zeemanConjecture_iff :
     ZeemanConjecture.{u} ↔
@@ -133,6 +144,10 @@ theorem zeemanConjecture_iff :
         K.Contractible2Complex →
           PreAbstractSimplicialComplex.Collapsible
             K.orderedCylinder.toPreAbstractSimplicialComplex :=
-  Iff.rfl
+  by
+    constructor
+    · intro h ι _ K hK
+      exact h.collapsible_orderedCylinder K hK
+    · exact fun h => h
 
 end TauCeti


### PR DESCRIPTION
This PR states Zeeman's conjecture for finite contractible simplicial complexes of dimension at most two: the existing ordered staircase cylinder becomes collapsible after passing to the pre-abstract complex where elementary collapses may remove vertices. It also proves that the ordered cylinder of any finite cone whose apex is the greatest vertex collapses to the corresponding terminal apex, with the full finite simplex as the first nontrivial family satisfying the conjecture's conclusion.

The exact roadmap target is `GeometricTopology/README.md`, Layer 11, milestone “Simplicial collapse and Zeeman's conjecture”: “for a contractible `2`-complex `K`, the product `K × I` is collapsible.” The dependency edge is direct: the merged `Contractible2Complex`, `orderedCylinder`, `IsFreePair`, `CollapsesTo`, and `Collapsible` declarations now assemble into the roadmap's statement, while the cone theorem checks that the chosen product triangulation and collapse API agree on full simplices. This is the most effective current step because all ingredients of the statement are already on `main`, no open PR covers their assembly, and it completes the statement rather than adding another peripheral primitive.

After this PR, the Zeeman statement itself is complete but intentionally unproved because the conjecture is open; the rest of Layer 11 still requires the general realization/product comparison, the PL reconciliation, and the Manolescu non-triangulability statement.

The new 101-line `TauCeti/AlgebraicTopology/SimplicialComplex/Collapse/Cylinder.lean` proves the cone-cylinder theorem, its finite collapse, and the full-simplex corollaries. `TauCeti/AlgebraicTopology/SimplicialComplex/Zeeman.lean` adds the universe-polymorphic proposition and its specialization theorem. The formulation follows E. C. Zeeman, *On the dunce hat*, Topology 2 (1964), 341–358, as recorded by Kirby's Problem 5.2; the collapse argument uses the cone theorem developed from Rourke–Sanderson, *Introduction to Piecewise-Linear Topology*, Chapter 3. These sources are credited in the module documentation. No Mathlib infrastructure or external formalization is vendored.

Roadmap: GeometricTopology

<!--tauceti-target:v1 {"focus":"GeometricTopology","id":"zeeman-conjecture"}-->

🤖 Prepared with Codex
