### PR TITLE
feat: the padded vertex exposure of a sampled graph

### DIFF
--- a/TauCeti/Combinatorics/DenseGraphLimits/HomDensity/Oscillation.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/HomDensity/Oscillation.lean
@@ -1,0 +1,106 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import TauCeti.Combinatorics.DenseGraphLimits.HomDensity.Finite
+import Mathlib.Data.Fintype.BigOperators
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.Positivity
+
+/-!
+# Changing a host graph at one vertex
+
+If two host graphs on the same finite vertex set `W` agree on every pair of vertices avoiding a
+fixed vertex `w`, then their homomorphism densities of a pattern `F` differ by at most
+`|V(F)| / |W|`.
+
+A vertex map `V(F) → W` whose range avoids `w` preserves adjacency into one host exactly when it
+preserves adjacency into the other, so only the maps whose range meets `w` can change status.
+A union bound over the vertex of `F` sent to `w` counts at most `|V(F)| · |W| ^ (|V(F)| - 1)` such
+maps among the `|W| ^ |V(F)|` in total.
+
+This is the bounded-differences estimate for the ordinary homomorphism density: in a sampled
+graph where resampling one vertex only changes the pairs at that vertex, it bounds the effect of
+the resampling on the estimator.
+
+## Main results
+
+* `abs_homDensityFin_sub_le_of_adj_iff` — the oscillation bound above.
+
+## References
+
+* L. Lovász, *Large Networks and Graph Limits*, AMS Colloquium Publications 60 (2012), §10.1.
+-/
+
+public section
+
+open Finset
+
+namespace TauCeti
+
+namespace DenseGraphLimits
+
+variable {V W : Type*} [Fintype V] [Fintype W]
+
+/-- **Oscillation of the homomorphism density at one vertex.** If two host graphs agree on every
+pair of vertices avoiding `w`, the homomorphism densities of `F` in them differ by at most
+`|V(F)| / |W|`: only the vertex maps meeting `w` can distinguish the two hosts. -/
+theorem abs_homDensityFin_sub_le_of_adj_iff (F : SimpleGraph V) {G G' : SimpleGraph W} (w : W)
+    (h : ∀ a b, a ≠ w → b ≠ w → (G.Adj a b ↔ G'.Adj a b)) :
+    |homDensityFin F G - homDensityFin F G'| ≤ (Fintype.card V : ℝ) / Fintype.card W := by
+  classical
+  have hm : 0 < Fintype.card W := Fintype.card_pos_iff.mpr ⟨w⟩
+  set S : Finset (V → W) := univ.filter fun ψ => ∃ v, ψ v = w with hS
+  -- The adjacency-preserving vertex maps into a host `H`.
+  let P : SimpleGraph W → Finset (V → W) := fun H =>
+    univ.filter fun ψ => ∀ a b, F.Adj a b → H.Adj (ψ a) (ψ b)
+  have hcard : ∀ H : SimpleGraph W, Nat.card (F →g H) = #(P H) := by
+    intro H
+    rw [card_hom_eq_card_adjPreservingMaps, Nat.card_eq_fintype_card, Fintype.card_subtype]
+  -- The maps avoiding `w` preserve adjacency into `G` exactly when they do into `G'`.
+  have hsdiff : P G \ S = P G' \ S := by
+    ext ψ
+    simp only [P, hS, mem_sdiff, mem_filter, mem_univ, true_and, not_exists]
+    exact ⟨fun ⟨hψ, hw⟩ => ⟨fun a b hab => (h _ _ (hw a) (hw b)).mp (hψ a b hab), hw⟩,
+      fun ⟨hψ, hw⟩ => ⟨fun a b hab => (h _ _ (hw a) (hw b)).mpr (hψ a b hab), hw⟩⟩
+  have hG := card_sdiff_add_card_inter (P G) S
+  have hG' := card_sdiff_add_card_inter (P G') S
+  have hGS : #(P G ∩ S) ≤ #S := card_le_card inter_subset_right
+  have hG'S : #(P G' ∩ S) ≤ #S := card_le_card inter_subset_right
+  -- A union bound over the vertex sent to `w`: each fibre `{ψ | ψ v = w}` has
+  -- `|W| ^ (|V| - 1)` elements.
+  have hSle : #S ≤ Fintype.card V * Fintype.card W ^ (Fintype.card V - 1) := by
+    have hunion : S = univ.biUnion fun v : V => univ.filter fun ψ : V → W => ψ v = w := by
+      ext ψ
+      simp [hS]
+    rw [hunion]
+    refine card_biUnion_le.trans ?_
+    simp only [Fintype.card_filter_piFinset_const_eq_of_mem (univ : Finset W) _ (mem_univ w),
+      ← Fintype.piFinset_univ, sum_const, card_univ, smul_eq_mul, le_refl]
+  have hSbound : (#S : ℝ) * Fintype.card W ≤
+      Fintype.card V * Fintype.card W ^ Fintype.card V := by
+    have hSnat : #S * Fintype.card W ≤ Fintype.card V * Fintype.card W ^ Fintype.card V := by
+      refine (Nat.mul_le_mul_right _ hSle).trans_eq ?_
+      rcases Nat.eq_zero_or_eq_succ_pred (Fintype.card V) with h | h
+      · simp [h]
+      · rw [h, Nat.succ_sub_one, pow_succ, mul_assoc]
+    exact_mod_cast hSnat
+  have hpow : (0 : ℝ) < (Fintype.card W : ℝ) ^ Fintype.card V := by positivity
+  have hmR : (0 : ℝ) < Fintype.card W := by exact_mod_cast hm
+  rw [homDensityFin_def, homDensityFin_def, hcard, hcard, ← hG, ← hG', hsdiff, ← sub_div,
+    abs_div, abs_of_pos hpow, div_le_div_iff₀ hpow hmR]
+  push_cast
+  have habs : |(#(P G' \ S) + #(P G ∩ S) : ℝ) - (#(P G' \ S) + #(P G' ∩ S))| ≤ #S := by
+    rw [add_sub_add_left_eq_sub, abs_le]
+    constructor <;> linarith [(Nat.cast_le (α := ℝ)).mpr hGS, (Nat.cast_le (α := ℝ)).mpr hG'S,
+      (Nat.cast_nonneg (α := ℝ) #(P G ∩ S)), (Nat.cast_nonneg (α := ℝ) #(P G' ∩ S))]
+  calc |(#(P G' \ S) + #(P G ∩ S) : ℝ) - (#(P G' \ S) + #(P G' ∩ S))| * Fintype.card W
+      ≤ #S * Fintype.card W := mul_le_mul_of_nonneg_right habs hmR.le
+    _ ≤ Fintype.card V * Fintype.card W ^ Fintype.card V := hSbound
+
+end DenseGraphLimits
+
+end TauCeti

--- a/TauCeti/Combinatorics/DenseGraphLimits/HomDensity/Oscillation.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/HomDensity/Oscillation.lean
@@ -28,7 +28,7 @@ the resampling on the estimator.
 
 ## Main results
 
-* `abs_homDensityFin_sub_le_of_adj_iff` — the oscillation bound above.
+* `SimpleGraph.abs_homDensityFin_sub_le_of_adj_iff` — the oscillation bound above.
 
 ## References
 
@@ -39,9 +39,9 @@ public section
 
 open Finset
 
-namespace TauCeti
+namespace SimpleGraph
 
-namespace DenseGraphLimits
+open TauCeti.DenseGraphLimits
 
 variable {V W : Type*} [Fintype V] [Fintype W]
 
@@ -101,6 +101,4 @@ theorem abs_homDensityFin_sub_le_of_adj_iff (F : SimpleGraph V) {G G' : SimpleGr
       ≤ #S * Fintype.card W := mul_le_mul_of_nonneg_right habs hmR.le
     _ ≤ Fintype.card V * Fintype.card W ^ Fintype.card V := hSbound
 
-end DenseGraphLimits
-
-end TauCeti
+end SimpleGraph

--- a/TauCeti/Combinatorics/DenseGraphLimits/Sampling/Exposure.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/Sampling/Exposure.lean
@@ -136,7 +136,6 @@ theorem measurable_exposedSample (W : Graphon Ω μ) :
 
 /-- Updating the coordinate of the vertex `i` leaves every pair avoiding `i` unchanged: such a pair
 reads its positions and its coin from vertices other than `i`. -/
-@[simp]
 theorem exposedSample_update_adj_iff (W : Graphon Ω μ) (x : Fin n → Ω × (Fin n → ℝ)) (i : Fin n)
     (y : Ω × (Fin n → ℝ)) {a b : Fin n} (ha : a ≠ i) (hb : b ≠ i) :
     (exposedSample W (Function.update x i y)).Adj a b ↔ (exposedSample W x).Adj a b := by

--- a/TauCeti/Combinatorics/DenseGraphLimits/Sampling/Exposure.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/Sampling/Exposure.lean
@@ -1,0 +1,285 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import TauCeti.Combinatorics.DenseGraphLimits.Sampling.Finite
+public import TauCeti.Combinatorics.DenseGraphLimits.HomDensity.Oscillation
+public import TauCeti.Probability.Distributions.Uniform
+public import TauCeti.Combinatorics.SimpleGraph.Measurable
+
+/-!
+# The padded vertex exposure of a sampled graph
+
+The finite sampling law `sampleGraph W n` is defined by its masses, so it does not present the
+sampled graph as a function of independent coordinates. A bounded-differences inequality needs
+exactly such a presentation: a product of independent coordinates, together with a bound on how
+much the estimator moves when one coordinate changes. Changing one sampled vertex position alone
+is not such a coordinate, because the edges at that vertex also carry their own independent
+randomness.
+
+The *padded exposure* supplies the product structure. Each of the `n` vertices carries its
+position in the graphon's carrier together with a full row of `n` independent uniform coins, and
+the exposure source is the `n`-fold product of these vertex coordinates. The edge `{i, j}` reads
+its coin from one designated row: row `max i j`, column `min i j`, and it is present when that coin
+falls below the graphon value at the two positions. Every coin of a row above the diagonal is
+padding that no edge reads. Since every edge reads a coin carried by one of its endpoints,
+changing the coordinate of one vertex changes only the pairs at that vertex.
+
+The two results of the file make this a genuine representation of `G(n, W)`:
+
+* the law identification: the exposure source pushed through the exposed graph is the finite
+  sampling law. At fixed positions the event that the exposed graph is a prescribed pattern is a
+  box in the coins, whose uniform product is the conditional mass `sampleIntegrand W H`;
+* the oscillation bound: changing one vertex coordinate moves the ordinary homomorphism density
+  of the exposed graph by at most `|V(F)| / n`.
+
+## Main definitions
+
+* `TauCeti.DenseGraphLimits.exposureMeasure` — the product source of positions and coin rows;
+* `TauCeti.DenseGraphLimits.exposedSample` — the graph read off an exposure.
+
+## Main results
+
+* `exposedSample_adj` — the designated-row rule for the edges;
+* `map_exposedSample` — the exposure source induces the finite sampling law;
+* `exposedSample_update_adj_iff` — updating one vertex coordinate only changes pairs at it;
+* `abs_homDensityFin_exposedSample_update_le` — the bounded-differences estimate.
+
+## References
+
+* L. Lovász, *Large Networks and Graph Limits*, AMS Colloquium Publications 60 (2012), §10.1.
+* C. Freer, `cameronfreer/graphon` at commit
+  `6eccca5bbe5c9df46d7129bf59575b8b9b1d6699`, Apache-2.0, `Graphon/SampleExposure.lean`. The
+  padded exposure source, the designated-row convention, the law identification and the `q / n`
+  oscillation bound are formalized there. The construction here is adapted to Tau Ceti's strict
+  graphon carrier and uses the uniform coin `TauCeti.Probability.uniformMeasure 0 1` and the strict
+  comparison of the joint sampler `infiniteSampleLaw`; the law identification evaluates the mass of
+  a single pattern as a box of coin intervals, and the oscillation bound is derived from a
+  host-graph statement, `abs_homDensityFin_sub_le_of_adj_iff`.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory
+
+open scoped ENNReal
+
+namespace TauCeti
+
+namespace DenseGraphLimits
+
+variable {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω} [IsProbabilityMeasure μ]
+
+section Source
+
+variable (μ) in
+/-- The **exposure source** of the `n`-vertex sampled graph: `n` independent vertex coordinates,
+each a position drawn from `μ` together with a row of `n` independent uniform coins on the unit
+interval. -/
+def exposureMeasure (n : ℕ) : Measure (Fin n → Ω × (Fin n → ℝ)) :=
+  Measure.pi fun _ : Fin n => μ.prod (Measure.pi fun _ : Fin n => Probability.uniformMeasure 0 1)
+
+omit [IsProbabilityMeasure μ] in
+variable (μ) in
+/-- The defining product of the exposure source. -/
+theorem exposureMeasure_def (n : ℕ) :
+    exposureMeasure μ n =
+      Measure.pi fun _ : Fin n =>
+        μ.prod (Measure.pi fun _ : Fin n => Probability.uniformMeasure 0 1) := (rfl)
+
+instance exposureMeasure_isProbabilityMeasure (n : ℕ) :
+    IsProbabilityMeasure (exposureMeasure μ n) := by
+  rw [exposureMeasure_def]
+  infer_instance
+
+end Source
+
+section Graph
+
+variable {n : ℕ}
+
+/-- The **exposed sampled graph**: the pair `{i, j}` is an edge exactly when the coin in row
+`max i j`, column `min i j` falls below the graphon value at the two positions. Every edge reads a
+coin carried by one of its endpoints, so changing one vertex coordinate changes only the pairs at
+that vertex. -/
+def exposedSample (W : Graphon Ω μ) (x : Fin n → Ω × (Fin n → ℝ)) : SimpleGraph (Fin n) where
+  Adj i j := i ≠ j ∧ (x (max i j)).2 (min i j) < W (x i).1 (x j).1
+  symm := ⟨fun i j h => ⟨h.1.symm, by rw [max_comm, min_comm, W.symm]; exact h.2⟩⟩
+  loopless := ⟨fun _ h => h.1 rfl⟩
+
+/-- **The designated-row rule.** The edge `{i, j}` of the exposed graph is present exactly when the
+coin in row `max i j`, column `min i j` falls below the graphon value at the two positions. -/
+@[simp]
+theorem exposedSample_adj (W : Graphon Ω μ) (x : Fin n → Ω × (Fin n → ℝ)) (i j : Fin n) :
+    (exposedSample W x).Adj i j ↔ i ≠ j ∧ (x (max i j)).2 (min i j) < W (x i).1 (x j).1 :=
+  Iff.rfl
+
+/-- The exposed graph depends measurably on the exposure. -/
+theorem measurable_exposedSample (W : Graphon Ω μ) :
+    Measurable (exposedSample (n := n) W) := by
+  rw [SimpleGraph.measurable_iff_adj]
+  intro i j
+  refine measurableSet_setOfPred.mp ?_
+  by_cases hij : i = j
+  · simp [hij]
+  · have hcoin : Measurable fun x : Fin n → Ω × (Fin n → ℝ) => (x (max i j)).2 (min i j) :=
+      (measurable_pi_apply _).comp (measurable_snd.comp (measurable_pi_apply _))
+    have hvalue : Measurable fun x : Fin n → Ω × (Fin n → ℝ) => W (x i).1 (x j).1 :=
+      W.measurable.comp ((measurable_fst.comp (measurable_pi_apply _)).prodMk
+        (measurable_fst.comp (measurable_pi_apply _)))
+    simpa [hij] using measurableSet_lt hcoin hvalue
+
+/-- Updating the coordinate of the vertex `i` leaves every pair avoiding `i` unchanged: such a pair
+reads its positions and its coin from vertices other than `i`. -/
+theorem exposedSample_update_adj_iff (W : Graphon Ω μ) (x : Fin n → Ω × (Fin n → ℝ)) (i : Fin n)
+    (y : Ω × (Fin n → ℝ)) {a b : Fin n} (ha : a ≠ i) (hb : b ≠ i) :
+    (exposedSample W (Function.update x i y)).Adj a b ↔ (exposedSample W x).Adj a b := by
+  have hmax : max a b ≠ i := by
+    rcases max_choice a b with h | h <;> rw [h] <;> assumption
+  simp only [exposedSample_adj, Function.update_of_ne ha, Function.update_of_ne hb,
+    Function.update_of_ne hmax]
+
+end Graph
+
+section Law
+
+variable {n : ℕ}
+
+open Classical in
+/-- The coins that make the exposed graph equal to the pattern `H` at the pair read from row `r`,
+column `s`. Only the coins below the diagonal are read; the others are padding and unconstrained. -/
+private def coinBox (W : Graphon Ω μ) (y : Fin n → Ω) (H : SimpleGraph (Fin n)) (r s : Fin n) :
+    Set ℝ :=
+  if s < r then {t | t < W (y r) (y s) ↔ H.Adj r s} else Set.univ
+
+/-- At fixed positions, the exposed graph is the pattern `H` exactly when every coin lies in its
+box. -/
+private theorem setOfPred_exposedSample_eq (W : Graphon Ω μ) (y : Fin n → Ω)
+    (H : SimpleGraph (Fin n)) :
+    {c : Fin n → Fin n → ℝ | exposedSample W (fun i => (y i, c i)) = H} =
+      Set.univ.pi fun r => Set.univ.pi fun s => coinBox W y H r s := by
+  ext c
+  simp only [Set.mem_ofPred_eq, Set.mem_univ_pi, coinBox]
+  constructor
+  · rintro rfl r s
+    split_ifs with hsr
+    · simp [hsr.ne', max_eq_left hsr.le, min_eq_right hsr.le]
+    · trivial
+  · intro h
+    ext a b
+    simp only [exposedSample_adj]
+    rcases lt_trichotomy a b with hab | rfl | hab
+    · have hba := h b a
+      simp only [hab, ↓reduceIte] at hba
+      rw [max_eq_right hab.le, min_eq_left hab.le, W.symm, H.adj_comm]
+      simpa [hab.ne] using hba
+    · simp
+    · have hab' := h a b
+      simp only [hab, ↓reduceIte] at hab'
+      rw [max_eq_left hab.le, min_eq_right hab.le]
+      simpa [hab.ne'] using hab'
+
+open Classical in
+/-- The uniform product of the coin boxes is the conditional mass of the pattern at the positions:
+the boxes below the diagonal correspond to the pairs of `Fin n`, each contributing the graphon
+value or its complement, and the padding boxes contribute `1`. -/
+private theorem pi_pi_coinBox (W : Graphon Ω μ) (y : Fin n → Ω) (H : SimpleGraph (Fin n)) :
+    (Measure.pi fun _ : Fin n => Measure.pi fun _ : Fin n => Probability.uniformMeasure 0 1)
+        (Set.univ.pi fun r => Set.univ.pi fun s => coinBox W y H r s) =
+      ENNReal.ofReal (sampleIntegrand W H y) := by
+  set g : Sym2 (Fin n) → ℝ := fun e =>
+    if e ∈ H.edgeFinset then edgeFactor W y e else 1 - edgeFactor W y e with hg
+  have hbox : ∀ r s, Probability.uniformMeasure 0 1 (coinBox W y H r s) =
+      if s < r then ENNReal.ofReal (g s(r, s)) else 1 := by
+    intro r s
+    rw [coinBox]
+    split_ifs with hsr
+    · by_cases hrs : H.Adj r s
+      · have hset : {t : ℝ | t < W (y r) (y s) ↔ H.Adj r s} = Set.Iio (W (y r) (y s)) := by
+          ext t
+          simp [hrs]
+        rw [hset, Probability.uniformMeasure_Iio zero_lt_one (W.le_one _ _)]
+        simp [hg, SimpleGraph.mem_edgeFinset, hrs]
+      · have hset : {t : ℝ | t < W (y r) (y s) ↔ H.Adj r s} = Set.Ici (W (y r) (y s)) := by
+          ext t
+          simp [hrs, not_lt]
+        rw [hset, Probability.uniformMeasure_Ici zero_lt_one (W.nonneg _ _)]
+        simp [hg, SimpleGraph.mem_edgeFinset, hrs]
+    · exact measure_univ
+  have hnonneg : ∀ e ∈ (⊤ : SimpleGraph (Fin n)).edgeFinset, 0 ≤ g e := by
+    intro e _
+    have h₀ := edgeFactor_nonneg W y e
+    have h₁ := edgeFactor_le_one W y e
+    simp only [hg]
+    split_ifs <;> linarith
+  simp_rw [Measure.pi_pi, hbox]
+  rw [sampleIntegrand_eq_prod_edgeFinset_top, ENNReal.ofReal_prod_of_nonneg hnonneg,
+    ← Finset.prod_product' (s := Finset.univ) (t := Finset.univ)
+      (f := fun r s => if s < r then ENNReal.ofReal (g s(r, s)) else 1),
+    ← Finset.prod_filter]
+  refine Finset.prod_nbij (fun p => s(p.1, p.2)) ?_ ?_ ?_ ?_
+  · intro p hp
+    simpa using (Finset.mem_filter.mp hp).2.ne'
+  · intro p hp q hq hpq
+    have hp' := (Finset.mem_filter.mp hp).2
+    have hq' := (Finset.mem_filter.mp hq).2
+    rcases Sym2.eq_iff.mp hpq with ⟨h₁, h₂⟩ | ⟨h₁, h₂⟩
+    · exact Prod.ext h₁ h₂
+    · exact absurd (hp'.trans (h₂ ▸ h₁ ▸ hq')) (lt_irrefl _)
+  · intro e he
+    induction e using Sym2.ind with
+    | _ a b =>
+      have hab : a ≠ b := by simpa using he
+      rcases hab.lt_or_gt with h | h
+      · exact ⟨(b, a), by simp [h], Sym2.eq_swap⟩
+      · exact ⟨(a, b), by simp [h], rfl⟩
+  · intro p _
+    rfl
+
+/-- **The law identification of the exposure.** Pushing the exposure source through the exposed
+graph gives the finite sampling law `G(n, W)`: the exposure is a representation of the sampled
+graph by independent vertex coordinates. -/
+theorem map_exposedSample (W : Graphon Ω μ) (n : ℕ) :
+    (exposureMeasure μ n).map (exposedSample W) = sampleGraph W n := by
+  refine Measure.ext_of_singleton fun H => ?_
+  set ν : Measure (Fin n → ℝ) := Measure.pi fun _ : Fin n => Probability.uniformMeasure 0 1
+  have hmp := measurePreserving_arrowProdEquivProdArrow Ω (Fin n → ℝ) (Fin n) (fun _ => μ)
+    (fun _ => ν)
+  have hfiber : MeasurableSet (exposedSample (n := n) W ⁻¹' {H}) :=
+    measurable_exposedSample W (measurableSet_singleton H)
+  rw [Measure.map_apply (measurable_exposedSample W) (measurableSet_singleton H),
+    exposureMeasure_def, ← hmp.symm.measure_preimage_equiv,
+    Measure.prod_apply (hfiber.preimage (by fun_prop)), sampleGraph_singleton]
+  have hslice : ∀ y : Fin n → Ω,
+      Prod.mk y ⁻¹' ((MeasurableEquiv.arrowProdEquivProdArrow Ω (Fin n → ℝ) (Fin n)).symm ⁻¹'
+        (exposedSample W ⁻¹' {H})) =
+      {c : Fin n → Fin n → ℝ | exposedSample W (fun i => (y i, c i)) = H} := fun _ => rfl
+  simp_rw [hslice, setOfPred_exposedSample_eq, ν, pi_pi_coinBox]
+  rw [← ofReal_integral_eq_lintegral_ofReal (integrable_sampleIntegrand W H)
+      (Filter.Eventually.of_forall (sampleIntegrand_nonneg W H)), sampleMass_def]
+
+end Law
+
+section Oscillation
+
+variable {V : Type*} [Fintype V]
+
+/-- **The bounded-differences estimate of the exposure.** Changing the coordinate of one exposed
+vertex moves the ordinary homomorphism density of the exposed graph by at most `|V(F)| / n`. -/
+theorem abs_homDensityFin_exposedSample_update_le (F : SimpleGraph V) (W : Graphon Ω μ) {n : ℕ}
+    (x : Fin n → Ω × (Fin n → ℝ)) (i : Fin n) (y : Ω × (Fin n → ℝ)) :
+    |homDensityFin F (exposedSample W (Function.update x i y)) -
+        homDensityFin F (exposedSample W x)| ≤ (Fintype.card V : ℝ) / n := by
+  simpa using abs_homDensityFin_sub_le_of_adj_iff F i
+    fun a b ha hb => exposedSample_update_adj_iff W x i y ha hb
+
+end Oscillation
+
+end DenseGraphLimits
+
+end TauCeti

--- a/TauCeti/Combinatorics/DenseGraphLimits/Sampling/Exposure.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/Sampling/Exposure.lean
@@ -24,7 +24,7 @@ The *padded exposure* supplies the product structure. Each of the `n` vertices c
 position in the graphon's carrier together with a full row of `n` independent uniform coins, and
 the exposure source is the `n`-fold product of these vertex coordinates. The edge `{i, j}` reads
 its coin from one designated row: row `max i j`, column `min i j`, and it is present when that coin
-falls below the graphon value at the two positions. Every coin of a row above the diagonal is
+falls below the graphon value at the two positions. Every coin on or above the diagonal is
 padding that no edge reads. Since every edge reads a coin carried by one of its endpoints,
 changing the coordinate of one vertex changes only the pairs at that vertex.
 
@@ -58,7 +58,7 @@ The two results of the file make this a genuine representation of `G(n, W)`:
   graphon carrier and uses the uniform coin `TauCeti.Probability.uniformMeasure 0 1` and the strict
   comparison of the joint sampler `infiniteSampleLaw`; the law identification evaluates the mass of
   a single pattern as a box of coin intervals, and the oscillation bound is derived from a
-  host-graph statement, `abs_homDensityFin_sub_le_of_adj_iff`.
+  host-graph statement, `SimpleGraph.abs_homDensityFin_sub_le_of_adj_iff`.
 -/
 
 public section
@@ -136,6 +136,7 @@ theorem measurable_exposedSample (W : Graphon Ω μ) :
 
 /-- Updating the coordinate of the vertex `i` leaves every pair avoiding `i` unchanged: such a pair
 reads its positions and its coin from vertices other than `i`. -/
+@[simp]
 theorem exposedSample_update_adj_iff (W : Graphon Ω μ) (x : Fin n → Ω × (Fin n → ℝ)) (i : Fin n)
     (y : Ω × (Fin n → ℝ)) {a b : Fin n} (ha : a ≠ i) (hb : b ≠ i) :
     (exposedSample W (Function.update x i y)).Adj a b ↔ (exposedSample W x).Adj a b := by
@@ -244,6 +245,7 @@ private theorem pi_pi_coinBox (W : Graphon Ω μ) (y : Fin n → Ω) (H : Simple
 /-- **The law identification of the exposure.** Pushing the exposure source through the exposed
 graph gives the finite sampling law `G(n, W)`: the exposure is a representation of the sampled
 graph by independent vertex coordinates. -/
+@[simp]
 theorem map_exposedSample (W : Graphon Ω μ) (n : ℕ) :
     (exposureMeasure μ n).map (exposedSample W) = sampleGraph W n := by
   refine Measure.ext_of_singleton fun H => ?_
@@ -275,7 +277,7 @@ theorem abs_homDensityFin_exposedSample_update_le (F : SimpleGraph V) (W : Graph
     (x : Fin n → Ω × (Fin n → ℝ)) (i : Fin n) (y : Ω × (Fin n → ℝ)) :
     |homDensityFin F (exposedSample W (Function.update x i y)) -
         homDensityFin F (exposedSample W x)| ≤ (Fintype.card V : ℝ) / n := by
-  simpa using abs_homDensityFin_sub_le_of_adj_iff F i
+  simpa using F.abs_homDensityFin_sub_le_of_adj_iff i
     fun a b ha hb => exposedSample_update_adj_iff W x i y ha hb
 
 end Oscillation


### PR DESCRIPTION
This PR adds the padded vertex exposure of the `W`-random graph, the product source that the Layer-9c concentration engine of the DenseGraphLimits roadmap runs on. It targets the exposure items of `DenseGraphLimits/README.md`, Layer 9c, "The concentration engine (padded vertex exposure)": `exposureMeasure`, `exposedSample`, the law identification `map_exposedSample`, and the oscillation bound `abs_homDensityFin_exposedSample_update_le`. The signatures in `DenseGraphLimits/Suggested.lean` pin these same items.

Roadmap: DenseGraphLimits

`TauCeti/Combinatorics/DenseGraphLimits/Sampling/Exposure.lean` defines `exposureMeasure μ n`. It is the `n`-fold product over vertices of a `μ`-position and a row of `n` independent uniform coins, and it carries a probability instance. `exposedSample W x` joins `{i, j}` when the coin in row `max i j`, column `min i j` falls below `W` at the two positions. The file proves:
- `exposedSample_adj`, the designated-row rule;
- `measurable_exposedSample`;
- `map_exposedSample`, which says `(exposureMeasure μ n).map (exposedSample W) = sampleGraph W n`. At fixed positions, the event that the graph is a given pattern is a box of coin intervals, and its uniform mass is `sampleIntegrand W H`;
- `exposedSample_update_adj_iff`, which says that changing one vertex coordinate changes only the pairs at that vertex;
- `abs_homDensityFin_exposedSample_update_le`, the `|V(F)| / n` bounded-differences estimate. It uses the ordinary hom density, as the README requires.

The oscillation bound comes from a general host-graph statement in `TauCeti/Combinatorics/DenseGraphLimits/HomDensity/Oscillation.lean`. `abs_homDensityFin_sub_le_of_adj_iff` says that if two hosts agree on every pair avoiding a vertex `w`, their hom densities of `F` differ by at most `|V(F)| / |W|`. The proof is a union bound over the vertex maps that meet `w`.

Some choices differ from `Suggested.lean`:
- The coins use Tau Ceti's existing `Probability.uniformMeasure 0 1` with a strict comparison, the same convention as the joint sampler `infiniteSampleLaw`. `Suggested.lean` uses `volume.restrict (Icc 0 1)` with `≤`.
- `n` is implicit in `exposedSample`, since the exposure determines it.
- The oscillation bound drops the unused `0 < n`, `DecidableEq V` and `DecidableRel F.Adj` hypotheses. Having `i : Fin n` already forces `n > 0`.

On ordering: Layer 9c consumes only the Layer-9a objects, which are merged (`sampleGraph`, `sampleIntegrand`, `homDensityFin`, `infiniteSampleLaw`), and the Layer-6b equivalence. The README states that Layer 9c is independent of Layers 9b and 8b. Only the final almost-sure upgrade needs Layer 6b. The exposure engine itself does not.

After this PR, the milestone `infiniteSampleLaw_ae_tendsto_cutDist` still needs McDiarmid's inequality on the exposure source (`sampleGraph_homDensityFin_concentration`, then `tsum_sampleGraph_homDensityFin_tail_ne_top` and Borel–Cantelli), and then the Layer-6b convergence equivalence.

Attribution: the padded exposure architecture, the designated-row convention, the law identification and the `q/n` oscillation bound follow `cameronfreer/graphon` at commit `6eccca5` (`Graphon/SampleExposure.lean`, Apache-2.0), as named in the roadmap. That source is credited in the module docstring. The mathematics is Lovász, *Large Networks and Graph Limits*, §10.1. This PR vendors no Mathlib material.

<!--tauceti-target:v1 {"focus":"DenseGraphLimits","id":"exposedsample"}-->

🤖 Prepared with Claude Code
