### PR TITLE
feat: associativity of the sheafified tensor product of sheaves of modules

### DIFF
--- a/TauCeti/Algebra/Category/ModuleCat/Presheaf/IsMonoidalW.lean
+++ b/TauCeti/Algebra/Category/ModuleCat/Presheaf/IsMonoidalW.lean
@@ -36,17 +36,6 @@ sheafifying `M ⊗ N` before tensoring with `P` does not change the sheafificati
   modules preserves local isomorphisms;
 * `PresheafOfModules.isMonoidal_inverseImage_W_toPresheaf`: the resulting `IsMonoidal` instance.
 
-## Proof
-
-For free presheaves of modules the statement is checked on sections: a section of
-`free F ⊗ N` over `U` is a finite sum `∑ z ⊗ n_z` indexed by distinct elements `z` of `F(U)`, and
-it is killed by `free F ◁ f` exactly when every coefficient `n_z` is killed by `f`. Local
-injectivity of `f` then makes all the coefficients vanish on a common covering sieve.
-A general presheaf of modules is a cokernel of a morphism between coproducts of free presheaves
-of modules (`PresheafOfModules.isColimitFreeYonedaCoproductsCokernelCofork`). Tensoring preserves
-colimits, and local isomorphisms are stable under colimits because sheafification preserves them,
-so the statement passes from free presheaves to all presheaves of modules. No formalization is
-vendored.
 -/
 
 public section
@@ -55,7 +44,7 @@ open CategoryTheory Limits MonoidalCategory Opposite TensorProduct
 
 namespace TauCeti
 
-universe u
+universe v u
 
 section Algebra
 
@@ -82,7 +71,10 @@ private lemma eq_sum_single_tmul [DecidableEq ι] (t : (ι →₀ S) ⊗[S] B) :
 
 end Algebra
 
-variable {C : Type u} [SmallCategory C] (J : GrothendieckTopology C) {R : Cᵒᵖ ⥤ CommRingCat.{u}}
+section Locality
+
+variable {C : Type u} [Category.{v} C] (J : GrothendieckTopology C)
+  {R : Cᵒᵖ ⥤ CommRingCat.{u}}
 
 /-- Tensoring with a presheaf of modules `P` preserves local surjectivity: a section of
 `P ⊗ N'` is locally a sum of elementary tensors whose second factors lift along `f`. -/
