### PR TITLE
feat(EllipticCurve): an embedding of the function field is determined by the generic point

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/GenericPoint.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/GenericPoint.lean
@@ -272,6 +272,26 @@ theorem evalEval_polynomialY_genericX_genericY_ne_zero [W.IsElliptic] :
     ((IsFractionRing.injective W.CoordinateRing W.FunctionField).eq_iff.mp
       (hz.trans (map_zero _).symm))
 
+/-- **An `F`-embedding of the function field into a field extension is determined by the image of
+the generic point.** The generic point's two coordinates generate the function field over `F`, so
+an embedding is recoverable from the point it induces. -/
+theorem map_genericPoint_injective [W.IsElliptic] {Ω : Type*} [Field Ω] [Algebra F Ω]
+    [DecidableEq Ω] :
+    Function.Injective fun σ : W.FunctionField →ₐ[F] Ω ↦ Point.map σ (genericPoint W) := by
+  intro σ τ h
+  have hx : σ (genericX W) = τ (genericX W) := by
+    simpa only [Point.xCoord_map, xCoord_genericPoint] using congrArg Point.xCoord h
+  have hy : σ (genericY W) = τ (genericY W) := by
+    simpa only [Point.yCoord_map, yCoord_genericPoint] using congrArg Point.yCoord h
+  have key : σ.comp (IsScalarTower.toAlgHom F W.CoordinateRing W.FunctionField) =
+      τ.comp (IsScalarTower.toAlgHom F W.CoordinateRing W.FunctionField) := by
+    refine CoordinateRing.algHom_ext ?_ ?_
+    · simpa [genericX_def] using hx
+    · simpa [genericY_def] using hy
+  refine AlgHom.coe_ringHom_injective
+    (IsFractionRing.ringHom_ext (A := W.CoordinateRing) fun a ↦ ?_)
+  exact congrArg (fun f : W.CoordinateRing →ₐ[F] Ω ↦ f a) key
+
 end Field
 
 end WeierstrassCurve.Affine

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/GenericPoint.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/GenericPoint.lean
@@ -62,6 +62,8 @@ consumer may rely on that.
   over the base field, so it takes no constant value.
 * `WeierstrassCurve.Affine.evalEval_polynomialY_genericX_genericY_ne_zero`: on an elliptic curve
   over a field the partial derivative `W_Y` is nonzero at the generic point.
+* `WeierstrassCurve.Affine.map_genericPoint_injective`: an `F`-algebra homomorphism from the
+  function field into a field extension is determined by the point it sends the generic point to.
 
 ## Roadmap
 
@@ -82,6 +84,13 @@ The generic coordinates and their equation are adapted from the AINTLIB `HasseWe
 `513e83879e2f8cbc626eb9e04d660e92be16ccba`, declarations `x_gen`, `y_gen`, `W_KE`, and
 `generic_equation`. Its transcendence statement is reproved here as `transcendental_genericX`.
 The bundled `genericPoint` and its coordinate-accessor API are not ported from that source.
+
+`map_genericPoint_injective` adapts the statement of that project's
+`HasseWeil/GapSpines.lean` declaration `emb_le_card_kernel`, same commit and license, which
+assigns a point to each embedding and shows the assignment injective. The proof differs: the
+source works with points over `AlgebraicClosure K(E)` and with an isogeny carrying its own point
+map, while here the point is the image of the generic point and injectivity comes from
+`CoordinateRing.algHom_ext` and `IsFractionRing.ringHom_ext`.
 -/
 
 public section


### PR DESCRIPTION
Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"EllipticCurves/README.md:layer1:kernel-card-eq-degree"}-->

Provenance: the statement is the first step of AINTLIB `HasseWeil` (Chris Birkbeck, Apache 2.0, commit `513e83879e2f8cbc626eb9e04d660e92be16ccba`), `GapSpines.lean`, `emb_le_card_kernel`, which assigns a point to each embedding and shows the assignment injective. The proof here is not a port: AINTLIB works with points over `AlgebraicClosure K(E)` and an `Isogeny` that carries a point map, while this is read off the generic point and `CoordinateRing.algHom_ext`.

## What this adds

One theorem, in the existing `Affine/FunctionField/GenericPoint.lean`:

- `WeierstrassCurve.Affine.map_genericPoint_injective`: for any field extension `Ω` of `F`, the map `σ ↦ Point.map σ (genericPoint W)` from `W.FunctionField →ₐ[F] Ω` to `(W⁄Ω).Point` is injective.

## The argument

The generic point has coordinates `genericX W` and `genericY W`, which are the images of the two coordinate-ring generators. So from `Point.map σ g = Point.map τ g`:

1. `Point.xCoord_map` and `Point.yCoord_map` give `σ (genericX W) = τ (genericX W)` and the same for `genericY`.
2. `CoordinateRing.algHom_ext` turns that into equality of `σ` and `τ` restricted along `IsScalarTower.toAlgHom F W.CoordinateRing W.FunctionField` — it is stated for an arbitrary target algebra, so `Ω` needs no special structure.
3. `IsFractionRing.ringHom_ext` lifts equality on the coordinate ring to its fraction field, which is `W.FunctionField`.

`[DecidableEq Ω]` is a hypothesis rather than `open scoped Classical`, matching the convention already in this area: the point group's addition branches on coordinate equality, and `FractionRing.instDecidableEq` is not `rfl`-equal to `Classical.propDecidable`, so the classical form breaks consumers that already carry the instance.

## Scope

This is infrastructure, not the count. Where it leads: `Field.finSepDegree` is a count of embeddings, so an injection from embeddings into points is what converts the separable degree of `K(W₁)` over `φ^*K(W₂)` into a bound by a number of points — the shape needed for the reverse inclusion `translationFixedField W₁ φ.ker ≤ φ.fieldPullback.fieldRange`, which #6411 showed is all that is left of `#ker φ = deg φ`.

The step that is genuinely still open is the descent: the points produced this way live over `Ω`, and showing they are `F`-rational is special to `1 − π_q`, whose geometric kernel is `E(𝔽_q)`. Nothing here claims that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
