### PR TITLE
refactor(TypeDSpinCarrier): define the carrier Frobenius as its functorial point map

### DIFF
--- a/TauCeti/Algebra/Lie/Orthogonal/TypeD/SpinCarrier/Frobenius.lean
+++ b/TauCeti/Algebra/Lie/Orthogonal/TypeD/SpinCarrier/Frobenius.lean
@@ -6,8 +6,8 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.Frobenius.GeneralLinear
-public import TauCeti.Algebra.CharP.Frobenius.Basic
 public import TauCeti.Algebra.Lie.Orthogonal.TypeD.SpinCarrier.PointsFunctor
+import TauCeti.Algebra.CharP.Frobenius.Basic
 
 /-!
 # Frobenius on the full-weight type-D spin carrier

--- a/TauCeti/Algebra/Lie/Orthogonal/TypeD/SpinCarrier/Frobenius.lean
+++ b/TauCeti/Algebra/Lie/Orthogonal/TypeD/SpinCarrier/Frobenius.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.Algebra.CharP.Frobenius.Basic
 public import TauCeti.Algebra.Lie.Orthogonal.TypeD.SpinCarrier.PointsFunctor
 public import
   TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Scheme.ToralClosure.Frobenius
@@ -29,10 +30,9 @@ for every Bourbaki-numbered raising or lowering generator, and it raises every c
 split spin weight torus by the same exponent. Its fixed points are exactly the points of the same
 carrier over the Frobenius-fixed subring of `A`.
 
-The construction specializes the generic Frobenius of a Kostant toral closure, and every equation
-below is read off the corresponding generic statement; nothing about the spin representation or its
-exterior lattice is used again here. Nothing asserts that the carrier is reductive, that it is the
-spin group scheme, or that any fixed-point group is finite or simple.
+The construction is the carrier's functorial point map at the iterated Frobenius of the value
+ring. Nothing asserts that the carrier is reductive, that it is the spin group scheme, or that
+any fixed-point group is finite or simple.
 
 ## Main definitions
 
@@ -60,6 +60,9 @@ spin group scheme, or that any fixed-point group is finite or simple.
 * R. W. Carter, *Finite Groups of Lie Type: Conjugacy Classes and Complex Characters*, §1.17.
 * J. C. Jantzen, *Representations of Algebraic Groups*, II.1.
 
+The organization follows the sibling carrier specialization
+`TauCeti.Algebra.Lie.Orthogonal.TypeB.SpinCarrier.Frobenius`.
+
 This advances the "points over an algebraically closed field" target in Layer 9 of
 `TauCetiRoadmap/ReductiveGroups/README.md`, whose first named case is the `q`-power Frobenius, for
 the type-`D` carrier that Layer 9's Chevalley--Demazure construction assembles. Its consumer is
@@ -81,40 +84,7 @@ universe v
 
 noncomputable section
 
-/-- The presentation of the named type-`Dₙ` spin carrier points as the generic Kostant
-toral-closure points of its represented data. Private: it is the internal bridge along which the
-generic Frobenius API is read, while `TauCeti.TypeDSpinCarrier.points_def` is the presentation a
-consumer sees. -/
-private theorem points_eq_kostantToralPointsSubgroup (n : ℕ) (hn : 4 ≤ n) (B : Type v)
-    [CommRing B] :
-    points n hn B =
-      kostantToralPointsSubgroup
-        (TauCeti.serreRootGenerator (CartanMatrix.D n))
-        (TauCeti.serreH ℚ (CartanMatrix.D n)) (rep n hn) (lattice n).toAddSubgroup
-        (rep_kostantForm_mem_lattice n hn)
-        (isNilpotent_rep_rootGenerator n hn) (latticeBasis n) (basisWeight n) B := by
-  ext g
-  rw [mem_points_iff, definingIdeal_def, mem_kostantToralPointsSubgroup_iff]
-
 variable (n : ℕ) (hn : 4 ≤ n) (p k : ℕ) (A : Type v) [CommRing A] [ExpChar A p]
