### PR TITLE
feat: add the degree-two finite-quotient system

### DIFF
--- a/TauCeti/RepresentationTheory/Homological/ContCohomology/ExplicitFunctoriality.lean
+++ b/TauCeti/RepresentationTheory/Homological/ContCohomology/ExplicitFunctoriality.lean
@@ -418,6 +418,24 @@ theorem explicitMap2_mk [ContinuousMul G] [ContinuousMul H]
       (cocyclesMap2 G M H N φ f hf hequiv c : H2 H N) :=
   QuotientAddGroup.map_mk _ _ _ _ c
 
+/-- Equality of compatible pairs gives equality of the induced maps on explicit `H²`. -/
+theorem explicitMap2_congr_of_eq [ContinuousMul G] [ContinuousMul H]
+    (φ ψ : H →ₜ* G) (f q : M →+ N) {hf : Continuous f} {hq : Continuous q}
+    {hφ : ∀ (h : H) (m : M), f (φ h • m) = h • f m}
+    {hψ : ∀ (h : H) (m : M), q (ψ h • m) = h • q m}
+    (hφeq : φ = ψ) (hfeq : f = q) :
+    explicitMap2 G M H N φ f hf hφ = explicitMap2 G M H N ψ q hq hψ := by
+  apply AddMonoidHom.ext
+  intro x
+  induction x using QuotientAddGroup.induction_on with
+  | _ c =>
+      rw [explicitMap2_mk, explicitMap2_mk]
+      apply congrArg (fun z : Z2 H N => (z : H2 H N))
+      ext p
+      obtain ⟨h, k⟩ := p
+      simp only [cocyclesMap2_apply]
+      rw [hφeq, hfeq]
+
 /-- Pullback by the identity compatible pair is the identity on explicit `H²`. -/
 @[simp]
 theorem explicitMap2_id [ContinuousMul G] :

--- a/TauCeti/RepresentationTheory/Homological/ContCohomology/FiniteQuotient/Explicit.lean
+++ b/TauCeti/RepresentationTheory/Homological/ContCohomology/FiniteQuotient/Explicit.lean
@@ -400,9 +400,7 @@ theorem explicitFiniteQuotientTransition2_comp (U V W : OpenNormalSubgroup G)
 /-- The explicit degree-two finite-quotient system of a discrete module. It sends an open normal
 subgroup `U` to `H²(G ⧸ U, M^U)` and an inclusion `V ≤ U` to the direct explicit transition from
 the `U`-level to the `V`-level. -/
--- The body is exposed for the same reason as the degree-one system: the source objects and arrows
--- of its comparison cocone must reduce to the named explicit groups and transition maps.
-@[expose] noncomputable def explicitFiniteQuotientSystem2 :
+noncomputable def explicitFiniteQuotientSystem2 :
     (OpenNormalSubgroup G)ᵒᵖ ⥤ AddCommGrpCat.{max u v} where
   obj U :=
     AddCommGrpCat.of

--- a/TauCeti/RepresentationTheory/Homological/ContCohomology/FiniteQuotient/Explicit.lean
+++ b/TauCeti/RepresentationTheory/Homological/ContCohomology/FiniteQuotient/Explicit.lean
@@ -9,13 +9,13 @@ public import TauCeti.RepresentationTheory.Homological.ContCohomology.ExplicitFu
 public import TauCeti.RepresentationTheory.Homological.ContCohomology.Invariants
 
 /-!
-# The explicit degree-one finite-quotient system
+# The explicit low-degree finite-quotient systems
 
 For a topological group `G` acting continuously on a discrete additive group `M`, the explicit
-first cohomology groups
+cohomology groups in degrees one and two
 
 ```text
-H¹(G ⧸ U, M^U)
+Hⁱ(G ⧸ U, M^U),  i = 1, 2,
 ```
 
 form a directed system as the open normal subgroup `U` shrinks.  If `V ≤ U`, its transition
@@ -25,10 +25,11 @@ When `G` is compact these discrete quotient groups are finite; the construction 
 require compactness.
 
 `TauCeti.finiteQuotientSystem` already packages the corresponding system in Mathlib's discrete
