### PR TITLE
refactor(SpStd): define the carrier Frobenius as its functorial point map

### DIFF
--- a/TauCeti/Algebra/Lie/Symplectic/StandardCarrier/Frobenius.lean
+++ b/TauCeti/Algebra/Lie/Symplectic/StandardCarrier/Frobenius.lean
@@ -56,14 +56,6 @@ that any fixed-point group is finite or simple.
 
 The organization follows the sibling carrier specialization
 `TauCeti.Algebra.Lie.Orthogonal.TypeB.SpinCarrier.Frobenius`.
-
-This advances the "points over an algebraically closed field" and "Chevalley--Demazure
-construction" targets in Layer 9 of `TauCetiRoadmap/ReductiveGroups/README.md`, whose first named
-case is the `q`-power Frobenius. Its consumer is milestone L1 of
-`TauCetiRoadmap/CFSGStatement/README.md`, whose Steinberg map for the untwisted family `C_n(q)` is
-`Frob_q` on the points of the pinned type-`C` ambient group over an algebraic closure of `ZMod p`.
-The type-`A` counterpart is
-`TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/Frobenius.lean`.
 -/
 
 public section

--- a/TauCeti/Algebra/Lie/Symplectic/StandardCarrier/Frobenius.lean
+++ b/TauCeti/Algebra/Lie/Symplectic/StandardCarrier/Frobenius.lean
@@ -5,8 +5,9 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.Algebra.AlgebraicGroup.Frobenius.GeneralLinear
+public import TauCeti.Algebra.CharP.Frobenius.Basic
 public import TauCeti.Algebra.Lie.Symplectic.StandardCarrier.PointsFunctor
-public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Scheme.ToralClosure.Frobenius
 
 /-!
 # Frobenius on the full-weight type-C carrier
@@ -27,10 +28,9 @@ for every Bourbaki-numbered raising or lowering generator, and it raises every c
 split weight torus by the same exponent. Its fixed points are exactly the points of the same
 carrier over the Frobenius-fixed subring.
 
-The construction specializes the generic Frobenius of a Kostant toral closure, and every equation
-below is read off the corresponding generic statement; nothing about the symplectic Lie algebra or
-its lattice is used again here. Nothing asserts that the carrier is reductive, that it is the
-symplectic group scheme, or that any fixed-point group is finite or simple.
+The construction is the carrier's functorial point map at the iterated Frobenius of the value
+ring. Nothing asserts that the carrier is reductive, that it is the symplectic group scheme, or
+that any fixed-point group is finite or simple.
 
 ## Main definitions
 
@@ -54,6 +54,9 @@ symplectic group scheme, or that any fixed-point group is finite or simple.
 * R. W. Carter, *Finite Groups of Lie Type: Conjugacy Classes and Complex Characters*, §1.17.
 * J. C. Jantzen, *Representations of Algebraic Groups*, II.1.
 
+The organization follows the sibling carrier specialization
+`TauCeti.Algebra.Lie.Orthogonal.TypeB.SpinCarrier.Frobenius`.
+
 This advances the "points over an algebraically closed field" and "Chevalley--Demazure
 construction" targets in Layer 9 of `TauCetiRoadmap/ReductiveGroups/README.md`, whose first named
 case is the `q`-power Frobenius. Its consumer is milestone L1 of
@@ -75,51 +78,12 @@ noncomputable section
 
 variable (n p k : ℕ) (A : Type v) [CommRing A] [ExpChar A p]
 
