### PR TITLE
feat: Witt cancellation for a regular summand

### DIFF
--- a/TauCeti/LinearAlgebra/QuadraticForm/Isometry.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/Isometry.lean
@@ -1,0 +1,37 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.LinearAlgebra.QuadraticForm.IsometryEquiv
+
+/-!
+# Isometries of quadratic maps
+
+This file records general properties of quadratic-map isometries.
+
+## Main results
+
+* `QuadraticMap.Isometry.polar_apply`: an isometry preserves polarization.
+-/
+
+public section
+
+namespace TauCeti
+
+open QuadraticMap
+
+universe u v w
+
+/-- An isometry preserves the polarization of a quadratic map. -/
+@[simp]
+theorem _root_.QuadraticMap.Isometry.polar_apply {R : Type u} {M₁ : Type v} {M₂ : Type*}
+    {N : Type w} [CommSemiring R] [AddCommGroup M₁] [Module R M₁] [AddCommGroup M₂]
+    [Module R M₂] [AddCommGroup N] [Module R N] {Q₁ : QuadraticMap R M₁ N}
+    {Q₂ : QuadraticMap R M₂ N} (f : Q₁ →qᵢ Q₂) (x y : M₁) :
+    polar Q₂ (f x) (f y) = polar Q₁ x y := by
+  simp only [QuadraticMap.polar, ← map_add f, QuadraticMap.Isometry.map_app]
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
@@ -30,10 +30,10 @@ the hyperplanes of vectors of invertible norm. The orthogonal group is the targe
 twisted-conjugation homomorphism out of the Pin group, so it is the object the Pin/Spin double
 covers are stated against, and the reflections are the generators an eventual Cartan-Dieudonné
 theorem factors an orthogonal automorphism into. The structural and reflection declarations below
-hold over an arbitrary commutative ring. The equal-norm dichotomy and fixed-subspace correction
-assume a field in which `2` is nonzero. The characteristic restriction is not incidental: in
-characteristic two `polar Q v v = 2 • Q v` vanishes, so `reflection Q v` fixes `v` instead of
-negating it and is a transvection rather than a reflection in `v ^ ⊥`.
+hold over an arbitrary commutative ring. The equal-norm dichotomy, Witt transitivity and the
+fixed-subspace correction assume a field in which `2` is nonzero. The characteristic restriction
+is not incidental: in characteristic two `polar Q v v = 2 • Q v` vanishes, so `reflection Q v`
+fixes `v` instead of negating it and is a transvection rather than a reflection in `v ^ ⊥`.
 
 ## Main definitions
 
@@ -51,8 +51,9 @@ negating it and is a transvection rather than a reflection in `v ^ ⊥`.
 
 ## Main results
 
-* `TauCeti.QuadraticMap.polar_apply_of_mem_orthogonalGroup`: an orthogonal automorphism preserves
-  the polarization of `Q`; it preserves the orthogonality relation as well
+* `QuadraticMap.Isometry.polar_apply`: an isometry preserves the polarization of a quadratic map.
+  `TauCeti.QuadraticMap.polar_apply_of_mem_orthogonalGroup` says the same of an orthogonal
+  automorphism, which preserves the orthogonality relation as well
   (`isOrtho_iff_of_mem_orthogonalGroup`). As soon as `2` acts injectively on the target the
   converse holds, `TauCeti.QuadraticMap.mem_orthogonalGroup_iff_polar`, which is the usual
   identification of the isometries of a quadratic form with the isometries of its polar bilinear
@@ -78,6 +79,9 @@ negating it and is a transvection rather than a reflection in `v ^ ⊥`.
   under hypotheses (a field of characteristic not two, a nondegenerate form, finite dimension)
   that are not assumed here, and the image of the Pin group's generating vectors under twisted
   conjugation.
+* `QuadraticMap.exists_isometryEquiv_apply_eq_of_map_eq`: **Witt transitivity**, the orthogonal
+  group acts transitively on the vectors of a fixed nonzero value, by reflecting in `x - y` or in
+  `x + y`.
 * `TauCeti.QuadraticMap.exists_mem_subgroup_mul_eqOn_sup_span_singleton_of_reflection_mem`: a
   subgroup containing the invertible-norm reflections supplies the one-step fixed-subspace
   correction used by Cartan--Dieudonne induction.
@@ -227,6 +231,15 @@ section Polar
 
 variable {R : Type u} {M : Type v} {N : Type w} [CommSemiring R]
   [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N] {Q : QuadraticMap R M N}
+
+/-- An isometry preserves the polarization of a quadratic map, because the polarization is built
+from the map and the additive structure alone. Mathlib records that an isometry preserves the
+values of a quadratic map (`QuadraticMap.Isometry.map_app`), but not this. -/
+theorem _root_.QuadraticMap.Isometry.polar_apply {M₁ : Type*} {M₂ : Type*} [AddCommGroup M₁]
+    [Module R M₁] [AddCommGroup M₂] [Module R M₂] {Q₁ : QuadraticMap R M₁ N}
+    {Q₂ : QuadraticMap R M₂ N} (f : Q₁ →qᵢ Q₂) (x y : M₁) :
+    polar Q₂ (f x) (f y) = polar Q₁ x y := by
+  simp only [QuadraticMap.polar, ← map_add f, QuadraticMap.Isometry.map_app]
 
 /-- An orthogonal automorphism preserves the polarization of `Q`, because the polarization is
 built from `Q` and the additive structure alone. -/
@@ -609,6 +622,25 @@ theorem isUnit_sub_or_add_of_map_eq (x y : V) (hxy : Q x = Q y) (hy : Q y ≠ 0)
         mul_ne_zero (NeZero.ne (2 : K)) (NeZero.ne (2 : K))
     exact hy ((mul_eq_zero.mp hzero).resolve_left h4)
   · exact Or.inl hsub
+
+/-- **Witt transitivity** (Lam I.4.5): over a field of characteristic different from two, the
+orthogonal group of a quadratic form acts transitively on the vectors of a fixed nonzero value.
+
+One of `x - y` and `x + y` has nonzero, hence invertible, norm. In the first case the reflection
+in `x - y` carries `x` to `y`; in the second the reflection in `x + y` carries `x` to `-y`, which
+the reflection in `y` sends to `y`. -/
+theorem _root_.QuadraticMap.exists_isometryEquiv_apply_eq_of_map_eq {x y : V} (hxy : Q x = Q y)
+    (hy : Q y ≠ 0) : ∃ f : Q.IsometryEquiv Q, f x = y := by
+  rcases isUnit_sub_or_add_of_map_eq Q x y hxy hy with h | h
+  · have := h.invertible
+    exact ⟨orthogonalGroupEquivIsometryEquiv Q (reflectionOrthogonal Q (x - y)),
+      by simpa using reflection_sub_apply_eq_of_map_eq Q x y hxy⟩
+  · have : Invertible (Q y) := (isUnit_iff_ne_zero.mpr hy).invertible
+    have : Invertible (Q (x - -y)) := by simpa only [sub_neg_eq_add] using h.invertible
+    have hneg : reflection Q (x - -y) x = -y :=
+      reflection_sub_apply_eq_of_map_eq Q x (-y) (hxy.trans (Q.map_neg y).symm)
+    exact ⟨orthogonalGroupEquivIsometryEquiv Q
+      (reflectionOrthogonal Q y * reflectionOrthogonal Q (x - -y)), by simp [hneg, map_neg]⟩
 
 end Field
 

--- a/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
@@ -5,8 +5,8 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.LinearAlgebra.QuadraticForm.IsometryEquiv
 public import TauCeti.LinearAlgebra.BilinearForm.Isometry
+public import TauCeti.LinearAlgebra.QuadraticForm.Isometry
 public import TauCeti.LinearAlgebra.Reflection
 import Mathlib.LinearAlgebra.SpecialLinearGroup
 import TauCeti.Algebra.Group.Subgroup.Map
@@ -51,9 +51,8 @@ fixes `v` instead of negating it and is a transvection rather than a reflection 
 
 ## Main results
 
-* `QuadraticMap.Isometry.polar_apply`: an isometry preserves the polarization of a quadratic map.
-  `TauCeti.QuadraticMap.polar_apply_of_mem_orthogonalGroup` says the same of an orthogonal
-  automorphism, which preserves the orthogonality relation as well
+* `TauCeti.QuadraticMap.polar_apply_of_mem_orthogonalGroup`: an orthogonal automorphism preserves
+  polarization and the orthogonality relation
   (`isOrtho_iff_of_mem_orthogonalGroup`). As soon as `2` acts injectively on the target the
   converse holds, `TauCeti.QuadraticMap.mem_orthogonalGroup_iff_polar`, which is the usual
   identification of the isometries of a quadratic form with the isometries of its polar bilinear
@@ -231,14 +230,6 @@ section Polar
 
 variable {R : Type u} {M : Type v} {N : Type w} [CommSemiring R]
   [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N] {Q : QuadraticMap R M N}
