### PR TITLE
feat(MeasureTheory): the measurable structure of the standard simplex

### DIFF
--- a/TauCeti/MeasureTheory/MeasurableSpace/StdSimplex.lean
+++ b/TauCeti/MeasureTheory/MeasurableSpace/StdSimplex.lean
@@ -7,7 +7,6 @@ module
 
 public import Mathlib.Geometry.Convex.ConvexSpace.Defs
 public import Mathlib.MeasureTheory.MeasurableSpace.Constructions
-public import Mathlib.MeasureTheory.Constructions.BorelSpace.Basic
 
 /-!
 # The measurable structure of the standard simplex
@@ -25,8 +24,8 @@ Mathlib's topology on the simplex is stated over a ring and does not reach coeff
 
 * `Convexity.StdSimplex.instMeasurableSpace` — the σ-algebra induced by `StdSimplex.weights`;
 * `Convexity.StdSimplex.measurable_toFun_comp_weights` — the weight vector is measurable;
-* `Convexity.StdSimplex.measurable_iff_weights` — measurability into the simplex is measurability
-  of the weight vector.
+* `Convexity.StdSimplex.measurable_iff_toFun_comp_weights` — measurability into the simplex is
+  measurability of the weight vector.
 -/
 
 public section
@@ -47,7 +46,7 @@ theorem measurable_toFun_comp_weights : Measurable fun p : StdSimplex R ι => (p
   comap_measurable _
 
 /-- A map into the simplex is measurable iff its weight-vector map is. -/
-theorem measurable_iff_weights {δ : Type*} [MeasurableSpace δ] {f : δ → StdSimplex R ι} :
+theorem measurable_iff_toFun_comp_weights {δ : Type*} [MeasurableSpace δ] {f : δ → StdSimplex R ι} :
     Measurable f ↔ Measurable fun x => ((f x).weights : ι → R) :=
   measurable_comap_iff
 

--- a/TauCeti/MeasureTheory/MeasurableSpace/StdSimplex.lean
+++ b/TauCeti/MeasureTheory/MeasurableSpace/StdSimplex.lean
@@ -1,0 +1,56 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Geometry.Convex.ConvexSpace.Defs
+public import Mathlib.MeasureTheory.MeasurableSpace.Constructions
+public import Mathlib.MeasureTheory.Constructions.BorelSpace.Real
+
+/-!
+# The measurable structure of the standard simplex
+
+A point of the standard simplex `StdSimplex ℝ≥0 ι` is determined by its weight vector
+`ι → ℝ≥0`. This file gives the simplex the σ-algebra induced by that weight vector,
+so that a probability vector is a measurable parameter: a map into the simplex is measurable
+exactly when its weight-vector map is, and the weight vector itself is measurable.
+
+Mathlib's topology on the simplex is stated over a ring and does not apply to `ℝ≥0`; the induced
+σ-algebra needs no topology.
+
+## Main declarations
+
+* `Convexity.StdSimplex.instMeasurableSpace` — the σ-algebra induced by `StdSimplex.weights`;
+* `Convexity.StdSimplex.measurable_weights` — the weight vector is measurable;
+* `Convexity.StdSimplex.measurable_iff_weights` — measurability into the simplex is measurability
+  of the weight vector.
+-/
+
+public section
+
+open MeasureTheory
+open scoped NNReal
+
+namespace Convexity.StdSimplex
+
+variable {ι : Type*}
+
+/-- The σ-algebra on the standard simplex induced by its weight vector. -/
+instance instMeasurableSpace : MeasurableSpace (StdSimplex ℝ≥0 ι) :=
+  MeasurableSpace.comap (fun p : StdSimplex ℝ≥0 ι => (p.weights : ι → ℝ≥0)) inferInstance
+
+/-- The weight vector of a simplex point is measurable. -/
+@[fun_prop]
+theorem measurable_weights : Measurable fun p : StdSimplex ℝ≥0 ι => (p.weights : ι → ℝ≥0) :=
+  comap_measurable _
+
+/-- A map into the simplex is measurable iff its weight-vector map is. -/
+theorem measurable_iff_weights {δ : Type*} [MeasurableSpace δ] {f : δ → StdSimplex ℝ≥0 ι} :
+    Measurable f ↔ Measurable fun x => ((f x).weights : ι → ℝ≥0) := by
+  rw [measurable_iff_comap_le]
+  simp only [instMeasurableSpace, MeasurableSpace.comap_comp]
+  exact measurable_iff_comap_le.symm
+
+end Convexity.StdSimplex

--- a/TauCeti/MeasureTheory/MeasurableSpace/StdSimplex.lean
+++ b/TauCeti/MeasureTheory/MeasurableSpace/StdSimplex.lean
@@ -7,42 +7,48 @@ module
 
 public import Mathlib.Geometry.Convex.ConvexSpace.Defs
 public import Mathlib.MeasureTheory.MeasurableSpace.Constructions
-public import Mathlib.MeasureTheory.Constructions.BorelSpace.Real
+public import Mathlib.MeasureTheory.Constructions.BorelSpace.Basic
 
 /-!
 # The measurable structure of the standard simplex
 
-A point of the standard simplex `StdSimplex ℝ≥0 ι` is determined by its weight vector
-`ι → ℝ≥0`. This file gives the simplex the σ-algebra induced by that weight vector,
-so that a probability vector is a measurable parameter, and records that the weight vector is
-measurable, which is what a consumer needs to compose with.
+A point of the standard simplex `StdSimplex R ι` is determined by its weight vector `ι → R`.
+This file gives the simplex the σ-algebra induced by that weight vector, for any coefficient type
+`R` carrying a measurable structure, so that a probability vector is a measurable parameter: the
+weight vector is measurable, and a map into the simplex is measurable exactly when its
+weight-vector map is.
 
-Mathlib's topology on the simplex is stated over a ring and does not apply to `ℝ≥0`; the induced
-σ-algebra needs no topology.
+Mathlib's topology on the simplex is stated over a ring and does not reach coefficients such as
+`ℝ≥0`; the induced σ-algebra needs no topology.
 
 ## Main declarations
 
 * `Convexity.StdSimplex.instMeasurableSpace` — the σ-algebra induced by `StdSimplex.weights`;
-* `Convexity.StdSimplex.measurable_weights` — the weight vector is measurable, the one fact
-  consumers need of the instance.
+* `Convexity.StdSimplex.measurable_toFun_comp_weights` — the weight vector is measurable;
+* `Convexity.StdSimplex.measurable_iff_weights` — measurability into the simplex is measurability
+  of the weight vector.
 -/
 
 public section
 
 open MeasureTheory
-open scoped NNReal
 
 namespace Convexity.StdSimplex
 
-variable {ι : Type*}
+variable {R ι : Type*} [LE R] [AddCommMonoid R] [One R] [MeasurableSpace R]
 
 /-- The σ-algebra on the standard simplex induced by its weight vector. -/
-instance instMeasurableSpace : MeasurableSpace (StdSimplex ℝ≥0 ι) :=
-  MeasurableSpace.comap (fun p : StdSimplex ℝ≥0 ι => (p.weights : ι → ℝ≥0)) inferInstance
+instance instMeasurableSpace : MeasurableSpace (StdSimplex R ι) :=
+  MeasurableSpace.comap (fun p : StdSimplex R ι => (p.weights : ι → R)) inferInstance
 
 /-- The weight vector of a simplex point is measurable. -/
 @[fun_prop]
-theorem measurable_weights : Measurable fun p : StdSimplex ℝ≥0 ι => (p.weights : ι → ℝ≥0) :=
+theorem measurable_toFun_comp_weights : Measurable fun p : StdSimplex R ι => (p.weights : ι → R) :=
   comap_measurable _
+
+/-- A map into the simplex is measurable iff its weight-vector map is. -/
+theorem measurable_iff_weights {δ : Type*} [MeasurableSpace δ] {f : δ → StdSimplex R ι} :
+    Measurable f ↔ Measurable fun x => ((f x).weights : ι → R) :=
+  measurable_comap_iff
 
 end Convexity.StdSimplex

--- a/TauCeti/MeasureTheory/MeasurableSpace/StdSimplex.lean
+++ b/TauCeti/MeasureTheory/MeasurableSpace/StdSimplex.lean
@@ -14,8 +14,8 @@ public import Mathlib.MeasureTheory.Constructions.BorelSpace.Real
 
 A point of the standard simplex `StdSimplex ℝ≥0 ι` is determined by its weight vector
 `ι → ℝ≥0`. This file gives the simplex the σ-algebra induced by that weight vector,
-so that a probability vector is a measurable parameter: a map into the simplex is measurable
-exactly when its weight-vector map is, and the weight vector itself is measurable.
+so that a probability vector is a measurable parameter, and records that the weight vector is
+measurable, which is what a consumer needs to compose with.
 
 Mathlib's topology on the simplex is stated over a ring and does not apply to `ℝ≥0`; the induced
 σ-algebra needs no topology.
@@ -23,9 +23,8 @@ Mathlib's topology on the simplex is stated over a ring and does not apply to `�
 ## Main declarations
 
 * `Convexity.StdSimplex.instMeasurableSpace` — the σ-algebra induced by `StdSimplex.weights`;
-* `Convexity.StdSimplex.measurable_weights` — the weight vector is measurable;
-* `Convexity.StdSimplex.measurable_iff_weights` — measurability into the simplex is measurability
-  of the weight vector.
+* `Convexity.StdSimplex.measurable_weights` — the weight vector is measurable, the one fact
+  consumers need of the instance.
 -/
 
 public section
@@ -45,12 +44,5 @@ instance instMeasurableSpace : MeasurableSpace (StdSimplex ℝ≥0 ι) :=
 @[fun_prop]
 theorem measurable_weights : Measurable fun p : StdSimplex ℝ≥0 ι => (p.weights : ι → ℝ≥0) :=
   comap_measurable _
-
-/-- A map into the simplex is measurable iff its weight-vector map is. -/
-theorem measurable_iff_weights {δ : Type*} [MeasurableSpace δ] {f : δ → StdSimplex ℝ≥0 ι} :
-    Measurable f ↔ Measurable fun x => ((f x).weights : ι → ℝ≥0) := by
-  rw [measurable_iff_comap_le]
-  simp only [instMeasurableSpace, MeasurableSpace.comap_comp]
-  exact measurable_iff_comap_le.symm
 
 end Convexity.StdSimplex


### PR DESCRIPTION
A point of `StdSimplex ℝ≥0 ι` is its weight vector `ι → ℝ≥0`. This gives the simplex the σ-algebra induced by that vector, so a probability vector can serve as a measurable parameter:

```lean
instance : MeasurableSpace (StdSimplex ℝ≥0 ι) :=
  MeasurableSpace.comap (fun p => (p.weights : ι → ℝ≥0)) inferInstance

theorem measurable_weights : Measurable fun p : StdSimplex ℝ≥0 ι => (p.weights : ι → ℝ≥0)
theorem measurable_iff_weights {f : δ → StdSimplex ℝ≥0 ι} :
    Measurable f ↔ Measurable fun x => ((f x).weights : ι → ℝ≥0)
```

No finiteness or topology is needed: Mathlib's simplex topology is stated over a ring and does not reach `ℝ≥0`, and the induced σ-algebra is the standard way to make a subtype-like carrier measurable through its coordinates. The module is neutral, in `MeasureTheory/MeasurableSpace/`, with no distribution imports.

## Why now

#5939 introduced `StdSimplex` as the multinomial parameter type and recorded that parameter measurability had to wait "once the canonical simplex carrier has a measurable structure". This is that structure; the multinomial parameter-measurability theorem follows in its own PR and is its first consumer, with the Dirichlet family the next.

## Roadmap

Roadmap: StandardDistributions

A prerequisite of the parameter-measurability requirement that every family must provide (`TauCetiRoadmap/StandardDistributions/README.md`, "What every distribution must provide", item 4), shipped ahead of its first consumer as its own PR. No roadmap target is claimed by this PR itself.

🤖 Directed by Cameron Freer, drafted by Claude