-private theorem points_eq_kostantToralPointsSubgroup :
-    points n A =
-      TauCeti.UniversalEnvelopingAlgebra.kostantToralPointsSubgroup (rootGenerator n)
-        (cartanGenerator n) (rep n) (lattice n).toAddSubgroup
-        (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice n hu hv)
-        (isNilpotent_rep_rootGenerator n) (latticeBasis n) (basisWeight n) A := by
-  ext g
-  rw [mem_points_iff, definingIdeal_def,
-    TauCeti.UniversalEnvelopingAlgebra.mem_kostantToralPointsSubgroup_iff]
-
-/-- The presentation of the named carrier points as the generic Kostant toral-closure points. -/
-private def pointsEquivKostantToralPoints :
-    points n A ≃*
-      TauCeti.UniversalEnvelopingAlgebra.kostantToralPointsSubgroup (rootGenerator n)
-        (cartanGenerator n) (rep n) (lattice n).toAddSubgroup
-        (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice n hu hv)
-        (isNilpotent_rep_rootGenerator n) (latticeBasis n) (basisWeight n) A :=
-  MulEquiv.subgroupCongr (points_eq_kostantToralPointsSubgroup n A)
-
-@[simp]
-private theorem coe_pointsEquivKostantToralPoints (g : points n A) :
-    (pointsEquivKostantToralPoints n A g :
-      _root_.Matrix.GeneralLinearGroup (Fin ((n + 1) + (n + 1))) A) = g :=
-  rfl
-
 /-- **The `p ^ k`-power Frobenius endomorphism of the full-weight type-`C_(n+1)` carrier.**
 
 For `p` prime, `0 < k`, and `A` an algebraic closure of `ZMod p`, this is the Frobenius component
 intended for a future construction of the `C_(n+1)(p ^ k)` Steinberg map. -/
 def frobenius : points n A →* points n A :=
-  (TauCeti.UniversalEnvelopingAlgebra.kostantToralFrobenius (rootGenerator n)
-      (cartanGenerator n) (rep n) (lattice n).toAddSubgroup
-      (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice n hu hv)
-      (isNilpotent_rep_rootGenerator n) (latticeBasis n) (basisWeight n) p k A).subgroupCongr
-    (points_eq_kostantToralPointsSubgroup n A) (points_eq_kostantToralPointsSubgroup n A)
-
-private theorem pointsEquivKostantToralPoints_frobenius (g : points n A) :
-    pointsEquivKostantToralPoints n A (frobenius n p k A g) =
-      TauCeti.UniversalEnvelopingAlgebra.kostantToralFrobenius (rootGenerator n)
-        (cartanGenerator n) (rep n) (lattice n).toAddSubgroup
-        (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice n hu hv)
-        (isNilpotent_rep_rootGenerator n) (latticeBasis n) (basisWeight n) p k A
-        (pointsEquivKostantToralPoints n A g) := by
-  apply Subtype.ext
-  simp [frobenius]
+  pointsMap n (iterateFrobenius A p k)
 
 /-- The Frobenius endomorphism of the type-`C_(n+1)` carrier acts by entrywise Frobenius.
 
@@ -128,18 +92,13 @@ normal form. -/
 theorem coe_frobenius (g : points n A) :
     (frobenius n p k A g : _root_.Matrix.GeneralLinearGroup (Fin ((n + 1) + (n + 1))) A) =
       _root_.Matrix.GeneralLinearGroup.map (iterateFrobenius A p k) g := by
-  have h := congrArg Subtype.val (pointsEquivKostantToralPoints_frobenius n p k A g)
-  rw [TauCeti.UniversalEnvelopingAlgebra.coe_kostantToralFrobenius] at h
-  simpa only [coe_pointsEquivKostantToralPoints] using h
+  rw [frobenius, coe_pointsMap]
 
 /-- The carrier Frobenius is the functorial map on points induced by the iterated Frobenius
 endomorphism of the value ring. -/
 theorem frobenius_eq_pointsMap :
     frobenius n p k A = pointsMap n (iterateFrobenius A p k) := by
-  apply MonoidHom.ext
-  intro g
-  apply Subtype.ext
-  rw [coe_frobenius, coe_pointsMap]
+  rw [frobenius]
 
 /-- Entrywise, the Frobenius endomorphism raises each matrix coefficient to its
 `p ^ k`-th power. -/
@@ -149,13 +108,7 @@ theorem coe_frobenius_apply (g : points n A) (i j : Fin ((n + 1) + (n + 1))) :
         _root_.Matrix (Fin ((n + 1) + (n + 1))) (Fin ((n + 1) + (n + 1))) A) i j =
       ((g : _root_.Matrix.GeneralLinearGroup (Fin ((n + 1) + (n + 1))) A) :
         _root_.Matrix (Fin ((n + 1) + (n + 1))) (Fin ((n + 1) + (n + 1))) A) i j ^ p ^ k := by
