### PR TITLE
feat(Isogeny): a separable [n] has separable degree n²

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/InvariantDifferential.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/InvariantDifferential.lean
@@ -27,6 +27,8 @@ by `W_Y⁻¹` gives the invariant-differential basis.
 * `WeierstrassCurve.Affine.invariantDifferential`: the invariant differential `ω`, as an
   element of `Ω[K(E)/F]`.
 * `WeierstrassCurve.Affine.invariantDifferentialBasis`: `ω` as a basis of `Ω[K(E)/F]`.
+* `WeierstrassCurve.Affine.zsmul_invariantDifferential_eq_zero_iff`: an integer multiple of `ω`
+  vanishes exactly when the integer does in the base field.
 
 ## Main results
 
@@ -163,5 +165,14 @@ theorem existsUnique_smul_invariantDifferential [E.IsElliptic]
   rcases smul_eq_zero.mp h with h' | h'
   · exact sub_eq_zero.mp h'
   · exact absurd h' (invariantDifferential_ne_zero E)
+
+/-- **An integer multiple of `ω` vanishes exactly when the integer does in the base field.** -/
+@[simp]
+theorem zsmul_invariantDifferential_eq_zero_iff [E.IsElliptic] (n : ℤ) :
+    n • invariantDifferential E = 0 ↔ (n : F) = 0 := by
+  rw [← Int.cast_smul_eq_zsmul E.FunctionField n (invariantDifferential E),
+    smul_eq_zero, or_iff_left (invariantDifferential_ne_zero E)]
+  rw [← map_intCast (algebraMap F E.FunctionField) n]
+  exact map_eq_zero_iff _ (algebraMap F E.FunctionField).injective
 
 end WeierstrassCurve.Affine

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Hom/Differential.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Hom/Differential.lean
@@ -33,6 +33,8 @@ over a finite field, `TauCeti.Isogeny.isSeparable_oneSubFrobeniusIsogeny`:
 * `TauCeti.Isogeny.Hom.pullbackDifferential_add_invariantDifferential`: `(f + g)^*ω = f^*ω + g^*ω`.
 * `TauCeti.Isogeny.Hom.pullbackDifferential_neg_invariantDifferential`: `(-f)^*ω = -f^*ω`.
 * `TauCeti.Isogeny.Hom.pullbackDifferential_sub_invariantDifferential`: `(f - g)^*ω = f^*ω - g^*ω`.
+* `TauCeti.Isogeny.Hom.pullbackDifferential_zsmul_invariantDifferential`: `(n • f)^*ω = n • f^*ω`.
+* `TauCeti.Isogeny.Hom.pullbackDifferential_zsmul_id_invariantDifferential`: `[n]^*ω = n • ω`.
 * `TauCeti.Isogeny.Hom.pullbackDifferential_id` and `pullbackDifferential_comp`: the pullback is
   functorial in the morphism.
 
@@ -152,6 +154,28 @@ theorem pullbackDifferential_sub_invariantDifferential (f g : Hom W₁ W₂) :
         g.pullbackDifferential (invariantDifferential W₂) := by
   rw [sub_eq_add_neg, pullbackDifferential_add_invariantDifferential,
     pullbackDifferential_neg_invariantDifferential, sub_eq_add_neg]
+
+/-- **The pullback of `ω` scales with an integer multiple of a morphism**:
+`(n • f)^*ω = n • f^*ω`. -/
+@[simp]
+theorem pullbackDifferential_zsmul_invariantDifferential (n : ℤ) (f : Hom W₁ W₂) :
+    (n • f).pullbackDifferential (invariantDifferential W₂) =
+      n • f.pullbackDifferential (invariantDifferential W₂) := by
+  induction n using Int.induction_on with
+  | zero => simp [pullbackDifferential_zero]
+  | succ k ih =>
+    rw [add_smul, one_smul, pullbackDifferential_add_invariantDifferential, ih, add_smul, one_smul]
+  | pred k ih =>
+    rw [sub_smul, one_smul, pullbackDifferential_sub_invariantDifferential, ih, sub_smul, one_smul]
+
+/-- **`[n]^*ω = n • ω`** (Silverman III.5.4): the invariant differential pulls back along
+multiplication by `n` with the factor `n`. -/
+theorem pullbackDifferential_zsmul_id_invariantDifferential (W : WeierstrassCurve.Affine F)
+    [W.IsElliptic] (n : ℤ) :
+    (n • Hom.id W).pullbackDifferential (invariantDifferential W) =
+      n • invariantDifferential W := by
+  rw [pullbackDifferential_zsmul_invariantDifferential, pullbackDifferential_id,
+    LinearMap.id_apply]
 
 end Hom
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/MulByInt/Hom.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/MulByInt/Hom.lean
@@ -1,0 +1,45 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.Hom.Add
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.MulByInt.MapsInfinity
+
+/-!
+# Multiplication by `n` is `n` times the identity
+
+`[n]` is built from the division polynomials, while the additive group of morphisms is built from
+tautological points; this file says the two agree, so that results about the additive structure
+apply to `[n]` and results about `[n]` are available additively.
+
+## Main results
+
+* `TauCeti.Isogeny.ofIsogeny_mulByIntIsogeny`: `[n] = n • id` in `Hom W W`.
+
+## References
+
+* [J. Silverman, *The Arithmetic of Elliptic Curves*][silverman2009], III.4.
+-/
+
+public section
+
+namespace TauCeti.Isogeny
+
+open WeierstrassCurve.Affine
+
+variable {F : Type*} [Field F] (W : WeierstrassCurve.Affine F)
+
+/-- **`[n]` is `n` times the identity** in the additive group of morphisms. The division-polynomial
+construction of `[n]` and the additive structure on `Hom` therefore describe the same map. -/
+@[simp]
+theorem ofIsogeny_mulByIntIsogeny [W.IsElliptic] {n : ℤ} (hn : psiFunctionField W n ≠ 0) :
+    Hom.ofIsogeny (mulByIntIsogeny W hn) = n • Hom.id W := by
+  refine Hom.ext_tautologicalPoint ?_
+  simp [Hom.id_def, mulByIntIsogeny_pullback, tautologicalPoint_mulByIntPullback]
+
+end TauCeti.Isogeny
+
+end

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/MulByInt/Hom.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/MulByInt/Hom.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.Hom.Add
+import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.Hom.Differential
 public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.MulByInt.MapsInfinity
 
 /-!
