### PR TITLE
feat: descend divisor line bundles to class groups

### DIFF
--- a/TauCeti/AlgebraicGeometry/LineBundle/Class.lean
+++ b/TauCeti/AlgebraicGeometry/LineBundle/Class.lean
@@ -64,10 +64,6 @@ lemma mk_eq_mk_iff {L K : InvertibleSheaf X} :
   exact (ObjectProperty.toSkeleton_eq_toSkeleton_iff_nonempty_iso
     (SheafOfModules.isInvertible X) L.property K.property)
 
-/-- Every line-bundle class has a representative. -/
-lemma mk_surjective : Function.Surjective (mk : InvertibleSheaf X → LineBundleClass X) :=
-  Quotient.mk_surjective
-
 /-- Tensor product of line bundles descends to their isomorphism classes. -/
 noncomputable def tensorProduct (a b : LineBundleClass X) : LineBundleClass X :=
   Quotient.map₂ InvertibleSheaf.tensorProduct
@@ -79,10 +75,8 @@ noncomputable instance : Mul (LineBundleClass X) where
 /-- The class of a tensor product is the product of the two classes. -/
 @[simp]
 lemma mk_tensorProduct (L K : InvertibleSheaf X) :
-    mk (InvertibleSheaf.tensorProduct L K) = mk L * mk K := by
-  change mk (InvertibleSheaf.tensorProduct L K) = tensorProduct (mk L) (mk K)
-  unfold mk tensorProduct
-  exact (Quotient.map₂_mk _ _ L K).symm
+    mk (InvertibleSheaf.tensorProduct L K) = mk L * mk K :=
+  (rfl)
 
 /-- The tensor product of line-bundle classes is commutative. -/
 lemma mul_comm (a b : LineBundleClass X) : a * b = b * a := by

--- a/TauCeti/AlgebraicGeometry/LineBundle/Class.lean
+++ b/TauCeti/AlgebraicGeometry/LineBundle/Class.lean
@@ -76,15 +76,11 @@ noncomputable def tensorProduct (a b : LineBundleClass X) : LineBundleClass X :=
 noncomputable instance : Mul (LineBundleClass X) where
   mul := tensorProduct
 
-/-- Multiplication of line-bundle classes is their descended tensor product. -/
-lemma mul_def (a b : LineBundleClass X) : a * b = tensorProduct a b :=
-  (rfl)
-
 /-- The class of a tensor product is the product of the two classes. -/
 @[simp]
 lemma mk_tensorProduct (L K : InvertibleSheaf X) :
     mk (InvertibleSheaf.tensorProduct L K) = mk L * mk K := by
-  rw [mul_def]
+  change mk (InvertibleSheaf.tensorProduct L K) = tensorProduct (mk L) (mk K)
   unfold mk tensorProduct
   exact (Quotient.map₂_mk _ _ L K).symm
 

--- a/TauCeti/AlgebraicGeometry/LineBundle/Class.lean
+++ b/TauCeti/AlgebraicGeometry/LineBundle/Class.lean
@@ -46,7 +46,7 @@ universe u
 noncomputable section
 
 /-- The type of isomorphism classes of line bundles on a scheme. -/
-abbrev LineBundleClass (X : Scheme.{u}) : Type _ :=
+def LineBundleClass (X : Scheme.{u}) : Type _ :=
   Skeleton (InvertibleSheaf X)
 
 namespace LineBundleClass
@@ -68,20 +68,10 @@ lemma mk_eq_mk_iff {L K : InvertibleSheaf X} :
 lemma mk_surjective : Function.Surjective (mk : InvertibleSheaf X → LineBundleClass X) :=
   Quotient.mk_surjective
 
-/-- Tensor product preserves isomorphism of line bundles in both variables. -/
-lemma isIsomorphic_tensorProduct {L L' K K' : InvertibleSheaf X}
-    (hL : IsIsomorphic L L') (hK : IsIsomorphic K K') :
-    IsIsomorphic (InvertibleSheaf.tensorProduct L K)
-      (InvertibleSheaf.tensorProduct L' K') := by
-  obtain ⟨e⟩ := hL
-  obtain ⟨f⟩ := hK
-  exact ⟨InvertibleSheaf.tensorProductCongrLeft e ≪≫
-    InvertibleSheaf.tensorProductCongrRight f⟩
-
 /-- Tensor product of line bundles descends to their isomorphism classes. -/
 noncomputable def tensorProduct (a b : LineBundleClass X) : LineBundleClass X :=
   Quotient.map₂ InvertibleSheaf.tensorProduct