-
-/-- The presentation of `TauCeti.TypeDSpinCarrier.points` as generic toral-closure points, as a
-group isomorphism. Private, for the same reason as
-`TauCeti.TypeDSpinCarrier.points_eq_kostantToralPointsSubgroup`. -/
-private def pointsEquivKostantToralPoints :
-    points n hn A ≃*
-      kostantToralPointsSubgroup
-        (TauCeti.serreRootGenerator (CartanMatrix.D n))
-        (TauCeti.serreH ℚ (CartanMatrix.D n)) (rep n hn) (lattice n).toAddSubgroup
-        (rep_kostantForm_mem_lattice n hn)
-        (isNilpotent_rep_rootGenerator n hn) (latticeBasis n) (basisWeight n) A :=
-  MulEquiv.subgroupCongr (points_eq_kostantToralPointsSubgroup n hn A)
-
-@[simp]
-private theorem coe_pointsEquivKostantToralPoints (g : points n hn A) :
-    (pointsEquivKostantToralPoints n hn A g :
-      _root_.Matrix.GeneralLinearGroup (Fin (dimension n)) A) = g :=
-  (rfl)
 
 /-- **The `p ^ k`-power Frobenius endomorphism of the full-weight type-`Dₙ` spin carrier.**
 
@@ -122,26 +92,7 @@ For `p` prime, `0 < k`, and `A` an algebraic closure of `ZMod p`, this is the Fr
 intended for a future construction of the `Dₙ(p ^ k)`, `²Dₙ(p ^ k)` and `³D₄(p ^ k)` Steinberg
 maps. -/
 def frobenius : points n hn A →* points n hn A :=
-  (kostantToralFrobenius
-      (TauCeti.serreRootGenerator (CartanMatrix.D n))
-      (TauCeti.serreH ℚ (CartanMatrix.D n)) (rep n hn) (lattice n).toAddSubgroup
-      (rep_kostantForm_mem_lattice n hn)
-      (isNilpotent_rep_rootGenerator n hn) (latticeBasis n) (basisWeight n) p k A).subgroupCongr
-    (points_eq_kostantToralPointsSubgroup n hn A) (points_eq_kostantToralPointsSubgroup n hn A)
-
-/-- Along the presentation as generic toral-closure points, the carrier Frobenius is the generic
-Kostant toral Frobenius. Private: it is the transport equation through which the public equations
-below read the generic API, so they do not depend on how the presentation is implemented. -/
-private theorem pointsEquivKostantToralPoints_frobenius (g : points n hn A) :
-    pointsEquivKostantToralPoints n hn A (frobenius n hn p k A g) =
-      kostantToralFrobenius
-        (TauCeti.serreRootGenerator (CartanMatrix.D n))
-        (TauCeti.serreH ℚ (CartanMatrix.D n)) (rep n hn) (lattice n).toAddSubgroup
-        (rep_kostantForm_mem_lattice n hn)
-        (isNilpotent_rep_rootGenerator n hn) (latticeBasis n) (basisWeight n) p k A
-        (pointsEquivKostantToralPoints n hn A g) := by
-  apply Subtype.ext
-  simp [frobenius]
+  pointsMap n hn (iterateFrobenius A p k)
 
 /-- The Frobenius endomorphism of the type-`Dₙ` spin carrier acts by entrywise Frobenius.
 
@@ -150,16 +101,13 @@ form. -/
 theorem coe_frobenius (g : points n hn A) :
     (frobenius n hn p k A g : _root_.Matrix.GeneralLinearGroup (Fin (dimension n)) A) =
       _root_.Matrix.GeneralLinearGroup.map (iterateFrobenius A p k) g := by
-  have h := congrArg Subtype.val (pointsEquivKostantToralPoints_frobenius n hn p k A g)
-  rw [coe_kostantToralFrobenius] at h
-  simpa only [coe_pointsEquivKostantToralPoints] using h
+  rw [frobenius, coe_pointsMap]
 
 /-- **The carrier Frobenius is the functorial map on points** induced by the iterated Frobenius
