### PR TITLE
feat: identify the depth-zero unit graded piece

### DIFF
--- a/TauCeti/NumberTheory/LocalField/UnitFiltration.lean
+++ b/TauCeti/NumberTheory/LocalField/UnitFiltration.lean
@@ -61,10 +61,6 @@ The valuation appearing in the criteria is Mathlib's multiplicative `ValuativeRe
 for which greater depth means a smaller value and for which `0` is the smallest value; this is
 what lets `1` belong to every step.
 
-The two cardinality statements at depth zero are deliberately not `simp` lemmas. `simp` rewrites
-`unitFiltration K 0` and `unitFiltration K 1` to Mathlib's unit and principal unit groups, so
-neither left-hand side is in `simp` normal form.
-
 ## References
 
 * [J.-P. Serre, *Corps Locaux*][serre1968], Chapter IV, §2.
@@ -196,17 +192,20 @@ theorem unitFiltration_one :
 
 /-! ### The depth-zero graded piece
 
-The mathematical content of the depth-zero identification is entirely Mathlib's
-`ValuationSubring.unitsModPrincipalUnitsEquivResidueFieldUnits`, together with the reduction map
-`ValuationSubring.unitGroupToResidueFieldUnits` it is built from
-(`Mathlib/RingTheory/Valuation/ValuationSubring.lean`). The declarations below only transport that
-equivalence from the unit and principal unit groups to the two shallow steps of the filtration. -/
+Reduction modulo `𝓂[K]` carries `U(K,0)`, the units of `𝒪[K]`, onto the multiplicative group
+`𝓀[K]ˣ` of the residue field, and a unit reduces to `1` exactly when it lies in `U(K,1)`. So
+reduction has kernel `U(K,1)` and identifies the depth-zero graded piece `U(K,0) / U(K,1)` with
+`𝓀[K]ˣ`; in particular that quotient is finite of order `q - 1`, where `q = #𝓀[K]`. -/
 
 /-- The successive quotient `U(K,i) / U(K,i+1)` of the unit filtration. -/
 abbrev UnitFiltrationGraded (K : Type*) [Field K] [ValuativeRel K] [TopologicalSpace K]
     [IsNonarchimedeanLocalField K] (i : ℕ) :=
   unitFiltration K i ⧸ (unitFiltration K (i + 1)).subgroupOf (unitFiltration K i)
 
+-- Provenance: the equivalence below is Mathlib's
+-- `ValuationSubring.unitsModPrincipalUnitsEquivResidueFieldUnits`, built from the reduction map
+-- `ValuationSubring.unitGroupToResidueFieldUnits`, both in
+-- `Mathlib/RingTheory/Valuation/ValuationSubring.lean`.
 /-- The depth-zero graded piece `U(K,0) / U(K,1)` is the multiplicative group of the residue
 field. The isomorphism is induced by reduction modulo the maximal ideal. -/
 noncomputable def unitFiltrationGradedZeroEquivResidueFieldUnits :
@@ -259,6 +258,9 @@ noncomputable instance unitFiltration_one_isFiniteRelIndex_zero :
   rw [Subgroup.isFiniteRelIndex_iff_finiteIndex, Subgroup.finiteIndex_iff_finite_quotient]
   infer_instance
 
+-- The two cardinalities below are deliberately not `simp` lemmas: `simp` rewrites
+-- `unitFiltration K 0` and `unitFiltration K 1` to Mathlib's unit and principal unit groups, so
+-- neither left-hand side is in `simp` normal form.
 /-- The depth-zero graded piece has `q - 1` elements, where `q` is the cardinality of the residue
 field. -/
 theorem natCard_unitFiltrationGraded_zero :

--- a/TauCeti/NumberTheory/LocalField/UnitFiltration.lean
+++ b/TauCeti/NumberTheory/LocalField/UnitFiltration.lean
@@ -43,8 +43,8 @@ action on a finite extension, and its behaviour under a field embedding.
   already forces `x` to be a unit of `𝒪[K]`.
 * `TauCeti.unitFiltration_zero` and `TauCeti.unitFiltration_one`: the two shallow steps are
   Mathlib's `ValuationSubring.unitGroup` and `ValuationSubring.principalUnitGroup`.
