### PR TITLE
feat: dissociated exchangeable graph laws

### DIFF
--- a/TauCeti/Combinatorics/DenseGraphLimits/ExchangeableGraphLaw/Defs.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/ExchangeableGraphLaw/Defs.lean
@@ -8,6 +8,7 @@ module
 public import TauCeti.Combinatorics.SimpleGraph.Measurable
 public import Mathlib.MeasureTheory.Measure.Typeclasses.Probability
 import Mathlib.MeasureTheory.Measure.Dirac.Basic
+import TauCeti.MeasureTheory.Measure.FiniteOrder
 
 /-!
 # Exchangeable graph laws
@@ -25,7 +26,8 @@ masses take values in `[0, 1]`, take the value `1` at the edgeless pattern, and 
 relabelling a pattern along an injection — the consistency hypothesis seen on upper events. They
 are a complete observable: an upper mass is the total probability of the graphs above the pattern,
 so downward induction along the finite lattice of graphs recovers the probability of an individual
-graph, and hence the whole law, from the upper masses.
+graph, and hence the whole law, from the upper masses
+(`MeasureTheory.Measure.ext_of_Ici_of_finite`).
 
 The label set is always a finite `Fin k`, so its graphs form a finite measurable space and every
 set of them is measurable; no measurability side conditions appear below.
@@ -153,37 +155,13 @@ theorem upperMass_eq_sum (F : SimpleGraph (Fin k)) :
   rw [upperMass_def, hset, ← sum_measure_singleton,
     ENNReal.toReal_sum fun G _ => measure_ne_top _ _]
 
