### PR TITLE
feat(Isogeny): [m + n] = [m] + [n]

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/MulByInt/Hom.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/MulByInt/Hom.lean
@@ -1,0 +1,45 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.Hom.Add
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.MulByInt.MapsInfinity
+
+/-!
+# Multiplication by `n` is `n` times the identity
+
+`[n]` is built from the division polynomials, while the additive group of morphisms is built from
+tautological points; this file says the two agree, so that results about the additive structure
+apply to `[n]` and results about `[n]` are available additively.
+
+## Main results
+
+* `TauCeti.Isogeny.ofIsogeny_mulByIntIsogeny`: `[n] = n • id` in `Hom W W`.
+
+## References
+
+* [J. Silverman, *The Arithmetic of Elliptic Curves*][silverman2009], III.4.
+-/
+
+public section
+
+namespace TauCeti.Isogeny
+
+open WeierstrassCurve.Affine
+
+variable {F : Type*} [Field F] (W : WeierstrassCurve.Affine F)
+
+/-- **`[n]` is `n` times the identity** in the additive group of morphisms. The division-polynomial
+construction of `[n]` and the additive structure on `Hom` therefore describe the same map. -/
+@[simp]
+theorem ofIsogeny_mulByIntIsogeny [W.IsElliptic] {n : ℤ} (hn : psiFunctionField W n ≠ 0) :
+    Hom.ofIsogeny (mulByIntIsogeny W hn) = n • Hom.id W := by
+  refine Hom.ext_tautologicalPoint ?_
+  simp [Hom.id_def, mulByIntIsogeny_pullback, tautologicalPoint_mulByIntPullback]
+
+end TauCeti.Isogeny
+
+end

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/MulByInt/Hom.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/MulByInt/Hom.lean
@@ -18,6 +18,7 @@ apply to `[n]` and results about `[n]` are available additively.
 ## Main results
 
 * `TauCeti.Isogeny.ofIsogeny_mulByIntIsogeny`: `[n] = n • id` in `Hom W W`.
+* `TauCeti.Isogeny.ofIsogeny_mulByIntIsogeny_add`: `[m + n] = [m] + [n]`.
 
 ## References
 
@@ -39,6 +40,15 @@ theorem ofIsogeny_mulByIntIsogeny [W.IsElliptic] {n : ℤ} (hn : psiFunctionFiel
     Hom.ofIsogeny (mulByIntIsogeny W hn) = n • Hom.id W := by
   refine Hom.ext_tautologicalPoint ?_
   simp [Hom.id_def, mulByIntIsogeny_pullback, tautologicalPoint_mulByIntPullback]
+
+/-- **`[m + n] = [m] + [n]`.** Composition of the two is already `[m * n]`
+(`mulByIntIsogeny_comp_mulByIntIsogeny`); this is the additive law beside it. -/
+theorem ofIsogeny_mulByIntIsogeny_add [W.IsElliptic] {m n : ℤ}
+    (hm : psiFunctionField W m ≠ 0) (hn : psiFunctionField W n ≠ 0)
+    (hmn : psiFunctionField W (m + n) ≠ 0) :
+    Hom.ofIsogeny (mulByIntIsogeny W hmn) =
+      Hom.ofIsogeny (mulByIntIsogeny W hm) + Hom.ofIsogeny (mulByIntIsogeny W hn) := by
+  rw [ofIsogeny_mulByIntIsogeny, ofIsogeny_mulByIntIsogeny, ofIsogeny_mulByIntIsogeny, add_smul]
 
 end TauCeti.Isogeny
 


### PR DESCRIPTION
Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"EllipticCurves/README.md:layer1:mulbyint"}-->

Provenance: no port. AINTLIB has no additive `Hom`, so its multiplication maps carry no additive law to port.

Stacked on #6455 (`[n] = n • id`), which is what makes this a rewrite rather than a construction.

## What this adds

- `Isogeny.ofIsogeny_mulByIntIsogeny_add`: **`[m + n] = [m] + [n]`** in `Hom W W`.

## Why

`MulByInt/Comp.lean` already proves the multiplicative law `[m] ∘ [n] = [m * n]` (`mulByIntIsogeny_comp_mulByIntIsogeny`), `[1] = id`, `[-1] = negIsogeny`, and injectivity of `n ↦ [n]`. The additive law was the one missing side. `STATUS.md` lists a ring structure on `End` among Layer 1's gaps; with composition already present, this supplies the other operation's law.

## The argument

Three rewrites by `[n] = n • id` (#6455) and `add_smul`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