-* `TauCeti.unitFiltrationGradedZeroEquivResidueFieldUnits`: reduction identifies the depth-zero
-  graded piece with the multiplicative group of the residue field.
+* `TauCeti.unitFiltrationGradedPieceZeroEquivResidueFieldUnits`: reduction identifies the
+  depth-zero graded piece with the multiplicative group of the residue field.
 * `TauCeti.unitFiltration_antitone`: the filtration is decreasing.
 * `TauCeti.iInf_unitFiltration`: the filtration separates points, `⨅ i, U(K,i) = ⊥`.
 * `TauCeti.isOpen_unitFiltration`, `TauCeti.isCompact_unitFiltration` and
@@ -193,14 +193,14 @@ theorem unitFiltration_one :
 /-! ### The depth-zero graded piece -/
 
 /-- The successive quotient `U(K,i) / U(K,i+1)` of the unit filtration. -/
-abbrev UnitFiltrationGraded (K : Type*) [Field K] [ValuativeRel K] [TopologicalSpace K]
+abbrev UnitFiltrationGradedPiece (K : Type*) [Field K] [ValuativeRel K] [TopologicalSpace K]
     [IsNonarchimedeanLocalField K] (i : ℕ) :=
   unitFiltration K i ⧸ (unitFiltration K (i + 1)).subgroupOf (unitFiltration K i)
 
 /-- The depth-zero graded piece `U(K,0) / U(K,1)` is the multiplicative group of the residue
 field. The isomorphism is induced by reduction modulo the maximal ideal. -/
-noncomputable def unitFiltrationGradedZeroEquivResidueFieldUnits :
-    UnitFiltrationGraded K 0 ≃* (𝓀[K])ˣ :=
+noncomputable def unitFiltrationGradedPieceZeroEquivResidueFieldUnits :
+    UnitFiltrationGradedPiece K 0 ≃* (𝓀[K])ˣ :=
   (QuotientGroup.equivQuotientSubgroupOfOfEq
       (unitFiltration_one (K := K)) (unitFiltration_zero (K := K))).trans
     (valuation K).valuationSubring.unitsModPrincipalUnitsEquivResidueFieldUnits
@@ -208,14 +208,41 @@ noncomputable def unitFiltrationGradedZeroEquivResidueFieldUnits :
 /-- On a class represented by `x ∈ U(K,0)`, the depth-zero graded equivalence is reduction of
 `x` modulo the maximal ideal. -/
 @[simp]
-theorem unitFiltrationGradedZeroEquivResidueFieldUnits_mk (x : unitFiltration K 0) :
-    unitFiltrationGradedZeroEquivResidueFieldUnits (K := K) (QuotientGroup.mk x) =
+theorem unitFiltrationGradedPieceZeroEquivResidueFieldUnits_mk (x : unitFiltration K 0) :
+    unitFiltrationGradedPieceZeroEquivResidueFieldUnits (K := K) (QuotientGroup.mk x) =
       (valuation K).valuationSubring.unitGroupToResidueFieldUnits
-        ⟨(x : Kˣ), (unitFiltration_zero (K := K)).le x.prop⟩ := (rfl)
+        ⟨(x : Kˣ), (unitFiltration_zero (K := K)).le x.prop⟩ := by
+  have htransport :
+      QuotientGroup.equivQuotientSubgroupOfOfEq
+          (unitFiltration_one (K := K)) (unitFiltration_zero (K := K))
+          (QuotientGroup.mk x) =
+        QuotientGroup.mk
+          (⟨(x : Kˣ), (unitFiltration_zero (K := K)).le x.prop⟩ :
+            (valuation K).valuationSubring.unitGroup) := by
+    change
+      QuotientGroup.quotientMapSubgroupOfOfLe
+          (unitFiltration_one (K := K)).le (unitFiltration_zero (K := K)).le
+          (QuotientGroup.mk x) = _
+    rw [QuotientGroup.quotientMapSubgroupOfOfLe_mk]
+    rfl
+  change
+    (valuation K).valuationSubring.unitsModPrincipalUnitsEquivResidueFieldUnits
+        (QuotientGroup.equivQuotientSubgroupOfOfEq
+          (unitFiltration_one (K := K)) (unitFiltration_zero (K := K))
+          (QuotientGroup.mk x)) =
+      (valuation K).valuationSubring.unitGroupToResidueFieldUnits
+        ⟨(x : Kˣ), (unitFiltration_zero (K := K)).le x.prop⟩
+  rw [htransport]
+  exact
+    ValuationSubring.unitsModPrincipalUnitsEquivResidueFieldUnits_comp_quotientGroup_mk_apply
+      (A := (valuation K).valuationSubring)
+      ⟨(x : Kˣ), (unitFiltration_zero (K := K)).le x.prop⟩
 
 /-- The depth-zero graded piece is finite. -/