-
-/-- An isometry preserves the polarization of a quadratic map. -/
-@[simp]
-theorem _root_.QuadraticMap.Isometry.polar_apply {M₁ : Type*} {M₂ : Type*} [AddCommGroup M₁]
-    [Module R M₁] [AddCommGroup M₂] [Module R M₂] {Q₁ : QuadraticMap R M₁ N}
-    {Q₂ : QuadraticMap R M₂ N} (f : Q₁ →qᵢ Q₂) (x y : M₁) :
-    polar Q₂ (f x) (f y) = polar Q₁ x y := by
-  simp only [QuadraticMap.polar, ← map_add f, QuadraticMap.Isometry.map_app]
 
 /-- An orthogonal automorphism preserves the polarization of `Q`, because the polarization is
 built from `Q` and the additive structure alone. -/

--- a/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
@@ -232,9 +232,8 @@ section Polar
 variable {R : Type u} {M : Type v} {N : Type w} [CommSemiring R]
   [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N] {Q : QuadraticMap R M N}
 
-/-- An isometry preserves the polarization of a quadratic map, because the polarization is built
-from the map and the additive structure alone. Mathlib records that an isometry preserves the
-values of a quadratic map (`QuadraticMap.Isometry.map_app`), but not this. -/
+/-- An isometry preserves the polarization of a quadratic map. -/
+@[simp]
 theorem _root_.QuadraticMap.Isometry.polar_apply {M₁ : Type*} {M₂ : Type*} [AddCommGroup M₁]
     [Module R M₁] [AddCommGroup M₂] [Module R M₂] {Q₁ : QuadraticMap R M₁ N}
     {Q₂ : QuadraticMap R M₂ N} (f : Q₁ →qᵢ Q₂) (x y : M₁) :
@@ -623,12 +622,8 @@ theorem isUnit_sub_or_add_of_map_eq (x y : V) (hxy : Q x = Q y) (hy : Q y ≠ 0)
     exact hy ((mul_eq_zero.mp hzero).resolve_left h4)
   · exact Or.inl hsub
 
-/-- **Witt transitivity** (Lam I.4.5): over a field of characteristic different from two, the
-orthogonal group of a quadratic form acts transitively on the vectors of a fixed nonzero value.
-
-One of `x - y` and `x + y` has nonzero, hence invertible, norm. In the first case the reflection
-in `x - y` carries `x` to `y`; in the second the reflection in `x + y` carries `x` to `-y`, which
-the reflection in `y` sends to `y`. -/
+/-- **Witt transitivity** (Lam I.4.5): over a field of characteristic different from two, any two
+vectors with the same nonzero value are related by an isometry of the quadratic form. -/
 theorem _root_.QuadraticMap.exists_isometryEquiv_apply_eq_of_map_eq {x y : V} (hxy : Q x = Q y)
     (hy : Q y ≠ 0) : ∃ f : Q.IsometryEquiv Q, f x = y := by
   rcases isUnit_sub_or_add_of_map_eq Q x y hxy hy with h | h

--- a/TauCeti/LinearAlgebra/QuadraticForm/Radical.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/Radical.lean
@@ -150,19 +150,20 @@ end LinearMap
 
 namespace TauCeti
 
-variable {K V : Type*} [Field K] [Invertible (2 : K)] [AddCommGroup V] [Module K V]
+variable {R V : Type*} [CommRing R] [IsDomain R] [Invertible (2 : R)] [AddCommGroup V]
+  [Module R V]
 
 /-- A form on a line spanned by a vector of nonzero value is nondegenerate. -/