-  have h := TauCeti.UniversalEnvelopingAlgebra.coe_kostantToralFrobenius_apply
-      (rootGenerator n) (cartanGenerator n) (rep n) (lattice n).toAddSubgroup
-      (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice n hu hv)
-      (isNilpotent_rep_rootGenerator n) (latticeBasis n) (basisWeight n) p k A
-      (pointsEquivKostantToralPoints n A g) i j
-  rw [← pointsEquivKostantToralPoints_frobenius] at h
-  simpa only [coe_pointsEquivKostantToralPoints] using h
+  rw [coe_frobenius, Matrix.GeneralLinearGroup.map_apply, iterateFrobenius_def]
 
 /-- **Frobenius raises the parameter of a numbered type-`C_(n+1)` root subgroup to its
 `p ^ k`-th power.** -/
@@ -164,67 +117,24 @@ theorem frobenius_rootSubgroupPoints (i : Fin (n + 1) ⊕ Fin (n + 1)) (u : Mult
     frobenius n p k A (rootSubgroupPoints n i A u) =
       rootSubgroupPoints n i A
         (Multiplicative.ofAdd (Multiplicative.toAdd u ^ p ^ k)) := by
-  apply (pointsEquivKostantToralPoints n A).injective
-  rw [pointsEquivKostantToralPoints_frobenius]
-  apply Subtype.ext
-  rw [TauCeti.UniversalEnvelopingAlgebra.coe_kostantToralFrobenius,
-    coe_pointsEquivKostantToralPoints, coe_rootSubgroupPoints,
-    coe_pointsEquivKostantToralPoints, coe_rootSubgroupPoints]
-  have h := congrArg Subtype.val
-    (TauCeti.UniversalEnvelopingAlgebra.kostantToralFrobenius_kostantRootSubgroupMatrix
-      (rootGenerator n) (cartanGenerator n) (rep n) (lattice n).toAddSubgroup
-      (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice n hu hv)
-      (isNilpotent_rep_rootGenerator n) (latticeBasis n) (basisWeight n) p k A i u)
-  rw [TauCeti.UniversalEnvelopingAlgebra.coe_kostantToralFrobenius] at h
-  exact h
+  rw [frobenius, pointsMap_rootSubgroupPoints]
+  exact Subtype.ext (by rw [iterateFrobenius_def])
 
 /-- **Frobenius raises every coordinate of the pinned split torus to its `p ^ k`-th power.** -/
 @[simp]
 theorem frobenius_weightTorusPoints (s : Fin (n + 1) → Aˣ) :
     frobenius n p k A (weightTorusPoints n A s) = weightTorusPoints n A (s ^ p ^ k) := by
-  apply (pointsEquivKostantToralPoints n A).injective
-  rw [pointsEquivKostantToralPoints_frobenius]
-  apply Subtype.ext
-  rw [TauCeti.UniversalEnvelopingAlgebra.coe_kostantToralFrobenius,
-    coe_pointsEquivKostantToralPoints, coe_weightTorusPoints,
-    coe_pointsEquivKostantToralPoints, coe_weightTorusPoints]
-  have h := congrArg Subtype.val
-    (TauCeti.UniversalEnvelopingAlgebra.kostantToralFrobenius_kostantTorusMatrix
-      (rootGenerator n) (cartanGenerator n) (rep n) (lattice n).toAddSubgroup
-      (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice n hu hv)
-      (isNilpotent_rep_rootGenerator n) (latticeBasis n) (basisWeight n) p k A s)
-  rw [TauCeti.UniversalEnvelopingAlgebra.coe_kostantToralFrobenius] at h
-  simpa only [TauCeti.UniversalEnvelopingAlgebra.kostantTorusMatrix_apply] using h
+  rw [frobenius, pointsMap_weightTorusPoints, map_iterateFrobenius_units_eq_pow]
 
 /-- The zeroth Frobenius iterate is the identity on the type-`C_(n+1)` point group. -/
 @[simp]
 theorem frobenius_zero : frobenius n p 0 A = MonoidHom.id _ := by
-  apply MonoidHom.ext
-  intro g
-  apply (pointsEquivKostantToralPoints n A).injective
-  rw [pointsEquivKostantToralPoints_frobenius, MonoidHom.id_apply]
-  have h := DFunLike.congr_fun
-    (TauCeti.UniversalEnvelopingAlgebra.kostantToralFrobenius_zero
-      (rootGenerator n) (cartanGenerator n) (rep n) (lattice n).toAddSubgroup
-      (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice n hu hv)
-      (isNilpotent_rep_rootGenerator n) (latticeBasis n) (basisWeight n) p A)
-    (pointsEquivKostantToralPoints n A g)
-  simpa only [MonoidHom.id_apply] using h
+  rw [frobenius, iterateFrobenius_zero, pointsMap_id]
 
 /-- Frobenius iterates add under composition on the type-`C_(n+1)` point group. -/
 theorem frobenius_add (m : ℕ) :
     frobenius n p (k + m) A = (frobenius n p k A).comp (frobenius n p m A) := by
-  apply MonoidHom.ext
-  intro g
-  apply (pointsEquivKostantToralPoints n A).injective
-  rw [pointsEquivKostantToralPoints_frobenius, MonoidHom.comp_apply,
-    pointsEquivKostantToralPoints_frobenius, pointsEquivKostantToralPoints_frobenius]
-  exact DFunLike.congr_fun
-    (TauCeti.UniversalEnvelopingAlgebra.kostantToralFrobenius_add
-      (rootGenerator n) (cartanGenerator n) (rep n) (lattice n).toAddSubgroup
-      (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice n hu hv)
-      (isNilpotent_rep_rootGenerator n) (latticeBasis n) (basisWeight n) p k A m)
-    (pointsEquivKostantToralPoints n A g)
+  rw [frobenius, frobenius, frobenius, iterateFrobenius_add, pointsMap_comp]
 
 /-- A type-`C_(n+1)` carrier point is fixed by Frobenius exactly when all of its matrix entries lie
 in the Frobenius-fixed subring. -/
@@ -234,18 +144,8 @@ theorem frobenius_eq_self_iff (g : points n A) :
       ∀ i j, ((g : _root_.Matrix.GeneralLinearGroup (Fin ((n + 1) + (n + 1))) A) :
           _root_.Matrix (Fin ((n + 1) + (n + 1))) (Fin ((n + 1) + (n + 1))) A) i j ∈
         frobeniusFixedSubring A p k := by
-  have h := TauCeti.UniversalEnvelopingAlgebra.kostantToralFrobenius_eq_self_iff
-      (rootGenerator n) (cartanGenerator n) (rep n) (lattice n).toAddSubgroup
-      (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice n hu hv)
-      (isNilpotent_rep_rootGenerator n) (latticeBasis n) (basisWeight n) p k A
-      (pointsEquivKostantToralPoints n A g)
-  rw [← pointsEquivKostantToralPoints_frobenius] at h
-  simp only [coe_pointsEquivKostantToralPoints] at h
-  constructor
-  · intro hg
-    exact h.mp (congrArg (pointsEquivKostantToralPoints n A) hg)
-  · intro hg
-    exact (pointsEquivKostantToralPoints n A).injective (h.mpr hg)
+  rw [← SetLike.coe_eq_coe, coe_frobenius,
+    Matrix.GeneralLinearGroup.map_iterateFrobenius_eq_self_iff]
 
 /-- **The Frobenius-fixed points of the full-weight type-`C_(n+1)` carrier are its points over the
 Frobenius-fixed subring.** -/
@@ -254,14 +154,9 @@ theorem map_subtype_fixedSubgroup_frobenius_eq :
       (points n ↥(frobeniusFixedSubring A p k)).map
         (_root_.Matrix.GeneralLinearGroup.map (frobeniusFixedSubring A p k).subtype) := by
   rw [TauCeti.map_subtype_fixedSubgroup_of_coe_eq (frobenius n p k A) _
-    (coe_frobenius n p k A)]
-  rw [points_eq_kostantToralPointsSubgroup, points_eq_kostantToralPointsSubgroup]
-  rw [← TauCeti.UniversalEnvelopingAlgebra.map_subtype_fixedSubgroup_kostantToralFrobenius]
-  exact
-    TauCeti.UniversalEnvelopingAlgebra.map_subtype_fixedSubgroup_kostantToralFrobenius_eq
-      (rootGenerator n) (cartanGenerator n) (rep n) (lattice n).toAddSubgroup
-      (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice n hu hv)
-      (isNilpotent_rep_rootGenerator n) (latticeBasis n) (basisWeight n) p k A
+      (coe_frobenius n p k A),
+    points_def n A, points_def n ↥(frobeniusFixedSubring A p k),
+    TauCeti.GeneralLinear.map_hopfIdealPointsSubgroup_frobeniusFixedSubring]
 
 end
 


