### PR TITLE
refactor(ZMod): modulus-indexed declarations leave the `ZMod` namespace

### DIFF
--- a/TauCeti/Data/ZMod/FinEquiv.lean
+++ b/TauCeti/Data/ZMod/FinEquiv.lean
@@ -20,8 +20,9 @@ indexed by `Fin n` rewrites into `ZMod n` arithmetic instead of being unfolded a
 * `ZMod.finEquiv_symm_apply_val`: it is `(ZMod.finEquiv n).symm` that produces the canonical `Fin n`
   representative of an element of `ZMod n`, and that representative's coerced natural value is
   the element's `val`.
-* `ZMod.mulModEquiv`: multiplication by `d` modulo `p` as a permutation of `Fin p`, for `d`
-  coprime to `p`, with its evaluation rule `ZMod.coe_mulModEquiv`.
+* `TauCeti.mulModEquiv`: multiplication by `d` modulo `p` as a permutation of `Fin p`, for `d`
+  coprime to `p`, with its evaluation rule `TauCeti.mulModEquiv_apply_val`. These take a modulus
+  rather than a `ZMod` value, so they are not dot notation on `ZMod` and live in `TauCeti`.
 -/
 
 public section
@@ -56,6 +57,10 @@ lemma finEquiv_symm_apply_val {n : ℕ} [NeZero n] (z : ZMod n) :
   conv_rhs => rw [← (ZMod.finEquiv n).apply_symm_apply z, finEquiv_apply]
   exact (ZMod.val_natCast_of_lt ((ZMod.finEquiv n).symm z).isLt).symm
 
+end ZMod
+
+namespace TauCeti
+
 /-- **Multiplication by a unit permutes the residues**: for `d` coprime to `p`, the map
 `b ↦ d b mod p` is a permutation of `Fin p`. It is multiplication by the unit
 `ZMod.unitOfCoprime d hdp` of `ZMod p`, read through `ZMod.finEquiv`. -/