-    (fun _ _ hL _ _ hK ↦ isIsomorphic_tensorProduct hL hK) a b
+    (fun _ _ hL _ _ hK ↦ InvertibleSheaf.isIsomorphic_tensorProduct hL hK) a b
 
 noncomputable instance : Mul (LineBundleClass X) where
   mul := tensorProduct

--- a/TauCeti/AlgebraicGeometry/LineBundle/Class.lean
+++ b/TauCeti/AlgebraicGeometry/LineBundle/Class.lean
@@ -1,0 +1,135 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.LineBundle.TensorProduct
+public import TauCeti.CategoryTheory.Skeletal
+
+/-!
+# Isomorphism classes of line bundles
+
+The Picard group of a scheme consists of line bundles up to isomorphism, with tensor product as
+its operation. This file constructs the underlying type of isomorphism classes and descends the
+tensor product and the trivial line bundle to it. Tensor symmetry and the unit isomorphisms give
+the corresponding laws on classes.
+
+Associativity and inverses are deliberately not asserted here: they require, respectively, an
+associator for the sheafified tensor product and the dual of an invertible sheaf. Once those are
+available, the operations defined here are the operations of the Picard group.
+
+## Main declarations
+
+* `LineBundleClass X` is the type of line bundles on `X` up to isomorphism;
+* `LineBundleClass.mk` sends a line bundle to its isomorphism class;
+* `LineBundleClass.mk_eq_mk_iff` characterizes equality by an isomorphism of the underlying
+  sheaves;
+* multiplication is induced by `InvertibleSheaf.tensorProduct`, and `1` is the class of the
+  trivial line bundle.
+
+The construction uses Mathlib's `CategoryTheory.Skeleton`, its standard implementation of the
+isomorphism classes of objects of a category.
+-/
+
+public section
+
+open AlgebraicGeometry CategoryTheory
+
+namespace TauCeti
+
+namespace AlgebraicGeometry
+
+universe u
+
+noncomputable section
+
+/-- The type of isomorphism classes of line bundles on a scheme. -/
+abbrev LineBundleClass (X : Scheme.{u}) : Type _ :=
+  Skeleton (InvertibleSheaf X)
+
+namespace LineBundleClass
+
+variable {X : Scheme.{u}}
+
+/-- The isomorphism class of a line bundle. -/
+def mk (L : InvertibleSheaf X) : LineBundleClass X :=
+  toSkeleton L
+
+/-- Two line bundles have the same class exactly when their underlying sheaves are isomorphic. -/
+@[simp]
+lemma mk_eq_mk_iff {L K : InvertibleSheaf X} :
+    mk L = mk K ↔ Nonempty (L.obj ≅ K.obj) := by
+  exact (ObjectProperty.toSkeleton_eq_toSkeleton_iff_nonempty_iso
+    (SheafOfModules.isInvertible X) L.property K.property)
+
+/-- Every line-bundle class has a representative. -/
+lemma mk_surjective : Function.Surjective (mk : InvertibleSheaf X → LineBundleClass X) :=
+  Quotient.mk_surjective
+
+/-- Tensor product preserves isomorphism of line bundles in both variables. -/
+lemma isIsomorphic_tensorProduct {L L' K K' : InvertibleSheaf X}
+    (hL : IsIsomorphic L L') (hK : IsIsomorphic K K') :
+    IsIsomorphic (InvertibleSheaf.tensorProduct L K)
+      (InvertibleSheaf.tensorProduct L' K') := by
+  obtain ⟨e⟩ := hL
+  obtain ⟨f⟩ := hK
+  exact ⟨InvertibleSheaf.tensorProductCongrLeft e ≪≫
+    InvertibleSheaf.tensorProductCongrRight f⟩
+
+/-- Tensor product of line bundles descends to their isomorphism classes. -/
+noncomputable def tensorProduct (a b : LineBundleClass X) : LineBundleClass X :=
+  Quotient.map₂ InvertibleSheaf.tensorProduct
+    (fun _ _ hL _ _ hK ↦ isIsomorphic_tensorProduct hL hK) a b
+
+noncomputable instance : Mul (LineBundleClass X) where
+  mul := tensorProduct
+
+/-- Multiplication of line-bundle classes is their descended tensor product. -/
+lemma mul_def (a b : LineBundleClass X) : a * b = tensorProduct a b :=
+  (rfl)
+
+/-- The class of a tensor product is the product of the two classes. -/
+@[simp]
+lemma mk_tensorProduct (L K : InvertibleSheaf X) :
+    mk (InvertibleSheaf.tensorProduct L K) = mk L * mk K := by
+  rw [mul_def]
+  unfold mk tensorProduct
+  exact (Quotient.map₂_mk _ _ L K).symm
+
+/-- The tensor product of line-bundle classes is commutative. -/
+lemma mul_comm (a b : LineBundleClass X) : a * b = b * a := by
+  induction a using Quotient.inductionOn with
+  | _ L =>
+    induction b using Quotient.inductionOn with
+    | _ K => exact congr_toSkeleton_of_iso (InvertibleSheaf.tensorProductComm L K)
+
+/-- The unit for tensor product is the class of the trivial line bundle. -/
+noncomputable instance : One (LineBundleClass X) where
+  one := mk (InvertibleSheaf.trivial X)
+
+/-- The class of the trivial line bundle is the tensor unit. -/
+@[simp]
+lemma mk_trivial : mk (InvertibleSheaf.trivial X) = (1 : LineBundleClass X) :=
+  rfl
+
+/-- The trivial line bundle is a left unit on isomorphism classes. -/
+@[simp]
+lemma one_mul (a : LineBundleClass X) : 1 * a = a := by
+  induction a using Quotient.inductionOn with
+  | _ L => exact congr_toSkeleton_of_iso (InvertibleSheaf.tensorTrivialLeftIso L)
+
+/-- The trivial line bundle is a right unit on isomorphism classes. -/
+@[simp]
+lemma mul_one (a : LineBundleClass X) : a * 1 = a := by
+  induction a using Quotient.inductionOn with
+  | _ L => exact congr_toSkeleton_of_iso (InvertibleSheaf.tensorTrivialRightIso L)
+
+end LineBundleClass
+
+end
+
+end AlgebraicGeometry
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/LineBundle/TensorProduct.lean
+++ b/TauCeti/AlgebraicGeometry/LineBundle/TensorProduct.lean
@@ -22,7 +22,8 @@ for the trivial line bundle.
 * `InvertibleSheaf.tensorProduct` packages the tensor product of two line bundles;
 * `InvertibleSheaf.tensorProduct_obj` identifies its underlying sheaf;
 * `InvertibleSheaf.tensorProductCongrLeft` and `InvertibleSheaf.tensorProductCongrRight` transport
