### PR TITLE
feat(Isogeny): [n] is separable exactly when n is nonzero in the base field

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/InvariantDifferential.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/InvariantDifferential.lean
@@ -27,6 +27,8 @@ by `W_Y⁻¹` gives the invariant-differential basis.
 * `WeierstrassCurve.Affine.invariantDifferential`: the invariant differential `ω`, as an
   element of `Ω[K(E)/F]`.
 * `WeierstrassCurve.Affine.invariantDifferentialBasis`: `ω` as a basis of `Ω[K(E)/F]`.
+* `WeierstrassCurve.Affine.zsmul_invariantDifferential_eq_zero_iff`: an integer multiple of `ω`
+  vanishes exactly when the integer does in the base field.
 
 ## Main results
 
@@ -163,5 +165,14 @@ theorem existsUnique_smul_invariantDifferential [E.IsElliptic]
   rcases smul_eq_zero.mp h with h' | h'
   · exact sub_eq_zero.mp h'
   · exact absurd h' (invariantDifferential_ne_zero E)
+
+/-- **An integer multiple of `ω` vanishes exactly when the integer does in the base field.** -/
+@[simp]
+theorem zsmul_invariantDifferential_eq_zero_iff [E.IsElliptic] (n : ℤ) :
+    n • invariantDifferential E = 0 ↔ (n : F) = 0 := by
+  rw [← Int.cast_smul_eq_zsmul E.FunctionField n (invariantDifferential E),
+    smul_eq_zero, or_iff_left (invariantDifferential_ne_zero E)]
+  rw [← map_intCast (algebraMap F E.FunctionField) n]
+  exact map_eq_zero_iff _ (algebraMap F E.FunctionField).injective
 
 end WeierstrassCurve.Affine

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Hom/Differential.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Hom/Differential.lean
@@ -33,6 +33,8 @@ over a finite field, `TauCeti.Isogeny.isSeparable_oneSubFrobeniusIsogeny`:
 * `TauCeti.Isogeny.Hom.pullbackDifferential_add_invariantDifferential`: `(f + g)^*ω = f^*ω + g^*ω`.
 * `TauCeti.Isogeny.Hom.pullbackDifferential_neg_invariantDifferential`: `(-f)^*ω = -f^*ω`.
 * `TauCeti.Isogeny.Hom.pullbackDifferential_sub_invariantDifferential`: `(f - g)^*ω = f^*ω - g^*ω`.
+* `TauCeti.Isogeny.Hom.pullbackDifferential_zsmul_invariantDifferential`: `(n • f)^*ω = n • f^*ω`.
+* `TauCeti.Isogeny.Hom.pullbackDifferential_zsmul_id_invariantDifferential`: `[n]^*ω = n • ω`.
 * `TauCeti.Isogeny.Hom.pullbackDifferential_id` and `pullbackDifferential_comp`: the pullback is
   functorial in the morphism.
 
@@ -152,6 +154,32 @@ theorem pullbackDifferential_sub_invariantDifferential (f g : Hom W₁ W₂) :
         g.pullbackDifferential (invariantDifferential W₂) := by
   rw [sub_eq_add_neg, pullbackDifferential_add_invariantDifferential,
     pullbackDifferential_neg_invariantDifferential, sub_eq_add_neg]
+
+/-- **The pullback of `ω` scales with an integer multiple of a morphism**:
+`(n • f)^*ω = n • f^*ω`. -/
+@[simp]
+theorem pullbackDifferential_zsmul_invariantDifferential (f : Hom W₁ W₂) (n : ℤ) :
+    (n • f).pullbackDifferential (invariantDifferential W₂) =
+      n • f.pullbackDifferential (invariantDifferential W₂) := by
+  induction n using Int.induction_on with
+  | zero => simp [pullbackDifferential_zero]
+  | succ k ih =>
+    rw [add_smul, one_smul, pullbackDifferential_add_invariantDifferential, ih, add_smul, one_smul]
+  | pred k ih =>
+    rw [sub_smul, one_smul, pullbackDifferential_sub_invariantDifferential, ih, sub_smul, one_smul]
+
+/-- **`[n]^*ω = n • ω`** (Silverman III.5.4): the invariant differential pulls back along
+multiplication by `n` with the factor `n`. -/
+-- Not `@[simp]`, unlike the two scaling rules above: they are what reduce this left-hand side, so
+-- `simp` already closes this goal with
+-- `simp only [pullbackDifferential_zsmul_invariantDifferential, pullbackDifferential_id,
+-- LinearMap.id_coe, id_eq]`, and `simpNF` rejects a rule whose left-hand side is not normal.
+theorem pullbackDifferential_zsmul_id_invariantDifferential (W : WeierstrassCurve.Affine F)
+    [W.IsElliptic] (n : ℤ) :
+    (n • Hom.id W).pullbackDifferential (invariantDifferential W) =
+      n • invariantDifferential W := by
+  rw [pullbackDifferential_zsmul_invariantDifferential, pullbackDifferential_id,
+    LinearMap.id_apply]
 
 end Hom
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/MulByInt/Hom.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/MulByInt/Hom.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.Hom.Add
+import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.Hom.Differential
 public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.MulByInt.MapsInfinity
 
 /-!
