### PR TITLE
feat: state Brown's bicollaring theorem

### DIFF
--- a/TauCeti/Geometry/Manifold/LocallyFlat/Sphere.lean
+++ b/TauCeti/Geometry/Manifold/LocallyFlat/Sphere.lean
@@ -1,0 +1,121 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Geometry.Manifold.Instances.Sphere
+public import Mathlib.Topology.Maps.Basic
+public import TauCeti.Geometry.Manifold.LocallyFlat.Bicollar
+
+/-!
+# Brown's bicollaring theorem for locally flat spheres
+
+A locally flat codimension-one sphere in a sphere has a global bicollar.  This is the global
+collaring theorem that turns the local product charts in `TauCeti.IsLocallyFlat` into one product
+neighbourhood of the entire embedded sphere.  It is the structural input to the annulus theorem:
+the two sides of the bicollar distinguish the regions adjacent to a locally flat sphere, a
+conclusion which fails for wild embeddings such as the Alexander horned sphere.
+
+This file records Brown's theorem as the dimension-indexed proposition
+`TauCeti.BrownBicollaring`.  The theorem is stated rather than proved.  The existing local
+comparison shows that its hypothesis can equivalently be expressed as an embedding which is
+locally bicollared; `TauCeti.brownBicollaring_iff_isEmbedding_and_isLocallyBicollared` records
+that form explicitly.
+
+The indexing uses an `n`-sphere in `EuclideanSpace ℝ (Fin (n + 1))` embedded in the
+`(n + 1)`-sphere in `EuclideanSpace ℝ (Fin (n + 2))`.  Local flatness is read in the split
+ambient model `EuclideanSpace ℝ (Fin n) × ℝ`: the first factor is the model of the source
+sphere, and the second is its one-dimensional normal direction.  No orientation or choice of
+side is included in the statement.
+
+## Main definitions
+
+* `TauCeti.BrownBicollaring`: every locally flat embedding `Sⁿ → Sⁿ⁺¹` is globally
+  bicollared.
+
+## Main results
+
+* `TauCeti.brownBicollaring_iff_isEmbedding_and_isLocallyBicollared`: Brown's theorem in its
+  equivalent local-to-global collar form.
+* `TauCeti.BrownBicollaring.isBicollared` and `.exists_isBicollar`: elimination forms for using
+  the statement at a chosen embedding.
+
+## References
+
+* M. Brown, *Locally flat imbeddings of topological manifolds*, Annals of Mathematics 75 (1962),
+  331–341.
+* R. J. Daverman and G. A. Venema, *Embeddings in Manifolds*, Graduate Studies in Mathematics
+  106, American Mathematical Society (2009), Chapter 2.
+-/
+
+public section
+
+noncomputable section
+
+namespace TauCeti
+
+open Metric
+open Topology
+open scoped EuclideanSpace
+
+/-- **Brown's bicollaring theorem in dimension `n`:** every locally flat embedding of the
+standard `n`-sphere in the standard `(n + 1)`-sphere admits a global bicollar.
+
+The local-flatness model is `EuclideanSpace ℝ (Fin n) × ℝ`: its zero slice has dimension
+`n`, and its complementary factor has dimension one.  Thus the hypothesis says precisely that
+the embedding is locally a codimension-one coordinate slice.  The conclusion is the existence of
+an open embedding `Sⁿ × ℝ → Sⁿ⁺¹` whose zero slice is the original embedding. -/
+def BrownBicollaring (n : ℕ) : Prop :=
+  ∀ f :
+      sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1 →
+        sphere (0 : EuclideanSpace ℝ (Fin (n + 2))) 1,
+    IsLocallyFlat (EuclideanSpace ℝ (Fin n)) ℝ f → IsBicollared f
+
+namespace BrownBicollaring
+
+variable {n : ℕ}
+
+/-- A proof of Brown's bicollaring statement supplies a global bicollar for a chosen locally flat
+embedding between the standard spheres. -/
+theorem isBicollared (h : BrownBicollaring n)
+    (f :
+      sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1 →
+        sphere (0 : EuclideanSpace ℝ (Fin (n + 2))) 1)
+    (hf : IsLocallyFlat (EuclideanSpace ℝ (Fin n)) ℝ f) : IsBicollared f :=
+  h f hf
+
+/-- A proof of Brown's bicollaring statement produces an open product embedding whose zero slice
+is a chosen locally flat embedding between the standard spheres. -/
+theorem exists_isBicollar (h : BrownBicollaring n)
+    (f :
+      sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1 →
+        sphere (0 : EuclideanSpace ℝ (Fin (n + 2))) 1)
+    (hf : IsLocallyFlat (EuclideanSpace ℝ (Fin n)) ℝ f) :
+    ∃ b :
+        sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1 × ℝ →
+          sphere (0 : EuclideanSpace ℝ (Fin (n + 2))) 1,
+      IsBicollar f b :=
+  isBicollared_iff.mp (h.isBicollared f hf)
+
+end BrownBicollaring
+
+/-- Brown's theorem is equivalently the local-to-global assertion that every embedded standard
+sphere which is locally bicollared is globally bicollared.
+
+The explicit embedding hypothesis is essential: local bicollars only constrain a map near each
+point of its domain and do not by themselves rule out distinct source points with the same image. -/
+theorem brownBicollaring_iff_isEmbedding_and_isLocallyBicollared {n : ℕ} :
+    BrownBicollaring n ↔
+      ∀ f :
+          sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1 →
+            sphere (0 : EuclideanSpace ℝ (Fin (n + 2))) 1,
+        IsEmbedding f ∧ IsLocallyBicollared f → IsBicollared f := by
+  constructor
+  · intro h f hf
+    exact h.isBicollared f (hf.2.isLocallyFlat hf.1)
+  · intro h f hf
+    exact h f ⟨hf.isEmbedding, hf.isLocallyBicollared⟩
+
+end TauCeti