-  isomorphisms through either tensor factor;
+  isomorphisms through either tensor factor, so `InvertibleSheaf.isIsomorphic_tensorProduct`
+  shows that tensor product respects isomorphism;
 * `InvertibleSheaf.tensorProductComm` exchanges the two tensor factors;
 * `InvertibleSheaf.tensorTrivialLeftIso` and `InvertibleSheaf.tensorTrivialRightIso` are the
   unit isomorphisms in the full category of invertible sheaves.
@@ -121,6 +122,14 @@ lemma tensorProductCongrRight_inv_val {L K K' : InvertibleSheaf X} (e : K ≅ K'
       (tensorProductCongrRightIso e).inv.val := by
   simp only [tensorProductCongrRight, ObjectProperty.isoMk, ObjectProperty.homMk,
     _root_.AlgebraicGeometry.Scheme.Modules.isoOfSheafIso_inv_val]
+
+/-- Tensor product preserves isomorphism of line bundles in both variables. -/
+lemma isIsomorphic_tensorProduct {L L' K K' : InvertibleSheaf X}
+    (hL : IsIsomorphic L L') (hK : IsIsomorphic K K') :
+    IsIsomorphic (tensorProduct L K) (tensorProduct L' K') := by
+  obtain ⟨e⟩ := hL
+  obtain ⟨f⟩ := hK
+  exact ⟨tensorProductCongrLeft e ≪≫ tensorProductCongrRight f⟩
 
 /-- The sheaf isomorphism underlying symmetry of the tensor product of line bundles. -/
 def tensorProductCommIso (L K : InvertibleSheaf X) :

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Scheme/LineBundle.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Scheme/LineBundle.lean
@@ -1,0 +1,132 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.LineBundle.Class
+public import TauCeti.AlgebraicGeometry.WeilDivisor.Scheme.LocalTriviality
+public import TauCeti.AlgebraicGeometry.WeilDivisor.Scheme.LocallyPrincipal
+
+/-!
+# Line-bundle classes attached to Weil divisors
+
+On a Noetherian integral scheme of dimension at most one whose codimension-one local rings are
+discrete valuation rings, every Weil divisor `D` is locally principal. Its sheaf `𝓞_X(D)` is
+therefore a line bundle. Linearly equivalent divisors have isomorphic sheaves, so this
+construction descends from Weil divisors to the divisor class group.
+
+## Main declarations
+
+* `SchemeWeilDivisor.toInvertibleSheaf` packages `𝓞_X(D)` as an invertible sheaf;
+* `SchemeWeilDivisor.toLineBundleClass` is its isomorphism class;
+* `SchemeWeilDivisor.classGroupToLineBundleClass` is the induced map from the divisor class
+  group to line-bundle classes.
+
+This is the set-level divisor-to-line-bundle comparison. Proving compatibility with addition
+and tensor product, and proving that the comparison is bijective, require further structure.
+-/
+
+public section
+
+open AlgebraicGeometry CategoryTheory Order
+
+namespace TauCeti
+
+namespace AlgebraicGeometry
+
+universe u
+
+namespace SchemeWeilDivisor
+
+variable {X : Scheme.{u}} [IsIntegral X] [IsNoetherian X]
+  [∀ y : CodimensionOnePoint X, IsDiscreteValuationRing (X.presheaf.stalk (y : X))]
+
+noncomputable section
+
+variable (hX : ∀ y : X, coheight y ≤ 1)
+
+/-- The invertible sheaf `𝓞_X(D)` associated to a Weil divisor on a Noetherian integral
+scheme of dimension at most one whose codimension-one local rings are DVRs. -/
+def toInvertibleSheaf (D : SchemeWeilDivisor X) : InvertibleSheaf X :=
+  (isLocallyPrincipal_of_forall_coheight_le_one hX D).toInvertibleSheaf hX
+
+/-- The underlying sheaf of `SchemeWeilDivisor.toInvertibleSheaf` is `𝓞_X(D)`. -/
+@[simp]
+lemma toInvertibleSheaf_obj (D : SchemeWeilDivisor X) :
+    (toInvertibleSheaf hX D).obj = sheaf D :=
+  IsLocallyPrincipal.toInvertibleSheaf_obj
+    (isLocallyPrincipal_of_forall_coheight_le_one hX D) hX
+
+/-- The isomorphism class of the line bundle `𝓞_X(D)` associated to a Weil divisor. -/
+def toLineBundleClass (D : SchemeWeilDivisor X) : LineBundleClass X :=
+  LineBundleClass.mk (toInvertibleSheaf hX D)
+
+/-- The line-bundle class of a divisor is represented by its associated invertible sheaf. -/
+lemma toLineBundleClass_eq_mk (D : SchemeWeilDivisor X) :
+    toLineBundleClass hX D = LineBundleClass.mk (toInvertibleSheaf hX D) :=
+  (rfl)
+
+/-- Linearly equivalent Weil divisors determine the same line-bundle class. -/
+theorem toLineBundleClass_eq_of_linearlyEquivalent {D E : SchemeWeilDivisor X}
+    (hDE : (WeilDivisor.OrderSystem.ofScheme X).LinearlyEquivalent D E) :
+    toLineBundleClass hX D = toLineBundleClass hX E := by
+  rw [toLineBundleClass_eq_mk, toLineBundleClass_eq_mk, LineBundleClass.mk_eq_mk_iff]
+  simpa only [toInvertibleSheaf_obj] using nonempty_iso_sheaf_of_linearlyEquivalent hDE
+
+/-- The zero divisor determines the trivial line-bundle class. -/
+@[simp]
+lemma toLineBundleClass_zero :
+    toLineBundleClass hX (0 : SchemeWeilDivisor X) = 1 := by
+  rw [toLineBundleClass_eq_mk, ← LineBundleClass.mk_trivial, LineBundleClass.mk_eq_mk_iff]
+  simpa only [toInvertibleSheaf_obj, InvertibleSheaf.trivial_obj] using
+    ⟨(unitIsoSheafZero hX).symm ≪≫
+      (TauCeti.SheafOfModules.freePUnitIsoUnit X.ringCatSheaf).symm⟩
+
+/-- A principal divisor determines the trivial line-bundle class. -/
+@[simp]
+lemma toLineBundleClass_principalDivisor (g : Additive X.functionFieldˣ) :
+    toLineBundleClass hX
+        ((WeilDivisor.OrderSystem.ofScheme X).principalDivisor g) = 1 := by
+  rw [toLineBundleClass_eq_mk, ← LineBundleClass.mk_trivial, LineBundleClass.mk_eq_mk_iff]
+  simpa only [toInvertibleSheaf_obj, InvertibleSheaf.trivial_obj] using
+    ⟨sheafPrincipalDivisorIsoUnit hX g ≪≫
+      (TauCeti.SheafOfModules.freePUnitIsoUnit X.ringCatSheaf).symm⟩
+
+/-- The map from the divisor class group to isomorphism classes of line bundles which sends
+the class of `D` to the class of `𝓞_X(D)`. -/
+def classGroupToLineBundleClass :
+    (WeilDivisor.OrderSystem.ofScheme X).ClassGroup → LineBundleClass X :=
+  Quotient.lift (toLineBundleClass hX) fun D E hDE ↦ by
+    apply toLineBundleClass_eq_of_linearlyEquivalent hX
+    apply WeilDivisor.OrderSystem.LinearlyEquivalent.symm
+    rw [WeilDivisor.OrderSystem.linearlyEquivalent_iff]
+    simpa [sub_eq_add_neg, add_comm] using
+      (QuotientAddGroup.leftRel_apply.mp hDE)
+
+/-- The map from divisor classes to line-bundle classes sends the class of `D` to the class of
+`𝓞_X(D)`. -/
+@[simp]
+lemma classGroupToLineBundleClass_divisorClass (D : SchemeWeilDivisor X) :
+    classGroupToLineBundleClass hX
+        ((WeilDivisor.OrderSystem.ofScheme X).divisorClass D) =
+      toLineBundleClass hX D := by
+  rw [WeilDivisor.OrderSystem.divisorClass_eq_mk']
+  rfl
+
+/-- The zero divisor class maps to the trivial line-bundle class. -/
+@[simp]
+lemma classGroupToLineBundleClass_zero :
+    classGroupToLineBundleClass hX
+        (0 : (WeilDivisor.OrderSystem.ofScheme X).ClassGroup) = 1 := by
+  rw [← map_zero (WeilDivisor.OrderSystem.ofScheme X).divisorClass,
+    classGroupToLineBundleClass_divisorClass, toLineBundleClass_zero]
+
+end
+
+end SchemeWeilDivisor
+
+end AlgebraicGeometry
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Scheme/LineBundle.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Scheme/LineBundle.lean
@@ -66,8 +66,7 @@ def toLineBundleClass (D : SchemeWeilDivisor X) : LineBundleClass X :=
 theorem toLineBundleClass_eq_of_linearlyEquivalent {D E : SchemeWeilDivisor X}
     (hDE : (WeilDivisor.OrderSystem.ofScheme X).LinearlyEquivalent D E) :
     toLineBundleClass hX D = toLineBundleClass hX E := by
-  change LineBundleClass.mk (toInvertibleSheaf hX D) =
-    LineBundleClass.mk (toInvertibleSheaf hX E)
+  unfold toLineBundleClass
   rw [LineBundleClass.mk_eq_mk_iff]
   simpa only [toInvertibleSheaf_obj] using nonempty_iso_sheaf_of_linearlyEquivalent hDE
 
@@ -75,7 +74,7 @@ theorem toLineBundleClass_eq_of_linearlyEquivalent {D E : SchemeWeilDivisor X}
 @[simp]
 lemma toLineBundleClass_zero :
     toLineBundleClass hX (0 : SchemeWeilDivisor X) = 1 := by
-  change LineBundleClass.mk (toInvertibleSheaf hX 0) = 1
+  unfold toLineBundleClass
   rw [← LineBundleClass.mk_trivial, LineBundleClass.mk_eq_mk_iff]
   simpa only [toInvertibleSheaf_obj, InvertibleSheaf.trivial_obj] using
     ⟨(unitIsoSheafZero hX).symm ≪≫

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Scheme/LineBundle.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Scheme/LineBundle.lean
@@ -62,23 +62,21 @@ lemma toInvertibleSheaf_obj (D : SchemeWeilDivisor X) :
 def toLineBundleClass (D : SchemeWeilDivisor X) : LineBundleClass X :=
   LineBundleClass.mk (toInvertibleSheaf hX D)
 
-/-- The line-bundle class of a divisor is represented by its associated invertible sheaf. -/
-lemma toLineBundleClass_eq_mk (D : SchemeWeilDivisor X) :
-    toLineBundleClass hX D = LineBundleClass.mk (toInvertibleSheaf hX D) :=
-  (rfl)
-
 /-- Linearly equivalent Weil divisors determine the same line-bundle class. -/
 theorem toLineBundleClass_eq_of_linearlyEquivalent {D E : SchemeWeilDivisor X}
     (hDE : (WeilDivisor.OrderSystem.ofScheme X).LinearlyEquivalent D E) :
     toLineBundleClass hX D = toLineBundleClass hX E := by
-  rw [toLineBundleClass_eq_mk, toLineBundleClass_eq_mk, LineBundleClass.mk_eq_mk_iff]
+  change LineBundleClass.mk (toInvertibleSheaf hX D) =
+    LineBundleClass.mk (toInvertibleSheaf hX E)
+  rw [LineBundleClass.mk_eq_mk_iff]
   simpa only [toInvertibleSheaf_obj] using nonempty_iso_sheaf_of_linearlyEquivalent hDE
 
 /-- The zero divisor determines the trivial line-bundle class. -/
 @[simp]
 lemma toLineBundleClass_zero :
     toLineBundleClass hX (0 : SchemeWeilDivisor X) = 1 := by
-  rw [toLineBundleClass_eq_mk, ← LineBundleClass.mk_trivial, LineBundleClass.mk_eq_mk_iff]
+  change LineBundleClass.mk (toInvertibleSheaf hX 0) = 1
+  rw [← LineBundleClass.mk_trivial, LineBundleClass.mk_eq_mk_iff]
   simpa only [toInvertibleSheaf_obj, InvertibleSheaf.trivial_obj] using
     ⟨(unitIsoSheafZero hX).symm ≪≫
       (TauCeti.SheafOfModules.freePUnitIsoUnit X.ringCatSheaf).symm⟩

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Scheme/LineBundle.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Scheme/LineBundle.lean
@@ -7,7 +7,6 @@ module
 
 public import TauCeti.AlgebraicGeometry.LineBundle.Class
 public import TauCeti.AlgebraicGeometry.WeilDivisor.Scheme.LocalTriviality
-public import TauCeti.AlgebraicGeometry.WeilDivisor.Scheme.LocallyPrincipal
 
 /-!
 # Line-bundle classes attached to Weil divisors
@@ -89,10 +88,10 @@ lemma toLineBundleClass_zero :
 lemma toLineBundleClass_principalDivisor (g : Additive X.functionFieldˣ) :
     toLineBundleClass hX
         ((WeilDivisor.OrderSystem.ofScheme X).principalDivisor g) = 1 := by
-  rw [toLineBundleClass_eq_mk, ← LineBundleClass.mk_trivial, LineBundleClass.mk_eq_mk_iff]
-  simpa only [toInvertibleSheaf_obj, InvertibleSheaf.trivial_obj] using
-    ⟨sheafPrincipalDivisorIsoUnit hX g ≪≫
-      (TauCeti.SheafOfModules.freePUnitIsoUnit X.ringCatSheaf).symm⟩
+  rw [← toLineBundleClass_zero hX,
+    ← zero_add ((WeilDivisor.OrderSystem.ofScheme X).principalDivisor g)]
+  exact toLineBundleClass_eq_of_linearlyEquivalent hX
+    ((WeilDivisor.OrderSystem.ofScheme X).linearlyEquivalent_add_principalDivisor 0 g)
 
 /-- The map from the divisor class group to isomorphism classes of line bundles which sends
 the class of `D` to the class of `𝓞_X(D)`. -/


### PR DESCRIPTION
## Summary

- define `LineBundleClass X` via `CategoryTheory.Skeleton`, with descended tensor product, the trivial class, commutativity, and both unit laws
- package `𝓞_X(D)` as an invertible sheaf for every Weil divisor on the dimension-one schemes already covered by the library
- prove linear equivalence preserves the line-bundle class and descend the construction to a canonical map from the divisor class group

## Roadmap

Roadmap: JacobianChallenge

This advances the **Layer A — Divisors, line bundles, Picard groups, degree** milestone in [`JacobianChallenge/README.md`](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/JacobianChallenge/README.md), specifically the target identifying the divisor class group with the Picard group: it supplies the isomorphism-class target and the well-defined map from divisor classes.

After this PR, tensor associativity and duals must promote line-bundle classes to the Picard group, the divisor-class map must be proved tensor-compatible and bijective, and its degree comparison must be established to complete the milestone.

<!--tauceti-target:v1 {"focus":"JacobianChallenge","id":"divisor-class-to-line-bundle-class"}-->

🤖 Prepared with Codex