### PR TITLE
refactor(RepresentationTheory): merge adjacent single-lemma rw steps

### DIFF
--- a/TauCeti/RepresentationTheory/CharacterTable/ClassSum/StructureConstants.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassSum/StructureConstants.lean
@@ -48,8 +48,7 @@ private def structureConstantFiberEquiv (Cᵢ Cⱼ : ConjClasses G) {g h : G}
   invFun p := ⟨
     (conjugateCarrierEquiv s⁻¹ Cᵢ p.1.1, conjugateCarrierEquiv s⁻¹ Cⱼ p.1.2),
     by
-      rw [conjugateCarrierEquiv_apply, conjugateCarrierEquiv_apply, conj_mul, p.2]
-      rw [← hs]
+      rw [conjugateCarrierEquiv_apply, conjugateCarrierEquiv_apply, conj_mul, p.2, ← hs]
       simp [mul_assoc]⟩
   left_inv p := by
     apply Subtype.ext

--- a/TauCeti/RepresentationTheory/CharacterTable/Dixon/Cyclotomic/CyclicThree.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Dixon/Cyclotomic/CyclicThree.lean
@@ -230,8 +230,7 @@ theorem cyclicGroupThreeExactCharacterTable_natAbs_coeff_le_sqrt
     (i j : CyclicGroupThreeClassIndex) (k : Fin (3 : ℕ).totient) :
     ((cyclicGroupThreeExactCharacterTable i j).coeff k).natAbs ≤
       Nat.sqrt (Nat.card (Multiplicative (ZMod 3))) := by
-  rw [natCard_cyclicGroup_three]
-  rw [sqrt_three]
+  rw [natCard_cyclicGroup_three, sqrt_three]
   fin_cases i <;> fin_cases j <;> fin_cases k <;> decide
 
 /-- **The structured cyclotomic lift recovers every exact table entry from its residues at the

--- a/TauCeti/RepresentationTheory/CharacterTable/Pairing.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Pairing.lean
@@ -140,8 +140,7 @@ theorem characterPairing_classIndicator_inv (f : ClassFunction k G) (x : G) :
       intro g hg
       exact ClassFunction.eq_of_isConj f (by simpa using Finset.mem_filter.mp hg |>.2)
     _ = _ := by
-      rw [Finset.sum_const, nsmul_eq_mul]
-      rw [hcarrier, Nat.card_eq_fintype_card]
+      rw [Finset.sum_const, nsmul_eq_mul, hcarrier, Nat.card_eq_fintype_card]
       rw [(Fintype.card_ofFinset (p := {g | IsConj g x})
         (Finset.univ.filter fun g => IsConj g x) (by simp)).symm]
 

--- a/TauCeti/RepresentationTheory/ClassicalGroups/Weight/Decomposition.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/Weight/Decomposition.lean
@@ -113,8 +113,7 @@ theorem IsRationalRep.exists_forall_diagGL_eq_sum_smul (h : IsRationalRep ρ) :
     fun l hl ↦ Finset.mem_biUnion.mpr ⟨(i, j), Finset.mem_univ _, hl⟩
   have hleft : LinearMap.toMatrix b b (ρ (diagGL t)) i j
       = ∑ l ∈ Finset.univ.biUnion fun q ↦ (c q).support, c (i, j) l * weightCharHom ℂ l t := by
-    rw [← congrFun (hc (i, j)) t, Finsupp.sum]
-    rw [Finset.sum_apply]
+    rw [← congrFun (hc (i, j)) t, Finsupp.sum, Finset.sum_apply]
     refine Finset.sum_subset hsub fun l _ hl ↦ ?_
     rw [Finsupp.notMem_support_iff.mp hl, zero_smul, Pi.zero_apply]
   rw [hleft, Matrix.sum_apply]

--- a/TauCeti/RepresentationTheory/ClassicalGroups/WeylDimension.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/WeylDimension.lean
@@ -293,8 +293,7 @@ theorem weylDimension_fin_one (l : DominantWeight 1) : weylDimension l = 1 :=
 theorem weylDimension_fin_two (l : DominantWeight 2) :
     (weylDimension l : ℤ) = l.1 0 - l.1 1 + 1 := by
   have hnum : weylDimensionNumerator l = l.1 0 - l.1 1 + 1 := by
-    rw [weylDimensionNumerator_eq_prod_prod]
-    rw [Fin.prod_univ_two]
+    rw [weylDimensionNumerator_eq_prod_prod, Fin.prod_univ_two]
     have h0 : (Ioi (0 : Fin 2)) = {1} := by decide
     have h1 : (Ioi (1 : Fin 2)) = ∅ := by decide
     rw [h0, h1]

