### PR TITLE
feat: add generic and special fibre immersions

### DIFF
--- a/TauCeti/AlgebraicGeometry/Curves/StableReduction/Fibers.lean
+++ b/TauCeti/AlgebraicGeometry/Curves/StableReduction/Fibers.lean
@@ -124,17 +124,15 @@ variable [Field K] [Algebra R K] [IsFractionRing R K]
 variable {C : Scheme.{u}} {toK : C ⟶ Spec (.of K)}
 
 /-- The chosen generic fibre of a model, included into its total space. -/
-noncomputable abbrev genericι (M : Model R K C toK) : C ⟶ M.total :=
+noncomputable def genericι (M : Model R K C toK) : C ⟶ M.total :=
   M.genericFiberIso.inv.left ≫ genericFiberι R K M.toBase
 
 /-- The inclusion of a model's chosen generic fibre lies over the fraction-field morphism. -/
 @[reassoc (attr := simp)]
 lemma genericι_toBase (M : Model R K C toK) :
-    M.genericFiberIso.inv.left ≫
-        (pullback.snd M.toBase (Spec.map (CommRingCat.ofHom (algebraMap R K))) ≫
-          Spec.map (CommRingCat.ofHom (algebraMap R K))) =
+    M.genericι ≫ M.toBase =
       toK ≫ Spec.map (CommRingCat.ofHom (algebraMap R K)) := by
-  rw [← genericFiber_hom, ← Category.assoc, Over.w]
+  rw [genericι, Category.assoc, genericFiberι_toBase, ← Category.assoc, Over.w]
   rfl
 
 /-- A model's chosen generic fibre is an open subscheme of its total space. -/

--- a/TauCeti/AlgebraicGeometry/Curves/StableReduction/Fibers.lean
+++ b/TauCeti/AlgebraicGeometry/Curves/StableReduction/Fibers.lean
@@ -5,22 +5,13 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.AlgebraicGeometry.Morphisms.ClosedImmersion
-public import Mathlib.AlgebraicGeometry.OpenImmersion
 public import TauCeti.AlgebraicGeometry.Curves.StableReduction.Model
-public import TauCeti.RingTheory.DiscreteValuationRing.FractionRing
 
 /-!
-# Generic and special fibres over a discrete valuation ring
+# Generic fibres of models over a discrete valuation ring
 
-For a scheme over a discrete valuation ring `R` with fraction field `K`, this file records the
-canonical inclusions of its generic and special fibres into the total space. The generic fibre is
-an open subscheme because `K` is obtained by inverting a uniformizer. The special fibre is a
-closed subscheme because the residue map `R → κ` is surjective.
-
-The generic-fibre object is the one used by `TauCeti.Model`, while the special-fibre object is its
-parallel pullback along `Spec κ → Spec R`. The projection lemmas expose both pullback squares to
-later model and reduction arguments.
+This file defines the canonical inclusion of a model's chosen generic fibre into its total space.
+It records compatibility with the structure morphism and proves that the inclusion is open.
 -/
 
 public section
@@ -33,89 +24,6 @@ open AlgebraicGeometry IsLocalRing
 namespace TauCeti
 
 universe u