-`groupCohomology`.  The system here is instead constructed directly with
-`TauCeti.ContCohomology.explicitMap1`.  In particular it is universe-polymorphic and does not
-transport its arrows through the universe-restricted comparison with discrete group cohomology.
-It is the source diagram for the explicit degree-one finite-quotient colimit theorem.
+`groupCohomology`.  The systems here are instead constructed directly with
+`TauCeti.ContCohomology.explicitMap1` and `explicitMap2`.  In particular they are
+universe-polymorphic and do not transport their arrows through the universe-restricted comparison
+with discrete group cohomology.  They are the source diagrams for the explicit finite-quotient
+colimit theorems in degrees one and two.
 
 ## Main definitions
 
@@ -36,6 +37,8 @@ It is the source diagram for the explicit degree-one finite-quotient colimit the
   `H¹(G ⧸ U, M^U) → H¹(G ⧸ V, M^V)` for `V ≤ U`.
 * `TauCeti.ContCohomology.explicitFiniteQuotientSystem1`: the resulting functor on
   `(OpenNormalSubgroup G)ᵒᵖ`.
+* `TauCeti.ContCohomology.explicitFiniteQuotientTransition2` and
+  `explicitFiniteQuotientSystem2`: the corresponding transition and functor in degree two.
 
 ## Main statements
 
@@ -45,6 +48,7 @@ It is the source diagram for the explicit degree-one finite-quotient colimit the
   identity and composition laws for the transition maps.
 * `explicitFiniteQuotientSystem1_obj` and `explicitFiniteQuotientSystem1_map` identify the
   objects and arrows of the packaged functor.
+* The corresponding declarations ending in `2` give the same characteristic API in degree two.
 
 ## References
 
@@ -250,6 +254,186 @@ theorem explicitFiniteQuotientSystem1_map
         (explicitFiniteQuotientSystem1 G M).map f ≫
       eqToHom (explicitFiniteQuotientSystem1_obj G M V.unop) = AddCommGrpCat.ofHom
       (explicitFiniteQuotientTransition1 G M U.unop V.unop (leOfHom f.unop)) :=
