### PR TITLE
feat: the complex resolvent set and holomorphy of a C₀-semigroup resolvent

### DIFF
--- a/TauCeti/Analysis/Normed/Operator/Resolvent/RestrictScalars.lean
+++ b/TauCeti/Analysis/Normed/Operator/Resolvent/RestrictScalars.lean
@@ -107,6 +107,7 @@ theorem exists_isResolventAt_of_isResolventAt_restrictScalars
 
 /-- The resolvent sets of an operator and of its restriction of scalars agree at the points of the
 smaller field. -/
+@[simp]
 theorem mem_resolventSet_restrictScalars_iff :
     mu ∈ resolventSet (A.restrictScalars 𝕜) ↔ algebraMap 𝕜 𝕜' mu ∈ resolventSet A := by
   rw [mem_resolventSet_iff, mem_resolventSet_iff]
@@ -118,6 +119,7 @@ theorem mem_resolventSet_restrictScalars_iff :
     exact ⟨R.restrictScalars 𝕜, hR.restrictScalars⟩
 
 /-- The resolvent of the restriction of scalars is the restriction of scalars of the resolvent. -/
+@[simp]
 theorem restrictScalars_resolvent (h : mu ∈ resolventSet (A.restrictScalars 𝕜)) :
     (resolvent A (algebraMap 𝕜 𝕜' mu)).restrictScalars 𝕜 = resolvent (A.restrictScalars 𝕜) mu :=
   (resolvent_eq_of_isResolventAt

--- a/TauCeti/Analysis/Normed/Operator/Resolvent/RestrictScalars.lean
+++ b/TauCeti/Analysis/Normed/Operator/Resolvent/RestrictScalars.lean
@@ -1,0 +1,129 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.Normed.Operator.Resolvent.Unbounded
+public import TauCeti.LinearAlgebra.LinearPMap.RestrictScalars
+
+/-!
+# Resolvents and restriction of scalars
+
+An unbounded operator `A : X →ₗ.[𝕜'] X` over a normed algebra `𝕜'` can also be read over a
+smaller field `𝕜`, as `A.restrictScalars 𝕜`. This file shows that the two resolvent notions
+agree at the points of `𝕜`: for `mu : 𝕜`,
+
+`mu ∈ resolventSet (A.restrictScalars 𝕜) ↔ algebraMap 𝕜 𝕜' mu ∈ resolventSet A`,
+
+and the resolvents themselves correspond under `ContinuousLinearMap.restrictScalars`.
+
+Only the forward direction has content. A bounded `𝕜`-linear inverse `R` of `mu • I - A` is
+automatically `𝕜'`-homogeneous: `z • R y` and `R (z • y)` have the same image under
+`mu • I - A`, because `A` is `𝕜'`-linear, so they agree.
+
+This is what lets a real-variable theorem about an operator on a complex Banach space — such as
+the Laplace-transform resolvent of a C₀-semigroup, which is built over `ℝ` — be read as a
+statement about the genuinely complex resolvent set.
+
+## Main results
+
+* `TauCeti.LinearPMap.IsResolventAt.restrictScalars`: restricting scalars in an inverse of
+  `lambda • I - A`.
+* `TauCeti.LinearPMap.map_smul_of_isResolventAt_restrictScalars`: a bounded inverse over `𝕜` is
+  `𝕜'`-homogeneous.
+* `TauCeti.LinearPMap.exists_isResolventAt_of_isResolventAt_restrictScalars`: it therefore comes
+  from an inverse over `𝕜'`.
+* `TauCeti.LinearPMap.mem_resolventSet_restrictScalars_iff`: the resolvent sets agree at the
+  points of `𝕜`.
+* `TauCeti.LinearPMap.restrictScalars_resolvent`: the resolvents agree there.
+-/
+
+public section
+
+noncomputable section
+
+namespace TauCeti.LinearPMap
+
+variable {𝕜 𝕜' X : Type*} [NontriviallyNormedField 𝕜] [NontriviallyNormedField 𝕜']
+  [NormedAlgebra 𝕜 𝕜'] [NormedAddCommGroup X] [NormedSpace 𝕜 X] [NormedSpace 𝕜' X]
+  [IsScalarTower 𝕜 𝕜' X] {A : X →ₗ.[𝕜'] X} {mu : 𝕜} {R : X →L[𝕜'] X} {R₀ : X →L[𝕜] X}
+
+/-- An inverse of `algebraMap 𝕜 𝕜' mu • I - A` restricts to an inverse of `mu • I - A` for the
+restriction of scalars. -/
+theorem IsResolventAt.restrictScalars (h : IsResolventAt A (algebraMap 𝕜 𝕜' mu) R) :
+    IsResolventAt (A.restrictScalars 𝕜) mu (R.restrictScalars 𝕜) where
+  mem_domain y := by
+    simp only [ContinuousLinearMap.coe_restrictScalars']
+    exact (A.mem_restrictScalars_domain 𝕜).mpr (h.mem_domain y)
+  smul_sub_apply y := by
+    simp only [ContinuousLinearMap.coe_restrictScalars', LinearPMap.restrictScalars_apply,
+      ← algebraMap_smul 𝕜' mu]
+    exact h.smul_sub_apply y
+  apply_smul_sub x := by
+    simp only [ContinuousLinearMap.coe_restrictScalars', LinearPMap.restrictScalars_apply,
+      ← algebraMap_smul 𝕜' mu]
+    exact h.apply_smul_sub ⟨(x : X), (A.mem_restrictScalars_domain 𝕜).mp x.property⟩
+
+/-- A bounded `𝕜`-linear inverse of `mu • I - A` is homogeneous for the larger field `𝕜'`: it is
+the inverse of a `𝕜'`-linear bijection. -/
+theorem map_smul_of_isResolventAt_restrictScalars
+    (h : IsResolventAt (A.restrictScalars 𝕜) mu R₀) (z : 𝕜') (y : X) :
+    R₀ (z • y) = z • R₀ y := by
+  have hmem : ∀ w : X, R₀ w ∈ A.domain := fun w =>
+    (A.mem_restrictScalars_domain 𝕜).mp (h.mem_domain w)
+  have hsmul : z • R₀ y ∈ A.domain := A.domain.smul_mem z (hmem y)
+  have hinv : algebraMap 𝕜 𝕜' mu • R₀ y - A ⟨R₀ y, hmem y⟩ = y := by
+    have := h.smul_sub_apply y
+    simpa only [LinearPMap.restrictScalars_apply, ← algebraMap_smul 𝕜' mu] using this
+  have hkey : algebraMap 𝕜 𝕜' mu • (z • R₀ y) - A ⟨z • R₀ y, hsmul⟩ = z • y := by
+    have hA : A ⟨z • R₀ y, hsmul⟩ = z • A ⟨R₀ y, hmem y⟩ := A.map_smul z ⟨R₀ y, hmem y⟩
+    rw [hA, smul_comm, ← smul_sub, hinv]
+  have hback := h.apply_smul_sub ⟨z • R₀ y, (A.mem_restrictScalars_domain 𝕜).mpr hsmul⟩
+  simp only [LinearPMap.restrictScalars_apply, ← algebraMap_smul 𝕜' mu] at hback
+  rw [hkey] at hback
+  exact hback
+
+/-- A bounded inverse of `mu • I - A` over the smaller field is the restriction of scalars of a
+bounded inverse over the larger one. -/
+theorem exists_isResolventAt_of_isResolventAt_restrictScalars
+    (h : IsResolventAt (A.restrictScalars 𝕜) mu R₀) :
+    ∃ R : X →L[𝕜'] X, R.restrictScalars 𝕜 = R₀ ∧
+      IsResolventAt A (algebraMap 𝕜 𝕜' mu) R := by
+  refine ⟨{ toFun := R₀
+            map_add' := R₀.map_add
+            map_smul' := map_smul_of_isResolventAt_restrictScalars h
+            cont := R₀.continuous }, ContinuousLinearMap.ext fun _ => rfl, ?_⟩
+  have hmem : ∀ y : X, R₀ y ∈ A.domain := fun y =>
+    (A.mem_restrictScalars_domain 𝕜).mp (h.mem_domain y)
+  have hright : ∀ y : X, algebraMap 𝕜 𝕜' mu • R₀ y - A ⟨R₀ y, hmem y⟩ = y := fun y => by
+    have hy := h.smul_sub_apply y
+    simpa only [LinearPMap.restrictScalars_apply, ← algebraMap_smul 𝕜' mu] using hy
+  have hleft : ∀ x : A.domain, R₀ (algebraMap 𝕜 𝕜' mu • (x : X) - A x) = (x : X) := fun x => by
+    have hx := h.apply_smul_sub ⟨(x : X), (A.mem_restrictScalars_domain 𝕜).mpr x.property⟩
+    simpa only [LinearPMap.restrictScalars_apply, ← algebraMap_smul 𝕜' mu] using hx
+  exact { mem_domain := hmem, smul_sub_apply := hright, apply_smul_sub := hleft }
+
+/-- The resolvent sets of an operator and of its restriction of scalars agree at the points of the
+smaller field. -/
+theorem mem_resolventSet_restrictScalars_iff :
+    mu ∈ resolventSet (A.restrictScalars 𝕜) ↔ algebraMap 𝕜 𝕜' mu ∈ resolventSet A := by
+  rw [mem_resolventSet_iff, mem_resolventSet_iff]
+  constructor
+  · rintro ⟨R₀, hR₀⟩
+    obtain ⟨R, -, hR⟩ := exists_isResolventAt_of_isResolventAt_restrictScalars hR₀
+    exact ⟨R, hR⟩
+  · rintro ⟨R, hR⟩
+    exact ⟨R.restrictScalars 𝕜, hR.restrictScalars⟩
+
+/-- The resolvent of the restriction of scalars is the restriction of scalars of the resolvent. -/
+theorem restrictScalars_resolvent (h : mu ∈ resolventSet (A.restrictScalars 𝕜)) :
+    (resolvent A (algebraMap 𝕜 𝕜' mu)).restrictScalars 𝕜 = resolvent (A.restrictScalars 𝕜) mu :=
+  (resolvent_eq_of_isResolventAt
+    (IsResolventAt.restrictScalars
+      (isResolventAt_resolvent (mem_resolventSet_restrictScalars_iff.mp h)))).symm
+
+end TauCeti.LinearPMap
+
+end

--- a/TauCeti/Analysis/Normed/Operator/Resolvent/Shift.lean
+++ b/TauCeti/Analysis/Normed/Operator/Resolvent/Shift.lean
@@ -17,8 +17,10 @@ unchanged and translates its resolvent:
 `R(lambda, A - omega I) = R(lambda + omega, A)`.
 
 This file develops the characteristic resolvent API of the generic scalar shift from
-`TauCeti.LinearAlgebra.LinearPMap.Shift`.  The construction is independent of
-semigroups; in particular, it can be used for an operator not yet known to generate one.
+`TauCeti.LinearAlgebra.LinearPMap.Shift`, over an arbitrary nontrivially normed field — the
+generality of `TauCeti.LinearPMap.resolventSet` itself, so that a complex shift of a complex
+unbounded operator is covered.  The construction is independent of semigroups; in particular, it
+can be used for an operator not yet known to generate one.
 
 ## Main results
 
@@ -32,13 +34,14 @@ noncomputable section
 
 namespace TauCeti.LinearPMap
 
-variable {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X]
+variable {𝕜 X : Type*} [NontriviallyNormedField 𝕜] [NormedAddCommGroup X]
+  [NormedSpace 𝕜 X]
 
 /-- An inverse for `lambda I - (A - omega I)` is the same as an inverse for
 `(lambda + omega) I - A`. -/
 @[simp]
-theorem isResolventAt_subScalar_iff {A : X →ₗ.[ℝ] X} {omega lambda : ℝ}
-    {R : X →L[ℝ] X} :
+theorem isResolventAt_subScalar_iff {A : X →ₗ.[𝕜] X} {omega lambda : 𝕜}
+    {R : X →L[𝕜] X} :
     IsResolventAt (subScalar A omega) lambda R ↔ IsResolventAt A (lambda + omega) R := by
   constructor
   · intro h
@@ -82,7 +85,7 @@ theorem isResolventAt_subScalar_iff {A : X →ₗ.[ℝ] X} {omega lambda : ℝ}
 
 /-- Translation of the resolvent set under the scalar shift `A ↦ A - omega I`. -/
 @[simp]
-theorem mem_resolventSet_subScalar_iff {A : X →ₗ.[ℝ] X} {omega lambda : ℝ} :
+theorem mem_resolventSet_subScalar_iff {A : X →ₗ.[𝕜] X} {omega lambda : 𝕜} :
     lambda ∈ resolventSet (subScalar A omega) ↔ lambda + omega ∈ resolventSet A := by
   rw [mem_resolventSet_iff, mem_resolventSet_iff]
   constructor <;> rintro ⟨R, hR⟩ <;> refine ⟨R, ?_⟩
@@ -91,7 +94,7 @@ theorem mem_resolventSet_subScalar_iff {A : X →ₗ.[ℝ] X} {omega lambda : �
 
 /-- Exact translation of the resolvent under the scalar shift `A ↦ A - omega I`. -/
 @[simp]
-theorem resolvent_subScalar {A : X →ₗ.[ℝ] X} {omega lambda : ℝ}
+theorem resolvent_subScalar {A : X →ₗ.[𝕜] X} {omega lambda : 𝕜}
     (hlambda : lambda + omega ∈ resolventSet A) :
     resolvent (subScalar A omega) lambda = resolvent A (lambda + omega) := by
   apply resolvent_eq_of_isResolventAt

--- a/TauCeti/Analysis/Semigroups/PhaseShift.lean
+++ b/TauCeti/Analysis/Semigroups/PhaseShift.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.Analysis.Semigroups.Generator.ComplexLinear
 public import TauCeti.Analysis.Semigroups.GrowthBound
+public import TauCeti.Analysis.SpecialFunctions.Complex.ExpSlope
 public import TauCeti.LinearAlgebra.LinearPMap.Shift
 import Mathlib.Analysis.SpecialFunctions.Complex.Analytic
 
@@ -165,24 +166,6 @@ end HasGrowthBound
 /-! ## The generator of a phase shift -/
 
 omit [CompleteSpace X] in
-/-- The phase `t ↦ exp (-i b t)` has derivative `-i b` at `0`, in difference-quotient form along
-the positive reals. -/
-private theorem tendsto_phase_slope (b : ℝ) :
-    Tendsto (fun t : ℝ => t⁻¹ • (Complex.exp (-(b * t) * Complex.I) - 1))
-      (𝓝[>] (0 : ℝ)) (𝓝 (-(b * Complex.I))) := by
-  have hderiv : HasDerivAt (fun t : ℝ => Complex.exp (-(b * t) * Complex.I))
-      (-(b * Complex.I)) 0 := by
-    have h : HasDerivAt (fun t : ℝ => (-(b * (t : ℂ)) * Complex.I)) (-(b * Complex.I)) 0 := by
-      simpa using ((hasDerivAt_id (0 : ℝ)).ofReal_comp.const_mul (-(b : ℂ))).mul_const Complex.I
-    simpa using h.cexp
-  have hslope := hasDerivAt_iff_tendsto_slope.mp hderiv
-  refine (hslope.mono_left (nhdsWithin_mono _ ?_)).congr ?_
-  · intro t ht
-    exact ne_of_gt ht
-  · intro t
-    simp [slope_def_module]
-
-omit [CompleteSpace X] in
 /-- Phase shifting a semigroup shifts the limit of a generator difference quotient by `-i b`. -/
 private theorem tendsto_phaseShift_genQuot (S : StronglyContinuousSemigroup X)
     (hS : S.IsComplexLinear) (b : ℝ) {x Ax : X}
@@ -194,7 +177,11 @@ private theorem tendsto_phaseShift_genQuot (S : StronglyContinuousSemigroup X)
       (𝓝[>] (0 : ℝ)) (𝓝 1) := by
     have hcont : ContinuousAt (fun t : ℝ => Complex.exp (-(b * t) * Complex.I)) 0 := by fun_prop
     simpa using hcont.tendsto.mono_left nhdsWithin_le_nhds
-  have hsum := (hphase.smul hgen).add ((tendsto_phase_slope b).smul
+  have hphaseSlope : Tendsto (fun t : ℝ => t⁻¹ • (Complex.exp (-(b * t) * Complex.I) - 1))
+      (𝓝[>] (0 : ℝ)) (𝓝 (-(b * Complex.I))) :=
+    (TauCeti.tendsto_inv_smul_exp_mul_ofReal_sub_one (-(b * Complex.I))).congr fun t => by
+      rw [show -((b : ℂ) * Complex.I) * (t : ℂ) = -((b : ℂ) * (t : ℂ)) * Complex.I by ring]
+  have hsum := (hphase.smul hgen).add (hphaseSlope.smul
     (tendsto_const_nhds : Tendsto (fun _ : ℝ => x) (𝓝[>] (0 : ℝ)) (𝓝 x)))
   have hsum' : Tendsto
       (fun t : ℝ => Complex.exp (-(b * t) * Complex.I) • ((1 / t) • (S.realOperator t x - x)) +

--- a/TauCeti/Analysis/Semigroups/PhaseShift.lean
+++ b/TauCeti/Analysis/Semigroups/PhaseShift.lean
@@ -1,0 +1,264 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.Semigroups.Generator.ComplexLinear
+public import TauCeti.Analysis.Semigroups.GrowthBound
+public import TauCeti.LinearAlgebra.LinearPMap.Shift
+import Mathlib.Analysis.SpecialFunctions.Complex.Analytic
+
+/-!
+# Phase shifts of a complex-linear strongly continuous semigroup
+
+For a C₀-semigroup `S` acting by complex-linear operators on a complex Banach space and a real
+number `b`, the *phase shift* is the semigroup
+
+`(S.phaseShift hS b) t = exp (-i b t) • S t`.
+
+Unlike the exponential shift `t ↦ exp (-omega t) • S t` of
+`TauCeti/Analysis/Semigroups/ExponentialShift.lean`, which damps the semigroup and moves its
+growth exponent, a phase shift multiplies by a unimodular scalar: it preserves every growth
+bound `(omega, M)` exactly, and it subtracts `i b` from the generator. Composing the two shifts
+realizes `t ↦ exp (-lambda t) • S t` for an arbitrary complex `lambda`.
+
+This is the device that moves a spectral parameter parallel to the imaginary axis. Since the
+Laplace-transform resolvent of a C₀-semigroup is a *real*-variable construction, it only ever
+produces real points of the resolvent set; the phase shift converts a real point for the shifted
+semigroup into the point `lambda = mu + i b` for `S`, which is how the complex resolvent set of
+the complex generator is reached in
+`TauCeti/Analysis/Semigroups/Resolvent/Complex.lean`.
+
+## Main definitions and results
+
+* `TauCeti.Semigroups.StronglyContinuousSemigroup.phaseShift`: the semigroup
+  `t ↦ exp (-i b t) • S t`.
+* `TauCeti.Semigroups.StronglyContinuousSemigroup.IsComplexLinear.phaseShift` and
+  `TauCeti.Semigroups.StronglyContinuousSemigroup.HasGrowthBound.phaseShift`: a phase shift is
+  again complex linear, and has the same growth bounds.
+* `TauCeti.Semigroups.StronglyContinuousSemigroup.phaseShift_domain`: a phase shift does not
+  change the generator domain.
+* `TauCeti.Semigroups.StronglyContinuousSemigroup.complexGenerator_phaseShift`: the complex
+  generator of `t ↦ exp (-i b t) • S t` is `A - i b`.
+
+## References
+
+* K.-J. Engel and R. Nagel, *One-Parameter Semigroups for Linear Evolution Equations*,
+  Section II.2.2 (rescaled semigroups).
+
+The construction is new here: it is built on Tau Ceti's own semigroup and generator API, not
+ported. (The real-parameter resolvent files of `TauCeti/Analysis/Semigroups/Resolvent/` record
+their own provenance in `mrdouglasny/hille-yosida`; nothing below is taken from it.)
+-/
+
+public section
+
+noncomputable section
+
+open Filter
+open scoped NNReal Topology
+
+namespace TauCeti.Semigroups.StronglyContinuousSemigroup
+
+variable {X : Type*} [NormedAddCommGroup X] [NormedSpace ℂ X] [CompleteSpace X]
+
+/-- The phase shift of a complex-linear C₀-semigroup by `b : ℝ`: the semigroup
+`t ↦ exp (-i b t) • S t`. -/
+def phaseShift (S : StronglyContinuousSemigroup X) (hS : S.IsComplexLinear) (b : ℝ) :
+    StronglyContinuousSemigroup X where
+  toFun t := Complex.exp (-(b * (t : ℝ)) * Complex.I) • S t
+  map_zero' := by
+    simp
+  map_add' s t := by
+    ext x
+    simp only [NNReal.coe_add, ContinuousLinearMap.comp_apply, smul_apply]
+    rw [S.map_add_apply, hS.map_smul, smul_smul, ← Complex.exp_add]
+    congr 2
+    push_cast
+    ring
+  continuousAt_zero' x := by
+    have h_phase : Tendsto (fun t : ℝ≥0 => Complex.exp (-(b * (t : ℝ)) * Complex.I))
+        (nhds 0) (nhds 1) := by
+      have h_cont : ContinuousAt
+          (fun t : ℝ≥0 => Complex.exp (-(b * (t : ℝ)) * Complex.I)) 0 := by fun_prop
+      simpa using h_cont.tendsto
+    have h_orbit := S.continuousAt_zero_tendsto x
+    simpa [ContinuousAt, S.map_zero_apply] using h_phase.smul h_orbit
+
+omit [CompleteSpace X] in
+/-- The native nonnegative-time operator of a phase shift. -/
+@[simp]
+theorem phaseShift_apply (S : StronglyContinuousSemigroup X) (hS : S.IsComplexLinear) (b : ℝ)
+    (t : ℝ≥0) : S.phaseShift hS b t = Complex.exp (-(b * (t : ℝ)) * Complex.I) • S t := by
+  rw [phaseShift]; rfl
+
+omit [CompleteSpace X] in
+/-- Pointwise form of `StronglyContinuousSemigroup.phaseShift_apply`. -/
+theorem phaseShift_apply_apply (S : StronglyContinuousSemigroup X) (hS : S.IsComplexLinear)
+    (b : ℝ) (t : ℝ≥0) (x : X) :
+    S.phaseShift hS b t x = Complex.exp (-(b * (t : ℝ)) * Complex.I) • S t x := by
+  rw [phaseShift_apply, smul_apply]
+
+omit [CompleteSpace X] in
+/-- Real-time form of a phase-shifted operator at nonnegative times. -/
+theorem phaseShift_realOperator_of_nonneg (S : StronglyContinuousSemigroup X)
+    (hS : S.IsComplexLinear) (b t : ℝ) (ht : 0 ≤ t) :
+    (S.phaseShift hS b).realOperator t
+      = Complex.exp (-(b * t) * Complex.I) • S.realOperator t := by
+  have ht_coe : ((t.toNNReal : ℝ) = t) := Real.coe_toNNReal t ht
+  rw [← ht_coe, realOperator_coe, realOperator_coe, phaseShift_apply]
+
+omit [CompleteSpace X] in
+/-- Pointwise real-time form of a phase-shifted operator at nonnegative times. -/
+theorem phaseShift_realOperator_apply_of_nonneg (S : StronglyContinuousSemigroup X)
+    (hS : S.IsComplexLinear) (b t : ℝ) (ht : 0 ≤ t) (x : X) :
+    (S.phaseShift hS b).realOperator t x
+      = Complex.exp (-(b * t) * Complex.I) • S.realOperator t x := by
+  rw [S.phaseShift_realOperator_of_nonneg hS b t ht, smul_apply]
+
+omit [CompleteSpace X] in
+/-- A phase shift is again complex linear. -/
+theorem IsComplexLinear.phaseShift {S : StronglyContinuousSemigroup X} (hS : S.IsComplexLinear)
+    (b : ℝ) : (S.phaseShift hS b).IsComplexLinear := by
+  rw [isComplexLinear_iff]
+  intro t z x
+  rw [phaseShift_apply_apply, phaseShift_apply_apply, hS.map_smul, smul_comm]
+
+omit [CompleteSpace X] in
+/-- The zero phase shift is the original semigroup. -/
+@[simp]
+theorem phaseShift_zero (S : StronglyContinuousSemigroup X) (hS : S.IsComplexLinear) :
+    S.phaseShift hS 0 = S := by
+  ext t x
+  simp
+
+omit [CompleteSpace X] in
+/-- Successive phase shifts add their parameters. -/
+@[simp]
+theorem phaseShift_phaseShift (S : StronglyContinuousSemigroup X) (hS : S.IsComplexLinear)
+    (b c : ℝ) (hSb : (S.phaseShift hS b).IsComplexLinear) :
+    (S.phaseShift hS b).phaseShift hSb c = S.phaseShift hS (b + c) := by
+  ext t x
+  simp only [phaseShift_apply_apply]
+  rw [smul_smul, ← Complex.exp_add]
+  congr 2
+  push_cast
+  ring
+
+namespace HasGrowthBound
+
+omit [CompleteSpace X] in
+/-- A phase shift multiplies by a unimodular scalar, so it preserves every growth bound. -/
+theorem phaseShift {S : StronglyContinuousSemigroup X} {omega M : ℝ}
+    (hb : S.HasGrowthBound omega M) (hS : S.IsComplexLinear) (b : ℝ) :
+    (S.phaseShift hS b).HasGrowthBound omega M := by
+  refine StronglyContinuousSemigroup.hasGrowthBound_of_bound hb.one_le (fun t ht => ?_)
+  rw [S.phaseShift_realOperator_of_nonneg hS b t ht]
+  calc ‖Complex.exp (-(b * t) * Complex.I) • S.realOperator t‖
+      ≤ ‖Complex.exp (-(b * t) * Complex.I)‖ * ‖S.realOperator t‖ :=
+        ContinuousLinearMap.opNorm_smul_le _ _
+    _ = ‖S.realOperator t‖ := by
+        rw [Complex.norm_exp]
+        simp
+    _ ≤ M * Real.exp (omega * t) := hb.bound t ht
+
+end HasGrowthBound
+
+/-! ## The generator of a phase shift -/
+
+omit [CompleteSpace X] in
+/-- The phase `t ↦ exp (-i b t)` has derivative `-i b` at `0`, in difference-quotient form along
+the positive reals. -/
+private theorem tendsto_phase_slope (b : ℝ) :
+    Tendsto (fun t : ℝ => t⁻¹ • (Complex.exp (-(b * t) * Complex.I) - 1))
+      (𝓝[>] (0 : ℝ)) (𝓝 (-(b * Complex.I))) := by
+  have hderiv : HasDerivAt (fun t : ℝ => Complex.exp (-(b * t) * Complex.I))
+      (-(b * Complex.I)) 0 := by
+    have h : HasDerivAt (fun t : ℝ => (-(b * (t : ℂ)) * Complex.I)) (-(b * Complex.I)) 0 := by
+      simpa using ((hasDerivAt_id (0 : ℝ)).ofReal_comp.const_mul (-(b : ℂ))).mul_const Complex.I
+    simpa using h.cexp
+  have hslope := hasDerivAt_iff_tendsto_slope.mp hderiv
+  refine (hslope.mono_left (nhdsWithin_mono _ ?_)).congr ?_
+  · intro t ht
+    exact ne_of_gt ht
+  · intro t
+    simp [slope_def_module]
+
+omit [CompleteSpace X] in
+/-- Phase shifting a semigroup shifts the limit of a generator difference quotient by `-i b`. -/
+private theorem tendsto_phaseShift_genQuot (S : StronglyContinuousSemigroup X)
+    (hS : S.IsComplexLinear) (b : ℝ) {x Ax : X}
+    (hgen : Tendsto (fun t : ℝ => (1 / t) • (S.realOperator t x - x))
+      (𝓝[>] (0 : ℝ)) (𝓝 Ax)) :
+    Tendsto (fun t : ℝ => (1 / t) • ((S.phaseShift hS b).realOperator t x - x))
+      (𝓝[>] (0 : ℝ)) (𝓝 (Ax - (b * Complex.I) • x)) := by
+  have hphase : Tendsto (fun t : ℝ => Complex.exp (-(b * t) * Complex.I))
+      (𝓝[>] (0 : ℝ)) (𝓝 1) := by
+    have hcont : ContinuousAt (fun t : ℝ => Complex.exp (-(b * t) * Complex.I)) 0 := by fun_prop
+    simpa using hcont.tendsto.mono_left nhdsWithin_le_nhds
+  have hsum := (hphase.smul hgen).add ((tendsto_phase_slope b).smul
+    (tendsto_const_nhds : Tendsto (fun _ : ℝ => x) (𝓝[>] (0 : ℝ)) (𝓝 x)))
+  have hsum' : Tendsto
+      (fun t : ℝ => Complex.exp (-(b * t) * Complex.I) • ((1 / t) • (S.realOperator t x - x)) +
+        (t⁻¹ • (Complex.exp (-(b * t) * Complex.I) - 1)) • x)
+      (𝓝[>] (0 : ℝ)) (𝓝 (Ax - (b * Complex.I) • x)) := by
+    simpa only [one_smul, neg_smul, sub_eq_add_neg] using hsum
+  refine hsum'.congr' ?_
+  filter_upwards [self_mem_nhdsWithin] with t ht
+  rw [S.phaseShift_realOperator_apply_of_nonneg hS b t (le_of_lt ht), smul_comm, smul_assoc,
+    one_div, ← smul_add]
+  congr 1
+  rw [sub_smul, one_smul, smul_sub]
+  abel
+
+omit [CompleteSpace X] in
+/-- A vector of the generator domain stays in the domain after a phase shift. -/
+private theorem mem_domain_phaseShift (S : StronglyContinuousSemigroup X)
+    (hS : S.IsComplexLinear) (b : ℝ) {x : X} (hx : x ∈ S.domain) :
+    x ∈ (S.phaseShift hS b).domain :=
+  ((S.phaseShift hS b).mem_domain_iff_tendsto x).mpr
+    ⟨_, tendsto_phaseShift_genQuot S hS b (S.generator_tendsto ⟨x, hx⟩)⟩
+
+omit [CompleteSpace X] in
+/-- A phase shift does not change the generator domain. -/
+@[simp]
+theorem phaseShift_domain (S : StronglyContinuousSemigroup X) (hS : S.IsComplexLinear) (b : ℝ) :
+    (S.phaseShift hS b).domain = S.domain := by
+  refine le_antisymm (fun x hx => ?_) (fun x hx => mem_domain_phaseShift S hS b hx)
+  have h := mem_domain_phaseShift (S.phaseShift hS b) (hS.phaseShift b) (-b) hx
+  rwa [phaseShift_phaseShift, add_neg_cancel, phaseShift_zero] at h
+
+omit [CompleteSpace X] in
+/-- The generator of a phase-shifted semigroup acts as `A - i b`. -/
+theorem generator_phaseShift_apply (S : StronglyContinuousSemigroup X) (hS : S.IsComplexLinear)
+    (b : ℝ) {x : X} (hx : x ∈ S.domain) :
+    (S.phaseShift hS b).generator ⟨x, by rw [generator_domain, phaseShift_domain]; exact hx⟩
+      = S.generator ⟨x, by rwa [generator_domain]⟩ - (b * Complex.I) • x :=
+  (S.phaseShift hS b).generator_eq_of_tendsto (by rw [phaseShift_domain]; exact hx)
+    (tendsto_phaseShift_genQuot S hS b (S.generator_tendsto ⟨x, hx⟩))
+
+omit [CompleteSpace X] in
+/-- **The generator of a phase shift.** The complex generator of `t ↦ exp (-i b t) • S t` is
+`A - i b`, where `A` is the complex generator of `S`. -/
+theorem complexGenerator_phaseShift (S : StronglyContinuousSemigroup X) (hS : S.IsComplexLinear)
+    (b : ℝ) :
+    (S.phaseShift hS b).complexGenerator (hS.phaseShift b)
+      = TauCeti.LinearPMap.subScalar (S.complexGenerator hS) (b * Complex.I) := by
+  have hdom : ∀ x : X, x ∈ (S.phaseShift hS b).complexDomain (hS.phaseShift b) ↔
+      x ∈ S.complexDomain hS := by
+    intro x
+    rw [mem_complexDomain_iff, mem_complexDomain_iff, phaseShift_domain]
+  refine LinearPMap.ext ?_ ?_
+  · rw [complexGenerator_domain, TauCeti.LinearPMap.subScalar_domain, complexGenerator_domain]
+    exact Submodule.ext hdom
+  · intro x hx _
+    rw [complexGenerator_domain] at hx
+    have hxS : x ∈ S.domain := (mem_complexDomain_iff _ _ _).mp ((hdom x).mp hx)
+    rw [complexGenerator_apply, TauCeti.LinearPMap.subScalar_apply, complexGenerator_apply,
+      generator_phaseShift_apply S hS b hxS]
+
+end TauCeti.Semigroups.StronglyContinuousSemigroup
+
+end

--- a/TauCeti/Analysis/Semigroups/PhaseShift.lean
+++ b/TauCeti/Analysis/Semigroups/PhaseShift.lean
@@ -47,10 +47,6 @@ the complex generator is reached in
 
 * K.-J. Engel and R. Nagel, *One-Parameter Semigroups for Linear Evolution Equations*,
   Section II.2.2 (rescaled semigroups).
-
-The construction is new here: it is built on Tau Ceti's own semigroup and generator API, not
-ported. (The real-parameter resolvent files of `TauCeti/Analysis/Semigroups/Resolvent/` record
-their own provenance in `mrdouglasny/hille-yosida`; nothing below is taken from it.)
 -/
 
 public section
@@ -138,8 +134,8 @@ omit [CompleteSpace X] in
 /-- Successive phase shifts add their parameters. -/
 @[simp]
 theorem phaseShift_phaseShift (S : StronglyContinuousSemigroup X) (hS : S.IsComplexLinear)
-    (b c : ℝ) (hSb : (S.phaseShift hS b).IsComplexLinear) :
-    (S.phaseShift hS b).phaseShift hSb c = S.phaseShift hS (b + c) := by
+    (b c : ℝ) :
+    (S.phaseShift hS b).phaseShift (hS.phaseShift b) c = S.phaseShift hS (b + c) := by
   ext t x
   simp only [phaseShift_apply_apply]
   rw [smul_smul, ← Complex.exp_add]

--- a/TauCeti/Analysis/Semigroups/Resolvent/Complex.lean
+++ b/TauCeti/Analysis/Semigroups/Resolvent/Complex.lean
@@ -1,0 +1,173 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.Normed.Operator.Resolvent.Analytic
+import TauCeti.Analysis.Normed.Operator.Resolvent.RestrictScalars
+import TauCeti.Analysis.Normed.Operator.Resolvent.Shift
+public import TauCeti.Analysis.Semigroups.PhaseShift
+public import TauCeti.Analysis.Semigroups.Resolvent.Identity
+
+/-!
+# The complex resolvent of a strongly continuous semigroup
+
+A C₀-semigroup acting by complex-linear operators on a complex Banach space `X` has a complex
+generator `A` (`TauCeti.Semigroups.StronglyContinuousSemigroup.complexGenerator`), an unbounded
+operator over `ℂ`. This file locates the **open half-plane** `{lambda | omega < re lambda}` of a
+growth bound `(omega, M)` inside the complex resolvent set of `A`, identifies the resolvent there
+with the Laplace transform
+
+`R(lambda, A) x = ∫₀^∞ exp (-lambda t) S(t) x dt`,
+
+bounds it by `M / (re lambda - omega)`, and concludes that `lambda ↦ R(lambda, A)` is
+**holomorphic** on that half-plane.
+
+The Laplace-transform resolvent of `TauCeti/Analysis/Semigroups/Resolvent/Basic.lean` is a
+real-variable construction: the semigroup is indexed by nonnegative reals and acts by real
+bounded operators, so it only produces *real* points of the resolvent set. Two bridges cross to
+the complex picture. Moving parallel to the imaginary axis is the phase shift
+`t ↦ exp (-i b t) S(t)`, whose generator is `A - i b`
+(`TauCeti.Semigroups.StronglyContinuousSemigroup.complexGenerator_phaseShift`) and whose growth
+bound is that of `S`; moving from a real to a complex scalar field is
+`TauCeti.LinearPMap.mem_resolventSet_restrictScalars_iff`, which upgrades a bounded real-linear
+inverse of `mu • I - A` to the complex resolvent. Holomorphy is then the abstract
+`LinearPMap.analyticOnNhd_resolvent` restricted to the half-plane.
+
+## Main results
+
+* `TauCeti.Semigroups.StronglyContinuousSemigroup.mem_resolventSet_complexGenerator` and
+  `TauCeti.Semigroups.StronglyContinuousSemigroup.setOf_lt_re_subset_resolventSet_complexGenerator`:
+  the half-plane `omega < re lambda` lies in the complex resolvent set.
+* `TauCeti.Semigroups.StronglyContinuousSemigroup.resolvent_complexGenerator_apply`: the complex
+  resolvent is the Laplace transform of the semigroup.
+* `TauCeti.Semigroups.StronglyContinuousSemigroup.norm_resolvent_complexGenerator_le`: the
+  Hille--Yosida bound `‖R(lambda, A)‖ ≤ M / (re lambda - omega)`.
+* `TauCeti.Semigroups.StronglyContinuousSemigroup.analyticOnNhd_resolvent_complexGenerator`: the
+  complex resolvent is holomorphic on the half-plane.
+
+## References
+
+* K.-J. Engel and R. Nagel, *One-Parameter Semigroups for Linear Evolution Equations*,
+  Theorem II.1.10 and Section IV.1.
+* A. Pazy, *Semigroups of Linear Operators and Applications to Partial Differential Equations*,
+  Theorem 1.5.3.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory
+
+namespace TauCeti.Semigroups.StronglyContinuousSemigroup
+
+variable {X : Type*} [NormedAddCommGroup X] [NormedSpace ℂ X] [CompleteSpace X]
+  {omega M : ℝ} {lambda : ℂ}
+
+/-- **The complex resolvent set of the generator contains the half-plane of the growth bound.**
+Every `lambda` with `omega < re lambda` is a resolvent point of the complex generator. -/
+theorem mem_resolventSet_complexGenerator (S : StronglyContinuousSemigroup X)
+    (hS : S.IsComplexLinear) (hb : S.HasGrowthBound omega M)
+    (hlambda : omega < lambda.re) :
+    lambda ∈ TauCeti.LinearPMap.resolventSet (S.complexGenerator hS) := by
+  have hT : (S.phaseShift hS lambda.im).IsComplexLinear := hS.phaseShift lambda.im
+  have hreal : lambda.re ∈
+      TauCeti.LinearPMap.resolventSet
+        (((S.phaseShift hS lambda.im).complexGenerator hT).restrictScalars ℝ) := by
+    rw [(S.phaseShift hS lambda.im).complexGenerator_restrictScalars hT]
+    exact (S.phaseShift hS lambda.im).mem_resolventSet_generator
+      (hb.phaseShift hS lambda.im) hlambda
+  have hc := TauCeti.LinearPMap.mem_resolventSet_restrictScalars_iff.mp hreal
+  rw [Complex.coe_algebraMap, complexGenerator_phaseShift] at hc
+  have hshift := (TauCeti.LinearPMap.mem_resolventSet_subScalar_iff
+    (A := S.complexGenerator hS) (omega := (lambda.im : ℂ) * Complex.I)
+    (lambda := (lambda.re : ℂ))).mp hc
+  rwa [Complex.re_add_im] at hshift
+
+/-- The resolvent of the complex generator at a point of the open half-plane
+`omega < re lambda`, read over the reals, is the Laplace-transform resolvent of the phase-shifted
+semigroup `t ↦ exp (-i (im lambda) t) S(t)` at the real point `re lambda`. -/
+theorem restrictScalars_resolvent_complexGenerator (S : StronglyContinuousSemigroup X)
+    (hS : S.IsComplexLinear) (hb : S.HasGrowthBound omega M)
+    (hlambda : omega < lambda.re) :
+    (TauCeti.LinearPMap.resolvent (S.complexGenerator hS) lambda).restrictScalars ℝ
+      = (S.phaseShift hS lambda.im).resolvent (hb.phaseShift hS lambda.im) lambda.re hlambda := by
+  have hT : (S.phaseShift hS lambda.im).IsComplexLinear := hS.phaseShift lambda.im
+  have hreal : lambda.re ∈
+      TauCeti.LinearPMap.resolventSet (S.phaseShift hS lambda.im).generator :=
+    (S.phaseShift hS lambda.im).mem_resolventSet_generator (hb.phaseShift hS lambda.im) hlambda
+  have hrestrict :
+      ((S.phaseShift hS lambda.im).complexGenerator hT).restrictScalars ℝ =
+        (S.phaseShift hS lambda.im).generator :=
+    (S.phaseShift hS lambda.im).complexGenerator_restrictScalars hT
+  have hmem : (lambda.re : ℂ) + (lambda.im : ℂ) * Complex.I ∈
+      TauCeti.LinearPMap.resolventSet (S.complexGenerator hS) := by
+    rw [Complex.re_add_im]
+    exact S.mem_resolventSet_complexGenerator hS hb hlambda
+  have hshift : TauCeti.LinearPMap.resolvent
+      ((S.phaseShift hS lambda.im).complexGenerator hT) (lambda.re : ℂ)
+      = TauCeti.LinearPMap.resolvent (S.complexGenerator hS) lambda := by
+    rw [complexGenerator_phaseShift]
+    rw [TauCeti.LinearPMap.resolvent_subScalar (A := S.complexGenerator hS)
+      (omega := (lambda.im : ℂ) * Complex.I) (lambda := (lambda.re : ℂ)) hmem, Complex.re_add_im]
+  have hbridge := TauCeti.LinearPMap.restrictScalars_resolvent
+    (A := (S.phaseShift hS lambda.im).complexGenerator hT) (mu := lambda.re)
+    (by rwa [hrestrict])
+  rw [Complex.coe_algebraMap, hshift, hrestrict] at hbridge
+  rw [hbridge, (S.phaseShift hS lambda.im).generator_resolvent_eq
+    (hb.phaseShift hS lambda.im) hlambda]
+
+/-- The open half-plane `omega < re lambda` of a growth bound `(omega, M)` lies in the complex
+resolvent set of the generator. -/
+theorem setOf_lt_re_subset_resolventSet_complexGenerator (S : StronglyContinuousSemigroup X)
+    (hS : S.IsComplexLinear) (hb : S.HasGrowthBound omega M) :
+    {z : ℂ | omega < z.re} ⊆ TauCeti.LinearPMap.resolventSet (S.complexGenerator hS) :=
+  fun _ hz => S.mem_resolventSet_complexGenerator hS hb hz
+
+/-- **The complex Laplace-transform bridge.** On the half-plane `omega < re lambda` the resolvent
+of the complex generator is the pointwise Bochner integral
+`R(lambda, A) x = ∫₀^∞ exp (-lambda t) S(t) x dt`. -/
+theorem resolvent_complexGenerator_apply (S : StronglyContinuousSemigroup X)
+    (hS : S.IsComplexLinear) (hb : S.HasGrowthBound omega M)
+    (hlambda : omega < lambda.re) (x : X) :
+    TauCeti.LinearPMap.resolvent (S.complexGenerator hS) lambda x
+      = ∫ t in Set.Ioi (0 : ℝ), Complex.exp (-(lambda * t)) • S.realOperator t x := by
+  have hrestrict := congrArg (fun R : X →L[ℝ] X => R x)
+    (S.restrictScalars_resolvent_complexGenerator hS hb hlambda)
+  simp only [ContinuousLinearMap.coe_restrictScalars'] at hrestrict
+  rw [hrestrict, (S.phaseShift hS lambda.im).resolvent_apply]
+  refine setIntegral_congr_fun measurableSet_Ioi fun t ht => ?_
+  rw [S.phaseShift_realOperator_apply_of_nonneg hS lambda.im t (le_of_lt ht),
+    ← algebraMap_smul ℂ (Real.exp (-(lambda.re * t))), Complex.coe_algebraMap, smul_smul,
+    Complex.ofReal_exp, ← Complex.exp_add]
+  congr 2
+  conv_rhs => rw [← Complex.re_add_im lambda]
+  push_cast
+  ring
+
+/-- **The Hille--Yosida bound at a complex spectral parameter**: on the half-plane of a growth
+bound `(omega, M)`, `‖R(lambda, A)‖ ≤ M / (re lambda - omega)`. -/
+theorem norm_resolvent_complexGenerator_le (S : StronglyContinuousSemigroup X)
+    (hS : S.IsComplexLinear) (hb : S.HasGrowthBound omega M)
+    (hlambda : omega < lambda.re) :
+    ‖TauCeti.LinearPMap.resolvent (S.complexGenerator hS) lambda‖ ≤ M / (lambda.re - omega) := by
+  rw [← ContinuousLinearMap.norm_restrictScalars (𝕜' := ℝ),
+    S.restrictScalars_resolvent_complexGenerator hS hb hlambda]
+  exact (S.phaseShift hS lambda.im).resolvent_norm_le (hb.phaseShift hS lambda.im) lambda.re
+    hlambda
+
+/-- **The resolvent of a C₀-semigroup is holomorphic.** On the half-plane `omega < re lambda` of a
+growth bound `(omega, M)`, the resolvent of the complex generator is analytic in operator norm. -/
+theorem analyticOnNhd_resolvent_complexGenerator (S : StronglyContinuousSemigroup X)
+    (hS : S.IsComplexLinear) (hb : S.HasGrowthBound omega M) :
+    AnalyticOnNhd ℂ (TauCeti.LinearPMap.resolvent (S.complexGenerator hS))
+      {z : ℂ | omega < z.re} :=
+  (LinearPMap.analyticOnNhd_resolvent (S.complexGenerator hS)).mono
+    (S.setOf_lt_re_subset_resolventSet_complexGenerator hS hb)
+
+end TauCeti.Semigroups.StronglyContinuousSemigroup
+
+end

--- a/TauCeti/Analysis/SpecialFunctions/Complex/ExpSlope.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Complex/ExpSlope.lean
@@ -1,0 +1,50 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.SpecialFunctions.ExpDeriv
+import Mathlib.Analysis.Calculus.Deriv.Slope
+import Mathlib.Analysis.Complex.RealDeriv
+
+/-!
+# The difference quotient of a complex exponential at `0`, along the positive reals
+
+For `c : ℂ`, the function `t ↦ exp (c t)` of a real variable has derivative `c` at `0`. This file
+records that derivative in the one-sided difference-quotient form
+
+`t⁻¹ • (exp (c t) - 1) → c` as `t → 0⁺`,
+
+which is the shape a generator difference quotient takes: the semigroup parameter of a
+C₀-semigroup runs over the nonnegative reals, so its generator is a limit along `𝓝[>] 0`.
+
+## Main results
+
+* `TauCeti.tendsto_inv_smul_exp_mul_ofReal_sub_one`: the one-sided difference quotient of
+  `t ↦ exp (c t)` at `0` tends to `c`.
+-/
+
+public section
+
+open Filter
+open scoped Topology
+
+namespace TauCeti
+
+/-- The difference quotient of `t ↦ exp (c t)` at `0`, taken along the positive reals, tends to
+`c`: the derivative of a complex exponential at the origin, one-sidedly. -/
+theorem tendsto_inv_smul_exp_mul_ofReal_sub_one (c : ℂ) :
+    Tendsto (fun t : ℝ => t⁻¹ • (Complex.exp (c * t) - 1)) (𝓝[>] (0 : ℝ)) (𝓝 c) := by
+  have hderiv : HasDerivAt (fun t : ℝ => Complex.exp (c * t)) c 0 := by
+    have h : HasDerivAt (fun t : ℝ => c * (t : ℂ)) c 0 := by
+      simpa using (hasDerivAt_id (0 : ℝ)).ofReal_comp.const_mul c
+    simpa using h.cexp
+  refine ((hasDerivAt_iff_tendsto_slope.mp hderiv).mono_left
+    (nhdsWithin_mono _ fun t ht => ne_of_gt ht)).congr fun t => ?_
+  simp [slope_def_module]
+
+end TauCeti
+
+end


### PR DESCRIPTION
This PR puts the open half-plane `{lambda : ℂ | omega < re lambda}` of a growth bound `(omega, M)` inside the **complex** resolvent set of the complex generator of a C₀-semigroup, identifies the resolvent there with the Laplace transform `R(lambda, A) x = ∫₀^∞ exp (-lambda t) S(t) x dt`, bounds it by `M / (re lambda - omega)`, and concludes that `lambda ↦ R(lambda, A)` is holomorphic in operator norm on that half-plane. This is the roadmap's Part A resolvent-theory item "**analyticity** of `λ ↦ R(λ,A)` on the resolvent set" read at the generality its generality bar demands — "Get the **complex** resolvent set and the analyticity of `λ ↦ R(λ,A)`" — and it is the first live frontier item `OneParameterSemigroups/STATUS.md` names ("Complex resolvent analyticity"). The milestone it serves is Part A's Hille–Yosida generation theorem, whose resolvent API this completes on the complex side; all of Part A's named milestones are already established, so this is a declared-but-unbuilt API item rather than a new headline.

Everything Tau Ceti had about the resolvent of a generator was a real-variable statement: the semigroup is indexed by `ℝ≥0` and acts by real bounded operators, so the Laplace transform only ever produced *real* points of the resolvent set (`Ioi_subset_resolventSet_generator`). Two bridges cross to the complex picture, and they are the two new pieces of infrastructure here. Moving parallel to the imaginary axis is the **phase shift** `t ↦ exp (-i b t) S(t)` of a complex-linear semigroup: unlike the existing exponential shift `t ↦ exp (-omega t) S(t)`, it multiplies by a unimodular scalar, so it preserves every growth bound exactly, and its complex generator is `A - i b` (`complexGenerator_phaseShift`). Moving from the real scalar field to the complex one is `mem_resolventSet_restrictScalars_iff`: a bounded `𝕜`-linear inverse of `mu • I - A` for `A.restrictScalars 𝕜` is automatically `𝕜'`-homogeneous, because `z • R y` and `R (z • y)` have the same image under the `𝕜'`-linear bijection `mu • I - A`. Composing them sends the real resolvent point `re lambda` of the phase-shifted semigroup to the complex resolvent point `lambda` of `S`. Holomorphy is then the already-proved abstract `LinearPMap.analyticOnNhd_resolvent` restricted to the half-plane, so no new analyticity argument is needed — which is the point of having the abstract statement.

The semigroup is taken to act by complex-linear operators on a complex Banach space, which is exactly the setting of the existing `complexGenerator` and is what the roadmap's generality bar contemplates when it says a complex Hilbert space is usable as a real Banach space for the semigroup action. What remains on this frontier item afterwards is the genuinely real case: complexifying a real Banach space `X ↦ X_ℂ`, for which Mathlib has no complexification of a normed module, so it is a build of its own; the complex iterated bound `‖R(lambda, A)ⁿ‖ ≤ M / (re lambda - omega)ⁿ` is then a short corollary of `restrictScalars_resolvent_complexGenerator` once `ContinuousLinearMap.restrictScalars` is known to be multiplicative.

New files: `TauCeti/Analysis/SpecialFunctions/Complex/ExpSlope.lean` (the one-sided difference quotient of `t ↦ exp (c t)` at `0`), `TauCeti/Analysis/Semigroups/PhaseShift.lean` (the phase shift, its complex linearity, growth bounds and generator), `TauCeti/Analysis/Semigroups/Resolvent/Complex.lean` (the half-plane, the Laplace formula, the norm bound, holomorphy), and `TauCeti/Analysis/Normed/Operator/Resolvent/RestrictScalars.lean` (resolvents under restriction of scalars, stated for an arbitrary normed-algebra tower `𝕜 ⊆ 𝕜'`). The one change to an existing file generalizes `TauCeti/Analysis/Normed/Operator/Resolvent/Shift.lean` from `ℝ` to an arbitrary nontrivially normed field — the generality of `TauCeti.LinearPMap.resolventSet` itself, and a prerequisite here since the shift used is by the complex scalar `i b`; the proofs are unchanged.

No Mathlib infrastructure is vendored. The construction is new rather than ported: it is built on Tau Ceti's own semigroup, generator and resolvent API. (The real-parameter resolvent files record their own provenance in `mrdouglasny/hille-yosida`; nothing here is taken from it.)

Roadmap: OneParameterSemigroups

<!--tauceti-target:v1 {"focus":"OneParameterSemigroups","id":"complex-resolvent-set-analyticity"}-->

🤖 Prepared with Claude Code
