### PR TITLE
feat(Isogeny): [n]^*ω = n • ω

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Hom/Differential.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Hom/Differential.lean
@@ -33,6 +33,8 @@ over a finite field, `TauCeti.Isogeny.isSeparable_oneSubFrobeniusIsogeny`:
 * `TauCeti.Isogeny.Hom.pullbackDifferential_add_invariantDifferential`: `(f + g)^*ω = f^*ω + g^*ω`.
 * `TauCeti.Isogeny.Hom.pullbackDifferential_neg_invariantDifferential`: `(-f)^*ω = -f^*ω`.
 * `TauCeti.Isogeny.Hom.pullbackDifferential_sub_invariantDifferential`: `(f - g)^*ω = f^*ω - g^*ω`.
+* `TauCeti.Isogeny.Hom.pullbackDifferential_zsmul_invariantDifferential`: `(n • f)^*ω = n • f^*ω`.
+* `TauCeti.Isogeny.Hom.pullbackDifferential_zsmul_id_invariantDifferential`: `[n]^*ω = n • ω`.
 * `TauCeti.Isogeny.Hom.pullbackDifferential_id` and `pullbackDifferential_comp`: the pullback is
   functorial in the morphism.
 
@@ -152,6 +154,32 @@ theorem pullbackDifferential_sub_invariantDifferential (f g : Hom W₁ W₂) :
         g.pullbackDifferential (invariantDifferential W₂) := by
   rw [sub_eq_add_neg, pullbackDifferential_add_invariantDifferential,
     pullbackDifferential_neg_invariantDifferential, sub_eq_add_neg]
+
+/-- **The pullback of `ω` scales with an integer multiple of a morphism**:
+`(n • f)^*ω = n • f^*ω`. -/
+@[simp]
+theorem pullbackDifferential_zsmul_invariantDifferential (f : Hom W₁ W₂) (n : ℤ) :
+    (n • f).pullbackDifferential (invariantDifferential W₂) =
+      n • f.pullbackDifferential (invariantDifferential W₂) := by
+  induction n using Int.induction_on with
+  | zero => simp [pullbackDifferential_zero]
+  | succ k ih =>
+    rw [add_smul, one_smul, pullbackDifferential_add_invariantDifferential, ih, add_smul, one_smul]
+  | pred k ih =>
+    rw [sub_smul, one_smul, pullbackDifferential_sub_invariantDifferential, ih, sub_smul, one_smul]
+
+/-- **`[n]^*ω = n • ω`** (Silverman III.5.4): the invariant differential pulls back along
+multiplication by `n` with the factor `n`. -/
+-- Not `@[simp]`, unlike the two scaling rules above: they are what reduce this left-hand side, so
+-- `simp` already closes this goal with
+-- `simp only [pullbackDifferential_zsmul_invariantDifferential, pullbackDifferential_id,
+-- LinearMap.id_coe, id_eq]`, and `simpNF` rejects a rule whose left-hand side is not normal.
+theorem pullbackDifferential_zsmul_id_invariantDifferential (W : WeierstrassCurve.Affine F)
+    [W.IsElliptic] (n : ℤ) :
+    (n • Hom.id W).pullbackDifferential (invariantDifferential W) =
+      n • invariantDifferential W := by
+  rw [pullbackDifferential_zsmul_invariantDifferential, pullbackDifferential_id,
+    LinearMap.id_apply]
 
 end Hom
 


### PR DESCRIPTION
Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"EllipticCurves/README.md:layer1:invariant-differential"}-->

Provenance: no port. The additivity this rests on, `pullbackDifferential_add_invariantDifferential`, is already on `main`; AINTLIB reaches the same scaling through `omegaPullbackCoeff` on endomorphisms rather than through an additive `Hom`.

## What this adds

In the existing `Isogeny/Hom/Differential.lean`:

- `Hom.pullbackDifferential_zsmul_invariantDifferential`: `(n • f)^*ω = n • f^*ω`.
- `Hom.pullbackDifferential_zsmul_id_invariantDifferential`: **`[n]^*ω = n • ω`**, Silverman III.5.4.

`STATUS.md` lists `[n]^*ω = n • ω` among Layer 1's gaps; this closes it.

## The argument

`(f + g)^*ω = f^*ω + g^*ω` is on `main`, and `Hom W₁ W₂` is an additive group, so induction gives the natural multiple and `Int.induction_on` the integer one, using the `sub` form already present for the negative branch. Multiplication by `n` is `n • Hom.id W`, and `pullbackDifferential_id` reduces the identity's pullback to `LinearMap.id`.

## `@[simp]` on the two scaling rules but not on `[n]^*ω = n • ω`

The scaling rules are the normal form and carry `@[simp]`. The `[n]` case deliberately does not, and the reason is recorded next to the declaration: those two rules are exactly what reduce its left-hand side, so `simp` already closes that goal on its own —

```
example (W : WeierstrassCurve.Affine F) [W.IsElliptic] (n : ℤ) :
    (n • Hom.id W).pullbackDifferential (invariantDifferential W) =
      n • invariantDifferential W := by simp?
-- Try this: simp only [pullbackDifferential_zsmul_invariantDifferential,
--   pullbackDifferential_id, LinearMap.id_coe, id_eq]
```

so marking it `@[simp]` would add a rule whose left-hand side is not in simp normal form, which `simpNF` rejects. This is the same call, for the same reason, as `Isogeny.tautologicalPoint_comp` in `GenericPoint.lean` and `Hom.neg_def` in `Neg.lean`, both of which carry the same kind of note.

Both scaling rules take the morphism as their first explicit argument, so dot notation works in the `Hom` namespace they live in:

```
#check @pullbackDifferential_zsmul_invariantDifferential
-- ∀ {F} [Field F] {W₁ W₂ : WeierstrassCurve.Affine F} [W₂.IsElliptic] (f : Hom W₁ W₂) (n : ℤ), …
```

## Why there is no natural-scalar form

An earlier revision also carried `pullbackDifferential_nsmul_invariantDifferential`, the `ℕ` twin. It is gone because `reuse` required it, on **#6473** — where this branch's commit appears as stacked content — and held to that after being contested:

> **reuse — #6473: re-reviewed on `047076e`; the finding stands** — *"One public theorem remains an unconsumed thin specialization of the adjacent integer-scalar result."*

Its original wording was explicit: *"`pullbackDifferential_nsmul_invariantDifferential` duplicates `pullbackDifferential_zsmul_invariantDifferential` after coercing `n : ℕ` to `ℤ`, and no added code consumes the natural-number wrapper. Fix: Delete the `nsmul` theorem and use `pullbackDifferential_zsmul_invariantDifferential` with `natCast_zsmul` at any future call site."*

I contested it once, on the ground that `reuse` had passed the same declaration green on this PR at round 5; the answer stood, so I removed it here at its source rather than in a descendant. Nothing in the repository consumes it. A caller holding a natural scalar has `natCast_zsmul`, which is the route that finding named.

## Scope

Only the differential side. Separability of `[n]` iff `(n : F) ≠ 0` follows by feeding this to `isSeparable_iff_pullbackDifferential_ne_zero`, but that needs `n • ω ≠ 0`, which is a statement about the characteristic rather than about differentials, and is left for its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