@@ -91,6 +83,7 @@ theorem _root_.PresheafOfModules.isLocallySurjective_whiskerLeft
     (f : N ⟶ N') [Presheaf.IsLocallySurjective J ((PresheafOfModules.toPresheaf _).map f)] :
     Presheaf.IsLocallySurjective J ((PresheafOfModules.toPresheaf _).map (P ◁ f)) where
   imageSieve_mem {U} t := by
+    -- Expose the sectionwise tensor product in order to use tensor-product induction.
     change (P.obj (op U) ⊗ N'.obj (op U) : ModuleCat _) at t
     induction t using TensorProduct.induction_on with
     | zero =>
@@ -102,7 +95,9 @@ theorem _root_.PresheafOfModules.isLocallySurjective_whiskerLeft
         (Presheaf.imageSieve_mem J ((PresheafOfModules.toPresheaf _).map f) n')
       rintro V g ⟨n, hn⟩
       refine ⟨P.map g.op p ⊗ₜ n, ?_⟩
+      -- Expose the component of the whiskered morphism as a tensor product of module maps.
       change P.map g.op p ⊗ₜ f.app (op V) n = (P ⊗ N').map g.op (p ⊗ₜ n')
+      -- Expose the underlying-presheaf components in the local lifting equation.
       change f.app (op V) n = N'.map g.op n' at hn
       rw [hn]
       rfl
@@ -143,9 +138,14 @@ theorem _root_.PresheafOfModules.isLocallyInjective_free_whiskerLeft (F : Cᵒ�
     have key : ((PresheafOfModules.free _).obj F ⊗ N).map g.op t = 0 := by
       refine (congrArg _ (eq_sum_single_tmul t)).trans
         ((map_sum _ _ _).trans (Finset.sum_eq_zero fun z hz ↦ ?_))
+      -- Expose the sectionwise tensor map in order to rewrite its second tensor factor.
       change _ ⊗ₜ N.map g.op (e t z) = 0
       exact (congrArg _ (hg' z hz)).trans (tmul_zero _ _)
     exact sub_eq_zero.1 ((map_sub _ x y).symm.trans key)
+
+end Locality
+
+variable {C : Type u} [SmallCategory C] (J : GrothendieckTopology C) {R : Cᵒᵖ ⥤ CommRingCat.{u}}
 
 variable [HasWeakSheafify J AddCommGrpCat.{u}]
 

--- a/TauCeti/Algebra/Category/ModuleCat/Presheaf/IsMonoidalW.lean
+++ b/TauCeti/Algebra/Category/ModuleCat/Presheaf/IsMonoidalW.lean
@@ -1,0 +1,230 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Category.ModuleCat.Presheaf.Generator
+public import Mathlib.Algebra.Category.ModuleCat.Presheaf.Monoidal
+public import Mathlib.CategoryTheory.Localization.Monoidal.Basic
+public import Mathlib.CategoryTheory.MorphismProperty.Limits
+public import Mathlib.CategoryTheory.Sites.LocallyBijective
+public import Mathlib.CategoryTheory.Sites.Localization
+public import Mathlib.LinearAlgebra.DirectSum.Finsupp
+
+/-!
+# Local isomorphisms of presheaves of modules are stable under tensor products
+
+Let `R` be a presheaf of commutative rings on a small site `(C, J)`. A morphism `f` of presheaves
+of `R`-modules is a *local isomorphism* when its underlying morphism of presheaves of abelian
+groups lies in `J.W`, i.e. becomes an isomorphism after sheafification. This file proves that the
+sectionwise tensor product of presheaves of modules preserves local isomorphisms in each variable:
+the morphism property `J.W.inverseImage (PresheafOfModules.toPresheaf _)` is monoidal.
+
+This is the input needed to compare iterated sheafified tensor products of sheaves of modules:
+sheafifying `M ⊗ N` before tensoring with `P` does not change the sheafification of the result.
+
+## Main declarations
+
+* `PresheafOfModules.isLocallySurjective_whiskerLeft`: tensoring with any presheaf of modules
+  preserves local surjectivity;
+* `PresheafOfModules.isLocallyInjective_free_whiskerLeft`: tensoring with a free presheaf of
+  modules preserves local injectivity;
+* `PresheafOfModules.inverseImage_W_toPresheaf_whiskerLeft` and
+  `PresheafOfModules.inverseImage_W_toPresheaf_whiskerRight`: tensoring with any presheaf of
+  modules preserves local isomorphisms;
+* `PresheafOfModules.isMonoidal_inverseImage_W_toPresheaf`: the resulting `IsMonoidal` instance.
+
+## Proof
+
+For free presheaves of modules the statement is checked on sections: a section of
+`free F ⊗ N` over `U` is a finite sum `∑ z ⊗ n_z` indexed by distinct elements `z` of `F(U)`, and
+it is killed by `free F ◁ f` exactly when every coefficient `n_z` is killed by `f`. Local
+injectivity of `f` then makes all the coefficients vanish on a common covering sieve.
+A general presheaf of modules is a cokernel of a morphism between coproducts of free presheaves
+of modules (`PresheafOfModules.isColimitFreeYonedaCoproductsCokernelCofork`). Tensoring preserves
+colimits, and local isomorphisms are stable under colimits because sheafification preserves them,
+so the statement passes from free presheaves to all presheaves of modules. No formalization is
+vendored.
+-/
+
+public section
+
+open CategoryTheory Limits MonoidalCategory Opposite TensorProduct
+
+namespace TauCeti
+
+universe u
+
+section Algebra
+
+variable {S : Type*} [CommRing S] {ι : Type*} {B B' : Type*} [AddCommGroup B] [Module S B]
+  [AddCommGroup B'] [Module S B']
+
+/-- The coefficients of `(1 ⊗ g) t` in the free module `(ι →₀ S) ⊗ B'` are the images under `g`
+of the coefficients of `t`. -/
+private lemma finsuppScalarLeft_lTensor_apply [DecidableEq ι] (g : B →ₗ[S] B')
+    (t : (ι →₀ S) ⊗[S] B) (z : ι) :
+    finsuppScalarLeft S B' ι (g.lTensor _ t) z = g (finsuppScalarLeft S B ι t z) := by
+  induction t using TensorProduct.induction_on with
+  | zero => simp
+  | tmul p n => simp
+  | add a b ha hb => simp [ha, hb]
+
+/-- An element of `(ι →₀ S) ⊗ B` is the sum of its coefficients against the basis vectors. -/
+private lemma eq_sum_single_tmul [DecidableEq ι] (t : (ι →₀ S) ⊗[S] B) :
+    t = ∑ z ∈ (finsuppScalarLeft S B ι t).support,
+      Finsupp.single z (1 : S) ⊗ₜ finsuppScalarLeft S B ι t z := by
+  conv_lhs => rw [← (finsuppScalarLeft S B ι).symm_apply_apply t,
+    ← Finsupp.sum_single (finsuppScalarLeft S B ι t)]
+  simp [Finsupp.sum, finsuppScalarLeft_symm_apply_single]
+
+end Algebra
+
+variable {C : Type u} [SmallCategory C] (J : GrothendieckTopology C) {R : Cᵒᵖ ⥤ CommRingCat.{u}}
+
+/-- Tensoring with a presheaf of modules `P` preserves local surjectivity: a section of
+`P ⊗ N'` is locally a sum of elementary tensors whose second factors lift along `f`. -/
+theorem _root_.PresheafOfModules.isLocallySurjective_whiskerLeft
+    (P : PresheafOfModules.{u} (R ⋙ forget₂ _ _)) {N N' : PresheafOfModules.{u} (R ⋙ forget₂ _ _)}
+    (f : N ⟶ N') [Presheaf.IsLocallySurjective J ((PresheafOfModules.toPresheaf _).map f)] :
+    Presheaf.IsLocallySurjective J ((PresheafOfModules.toPresheaf _).map (P ◁ f)) where
+  imageSieve_mem {U} t := by
+    change (P.obj (op U) ⊗ N'.obj (op U) : ModuleCat _) at t
+    induction t using TensorProduct.induction_on with
+    | zero =>
+      refine J.superset_covering ?_ (J.top_mem U)
+      rintro V g -
+      exact ⟨0, (map_zero _).trans (map_zero _).symm⟩
+    | tmul p n' =>
+      refine J.superset_covering ?_
+        (Presheaf.imageSieve_mem J ((PresheafOfModules.toPresheaf _).map f) n')
+      rintro V g ⟨n, hn⟩
+      refine ⟨P.map g.op p ⊗ₜ n, ?_⟩
+      change P.map g.op p ⊗ₜ f.app (op V) n = (P ⊗ N').map g.op (p ⊗ₜ n')
+      change f.app (op V) n = N'.map g.op n' at hn
+      rw [hn]
+      rfl
+    | add a b ha hb =>
+      refine J.superset_covering ?_ (J.intersection_covering ha hb)
+      rintro V g ⟨⟨a', ha'⟩, ⟨b', hb'⟩⟩
+      exact ⟨a' + b', (map_add _ a' b').trans
+        ((congrArg₂ (· + ·) ha' hb').trans (map_add _ a b).symm)⟩
+
+/-- Tensoring with the free presheaf of modules on a presheaf of types `F` preserves local
+injectivity. A section of `free F ⊗ N` killed by `free F ◁ f` has all its coefficients killed by
+`f`, and these finitely many coefficients vanish together on a covering sieve. -/
+theorem _root_.PresheafOfModules.isLocallyInjective_free_whiskerLeft (F : Cᵒᵖ ⥤ Type u)
+    {N N' : PresheafOfModules.{u} (R ⋙ forget₂ _ _)} (f : N ⟶ N')
+    [Presheaf.IsLocallyInjective J ((PresheafOfModules.toPresheaf _).map f)] :
+    Presheaf.IsLocallyInjective J
+      ((PresheafOfModules.toPresheaf _).map ((PresheafOfModules.free _).obj F ◁ f)) where
+  equalizerSieve_mem {U} x y hxy := by
+    classical
+    let e := finsuppScalarLeft ((R ⋙ forget₂ _ RingCat).obj U) (N.obj U) (F.obj U)
+    let t : (F.obj U →₀ (R ⋙ forget₂ _ RingCat).obj U) ⊗[(R ⋙ forget₂ _ RingCat).obj U]
+      N.obj U := x - y
+    have ht : (f.app U).hom.lTensor _ t = 0 := (map_sub _ x y).trans (sub_eq_zero.2 hxy)
+    have hz : ∀ z ∈ (e t).support, Presheaf.equalizerSieve
+        (F := (PresheafOfModules.toPresheaf _).obj N) (e t z) 0 ∈ J U.unop := fun z _ ↦
+      Presheaf.equalizerSieve_mem J ((PresheafOfModules.toPresheaf _).map f) _ _ <| by
+        have := congrArg (fun s ↦ finsuppScalarLeft ((R ⋙ forget₂ _ RingCat).obj U) (N'.obj U)
+          (F.obj U) s z) ht
+        simp only [finsuppScalarLeft_lTensor_apply, map_zero, Finsupp.coe_zero,
+          Pi.zero_apply] at this
+        exact this.trans (map_zero _).symm
+    refine J.superset_covering ?_ (Finset.inf_induction (J.top_mem _)
+      (fun _ h₁ _ h₂ ↦ J.intersection_covering h₁ h₂) hz)
+    intro V g hg
+    have hg' : ∀ z ∈ (e t).support, N.map g.op (e t z) = 0 := fun z hz ↦
+      (Finset.inf_le (f := fun z ↦ Presheaf.equalizerSieve
+        (F := (PresheafOfModules.toPresheaf _).obj N) (e t z) 0) hz g hg).trans (map_zero _)
+    have key : ((PresheafOfModules.free _).obj F ⊗ N).map g.op t = 0 := by
+      refine (congrArg _ (eq_sum_single_tmul t)).trans
+        ((map_sum _ _ _).trans (Finset.sum_eq_zero fun z hz ↦ ?_))
+      change _ ⊗ₜ N.map g.op (e t z) = 0
+      exact (congrArg _ (hg' z hz)).trans (tmul_zero _ _)
+    exact sub_eq_zero.1 ((map_sub _ x y).symm.trans key)
+
+variable [HasWeakSheafify J AddCommGrpCat.{u}]
+
+/-- Local isomorphisms of presheaves of modules are stable under every shape of colimits which
+the forgetful functor to presheaves of abelian groups and sheafification preserve. -/
+private lemma isStableUnderColimitsOfShape_inverseImage_W_toPresheaf (K : Type*) [Category K]
+    [PreservesColimitsOfShape K (PresheafOfModules.toPresheaf.{u} (R ⋙ forget₂ _ _))]
+    [PreservesColimitsOfShape K (presheafToSheaf J AddCommGrpCat.{u})] :
+    MorphismProperty.IsStableUnderColimitsOfShape ((J.W (A := AddCommGrpCat.{u})).inverseImage
+      (PresheafOfModules.toPresheaf (R ⋙ forget₂ _ _))) K where
+  condition X₁ X₂ c₁ c₂ h₁ h₂ f hf φ hφ := by
+    let G := PresheafOfModules.toPresheaf (R ⋙ forget₂ _ _) ⋙
+      presheafToSheaf J AddCommGrpCat.{u}
+    have : PreservesColimitsOfShape K G := comp_preservesColimitsOfShape _ _
+    have hW : ∀ {M M' : PresheafOfModules.{u} (R ⋙ forget₂ _ _)} (g : M ⟶ M'),
+        (J.W (A := AddCommGrpCat.{u})).inverseImage
+          (PresheafOfModules.toPresheaf (R ⋙ forget₂ _ _)) g ↔ IsIso (G.map g) := fun g ↦ by
+      rw [MorphismProperty.inverseImage_iff, J.W_eq_inverseImage_isomorphisms]
+      rfl
+    rw [hW]
+    exact MorphismProperty.IsStableUnderColimitsOfShape.condition (W := .isomorphisms _)
+      (X₁ ⋙ G) (X₂ ⋙ G) (G.mapCocone c₁) (G.mapCocone c₂) (isColimitOfPreserves G h₁)
+      (isColimitOfPreserves G h₂) (Functor.whiskerRight f G) (fun k ↦ (hW _).1 (hf k))
+      (G.map φ) (fun k ↦ by simp [G, ← Functor.map_comp, hφ])
+
+/-- If tensoring with each term of a diagram preserves a local isomorphism `f`, then so does
+tensoring with the colimit of the diagram. -/
+private lemma inverseImage_W_toPresheaf_whiskerLeft_of_isColimit {K : Type*} [Category K]
+    [PreservesColimitsOfShape K (PresheafOfModules.toPresheaf.{u} (R ⋙ forget₂ _ _))]
+    [∀ N : PresheafOfModules.{u} (R ⋙ forget₂ _ _), PreservesColimitsOfShape K (tensorRight N)]
+    {D : K ⥤ PresheafOfModules.{u} (R ⋙ forget₂ _ _)} {c : Cocone D} (hc : IsColimit c)
+    {N N' : PresheafOfModules.{u} (R ⋙ forget₂ _ _)} (f : N ⟶ N')
+    (hD : ∀ k, (J.W (A := AddCommGrpCat.{u})).inverseImage
+      (PresheafOfModules.toPresheaf _) (D.obj k ◁ f)) :
+    (J.W (A := AddCommGrpCat.{u})).inverseImage (PresheafOfModules.toPresheaf _) (c.pt ◁ f) :=
+  (isStableUnderColimitsOfShape_inverseImage_W_toPresheaf J K).condition
+    (D ⋙ tensorRight N) (D ⋙ tensorRight N')
+    ((tensorRight N).mapCocone c) ((tensorRight N').mapCocone c) (isColimitOfPreserves _ hc)
+    (isColimitOfPreserves _ hc) (Functor.whiskerLeft D ((tensoringRight _).map f)) hD
+    (c.pt ◁ f) (fun _ ↦ (whisker_exchange _ _).symm)
+
+variable [J.WEqualsLocallyBijective AddCommGrpCat.{u}]
+
+/-- Tensoring with a presheaf of modules on the left preserves local isomorphisms. -/
+theorem _root_.PresheafOfModules.inverseImage_W_toPresheaf_whiskerLeft
+    (P : PresheafOfModules.{u} (R ⋙ forget₂ _ _)) {N N' : PresheafOfModules.{u} (R ⋙ forget₂ _ _)}
+    {f : N ⟶ N'}
+    (hf : (J.W (A := AddCommGrpCat.{u})).inverseImage (PresheafOfModules.toPresheaf _) f) :
+    (J.W (A := AddCommGrpCat.{u})).inverseImage (PresheafOfModules.toPresheaf _) (P ◁ f) := by
+  rw [MorphismProperty.inverseImage_iff, J.W_iff_isLocallyBijective] at hf
+  obtain ⟨_, _⟩ := hf
+  have hfree (F : Cᵒᵖ ⥤ Type u) : (J.W (A := AddCommGrpCat.{u})).inverseImage
+      (PresheafOfModules.toPresheaf _) ((PresheafOfModules.free _).obj F ◁ f) := by
+    have := PresheafOfModules.isLocallySurjective_whiskerLeft J
+      ((PresheafOfModules.free _).obj F) f
+    have := PresheafOfModules.isLocallyInjective_free_whiskerLeft J F f
+    exact J.W_of_isLocallyBijective _
+  have hcoprod (M : PresheafOfModules.{u} (R ⋙ forget₂ _ _)) :
+      (J.W (A := AddCommGrpCat.{u})).inverseImage (PresheafOfModules.toPresheaf _)
+        (M.freeYonedaCoproduct ◁ f) :=
+    inverseImage_W_toPresheaf_whiskerLeft_of_isColimit J (colimit.isColimit _) f
+      fun _ ↦ hfree _
+  exact inverseImage_W_toPresheaf_whiskerLeft_of_isColimit J
+    P.isColimitFreeYonedaCoproductsCokernelCofork f (by rintro (_ | _) <;> exact hcoprod _)
+
+/-- Tensoring with a presheaf of modules on the right preserves local isomorphisms. -/
+theorem _root_.PresheafOfModules.inverseImage_W_toPresheaf_whiskerRight
+    {N N' : PresheafOfModules.{u} (R ⋙ forget₂ _ _)} {f : N ⟶ N'}
+    (hf : (J.W (A := AddCommGrpCat.{u})).inverseImage (PresheafOfModules.toPresheaf _) f)
+    (P : PresheafOfModules.{u} (R ⋙ forget₂ _ _)) :
+    (J.W (A := AddCommGrpCat.{u})).inverseImage (PresheafOfModules.toPresheaf _) (f ▷ P) :=
+  (MorphismProperty.arrow_mk_iso_iff _ (Arrow.isoMk (β_ N P) (β_ N' P))).2
+    (PresheafOfModules.inverseImage_W_toPresheaf_whiskerLeft J P hf)
+
+/-- Local isomorphisms of presheaves of modules form a monoidal morphism property. -/
+instance _root_.PresheafOfModules.isMonoidal_inverseImage_W_toPresheaf :
+    MorphismProperty.IsMonoidal ((J.W (A := AddCommGrpCat.{u})).inverseImage
+      (PresheafOfModules.toPresheaf.{u} (R ⋙ forget₂ _ _))) where
+  whiskerLeft P _ _ _ hg := PresheafOfModules.inverseImage_W_toPresheaf_whiskerLeft J P hg
+  whiskerRight _ hf P := PresheafOfModules.inverseImage_W_toPresheaf_whiskerRight J hf P
+
+end TauCeti

--- a/TauCeti/Algebra/Category/ModuleCat/Sheaf/TensorProduct/Associator.lean
+++ b/TauCeti/Algebra/Category/ModuleCat/Sheaf/TensorProduct/Associator.lean
@@ -1,0 +1,143 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Category.ModuleCat.Sheaf.Localization
+public import TauCeti.Algebra.Category.ModuleCat.Presheaf.IsMonoidalW
+public import TauCeti.Algebra.Category.ModuleCat.Sheaf.TensorProduct.Basic
+
+/-!
+# Associativity of the tensor product of sheaves of modules
+
+Let `R` be a sheaf of commutative rings on a small site. The tensor product of sheaves of
+`R`-modules `SheafOfModules.tensorProduct R M N` is the sheafification of the sectionwise tensor
+product `M ⊗ N` of the underlying presheaves of modules. This file constructs the associativity
+isomorphism `(M ⊗ N) ⊗ P ≅ M ⊗ (N ⊗ P)`.
+
+Both sides are sheafifications of iterated sectionwise tensor products in which an inner tensor
+product has already been sheafified. The unit `M ⊗ N ⟶ a(M ⊗ N)` of the sheafification
+adjunction is a local isomorphism, and tensoring preserves local isomorphisms
+(`PresheafOfModules.isMonoidal_inverseImage_W_toPresheaf`), so sheafifying
+`(M ⊗ N) ⊗ P ⟶ a(M ⊗ N) ⊗ P` gives an isomorphism, and similarly on the other side. The
+associator is the sheafification of the sectionwise associator read through these two
+isomorphisms. The scheme-level line-bundle associator
+`TauCeti.AlgebraicGeometry.InvertibleSheaf.tensorProductAssoc` is its specialization.
+
+## Main declarations
+
+* `SheafOfModules.isIso_sheafification_map_of_inverseImage_W_toPresheaf`: sheafification inverts
+  local isomorphisms of presheaves of modules;
+* `SheafOfModules.tensorProductAssoc`: the associativity isomorphism of the sheafified tensor
+  product;
+* `SheafOfModules.tensorProductAssoc_hom`: its forward map, spelled out through the sectionwise
+  associator.
+
+The site is assumed small, with modules in the universe of its objects and morphisms, because the
+comparison of local isomorphisms passes through Mathlib's presentation of presheaves of modules
+by free presheaves of modules. No formalization is vendored.
+-/
+
+public section
+
+open CategoryTheory Category MonoidalCategory
+
+namespace TauCeti
+
+universe u
+
+noncomputable section
+
+variable {C : Type u} [SmallCategory C] {J : GrothendieckTopology C}
+variable [J.HasSheafCompose (forget₂ CommRingCat RingCat.{u})]
+variable [HasWeakSheafify J AddCommGrpCat.{u}] [J.WEqualsLocallyBijective AddCommGrpCat.{u}]
+
+namespace SheafOfModules
+
+variable (R : Sheaf J CommRingCat.{u})
+
+/-- Sheafification of presheaves of modules inverts local isomorphisms: morphisms whose
+underlying morphism of presheaves of abelian groups becomes an isomorphism after
+sheafification. -/
+theorem isIso_sheafification_map_of_inverseImage_W_toPresheaf
+    {M₀ N₀ : PresheafOfModules.{u} (ringCatSheaf R).obj} {g : M₀ ⟶ N₀}
+    (hg : (J.W (A := AddCommGrpCat.{u})).inverseImage (PresheafOfModules.toPresheaf _) g) :
+    IsIso ((PresheafOfModules.sheafification (𝟙 (ringCatSheaf R).obj)).map g) := by
+  rwa [PresheafOfModules.inverseImage_W_toPresheaf_eq_inverseImage_isomorphisms
+    (𝟙 (ringCatSheaf R).obj)] at hg
+
+/-- The unit `M₀ ⟶ a(M₀)` of the sheafification adjunction for presheaves of modules is a local
+isomorphism. -/
+theorem inverseImage_W_toPresheaf_sheafificationAdjunction_unit_app
+    (M₀ : PresheafOfModules.{u} (ringCatSheaf R).obj) :
+    (J.W (A := AddCommGrpCat.{u})).inverseImage (PresheafOfModules.toPresheaf _)
+      ((PresheafOfModules.sheafificationAdjunction (𝟙 (ringCatSheaf R).obj)).unit.app M₀) :=
+  J.W_toSheafify M₀.presheaf
+
+/-- Sheafifying the whiskered unit `(M ⊗ N) ⊗ P ⟶ a(M ⊗ N) ⊗ P` gives an isomorphism. -/
+instance (M₀ P₀ : PresheafOfModules.{u} (ringCatSheaf R).obj) :
+    IsIso ((PresheafOfModules.sheafification (𝟙 (ringCatSheaf R).obj)).map
+      ((PresheafOfModules.sheafificationAdjunction (𝟙 (ringCatSheaf R).obj)).unit.app M₀ ▷
+        P₀)) :=
+  isIso_sheafification_map_of_inverseImage_W_toPresheaf R
+    (PresheafOfModules.inverseImage_W_toPresheaf_whiskerRight J
+      (inverseImage_W_toPresheaf_sheafificationAdjunction_unit_app R M₀) P₀)
+
+/-- Sheafifying the whiskered unit `M ⊗ (N ⊗ P) ⟶ M ⊗ a(N ⊗ P)` gives an isomorphism. -/
+instance (M₀ P₀ : PresheafOfModules.{u} (ringCatSheaf R).obj) :
+    IsIso ((PresheafOfModules.sheafification (𝟙 (ringCatSheaf R).obj)).map
+      (M₀ ◁ (PresheafOfModules.sheafificationAdjunction (𝟙 (ringCatSheaf R).obj)).unit.app
+        P₀)) :=
+  isIso_sheafification_map_of_inverseImage_W_toPresheaf R
+    (PresheafOfModules.inverseImage_W_toPresheaf_whiskerLeft J M₀
+      (inverseImage_W_toPresheaf_sheafificationAdjunction_unit_app R P₀))
+
+/-- Associativity of the tensor product of sheaves of `R`-modules. Through the defining
+identifications `tensorProductIso`, it is the sheafification of the sectionwise associator,
+composed with the inverse of the sheafified unit `a((M ⊗ N) ⊗ P) ≅ a(a(M ⊗ N) ⊗ P)` and with the
+sheafified unit `a(M ⊗ (N ⊗ P)) ≅ a(M ⊗ a(N ⊗ P))`. -/
+def tensorProductAssoc (M N P : SheafOfModules.{u} (ringCatSheaf R)) :
+    tensorProduct R (tensorProduct R M N) P ≅ tensorProduct R M (tensorProduct R N P) :=
+  tensorProductIso R (tensorProduct R M N) P ≪≫
+    (PresheafOfModules.sheafification (𝟙 (ringCatSheaf R).obj)).mapIso
+      (whiskerRightIso ((_root_.SheafOfModules.forget _).mapIso (tensorProductIso R M N))
+        P.val) ≪≫
+    (asIso ((PresheafOfModules.sheafification (𝟙 (ringCatSheaf R).obj)).map
+      ((PresheafOfModules.sheafificationAdjunction (𝟙 (ringCatSheaf R).obj)).unit.app
+        (M.val ⊗ N.val) ▷ P.val))).symm ≪≫
+    (PresheafOfModules.sheafification (𝟙 (ringCatSheaf R).obj)).mapIso (α_ M.val N.val P.val) ≪≫
+    asIso ((PresheafOfModules.sheafification (𝟙 (ringCatSheaf R).obj)).map
+      (M.val ◁ (PresheafOfModules.sheafificationAdjunction (𝟙 (ringCatSheaf R).obj)).unit.app
+        (N.val ⊗ P.val))) ≪≫
+    (PresheafOfModules.sheafification (𝟙 (ringCatSheaf R).obj)).mapIso
+      (whiskerLeftIso M.val
+        ((_root_.SheafOfModules.forget _).mapIso (tensorProductIso R N P))).symm ≪≫
+    (tensorProductIso R M (tensorProduct R N P)).symm
+
+/-- The forward map of `tensorProductAssoc`: the sheafified sectionwise associator, read through
+the defining identifications of the tensor products and the sheafified units. -/
+theorem tensorProductAssoc_hom (M N P : SheafOfModules.{u} (ringCatSheaf R)) :
+    (tensorProductAssoc R M N P).hom =
+      (tensorProductIso R (tensorProduct R M N) P).hom ≫
+        (PresheafOfModules.sheafification (𝟙 (ringCatSheaf R).obj)).map
+          ((_root_.SheafOfModules.forget _).map (tensorProductIso R M N).hom ▷ P.val) ≫
+        (asIso ((PresheafOfModules.sheafification (𝟙 (ringCatSheaf R).obj)).map
+          ((PresheafOfModules.sheafificationAdjunction (𝟙 (ringCatSheaf R).obj)).unit.app
+            (M.val ⊗ N.val) ▷ P.val))).inv ≫
+        (PresheafOfModules.sheafification (𝟙 (ringCatSheaf R).obj)).map
+          (α_ M.val N.val P.val).hom ≫
+        (PresheafOfModules.sheafification (𝟙 (ringCatSheaf R).obj)).map
+          (M.val ◁ (PresheafOfModules.sheafificationAdjunction (𝟙 (ringCatSheaf R).obj)).unit.app
+            (N.val ⊗ P.val)) ≫
+        (PresheafOfModules.sheafification (𝟙 (ringCatSheaf R).obj)).map
+          (M.val ◁ (_root_.SheafOfModules.forget _).map (tensorProductIso R N P).inv) ≫
+        (tensorProductIso R M (tensorProduct R N P)).inv :=
+  (rfl)
+
+end SheafOfModules
+
+end
+
+end TauCeti

--- a/TauCeti/Algebra/Category/ModuleCat/Sheaf/TensorProduct/Associator.lean
+++ b/TauCeti/Algebra/Category/ModuleCat/Sheaf/TensorProduct/Associator.lean
@@ -61,10 +61,8 @@ instance (M₀ P₀ : PresheafOfModules.{u} (ringCatSheaf R).obj) :
     IsIso ((PresheafOfModules.sheafification (𝟙 (ringCatSheaf R).obj)).map
       ((PresheafOfModules.sheafificationAdjunction (𝟙 (ringCatSheaf R).obj)).unit.app M₀ ▷
         P₀)) := by
-  change ((MorphismProperty.isomorphisms _).inverseImage
-    (PresheafOfModules.sheafification (𝟙 (ringCatSheaf R).obj)))
-      ((PresheafOfModules.sheafificationAdjunction (𝟙 (ringCatSheaf R).obj)).unit.app M₀ ▷ P₀)
-  rw [← PresheafOfModules.inverseImage_W_toPresheaf_eq_inverseImage_isomorphisms]
+  rw [← MorphismProperty.isomorphisms.iff, ← MorphismProperty.inverseImage_iff (.isomorphisms _),
+    ← PresheafOfModules.inverseImage_W_toPresheaf_eq_inverseImage_isomorphisms]
   exact PresheafOfModules.inverseImage_W_toPresheaf_whiskerRight J
     (f := (PresheafOfModules.sheafificationAdjunction
       (𝟙 (ringCatSheaf R).obj)).unit.app M₀) (J.W_toSheafify M₀.presheaf) P₀
@@ -74,11 +72,8 @@ instance (M₀ P₀ : PresheafOfModules.{u} (ringCatSheaf R).obj) :
     IsIso ((PresheafOfModules.sheafification (𝟙 (ringCatSheaf R).obj)).map
       (M₀ ◁ (PresheafOfModules.sheafificationAdjunction (𝟙 (ringCatSheaf R).obj)).unit.app
         P₀)) := by
-  change ((MorphismProperty.isomorphisms _).inverseImage
-    (PresheafOfModules.sheafification (𝟙 (ringCatSheaf R).obj)))
-      (M₀ ◁ (PresheafOfModules.sheafificationAdjunction
-        (𝟙 (ringCatSheaf R).obj)).unit.app P₀)
-  rw [← PresheafOfModules.inverseImage_W_toPresheaf_eq_inverseImage_isomorphisms]
+  rw [← MorphismProperty.isomorphisms.iff, ← MorphismProperty.inverseImage_iff (.isomorphisms _),
+    ← PresheafOfModules.inverseImage_W_toPresheaf_eq_inverseImage_isomorphisms]
   exact PresheafOfModules.inverseImage_W_toPresheaf_whiskerLeft J M₀
     (f := (PresheafOfModules.sheafificationAdjunction
       (𝟙 (ringCatSheaf R).obj)).unit.app P₀) (J.W_toSheafify P₀.presheaf)

--- a/TauCeti/Algebra/Category/ModuleCat/Sheaf/TensorProduct/Associator.lean
+++ b/TauCeti/Algebra/Category/ModuleCat/Sheaf/TensorProduct/Associator.lean
@@ -28,8 +28,6 @@ isomorphisms. The scheme-level line-bundle associator
 
 ## Main declarations
 
-* `SheafOfModules.isIso_sheafification_map_of_inverseImage_W_toPresheaf`: sheafification inverts
-  local isomorphisms of presheaves of modules;
 * `SheafOfModules.tensorProductAssoc`: the associativity isomorphism of the sheafified tensor
   product;
 * `SheafOfModules.tensorProductAssoc_hom`: its forward map, spelled out through the sectionwise
@@ -37,7 +35,7 @@ isomorphisms. The scheme-level line-bundle associator
 
 The site is assumed small, with modules in the universe of its objects and morphisms, because the
 comparison of local isomorphisms passes through Mathlib's presentation of presheaves of modules
-by free presheaves of modules. No formalization is vendored.
+by free presheaves of modules.
 -/
 
 public section
@@ -58,41 +56,32 @@ namespace SheafOfModules
 
 variable (R : Sheaf J CommRingCat.{u})
 
-/-- Sheafification of presheaves of modules inverts local isomorphisms: morphisms whose
-underlying morphism of presheaves of abelian groups becomes an isomorphism after
-sheafification. -/
-theorem isIso_sheafification_map_of_inverseImage_W_toPresheaf
-    {M₀ N₀ : PresheafOfModules.{u} (ringCatSheaf R).obj} {g : M₀ ⟶ N₀}
-    (hg : (J.W (A := AddCommGrpCat.{u})).inverseImage (PresheafOfModules.toPresheaf _) g) :
-    IsIso ((PresheafOfModules.sheafification (𝟙 (ringCatSheaf R).obj)).map g) := by
-  rwa [PresheafOfModules.inverseImage_W_toPresheaf_eq_inverseImage_isomorphisms
-    (𝟙 (ringCatSheaf R).obj)] at hg
-
-/-- The unit `M₀ ⟶ a(M₀)` of the sheafification adjunction for presheaves of modules is a local
-isomorphism. -/
-theorem inverseImage_W_toPresheaf_sheafificationAdjunction_unit_app
-    (M₀ : PresheafOfModules.{u} (ringCatSheaf R).obj) :
-    (J.W (A := AddCommGrpCat.{u})).inverseImage (PresheafOfModules.toPresheaf _)
-      ((PresheafOfModules.sheafificationAdjunction (𝟙 (ringCatSheaf R).obj)).unit.app M₀) :=
-  J.W_toSheafify M₀.presheaf
-
 /-- Sheafifying the whiskered unit `(M ⊗ N) ⊗ P ⟶ a(M ⊗ N) ⊗ P` gives an isomorphism. -/
 instance (M₀ P₀ : PresheafOfModules.{u} (ringCatSheaf R).obj) :
     IsIso ((PresheafOfModules.sheafification (𝟙 (ringCatSheaf R).obj)).map
       ((PresheafOfModules.sheafificationAdjunction (𝟙 (ringCatSheaf R).obj)).unit.app M₀ ▷
-        P₀)) :=
-  isIso_sheafification_map_of_inverseImage_W_toPresheaf R
-    (PresheafOfModules.inverseImage_W_toPresheaf_whiskerRight J
-      (inverseImage_W_toPresheaf_sheafificationAdjunction_unit_app R M₀) P₀)
+        P₀)) := by
+  change ((MorphismProperty.isomorphisms _).inverseImage
+    (PresheafOfModules.sheafification (𝟙 (ringCatSheaf R).obj)))
+      ((PresheafOfModules.sheafificationAdjunction (𝟙 (ringCatSheaf R).obj)).unit.app M₀ ▷ P₀)
+  rw [← PresheafOfModules.inverseImage_W_toPresheaf_eq_inverseImage_isomorphisms]
+  exact PresheafOfModules.inverseImage_W_toPresheaf_whiskerRight J
+    (f := (PresheafOfModules.sheafificationAdjunction
+      (𝟙 (ringCatSheaf R).obj)).unit.app M₀) (J.W_toSheafify M₀.presheaf) P₀
 
 /-- Sheafifying the whiskered unit `M ⊗ (N ⊗ P) ⟶ M ⊗ a(N ⊗ P)` gives an isomorphism. -/
 instance (M₀ P₀ : PresheafOfModules.{u} (ringCatSheaf R).obj) :
     IsIso ((PresheafOfModules.sheafification (𝟙 (ringCatSheaf R).obj)).map
       (M₀ ◁ (PresheafOfModules.sheafificationAdjunction (𝟙 (ringCatSheaf R).obj)).unit.app
-        P₀)) :=
-  isIso_sheafification_map_of_inverseImage_W_toPresheaf R
-    (PresheafOfModules.inverseImage_W_toPresheaf_whiskerLeft J M₀
-      (inverseImage_W_toPresheaf_sheafificationAdjunction_unit_app R P₀))
+        P₀)) := by
+  change ((MorphismProperty.isomorphisms _).inverseImage
+    (PresheafOfModules.sheafification (𝟙 (ringCatSheaf R).obj)))
+      (M₀ ◁ (PresheafOfModules.sheafificationAdjunction
+        (𝟙 (ringCatSheaf R).obj)).unit.app P₀)
+  rw [← PresheafOfModules.inverseImage_W_toPresheaf_eq_inverseImage_isomorphisms]
+  exact PresheafOfModules.inverseImage_W_toPresheaf_whiskerLeft J M₀
+    (f := (PresheafOfModules.sheafificationAdjunction
+      (𝟙 (ringCatSheaf R).obj)).unit.app P₀) (J.W_toSheafify P₀.presheaf)
 
 /-- Associativity of the tensor product of sheaves of `R`-modules. Through the defining
 identifications `tensorProductIso`, it is the sheafification of the sectionwise associator,

--- a/TauCeti/AlgebraicGeometry/LineBundle/TensorProduct.lean
+++ b/TauCeti/AlgebraicGeometry/LineBundle/TensorProduct.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.Category.ModuleCat.Sheaf.Invertible.TensorProduct.Closure
+public import TauCeti.Algebra.Category.ModuleCat.Sheaf.TensorProduct.Associator
 public import TauCeti.AlgebraicGeometry.Modules.Sheaf
 public import TauCeti.AlgebraicGeometry.Modules.TensorProduct
 public import TauCeti.AlgebraicGeometry.LineBundle.Basic
@@ -24,11 +25,13 @@ for the trivial line bundle.
 * `InvertibleSheaf.tensorProductCongrLeft` and `InvertibleSheaf.tensorProductCongrRight` transport
   isomorphisms through either tensor factor;
 * `InvertibleSheaf.tensorProductComm` exchanges the two tensor factors;
+* `InvertibleSheaf.tensorProductAssoc` is the associativity isomorphism;
 * `InvertibleSheaf.tensorTrivialLeftIso` and `InvertibleSheaf.tensorTrivialRightIso` are the
   unit isomorphisms in the full category of invertible sheaves.
 
-The underlying sheaf is exposed by `tensorProduct_obj`, while the congruence, symmetry, and unit
-isomorphisms provide the categorical API for manipulating tensor products of line bundles.
+The underlying sheaf is exposed by `tensorProduct_obj`, while the congruence, symmetry,
+associativity, and unit isomorphisms provide the categorical API for manipulating tensor products
+of line bundles.
 -/
 
 -- This implementation follows `TauCetiRoadmap/JacobianChallenge/README.md`, Layer A.
@@ -147,6 +150,35 @@ lemma tensorProductComm_inv_val (L K : InvertibleSheaf X) :
     (tensorProductComm L K).inv.hom.val =
       (tensorProductCommIso L K).inv.val := by
   simp only [tensorProductComm, ObjectProperty.isoMk, ObjectProperty.homMk,
+    _root_.AlgebraicGeometry.Scheme.Modules.isoOfSheafIso_inv_val]
+
+/-- The sheaf isomorphism underlying associativity of the tensor product of line bundles. -/
+def tensorProductAssocIso (L K M : InvertibleSheaf X) :
+    @Iso (SheafOfModules X.ringCatSheaf) _ (tensorProduct (tensorProduct L K) M).obj
+      (tensorProduct L (tensorProduct K M)).obj := by
+  simpa only [tensorProduct_obj, ObjectProperty.ι_obj,
+    _root_.AlgebraicGeometry.Scheme.Modules.tensorProduct] using
+    (SheafOfModules.tensorProductAssoc X.sheaf L.obj K.obj M.obj)
+
+/-- The tensor product of line bundles is associative. -/
+def tensorProductAssoc (L K M : InvertibleSheaf X) :
+    tensorProduct (tensorProduct L K) M ≅ tensorProduct L (tensorProduct K M) :=
+  ObjectProperty.isoMk (SheafOfModules.isInvertible X)
+    (_root_.AlgebraicGeometry.Scheme.Modules.isoOfSheafIso X
+      (tensorProductAssocIso L K M))
+
+@[simp]
+lemma tensorProductAssoc_hom_val (L K M : InvertibleSheaf X) :
+    (tensorProductAssoc L K M).hom.hom.val =
+      (tensorProductAssocIso L K M).hom.val := by
+  simp only [tensorProductAssoc, ObjectProperty.isoMk, ObjectProperty.homMk,
+    _root_.AlgebraicGeometry.Scheme.Modules.isoOfSheafIso_hom_val]
+
+@[simp]
+lemma tensorProductAssoc_inv_val (L K M : InvertibleSheaf X) :
+    (tensorProductAssoc L K M).inv.hom.val =
+      (tensorProductAssocIso L K M).inv.val := by
+  simp only [tensorProductAssoc, ObjectProperty.isoMk, ObjectProperty.homMk,
     _root_.AlgebraicGeometry.Scheme.Modules.isoOfSheafIso_inv_val]
 
 /-- The sheaf isomorphism underlying the left unit for the tensor product of line bundles. -/


### PR DESCRIPTION
This PR constructs the associativity isomorphism of the sheafified tensor product of sheaves of modules on a small site, and specializes it to line bundles on a scheme. The key input is that the sectionwise tensor product of presheaves of modules preserves local isomorphisms (morphisms inverted by sheafification) in each variable: `PresheafOfModules.isMonoidal_inverseImage_W_toPresheaf`. For free presheaves of modules this is checked on sections (a section of `free F ⊗ N` killed by `free F ◁ f` has all of its finitely many coefficients killed by `f`, so they vanish together on a covering sieve, and local surjectivity is elementwise for any `P`); it then passes to every presheaf of modules through Mathlib's presentation `PresheafOfModules.isColimitFreeYonedaCoproductsCokernelCofork`, since tensoring and sheafification preserve colimits.

New and changed files:
- `TauCeti/Algebra/Category/ModuleCat/Presheaf/IsMonoidalW.lean` (new): `PresheafOfModules.isLocallySurjective_whiskerLeft`, `PresheafOfModules.isLocallyInjective_free_whiskerLeft`, `PresheafOfModules.inverseImage_W_toPresheaf_whiskerLeft`/`_whiskerRight`, and the `MorphismProperty.IsMonoidal` instance.
- `TauCeti/Algebra/Category/ModuleCat/Sheaf/TensorProduct/Associator.lean` (new): `SheafOfModules.isIso_sheafification_map_of_inverseImage_W_toPresheaf`, `SheafOfModules.tensorProductAssoc` and `SheafOfModules.tensorProductAssoc_hom`.
- `TauCeti/AlgebraicGeometry/LineBundle/TensorProduct.lean`: `InvertibleSheaf.tensorProductAssoc` (with `_hom_val`/`_inv_val`), next to the existing symmetry and unit isomorphisms.

Roadmap target: `JacobianChallenge/README.md`, Layer A ("line bundles, divisors, Picard group, degree"), item "Invertible sheaves on a scheme; the Picard group `Pic X` under `⊗`". Associativity is one of the two group laws on isomorphism classes of line bundles that are still missing; the open PR #6469 builds `LineBundleClass X` with commutativity and units and states in its docstring that associativity waits on "an associator for the sheafified tensor product", which `InvertibleSheaf.tensorProductAssoc` supplies (it gives `mul_assoc` via `congr_toSkeleton_of_iso`, exactly as `tensorProductComm` gives `mul_comm` there). What remains for `Pic X` as a group after this PR is inverses, i.e. the dual of an invertible sheaf with `L ⊗ L^∨ ≅ 𝒪_X`.

The site is assumed small with modules in the universe of its objects and morphisms, as Mathlib's free-Yoneda presentation requires; schemes (`Opens X`) satisfy this. No formalization is vendored; the proof uses Mathlib's `PresheafOfModules` monoidal structure, sheafification adjunction and `inverseImage_W_toPresheaf_eq_inverseImage_isomorphisms`.

Roadmap: JacobianChallenge

<!--tauceti-target:v1 {"focus":"JacobianChallenge","id":"sheaf-of-modules-tensor-product-associator"}-->

🤖 Prepared with Claude Code
