### PR TITLE
feat: prove CAR isotypy

### DIFF
--- a/TauCeti/Algebra/Lie/GeneralLinear/CAR/Isotypic.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/CAR/Isotypic.lean
@@ -10,6 +10,7 @@ public import TauCeti.Algebra.Lie.GeneralLinear.Isotypic
 import TauCeti.Algebra.Lie.GeneralLinear.CAR.Casimir
 import TauCeti.Algebra.Lie.GeneralLinear.CAR.WeightUniqueness
 import TauCeti.Algebra.Lie.GeneralLinear.Existence
+import TauCeti.Data.Fin.Basic
 import TauCeti.LinearAlgebra.CliffordAlgebra.Dimension
 
 /-!
@@ -52,39 +53,6 @@ noncomputable section
 attribute [local instance] Classical.decEq
 attribute [local instance 100] LieRing.ofAssociativeRing
 
-private theorem sum_range_rev (N k : ℕ) (hk : k ≤ N) :
-    Finset.sum (Finset.range k) (fun x => N - (x + 1)) =
-      k.choose 2 + k * (N - k) := by
-  calc
-    Finset.sum (Finset.range k) (fun x => N - (x + 1)) =
-        Finset.sum (Finset.range k) (fun x => (N - k) + (k - 1 - x)) := by
-      apply Finset.sum_congr rfl
-      intro x hx
-      have hxk := Finset.mem_range.mp hx
-      omega
-    _ = k * (N - k) + Finset.sum (Finset.range k) (fun x => k - 1 - x) := by
-      rw [Finset.sum_add_distrib]
-      simp
-    _ = k * (N - k) + Finset.sum (Finset.range k) (fun x => x) := by
-      rw [Finset.sum_range_reflect (fun x => x) k]
-    _ = k.choose 2 + k * (N - k) := by
-      rw [Finset.sum_range_id, Nat.choose_two_right]
-      omega
-
-private theorem sum_fin_rev_castLE (N k : ℕ) (hk : k ≤ N) :
-    (∑ i : Fin k, (Fin.rev (Fin.castLE hk i) : ℕ)) =
-      k.choose 2 + k * (N - k) := by
-  rw [Finset.sum_fin_eq_sum_range]
-  simp only [Fin.rev, Fin.castLE]
-  calc
-    Finset.sum (Finset.range k)
-        (fun x => if h : x < k then N - (x + 1) else 0) =
-        Finset.sum (Finset.range k) (fun x => N - (x + 1)) := by
-      apply Finset.sum_congr rfl
-      intro x hx
-      simp [Finset.mem_range.mp hx]
-    _ = _ := sum_range_rev N k hk
-
 namespace IsGlHighestWeightVector
 
 variable {K : Type*} [Field K] [CharZero K] {N : ℕ}
@@ -110,7 +78,7 @@ theorem eq_glHalfStaircase {μ : Fin N → K}
       (fun i _ => hv.lie_single_self_eq_smul i) (fun i _ => hμ i)
     have hnat : (∑ i : Fin k, a (Fin.castLE hk.le i)) ≤
         ∑ i : Fin k, (Fin.rev (Fin.castLE hk.le i) : ℕ) := by
-      rw [sum_fin_rev_castLE N k hk.le]
+      rw [Fin.sum_rev_castLE N k hk.le]
       simpa [s] using hbound
     exact_mod_cast hnat
   have hsum : (∑ i : Fin N, (a i : ℤ)) =