-
-/-- The special fibre of a scheme over a local ring, as a scheme over the residue field. -/
-noncomputable abbrev specialFiber (R : Type u) [CommRing R] [IsLocalRing R]
-    {X : Scheme.{u}} (toBase : X ⟶ Spec (.of R)) : Over (Spec (.of (ResidueField R))) :=
-  (Over.pullback (Spec.map (CommRingCat.ofHom (algebraMap R (ResidueField R))))).obj
-    (Over.mk toBase)
-
-/-- The canonical morphism from the special fibre to the total space. -/
-noncomputable abbrev specialFiberι (R : Type u) [CommRing R] [IsLocalRing R]
-    {X : Scheme.{u}} (toBase : X ⟶ Spec (.of R)) : (specialFiber R toBase).left ⟶ X :=
-  pullback.fst toBase (Spec.map (CommRingCat.ofHom (algebraMap R (ResidueField R))))
-
-/-- The structure morphism of the generic fibre is the second projection of its defining
-pullback square. -/
-@[simp]
-lemma genericFiber_hom (R K : Type u) [CommRing R] [Field K] [Algebra R K]
-    {X : Scheme.{u}} (toBase : X ⟶ Spec (.of R)) :
-    (genericFiber R K toBase).hom =
-      pullback.snd toBase (Spec.map (CommRingCat.ofHom (algebraMap R K))) := rfl
-
-/-- The structure morphism of the special fibre is the second projection of its defining
-pullback square. -/
-@[simp]
-lemma specialFiber_hom (R : Type u) [CommRing R] [IsLocalRing R]
-    {X : Scheme.{u}} (toBase : X ⟶ Spec (.of R)) :
-    (specialFiber R toBase).hom =
-      pullback.snd toBase
-        (Spec.map (CommRingCat.ofHom (algebraMap R (ResidueField R)))) := rfl
-
-/-- The generic-fibre inclusion and structure morphism form the defining pullback square. -/
-@[reassoc (attr := simp)]
-lemma genericFiberι_toBase (R K : Type u) [CommRing R] [Field K] [Algebra R K]
-    {X : Scheme.{u}} (toBase : X ⟶ Spec (.of R)) :
-    genericFiberι R K toBase ≫ toBase =
-      (genericFiber R K toBase).hom ≫
-        Spec.map (CommRingCat.ofHom (algebraMap R K)) :=
-  pullback.condition
-
-/-- The special-fibre inclusion and structure morphism form the defining pullback square. -/
-@[reassoc (attr := simp)]
-lemma specialFiberι_toBase (R : Type u) [CommRing R] [IsLocalRing R]
-    {X : Scheme.{u}} (toBase : X ⟶ Spec (.of R)) :
-    specialFiberι R toBase ≫ toBase =
-      (specialFiber R toBase).hom ≫
-        Spec.map (CommRingCat.ofHom (algebraMap R (ResidueField R))) :=
-  pullback.condition
-
-/-- The morphism from the spectrum of a DVR's fraction field is an open immersion. -/
-lemma isOpenImmersion_Spec_map_fractionRing (R K : Type u) [CommRing R] [IsDomain R]
-    [IsDiscreteValuationRing R] [Field K] [Algebra R K] [IsFractionRing R K] :
-    IsOpenImmersion (Spec.map (CommRingCat.ofHom (algebraMap R K))) := by
-  obtain ⟨ϖ, hϖ⟩ := IsDiscreteValuationRing.exists_irreducible R
-  let : IsLocalization.Away ϖ K :=
-    isLocalizationAway_fractionRing hϖ
-  exact IsOpenImmersion.of_isLocalization ϖ
-
-/-- The morphism from the spectrum of a local ring's residue field is a closed immersion. -/
-lemma isClosedImmersion_Spec_map_residue (R : Type u) [CommRing R] [IsLocalRing R] :
-    IsClosedImmersion
-      (Spec.map (CommRingCat.ofHom (algebraMap R (ResidueField R)))) := by
-  apply IsClosedImmersion.spec_of_surjective
-  intro y
-  obtain ⟨x, rfl⟩ := residue_surjective (R := R) y
-  exact ⟨x, by simp [ResidueField.algebraMap_eq]⟩
-
-/-- The generic fibre of a scheme over a discrete valuation ring is an open subscheme of the
-total space. -/
-lemma isOpenImmersion_genericFiberι (R K : Type u) [CommRing R] [IsDomain R]
-    [IsDiscreteValuationRing R] [Field K] [Algebra R K] [IsFractionRing R K]
-    {X : Scheme.{u}} (toBase : X ⟶ Spec (.of R)) :
-    IsOpenImmersion (genericFiberι R K toBase) := by
-  let : IsOpenImmersion (Spec.map (CommRingCat.ofHom (algebraMap R K))) :=
-    isOpenImmersion_Spec_map_fractionRing R K
-  exact inferInstance
-
-/-- The special fibre of a scheme over a local ring is a closed subscheme of the total space. -/
-lemma isClosedImmersion_specialFiberι (R : Type u) [CommRing R] [IsLocalRing R]
-    {X : Scheme.{u}} (toBase : X ⟶ Spec (.of R)) :
-    IsClosedImmersion (specialFiberι R toBase) := by
-  let : IsClosedImmersion
-      (Spec.map (CommRingCat.ofHom (algebraMap R (ResidueField R)))) :=
-    isClosedImmersion_Spec_map_residue R
-  exact inferInstance
 
 namespace Model
 
@@ -141,8 +49,8 @@ lemma isOpenImmersion_genericι (M : Model R K C toK) : IsOpenImmersion M.generi
     isOpenImmersion_genericFiberι R K M.toBase
   let : IsIso M.genericFiberIso.inv.left :=
     inferInstanceAs (IsIso ((Over.forget _).map M.genericFiberIso.inv))
-  change IsOpenImmersion (M.genericFiberIso.inv.left ≫ genericFiberι R K M.toBase)
-  exact inferInstance
+  rw [genericι]
+  infer_instance
 
 end Model
 