--- a/TauCeti/Geometry/Manifold/LocallyFlat/Sphere.lean
+++ b/TauCeti/Geometry/Manifold/LocallyFlat/Sphere.lean
@@ -34,6 +34,9 @@ side is included in the statement.
 ## Main results
 
 * `TauCeti.brownBicollaring_iff`: the defining characterization of Brown's theorem.
+* `TauCeti.BrownBicollaring.exists_isOpen_sdiff_range_eq_union`: granting Brown's theorem, a
+  locally flat sphere is two-sided, so it separates a neighbourhood of itself into two disjoint
+  nonempty open sides.
 
 ## References
 
@@ -49,7 +52,7 @@ noncomputable section
 
 namespace TauCeti
 
-open Metric
+open Metric Set
 open Topology
 open scoped EuclideanSpace
 
@@ -74,5 +77,29 @@ theorem brownBicollaring_iff {n : ℕ} :
             sphere (0 : EuclideanSpace ℝ (Fin (n + 2))) 1,
         IsLocallyFlat (EuclideanSpace ℝ (Fin n)) ℝ f → IsBicollared f :=
   by rfl
+
+/-- Granting Brown's theorem, a locally flat `n`-sphere in the `(n + 1)`-sphere is **two-sided**:
+it has an open neighbourhood whose complement in that neighbourhood is the union of two disjoint
+nonempty open sets, the two sides of the collar the theorem provides.  This is the separation
+statement the annulus theorem consumes, and the conclusion that fails for a wild embedding such
+as the Alexander horned sphere. -/
+theorem BrownBicollaring.exists_isOpen_sdiff_range_eq_union {n : ℕ} (h : BrownBicollaring n)
+    (f : sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1 →
+      sphere (0 : EuclideanSpace ℝ (Fin (n + 2))) 1)
+    (hf : IsLocallyFlat (EuclideanSpace ℝ (Fin n)) ℝ f) :
+    ∃ U V W : Set (sphere (0 : EuclideanSpace ℝ (Fin (n + 2))) 1),
+      IsOpen U ∧ IsOpen V ∧ IsOpen W ∧ range f ⊆ U ∧ V.Nonempty ∧ W.Nonempty ∧
+        Disjoint V W ∧ U \ range f = V ∪ W := by
+  obtain ⟨b, hb⟩ := isBicollared_iff.mp (h f hf)
+  obtain ⟨x, hx⟩ : (sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1).Nonempty :=
+    NormedSpace.sphere_nonempty.2 zero_le_one
+  exact ⟨range b, b '' (univ ×ˢ Ioi 0), b '' (univ ×ˢ Iio 0),
+    hb.isOpenEmbedding.isOpen_range,
+    hb.isOpenEmbedding.isOpenMap _ (isOpen_univ.prod isOpen_Ioi),
+    hb.isOpenEmbedding.isOpenMap _ (isOpen_univ.prod isOpen_Iio),
+    hb.range_subset_range,
+    ⟨b (⟨x, hx⟩, 1), mem_image_of_mem _ ⟨mem_univ _, mem_Ioi.2 one_pos⟩⟩,
+    ⟨b (⟨x, hx⟩, -1), mem_image_of_mem _ ⟨mem_univ _, mem_Iio.2 (by norm_num)⟩⟩,
+    hb.disjoint_image_Ioi_Iio, hb.range_diff_range_eq_union⟩
 
 end TauCeti