-noncomputable instance finite_unitFiltrationGraded_zero : Finite (UnitFiltrationGraded K 0) :=
-  Finite.of_equiv (𝓀[K])ˣ unitFiltrationGradedZeroEquivResidueFieldUnits.symm.toEquiv
+noncomputable instance finite_unitFiltrationGradedPiece_zero :
+    Finite (UnitFiltrationGradedPiece K 0) :=
+  Finite.of_equiv (𝓀[K])ˣ
+    unitFiltrationGradedPieceZeroEquivResidueFieldUnits.symm.toEquiv
 
 /-- The first positive-depth step has finite relative index in the depth-zero step. -/
 noncomputable instance unitFiltration_one_isFiniteRelIndex_zero :
@@ -225,16 +252,18 @@ noncomputable instance unitFiltration_one_isFiniteRelIndex_zero :
 
 /-- The depth-zero graded piece has `q - 1` elements, where `q` is the cardinality of the residue
 field. -/
-theorem natCard_unitFiltrationGraded_zero :
-    Nat.card (UnitFiltrationGraded K 0) = Nat.card 𝓀[K] - 1 := by
+theorem natCard_unitFiltrationGradedPiece_zero :
+    Nat.card (UnitFiltrationGradedPiece K 0) = Nat.card 𝓀[K] - 1 := by
   rw [← Nat.card_units]
-  exact Nat.card_congr unitFiltrationGradedZeroEquivResidueFieldUnits.toEquiv
+  exact Nat.card_congr unitFiltrationGradedPieceZeroEquivResidueFieldUnits.toEquiv
 
 /-- The relative index `[U(K,0) : U(K,1)]` is one less than the cardinality of the residue
 field. -/
 theorem relIndex_unitFiltration_one_zero :
     (unitFiltration K 1).relIndex (unitFiltration K 0) = Nat.card 𝓀[K] - 1 := by
-  exact natCard_unitFiltrationGraded_zero (K := K)
+  rw [Subgroup.relIndex, Subgroup.index]
+  simpa only [UnitFiltrationGradedPiece, zero_add] using
+    natCard_unitFiltrationGradedPiece_zero (K := K)
 
 /-- The unit filtration is decreasing. -/
 theorem unitFiltration_antitone : Antitone (unitFiltration K) := by

--- a/TauCeti/NumberTheory/LocalField/UnitFiltration.lean
+++ b/TauCeti/NumberTheory/LocalField/UnitFiltration.lean
@@ -43,7 +43,7 @@ action on a finite extension, and its behaviour under a field embedding.
   already forces `x` to be a unit of `𝒪[K]`.
 * `TauCeti.unitFiltration_zero` and `TauCeti.unitFiltration_one`: the two shallow steps are
   Mathlib's `ValuationSubring.unitGroup` and `ValuationSubring.principalUnitGroup`.
-* `TauCeti.unitFiltrationGradedPieceZeroEquivResidueFieldUnits`: reduction identifies the
+* `TauCeti.unitFiltrationGradedZeroEquivResidueFieldUnits`: reduction identifies the
   depth-zero graded piece with the multiplicative group of the residue field.
 * `TauCeti.unitFiltration_antitone`: the filtration is decreasing.
 * `TauCeti.iInf_unitFiltration`: the filtration separates points, `⨅ i, U(K,i) = ⊥`.