--- a/TauCeti/RepresentationTheory/Compact/Haar.lean
+++ b/TauCeti/RepresentationTheory/Compact/Haar.lean
@@ -99,8 +99,7 @@ theorem haarProb_def :
   by
     rw [haarProb,
       FiniteMeasure.toMeasure_normalize_eq_of_nonzero (haarFinite G) (haarFinite_ne_zero G)]
-    rw [← haarFinite_toMeasure]
-    rw [← FiniteMeasure.ennreal_mass, ← ENNReal.coe_inv]
+    rw [← haarFinite_toMeasure, ← FiniteMeasure.ennreal_mass, ← ENNReal.coe_inv]
     · rfl
     · exact (FiniteMeasure.mass_nonzero_iff (haarFinite G)).mpr (haarFinite_ne_zero G)
 

--- a/TauCeti/RepresentationTheory/Quiver/Kronecker/Indecomposable.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Kronecker/Indecomposable.lean
@@ -352,8 +352,7 @@ private theorem finrank_indecProjRep_obj_src :
       (Quiver.Kronecker.src : Paths (Quiver.Kronecker A))) = 1 := by
   have h := dimVector_indecProjRep (k := k) Quiver.Kronecker.src
     (Quiver.Kronecker.src : Quiver.Kronecker A)
-  rw [dimVector_apply] at h
-  rw [Paths.of_obj] at h
+  rw [dimVector_apply, Paths.of_obj] at h
   rw [h, Nat.card_unique]
 
 /-- The projective `P₁` of the `A₂` quiver is a line at the target: its single arrow is the only
@@ -363,8 +362,7 @@ private theorem finrank_indecProjRep_obj_tgt :
       (Quiver.Kronecker.tgt : Paths (Quiver.Kronecker A))) = 1 := by
   have h := dimVector_indecProjRep (k := k) Quiver.Kronecker.src
     (Quiver.Kronecker.tgt : Quiver.Kronecker A)
-  rw [dimVector_apply] at h
-  rw [Paths.of_obj] at h
+  rw [dimVector_apply, Paths.of_obj] at h
   rw [h, Nat.card_congr Quiver.Kronecker.pathEquivArrow, Nat.card_unique]
 
 /-- **Every indecomposable representation of the `A₂` quiver is one of the three**: the two vertex

--- a/TauCeti/RepresentationTheory/Quiver/Preprojective/Orientation.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Preprojective/Orientation.lean
@@ -422,8 +422,7 @@ theorem reorientPreprojectiveAlgebraEquiv_preprojectiveMk_ofArrow_keep {i j : Q}
       = preprojectiveMk k Q (ofArrow (Symmetrify.of.map a)) := by
   have h : reorientDoubledEquiv k σ (ofArrow (Symmetrify.of.map (reorientKeep σ a ha)))
       = ofArrow (Symmetrify.of.map a) := by
-    rw [reorientDoubledEquiv_ofArrow_normalized]
-    rw [reorientSymmetrify_map_of_keep]
+    rw [reorientDoubledEquiv_ofArrow_normalized, reorientSymmetrify_map_of_keep]
     exact ofArrow_homOfEq _ _ _
   rw [reorientPreprojectiveAlgebraEquiv_preprojectiveMk, h, rescale_ofArrow, doubledLabelling_of,
     reorientSign_of_false k ha, one_smul]
