### PR TITLE
feat: restriction and corestriction in Tate degrees 0 and -1

### DIFF
--- a/TauCeti/Algebra/Category/ModuleCat/Quotient.lean
+++ b/TauCeti/Algebra/Category/ModuleCat/Quotient.lean
@@ -1,0 +1,55 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Category.ModuleCat.Basic
+public import Mathlib.LinearAlgebra.Quotient.Basic
+
+/-!
+# Maps induced on presented quotients in `ModuleCat`
+
+An object `A` of `ModuleCat R` is frequently *presented* as a quotient `X ⧸ p`, by an isomorphism
+`e : A ≅ ModuleCat.of R (X ⧸ p)` together with a projection `π : ModuleCat.of R X ⟶ A` playing
+the role of `Submodule.mkQ`, in the sense that `π ≫ e.hom = ModuleCat.ofHom p.mkQ`. A linear map
+`f : X₁ →ₗ[R] X₂` carrying `p₁` into `p₂` then induces a map `A₁ ⟶ A₂`, namely `Submodule.mapQ`
+conjugated by the two presentations.
+
+This file records the one fact such an induced map is used through: it sends the class `π₁ x` of a
+representative to the class `π₂ (f x)`, which is Mathlib's `Submodule.mapQ_mkQ` transported along
+the two presentations. Since the presentations are only given up to isomorphism, this
+characterisation — rather than a definitional unfolding — is how the induced map is computed.
+
+## Main statements
+
+* `ModuleCat.comp_conj_mapQ`: the map induced by `f` on two presented quotients composed with the
+  projection of the source is the projection of the target composed with `f`.
+-/
+
+public section
+
+open CategoryTheory
+
+universe u v
+
+namespace ModuleCat
+
+variable {R : Type v} [Ring R]
+
+/-- A map conjugated from `Submodule.mapQ p₁ p₂ f` along presentations `e₁`, `e₂` of two objects
+as the quotients sends the class `π₁ x` of a representative to the class `π₂ (f x)`. This is
+`Submodule.mapQ_mkQ` transported along the two presentations. -/
+theorem comp_conj_mapQ {X₁ X₂ : Type u} [AddCommGroup X₁] [Module R X₁] [AddCommGroup X₂]
+    [Module R X₂] {p₁ : Submodule R X₁} {p₂ : Submodule R X₂} {A₁ A₂ : ModuleCat.{u} R}
+    (e₁ : A₁ ≅ ModuleCat.of R (X₁ ⧸ p₁)) (e₂ : A₂ ≅ ModuleCat.of R (X₂ ⧸ p₂))
+    {π₁ : ModuleCat.of R X₁ ⟶ A₁} {π₂ : ModuleCat.of R X₂ ⟶ A₂}
+    (hπ₁ : π₁ ≫ e₁.hom = ModuleCat.ofHom p₁.mkQ) (hπ₂ : π₂ ≫ e₂.hom = ModuleCat.ofHom p₂.mkQ)
+    (f : X₁ →ₗ[R] X₂) (hf : p₁ ≤ p₂.comap f) :
+    π₁ ≫ e₁.hom ≫ ModuleCat.ofHom (p₁.mapQ p₂ f hf) ≫ e₂.inv = ModuleCat.ofHom f ≫ π₂ := by
+  rw [← cancel_mono e₂.hom]
+  simp only [Category.assoc, Iso.inv_hom_id, Category.comp_id, reassoc_of% hπ₁, hπ₂,
+    ← ModuleCat.ofHom_comp, Submodule.mapQ_mkQ]
+
+end ModuleCat

--- a/TauCeti/GroupTheory/QuotientGroup/Basic.lean
+++ b/TauCeti/GroupTheory/QuotientGroup/Basic.lean
@@ -40,9 +40,8 @@ For a finite group, a sum can also be split over the left or right cosets of a s
   `G ⧸ ⊥` with left translation in `G`.
 * `TauCeti.quotientBot_smul_eq_self_iff`: a group element fixes a coset of the trivial subgroup
   only when it is the identity.
-* `TauCeti.Subgroup.sum_eq_sum_leftCosets` and
-  `TauCeti.Subgroup.sum_eq_sum_rightCosets`: split a finite sum along the left or right cosets of
-  a subgroup.
+* `Subgroup.sum_eq_sum_leftCosets` and `Subgroup.sum_eq_sum_rightCosets`: split a finite sum
+  along the left or right cosets of a subgroup.
 -/
 
 public section
@@ -115,8 +114,6 @@ section Finite
 
 variable {M : Type*} [AddCommMonoid M] [Fintype G] (H : Subgroup G)
 
-namespace Subgroup
-
 /-- A subgroup of a finite group is a finite type. -/
 noncomputable local instance fintypeSubgroup : Fintype H := Fintype.ofFinite H
 
@@ -126,7 +123,7 @@ noncomputable local instance fintypeQuotientGroup : Fintype (G ⧸ H) :=
 
 /-- Every element of a finite group `G` is uniquely the product of the `Quotient.out`
 representative of a left coset of `H` and an element of `H`. -/