--- a/TauCeti/AlgebraicGeometry/Curves/StableReduction/Fibers.lean
+++ b/TauCeti/AlgebraicGeometry/Curves/StableReduction/Fibers.lean
@@ -86,7 +86,7 @@ lemma isOpenImmersion_Spec_map_fractionRing (R K : Type u) [CommRing R] [IsDomai
     IsOpenImmersion (Spec.map (CommRingCat.ofHom (algebraMap R K))) := by
   obtain ⟨ϖ, hϖ⟩ := IsDiscreteValuationRing.exists_irreducible R
   let : IsLocalization.Away ϖ K :=
-    TauCeti.Irreducible.isLocalizationAway_fractionRing hϖ
+    isLocalizationAway_fractionRing hϖ
   exact IsOpenImmersion.of_isLocalization ϖ
 
 /-- The morphism from the spectrum of a local ring's residue field is a closed immersion. -/

--- a/TauCeti/AlgebraicGeometry/Curves/StableReduction/Fibers.lean
+++ b/TauCeti/AlgebraicGeometry/Curves/StableReduction/Fibers.lean
@@ -1,0 +1,151 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.AlgebraicGeometry.Morphisms.ClosedImmersion
+public import Mathlib.AlgebraicGeometry.OpenImmersion
+public import TauCeti.AlgebraicGeometry.Curves.StableReduction.Model
+public import TauCeti.RingTheory.DiscreteValuationRing.FractionRing
+
+/-!
+# Generic and special fibres over a discrete valuation ring
+
+For a scheme over a discrete valuation ring `R` with fraction field `K`, this file records the
+canonical inclusions of its generic and special fibres into the total space. The generic fibre is
+an open subscheme because `K` is obtained by inverting a uniformizer. The special fibre is a
+closed subscheme because the residue map `R → κ` is surjective.
+
+The generic-fibre object is the one used by `TauCeti.Model`, while the special-fibre object is its
+parallel pullback along `Spec κ → Spec R`. The projection lemmas expose both pullback squares to
+later model and reduction arguments.
+-/
+
+public section
+
+noncomputable section
+
+open CategoryTheory Limits
+open AlgebraicGeometry IsLocalRing
+
+namespace TauCeti
+
+universe u
+
+/-- The special fibre of a scheme over a local ring, as a scheme over the residue field. -/
+noncomputable abbrev specialFiber (R : Type u) [CommRing R] [IsLocalRing R]
+    {X : Scheme.{u}} (toBase : X ⟶ Spec (.of R)) : Over (Spec (.of (ResidueField R))) :=
+  (Over.pullback (Spec.map (CommRingCat.ofHom (algebraMap R (ResidueField R))))).obj
+    (Over.mk toBase)
+
+/-- The canonical morphism from the special fibre to the total space. -/
+noncomputable abbrev specialFiberι (R : Type u) [CommRing R] [IsLocalRing R]
+    {X : Scheme.{u}} (toBase : X ⟶ Spec (.of R)) : (specialFiber R toBase).left ⟶ X :=
+  pullback.fst toBase (Spec.map (CommRingCat.ofHom (algebraMap R (ResidueField R))))
+
+/-- The structure morphism of the generic fibre is the second projection of its defining
+pullback square. -/
+@[simp]
+lemma genericFiber_hom (R K : Type u) [CommRing R] [Field K] [Algebra R K]
+    {X : Scheme.{u}} (toBase : X ⟶ Spec (.of R)) :
+    (genericFiber R K toBase).hom =
+      pullback.snd toBase (Spec.map (CommRingCat.ofHom (algebraMap R K))) := rfl
+
+/-- The structure morphism of the special fibre is the second projection of its defining
+pullback square. -/
+@[simp]
+lemma specialFiber_hom (R : Type u) [CommRing R] [IsLocalRing R]
+    {X : Scheme.{u}} (toBase : X ⟶ Spec (.of R)) :
+    (specialFiber R toBase).hom =
+      pullback.snd toBase
+        (Spec.map (CommRingCat.ofHom (algebraMap R (ResidueField R)))) := rfl
+
+/-- The generic-fibre inclusion and structure morphism form the defining pullback square. -/
+@[reassoc (attr := simp)]
+lemma genericFiberι_toBase (R K : Type u) [CommRing R] [Field K] [Algebra R K]
+    {X : Scheme.{u}} (toBase : X ⟶ Spec (.of R)) :
+    genericFiberι R K toBase ≫ toBase =
+      (genericFiber R K toBase).hom ≫
+        Spec.map (CommRingCat.ofHom (algebraMap R K)) :=
+  pullback.condition
+
+/-- The special-fibre inclusion and structure morphism form the defining pullback square. -/
+@[reassoc (attr := simp)]
+lemma specialFiberι_toBase (R : Type u) [CommRing R] [IsLocalRing R]
+    {X : Scheme.{u}} (toBase : X ⟶ Spec (.of R)) :
+    specialFiberι R toBase ≫ toBase =
+      (specialFiber R toBase).hom ≫
+        Spec.map (CommRingCat.ofHom (algebraMap R (ResidueField R))) :=
+  pullback.condition
+
+/-- The morphism from the spectrum of a DVR's fraction field is an open immersion. -/
+lemma isOpenImmersion_Spec_map_fractionRing (R K : Type u) [CommRing R] [IsDomain R]
+    [IsDiscreteValuationRing R] [Field K] [Algebra R K] [IsFractionRing R K] :
+    IsOpenImmersion (Spec.map (CommRingCat.ofHom (algebraMap R K))) := by
+  obtain ⟨ϖ, hϖ⟩ := IsDiscreteValuationRing.exists_irreducible R
+  let : IsLocalization.Away ϖ K :=
+    TauCeti.Irreducible.isLocalizationAway_fractionRing hϖ
+  exact IsOpenImmersion.of_isLocalization ϖ
+
+/-- The morphism from the spectrum of a local ring's residue field is a closed immersion. -/
+lemma isClosedImmersion_Spec_map_residue (R : Type u) [CommRing R] [IsLocalRing R] :
+    IsClosedImmersion
+      (Spec.map (CommRingCat.ofHom (algebraMap R (ResidueField R)))) := by
+  apply IsClosedImmersion.spec_of_surjective
+  intro y
+  obtain ⟨x, rfl⟩ := residue_surjective (R := R) y
+  exact ⟨x, by simp [ResidueField.algebraMap_eq]⟩
+
+/-- The generic fibre of a scheme over a discrete valuation ring is an open subscheme of the
+total space. -/
+lemma isOpenImmersion_genericFiberι (R K : Type u) [CommRing R] [IsDomain R]
+    [IsDiscreteValuationRing R] [Field K] [Algebra R K] [IsFractionRing R K]
+    {X : Scheme.{u}} (toBase : X ⟶ Spec (.of R)) :
+    IsOpenImmersion (genericFiberι R K toBase) := by
+  let : IsOpenImmersion (Spec.map (CommRingCat.ofHom (algebraMap R K))) :=
+    isOpenImmersion_Spec_map_fractionRing R K
+  exact inferInstance
+
+/-- The special fibre of a scheme over a local ring is a closed subscheme of the total space. -/
+lemma isClosedImmersion_specialFiberι (R : Type u) [CommRing R] [IsLocalRing R]
+    {X : Scheme.{u}} (toBase : X ⟶ Spec (.of R)) :
+    IsClosedImmersion (specialFiberι R toBase) := by
+  let : IsClosedImmersion
+      (Spec.map (CommRingCat.ofHom (algebraMap R (ResidueField R)))) :=
+    isClosedImmersion_Spec_map_residue R
+  exact inferInstance
+
+namespace Model
+
+variable {R K : Type u} [CommRing R] [IsDomain R] [IsDiscreteValuationRing R]
+variable [Field K] [Algebra R K] [IsFractionRing R K]
+variable {C : Scheme.{u}} {toK : C ⟶ Spec (.of K)}
+
+/-- The chosen generic fibre of a model, included into its total space. -/
+noncomputable abbrev genericι (M : Model R K C toK) : C ⟶ M.total :=
+  M.genericFiberIso.inv.left ≫ genericFiberι R K M.toBase
+
+/-- The inclusion of a model's chosen generic fibre lies over the fraction-field morphism. -/
+@[reassoc (attr := simp)]
+lemma genericι_toBase (M : Model R K C toK) :
+    M.genericFiberIso.inv.left ≫
+        (pullback.snd M.toBase (Spec.map (CommRingCat.ofHom (algebraMap R K))) ≫
+          Spec.map (CommRingCat.ofHom (algebraMap R K))) =
+      toK ≫ Spec.map (CommRingCat.ofHom (algebraMap R K)) := by
+  rw [← genericFiber_hom, ← Category.assoc, Over.w]
+  rfl
+
+/-- A model's chosen generic fibre is an open subscheme of its total space. -/
+lemma isOpenImmersion_genericι (M : Model R K C toK) : IsOpenImmersion M.genericι := by
+  let : IsOpenImmersion (genericFiberι R K M.toBase) :=
+    isOpenImmersion_genericFiberι R K M.toBase
+  let : IsIso M.genericFiberIso.inv.left :=
+    inferInstanceAs (IsIso ((Over.forget _).map M.genericFiberIso.inv))
+  change IsOpenImmersion (M.genericFiberIso.inv.left ≫ genericFiberι R K M.toBase)
+  exact inferInstance
+
+end Model
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/Curves/StableReduction/Fibers.lean
+++ b/TauCeti/AlgebraicGeometry/Curves/StableReduction/Fibers.lean
@@ -43,6 +43,19 @@ lemma genericι_toBase (M : Model R K C toK) :
   rw [genericι, Category.assoc, genericFiberι_toBase, ← Category.assoc, Over.w]
   rfl
 
+/-- The square defining a model's chosen generic fibre is a pullback. -/
+lemma isPullback_genericι (M : Model R K C toK) :
+    IsPullback M.genericι toK M.toBase
+      (Spec.map (CommRingCat.ofHom (algebraMap R K))) := by
+  refine (isPullback_genericFiber R K M.toBase).of_iso (Comma.leftIso M.genericFiberIso)
+    (Iso.refl _) (Iso.refl _) (Iso.refl _) ?_ ?_ ?_ ?_
+  · change genericFiberι R K M.toBase =
+      M.genericFiberIso.hom.left ≫ M.genericFiberIso.inv.left ≫ genericFiberι R K M.toBase
+    rw [← Category.assoc, Over.hom_left_inv_left, Category.id_comp]
+  · exact M.genericFiberIso.hom.w.symm
+  · simp
+  · simp
+
 /-- A model's chosen generic fibre is an open subscheme of its total space. -/
 lemma isOpenImmersion_genericι (M : Model R K C toK) : IsOpenImmersion M.genericι := by
   let : IsOpenImmersion (genericFiberι R K M.toBase) :=

--- a/TauCeti/AlgebraicGeometry/Curves/StableReduction/Fibers.lean
+++ b/TauCeti/AlgebraicGeometry/Curves/StableReduction/Fibers.lean
@@ -49,9 +49,10 @@ lemma isPullback_genericι (M : Model R K C toK) :
       (Spec.map (CommRingCat.ofHom (algebraMap R K))) := by
   refine (isPullback_genericFiber R K M.toBase).of_iso (Comma.leftIso M.genericFiberIso)
     (Iso.refl _) (Iso.refl _) (Iso.refl _) ?_ ?_ ?_ ?_
-  · change genericFiberι R K M.toBase =
-      M.genericFiberIso.hom.left ≫ M.genericFiberIso.inv.left ≫ genericFiberι R K M.toBase
-    rw [← Category.assoc, Over.hom_left_inv_left, Category.id_comp]
+  · have hleft :
+        (Comma.leftIso M.genericFiberIso).hom = M.genericFiberIso.hom.left := rfl
+    rw [hleft, genericι, ← Category.assoc, Over.hom_left_inv_left, Category.id_comp]
+    simp
   · exact M.genericFiberIso.hom.w.symm
   · simp
   · simp

--- a/TauCeti/AlgebraicGeometry/Curves/StableReduction/Model.lean
+++ b/TauCeti/AlgebraicGeometry/Curves/StableReduction/Model.lean
@@ -8,7 +8,7 @@ module
 public import Mathlib.AlgebraicGeometry.Morphisms.Flat
 public import Mathlib.AlgebraicGeometry.Morphisms.FinitePresentation
 public import Mathlib.AlgebraicGeometry.Morphisms.Proper
-public import Mathlib.RingTheory.DiscreteValuationRing.Basic
+public import TauCeti.AlgebraicGeometry.Fibers
 
 /-!
 # Models over discrete valuation rings
@@ -35,19 +35,6 @@ universe u
 
 -- The categorical packaging below adapts the target signature in
 -- `TauCetiRoadmap/StableReduction/Suggested.lean`.
-
-/-- The scalar extension of a scheme over `R` to a field `K`, regarded as a scheme over `K`.
-When `K` is a fraction field of `R`, this is the generic fibre. -/
-noncomputable abbrev genericFiber (R K : Type u) [CommRing R] [Field K] [Algebra R K]
-    {X : Scheme.{u}} (toBase : X ⟶ Spec (.of R)) :
-    Over (Spec (.of K)) :=
-  (Over.pullback (Spec.map (CommRingCat.ofHom (algebraMap R K)))).obj (Over.mk toBase)
-
-/-- The canonical morphism from the scalar-extended fibre to the original total space. -/
-noncomputable abbrev genericFiberι (R K : Type u) [CommRing R] [Field K] [Algebra R K]
-    {X : Scheme.{u}} (toBase : X ⟶ Spec (.of R)) :
-    (genericFiber R K toBase).left ⟶ X :=
-  pullback.fst toBase (Spec.map (CommRingCat.ofHom (algebraMap R K)))
 
 /-- A flat finitely presented model over a discrete valuation ring, together with an explicit
 identification of its generic fibre with a fixed scheme over the fraction field.

--- a/TauCeti/AlgebraicGeometry/Fibers.lean
+++ b/TauCeti/AlgebraicGeometry/Fibers.lean
@@ -1,0 +1,146 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.AlgebraicGeometry.Morphisms.ClosedImmersion
+public import Mathlib.AlgebraicGeometry.OpenImmersion
+public import TauCeti.RingTheory.DiscreteValuationRing.FractionRing
+
+/-!
+# Generic and special fibres
+
+For a scheme over a ring `R`, this file defines its scalar-extension fibre along a ring map
+`R → K`. For a local ring, it also defines the special fibre obtained by base change to the
+residue field. The projection identities and pullback witnesses expose the defining squares.
+
+When `R` is a discrete valuation ring and `K` is a fraction ring, the generic fibre is an open
+subscheme of the total space. The special fibre over any local ring is a closed subscheme.
+-/
+
+public section
+
+noncomputable section
+
+open CategoryTheory Limits
+open AlgebraicGeometry IsLocalRing
+
+namespace TauCeti
+
+universe u
+
+/-- The scalar extension of a scheme over `R` to a ring `K`, regarded as a scheme over `K`.
+When `K` is a fraction field of `R`, this is the generic fibre. -/
+noncomputable abbrev genericFiber (R K : Type u) [CommRing R] [CommRing K] [Algebra R K]
+    {X : Scheme.{u}} (toBase : X ⟶ Spec (.of R)) :
+    Over (Spec (.of K)) :=
+  (Over.pullback (Spec.map (CommRingCat.ofHom (algebraMap R K)))).obj (Over.mk toBase)
+
+/-- The canonical morphism from the scalar-extended fibre to the original total space. -/
+noncomputable abbrev genericFiberι (R K : Type u) [CommRing R] [CommRing K] [Algebra R K]
+    {X : Scheme.{u}} (toBase : X ⟶ Spec (.of R)) :
+    (genericFiber R K toBase).left ⟶ X :=
+  pullback.fst toBase (Spec.map (CommRingCat.ofHom (algebraMap R K)))
+
+/-- The special fibre of a scheme over a local ring, as a scheme over the residue field. -/
+noncomputable abbrev specialFiber (R : Type u) [CommRing R] [IsLocalRing R]
+    {X : Scheme.{u}} (toBase : X ⟶ Spec (.of R)) : Over (Spec (.of (ResidueField R))) :=
+  (Over.pullback (Spec.map (CommRingCat.ofHom (algebraMap R (ResidueField R))))).obj
+    (Over.mk toBase)
+
+/-- The canonical morphism from the special fibre to the total space. -/
+noncomputable abbrev specialFiberι (R : Type u) [CommRing R] [IsLocalRing R]
+    {X : Scheme.{u}} (toBase : X ⟶ Spec (.of R)) : (specialFiber R toBase).left ⟶ X :=
+  pullback.fst toBase (Spec.map (CommRingCat.ofHom (algebraMap R (ResidueField R))))
+
+/-- The structure morphism of the generic fibre is the second projection of its defining
+pullback square. -/
+@[simp]
+lemma genericFiber_hom (R K : Type u) [CommRing R] [CommRing K] [Algebra R K]
+    {X : Scheme.{u}} (toBase : X ⟶ Spec (.of R)) :
+    (genericFiber R K toBase).hom =
+      pullback.snd toBase (Spec.map (CommRingCat.ofHom (algebraMap R K))) := rfl
+
+/-- The structure morphism of the special fibre is the second projection of its defining
+pullback square. -/
+@[simp]
+lemma specialFiber_hom (R : Type u) [CommRing R] [IsLocalRing R]
+    {X : Scheme.{u}} (toBase : X ⟶ Spec (.of R)) :
+    (specialFiber R toBase).hom =
+      pullback.snd toBase
+        (Spec.map (CommRingCat.ofHom (algebraMap R (ResidueField R)))) := rfl
+
+/-- The generic-fibre projections satisfy their defining commutativity identity. -/
+@[reassoc (attr := simp)]
+lemma genericFiberι_toBase (R K : Type u) [CommRing R] [CommRing K] [Algebra R K]
+    {X : Scheme.{u}} (toBase : X ⟶ Spec (.of R)) :
+    genericFiberι R K toBase ≫ toBase =
+      (genericFiber R K toBase).hom ≫
+        Spec.map (CommRingCat.ofHom (algebraMap R K)) :=
+  pullback.condition
+
+/-- The special-fibre projections satisfy their defining commutativity identity. -/
+@[reassoc (attr := simp)]
+lemma specialFiberι_toBase (R : Type u) [CommRing R] [IsLocalRing R]
+    {X : Scheme.{u}} (toBase : X ⟶ Spec (.of R)) :
+    specialFiberι R toBase ≫ toBase =
+      (specialFiber R toBase).hom ≫
+        Spec.map (CommRingCat.ofHom (algebraMap R (ResidueField R))) :=
+  pullback.condition
+
+/-- The square defining the generic fibre is a pullback. -/
+lemma isPullback_genericFiber (R K : Type u) [CommRing R] [CommRing K] [Algebra R K]
+    {X : Scheme.{u}} (toBase : X ⟶ Spec (.of R)) :
+    IsPullback (genericFiberι R K toBase) (genericFiber R K toBase).hom toBase
+      (Spec.map (CommRingCat.ofHom (algebraMap R K))) := by
+  rw [genericFiber_hom]
+  exact IsPullback.of_hasPullback _ _
+
+/-- The square defining the special fibre is a pullback. -/
+lemma isPullback_specialFiber (R : Type u) [CommRing R] [IsLocalRing R]
+    {X : Scheme.{u}} (toBase : X ⟶ Spec (.of R)) :
+    IsPullback (specialFiberι R toBase) (specialFiber R toBase).hom toBase
+      (Spec.map (CommRingCat.ofHom (algebraMap R (ResidueField R)))) := by
+  rw [specialFiber_hom]
+  exact IsPullback.of_hasPullback _ _
+
+/-- The morphism from the spectrum of a DVR's fraction ring is an open immersion. -/
+lemma isOpenImmersion_Spec_map_fractionRing (R K : Type u) [CommRing R] [IsDomain R]
+    [IsDiscreteValuationRing R] [CommRing K] [Algebra R K] [IsFractionRing R K] :
+    IsOpenImmersion (Spec.map (CommRingCat.ofHom (algebraMap R K))) := by
+  obtain ⟨ϖ, hϖ⟩ := IsDiscreteValuationRing.exists_irreducible R
+  let : IsLocalization.Away ϖ K :=
+    isLocalizationAway_fractionRing hϖ
+  exact IsOpenImmersion.of_isLocalization ϖ
+
+/-- The morphism from the spectrum of a local ring's residue field is a closed immersion. -/
+lemma isClosedImmersion_Spec_map_residue (R : Type u) [CommRing R] [IsLocalRing R] :
+    IsClosedImmersion
+      (Spec.map (CommRingCat.ofHom (algebraMap R (ResidueField R)))) := by
+  apply IsClosedImmersion.spec_of_surjective
+  intro y
+  obtain ⟨x, rfl⟩ := residue_surjective (R := R) y
+  exact ⟨x, by simp [ResidueField.algebraMap_eq]⟩
+
+/-- The generic fibre of a scheme over a discrete valuation ring is an open subscheme of the
+total space. -/
+lemma isOpenImmersion_genericFiberι (R K : Type u) [CommRing R] [IsDomain R]
+    [IsDiscreteValuationRing R] [CommRing K] [Algebra R K] [IsFractionRing R K]
+    {X : Scheme.{u}} (toBase : X ⟶ Spec (.of R)) :
+    IsOpenImmersion (genericFiberι R K toBase) := by
+  let : IsOpenImmersion (Spec.map (CommRingCat.ofHom (algebraMap R K))) :=
+    isOpenImmersion_Spec_map_fractionRing R K
+  exact inferInstance
+
+/-- The special fibre of a scheme over a local ring is a closed subscheme of the total space. -/
+lemma isClosedImmersion_specialFiberι (R : Type u) [CommRing R] [IsLocalRing R]
+    {X : Scheme.{u}} (toBase : X ⟶ Spec (.of R)) :
+    IsClosedImmersion (specialFiberι R toBase) := by
+  let : IsClosedImmersion
+      (Spec.map (CommRingCat.ofHom (algebraMap R (ResidueField R)))) :=
+    isClosedImmersion_Spec_map_residue R
+  exact inferInstance
+
+end TauCeti

--- a/TauCeti/RingTheory/DiscreteValuationRing/FractionRing.lean
+++ b/TauCeti/RingTheory/DiscreteValuationRing/FractionRing.lean
@@ -26,7 +26,7 @@ open IsDiscreteValuationRing
 /-- The fraction field of a discrete valuation ring is the localization away from any
 uniformizer. Here uniformizers are expressed using Mathlib's equivalent `Irreducible` predicate.
 -/
-lemma Irreducible.isLocalizationAway_fractionRing {R K : Type*} [CommRing R] [IsDomain R]
+lemma isLocalizationAway_fractionRing {R K : Type*} [CommRing R] [IsDomain R]
     [IsDiscreteValuationRing R] [Field K] [Algebra R K] [IsFractionRing R K]
     {ϖ : R} (hϖ : Irreducible ϖ) : IsLocalization.Away ϖ K := by
   refine (IsLocalization.iff_of_le_of_exists_dvd (S := K) (M := Submonoid.powers ϖ)

--- a/TauCeti/RingTheory/DiscreteValuationRing/FractionRing.lean
+++ b/TauCeti/RingTheory/DiscreteValuationRing/FractionRing.lean
@@ -27,7 +27,7 @@ open IsDiscreteValuationRing
 uniformizer. Here uniformizers are expressed using Mathlib's equivalent `Irreducible` predicate.
 -/
 lemma isLocalizationAway_fractionRing {R K : Type*} [CommRing R] [IsDomain R]
-    [IsDiscreteValuationRing R] [Field K] [Algebra R K] [IsFractionRing R K]
+    [IsDiscreteValuationRing R] [CommRing K] [Algebra R K] [IsFractionRing R K]
     {ϖ : R} (hϖ : Irreducible ϖ) : IsLocalization.Away ϖ K := by
   refine (IsLocalization.iff_of_le_of_exists_dvd (S := K) (M := Submonoid.powers ϖ)
     (nonZeroDivisors R) (by

--- a/TauCeti/RingTheory/DiscreteValuationRing/FractionRing.lean
+++ b/TauCeti/RingTheory/DiscreteValuationRing/FractionRing.lean
@@ -35,12 +35,7 @@ lemma isLocalizationAway_fractionRing {R K : Type*} [CommRing R] [IsDomain R]
       exact pow_mem (mem_nonZeroDivisors_iff_ne_zero.mpr hϖ.ne_zero) n) (by
       rintro x hx
       rw [mem_nonZeroDivisors_iff_ne_zero] at hx
-      let hR : HasUnitMulPowIrreducibleFactorization R :=
-        .of_ufd_of_unique_irreducible (exists_irreducible R)
-          (fun _ _ ha hb ↦ associated_of_irreducible R ha hb)
-      obtain ⟨π, hπ, H⟩ := hR
-      obtain ⟨n, hn⟩ := H hx
-      have hπϖ : Associated π ϖ := associated_of_irreducible R hπ hϖ
-      exact ⟨ϖ ^ n, ⟨n, rfl⟩, hn.symm.dvd.trans hπϖ.pow_pow.dvd⟩)).mpr inferInstance
+      obtain ⟨n, hn⟩ := associated_pow_irreducible hx hϖ
+      exact ⟨ϖ ^ n, ⟨n, rfl⟩, hn.dvd⟩)).mpr inferInstance
 
 end TauCeti