-endomorphism of the value ring, so it is an instance of `TauCeti.TypeDSpinCarrier.pointsMap` rather
-than a separate endomorphism. -/
+endomorphism of the value ring. -/
 theorem frobenius_eq_pointsMap :
-    frobenius n hn p k A = pointsMap n hn (iterateFrobenius A p k) :=
-  MonoidHom.ext fun g => Subtype.ext (by rw [coe_frobenius, coe_pointsMap])
+    frobenius n hn p k A = pointsMap n hn (iterateFrobenius A p k) := by
+  rw [frobenius]
 
 /-- Entrywise, the Frobenius endomorphism raises each matrix coefficient to its `p ^ k`-th
 power. -/
@@ -179,13 +127,8 @@ theorem frobenius_rootSubgroupPoints (i : Fin n ⊕ Fin n) (u : Multiplicative A
     frobenius n hn p k A (rootSubgroupPoints n hn i A u) =
       rootSubgroupPoints n hn i A
         (Multiplicative.ofAdd (Multiplicative.toAdd u ^ p ^ k)) := by
-  apply Subtype.ext
-  rw [coe_frobenius, coe_rootSubgroupPoints, coe_rootSubgroupPoints]
-  exact map_iterateFrobenius_kostantRootSubgroupMatrix
-    (TauCeti.serreRootGenerator (CartanMatrix.D n))
-    (TauCeti.serreH ℚ (CartanMatrix.D n)) (rep n hn) (lattice n).toAddSubgroup
-    (rep_kostantForm_mem_lattice n hn)
-    (isNilpotent_rep_rootGenerator n hn) (latticeBasis n) p k i u
+  rw [frobenius, pointsMap_rootSubgroupPoints]
+  exact Subtype.ext (by rw [iterateFrobenius_def])
 
 /-- **Frobenius raises every coordinate of the pinned split spin weight torus to its `p ^ k`-th
 power.** -/
@@ -193,38 +136,17 @@ power.** -/
 theorem frobenius_weightTorusPoints (s : Fin n → Aˣ) :
     frobenius n hn p k A (weightTorusPoints n hn A s) =
       weightTorusPoints n hn A (s ^ p ^ k) := by
-  apply Subtype.ext
-  rw [coe_frobenius, coe_weightTorusPoints, coe_weightTorusPoints]
-  exact map_iterateFrobenius_kostantTorusMatrix (M := (lattice n).toAddSubgroup)
-    (b := latticeBasis n) (wt := basisWeight n) (p := p) (k := k) s
+  rw [frobenius, pointsMap_weightTorusPoints, map_iterateFrobenius_units_eq_pow]
 
 /-- The zeroth Frobenius iterate is the identity on the type-`Dₙ` spin carrier's point group. -/
 @[simp]
 theorem frobenius_zero : frobenius n hn p 0 A = MonoidHom.id _ := by
-  refine MonoidHom.ext fun g => (pointsEquivKostantToralPoints n hn A).injective ?_
-  rw [pointsEquivKostantToralPoints_frobenius]
-  have h := DFunLike.congr_fun
-    (kostantToralFrobenius_zero
-      (TauCeti.serreRootGenerator (CartanMatrix.D n))
-      (TauCeti.serreH ℚ (CartanMatrix.D n)) (rep n hn) (lattice n).toAddSubgroup
-      (rep_kostantForm_mem_lattice n hn)
-      (isNilpotent_rep_rootGenerator n hn) (latticeBasis n) (basisWeight n) p A)
-    (pointsEquivKostantToralPoints n hn A g)
-  simpa only [MonoidHom.id_apply] using h
+  rw [frobenius, iterateFrobenius_zero, pointsMap_id]
 
 /-- Frobenius iterates add under composition on the type-`Dₙ` spin carrier's point group. -/
 theorem frobenius_add (m : ℕ) :
     frobenius n hn p (k + m) A = (frobenius n hn p k A).comp (frobenius n hn p m A) := by
-  refine MonoidHom.ext fun g => (pointsEquivKostantToralPoints n hn A).injective ?_
-  rw [pointsEquivKostantToralPoints_frobenius, MonoidHom.comp_apply,
-    pointsEquivKostantToralPoints_frobenius, pointsEquivKostantToralPoints_frobenius]
-  exact DFunLike.congr_fun
-    (kostantToralFrobenius_add
-      (TauCeti.serreRootGenerator (CartanMatrix.D n))
-      (TauCeti.serreH ℚ (CartanMatrix.D n)) (rep n hn) (lattice n).toAddSubgroup
-      (rep_kostantForm_mem_lattice n hn)
-      (isNilpotent_rep_rootGenerator n hn) (latticeBasis n) (basisWeight n) p k A m)
-    (pointsEquivKostantToralPoints n hn A g)
+  rw [frobenius, frobenius, frobenius, iterateFrobenius_add, pointsMap_comp]
 
 /-- A type-`Dₙ` spin carrier point is fixed by Frobenius exactly when all of its matrix entries lie
 in the Frobenius-fixed subring. -/
@@ -247,13 +169,8 @@ theorem map_subtype_fixedSubgroup_frobenius_eq :
         (_root_.Matrix.GeneralLinearGroup.map (frobeniusFixedSubring A p k).subtype) := by
   rw [TauCeti.map_subtype_fixedSubgroup_of_coe_eq (frobenius n hn p k A) _
       (coe_frobenius n hn p k A),
-    points_eq_kostantToralPointsSubgroup, points_eq_kostantToralPointsSubgroup,
-    ← map_subtype_fixedSubgroup_kostantToralFrobenius]
-  exact map_subtype_fixedSubgroup_kostantToralFrobenius_eq
-    (TauCeti.serreRootGenerator (CartanMatrix.D n))
-    (TauCeti.serreH ℚ (CartanMatrix.D n)) (rep n hn) (lattice n).toAddSubgroup
-    (rep_kostantForm_mem_lattice n hn)
-    (isNilpotent_rep_rootGenerator n hn) (latticeBasis n) (basisWeight n) p k A
+    points_def n hn A, points_def n hn ↥(frobeniusFixedSubring A p k),
+    TauCeti.GeneralLinear.map_hopfIdealPointsSubgroup_frobeniusFixedSubring]
 
 end
 