@@ -437,8 +436,7 @@ theorem reorientPreprojectiveAlgebraEquiv_preprojectiveMk_ofArrow_reverse_keep {
   have h : reorientDoubledEquiv k σ
         (ofArrow (Quiver.reverse (Symmetrify.of.map (reorientKeep σ a ha))))
       = ofArrow (Quiver.reverse (Symmetrify.of.map a)) := by
-    rw [reorientDoubledEquiv_ofArrow_normalized]
-    rw [reorientSymmetrify_map_reverse_of_keep]
+    rw [reorientDoubledEquiv_ofArrow_normalized, reorientSymmetrify_map_reverse_of_keep]
     exact ofArrow_homOfEq _ _ _
   rw [reorientPreprojectiveAlgebraEquiv_preprojectiveMk, h, rescale_ofArrow,
     doubledLabelling_reverse_of, one_smul]
@@ -453,8 +451,7 @@ theorem reorientPreprojectiveAlgebraEquiv_preprojectiveMk_ofArrow_flip {i j : Q}
       = preprojectiveMk k Q (ofArrow (Quiver.reverse (Symmetrify.of.map a))) := by
   have h : reorientDoubledEquiv k σ (ofArrow (Symmetrify.of.map (reorientFlip σ a ha)))
       = ofArrow (Quiver.reverse (Symmetrify.of.map a)) := by
-    rw [reorientDoubledEquiv_ofArrow_normalized]
-    rw [reorientSymmetrify_map_of_flip]
+    rw [reorientDoubledEquiv_ofArrow_normalized, reorientSymmetrify_map_of_flip]
     exact ofArrow_homOfEq _ _ _
   rw [reorientPreprojectiveAlgebraEquiv_preprojectiveMk, h, rescale_ofArrow,
     doubledLabelling_reverse_of, one_smul]
@@ -470,8 +467,7 @@ theorem reorientPreprojectiveAlgebraEquiv_preprojectiveMk_ofArrow_reverse_flip {
   have h : reorientDoubledEquiv k σ
         (ofArrow (Quiver.reverse (Symmetrify.of.map (reorientFlip σ a ha))))
       = ofArrow (Symmetrify.of.map a) := by
-    rw [reorientDoubledEquiv_ofArrow_normalized]
-    rw [reorientSymmetrify_map_reverse_of_flip]
+    rw [reorientDoubledEquiv_ofArrow_normalized, reorientSymmetrify_map_reverse_of_flip]
     exact ofArrow_homOfEq _ _ _
   rw [reorientPreprojectiveAlgebraEquiv_preprojectiveMk, h, rescale_ofArrow, doubledLabelling_of,
     reorientSign_of_true k ha, neg_one_smul, map_neg]

--- a/TauCeti/RepresentationTheory/Quiver/Reflection/Coxeter.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Reflection/Coxeter.lean
@@ -182,8 +182,7 @@ private theorem map_vertexReflection_toLinearMap {l : List Q}
     (l.attach.map fun i : {i // i ∈ l} ↦ vertexReflection Q (hl i.1 i.2)).map
         (fun e ↦ e.toLinearMap)
       = l.map (vertexPreReflection Q) := by
-  rw [List.map_map]
-  rw [← List.attach_map_val (f := vertexPreReflection Q)]
+  rw [List.map_map, ← List.attach_map_val (f := vertexPreReflection Q)]
   apply List.map_congr_left
   intro i hi
   apply LinearMap.coe_injective

--- a/TauCeti/RepresentationTheory/Spin/Polarization/TypeD/Basic.lean
+++ b/TauCeti/RepresentationTheory/Spin/Polarization/TypeD/Basic.lean
@@ -155,8 +155,7 @@ corresponding polarization coordinate. -/
     · rw [Matrix.toLinAlgEquiv_self]
       simp only [typeDDiagonalMatrix_apply, ite_smul, zero_smul, Finset.sum_ite_eq',
         Finset.mem_univ, ↓reduceIte, typeDDiagonalValue_inr, typeDBasis_inr, neg_smul]
-      rw [P.polar_W'_eq_zero, zero_smul, zero_sub, P.polar_dualVector, neg_inj]
-      rw [Pi.single_apply]
+      rw [P.polar_W'_eq_zero, zero_smul, zero_sub, P.polar_dualVector, neg_inj, Pi.single_apply]
       split <;> simp_all [eq_comm]
   rw [key]
   exact Subtype.ext (P.diagonalBivector_def b i).symm

--- a/TauCeti/RepresentationTheory/Spin/Polarization/TypeD/KostantLattice.lean
+++ b/TauCeti/RepresentationTheory/Spin/Polarization/TypeD/KostantLattice.lean
@@ -288,8 +288,7 @@ theorem spinAction_typeDSimpleCorootBivector_exteriorBasis
     have hspin : spinWeight ℚ s i = spinWeight ℚ s (⟨n - 1, by omega⟩ : Fin n) :=
       congrArg (spinWeight ℚ s) hi
     have hwt := TauCeti.DynkinType.algebraMap_typeDSpinWeight_apply (K := ℚ) s i
-    rw [dite_eq_right hnext, hprev] at hwt
-    rw [hspin] at hwt
+    rw [dite_eq_right hnext, hprev, hspin] at hwt
     simpa only [algebraMap_int_eq, Int.coe_castRingHom] using
       (congrArg (fun z : ℚ ↦ z • b.ExteriorAlgebra s) hwt).symm
 

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/Straightening.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/Straightening.lean
@@ -289,8 +289,7 @@ private theorem straightWeight_lt_of_swap {t : YoungTableau μ} {x y : Fin μ.ca
     have hstep : rowMoment t + (rowIndex t x * (x : ℕ) + rowIndex t y * (y : ℕ)) <
         rowMoment t + (rowIndex t x * (y : ℕ) + rowIndex t y * (x : ℕ)) :=
       Nat.add_lt_add_left (mul_add_mul_lt_mul_add_mul hrow (Fin.lt_def.mp hyx)) _
-    rw [rowMoment] at hstep
-    rw [← hr] at hstep
+    rw [rowMoment, ← hr] at hstep
     exact lt_of_add_lt_add_right hstep
   rw [straightWeight, straightWeight, hcol']
   exact Nat.add_lt_add_left hrow' _

--- a/TauCeti/RepresentationTheory/Symmetric/TableauSubgroupConjugacy.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/TableauSubgroupConjugacy.lean
@@ -36,8 +36,7 @@ private abbrev rowBlocks (l : List ℕ) : Type :=
 private noncomputable def rowCellsEquiv (μ : YoungDiagram) :
     rowBlocks μ.rowLens ≃ ↥μ.cells where
   toFun x := ⟨(x.1, x.2), by
-    rw [YoungDiagram.mem_cells, YoungDiagram.mem_iff_lt_rowLen]
-    rw [← YoungDiagram.get_rowLens]
+    rw [YoungDiagram.mem_cells, YoungDiagram.mem_iff_lt_rowLen, ← YoungDiagram.get_rowLens]
     exact x.2.2⟩
   invFun c :=
     ⟨⟨c.1.1, by

--- a/TauCeti/RepresentationTheory/Symmetric/YoungSubgroup.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/YoungSubgroup.lean
@@ -208,13 +208,11 @@ theorem youngSubgroupMulEquiv_apply_youngBlocksEquiv {n : ℕ} (μ : n.Partition
         ((σ : Equiv.Perm (Fin n)) (youngBlocksEquiv μ ⟨i, j⟩)) =
       ⟨i, (youngSubgroupMulEquiv μ σ) i j⟩ := by
   apply (youngBlocksEquiv μ).injective
-  rw [Equiv.apply_symm_apply]
-  rw [← youngBlockEquiv_val μ i ((youngSubgroupMulEquiv μ σ) i j)]
+  rw [Equiv.apply_symm_apply, ← youngBlockEquiv_val μ i ((youngSubgroupMulEquiv μ σ) i j)]
   have h := DomMulAct.stabilizerMulEquiv_apply
     (youngSubgroupStabilizerMulEquiv μ σ) (youngBlock_youngBlocksEquiv μ ⟨i, j⟩)
   rw [youngSubgroupStabilizerMulEquiv_apply] at h
-  rw [← h]
-  rw [← youngBlockEquiv_apply μ i j, youngSubgroupMulEquiv_apply]
+  rw [← h, ← youngBlockEquiv_apply μ i j, youngSubgroupMulEquiv_apply]
   rw [Equiv.permCongrHom_coe, Equiv.permCongr_apply, Equiv.symm_symm,
     Equiv.apply_symm_apply]
 

--- a/TauCeti/RepresentationTheory/Unipotent/NormalJoin.lean
+++ b/TauCeti/RepresentationTheory/Unipotent/NormalJoin.lean
@@ -145,8 +145,7 @@ private theorem _root_.Representation.isNilpotent_sub_one_of_normal_isUnipotent
           rw [← ha, map_smul, hfixed]
         have hp (z : G) : p ≤ p.comap (rho z) := by
           intro y hy
-          rw [Submodule.mem_comap]
-          rw [hp_fixed z ⟨y, hy⟩]
+          rw [Submodule.mem_comap, hp_fixed z ⟨y, hy⟩]
           exact hy
         let q : Representation K G (V ⧸ p) := rho.quotient p hp
         have quotient_sub_one_eq_mapQ (z : G)

--- a/TauCeti/RepresentationTheory/Unipotent/Solvable.lean
+++ b/TauCeti/RepresentationTheory/Unipotent/Solvable.lean
@@ -134,8 +134,7 @@ theorem _root_.Representation.exists_basis_isUpperUnitriangular_of_isUnipotent
                   rw [finSumFinEquiv_apply_right, finSumFinEquiv_apply_right,
                     LinearMap.toMatrixAlgEquiv_apply,
                     extensionBasis_repr_natAdd]
-                  rw [← q_apply]
-                  rw [Submodule.mkQ_apply, extensionBasis_natAdd_mkQ]
+                  rw [← q_apply, Submodule.mkQ_apply, extensionBasis_natAdd_mkQ]
                   simpa only [LinearMap.toMatrixAlgEquiv_apply] using
                     (hbq g |>.isUpperTriangular
                       ((Fin.strictMono_natAdd 1).lt_iff_lt.mp hji))
@@ -153,8 +152,7 @@ theorem _root_.Representation.exists_basis_isUpperUnitriangular_of_isUnipotent
           | inr i =>
               rw [finSumFinEquiv_apply_right, LinearMap.toMatrixAlgEquiv_apply,
                 extensionBasis_repr_natAdd]
-              rw [← q_apply]
-              rw [Submodule.mkQ_apply, extensionBasis_natAdd_mkQ]
+              rw [← q_apply, Submodule.mkQ_apply, extensionBasis_natAdd_mkQ]
               simpa only [LinearMap.toMatrixAlgEquiv_apply] using hbq g |>.apply_diag i
       · let _ : Subsingleton V := not_nontrivial_iff_subsingleton.mp hV
         have hzero : finrank K V = 0 := Module.finrank_zero_of_subsingleton


### PR DESCRIPTION
Several proofs under `TauCeti/RepresentationTheory/` close with a run of consecutive one-lemma
`rw` calls where a single `rw [...]` list says the same thing. This merges those runs across the
subtree: **22 merges in 16 files, removing 22 lines**. No statement changes.

## The rule applied

A run is merged only when the `rw` lines are

* **adjacent**, with nothing between them — runs separated by an `apply`, a `simp only`, or a
  comment explaining that step are left alone,
* at the **same indentation**, and
* carrying the **same location clause** (all bare, or all `at h` for the same `h`).

Where the merged list would exceed the 100-character limit and need wrapping onto a second line,
nothing is saved and the split form is at least as readable, so it is left untouched. That is why
**11 of the 33 candidates in this subtree are not merged** — they are listed below so the omission
reads as deliberate rather than missed.

## This is not a pure reformat

Merging changes the intermediate goals, so a later lemma in a merged list can match a different
instance of its pattern than it did when run on its own. Every merge was rebuilt, not assumed.

Two of the 22 sit inside `private def` bodies (`structureConstantFiberEquiv`, `rowCellsEquiv`)
rather than theorems. In both the run is inside a `by` block discharging a `Prop` obligation — a
subtype membership proof — so proof irrelevance leaves the definitions themselves unchanged.

## Verification

All three local gates on the rebased head:

| gate | result |
|---|---|
| `lake build` (whole library) | 11201 jobs, no errors, no linter warnings |
| `lake exe axioms` | 112366 declarations, all within `[propext, Classical.choice, Quot.sound]` |
| `bash scripts/lint-style.sh` | 5037 files, conforming |

## Deliberately left alone

The 11 candidates in this subtree whose merged line would exceed 100 characters:

| file | line | merged width |
|---|---|---|
| `ClassicalGroups/Symplectic.lean` | 141 | 132 |
| `ClassicalGroups/Weight/Decomposition.lean` | 122 | 104 |
| `Compact/SchurOrthogonality.lean` | 133 | 108 |
| `Homological/TateCohomology/HerbrandQuotient.lean` | 169 | 112 |
| `Induction/Clifford/Equivalence.lean` | 99 | 135 |
| `Induction/Ideal.lean` | 273 | 143 |
| `Quiver/Reflection/Representation.lean` | 480 | 147 |
| `Spin/Polarization/TypeD/Basic.lean` | 151 | 111 |
| `Symmetric/PermutationModule/Basic.lean` | 88 | 114 |
| `Symmetric/Specht/Completeness.lean` | 259 | 116 |
| `Tensor/Power.lean` | 144 | 146 |

## Scope

Improving already-merged code, which `AGENTS.md` puts permanently in scope and which needs no
roadmap entry. It is a single topic — one mechanical transformation, one rule, applied to one
subtree — and adds no mathematics.

On the attribution line: rather than infer the area from the `TauCeti/RepresentationTheory/`
directory name, which `AGENTS.md` warns against, I checked the roadmap paths the 16 touched files
cite in their own docstrings. Ten cite `RepresentationTheory`, one cites `ZigzagPreprojective`
(`Quiver/Preprojective/Orientation.lean`), and five cite none. `RepresentationTheory` is therefore
the roadmap chiefly motivating the work.

Roadmap: RepresentationTheory

🤖 Generated with [Claude Code](https://claude.com/claude-code)
