### PR TITLE
feat: distinguish combinatorial triangulability

### DIFF
--- a/TauCeti/Topology/CombinatoriallyTriangulable.lean
+++ b/TauCeti/Topology/CombinatoriallyTriangulable.lean
@@ -1,0 +1,57 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Topology.Triangulable
+public import TauCeti.AlgebraicTopology.SimplicialComplex.CombinatorialManifold
+
+/-!
+# Combinatorially triangulable spaces
+
+This predicate records the stronger witness needed when a triangulation is required to carry
+the link condition of a combinatorial manifold.  It is kept separate from `IsTriangulable`:
+an arbitrary simplicial complex can realize a triangulable space without presenting a PL
+manifold.
+-/
+
+public section
+
+namespace TauCeti
+
+noncomputable section
+attribute [local instance] Classical.decEq
+
+universe u v
+
+variable {X : Type u} [TopologicalSpace X]
+
+/-- `X` has a triangulation by a combinatorial `n`-manifold. -/
+def IsCombinatoriallyTriangulable (X : Type u) [TopologicalSpace X] (n : ℕ) : Prop :=
+  ∃ (ι : Type v) (K : AbstractSimplicialComplex ι),
+    K.toPreAbstractSimplicialComplex.IsCombinatorialManifold n ∧
+      Nonempty (AbstractSimplicialComplex.Realization K ≃ₜ X)
+
+/-- A combinatorial triangulation is, in particular, a triangulation. -/
+theorem IsCombinatoriallyTriangulable.isTriangulable
+    (h : IsCombinatoriallyTriangulable.{u, v} X n) : IsTriangulable.{v} X := by
+  rcases h with ⟨ι, K, _, ⟨e⟩⟩
+  exact (Homeomorph.isTriangulable_iff e).mp
+    (AbstractSimplicialComplex.isTriangulable_realization K)
+
+/-- Combinatorial triangulability is invariant under homeomorphism of the ambient space. -/
+theorem Homeomorph.isCombinatoriallyTriangulable_iff
+    {Y : Type u} [TopologicalSpace Y] (e : X ≃ₜ Y) :
+    IsCombinatoriallyTriangulable.{u, v} X n ↔
+      IsCombinatoriallyTriangulable.{u, v} Y n := by
+  constructor
+  · rintro ⟨ι, K, hK, ⟨h⟩⟩
+    exact ⟨ι, K, hK, ⟨h.trans e⟩⟩
+  · rintro ⟨ι, K, hK, ⟨h⟩⟩
+    exact ⟨ι, K, hK, ⟨h.trans e.symm⟩⟩
+
+end
+
+end TauCeti


### PR DESCRIPTION
This PR adds `IsCombinatoriallyTriangulable`, the dimension-indexed predicate that a space is homeomorphic to the realization of a combinatorial manifold, together with its implication to `IsTriangulable` and homeomorphism invariance. It advances GeometricTopology Layer 11’s requirement to keep triangulable, combinatorially triangulable, and PL notions distinct. After this PR, the layer still needs the realization/link reconciliation with `PLGroupoid`, plus the Manolescu and collapse statements.

The definition uses the existing abstract simplicial-complex realization and link-condition API; no Mathlib infrastructure is vendored.

Roadmap: GeometricTopology

<!--tauceti-target:v1 {"focus":"GeometricTopology","id":"triangulable-space"}-->

🤖 Prepared with Codex