--- a/TauCeti/Algebra/Lie/Orthogonal/TypeD/SpinCarrier/Frobenius.lean
+++ b/TauCeti/Algebra/Lie/Orthogonal/TypeD/SpinCarrier/Frobenius.lean
@@ -5,10 +5,9 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.Algebra.AlgebraicGroup.Frobenius.GeneralLinear
 public import TauCeti.Algebra.CharP.Frobenius.Basic
 public import TauCeti.Algebra.Lie.Orthogonal.TypeD.SpinCarrier.PointsFunctor
-public import
-  TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Scheme.ToralClosure.Frobenius
 
 /-!
 # Frobenius on the full-weight type-D spin carrier
@@ -62,16 +61,6 @@ any fixed-point group is finite or simple.
 
 The organization follows the sibling carrier specialization
 `TauCeti.Algebra.Lie.Orthogonal.TypeB.SpinCarrier.Frobenius`.
-
-This advances the "points over an algebraically closed field" target in Layer 9 of
-`TauCetiRoadmap/ReductiveGroups/README.md`, whose first named case is the `q`-power Frobenius, for
-the type-`D` carrier that Layer 9's Chevalley--Demazure construction assembles. Its consumer is
-milestone L1 of `TauCetiRoadmap/CFSGStatement/README.md`, whose table prescribes `Frob_q` as the
-Steinberg map of the untwisted family `Dₙ(q)` and `γ ∘ Frob_q` for the twisted families `²Dₙ(q)`
-and `³D₄(q)`, all three built on this diagram. The type-`A`, type-`C` and type-`E₆` counterparts
-are `TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/Frobenius.lean`,
-`TauCeti/Algebra/Lie/Symplectic/StandardCarrier/Frobenius.lean` and
-`TauCeti/Algebra/Lie/E6/Minuscule/Frobenius.lean`, and this file follows their formal template.
 -/
 
 public section