-theorem sum_eq_sum_leftCosets (f : G → M) :
+theorem _root_.Subgroup.sum_eq_sum_leftCosets (f : G → M) :
     ∑ g : G, f g = ∑ q : G ⧸ H, ∑ h : H, f (q.out * h) := by
   have hmk (q : G ⧸ H) (h : H) : ((q.out * h : G) : G ⧸ H) = q := by
     rw [QuotientGroup.mk_mul_of_mem _ h.2, QuotientGroup.out_eq']
@@ -141,17 +138,15 @@ theorem sum_eq_sum_leftCosets (f : G → M) :
     (fun p : (G ⧸ H) × H => f ((p.1.out : G) * (p.2 : G))) f fun _ => rfl
   rw [← key, Fintype.sum_prod_type]
 
-/-- The right-coset form of `TauCeti.Subgroup.sum_eq_sum_leftCosets`. -/
-theorem sum_eq_sum_rightCosets (f : G → M) :
+/-- The right-coset form of `Subgroup.sum_eq_sum_leftCosets`. -/
+theorem _root_.Subgroup.sum_eq_sum_rightCosets (f : G → M) :
     ∑ g : G, f g = ∑ q : G ⧸ H, ∑ h : H, f ((h : G) * (q.out : G)⁻¹) := by
   have h1 : ∑ g : G, f g = ∑ g : G, f g⁻¹ :=
     Fintype.sum_equiv (Equiv.inv G) _ _ fun _ => by simp
-  rw [h1, sum_eq_sum_leftCosets H fun g => f g⁻¹]
+  rw [h1, H.sum_eq_sum_leftCosets fun g => f g⁻¹]
   refine Finset.sum_congr rfl fun q _ => ?_
   exact (Fintype.sum_equiv (Equiv.inv H) (fun h => f ((h : G) * (q.out : G)⁻¹))
     (fun h => f ((q.out * (h : G))⁻¹)) fun _ => by simp).symm
-
-end Subgroup
 
 end Finite
 

--- a/TauCeti/GroupTheory/QuotientGroup/Basic.lean
+++ b/TauCeti/GroupTheory/QuotientGroup/Basic.lean
@@ -40,8 +40,9 @@ For a finite group, a sum can also be split over the left or right cosets of a s
   `G ⧸ ⊥` with left translation in `G`.
 * `TauCeti.quotientBot_smul_eq_self_iff`: a group element fixes a coset of the trivial subgroup
   only when it is the identity.
-* `TauCeti.sum_eq_sum_quotient_sum` and `TauCeti.sum_eq_sum_quotient_sum'`: split a finite sum
-  along the left or right cosets of a subgroup.
+* `TauCeti.Subgroup.sum_eq_sum_leftCosets` and
+  `TauCeti.Subgroup.sum_eq_sum_rightCosets`: split a finite sum along the left or right cosets of
+  a subgroup.
 -/
 
 public section
@@ -114,6 +115,8 @@ section Finite
 
 variable {M : Type*} [AddCommMonoid M] [Fintype G] (H : Subgroup G)
 
+namespace Subgroup
+
 /-- A subgroup of a finite group is a finite type. -/
 noncomputable local instance fintypeSubgroup : Fintype H := Fintype.ofFinite H
 
@@ -123,7 +126,7 @@ noncomputable local instance fintypeQuotientGroup : Fintype (G ⧸ H) :=
 
 /-- Every element of a finite group `G` is uniquely the product of the `Quotient.out`
 representative of a left coset of `H` and an element of `H`. -/
-theorem sum_eq_sum_quotient_sum (f : G → M) :
+theorem sum_eq_sum_leftCosets (f : G → M) :
     ∑ g : G, f g = ∑ q : G ⧸ H, ∑ h : H, f (q.out * h) := by
   have hmk (q : G ⧸ H) (h : H) : ((q.out * h : G) : G ⧸ H) = q := by
     rw [QuotientGroup.mk_mul_of_mem _ h.2, QuotientGroup.out_eq']
@@ -138,15 +141,17 @@ theorem sum_eq_sum_quotient_sum (f : G → M) :
     (fun p : (G ⧸ H) × H => f ((p.1.out : G) * (p.2 : G))) f fun _ => rfl
   rw [← key, Fintype.sum_prod_type]
 
-/-- The right-coset form of `TauCeti.sum_eq_sum_quotient_sum`. -/
-theorem sum_eq_sum_quotient_sum' (f : G → M) :
+/-- The right-coset form of `TauCeti.Subgroup.sum_eq_sum_leftCosets`. -/
+theorem sum_eq_sum_rightCosets (f : G → M) :
     ∑ g : G, f g = ∑ q : G ⧸ H, ∑ h : H, f ((h : G) * (q.out : G)⁻¹) := by
   have h1 : ∑ g : G, f g = ∑ g : G, f g⁻¹ :=
     Fintype.sum_equiv (Equiv.inv G) _ _ fun _ => by simp
-  rw [h1, sum_eq_sum_quotient_sum H fun g => f g⁻¹]
+  rw [h1, sum_eq_sum_leftCosets H fun g => f g⁻¹]
   refine Finset.sum_congr rfl fun q _ => ?_
   exact (Fintype.sum_equiv (Equiv.inv H) (fun h => f ((h : G) * (q.out : G)⁻¹))
     (fun h => f ((q.out * (h : G))⁻¹)) fun _ => by simp).symm
+
+end Subgroup
 
 end Finite
 

--- a/TauCeti/GroupTheory/QuotientGroup/Basic.lean
+++ b/TauCeti/GroupTheory/QuotientGroup/Basic.lean
@@ -114,8 +114,12 @@ section Finite
 
 variable {M : Type*} [AddCommMonoid M] [Fintype G] (H : Subgroup G)
 
-noncomputable local instance : Fintype H := Fintype.ofFinite H
-noncomputable local instance : Fintype (G ⧸ H) := H.fintypeQuotientOfFiniteIndex
+/-- A subgroup of a finite group is a finite type. -/
+noncomputable local instance fintypeSubgroup : Fintype H := Fintype.ofFinite H
+
+/-- The quotient of a finite group by a subgroup is a finite type. -/
+noncomputable local instance fintypeQuotientGroup : Fintype (G ⧸ H) :=
+  H.fintypeQuotientOfFiniteIndex
 
 /-- Every element of a finite group `G` is uniquely the product of the `Quotient.out`
 representative of a left coset of `H` and an element of `H`. -/

--- a/TauCeti/GroupTheory/QuotientGroup/Basic.lean
+++ b/TauCeti/GroupTheory/QuotientGroup/Basic.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Algebra.Group.Subgroup.Pointwise
 public import Mathlib.GroupTheory.GroupAction.Quotient
+public import Mathlib.GroupTheory.Index
 public import Mathlib.GroupTheory.QuotientGroup.Basic
 
 /-!
@@ -27,6 +28,9 @@ The cosets of `⊥` in a group `G` are the elements of `G`, and Mathlib's
 `QuotientGroup.quotientBot` is that identification.  The identification is equivariant for left
 translation, and the only element of `G` fixing a coset of `⊥` is the identity.
 
+For a finite group, a sum can also be split over the left or right cosets of a subgroup by using
+`Quotient.out` as a transversal.
+
 ## Main statements
 
 * `TauCeti.stabilizer_quotientGroup_mk`: the stabilizer of `sH` in `G` is `sHs⁻¹`.
@@ -36,6 +40,8 @@ translation, and the only element of `G` fixing a coset of `⊥` is the identity
   `G ⧸ ⊥` with left translation in `G`.
 * `TauCeti.quotientBot_smul_eq_self_iff`: a group element fixes a coset of the trivial subgroup
   only when it is the identity.
+* `TauCeti.sum_eq_sum_quotient_sum` and `TauCeti.sum_eq_sum_quotient_sum'`: split a finite sum
+  along the left or right cosets of a subgroup.
 -/
 
 public section
@@ -103,5 +109,41 @@ theorem quotientBot_smul_eq_self_iff (g : G) (q : G ⧸ (⊥ : Subgroup G)) :
     | H x => simpa [quotientBot_smul] using this
   · rintro rfl
     exact one_smul _ _
+
+section Finite
+
+variable {M : Type*} [AddCommMonoid M] [Fintype G] (H : Subgroup G)
+
+noncomputable local instance : Fintype H := Fintype.ofFinite H
+noncomputable local instance : Fintype (G ⧸ H) := H.fintypeQuotientOfFiniteIndex
+
+/-- Every element of a finite group `G` is uniquely the product of the `Quotient.out`
+representative of a left coset of `H` and an element of `H`. -/
+theorem sum_eq_sum_quotient_sum (f : G → M) :
+    ∑ g : G, f g = ∑ q : G ⧸ H, ∑ h : H, f (q.out * h) := by
+  have hmk (q : G ⧸ H) (h : H) : ((q.out * h : G) : G ⧸ H) = q := by
+    rw [QuotientGroup.mk_mul_of_mem _ h.2, QuotientGroup.out_eq']
+  have hbij : Function.Bijective fun p : (G ⧸ H) × H => (p.1.out : G) * (p.2 : G) := by
+    refine Function.bijective_iff_has_inverse.2 ⟨fun g => ((g : G ⧸ H),
+      ⟨(Quotient.out (g : G ⧸ H))⁻¹ * g, QuotientGroup.eq.mp (QuotientGroup.out_eq' _)⟩),
+      fun p => ?_, fun g => ?_⟩
+    · refine Prod.ext (hmk p.1 p.2) (Subtype.ext ?_)
+      simp [hmk p.1 p.2]
+    · simp
+  have key := Fintype.sum_bijective _ hbij
+    (fun p : (G ⧸ H) × H => f ((p.1.out : G) * (p.2 : G))) f fun _ => rfl
+  rw [← key, Fintype.sum_prod_type]
+
+/-- The right-coset form of `TauCeti.sum_eq_sum_quotient_sum`. -/
+theorem sum_eq_sum_quotient_sum' (f : G → M) :
+    ∑ g : G, f g = ∑ q : G ⧸ H, ∑ h : H, f ((h : G) * (q.out : G)⁻¹) := by
+  have h1 : ∑ g : G, f g = ∑ g : G, f g⁻¹ :=
+    Fintype.sum_equiv (Equiv.inv G) _ _ fun _ => by simp
+  rw [h1, sum_eq_sum_quotient_sum H fun g => f g⁻¹]
+  refine Finset.sum_congr rfl fun q _ => ?_
+  exact (Fintype.sum_equiv (Equiv.inv H) (fun h => f ((h : G) * (q.out : G)⁻¹))
+    (fun h => f ((q.out * (h : G))⁻¹)) fun _ => by simp).symm
+
+end Finite
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/Homological/TateCohomology/Restriction.lean
+++ b/TauCeti/RepresentationTheory/Homological/TateCohomology/Restriction.lean
@@ -1,0 +1,227 @@
+/-
+Copyright (c) 2026 Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import TauCeti.RepresentationTheory.Homological.TateCohomology.LowDegree
+public import TauCeti.RepresentationTheory.RelativeNorm
+public import Mathlib.RepresentationTheory.Rep.Res
+
+/-!
+# Restriction and corestriction to a subgroup in degrees `0` and `-1` of Tate cohomology
+
+Let `G` be a finite group, `H ≤ G` a subgroup and `M` a `G`-representation. In every Tate degree
+there are a restriction map `tateCohomology M n ⟶ tateCohomology (Rep.res H.subtype M) n` and a
+corestriction map back, and the composite of the two is multiplication by the index `[G : H]`.
+In the degrees where the Tate complex is the complex of inhomogeneous cochains — that is, in
+degrees `≥ 1` — restriction is the ordinary restriction of group cohomology, and in the degrees
+where it is the complex of inhomogeneous chains — degrees `≤ -2` — corestriction is the ordinary
+change-of-group map of group homology, both of which Mathlib already provides. Degrees `0` and
+`-1` are the two degrees where the Tate complex is neither, being glued there by the norm map:
+degree `0` is `Mᴳ / N_G M` and degree `-1` is `ker N_G / I_G M`.
+
+This file supplies all four maps in exactly those two degrees, using the identifications of
+`TauCeti.RepresentationTheory.Homological.TateCohomology.LowDegree`. Restriction in degree `0` and
+corestriction in degree `-1` are induced by inclusions of representatives, `Mᴳ ⊆ Mᴴ` and
+`ker N_G ⊇ ker N_H`. The other two are induced by the relative norm and the relative transfer of
+`H` in `G` of `TauCeti.RepresentationTheory.RelativeNorm`: corestriction in degree `0` is the
+relative norm `N_{G/H} : Mᴴ → Mᴳ`, and restriction in degree `-1` is the relative transfer, which
+carries `ker N_G` into `ker N_H` and `I_G M` into `I_H M`.
+
+In both degrees the composite of restriction and corestriction is multiplication by `[G : H]`,
+because the relative norm is `[G : H] • ·` on `Mᴳ` and the relative transfer is `[G : H] • ·`
+modulo `I_G M`.
+
+## Main definitions
+
+* `TauCeti.TateCohomology.H0Res`, `TauCeti.TateCohomology.H0Cor`: restriction and corestriction
+  in degree `0`.
+* `TauCeti.TateCohomology.HNegOneRes`, `TauCeti.TateCohomology.HNegOneCor`: restriction and
+  corestriction in degree `-1`.
+
+## Main results
+
+* `TauCeti.TateCohomology.H0π_comp_H0Res`, `TauCeti.TateCohomology.H0π_comp_H0Cor`,
+  `TauCeti.TateCohomology.HNegOneπ_comp_HNegOneRes`,
+  `TauCeti.TateCohomology.HNegOneπ_comp_HNegOneCor`: the effect of each map on the class of a
+  representative.
+* `TauCeti.TateCohomology.H0Res_comp_H0Cor` and
+  `TauCeti.TateCohomology.HNegOneRes_comp_HNegOneCor`: corestriction after restriction is
+  multiplication by the index.
+
+## References
+
+* E. Artin and J. Tate, *Class Field Theory*, Chapter IV, §6 and Chapter XIV, §4.
+* K. S. Brown, *Cohomology of Groups*, Chapter III, §9 and Chapter VI, §5.
+* J. S. Milne, *Class Field Theory*, v4.03, Chapter II, §1.
+-/
+
+public noncomputable section
+
+universe u
+
+open CategoryTheory LinearMap Rep Representation
+
+namespace TauCeti.TateCohomology
+
+variable {R G : Type u} [CommRing R] [Group G] [Fintype G] (M : Rep R G)
+  (H : Subgroup G) [DecidablePred (· ∈ H)]
+
+section Zero
+
+private theorem h0_res_le :
+    (range M.ρ.norm).submoduleOf M.ρ.invariants ≤
+      Submodule.comap
+        (Submodule.inclusion
+          (Representation.invariants_le_invariants_comp_subtype (ρ := M.ρ) (H := H)))
+        ((range (Rep.res H.subtype M).ρ.norm).submoduleOf (Rep.res H.subtype M).ρ.invariants) :=
+  fun _ hx => Representation.range_norm_le_range_norm_comp_subtype (H := H) hx
+
+private theorem h0_cor_le :
+    (range (Rep.res H.subtype M).ρ.norm).submoduleOf (Rep.res H.subtype M).ρ.invariants ≤
+      Submodule.comap (Representation.relNormInvariants M.ρ H)
+        ((range M.ρ.norm).submoduleOf M.ρ.invariants) := by
+  rintro ⟨x, hx⟩ ⟨y, rfl⟩
+  refine ⟨y, ?_⟩
+  simpa using (Representation.relNorm_norm_apply (ρ := M.ρ) (H := H) y).symm
+
+/-- Restriction to a subgroup in degree zero Tate cohomology, induced by the inclusion of the
+invariants `Mᴳ ⊆ Mᴴ`. -/
+def H0Res : tateCohomology M 0 ⟶ tateCohomology (Rep.res H.subtype M) 0 :=
+  (H0IsoNormQuotient M).hom ≫
+    ModuleCat.ofHom (Submodule.mapQ _ _ _ (h0_res_le M H)) ≫
+    (H0IsoNormQuotient (Rep.res H.subtype M)).inv
+
+/-- Corestriction from a subgroup in degree zero Tate cohomology, induced by the relative norm
+`Mᴴ → Mᴳ`. -/
+def H0Cor : tateCohomology (Rep.res H.subtype M) 0 ⟶ tateCohomology M 0 :=
+  (H0IsoNormQuotient (Rep.res H.subtype M)).hom ≫
+    ModuleCat.ofHom (Submodule.mapQ _ _ _ (h0_cor_le M H)) ≫
+    (H0IsoNormQuotient M).inv
+
+/-- Restriction in degree zero sends the class of a `G`-invariant element to the class of the
+same element, viewed as an `H`-invariant element. -/
+@[reassoc (attr := simp), elementwise (attr := simp)]
+theorem H0π_comp_H0Res :
+    H0π M ≫ H0Res M H =
+      ModuleCat.ofHom (Submodule.inclusion
+        (Representation.invariants_le_invariants_comp_subtype (ρ := M.ρ) (H := H))) ≫
+        H0π (Rep.res H.subtype M) := by
+  rw [← cancel_mono (H0IsoNormQuotient (Rep.res H.subtype M)).hom, Category.assoc,
+    Category.assoc, H0π_comp_H0IsoNormQuotient_hom, H0Res, Category.assoc, Category.assoc,
+    Iso.inv_hom_id, Category.comp_id, H0π_comp_H0IsoNormQuotient_hom_assoc]
+  ext x
+  rfl
+
+/-- Corestriction in degree zero sends the class of an `H`-invariant element to the class of its
+relative norm. -/
+@[reassoc (attr := simp), elementwise (attr := simp)]
+theorem H0π_comp_H0Cor :
+    H0π (Rep.res H.subtype M) ≫ H0Cor M H =
+      ModuleCat.ofHom (Representation.relNormInvariants M.ρ H) ≫ H0π M := by
+  rw [← cancel_mono (H0IsoNormQuotient M).hom, Category.assoc,
+    Category.assoc, H0π_comp_H0IsoNormQuotient_hom, H0Cor, Category.assoc, Category.assoc,
+    Iso.inv_hom_id, Category.comp_id, H0π_comp_H0IsoNormQuotient_hom_assoc]
+  ext x
+  rfl
+
+/-- Corestriction of the restriction of a degree-zero class is the index multiple of it. -/
+theorem H0Cor_H0Res_apply (x : tateCohomology M 0) :
+    H0Cor M H (H0Res M H x) = H.index • x := by
+  induction x using H0_induction_on with
+  | h y =>
+    rw [H0π_comp_H0Res_apply, H0π_comp_H0Cor_apply, ← map_nsmul]
+    congr 1
+    ext
+    simpa using Representation.relNorm_apply_of_mem_invariants (H := H) y.2
+
+/-- Restriction followed by corestriction is multiplication by the index, in degree zero. -/
+theorem H0Res_comp_H0Cor :
+    H0Res M H ≫ H0Cor M H = H.index • 𝟙 (tateCohomology M 0) := by
+  ext x
+  simpa using H0Cor_H0Res_apply M H x
+
+end Zero
+
+section NegOne
+
+private theorem hNegOne_res_le :
+    (Coinvariants.ker M.ρ).submoduleOf (ker M.ρ.norm) ≤
+      Submodule.comap (Representation.relTransferKerNorm M.ρ H)
+        ((Coinvariants.ker (Rep.res H.subtype M).ρ).submoduleOf
+          (ker (Rep.res H.subtype M).ρ.norm)) :=
+  fun _ hx => Representation.relTransfer_mem_coinvariantsKer (H := H) hx
+
+private theorem hNegOne_cor_le :
+    (Coinvariants.ker (Rep.res H.subtype M).ρ).submoduleOf (ker (Rep.res H.subtype M).ρ.norm) ≤
+      Submodule.comap
+        (Submodule.inclusion
+          (Representation.ker_norm_comp_subtype_le_ker_norm (ρ := M.ρ) (H := H)))
+        ((Coinvariants.ker M.ρ).submoduleOf (ker M.ρ.norm)) :=
+  fun _ hx => Representation.coinvariantsKer_comp_subtype_le (H := H) hx
+
+/-- Restriction to a subgroup in degree `-1` Tate cohomology, induced by the relative transfer. -/
+def HNegOneRes :
+    tateCohomology M (-1) ⟶ tateCohomology (Rep.res H.subtype M) (-1) :=
+  (HNegOneIsoNormKernelQuotient M).hom ≫
+    ModuleCat.ofHom (Submodule.mapQ _ _ _ (hNegOne_res_le M H)) ≫
+    (HNegOneIsoNormKernelQuotient (Rep.res H.subtype M)).inv
+
+/-- Corestriction from a subgroup in degree `-1` Tate cohomology, induced by the inclusion of the
+kernel of the norm of `H` in the kernel of the norm of `G`. -/
+def HNegOneCor :
+    tateCohomology (Rep.res H.subtype M) (-1) ⟶ tateCohomology M (-1) :=
+  (HNegOneIsoNormKernelQuotient (Rep.res H.subtype M)).hom ≫
+    ModuleCat.ofHom (Submodule.mapQ _ _ _ (hNegOne_cor_le M H)) ≫
+    (HNegOneIsoNormKernelQuotient M).inv
+
+/-- Restriction in degree `-1` sends the class of a norm-zero element to the class of its
+relative transfer. -/
+@[reassoc (attr := simp), elementwise (attr := simp)]
+theorem HNegOneπ_comp_HNegOneRes :
+    HNegOneπ M ≫ HNegOneRes M H =
+      ModuleCat.ofHom (Representation.relTransferKerNorm M.ρ H) ≫
+        HNegOneπ (Rep.res H.subtype M) := by
+  rw [← cancel_mono (HNegOneIsoNormKernelQuotient (Rep.res H.subtype M)).hom, Category.assoc,
+    Category.assoc, HNegOneπ_comp_HNegOneIsoNormKernelQuotient_hom, HNegOneRes, Category.assoc,
+    Category.assoc, Iso.inv_hom_id, Category.comp_id,
+    HNegOneπ_comp_HNegOneIsoNormKernelQuotient_hom_assoc]
+  ext x
+  rfl
+
+/-- Corestriction in degree `-1` sends the class of a norm-zero element to the class of the same
+element. -/
+@[reassoc (attr := simp), elementwise (attr := simp)]
+theorem HNegOneπ_comp_HNegOneCor :
+    HNegOneπ (Rep.res H.subtype M) ≫ HNegOneCor M H =
+      ModuleCat.ofHom (Submodule.inclusion
+        (Representation.ker_norm_comp_subtype_le_ker_norm (ρ := M.ρ) (H := H))) ≫
+        HNegOneπ M := by
+  rw [← cancel_mono (HNegOneIsoNormKernelQuotient M).hom, Category.assoc,
+    Category.assoc, HNegOneπ_comp_HNegOneIsoNormKernelQuotient_hom, HNegOneCor, Category.assoc,
+    Category.assoc, Iso.inv_hom_id, Category.comp_id,
+    HNegOneπ_comp_HNegOneIsoNormKernelQuotient_hom_assoc]
+  ext x
+  rfl
+
+/-- Corestriction of the restriction of a degree `-1` class is the index multiple of it. -/
+theorem HNegOneCor_HNegOneRes_apply (x : tateCohomology M (-1)) :
+    HNegOneCor M H (HNegOneRes M H x) = H.index • x := by
+  induction x using HNegOne_induction_on with
+  | h y =>
+    rw [HNegOneπ_comp_HNegOneRes_apply, HNegOneπ_comp_HNegOneCor_apply, ← map_nsmul,
+      HNegOneπ_eq_iff]
+    refine Submodule.mem_comap.2 ?_
+    simpa using Representation.relTransfer_sub_index_nsmul_mem (ρ := M.ρ) (H := H) (y : M.V)
+
+/-- Restriction followed by corestriction is multiplication by the index, in degree `-1`. -/
+theorem HNegOneRes_comp_HNegOneCor :
+    HNegOneRes M H ≫ HNegOneCor M H = H.index • 𝟙 (tateCohomology M (-1)) := by
+  ext x
+  simpa using HNegOneCor_HNegOneRes_apply M H x
+
+end NegOne
+
+end TauCeti.TateCohomology

--- a/TauCeti/RepresentationTheory/Homological/TateCohomology/Restriction.lean
+++ b/TauCeti/RepresentationTheory/Homological/TateCohomology/Restriction.lean
@@ -5,6 +5,7 @@ Authors: Claude
 -/
 module
 
+public import TauCeti.Algebra.Category.ModuleCat.Quotient
 public import TauCeti.RepresentationTheory.Homological.TateCohomology.LowDegree
 public import TauCeti.RepresentationTheory.RelativeNorm
 
@@ -75,19 +76,6 @@ noncomputable local instance fintypeSubgroup : Fintype H := Fintype.ofFinite H
 noncomputable local instance fintypeQuotientGroup : Fintype (G ⧸ H) :=
   H.fintypeQuotientOfFiniteIndex
 
-/-- A map conjugated from `Submodule.mapQ p₁ p₂ f` along identifications `e₁`, `e₂` of two
-objects with the quotients sends the class `π₁ x` of a representative to the class `π₂ (f x)`. -/
-private theorem comp_conj_mapQ {X₁ X₂ : Type u} [AddCommGroup X₁] [Module R X₁] [AddCommGroup X₂]
-    [Module R X₂] {p₁ : Submodule R X₁} {p₂ : Submodule R X₂} {A₁ A₂ : ModuleCat.{u} R}
-    (e₁ : A₁ ≅ ModuleCat.of R (X₁ ⧸ p₁)) (e₂ : A₂ ≅ ModuleCat.of R (X₂ ⧸ p₂))
-    {π₁ : ModuleCat.of R X₁ ⟶ A₁} {π₂ : ModuleCat.of R X₂ ⟶ A₂}
-    (hπ₁ : π₁ ≫ e₁.hom = ModuleCat.ofHom p₁.mkQ) (hπ₂ : π₂ ≫ e₂.hom = ModuleCat.ofHom p₂.mkQ)
-    (f : X₁ →ₗ[R] X₂) (hf : p₁ ≤ p₂.comap f) :
-    π₁ ≫ e₁.hom ≫ ModuleCat.ofHom (p₁.mapQ p₂ f hf) ≫ e₂.inv = ModuleCat.ofHom f ≫ π₂ := by
-  rw [← cancel_mono e₂.hom]
-  simp only [Category.assoc, Iso.inv_hom_id, Category.comp_id, reassoc_of% hπ₁, hπ₂,
-    ← ModuleCat.ofHom_comp, Submodule.mapQ_mkQ]
-
 section Zero
 
 private theorem h0_res_le :
@@ -129,7 +117,7 @@ theorem H0π_comp_H0Res :
         (Representation.invariants_le_invariants_comp_subtype (ρ := M.ρ) (H := H))) ≫
         H0π (Rep.res H.subtype M) := by
   rw [H0Res]
-  exact comp_conj_mapQ _ _ (H0π_comp_H0IsoNormQuotient_hom _)
+  exact ModuleCat.comp_conj_mapQ _ _ (H0π_comp_H0IsoNormQuotient_hom _)
     (H0π_comp_H0IsoNormQuotient_hom _) _ _
 
 /-- Corestriction in degree zero sends the class of an `H`-invariant element to the class of its
@@ -139,7 +127,7 @@ theorem H0π_comp_H0Cor :
     H0π (Rep.res H.subtype M) ≫ H0Cor M H =
       ModuleCat.ofHom (Representation.relNormInvariants M.ρ H) ≫ H0π M := by
   rw [H0Cor]
-  exact comp_conj_mapQ _ _ (H0π_comp_H0IsoNormQuotient_hom _)
+  exact ModuleCat.comp_conj_mapQ _ _ (H0π_comp_H0IsoNormQuotient_hom _)
     (H0π_comp_H0IsoNormQuotient_hom _) _ _
 
 /-- Corestriction of the restriction of a degree-zero class is the index multiple of it. -/
@@ -203,7 +191,7 @@ theorem HNegOneπ_comp_HNegOneRes :
       ModuleCat.ofHom (Representation.relTransferKerNorm M.ρ H) ≫
         HNegOneπ (Rep.res H.subtype M) := by
   rw [HNegOneRes]
-  exact comp_conj_mapQ _ _ (HNegOneπ_comp_HNegOneIsoNormKernelQuotient_hom _)
+  exact ModuleCat.comp_conj_mapQ _ _ (HNegOneπ_comp_HNegOneIsoNormKernelQuotient_hom _)
     (HNegOneπ_comp_HNegOneIsoNormKernelQuotient_hom _) _ _
 
 /-- Corestriction in degree `-1` sends the class of a norm-zero element to the class of the same
@@ -215,7 +203,7 @@ theorem HNegOneπ_comp_HNegOneCor :
         (Representation.ker_norm_comp_subtype_le_ker_norm (ρ := M.ρ) (H := H))) ≫
         HNegOneπ M := by
   rw [HNegOneCor]
-  exact comp_conj_mapQ _ _ (HNegOneπ_comp_HNegOneIsoNormKernelQuotient_hom _)
+  exact ModuleCat.comp_conj_mapQ _ _ (HNegOneπ_comp_HNegOneIsoNormKernelQuotient_hom _)
     (HNegOneπ_comp_HNegOneIsoNormKernelQuotient_hom _) _ _
 
 /-- Corestriction of the restriction of a degree `-1` class is the index multiple of it. -/

--- a/TauCeti/RepresentationTheory/Homological/TateCohomology/Restriction.lean
+++ b/TauCeti/RepresentationTheory/Homological/TateCohomology/Restriction.lean
@@ -7,7 +7,6 @@ module
 
 public import TauCeti.RepresentationTheory.Homological.TateCohomology.LowDegree
 public import TauCeti.RepresentationTheory.RelativeNorm
-public import Mathlib.RepresentationTheory.Rep.Res
 
 /-!
 # Restriction and corestriction to a subgroup in degrees `0` and `-1` of Tate cohomology
@@ -144,7 +143,7 @@ theorem H0π_comp_H0Cor :
     (H0π_comp_H0IsoNormQuotient_hom _) _ _
 
 /-- Corestriction of the restriction of a degree-zero class is the index multiple of it. -/
-theorem H0Cor_H0Res_apply (x : tateCohomology M 0) :
+theorem H0Cor_comp_H0Res_apply (x : tateCohomology M 0) :
     H0Cor M H (H0Res M H x) = H.index • x := by
   induction x using H0_induction_on with
   | h y =>
@@ -157,7 +156,7 @@ theorem H0Cor_H0Res_apply (x : tateCohomology M 0) :
 theorem H0Res_comp_H0Cor :
     H0Res M H ≫ H0Cor M H = H.index • 𝟙 (tateCohomology M 0) := by
   ext x
-  simpa using H0Cor_H0Res_apply M H x
+  simpa using H0Cor_comp_H0Res_apply M H x
 
 end Zero
 
@@ -220,7 +219,7 @@ theorem HNegOneπ_comp_HNegOneCor :
     (HNegOneπ_comp_HNegOneIsoNormKernelQuotient_hom _) _ _
 
 /-- Corestriction of the restriction of a degree `-1` class is the index multiple of it. -/
-theorem HNegOneCor_HNegOneRes_apply (x : tateCohomology M (-1)) :
+theorem HNegOneCor_comp_HNegOneRes_apply (x : tateCohomology M (-1)) :
     HNegOneCor M H (HNegOneRes M H x) = H.index • x := by
   induction x using HNegOne_induction_on with
   | h y =>
@@ -233,7 +232,7 @@ theorem HNegOneCor_HNegOneRes_apply (x : tateCohomology M (-1)) :
 theorem HNegOneRes_comp_HNegOneCor :
     HNegOneRes M H ≫ HNegOneCor M H = H.index • 𝟙 (tateCohomology M (-1)) := by
   ext x
-  simpa using HNegOneCor_HNegOneRes_apply M H x
+  simpa using HNegOneCor_comp_HNegOneRes_apply M H x
 
 end NegOne
 

--- a/TauCeti/RepresentationTheory/Homological/TateCohomology/Restriction.lean
+++ b/TauCeti/RepresentationTheory/Homological/TateCohomology/Restriction.lean
@@ -76,6 +76,19 @@ noncomputable local instance fintypeSubgroup : Fintype H := Fintype.ofFinite H
 noncomputable local instance fintypeQuotientGroup : Fintype (G ⧸ H) :=
   H.fintypeQuotientOfFiniteIndex
 
+/-- A map conjugated from `Submodule.mapQ p₁ p₂ f` along identifications `e₁`, `e₂` of two
+objects with the quotients sends the class `π₁ x` of a representative to the class `π₂ (f x)`. -/
+private theorem comp_conj_mapQ {X₁ X₂ : Type u} [AddCommGroup X₁] [Module R X₁] [AddCommGroup X₂]
+    [Module R X₂] {p₁ : Submodule R X₁} {p₂ : Submodule R X₂} {A₁ A₂ : ModuleCat.{u} R}
+    (e₁ : A₁ ≅ ModuleCat.of R (X₁ ⧸ p₁)) (e₂ : A₂ ≅ ModuleCat.of R (X₂ ⧸ p₂))
+    {π₁ : ModuleCat.of R X₁ ⟶ A₁} {π₂ : ModuleCat.of R X₂ ⟶ A₂}
+    (hπ₁ : π₁ ≫ e₁.hom = ModuleCat.ofHom p₁.mkQ) (hπ₂ : π₂ ≫ e₂.hom = ModuleCat.ofHom p₂.mkQ)
+    (f : X₁ →ₗ[R] X₂) (hf : p₁ ≤ p₂.comap f) :
+    π₁ ≫ e₁.hom ≫ ModuleCat.ofHom (p₁.mapQ p₂ f hf) ≫ e₂.inv = ModuleCat.ofHom f ≫ π₂ := by
+  rw [← cancel_mono e₂.hom]
+  simp only [Category.assoc, Iso.inv_hom_id, Category.comp_id, reassoc_of% hπ₁, hπ₂,
+    ← ModuleCat.ofHom_comp, Submodule.mapQ_mkQ]
+
 section Zero
 
 private theorem h0_res_le :
@@ -116,12 +129,9 @@ theorem H0π_comp_H0Res :
       ModuleCat.ofHom (Submodule.inclusion
         (Representation.invariants_le_invariants_comp_subtype (ρ := M.ρ) (H := H))) ≫
         H0π (Rep.res H.subtype M) := by
-  rw [← cancel_mono (H0IsoNormQuotient (Rep.res H.subtype M)).hom, Category.assoc,
-    Category.assoc, H0π_comp_H0IsoNormQuotient_hom, H0Res, Category.assoc, Category.assoc,
-    Iso.inv_hom_id, Category.comp_id, H0π_comp_H0IsoNormQuotient_hom_assoc]
-  ext x
-  simp only [ModuleCat.hom_comp, ModuleCat.hom_ofHom, LinearMap.comp_apply,
-    Submodule.mkQ_apply, Submodule.mapQ_apply]
+  rw [H0Res]
+  exact comp_conj_mapQ _ _ (H0π_comp_H0IsoNormQuotient_hom _)
+    (H0π_comp_H0IsoNormQuotient_hom _) _ _
 
 /-- Corestriction in degree zero sends the class of an `H`-invariant element to the class of its
 relative norm. -/
@@ -129,12 +139,9 @@ relative norm. -/
 theorem H0π_comp_H0Cor :
     H0π (Rep.res H.subtype M) ≫ H0Cor M H =
       ModuleCat.ofHom (Representation.relNormInvariants M.ρ H) ≫ H0π M := by
-  rw [← cancel_mono (H0IsoNormQuotient M).hom, Category.assoc,
-    Category.assoc, H0π_comp_H0IsoNormQuotient_hom, H0Cor, Category.assoc, Category.assoc,
-    Iso.inv_hom_id, Category.comp_id, H0π_comp_H0IsoNormQuotient_hom_assoc]
-  ext x
-  simp only [ModuleCat.hom_comp, ModuleCat.hom_ofHom, LinearMap.comp_apply,
-    Submodule.mkQ_apply, Submodule.mapQ_apply]
+  rw [H0Cor]
+  exact comp_conj_mapQ _ _ (H0π_comp_H0IsoNormQuotient_hom _)
+    (H0π_comp_H0IsoNormQuotient_hom _) _ _
 
 /-- Corestriction of the restriction of a degree-zero class is the index multiple of it. -/
 theorem H0Cor_H0Res_apply (x : tateCohomology M 0) :
@@ -162,9 +169,8 @@ private theorem hNegOne_res_le :
         ((Coinvariants.ker (Rep.res H.subtype M).ρ).submoduleOf
           (ker (Rep.res H.subtype M).ρ.norm)) :=
   fun x hx => by
-    change (Representation.relTransferKerNorm M.ρ H x : M.V) ∈
-      Coinvariants.ker (Rep.res H.subtype M).ρ
-    rw [Representation.coe_relTransferKerNorm]
+    rw [Submodule.mem_comap, Submodule.submoduleOf, Submodule.mem_comap, Submodule.subtype_apply,
+      Representation.coe_relTransferKerNorm]
     exact Representation.relTransfer_mem_coinvariantsKer (H := H) hx
 
 private theorem hNegOne_cor_le :
@@ -197,13 +203,9 @@ theorem HNegOneπ_comp_HNegOneRes :
     HNegOneπ M ≫ HNegOneRes M H =
       ModuleCat.ofHom (Representation.relTransferKerNorm M.ρ H) ≫
         HNegOneπ (Rep.res H.subtype M) := by
-  rw [← cancel_mono (HNegOneIsoNormKernelQuotient (Rep.res H.subtype M)).hom, Category.assoc,
-    Category.assoc, HNegOneπ_comp_HNegOneIsoNormKernelQuotient_hom, HNegOneRes, Category.assoc,
-    Category.assoc, Iso.inv_hom_id, Category.comp_id,
-    HNegOneπ_comp_HNegOneIsoNormKernelQuotient_hom_assoc]
-  ext x
-  simp only [ModuleCat.hom_comp, ModuleCat.hom_ofHom, LinearMap.comp_apply,
-    Submodule.mkQ_apply, Submodule.mapQ_apply]
+  rw [HNegOneRes]
+  exact comp_conj_mapQ _ _ (HNegOneπ_comp_HNegOneIsoNormKernelQuotient_hom _)
+    (HNegOneπ_comp_HNegOneIsoNormKernelQuotient_hom _) _ _
 
 /-- Corestriction in degree `-1` sends the class of a norm-zero element to the class of the same
 element. -/
@@ -213,13 +215,9 @@ theorem HNegOneπ_comp_HNegOneCor :
       ModuleCat.ofHom (Submodule.inclusion
         (Representation.ker_norm_comp_subtype_le_ker_norm (ρ := M.ρ) (H := H))) ≫
         HNegOneπ M := by
-  rw [← cancel_mono (HNegOneIsoNormKernelQuotient M).hom, Category.assoc,
-    Category.assoc, HNegOneπ_comp_HNegOneIsoNormKernelQuotient_hom, HNegOneCor, Category.assoc,
-    Category.assoc, Iso.inv_hom_id, Category.comp_id,
-    HNegOneπ_comp_HNegOneIsoNormKernelQuotient_hom_assoc]
-  ext x
-  simp only [ModuleCat.hom_comp, ModuleCat.hom_ofHom, LinearMap.comp_apply,
-    Submodule.mkQ_apply, Submodule.mapQ_apply]
+  rw [HNegOneCor]
+  exact comp_conj_mapQ _ _ (HNegOneπ_comp_HNegOneIsoNormKernelQuotient_hom _)
+    (HNegOneπ_comp_HNegOneIsoNormKernelQuotient_hom _) _ _
 
 /-- Corestriction of the restriction of a degree `-1` class is the index multiple of it. -/
 theorem HNegOneCor_HNegOneRes_apply (x : tateCohomology M (-1)) :

--- a/TauCeti/RepresentationTheory/Homological/TateCohomology/Restriction.lean
+++ b/TauCeti/RepresentationTheory/Homological/TateCohomology/Restriction.lean
@@ -67,7 +67,10 @@ open CategoryTheory LinearMap Rep Representation
 namespace TauCeti.TateCohomology
 
 variable {R G : Type u} [CommRing R] [Group G] [Fintype G] (M : Rep R G)
-  (H : Subgroup G) [DecidablePred (· ∈ H)]
+  (H : Subgroup G)
+
+noncomputable local instance : Fintype H := Fintype.ofFinite H
+noncomputable local instance : Fintype (G ⧸ H) := H.fintypeQuotientOfFiniteIndex
 
 section Zero
 
@@ -113,7 +116,8 @@ theorem H0π_comp_H0Res :
     Category.assoc, H0π_comp_H0IsoNormQuotient_hom, H0Res, Category.assoc, Category.assoc,
     Iso.inv_hom_id, Category.comp_id, H0π_comp_H0IsoNormQuotient_hom_assoc]
   ext x
-  rfl
+  simp only [ModuleCat.hom_comp, ModuleCat.hom_ofHom, LinearMap.comp_apply,
+    Submodule.mkQ_apply, Submodule.mapQ_apply]
 
 /-- Corestriction in degree zero sends the class of an `H`-invariant element to the class of its
 relative norm. -/
@@ -125,7 +129,8 @@ theorem H0π_comp_H0Cor :
     Category.assoc, H0π_comp_H0IsoNormQuotient_hom, H0Cor, Category.assoc, Category.assoc,
     Iso.inv_hom_id, Category.comp_id, H0π_comp_H0IsoNormQuotient_hom_assoc]
   ext x
-  rfl
+  simp only [ModuleCat.hom_comp, ModuleCat.hom_ofHom, LinearMap.comp_apply,
+    Submodule.mkQ_apply, Submodule.mapQ_apply]
 
 /-- Corestriction of the restriction of a degree-zero class is the index multiple of it. -/
 theorem H0Cor_H0Res_apply (x : tateCohomology M 0) :
@@ -152,7 +157,11 @@ private theorem hNegOne_res_le :
       Submodule.comap (Representation.relTransferKerNorm M.ρ H)
         ((Coinvariants.ker (Rep.res H.subtype M).ρ).submoduleOf
           (ker (Rep.res H.subtype M).ρ.norm)) :=
-  fun _ hx => Representation.relTransfer_mem_coinvariantsKer (H := H) hx
+  fun x hx => by
+    change (Representation.relTransferKerNorm M.ρ H x : M.V) ∈
+      Coinvariants.ker (Rep.res H.subtype M).ρ
+    rw [Representation.coe_relTransferKerNorm]
+    exact Representation.relTransfer_mem_coinvariantsKer (H := H) hx
 
 private theorem hNegOne_cor_le :
     (Coinvariants.ker (Rep.res H.subtype M).ρ).submoduleOf (ker (Rep.res H.subtype M).ρ.norm) ≤
@@ -189,7 +198,8 @@ theorem HNegOneπ_comp_HNegOneRes :
     Category.assoc, Iso.inv_hom_id, Category.comp_id,
     HNegOneπ_comp_HNegOneIsoNormKernelQuotient_hom_assoc]
   ext x