+  by rfl
+
+/-! ### Degree two -/
+
+/-- The explicit degree-two transition from the `U`-level to the `V`-level, for `V ≤ U`.
+
+It is defined directly by compatible-pair functoriality from the quotient homomorphism
+`G ⧸ V → G ⧸ U` and the inclusion of invariant coefficients `M^U → M^V`. -/
+noncomputable def explicitFiniteQuotientTransition2 (U V : OpenNormalSubgroup G) (hVU : V ≤ U) :
+    H2 (G ⧸ U.toSubgroup) (FixedPoints.addSubgroup U.toSubgroup M) →+
+      H2 (G ⧸ V.toSubgroup) (FixedPoints.addSubgroup V.toSubgroup M) :=
+  explicitMap2 (G ⧸ U.toSubgroup) (FixedPoints.addSubgroup U.toSubgroup M)
+    (G ⧸ V.toSubgroup) (FixedPoints.addSubgroup V.toSubgroup M)
+    (continuousFiniteQuotientMap G hVU) (fixedPointsInclusion hVU)
+    continuous_of_discreteTopology
+      (fixedPointsInclusion_continuousFiniteQuotientMap_smul G M hVU)
+
+omit [ContinuousSMul G M] in
+/-- A degree-two finite-quotient transition sends the class of a cocycle to its compatible-pair
+pullback. -/
+@[simp]
+theorem explicitFiniteQuotientTransition2_mk {U V : OpenNormalSubgroup G} (hVU : V ≤ U)
+    (c : Z2 (G ⧸ U.toSubgroup) (FixedPoints.addSubgroup U.toSubgroup M)) :
+    explicitFiniteQuotientTransition2 G M U V hVU
+        (c : H2 (G ⧸ U.toSubgroup) (FixedPoints.addSubgroup U.toSubgroup M)) =
+      H2pi (G ⧸ V.toSubgroup) (FixedPoints.addSubgroup V.toSubgroup M)
+        (cocyclesMap2 (G ⧸ U.toSubgroup) (FixedPoints.addSubgroup U.toSubgroup M)
+        (G ⧸ V.toSubgroup) (FixedPoints.addSubgroup V.toSubgroup M)
+        (continuousFiniteQuotientMap G hVU) (fixedPointsInclusion hVU)
+        continuous_of_discreteTopology
+          (fixedPointsInclusion_continuousFiniteQuotientMap_smul G M hVU) c) :=
+  explicitMap2_mk _ _ _ _ _ _ _ _ c
+
+omit [ContinuousSMul G M] in
+/-- A degree-two finite-quotient transition is the compatible-pair pullback along the quotient
+homomorphism `G ⧸ V → G ⧸ U` and the inclusion of invariant coefficients `M^U → M^V`. -/
+theorem explicitFiniteQuotientTransition2_eq_explicitMap2 {U V : OpenNormalSubgroup G}
+    (hVU : V ≤ U) :
+    explicitFiniteQuotientTransition2 G M U V hVU =
+      (explicitMap2 (G ⧸ U.toSubgroup) (FixedPoints.addSubgroup U.toSubgroup M)
+        (G ⧸ V.toSubgroup) (FixedPoints.addSubgroup V.toSubgroup M)
+        (continuousFiniteQuotientMap G hVU) (fixedPointsInclusion hVU)
+        continuous_of_discreteTopology
+          (fixedPointsInclusion_continuousFiniteQuotientMap_smul G M hVU) :
+        H2 (G ⧸ U.toSubgroup) (FixedPoints.addSubgroup U.toSubgroup M) →+
+          H2 (G ⧸ V.toSubgroup) (FixedPoints.addSubgroup V.toSubgroup M)) := by
+  refine AddMonoidHom.ext fun x => ?_
+  induction x using QuotientAddGroup.induction_on with
+  | _ c =>
+    exact (explicitFiniteQuotientTransition2_mk G M hVU c).trans
+      (explicitMap2_mk _ _ _ _ _ _ _ _ c).symm
+
+omit [ContinuousSMul G M] in
+/-- The degree-two transition from an open normal subgroup to itself is the identity. -/
+@[simp]
+theorem explicitFiniteQuotientTransition2_id (U : OpenNormalSubgroup G) :
+    explicitFiniteQuotientTransition2 G M U U le_rfl = AddMonoidHom.id _ := by
+  rw [explicitFiniteQuotientTransition2]
+  calc
+    _ = explicitMap2 (G ⧸ U.toSubgroup) (FixedPoints.addSubgroup U.toSubgroup M)
+        (G ⧸ U.toSubgroup) (FixedPoints.addSubgroup U.toSubgroup M)
+        (ContinuousMonoidHom.id _) (AddMonoidHom.id _) continuous_id (fun _ _ => rfl) := by
+      apply explicitMap2_congr_of_eq
+      · exact continuousFiniteQuotientMap_refl G U
+      · exact fixedPointsInclusion_self M U.toSubgroup
+    _ = AddMonoidHom.id _ := explicitMap2_id _ _
+
+/-- For `W ≤ V ≤ U`, the degree-two transition from the `U`-level to the `W`-level is the
+composite through the `V`-level. -/
+theorem explicitFiniteQuotientTransition2_comp (U V W : OpenNormalSubgroup G)
+    (hVU : V ≤ U) (hWV : W ≤ V) :
+    explicitFiniteQuotientTransition2 G M U W (hWV.trans hVU) =
+      (explicitFiniteQuotientTransition2 G M V W hWV).comp
+        (explicitFiniteQuotientTransition2 G M U V hVU) := by
+  rw [explicitFiniteQuotientTransition2, explicitFiniteQuotientTransition2,
+    explicitFiniteQuotientTransition2]
+  have hcomp : ∀ (q : G ⧸ W.toSubgroup)
+      (m : FixedPoints.addSubgroup U.toSubgroup M),
+      (fixedPointsInclusion hWV :
+          FixedPoints.addSubgroup V.toSubgroup M →+
+            FixedPoints.addSubgroup W.toSubgroup M)
+          ((fixedPointsInclusion hVU :
+            FixedPoints.addSubgroup U.toSubgroup M →+
+              FixedPoints.addSubgroup V.toSubgroup M)
+            (continuousFiniteQuotientMap G hVU
+              (continuousFiniteQuotientMap G hWV q) • m)) =
+        q • (fixedPointsInclusion hWV :
+          FixedPoints.addSubgroup V.toSubgroup M →+
+            FixedPoints.addSubgroup W.toSubgroup M)
+          ((fixedPointsInclusion hVU :
+            FixedPoints.addSubgroup U.toSubgroup M →+
+              FixedPoints.addSubgroup V.toSubgroup M) m) := by
+    intro q m
+    rw [fixedPointsInclusion_continuousFiniteQuotientMap_smul G M hVU]
+    exact fixedPointsInclusion_continuousFiniteQuotientMap_smul G M hWV q
+      ((fixedPointsInclusion hVU :
+        FixedPoints.addSubgroup U.toSubgroup M →+
+          FixedPoints.addSubgroup V.toSubgroup M) m)
+  calc
+    _ = @explicitMap2
+        (G ⧸ U.toSubgroup) inferInstance inferInstance
+        (FixedPoints.addSubgroup U.toSubgroup M) inferInstance inferInstance inferInstance
+        inferInstance (continuousSMulQuotientFixedPointsOfContinuousSMul G M U.toSubgroup)
+        (G ⧸ W.toSubgroup) inferInstance inferInstance
+        (FixedPoints.addSubgroup W.toSubgroup M) inferInstance inferInstance inferInstance
+        inferInstance (continuousSMulQuotientFixedPointsOfContinuousSMul G M W.toSubgroup)
+        inferInstance inferInstance
+        ((continuousFiniteQuotientMap G hVU).comp (continuousFiniteQuotientMap G hWV))
+        ((fixedPointsInclusion hWV :
+          FixedPoints.addSubgroup V.toSubgroup M →+
+            FixedPoints.addSubgroup W.toSubgroup M).comp
+          (fixedPointsInclusion hVU :
+            FixedPoints.addSubgroup U.toSubgroup M →+
+              FixedPoints.addSubgroup V.toSubgroup M))
+        (continuous_of_discreteTopology.comp continuous_of_discreteTopology)
+        (fun q m ↦ hcomp q m) := by
+      apply explicitMap2_congr_of_eq
+      · exact (continuousFiniteQuotientMap_comp G hWV hVU).symm
+      · exact (fixedPointsInclusion_comp_fixedPointsInclusion hVU hWV).symm
+    _ = _ := by
+      convert @explicitMap2_comp
+        (G ⧸ U.toSubgroup) inferInstance inferInstance
+        (FixedPoints.addSubgroup U.toSubgroup M) inferInstance inferInstance inferInstance
+        inferInstance (continuousSMulQuotientFixedPointsOfContinuousSMul G M U.toSubgroup)
+        (G ⧸ V.toSubgroup) inferInstance inferInstance
+        (FixedPoints.addSubgroup V.toSubgroup M) inferInstance inferInstance inferInstance
+        inferInstance (continuousSMulQuotientFixedPointsOfContinuousSMul G M V.toSubgroup)
+        inferInstance inferInstance
+        (continuousFiniteQuotientMap G hVU)
+        (fixedPointsInclusion hVU : FixedPoints.addSubgroup U.toSubgroup M →+
+          FixedPoints.addSubgroup V.toSubgroup M)
+        continuous_of_discreteTopology
+          (fixedPointsInclusion_continuousFiniteQuotientMap_smul G M hVU)
+        (G ⧸ W.toSubgroup) inferInstance inferInstance inferInstance
+        (FixedPoints.addSubgroup W.toSubgroup M) inferInstance inferInstance inferInstance
+        inferInstance (continuousSMulQuotientFixedPointsOfContinuousSMul G M W.toSubgroup)
+        (continuousFiniteQuotientMap G hWV)
+        (fixedPointsInclusion hWV : FixedPoints.addSubgroup V.toSubgroup M →+
+          FixedPoints.addSubgroup W.toSubgroup M)
+        continuous_of_discreteTopology
+          (fixedPointsInclusion_continuousFiniteQuotientMap_smul G M hWV) using 1
+      apply explicitMap2_congr_of_eq <;> rfl
+
+/-- The explicit degree-two finite-quotient system of a discrete module. It sends an open normal
+subgroup `U` to `H²(G ⧸ U, M^U)` and an inclusion `V ≤ U` to the direct explicit transition from
+the `U`-level to the `V`-level. -/
+-- The body is exposed for the same reason as the degree-one system: the source objects and arrows
+-- of its comparison cocone must reduce to the named explicit groups and transition maps.
+@[expose] noncomputable def explicitFiniteQuotientSystem2 :
+    (OpenNormalSubgroup G)ᵒᵖ ⥤ AddCommGrpCat.{max u v} where
+  obj U :=
+    AddCommGrpCat.of
+      (H2 (G ⧸ U.unop.toSubgroup) (FixedPoints.addSubgroup U.unop.toSubgroup M))
+  map := fun {U V} f => AddCommGrpCat.ofHom
+    (explicitFiniteQuotientTransition2 G M U.unop V.unop (leOfHom f.unop))
+  map_id U := by
+    rw [explicitFiniteQuotientTransition2_id]
+    rfl
+  map_comp f g := by
+    rw [explicitFiniteQuotientTransition2_comp G M _ _ _
+      (leOfHom f.unop) (leOfHom g.unop)]
+    rfl
+
+/-- The object at `U` of the explicit degree-two finite-quotient system is
+`H²(G ⧸ U, M^U)`. -/
+@[simp]
+theorem explicitFiniteQuotientSystem2_obj (U : OpenNormalSubgroup G) :
+    (explicitFiniteQuotientSystem2 G M).obj (Opposite.op U) =
+      AddCommGrpCat.of (H2 (G ⧸ U.toSubgroup) (FixedPoints.addSubgroup U.toSubgroup M)) :=
+  by rfl
+
+/-- Under the object identifications above, every arrow of the explicit degree-two finite-quotient
+system is the direct transition built from `explicitMap2`. -/
+@[simp]
+theorem explicitFiniteQuotientSystem2_map
+    {U V : (OpenNormalSubgroup G)ᵒᵖ} (f : U ⟶ V) :
+    eqToHom (explicitFiniteQuotientSystem2_obj G M U.unop).symm ≫
+        (explicitFiniteQuotientSystem2 G M).map f ≫
+      eqToHom (explicitFiniteQuotientSystem2_obj G M V.unop) = AddCommGrpCat.ofHom
+      (explicitFiniteQuotientTransition2 G M U.unop V.unop (leOfHom f.unop)) :=
   by rfl
 
 end System