--- a/TauCeti/Geometry/Manifold/LocallyFlat/Sphere.lean
+++ b/TauCeti/Geometry/Manifold/LocallyFlat/Sphere.lean
@@ -14,8 +14,9 @@ public import TauCeti.Geometry.Manifold.LocallyFlat.Bicollar
 A locally flat codimension-one sphere in a sphere has a global bicollar.  This is the global
 collaring theorem that turns the local product charts in `TauCeti.IsLocallyFlat` into one product
 neighbourhood of the entire embedded sphere.  It is the structural input to the annulus theorem:
-the two sides of the bicollar distinguish the regions adjacent to a locally flat sphere, a
-conclusion which fails for wild embeddings such as the Alexander horned sphere.
+the collar presents a whole neighbourhood of the sphere as a product, which is what identifies
+the regions adjacent to it.  It is that global bicollar that wild embeddings such as the
+Alexander horned sphere fail to admit.
 
 This file records Brown's theorem as the dimension-indexed proposition
 `TauCeti.BrownBicollaring`.  The theorem is stated rather than proved.
@@ -69,7 +70,10 @@ def BrownBicollaring (n : ℕ) : Prop :=
         sphere (0 : EuclideanSpace ℝ (Fin (n + 2))) 1,
     IsLocallyFlat (EuclideanSpace ℝ (Fin n)) ℝ f → IsBicollared f
 
-/-- The defining characterization of Brown's bicollaring theorem. -/
+/-- The defining characterization of Brown's bicollaring theorem.  The module system does not
+expose the body of `TauCeti.BrownBicollaring`, so a downstream file cannot unfold it; this lemma
+is how the proposition is introduced and eliminated there. -/
+@[simp]
 theorem brownBicollaring_iff {n : ℕ} :
     BrownBicollaring n ↔
       ∀ f :
@@ -81,8 +85,9 @@ theorem brownBicollaring_iff {n : ℕ} :
 /-- Granting Brown's theorem, a locally flat `n`-sphere in the `(n + 1)`-sphere is **two-sided**:
 it has an open neighbourhood whose complement in that neighbourhood is the union of two disjoint
 nonempty open sets, the two sides of the collar the theorem provides.  This is the separation
-statement the annulus theorem consumes, and the conclusion that fails for a wild embedding such
-as the Alexander horned sphere. -/
+statement the annulus theorem consumes.  What local flatness supplies is the collar, not the
+separation on its own: a wild embedding such as the Alexander horned sphere admits no global
+bicollar, even though its complement is still a union of two open regions. -/
 theorem BrownBicollaring.exists_isOpen_sdiff_range_eq_union {n : ℕ} (h : BrownBicollaring n)
     (f : sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1 →
       sphere (0 : EuclideanSpace ℝ (Fin (n + 2))) 1)

--- a/TauCeti/Geometry/Manifold/LocallyFlat/Sphere.lean
+++ b/TauCeti/Geometry/Manifold/LocallyFlat/Sphere.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Geometry.Manifold.Instances.Sphere
-public import Mathlib.Topology.Maps.Basic
 public import TauCeti.Geometry.Manifold.LocallyFlat.Bicollar
 
 /-!
@@ -19,10 +18,7 @@ the two sides of the bicollar distinguish the regions adjacent to a locally flat
 conclusion which fails for wild embeddings such as the Alexander horned sphere.
 
 This file records Brown's theorem as the dimension-indexed proposition
-`TauCeti.BrownBicollaring`.  The theorem is stated rather than proved.  The existing local
-comparison shows that its hypothesis can equivalently be expressed as an embedding which is
-locally bicollared; `TauCeti.brownBicollaring_iff_isEmbedding_and_isLocallyBicollared` records
-that form explicitly.
+`TauCeti.BrownBicollaring`.  The theorem is stated rather than proved.
 
 The indexing uses an `n`-sphere in `EuclideanSpace ℝ (Fin (n + 1))` embedded in the
 `(n + 1)`-sphere in `EuclideanSpace ℝ (Fin (n + 2))`.  Local flatness is read in the split
@@ -37,10 +33,7 @@ side is included in the statement.
 
 ## Main results
 
-* `TauCeti.brownBicollaring_iff_isEmbedding_and_isLocallyBicollared`: Brown's theorem in its
-  equivalent local-to-global collar form.
-* `TauCeti.BrownBicollaring.isBicollared` and `.exists_isBicollar`: elimination forms for using
-  the statement at a chosen embedding.
+* `TauCeti.brownBicollaring_iff`: the defining characterization of Brown's theorem.
 
 ## References
 