-  rfl
+  simp only [ModuleCat.hom_comp, ModuleCat.hom_ofHom, LinearMap.comp_apply,
+    Submodule.mkQ_apply, Submodule.mapQ_apply]
 
 /-- Corestriction in degree `-1` sends the class of a norm-zero element to the class of the same
 element. -/
@@ -204,7 +214,8 @@ theorem HNegOneπ_comp_HNegOneCor :
     Category.assoc, Iso.inv_hom_id, Category.comp_id,
     HNegOneπ_comp_HNegOneIsoNormKernelQuotient_hom_assoc]
   ext x
-  rfl
+  simp only [ModuleCat.hom_comp, ModuleCat.hom_ofHom, LinearMap.comp_apply,
+    Submodule.mkQ_apply, Submodule.mapQ_apply]
 
 /-- Corestriction of the restriction of a degree `-1` class is the index multiple of it. -/
 theorem HNegOneCor_HNegOneRes_apply (x : tateCohomology M (-1)) :

--- a/TauCeti/RepresentationTheory/Homological/TateCohomology/Restriction.lean
+++ b/TauCeti/RepresentationTheory/Homological/TateCohomology/Restriction.lean
@@ -69,8 +69,12 @@ namespace TauCeti.TateCohomology
 variable {R G : Type u} [CommRing R] [Group G] [Fintype G] (M : Rep R G)
   (H : Subgroup G)
 