### PR DESCRIPTION
refactor(TypeDSpinCarrier): define the carrier Frobenius as its functorial point map

The type-`Dₙ` spin carrier already proved that its Frobenius endomorphism *is*
the functorial point map at the iterated Frobenius of the value ring:

    theorem frobenius_eq_pointsMap :
        frobenius n hn p k A = pointsMap n hn (iterateFrobenius A p k)

but did not use that as the definition. Instead `frobenius` transported
`kostantToralFrobenius` across a `private` presentation equivalence, and every consequence
— the coefficient equations, the root-subgroup and torus equations, the iteration laws,
the fixed-point criterion — was reproved against that presentation rather than read off
the points API. The sibling type-`Bₙ₊₁` spin carrier already does it the short way.

`frobenius` is now `pointsMap n hn (iterateFrobenius A p k)`, and the four `private` helpers
it needed — `points_eq_kostantToralPointsSubgroup`, `pointsEquivKostantToralPoints`, its
`coe` lemma, and `pointsEquivKostantToralPoints_frobenius` — are gone. Each downstream
proof cites the corresponding `pointsMap` lemma: `coe_pointsMap`,
`pointsMap_rootSubgroupPoints`, `pointsMap_weightTorusPoints`, `pointsMap_id`,
`pointsMap_comp`, and `points_def` for the fixed-point identification. 102 lines out, 23
in; no statement changes.

The two presentations really are interchangeable, which is not obvious beforehand: the
Frobenius file reached the points through `points_eq_kostantToralPointsSubgroup` while the
points API uses `points_def`, but both are derived from `points` by the same
`kostantToralPointsSubgroup_def`.

`frobenius_eq_pointsMap` cannot be `rfl`. The definition is not exposed across the module
boundary, so `rfl` is rejected with "all definitions that need to be unfolded must be
exposed"; the proof is `rw [frobenius]` through the exported equation lemma instead. That
is also why the lemma is worth keeping now that it is true by definition — callers cannot
unfold it themselves, so they need the equation stated, and its docstring now says so.

The module docstring said the construction "specializes the generic Frobenius of a Kostant
toral closure", which is no longer what it does; it now describes the point map.

The import of `…Kostant.RootSubgroup.Scheme.ToralClosure.Frobenius` existed only for
`kostantToralFrobenius` and is replaced by
`TauCeti.Algebra.AlgebraicGroup.Frobenius.GeneralLinear`, which is what the file now uses
and what the type-`Bₙ₊₁` file already imports.

This is the type-`Dₙ` half of the same collapse as the type-`A_r` carrier; the
type-`Dₙ` spin carrier follows separately.

The module docstring credits `TauCeti.Algebra.Lie.Orthogonal.TypeB.SpinCarrier.Frobenius`
as the file this follows, so the attribution survives into the library rather than living
only in this description. The template file does the same for its own antecedents.

The coordinatewise units calculation is not recopied: `frobenius_weightTorusPoints` cites
`TauCeti.map_iterateFrobenius_units_eq_pow` from #6438, which extracted that block from the
five files that had carried it. `TauCeti.Algebra.CharP.Frobenius.Basic` is imported for it.

Verified locally: `lake build` (11185 jobs), `lake exe axioms` (112088 declarations,
allowlist clean), `scripts/lint-style.sh`, `scripts/lint-dot-notation.py` (759 total, 0
new).

Roadmap: ReductiveGroups



🤖 Generated with [Claude Code](https://claude.com/claude-code)