@@ -64,10 +69,10 @@ noncomputable def mulModEquiv (p : ℕ) {d : ℕ} [NeZero p] (hdp : Nat.Coprime 
   (ZMod.finEquiv p).toEquiv.trans <|
     (Units.mulLeft (ZMod.unitOfCoprime d hdp)).trans (ZMod.finEquiv p).toEquiv.symm
 
-/-- **The value of `ZMod.mulModEquiv`**: it sends `b` to the residue `d b mod p`. -/
+/-- **The value of `TauCeti.mulModEquiv`**: it sends `b` to the residue `d b mod p`. -/
 @[simp]
-lemma coe_mulModEquiv (p : ℕ) {d : ℕ} [NeZero p] (hdp : Nat.Coprime d p) (b : Fin p) :
+lemma mulModEquiv_apply_val (p : ℕ) {d : ℕ} [NeZero p] (hdp : Nat.Coprime d p) (b : Fin p) :
     (mulModEquiv p hdp b : ℕ) = d * (b : ℕ) % p := by
   simp [mulModEquiv, ZMod.coe_unitOfCoprime, ← Nat.cast_mul, ZMod.val_natCast]
 
-end ZMod
+end TauCeti

--- a/TauCeti/Data/ZMod/OnePoint.lean
+++ b/TauCeti/Data/ZMod/OnePoint.lean
@@ -11,7 +11,7 @@ public import Mathlib.Topology.Compactification.OnePoint.Basic
 /-!
 # Multiplication on the one-point extension of `ZMod p`
 
-`ZMod.mulModEquiv` (`Data/ZMod/FinEquiv.lean`) is multiplication by a unit as a permutation of
+`TauCeti.mulModEquiv` (`Data/ZMod/FinEquiv.lean`) is multiplication by a unit as a permutation of
 the residues themselves. This file is its companion on the one-point extension: multiplication by
 a `d` coprime to `p`, acting on `OnePoint (ZMod p)` and fixing `∞`.
 
@@ -22,23 +22,24 @@ It is the projective line exactly when `p` is prime: for composite `p` the proje
 
 ## Main results
 
-* `ZMod.onePointMulPerm`: multiplication by `d` as a permutation of `OnePoint (ZMod p)`.
-* `ZMod.onePointMulPerm_coe` and `ZMod.onePointMulPerm_infty`: its two evaluation rules, on an
-  affine point and at `∞`.
+* `TauCeti.onePointMulPerm`: multiplication by `d` as a permutation of `OnePoint (ZMod p)`.
+* `TauCeti.onePointMulPerm_coe` and `TauCeti.onePointMulPerm_infty`: its two evaluation rules, on
+  an affine point and at `∞`. The first explicit argument is a modulus, not a `ZMod` value, so
+  these are not dot notation on `ZMod` and live in `TauCeti`.
 -/
 
 public section
 
-namespace ZMod
+namespace TauCeti
 
 /-- **Multiplication by `d` on the one-point extension of `ZMod p`**, fixing `∞`. The companion
-of `ZMod.mulModEquiv`: `d` coprime to `p` is a unit, so multiplying by it permutes the residues,
+of `TauCeti.mulModEquiv`: `d` coprime to `p` is a unit, so multiplying by it permutes the residues,
 and the permutation is extended by fixing the adjoined point. -/
 def onePointMulPerm (p : ℕ) {d : ℕ} (hdp : Nat.Coprime d p) :
     Equiv.Perm (OnePoint (ZMod p)) :=
   Equiv.optionCongr (Units.mulLeft (ZMod.unitOfCoprime d hdp))
 
-/-- **The value of `ZMod.onePointMulPerm` at an affine point**: it multiplies by `d`. -/
+/-- **The value of `TauCeti.onePointMulPerm` at an affine point**: it multiplies by `d`. -/
 @[simp]
 lemma onePointMulPerm_coe (p : ℕ) {d : ℕ} (hdp : Nat.Coprime d p) (x : ZMod p) :
     onePointMulPerm p hdp ((x : ZMod p) : OnePoint (ZMod p)) =
@@ -51,9 +52,9 @@ lemma onePointMulPerm_coe (p : ℕ) {d : ℕ} (hdp : Nat.Coprime d p) (x : ZMod 
       OnePoint (ZMod p)) = _
   rw [ZMod.coe_unitOfCoprime]
 
-/-- **`ZMod.onePointMulPerm` fixes the point at infinity.** -/
+/-- **`TauCeti.onePointMulPerm` fixes the point at infinity.** -/
 @[simp]
 lemma onePointMulPerm_infty (p : ℕ) {d : ℕ} (hdp : Nat.Coprime d p) :
     onePointMulPerm p hdp (OnePoint.infty : OnePoint (ZMod p)) = OnePoint.infty := (rfl)
 
-end ZMod
+end TauCeti

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/Periodic.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/Periodic.lean
@@ -200,12 +200,12 @@ theorem heckeSlashUpperTri_slash_scaleRep_comm (hd : 0 < d) (hp : 0 < p)
     exact slash_zpow_eq_self_of_slash_eq k f (by rwa [ModularForm.rat_slash_mapGL] at hT) q
   rw [heckeSlashUpperTri_def, heckeSlashUpperTri_def, SlashAction.sum_slash]
   have : NeZero p := ⟨hp.ne'⟩
-  rw [← Equiv.sum_comp (ZMod.mulModEquiv p hdp) fun b ↦ (f ∣[k] upperTriRep p b) ∣[k]
+  rw [← Equiv.sum_comp (TauCeti.mulModEquiv p hdp) fun b ↦ (f ∣[k] upperTriRep p b) ∣[k]
     (scaleRep d : GL (Fin 2) ℚ)]
   refine Finset.sum_congr rfl fun b _ ↦ ?_
-  -- the reindexed representative is `d b mod p`, by the defining lemma of `ZMod.mulModEquiv`
-  have hb : ZMod.mulModEquiv p hdp b = ⟨d * (b : ℕ) % p, Nat.mod_lt _ hp⟩ :=
-    Fin.ext (ZMod.coe_mulModEquiv p hdp b)
+  -- the reindexed representative is `d b mod p`, by the defining lemma of `TauCeti.mulModEquiv`
+  have hb : TauCeti.mulModEquiv p hdp b = ⟨d * (b : ℕ) % p, Nat.mod_lt _ hp⟩ :=
+    Fin.ext (TauCeti.mulModEquiv_apply_val p hdp b)
   rw [← SlashAction.slash_mul,
     scaleRep_mul_upperTriRep p hd b (Nat.mod_lt _ hp) (Nat.div_add_mod' (d * (b : ℕ)) p).symm,
     SlashAction.slash_mul, hTpow, SlashAction.slash_mul, hb]

--- a/TauCeti/NumberTheory/ModularForms/Newforms/Descent/LevelRaise/Commute.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Descent/LevelRaise/Commute.lean
@@ -239,7 +239,7 @@ private theorem slash_map_upperTriRep_zero_mul_mapGL_conjScale_eq {N : ℕ} (hp 
   rw [hδγ, map_mul, ← mul_assoc, hfacR, mul_assoc, SlashAction.slash_mul, hfβ]
 
 /-- **Multiplication by `l` on the descent's index set.** On the `p` upper-triangular members it
-is the permutation `ZMod.mulModEquiv` of the residues modulo `p`; the extra member, when there is
+is the permutation `mulModEquiv` of the residues modulo `p`; the extra member, when there is
 one, is fixed — read through `descendIndexEquiv`, it is the permutation of `OnePoint (ZMod p)`
 fixing `∞`, which for the prime `p` here is the projective line over `ZMod p`. -/
 private noncomputable def descendIndexMulPerm (hp : p.Prime) (hpl : Nat.Coprime p l) (N : ℕ) :
@@ -247,9 +247,9 @@ private noncomputable def descendIndexMulPerm (hp : p.Prime) (hpl : Nat.Coprime 
   haveI : NeZero p := ⟨hp.ne_zero⟩
   if h : p ^ 2 ∣ N then
     (finCongr (descendMatrixCount_of_sq_dvd h)).trans
-      ((ZMod.mulModEquiv p hpl.symm).trans (finCongr (descendMatrixCount_of_sq_dvd h).symm))
+      ((mulModEquiv p hpl.symm).trans (finCongr (descendMatrixCount_of_sq_dvd h).symm))
   else
-    (descendIndexEquiv p N h).symm.permCongr (ZMod.onePointMulPerm p hpl.symm)
+    (descendIndexEquiv p N h).symm.permCongr (onePointMulPerm p hpl.symm)
 
 /-- **The index map between the two descent families**: the two families have the same size
 (`descendMatrixCount_mul_left_of_coprime`), and the level-`l N` member at an index is the
@@ -273,7 +273,7 @@ private theorem val_descendIndexMulPerm_of_lt (hp : p.Prime) (hpl : Nat.Coprime 
   · simp
   · rename_i h
     rw [Equiv.permCongr_apply, Equiv.symm_symm, descendIndexEquiv_apply_of_lt h hw,
-      ZMod.onePointMulPerm_coe, descendIndexEquiv_symm_coe_val]
+      onePointMulPerm_coe, descendIndexEquiv_symm_coe_val]
     rw [← Nat.cast_mul, ZMod.val_natCast]
 
 private theorem val_descendIndexMulPerm_of_le (hp : p.Prime) (hpl : Nat.Coprime p l) (N : ℕ)
@@ -292,7 +292,7 @@ private theorem val_descendIndexMulPerm_of_le (hp : p.Prime) (hpl : Nat.Coprime 
   · rename_i hsq
     exact absurd hsq h
   · rw [Equiv.permCongr_apply, Equiv.symm_symm, descendIndexEquiv_apply_of_le h hw,
-      ZMod.onePointMulPerm_infty, descendIndexEquiv_symm_infty_val, hwp]
+      onePointMulPerm_infty, descendIndexEquiv_symm_infty_val, hwp]
 
 private theorem val_descendIndexMulEquiv_of_lt (hp : p.Prime) (hpl : Nat.Coprime p l) (N : ℕ)
     {v : Fin (descendMatrixCount p (l * N))} (hv : v.val < p) :


### PR DESCRIPTION
Five declarations leave Mathlib's `ZMod` namespace for `TauCeti`.

`ZMod.mulModEquiv`, `ZMod.coe_mulModEquiv` (`Data/ZMod/FinEquiv.lean`) and `ZMod.onePointMulPerm` with its two evaluation rules (`Data/ZMod/OnePoint.lean`) all take a modulus `(p : ℕ)` as their first explicit argument rather than a `ZMod` value. Dot notation therefore never applied to them, and the prefix only extended an upstream namespace with declarations Mathlib does not own.

- `TauCeti.mulModEquiv`, and `coe_mulModEquiv` renamed to `TauCeti.mulModEquiv_apply_val` for what it actually evaluates — the `Fin` value of the image.
- `TauCeti.onePointMulPerm`, `TauCeti.onePointMulPerm_coe`, `TauCeti.onePointMulPerm_infty`.

The two in-repository consumers, `HeckeSlash/UpperTri/Periodic.lean` and `Newforms/Descent/LevelRaise/Commute.lean`, are updated; `Commute.lean` sits inside `namespace TauCeti` and so uses the bare names.

Asked for independently by the `naming` rubrics of #6392 and #6409, which both observed that these are not dot notation on `ZMod`. The third declaration they named, `eq_comp_unitsMap_of_comp_unitsMap_eq`, was already moved on #6392.

**Verified:** every module importing either file builds; `#lint only unusedArguments simpNF` is clean on all four changed files; `lint-dot-notation` reports `0 new`; no line exceeds 100 characters. Statements and proofs are untouched — this is a rename and a namespace boundary.

**Note for the merge order:** #6374 also modifies `LevelRaise/Commute.lean` and will need one merge of `main` after this lands. #6382, #6392 and #6409 carry these files unchanged through the stack and pick the rename up when they merge `main`.

Roadmap: ModularForms

No `tauceti-target:v1` marker: this is a refactor and advances no roadmap target, so it has no deterministic target id to carry.