@@ -120,7 +88,7 @@ theorem eq_glHalfStaircase {μ : Fin N → K}
       hv.lie_single_self_eq_smul hμ
     have hnat : (∑ i : Fin N, a i) = ∑ i : Fin N, (Fin.rev i : ℕ) := by
       rw [hsum']
-      simpa using (sum_fin_rev_castLE N N le_rfl).symm
+      simpa using (Fin.sum_rev_castLE N N le_rfl).symm
     exact_mod_cast hnat
   have hfield :
       (∑ i : Fin N, μ i * (μ i + (N : K) - 1 - 2 * (i : K))) =

--- a/TauCeti/Algebra/Lie/GeneralLinear/CAR/Isotypic.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/CAR/Isotypic.lean
@@ -1,0 +1,201 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Lie.GeneralLinear.CAR.WeightSpectrum
+public import TauCeti.Algebra.Lie.GeneralLinear.Isotypic
+import TauCeti.Algebra.Lie.GeneralLinear.CAR.Casimir
+import TauCeti.Algebra.Lie.GeneralLinear.CAR.WeightUniqueness
+import TauCeti.Algebra.Lie.GeneralLinear.Existence
+import TauCeti.LinearAlgebra.CliffordAlgebra.Dimension
+
+/-!
+# Isotypy of the left-regular CAR module
+
+Over an algebraically closed field of characteristic zero, the left-regular Clifford algebra of
+the trace form is an isotypic `gl_N`-module. Its simple type has the half-shifted staircase highest
+weight
+
+`(N - 1/2, N - 3/2, ..., 1/2)`.
+
+To identify the weight, write its coordinates as natural occupation counts shifted by `1/2`.
+Highest-weight dominance makes the counts antitone, while the CAR cut identities bound their
+proper prefix sums and fix their total. The trace-form Casimir scalar supplies the remaining
+quadratic equality. The staircase majorization criterion then identifies every coordinate.
+
+## Main results
+
+* `TauCeti.IsGlHighestWeightVector.eq_glHalfStaircase`: every CAR highest-weight vector has the
+  half-shifted staircase weight.
+* `TauCeti.isIsotypicOfType_glIrreducible_car`: the left-regular CAR module is isotypic of the
+  simple module with that highest weight.
+
+## References
+
+* D. Panyushev, *The exterior algebra and "spin" of an orthogonal g-module*, Transformation Groups
+  6 (2001), 371–396, Proposition 2.4 and Example 2.5(1).
+* D. Shlyakhtenko, *Failure of Strong Convergence of Matrices with Fermionic Entries*,
+  arXiv:2606.28648, Section 2.3.
+-/
+
+public section
+
+open scoped BigOperators TauCeti
+
+namespace TauCeti
+
+noncomputable section
+
+attribute [local instance] Classical.decEq
+attribute [local instance 100] LieRing.ofAssociativeRing
+
+private theorem sum_range_rev (N k : ℕ) (hk : k ≤ N) :
+    Finset.sum (Finset.range k) (fun x => N - (x + 1)) =
+      k.choose 2 + k * (N - k) := by
+  induction k with
+  | zero => simp
+  | succ k ih =>
+      calc
+        Finset.sum (Finset.range (k + 1)) (fun x => N - (x + 1)) =
+            Finset.sum (Finset.range k) (fun x => N - (x + 1)) + (N - (k + 1)) :=
+          Finset.sum_range_succ _ _
+        _ = (k.choose 2 + k * (N - k)) + (N - (k + 1)) := by
+          rw [ih (by omega)]
+        _ = (k + 1).choose 2 + (k + 1) * (N - (k + 1)) := by
+          have hsub : N - k = (N - (k + 1)) + 1 := by omega
+          rw [hsub, Nat.choose_succ_succ, Nat.choose_one_right]
+          ring
+
+private theorem sum_fin_rev_castLE (N k : ℕ) (hk : k ≤ N) :
+    (∑ i : Fin k, (Fin.rev (Fin.castLE hk i) : ℕ)) =
+      k.choose 2 + k * (N - k) := by
+  rw [Finset.sum_fin_eq_sum_range]
+  simp only [Fin.rev, Fin.castLE]
+  calc
+    Finset.sum (Finset.range k)
+        (fun x => if h : x < k then N - (x + 1) else 0) =
+        Finset.sum (Finset.range k) (fun x => N - (x + 1)) := by
+      apply Finset.sum_congr rfl
+      intro x hx
+      simp [Finset.mem_range.mp hx]
+    _ = _ := sum_range_rev N k hk
+
+namespace IsGlHighestWeightVector
+
+variable {K : Type*} [Field K] [CharZero K] {N : ℕ}
+
+/-- Every highest-weight vector in the left-regular CAR module has the half-shifted staircase
+weight `(N - 1/2, N - 3/2, ..., 1/2)`.
+
+The result is uniform in the rank, including ranks zero and one. -/
+theorem eq_glHalfStaircase {μ : Fin N → K}
+    {v : CliffordAlgebra (traceQuadraticForm K (Fin N))}
+    (hv : IsGlHighestWeightVector μ v) : μ = glHalfStaircase K N := by
+  let a : Fin N → ℕ := fun i => (hv.exists_weight_apply_eq_natCast_add_inv_two i).choose
+  have hμ (i : Fin N) : μ i = (a i : K) + (2 : K)⁻¹ :=
+    (hv.exists_weight_apply_eq_natCast_add_inv_two i).choose_spec.2
+  have ha : Antitone a :=
+    hv.isGlDominantIntegral.antitone_of_eq_natCast_add_const (funext hμ)
+  have hmajor (k : ℕ) (hk : k < N) :
+      (∑ i : Fin k, (a (Fin.castLE hk.le i) : ℤ)) ≤
+        ∑ i : Fin k, ((Fin.rev (Fin.castLE hk.le i) : ℕ) : ℤ) := by
+    let s : Finset (Fin N) := Finset.univ.map (Fin.castLEEmb hk.le)
+    have hbound := sum_le_choose_two_add_card_mul_sub_of_lie_single_self_eq_smul
+      (K := K) (n := Fin N) (μ := μ) (a := a) (v := v) s hv.ne_zero
+      (fun i _ => hv.lie_single_self_eq_smul i) (fun i _ => hμ i)
+    have hnat : (∑ i : Fin k, a (Fin.castLE hk.le i)) ≤
+        ∑ i : Fin k, (Fin.rev (Fin.castLE hk.le i) : ℕ) := by
+      rw [sum_fin_rev_castLE N k hk.le]
+      simpa [s] using hbound
+    exact_mod_cast hnat
+  have hsum : (∑ i : Fin N, (a i : ℤ)) =
+      ∑ i : Fin N, ((Fin.rev i : ℕ) : ℤ) := by
+    have hsum' := sum_univ_eq_choose_two_of_lie_single_self_eq_smul
+      (K := K) (n := Fin N) (μ := μ) (a := a) (v := v) hv.ne_zero
+      hv.lie_single_self_eq_smul hμ
+    have hnat : (∑ i : Fin N, a i) = ∑ i : Fin N, (Fin.rev i : ℕ) := by
+      rw [hsum']
+      simpa using (sum_fin_rev_castLE N N le_rfl).symm
+    exact_mod_cast hnat
+  have hfield :
+      (∑ i : Fin N, μ i * (μ i + (N : K) - 1 - 2 * (i : K))) =
+        ∑ i : Fin N, glHalfStaircase K N i *
+          (glHalfStaircase K N i + (N : K) - 1 - 2 * (i : K)) := by
+    have hcar := glCasimir_smul_of_isGlHighestWeightVector (K := K) hv
+    rw [representation_glCasimir_car_apply] at hcar
+    have hscalar := smul_left_injective K hv.ne_zero hcar
+    rw [glCasimir_eigenvalue_glHalfStaircase]
+    exact hscalar.symm
+  have hcasimir :
+      (∑ i : Fin N, (a i : ℤ) * ((a i : ℤ) + (N : ℤ) - 2 * (i : ℕ))) =
+        ∑ i : Fin N, ((Fin.rev i : ℕ) : ℤ) *
+          (((Fin.rev i : ℕ) : ℤ) + (N : ℤ) - 2 * (i : ℕ)) := by
+    apply Int.cast_injective (α := K)
+    push_cast
+    let c : Fin N → K := fun i => (N : K) / 2 - 1 / 4 - (i : K)
+    have hshift (b : Fin N → ℕ) :
+        (∑ i : Fin N, ((b i : K) + (2 : K)⁻¹) *
+          ((b i : K) + (2 : K)⁻¹ + (N : K) - 1 - 2 * (i : K))) =
+          (∑ i : Fin N, (b i : K) * ((b i : K) + (N : K) - 2 * (i : K))) +
+            ∑ i : Fin N, c i := by
+      rw [← Finset.sum_add_distrib]
+      apply Finset.sum_congr rfl
+      intro i _
+      simp only [c, one_div]
+      ring
+    have hleft :
+        (∑ i : Fin N, μ i * (μ i + (N : K) - 1 - 2 * (i : K))) =
+          (∑ i : Fin N, (a i : K) * ((a i : K) + (N : K) - 2 * (i : K))) +
+            ∑ i : Fin N, c i := by
+      calc
+        _ = ∑ i : Fin N, ((a i : K) + (2 : K)⁻¹) *
+            ((a i : K) + (2 : K)⁻¹ + (N : K) - 1 - 2 * (i : K)) := by
+          apply Finset.sum_congr rfl
+          intro i _
+          rw [hμ i]
+        _ = _ := hshift a
+    have hrev (i : Fin N) :
+        glHalfStaircase K N i = ((Fin.rev i : ℕ) : K) + (2 : K)⁻¹ := by
+      simpa only [one_div] using
+        (Fin.natCast_rev_add_one_div_two_eq_glHalfStaircase (F := K) i).symm
+    have hright :
+        (∑ i : Fin N, glHalfStaircase K N i *
+          (glHalfStaircase K N i + (N : K) - 1 - 2 * (i : K))) =
+          (∑ i : Fin N, ((Fin.rev i : ℕ) : K) *
+            (((Fin.rev i : ℕ) : K) + (N : K) - 2 * (i : K))) +
+            ∑ i : Fin N, c i := by
+      calc
+        _ = ∑ i : Fin N, (((Fin.rev i : ℕ) : K) + (2 : K)⁻¹) *
+            (((Fin.rev i : ℕ) : K) + (2 : K)⁻¹ + (N : K) - 1 - 2 * (i : K)) := by
+          apply Finset.sum_congr rfl
+          intro i _
+          rw [hrev i]
+        _ = _ := hshift fun i => (Fin.rev i : ℕ)
+    rw [hleft, hright] at hfield
+    exact add_right_cancel hfield
+  have haeq := eq_finRev_of_antitone_of_prefix_sum_le_of_sum_eq_of_casimir_eq
+    a ha hmajor hsum hcasimir
+  funext i
+  rw [hμ i, congrFun haeq i]
+  simpa only [one_div] using
+    (Fin.natCast_rev_add_one_div_two_eq_glHalfStaircase (F := K) i)
+
+end IsGlHighestWeightVector
+
+/-- Over an algebraically closed field of characteristic zero, the left-regular CAR module is
+isotypic of the simple `gl_N`-module with half-shifted staircase highest weight. -/
+theorem isIsotypicOfType_glIrreducible_car
+    (K : Type*) [Field K] [CharZero K] [IsAlgClosed K] (N : ℕ) :
+    _root_.LieModule.IsIsotypicOfType K (Matrix (Fin N) (Fin N) K)
+      (CliffordAlgebra (traceQuadraticForm K (Fin N)))
+      (glIrreducible N (glHalfStaircase K N)) := by
+  apply isIsotypicOfType_glIrreducible_of_forall_isGlHighestWeightVector
+  intro μ v hv
+  exact hv.eq_glHalfStaircase
+
+end
+
+end TauCeti

--- a/TauCeti/Algebra/Lie/GeneralLinear/CAR/Isotypic.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/CAR/Isotypic.lean
@@ -55,19 +55,21 @@ attribute [local instance 100] LieRing.ofAssociativeRing
 private theorem sum_range_rev (N k : ℕ) (hk : k ≤ N) :
     Finset.sum (Finset.range k) (fun x => N - (x + 1)) =
       k.choose 2 + k * (N - k) := by
-  induction k with
-  | zero => simp
-  | succ k ih =>
-      calc
-        Finset.sum (Finset.range (k + 1)) (fun x => N - (x + 1)) =
-            Finset.sum (Finset.range k) (fun x => N - (x + 1)) + (N - (k + 1)) :=
-          Finset.sum_range_succ _ _
-        _ = (k.choose 2 + k * (N - k)) + (N - (k + 1)) := by
-          rw [ih (by omega)]
-        _ = (k + 1).choose 2 + (k + 1) * (N - (k + 1)) := by
-          have hsub : N - k = (N - (k + 1)) + 1 := by omega
-          rw [hsub, Nat.choose_succ_succ, Nat.choose_one_right]
-          ring
+  calc
+    Finset.sum (Finset.range k) (fun x => N - (x + 1)) =
+        Finset.sum (Finset.range k) (fun x => (N - k) + (k - 1 - x)) := by
+      apply Finset.sum_congr rfl
+      intro x hx
+      have hxk := Finset.mem_range.mp hx
+      omega
+    _ = k * (N - k) + Finset.sum (Finset.range k) (fun x => k - 1 - x) := by
+      rw [Finset.sum_add_distrib]
+      simp
+    _ = k * (N - k) + Finset.sum (Finset.range k) (fun x => x) := by
+      rw [Finset.sum_range_reflect (fun x => x) k]
+    _ = k.choose 2 + k * (N - k) := by
+      rw [Finset.sum_range_id, Nat.choose_two_right]
+      omega
 
 private theorem sum_fin_rev_castLE (N k : ℕ) (hk : k ≤ N) :
     (∑ i : Fin k, (Fin.rev (Fin.castLE hk i) : ℕ)) =

--- a/TauCeti/Data/Fin/Basic.lean
+++ b/TauCeti/Data/Fin/Basic.lean
@@ -10,6 +10,7 @@ public import Mathlib.Algebra.Group.End
 public import Mathlib.Algebra.Ring.Parity
 public import Mathlib.Logic.Equiv.Fin.Rotate
 
+import Mathlib.Algebra.BigOperators.Intervals
 import Mathlib.Algebra.Group.Fin.Basic
 import Mathlib.Tactic.FinCases
 
@@ -17,8 +18,8 @@ import Mathlib.Tactic.FinCases
 # Basic results about finite ordinal types
 
 This file collects elementary facts about finite ordinal types, including the classification of
-permutations of `Fin 2`, indicator sums indexed by `Fin n`, and the final value of a partial
-product.
+permutations of `Fin 2`, sums of reversed indices, indicator sums indexed by `Fin n`, and the final
+value of a partial product.
 
 `Fintype.sum_ite_eq` evaluates a sum whose indicator compares two elements of the index type.
 When the comparison is instead between a natural number and the `Fin.val` of the index — as it is
@@ -31,6 +32,8 @@ range, so the value is a `dite` rather than a plain application.
   transposition.
 * `Fin.rev_finRotate_rev` and `Fin.rev_finRotate_symm`: reversal carries forward rotation to
   backward rotation and conversely.
+* `Finset.sum_range_const_sub_succ`: the sum of a reversed initial segment of natural numbers.
+* `Fin.sum_rev_castLE`: the sum of the values of a reversed embedded finite ordinal.
 * `Fin.partialProd_last`: the final partial product is the product of all the entries.
 * `Fin.partialSum_last`: the final partial sum is the sum of all the entries.
 * `TauCeti.add_one_add_one_ne_self`: adding one twice in `Fin n` is nontrivial when `3 ≤ n`.
@@ -42,7 +45,48 @@ range, so the value is a `dite` rather than a plain application.
 
 public section
 
+open scoped BigOperators
+
+namespace Finset
+
+/-- The sum of the first `k` entries of the reversed range `N - 1, ..., 0`. -/
+theorem sum_range_const_sub_succ (N k : ℕ) (hk : k ≤ N) :
+    Finset.sum (Finset.range k) (fun x => N - (x + 1)) =
+      k.choose 2 + k * (N - k) := by
+  calc
+    Finset.sum (Finset.range k) (fun x => N - (x + 1)) =
+        Finset.sum (Finset.range k) (fun x => (N - k) + (k - 1 - x)) := by
+      apply Finset.sum_congr rfl
+      intro x hx
+      have hxk := Finset.mem_range.mp hx
+      omega
+    _ = k * (N - k) + Finset.sum (Finset.range k) (fun x => k - 1 - x) := by
+      rw [Finset.sum_add_distrib]
+      simp
+    _ = k * (N - k) + Finset.sum (Finset.range k) (fun x => x) := by
+      rw [Finset.sum_range_reflect (fun x => x) k]
+    _ = k.choose 2 + k * (N - k) := by
+      rw [Finset.sum_range_id, Nat.choose_two_right]
+      omega
+
+end Finset
+
 namespace Fin
+
+/-- The sum of the values in the first `k` positions of the reversed finite ordinal `Fin N`. -/
+theorem sum_rev_castLE (N k : ℕ) (hk : k ≤ N) :
+    (∑ i : Fin k, (Fin.rev (Fin.castLE hk i) : ℕ)) =
+      k.choose 2 + k * (N - k) := by
+  rw [Finset.sum_fin_eq_sum_range]
+  simp only [Fin.rev, Fin.castLE]
+  calc
+    Finset.sum (Finset.range k)
+        (fun x => if h : x < k then N - (x + 1) else 0) =
+        Finset.sum (Finset.range k) (fun x => N - (x + 1)) := by
+      apply Finset.sum_congr rfl
+      intro x hx
+      simp [Finset.mem_range.mp hx]
+    _ = _ := Finset.sum_range_const_sub_succ N k hk
 
 /-- The final partial product is the product of all the entries. -/
 @[to_additive /-- The final partial sum is the sum of all the entries. -/]


### PR DESCRIPTION
This PR proves CAR highest-weight identification and isotypy for the SpinRepresentations Layer 9 explicit CAR decomposition milestone.

Roadmap: RepresentationTheory

## Summary

The left-regular Clifford algebra of the trace form is isotypic, as a `gl_N`-module over an algebraically closed field of characteristic zero, of the simple module with half-shifted staircase highest weight. The proof identifies any CAR highest weight from its natural occupation counts: dominance orders the counts, the merged cut bounds majorize their prefixes and fix their total, and the trace-form Casimir scalar supplies the quadratic equality needed by the existing staircase uniqueness theorem. The supporting reversed-index sum identities are public in the shared finite-ordinal infrastructure and reused by the CAR proof.

## Roadmap target

This advances `RepresentationTheory/SpinRepresentations/README.md`, Layer 9, by proving the stated CAR isotypy and identifying its irreducible type. After this PR, the explicit direct-sum decomposition remains to be obtained by evaluating the simple module's dimension and hence the isotypic multiplicity, using the existing complete-reducibility and Clifford-dimension infrastructure.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"car-isotypic"}-->

## Verification

- Exact head: `2e1f4cf276881fea76c6fd3722d473cb6f33e31f`
- Local Lean build: `lake build --iofail` — pass (11,198 jobs)
- Axiom audit: `lake exe axioms` — pass (112,247 declarations; only `propext`, `Classical.choice`, and `Quot.sound`)
- Lint: `lake exe module-system` — pass (all 5,035 modules); GNU Bash/GNU sed `bash scripts/lint-env.sh` — pass (8,994 declarations documented, no new violations); `bash scripts/lint-style.sh` — pass (5,034 conforming headers)
- Proof golf: `ut-lean-golf` structural audit — found no exact pinned-library replacement for the two reversed-index sum identities, retained their reuse of Mathlib's reflected-range and closed-form sum lemmas, and moved the identities to the shared `Fin` infrastructure instead of duplicating them in CAR
- Public CI: pending on the repaired head

## Scale and generality

The highest-weight identification requires only a characteristic-zero field; algebraic closure is introduced exactly where the existing highest-weight isotypy criterion needs it. Both the weight and isotypy results are uniform in `N`, including ranks zero and one. The aggregate change adds one 171-line CAR module with two public theorems and two general public finite-sum lemmas in the existing finite-ordinal module.

## Scope

- **Consumes:** the merged CAR occupation-coordinate and cut-sum bounds, highest-weight dominance, the trace-form Casimir action and half-staircase eigenvalue, the staircase numerical uniqueness theorem, Mathlib's reflected-range sum identities, and the generic fixed-carrier `gl_N` isotypy criterion
- **Provides:** `Finset.sum_range_const_sub_succ`, `Fin.sum_rev_castLE`, `IsGlHighestWeightVector.eq_glHalfStaircase`, and `isIsotypicOfType_glIrreducible_car`
- **Fits:** closes the weight-identification and isotypy step needed before the Layer 9 multiplicity calculation
- **Boundary:** does not restate the existing generic direct-sum theorem or calculate the irreducible dimension and multiplicity

<sub>🤖 GPT-5.6 Sol high · TauCetiWorker @ [cd34d76f5173995310422b13b1be93c978d16f8f](https://github.com/utensil/TauCetiWorker/commit/cd34d76f5173995310422b13b1be93c978d16f8f) · rubrics @ [afb424eda89e8ac96d9eb69f6a88972055a4cd1b](https://github.com/utensil/TauCetiReview/commit/afb424eda89e8ac96d9eb69f6a88972055a4cd1b) · local review @ [b533e561b6d44df071c31335ed4a63ae647507d2](https://github.com/utensil/formal-land/commit/b533e561b6d44df071c31335ed4a63ae647507d2) · fixed: api-design, reuse, ut-aggregate-reuse</sub>