-noncomputable local instance : Fintype H := Fintype.ofFinite H
-noncomputable local instance : Fintype (G ⧸ H) := H.fintypeQuotientOfFiniteIndex
+/-- A subgroup of a finite group is a finite type. -/
+noncomputable local instance fintypeSubgroup : Fintype H := Fintype.ofFinite H
+
+/-- The quotient of a finite group by a subgroup is a finite type. -/
+noncomputable local instance fintypeQuotientGroup : Fintype (G ⧸ H) :=
+  H.fintypeQuotientOfFiniteIndex
 
 section Zero
 

--- a/TauCeti/RepresentationTheory/RelativeNorm.lean
+++ b/TauCeti/RepresentationTheory/RelativeNorm.lean
@@ -1,0 +1,294 @@
+/-
+Copyright (c) 2026 Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import Mathlib.RepresentationTheory.Coinvariants
+public import Mathlib.RepresentationTheory.Invariants
+public import Mathlib.GroupTheory.Complement
+public import Mathlib.GroupTheory.GroupAction.Quotient
+
+/-!
+# The relative norm and the relative transfer of a subgroup
+
+Let `ρ : Representation R G V` and let `H ≤ G` be a subgroup of finite index. Summing the action
+over a left transversal of `H` gives two endomorphisms of `V`,
+
+`relNorm ρ H = ∑ q : G ⧸ H, ρ q.out`   and   `relTransfer ρ H = ∑ q : G ⧸ H, ρ q.out⁻¹`,
+
+which refine the norm `Representation.norm ρ = ∑ g : G, ρ g` of a finite group: the norm of `G`
+is the relative norm composed with the norm of `H`, and it is also the norm of `H` composed with
+the relative transfer.
+
+Neither endomorphism is canonical — each depends on the chosen transversal, here `Quotient.out` —
+but each becomes canonical after passing to the appropriate quotient. The relative norm is
+independent of the transversal on the invariants `V^H`, where it takes values in `V^G` and
+restricts to multiplication by `[G : H]` on `V^G`; the relative transfer is independent of the
+transversal modulo the augmentation submodule of `H`, into which it carries the augmentation
+submodule of `G`, and modulo which it is multiplication by `[G : H]`.
+
+These are the two maps that give restriction and corestriction on the Tate cohomology of a
+subgroup in the two degrees where Tate cohomology is not ordinary group cohomology or homology.
+
+## Main definitions
+
+* `Representation.relNorm`: the relative norm `∑ q : G ⧸ H, ρ q.out`.
+* `Representation.relTransfer`: the relative transfer `∑ q : G ⧸ H, ρ q.out⁻¹`.
+
+## Main results
+
+* `Representation.relNorm_comp_norm`: `N_{G/H} ∘ N_H = N_G`.
+* `Representation.norm_comp_relTransfer`: `N_H ∘ N_{G/H}' = N_G`.
+* `Representation.relNorm_mem_invariants`: the relative norm carries `V^H` into `V^G`.
+* `Representation.relNorm_apply_of_mem_invariants`: on `V^G` the relative norm is `[G : H] • ·`.
+* `Representation.relTransfer_mem_coinvariantsKer`: the relative transfer carries the augmentation
+  submodule of `G` into the augmentation submodule of `H`.
+* `Representation.relTransfer_sub_index_nsmul_mem`: modulo the augmentation submodule of `G` the
+  relative transfer is `[G : H] • ·`.
+
+## References
+
+* K. S. Brown, *Cohomology of Groups*, Chapter III, §9.
+* J. S. Milne, *Class Field Theory*, v4.03, Chapter II, §1.
+-/
+
+@[expose] public noncomputable section
+
+namespace Representation
+
+variable {R G V : Type*} [CommRing R] [Group G] [AddCommGroup V] [Module R V]
+  (ρ : Representation R G V) (H : Subgroup G)
+
+section Defs
+
+variable [Fintype (G ⧸ H)]
+
+/-- The relative norm of a finite-index subgroup `H ≤ G`: the sum of `ρ` over the transversal of
+`H` given by `Quotient.out`. On the `H`-invariants it does not depend on that choice and lands in
+the `G`-invariants; see `Representation.relNorm_mem_invariants`. -/
+def relNorm : Module.End R V := ∑ q : G ⧸ H, ρ q.out
+
+/-- The relative transfer of a finite-index subgroup `H ≤ G`: the sum of `ρ` over the inverses of
+the transversal of `H` given by `Quotient.out`, which form a transversal of the right cosets.
+Modulo the augmentation submodule of `H` it does not depend on that choice; see
+`Representation.relTransfer_mem_coinvariantsKer`. -/
+def relTransfer : Module.End R V := ∑ q : G ⧸ H, ρ q.out⁻¹
+
+variable {ρ H}
+
+theorem relNorm_apply (x : V) : relNorm ρ H x = ∑ q : G ⧸ H, ρ q.out x := by
+  simp [relNorm]
+
+theorem relTransfer_apply (x : V) : relTransfer ρ H x = ∑ q : G ⧸ H, ρ q.out⁻¹ x := by
+  simp [relTransfer]
+
+end Defs
+
+section Sums
+
+variable {M : Type*} [AddCommMonoid M] [Fintype G] [DecidablePred (· ∈ H)]
+
+/-- Every element of `G` is uniquely the product of a `Quotient.out` representative of its coset
+and an element of `H`, so a sum over `G` splits as an iterated sum over `G ⧸ H` and over `H`. -/
+private theorem sum_eq_sum_quotient_sum (f : G → M) :
+    ∑ g : G, f g = ∑ q : G ⧸ H, ∑ h : H, f (q.out * h) := by
+  have hmk (q : G ⧸ H) (h : H) : ((q.out * h : G) : G ⧸ H) = q := by
+    rw [QuotientGroup.mk_mul_of_mem _ h.2, QuotientGroup.out_eq']
+  have hbij : Function.Bijective fun p : (G ⧸ H) × H => (p.1.out : G) * (p.2 : G) := by
+    refine Function.bijective_iff_has_inverse.2 ⟨fun g => ((g : G ⧸ H),
+      ⟨(Quotient.out (g : G ⧸ H))⁻¹ * g, QuotientGroup.eq.mp (QuotientGroup.out_eq' _)⟩),
+      fun p => ?_, fun g => ?_⟩
+    · refine Prod.ext (hmk p.1 p.2) (Subtype.ext ?_)
+      simp [hmk p.1 p.2]
+    · simp
+  have key := Fintype.sum_bijective _ hbij
+    (fun p : (G ⧸ H) × H => f ((p.1.out : G) * (p.2 : G))) f fun _ => rfl
+  rw [← key, Fintype.sum_prod_type]
+
+/-- The dual splitting of a sum over `G`, along the right cosets of `H`. -/
+private theorem sum_eq_sum_quotient_sum' (f : G → M) :
+    ∑ g : G, f g = ∑ q : G ⧸ H, ∑ h : H, f ((h : G) * (q.out : G)⁻¹) := by
+  have h1 : ∑ g : G, f g = ∑ g : G, f g⁻¹ :=
+    Fintype.sum_equiv (Equiv.inv G) _ _ fun _ => by simp
+  rw [h1, sum_eq_sum_quotient_sum (H := H) fun g => f g⁻¹]
+  refine Finset.sum_congr rfl fun q _ => ?_
+  exact (Fintype.sum_equiv (Equiv.inv H) (fun h => f ((h : G) * (q.out : G)⁻¹))
+    (fun h => f ((q.out * (h : G))⁻¹)) fun _ => by simp).symm
+
+end Sums
+
+section Norm
+
+variable [Fintype G] [DecidablePred (· ∈ H)] {ρ H}
+
+private theorem norm_apply' (x : V) : ρ.norm x = ∑ g : G, ρ g x := by
+  simp [Representation.norm]
+
+/-- The norm of `G` is the relative norm of `H` evaluated on the norm of `H`. -/
+theorem relNorm_norm_apply (x : V) :
+    relNorm ρ H (Representation.norm (ρ.comp H.subtype) x) = ρ.norm x := by
+  conv_rhs => rw [norm_apply', sum_eq_sum_quotient_sum (H := H) fun g => ρ g x]
+  rw [relNorm_apply]
+  refine Finset.sum_congr rfl fun q _ => ?_
+  simp [Representation.norm, map_sum, ← Module.End.mul_apply, ← map_mul]
+
+/-- The norm of `G` is the relative norm of `H` composed with the norm of `H`. -/
+theorem relNorm_comp_norm :
+    relNorm ρ H ∘ₗ Representation.norm (ρ.comp H.subtype) = ρ.norm :=
+  LinearMap.ext relNorm_norm_apply
+
+/-- The norm of `G` is the norm of `H` evaluated on the relative transfer of `H`. -/
+theorem norm_relTransfer_apply (x : V) :
+    Representation.norm (ρ.comp H.subtype) (relTransfer ρ H x) = ρ.norm x := by
+  conv_rhs => rw [norm_apply', sum_eq_sum_quotient_sum' (H := H) fun g => ρ g x]
+  rw [relTransfer_apply, map_sum]
+  refine Finset.sum_congr rfl fun q _ => ?_
+  simp [Representation.norm, LinearMap.sum_apply, ← Module.End.mul_apply, ← map_mul]
+
+/-- The norm of `G` is the norm of `H` composed with the relative transfer of `H`. -/
+theorem norm_comp_relTransfer :
+    Representation.norm (ρ.comp H.subtype) ∘ₗ relTransfer ρ H = ρ.norm :=
+  LinearMap.ext norm_relTransfer_apply
+
+/-- The image of the norm of `G` is contained in the image of the norm of `H`. -/
+theorem range_norm_le_range_norm_comp_subtype :
+    LinearMap.range ρ.norm ≤ LinearMap.range (Representation.norm (ρ.comp H.subtype)) := by
+  rintro _ ⟨x, rfl⟩
+  exact ⟨relTransfer ρ H x, norm_relTransfer_apply x⟩
+
+/-- The kernel of the norm of `H` is contained in the kernel of the norm of `G`. -/
+theorem ker_norm_comp_subtype_le_ker_norm :
+    LinearMap.ker (Representation.norm (ρ.comp H.subtype)) ≤ LinearMap.ker ρ.norm := by
+  intro x hx
+  rw [LinearMap.mem_ker, ← relNorm_norm_apply (H := H) x, LinearMap.mem_ker.mp hx, map_zero]
+
+variable (ρ H)
+
+/-- The relative transfer maps the kernel of the norm of `G` to the kernel of the norm of `H`. -/
+def relTransferKerNorm :
+    LinearMap.ker ρ.norm →ₗ[R]
+      LinearMap.ker (Representation.norm (ρ.comp H.subtype)) :=
+  (relTransfer ρ H).restrict fun x hx =>
+    LinearMap.mem_ker.2 <| (norm_relTransfer_apply x).trans (LinearMap.mem_ker.mp hx)
+
+@[simp]
+theorem coe_relTransferKerNorm (x : LinearMap.ker ρ.norm) :
+    (relTransferKerNorm ρ H x : V) = relTransfer ρ H x := rfl
+
+end Norm
+
+section Invariants
+
+variable {ρ H}
+
+/-- The image of an `H`-invariant element under `ρ` depends only on the coset `aH`, which is why
+the relative norm is independent of the transversal on the `H`-invariants. -/
+theorem apply_eq_apply_of_mk_eq {x : V}
+    (hx : x ∈ Representation.invariants (ρ.comp H.subtype)) {a b : G}
+    (hab : (a : G ⧸ H) = (b : G ⧸ H)) : ρ a x = ρ b x := by
+  obtain ⟨h, rfl⟩ : ∃ h : H, a * (h : G) = b :=
+    ⟨⟨a⁻¹ * b, QuotientGroup.eq.mp hab⟩, by simp⟩
+  rw [map_mul, Module.End.mul_apply]
+  exact congrArg (ρ a) (((mem_invariants _ _).mp hx h).symm)
+
+/-- A `G`-invariant element is `H`-invariant. -/
+theorem invariants_le_invariants_comp_subtype :
+    ρ.invariants ≤ Representation.invariants (ρ.comp H.subtype) :=
+  fun _ hx h => hx (h : G)
+
+variable [Fintype (G ⧸ H)]
+
+/-- The relative norm carries the `H`-invariants into the `G`-invariants. -/
+theorem relNorm_mem_invariants {x : V}
+    (hx : x ∈ Representation.invariants (ρ.comp H.subtype)) :
+    relNorm ρ H x ∈ ρ.invariants := by
+  rw [mem_invariants]
+  intro g
+  rw [relNorm_apply, map_sum]
+  refine Fintype.sum_bijective (g • ·) (MulAction.bijective g) _ _ fun q => ?_
+  rw [← Module.End.mul_apply, ← map_mul]
+  refine apply_eq_apply_of_mk_eq hx ?_
+  rw [QuotientGroup.out_eq', ← smul_eq_mul, ← MulAction.Quotient.smul_coe, QuotientGroup.out_eq']
+
+/-- On `G`-invariant elements the relative norm is multiplication by the index. -/
+theorem relNorm_apply_of_mem_invariants {x : V} (hx : x ∈ ρ.invariants) :
+    relNorm ρ H x = H.index • x := by
+  rw [relNorm_apply, Finset.sum_congr rfl fun q _ => (mem_invariants _ _).mp hx q.out,
+    Finset.sum_const, Finset.card_univ]
+  simp [Subgroup.index, Nat.card_eq_fintype_card]
+
+variable (ρ H)
+
+/-- The relative norm as a linear map from the `H`-invariants to the `G`-invariants. -/
+def relNormInvariants :
+    Representation.invariants (ρ.comp H.subtype) →ₗ[R] ρ.invariants :=
+  (relNorm ρ H).restrict fun _ hx => relNorm_mem_invariants hx
+
+@[simp]
+theorem coe_relNormInvariants (x : Representation.invariants (ρ.comp H.subtype)) :
+    (relNormInvariants ρ H x : V) = relNorm ρ H x := rfl
+
+end Invariants
+
+section Coinvariants
+
+variable {ρ H}
+
+/-- The augmentation submodule of `H` is contained in the augmentation submodule of `G`. -/
+theorem coinvariantsKer_comp_subtype_le :
+    Coinvariants.ker (ρ.comp H.subtype) ≤ Coinvariants.ker ρ := by
+  rw [Coinvariants.ker, Coinvariants.ker, Submodule.span_le]
+  rintro _ ⟨⟨h, y⟩, rfl⟩
+  exact Submodule.subset_span ⟨((h : G), y), rfl⟩
+
+variable [Fintype (G ⧸ H)]
+
+/-- Modulo the augmentation submodule of `G`, the relative transfer is multiplication by the
+index. -/
+theorem relTransfer_sub_index_nsmul_mem (x : V) :
+    relTransfer ρ H x - H.index • x ∈ Coinvariants.ker ρ := by
+  have hrw : relTransfer ρ H x - H.index • x = ∑ q : G ⧸ H, (ρ (q.out : G)⁻¹ x - x) := by
+    rw [relTransfer_apply, Finset.sum_sub_distrib, Finset.sum_const, Finset.card_univ]
+    simp [Subgroup.index, Nat.card_eq_fintype_card]
+  rw [hrw]
+  exact Submodule.sum_mem _ fun q _ => Coinvariants.sub_mem_ker _ _
+
+/-- The relative transfer carries the augmentation submodule of `G` into the augmentation
+submodule of `H`; it is therefore the transfer of `H` on coinvariants. -/
+theorem relTransfer_mem_coinvariantsKer {x : V} (hx : x ∈ Coinvariants.ker ρ) :
+    relTransfer ρ H x ∈ Coinvariants.ker (ρ.comp H.subtype) := by
+  have hmem : ∀ (g : G) (q : G ⧸ H), (g * ((g⁻¹ • q).out : G))⁻¹ * (q.out : G) ∈ H := by
+    intro g q
+    refine QuotientGroup.eq.mp ?_
+    rw [QuotientGroup.out_eq', ← smul_eq_mul, ← MulAction.Quotient.smul_coe,
+      QuotientGroup.out_eq', smul_inv_smul]
+  have hgrp : ∀ (g : G) (q : G ⧸ H),
+      ((g * ((g⁻¹ • q).out : G))⁻¹ * (q.out : G))⁻¹ * ((g⁻¹ • q).out : G)⁻¹ =
+        (q.out : G)⁻¹ * g := fun g q => by group
+  have hmap : (Coinvariants.ker ρ).map (relTransfer ρ H) ≤
+      Coinvariants.ker (ρ.comp H.subtype) := by
+    rw [Coinvariants.ker, Submodule.map_span_le]
+    rintro _ ⟨⟨g, y⟩, rfl⟩
+    have hreindex : ∑ q : G ⧸ H, ρ (q.out : G)⁻¹ y =
+        ∑ q : G ⧸ H, ρ (((g⁻¹ • q).out : G))⁻¹ y :=
+      (Fintype.sum_bijective (g⁻¹ • ·) (MulAction.bijective _) _ _ fun _ => rfl).symm
+    have hsum : relTransfer ρ H (ρ g y - y) =
+        ∑ q : G ⧸ H, (ρ (q.out : G)⁻¹ (ρ g y) - ρ (((g⁻¹ • q).out : G))⁻¹ y) := by
+      rw [map_sub, relTransfer_apply, relTransfer_apply, hreindex, ← Finset.sum_sub_distrib]
+    rw [hsum]
+    refine Submodule.sum_mem _ fun q _ => ?_
+    refine Coinvariants.mem_ker_of_eq
+      (⟨(g * ((g⁻¹ • q).out : G))⁻¹ * (q.out : G), hmem g q⟩⁻¹)
+      (ρ (((g⁻¹ • q).out : G))⁻¹ y) _ ?_
+    congr 1
+    rw [MonoidHom.comp_apply, ← Module.End.mul_apply, ← map_mul, ← Module.End.mul_apply,
+      ← map_mul]
+    congr 1
+    exact congrArg ρ (hgrp g q)
+  exact hmap ⟨x, hx, rfl⟩
+
+end Coinvariants
+
+end Representation

--- a/TauCeti/RepresentationTheory/RelativeNorm.lean
+++ b/TauCeti/RepresentationTheory/RelativeNorm.lean
@@ -90,8 +90,12 @@ section Norm
 
 variable [Fintype G] {ρ H}
 
-noncomputable local instance : Fintype H := Fintype.ofFinite H
-noncomputable local instance : Fintype (G ⧸ H) := H.fintypeQuotientOfFiniteIndex
+/-- A subgroup of a finite group is a finite type. -/
+noncomputable local instance fintypeSubgroup : Fintype H := Fintype.ofFinite H
+
+/-- The quotient of a finite group by a subgroup is a finite type. -/
+noncomputable local instance fintypeQuotientGroup : Fintype (G ⧸ H) :=
+  H.fintypeQuotientOfFiniteIndex
 
 private theorem norm_apply' (x : V) : ρ.norm x = ∑ g : G, ρ g x := by
   simp [Representation.norm]

--- a/TauCeti/RepresentationTheory/RelativeNorm.lean
+++ b/TauCeti/RepresentationTheory/RelativeNorm.lean
@@ -172,7 +172,7 @@ variable {ρ H}
 
 /-- The image of an `H`-invariant element under `ρ` depends only on the coset `aH`, which is why
 the relative norm is independent of the transversal on the `H`-invariants. -/
-theorem apply_eq_apply_of_mk_eq {x : V}
+theorem apply_eq_apply_of_quotientGroup_mk_eq {x : V}
     (hx : x ∈ Representation.invariants (ρ.comp H.subtype)) {a b : G}
     (hab : (a : G ⧸ H) = (b : G ⧸ H)) : ρ a x = ρ b x := by
   obtain ⟨h, rfl⟩ : ∃ h : H, a * (h : G) = b :=
@@ -196,7 +196,7 @@ theorem relNorm_mem_invariants {x : V}
   rw [relNorm_apply, map_sum]
   refine Fintype.sum_bijective (g • ·) (MulAction.bijective g) _ _ fun q => ?_
   rw [← Module.End.mul_apply, ← map_mul]
-  refine apply_eq_apply_of_mk_eq hx ?_
+  refine apply_eq_apply_of_quotientGroup_mk_eq hx ?_
   rw [QuotientGroup.out_eq', ← smul_eq_mul, ← MulAction.Quotient.smul_coe, QuotientGroup.out_eq']
 
 /-- On `G`-invariant elements the relative norm is multiplication by the index. -/

--- a/TauCeti/RepresentationTheory/RelativeNorm.lean
+++ b/TauCeti/RepresentationTheory/RelativeNorm.lean
@@ -7,8 +7,7 @@ module
 
 public import Mathlib.RepresentationTheory.Coinvariants
 public import Mathlib.RepresentationTheory.Invariants
-public import Mathlib.GroupTheory.Complement
-public import Mathlib.GroupTheory.GroupAction.Quotient
+public import TauCeti.GroupTheory.QuotientGroup.Basic
 
 /-!
 # The relative norm and the relative transfer of a subgroup
@@ -27,7 +26,8 @@ but each becomes canonical after passing to the appropriate quotient. The relati
 independent of the transversal on the invariants `V^H`, where it takes values in `V^G` and
 restricts to multiplication by `[G : H]` on `V^G`; the relative transfer is independent of the
 transversal modulo the augmentation submodule of `H`, into which it carries the augmentation
-submodule of `G`, and modulo which it is multiplication by `[G : H]`.
+submodule of `G`. Modulo the larger augmentation submodule of `G`, the relative transfer is
+multiplication by `[G : H]`.
 
 These are the two maps that give restriction and corestriction on the Tate cohomology of a
 subgroup in the two degrees where Tate cohomology is not ordinary group cohomology or homology.
@@ -54,7 +54,7 @@ subgroup in the two degrees where Tate cohomology is not ordinary group cohomolo
 * J. S. Milne, *Class Field Theory*, v4.03, Chapter II, §1.
 -/
 
-@[expose] public noncomputable section
+public noncomputable section
 
 namespace Representation
 
@@ -86,42 +86,12 @@ theorem relTransfer_apply (x : V) : relTransfer ρ H x = ∑ q : G ⧸ H, ρ q.o
 
 end Defs
 
-section Sums
-
-variable {M : Type*} [AddCommMonoid M] [Fintype G] [DecidablePred (· ∈ H)]
-
-/-- Every element of `G` is uniquely the product of a `Quotient.out` representative of its coset
-and an element of `H`, so a sum over `G` splits as an iterated sum over `G ⧸ H` and over `H`. -/
-private theorem sum_eq_sum_quotient_sum (f : G → M) :
-    ∑ g : G, f g = ∑ q : G ⧸ H, ∑ h : H, f (q.out * h) := by
-  have hmk (q : G ⧸ H) (h : H) : ((q.out * h : G) : G ⧸ H) = q := by
-    rw [QuotientGroup.mk_mul_of_mem _ h.2, QuotientGroup.out_eq']
-  have hbij : Function.Bijective fun p : (G ⧸ H) × H => (p.1.out : G) * (p.2 : G) := by
-    refine Function.bijective_iff_has_inverse.2 ⟨fun g => ((g : G ⧸ H),
-      ⟨(Quotient.out (g : G ⧸ H))⁻¹ * g, QuotientGroup.eq.mp (QuotientGroup.out_eq' _)⟩),
-      fun p => ?_, fun g => ?_⟩
-    · refine Prod.ext (hmk p.1 p.2) (Subtype.ext ?_)
-      simp [hmk p.1 p.2]
-    · simp
-  have key := Fintype.sum_bijective _ hbij
-    (fun p : (G ⧸ H) × H => f ((p.1.out : G) * (p.2 : G))) f fun _ => rfl
-  rw [← key, Fintype.sum_prod_type]
-
-/-- The dual splitting of a sum over `G`, along the right cosets of `H`. -/
-private theorem sum_eq_sum_quotient_sum' (f : G → M) :
-    ∑ g : G, f g = ∑ q : G ⧸ H, ∑ h : H, f ((h : G) * (q.out : G)⁻¹) := by
-  have h1 : ∑ g : G, f g = ∑ g : G, f g⁻¹ :=
-    Fintype.sum_equiv (Equiv.inv G) _ _ fun _ => by simp
-  rw [h1, sum_eq_sum_quotient_sum (H := H) fun g => f g⁻¹]
-  refine Finset.sum_congr rfl fun q _ => ?_
-  exact (Fintype.sum_equiv (Equiv.inv H) (fun h => f ((h : G) * (q.out : G)⁻¹))
-    (fun h => f ((q.out * (h : G))⁻¹)) fun _ => by simp).symm
-
-end Sums
-
 section Norm
 
-variable [Fintype G] [DecidablePred (· ∈ H)] {ρ H}
+variable [Fintype G] {ρ H}
+
+noncomputable local instance : Fintype H := Fintype.ofFinite H
+noncomputable local instance : Fintype (G ⧸ H) := H.fintypeQuotientOfFiniteIndex
 
 private theorem norm_apply' (x : V) : ρ.norm x = ∑ g : G, ρ g x := by
   simp [Representation.norm]
@@ -129,7 +99,7 @@ private theorem norm_apply' (x : V) : ρ.norm x = ∑ g : G, ρ g x := by
 /-- The norm of `G` is the relative norm of `H` evaluated on the norm of `H`. -/
 theorem relNorm_norm_apply (x : V) :
     relNorm ρ H (Representation.norm (ρ.comp H.subtype) x) = ρ.norm x := by
-  conv_rhs => rw [norm_apply', sum_eq_sum_quotient_sum (H := H) fun g => ρ g x]
+  conv_rhs => rw [norm_apply', TauCeti.sum_eq_sum_quotient_sum H fun g => ρ g x]
   rw [relNorm_apply]
   refine Finset.sum_congr rfl fun q _ => ?_
   simp [Representation.norm, map_sum, ← Module.End.mul_apply, ← map_mul]
@@ -142,7 +112,7 @@ theorem relNorm_comp_norm :
 /-- The norm of `G` is the norm of `H` evaluated on the relative transfer of `H`. -/
 theorem norm_relTransfer_apply (x : V) :
     Representation.norm (ρ.comp H.subtype) (relTransfer ρ H x) = ρ.norm x := by
-  conv_rhs => rw [norm_apply', sum_eq_sum_quotient_sum' (H := H) fun g => ρ g x]
+  conv_rhs => rw [norm_apply', TauCeti.sum_eq_sum_quotient_sum' H fun g => ρ g x]
   rw [relTransfer_apply, map_sum]
   refine Finset.sum_congr rfl fun q _ => ?_
   simp [Representation.norm, LinearMap.sum_apply, ← Module.End.mul_apply, ← map_mul]
@@ -175,7 +145,9 @@ def relTransferKerNorm :
 
 @[simp]
 theorem coe_relTransferKerNorm (x : LinearMap.ker ρ.norm) :
-    (relTransferKerNorm ρ H x : V) = relTransfer ρ H x := rfl
+    (relTransferKerNorm ρ H x : V) = relTransfer ρ H x := by
+  unfold relTransferKerNorm
+  rfl
 
 end Norm
 
@@ -228,7 +200,9 @@ def relNormInvariants :
 
 @[simp]
 theorem coe_relNormInvariants (x : Representation.invariants (ρ.comp H.subtype)) :
-    (relNormInvariants ρ H x : V) = relNorm ρ H x := rfl
+    (relNormInvariants ρ H x : V) = relNorm ρ H x := by
+  unfold relNormInvariants
+  rfl
 
 end Invariants
 

--- a/TauCeti/RepresentationTheory/RelativeNorm.lean
+++ b/TauCeti/RepresentationTheory/RelativeNorm.lean
@@ -58,7 +58,11 @@ public noncomputable section
 
 namespace Representation
 
-variable {R G V : Type*} [CommRing R] [Group G] [AddCommGroup V] [Module R V]
+variable {R G V : Type*} [Group G]
+
+section Semiring
+
+variable [Semiring R] [AddCommMonoid V] [Module R V]
   (ρ : Representation R G V) (H : Subgroup G)
 
 section Defs
@@ -154,6 +158,13 @@ theorem coe_relTransferKerNorm (x : LinearMap.ker ρ.norm) :
   rfl
 
 end Norm
+
+end Semiring
+
+section Ring
+
+variable [CommRing R] [AddCommGroup V] [Module R V]
+  (ρ : Representation R G V) (H : Subgroup G)
 
 section Invariants
 
@@ -268,5 +279,7 @@ theorem relTransfer_mem_coinvariantsKer {x : V} (hx : x ∈ Coinvariants.ker ρ)
   exact hmap ⟨x, hx, rfl⟩
 
 end Coinvariants
+
+end Ring
 
 end Representation

--- a/TauCeti/RepresentationTheory/RelativeNorm.lean
+++ b/TauCeti/RepresentationTheory/RelativeNorm.lean
@@ -107,7 +107,7 @@ private theorem norm_apply' (x : V) : ρ.norm x = ∑ g : G, ρ g x := by
 /-- The norm of `G` is the relative norm of `H` evaluated on the norm of `H`. -/
 theorem relNorm_norm_apply (x : V) :
     relNorm ρ H (Representation.norm (ρ.comp H.subtype) x) = ρ.norm x := by
-  conv_rhs => rw [norm_apply', TauCeti.Subgroup.sum_eq_sum_leftCosets H fun g => ρ g x]
+  conv_rhs => rw [norm_apply', H.sum_eq_sum_leftCosets fun g => ρ g x]
   rw [relNorm_apply]
   refine Finset.sum_congr rfl fun q _ => ?_
   simp [Representation.norm, map_sum, ← Module.End.mul_apply, ← map_mul]
@@ -120,7 +120,7 @@ theorem relNorm_comp_norm :
 /-- The norm of `G` is the norm of `H` evaluated on the relative transfer of `H`. -/
 theorem norm_relTransfer_apply (x : V) :
     Representation.norm (ρ.comp H.subtype) (relTransfer ρ H x) = ρ.norm x := by
-  conv_rhs => rw [norm_apply', TauCeti.Subgroup.sum_eq_sum_rightCosets H fun g => ρ g x]
+  conv_rhs => rw [norm_apply', H.sum_eq_sum_rightCosets fun g => ρ g x]
   rw [relTransfer_apply, map_sum]
   refine Finset.sum_congr rfl fun q _ => ?_
   simp [Representation.norm, LinearMap.sum_apply, ← Module.End.mul_apply, ← map_mul]

--- a/TauCeti/RepresentationTheory/RelativeNorm.lean
+++ b/TauCeti/RepresentationTheory/RelativeNorm.lean
@@ -107,7 +107,7 @@ private theorem norm_apply' (x : V) : ρ.norm x = ∑ g : G, ρ g x := by
 /-- The norm of `G` is the relative norm of `H` evaluated on the norm of `H`. -/
 theorem relNorm_norm_apply (x : V) :
     relNorm ρ H (Representation.norm (ρ.comp H.subtype) x) = ρ.norm x := by
-  conv_rhs => rw [norm_apply', TauCeti.sum_eq_sum_quotient_sum H fun g => ρ g x]
+  conv_rhs => rw [norm_apply', TauCeti.Subgroup.sum_eq_sum_leftCosets H fun g => ρ g x]
   rw [relNorm_apply]
   refine Finset.sum_congr rfl fun q _ => ?_
   simp [Representation.norm, map_sum, ← Module.End.mul_apply, ← map_mul]
@@ -120,7 +120,7 @@ theorem relNorm_comp_norm :
 /-- The norm of `G` is the norm of `H` evaluated on the relative transfer of `H`. -/
 theorem norm_relTransfer_apply (x : V) :
     Representation.norm (ρ.comp H.subtype) (relTransfer ρ H x) = ρ.norm x := by
-  conv_rhs => rw [norm_apply', TauCeti.sum_eq_sum_quotient_sum' H fun g => ρ g x]
+  conv_rhs => rw [norm_apply', TauCeti.Subgroup.sum_eq_sum_rightCosets H fun g => ρ g x]
   rw [relTransfer_apply, map_sum]
   refine Finset.sum_congr rfl fun q _ => ?_
   simp [Representation.norm, LinearMap.sum_apply, ← Module.End.mul_apply, ← map_mul]


### PR DESCRIPTION
This PR supplies restriction and corestriction on the Tate cohomology of a subgroup in the two degrees where nothing existing applies. For a finite group `G`, a subgroup `H ≤ G` and `M : Rep R G`, the Tate complex is the complex of inhomogeneous cochains in degrees `≥ 1`, where Tate restriction is Mathlib's `groupCohomology.map`, and the complex of inhomogeneous chains in degrees `≤ -2`, where Tate corestriction is Mathlib's `groupHomology.cores`; degrees `0` and `-1` are the splice, where the two halves are glued by the norm and Tate cohomology is `Mᴳ / N_G M` and `ker N_G / I_G M`. This PR adds all four maps there — `H0Res`, `H0Cor`, `HNegOneRes`, `HNegOneCor` — each characterised by its effect on the class of a representative (`H0π_comp_H0Res`, `H0π_comp_H0Cor`, `HNegOneπ_comp_HNegOneRes`, `HNegOneπ_comp_HNegOneCor`), and proves the normalisation `cor ∘ res = [G : H]` in both degrees (`H0Res_comp_H0Cor`, `HNegOneRes_comp_HNegOneCor`). Their representation-theoretic input is a second new file: the relative norm `N_{G/H} = ∑ q : G ⧸ H, ρ q.out` and the relative transfer `∑ q : G ⧸ H, ρ q.out⁻¹` of a finite-index subgroup, with the two factorisations of the norm of `G` that make them work (`relNorm_comp_norm`, `norm_comp_relTransfer`), the facts that the relative norm carries `Mᴴ` into `Mᴳ` and is `[G : H] • ·` on `Mᴳ`, and that the relative transfer carries `I_G M` into `I_H M` and is `[G : H] • ·` modulo `I_G M`. Restriction in degree `0` and corestriction in degree `-1` are the inclusions `Mᴳ ⊆ Mᴴ` and `ker N_H ⊆ ker N_G`; the other two are the relative norm and the relative transfer.

The roadmap target is `ClassFieldTheory`, `README.md` §4, Layer 0 ("audit and complete the cohomology suppliers"), step 4, which asks the generic supplier to prove what is genuinely missing, including "restriction and corestriction in every Tate degree, with `cor ∘ res = [G:H]`". Per §1 this belongs in the generic supplier under Mathlib namespaces, not under a class-field-theory directory, which is where both files land. The milestone that consumes it is Layer 1's requirement of "restriction and corestriction as separate named maps in every degree (`LayerRestriction.cohomologyRes`, `cohomologyCor`, `tateRes`, `tateCor`, `trivialTateRes`, `trivialTateCor`) with the normalization `cor ∘ res = [E:F]`", and downstream Layer 4, whose `artinMap_groundNorm` and `artinMap_groundInclusion` diagrams compare exactly the degree-zero maps `Ĥ⁰(U/V, A^V) = A^U / N A^V` added here with the transfer and inclusion on abelianised Galois groups. After this PR, the Layer 0 bullet still owes the remaining halves — the transfer on group cohomology in degrees `≥ 1` and on group homology in degrees `≤ -2`, for which Mathlib has no Verlagerung and the route is Tate Shapiro plus the finite-index counit of `Rep.indCoindIso` — and the Tate cup product, which is what Layer 3's `tateTheorem` needs.

Nothing is vendored. `Representation.relNorm` and `Representation.relTransfer` are new `Module.End` sums modelled on Mathlib's `Representation.norm`; the four Tate maps are `Submodule.mapQ` conjugated by the existing `TauCeti.TateCohomology.H0IsoNormQuotient` and `HNegOneIsoNormKernelQuotient` of `TateCohomology/LowDegree.lean` on `main`. The coset bookkeeping uses Mathlib's `Quotient.out` transversal and the `MulAction` of `G` on `G ⧸ H`; `Subgroup.IsComplement` was not usable because Mathlib's `groupEquivQuotientProdSubgroup` has no computation lemma for its inverse, so the transversal bijection is proved inline from `QuotientGroup.eq` and kept private.

New files: `TauCeti/RepresentationTheory/RelativeNorm.lean` and `TauCeti/RepresentationTheory/Homological/TateCohomology/Restriction.lean`.

Roadmap: ClassFieldTheory

Provenance: statements follow `TauCetiProject/TauCetiRoadmap`, `ClassFieldTheory/README.md` §4 Layer 0; the mathematics is Artin–Tate, *Class Field Theory*, Ch. IV §6 and Ch. XIV §4, Brown, *Cohomology of Groups*, Ch. III §9 and Ch. VI §5, and Milne, *Class Field Theory* v4.03, II 1.29–1.30. No code was ported from any other repository.

<!--tauceti-target:v1 {"focus":"ClassFieldTheory","id":"restriction-and-corestriction-in-tate-degrees-0-and-1"}-->

🤖 Prepared with Claude Code
