### PR TITLE
feat: compactly supported Sobolev functions have zero boundary values

### DIFF
--- a/TauCeti/Analysis/Sobolev/CompactSupport.lean
+++ b/TauCeti/Analysis/Sobolev/CompactSupport.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.Analysis.Calculus.BumpFunction.Cutoff
 public import TauCeti.Analysis.Sobolev.WeakDeriv
+import TauCeti.MeasureTheory.Integral.Bochner.Basic
 
 /-!
 # Extending a compactly supported weak derivative across the boundary
@@ -38,9 +39,8 @@ needs a Lipschitz boundary.
 
 ## References
 
-Lane A.2 of `TauCetiRoadmap/PDE/README.md`; L. C. Evans, *Partial Differential Equations*,
-§5.3.3, and H. Brezis, *Functional Analysis, Sobolev Spaces and Partial Differential Equations*,
-Lemma 9.5.
+L. C. Evans, *Partial Differential Equations*, §5.3.3, and H. Brezis, *Functional Analysis,
+Sobolev Spaces and Partial Differential Equations*, Lemma 9.5.
 -/
 
 public section
@@ -54,23 +54,6 @@ namespace TauCeti
 variable {E F : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [FiniteDimensional ℝ E]
   [MeasurableSpace E] [OpensMeasurableSpace E] [NormedAddCommGroup F] [NormedSpace ℝ F]
   {mu : Measure E} {Omega : Opens E} {u u' : E → F} {v : E} {K : Set E}
-
-omit [FiniteDimensional ℝ E] [NormedSpace ℝ E] [NormedSpace ℝ F] in
-/-- A function locally integrable on `Ω` and vanishing almost everywhere on `Ω` off a compact
-`K ⊆ Ω` is, after extension by zero, integrable on the whole space. -/
-private theorem integrable_indicator_of_isCompact (hK : IsCompact K) (hKO : K ⊆ Omega)
-    (hloc : LocallyIntegrableOn u Omega mu)
-    (hu : ∀ᵐ x ∂mu.restrict Omega, x ∉ K → u x = 0) :
-    Integrable ((Omega : Set E).indicator u) mu := by
-  have hae : (Omega : Set E).indicator u =ᵐ[mu] K.indicator u := by
-    filter_upwards [(ae_restrict_iff' Omega.isOpen.measurableSet).1 hu] with x hx
-    by_cases hxO : x ∈ (Omega : Set E)
-    · by_cases hxK : x ∈ K
-      · rw [indicator_of_mem hxO, indicator_of_mem hxK]
-      · rw [indicator_of_mem hxO, indicator_of_notMem hxK, hx hxO hxK]
-    · rw [indicator_of_notMem hxO, indicator_of_notMem fun hxK => hxO (hKO hxK)]
-  exact ((hloc.integrableOn_compact_subset hKO hK).integrable_indicator
-    hK.isClosed.measurableSet).congr hae.symm
 
 /-- **Extension by zero of a compactly supported weak directional derivative.**  If `u'` is a
 weak derivative of `u` in the direction `v` on `Ω`, and both vanish almost everywhere on `Ω`
@@ -105,9 +88,11 @@ theorem HasWeakLineDerivOn.indicator_of_isCompact (h : HasWeakLineDerivOn mu Ome
   have hu'O := (ae_restrict_iff' Omega.isOpen.measurableSet).1 hu'
   rw [hasWeakLineDerivOn_iff_testFunction]
   refine ⟨‹CompleteSpace F›,
-    (integrable_indicator_of_isCompact hK hKO h.locallyIntegrableOn hu).locallyIntegrable
+    (TauCeti.MeasureTheory.integrable_indicator_of_isCompact hK hKO h.locallyIntegrableOn hu)
+      |>.locallyIntegrable
       |>.locallyIntegrableOn _,
-    (integrable_indicator_of_isCompact hK hKO h.locallyIntegrableOn_deriv hu').locallyIntegrable
+    (TauCeti.MeasureTheory.integrable_indicator_of_isCompact hK hKO h.locallyIntegrableOn_deriv hu')
+      |>.locallyIntegrable
       |>.locallyIntegrableOn _, fun phi => ?_⟩
   -- `χ φ` is a test function on `Ω`
   obtain ⟨Phi, hPhi⟩ : ∃ Phi : 𝓓(Omega, ℝ), (Phi : E → ℝ) = chi * (phi : E → ℝ) :=

--- a/TauCeti/Analysis/Sobolev/CompactSupport.lean
+++ b/TauCeti/Analysis/Sobolev/CompactSupport.lean
@@ -1,0 +1,177 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.Calculus.BumpFunction.Cutoff
+public import TauCeti.Analysis.Sobolev.WeakDeriv
+
+/-!
+# Extending a compactly supported weak derivative across the boundary
+
+Extending a weakly differentiable function by zero across `∂Ω` destroys weak differentiability in
+general: the jump along the boundary contributes a singular term that no locally integrable
+function represents.  This file proves that the obstruction is entirely a boundary phenomenon.
+If `u` and its weak derivative vanish almost everywhere outside a **compact** `K ⊆ Ω`, then the
+extension of `u` by zero is weakly differentiable on the whole space, with the zero-extension of
+the weak derivative as its derivative.
+
+## The argument
+
+Test the extension against a test function `φ` on the whole space.  A smooth cutoff `χ` equal to
+`1` on a neighbourhood of `K` and compactly supported inside `Ω`
+(`IsCompact.exists_contDiff_cutoff`) turns `χ φ` into a test function *on `Ω`*, to which the
+hypothesis applies.  The product rule replaces `∂_v (χ φ)` by `χ ∂_v φ + (∂_v χ) φ`, and both
+correction terms vanish where they are paired with `u`: off `K` because `u` does, and on `K`
+because `χ` is constant there.  What is left is the defining identity for the extension.
+
+Nothing is assumed about `∂Ω`; the compact support is what replaces boundary regularity.  The
+same statement for a general `u ∈ W^{1,p}(Ω)` is false, and the extension theorem that repairs it
+needs a Lipschitz boundary.
+
+## Main declarations
+
+* `TauCeti.HasWeakLineDerivOn.indicator_of_isCompact`: the directional statement.
+* `TauCeti.HasWeakFDerivOn.indicator_of_isCompact`: its Fréchet form.
+
+## References
+
+Lane A.2 of `TauCetiRoadmap/PDE/README.md`; L. C. Evans, *Partial Differential Equations*,
+§5.3.3, and H. Brezis, *Functional Analysis, Sobolev Spaces and Partial Differential Equations*,
+Lemma 9.5.
+-/
+
+public section
+
+open MeasureTheory Set TopologicalSpace
+
+open scoped ContDiff Distributions
+
+namespace TauCeti
+
+variable {E F : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [FiniteDimensional ℝ E]
+  [MeasurableSpace E] [OpensMeasurableSpace E] [NormedAddCommGroup F] [NormedSpace ℝ F]
+  {mu : Measure E} {Omega : Opens E} {u u' : E → F} {v : E} {K : Set E}
+
+omit [FiniteDimensional ℝ E] [NormedSpace ℝ E] [NormedSpace ℝ F] in
+/-- A function locally integrable on `Ω` and vanishing almost everywhere on `Ω` off a compact
+`K ⊆ Ω` is, after extension by zero, integrable on the whole space. -/
+private theorem integrable_indicator_of_isCompact (hK : IsCompact K) (hKO : K ⊆ Omega)
+    (hloc : LocallyIntegrableOn u Omega mu)
+    (hu : ∀ᵐ x ∂mu.restrict Omega, x ∉ K → u x = 0) :
+    Integrable ((Omega : Set E).indicator u) mu := by
+  have hae : (Omega : Set E).indicator u =ᵐ[mu] K.indicator u := by
+    filter_upwards [(ae_restrict_iff' Omega.isOpen.measurableSet).1 hu] with x hx
+    by_cases hxO : x ∈ (Omega : Set E)
+    · by_cases hxK : x ∈ K
+      · rw [indicator_of_mem hxO, indicator_of_mem hxK]
+      · rw [indicator_of_mem hxO, indicator_of_notMem hxK, hx hxO hxK]
+    · rw [indicator_of_notMem hxO, indicator_of_notMem fun hxK => hxO (hKO hxK)]
+  exact ((hloc.integrableOn_compact_subset hKO hK).integrable_indicator
+    hK.isClosed.measurableSet).congr hae.symm
+
+/-- **Extension by zero of a compactly supported weak directional derivative.**  If `u'` is a
+weak derivative of `u` in the direction `v` on `Ω`, and both vanish almost everywhere on `Ω`
+outside a compact `K ⊆ Ω`, then the zero-extension of `u'` is a weak derivative of the
+zero-extension of `u` on the whole space.
+
+No regularity of `∂Ω` is used: the cutoff isolating `K` from `∂Ω` is what makes the extension
+weakly differentiable, and it exists for every open `Ω`. -/
+theorem HasWeakLineDerivOn.indicator_of_isCompact (h : HasWeakLineDerivOn mu Omega u u' v)
+    (hK : IsCompact K) (hKO : K ⊆ Omega)
+    (hu : ∀ᵐ x ∂mu.restrict Omega, x ∉ K → u x = 0)
+    (hu' : ∀ᵐ x ∂mu.restrict Omega, x ∉ K → u' x = 0) :
+    HasWeakLineDerivOn mu ⊤ ((Omega : Set E).indicator u) ((Omega : Set E).indicator u') v := by
+  have _ := h.completeSpace
+  obtain ⟨chi, hchi, -, hchi_one_nhds, hchi_cpt, hchi_tsupport⟩ :=
+    hK.exists_contDiff_cutoff Omega.isOpen hKO
+  -- the cutoff is constant near `K`, so it is one there and its derivative vanishes there
+  have hchi_nhds : ∀ x ∈ K, chi =ᶠ[nhds x] (fun _ => 1 : E → ℝ) := by
+    intro x hx
+    filter_upwards [isOpen_interior.mem_nhds (hchi_one_nhds hx)] with y hy
+    have hy' : y ∈ chi ⁻¹' ({1} : Set ℝ) := interior_subset hy
+    exact hy'
+  have hchi_one : ∀ x ∈ K, chi x = 1 := fun x hx => (hchi_nhds x hx).self_of_nhds
+  have hchi_fderiv_K : ∀ x ∈ K, fderiv ℝ chi x = 0 := fun x hx => by
+    rw [(hchi_nhds x hx).fderiv_eq]
+    simp
+  have hchi_zero : ∀ x ∉ (Omega : Set E), chi x = 0 := fun x hx =>
+    image_eq_zero_of_notMem_tsupport fun hx' => hx (hchi_tsupport hx')
+  have hchi_fderiv_zero : ∀ x ∉ (Omega : Set E), fderiv ℝ chi x = 0 := fun x hx =>
+    fderiv_of_notMem_tsupport ℝ fun hx' => hx (hchi_tsupport hx')
+  have huO := (ae_restrict_iff' Omega.isOpen.measurableSet).1 hu
+  have hu'O := (ae_restrict_iff' Omega.isOpen.measurableSet).1 hu'
+  rw [hasWeakLineDerivOn_iff_testFunction]
+  refine ⟨‹CompleteSpace F›,
+    (integrable_indicator_of_isCompact hK hKO h.locallyIntegrableOn hu).locallyIntegrable
+      |>.locallyIntegrableOn _,
+    (integrable_indicator_of_isCompact hK hKO h.locallyIntegrableOn_deriv hu').locallyIntegrable
+      |>.locallyIntegrableOn _, fun phi => ?_⟩
+  -- `χ φ` is a test function on `Ω`
+  obtain ⟨Phi, hPhi⟩ : ∃ Phi : 𝓓(Omega, ℝ), (Phi : E → ℝ) = chi * (phi : E → ℝ) :=
+    ⟨⟨chi * (phi : E → ℝ), hchi.mul phi.contDiff, hchi_cpt.mul_right,
+      tsupport_mul_subset_left.trans hchi_tsupport⟩, rfl⟩
+  -- the classical product rule for the two smooth factors
+  have hline : ∀ x, lineDeriv ℝ (Phi : E → ℝ) x v
+      = chi x * lineDeriv ℝ (phi : E → ℝ) x v + fderiv ℝ chi x v * (phi : E → ℝ) x := by
+    intro x
+    have hdchi : DifferentiableAt ℝ chi x := (hchi.differentiable (by simp)) x
+    have hdphi : DifferentiableAt ℝ (phi : E → ℝ) x := (phi.contDiff.differentiable (by simp)) x
+    rw [hPhi, (hdchi.mul hdphi).lineDeriv_eq_fderiv, hdphi.lineDeriv_eq_fderiv,
+      fderiv_mul hdchi hdphi]
+    simp only [add_apply, smul_apply, smul_eq_mul]
+    ring
+  have hleft : ∫ x, lineDeriv ℝ (phi : E → ℝ) x v • (Omega : Set E).indicator u x ∂mu
+      = ∫ x, lineDeriv ℝ (Phi : E → ℝ) x v • u x ∂mu := by
+    refine integral_congr_ae ?_
+    filter_upwards [huO] with x hx
+    rw [hline x]
+    by_cases hxO : x ∈ (Omega : Set E)
+    · by_cases hxK : x ∈ K
+      · rw [indicator_of_mem hxO, hchi_one x hxK, hchi_fderiv_K x hxK]
+        simp
+      · rw [indicator_of_mem hxO, hx hxO hxK]
+        simp
+    · rw [indicator_of_notMem hxO, hchi_zero x hxO, hchi_fderiv_zero x hxO]
+      simp
+  have hright : ∫ x, (phi : E → ℝ) x • (Omega : Set E).indicator u' x ∂mu
+      = ∫ x, (Phi : E → ℝ) x • u' x ∂mu := by
+    refine integral_congr_ae ?_
+    filter_upwards [hu'O] with x hx
+    rw [hPhi]
+    simp only [Pi.mul_apply]
+    by_cases hxO : x ∈ (Omega : Set E)
+    · by_cases hxK : x ∈ K
+      · rw [indicator_of_mem hxO, hchi_one x hxK]
+        simp
+      · rw [indicator_of_mem hxO, hx hxO hxK]
+        simp
+    · rw [indicator_of_notMem hxO, hchi_zero x hxO]
+      simp
+  rw [hleft, hright]
+  exact h.integral_lineDeriv_smul_eq_neg_integral_smul Phi
+
+/-- **Extension by zero of a compactly supported weak Fréchet derivative.**  The Fréchet form of
+`TauCeti.HasWeakLineDerivOn.indicator_of_isCompact`: a weakly differentiable function whose jet
+vanishes almost everywhere outside a compact subset of `Ω` extends by zero to a weakly
+differentiable function on the whole space. -/
+theorem HasWeakFDerivOn.indicator_of_isCompact {U : E → E →L[ℝ] F}
+    (h : HasWeakFDerivOn mu Omega u U) (hK : IsCompact K) (hKO : K ⊆ Omega)
+    (hu : ∀ᵐ x ∂mu.restrict Omega, x ∉ K → u x = 0)
+    (hU : ∀ᵐ x ∂mu.restrict Omega, x ∉ K → U x = 0) :
+    HasWeakFDerivOn mu ⊤ ((Omega : Set E).indicator u) ((Omega : Set E).indicator U) := by
+  rw [hasWeakFDerivOn_iff]
+  intro v
+  have hUv : ∀ᵐ x ∂mu.restrict Omega, x ∉ K → U x v = 0 := by
+    filter_upwards [hU] with x hx hxK
+    rw [hx hxK]
+    rfl
+  refine ((h.hasWeakLineDerivOn v).indicator_of_isCompact hK hKO hu hUv).congr_ae_deriv
+    (Filter.Eventually.of_forall fun x => ?_)
+  by_cases hxO : x ∈ (Omega : Set E)
+  · simp [indicator_of_mem hxO]
+  · simp [indicator_of_notMem hxO]
+
+end TauCeti

--- a/TauCeti/Analysis/Sobolev/W1p/Basic.lean
+++ b/TauCeti/Analysis/Sobolev/W1p/Basic.lean
@@ -50,6 +50,8 @@ boundary regularity of `Ω` is used.
 * `TauCeti.W1p.valueL` and `TauCeti.W1p.gradientL`: the two components as continuous linear
   projections from the Sobolev space, with `TauCeti.W1p.value_coe` and
   `TauCeti.W1p.gradient_coe` identifying them with the components of the ambient jet.
+* `TauCeti.W1p.gradient_ae_eq_zero_of_value_ae_eq_zero`: the weak gradient vanishes wherever
+  the value vanishes on an open subset.
 
 ## References
 
@@ -478,6 +480,20 @@ theorem W1p.hasWeakFDerivOn (u : W1p mu Omega p) :
     HasWeakFDerivOn mu Omega (W1p.value u)
       (fun x => innerSL ℝ (W1p.gradient u x)) :=
   (mem_w1pSubmodule_iff_hasWeakFDerivOn u.1).mp u.2
+
+/-- **A Sobolev function vanishing on an open subset has vanishing weak gradient there.** The
+weak gradient is determined almost everywhere by the function on every open set
+(`TauCeti.HasWeakFDerivOn.ae_eq`), and the zero function has zero weak gradient. -/
+theorem W1p.gradient_ae_eq_zero_of_value_ae_eq_zero {V : Opens E} (hV : V ≤ Omega)
+    {u : W1p mu Omega p} (hu : ∀ᵐ x ∂mu.restrict (V : Set E), W1p.value u x = 0) :
+    ∀ᵐ x ∂mu.restrict (V : Set E), W1p.gradient u x = 0 := by
+  have hzero : HasWeakFDerivOn mu V (W1p.value u) 0 :=
+    hasWeakFDerivOn_zero.congr_ae (by filter_upwards [hu] with x hx; exact hx.symm)
+  filter_upwards [((W1p.hasWeakFDerivOn u).mono hV).ae_eq hzero] with x hx
+  have h0 : innerSL ℝ (W1p.gradient u x) = innerSL ℝ (0 : E) := by
+    rw [map_zero]
+    simpa using hx
+  exact innerSL_inj.1 h0
 
 /-- Two Sobolev functions are equal when their `Lᵖ` value components are equal.  Uniqueness of
 weak derivatives determines the gradient component. -/

--- a/TauCeti/Analysis/Sobolev/W1p/CompactSupport.lean
+++ b/TauCeti/Analysis/Sobolev/W1p/CompactSupport.lean
@@ -1,0 +1,239 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.Sobolev.CompactSupport
+public import TauCeti.Analysis.Sobolev.W1p.Density
+public import TauCeti.Analysis.Sobolev.W1p.Extension
+
+/-!
+# Compactly supported Sobolev functions have zero boundary values
+
+`W^{1,p}_0(Ω)` is the closure of the test functions `C_c^∞(Ω)` in `W^{1,p}(Ω)`, the Sobolev form
+of the homogeneous Dirichlet condition.  Deciding that a given function lies in it is, in
+general, a boundary question.  This file settles the case in which there is no boundary to
+answer for: if `u ∈ W^{1,p}(Ω)` vanishes almost everywhere outside a **compact** `K ⊆ Ω`, then
+
+`u ∈ W^{1,p}_0(Ω)`.
+
+Only the value component is assumed to vanish; the gradient then vanishes off `K` by itself,
+because a Sobolev function that vanishes on an open set has vanishing weak gradient there
+(`TauCeti.W1p.gradient_ae_eq_zero_of_value_ae_eq_zero`).
+
+## The argument
+
+Extending `u` by zero gives a genuine element of `W^{1,p}(ℝⁿ)`
+(`TauCeti.HasWeakFDerivOn.indicator_of_isCompact`), which is where the compact support is used:
+for a general `u ∈ W^{1,p}(Ω)` the zero-extension need not be weakly differentiable at all.  On
+the whole space every Sobolev function is a limit of test functions
+(`TauCeti.W1p.mem_w1p0Submodule_top`), but those test functions are supported anywhere in `ℝⁿ`,
+so they do not exhibit `u` as a limit of test functions *on `Ω`*.  Multiplying by a cutoff `χ`
+which is `1` on `K` and compactly supported inside `Ω` repairs that: it leaves the extension of
+`u` unchanged, while carrying every test function on `ℝⁿ` into the image of `C_c^∞(Ω)`.  Since
+that image is closed — extension by zero is an isometry of `W^{1,p}_0(Ω)` onto its image — the
+limit stays in it, and restricting the isometry back gives `u` itself.
+
+## Consequences
+
+`TauCeti.W1p.contDiffSMul_mem_w1p0Submodule_of_hasCompactSupport` is the form localization
+arguments use: multiplying *any* `u ∈ W^{1,p}(Ω)` by a smooth cutoff compactly supported in `Ω`
+produces an element of `W^{1,p}_0(Ω)`.  The companion
+`TauCeti.W1p.contDiffSMul_mem_w1p0Submodule` needs `u` to lie in `W^{1,p}_0(Ω)` already, which is
+exactly what the compact support replaces here.  This is the localization step of Meyers--Serrin
+density and of the interior estimates, Lane A.2 and Lane E.20 of
+`TauCetiRoadmap/PDE/README.md`.
+
+## Main declarations
+
+* `TauCeti.W1p.gradient_ae_eq_zero_of_value_ae_eq_zero`: the weak gradient vanishes where the
+  function vanishes on an open set.
+* `TauCeti.W1p.mem_w1p0Submodule_of_isCompact`: a compactly supported Sobolev function has zero
+  boundary values.
+* `TauCeti.W1p.contDiffSMul_mem_w1p0Submodule_of_hasCompactSupport`: multiplication by a
+  compactly supported cutoff lands in `W^{1,p}_0(Ω)`.
+
+## References
+
+Lane A.2 of `TauCetiRoadmap/PDE/README.md`; L. C. Evans, *Partial Differential Equations*,
+§5.3.3; H. Brezis, *Functional Analysis, Sobolev Spaces and Partial Differential Equations*,
+Lemma 9.5.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory Set TopologicalSpace
+
+open scoped ContDiff Distributions ENNReal Gradient InnerProductSpace
+
+namespace TauCeti
+
+variable {E : Type*} [MeasurableSpace E] [NormedAddCommGroup E] [InnerProductSpace ℝ E]
+  [FiniteDimensional ℝ E] [BorelSpace E] {mu : Measure E} [mu.IsAddHaarMeasure]
+  {Omega : Opens E} {p : ENNReal} [Fact (1 ≤ p)] {K : Set E}
+
+/-! ### The gradient where the function vanishes -/
+
+/-- **A Sobolev function vanishing on an open subset has vanishing weak gradient there.**  The
+weak gradient is determined almost everywhere by the function on every open set
+(`TauCeti.HasWeakFDerivOn.ae_eq`), and the zero function has zero weak gradient. -/
+theorem W1p.gradient_ae_eq_zero_of_value_ae_eq_zero {V : Opens E} (hV : V ≤ Omega)
+    {u : W1p mu Omega p} (hu : ∀ᵐ x ∂mu.restrict (V : Set E), W1p.value u x = 0) :
+    ∀ᵐ x ∂mu.restrict (V : Set E), W1p.gradient u x = 0 := by
+  have hzero : HasWeakFDerivOn mu V (W1p.value u) 0 :=
+    hasWeakFDerivOn_zero.congr_ae (by filter_upwards [hu] with x hx; exact hx.symm)
+  filter_upwards [((W1p.hasWeakFDerivOn u).mono hV).ae_eq hzero] with x hx
+  have h0 : innerSL ℝ (W1p.gradient u x) = innerSL ℝ (0 : E) := by
+    rw [map_zero]
+    simpa using hx
+  exact innerSL_inj.1 h0
+
+/-! ### Zero boundary values -/
+
+/-- **A compactly supported Sobolev function lies in `W^{1,p}_0(Ω)`.**  If `u ∈ W^{1,p}(Ω)`
+vanishes almost everywhere outside a compact `K ⊆ Ω`, then `u` is a `W^{1,p}`-limit of test
+functions on `Ω`.
+
+No regularity of `∂Ω` is assumed, and none is needed: the hypothesis keeps `u` away from the
+boundary, so a cutoff can separate it from `∂Ω`. -/
+theorem W1p.mem_w1p0Submodule_of_isCompact (hp : p ≠ (∞ : ℝ≥0∞)) {u : W1p mu Omega p}
+    (hK : IsCompact K) (hKO : K ⊆ (Omega : Set E))
+    (hu : ∀ᵐ x ∂mu.restrict (Omega : Set E), x ∉ K → W1p.value u x = 0) :
+    u ∈ w1p0Submodule mu Omega p := by
+  have hmeas : MeasurableSet (Omega : Set E) := Omega.isOpen.measurableSet
+  have hsub : (Omega : Set E) ⊆ ((⊤ : Opens E) : Set E) := by simp
+  have humu : ∀ᵐ x ∂mu, x ∈ (Omega : Set E) → x ∉ K → W1p.value u x = 0 :=
+    (ae_restrict_iff' hmeas).1 hu
+  -- the weak gradient vanishes off `K` as well, because `u` vanishes on the open set `Ω \ K`
+  have hgrad : ∀ᵐ x ∂mu.restrict (Omega : Set E), x ∉ K → W1p.gradient u x = 0 := by
+    set V : Opens E := ⟨(Omega : Set E) \ K, Omega.isOpen.sdiff hK.isClosed⟩
+    have hVmeas : MeasurableSet (V : Set E) := V.isOpen.measurableSet
+    have hvalV : ∀ᵐ x ∂mu.restrict (V : Set E), W1p.value u x = 0 := by
+      rw [ae_restrict_iff' hVmeas]
+      filter_upwards [humu] with x hx hxV
+      exact hx hxV.1 hxV.2
+    have hgradV := (ae_restrict_iff' hVmeas).1
+      (W1p.gradient_ae_eq_zero_of_value_ae_eq_zero (V := V) Set.sdiff_subset hvalV)
+    rw [ae_restrict_iff' hmeas]
+    filter_upwards [hgradV] with x hx hxO hxK
+    exact hx ⟨hxO, hxK⟩
+  -- the zero-extension of `u` to the whole space is again a Sobolev function
+  have hweak : HasWeakFDerivOn mu ⊤
+      ((extendByZeroLpₗᵢ ℝ mu hmeas hsub (W1p.value u) : E → ℝ))
+      (fun x => innerSL ℝ (extendByZeroLpₗᵢ ℝ mu hmeas hsub (W1p.gradient u) x)) := by
+    have hU : ∀ᵐ x ∂mu.restrict (Omega : Set E), x ∉ K →
+        innerSL ℝ (W1p.gradient u x) = 0 := by
+      filter_upwards [hgrad] with x hx hxK
+      rw [hx hxK, map_zero]
+    refine (((W1p.hasWeakFDerivOn u).indicator_of_isCompact hK hKO hu hU).congr_ae
+      (coeFn_extendByZeroLpₗᵢ ℝ hmeas hsub (W1p.value u)).symm).congr_ae_deriv ?_
+    filter_upwards [coeFn_extendByZeroLpₗᵢ ℝ hmeas hsub (W1p.gradient u)] with x hx
+    rw [hx]
+    by_cases hxO : x ∈ (Omega : Set E) <;> simp [hxO]
+  set w : W1p mu (⊤ : Opens E) p :=
+    W1p.mk (extendByZeroLpₗᵢ ℝ mu hmeas hsub (W1p.value u))
+      (extendByZeroLpₗᵢ ℝ mu hmeas hsub (W1p.gradient u)) hweak with hwdef
+  have hvalw : ⇑(W1p.value w) =ᵐ[mu.restrict ((⊤ : Opens E) : Set E)]
+      (Omega : Set E).indicator (W1p.value u : E → ℝ) := by
+    rw [hwdef, W1p.value_mk]
+    exact coeFn_extendByZeroLpₗᵢ ℝ hmeas hsub (W1p.value u)
+  -- a smooth cutoff, equal to one on `K` and compactly supported inside `Ω`
+  obtain ⟨chi, hchi, hchi_range, hchi_one_nhds, hchi_cpt, hchi_ts⟩ :=
+    hK.exists_contDiff_cutoff Omega.isOpen hKO
+  have hchi_mem : ∀ x, chi x ∈ Icc (0 : ℝ) 1 := fun x => hchi_range (mem_range_self x)
+  have hchi_one : ∀ x ∈ K, chi x = 1 := fun x hx => by
+    have hx' : x ∈ chi ⁻¹' ({1} : Set ℝ) := interior_subset (hchi_one_nhds hx)
+    exact hx'
+  obtain ⟨C, hC⟩ := (hchi.continuous_fderiv (by simp)).norm.bddAbove_range_of_hasCompactSupport
+    ((hchi_cpt.fderiv ℝ).norm)
+  set M : ℝ := max 1 C
+  have hM0 : (0 : ℝ) ≤ M := le_trans zero_le_one (le_max_left _ _)
+  have hchiM : ∀ x ∈ ((⊤ : Opens E) : Set E), |chi x| ≤ M := fun x _ => by
+    rw [abs_of_nonneg (hchi_mem x).1]
+    exact le_trans (hchi_mem x).2 (le_max_left _ _)
+  have hchigradM : ∀ x ∈ ((⊤ : Opens E) : Set E), ‖∇ chi x‖ ≤ M := fun x _ => by
+    rw [_root_.gradient, LinearIsometryEquiv.norm_map]
+    exact le_trans (hC ⟨x, rfl⟩) (le_max_right _ _)
+  -- the cutoff leaves the extension unchanged
+  have hLw : W1p.contDiffSMul chi hchi hM0 hchiM hchigradM w = w := by
+    refine W1p.ext_value (Lp.ext ?_)
+    filter_upwards [W1p.value_contDiffSMul_ae hchi hM0 hchiM hchigradM w, hvalw,
+      humu.filter_mono (ae_mono Measure.restrict_le_self)] with x h1 h2 h3
+    rw [h1]
+    by_cases hxK : x ∈ K
+    · rw [hchi_one x hxK]
+      simp
+    · have hzero : W1p.value w x = 0 := by
+        rw [h2]
+        by_cases hxO : x ∈ (Omega : Set E)
+        · rw [indicator_of_mem hxO, h3 hxO hxK]
+        · rw [indicator_of_notMem hxO]
+      rw [hzero, smul_zero]
+  -- the image of `W^{1,p}_0(Ω)` under extension by zero is closed
+  have hcomplete : CompleteSpace (W1p0 mu Omega p) :=
+    (w1p0Submodule mu Omega p).isClosed.completeSpace_coe
+  set F : W1p0 mu Omega p →L[ℝ] W1p mu (⊤ : Opens E) p :=
+    (w1p0Submodule mu (⊤ : Opens E) p).toSubmodule.subtypeL.comp
+      (W1p0.extendByZeroL (le_top : Omega ≤ ⊤)) with hFdef
+  have hFiso : Isometry F :=
+    AddMonoidHomClass.isometry_of_norm F fun z => W1p0.norm_extendByZeroL le_top z
+  have hclosed : IsClosed (Set.range F) := hFiso.isClosedEmbedding.isClosed_range
+  -- every test function on `ℝⁿ`, cut off, comes from a test function on `Ω`
+  have htest : ∀ phi : 𝓓((⊤ : Opens E), ℝ),
+      W1p.ofTestFunctionₗ mu (⊤ : Opens E) p phi ∈
+        W1p.contDiffSMulL chi hchi hM0 hchiM hchigradM ⁻¹' Set.range F := by
+    intro phi
+    obtain ⟨Psi, hPsi⟩ : ∃ Psi : 𝓓(Omega, ℝ), (Psi : E → ℝ) = chi * (phi : E → ℝ) :=
+      ⟨⟨chi * (phi : E → ℝ), hchi.mul phi.contDiff, hchi_cpt.mul_right,
+        tsupport_mul_subset_left.trans hchi_ts⟩, rfl⟩
+    have hcoe : ((TestFunction.monoCLM ℝ Psi : 𝓓((⊤ : Opens E), ℝ)) : E → ℝ)
+        = chi * (phi : E → ℝ) := by
+      rw [TestFunction.monoCLM_apply, ← hPsi]
+      simp
+    refine ⟨⟨W1p.ofTestFunctionₗ mu Omega p Psi, W1p.ofTestFunctionₗ_mem_w1p0Submodule Psi⟩, ?_⟩
+    rw [W1p.contDiffSMulL_apply,
+      W1p.contDiffSMul_ofTestFunctionₗ hchi hM0 hchiM hchigradM phi
+        (TestFunction.monoCLM ℝ Psi) hcoe]
+    refine Subtype.ext ?_
+    rw [hFdef]
+    simp only [ContinuousLinearMap.coe_comp, Function.comp_apply, Submodule.coe_subtypeL,
+      Submodule.coe_subtype]
+    rw [W1p0.coe_extendByZeroL]
+    exact Sobolev1JetLp.extendByZeroₗᵢ_ofTestFunctionₗ le_top Psi
+  -- the extension is therefore the zero-extension of a function in `W^{1,p}_0(Ω)`
+  have hwmem : w ∈ Set.range F := by
+    have hmem := w1p0Submodule_subset_of_isClosed
+      (hclosed.preimage (W1p.contDiffSMulL chi hchi hM0 hchiM hchigradM).continuous) htest
+      (W1p.mem_w1p0Submodule_top hp w)
+    rw [Set.mem_preimage, W1p.contDiffSMulL_apply, hLw] at hmem
+    exact hmem
+  obtain ⟨z, hz⟩ := hwmem
+  have hvalz : W1p.value (z : W1p mu Omega p) = W1p.value u := by
+    have h1 : W1p.value (F z) =
+        extendByZeroLpₗᵢ ℝ mu hmeas hsub (W1p.value (z : W1p mu Omega p)) :=
+      W1p0.value_extendByZeroL le_top z
+    rw [hz, hwdef, W1p.value_mk] at h1
+    exact (extendByZeroLpₗᵢ ℝ mu hmeas hsub).injective h1.symm
+  exact W1p.ext_value hvalz ▸ z.2
+
+/-! ### Multiplication by a compactly supported cutoff -/
+
+/-- **Multiplying by a cutoff compactly supported in `Ω` lands in `W^{1,p}_0(Ω)`.**  Unlike
+`TauCeti.W1p.contDiffSMul_mem_w1p0Submodule`, nothing is assumed about the boundary behaviour of
+`u`: the support of `ψ` keeps the product away from `∂Ω`.  This is the localization device that
+turns a statement about `W^{1,p}(Ω)` into one about the test-function closure. -/
+theorem W1p.contDiffSMul_mem_w1p0Submodule_of_hasCompactSupport (hp : p ≠ (∞ : ℝ≥0∞))
+    {psi : E → ℝ}
+    (hpsi : ContDiff ℝ ∞ psi) {M : ℝ} (hM : 0 ≤ M) (hpsiM : ∀ x ∈ Omega, |psi x| ≤ M)
+    (hgradM : ∀ x ∈ Omega, ‖∇ psi x‖ ≤ M) (hcpt : HasCompactSupport psi)
+    (hts : tsupport psi ⊆ (Omega : Set E)) (u : W1p mu Omega p) :
+    W1p.contDiffSMul psi hpsi hM hpsiM hgradM u ∈ w1p0Submodule mu Omega p := by
+  refine W1p.mem_w1p0Submodule_of_isCompact hp hcpt hts ?_
+  filter_upwards [W1p.value_contDiffSMul_ae hpsi hM hpsiM hgradM u] with x hx hxK
+  rw [hx, image_eq_zero_of_notMem_tsupport hxK, zero_smul]
+
+end TauCeti

--- a/TauCeti/Analysis/Sobolev/W1p/CompactSupport.lean
+++ b/TauCeti/Analysis/Sobolev/W1p/CompactSupport.lean
@@ -43,13 +43,10 @@ arguments use: multiplying *any* `u ∈ W^{1,p}(Ω)` by a smooth cutoff compactl
 produces an element of `W^{1,p}_0(Ω)`.  The companion
 `TauCeti.W1p.contDiffSMul_mem_w1p0Submodule` needs `u` to lie in `W^{1,p}_0(Ω)` already, which is
 exactly what the compact support replaces here.  This is the localization step of Meyers--Serrin
-density and of the interior estimates, Lane A.2 and Lane E.20 of
-`TauCetiRoadmap/PDE/README.md`.
+density and of interior estimates.
 
 ## Main declarations
 
-* `TauCeti.W1p.gradient_ae_eq_zero_of_value_ae_eq_zero`: the weak gradient vanishes where the
-  function vanishes on an open set.
 * `TauCeti.W1p.mem_w1p0Submodule_of_isCompact`: a compactly supported Sobolev function has zero
   boundary values.
 * `TauCeti.W1p.contDiffSMul_mem_w1p0Submodule_of_hasCompactSupport`: multiplication by a
@@ -57,9 +54,8 @@ density and of the interior estimates, Lane A.2 and Lane E.20 of
 
 ## References
 
-Lane A.2 of `TauCetiRoadmap/PDE/README.md`; L. C. Evans, *Partial Differential Equations*,
-§5.3.3; H. Brezis, *Functional Analysis, Sobolev Spaces and Partial Differential Equations*,
-Lemma 9.5.
+L. C. Evans, *Partial Differential Equations*, §5.3.3; H. Brezis, *Functional Analysis,
+Sobolev Spaces and Partial Differential Equations*, Lemma 9.5.
 -/
 
 public section
@@ -75,22 +71,6 @@ namespace TauCeti
 variable {E : Type*} [MeasurableSpace E] [NormedAddCommGroup E] [InnerProductSpace ℝ E]
   [FiniteDimensional ℝ E] [BorelSpace E] {mu : Measure E} [mu.IsAddHaarMeasure]
   {Omega : Opens E} {p : ENNReal} [Fact (1 ≤ p)] {K : Set E}
-
-/-! ### The gradient where the function vanishes -/
-
-/-- **A Sobolev function vanishing on an open subset has vanishing weak gradient there.**  The
-weak gradient is determined almost everywhere by the function on every open set
-(`TauCeti.HasWeakFDerivOn.ae_eq`), and the zero function has zero weak gradient. -/
-theorem W1p.gradient_ae_eq_zero_of_value_ae_eq_zero {V : Opens E} (hV : V ≤ Omega)
-    {u : W1p mu Omega p} (hu : ∀ᵐ x ∂mu.restrict (V : Set E), W1p.value u x = 0) :
-    ∀ᵐ x ∂mu.restrict (V : Set E), W1p.gradient u x = 0 := by
-  have hzero : HasWeakFDerivOn mu V (W1p.value u) 0 :=
-    hasWeakFDerivOn_zero.congr_ae (by filter_upwards [hu] with x hx; exact hx.symm)
-  filter_upwards [((W1p.hasWeakFDerivOn u).mono hV).ae_eq hzero] with x hx
-  have h0 : innerSL ℝ (W1p.gradient u x) = innerSL ℝ (0 : E) := by
-    rw [map_zero]
-    simpa using hx
-  exact innerSL_inj.1 h0
 
 /-! ### Zero boundary values -/
 

--- a/TauCeti/MeasureTheory/Integral/Bochner/Basic.lean
+++ b/TauCeti/MeasureTheory/Integral/Bochner/Basic.lean
@@ -29,6 +29,11 @@ for set and probability integrals.
 * The set-integral inequality specializes to the second-moment lower bound for a real-valued
   function on a probability space.
 
+## Compact support
+
+* `integrable_indicator_of_isCompact` promotes local integrability on an open set to global
+  integrability when the function vanishes almost everywhere away from a compact subset.
+
 ## `L¹` convergence
 
 `L¹` convergence is often produced in the Bochner form `∫ ω, ‖f i ω - g ω‖ ∂μ → 0` but consumed
@@ -59,13 +64,31 @@ public section
 
 noncomputable section
 
-open MeasureTheory Filter
+open MeasureTheory Filter TopologicalSpace
 
 open scoped ENNReal Topology
 
 namespace TauCeti
 
 namespace MeasureTheory
+
+/-- A function locally integrable on `Ω` and vanishing almost everywhere on `Ω` off a compact
+`K ⊆ Ω` is, after extension by zero, integrable on the whole space. -/
+theorem integrable_indicator_of_isCompact {X F : Type*} [NormedAddCommGroup X]
+    [MeasurableSpace X] [OpensMeasurableSpace X] [NormedAddCommGroup F] {μ : Measure X}
+    {Ω : Opens X} {f : X → F} {K : Set X} (hK : IsCompact K) (hKΩ : K ⊆ Ω)
+    (hloc : LocallyIntegrableOn f Ω μ)
+    (hf : ∀ᵐ x ∂μ.restrict Ω, x ∉ K → f x = 0) :
+    Integrable ((Ω : Set X).indicator f) μ := by
+  have hae : (Ω : Set X).indicator f =ᵐ[μ] K.indicator f := by
+    filter_upwards [(ae_restrict_iff' Ω.isOpen.measurableSet).1 hf] with x hx
+    by_cases hxΩ : x ∈ (Ω : Set X)
+    · by_cases hxK : x ∈ K
+      · rw [Set.indicator_of_mem hxΩ, Set.indicator_of_mem hxK]
+      · rw [Set.indicator_of_mem hxΩ, Set.indicator_of_notMem hxK, hx hxΩ hxK]
+    · rw [Set.indicator_of_notMem hxΩ, Set.indicator_of_notMem fun hxK => hxΩ (hKΩ hxK)]
+  exact ((hloc.integrableOn_compact_subset hKΩ hK).integrable_indicator
+    hK.isClosed.measurableSet).congr hae.symm
 
 /-- A function whose norm is eventually at least a positive constant at `atTop` is not integrable
 on any right half-line: it is bounded below in norm on a set of infinite measure. -/


### PR DESCRIPTION
This PR proves that a `W^{1,p}(Ω)` function whose value vanishes almost everywhere outside a compact `K ⊆ Ω` lies in `W^{1,p}_0(Ω)`, the closure of `C_c^∞(Ω)` — compact support inside the domain forces zero boundary values, with no regularity assumed of `∂Ω`. This is the localization step of Lane A.2 of `TauCetiRoadmap/PDE/README.md` ("Density and `W^{k,p}_0`": mollification gives `C^∞ ∩ W^{k,p}` dense, Meyers–Serrin `H = W`, with `W^{k,p}_0(Ω)` the `C_c^∞(Ω)`-closure), the milestone this serves; what remains for it after this PR is the locally finite partition-of-unity assembly that turns this local statement into `C^∞(Ω) ∩ W^{1,p}(Ω)` density on a general `Ω`. The same result is what an interior estimate needs in order to cut a Sobolev function off and work with the zero-boundary space (Lane E.20).

`TauCeti/Analysis/Sobolev/CompactSupport.lean` (174 lines) carries the analytic half at the level of weak derivatives, for an arbitrary measure and Banach codomain: `TauCeti.HasWeakLineDerivOn.indicator_of_isCompact` and its Fréchet form show that extension by zero across `∂Ω` preserves weak differentiability once the function and its derivative vanish off a compact subset of `Ω`. The proof tests the extension against a test function `φ` on the whole space, multiplies by a smooth cutoff `χ` that is `1` near `K` and compactly supported in `Ω` — consuming `IsCompact.exists_contDiff_cutoff`, which landed unused in #6127 — and discards the two product-rule corrections, one because `u` vanishes off `K` and the other because `χ` is locally constant on `K`. For a general `u ∈ W^{1,p}(Ω)` the zero-extension genuinely fails to be weakly differentiable, so the compact support is doing the work a Lipschitz boundary would otherwise have to do.

`TauCeti/Analysis/Sobolev/W1p/CompactSupport.lean` (238 lines) assembles the Sobolev statement `TauCeti.W1p.mem_w1p0Submodule_of_isCompact`. Only the value component is assumed to vanish off `K`: `TauCeti.W1p.gradient_ae_eq_zero_of_value_ae_eq_zero` recovers the gradient from uniqueness of weak derivatives on the open set `Ω \ K`. The extension by zero is then an element of `W^{1,p}(ℝⁿ)`, hence a limit of test functions there (`TauCeti.W1p.mem_w1p0Submodule_top`); multiplying by the cutoff leaves it unchanged while carrying every whole-space test function into the image of `C_c^∞(Ω)`, and that image is closed because extension by zero is an isometry out of a complete space, so the limit stays in it and injectivity of the extension returns `u` itself. The consumer form `TauCeti.W1p.contDiffSMul_mem_w1p0Submodule_of_hasCompactSupport` records that multiplying *any* `u ∈ W^{1,p}(Ω)` by a smooth cutoff compactly supported in `Ω` lands in `W^{1,p}_0(Ω)`; the existing `TauCeti.W1p.contDiffSMul_mem_w1p0Submodule` needs `u` to be there already, which is exactly the hypothesis the compact support replaces.

No Mathlib source is vendored; the cutoff rests on Mathlib's manifold smooth Urysohn lemma through the already-merged `TauCeti.Analysis.Calculus.BumpFunction.Cutoff`, and no file outside `TauCeti/` is touched.

Roadmap: PDE

<!--tauceti-target:v1 {"focus":"PDE","id":"w1p-mem-w1p0submodule-of-compact-support"}-->

🤖 Prepared with Claude Code
