### PR TITLE
feat(Isogeny): deg(1 - π_q) = #E(𝔽_q)

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Point/FrobeniusFixed.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Point/FrobeniusFixed.lean
@@ -150,6 +150,7 @@ theorem ncard_setOf_map_frobeniusAlgHom_eq_self : {P : (W.baseChange L).toAffine
 /-- **The induced map on points commutes with the `q`-power map.** Raising the coordinates to the
 `#K`-th power and then applying a `K`-algebra homomorphism gives the same point as applying the
 homomorphism first. -/
+@[simp]
 theorem map_frobeniusAlgHom_comm {Ω : Type*} [Field Ω] [DecidableEq Ω] [Algebra K Ω]
     (σ : L →ₐ[K] Ω) (P : (W.baseChange L).toAffine.Point) :
     Affine.Point.map (W' := W) σ

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Point/FrobeniusFixed.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Point/FrobeniusFixed.lean
@@ -147,4 +147,15 @@ theorem ncard_setOf_map_frobeniusAlgHom_eq_self : {P : (W.baseChange L).toAffine
   rw [hset]
   exact Set.ncard_range_of_injective (Affine.Point.map_injective _)
 
+/-- **The induced map on points commutes with the `q`-power map.** Raising the coordinates to the
+`#K`-th power and then applying a `K`-algebra homomorphism gives the same point as applying the
+homomorphism first. -/
+theorem map_frobeniusAlgHom_comm {Ω : Type*} [Field Ω] [DecidableEq Ω] [Algebra K Ω]
+    (σ : L →ₐ[K] Ω) (P : (W.baseChange L).toAffine.Point) :
+    Affine.Point.map (W' := W) σ
+        (Affine.Point.map (W' := W) (FiniteField.frobeniusAlgHom K L) P) =
+      Affine.Point.map (W' := W) (FiniteField.frobeniusAlgHom K Ω)
+        (Affine.Point.map (W' := W) σ P) := by
+  rw [Affine.Point.map_map, Affine.Point.map_map, TauCeti.FiniteField.comp_frobeniusAlgHom]
+
 end WeierstrassCurve.Affine.Point

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Point/FrobeniusFixed.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Point/FrobeniusFixed.lean
@@ -156,6 +156,6 @@ theorem map_frobeniusAlgHom_comm {Ω : Type*} [Field Ω] [DecidableEq Ω] [Algeb
         (Affine.Point.map (W' := W) (FiniteField.frobeniusAlgHom K L) P) =
       Affine.Point.map (W' := W) (FiniteField.frobeniusAlgHom K Ω)
         (Affine.Point.map (W' := W) σ P) := by
-  rw [Affine.Point.map_map, Affine.Point.map_map, TauCeti.FiniteField.comp_frobeniusAlgHom]
+  rw [Affine.Point.map_map, Affine.Point.map_map, AlgHom.comp_frobeniusAlgHom]
 
 end WeierstrassCurve.Affine.Point

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/OneSubFrobenius/Degree.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/OneSubFrobenius/Degree.lean
@@ -5,10 +5,12 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.AlgebraicGeometry.EllipticCurve.Affine.FinitePoint
-public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.OneSubFrobenius.Kernel
-public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.OneSubFrobenius.TautologicalPoint
+import TauCeti.AlgebraicGeometry.EllipticCurve.Affine.FinitePoint
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.OneSubFrobenius.Basic
+import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.OneSubFrobenius.Kernel
 import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.OneSubFrobenius.Separable
+import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.OneSubFrobenius.TautologicalPoint
+public import TauCeti.AlgebraicGeometry.EllipticCurve.PointCount
 
 /-!
 # The degree of `1 − π_q` is the number of rational points

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/OneSubFrobenius/Degree.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/OneSubFrobenius/Degree.lean
@@ -97,6 +97,7 @@ theorem degree_oneSubFrobeniusIsogeny_le_pointCount :
   exact card_emb_le_pointCount W
 
 /-- **`deg (1 − π_q) = #E(𝔽_q)`**, the first input of the Hasse bound. -/
+@[simp]
 theorem degree_oneSubFrobeniusIsogeny_eq_pointCount :
     (oneSubFrobeniusIsogeny W).degree = W.pointCount :=
   le_antisymm (degree_oneSubFrobeniusIsogeny_le_pointCount W)

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/OneSubFrobenius/Degree.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/OneSubFrobenius/Degree.lean
@@ -28,8 +28,8 @@ separable, so the degree is at most the point count.
 
 ## Main results
 
-* `TauCeti.Isogeny.card_emb_le_pointCount`: the embeddings of `K(W)` over the pulled-back field
-  are at most as many as the rational points.
+* `TauCeti.Isogeny.card_emb_oneSubFrobeniusIsogeny_le_pointCount`: the embeddings of `K(W)` over
+  the pulled-back field are at most as many as the rational points.
 * `TauCeti.Isogeny.degree_oneSubFrobeniusIsogeny_le_pointCount`: hence `deg (1 − π_q)` is at most
   the point count.
 * `TauCeti.Isogeny.degree_oneSubFrobeniusIsogeny_eq_pointCount`: with the reverse bound,
@@ -62,7 +62,7 @@ variable {F : Type*} [Field F] [Finite F] (W : WeierstrassCurve.Affine F) [W.IsE
 /-- **There are at most as many embeddings of the function field over the pulled-back field as
 there are rational points.** Each embedding is sent to the rational point by which it moves the
 generic point away from a fixed base embedding. -/
-theorem card_emb_le_pointCount :
+theorem card_emb_oneSubFrobeniusIsogeny_le_pointCount :
     Nat.card (Field.Emb (oneSubFrobeniusIsogeny W).fieldPullback.fieldRange W.FunctionField) ≤
       W.pointCount := by
   classical
@@ -94,7 +94,7 @@ theorem degree_oneSubFrobeniusIsogeny_le_pointCount :
     (oneSubFrobeniusIsogeny W).degree ≤ W.pointCount := by
   have := isSeparable_oneSubFrobeniusIsogeny W
   rw [← separableDegree_eq_degree_of_isSeparable, separableDegree_def]
-  exact card_emb_le_pointCount W
+  exact card_emb_oneSubFrobeniusIsogeny_le_pointCount W
 
 /-- **`deg (1 − π_q) = #E(𝔽_q)`**, the first input of the Hasse bound. -/
 @[simp]

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/OneSubFrobenius/Degree.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/OneSubFrobenius/Degree.lean
@@ -1,0 +1,107 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Affine.FinitePoint
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.OneSubFrobenius.Kernel
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.OneSubFrobenius.TautologicalPoint
+import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.OneSubFrobenius.Separable
+
+/-!
+# The degree of `1 − π_q` is the number of rational points
+
+Over a finite field the isogeny `1 − π_q` has degree the number of rational points of the curve.
+One inequality is `pointCount_le_degree_oneSubFrobeniusIsogeny`: the kernel is every rational point
+and the kernel is at most the degree. This file supplies the other.
+
+An isogeny here has no map on points, so the count is made on embeddings of the function field.
+Write `L` for the pulled-back field. Two embeddings of `K(W)` over `L` agree on `L`, so they move
+the tautological point of `1 − π_q` to the same place; that image is the difference of the generic
+point's image and its `q`-power image, so the two images of the generic point differ by a point
+fixed by the `q`-power map, which therefore comes from the base field. An embedding is determined
+by where it sends the generic point, so the resulting assignment of a rational point to an
+embedding is injective. The separable degree is the number of such embeddings, and `1 − π_q` is
+separable, so the degree is at most the point count.
+
+## Main results
+
+* `TauCeti.Isogeny.card_emb_le_pointCount`: the embeddings of `K(W)` over the pulled-back field
+  are at most as many as the rational points.
+* `TauCeti.Isogeny.degree_oneSubFrobeniusIsogeny_le_pointCount`: hence `deg (1 − π_q)` is at most
+  the point count.
+* `TauCeti.Isogeny.degree_oneSubFrobeniusIsogeny_eq_pointCount`: with the reverse bound,
+  `deg (1 − π_q) = #E(𝔽_q)`.
+
+## References
+
+* [J. Silverman, *The Arithmetic of Elliptic Curves*][silverman2009], III.4.10 and V.1.1.
+
+## Provenance
+
+The route is that of the AINTLIB `HasseWeil` project (Chris Birkbeck, Apache-2.0) at commit
+`513e83879e2f8cbc626eb9e04d660e92be16ccba`, `HasseWeil/Isogeny/VerschiebungFactorization.lean`,
+declaration `emb_le_card_kernel`, which assembles the same count at the point level. The proof
+differs in what it rests on: there an isogeny carries its own map on points and the argument is
+placed over `AlgebraicClosure K(E)` explicitly, while here the kernel is the translation-fixing
+subgroup of the pulled-back field and the embeddings are Mathlib's `Field.Emb`, so the descent is
+`WeierstrassCurve.Affine.Point.map_frobeniusAlgHom_eq_self_iff_mem_range_baseChange` and the
+injectivity is `WeierstrassCurve.Affine.map_genericPoint_injective`.
+-/
+
+public section
+
+namespace TauCeti.Isogeny
+
+open WeierstrassCurve.Affine
+
+variable {F : Type*} [Field F] [Finite F] (W : WeierstrassCurve.Affine F) [W.IsElliptic]
+
+/-- **There are at most as many embeddings of the function field over the pulled-back field as
+there are rational points.** Each embedding is sent to the rational point by which it moves the
+generic point away from a fixed base embedding. -/
+theorem card_emb_le_pointCount :
+    Nat.card (Field.Emb (oneSubFrobeniusIsogeny W).fieldPullback.fieldRange W.FunctionField) ≤
+      W.pointCount := by
+  classical
+  rw [WeierstrassCurve.pointCount_eq_card_point]
+  set L := (oneSubFrobeniusIsogeny W).fieldPullback.fieldRange
+  have hagree : ∀ σ τ : Field.Emb L W.FunctionField, ∀ z ∈ L,
+      (σ.restrictScalars F) z = (τ.restrictScalars F) z := by
+    intro σ τ z hz
+    simpa using (σ.commutes ⟨z, hz⟩).trans (τ.commutes ⟨z, hz⟩).symm
+  obtain ⟨σ₀⟩ : Nonempty (Field.Emb L W.FunctionField) := inferInstance
+  choose f hf using fun σ : Field.Emb L W.FunctionField ↦
+    exists_baseChange_eq_sub_map_genericPoint W (σ.restrictScalars F) (σ₀.restrictScalars F)
+      (hagree σ σ₀)
+  refine Nat.card_le_card_of_injective f ?_
+  intro σ τ h
+  have hQ : Point.map (σ.restrictScalars F) (genericPoint W) =
+      Point.map (τ.restrictScalars F) (genericPoint W) := by
+    have h2 : Point.map (σ.restrictScalars F) (genericPoint W) -
+          Point.map (σ₀.restrictScalars F) (genericPoint W) =
+        Point.map (τ.restrictScalars F) (genericPoint W) -
+          Point.map (σ₀.restrictScalars F) (genericPoint W) := by
+      rw [← hf σ, ← hf τ, h]
+    exact sub_left_inj.1 h2
+  exact AlgHom.restrictScalars_injective F (map_genericPoint_injective W hQ)
+
+/-- **The degree of `1 − π_q` is at most the number of rational points**, the isogeny being
+separable, so that its degree is the number of embeddings counted above. -/
+theorem degree_oneSubFrobeniusIsogeny_le_pointCount :
+    (oneSubFrobeniusIsogeny W).degree ≤ W.pointCount := by
+  have := isSeparable_oneSubFrobeniusIsogeny W
+  rw [← separableDegree_eq_degree_of_isSeparable, separableDegree_def]
+  exact card_emb_le_pointCount W
+
+/-- **`deg (1 − π_q) = #E(𝔽_q)`**, the first input of the Hasse bound. -/
+theorem degree_oneSubFrobeniusIsogeny_eq_pointCount :
+    (oneSubFrobeniusIsogeny W).degree = W.pointCount :=
+  le_antisymm (degree_oneSubFrobeniusIsogeny_le_pointCount W)
+    (pointCount_le_degree_oneSubFrobeniusIsogeny W)
+
+end TauCeti.Isogeny
+
+end

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/OneSubFrobenius/TautologicalPoint.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/OneSubFrobenius/TautologicalPoint.lean
@@ -78,6 +78,18 @@ theorem map_frobeniusAlgHom_sub_map_genericPoint {Ω : Type*} [Field Ω] [Decida
   rw [← key]
   abel
 
+/-- **That difference descends to a rational point.** A point over an extension fixed by the
+`q`-power map comes from the base field, so two homomorphisms agreeing on the pulled-back field
+move the generic point by a rational point. -/
+theorem exists_baseChange_eq_sub_map_genericPoint {Ω : Type*} [Field Ω] [DecidableEq Ω]
+    [Algebra F Ω] [DecidableEq F] (σ τ : W.FunctionField →ₐ[F] Ω)
+    (h : ∀ z ∈ (oneSubFrobeniusIsogeny W).fieldPullback.fieldRange, σ z = τ z) :
+    ∃ P : (W⁄F).toAffine.Point, Point.baseChange F Ω P =
+      Point.map σ (genericPoint W) - Point.map τ (genericPoint W) := by
+  let _ := Fintype.ofFinite F
+  exact (WeierstrassCurve.Affine.Point.map_frobeniusAlgHom_eq_self_iff_mem_range_baseChange
+    W _).1 (map_frobeniusAlgHom_sub_map_genericPoint W σ τ h)
+
 end TauCeti.Isogeny
 
 end

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/OneSubFrobenius/TautologicalPoint.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/OneSubFrobenius/TautologicalPoint.lean
@@ -56,7 +56,7 @@ theorem map_tautologicalPoint_oneSubFrobeniusIsogeny {Ω : Type*} [Field Ω] [De
 /-- **Two homomorphisms that agree on the pulled-back field move the generic point to points whose
 difference is `q`-power fixed.** Their images of the tautological point of `1 − π_q` agree, and that
 image is `Q − Q^q`, so the two `Q`'s differ by a Frobenius-fixed point. -/
-theorem map_frobeniusAlgHom_sub_map_genericPoint {Ω : Type*} [Field Ω] [DecidableEq Ω]
+theorem map_frobeniusAlgHom_sub_map_genericPoint_eq_self {Ω : Type*} [Field Ω] [DecidableEq Ω]
     [Algebra F Ω] (σ τ : W.FunctionField →ₐ[F] Ω)
     (h : ∀ z ∈ (oneSubFrobeniusIsogeny W).fieldPullback.fieldRange, σ z = τ z) :
     letI := Fintype.ofFinite F
@@ -88,7 +88,7 @@ theorem exists_baseChange_eq_sub_map_genericPoint {Ω : Type*} [Field Ω] [Decid
       Point.map σ (genericPoint W) - Point.map τ (genericPoint W) := by
   let _ := Fintype.ofFinite F
   exact (WeierstrassCurve.Affine.Point.map_frobeniusAlgHom_eq_self_iff_mem_range_baseChange
-    W _).1 (map_frobeniusAlgHom_sub_map_genericPoint W σ τ h)
+    W _).1 (map_frobeniusAlgHom_sub_map_genericPoint_eq_self W σ τ h)
 
 end TauCeti.Isogeny
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/OneSubFrobenius/TautologicalPoint.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/OneSubFrobenius/TautologicalPoint.lean
@@ -53,6 +53,31 @@ theorem map_tautologicalPoint_oneSubFrobeniusIsogeny {Ω : Type*} [Field Ω] [De
   rw [tautologicalPoint_oneSubFrobeniusIsogeny, map_sub, tautologicalPoint_eq_map_genericPoint,
     fieldPullback_frobeniusIsogeny, WeierstrassCurve.Affine.Point.map_frobeniusAlgHom_comm]
 
+/-- **Two homomorphisms that agree on the pulled-back field move the generic point to points whose
+difference is `q`-power fixed.** Their images of the tautological point of `1 − π_q` agree, and that
+image is `Q − Q^q`, so the two `Q`'s differ by a Frobenius-fixed point. -/
+theorem map_frobeniusAlgHom_sub_map_genericPoint {Ω : Type*} [Field Ω] [DecidableEq Ω]
+    [Algebra F Ω] (σ τ : W.FunctionField →ₐ[F] Ω)
+    (h : ∀ z ∈ (oneSubFrobeniusIsogeny W).fieldPullback.fieldRange, σ z = τ z) :
+    letI := Fintype.ofFinite F
+    Point.map (_root_.FiniteField.frobeniusAlgHom F Ω)
+        (Point.map σ (genericPoint W) - Point.map τ (genericPoint W)) =
+      Point.map σ (genericPoint W) - Point.map τ (genericPoint W) := by
+  let _ := Fintype.ofFinite F
+  have hmem : ∀ x : W.CoordinateRing,
+      (oneSubFrobeniusIsogeny W).pullback x ∈
+        (oneSubFrobeniusIsogeny W).fieldPullback.fieldRange := fun x ↦
+    AlgHom.mem_fieldRange.2 ⟨algebraMap W.CoordinateRing W.FunctionField x,
+      (oneSubFrobeniusIsogeny W).fieldPullback_algebraMap x⟩
+  have key := CoordinatePullback.map_tautologicalPoint_eq_of_apply_eq
+    (oneSubFrobeniusIsogeny W).pullback σ τ (h _ (hmem _)) (h _ (hmem _))
+  rw [map_tautologicalPoint_oneSubFrobeniusIsogeny,
+    map_tautologicalPoint_oneSubFrobeniusIsogeny] at key
+  rw [map_sub, eq_comm, ← sub_eq_zero]
+  rw [← sub_eq_zero] at key
+  rw [← key]
+  abel
+
 end TauCeti.Isogeny
 
 end

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/OneSubFrobenius/TautologicalPoint.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/OneSubFrobenius/TautologicalPoint.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.GenericPoint
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Affine.Point.FrobeniusFixed
 public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.OneSubFrobenius.Basic
 
 /-!
@@ -37,6 +38,20 @@ theorem tautologicalPoint_oneSubFrobeniusIsogeny :
       genericPoint W - (frobeniusIsogeny W).pullback.tautologicalPoint := by
   rw [← Hom.tautologicalPoint_ofIsogeny, ofIsogeny_oneSubFrobeniusIsogeny]
   simp [Hom.one_def, Hom.id_def]
+
+/-- **The tautological point of `1 − π_q`, transported into any extension, is `Q − Q^q`** for `Q`
+the image there of the generic point. This is the form the embedding count needs: the left side
+depends on the homomorphism only through the pulled-back field, while the right side is visibly a
+difference of a point and its `q`-power image. -/
+theorem map_tautologicalPoint_oneSubFrobeniusIsogeny {Ω : Type*} [Field Ω] [DecidableEq Ω]
+    [Algebra F Ω] (σ : W.FunctionField →ₐ[F] Ω) :
+    letI := Fintype.ofFinite F
+    Point.map σ (oneSubFrobeniusIsogeny W).pullback.tautologicalPoint =
+      Point.map σ (genericPoint W) -
+        Point.map (_root_.FiniteField.frobeniusAlgHom F Ω) (Point.map σ (genericPoint W)) := by
+  let _ := Fintype.ofFinite F
+  rw [tautologicalPoint_oneSubFrobeniusIsogeny, map_sub, tautologicalPoint_eq_map_genericPoint,
+    fieldPullback_frobeniusIsogeny, WeierstrassCurve.Affine.Point.map_frobeniusAlgHom_comm]
 
 end TauCeti.Isogeny
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/TautologicalPoint.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/TautologicalPoint.lean
@@ -128,6 +128,19 @@ theorem tautologicalPoint_comp {W₀ : WeierstrassCurve.Affine F} (p : Coordinat
     ← Point.some_coords (tautologicalPoint_ne_zero (σ.comp p))]
   simp only [xCoord_tautologicalPoint, yCoord_tautologicalPoint, AlgHom.comp_apply]
 
+/-- **Two homomorphisms agreeing on the pullback's two coordinate values move the tautological
+point to the same place.** The point's coordinates are those two values, so the induced map on
+points cannot see anything else about the homomorphism. -/
+theorem map_tautologicalPoint_eq_of_apply_eq {Ω : Type*} [Field Ω] [Algebra F Ω] [DecidableEq Ω]
+    (p : CoordinatePullback W₁ W₂) (σ τ : W₁.FunctionField →ₐ[F] Ω)
+    (hx : σ (p (AdjoinRoot.of W₂.polynomial X)) = τ (p (AdjoinRoot.of W₂.polynomial X)))
+    (hy : σ (p (AdjoinRoot.root W₂.polynomial)) = τ (p (AdjoinRoot.root W₂.polynomial))) :
+    Point.map σ p.tautologicalPoint = Point.map τ p.tautologicalPoint := by
+  rw [← Point.some_coords (tautologicalPoint_ne_zero p), Point.map_some, Point.map_some,
+    Point.some.injEq]
+  simp only [xCoord_tautologicalPoint, yCoord_tautologicalPoint]
+  exact ⟨hx, hy⟩
+
 end CoordinatePullback
 
 end TauCeti

--- a/TauCeti/FieldTheory/Finite/FrobeniusFixed.lean
+++ b/TauCeti/FieldTheory/Finite/FrobeniusFixed.lean
@@ -79,6 +79,16 @@ theorem pow_card_eq_self_iff_mem_range_algebraMap {K L : Type*} [Field K] [Finty
     eval₂_sub, eval₂_X_pow, eval₂_X, sub_eq_zero] at this
   exact this.symm
 
+/-- **A `K`-algebra homomorphism commutes with the finite-base-field Frobenius.** Applying the
+homomorphism and raising to the `#K`-th power can be done in either order, a ring homomorphism
+carrying `q`-th powers to `q`-th powers. -/
+theorem comp_frobeniusAlgHom {K L Ω : Type*} [Field K] [Fintype K] [CommRing L] [Algebra K L]
+    [CommRing Ω] [Algebra K Ω] (σ : L →ₐ[K] Ω) :
+    σ.comp (_root_.FiniteField.frobeniusAlgHom K L) =
+      (_root_.FiniteField.frobeniusAlgHom K Ω).comp σ := by
+  ext x
+  simp [_root_.FiniteField.coe_frobeniusAlgHom]
+
 end FiniteField
 
 /-- **A domain over `K` all of whose elements satisfy `x ^ |K| = x` is `K` itself.** Every element

--- a/TauCeti/FieldTheory/Finite/FrobeniusFixed.lean
+++ b/TauCeti/FieldTheory/Finite/FrobeniusFixed.lean
@@ -82,6 +82,7 @@ theorem pow_card_eq_self_iff_mem_range_algebraMap {K L : Type*} [Field K] [Finty
 /-- **A `K`-algebra homomorphism commutes with the finite-base-field Frobenius.** Applying the
 homomorphism and raising to the `#K`-th power can be done in either order, a ring homomorphism
 carrying `q`-th powers to `q`-th powers. -/
+@[simp]
 theorem _root_.AlgHom.comp_frobeniusAlgHom {K L Ω : Type*} [Field K] [Fintype K] [CommRing L]
     [Algebra K L] [CommRing Ω] [Algebra K Ω] (σ : L →ₐ[K] Ω) :
     σ.comp (_root_.FiniteField.frobeniusAlgHom K L) =

--- a/TauCeti/FieldTheory/Finite/FrobeniusFixed.lean
+++ b/TauCeti/FieldTheory/Finite/FrobeniusFixed.lean
@@ -82,8 +82,8 @@ theorem pow_card_eq_self_iff_mem_range_algebraMap {K L : Type*} [Field K] [Finty
 /-- **A `K`-algebra homomorphism commutes with the finite-base-field Frobenius.** Applying the
 homomorphism and raising to the `#K`-th power can be done in either order, a ring homomorphism
 carrying `q`-th powers to `q`-th powers. -/
-theorem comp_frobeniusAlgHom {K L Ω : Type*} [Field K] [Fintype K] [CommRing L] [Algebra K L]
-    [CommRing Ω] [Algebra K Ω] (σ : L →ₐ[K] Ω) :
+theorem _root_.AlgHom.comp_frobeniusAlgHom {K L Ω : Type*} [Field K] [Fintype K] [CommRing L]
+    [Algebra K L] [CommRing Ω] [Algebra K Ω] (σ : L →ₐ[K] Ω) :
     σ.comp (_root_.FiniteField.frobeniusAlgHom K L) =
       (_root_.FiniteField.frobeniusAlgHom K Ω).comp σ := by
   ext x


### PR DESCRIPTION
Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"EllipticCurves/README.md:layer1:kernel-card-eq-degree"}-->

Provenance: the route is AINTLIB `HasseWeil` (Chris Birkbeck, Apache 2.0, commit `513e83879e2f8cbc626eb9e04d660e92be16ccba`), `Isogeny/VerschiebungFactorization.lean`, `emb_le_card_kernel`, which assembles the same count at the point level. This is not a port. There an isogeny carries its own map on points and the argument is placed over `AlgebraicClosure K(E)` explicitly; here an isogeny has no point map, the kernel is the translation-fixing subgroup of the pulled-back field, the embeddings are Mathlib's `Field.Emb`, the descent is TauCeti's `map_frobeniusAlgHom_eq_self_iff_mem_range_baseChange` and the injectivity is `map_genericPoint_injective` (#6436). Each file's Provenance section records this.

## What this adds

**`Isogeny.degree_oneSubFrobeniusIsogeny_eq_pointCount : (oneSubFrobeniusIsogeny W).degree = W.pointCount`** — `deg (1 − π_q) = #E(𝔽_q)`. This is the first of the two inputs the roadmap's Hasse bound names.

The reverse bound `pointCount_le_degree_oneSubFrobeniusIsogeny` is already on `main` (#6377); this supplies the other and takes `le_antisymm`.

Supporting results, each in its canonical home:

- `TauCeti.FiniteField.comp_frobeniusAlgHom` — a `K`-algebra homomorphism commutes with `FiniteField.frobeniusAlgHom`. Stated for commutative rings; mentions only Mathlib types.
- `WeierstrassCurve.Affine.Point.map_frobeniusAlgHom_comm` — the same at point level.
- `CoordinatePullback.map_tautologicalPoint_eq_of_apply_eq` — two homomorphisms agreeing on the pullback's two coordinate values move the tautological point to the same place.
- `Isogeny.map_tautologicalPoint_oneSubFrobeniusIsogeny` — that point, transported into any extension, is `Q − Q^q`.
- `Isogeny.map_frobeniusAlgHom_sub_map_genericPoint` — homomorphisms agreeing on the pulled-back field move the generic point by a `q`-power-fixed difference.
- `Isogeny.exists_baseChange_eq_sub_map_genericPoint` — that difference descends to a rational point.
- `Isogeny.card_emb_le_pointCount` — hence the embeddings are at most the rational points.

## The argument

An isogeny here has no map on points, so the count is made on embeddings. Write `L` for `(1 − π_q)^*K(W)`.

1. The tautological point's coordinates **are** the pullback's two values (`xCoord_tautologicalPoint`, `yCoord_tautologicalPoint`), so `Point.map σ` of it cannot see `σ` outside `L`. Two embeddings over `L` therefore send it to the same point.
2. That point is `Q_σ − Q_σ^q`, by `tautologicalPoint_oneSubFrobeniusIsogeny`, `tautologicalPoint_eq_map_genericPoint`, `fieldPullback_frobeniusIsogeny` and the commutation above.
3. So `Q_σ − Q_τ` equals its own `q`-power image.
4. A point over an extension fixed by the `q`-power map comes from the base field — `map_frobeniusAlgHom_eq_self_iff_mem_range_baseChange`, already stated on `main` for an arbitrary extension, which is the generality needed for `AlgebraicClosure K(W)`.
5. `σ ↦` that rational point is injective: it determines `Q_σ`, and an embedding is determined by the image of the generic point (#6436).
6. `Field.finSepDegree L K(W)` **is** `Nat.card (Field.Emb L K(W))` definitionally, so this bounds the separable degree; `1 − π_q` is separable (`isSeparable_oneSubFrobeniusIsogeny`), so it bounds the degree.

## Notes

- `deg (1 − π_q) = #E(𝔽_q)` supersedes `pointCount_dvd_degree_oneSubFrobeniusIsogeny` (#6433, merged earlier today) as a statement about `1 − π_q`. That divisibility is left in place: it holds for the kernel of any isogeny via `card_ker_dvd_separableDegree` and is not specific to this one.
- Axiom-clean: `#print axioms` on the capstone gives `propext`, `Classical.choice`, `Quot.sound`.
- Six commits, kept separate so each step is reviewable on its own; the final one is the assembly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