### PR DESCRIPTION
refactor(SpStd): define the carrier Frobenius as its functorial point map

The type-`C_(n+1)` standard carrier already proved that its Frobenius endomorphism *is*
the functorial point map at the iterated Frobenius of the value ring:

    theorem frobenius_eq_pointsMap :
        frobenius n p k A = pointsMap n (iterateFrobenius A p k)

but did not use that as the definition. Instead `frobenius` transported
`kostantToralFrobenius` across a `private` presentation equivalence, and every consequence
— the coefficient equations, the root-subgroup and torus equations, the iteration laws,
the fixed-point criterion — was reproved against that presentation rather than read off
the points API. The type-`Bₙ₊₁` spin carrier already does it the short way.

`frobenius` is now `pointsMap n (iterateFrobenius A p k)`, and the four `private` helpers
it needed — `points_eq_kostantToralPointsSubgroup`, `pointsEquivKostantToralPoints`, its
`coe` lemma, and `pointsEquivKostantToralPoints_frobenius` — are gone. Each downstream
proof cites the corresponding `pointsMap` lemma: `coe_pointsMap`,
`pointsMap_rootSubgroupPoints`, `pointsMap_weightTorusPoints`, `pointsMap_id`,
`pointsMap_comp`, and `points_def` for the fixed-point identification. 128 lines out, 27
in; no statement changes.