@@ -194,17 +194,23 @@ theorem unitFiltration_one :
     pow_one]
   exact hdvd _
 
-/-! ### The depth-zero graded piece -/
+/-! ### The depth-zero graded piece
+
+The mathematical content of the depth-zero identification is entirely Mathlib's
+`ValuationSubring.unitsModPrincipalUnitsEquivResidueFieldUnits`, together with the reduction map
+`ValuationSubring.unitGroupToResidueFieldUnits` it is built from
+(`Mathlib/RingTheory/Valuation/ValuationSubring.lean`). The declarations below only transport that
+equivalence from the unit and principal unit groups to the two shallow steps of the filtration. -/
 
 /-- The successive quotient `U(K,i) / U(K,i+1)` of the unit filtration. -/
-abbrev UnitFiltrationGradedPiece (K : Type*) [Field K] [ValuativeRel K] [TopologicalSpace K]
+abbrev UnitFiltrationGraded (K : Type*) [Field K] [ValuativeRel K] [TopologicalSpace K]
     [IsNonarchimedeanLocalField K] (i : ℕ) :=
   unitFiltration K i ⧸ (unitFiltration K (i + 1)).subgroupOf (unitFiltration K i)
 
 /-- The depth-zero graded piece `U(K,0) / U(K,1)` is the multiplicative group of the residue
 field. The isomorphism is induced by reduction modulo the maximal ideal. -/
-noncomputable def unitFiltrationGradedPieceZeroEquivResidueFieldUnits :
-    UnitFiltrationGradedPiece K 0 ≃* (𝓀[K])ˣ :=
+noncomputable def unitFiltrationGradedZeroEquivResidueFieldUnits :
+    UnitFiltrationGraded K 0 ≃* (𝓀[K])ˣ :=
   (QuotientGroup.equivQuotientSubgroupOfOfEq
       (unitFiltration_one (K := K)) (unitFiltration_zero (K := K))).trans
     (valuation K).valuationSubring.unitsModPrincipalUnitsEquivResidueFieldUnits
@@ -212,8 +218,8 @@ noncomputable def unitFiltrationGradedPieceZeroEquivResidueFieldUnits :
 /-- On a class represented by `x ∈ U(K,0)`, the depth-zero graded equivalence is reduction of
 `x` modulo the maximal ideal. -/
 @[simp]
-theorem unitFiltrationGradedPieceZeroEquivResidueFieldUnits_mk (x : unitFiltration K 0) :
-    unitFiltrationGradedPieceZeroEquivResidueFieldUnits (K := K) (QuotientGroup.mk x) =
+theorem unitFiltrationGradedZeroEquivResidueFieldUnits_mk (x : unitFiltration K 0) :
+    unitFiltrationGradedZeroEquivResidueFieldUnits (K := K) (QuotientGroup.mk x) =
       (valuation K).valuationSubring.unitGroupToResidueFieldUnits
         ⟨(x : Kˣ), (unitFiltration_zero (K := K)).le x.prop⟩ := by
   have htransport :
