### PR TITLE
feat(Isogeny): the kernel of [n] is the n-torsion

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Kernel.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Kernel.lean
@@ -7,6 +7,8 @@ module
 
 public import TauCeti.AlgebraicGeometry.EllipticCurve.Affine.FunctionField.Translation.FixedField
 public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.Separability
+-- Public: `mem_ker_iff_map_tautologicalPoint_eq` names the tautological point in its statement.
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.TautologicalPoint
 
 /-!
 # The kernel of an isogeny
@@ -31,6 +33,8 @@ is proved here.
 
 ## Main results
 
+* `TauCeti.Isogeny.mem_ker_iff_map_tautologicalPoint_eq`: membership is fixing the pullback's
+  tautological point.
 * `TauCeti.Isogeny.card_ker_le_degree`: the kernel has at most `deg φ` elements.
 * `TauCeti.Isogeny.ker_le_ker_comp`: postcomposition can only enlarge the kernel.
 * `TauCeti.Isogeny.ker_eq_bot_of_separableDegree_eq_one`: separable degree one forces this kernel
@@ -80,6 +84,32 @@ itself.** -/
 theorem mem_ker_iff {φ : Isogeny W₁ W₂} {P : (W₁⁄F).toAffine.Point} :
     P ∈ φ.ker ↔ ∀ z ∈ φ.fieldPullback.fieldRange, translation W₁ P z = z := by
   rw [ker_def]; exact mem_translationFixingSubgroup_iff W₁
