### PR TITLE
refactor(Isogeny): name the Frobenius commutation for what it says

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Point/FrobeniusFixed.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Point/FrobeniusFixed.lean
@@ -147,16 +147,4 @@ theorem ncard_setOf_map_frobeniusAlgHom_eq_self : {P : (W.baseChange L).toAffine
   rw [hset]
   exact Set.ncard_range_of_injective (Affine.Point.map_injective _)
 
-/-- **The induced map on points commutes with the `q`-power map.** Raising the coordinates to the
-`#K`-th power and then applying a `K`-algebra homomorphism gives the same point as applying the
-homomorphism first. -/
-@[simp]
-theorem map_frobeniusAlgHom_comm {Ω : Type*} [Field Ω] [DecidableEq Ω] [Algebra K Ω]
-    (σ : L →ₐ[K] Ω) (P : (W.baseChange L).toAffine.Point) :
-    Affine.Point.map (W' := W) σ
-        (Affine.Point.map (W' := W) (FiniteField.frobeniusAlgHom K L) P) =
-      Affine.Point.map (W' := W) (FiniteField.frobeniusAlgHom K Ω)
-        (Affine.Point.map (W' := W) σ P) := by
-  rw [Affine.Point.map_map, Affine.Point.map_map, AlgHom.comp_frobeniusAlgHom]
-
 end WeierstrassCurve.Affine.Point

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/OneSubFrobenius/TautologicalPoint.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/OneSubFrobenius/TautologicalPoint.lean
@@ -15,10 +15,25 @@ public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.OneSubFrobenius.Ba
 The tautological point is additive on morphisms, and the identity's is the generic point, so the
 tautological point of `1 − π_q` is the generic point minus that of Frobenius.
 
+Transported into an extension `Ω` of `F` along a homomorphism `σ` of the function field, that
+reads `Q − Q^q` for `Q = σ(g)` the image there of the generic point. This is the form the
+embedding count of `1 − π_q` is built from, and the rest of the file draws the two consequences it
+needs. The left-hand side depends on `σ` only through the pulled-back field, so two homomorphisms
+agreeing there give points `Q_σ`, `Q_τ` whose difference is fixed by the `q`-power map; and a
+point of `W` over `Ω` fixed by that map descends to a point over `F`. Together these say that the
+embeddings over the pulled-back field are indexed injectively by rational points, which is what
+bounds the degree of `1 − π_q` by the point count.
+
 ## Main results
 
 * `TauCeti.Isogeny.tautologicalPoint_oneSubFrobeniusIsogeny`: the tautological point of
   `1 − π_q` is `g − π_q(g)`.
+* `TauCeti.Isogeny.map_tautologicalPoint_oneSubFrobeniusIsogeny`: transported along `σ`, it is
+  `Q − Q^q`.
+* `TauCeti.Isogeny.map_frobeniusAlgHom_sub_map_genericPoint_eq_self`: two homomorphisms agreeing
+  on the pulled-back field move the generic point by a `q`-power-fixed difference.
+* `TauCeti.Isogeny.exists_baseChange_eq_sub_map_genericPoint`: that difference is the image of a
+  rational point.
 -/
 
 public section
@@ -51,7 +66,8 @@ theorem map_tautologicalPoint_oneSubFrobeniusIsogeny {Ω : Type*} [Field Ω] [De
         Point.map (_root_.FiniteField.frobeniusAlgHom F Ω) (Point.map σ (genericPoint W)) := by
   let _ := Fintype.ofFinite F
   rw [tautologicalPoint_oneSubFrobeniusIsogeny, map_sub, tautologicalPoint_eq_map_genericPoint,
-    fieldPullback_frobeniusIsogeny, WeierstrassCurve.Affine.Point.map_frobeniusAlgHom_comm]
+    fieldPullback_frobeniusIsogeny, Point.map_map, Point.map_map,
+    AlgHom.frobeniusAlgHom_comm]
 
 /-- **Two homomorphisms that agree on the pulled-back field move the generic point to points whose
 difference is `q`-power fixed.** Their images of the tautological point of `1 − π_q` agree, and that

--- a/TauCeti/FieldTheory/Finite/FrobeniusFixed.lean
+++ b/TauCeti/FieldTheory/Finite/FrobeniusFixed.lean
@@ -83,7 +83,7 @@ theorem pow_card_eq_self_iff_mem_range_algebraMap {K L : Type*} [Field K] [Finty
 homomorphism and raising to the `#K`-th power can be done in either order, a ring homomorphism
 carrying `q`-th powers to `q`-th powers. -/
 @[simp]
-theorem _root_.AlgHom.comp_frobeniusAlgHom {K L Ω : Type*} [Field K] [Fintype K] [CommRing L]
+theorem _root_.AlgHom.frobeniusAlgHom_comm {K L Ω : Type*} [Field K] [Fintype K] [CommRing L]
     [Algebra K L] [CommRing Ω] [Algebra K Ω] (σ : L →ₐ[K] Ω) :
     σ.comp (_root_.FiniteField.frobeniusAlgHom K L) =
       (_root_.FiniteField.frobeniusAlgHom K Ω).comp σ := by


### PR DESCRIPTION
Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"EllipticCurves/README.md:layer1:frobenius-commutation-naming"}-->

Provenance: no port. This is cleanup of material #6446 introduces.

## What this changes

- `AlgHom.comp_frobeniusAlgHom` → **`AlgHom.frobeniusAlgHom_comm`**. The statement is that a `K`-algebra homomorphism commutes with the finite-base-field Frobenius; the old name described the shape of the left-hand side instead of the content.
- **`Affine.Point.map_frobeniusAlgHom_comm` is deleted.** It transported the same statement to points and had exactly one consumer, whose proof now writes the two composition rewrites directly.
- The module docstring of `Isogeny/OneSubFrobenius/TautologicalPoint.lean` is extended. The file had grown the transported tautological-point identity, the Frobenius-fixed difference and the rational-point descent while its docstring still described only the first declaration; the opening explanation and Main results now cover all four and say what the file is for — the embedding count of `1 − π_q`.

## What this no longer adds

An earlier round of this PR added `degree_oneSubFrobeniusIsogeny_eq_sub_frobeniusTrace`, `deg (1 − π_q) = q + 1 − t`. **It has been removed at `reuse`'s request**, which the rubric maintained on re-review: `frobeniusTrace` is *defined* as `q + 1 − #E(𝔽_q)`, so the theorem rearranges that definition into `degree_oneSubFrobeniusIsogeny_eq_pointCount`, and its eventual consumer can do the same inline with `rw [frobeniusTrace_def, degree_oneSubFrobeniusIsogeny_eq_pointCount]; ring`. The roadmap target is retargeted accordingly, since this PR no longer addresses `layer3:frobenius-trace`.

## Stacking

On #6446 (`elliptic/taut-point-eqon`), whose declarations this cleans up; the diff shows that PR's content until it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
