### PR TITLE
feat: the Cholesky homeomorphism and lower-triangular coordinates

### DIFF
--- a/TauCeti/LinearAlgebra/Matrix/Cholesky/Coordinates.lean
+++ b/TauCeti/LinearAlgebra/Matrix/Cholesky/Coordinates.lean
@@ -72,11 +72,13 @@ theorem lowerTriangleCoordinatesHomeomorph_apply_coe (L : PosDiagLowerTriangular
     (lowerTriangleCoordinatesHomeomorph p L).1 ij = L.1 ij.1.1 ij.1.2 :=
   (rfl)
 
+@[simp]
 theorem lowerTriangleCoordinatesHomeomorph_symm_apply_coe_of_le (x : PosDiagLowerCoordinates p)
     {i j : Fin p} (h : j ≤ i) :
     ((lowerTriangleCoordinatesHomeomorph p).symm x).1 i j = x.1 ⟨(i, j), h⟩ :=
   dite_eq_left h
 
+@[simp]
 theorem lowerTriangleCoordinatesHomeomorph_symm_apply_coe_of_lt (x : PosDiagLowerCoordinates p)
     {i j : Fin p} (h : i < j) :
     ((lowerTriangleCoordinatesHomeomorph p).symm x).1 i j = 0 :=

--- a/TauCeti/LinearAlgebra/Matrix/Cholesky/Coordinates.lean
+++ b/TauCeti/LinearAlgebra/Matrix/Cholesky/Coordinates.lean
@@ -1,0 +1,101 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.LinearAlgebra.Matrix.Cholesky.Basic
+
+/-!
+# Coordinates on positive-diagonal lower-triangular matrices
+
+A lower-triangular matrix is determined by its on-or-below-diagonal entries. Reading off these
+entries identifies the positive-diagonal lower-triangular matrices with the functions on the
+lower-triangular positions whose diagonal values are positive. This file packages that
+identification as a homeomorphism for the subtype topologies on both sides, and as a measurable
+equivalence for the corresponding Borel structures. These are the product coordinates in which
+the Jacobian of Cholesky reconstruction is computed.
+
+## Main declarations
+
+* `TauCeti.lowerTriangle` — the index type of on-or-below-diagonal positions.
+* `TauCeti.PosDiagLowerCoordinates` — the coordinate functions with positive diagonal values.
+* `TauCeti.lowerTriangleCoordinatesHomeomorph` — the coordinate homeomorphism.
+* `TauCeti.lowerTriangleCoordinates` — its measurable-equivalence form.
+-/
+
+public section
+
+noncomputable section
+
+namespace TauCeti
+
+/-- The on-or-below-diagonal positions `(i, j)`, `j ≤ i`, of a `p × p` matrix. -/
+abbrev lowerTriangle (p : ℕ) := {ij : Fin p × Fin p // ij.2 ≤ ij.1}
+
+/-- Real functions on the lower-triangular positions whose diagonal values are positive: the
+coordinate space of `TauCeti.PosDiagLowerTriangular p`. -/
+abbrev PosDiagLowerCoordinates (p : ℕ) :=
+  {x : lowerTriangle p → ℝ // ∀ i : Fin p, 0 < x ⟨(i, i), le_rfl⟩}
+
+variable (p : ℕ)
+
+/-- Reading off the on-or-below-diagonal entries is a homeomorphism from the positive-diagonal
+lower-triangular matrices to their coordinate space. Its inverse fills the positions above the
+diagonal with zeros. -/
+def lowerTriangleCoordinatesHomeomorph :
+    PosDiagLowerTriangular p ≃ₜ PosDiagLowerCoordinates p where
+  toFun L := ⟨fun ij ↦ L.1 ij.1.1 ij.1.2, L.2.2⟩
+  invFun x :=
+    ⟨Matrix.of fun i j ↦ if h : j ≤ i then x.1 ⟨(i, j), h⟩ else 0,
+      fun i j hij ↦ dite_eq_right (not_le.2 hij), fun i ↦ by simpa using x.2 i⟩
+  left_inv L := by
+    refine Subtype.ext (Matrix.ext fun i j ↦ ?_)
+    by_cases h : j ≤ i
+    · exact dite_eq_left h
+    · exact (dite_eq_right h).trans (L.2.1 (not_le.1 h)).symm
+  right_inv x := Subtype.ext (funext fun ij ↦ dite_eq_left ij.2)
+  continuous_toFun := by
+    refine Continuous.subtype_mk (continuous_pi fun ij ↦ ?_) _
+    exact continuous_subtype_val.matrix_elem ij.1.1 ij.1.2
+  continuous_invFun := by
+    refine Continuous.subtype_mk (continuous_pi fun i ↦ continuous_pi fun j ↦ ?_) _
+    by_cases h : j ≤ i
+    · simp only [Matrix.of_apply, dite_eq_left h]
+      exact (continuous_apply _).comp continuous_subtype_val
+    · simpa only [Matrix.of_apply, dite_eq_right h] using continuous_const
+
+@[simp]
+theorem lowerTriangleCoordinatesHomeomorph_apply_coe (L : PosDiagLowerTriangular p)
+    (ij : lowerTriangle p) :
+    (lowerTriangleCoordinatesHomeomorph p L).1 ij = L.1 ij.1.1 ij.1.2 :=
+  (rfl)
+
+theorem lowerTriangleCoordinatesHomeomorph_symm_apply_coe_of_le (x : PosDiagLowerCoordinates p)
+    {i j : Fin p} (h : j ≤ i) :
+    ((lowerTriangleCoordinatesHomeomorph p).symm x).1 i j = x.1 ⟨(i, j), h⟩ :=
+  dite_eq_left h
+
+theorem lowerTriangleCoordinatesHomeomorph_symm_apply_coe_of_lt (x : PosDiagLowerCoordinates p)
+    {i j : Fin p} (h : i < j) :
+    ((lowerTriangleCoordinatesHomeomorph p).symm x).1 i j = 0 :=
+  dite_eq_right (not_le.2 h)
+
+/-- The measurable equivalence induced by `TauCeti.lowerTriangleCoordinatesHomeomorph`. -/
+def lowerTriangleCoordinates : PosDiagLowerTriangular p ≃ᵐ PosDiagLowerCoordinates p :=
+  (lowerTriangleCoordinatesHomeomorph p).toMeasurableEquiv
+
+@[simp]
+theorem lowerTriangleCoordinates_coe :
+    (lowerTriangleCoordinates p : PosDiagLowerTriangular p → PosDiagLowerCoordinates p) =
+      lowerTriangleCoordinatesHomeomorph p :=
+  (rfl)
+
+@[simp]
+theorem lowerTriangleCoordinates_symm_coe :
+    ((lowerTriangleCoordinates p).symm : PosDiagLowerCoordinates p → PosDiagLowerTriangular p) =
+      (lowerTriangleCoordinatesHomeomorph p).symm :=
+  (rfl)
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/Matrix/Cholesky/Topology.lean
+++ b/TauCeti/LinearAlgebra/Matrix/Cholesky/Topology.lean
@@ -53,13 +53,8 @@ variable {p : ℕ}
 theorem continuous_choleskyReconstruction :
     Continuous (@choleskyReconstruction p) := by
   refine continuous_induced_rng.2 (continuous_induced_rng.2 ?_)
-  have h : (fun L : PosDiagLowerTriangular p ↦
-      ((choleskyReconstruction L).1 : Matrix (Fin p) (Fin p) ℝ)) = fun L ↦ L.1 * L.1ᵀ :=
-    funext choleskyReconstruction_coe
-  change Continuous fun L : PosDiagLowerTriangular p ↦
-    ((choleskyReconstruction L).1 : Matrix (Fin p) (Fin p) ℝ)
-  rw [h]
-  exact continuous_subtype_val.matrix_mul continuous_subtype_val.matrix_transpose
+  exact (continuous_subtype_val.matrix_mul continuous_subtype_val.matrix_transpose).congr
+    fun L ↦ (choleskyReconstruction_coe L).symm
 
 /-- Reconstruction from positive-diagonal lower-triangular factors is a proper map: the factors of
 a compact set of positive-definite matrices form a compact set. -/

--- a/TauCeti/LinearAlgebra/Matrix/Cholesky/Topology.lean
+++ b/TauCeti/LinearAlgebra/Matrix/Cholesky/Topology.lean
@@ -1,0 +1,184 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.LinearAlgebra.Matrix.Cholesky.Equiv
+public import Mathlib.Topology.Maps.Proper.CompactlyGenerated
+
+/-!
+# Continuity and measurability of the Cholesky equivalence
+
+This file proves that Cholesky factorization is a homeomorphism between the positive-definite
+symmetric matrices and the positive-diagonal lower-triangular matrices, both carrying their
+subtype topologies, and hence a measurable equivalence for the corresponding Borel structures.
+
+Reconstruction `L ↦ L * Lᵀ` is visibly continuous. The continuity of the factorization itself is
+deduced from a properness argument rather than from formulas for the Cholesky entries: a compact
+set `K` of positive-definite matrices has bounded diagonal entries, and the `i`-th row of a Gram
+factor of `A` has squared norm `A i i`, so the factors of the matrices in `K` form a bounded set.
+It is also closed, since a lower-triangular limit with nonnegative diagonal and positive-definite
+Gram matrix has nonzero determinant, hence positive diagonal. Reconstruction is therefore a
+continuous proper bijection, hence closed, hence a homeomorphism.
+
+## Main results
+
+* `TauCeti.continuous_choleskyReconstruction` — reconstruction is continuous.
+* `TauCeti.isProperMap_choleskyReconstruction` — reconstruction is a proper map.
+* `TauCeti.continuous_cholesky` — Cholesky factorization is continuous.
+* `TauCeti.choleskyHomeomorph` — the resulting homeomorphism.
+* `TauCeti.measurable_cholesky`, `TauCeti.measurable_choleskyReconstruction` — measurability in
+  both directions.
+* `TauCeti.choleskyMeasurableEquiv` — the resulting measurable equivalence.
+
+## References
+
+* R. A. Horn and C. R. Johnson, *Matrix Analysis*, second edition, Cambridge University Press,
+  2013, Section 7.2.
+-/
+
+public section
+
+noncomputable section
+
+open scoped Matrix
+
+namespace TauCeti
+
+variable {p : ℕ}
+
+/-- Reconstructing a positive-definite matrix from its lower-triangular factor is continuous. -/
+theorem continuous_choleskyReconstruction :
+    Continuous (@choleskyReconstruction p) := by
+  refine continuous_induced_rng.2 (continuous_induced_rng.2 ?_)
+  have h : (fun L : PosDiagLowerTriangular p ↦
+      ((choleskyReconstruction L).1 : Matrix (Fin p) (Fin p) ℝ)) = fun L ↦ L.1 * L.1ᵀ :=
+    funext choleskyReconstruction_coe
+  change Continuous fun L : PosDiagLowerTriangular p ↦
+    ((choleskyReconstruction L).1 : Matrix (Fin p) (Fin p) ℝ)
+  rw [h]
+  exact continuous_subtype_val.matrix_mul continuous_subtype_val.matrix_transpose
+
+/-- Reconstruction from positive-diagonal lower-triangular factors is a proper map: the factors of
+a compact set of positive-definite matrices form a compact set. -/
+theorem isProperMap_choleskyReconstruction :
+    IsProperMap (@choleskyReconstruction p) := by
+  refine isProperMap_iff_isCompact_preimage.2 ⟨continuous_choleskyReconstruction, fun K hK ↦ ?_⟩
+  set K' := (fun A : PosDefMatrix p ↦ (A.1 : Matrix (Fin p) (Fin p) ℝ)) '' K
+  have hK'c : IsCompact K' := hK.image (continuous_subtype_val.comp continuous_subtype_val)
+  obtain ⟨c, hc⟩ := hK'c.bddAbove_image (continuous_id.matrix_trace).continuousOn
+  -- The factors of the matrices in `K` are the lower-triangular matrices with nonnegative diagonal
+  -- whose Gram matrix lies in `K'`; the positivity of the diagonal is then automatic.
+  set T : Set (Matrix (Fin p) (Fin p) ℝ) :=
+    {L | L.IsLowerTriangular ∧ (∀ i, 0 ≤ L i i) ∧ L * Lᵀ ∈ K'}
+  have himage : Subtype.val '' (choleskyReconstruction ⁻¹' K) = T := by
+    ext L
+    constructor
+    · rintro ⟨L, hL, rfl⟩
+      exact ⟨L.2.1, fun i ↦ (L.2.2 i).le, _, hL, choleskyReconstruction_coe L⟩
+    · rintro ⟨htri, hdiag, A, hA, hAL⟩
+      have hdet : (∏ i, L i i) ^ 2 ≠ 0 := by
+        have hAL' : (A.1 : Matrix (Fin p) (Fin p) ℝ) = L * Lᵀ := hAL
+        have h := A.2.det_pos
+        rw [hAL', Matrix.det_mul,
+          Matrix.det_transpose, Matrix.det_of_isLowerTriangular L htri, ← sq] at h
+        exact h.ne'
+      have hpos : ∀ i, 0 < L i i := fun i ↦ (hdiag i).lt_of_ne
+        (Finset.prod_ne_zero_iff.1 ((pow_ne_zero_iff two_ne_zero).1 hdet) i
+          (Finset.mem_univ i)).symm
+      refine ⟨⟨L, htri, hpos⟩, ?_, rfl⟩
+      have hrec : choleskyReconstruction ⟨L, htri, hpos⟩ = A :=
+        Subtype.ext (Subtype.ext ((choleskyReconstruction_coe _).trans hAL.symm))
+      rw [Set.mem_preimage, hrec]
+      exact hA
+  have hTclosed : IsClosed T := by
+    have htri : IsClosed {L : Matrix (Fin p) (Fin p) ℝ | L.IsLowerTriangular} := by
+      simp only [Matrix.IsLowerTriangular, Matrix.BlockTriangular, Set.ofPred_forall]
+      exact isClosed_iInter fun i ↦ isClosed_iInter fun j ↦ isClosed_iInter fun _ ↦
+        isClosed_eq (continuous_id.matrix_elem i j) continuous_const
+    have hdiag : IsClosed {L : Matrix (Fin p) (Fin p) ℝ | ∀ i, 0 ≤ L i i} := by
+      simp only [Set.ofPred_forall]
+      exact isClosed_iInter fun i ↦ isClosed_le continuous_const (continuous_id.matrix_elem i i)
+    exact htri.inter (hdiag.inter
+      (hK'c.isClosed.preimage (continuous_id.matrix_mul continuous_id.matrix_transpose)))
+  -- Each entry of a factor is bounded by the square root of the trace of its Gram matrix.
+  have hTbox : T ⊆ Set.pi Set.univ fun _ ↦ Set.pi Set.univ fun _ ↦ Set.Icc (-√c) √c := by
+    rintro L ⟨-, -, hL⟩ i - j -
+    refine abs_le.1 (Real.abs_le_sqrt ?_)
+    have htrace : (L * Lᵀ).trace = ∑ i, ∑ k, L i k * L i k := by
+      simp [Matrix.trace, Matrix.mul_apply]
+    calc L i j ^ 2 = L i j * L i j := sq _
+      _ ≤ ∑ k, L i k * L i k :=
+        Finset.single_le_sum (fun k _ ↦ mul_self_nonneg (L i k)) (Finset.mem_univ j)
+      _ ≤ ∑ i, ∑ k, L i k * L i k :=
+        Finset.single_le_sum (f := fun i ↦ ∑ k, L i k * L i k)
+          (fun i _ ↦ Finset.sum_nonneg fun k _ ↦ mul_self_nonneg (L i k)) (Finset.mem_univ i)
+      _ = (L * Lᵀ).trace := htrace.symm
+      _ ≤ c := hc ⟨_, hL, rfl⟩
+  have hTc : IsCompact T :=
+    (isCompact_univ_pi fun _ ↦ isCompact_univ_pi fun _ ↦ isCompact_Icc).of_isClosed_subset
+      hTclosed hTbox
+  exact Topology.IsInducing.subtypeVal.isCompact_iff.2 (himage ▸ hTc)
+
+/-- Cholesky factorization is continuous. -/
+theorem continuous_cholesky : Continuous (@cholesky p) := by
+  refine continuous_iff_isClosed.2 fun s hs ↦ ?_
+  have h : cholesky ⁻¹' s = choleskyReconstruction '' s := by
+    ext A
+    exact ⟨fun hA ↦ ⟨cholesky A, hA, choleskyReconstruction_cholesky A⟩,
+      fun ⟨L, hL, hLA⟩ ↦ by
+        subst hLA
+        simpa using hL⟩
+  exact h ▸ isProperMap_choleskyReconstruction.isClosedMap s hs
+
+/-- Cholesky factorization as a homeomorphism between positive-definite symmetric matrices and
+positive-diagonal lower-triangular matrices. -/
+def choleskyHomeomorph : PosDefMatrix p ≃ₜ PosDiagLowerTriangular p where
+  toFun := cholesky
+  invFun := choleskyReconstruction
+  left_inv := choleskyReconstruction_cholesky
+  right_inv := cholesky_choleskyReconstruction
+  continuous_toFun := continuous_cholesky
+  continuous_invFun := continuous_choleskyReconstruction
+
+/-- The equivalence underlying `choleskyHomeomorph` is `choleskyEquiv`. -/
+@[simp]
+theorem choleskyHomeomorph_toEquiv :
+    (choleskyHomeomorph (p := p)).toEquiv = choleskyEquiv :=
+  Equiv.ext fun A ↦ (choleskyEquiv_apply A).symm
+
+@[simp]
+theorem choleskyHomeomorph_apply (A : PosDefMatrix p) : choleskyHomeomorph A = cholesky A :=
+  (rfl)
+
+@[simp]
+theorem choleskyHomeomorph_symm_apply (L : PosDiagLowerTriangular p) :
+    choleskyHomeomorph.symm L = choleskyReconstruction L :=
+  (rfl)
+
+/-- Cholesky factorization is measurable. -/
+theorem measurable_cholesky : Measurable (@cholesky p) :=
+  continuous_cholesky.measurable
+
+/-- Reconstructing a positive-definite matrix from its lower-triangular factor is measurable. -/
+theorem measurable_choleskyReconstruction : Measurable (@choleskyReconstruction p) :=
+  continuous_choleskyReconstruction.measurable
+
+/-- Cholesky factorization as a measurable equivalence between positive-definite symmetric
+matrices and positive-diagonal lower-triangular matrices. -/
+def choleskyMeasurableEquiv : PosDefMatrix p ≃ᵐ PosDiagLowerTriangular p :=
+  choleskyHomeomorph.toMeasurableEquiv
+
+@[simp]
+theorem choleskyMeasurableEquiv_apply (A : PosDefMatrix p) :
+    choleskyMeasurableEquiv A = cholesky A :=
+  (rfl)
+
+@[simp]
+theorem choleskyMeasurableEquiv_symm_apply (L : PosDiagLowerTriangular p) :
+    choleskyMeasurableEquiv.symm L = choleskyReconstruction L :=
+  (rfl)
+
+end TauCeti


### PR DESCRIPTION
This PR makes Cholesky factorization a homeomorphism and a measurable equivalence, and adds the product coordinates on its lower-triangular carrier. Prove `TauCeti.continuous_choleskyReconstruction`, `TauCeti.isProperMap_choleskyReconstruction` and `TauCeti.continuous_cholesky`, package them as `TauCeti.choleskyHomeomorph : PosDefMatrix p ≃ₜ PosDiagLowerTriangular p`, and derive `TauCeti.measurable_cholesky`, `TauCeti.measurable_choleskyReconstruction` and `TauCeti.choleskyMeasurableEquiv` for the Borel structures of the retained subtype topologies (`TauCeti/LinearAlgebra/Matrix/Cholesky/Topology.lean`). Define the index type `TauCeti.lowerTriangle p` and the coordinate space `TauCeti.PosDiagLowerCoordinates p`, and prove that reading off the on-or-below-diagonal entries is a homeomorphism `TauCeti.lowerTriangleCoordinatesHomeomorph` for the subtype topology of `PosDiagLowerTriangular p`, with its measurable-equivalence form `TauCeti.lowerTriangleCoordinates` (`TauCeti/LinearAlgebra/Matrix/Cholesky/Coordinates.lean`).

Continuity of the factorization is proved without entry formulas: the factors of a compact set of positive-definite matrices are bounded (each entry squared is at most the trace of the Gram matrix) and closed (a lower-triangular limit with nonnegative diagonal and positive-definite Gram matrix has nonzero determinant, hence positive diagonal), so reconstruction is a continuous proper bijection, hence closed, hence a homeomorphism.

This advances the `StandardDistributions` Layer 6 milestone, item 2, **Cholesky decomposition**: "Prove both named inverse identities, continuity and measurability in both directions, and expose the resulting homeomorphism and measurable equivalence", and "Prove that its diagonal and strict-lower-triangular coordinate map is a homeomorphism for that subtype topology, and use the resulting product coordinates in the Jacobian theorem". It supplies the key declarations `choleskyHomeomorph` and `choleskyMeasurableEquiv`, with the declaration names and shapes of `TauCetiRoadmap/StandardDistributions/Suggested.lean`, section "Cholesky coordinates" (`continuous_cholesky`, `continuous_choleskyReconstruction`, `measurable_cholesky`, `measurable_choleskyReconstruction`, `lowerTriangle`, `PosDiagLowerCoordinates`, `lowerTriangleCoordinatesHomeomorph`, `lowerTriangleCoordinates`). The positive-diagonal lower-triangular carrier keeps its existing subtype topology and subtype Borel structure; no second topology or measurable structure is installed.

After this PR, item 2 still needs the Jacobian `abs_det_fderiv_choleskyReconstruction` in these coordinates and the change of variables `map_cholesky_symmetricLebesgue`, which in turn gate the multivariate Gamma integral (item 3) and the Wishart density (item 4).

The proofs reuse Tau Ceti's `TauCeti.choleskyEquiv` API (`choleskyReconstruction_coe`, `choleskyReconstruction_cholesky`, `cholesky_choleskyReconstruction`) and Mathlib's `isProperMap_iff_isCompact_preimage`, `IsProperMap.isClosedMap`, `Topology.IsInducing.isCompact_iff`, `isCompact_univ_pi`, `Matrix.det_of_isLowerTriangular`, `Matrix.PosDef.det_pos` and `Homeomorph.toMeasurableEquiv`. No upstream formalization is vendored.

Roadmap: StandardDistributions

<!--tauceti-target:v1 {"focus":"StandardDistributions","id":"choleskyhomeomorph"}-->

🤖 Prepared with Claude Code
