### PR TITLE
feat: characterize disjoint smooth link components

### DIFF
--- a/TauCeti/KnotTheory/SmoothLink.lean
+++ b/TauCeti/KnotTheory/SmoothLink.lean
@@ -98,19 +98,22 @@ theorem range_component_subset_range (L : SmoothLinkEmbedding I M n) (i : Fin n)
     Set.range (L i) ⊆ L.range :=
   Set.subset_iUnion (fun j ↦ Set.range (L j)) i
 
-/-- Two components of a smooth link have disjoint images exactly when they are distinct.
+theorem Pairwise.disjoint_iff_ne [PartialOrder α] [OrderBot α] {ι : Type*} {f : ι → α}
+    (h : Pairwise (Function.onFun Disjoint f)) (hne : ∀ i, f i ≠ ⊥) (i j : ι) :
+    Disjoint (f i) (f j) ↔ i ≠ j := by
+  constructor
+  · intro hd hij
+    exact (Disjoint.ne (hne i) hd) (congrArg f hij)
+  · intro hij
+    exact h hij
 
-The reverse implication uses that every smooth circle embedding has a nonempty range; this makes
-the characterization convenient for statements that quantify over pairs of link components. -/
+/-- Two components of a smooth link have disjoint images exactly when their labels differ. -/
+@[simp, grind =]
 theorem disjoint_range_iff (L : SmoothLinkEmbedding I M n) (i j : Fin n) :
     Disjoint (Set.range (L i)) (Set.range (L j)) ↔ i ≠ j := by
-  constructor
-  · intro h hij
-    subst hij
-    obtain ⟨x, hx⟩ := Set.range_nonempty (L i)
-    exact (h.le_bot ⟨hx, hx⟩)
-  · intro hij
-    exact L.pairwiseDisjoint_range hij
+  apply Pairwise.disjoint_iff_ne L.pairwiseDisjoint_range
+  intro i
+  exact Set.nonempty_iff_ne_empty.mp (Set.range_nonempty (L i))
 
 /-! ### Empty and one-component links -/
 

--- a/TauCeti/KnotTheory/SmoothLink.lean
+++ b/TauCeti/KnotTheory/SmoothLink.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.KnotTheory.SmoothCircle
+public import TauCeti.Order.Disjoint
 
 /-!
 # Smooth link presentations
@@ -97,15 +98,6 @@ theorem mem_range_iff (L : SmoothLinkEmbedding I M n) (x : M) :
 theorem range_component_subset_range (L : SmoothLinkEmbedding I M n) (i : Fin n) :
     Set.range (L i) ⊆ L.range :=
   Set.subset_iUnion (fun j ↦ Set.range (L j)) i
-
-theorem _root_.Pairwise.disjoint_iff_ne [PartialOrder α] [OrderBot α] {ι : Type*} {f : ι → α}
-    (h : Pairwise (Function.onFun Disjoint f)) (hne : ∀ i, f i ≠ ⊥) (i j : ι) :
-    Disjoint (f i) (f j) ↔ i ≠ j := by
-  constructor
-  · intro hd hij
-    exact (Disjoint.ne (hne i) hd) (congrArg f hij)
-  · intro hij
-    exact h hij
 
 /-- Two components of a smooth link have disjoint images exactly when their labels differ. -/
 @[simp, grind =]

--- a/TauCeti/KnotTheory/SmoothLink.lean
+++ b/TauCeti/KnotTheory/SmoothLink.lean
@@ -98,6 +98,20 @@ theorem range_component_subset_range (L : SmoothLinkEmbedding I M n) (i : Fin n)
     Set.range (L i) ⊆ L.range :=
   Set.subset_iUnion (fun j ↦ Set.range (L j)) i
 
+/-- Two components of a smooth link have disjoint images exactly when they are distinct.
+
+The reverse implication uses that every smooth circle embedding has a nonempty range; this makes
+the characterization convenient for statements that quantify over pairs of link components. -/
+theorem disjoint_range_iff (L : SmoothLinkEmbedding I M n) (i j : Fin n) :
+    Disjoint (Set.range (L i)) (Set.range (L j)) ↔ i ≠ j := by
+  constructor
+  · intro h hij
+    subst hij
+    obtain ⟨x, hx⟩ := Set.range_nonempty (L i)
+    exact (h.le_bot ⟨hx, hx⟩)
+  · intro hij
+    exact L.pairwiseDisjoint_range hij
+
 /-! ### Empty and one-component links -/
 
 /-- The smooth link with no components. -/

--- a/TauCeti/KnotTheory/SmoothLink.lean
+++ b/TauCeti/KnotTheory/SmoothLink.lean
@@ -98,7 +98,7 @@ theorem range_component_subset_range (L : SmoothLinkEmbedding I M n) (i : Fin n)
     Set.range (L i) ⊆ L.range :=
   Set.subset_iUnion (fun j ↦ Set.range (L j)) i
 
-theorem Pairwise.disjoint_iff_ne [PartialOrder α] [OrderBot α] {ι : Type*} {f : ι → α}
+theorem _root_.Pairwise.disjoint_iff_ne [PartialOrder α] [OrderBot α] {ι : Type*} {f : ι → α}
     (h : Pairwise (Function.onFun Disjoint f)) (hne : ∀ i, f i ≠ ⊥) (i j : ι) :
     Disjoint (f i) (f j) ↔ i ≠ j := by
   constructor

--- a/TauCeti/Order/Disjoint.lean
+++ b/TauCeti/Order/Disjoint.lean
@@ -1,0 +1,34 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Logic.Pairwise
+public import Mathlib.Order.Disjoint
+
+/-!
+# Pairwise disjoint families
+
+`Pairwise.disjoint_iff_ne` characterizes disjointness in a pairwise disjoint family of non-bottom
+elements by inequality of the indices. It reduces disjointness questions for such a family to
+questions about its labels.
+-/
+
+public section
+
+namespace Pairwise
+
+/-- In a pairwise disjoint family whose elements are all different from bottom, two elements are
+disjoint exactly when their indices differ. -/
+theorem disjoint_iff_ne {α : Type*} [PartialOrder α] [OrderBot α] {ι : Type*} {f : ι → α}
+    (h : Pairwise (Function.onFun Disjoint f)) (hne : ∀ i, f i ≠ ⊥) (i j : ι) :
+    Disjoint (f i) (f j) ↔ i ≠ j := by
+  constructor
+  · intro hd hij
+    exact (Disjoint.ne (hne i) hd) (congrArg f hij)
+  · intro hij
+    exact h hij
+
+end Pairwise


### PR DESCRIPTION
This PR adds the next reusable smooth-link presentation lemma for GeometricTopology Layer 4: component ranges are disjoint exactly when their labels differ. The characterization packages the existing pairwise-disjoint field together with nonemptiness of each circle image, which simplifies downstream pairwise component arguments. The Layer 4 presentation milestone still needs the remaining framing data and diagram/braid correspondence work.

Roadmap: GeometricTopology

<!--tauceti-target:v1 {"focus":"GeometricTopology","id":"smooth-link-range-disjoint-iff"}-->

🤖 Prepared with Codex
