### PR TITLE
feat(Isogeny): [n] is n times the identity

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/MulByInt/Hom.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/MulByInt/Hom.lean
@@ -1,0 +1,45 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.Hom.Add
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.MulByInt.MapsInfinity
+
+/-!
+# Multiplication by `n` is `n` times the identity
+
+`[n]` is built from the division polynomials, while the additive group of morphisms is built from
+tautological points; this file says the two agree, so that results about the additive structure
+apply to `[n]` and results about `[n]` are available additively.
+
+## Main results
+
+* `TauCeti.Isogeny.ofIsogeny_mulByIntIsogeny`: `[n] = n • id` in `Hom W W`.
+
+## References
+
+* [J. Silverman, *The Arithmetic of Elliptic Curves*][silverman2009], III.4.
+-/
+
+public section
+
+namespace TauCeti.Isogeny
+
+open WeierstrassCurve.Affine
+
+variable {F : Type*} [Field F] (W : WeierstrassCurve.Affine F)
+
+/-- **`[n]` is `n` times the identity** in the additive group of morphisms. The division-polynomial
+construction of `[n]` and the additive structure on `Hom` therefore describe the same map. -/
+@[simp]
+theorem ofIsogeny_mulByIntIsogeny [W.IsElliptic] {n : ℤ} (hn : psiFunctionField W n ≠ 0) :
+    Hom.ofIsogeny (mulByIntIsogeny W hn) = n • Hom.id W := by
+  refine Hom.ext_tautologicalPoint ?_
+  simp [Hom.id_def, mulByIntIsogeny_pullback, tautologicalPoint_mulByIntPullback]
+
+end TauCeti.Isogeny
+
+end


### PR DESCRIPTION
Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"EllipticCurves/README.md:layer1:mulbyint"}-->

Provenance: no port. AINTLIB has no additive `Hom` — its `Endomorphism.lean` defines `isogOneSub_mulByInt := mulByInt W (1−n)` and proves the corresponding facts by `rfl`, so there is nothing there to port; the plan's screening records that file as wrappers.

## What this adds

A new `Isogeny/MulByInt/Hom.lean` with one theorem:

- `Isogeny.ofIsogeny_mulByIntIsogeny`: **`[n] = n • id`** in `Hom W W`.

## Why

`[n]` is constructed from the division polynomials (`mulByIntPullback`, `psiFunctionField`), while the additive group of morphisms is constructed from tautological points. Nothing so far connects them, so results proved on one side do not reach the other. `STATUS.md` lists a ring structure on `End` among Layer 1's gaps, and that needs exactly this identification: without it, `[m] + [n] = [m + n]` is not available from the additive structure.

## The argument

Both sides are determined by their tautological point (`Hom.ext_tautologicalPoint`), and both give `n • g` for `g` the generic point — the left by `tautologicalPoint_mulByIntPullback`, already on `main`, and the right by `Hom.tautologicalPoint_zsmul` with `CoordinatePullback.tautologicalPoint_id`.

## Scope

Only the identification. The immediate consequence for differentials — `[n]^*ω = n • ω` for the isogeny rather than for `n • id` — needs #6453, and is deliberately left until that lands rather than stacked here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
