### PR TITLE
feat(Isogeny): the degree scales quadratically

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Hom/Add.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Hom/Add.lean
@@ -31,6 +31,8 @@ this bijection additive; the zero and the negation are those the carrier already
 
 * `TauCeti.Isogeny.Hom.tautologicalPoint`: the tautological point of a morphism.
 * `TauCeti.Isogeny.Hom.polePointsAddEquiv`: `Hom W₁ W₂ ≃+ polePoints W₂ (Place.infinity W₁)`.
+* `TauCeti.Isogeny.Hom.compRightHom`: precomposition by a morphism, as an additive homomorphism;
+  `zsmul_comp` and `nsmul_comp` are its `map_zsmul` and `map_nsmul`.
 * The `AddCommGroup (Hom W₁ W₂)` instance.
 
 ## Main results
@@ -290,6 +292,32 @@ omit [W₂.IsElliptic] in
 theorem sub_comp [W₃.IsElliptic] (g g' : Hom W₂ W₃) (f : Hom W₁ W₂) :
     (g - g').comp f = g.comp f - g'.comp f := by
   rw [sub_eq_add_neg, add_comp, neg_comp, sub_eq_add_neg]
+
+omit [W₂.IsElliptic] in
+/-- **Precomposition by `f`, as a homomorphism of the additive groups of morphisms.** -/
+noncomputable def compRightHom [W₃.IsElliptic] (f : Hom W₁ W₂) : Hom W₂ W₃ →+ Hom W₁ W₃ where
+  toFun g := g.comp f
+  map_zero' := zero_comp f
+  map_add' g g' := add_comp g g' f
+
+omit [W₂.IsElliptic] in
+@[simp]
+theorem compRightHom_apply [W₃.IsElliptic] (f : Hom W₁ W₂) (g : Hom W₂ W₃) :
+    compRightHom f g = g.comp f := (rfl)
+
+omit [W₂.IsElliptic] in
+/-- **Composition is `ℤ`-linear in the outer morphism.** -/
+@[simp]
+theorem zsmul_comp [W₃.IsElliptic] (n : ℤ) (g : Hom W₂ W₃) (f : Hom W₁ W₂) :
+    (n • g).comp f = n • g.comp f :=
+  (compRightHom (W₃ := W₃) f).map_zsmul n g
+
+omit [W₂.IsElliptic] in
+/-- **Composition is `ℕ`-linear in the outer morphism**, the rule for a natural scalar. -/
+@[simp]
+theorem nsmul_comp [W₃.IsElliptic] (n : ℕ) (g : Hom W₂ W₃) (f : Hom W₁ W₂) :
+    (n • g).comp f = n • g.comp f :=
+  (compRightHom (W₃ := W₃) f).map_nsmul n g
 
 end Hom
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/MulByInt/Hom.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/MulByInt/Hom.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.Hom.Add
 import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.Hom.Differential
+import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.MulByInt.Degree
 public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.MulByInt.MapsInfinity
 
 /-!
@@ -16,15 +17,25 @@ public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.MulByInt.MapsInfin
 tautological points; this file says the two agree, so that results about the additive structure
 apply to `[n]` and results about `[n]` are available additively.
 
+Read additively, the degree of `[n]` says that the degree **scales quadratically**,
+`deg (n • f) = n² · deg f`, for every morphism and not just for a multiplication: that is the
+homogeneity half of the statement that the degree is a quadratic form on `Hom W₁ W₂`, the form
+whose non-negativity gives the Hasse bound. The other half, that the associated pairing is
+additive, is not proved here.
+
 ## Main results
 
 * `TauCeti.Isogeny.ofIsogeny_mulByIntIsogeny`: `[n] = n • id` in `Hom W W`.
 * `TauCeti.Isogeny.isSeparable_mulByIntIsogeny_iff`: `[n]` is separable exactly when `n` is
   nonzero in the base field.
+* `TauCeti.Isogeny.Hom.degree_zsmul` and `TauCeti.Isogeny.Hom.degree_nsmul`:
+  `deg (n • f) = n² · deg f`, the degree's homogeneity, for an integer and a natural scalar.
 
 ## References
 
-* [J. Silverman, *The Arithmetic of Elliptic Curves*][silverman2009], III.4.
+* [J. Silverman, *The Arithmetic of Elliptic Curves*][silverman2009], III.4 for the identification
+  of `[n]` with `n • id`, III.6 for the degree as a quadratic form, of which `Hom.degree_zsmul` is
+  the homogeneity.
 -/
 
 public section
@@ -51,6 +62,30 @@ theorem isSeparable_mulByIntIsogeny_iff [W.IsElliptic] {n : ℤ} (hn : psiFuncti
   rw [isSeparable_iff_pullbackDifferential_ne_zero, ← Hom.pullbackDifferential_ofIsogeny,
     ofIsogeny_mulByIntIsogeny, Hom.pullbackDifferential_zsmul_id_invariantDifferential, ne_eq,
     zsmul_invariantDifferential_eq_zero_iff]
+variable {W₁ W₂ : WeierstrassCurve.Affine F}
+
+/-- **The degree scales quadratically**: `deg (n • f) = n² · deg f`.
+
+This is the homogeneity half of the degree being a quadratic form on `Hom W₁ W₂`. It holds with no
+hypothesis on `n` or `f`: at `n = 0` and at `f = 0` both sides are `0`, which is what the value
+`Hom.degree 0 = 0` is stipulated for. -/
+@[simp]
+theorem Hom.degree_zsmul [W₂.IsElliptic] (n : ℤ) (f : Hom W₁ W₂) :
+    (n • f).degree = n.natAbs ^ 2 * f.degree := by
+  have hcomp : n • f = (n • Hom.id W₂).comp f := by rw [Hom.zsmul_comp, Hom.id_comp]
+  have hid : (n • Hom.id W₂).degree = n.natAbs ^ 2 := by
+    rcases eq_or_ne n 0 with rfl | hn
+    · rw [zero_smul, Hom.degree_zero, Int.natAbs_zero, Nat.zero_pow two_pos]
+    · rw [← ofIsogeny_mulByIntIsogeny W₂
+        (psiFunctionField_ne_zero_of_Δ_ne_zero W₂ W₂.isUnit_Δ.ne_zero hn),
+        Hom.degree_ofIsogeny, degree_mulByIntIsogeny]
+  rw [hcomp, Hom.degree_comp, hid]
+
+/-- **The degree scales quadratically for a natural multiple**: `deg (n • f) = n² · deg f`. -/
+@[simp]
+theorem Hom.degree_nsmul [W₂.IsElliptic] (n : ℕ) (f : Hom W₁ W₂) :
+    (n • f).degree = n ^ 2 * f.degree := by
+  rw [← natCast_zsmul f n, Hom.degree_zsmul, Int.natAbs_natCast]
 
 end TauCeti.Isogeny
 


### PR DESCRIPTION
Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"EllipticCurves/README.md:layer1:degree-form"}-->

Provenance: no port. AINTLIB reaches the degree form through the Weil pairing and `det(φ|E[ℓ]) ≡ deg φ (mod ℓ)`; it has no additive `Hom`, so there is no homogeneity statement there to port. The proof here is Silverman III.6 read through TauCeti's own `Hom` carrier.

## What this adds

- `Isogeny.Hom.zsmul_comp` — **composition is `ℤ`-linear in the outer morphism**: `(n • g) ∘ f = n • (g ∘ f)`. Added next to the `add_comp`/`sub_comp` already in `Hom/Add.lean`, and `@[simp]` as they are. `nsmul_comp` is the natural-scalar rule, a different operation and so a separate lemma.
- `Isogeny.Hom.degree_zsmul` — **the degree scales quadratically**: `deg (n • f) = n² · deg f`; `degree_nsmul` likewise for a natural scalar.

## Why

`deg` is the quadratic form whose non-negativity gives the Hasse bound, and `deg (n • f) = n² · deg f` is its **homogeneity**. Nothing in the repository yet records that the degree is quadratic rather than linear in a morphism; this is the first statement that does. The other half of the quadratic-form property — additivity of `⟨f, g⟩ = deg (f + g) − deg f − deg g` — is not proved here, and is the remaining gap between the lane and `deg (rπ − s) = qr² − trs + s²`.

## The argument

`deg [n] = n²` is already on `main` (`degree_mulByIntIsogeny`, from the division-polynomial tower), and so is the bridge that lets it be read additively: `[n] = n • id` (`ofIsogeny_mulByIntIsogeny`, merged in #6455). Then

- `zsmul_comp` gives `n • f = (n • id) ∘ f`, by induction on `n` from `add_comp` and `sub_comp`;
- `degree_comp` turns that into `deg (n • id) · deg f`;
- `[n] = n • id` plus `deg [n] = n²` evaluates the first factor.

It holds unconditionally: at `n = 0` and at `f = 0` both sides are `0`, which is what the stipulation `Hom.degree 0 = 0` is for. The `n ≠ 0` side-condition of the division-polynomial construction is discharged with `psiFunctionField_ne_zero_of_Δ_ne_zero` against `IsElliptic`.

## Placement

`zsmul_comp` sits with the other composition-additivity lemmas in `Hom/Add.lean`. `degree_zsmul` sits in `MulByInt/Hom.lean`, the file #6455 introduced for exactly this traffic — its stated purpose is that "results about `[n]` are available additively", and the degree is the first one to cross. The import of `MulByInt/Degree` it needs is private: `degree_mulByIntIsogeny` appears only in the proof.

## Scope

This branch now sits **directly on `main`** and carries only the degree topic: two files, `zsmul_comp`/`nsmul_comp` and `degree_zsmul`/`degree_nsmul`. It was previously stacked on #6465 (behind #6464 and #6453), so its diff against `main` also showed those PRs' invariant-differential and separability work, which `scope` blocked as a second topic. Every declaration `degree_zsmul` uses — `ofIsogeny_mulByIntIsogeny`, `degree_mulByIntIsogeny`, `Hom.degree_comp`, `Hom.degree_ofIsogeny`, `Hom.degree_zero` — is already on `main`, so nothing was lost by unstacking; the separability results are not used here at all and stay in #6464/#6465 where they belong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