--- a/TauCeti/RingTheory/DiscreteValuationRing/FractionRing.lean
+++ b/TauCeti/RingTheory/DiscreteValuationRing/FractionRing.lean
@@ -1,0 +1,46 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RingTheory.DiscreteValuationRing.Basic
+public import Mathlib.RingTheory.Localization.Away.Basic
+public import Mathlib.RingTheory.Localization.FractionRing
+
+/-!
+# Fraction fields of discrete valuation rings
+
+This file relates the two natural descriptions of the fraction field of a discrete valuation
+ring. Besides being the localization at all non-zero elements, it is the localization away from
+any uniformizer. This identifies the induced map of spectra with a principal open immersion.
+-/
+
+public section
+
+namespace TauCeti
+
+open IsDiscreteValuationRing
+
+/-- The fraction field of a discrete valuation ring is the localization away from any
+uniformizer. Here uniformizers are expressed using Mathlib's equivalent `Irreducible` predicate.
+-/
+lemma Irreducible.isLocalizationAway_fractionRing {R K : Type*} [CommRing R] [IsDomain R]
+    [IsDiscreteValuationRing R] [Field K] [Algebra R K] [IsFractionRing R K]
+    {ϖ : R} (hϖ : Irreducible ϖ) : IsLocalization.Away ϖ K := by
+  refine (IsLocalization.iff_of_le_of_exists_dvd (S := K) (M := Submonoid.powers ϖ)
+    (nonZeroDivisors R) (by
+      rintro x ⟨n, rfl⟩
+      exact pow_mem (mem_nonZeroDivisors_iff_ne_zero.mpr hϖ.ne_zero) n) (by
+      rintro x hx
+      rw [mem_nonZeroDivisors_iff_ne_zero] at hx
+      let hR : HasUnitMulPowIrreducibleFactorization R :=
+        .of_ufd_of_unique_irreducible (exists_irreducible R)
+          (fun _ _ ha hb ↦ associated_of_irreducible R ha hb)
+      obtain ⟨π, hπ, H⟩ := hR
+      obtain ⟨n, hn⟩ := H hx
+      have hπϖ : Associated π ϖ := associated_of_irreducible R hπ hϖ
+      exact ⟨ϖ ^ n, ⟨n, rfl⟩, hn.symm.dvd.trans hπϖ.pow_pow.dvd⟩)).mpr inferInstance
+
+end TauCeti