@@ -73,49 +66,13 @@ def BrownBicollaring (n : ℕ) : Prop :=
         sphere (0 : EuclideanSpace ℝ (Fin (n + 2))) 1,
     IsLocallyFlat (EuclideanSpace ℝ (Fin n)) ℝ f → IsBicollared f
 
-namespace BrownBicollaring
-
-variable {n : ℕ}
-
-/-- A proof of Brown's bicollaring statement supplies a global bicollar for a chosen locally flat
-embedding between the standard spheres. -/
-theorem isBicollared (h : BrownBicollaring n)
-    (f :
-      sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1 →
-        sphere (0 : EuclideanSpace ℝ (Fin (n + 2))) 1)
-    (hf : IsLocallyFlat (EuclideanSpace ℝ (Fin n)) ℝ f) : IsBicollared f :=
-  h f hf
-
-/-- A proof of Brown's bicollaring statement produces an open product embedding whose zero slice
-is a chosen locally flat embedding between the standard spheres. -/
-theorem exists_isBicollar (h : BrownBicollaring n)
-    (f :
-      sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1 →
-        sphere (0 : EuclideanSpace ℝ (Fin (n + 2))) 1)
-    (hf : IsLocallyFlat (EuclideanSpace ℝ (Fin n)) ℝ f) :
-    ∃ b :
-        sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1 × ℝ →
-          sphere (0 : EuclideanSpace ℝ (Fin (n + 2))) 1,
-      IsBicollar f b :=
-  isBicollared_iff.mp (h.isBicollared f hf)
-
-end BrownBicollaring
-
-/-- Brown's theorem is equivalently the local-to-global assertion that every embedded standard
-sphere which is locally bicollared is globally bicollared.
-
-The explicit embedding hypothesis is essential: local bicollars only constrain a map near each
-point of its domain and do not by themselves rule out distinct source points with the same image. -/
-theorem brownBicollaring_iff_isEmbedding_and_isLocallyBicollared {n : ℕ} :
+/-- The defining characterization of Brown's bicollaring theorem. -/
+theorem brownBicollaring_iff {n : ℕ} :
     BrownBicollaring n ↔
       ∀ f :
           sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1 →
             sphere (0 : EuclideanSpace ℝ (Fin (n + 2))) 1,
-        IsEmbedding f ∧ IsLocallyBicollared f → IsBicollared f := by
-  constructor
-  · intro h f hf
-    exact h.isBicollared f (hf.2.isLocallyFlat hf.1)
-  · intro h f hf
-    exact h f ⟨hf.isEmbedding, hf.isLocallyBicollared⟩
+        IsLocallyFlat (EuclideanSpace ℝ (Fin n)) ℝ f → IsBicollared f :=
+  by rfl
 
 end TauCeti


### PR DESCRIPTION
This PR states Brown's bicollaring theorem in every dimension: every locally flat embedding of the standard `n`-sphere in the standard `(n + 1)`-sphere admits a global bicollar. It advances GeometricTopology Layer 2's “Codimension-1 collaring (Brown)” milestone by supplying the global sphere conclusion after the local bicollar infrastructure already on `main`.

The exact roadmap target is `GeometricTopology/README.md`, Layer 2, milestone “Codimension-1 collaring”: “a locally flat `(n-1)`-sphere in `Sⁿ` is globally bicollared.” The dependency edge is direct: the existing `IsLocallyFlat`, `IsBicollared`, and local-flatness/local-bicollaring comparison now assemble into the roadmap's dimension-indexed Brown statement. After this PR, the Brown statement surface is complete; Layer 2 still needs the Annulus Conjecture and its separation/region-between substrate, together with the smooth- and PL-embedding local-flatness bridges.

The new `TauCeti/Geometry/Manifold/LocallyFlat/Sphere.lean` states the proposition, exposes its defining characterization `brownBicollaring_iff` (the module system hides the `def` body, so this is how downstream code introduces and eliminates it), and derives the two-sidedness corollary the annulus theorem consumes. Consumers holding `IsEmbedding f ∧ IsLocallyBicollared f` reach the hypothesis in one step through the existing generic `isLocallyFlat_iff_isEmbedding_and_isLocallyBicollared`. The formulation follows M. Brown, *Locally flat imbeddings of topological manifolds*, Annals of Mathematics 75 (1962), 331–341; Daverman–Venema, *Embeddings in Manifolds*, Chapter 2, supplies the modern bicollar terminology. No Mathlib infrastructure or external formalization is vendored.

Roadmap: GeometricTopology

<!--tauceti-target:v1 {"focus":"GeometricTopology","id":"brown-bicollaring-theorem"}-->

🤖 Prepared with Codex