-open Classical in
-/-- **The upper masses determine the law.** The upper mass of a pattern is the probability of the
-pattern itself plus the upper masses contributed by the strictly larger patterns, so downward
-induction along the finite lattice of graphs recovers every marginal from the upper masses. -/
+/-- **The upper masses determine the law.** An upper mass is the mass of an upper ray in the finite
+lattice of graphs, and a finite measure on a finite partial order is determined by its upper rays:
+downward induction along the lattice recovers the probability of every individual graph. -/
 theorem ext_upperMass {L L' : ExchangeableGraphLaw}
-    (h : ∀ (k : ℕ) (F : SimpleGraph (Fin k)), L.upperMass F = L'.upperMass F) : L = L' := by
-  have key : ∀ (k : ℕ) (G : SimpleGraph (Fin k)),
-      (L.law k {G}).toReal = (L'.law k {G}).toReal := by
-    intro k G
-    induction G using WellFoundedGT.induction with
-    | ind G ih =>
-      -- The graphs containing `G` are `G` itself together with the ones strictly above it.
-      have hins : Finset.univ.filter (G ≤ ·) =
-          insert G (Finset.univ.filter (fun H : SimpleGraph (Fin k) => G < H)) := by
-        ext H
-        simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_insert]
-        exact ⟨fun hle => hle.lt_or_eq.symm.imp Eq.symm id, fun h => h.elim ge_of_eq le_of_lt⟩
-      have hG : G ∉ Finset.univ.filter (fun H : SimpleGraph (Fin k) => G < H) := by simp
-      have hsplit : ∀ M : ExchangeableGraphLaw, M.upperMass G = (M.law k {G}).toReal +
-          ∑ H ∈ Finset.univ.filter (fun H : SimpleGraph (Fin k) => G < H),
-            (M.law k {H}).toReal := fun M => by
-        rw [M.upperMass_eq_sum G, hins, Finset.sum_insert hG]
-      -- The strictly larger patterns contribute the same to both laws, so the rest does too.
-      have htail : ∑ H ∈ Finset.univ.filter (fun H : SimpleGraph (Fin k) => G < H),
-            (L.law k {H}).toReal =
-          ∑ H ∈ Finset.univ.filter (fun H : SimpleGraph (Fin k) => G < H),
-            (L'.law k {H}).toReal :=
-        Finset.sum_congr rfl fun H hH => ih H (Finset.mem_filter.1 hH).2
-      have hadd := ((hsplit L).symm.trans (h k G)).trans (hsplit L')
-      rwa [htail, add_right_cancel_iff] at hadd
-  exact ext fun k => Measure.ext_of_measureReal_singleton (key k)
+    (h : ∀ (k : ℕ) (F : SimpleGraph (Fin k)), L.upperMass F = L'.upperMass F) : L = L' :=
+  ext fun k => Measure.ext_of_Ici_of_finite _ _ fun F =>
+    (ENNReal.toReal_eq_toReal_iff' (measure_ne_top _ _) (measure_ne_top _ _)).1 (h k F)
 
 end ExchangeableGraphLaw
 

--- a/TauCeti/Combinatorics/DenseGraphLimits/ExchangeableGraphLaw/Dissociated.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/ExchangeableGraphLaw/Dissociated.lean
@@ -44,9 +44,6 @@ rectangle of their upper events.
 
 * P. Diaconis, S. Janson, *Graph limits and exchangeable random graphs*, Rend. Mat. Appl. (7) 28
   (2008), 33--61, Section 5.
-* Roadmap: `TauCetiRoadmap/DenseGraphLimits/README.md`, Layer 9b — dissociated graph laws. The
-  body of `IsDissociated` and the signature of `isDissociated_iff_upperMass_mul` follow
-  `TauCetiRoadmap/DenseGraphLimits/Suggested.lean`.
 -/
 
 public section

--- a/TauCeti/Combinatorics/DenseGraphLimits/ExchangeableGraphLaw/Dissociated.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/ExchangeableGraphLaw/Dissociated.lean
@@ -37,13 +37,16 @@ rectangle of their upper events.
 
 * `TauCeti.DenseGraphLimits.ExchangeableGraphLaw.upperMass_map_sum` — the upper mass of a disjoint
   union of patterns is the mass of a rectangle under the law of the pair of windows;
-* `TauCeti.DenseGraphLimits.ExchangeableGraphLaw.isDissociated_iff_upperMass_mul` — a law is
-  dissociated iff its upper masses are multiplicative over disjoint unions of patterns.
+* `TauCeti.DenseGraphLimits.isDissociated_iff_upperMass_mul` — a law is dissociated iff its upper
+  masses are multiplicative over disjoint unions of patterns.
 
 ## References
 
 * P. Diaconis, S. Janson, *Graph limits and exchangeable random graphs*, Rend. Mat. Appl. (7) 28
   (2008), 33--61, Section 5.
+* Roadmap: `TauCetiRoadmap/DenseGraphLimits/README.md`, Layer 9b — dissociated graph laws. The
+  body of `IsDissociated` and the signature of `isDissociated_iff_upperMass_mul` follow
+  `TauCetiRoadmap/DenseGraphLimits/Suggested.lean`.
 -/
 
 public section
@@ -69,14 +72,6 @@ def IsDissociated : Prop :=
         (fun G => (SimpleGraph.comap (Fin.castAdd l) G, SimpleGraph.comap (Fin.natAdd k) G))
       = (L.law k).prod (L.law l)
 
-/-- The defining identity of a dissociated law. -/
-theorem isDissociated_iff :
-    L.IsDissociated ↔
-      ∀ k l : ℕ,
-        (L.law (k + l)).map
-            (fun G => (SimpleGraph.comap (Fin.castAdd l) G, SimpleGraph.comap (Fin.natAdd k) G))
-          = (L.law k).prod (L.law l) := Iff.rfl
-
 /-- The upper mass of a disjoint union of two patterns, placed on the first `k` and the last `l`
 labels, is the mass of the rectangle of their two upper events under the law of the pair of
 windows: a graph contains the union exactly when its two windows contain the two patterns. -/
@@ -98,29 +93,30 @@ theorem upperMass_map_sum (F₁ : SimpleGraph (Fin k)) (F₂ : SimpleGraph (Fin 
     SimpleGraph.comap_comap, SimpleGraph.comap_comap, hinl, hinr]
   rfl
 
+end ExchangeableGraphLaw
+
 /-- **Dissociation via upper masses.** A law is dissociated iff its upper masses are multiplicative
 over disjoint unions of patterns. The forward direction evaluates the two laws on upper
 rectangles; the converse holds because the upper rectangles are the upper rays of the product of
 the two finite lattices of graphs, which determine a finite law on it. -/
-theorem isDissociated_iff_upperMass_mul :
+theorem isDissociated_iff_upperMass_mul (L : ExchangeableGraphLaw) :
     L.IsDissociated ↔
       ∀ (k l : ℕ) (F₁ : SimpleGraph (Fin k)) (F₂ : SimpleGraph (Fin l)),
         L.upperMass ((F₁ ⊕g F₂).map finSumFinEquiv.toEmbedding) =
           L.upperMass F₁ * L.upperMass F₂ := by
   constructor
   · intro h k l F₁ F₂
-    rw [upperMass_map_sum, h k l, Measure.prod_prod, ENNReal.toReal_mul, upperMass_def,
-      upperMass_def]
+    rw [ExchangeableGraphLaw.upperMass_map_sum, h k l, Measure.prod_prod, ENNReal.toReal_mul,
+      ExchangeableGraphLaw.upperMass_def, ExchangeableGraphLaw.upperMass_def]
     rfl
   · intro h k l
     refine Measure.ext_of_Ici_of_finite _ _ fun F => ?_
     rw [← Set.Ici_prod_Ici, Measure.prod_prod]
     refine (ENNReal.toReal_eq_toReal_iff' (measure_ne_top _ _) ?_).1 ?_
     · exact ENNReal.mul_ne_top (measure_ne_top _ _) (measure_ne_top _ _)
-    · rw [ENNReal.toReal_mul, ← upperMass_map_sum, h k l F.1 F.2, upperMass_def, upperMass_def]
+    · rw [ENNReal.toReal_mul, ← ExchangeableGraphLaw.upperMass_map_sum, h k l F.1 F.2,
+        ExchangeableGraphLaw.upperMass_def, ExchangeableGraphLaw.upperMass_def]
       rfl
-
-end ExchangeableGraphLaw
 
 end DenseGraphLimits
 

--- a/TauCeti/Combinatorics/DenseGraphLimits/ExchangeableGraphLaw/Dissociated.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/ExchangeableGraphLaw/Dissociated.lean
@@ -16,8 +16,9 @@ import TauCeti.MeasureTheory.Measure.FiniteOrder
 An exchangeable graph law is **dissociated** when the random graph restricted to two disjoint
 windows of labels consists of two independent pieces: the level-`(k + l)` marginal, pushed to the
 pair of graphs it induces on the first `k` and on the last `l` labels, is the product of the
-level-`k` and level-`l` marginals. By consistency the choice of the two windows is immaterial, so
-the first `k` and the last `l` labels of `Fin (k + l)` suffice.
+level-`k` and level-`l` marginals. By exchangeability two disjoint windows of sizes `k` and `l`
+can be relabelled as the first `k` and the next `l` labels, and by consistency the labels beyond
+them can then be dropped, so the first `k` and the last `l` labels of `Fin (k + l)` suffice.
 
 Dissociation is an identity between two laws on pairs of graphs, while the upper masses of a law
 only see its upper events. The two meet in the bridge `isDissociated_iff_upperMass_mul`: a law is

--- a/TauCeti/Combinatorics/DenseGraphLimits/ExchangeableGraphLaw/Dissociated.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/ExchangeableGraphLaw/Dissociated.lean
@@ -1,0 +1,127 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import TauCeti.Combinatorics.DenseGraphLimits.ExchangeableGraphLaw.Defs
+public import TauCeti.Combinatorics.SimpleGraph.Sum
+public import Mathlib.MeasureTheory.Measure.Prod
+import TauCeti.MeasureTheory.Measure.FiniteOrder
+
+/-!
+# Dissociated exchangeable graph laws
+
+An exchangeable graph law is **dissociated** when the random graph restricted to two disjoint
+windows of labels consists of two independent pieces: the level-`(k + l)` marginal, pushed to the
+pair of graphs it induces on the first `k` and on the last `l` labels, is the product of the
+level-`k` and level-`l` marginals. By consistency the choice of the two windows is immaterial, so
+the first `k` and the last `l` labels of `Fin (k + l)` suffice.
+
+Dissociation is an identity between two laws on pairs of graphs, while the upper masses of a law
+only see its upper events. The two meet in the bridge `isDissociated_iff_upperMass_mul`: a law is
+dissociated exactly when its upper masses are multiplicative over disjoint unions of patterns.
+One direction reads the multiplicativity off the upper rectangles. The other needs that the upper
+rectangles determine a law on pairs of graphs, which is Möbius inversion over the product of the
+two finite lattices of graphs — the downward induction of
+`MeasureTheory.Measure.ext_of_Ici_of_finite`, since the upper ray at a pair of patterns is the
+rectangle of their upper events.
+
+## Main definitions
+
+* `TauCeti.DenseGraphLimits.ExchangeableGraphLaw.IsDissociated` — restrictions to disjoint label
+  windows are independent.
+
+## Main results
+
+* `TauCeti.DenseGraphLimits.ExchangeableGraphLaw.upperMass_map_sum` — the upper mass of a disjoint
+  union of patterns is the mass of a rectangle under the law of the pair of windows;
+* `TauCeti.DenseGraphLimits.ExchangeableGraphLaw.isDissociated_iff_upperMass_mul` — a law is
+  dissociated iff its upper masses are multiplicative over disjoint unions of patterns.
+
+## References
+
+* P. Diaconis, S. Janson, *Graph limits and exchangeable random graphs*, Rend. Mat. Appl. (7) 28
+  (2008), 33--61, Section 5.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory
+
+namespace TauCeti
+
+namespace DenseGraphLimits
+
+namespace ExchangeableGraphLaw
+
+variable (L : ExchangeableGraphLaw) {k l : ℕ}
+
+/-- A law is **dissociated** when restrictions to disjoint label windows are independent: the
+level-`(k + l)` marginal pushed to the pair of windows is the product of the level-`k` and
+level-`l` marginals. -/
+def IsDissociated : Prop :=
+  ∀ k l : ℕ,
+    (L.law (k + l)).map
+        (fun G => (SimpleGraph.comap (Fin.castAdd l) G, SimpleGraph.comap (Fin.natAdd k) G))
+      = (L.law k).prod (L.law l)
+
+/-- The defining identity of a dissociated law. -/
+theorem isDissociated_iff :
+    L.IsDissociated ↔
+      ∀ k l : ℕ,
+        (L.law (k + l)).map
+            (fun G => (SimpleGraph.comap (Fin.castAdd l) G, SimpleGraph.comap (Fin.natAdd k) G))
+          = (L.law k).prod (L.law l) := Iff.rfl
+
+/-- The upper mass of a disjoint union of two patterns, placed on the first `k` and the last `l`
+labels, is the mass of the rectangle of their two upper events under the law of the pair of
+windows: a graph contains the union exactly when its two windows contain the two patterns. -/
+theorem upperMass_map_sum (F₁ : SimpleGraph (Fin k)) (F₂ : SimpleGraph (Fin l)) :
+    L.upperMass ((F₁ ⊕g F₂).map finSumFinEquiv.toEmbedding) =
+      ((L.law (k + l)).map
+          (fun G => (SimpleGraph.comap (Fin.castAdd l) G, SimpleGraph.comap (Fin.natAdd k) G))
+        (Set.Ici F₁ ×ˢ Set.Ici F₂)).toReal := by
+  have hinl : ⇑finSumFinEquiv.toEmbedding ∘ Sum.inl = (Fin.castAdd l : Fin k → Fin (k + l)) := by
+    funext i
+    simp
+  have hinr : ⇑finSumFinEquiv.toEmbedding ∘ Sum.inr = (Fin.natAdd k : Fin l → Fin (k + l)) := by
+    funext i
+    simp
+  rw [upperMass_def, Measure.map_apply (by fun_prop) MeasurableSet.of_discrete]
+  congr 2
+  ext G
+  rw [Set.mem_ofPred_eq, SimpleGraph.map_le_iff_le_comap, SimpleGraph.sum_le_iff,
+    SimpleGraph.comap_comap, SimpleGraph.comap_comap, hinl, hinr]
+  rfl
+
+/-- **Dissociation via upper masses.** A law is dissociated iff its upper masses are multiplicative
+over disjoint unions of patterns. The forward direction evaluates the two laws on upper
+rectangles; the converse holds because the upper rectangles are the upper rays of the product of
+the two finite lattices of graphs, which determine a finite law on it. -/
+theorem isDissociated_iff_upperMass_mul :
+    L.IsDissociated ↔
+      ∀ (k l : ℕ) (F₁ : SimpleGraph (Fin k)) (F₂ : SimpleGraph (Fin l)),
+        L.upperMass ((F₁ ⊕g F₂).map finSumFinEquiv.toEmbedding) =
+          L.upperMass F₁ * L.upperMass F₂ := by
+  constructor
+  · intro h k l F₁ F₂
+    rw [upperMass_map_sum, h k l, Measure.prod_prod, ENNReal.toReal_mul, upperMass_def,
+      upperMass_def]
+    rfl
+  · intro h k l
+    refine Measure.ext_of_Ici_of_finite _ _ fun F => ?_
+    rw [← Set.Ici_prod_Ici, Measure.prod_prod]
+    refine (ENNReal.toReal_eq_toReal_iff' (measure_ne_top _ _) ?_).1 ?_
+    · exact ENNReal.mul_ne_top (measure_ne_top _ _) (measure_ne_top _ _)
+    · rw [ENNReal.toReal_mul, ← upperMass_map_sum, h k l F.1 F.2, upperMass_def, upperMass_def]
+      rfl
+
+end ExchangeableGraphLaw
+
+end DenseGraphLimits
+
+end TauCeti

--- a/TauCeti/Combinatorics/DenseGraphLimits/ExchangeableGraphLaw/Dissociated.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/ExchangeableGraphLaw/Dissociated.lean
@@ -35,6 +35,8 @@ rectangle of their upper events.
 
 ## Main results
 
+* `TauCeti.DenseGraphLimits.ExchangeableGraphLaw.isDissociated_iff` — the defining identity of a
+  dissociated law;
 * `TauCeti.DenseGraphLimits.ExchangeableGraphLaw.upperMass_map_sum` — the upper mass of a disjoint
   union of patterns is the mass of a rectangle under the law of the pair of windows;
 * `TauCeti.DenseGraphLimits.isDissociated_iff_upperMass_mul` — a law is dissociated iff its upper
@@ -45,6 +47,9 @@ rectangle of their upper events.
 * P. Diaconis, S. Janson, *Graph limits and exchangeable random graphs*, Rend. Mat. Appl. (7) 28
   (2008), 33--61, Section 5.
 -/
+
+-- Provenance: the body of `IsDissociated` and the signature of `isDissociated_iff_upperMass_mul`
+-- follow `TauCetiRoadmap/DenseGraphLimits/Suggested.lean`.
 
 public section
 
@@ -68,6 +73,16 @@ def IsDissociated : Prop :=
     (L.law (k + l)).map
         (fun G => (SimpleGraph.comap (Fin.castAdd l) G, SimpleGraph.comap (Fin.natAdd k) G))
       = (L.law k).prod (L.law l)
+
+/-- The defining identity of a dissociated law: the level-`(k + l)` marginal pushed to the pair of
+windows is the product of the level-`k` and level-`l` marginals. -/
+@[simp]
+theorem isDissociated_iff :
+    L.IsDissociated ↔
+      ∀ k l : ℕ,
+        (L.law (k + l)).map
+            (fun G => (SimpleGraph.comap (Fin.castAdd l) G, SimpleGraph.comap (Fin.natAdd k) G))
+          = (L.law k).prod (L.law l) := (Iff.rfl)
 
 /-- The upper mass of a disjoint union of two patterns, placed on the first `k` and the last `l`
 labels, is the mass of the rectangle of their two upper events under the law of the pair of

--- a/TauCeti/Combinatorics/DenseGraphLimits/ExchangeableGraphLaw/Sampling.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/ExchangeableGraphLaw/Sampling.lean
@@ -5,7 +5,8 @@ Authors: Claude
 -/
 module
 
-public import TauCeti.Combinatorics.DenseGraphLimits.ExchangeableGraphLaw.Defs
+public import TauCeti.Combinatorics.DenseGraphLimits.ExchangeableGraphLaw.Dissociated
+public import TauCeti.Combinatorics.DenseGraphLimits.HomDensity.Structural
 public import TauCeti.Combinatorics.DenseGraphLimits.Sampling.Consistency
 public import TauCeti.Combinatorics.DenseGraphLimits.Sampling.Unbiased
 
@@ -20,7 +21,8 @@ law, which is what this file packages.
 
 The upper mass of a pattern under a sampling law is its graphon homomorphism density: the sample
 contains `F` exactly when every edge of `F` wins its coin toss, whose conditional probability at
-fixed positions is the product of the edge factors of `F`.
+fixed positions is the product of the edge factors of `F`. Hence sampling laws are dissociated:
+the upper masses of a disjoint union of patterns multiply because homomorphism densities do.
 
 ## Main definitions
 
@@ -30,7 +32,8 @@ fixed positions is the product of the edge factors of `F`.
 ## Main results
 
 * `TauCeti.DenseGraphLimits.upperMass_sampleExchangeableLaw` — the upper mass of a pattern under
-  a sampling law is its homomorphism density.
+  a sampling law is its homomorphism density;
+* `TauCeti.DenseGraphLimits.isDissociated_sampleExchangeableLaw` — sampling laws are dissociated.
 
 ## References
 
@@ -83,6 +86,17 @@ theorem upperMass_sampleExchangeableLaw {k : ℕ} (F : SimpleGraph (Fin k)) [Dec
   rw [← ENNReal.ofReal_sum_of_nonneg fun G _ => sampleMass_nonneg W G,
     sum_sampleMass_supergraph_eq_homDensity W F,
     ENNReal.toReal_ofReal (homDensity_nonneg F W)]
+
+/-- **Sampling laws are dissociated.** Disjoint label windows of a graphon sample read disjoint
+sets of sampled points and coins. Through upper masses this is the multiplicativity of
+homomorphism densities over disjoint unions: the upper mass of a pattern is its homomorphism
+density, which is unchanged by relabelling the pattern into `Fin (k + l)`. -/
+theorem isDissociated_sampleExchangeableLaw (W : Graphon Ω μ) :
+    (sampleExchangeableLaw W).IsDissociated := by
+  classical
+  refine (ExchangeableGraphLaw.isDissociated_iff_upperMass_mul _).2 fun k l F₁ F₂ => ?_
+  rw [upperMass_sampleExchangeableLaw, upperMass_sampleExchangeableLaw,
+    upperMass_sampleExchangeableLaw, homDensity_map_embedding, homDensity_sum]
 
 end DenseGraphLimits
 

--- a/TauCeti/Combinatorics/DenseGraphLimits/ExchangeableGraphLaw/Sampling.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/ExchangeableGraphLaw/Sampling.lean
@@ -46,6 +46,10 @@ the upper masses of a disjoint union of patterns multiply because homomorphism d
   `Graphon/ExchangeableGraphLaw.lean`. The packaging of the sampling laws and the identification of
   the upper mass with a homomorphism density follow that source, adapted to Tau Ceti's strict
   graphon carrier.
+* Roadmap: `TauCetiRoadmap/DenseGraphLimits/README.md`, Layer 9b — the sampling anchor
+  `upperMass_sampleExchangeableLaw` and the dissociation of sampling laws
+  `isDissociated_sampleExchangeableLaw`. The signatures follow
+  `TauCetiRoadmap/DenseGraphLimits/Suggested.lean`.
 -/
 
 public section
@@ -94,7 +98,7 @@ density, which is unchanged by relabelling the pattern into `Fin (k + l)`. -/
 theorem isDissociated_sampleExchangeableLaw (W : Graphon Ω μ) :
     (sampleExchangeableLaw W).IsDissociated := by
   classical
-  refine (ExchangeableGraphLaw.isDissociated_iff_upperMass_mul _).2 fun k l F₁ F₂ => ?_
+  refine (isDissociated_iff_upperMass_mul _).2 fun k l F₁ F₂ => ?_
   rw [upperMass_sampleExchangeableLaw, upperMass_sampleExchangeableLaw,
     upperMass_sampleExchangeableLaw, homDensity_map_embedding, homDensity_sum]
 

--- a/TauCeti/Combinatorics/DenseGraphLimits/ExchangeableGraphLaw/Sampling.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/ExchangeableGraphLaw/Sampling.lean
@@ -46,10 +46,6 @@ the upper masses of a disjoint union of patterns multiply because homomorphism d
   `Graphon/ExchangeableGraphLaw.lean`. The packaging of the sampling laws and the identification of
   the upper mass with a homomorphism density follow that source, adapted to Tau Ceti's strict
   graphon carrier.
-* Roadmap: `TauCetiRoadmap/DenseGraphLimits/README.md`, Layer 9b — the sampling anchor
-  `upperMass_sampleExchangeableLaw` and the dissociation of sampling laws
-  `isDissociated_sampleExchangeableLaw`. The signatures follow
-  `TauCetiRoadmap/DenseGraphLimits/Suggested.lean`.
 -/
 
 public section

--- a/TauCeti/Combinatorics/DenseGraphLimits/ExchangeableGraphLaw/Sampling.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/ExchangeableGraphLaw/Sampling.lean
@@ -6,7 +6,6 @@ Authors: Claude
 module
 
 public import TauCeti.Combinatorics.DenseGraphLimits.ExchangeableGraphLaw.Dissociated
-public import TauCeti.Combinatorics.DenseGraphLimits.HomDensity.Structural
 public import TauCeti.Combinatorics.DenseGraphLimits.Sampling.Consistency
 public import TauCeti.Combinatorics.DenseGraphLimits.Sampling.Unbiased
 

--- a/TauCeti/Combinatorics/SimpleGraph/Sum.lean
+++ b/TauCeti/Combinatorics/SimpleGraph/Sum.lean
@@ -10,12 +10,16 @@ public import Mathlib.Combinatorics.SimpleGraph.Sum
 /-!
 # Disjoint sums of graphs
 
-Two gaps in Mathlib's `SimpleGraph.sum` API.
+Three gaps in Mathlib's `SimpleGraph.sum` API.
 
 `SimpleGraph.sum` has no `DecidableRel` instance in Mathlib. Consequently, even when adjacency in
 both summands is decidable, `(G ⊕g H).edgeFinset` is not expressible without supplying an
 instance. `TauCeti.instDecidableRelSumAdj` supplies it by the four-way case split in the definition
 of `SimpleGraph.sum`.
+
+Nor does it describe the graphs containing a disjoint sum: `SimpleGraph.sum_le_iff` says a graph on
+`V ⊕ W` contains `G ⊕g H` exactly when its two sides contain `G` and `H`, which is how containing a
+disjoint union of patterns splits into two independent containment events.
 
 `SimpleGraph.sum` has no `bot` law in Mathlib either: `TauCeti.SimpleGraph.sum_bot_bot` says a
 disjoint sum of edgeless graphs is edgeless, the form in which a graph parameter that is
@@ -24,6 +28,8 @@ multiplicative over disjoint sums is evaluated on an edgeless graph.
 ## Main results
 
 * `TauCeti.instDecidableRelSumAdj` — adjacency in a disjoint sum is decidable;
+* `SimpleGraph.sum_le_iff` — a graph contains a disjoint sum exactly when its two sides contain the
+  summands;
 * `TauCeti.SimpleGraph.sum_bot_bot` — a disjoint sum of edgeless graphs is edgeless.
 -/
 
@@ -43,6 +49,18 @@ instance instDecidableRelSumAdj (G : SimpleGraph V) (H : SimpleGraph W)
   | .inr u, .inr v => ‹DecidableRel H.Adj› u v
   | .inl _, .inr _ => isFalse (by simp)
   | .inr _, .inl _ => isFalse (by simp)
+
+/-- A graph on `V ⊕ W` contains the disjoint sum `G ⊕g H` exactly when its restrictions to the two
+sides contain `G` and `H`: the sum has no edges across the sides. -/
+theorem _root_.SimpleGraph.sum_le_iff {K : SimpleGraph (V ⊕ W)} :
+    G ⊕g H ≤ K ↔ G ≤ K.comap Sum.inl ∧ H ≤ K.comap Sum.inr := by
+  refine ⟨fun h => ⟨fun a b hab => h (sum_adj_inl.2 hab), fun a b hab => h (sum_adj_inr.2 hab)⟩,
+    ?_⟩
+  rintro ⟨hG, hH⟩ (a | a) (b | b) hab
+  · exact hG (sum_adj_inl.1 hab)
+  · simp at hab
+  · simp at hab
+  · exact hH (sum_adj_inr.1 hab)
 
 namespace SimpleGraph
 

--- a/TauCeti/Combinatorics/SimpleGraph/Sum.lean
+++ b/TauCeti/Combinatorics/SimpleGraph/Sum.lean
@@ -52,6 +52,7 @@ instance instDecidableRelSumAdj (G : SimpleGraph V) (H : SimpleGraph W)
 
 /-- A graph on `V ⊕ W` contains the disjoint sum `G ⊕g H` exactly when its restrictions to the two
 sides contain `G` and `H`: the sum has no edges across the sides. -/
+@[simp]
 theorem _root_.SimpleGraph.sum_le_iff {K : SimpleGraph (V ⊕ W)} :
     G ⊕g H ≤ K ↔ G ≤ K.comap Sum.inl ∧ H ≤ K.comap Sum.inr := by
   refine ⟨fun h => ⟨fun a b hab => h (sum_adj_inl.2 hab), fun a b hab => h (sum_adj_inr.2 hab)⟩,

--- a/TauCeti/MeasureTheory/Measure/FiniteOrder.lean
+++ b/TauCeti/MeasureTheory/Measure/FiniteOrder.lean
@@ -1,0 +1,60 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import Mathlib.MeasureTheory.Measure.Dirac.Basic
+public import Mathlib.MeasureTheory.Measure.Typeclasses.Finite
+public import Mathlib.Order.Interval.Set.Basic
+
+/-!
+# Measures on a finite partial order are determined by their upper sets
+
+Mathlib's `MeasureTheory.Measure.ext_of_Ici` says that a finite Borel measure on a second-countable
+linear order is determined by its values on the closed upper rays `Set.Ici a`. On a *finite*
+partial order no topology is needed, and neither is a total order: the ray `Set.Ici a` is the point
+`a` together with the strictly larger points, so downward induction along the order recovers the
+mass of every singleton from the masses of the rays, and a measure on a countable space with
+measurable singletons is determined by its singletons.
+
+The typical consumers are laws on finite lattices of finite graphs, where the mass of a ray is the
+probability that a random graph contains a fixed pattern, and on products of such lattices.
+
+## Main results
+
+* `MeasureTheory.Measure.ext_of_Ici_of_finite` — two measures on a finite partial order with
+  measurable singletons, the first of them finite, agree once they agree on every `Set.Ici a`.
+-/
+
+public section
+
+open MeasureTheory Set
+
+namespace TauCeti
+
+variable {α : Type*} [Finite α] [PartialOrder α] [MeasurableSpace α] [MeasurableSingletonClass α]
+
+/-- Two measures on a finite partial order with measurable singletons are equal if they agree on
+all closed upper rays `Set.Ici a` and the first is finite: the ray at `a` is `a` together with the
+strictly larger points, so downward induction recovers the mass of every singleton. -/
+theorem _root_.MeasureTheory.Measure.ext_of_Ici_of_finite (μ ν : Measure α) [IsFiniteMeasure μ]
+    (h : ∀ a, μ (Ici a) = ν (Ici a)) : μ = ν := by
+  refine Measure.ext_of_singleton fun a => ?_
+  induction a using WellFoundedGT.induction with
+  | ind a ih =>
+    -- The strictly larger points form a finite union of singletons, on which both agree.
+    have hIoi : μ (Ioi a) = ν (Ioi a) := by
+      have hfin := (toFinite (Ioi a)).coe_toFinset
+      rw [← hfin, ← sum_measure_singleton, ← sum_measure_singleton]
+      exact Finset.sum_congr rfl fun b hb => ih b ((toFinite (Ioi a)).mem_toFinset.1 hb)
+    have hsplit : ∀ ρ : Measure α, ρ (Ici a) = ρ {a} + ρ (Ioi a) := fun ρ => by
+      rw [← Ioi_union_left, union_comm,
+        measure_union' (s₂ := Ioi a) (disjoint_singleton_left.2 (lt_irrefl a))
+          (measurableSet_singleton a)]
+    have hne : μ (Ioi a) ≠ ⊤ := measure_ne_top μ _
+    have hadd := (hsplit μ).symm.trans ((h a).trans (hsplit ν))
+    rwa [hIoi, ENNReal.add_left_inj (hIoi ▸ hne)] at hadd
+
+end TauCeti

--- a/TauCeti/MeasureTheory/Measure/FiniteOrder.lean
+++ b/TauCeti/MeasureTheory/Measure/FiniteOrder.lean
@@ -5,9 +5,9 @@ Authors: Claude
 -/
 module
 
-public import Mathlib.MeasureTheory.Measure.Dirac.Basic
 public import Mathlib.MeasureTheory.Measure.Typeclasses.Finite
 public import Mathlib.Order.Interval.Set.Basic
+import Mathlib.MeasureTheory.Measure.Dirac.Basic
 
 /-!
 # Measures on a finite partial order are determined by their upper sets


### PR DESCRIPTION
This PR defines dissociated exchangeable graph laws, proves that a law is dissociated exactly when its upper masses are multiplicative over disjoint unions of patterns, and proves that the sampling laws of a graphon are dissociated. These are three Layer 9b targets pinned in `DenseGraphLimits/Suggested.lean`: `ExchangeableGraphLaw.IsDissociated` (with the roadmap's body, restrictions to the first `k` and last `l` labels of `Fin (k + l)` having the product law), `isDissociated_iff_upperMass_mul`, and `isDissociated_sampleExchangeableLaw`.

Roadmap: DenseGraphLimits

<!--tauceti-target:v1 {"focus":"DenseGraphLimits","id":"exchangeablegraphlaw-isdissociated"}-->

The milestone is Layer 9b, the Diaconis–Janson graph-law representation. After #6381, which added `ExchangeableGraphLaw`, `upperMass` and the sampling anchor `upperMass_sampleExchangeableLaw`, the next item in the layer's chain is dissociation. The README's Layer 8b spine also consumes it by name: it says `isDissociated_paramExchangeableLaw` is "visible through the Layer-9b bridge `isDissociated_iff_upperMass_mul`". So this PR supplies an input to both summits. What remains after this PR in Layer 9b's dissociation part is the extremality theorem `exists_graphon_of_isDissociated`, which depends on Layer 4 compactness through the empirical-mixing spine.

The bridge is a real theorem and does not just rewrite the definition. Dissociation is an equality of laws on pairs of graphs, while upper masses only see upper events. The forward direction evaluates both laws on the rectangle of two upper events (`upperMass_map_sum`). For the converse, those rectangles are exactly the upper rays `Set.Ici (F₁, F₂)` of the product of the two finite lattices of graphs, and a finite measure on a finite partial order is determined by its upper rays. That fact is the new general lemma `MeasureTheory.Measure.ext_of_Ici_of_finite` in `TauCeti/MeasureTheory/Measure/FiniteOrder.lean`: downward induction, with the ray at `a` split into `{a}` and `Set.Ioi a`. It is the finite, order-theoretic counterpart of Mathlib's topological `MeasureTheory.Measure.ext_of_Ici`. The existing `ExchangeableGraphLaw.ext_upperMass` in `ExchangeableGraphLaw/Defs.lean` ran the same induction by hand for a single lattice, so it is now a three-line application of the general lemma. `isDissociated_sampleExchangeableLaw` then follows from the bridge, because upper masses of sampling laws are homomorphism densities and the existing `homDensity_map_embedding` and `homDensity_sum` make those multiplicative. The one missing graph fact, `SimpleGraph.sum_le_iff` (a graph on `V ⊕ W` contains `G ⊕g H` iff its two sides contain `G` and `H`), joins `TauCeti/Combinatorics/SimpleGraph/Sum.lean`, which already fills gaps in Mathlib's `SimpleGraph.sum` API. No code is vendored.

New modules: `TauCeti/Combinatorics/DenseGraphLimits/ExchangeableGraphLaw/Dissociated.lean` and `TauCeti/MeasureTheory/Measure/FiniteOrder.lean`. Edited: `ExchangeableGraphLaw/Defs.lean`, `ExchangeableGraphLaw/Sampling.lean`, `Combinatorics/SimpleGraph/Sum.lean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Prepared with Claude Code