### PR DESCRIPTION
This PR adds the canonical generic- and special-fibre immersions for schemes over a discrete valuation ring. It advances StableReduction's Layer 0 milestone, specifically the target “Develop generic and special fibres over a DVR, including the open immersion of the generic fibre, the closed immersion of the special fibre, and explicit comparison with `Scheme.Hom.fiber`,” by completing the two immersion statements and connecting the generic one to the chosen generic fibre of a `Model`.

The reusable ring-theoretic input proves that a DVR fraction field is the localization away from any uniformizer. The geometric layer defines the special fibre, records both pullback squares, proves that the generic base morphism is open and the residue base morphism is closed, transfers these properties across pullback, and equips every `Model` with its canonical open generic inclusion.

After this PR, the Layer 0 fibre milestone still needs the canonical comparison between the chosen fraction-field pullback and `Scheme.Hom.fiber` at the generic point, together with the stated scalar-extension compatibility.

No Mathlib infrastructure is vendored. The proofs reuse Mathlib's `IsLocalization.iff_of_le_of_exists_dvd`, `IsOpenImmersion.of_isLocalization`, `IsClosedImmersion.spec_of_surjective`, and pullback-stability instances; the mathematical input is the standard unit-times-uniformizer-power factorization in a discrete valuation ring.

Roadmap: StableReduction

<!--tauceti-target:v1 {"focus":"StableReduction","id":"generic-special-fibres-dvr"}-->

🤖 Prepared with Codex
