### PR TITLE
feat: add relative singular chains

### DIFF
--- a/TauCeti/AlgebraicTopology/Singular/Relative.lean
+++ b/TauCeti/AlgebraicTopology/Singular/Relative.lean
@@ -122,7 +122,7 @@ noncomputable abbrev singularChainComplexπ :
   (toSSetPair.obj P).chainComplexπ R
 
 @[simp]
-lemma singularChainComplexMap_comp_singularChainComplexπ :
+lemma chainComplexMap_comp_singularChainComplexπ :
     SSet.chainComplexMap (TopCat.toSSet.map P.map) R ≫ P.singularChainComplexπ R = 0 := by
   rw [← toSSetPair_obj_hom]
   exact (toSSetPair.obj P).chainComplex_condition R

--- a/TauCeti/AlgebraicTopology/Singular/Relative.lean
+++ b/TauCeti/AlgebraicTopology/Singular/Relative.lean
@@ -1,0 +1,206 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.AlgebraicTopology.SimplicialSet.Homology.Relative
+public import Mathlib.AlgebraicTopology.SingularHomology.Basic
+public import Mathlib.Topology.Category.TopCat.EpiMono
+public import Mathlib.Topology.Category.TopPair
+
+/-!
+# Relative singular chains
+
+This file sends a topological pair to the corresponding pair of singular simplicial sets and
+defines its relative singular chain complex.  The complex is the cokernel of the inclusion of the
+singular chains of the subspace into those of the ambient space.  In an abelian coefficient
+category this gives the short exact sequence of chain complexes used to construct the connecting
+morphisms in relative singular homology.
+
+The construction follows the quotient-chain presentation in Eilenberg--Steenrod, *Foundations of
+Algebraic Topology*, Chapters I--III, and is implemented using Mathlib's `SSetPair` relative-chain
+functor.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open CategoryTheory Limits
+
+universe w v u
+
+namespace TopPair
+
+/-- An embedding of topological spaces induces a monomorphism of singular simplicial sets. -/
+instance (P : TopPair.{w}) : Mono (TopCat.toSSet.map P.map) := by
+  let _ : Mono P.map := (TopCat.mono_iff_injective _).mpr P.isEmbedding_map.injective
+  apply Functor.map_mono
+
+/-- The singular simplicial-set pair associated to a topological pair. -/
+def toSSetPair : TopPair.{w} ⥤ SSetPair.{w} :=
+  MorphismProperty.Comma.lift
+    (MorphismProperty.Arrow.forget TopCat.isEmbedding ⊤ ⊤ ⋙ TopCat.toSSet.mapArrow)
+    (fun P ↦ inferInstanceAs (Mono (TopCat.toSSet.map P.map)))
+    (fun _ ↦ trivial) (fun _ ↦ trivial)
+
+@[simp]
+lemma toSSetPair_obj_left (P : TopPair.{w}) :
+    (toSSetPair.obj P).left = TopCat.toSSet.obj P.snd := rfl
+
+@[simp]
+lemma toSSetPair_obj_right (P : TopPair.{w}) :
+    (toSSetPair.obj P).right = TopCat.toSSet.obj P.fst := rfl
+
+@[simp]
+lemma toSSetPair_obj_hom (P : TopPair.{w}) :
+    (toSSetPair.obj P).hom = TopCat.toSSet.map P.map := rfl
+
+@[simp]
+lemma toSSetPair_map_left {P P' : TopPair.{w}} (f : P ⟶ P') :
+    (toSSetPair.map f).left = TopCat.toSSet.map (Hom.snd f) := rfl
+
+@[simp]
+lemma toSSetPair_map_right {P P' : TopPair.{w}} (f : P ⟶ P') :
+    (toSSetPair.map f).right = TopCat.toSSet.map (Hom.fst f) := rfl
+
+variable (C : Type u) [Category.{v} C] [HasCoproducts.{w} C] [Preadditive C]
+
+/-- The relative singular chain complex functor on topological pairs. -/
+@[no_expose]
+noncomputable def singularChainComplexFunctor :
+    C ⥤ TopPair.{w} ⥤ ChainComplex C ℕ :=
+  SSetPair.chainComplexFunctor C ⋙
+    (Functor.whiskeringLeft _ _ _).obj toSSetPair
+
+variable {C} (P P' : TopPair.{w}) (f : P ⟶ P') (R : C)
+
+/-- The relative singular chain complex of a topological pair. -/
+noncomputable abbrev singularChainComplex : ChainComplex C ℕ :=
+  (toSSetPair.obj P).chainComplex R
+
+variable {P P'} in
+/-- The chain map on relative singular chains induced by a map of topological pairs. -/
+noncomputable abbrev singularChainComplexMap :
+    P.singularChainComplex R ⟶ P'.singularChainComplex R :=
+  SSetPair.chainComplexMap (toSSetPair.map f) R
+
+/-- The quotient map from ambient singular chains to relative singular chains. -/
+noncomputable abbrev singularChainComplexπ :
+    (toSSetPair.obj P).right.chainComplex R ⟶ P.singularChainComplex R :=
+  (toSSetPair.obj P).chainComplexπ R
+
+@[simp]
+lemma singularChainComplex_condition :
+    SSet.chainComplexMap (TopCat.toSSet.map P.map) R ≫ P.singularChainComplexπ R = 0 := by
+  rw [← toSSetPair_obj_hom]
+  exact (toSSetPair.obj P).chainComplex_condition R
+
+/-- The cokernel cofork presenting the relative singular chain complex as the quotient of the
+ambient singular chains by the subspace singular chains. -/
+noncomputable abbrev cokernelCoforkSingularChainComplex :
+    CokernelCofork (SSet.chainComplexMap (toSSetPair.obj P).hom R) :=
+  (toSSetPair.obj P).cokernelCoforkChainComplex R
+
+/-- The relative singular chain complex is the cokernel of the map from the singular chains of
+the subspace to those of the ambient space. -/
+@[no_expose]
+noncomputable def isColimitCokernelCoforkSingularChainComplex :
+    IsColimit (P.cokernelCoforkSingularChainComplex R) :=
+  (toSSetPair.obj P).isColimitCokernelCoforkChainComplex R
+
+/-- The chain complex sequence of a topological pair: subspace chains, ambient chains, and
+relative chains. -/
+noncomputable abbrev singularChainComplexShortComplex : ShortComplex (ChainComplex C ℕ) :=
+  (toSSetPair.obj P).chainComplexShortComplex R
+
+section
+
+variable {A : Type u} [Category.{v} A] [HasCoproducts.{w} A] [Abelian A]
+  (P : TopPair.{w}) (R : A)
+
+/-- The singular chain sequence of a topological pair is short exact. -/
+lemma shortExact_singularChainComplexShortComplex :
+    (P.singularChainComplexShortComplex R).ShortExact :=
+  (toSSetPair.obj P).shortExact_chainComplexShortComplex R
+
+end
+
+section Homology
+
+variable [CategoryWithHomology C]
+
+/-- The relative singular homology of a topological pair in degree `n`. -/
+protected noncomputable abbrev singularHomology (n : ℕ) : C :=
+  (toSSetPair.obj P).homology R n
+
+variable {P P'} in
+/-- The map on relative singular homology induced by a map of topological pairs. -/
+protected noncomputable abbrev singularHomologyMap (n : ℕ) :
+    P.singularHomology R n ⟶ P'.singularHomology R n :=
+  SSetPair.homologyMap (toSSetPair.map f) R n
+
+/-- Relative singular homology as a functor on topological pairs. -/
+@[implicit_reducible]
+noncomputable def singularHomologyFunctor (n : ℕ) : TopPair.{w} ⥤ C :=
+  toSSetPair ⋙ SSetPair.homologyFunctor R n
+
+/-- The map from ambient singular homology to relative singular homology. -/
+noncomputable abbrev singularHomologyπ (n : ℕ) :
+    (toSSetPair.obj P).right.homology R n ⟶ P.singularHomology R n :=
+  (toSSetPair.obj P).homologyπ R n
+
+@[simp]
+lemma singularHomologyMap_map_singularHomologyπ (n : ℕ) :
+    SSet.homologyMap (TopCat.toSSet.map P.map) R n ≫ P.singularHomologyπ R n = 0 := by
+  rw [← toSSetPair_obj_hom]
+  exact (toSSetPair.obj P).homologyMap_hom_homologyπ R n
+
+end Homology
+
+section LongExactSequence
+
+variable {A : Type u} [Category.{v} A] [HasCoproducts.{w} A] [Abelian A]
+  (P : TopPair.{w}) (R : A)
+
+/-- The connecting morphism from relative singular homology in degree `n` to the singular homology
+of the subspace in degree `m`, where `m + 1 = n`. -/
+noncomputable abbrev singularHomologyδ (n m : ℕ) (h : m + 1 = n := by lia) :
+    P.singularHomology R n ⟶ (toSSetPair.obj P).left.homology R m :=
+  (toSSetPair.obj P).homologyδ R n m h
+
+@[simp]
+lemma singularHomologyδ_comp (n m : ℕ) (h : m + 1 = n := by lia) :
+    P.singularHomologyδ R n m h ≫ SSet.homologyMap (TopCat.toSSet.map P.map) R m = 0 := by
+  rw [← toSSetPair_obj_hom]
+  exact (toSSetPair.obj P).homologyδ_comp R n m h
+
+@[simp]
+lemma singularHomologyπ_comp_singularHomologyδ
+    (n m : ℕ) (h : m + 1 = n := by lia) :
+    P.singularHomologyπ R n ≫ P.singularHomologyδ R n m h = 0 :=
+  (toSSetPair.obj P).comp_homologyδ R n m h
+
+/-- Exactness at subspace homology in the long exact sequence of a topological pair. -/
+lemma singularHomology_exact_subspace (n m : ℕ) (h : m + 1 = n := by lia) :
+    (ShortComplex.mk _ _ (P.singularHomologyδ_comp R n m h)).Exact :=
+  (toSSetPair.obj P).homology_exact₁ R n m h
+
+/-- Exactness at ambient homology in the long exact sequence of a topological pair. -/
+lemma singularHomology_exact_space (n : ℕ) :
+    (ShortComplex.mk _ _ (P.singularHomologyMap_map_singularHomologyπ R n)).Exact :=
+  (toSSetPair.obj P).homology_exact₂ R n
+
+/-- Exactness at relative homology in the long exact sequence of a topological pair. -/
+lemma singularHomology_exact_relative (n m : ℕ) (h : m + 1 = n := by lia) :
+    (ShortComplex.mk _ _ (P.singularHomologyπ_comp_singularHomologyδ R n m h)).Exact :=
+  (toSSetPair.obj P).homology_exact₃ R n m h
+
+/-- The map from ambient zeroth homology to relative zeroth homology is an epimorphism. -/
+instance : Epi (P.singularHomologyπ R 0) := inferInstance
+
+end LongExactSequence
+
+end TopPair

--- a/TauCeti/AlgebraicTopology/Singular/Relative.lean
+++ b/TauCeti/AlgebraicTopology/Singular/Relative.lean
@@ -81,11 +81,40 @@ variable {C} (P P' : TopPair.{w}) (f : P ⟶ P') (R : C)
 noncomputable abbrev singularChainComplex : ChainComplex C ℕ :=
   (toSSetPair.obj P).chainComplex R
 
+@[simp]
+lemma singularChainComplexFunctor_obj_obj :
+    ((singularChainComplexFunctor C).obj R).obj P = P.singularChainComplex R := by
+  rw [singularChainComplexFunctor.eq_def, singularChainComplex.eq_def,
+    SSetPair.chainComplex.eq_def, Functor.comp_obj, Functor.whiskeringLeft_obj_obj,
+    Functor.comp_obj]
+
+@[simp]
+lemma singularChainComplexFunctor_map_app {R R' : C} (g : R ⟶ R') :
+    ((singularChainComplexFunctor C).map g).app P =
+      eqToHom (singularChainComplexFunctor_obj_obj (C := C) P R) ≫
+        ((SSetPair.chainComplexFunctor C).map g).app (toSSetPair.obj P) ≫
+          eqToHom (singularChainComplexFunctor_obj_obj (C := C) P R').symm := by
+  apply (conj_eqToHom_iff_heq _ _ (singularChainComplexFunctor_obj_obj (C := C) P R)
+    (singularChainComplexFunctor_obj_obj (C := C) P R')).2
+  rw [singularChainComplexFunctor.eq_def, Functor.comp_map,
+    Functor.whiskeringLeft_obj_map, Functor.whiskerLeft_app]
+
 variable {P P'} in
 /-- The chain map on relative singular chains induced by a map of topological pairs. -/
 noncomputable abbrev singularChainComplexMap :
     P.singularChainComplex R ⟶ P'.singularChainComplex R :=
   SSetPair.chainComplexMap (toSSetPair.map f) R
+
+@[simp]
+lemma singularChainComplexFunctor_obj_map :
+    ((singularChainComplexFunctor C).obj R).map f =
+      eqToHom (singularChainComplexFunctor_obj_obj (C := C) P R) ≫
+        singularChainComplexMap f R ≫
+          eqToHom (singularChainComplexFunctor_obj_obj (C := C) P' R).symm := by
+  apply (conj_eqToHom_iff_heq _ _ (singularChainComplexFunctor_obj_obj (C := C) P R)
+    (singularChainComplexFunctor_obj_obj (C := C) P' R)).2
+  rw [singularChainComplexFunctor.eq_def, Functor.comp_obj,
+    Functor.whiskeringLeft_obj_obj, Functor.comp_map, singularChainComplexMap.eq_def]
 
 /-- The quotient map from ambient singular chains to relative singular chains. -/
 noncomputable abbrev singularChainComplexπ :
@@ -93,7 +122,7 @@ noncomputable abbrev singularChainComplexπ :
   (toSSetPair.obj P).chainComplexπ R
 
 @[simp]
-lemma singularChainComplex_condition :
+lemma singularChainComplexMap_comp_singularChainComplexπ :
     SSet.chainComplexMap (TopCat.toSSet.map P.map) R ≫ P.singularChainComplexπ R = 0 := by
   rw [← toSSetPair_obj_hom]
   exact (toSSetPair.obj P).chainComplex_condition R
@@ -143,9 +172,26 @@ protected noncomputable abbrev singularHomologyMap (n : ℕ) :
   SSetPair.homologyMap (toSSetPair.map f) R n
 
 /-- Relative singular homology as a functor on topological pairs. -/
-@[implicit_reducible]
+@[no_expose]
 noncomputable def singularHomologyFunctor (n : ℕ) : TopPair.{w} ⥤ C :=
   toSSetPair ⋙ SSetPair.homologyFunctor R n
+
+@[simp]
+lemma singularHomologyFunctor_obj (n : ℕ) :
+    (singularHomologyFunctor R n).obj P = P.singularHomology R n := by
+  rw [singularHomologyFunctor.eq_def, singularHomology.eq_def, Functor.comp_obj,
+    SSetPair.homologyFunctor_obj]
+
+@[simp]
+lemma singularHomologyFunctor_map (n : ℕ) :
+    (singularHomologyFunctor R n).map f =
+      eqToHom (singularHomologyFunctor_obj P R n) ≫
+        P.singularHomologyMap f R n ≫
+          eqToHom (singularHomologyFunctor_obj P' R n).symm := by
+  apply (conj_eqToHom_iff_heq _ _ (singularHomologyFunctor_obj P R n)
+    (singularHomologyFunctor_obj P' R n)).2
+  rw [singularHomologyFunctor.eq_def, Functor.comp_map, singularHomologyMap.eq_def,
+    SSetPair.homologyFunctor_map]
 
 /-- The map from ambient singular homology to relative singular homology. -/
 noncomputable abbrev singularHomologyπ (n : ℕ) :
@@ -153,7 +199,7 @@ noncomputable abbrev singularHomologyπ (n : ℕ) :
   (toSSetPair.obj P).homologyπ R n
 
 @[simp]
-lemma singularHomologyMap_map_singularHomologyπ (n : ℕ) :
+lemma homologyMap_comp_singularHomologyπ (n : ℕ) :
     SSet.homologyMap (TopCat.toSSet.map P.map) R n ≫ P.singularHomologyπ R n = 0 := by
   rw [← toSSetPair_obj_hom]
   exact (toSSetPair.obj P).homologyMap_hom_homologyπ R n
@@ -190,7 +236,7 @@ lemma singularHomology_exact_subspace (n m : ℕ) (h : m + 1 = n := by lia) :
 
 /-- Exactness at ambient homology in the long exact sequence of a topological pair. -/
 lemma singularHomology_exact_space (n : ℕ) :
-    (ShortComplex.mk _ _ (P.singularHomologyMap_map_singularHomologyπ R n)).Exact :=
+    (ShortComplex.mk _ _ (P.homologyMap_comp_singularHomologyπ R n)).Exact :=
   (toSSetPair.obj P).homology_exact₂ R n
 
 /-- Exactness at relative homology in the long exact sequence of a topological pair. -/


### PR DESCRIPTION
This PR adds the relative singular-chain and homology functors on `TopPair` by sending each topological embedding to its induced monomorphism of singular simplicial sets and composing with Mathlib's `SSetPair` construction. It advances `AlgebraicTopology/README.md`, Stage 2, item 1, “Extend singular chains from `TopCat` to `TopPair`,” and supplies the functorial quotient-chain and short-exact-sequence foundation consumed by Stage 2 items 2 and 3. After this PR, Stage 2 still needs the natural comparison for `(X, ∅)`, homotopy invariance and the remaining Eilenberg--Steenrod instances, calculations, and local coefficients.

The new `TauCeti/AlgebraicTopology/Singular/Relative.lean` defines `TopPair.toSSetPair`, the relative singular chain and homology functors, their induced maps, the cokernel presentation, the short exact chain sequence, the connecting morphism, and exactness at all three terms of the resulting long exact homology sequence. Its coefficient assumptions are inherited from Mathlib's categorical simplicial chains: a preadditive category with the required coproducts for chains, `CategoryWithHomology` for homology, and an abelian category for connecting morphisms and exactness.

No Mathlib infrastructure is vendored. The implementation reuses `TopCat.toSSet`, `SSetPair.chainComplexFunctor`, its cokernel universal property, and `SSetPair`'s short-exact and homology-exactness API from the pinned dependency. The mathematical presentation follows Eilenberg--Steenrod, *Foundations of Algebraic Topology*, Chapters I--III.

Roadmap: AlgebraicTopology

<!--tauceti-target:v1 {"focus":"AlgebraicTopology","id":"relative-singular-chain-complex"}-->

🤖 Prepared with Codex
