### PR TITLE
feat: the action of the fundamental group on the higher homotopy groups

### DIFF
--- a/TauCeti/Topology/Homotopy/HomotopyGroup/BasepointChange.lean
+++ b/TauCeti/Topology/Homotopy/HomotopyGroup/BasepointChange.lean
@@ -294,6 +294,7 @@ theorem homotopic_transAt_transport [DecidableEq N] (i : N) (γ : Path x y) (f f
 /-! ### Naturality of transport -/
 
 /-- Postcomposition with a continuous map commutes with transport, along the image path. -/
+@[simp]
 theorem map_transport {Y : Type*} [TopologicalSpace Y] (F : C(X, Y)) (γ : Path x y)
     (f : Ω^ N X x) :
     _root_.GenLoop.map F rfl (transport γ f) =

--- a/TauCeti/Topology/Homotopy/HomotopyGroup/BasepointChange.lean
+++ b/TauCeti/Topology/Homotopy/HomotopyGroup/BasepointChange.lean
@@ -156,9 +156,8 @@ theorem homotopic_transport_of_path_homotopic {γ δ : Path x y} (h : γ.Homotop
 /-! ### Functoriality of transport -/
 
 /-- The constant homotopy is a homotopy along the constant path. -/
-def HomotopyAlong.refl (f : Ω^ N X x) : HomotopyAlong (Path.refl x) f f where
-  toHomotopy := ContinuousMap.Homotopy.refl (f : C(I^N, X))
-  map_boundary _ z hz := f.2 z hz
+def HomotopyAlong.refl (f : Ω^ N X x) : HomotopyAlong (Path.refl x) f f :=
+  HomotopyAlong.ofHomotopyRel (ContinuousMap.HomotopyRel.refl _ _)
 
 /-- Transport along a constant path does nothing, up to homotopy. -/
 theorem homotopic_transport_refl (f : Ω^ N X x) :

--- a/TauCeti/Topology/Homotopy/HomotopyGroup/BasepointChange.lean
+++ b/TauCeti/Topology/Homotopy/HomotopyGroup/BasepointChange.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Topology.Homotopy.HomotopyGroup.Collar
+public import TauCeti.Topology.Homotopy.HomotopyGroup.Map
 
 /-!
 # Base-point change for higher homotopy groups
@@ -289,6 +290,18 @@ theorem homotopic_transAt_transport [DecidableEq N] (i : N) (γ : Path x y) (f f
     GenLoop.Homotopic (_root_.GenLoop.transAt i (transport γ f) (transport γ f'))
       (transport γ (_root_.GenLoop.transAt i f f')) :=
   ((collarHomotopyAlong γ f).transAt i (collarHomotopyAlong γ f')).homotopic_transport
+
+/-! ### Naturality of transport -/
+
+/-- Postcomposition with a continuous map commutes with transport, along the image path. -/
+theorem map_transport {Y : Type*} [TopologicalSpace Y] (F : C(X, Y)) (γ : Path x y)
+    (f : Ω^ N X x) :
+    _root_.GenLoop.map F rfl (transport γ f) =
+      transport (γ.map F.continuous) (_root_.GenLoop.map F rfl f) := by
+  apply _root_.GenLoop.ext
+  intro z
+  rw [_root_.GenLoop.map_apply, transport_apply_eq, transport_apply_eq, apply_ite F]
+  split_ifs <;> simp
 
 end GenLoop
 

--- a/TauCeti/Topology/Homotopy/HomotopyGroup/Collar.lean
+++ b/TauCeti/Topology/Homotopy/HomotopyGroup/Collar.lean
@@ -272,6 +272,22 @@ instance {γ : Path x y} {f : Ω^ N X x} {g : Ω^ N X y} :
 
 end HomotopyAlong
 
+omit [Fintype N] in
+/-- A homotopy relative to the cube boundary is a homotopy along the constant path: the base
+point does not move. -/
+def HomotopyAlong.ofHomotopyRel {f g : Ω^ N X x}
+    (K : ContinuousMap.HomotopyRel (f : C(I^N, X)) (g : C(I^N, X)) (Cube.boundary N)) :
+    HomotopyAlong (Path.refl x) f g where
+  toHomotopy := K.toHomotopy
+  map_boundary t z hz := (K.eq_fst t hz).trans (f.2 z hz)
+
+omit [Fintype N] in
+/-- Generalized loops homotopic relative to the cube boundary are connected by a homotopy along
+the constant path. -/
+theorem HomotopyAlong.nonempty_of_homotopic {f g : Ω^ N X x}
+    (h : _root_.GenLoop.Homotopic f g) : Nonempty (HomotopyAlong (Path.refl x) f g) :=
+  Nonempty.map HomotopyAlong.ofHomotopyRel h
+
 /-- The collar homotopy is a homotopy along `γ` from `f` to the transported loop. -/
 def collarHomotopyAlong (γ : Path x y) (f : Ω^ N X x) :
     HomotopyAlong γ f (transport γ f) where

--- a/TauCeti/Topology/Homotopy/HomotopyGroup/Collar.lean
+++ b/TauCeti/Topology/Homotopy/HomotopyGroup/Collar.lean
@@ -281,13 +281,6 @@ def HomotopyAlong.ofHomotopyRel {f g : Ω^ N X x}
   toHomotopy := K.toHomotopy
   map_boundary t z hz := (K.eq_fst t hz).trans (f.2 z hz)
 
-omit [Fintype N] in
-/-- Generalized loops homotopic relative to the cube boundary are connected by a homotopy along
-the constant path. -/
-theorem HomotopyAlong.nonempty_of_homotopic {f g : Ω^ N X x}
-    (h : _root_.GenLoop.Homotopic f g) : Nonempty (HomotopyAlong (Path.refl x) f g) :=
-  Nonempty.map HomotopyAlong.ofHomotopyRel h
-
 /-- The collar homotopy is a homotopy along `γ` from `f` to the transported loop. -/
 def collarHomotopyAlong (γ : Path x y) (f : Ω^ N X x) :
     HomotopyAlong γ f (transport γ f) where

--- a/TauCeti/Topology/Homotopy/HomotopyGroup/FundamentalGroupAction.lean
+++ b/TauCeti/Topology/Homotopy/HomotopyGroup/FundamentalGroupAction.lean
@@ -25,8 +25,10 @@ abelian) abbreviates. Its orbits have a purely topological meaning, recorded her
 lie in the
 same orbit exactly when they are *freely* homotopic, that is, when some homotopy connects them
 through generalized loops whose base points sweep out a loop at `x`. So the quotient of
-`π_n(X, x)` by the action is the set of free homotopy classes of maps `Sⁿ → X`, and the action
-is trivial precisely when based and free homotopy classes agree.
+`π_n(X, x)` by the action is the set of free homotopy classes of maps `Sⁿ → X` in positive
+dimensions. In dimension zero, it instead records the classes for which the distinguished point
+of `S⁰` remains in the path component of `x`. The action is trivial precisely when the
+corresponding based and free homotopy classes agree.
 
 ## Conventions
 
@@ -50,7 +52,8 @@ monodromy action `IsCoveringMap.fundamentalGroupMulAction` a left action.
   source and target, along the homomorphism it induces on fundamental groups.
 * `TauCeti.homotopyGroup_mem_orbit_iff` and
   `TauCeti.homotopyGroup_mem_orbit_iff_exists_homotopyAlong`: **the orbits of the action are
-  the free homotopy classes**, the latter through
+  the free homotopy classes in positive dimensions (with the distinguished point restricted to
+  the component of `x` in dimension zero)**, the latter through
   `TauCeti.GenLoop.exists_homotopyAlong_iff_exists_homotopic_transport`, which reads free
   homotopy as transport up to based homotopy.
 * `TauCeti.fundamentalGroup_smul_eq_self`: on a simply connected space the action is trivial.
@@ -248,11 +251,13 @@ theorem exists_homotopyAlong_iff_exists_homotopic_transport (f g : Ω^ N X x) :
 
 end GenLoop
 
-/-- **The orbits of the action of `π₁(X, x)` on `π_n(X, x)` are the free homotopy classes.**
-Classes of two generalized loops based at `x` lie in the same orbit exactly when some homotopy
-connects the two loops through generalized loops, the base point sweeping out a loop at `x`. So
-the quotient of `π_n(X, x)` by the action is the set of free homotopy classes of maps
-`Sⁿ → X`.
+/-- **In positive dimensions, the orbits of the action of `π₁(X, x)` on `π_n(X, x)` are the
+free homotopy classes.** Classes of two generalized loops based at `x` lie in the same orbit
+exactly when some homotopy connects the two loops through generalized loops, the base point
+sweeping out a loop at `x`. Thus in positive dimensions the quotient of `π_n(X, x)` by the
+action is the set of free homotopy classes of maps `Sⁿ → X`. In dimension zero, it instead
+classifies the free homotopy classes of maps `S⁰ → X` whose distinguished point lies in the path
+component of `x`.
 
 The two classes are given by representatives rather than written as `⟦f⟧` and `⟦g⟧` directly,
 because the type of `⟦f⟧` is the underlying quotient rather than `HomotopyGroup N X x`, which
@@ -269,7 +274,9 @@ theorem homotopyGroup_mem_orbit_iff_exists_homotopyAlong {a b : HomotopyGroup N 
   exact Quotient.eq
 
 /-- On a space with trivial fundamental group at `x` — a simply connected space, for instance —
-the action is trivial, so based and free homotopy classes of maps `Sⁿ → X` agree. -/
+the action is trivial. Thus in positive dimensions based and free homotopy classes of maps
+`Sⁿ → X` agree; in dimension zero this uses the interpretation with the distinguished point
+restricted to the path component of `x`. -/
 theorem fundamentalGroup_smul_eq_self [Subsingleton (FundamentalGroup X x)]
     (γ : FundamentalGroup X x) (a : HomotopyGroup N X x) : γ • a = a := by
   rw [Subsingleton.elim γ 1, one_smul]

--- a/TauCeti/Topology/Homotopy/HomotopyGroup/FundamentalGroupAction.lean
+++ b/TauCeti/Topology/Homotopy/HomotopyGroup/FundamentalGroupAction.lean
@@ -25,10 +25,10 @@ abelian) abbreviates. Its orbits have a purely topological meaning, recorded her
 lie in the
 same orbit exactly when they are *freely* homotopic, that is, when some homotopy connects them
 through generalized loops whose base points sweep out a loop at `x`. So the quotient of
-`π_n(X, x)` by the action is the set of free homotopy classes of maps `Sⁿ → X` in positive
-dimensions. In dimension zero, it instead records the classes for which the distinguished point
-of `S⁰` remains in the path component of `x`. The action is trivial precisely when the
-corresponding based and free homotopy classes agree.
+`π_n(X, x)` by the action is, in positive dimensions, the set of free homotopy classes of maps
+`Sⁿ → X` landing in the path component of `x`. In dimension zero, it instead records the
+classes for which the distinguished point of `S⁰` remains in the path component of `x`. The
+action is trivial precisely when the corresponding based and free homotopy classes agree.
 
 ## Conventions
 
@@ -52,17 +52,15 @@ monodromy action `IsCoveringMap.fundamentalGroupMulAction` a left action.
   source and target, along the homomorphism it induces on fundamental groups.
 * `TauCeti.homotopyGroup_mem_orbit_iff` and
   `TauCeti.homotopyGroup_mem_orbit_iff_exists_homotopyAlong`: **the orbits of the action are
-  the free homotopy classes in positive dimensions (with the distinguished point restricted to
-  the component of `x` in dimension zero)**, the latter through
+  the free homotopy classes into the path component of `x` in positive dimensions (with the
+  distinguished point restricted to the component of `x` in dimension zero)**, the latter through
   `TauCeti.GenLoop.exists_homotopyAlong_iff_exists_homotopic_transport`, which reads free
   homotopy as transport up to based homotopy.
 * `TauCeti.fundamentalGroup_smul_eq_self`: on a simply connected space the action is trivial.
 
 ## References
 
-This continues the higher-homotopy API requested in `TauCetiRoadmap/UniversalCovers/README.md`,
-Stage 3, item 9, whose base-point-change half is `TauCeti.homotopyGroupMulEquivOfPath`. See
-Hatcher, *Algebraic Topology*, Section 4.1, where the action is introduced immediately after
+See Hatcher, *Algebraic Topology*, Section 4.1, where the action is introduced immediately after
 base-point change and the description of its orbits is the definition of an `n`-simple space.
 -/
 
@@ -113,26 +111,28 @@ theorem homotopyGroupTransportQuotient_trans {x'' : X} (γ : Path.Homotopic.Quot
 
 /-! ### The action of the fundamental group -/
 
+/-- The fundamental group at `x` acts on a homotopy group based at `x` by transport around
+loops; `TauCeti.homotopyGroupMulAction` shows that this is a group action. -/
+instance homotopyGroupSMul : SMul (FundamentalGroup X x) (HomotopyGroup N X x) where
+  smul γ a := homotopyGroupTransportQuotient γ.toPath a
+
+/-- The action of the fundamental group is transport along the class of loops. -/
+theorem fundamentalGroup_smul_def (γ : FundamentalGroup X x) (a : HomotopyGroup N X x) :
+    γ • a = homotopyGroupTransportQuotient γ.toPath a := by
+  rfl
+
 /-- **The fundamental group at `x` acts on every homotopy group based at `x`**, an element of
 `π₁(X, x)` acting by transport around the loop it represents.
 
 The action is a left action: transport composes covariantly and `FundamentalGroup.mul_def`
 reverses the order of concatenation, so the two reversals cancel. -/
 instance homotopyGroupMulAction : MulAction (FundamentalGroup X x) (HomotopyGroup N X x) where
-  smul γ a := homotopyGroupTransportQuotient γ.toPath a
   one_smul a := by
-    change homotopyGroupTransportQuotient (1 : FundamentalGroup X x).toPath a = a
-    rw [FundamentalGroup.one_def, homotopyGroupTransportQuotient_refl, id_eq]
+    rw [fundamentalGroup_smul_def, FundamentalGroup.one_def, homotopyGroupTransportQuotient_refl,
+      id_eq]
   mul_smul γ δ a := by
-    change homotopyGroupTransportQuotient (γ * δ).toPath a =
-      homotopyGroupTransportQuotient γ.toPath (homotopyGroupTransportQuotient δ.toPath a)
-    rw [FundamentalGroup.mul_def, homotopyGroupTransportQuotient_trans]
-    rfl
-
-/-- The action of the fundamental group is transport along the class of loops. -/
-theorem fundamentalGroup_smul_def (γ : FundamentalGroup X x) (a : HomotopyGroup N X x) :
-    γ • a = homotopyGroupTransportQuotient γ.toPath a := by
-  rfl
+    rw [fundamentalGroup_smul_def, fundamentalGroup_smul_def, fundamentalGroup_smul_def,
+      FundamentalGroup.mul_def, homotopyGroupTransportQuotient_trans, Function.comp_apply]
 
 /-- An element of `π₁(X, x)` represented by a loop `p` acts by transport along `p`. -/
 theorem fundamentalGroup_smul_eq_transport {γ : FundamentalGroup X x} {p : Path x x}
@@ -182,19 +182,6 @@ theorem fundamentalGroupMulAut_apply [Nonempty N] [DecidableEq N] (γ : Fundamen
   rfl
 
 /-! ### Naturality -/
-
-namespace GenLoop
-
-/-- Postcomposition with a continuous map commutes with transport, along the image path. -/
-theorem map_transport (F : C(X, Y)) (γ : Path x x') (f : Ω^ N X x) :
-    _root_.GenLoop.map F rfl (transport γ f) =
-      transport (γ.map F.continuous) (_root_.GenLoop.map F rfl f) := by
-  apply _root_.GenLoop.ext
-  intro z
-  rw [_root_.GenLoop.map_apply, transport_apply_eq, transport_apply_eq, apply_ite F]
-  split_ifs <;> simp
-
-end GenLoop
 
 /-- Postcomposition with a continuous map commutes with transport of homotopy classes, along
 the image class of paths. -/
@@ -255,13 +242,9 @@ end GenLoop
 free homotopy classes.** Classes of two generalized loops based at `x` lie in the same orbit
 exactly when some homotopy connects the two loops through generalized loops, the base point
 sweeping out a loop at `x`. Thus in positive dimensions the quotient of `π_n(X, x)` by the
-action is the set of free homotopy classes of maps `Sⁿ → X`. In dimension zero, it instead
-classifies the free homotopy classes of maps `S⁰ → X` whose distinguished point lies in the path
-component of `x`.
-
-The two classes are given by representatives rather than written as `⟦f⟧` and `⟦g⟧` directly,
-because the type of `⟦f⟧` is the underlying quotient rather than `HomotopyGroup N X x`, which
-hides the action from instance search. -/
+action is the set of free homotopy classes of maps `Sⁿ → X` landing in the path component of
+`x`. In dimension zero, it instead classifies the free homotopy classes of maps `S⁰ → X` whose
+distinguished point lies in the path component of `x`. -/
 theorem homotopyGroup_mem_orbit_iff_exists_homotopyAlong {a b : HomotopyGroup N X x}
     {f g : Ω^ N X x}
     (ha : a = ⟦f⟧) (hb : b = ⟦g⟧) :
@@ -275,8 +258,8 @@ theorem homotopyGroup_mem_orbit_iff_exists_homotopyAlong {a b : HomotopyGroup N 
 
 /-- On a space with trivial fundamental group at `x` — a simply connected space, for instance —
 the action is trivial. Thus in positive dimensions based and free homotopy classes of maps
-`Sⁿ → X` agree; in dimension zero this uses the interpretation with the distinguished point
-restricted to the path component of `x`. -/
+`Sⁿ → X` landing in the path component of `x` agree; in dimension zero this uses the
+interpretation with the distinguished point restricted to the path component of `x`. -/
 theorem fundamentalGroup_smul_eq_self [Subsingleton (FundamentalGroup X x)]
     (γ : FundamentalGroup X x) (a : HomotopyGroup N X x) : γ • a = a := by
   rw [Subsingleton.elim γ 1, one_smul]

--- a/TauCeti/Topology/Homotopy/HomotopyGroup/FundamentalGroupAction.lean
+++ b/TauCeti/Topology/Homotopy/HomotopyGroup/FundamentalGroupAction.lean
@@ -14,16 +14,17 @@ public import TauCeti.Topology.Homotopy.HomotopyGroup.BasepointChange
 Transporting a generalized loop along a path `γ` from `x` to `y` gives an isomorphism
 `π_n(X, x) ≃* π_n(X, y)` depending only on the homotopy class of `γ`
 (`TauCeti.homotopyGroupMulEquivOfPath`). Taking `y = x` turns that isomorphism into extra
-structure carried by a single homotopy group: the fundamental group at `x` acts on `π_n(X, x)`
+structure carried by a single homotopy group: the fundamental group at `x` acts on the type
+`π_n(X, x)`, and in positive dimensions — where that type carries a group structure — it acts
 by group automorphisms. This file builds that action and identifies its orbits.
 
 The action is the higher-dimensional analogue of the conjugation action of `π₁(X, x)` on
-itself, and it is what the phrase "`π_n` is a `π₁`-module" (for `n ≥ 2`, where `π_n` is
-abelian) abbreviates. Its orbits have a purely topological meaning, recorded here in
-`TauCeti.homotopyGroup_mem_orbit_iff_exists_homotopyAlong`: two generalized loops based at `x`
-lie in the
-same orbit exactly when they are *freely* homotopic, that is, when some homotopy connects them
-through generalized loops whose base points sweep out a loop at `x`. So the quotient of
+itself, and in dimensions at least two, where `π_n` is abelian, it is what the phrase
+"`π_n` is a `π₁`-module" abbreviates. Its orbits have a purely topological meaning, recorded
+here in `TauCeti.homotopyGroup_mem_orbit_iff_exists_homotopyAlong`: two generalized loops based
+at `x` lie in the same orbit exactly when they are *freely* homotopic, that is, when some
+homotopy connects them through generalized loops whose base points sweep out a loop at `x`.
+So the quotient of
 `π_n(X, x)` by the action is, in positive dimensions, the set of free homotopy classes of maps
 `Sⁿ → X` landing in the path component of `x`. In dimension zero, it instead records the
 classes for which the distinguished point of `S⁰` remains in the path component of `x`. The
@@ -169,7 +170,9 @@ instance homotopyGroupMulDistribMulAction [Nonempty N] [DecidableEq N] :
 
 variable (N) in
 /-- **The action of the fundamental group on a positive-dimensional homotopy group, as a
-homomorphism into the automorphism group.** This is the `π₁`-module structure on `π_n`. -/
+homomorphism into the automorphism group.** In dimensions at least two, where `π_n` is abelian,
+this is the `π₁`-module structure on `π_n`; in dimension one it is an action of `π₁(X, x)` on
+itself by group automorphisms. -/
 def fundamentalGroupMulAut [Nonempty N] [DecidableEq N] (x : X) :
     FundamentalGroup X x →* MulAut (HomotopyGroup N X x) :=
   MulDistribMulAction.toMulAut _ _

--- a/TauCeti/Topology/Homotopy/HomotopyGroup/FundamentalGroupAction.lean
+++ b/TauCeti/Topology/Homotopy/HomotopyGroup/FundamentalGroupAction.lean
@@ -1,0 +1,277 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.AlgebraicTopology.FundamentalGroupoid.SimplyConnected
+public import TauCeti.Topology.Homotopy.HomotopyGroup.BasepointChange
+public import TauCeti.Topology.Homotopy.HomotopyGroup.Map
+
+/-!
+# The action of the fundamental group on the higher homotopy groups
+
+Transporting a generalized loop along a path `γ` from `x` to `y` gives an isomorphism
+`π_n(X, x) ≃* π_n(X, y)` depending only on the homotopy class of `γ`
+(`TauCeti.homotopyGroupMulEquivOfPath`). Taking `y = x` turns that isomorphism into extra
+structure carried by a single homotopy group: the fundamental group at `x` acts on `π_n(X, x)`
+by group automorphisms. This file builds that action and identifies its orbits.
+
+The action is the higher-dimensional analogue of the conjugation action of `π₁(X, x)` on
+itself, and it is what the phrase "`π_n` is a `π₁`-module" (for `n ≥ 2`, where `π_n` is
+abelian) abbreviates. Its orbits have a purely topological meaning, recorded here in
+`TauCeti.homotopyGroup_mem_orbit_iff_exists_homotopyAlong`: two generalized loops based at `x`
+lie in the
+same orbit exactly when they are *freely* homotopic, that is, when some homotopy connects them
+through generalized loops whose base points sweep out a loop at `x`. So the quotient of
+`π_n(X, x)` by the action is the set of free homotopy classes of maps `Sⁿ → X`, and the action
+is trivial precisely when based and free homotopy classes agree.
+
+## Conventions
+
+Transport composes covariantly — transporting along `γ` and then along `δ` transports along
+`γ.trans δ` — while multiplication in `FundamentalGroup X x` is
+`FundamentalGroup.mul_def : p * q = q.trans p`. The two conventions match, so transport is a
+*left* action and no `ᵐᵒᵖ` is needed; this is the same bookkeeping that makes Mathlib's
+monodromy action `IsCoveringMap.fundamentalGroupMulAction` a left action.
+
+## Main declarations
+
+* `TauCeti.homotopyGroupTransportQuotient`: transport of homotopy classes along a homotopy
+  class of paths, with `TauCeti.homotopyGroupTransportQuotient_refl` and
+  `TauCeti.homotopyGroupTransportQuotient_trans`.
+* `TauCeti.homotopyGroupMulAction`: **the fundamental group acts on every homotopy group at
+  the same base point**, with `TauCeti.fundamentalGroup_smul_mk` computing the action of the
+  class of a loop.
+* `TauCeti.homotopyGroupMulDistribMulAction` and `TauCeti.fundamentalGroupMulAut`: **in
+  positive dimensions the action is by group automorphisms**.
+* `TauCeti.map_fundamentalGroup_smul`: a based continuous map is equivariant for the actions on
+  source and target, along the homomorphism it induces on fundamental groups.
+* `TauCeti.homotopyGroup_mem_orbit_iff` and
+  `TauCeti.homotopyGroup_mem_orbit_iff_exists_homotopyAlong`: **the orbits of the action are
+  the free homotopy classes**, the latter through
+  `TauCeti.GenLoop.exists_homotopyAlong_iff_exists_homotopic_transport`, which reads free
+  homotopy as transport up to based homotopy.
+* `TauCeti.fundamentalGroup_smul_eq_self`: on a simply connected space the action is trivial.
+
+## References
+
+This continues the higher-homotopy API requested in `TauCetiRoadmap/UniversalCovers/README.md`,
+Stage 3, item 9, whose base-point-change half is `TauCeti.homotopyGroupMulEquivOfPath`. See
+Hatcher, *Algebraic Topology*, Section 4.1, where the action is introduced immediately after
+base-point change and the description of its orbits is the definition of an `n`-simple space.
+-/
+
+public section
+noncomputable section
+
+namespace TauCeti
+
+open scoped unitInterval Topology Topology.Homotopy
+open Topology.Homotopy
+
+variable {N : Type*} [Fintype N] {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
+  {x x' : X}
+
+/-! ### Transport along a homotopy class of paths -/
+
+/-- Transport of homotopy classes along a homotopy *class* of paths. This is
+`TauCeti.homotopyGroupTransport` descended to `Path.Homotopic.Quotient`, which is legitimate
+because homotopic paths transport alike. -/
+def homotopyGroupTransportQuotient (γ : Path.Homotopic.Quotient x x') :
+    HomotopyGroup N X x → HomotopyGroup N X x' :=
+  Quotient.liftOn γ homotopyGroupTransport fun _ _ h => homotopyGroupTransport_congr h
+
+/-- Transport along the class of a path is transport along the path. -/
+@[simp]
+theorem homotopyGroupTransportQuotient_mk (γ : Path x x') :
+    homotopyGroupTransportQuotient (N := N) (.mk γ) = homotopyGroupTransport γ := by
+  rfl
+
+/-- Transport along the class of the constant path is the identity. -/
+@[simp]
+theorem homotopyGroupTransportQuotient_refl :
+    homotopyGroupTransportQuotient (N := N) (.refl x) = id := by
+  rw [← Path.Homotopic.Quotient.mk_refl, homotopyGroupTransportQuotient_mk,
+    homotopyGroupTransport_refl]
+
+/-- Transport along a composite of classes of paths is the composite of the two transports. -/
+@[simp]
+theorem homotopyGroupTransportQuotient_trans {x'' : X} (γ : Path.Homotopic.Quotient x x')
+    (δ : Path.Homotopic.Quotient x' x'') :
+    homotopyGroupTransportQuotient (N := N) (γ.trans δ) =
+      homotopyGroupTransportQuotient δ ∘ homotopyGroupTransportQuotient γ := by
+  induction γ with | mk p =>
+  induction δ with | mk q =>
+  rw [← Path.Homotopic.Quotient.mk_trans, homotopyGroupTransportQuotient_mk,
+    homotopyGroupTransportQuotient_mk, homotopyGroupTransportQuotient_mk,
+    homotopyGroupTransport_trans]
+
+/-! ### The action of the fundamental group -/
+
+/-- **The fundamental group at `x` acts on every homotopy group based at `x`**, an element of
+`π₁(X, x)` acting by transport around the loop it represents.
+
+The action is a left action: transport composes covariantly and `FundamentalGroup.mul_def`
+reverses the order of concatenation, so the two reversals cancel. -/
+instance homotopyGroupMulAction : MulAction (FundamentalGroup X x) (HomotopyGroup N X x) where
+  smul γ a := homotopyGroupTransportQuotient γ.toPath a
+  one_smul a := by
+    change homotopyGroupTransportQuotient (1 : FundamentalGroup X x).toPath a = a
+    rw [FundamentalGroup.one_def, homotopyGroupTransportQuotient_refl, id_eq]
+  mul_smul γ δ a := by
+    change homotopyGroupTransportQuotient (γ * δ).toPath a =
+      homotopyGroupTransportQuotient γ.toPath (homotopyGroupTransportQuotient δ.toPath a)
+    rw [FundamentalGroup.mul_def, homotopyGroupTransportQuotient_trans]
+    rfl
+
+/-- The action of the fundamental group is transport along the class of loops. -/
+theorem fundamentalGroup_smul_def (γ : FundamentalGroup X x) (a : HomotopyGroup N X x) :
+    γ • a = homotopyGroupTransportQuotient γ.toPath a := by
+  rfl
+
+/-- An element of `π₁(X, x)` represented by a loop `p` acts by transport along `p`. -/
+theorem fundamentalGroup_smul_eq_transport {γ : FundamentalGroup X x} {p : Path x x}
+    (h : γ.toPath = .mk p) (a : HomotopyGroup N X x) :
+    γ • a = homotopyGroupTransport p a := by
+  rw [fundamentalGroup_smul_def, h]
+  exact congrFun (homotopyGroupTransportQuotient_mk p) a
+
+/-- The class of a loop `p` acts by transport along `p`. -/
+@[simp]
+theorem fundamentalGroup_smul_mk (p : Path x x) (a : HomotopyGroup N X x) :
+    (FundamentalGroup.fromPath (.mk p) : FundamentalGroup X x) • a =
+      homotopyGroupTransport p a :=
+  fundamentalGroup_smul_eq_transport rfl a
+
+/-- Acting by an element of `π₁(X, x)` is base-point change along a representing loop. -/
+theorem fundamentalGroup_smul_eq_homotopyGroupMulEquivOfPath [Nonempty N] [DecidableEq N]
+    (p : Path x x) (a : HomotopyGroup N X x) :
+    (FundamentalGroup.fromPath (.mk p) : FundamentalGroup X x) • a =
+      homotopyGroupMulEquivOfPath p a := by
+  rw [fundamentalGroup_smul_mk, homotopyGroupMulEquivOfPath_apply]
+
+/-- **In positive dimensions the fundamental group acts by group automorphisms.** -/
+instance homotopyGroupMulDistribMulAction [Nonempty N] [DecidableEq N] :
+    MulDistribMulAction (FundamentalGroup X x) (HomotopyGroup N X x) where
+  __ := (inferInstance : MulAction (FundamentalGroup X x) (HomotopyGroup N X x))
+  smul_mul γ a b := by
+    obtain ⟨p, rfl⟩ := Path.Homotopic.Quotient.mk_surjective γ.toPath
+    rw [fundamentalGroup_smul_eq_homotopyGroupMulEquivOfPath,
+      fundamentalGroup_smul_eq_homotopyGroupMulEquivOfPath,
+      fundamentalGroup_smul_eq_homotopyGroupMulEquivOfPath, map_mul]
+  smul_one γ := by
+    obtain ⟨p, rfl⟩ := Path.Homotopic.Quotient.mk_surjective γ.toPath
+    rw [fundamentalGroup_smul_eq_homotopyGroupMulEquivOfPath, map_one]
+
+variable (N) in
+/-- **The action of the fundamental group on a positive-dimensional homotopy group, as a
+homomorphism into the automorphism group.** This is the `π₁`-module structure on `π_n`. -/
+def fundamentalGroupMulAut [Nonempty N] [DecidableEq N] (x : X) :
+    FundamentalGroup X x →* MulAut (HomotopyGroup N X x) :=
+  MulDistribMulAction.toMulAut _ _
+
+/-- The automorphism attached to an element of the fundamental group acts by that element. -/
+@[simp]
+theorem fundamentalGroupMulAut_apply [Nonempty N] [DecidableEq N] (γ : FundamentalGroup X x)
+    (a : HomotopyGroup N X x) : fundamentalGroupMulAut N x γ a = γ • a := by
+  rfl
+
+/-! ### Naturality -/
+
+namespace GenLoop
+
+/-- Postcomposition with a continuous map commutes with transport, along the image path. -/
+theorem map_transport (F : C(X, Y)) (γ : Path x x') (f : Ω^ N X x) :
+    _root_.GenLoop.map F rfl (transport γ f) =
+      transport (γ.map F.continuous) (_root_.GenLoop.map F rfl f) := by
+  apply _root_.GenLoop.ext
+  intro z
+  rw [_root_.GenLoop.map_apply, transport_apply_eq, transport_apply_eq, apply_ite F]
+  split_ifs <;> simp
+
+end GenLoop
+
+/-- Postcomposition with a continuous map commutes with transport of homotopy classes, along
+the image class of paths. -/
+theorem map_homotopyGroupTransportQuotient (F : C(X, Y)) (γ : Path.Homotopic.Quotient x x')
+    (a : HomotopyGroup N X x) :
+    _root_.HomotopyGroup.map F rfl (homotopyGroupTransportQuotient γ a) =
+      homotopyGroupTransportQuotient (γ.map F) (_root_.HomotopyGroup.map F rfl a) := by
+  induction γ with | mk p =>
+  induction a using Quotient.inductionOn with | _ f =>
+  rw [← Path.Homotopic.Quotient.mk_map, homotopyGroupTransportQuotient_mk,
+    homotopyGroupTransportQuotient_mk]
+  simp only [homotopyGroupTransport_mk, _root_.HomotopyGroup.map_mk]
+  rw [GenLoop.map_transport]
+
+/-- **A based continuous map is equivariant** for the actions of the fundamental groups on
+source and target, along the homomorphism it induces on fundamental groups. -/
+theorem map_fundamentalGroup_smul (F : C(X, Y)) (γ : FundamentalGroup X x)
+    (a : HomotopyGroup N X x) :
+    _root_.HomotopyGroup.map F rfl (γ • a) =
+      FundamentalGroup.map F x γ • _root_.HomotopyGroup.map F rfl a := by
+  rw [fundamentalGroup_smul_def, fundamentalGroup_smul_def,
+    map_homotopyGroupTransportQuotient]
+  rfl
+
+/-! ### The orbits of the action -/
+
+/-- Membership in an orbit of the action is transport: a class `b` lies in the orbit of `a`
+exactly when some loop at `x` transports `a` to `b`. -/
+theorem homotopyGroup_mem_orbit_iff (a b : HomotopyGroup N X x) :
+    b ∈ MulAction.orbit (FundamentalGroup X x) a ↔
+      ∃ p : Path x x, homotopyGroupTransport p a = b := by
+  constructor
+  · rintro ⟨γ, hγ⟩
+    obtain ⟨p, hp⟩ := Path.Homotopic.Quotient.mk_surjective γ.toPath
+    exact ⟨p, (fundamentalGroup_smul_eq_transport hp.symm a).symm.trans hγ⟩
+  · rintro ⟨p, rfl⟩
+    exact ⟨FundamentalGroup.fromPath (.mk p), fundamentalGroup_smul_mk p a⟩
+
+namespace GenLoop
+
+/-- **Free homotopy is transport up to based homotopy.** A homotopy connecting two generalized
+loops based at `x` through generalized loops, its base point sweeping out a loop, exists
+exactly when one of them is homotopic, relative to the cube boundary, to the transport of the
+other along a loop. -/
+theorem exists_homotopyAlong_iff_exists_homotopic_transport (f g : Ω^ N X x) :
+    (∃ γ : Path x x, Nonempty (HomotopyAlong γ f g)) ↔
+      ∃ p : Path x x, _root_.GenLoop.Homotopic (transport p f) g := by
+  constructor
+  · rintro ⟨γ, ⟨h⟩⟩
+    exact ⟨γ, h.homotopic_transport.symm⟩
+  · rintro ⟨p, hp⟩
+    obtain ⟨K⟩ := HomotopyAlong.nonempty_of_homotopic hp
+    exact ⟨p.trans (Path.refl x), ⟨(collarHomotopyAlong p f).trans K⟩⟩
+
+end GenLoop
+
+/-- **The orbits of the action of `π₁(X, x)` on `π_n(X, x)` are the free homotopy classes.**
+Classes of two generalized loops based at `x` lie in the same orbit exactly when some homotopy
+connects the two loops through generalized loops, the base point sweeping out a loop at `x`. So
+the quotient of `π_n(X, x)` by the action is the set of free homotopy classes of maps
+`Sⁿ → X`.
+
+The two classes are given by representatives rather than written as `⟦f⟧` and `⟦g⟧` directly,
+because the type of `⟦f⟧` is the underlying quotient rather than `HomotopyGroup N X x`, which
+hides the action from instance search. -/
+theorem homotopyGroup_mem_orbit_iff_exists_homotopyAlong {a b : HomotopyGroup N X x}
+    {f g : Ω^ N X x}
+    (ha : a = ⟦f⟧) (hb : b = ⟦g⟧) :
+    b ∈ MulAction.orbit (FundamentalGroup X x) a ↔
+      ∃ γ : Path x x, Nonempty (GenLoop.HomotopyAlong γ f g) := by
+  rw [homotopyGroup_mem_orbit_iff,
+    GenLoop.exists_homotopyAlong_iff_exists_homotopic_transport]
+  refine exists_congr fun p => ?_
+  rw [ha, hb, homotopyGroupTransport_mk]
+  exact Quotient.eq
+
+/-- On a space with trivial fundamental group at `x` — a simply connected space, for instance —
+the action is trivial, so based and free homotopy classes of maps `Sⁿ → X` agree. -/
+theorem fundamentalGroup_smul_eq_self [Subsingleton (FundamentalGroup X x)]
+    (γ : FundamentalGroup X x) (a : HomotopyGroup N X x) : γ • a = a := by
+  rw [Subsingleton.elim γ 1, one_smul]
+
+end TauCeti

--- a/TauCeti/Topology/Homotopy/HomotopyGroup/FundamentalGroupAction.lean
+++ b/TauCeti/Topology/Homotopy/HomotopyGroup/FundamentalGroupAction.lean
@@ -5,9 +5,8 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.AlgebraicTopology.FundamentalGroupoid.SimplyConnected
+public import Mathlib.AlgebraicTopology.FundamentalGroupoid.FundamentalGroup
 public import TauCeti.Topology.Homotopy.HomotopyGroup.BasepointChange
-public import TauCeti.Topology.Homotopy.HomotopyGroup.Map
 
 /-!
 # The action of the fundamental group on the higher homotopy groups
@@ -185,6 +184,7 @@ theorem fundamentalGroupMulAut_apply [Nonempty N] [DecidableEq N] (γ : Fundamen
 
 /-- Postcomposition with a continuous map commutes with transport of homotopy classes, along
 the image class of paths. -/
+@[simp]
 theorem map_homotopyGroupTransportQuotient (F : C(X, Y)) (γ : Path.Homotopic.Quotient x x')
     (a : HomotopyGroup N X x) :
     _root_.HomotopyGroup.map F rfl (homotopyGroupTransportQuotient γ a) =
@@ -198,13 +198,14 @@ theorem map_homotopyGroupTransportQuotient (F : C(X, Y)) (γ : Path.Homotopic.Qu
 
 /-- **A based continuous map is equivariant** for the actions of the fundamental groups on
 source and target, along the homomorphism it induces on fundamental groups. -/
+@[simp]
 theorem map_fundamentalGroup_smul (F : C(X, Y)) (γ : FundamentalGroup X x)
     (a : HomotopyGroup N X x) :
     _root_.HomotopyGroup.map F rfl (γ • a) =
       FundamentalGroup.map F x γ • _root_.HomotopyGroup.map F rfl a := by
   rw [fundamentalGroup_smul_def, fundamentalGroup_smul_def,
     map_homotopyGroupTransportQuotient]
-  rfl
+  rw [FundamentalGroup.map_apply]
 
 /-! ### The orbits of the action -/
 
@@ -233,7 +234,7 @@ theorem exists_homotopyAlong_iff_exists_homotopic_transport (f g : Ω^ N X x) :
   · rintro ⟨γ, ⟨h⟩⟩
     exact ⟨γ, h.homotopic_transport.symm⟩
   · rintro ⟨p, hp⟩
-    obtain ⟨K⟩ := HomotopyAlong.nonempty_of_homotopic hp
+    obtain ⟨K⟩ := Nonempty.map HomotopyAlong.ofHomotopyRel hp
     exact ⟨p.trans (Path.refl x), ⟨(collarHomotopyAlong p f).trans K⟩⟩
 
 end GenLoop
@@ -260,6 +261,7 @@ theorem homotopyGroup_mem_orbit_iff_exists_homotopyAlong {a b : HomotopyGroup N 
 the action is trivial. Thus in positive dimensions based and free homotopy classes of maps
 `Sⁿ → X` landing in the path component of `x` agree; in dimension zero this uses the
 interpretation with the distinguished point restricted to the path component of `x`. -/
+@[simp]
 theorem fundamentalGroup_smul_eq_self [Subsingleton (FundamentalGroup X x)]
     (γ : FundamentalGroup X x) (a : HomotopyGroup N X x) : γ • a = a := by
   rw [Subsingleton.elim γ 1, one_smul]


### PR DESCRIPTION
This PR makes the fundamental group act on the higher homotopy groups at the same base point, and identifies the orbits of that action. Transporting a generalized loop along a path already gives `TauCeti.homotopyGroupMulEquivOfPath : π_n(X, x) ≃* π_n(X, y)`, depending only on the homotopy class of the path; taking `y = x` leaves that isomorphism behind as structure carried by a single homotopy group. The new module descends transport to `Path.Homotopic.Quotient` (`homotopyGroupTransportQuotient`), checks that the resulting operation of `FundamentalGroup X x` on `HomotopyGroup N X x` is a left action — the covariance of transport and `FundamentalGroup.mul_def : p * q = q.trans p` cancel, the same bookkeeping that makes Mathlib's monodromy action a left action, so no `ᵐᵒᵖ` is needed — and upgrades it in positive dimensions to a `MulDistribMulAction`, packaged as `fundamentalGroupMulAut : FundamentalGroup X x →* MulAut (HomotopyGroup N X x)`. This is the `π₁`-module structure on `π_n`.

Two results give the action content beyond its construction. `map_fundamentalGroup_smul` is naturality: a based continuous map is equivariant along the homomorphism it induces on fundamental groups, which rests on the new `GenLoop.map_transport` — postcomposition commutes with the collar construction, along the image path. And `homotopyGroup_mem_orbit_iff_exists_homotopyAlong` identifies the orbits: two generalized loops based at `x` have classes in the same orbit exactly when some homotopy connects them through generalized loops with the base point sweeping out a loop at `x`. So the quotient of `π_n(X, x)` by the action is the set of free homotopy classes of maps `Sⁿ → X`, and by `fundamentalGroup_smul_eq_self` the action is trivial when `π₁(X, x)` is — for instance on a simply connected space, where based and free homotopy classes therefore agree. The orbit statement factors through `GenLoop.exists_homotopyAlong_iff_exists_homotopic_transport`, which reads free homotopy as transport up to based homotopy, and through `homotopyGroup_mem_orbit_iff`, which reads orbit membership as transport; both are stated without quotients and are usable on their own.

The milestone is `TauCetiRoadmap/UniversalCovers/README.md`, Stage 3, item 9, the `π_n` API ("Mathlib's `HomotopyGroup` is thin here; this is the bulk of the work"), and specifically its base-point-change clause: five merged modules under `TauCeti/Topology/Homotopy/HomotopyGroup/` cite that item, and this PR adds the structure that base-point change leaves behind when the two base points coincide. After this PR the README asks for nothing further on Stage 3 — item 10, `p_* : π_n(X̃) ≅ π_n(X)` for `n ≥ 2`, is already proved in `HomotopyGroup/Covering.lean` — so what remains for higher homotopy on this roadmap is only the frontier that its own text places outside itself, computing `π_n(Sⁿ)`, which needs a degree or Hurewicz argument.

Two supporting changes land in the existing files. `GenLoop.HomotopyAlong.ofHomotopyRel` and `GenLoop.HomotopyAlong.nonempty_of_homotopic` are added to `Collar.lean`, beside the structure they build: a homotopy relative to the cube boundary is a homotopy along the constant path. `HomotopyAlong.refl` in `BasepointChange.lean` is then the constant homotopy fed through `ofHomotopyRel` rather than a second hand-built instance of the same structure. Both are stated without `[Fintype N]`, which the cube radius needs but the structure does not. No Mathlib proof is vendored.

The orbit theorem takes the two homotopy classes through representative hypotheses `a = ⟦f⟧`, `b = ⟦g⟧` rather than writing `⟦f⟧` and `⟦g⟧` inline: the inferred type of `⟦f⟧` is the underlying quotient rather than `HomotopyGroup N X x`, which hides the `MulAction` instance from instance search. The same reason is why `fundamentalGroup_smul_mk` is stated for an arbitrary class rather than for a class of generalized loops.

Roadmap: UniversalCovers

<!--tauceti-target:v1 {"focus":"UniversalCovers","id":"fundamental-group-action-on-homotopy-groups"}-->

🤖 Prepared with Claude Code