+
+/-- **Membership in the kernel is fixing the tautological point.** A translation fixes every
+pulled-back function exactly when it fixes the coordinate pullback, and a coordinate pullback is
+determined by its tautological point, so the kernel is read off that point alone. -/
+theorem mem_ker_iff_map_tautologicalPoint_eq [W₂.IsElliptic] (φ : Isogeny W₁ W₂)
+    {P : (W₁⁄F).toAffine.Point} :
+    P ∈ φ.ker ↔
+      Point.map (translation W₁ P).toAlgHom (CoordinatePullback.tautologicalPoint φ.pullback) =
+        CoordinatePullback.tautologicalPoint φ.pullback := by
+  rw [mem_ker_iff]
+  constructor
+  · intro h
+    rw [← CoordinatePullback.tautologicalPoint_comp]
+    refine congrArg _ ?_
+    refine CoordinateRing.algHom_ext ?_ ?_ <;>
+      · rw [AlgHom.comp_apply]
+        exact h _ ⟨_, fieldPullback_algebraMap _ _⟩
+  · intro h
+    have hcoord : (translation W₁ P).toAlgHom.comp φ.pullback = φ.pullback :=
+      CoordinatePullback.tautologicalPoint_injective
+        (by rw [CoordinatePullback.tautologicalPoint_comp, h])
+    have hfield : (translation W₁ P).toAlgHom.comp φ.fieldPullback = φ.fieldPullback :=
+      fieldPullback_unique _ _ fun x ↦ by
+        rw [AlgHom.comp_apply, fieldPullback_algebraMap, ← AlgHom.comp_apply, hcoord]
+    rintro _ ⟨z, rfl⟩
+    simpa using DFunLike.congr_fun hfield z
 
 /-- **The kernel is finite**, the pulled-back field being of finite index. -/
 instance finite_ker (φ : Isogeny W₁ W₂) : Finite φ.ker :=

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/MulByInt/Kernel.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/MulByInt/Kernel.lean
@@ -1,0 +1,86 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.Kernel
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.MulByInt.MapsInfinity
+
+/-!
+# The kernel of multiplication by `n` is the `n`-torsion
+
+An isogeny in this development has no point map, so its kernel is the subgroup of points whose
+translation fixes the pulled-back field (`Isogeny.ker`). For `[n]` that subgroup is the one the
+classical statement names: the `n`-torsion of `W` over the base field.
+
+`[n]` is an isogeny only where the division polynomial does not vanish, so the statement carries
+`psiFunctionField W n ≠ 0` — the same hypothesis `mulByIntIsogeny` is built from, and not a
+restriction beyond it. On an elliptic curve it holds for every `n ≠ 0`, by
+`psiFunctionField_ne_zero_of_Δ_ne_zero`.
+
+The bridge is the tautological point. A coordinate pullback is determined by it, that of `[n]` is
+`n` times the generic point, and translating by `P` moves the generic point to `g + P`. So the
+translation fixes `[n]` exactly when `n • (g + P) = n • g`, which is `n • P = 0`.
+
+Only the base field's points appear, as everywhere in `Isogeny.ker`: this is the rational
+`n`-torsion, not the geometric one, and the two differ unless the base field carries the whole
+kernel.
+
+## Main results
+
+* `TauCeti.Isogeny.mem_ker_mulByIntIsogeny_iff`: `P ∈ ker [n] ↔ n • P = 0`, for an `n` whose
+  division polynomial does not vanish, and
+  `TauCeti.Isogeny.mem_ker_mulByIntIsogenyOfNeZero_iff`, the same at the `n ≠ 0` the elliptic case
+  discharges it from.
+
+## References
+
+* [J. Silverman, *The Arithmetic of Elliptic Curves*][silverman2009], III.4 and III.6.
+-/
+
+public section
+
+namespace TauCeti.Isogeny
+
+open WeierstrassCurve.Affine
+
+variable {F : Type*} [Field F] [DecidableEq F] (W : WeierstrassCurve.Affine F) [W.IsElliptic]
+
+/-- **A point is in the kernel of `[n]` exactly when it is `n`-torsion**, for an `n` whose
+division polynomial does not vanish — the hypothesis `mulByIntIsogeny` itself carries. -/
+-- Not `@[simp]`: `Isogeny.mem_ker_iff` is, and rewrites this left-hand side first, so the
+-- annotation is a simp-normal-form violation.
+theorem mem_ker_mulByIntIsogeny_iff {n : ℤ} (hn : psiFunctionField W n ≠ 0)
+    {P : (W⁄F).toAffine.Point} :
+    P ∈ (mulByIntIsogeny W hn).ker ↔ n • P = 0 := by
+  rw [mem_ker_iff_map_tautologicalPoint_eq, mulByIntIsogeny_pullback,
+    tautologicalPoint_mulByIntPullback,
+    map_zsmul, map_translation_genericPoint, translatedGenericPoint_def]
+  -- The scalar action here arrives through `map_zsmul` as `SubNegMonoid.toZSMul`, so the rule is
+  -- `zsmul_add`; `smul_add` is stated for the `Module ℤ` action and its pattern does not match.
+  have hsmul : n • (W.genericPoint + Point.baseChange (W' := W) F W.FunctionField P) =
+      n • W.genericPoint + n • Point.baseChange (W' := W) F W.FunctionField P :=
+    zsmul_add _ _ _
+  have hzero : n • Point.baseChange (W' := W) F W.FunctionField P =
+      Point.baseChange (W' := W) F W.FunctionField (n • P) := (map_zsmul _ _ _).symm
+  rw [hsmul, hzero]
+  constructor
+  · intro h
+    refine Point.map_injective (W' := W) (f := Algebra.ofId F W.FunctionField) ?_
+    rw [map_zero]
+    exact add_left_cancel (h.trans (add_zero _).symm)
+  · intro h
+    rw [h, map_zero, add_zero]
+
+/-- **A point is in the kernel of `[n]` exactly when it is `n`-torsion**, with the non-vanishing
+hypothesis discharged from `n ≠ 0` as in `mulByIntIsogenyOfNeZero`. -/
+theorem mem_ker_mulByIntIsogenyOfNeZero_iff {n : ℤ} (hn : n ≠ 0)
+    {P : (W⁄F).toAffine.Point} :
+    P ∈ (mulByIntIsogenyOfNeZero W hn).ker ↔ n • P = 0 := by
+  simpa only [mulByIntIsogenyOfNeZero] using mem_ker_mulByIntIsogeny_iff W _
+
+end TauCeti.Isogeny
+
+end


### PR DESCRIPTION
Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"EllipticCurves/README.md:layer1:mulbyint-kernel"}-->

Provenance: no port. AINTLIB's kernel (`EC/IsogenyKernel.lean`) is a fibre of a point map its `Isogeny` carries as an independent field, and its `EC/SeparableKernelTorsor.lean` is parametric on a coherence witness between that map and the pullback. `Isogeny.ker` here is defined *from* the pullback, so neither has a counterpart; the argument below is Silverman III.4 read at the generic point, in this repository's own terms.

## What this adds

One theorem, in a new `Isogeny/MulByInt/Kernel.lean`:

- `Isogeny.mem_ker_mulByIntIsogeny_iff`: **`P ∈ ker [n] ↔ n • P = 0`.**

## Why

`Isogeny.ker` is the subgroup of points whose translation fixes the pulled-back field — an isogeny here has no point map to take a fibre of. That definition is what lets the kernel exist for every isogeny over every field, but it leaves every classical statement about kernels unavailable until something identifies it. This is that identification for `[n]`, and it is the first one for an isogeny other than `1 − π_q`.

It is also the next step on the Hasse route. The Weil-pairing input the bound needs is a symplectic multiplier for the three isogenies acting on `E[ℓ]`, which requires `E[ℓ]` to be a rank-2 `ZMod ℓ`-module; the order statement `#E[n] = n²` behind that is `#ker [n] = deg [n]`, and it cannot even be *stated* against `Isogeny.ker` without knowing that `ker [n]` is the torsion.

## The argument

A coordinate pullback is determined by its tautological point (`tautologicalPoint_injective`), that of `[n]` is `n • g` (`tautologicalPoint_mulByIntPullback`), and translation by `P` sends `g` to `g + P` (`map_translation_genericPoint`). So translation by `P` fixes `[n]` exactly when `n • (g + P) = n • g`, which after cancelling is `n • P = 0` in the function field — and `P` is rational, so `Point.map_injective` brings it back down.

The two directions of the fixed-field statement are not symmetric:

- from the tautological point to the field, `fieldPullback_unique` rebuilds the field-level equality from the coordinate-level one (the same step `ker_oneSubFrobeniusIsogeny` uses);
- from the field to the tautological point, `CoordinateRing.algHom_ext` reduces to the two generators, each of which is in the pulled-back range by `fieldPullback_algebraMap`.

## Scope

Only the identification. `#ker [n] = n²` needs the reverse fixed-field inclusion of `card_ker_eq_degree_iff` — which for `[n]` should be easier than the embedding count #6446 needed for `1 − π_q`, since `[n]` is separable outright — and the rationality hypothesis that makes the rational kernel the geometric one. Both are left for their own PRs rather than bundled here.

## Gates

`lake build` green against the pin `369aeb92f4`; no `sorry`, `native_decide` or `maxHeartbeats`; no new `@[simp]`; 88 lines, none over 100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