### PR DESCRIPTION
This PR adds the explicit degree-two finite-quotient transition maps and packages them as the universe-polymorphic functor `U ↦ H²(G ⧸ U, M^U)`, using compatible-pair pullback directly rather than transporting through discrete group cohomology.

The exact ProfiniteCohomology Layer 4 target is `explicitFiniteQuotientSystem2` in the finite-quotient colimit milestone. It includes the cocycle-class formula, identity and composition laws, and the object/map characterizations needed to build the named comparison cocone. After this PR, the degree-two comparison natural transformation and cocone remain, followed by the uniform-local-constancy and deeper-level coboundary arguments proving `explicitFiniteQuotientColimit2`.

This is an explicit prerequisite switch from the designated roadmap: ClassFieldTheory Layer 5 constructs `Br`, `invMap`, and `h2MuEquivZMod_mixed` from continuous degree-two cohomology, with its unramified finite-layer passage supplied by ProfiniteCohomology Layer 4; concretely, the dependency edge is ClassFieldTheory Layer 5 `Br`/`invMap` ← ProfiniteCohomology Layer 4 `explicitFiniteQuotientColimit2` ← `explicitFiniteQuotientSystem2`.

The proof reuses Tau Ceti's existing `explicitMap2`, `explicitMap2_id`, `explicitMap2_comp`, continuous finite quotient maps, and fixed-point inclusions. It adds the missing degree-two congruence lemma beside its degree-one analogue. No Mathlib implementation is vendored; the mathematical construction follows Neukirch–Schmidt–Wingberg §1.2.5 and Ribes–Zalesskii Corollary 6.5.6(a), as attributed in the module documentation.

Roadmap: ProfiniteCohomology

Consumer roadmap: ClassFieldTheory

<!--tauceti-target:v1 {"focus":"ProfiniteCohomology","id":"explicitfinitequotientsystem2"}-->

🤖 Prepared with Codex