@@ -242,10 +248,10 @@ theorem unitFiltrationGradedPieceZeroEquivResidueFieldUnits_mk (x : unitFiltrati
       ⟨(x : Kˣ), (unitFiltration_zero (K := K)).le x.prop⟩
 
 /-- The depth-zero graded piece is finite. -/
-noncomputable instance finite_unitFiltrationGradedPiece_zero :
-    Finite (UnitFiltrationGradedPiece K 0) :=
+noncomputable instance finite_unitFiltrationGraded_zero :
+    Finite (UnitFiltrationGraded K 0) :=
   Finite.of_equiv (𝓀[K])ˣ
-    unitFiltrationGradedPieceZeroEquivResidueFieldUnits.symm.toEquiv
+    unitFiltrationGradedZeroEquivResidueFieldUnits.symm.toEquiv
 
 /-- The first positive-depth step has finite relative index in the depth-zero step. -/
 noncomputable instance unitFiltration_one_isFiniteRelIndex_zero :
@@ -255,18 +261,18 @@ noncomputable instance unitFiltration_one_isFiniteRelIndex_zero :
 
 /-- The depth-zero graded piece has `q - 1` elements, where `q` is the cardinality of the residue
 field. -/
-theorem natCard_unitFiltrationGradedPiece_zero :
-    Nat.card (UnitFiltrationGradedPiece K 0) = Nat.card 𝓀[K] - 1 := by
+theorem natCard_unitFiltrationGraded_zero :
+    Nat.card (UnitFiltrationGraded K 0) = Nat.card 𝓀[K] - 1 := by
   rw [← Nat.card_units]
-  exact Nat.card_congr unitFiltrationGradedPieceZeroEquivResidueFieldUnits.toEquiv
+  exact Nat.card_congr unitFiltrationGradedZeroEquivResidueFieldUnits.toEquiv
 
 /-- The relative index `[U(K,0) : U(K,1)]` is one less than the cardinality of the residue
 field. -/
 theorem relIndex_unitFiltration_one_zero :
     (unitFiltration K 1).relIndex (unitFiltration K 0) = Nat.card 𝓀[K] - 1 := by
   rw [Subgroup.relIndex, Subgroup.index]
-  simpa only [UnitFiltrationGradedPiece, zero_add] using
-    natCard_unitFiltrationGradedPiece_zero (K := K)
+  simpa only [UnitFiltrationGraded, zero_add] using
+    natCard_unitFiltrationGraded_zero (K := K)
 
 /-- The unit filtration is decreasing. -/
 theorem unitFiltration_antitone : Antitone (unitFiltration K) := by

--- a/TauCeti/NumberTheory/LocalField/UnitFiltration.lean
+++ b/TauCeti/NumberTheory/LocalField/UnitFiltration.lean
@@ -219,12 +219,11 @@ theorem unitFiltrationGradedPieceZeroEquivResidueFieldUnits_mk (x : unitFiltrati
         QuotientGroup.mk
           (⟨(x : Kˣ), (unitFiltration_zero (K := K)).le x.prop⟩ :
             (valuation K).valuationSubring.unitGroup) := by
-    change
-      QuotientGroup.quotientMapSubgroupOfOfLe
-          (unitFiltration_one (K := K)).le (unitFiltration_zero (K := K)).le
-          (QuotientGroup.mk x) = _
-    rw [QuotientGroup.quotientMapSubgroupOfOfLe_mk]
-    rfl
+    exact QuotientGroup.quotientMapSubgroupOfOfLe_mk
+      (unitFiltration_one (K := K)).le (unitFiltration_zero (K := K)).le x
+  -- Mathlib states the residue-field equivalence using `principalUnitGroup.comap`, whereas the
+  -- transported quotient is written with `principalUnitGroup.subgroupOf`. These subgroups are
+  -- definitionally equal, but there is no propositional rewrite lemma between the presentations.
   change
     (valuation K).valuationSubring.unitsModPrincipalUnitsEquivResidueFieldUnits
         (QuotientGroup.equivQuotientSubgroupOfOfEq
@@ -252,6 +251,7 @@ noncomputable instance unitFiltration_one_isFiniteRelIndex_zero :
 
 /-- The depth-zero graded piece has `q - 1` elements, where `q` is the cardinality of the residue
 field. -/
+@[simp]
 theorem natCard_unitFiltrationGradedPiece_zero :
     Nat.card (UnitFiltrationGradedPiece K 0) = Nat.card 𝓀[K] - 1 := by
   rw [← Nat.card_units]
@@ -259,6 +259,7 @@ theorem natCard_unitFiltrationGradedPiece_zero :
 
 /-- The relative index `[U(K,0) : U(K,1)]` is one less than the cardinality of the residue
 field. -/
+@[simp]
 theorem relIndex_unitFiltration_one_zero :
     (unitFiltration K 1).relIndex (unitFiltration K 0) = Nat.card 𝓀[K] - 1 := by
   rw [Subgroup.relIndex, Subgroup.index]

--- a/TauCeti/NumberTheory/LocalField/UnitFiltration.lean
+++ b/TauCeti/NumberTheory/LocalField/UnitFiltration.lean
@@ -61,6 +61,10 @@ The valuation appearing in the criteria is Mathlib's multiplicative `ValuativeRe
 for which greater depth means a smaller value and for which `0` is the smallest value; this is
 what lets `1` belong to every step.
 
+The two cardinality statements at depth zero are deliberately not `simp` lemmas. `simp` rewrites
+`unitFiltration K 0` and `unitFiltration K 1` to Mathlib's unit and principal unit groups, so
+neither left-hand side is in `simp` normal form.
+
 ## References
 
 * [J.-P. Serre, *Corps Locaux*][serre1968], Chapter IV, §2.
@@ -251,7 +255,6 @@ noncomputable instance unitFiltration_one_isFiniteRelIndex_zero :
 
 /-- The depth-zero graded piece has `q - 1` elements, where `q` is the cardinality of the residue
 field. -/
-@[simp]
 theorem natCard_unitFiltrationGradedPiece_zero :
     Nat.card (UnitFiltrationGradedPiece K 0) = Nat.card 𝓀[K] - 1 := by
   rw [← Nat.card_units]
@@ -259,7 +262,6 @@ theorem natCard_unitFiltrationGradedPiece_zero :
 
 /-- The relative index `[U(K,0) : U(K,1)]` is one less than the cardinality of the residue
 field. -/
-@[simp]
 theorem relIndex_unitFiltration_one_zero :
     (unitFiltration K 1).relIndex (unitFiltration K 0) = Nat.card 𝓀[K] - 1 := by
   rw [Subgroup.relIndex, Subgroup.index]

--- a/TauCeti/NumberTheory/LocalField/UnitFiltration.lean
+++ b/TauCeti/NumberTheory/LocalField/UnitFiltration.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.NumberTheory.LocalField.Basic
+public import Mathlib.GroupTheory.Index
 
 /-!
 # The unit filtration of a nonarchimedean local field
@@ -42,6 +43,8 @@ action on a finite extension, and its behaviour under a field embedding.
   already forces `x` to be a unit of `𝒪[K]`.
 * `TauCeti.unitFiltration_zero` and `TauCeti.unitFiltration_one`: the two shallow steps are
   Mathlib's `ValuationSubring.unitGroup` and `ValuationSubring.principalUnitGroup`.
+* `TauCeti.unitFiltrationGradedZeroEquivResidueFieldUnits`: reduction identifies the depth-zero
+  graded piece with the multiplicative group of the residue field.
 * `TauCeti.unitFiltration_antitone`: the filtration is decreasing.
 * `TauCeti.iInf_unitFiltration`: the filtration separates points, `⨅ i, U(K,i) = ⊥`.
 * `TauCeti.isOpen_unitFiltration`, `TauCeti.isCompact_unitFiltration` and
@@ -186,6 +189,52 @@ theorem unitFiltration_one :
     ← (Valuation.isEquiv_valuation_valuationSubring (valuation K)).lt_one_iff_lt_one, zero_add,
     pow_one]
   exact hdvd _
+
+/-! ### The depth-zero graded piece -/
+
+/-- The successive quotient `U(K,i) / U(K,i+1)` of the unit filtration. -/
+abbrev UnitFiltrationGraded (K : Type*) [Field K] [ValuativeRel K] [TopologicalSpace K]
+    [IsNonarchimedeanLocalField K] (i : ℕ) :=
+  unitFiltration K i ⧸ (unitFiltration K (i + 1)).subgroupOf (unitFiltration K i)
+
+/-- The depth-zero graded piece `U(K,0) / U(K,1)` is the multiplicative group of the residue
+field. The isomorphism is induced by reduction modulo the maximal ideal. -/
+noncomputable def unitFiltrationGradedZeroEquivResidueFieldUnits :
+    UnitFiltrationGraded K 0 ≃* (𝓀[K])ˣ :=
+  (QuotientGroup.equivQuotientSubgroupOfOfEq
+      (unitFiltration_one (K := K)) (unitFiltration_zero (K := K))).trans
+    (valuation K).valuationSubring.unitsModPrincipalUnitsEquivResidueFieldUnits
+
+/-- On a class represented by `x ∈ U(K,0)`, the depth-zero graded equivalence is reduction of
+`x` modulo the maximal ideal. -/
+@[simp]
+theorem unitFiltrationGradedZeroEquivResidueFieldUnits_mk (x : unitFiltration K 0) :
+    unitFiltrationGradedZeroEquivResidueFieldUnits (K := K) (QuotientGroup.mk x) =
+      (valuation K).valuationSubring.unitGroupToResidueFieldUnits
+        ⟨(x : Kˣ), (unitFiltration_zero (K := K)).le x.prop⟩ := (rfl)
+
+/-- The depth-zero graded piece is finite. -/
+noncomputable instance finite_unitFiltrationGraded_zero : Finite (UnitFiltrationGraded K 0) :=
+  Finite.of_equiv (𝓀[K])ˣ unitFiltrationGradedZeroEquivResidueFieldUnits.symm.toEquiv
+
+/-- The first positive-depth step has finite relative index in the depth-zero step. -/
+noncomputable instance unitFiltration_one_isFiniteRelIndex_zero :
+    (unitFiltration K 1).IsFiniteRelIndex (unitFiltration K 0) := by
+  rw [Subgroup.isFiniteRelIndex_iff_finiteIndex, Subgroup.finiteIndex_iff_finite_quotient]
+  infer_instance
+
+/-- The depth-zero graded piece has `q - 1` elements, where `q` is the cardinality of the residue
+field. -/
+theorem natCard_unitFiltrationGraded_zero :
+    Nat.card (UnitFiltrationGraded K 0) = Nat.card 𝓀[K] - 1 := by
+  rw [← Nat.card_units]
+  exact Nat.card_congr unitFiltrationGradedZeroEquivResidueFieldUnits.toEquiv
+
+/-- The relative index `[U(K,0) : U(K,1)]` is one less than the cardinality of the residue
+field. -/
+theorem relIndex_unitFiltration_one_zero :
+    (unitFiltration K 1).relIndex (unitFiltration K 0) = Nat.card 𝓀[K] - 1 := by
+  exact natCard_unitFiltrationGraded_zero (K := K)
 
 /-- The unit filtration is decreasing. -/
 theorem unitFiltration_antitone : Antitone (unitFiltration K) := by


### PR DESCRIPTION
This PR identifies the depth-zero unit-filtration graded piece `U(K,0) / U(K,1)` with the multiplicative group `𝓀[K]ˣ` of the residue field, records its reduction-on-representatives equation, installs its finiteness and finite-relative-index instances, and proves both `#(U(K,0) / U(K,1)) = q - 1` and `[U(K,0) : U(K,1)] = q - 1`.

It advances the exact target `LocalFieldsRamification/README.md`, Layer 1 milestone “Graded pieces”: “Prove `U(K,0)/U(K,1) ≃* 𝓀[K]ˣ` by reduction,” including its `q - 1` count. After this PR, that milestone still needs the positive-depth equivalences `U(K,i)/U(K,i+1) ≃* 𝓀[K]⁺` for `i ≥ 1`, their uniformizer-independence and naturality, and compatibility with the Layer 3 embeddings `θ_i`.

This is the most effective current step because the prerequisite unit filtration and its identifications `unitFiltration_zero` and `unitFiltration_one` have just landed on `main`, while the normalized `ℚ_p` absolute-value comparison is already covered by open PR #6336. The depth-zero quotient is therefore the first unclaimed part of the next Layer 1 milestone whose prerequisites are present.

The implementation transports Mathlib’s `ValuationSubring.unitsModPrincipalUnitsEquivResidueFieldUnits` through `QuotientGroup.equivQuotientSubgroupOfOfEq`, then uses `Nat.card_units` for the count. No Mathlib infrastructure is vendored. The existing module’s Serre and Neukirch references cover the mathematical result.

The single changed file is `TauCeti/NumberTheory/LocalField/UnitFiltration.lean`, with 49 lines added.

Roadmap: LocalFieldsRamification

<!--tauceti-target:v1 {"focus":"LocalFieldsRamification","id":"unit-filtration-depth-zero-graded-piece"}-->

🤖 Prepared with Codex