-theorem nondegenerate_of_span_singleton_eq_top {Q : QuadraticForm K V} {v : V}
-    (hspan : Submodule.span K {v} = ⊤) (hv : Q v ≠ 0) : Q.Nondegenerate := by
+theorem nondegenerate_of_span_singleton_eq_top {Q : QuadraticForm R V} {v : V}
+    (hspan : Submodule.span R {v} = ⊤) (hv : Q v ≠ 0) : Q.Nondegenerate := by
   rw [QuadraticMap.nondegenerate_iff_radical_eq_bot, QuadraticMap.radical_eq_ker_polarBilin,
     LinearMap.ker_eq_bot']
   intro z hz
-  obtain ⟨c, rfl⟩ := (Submodule.span_singleton_eq_top_iff K v).mp hspan z
+  obtain ⟨c, rfl⟩ := (Submodule.span_singleton_eq_top_iff R v).mp hspan z
   have hpolar : QuadraticMap.polar Q (c • v) v = 0 := by
-    simpa using congrArg (fun L : V →ₗ[K] K => L v) hz
+    simpa using congrArg (fun L : V →ₗ[R] R => L v) hz
   rw [QuadraticMap.polar_smul_left, QuadraticMap.polar_self] at hpolar
-  have hc : c = 0 := by simpa [(isUnit_of_invertible (2 : K)).ne_zero, hv] using hpolar
+  have hc : c = 0 := by simpa [(isUnit_of_invertible (2 : R)).ne_zero, hv] using hpolar
   rw [hc, zero_smul]
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/QuadraticForm/Radical.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/Radical.lean
@@ -26,6 +26,8 @@ its polar form is `2 • B`, and nondegeneracy passes from `B` to it as soon as 
 * `QuadraticMap.Nondegenerate.prod`: nondegeneracy passes to an orthogonal product.
 * `QuadraticMap.Nondegenerate.ne_zero`: a nondegenerate quadratic form on a nontrivial module is
   nonzero.
+* `TauCeti.nondegenerate_of_span_singleton_eq_top`: a form on a line is nondegenerate when it is
+  nonzero on a spanning vector.
 * `QuadraticMap.Anisotropic.radical_eq_bot`: an anisotropic quadratic map has trivial radical.
 * `QuadraticMap.Anisotropic.nondegenerate`: an anisotropic quadratic map is nondegenerate when
   `2` is invertible.
@@ -145,3 +147,22 @@ theorem BilinForm.Nondegenerate.toQuadraticMap [Invertible (2 : R)] {B : LinearM
   · simpa only [LinearMap.smul_apply, smul_eq_mul, h2.mul_right_eq_zero] using hy x
 
 end LinearMap
+
+namespace TauCeti
+
+variable {K V : Type*} [Field K] [Invertible (2 : K)] [AddCommGroup V] [Module K V]
+
+/-- A form on a line spanned by a vector of nonzero value is nondegenerate. -/
+theorem nondegenerate_of_span_singleton_eq_top {Q : QuadraticForm K V} {v : V}
+    (hspan : Submodule.span K {v} = ⊤) (hv : Q v ≠ 0) : Q.Nondegenerate := by
+  rw [QuadraticMap.nondegenerate_iff_radical_eq_bot, QuadraticMap.radical_eq_ker_polarBilin,
+    LinearMap.ker_eq_bot']
+  intro z hz
+  obtain ⟨c, rfl⟩ := (Submodule.span_singleton_eq_top_iff K v).mp hspan z
+  have hpolar : QuadraticMap.polar Q (c • v) v = 0 := by
+    simpa using congrArg (fun L : V →ₗ[K] K => L v) hz
+  rw [QuadraticMap.polar_smul_left, QuadraticMap.polar_self] at hpolar
+  have hc : c = 0 := by simpa [(isUnit_of_invertible (2 : K)).ne_zero, hv] using hpolar
+  rw [hc, zero_smul]
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/QuadraticForm/RegularFormClass/Basic.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/RegularFormClass/Basic.lean
@@ -46,6 +46,8 @@ rank is additive.
 * `TauCeti.formClass_mk`: the class of a form is computed by any of its diagonalizations.
 * `TauCeti.formClass_eq_iff`: two regular forms are isometric exactly when their classes agree.
 * `TauCeti.presentedFormAppendIsometryEquiv`: concatenating weights presents the orthogonal sum.
+* `TauCeti.presentedFormConsIsometryEquiv`: peeling the first weight off presents the form as a
+  line orthogonal to the presentation of the remaining weights.
 * `TauCeti.formClass_prod`: the class of an orthogonal product is the sum of the classes.
 
 ## References
@@ -240,6 +242,20 @@ theorem equivalent_presentedForm_append_prod (p q : RegularFormPresentation K) :
     (presentedForm (RegularFormPresentation.append p q)).Equivalent
       ((presentedForm p).prod (presentedForm q)) :=
   ⟨presentedFormAppendIsometryEquiv p q⟩
+
+/-- Peeling the first weight off a presentation of positive rank exhibits the presented form as
+the orthogonal sum of the line `⟨w 0⟩` and the presentation of the remaining weights:
+`⟨w 0⟩ ⊥ ⟨w 1, …, w n⟩ ≅ ⟨w 0, …, w n⟩`. The first factor is carried by `K` itself rather than by
+`Fin 1 → K`, which is what makes it a line spanned by `1`. -/
+def presentedFormConsIsometryEquiv {n : ℕ} (w : Fin (n + 1) → Kˣ) :
+    (((w 0 : K) • (QuadraticMap.sq : QuadraticForm K K)).prod
+        (presentedForm ⟨n, fun i => w i.succ⟩)).IsometryEquiv (presentedForm ⟨n + 1, w⟩) where
+  toLinearEquiv := Fin.consLinearEquiv K fun _ : Fin (n + 1) => K
+  map_app' x := by
+    -- `presentedForm_apply` does not fire under `simp` here: the rank of the presentation appears
+    -- in the type of `x`, so the rewrite has to be directed by hand.
+    rw [presentedForm_apply, QuadraticMap.prod_apply, presentedForm_apply, Fin.sum_univ_succ]
+    simp
 
 /-- Concatenation of presentations respects isometry in each argument. -/
 theorem presentedForm_append_congr {p p' q q' : RegularFormPresentation K}

--- a/TauCeti/LinearAlgebra/QuadraticForm/RegularFormClass/Basic.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/RegularFormClass/Basic.lean
@@ -257,12 +257,17 @@ def presentedFormConsIsometryEquiv {n : ℕ} (w : Fin (n + 1) → Kˣ) :
     rw [presentedForm_apply, QuadraticMap.prod_apply, presentedForm_apply, Fin.sum_univ_succ]
     simp
 
+private theorem presentedFormConsIsometryEquiv_toLinearEquiv {n : ℕ} (w : Fin (n + 1) → Kˣ) :
+    (presentedFormConsIsometryEquiv w).toLinearEquiv =
+      Fin.consLinearEquiv K (fun _ : Fin (n + 1) ↦ K) := rfl
+
 /-- The forward map of `TauCeti.presentedFormConsIsometryEquiv` prepends the line coordinate. -/
 @[simp]
 theorem presentedFormConsIsometryEquiv_apply {n : ℕ} (w : Fin (n + 1) → Kˣ)
     (x : K × (Fin n → K)) :
     presentedFormConsIsometryEquiv w x = Fin.cons x.1 x.2 := by
-  change (Fin.consLinearEquiv K fun _ : Fin (n + 1) ↦ K) x = _
+  change (presentedFormConsIsometryEquiv w).toLinearEquiv x = _
+  rw [presentedFormConsIsometryEquiv_toLinearEquiv]
   ext i
   exact Fin.consLinearEquiv_apply K (fun _ : Fin (n + 1) ↦ K) x i
 
@@ -272,7 +277,8 @@ from the remaining coordinates. -/
 theorem presentedFormConsIsometryEquiv_symm_apply {n : ℕ} (w : Fin (n + 1) → Kˣ)
     (x : Fin (n + 1) → K) :
     (presentedFormConsIsometryEquiv w).symm x = (x 0, Fin.tail x) := by
-  change (Fin.consLinearEquiv K fun _ : Fin (n + 1) ↦ K).symm x = _
+  change (presentedFormConsIsometryEquiv w).toLinearEquiv.symm x = _
+  rw [presentedFormConsIsometryEquiv_toLinearEquiv]
   exact Fin.consLinearEquiv_symm_apply K (fun _ : Fin (n + 1) ↦ K) x
 
 /-- Concatenation of presentations respects isometry in each argument. -/

--- a/TauCeti/LinearAlgebra/QuadraticForm/RegularFormClass/Basic.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/RegularFormClass/Basic.lean
@@ -257,6 +257,24 @@ def presentedFormConsIsometryEquiv {n : ℕ} (w : Fin (n + 1) → Kˣ) :
     rw [presentedForm_apply, QuadraticMap.prod_apply, presentedForm_apply, Fin.sum_univ_succ]
     simp
 
+/-- The forward map of `TauCeti.presentedFormConsIsometryEquiv` prepends the line coordinate. -/
+@[simp]
+theorem presentedFormConsIsometryEquiv_apply {n : ℕ} (w : Fin (n + 1) → Kˣ)
+    (x : K × (Fin n → K)) :
+    presentedFormConsIsometryEquiv w x = Fin.cons x.1 x.2 := by
+  change (Fin.consLinearEquiv K fun _ : Fin (n + 1) ↦ K) x = _
+  ext i
+  exact Fin.consLinearEquiv_apply K (fun _ : Fin (n + 1) ↦ K) x i
+
+/-- The inverse map of `TauCeti.presentedFormConsIsometryEquiv` separates the first coordinate
+from the remaining coordinates. -/
+@[simp]
+theorem presentedFormConsIsometryEquiv_symm_apply {n : ℕ} (w : Fin (n + 1) → Kˣ)
+    (x : Fin (n + 1) → K) :
+    (presentedFormConsIsometryEquiv w).symm x = (x 0, Fin.tail x) := by
+  change (Fin.consLinearEquiv K fun _ : Fin (n + 1) ↦ K).symm x = _
+  exact Fin.consLinearEquiv_symm_apply K (fun _ : Fin (n + 1) ↦ K) x
+
 /-- Concatenation of presentations respects isometry in each argument. -/
 theorem presentedForm_append_congr {p p' q q' : RegularFormPresentation K}
     (hp : (presentedForm p).Equivalent (presentedForm p'))

--- a/TauCeti/LinearAlgebra/QuadraticForm/RegularFormClass/Basic.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/RegularFormClass/Basic.lean
@@ -266,8 +266,7 @@ private theorem presentedFormConsIsometryEquiv_toLinearEquiv {n : ℕ} (w : Fin 
 theorem presentedFormConsIsometryEquiv_apply {n : ℕ} (w : Fin (n + 1) → Kˣ)
     (x : K × (Fin n → K)) :
     presentedFormConsIsometryEquiv w x = Fin.cons x.1 x.2 := by
-  change (presentedFormConsIsometryEquiv w).toLinearEquiv x = _
-  rw [presentedFormConsIsometryEquiv_toLinearEquiv]
+  rw [← QuadraticMap.IsometryEquiv.coe_toLinearEquiv, presentedFormConsIsometryEquiv_toLinearEquiv]
   ext i
   exact Fin.consLinearEquiv_apply K (fun _ : Fin (n + 1) ↦ K) x i
 
@@ -277,9 +276,8 @@ from the remaining coordinates. -/
 theorem presentedFormConsIsometryEquiv_symm_apply {n : ℕ} (w : Fin (n + 1) → Kˣ)
     (x : Fin (n + 1) → K) :
     (presentedFormConsIsometryEquiv w).symm x = (x 0, Fin.tail x) := by
-  change (presentedFormConsIsometryEquiv w).toLinearEquiv.symm x = _
-  rw [presentedFormConsIsometryEquiv_toLinearEquiv]
-  exact Fin.consLinearEquiv_symm_apply K (fun _ : Fin (n + 1) ↦ K) x
+  rw [QuadraticMap.IsometryEquiv.symm_apply_eq, presentedFormConsIsometryEquiv_apply,
+    Fin.cons_self_tail]
 
 /-- Concatenation of presentations respects isometry in each argument. -/
 theorem presentedForm_append_congr {p p' q q' : RegularFormPresentation K}

--- a/TauCeti/LinearAlgebra/QuadraticForm/WittCancellation.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/WittCancellation.lean
@@ -1,0 +1,325 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.LinearAlgebra.QuadraticForm.RegularFormClass.Basic
+
+/-!
+# Witt cancellation
+
+Over a field in which `2` is invertible, a regular summand may be cancelled from an orthogonal
+sum: if `q ⊥ q₁` and `q ⊥ q₂` are isometric and `q` is regular and finite dimensional, then `q₁`
+and `q₂` are isometric. This is Witt's cancellation theorem, and it is what makes the isometry
+classes of regular forms cancellative under orthogonal sum, hence a monoid with a Grothendieck
+group.
+
+The proof follows Lam I.4.5-I.4.7 and runs in three steps.
+
+The first step uses no reflection: an isometry `e` of `q ⊥ q₁` onto `q ⊥ q₂` that fixes the first
+summand *pointwise* carries the second summand into the second summand, because the first
+component of `e (0, v)` is orthogonal to the whole of the first summand and so lies in the radical
+of `q`. The second component of `e (0, ·)` is then an isometry of `q₁` onto `q₂`
+(`TauCeti.prodCancelIsometryEquiv`).
+
+The second step makes an arbitrary isometry fix a line pointwise. Over a field of characteristic
+different from two the orthogonal group of a form acts transitively on the vectors of a fixed
+nonzero value (`TauCeti.exists_isometryEquiv_apply_eq_of_map_eq`): one of `x - y` and `x + y` has
+nonzero norm, and the reflection in it carries `x` to `y` or to `-y`. Composing the given isometry
+with such an element cancels a summand spanned by a single vector of nonzero value
+(`TauCeti.equivalent_of_equivalent_prod_of_span_singleton_eq_top`).
+
+The third step is induction on a diagonalization of the cancelled summand: peeling the first
+weight off `⟨a₀, …, aₙ⟩` with `Fin.consLinearEquiv` exhibits it as `⟨a₀⟩ ⊥ ⟨a₁, …, aₙ⟩`, whose
+first factor is carried by the line `K` and is cancelled by the second step.
+
+## Main definitions
+
+* `TauCeti.prodCancelIsometryEquiv`: the isometry obtained by cancelling a regular summand that an
+  isometry of orthogonal sums fixes pointwise.
+
+## Main results
+
+* `TauCeti.exists_isometryEquiv_apply_eq_of_map_eq`: **Witt transitivity**, the orthogonal group
+  acts transitively on the vectors of a fixed nonzero value.
+* `TauCeti.equivalent_of_equivalent_prod_of_span_singleton_eq_top`: cancellation of a summand
+  carried by a line spanned by a vector of nonzero value.
+* `TauCeti.equivalent_of_equivalent_prod`: **Witt cancellation** for a regular finite-dimensional
+  summand, and `TauCeti.equivalent_of_equivalent_prod_right` on the other side.
+* `TauCeti.RegularFormClass` is cancellative under orthogonal sum.
+
+## Implementation notes
+
+Cancellation of a *degenerate* summand is not proved here, and is not a matter of weakening a
+hypothesis: over a field in which `2` is invertible it reduces to the uniqueness half of the Witt
+decomposition, which splits a form as a regular part orthogonal to the zero form on its radical.
+That decomposition is a separate milestone, and the reflection route below genuinely needs
+regularity, because a reflection is only defined in a vector of invertible value.
+
+## References
+
+* T. Y. Lam, *Introduction to Quadratic Forms over Fields* (2005), Chapter I, §4.
+-/
+
+public section
+
+open QuadraticMap
+
+namespace TauCeti
+
+universe u v v₀ v₁ v₂
+
+/-! ### Cancelling a summand that is fixed pointwise -/
+
+section CommRing
+
+variable {R : Type u} [CommRing R] [Invertible (2 : R)]
+  {P : Type v} [AddCommGroup P] [Module R P]
+  {V₀ : Type v₀} [AddCommGroup V₀] [Module R V₀]
+  {V₁ : Type v₁} [AddCommGroup V₁] [Module R V₁]
+  {V₂ : Type v₂} [AddCommGroup V₂] [Module R V₂]
+  {Q₀ : QuadraticMap R V₀ P} {Q₁ : QuadraticMap R V₁ P} {Q₂ : QuadraticMap R V₂ P}
+
+-- Mathlib records that an isometry preserves the values of a quadratic map, but not that it
+-- preserves its polarization; that is all the proofs below need of it.
+omit [Invertible (2 : R)] in
+private theorem polar_apply_isometryEquiv (e : Q₁.IsometryEquiv Q₂) (x y : V₁) :
+    polar Q₂ (e x) (e y) = polar Q₁ x y := by
+  simp only [QuadraticMap.polar, ← map_add e, IsometryEquiv.map_app]
+
+-- The candidate isometry: transport the second summand through `e` and forget the first
+-- coordinate. `TauCeti.isometryEquiv_prod_fst_eq_zero` shows that nothing is forgotten.
+private def prodCancelMap (e : (Q₀.prod Q₁).IsometryEquiv (Q₀.prod Q₂)) : V₁ →ₗ[R] V₂ :=
+  LinearMap.snd R V₀ V₂ ∘ₗ (e : (V₀ × V₁) ≃ₗ[R] V₀ × V₂).toLinearMap ∘ₗ LinearMap.inr R V₀ V₁
+
+omit [Invertible (2 : R)] in
+private theorem prodCancelMap_apply (e : (Q₀.prod Q₁).IsometryEquiv (Q₀.prod Q₂)) (v : V₁) :
+    prodCancelMap e v = (e (0, v)).2 := (rfl)
+
+omit [Invertible (2 : R)] in
+private theorem isometryEquiv_symm_apply_inl (e : (Q₀.prod Q₁).IsometryEquiv (Q₀.prod Q₂))
+    (he : ∀ u : V₀, e (u, 0) = (u, 0)) (u : V₀) : e.symm (u, 0) = (u, 0) := by
+  rw [← he u, e.symm_apply_apply]
+
+/-- An isometry of orthogonal sums that fixes the first summand pointwise carries the second
+summand into the second summand, as soon as the first summand is regular: the first component of
+`e (0, v)` is orthogonal to all of `V₀`, hence lies in the radical of `Q₀`. -/
+theorem isometryEquiv_prod_fst_eq_zero (hQ₀ : Q₀.Nondegenerate)
+    (e : (Q₀.prod Q₁).IsometryEquiv (Q₀.prod Q₂)) (he : ∀ u : V₀, e (u, 0) = (u, 0)) (v : V₁) :
+    (e (0, v)).1 = 0 := by
+  have hmem : (e (0, v)).1 ∈ Q₀.radical := by
+    rw [QuadraticMap.radical_eq_ker_polarBilin, LinearMap.mem_ker]
+    ext u
+    have h := polar_apply_isometryEquiv e (0, v) (u, 0)
+    rw [he u] at h
+    simpa using h
+  rw [hQ₀.radical_eq_bot] at hmem
+  simpa using hmem
+
+/-- Cancel the first summand of an orthogonal sum along an isometry that fixes it pointwise: the
+second component of `e (0, ·)` is an isometry of the second summands. -/
+def prodCancelIsometryEquiv (hQ₀ : Q₀.Nondegenerate)
+    (e : (Q₀.prod Q₁).IsometryEquiv (Q₀.prod Q₂)) (he : ∀ u : V₀, e (u, 0) = (u, 0)) :
+    Q₁.IsometryEquiv Q₂ where
+  toLinearEquiv :=
+    LinearEquiv.ofLinearMap (prodCancelMap e) (prodCancelMap e.symm)
+      (LinearMap.ext fun w => by
+        have hzero := isometryEquiv_prod_fst_eq_zero hQ₀ e.symm
+          (isometryEquiv_symm_apply_inl e he) w
+        have h : ((0 : V₀), (e.symm (0, w)).2) = e.symm (0, w) := Prod.ext hzero.symm rfl
+        simp only [LinearMap.coe_comp, Function.comp_apply, prodCancelMap_apply, h,
+          e.apply_symm_apply, LinearMap.id_coe, id_eq])
+      (LinearMap.ext fun v => by
+        have h : ((0 : V₀), (e (0, v)).2) = e (0, v) :=
+          Prod.ext (isometryEquiv_prod_fst_eq_zero hQ₀ e he v).symm rfl
+        simp only [LinearMap.coe_comp, Function.comp_apply, prodCancelMap_apply, h,
+          e.symm_apply_apply, LinearMap.id_coe, id_eq])
+  map_app' v := by
+    have h := e.map_app (0, v)
+    rw [QuadraticMap.prod_apply, QuadraticMap.prod_apply,
+      isometryEquiv_prod_fst_eq_zero hQ₀ e he v] at h
+    simpa [prodCancelMap_apply] using h
+
+@[simp]
+theorem prodCancelIsometryEquiv_apply (hQ₀ : Q₀.Nondegenerate)
+    (e : (Q₀.prod Q₁).IsometryEquiv (Q₀.prod Q₂)) (he : ∀ u : V₀, e (u, 0) = (u, 0)) (v : V₁) :
+    prodCancelIsometryEquiv hQ₀ e he v = (e (0, v)).2 := (rfl)
+
+end CommRing
+
+/-! ### Witt transitivity -/
+
+section Transitivity
+
+variable {K : Type u} [Field K] [NeZero (2 : K)] {V : Type v} [AddCommGroup V] [Module K V]
+
+/-- **Witt transitivity** (Lam I.4.5): over a field of characteristic different from two, the
+orthogonal group of a quadratic form acts transitively on the vectors of a fixed nonzero value.
+
+One of `x - y` and `x + y` has nonzero, hence invertible, norm. In the first case the reflection
+in `x - y` carries `x` to `y`; in the second the reflection in `x + y` carries `x` to `-y`, which
+the reflection in `y` sends to `y`. -/
+theorem exists_isometryEquiv_apply_eq_of_map_eq (Q : QuadraticForm K V) {x y : V}
+    (hxy : Q x = Q y) (hy : Q y ≠ 0) : ∃ f : Q.IsometryEquiv Q, f x = y := by
+  rcases QuadraticMap.isUnit_sub_or_add_of_map_eq Q x y hxy hy with h | h
+  · have := h.invertible
+    refine ⟨QuadraticMap.orthogonalGroupEquivIsometryEquiv Q
+      ⟨QuadraticMap.reflection Q (x - y), QuadraticMap.reflection_mem_orthogonalGroup Q _⟩, ?_⟩
+    simpa using QuadraticMap.reflection_sub_apply_eq_of_map_eq Q x y hxy
+  · have : Invertible (Q y) := (isUnit_iff_ne_zero.mpr hy).invertible
+    have : Invertible (Q (x - -y)) := by simpa only [sub_neg_eq_add] using h.invertible
+    have hmem : (QuadraticMap.reflection Q (x - -y)).trans (QuadraticMap.reflection Q y) ∈
+        QuadraticMap.orthogonalGroup Q :=
+      QuadraticMap.mem_orthogonalGroup_iff.mpr fun m => by
+      rw [LinearEquiv.trans_apply,
+        QuadraticMap.map_app_of_mem_orthogonalGroup
+          (QuadraticMap.reflection_mem_orthogonalGroup Q y),
+        QuadraticMap.map_app_of_mem_orthogonalGroup
+          (QuadraticMap.reflection_mem_orthogonalGroup Q (x - -y))]
+    refine ⟨QuadraticMap.orthogonalGroupEquivIsometryEquiv Q ⟨_, hmem⟩, ?_⟩
+    have hneg : QuadraticMap.reflection Q (x - -y) x = -y :=
+      QuadraticMap.reflection_sub_apply_eq_of_map_eq Q x (-y) (hxy.trans (Q.map_neg y).symm)
+    simp [hneg, map_neg]
+
+end Transitivity
+
+/-! ### Cancelling a line -/
+
+section Line
+
+variable {K : Type u} [Field K] [Invertible (2 : K)]
+  {V₀ : Type v₀} [AddCommGroup V₀] [Module K V₀]
+  {V₁ : Type v₁} [AddCommGroup V₁] [Module K V₁]
+  {V₂ : Type v₂} [AddCommGroup V₂] [Module K V₂]
+
+/-- A form on a line spanned by a vector of nonzero value is regular. -/
+theorem nondegenerate_of_span_singleton_eq_top {Q₀ : QuadraticForm K V₀} {v₀ : V₀}
+    (hspan : Submodule.span K {v₀} = ⊤) (hv₀ : Q₀ v₀ ≠ 0) : Q₀.Nondegenerate := by
+  rw [QuadraticMap.nondegenerate_iff_radical_eq_bot, QuadraticMap.radical_eq_ker_polarBilin,
+    LinearMap.ker_eq_bot']
+  intro z hz
+  obtain ⟨c, rfl⟩ := (Submodule.span_singleton_eq_top_iff K v₀).mp hspan z
+  have hpolar : polar Q₀ (c • v₀) v₀ = 0 := by
+    simpa using congrArg (fun L : V₀ →ₗ[K] K => L v₀) hz
+  rw [QuadraticMap.polar_smul_left, QuadraticMap.polar_self] at hpolar
+  have hc : c = 0 := by simpa [(isUnit_of_invertible (2 : K)).ne_zero, hv₀] using hpolar
+  rw [hc, zero_smul]
+
+/-- **Witt cancellation** for a summand carried by a line: a form on a space spanned by a single
+vector of nonzero value cancels from an orthogonal sum.
+
+Witt transitivity moves the image of the spanning vector back onto itself, after which the
+isometry fixes the whole line and `TauCeti.prodCancelIsometryEquiv` applies. -/
+theorem equivalent_of_equivalent_prod_of_span_singleton_eq_top {Q₀ : QuadraticForm K V₀} {v₀ : V₀}
+    (hspan : Submodule.span K {v₀} = ⊤) (hv₀ : Q₀ v₀ ≠ 0) {Q₁ : QuadraticForm K V₁}
+    {Q₂ : QuadraticForm K V₂} (h : (Q₀.prod Q₁).Equivalent (Q₀.prod Q₂)) : Q₁.Equivalent Q₂ := by
+  have : NeZero (2 : K) := ⟨(isUnit_of_invertible (2 : K)).ne_zero⟩
+  obtain ⟨e⟩ := h
+  obtain ⟨f, hf⟩ := exists_isometryEquiv_apply_eq_of_map_eq (Q₀.prod Q₂)
+    (x := e (v₀, 0)) (y := (v₀, 0)) (by simp) (by simpa using hv₀)
+  have hfix : ∀ u : V₀, (e.trans f) (u, 0) = (u, 0) := by
+    intro u
+    obtain ⟨c, rfl⟩ := (Submodule.span_singleton_eq_top_iff K v₀).mp hspan u
+    have hsmul : ((c • v₀ : V₀), (0 : V₁)) = c • ((v₀, 0) : V₀ × V₁) := by simp
+    have hv : (e.trans f) (v₀, 0) = (v₀, 0) := hf
+    rw [hsmul, map_smul, hv, Prod.smul_mk, smul_zero]
+  exact ⟨prodCancelIsometryEquiv (nondegenerate_of_span_singleton_eq_top hspan hv₀)
+    (e.trans f) hfix⟩
+
+end Line
+
+/-! ### Witt cancellation -/
+
+section Cancellation
+
+variable {K : Type u} [Field K] [Invertible (2 : K)]
+  {V₀ : Type v₀} [AddCommGroup V₀] [Module K V₀]
+  {V₁ : Type v₁} [AddCommGroup V₁] [Module K V₁]
+  {V₂ : Type v₂} [AddCommGroup V₂] [Module K V₂]
+
+-- Peel the first weight off a diagonal presentation: `⟨a₀, …, aₙ⟩ ≅ ⟨a₀⟩ ⊥ ⟨a₁, …, aₙ⟩`, with the
+-- first factor carried by the line `K`, so that the line cancellation above applies to it.
+private def presentedFormConsIsometryEquiv {n : ℕ} (w : Fin (n + 1) → Kˣ) :
+    (((w 0 : K) • (QuadraticMap.sq : QuadraticForm K K)).prod
+        (presentedForm ⟨n, fun i => w i.succ⟩)).IsometryEquiv (presentedForm ⟨n + 1, w⟩) where
+  toLinearEquiv := Fin.consLinearEquiv K fun _ : Fin (n + 1) => K
+  map_app' x := by
+    -- `presentedForm_apply` does not fire under `simp` here: the rank of the presentation appears
+    -- in the type of `x`, so the rewrite has to be directed by hand.
+    rw [presentedForm_apply, QuadraticMap.prod_apply, presentedForm_apply, Fin.sum_univ_succ]
+    simp
+
+private theorem equivalent_of_equivalent_presentedForm_prod {Q₁ : QuadraticForm K V₁}
+    {Q₂ : QuadraticForm K V₂} (n : ℕ) (w : Fin n → Kˣ)
+    (h : ((presentedForm ⟨n, w⟩).prod Q₁).Equivalent ((presentedForm ⟨n, w⟩).prod Q₂)) :
+    Q₁.Equivalent Q₂ := by
+  induction n with
+  | zero =>
+    have e₁ : ((presentedForm ⟨0, w⟩).prod Q₁).Equivalent Q₁ :=
+      ⟨QuadraticMap.IsometryEquiv.uniqueProd _ Q₁⟩
+    have e₂ : ((presentedForm ⟨0, w⟩).prod Q₂).Equivalent Q₂ :=
+      ⟨QuadraticMap.IsometryEquiv.uniqueProd _ Q₂⟩
+    exact e₁.symm.trans (h.trans e₂)
+  | succ n ih =>
+    set a : QuadraticForm K K := (w 0 : K) • QuadraticMap.sq with ha
+    set B : QuadraticForm K (Fin n → K) := presentedForm ⟨n, fun i => w i.succ⟩
+    have hcons : (a.prod B).Equivalent (presentedForm ⟨n + 1, w⟩) :=
+      ⟨presentedFormConsIsometryEquiv w⟩
+    have hassoc₁ : ((a.prod B).prod Q₁).Equivalent (a.prod (B.prod Q₁)) :=
+      ⟨QuadraticMap.IsometryEquiv.prodAssoc a B Q₁⟩
+    have hassoc₂ : ((a.prod B).prod Q₂).Equivalent (a.prod (B.prod Q₂)) :=
+      ⟨QuadraticMap.IsometryEquiv.prodAssoc a B Q₂⟩
+    have hstep : ((a.prod B).prod Q₁).Equivalent ((a.prod B).prod Q₂) :=
+      (hcons.prod (QuadraticMap.Equivalent.refl Q₁)).trans
+        (h.trans (hcons.prod (QuadraticMap.Equivalent.refl Q₂)).symm)
+    have key : (a.prod (B.prod Q₁)).Equivalent (a.prod (B.prod Q₂)) :=
+      hassoc₁.symm.trans (hstep.trans hassoc₂)
+    have hspan : Submodule.span K {(1 : K)} = ⊤ :=
+      (Submodule.span_singleton_eq_top_iff K (1 : K)).mpr fun x => ⟨x, by simp⟩
+    exact ih (fun i => w i.succ)
+      (equivalent_of_equivalent_prod_of_span_singleton_eq_top hspan (by simp [ha]) key)
+
+/-- **Witt cancellation** (Lam I.4.2): a regular finite-dimensional summand cancels from an
+orthogonal sum.
+
+Regularity of the cancelled summand is Lam's hypothesis and is what the reflection argument needs;
+see the implementation notes of this file for what cancelling a degenerate summand would take. -/
+theorem equivalent_of_equivalent_prod [FiniteDimensional K V₀] {Q₀ : QuadraticForm K V₀}
+    (hQ₀ : Q₀.Nondegenerate) {Q₁ : QuadraticForm K V₁} {Q₂ : QuadraticForm K V₂}
+    (h : (Q₀.prod Q₁).Equivalent (Q₀.prod Q₂)) : Q₁.Equivalent Q₂ := by
+  obtain ⟨p, hp⟩ := exists_presentedForm_equivalent Q₀ hQ₀
+  exact equivalent_of_equivalent_presentedForm_prod p.1 p.2
+    (((hp.symm.prod (QuadraticMap.Equivalent.refl Q₁)).trans h).trans
+      (hp.prod (QuadraticMap.Equivalent.refl Q₂)))
+
+/-- **Witt cancellation**, cancelling the summand on the right. -/
+theorem equivalent_of_equivalent_prod_right [FiniteDimensional K V₀] {Q₀ : QuadraticForm K V₀}
+    (hQ₀ : Q₀.Nondegenerate) {Q₁ : QuadraticForm K V₁} {Q₂ : QuadraticForm K V₂}
+    (h : (Q₁.prod Q₀).Equivalent (Q₂.prod Q₀)) : Q₁.Equivalent Q₂ := by
+  have hcomm₁ : (Q₀.prod Q₁).Equivalent (Q₁.prod Q₀) :=
+    ⟨QuadraticMap.IsometryEquiv.prodComm Q₀ Q₁⟩
+  have hcomm₂ : (Q₂.prod Q₀).Equivalent (Q₀.prod Q₂) :=
+    ⟨QuadraticMap.IsometryEquiv.prodComm Q₂ Q₀⟩
+  exact equivalent_of_equivalent_prod hQ₀ (hcomm₁.trans (h.trans hcomm₂))
+
+private theorem isLeftCancelAdd_regularFormClass : IsLeftCancelAdd (RegularFormClass K) where
+  add_left_cancel x y z h := by
+    revert h
+    refine Quotient.inductionOn₃ x y z fun p q r h => ?_
+    simp only [RegularFormClass.mk_add_mk, RegularFormClass.mk_eq_mk_iff] at h ⊢
+    exact equivalent_of_equivalent_prod (nondegenerate_presentedForm p)
+      ((equivalent_presentedForm_append_prod p q).symm.trans
+        (h.trans (equivalent_presentedForm_append_prod p r)))
+
+/-- Orthogonal sum is cancellative on the isometry classes of regular forms: this is Witt
+cancellation read on `TauCeti.RegularFormClass`, and it is what gives the Witt-Grothendieck ring
+its Grothendieck group. -/
+instance : IsCancelAdd (RegularFormClass K) :=
+  have := isLeftCancelAdd_regularFormClass (K := K)
+  AddCommMagma.IsLeftCancelAdd.toIsCancelAdd _
+
+end Cancellation
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/QuadraticForm/WittCancellation.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/WittCancellation.lean
@@ -132,19 +132,6 @@ variable {K : Type u} [Field K] [Invertible (2 : K)]
   {V₁ : Type v₁} [AddCommGroup V₁] [Module K V₁]
   {V₂ : Type v₂} [AddCommGroup V₂] [Module K V₂]
 
-/-- A form on a line spanned by a vector of nonzero value is regular. -/
-theorem nondegenerate_of_span_singleton_eq_top {Q₀ : QuadraticForm K V₀} {v₀ : V₀}
-    (hspan : Submodule.span K {v₀} = ⊤) (hv₀ : Q₀ v₀ ≠ 0) : Q₀.Nondegenerate := by
-  rw [QuadraticMap.nondegenerate_iff_radical_eq_bot, QuadraticMap.radical_eq_ker_polarBilin,
-    LinearMap.ker_eq_bot']
-  intro z hz
-  obtain ⟨c, rfl⟩ := (Submodule.span_singleton_eq_top_iff K v₀).mp hspan z
-  have hpolar : polar Q₀ (c • v₀) v₀ = 0 := by
-    simpa using congrArg (fun L : V₀ →ₗ[K] K => L v₀) hz
-  rw [QuadraticMap.polar_smul_left, QuadraticMap.polar_self] at hpolar
-  have hc : c = 0 := by simpa [(isUnit_of_invertible (2 : K)).ne_zero, hv₀] using hpolar
-  rw [hc, zero_smul]
-
 /-- **Witt cancellation** for a summand carried by a line: a form on a space spanned by a single
 vector of nonzero value cancels from an orthogonal sum. -/
 theorem equivalent_of_equivalent_prod_of_span_singleton_eq_top {Q₀ : QuadraticForm K V₀} {v₀ : V₀}

--- a/TauCeti/LinearAlgebra/QuadraticForm/WittCancellation.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/WittCancellation.lean
@@ -13,8 +13,8 @@ public import TauCeti.LinearAlgebra.QuadraticForm.RegularFormClass.Basic
 Over a field in which `2` is invertible, a regular summand may be cancelled from an orthogonal
 sum: if `q ⊥ q₁` and `q ⊥ q₂` are isometric and `q` is regular and finite dimensional, then `q₁`
 and `q₂` are isometric. This is Witt's cancellation theorem, and it is what makes the isometry
-classes of regular forms cancellative under orthogonal sum, hence a monoid with a Grothendieck
-group.
+classes of regular forms cancellative under orthogonal sum, hence a monoid that embeds into its
+Grothendieck group.
 
 The proof follows Lam I.4.5-I.4.7 and runs in three steps.
 
@@ -26,14 +26,15 @@ of `q`. The second component of `e (0, ·)` is then an isometry of `q₁` onto `
 
 The second step makes an arbitrary isometry fix a line pointwise. Over a field of characteristic
 different from two the orthogonal group of a form acts transitively on the vectors of a fixed
-nonzero value (`TauCeti.exists_isometryEquiv_apply_eq_of_map_eq`): one of `x - y` and `x + y` has
-nonzero norm, and the reflection in it carries `x` to `y` or to `-y`. Composing the given isometry
-with such an element cancels a summand spanned by a single vector of nonzero value
+nonzero value (`QuadraticMap.exists_isometryEquiv_apply_eq_of_map_eq`): one of `x - y` and `x + y`
+has nonzero norm, and the reflection in it carries `x` to `y` or to `-y`. Composing the given
+isometry with such an element cancels a summand spanned by a single vector of nonzero value
 (`TauCeti.equivalent_of_equivalent_prod_of_span_singleton_eq_top`).
 
 The third step is induction on a diagonalization of the cancelled summand: peeling the first
-weight off `⟨a₀, …, aₙ⟩` with `Fin.consLinearEquiv` exhibits it as `⟨a₀⟩ ⊥ ⟨a₁, …, aₙ⟩`, whose
-first factor is carried by the line `K` and is cancelled by the second step.
+weight off `⟨a₀, …, aₙ⟩` with `TauCeti.presentedFormConsIsometryEquiv` exhibits it as
+`⟨a₀⟩ ⊥ ⟨a₁, …, aₙ⟩`, whose first factor is carried by the line `K` and is cancelled by the second
+step.
 
 ## Main definitions
 
@@ -42,8 +43,6 @@ first factor is carried by the line `K` and is cancelled by the second step.
 
 ## Main results
 
-* `TauCeti.exists_isometryEquiv_apply_eq_of_map_eq`: **Witt transitivity**, the orthogonal group
-  acts transitively on the vectors of a fixed nonzero value.
 * `TauCeti.equivalent_of_equivalent_prod_of_span_singleton_eq_top`: cancellation of a summand
   carried by a line spanned by a vector of nonzero value.
 * `TauCeti.equivalent_of_equivalent_prod`: **Witt cancellation** for a regular finite-dimensional
@@ -82,13 +81,6 @@ variable {R : Type u} [CommRing R] [Invertible (2 : R)]
   {V₂ : Type v₂} [AddCommGroup V₂] [Module R V₂]
   {Q₀ : QuadraticMap R V₀ P} {Q₁ : QuadraticMap R V₁ P} {Q₂ : QuadraticMap R V₂ P}
 
--- Mathlib records that an isometry preserves the values of a quadratic map, but not that it
--- preserves its polarization; that is all the proofs below need of it.
-omit [Invertible (2 : R)] in
-private theorem polar_apply_isometryEquiv (e : Q₁.IsometryEquiv Q₂) (x y : V₁) :
-    polar Q₂ (e x) (e y) = polar Q₁ x y := by
-  simp only [QuadraticMap.polar, ← map_add e, IsometryEquiv.map_app]
-
 -- The candidate isometry: transport the second summand through `e` and forget the first
 -- coordinate. `TauCeti.isometryEquiv_prod_fst_eq_zero` shows that nothing is forgotten.
 private def prodCancelMap (e : (Q₀.prod Q₁).IsometryEquiv (Q₀.prod Q₂)) : V₁ →ₗ[R] V₂ :=
@@ -112,8 +104,8 @@ theorem isometryEquiv_prod_fst_eq_zero (hQ₀ : Q₀.Nondegenerate)
   have hmem : (e (0, v)).1 ∈ Q₀.radical := by
     rw [QuadraticMap.radical_eq_ker_polarBilin, LinearMap.mem_ker]
     ext u
-    have h := polar_apply_isometryEquiv e (0, v) (u, 0)
-    rw [he u] at h
+    have h := QuadraticMap.Isometry.polar_apply e.toIsometry (0, v) (u, 0)
+    simp only [QuadraticMap.IsometryEquiv.toIsometry_apply, he] at h
     simpa using h
   rw [hQ₀.radical_eq_bot] at hmem
   simpa using hmem
@@ -149,42 +141,6 @@ theorem prodCancelIsometryEquiv_apply (hQ₀ : Q₀.Nondegenerate)
 
 end CommRing
 
-/-! ### Witt transitivity -/
-
-section Transitivity
-
-variable {K : Type u} [Field K] [NeZero (2 : K)] {V : Type v} [AddCommGroup V] [Module K V]
-
-/-- **Witt transitivity** (Lam I.4.5): over a field of characteristic different from two, the
-orthogonal group of a quadratic form acts transitively on the vectors of a fixed nonzero value.
-
-One of `x - y` and `x + y` has nonzero, hence invertible, norm. In the first case the reflection
-in `x - y` carries `x` to `y`; in the second the reflection in `x + y` carries `x` to `-y`, which
-the reflection in `y` sends to `y`. -/
-theorem exists_isometryEquiv_apply_eq_of_map_eq (Q : QuadraticForm K V) {x y : V}
-    (hxy : Q x = Q y) (hy : Q y ≠ 0) : ∃ f : Q.IsometryEquiv Q, f x = y := by
-  rcases QuadraticMap.isUnit_sub_or_add_of_map_eq Q x y hxy hy with h | h
-  · have := h.invertible
-    refine ⟨QuadraticMap.orthogonalGroupEquivIsometryEquiv Q
-      ⟨QuadraticMap.reflection Q (x - y), QuadraticMap.reflection_mem_orthogonalGroup Q _⟩, ?_⟩
-    simpa using QuadraticMap.reflection_sub_apply_eq_of_map_eq Q x y hxy
-  · have : Invertible (Q y) := (isUnit_iff_ne_zero.mpr hy).invertible
-    have : Invertible (Q (x - -y)) := by simpa only [sub_neg_eq_add] using h.invertible
-    have hmem : (QuadraticMap.reflection Q (x - -y)).trans (QuadraticMap.reflection Q y) ∈
-        QuadraticMap.orthogonalGroup Q :=
-      QuadraticMap.mem_orthogonalGroup_iff.mpr fun m => by
-      rw [LinearEquiv.trans_apply,
-        QuadraticMap.map_app_of_mem_orthogonalGroup
-          (QuadraticMap.reflection_mem_orthogonalGroup Q y),
-        QuadraticMap.map_app_of_mem_orthogonalGroup
-          (QuadraticMap.reflection_mem_orthogonalGroup Q (x - -y))]
-    refine ⟨QuadraticMap.orthogonalGroupEquivIsometryEquiv Q ⟨_, hmem⟩, ?_⟩
-    have hneg : QuadraticMap.reflection Q (x - -y) x = -y :=
-      QuadraticMap.reflection_sub_apply_eq_of_map_eq Q x (-y) (hxy.trans (Q.map_neg y).symm)
-    simp [hneg, map_neg]
-
-end Transitivity
-
 /-! ### Cancelling a line -/
 
 section Line
@@ -217,7 +173,7 @@ theorem equivalent_of_equivalent_prod_of_span_singleton_eq_top {Q₀ : Quadratic
     {Q₂ : QuadraticForm K V₂} (h : (Q₀.prod Q₁).Equivalent (Q₀.prod Q₂)) : Q₁.Equivalent Q₂ := by
   have : NeZero (2 : K) := ⟨(isUnit_of_invertible (2 : K)).ne_zero⟩
   obtain ⟨e⟩ := h
-  obtain ⟨f, hf⟩ := exists_isometryEquiv_apply_eq_of_map_eq (Q₀.prod Q₂)
+  obtain ⟨f, hf⟩ := (Q₀.prod Q₂).exists_isometryEquiv_apply_eq_of_map_eq
     (x := e (v₀, 0)) (y := (v₀, 0)) (by simp) (by simpa using hv₀)
   have hfix : ∀ u : V₀, (e.trans f) (u, 0) = (u, 0) := by
     intro u
@@ -238,18 +194,6 @@ variable {K : Type u} [Field K] [Invertible (2 : K)]
   {V₀ : Type v₀} [AddCommGroup V₀] [Module K V₀]
   {V₁ : Type v₁} [AddCommGroup V₁] [Module K V₁]
   {V₂ : Type v₂} [AddCommGroup V₂] [Module K V₂]
-
--- Peel the first weight off a diagonal presentation: `⟨a₀, …, aₙ⟩ ≅ ⟨a₀⟩ ⊥ ⟨a₁, …, aₙ⟩`, with the
--- first factor carried by the line `K`, so that the line cancellation above applies to it.
-private def presentedFormConsIsometryEquiv {n : ℕ} (w : Fin (n + 1) → Kˣ) :
-    (((w 0 : K) • (QuadraticMap.sq : QuadraticForm K K)).prod
-        (presentedForm ⟨n, fun i => w i.succ⟩)).IsometryEquiv (presentedForm ⟨n + 1, w⟩) where
-  toLinearEquiv := Fin.consLinearEquiv K fun _ : Fin (n + 1) => K
-  map_app' x := by
-    -- `presentedForm_apply` does not fire under `simp` here: the rank of the presentation appears
-    -- in the type of `x`, so the rewrite has to be directed by hand.
-    rw [presentedForm_apply, QuadraticMap.prod_apply, presentedForm_apply, Fin.sum_univ_succ]
-    simp
 
 private theorem equivalent_of_equivalent_presentedForm_prod {Q₁ : QuadraticForm K V₁}
     {Q₂ : QuadraticForm K V₂} (n : ℕ) (w : Fin n → Kˣ)
@@ -314,8 +258,8 @@ private theorem isLeftCancelAdd_regularFormClass : IsLeftCancelAdd (RegularFormC
         (h.trans (equivalent_presentedForm_append_prod p r)))
 
 /-- Orthogonal sum is cancellative on the isometry classes of regular forms: this is Witt
-cancellation read on `TauCeti.RegularFormClass`, and it is what gives the Witt-Grothendieck ring
-its Grothendieck group. -/
+cancellation read on `TauCeti.RegularFormClass`, and it is what makes the canonical map from the
+monoid of isometry classes into the Witt-Grothendieck ring injective. -/
 instance : IsCancelAdd (RegularFormClass K) :=
   have := isLeftCancelAdd_regularFormClass (K := K)
   AddCommMagma.IsLeftCancelAdd.toIsCancelAdd _

--- a/TauCeti/LinearAlgebra/QuadraticForm/WittCancellation.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/WittCancellation.lean
@@ -16,25 +16,9 @@ and `q₂` are isometric. This is Witt's cancellation theorem, and it is what ma
 classes of regular forms cancellative under orthogonal sum, hence a monoid that embeds into its
 Grothendieck group.
 
-The proof follows Lam I.4.5-I.4.7 and runs in three steps.
-
-The first step uses no reflection: an isometry `e` of `q ⊥ q₁` onto `q ⊥ q₂` that fixes the first
-summand *pointwise* carries the second summand into the second summand, because the first
-component of `e (0, v)` is orthogonal to the whole of the first summand and so lies in the radical
-of `q`. The second component of `e (0, ·)` is then an isometry of `q₁` onto `q₂`
-(`TauCeti.prodCancelIsometryEquiv`).
-
-The second step makes an arbitrary isometry fix a line pointwise. Over a field of characteristic
-different from two the orthogonal group of a form acts transitively on the vectors of a fixed
-nonzero value (`QuadraticMap.exists_isometryEquiv_apply_eq_of_map_eq`): one of `x - y` and `x + y`
-has nonzero norm, and the reflection in it carries `x` to `y` or to `-y`. Composing the given
-isometry with such an element cancels a summand spanned by a single vector of nonzero value
-(`TauCeti.equivalent_of_equivalent_prod_of_span_singleton_eq_top`).
-
-The third step is induction on a diagonalization of the cancelled summand: peeling the first
-weight off `⟨a₀, …, aₙ⟩` with `TauCeti.presentedFormConsIsometryEquiv` exhibits it as
-`⟨a₀⟩ ⊥ ⟨a₁, …, aₙ⟩`, whose first factor is carried by the line `K` and is cancelled by the second
-step.
+The file also provides cancellation interfaces for a summand fixed pointwise and for a form on a
+space spanned by one vector of nonzero value. The proof of the general theorem follows Lam
+I.4.5–I.4.7.
 
 ## Main definitions
 
@@ -48,14 +32,6 @@ step.
 * `TauCeti.equivalent_of_equivalent_prod`: **Witt cancellation** for a regular finite-dimensional
   summand, and `TauCeti.equivalent_of_equivalent_prod_right` on the other side.
 * `TauCeti.RegularFormClass` is cancellative under orthogonal sum.
-
-## Implementation notes
-
-Cancellation of a *degenerate* summand is not proved here, and is not a matter of weakening a
-hypothesis: over a field in which `2` is invertible it reduces to the uniqueness half of the Witt
-decomposition, which splits a form as a regular part orthogonal to the zero form on its radical.
-That decomposition is a separate milestone, and the reflection route below genuinely needs
-regularity, because a reflection is only defined in a vector of invertible value.
 
 ## References
 
@@ -95,9 +71,8 @@ private theorem isometryEquiv_symm_apply_inl (e : (Q₀.prod Q₁).IsometryEquiv
     (he : ∀ u : V₀, e (u, 0) = (u, 0)) (u : V₀) : e.symm (u, 0) = (u, 0) := by
   rw [← he u, e.symm_apply_apply]
 
-/-- An isometry of orthogonal sums that fixes the first summand pointwise carries the second
-summand into the second summand, as soon as the first summand is regular: the first component of
-`e (0, v)` is orthogonal to all of `V₀`, hence lies in the radical of `Q₀`. -/
+/-- If an isometry of orthogonal sums fixes a regular first summand pointwise, the first component
+of the image of every vector in the second summand is zero. -/
 theorem isometryEquiv_prod_fst_eq_zero (hQ₀ : Q₀.Nondegenerate)
     (e : (Q₀.prod Q₁).IsometryEquiv (Q₀.prod Q₂)) (he : ∀ u : V₀, e (u, 0) = (u, 0)) (v : V₁) :
     (e (0, v)).1 = 0 := by
@@ -139,6 +114,13 @@ theorem prodCancelIsometryEquiv_apply (hQ₀ : Q₀.Nondegenerate)
     (e : (Q₀.prod Q₁).IsometryEquiv (Q₀.prod Q₂)) (he : ∀ u : V₀, e (u, 0) = (u, 0)) (v : V₁) :
     prodCancelIsometryEquiv hQ₀ e he v = (e (0, v)).2 := (rfl)
 
+/-- The inverse cancellation isometry is the second component of `e.symm` on the second
+summand. -/
+@[simp]
+theorem prodCancelIsometryEquiv_symm_apply (hQ₀ : Q₀.Nondegenerate)
+    (e : (Q₀.prod Q₁).IsometryEquiv (Q₀.prod Q₂)) (he : ∀ u : V₀, e (u, 0) = (u, 0)) (w : V₂) :
+    (prodCancelIsometryEquiv hQ₀ e he).symm w = (e.symm (0, w)).2 := (rfl)
+
 end CommRing
 
 /-! ### Cancelling a line -/
@@ -164,10 +146,7 @@ theorem nondegenerate_of_span_singleton_eq_top {Q₀ : QuadraticForm K V₀} {v�
   rw [hc, zero_smul]
 
 /-- **Witt cancellation** for a summand carried by a line: a form on a space spanned by a single
-vector of nonzero value cancels from an orthogonal sum.
-
-Witt transitivity moves the image of the spanning vector back onto itself, after which the
-isometry fixes the whole line and `TauCeti.prodCancelIsometryEquiv` applies. -/
+vector of nonzero value cancels from an orthogonal sum. -/
 theorem equivalent_of_equivalent_prod_of_span_singleton_eq_top {Q₀ : QuadraticForm K V₀} {v₀ : V₀}
     (hspan : Submodule.span K {v₀} = ⊤) (hv₀ : Q₀ v₀ ≠ 0) {Q₁ : QuadraticForm K V₁}
     {Q₂ : QuadraticForm K V₂} (h : (Q₀.prod Q₁).Equivalent (Q₀.prod Q₂)) : Q₁.Equivalent Q₂ := by
@@ -226,10 +205,7 @@ private theorem equivalent_of_equivalent_presentedForm_prod {Q₁ : QuadraticFor
       (equivalent_of_equivalent_prod_of_span_singleton_eq_top hspan (by simp [ha]) key)
 
 /-- **Witt cancellation** (Lam I.4.2): a regular finite-dimensional summand cancels from an
-orthogonal sum.
-
-Regularity of the cancelled summand is Lam's hypothesis and is what the reflection argument needs;
-see the implementation notes of this file for what cancelling a degenerate summand would take. -/
+orthogonal sum. -/
 theorem equivalent_of_equivalent_prod [FiniteDimensional K V₀] {Q₀ : QuadraticForm K V₀}
     (hQ₀ : Q₀.Nondegenerate) {Q₁ : QuadraticForm K V₁} {Q₂ : QuadraticForm K V₂}
     (h : (Q₀.prod Q₁).Equivalent (Q₀.prod Q₂)) : Q₁.Equivalent Q₂ := by


### PR DESCRIPTION
This PR proves Witt's cancellation theorem: over a field in which `2` is invertible, a regular
finite-dimensional summand cancels from an orthogonal sum, so `q ⊥ q₁ ≅ q ⊥ q₂` forces
`q₁ ≅ q₂`. It closes the third milestone of Layer 1 of the quadratic-forms roadmap, "Witt
cancellation (Lam I.4.2): `q ⊥ q₁ ≅ q ⊥ q₂ → q₁ ≅ q₂` for regular `q`, proved through hyperplane
reflections (Lam I.4.5 to I.4.7)", and supplies the downstream interface the same layer promises
Layer 4, "Layer 4 needs cancellation for the Witt ring": the isometry classes
`TauCeti.RegularFormClass K` become cancellative under orthogonal sum. After this PR the open
Layer 1 milestones are Witt decomposition with its uniqueness statement, Cartan-Dieudonné in the
counted form, and Witt's extension theorem.

Roadmap: QuadraticFormInvariants

<!--tauceti-target:v1 {"focus":"QuadraticFormInvariants","id":"witt-cancellation"}-->

The new file is `TauCeti/LinearAlgebra/QuadraticForm/WittCancellation.lean`, which is the home the
roadmap designates for Witt theory. It proves the theorem in three steps. Two general-purpose
pieces the proof needs are added to the modules that already own them rather than to the new file:
`QuadraticMap.exists_isometryEquiv_apply_eq_of_map_eq` and `QuadraticMap.Isometry.polar_apply` go
into `TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean`, and
`TauCeti.presentedFormConsIsometryEquiv` into
`TauCeti/LinearAlgebra/QuadraticForm/RegularFormClass/Basic.lean`.

`TauCeti.prodCancelIsometryEquiv` cancels a regular summand that an isometry fixes *pointwise*,
and it needs no reflection and no field: the first component of `e (0, v)` is orthogonal to the
whole first summand, hence lies in the radical of `q`, hence vanishes, so the second component of
`e (0, ·)` is an isometry. This step is stated over a commutative ring with `2` invertible and for
quadratic maps into an arbitrary module, since nothing more is used.

`QuadraticMap.exists_isometryEquiv_apply_eq_of_map_eq` is Witt transitivity: the orthogonal group
acts transitively on the vectors of a fixed nonzero value. It consumes the two halves already in
`TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean` that were written for
Cartan-Dieudonné, `QuadraticMap.isUnit_sub_or_add_of_map_eq` and
`QuadraticMap.reflection_sub_apply_eq_of_map_eq`, so the reflection calculus is reused rather than
repeated, and multiplies the bundled `QuadraticMap.reflectionOrthogonal` elements in the
orthogonal group rather than re-proving that a composite of reflections is orthogonal. It is
stated in that file, next to those lemmas. Composing a given isometry with such an element makes it fix a line, which yields
`TauCeti.equivalent_of_equivalent_prod_of_span_singleton_eq_top`, cancellation of a summand
carried by a line spanned by a vector of nonzero value.

The general case is induction on a diagonalization. `TauCeti.presentedFormConsIsometryEquiv`
peels the first weight off `⟨a₀, …, aₙ⟩` as `⟨a₀⟩ ⊥ ⟨a₁, …, aₙ⟩` with the first factor carried by
the line `K`, the line
cancellation removes it, and the induction hypothesis removes the rest; the diagonalization itself
is Layer 0's `TauCeti.exists_presentedForm_equivalent`. `TauCeti.equivalent_of_equivalent_prod` is
the result, `TauCeti.equivalent_of_equivalent_prod_right` cancels on the other side, and the
`IsCancelAdd (RegularFormClass K)` instance reads the theorem on Layer 0's carrier through
`TauCeti.equivalent_presentedForm_append_prod`.

Two deviations from `Suggested.lean` are deliberate. Its statement of this milestone carries
`[FiniteDimensional K V₁]`, `[FiniteDimensional K V₂]` and regularity of `Q₁` and `Q₂`; the proof
uses none of the four, so they are dropped and the theorem is stated for arbitrary quadratic forms
on the two cancelled sides. Regularity and finiteness of the cancelled summand are kept, because
the reflection route needs a vector of invertible value and the induction needs a diagonalization.
Cancelling a *degenerate* summand is not a matter of weakening a hypothesis: it reduces to the
uniqueness half of the Witt decomposition, which is a separate Layer 1 milestone, and the file's
implementation notes say so.

No Mathlib infrastructure was vendored. Mathlib has no cancellation theorem for quadratic forms;
the one general fact the proofs needed and Mathlib does not state, that an isometry preserves the
polarization of a quadratic map, is `QuadraticMap.Isometry.polar_apply`, added to
`OrthogonalGroup.lean` beside the orthogonal-group special case
`TauCeti.QuadraticMap.polar_apply_of_mem_orthogonalGroup`.

🤖 Prepared with Claude Code