@@ -18,6 +19,8 @@ apply to `[n]` and results about `[n]` are available additively.
 ## Main results
 
 * `TauCeti.Isogeny.ofIsogeny_mulByIntIsogeny`: `[n] = n • id` in `Hom W W`.
+* `TauCeti.Isogeny.isSeparable_mulByIntIsogeny_iff`: `[n]` is separable exactly when `n` is
+  nonzero in the base field.
 
 ## References
 
@@ -39,6 +42,15 @@ theorem ofIsogeny_mulByIntIsogeny [W.IsElliptic] {n : ℤ} (hn : psiFunctionFiel
     Hom.ofIsogeny (mulByIntIsogeny W hn) = n • Hom.id W := by
   refine Hom.ext_tautologicalPoint ?_
   simp [Hom.id_def, mulByIntIsogeny_pullback, tautologicalPoint_mulByIntPullback]
+
+/-- **`[n]` is separable exactly when `n` is nonzero in the base field** (Silverman III.5.4). -/
+@[simp]
+theorem isSeparable_mulByIntIsogeny_iff [W.IsElliptic] {n : ℤ} (hn : psiFunctionField W n ≠ 0) :
+    Algebra.IsSeparable (mulByIntIsogeny W hn).fieldPullback.fieldRange W.FunctionField ↔
+      (n : F) ≠ 0 := by
+  rw [isSeparable_iff_pullbackDifferential_ne_zero, ← Hom.pullbackDifferential_ofIsogeny,
+    ofIsogeny_mulByIntIsogeny, Hom.pullbackDifferential_zsmul_id_invariantDifferential, ne_eq,
+    zsmul_invariantDifferential_eq_zero_iff]
 
 end TauCeti.Isogeny
 


### PR DESCRIPTION
Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"EllipticCurves/README.md:layer1:mulbyint-separable"}-->


Replaces #6456, which queue housekeeping closed as a duplicate roadmap target: it shared the `layer1:mulbyint` id with #6455 because I copied that id rather than giving this result its own. The id is corrected here and the content is unchanged apart from the `nsmul` rule #6453 gained this round. #6456 had reached ten green rubrics; GitHub refuses to reopen it because the branch was force-pushed after it closed.


Provenance: no port. AINTLIB assumes the differential criterion for separability as a hypothesis rather than proving it, so there is nothing to port here; TauCeti proves it (`isSeparable_iff_pullbackDifferential_ne_zero`, on `main` since #6299).

Stacked on #6453 (`[n]^*ω = n • ω`) and #6455 (`[n] = n • id`); both are needed and neither has a consumer without this, so the three go together.

## What this adds

- `WeierstrassCurve.Affine.zsmul_invariantDifferential_eq_zero_iff`: `n • ω = 0 ↔ (n : F) = 0`.
- `Isogeny.isSeparable_mulByIntIsogeny_iff`: **`[n]` is separable exactly when `(n : F) ≠ 0`** — Silverman III.5.4.

## The argument

`isSeparable_iff_pullbackDifferential_ne_zero` turns separability of `[n]` into `[n]^*ω ≠ 0`. Rewriting `[n]` as `n • id` (#6455) and using `(n • f)^*ω = n • f^*ω` with `pullbackDifferential_id` (#6453) makes that `n • ω ≠ 0`. Since `ω` is a basis of `Ω[K(E)/F]` over the function field, `n • ω = 0` exactly when `(n : K(E)) = 0`, and `algebraMap F K(E)` is injective, so exactly when `(n : F) = 0`.

In characteristic zero this says every `[n]` with `n ≠ 0` is separable; in characteristic `p` it says `[n]` is separable exactly when `p ∤ n`, which is the statement the reduction theory uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