The two presentations really are interchangeable, which is not obvious beforehand: the
Frobenius file reached the points through `points_eq_kostantToralPointsSubgroup` while the
points API uses `points_def`, but both are derived from `points` by the same
`kostantToralPointsSubgroup_def`.

`frobenius_eq_pointsMap` cannot be `rfl`. The definition is not exposed across the module
boundary, so `rfl` is rejected with "all definitions that need to be unfolded must be
exposed"; the proof is `rw [frobenius]` through the exported equation lemma instead. That
is also why the lemma is worth keeping now that it is true by definition — callers cannot
unfold it themselves, so they need the equation stated, and its docstring now says so.

The module docstring said the construction "specializes the generic Frobenius of a Kostant
toral closure", which is no longer what it does; it now describes the point map.

The import of `…Kostant.RootSubgroup.Scheme.ToralClosure.Frobenius` existed only for
`kostantToralFrobenius` and is replaced by
`TauCeti.Algebra.AlgebraicGroup.Frobenius.GeneralLinear`, which is what the file now uses
and what the type-`Bₙ₊₁` file already imports.

This is the type-`C_(n+1)` half of the same collapse as the type-`A_r` carrier; the
type-`Dₙ` spin carrier follows separately.

The module docstring credits `TauCeti.Algebra.Lie.Orthogonal.TypeB.SpinCarrier.Frobenius`
as the file this follows, so the attribution survives into the library rather than living
only in this description. The template file does the same for its own antecedents.

The coordinatewise units calculation is not recopied: `frobenius_weightTorusPoints` cites
`TauCeti.map_iterateFrobenius_units_eq_pow` from #6438, which extracted that block from the
five files that had carried it. `TauCeti.Algebra.CharP.Frobenius.Basic` is imported for it.

Verified locally: `lake build` (11185 jobs), `lake exe axioms` (112088 declarations,
allowlist clean), `scripts/lint-style.sh`, `scripts/lint-dot-notation.py` (759 total, 0
new).

Roadmap: ReductiveGroups



🤖 Generated with [Claude Code](https://claude.com/claude-code)