@@ -18,6 +19,8 @@ apply to `[n]` and results about `[n]` are available additively.
 ## Main results
 
 * `TauCeti.Isogeny.ofIsogeny_mulByIntIsogeny`: `[n] = n • id` in `Hom W W`.
+* `TauCeti.Isogeny.isSeparable_mulByIntIsogeny_iff`: `[n]` is separable exactly when `n` is
+  nonzero in the base field.
 
 ## References
 
@@ -39,6 +42,15 @@ theorem ofIsogeny_mulByIntIsogeny [W.IsElliptic] {n : ℤ} (hn : psiFunctionFiel
     Hom.ofIsogeny (mulByIntIsogeny W hn) = n • Hom.id W := by
   refine Hom.ext_tautologicalPoint ?_
   simp [Hom.id_def, mulByIntIsogeny_pullback, tautologicalPoint_mulByIntPullback]
+
+/-- **`[n]` is separable exactly when `n` is nonzero in the base field** (Silverman III.5.4). -/
+@[simp]
+theorem isSeparable_mulByIntIsogeny_iff [W.IsElliptic] {n : ℤ} (hn : psiFunctionField W n ≠ 0) :
+    Algebra.IsSeparable (mulByIntIsogeny W hn).fieldPullback.fieldRange W.FunctionField ↔
+      (n : F) ≠ 0 := by
+  rw [isSeparable_iff_pullbackDifferential_ne_zero, ← Hom.pullbackDifferential_ofIsogeny,
+    ofIsogeny_mulByIntIsogeny, Hom.pullbackDifferential_zsmul_id_invariantDifferential, ne_eq,
+    zsmul_invariantDifferential_eq_zero_iff]
 
 end TauCeti.Isogeny
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/MulByInt/Hom.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/MulByInt/Hom.lean
@@ -7,7 +7,9 @@ module
 
 public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.Hom.Add
 import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.Hom.Differential
+import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.MulByInt.Degree
 public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.MulByInt.MapsInfinity
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.Separability
 
 /-!
 # Multiplication by `n` is `n` times the identity
@@ -21,6 +23,7 @@ apply to `[n]` and results about `[n]` are available additively.
 * `TauCeti.Isogeny.ofIsogeny_mulByIntIsogeny`: `[n] = n • id` in `Hom W W`.
 * `TauCeti.Isogeny.isSeparable_mulByIntIsogeny_iff`: `[n]` is separable exactly when `n` is
   nonzero in the base field.
+* `TauCeti.Isogeny.separableDegree_mulByIntIsogeny`: in that case its separable degree is `n ²`.
 
 ## References
 
@@ -51,6 +54,13 @@ theorem isSeparable_mulByIntIsogeny_iff [W.IsElliptic] {n : ℤ} (hn : psiFuncti
   rw [isSeparable_iff_pullbackDifferential_ne_zero, ← Hom.pullbackDifferential_ofIsogeny,
     ofIsogeny_mulByIntIsogeny, Hom.pullbackDifferential_zsmul_id_invariantDifferential, ne_eq,
     zsmul_invariantDifferential_eq_zero_iff]
+
+/-- **A separable `[n]` has separable degree `n ²`**, its degree, since nothing is inseparable. -/
+theorem separableDegree_mulByIntIsogeny [W.IsElliptic] {n : ℤ}
+    (hn : psiFunctionField W n ≠ 0) (hchar : (n : F) ≠ 0) :
+    (mulByIntIsogeny W hn).separableDegree = n.natAbs ^ 2 := by
+  have := (isSeparable_mulByIntIsogeny_iff W hn).2 hchar
+  rw [separableDegree_eq_degree_of_isSeparable, degree_mulByIntIsogeny]
 
 end TauCeti.Isogeny
 


### PR DESCRIPTION
Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"EllipticCurves/README.md:layer1:mulbyint-sepdegree"}-->

Provenance: no port. The separable/inseparable degree split is TauCeti's own (`Isogeny/Separability.lean`); AINTLIB tracks separability of `[n]` only as a hypothesis where it needs it.

Stacked on #6453, #6455 and #6456.

## What this adds

- `Isogeny.separableDegree_mulByIntIsogeny`: for `(n : F) ≠ 0`, **`sepDeg [n] = n²`**.

## Why

`degree_mulByIntIsogeny = n.natAbs ^ 2` is on `main`, and #6456 gives separability of `[n]` exactly when `(n : F) ≠ 0`. Together they say `[n]` is as separable as its degree allows away from the characteristic — the form the torsion and reduction arguments want, since it is the separable degree, not the degree, that counts points of the kernel.

## The argument

`separableDegree_eq_degree_of_isSeparable` applied to the instance from #6456, then `degree_mulByIntIsogeny`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

