### PR TITLE
feat: add the prime decomposition in the Main Lemma

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/Newforms/AtkinLehner.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/AtkinLehner.lean
@@ -37,9 +37,13 @@ instead assumes `QExpansionSupportedOnDvd l f` and obtains `φ` from it.
 
 * `TauCeti.mem_cuspFormsOld_of_slash_T_eq`: a cusp form of level `Γ₁(N)` with a nebentypus, whose
   level-`l` descent is invariant under the weight-`k` slash action of `T`, is old.
+* `TauCeti.exists_eq_levelRaise_of_mem_qSupportedOnDvdSubmodule`: a supported form in one
+  nebentypus space is an actual `V_l`-image from level `N / l`.
 * `TauCeti.mem_cuspFormsOld_of_qExpansionSupportedOnDvd`: **the Atkin–Lehner step at one
   divisor** — the same conclusion from the `q`-expansion support condition alone, the descent
   being supplied by `Newforms/Descent/Basic.lean`.
+* `TauCeti.qSupportedOnDvdSubmodule_inf_cuspFormCharSpace_eq_range_inf`: the exact subspace
+  characterization of supported forms at a fixed nebentypus.
 
 ## Provenance
 
@@ -95,6 +99,38 @@ theorem mem_cuspFormsOld_of_slash_T_eq {l : ℕ} (hl : l ≠ 1) (hlN : l ∣ N)
       rw [hf, hφ, SlashAction.zero_slash, smul_zero, FunLike.coe_zero]
     exact hf0 ▸ (cuspFormsOld N k).zero_mem
 
+/-- **A supported form is a degeneracy image from the quotient level.** If a cusp form in a
+nebentypus space has its period-one `q`-expansion supported on multiples of `l`, for `l ∣ N`,
+then it is `V_l F` for a cusp form `F` of level `N / l`. The character either descends to that
+level, in which case the level-lowering dichotomy supplies `F`, or forces the descended function
+to vanish, in which case `F = 0` works. -/
+theorem exists_eq_levelRaise_of_mem_qSupportedOnDvdSubmodule {l : ℕ} [NeZero l]
+    (hlN : l ∣ N) (χ : (ZMod N)ˣ →* ℂˣ)
+    {f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k}
+    (hfχ : f ∈ cuspFormCharSpace k χ)
+    (hf : f ∈ qSupportedOnDvdSubmodule N k l) :
+    ∃ F : CuspForm ((Gamma1 (N / l)).map (mapGL ℝ)) k,
+      f = CuspForm.levelRaise l
+        (Gamma1_map_le_conjAct_scaleGL_of_dvd (Nat.mul_div_cancel' hlN).dvd) F := by
+  obtain ⟨φ, hraise, hT⟩ :=
+    CuspForm.exists_eq_smul_slash_scaleGL_and_slash_T_eq_of_qExpansionSupportedOnDvd f
+      (mem_qSupportedOnDvdSubmodule.mp hf)
+  let χ' : DirichletCharacter ℂ N := MulChar.ofUnitHom χ
+  have hχ' : χ'.toUnitHom = χ := MulChar.equivToUnitHom.apply_symm_apply χ
+  rcases
+      exists_cuspForm_mem_cuspFormCharSpace_or_eq_zero hlN k χ' φ f (hχ' ▸ hfχ) hraise hT with
+    ⟨_, F, _, hF⟩ | hzero
+  · refine ⟨F, DFunLike.coe_injective ?_⟩
+    rw [CuspForm.coe_levelRaise, hF, hraise]
+  · have hf0 : f = 0 := by
+      apply CuspForm.ext
+      intro z
+      have hz := congrFun hraise z
+      simpa [hzero] using hz
+    subst f
+    refine ⟨0, ?_⟩
+    rw [← CuspForm.levelRaiseₗ_apply, map_zero]
+
 /-- **The Atkin–Lehner step at one divisor.** A cusp form of level `Γ₁(N)` with a nebentypus,
 whose period-one `q`-expansion is supported on the multiples of a divisor `l ≠ 1` of `N`, is old.
 
@@ -115,14 +151,32 @@ theorem mem_cuspFormsOld_of_qExpansionSupportedOnDvd {l : ℕ} (hl : l ≠ 1) (h
     (hf : haveI : NeZero l := NeZero.of_dvd hlN
       QExpansionSupportedOnDvd l f) :
     f ∈ cuspFormsOld N k := by
-  -- The support condition is spent entirely on manufacturing the descent:
-  -- `Newforms/Descent/Basic.lean` turns
-  -- it into a `T`-invariant `φ` with `f = l ^ (1 - k) • (φ ∣[k] diag(l, 1))`, and
-  -- `mem_cuspFormsOld_of_slash_T_eq` reads the level-lowering dichotomy off that.
   have : NeZero l := NeZero.of_dvd hlN
-  obtain ⟨φ, hφ, hT⟩ :=
-    CuspForm.exists_eq_smul_slash_scaleGL_and_slash_T_eq_of_qExpansionSupportedOnDvd f hf
-  exact mem_cuspFormsOld_of_slash_T_eq hl hlN χ φ hfχ hφ hT
+  obtain ⟨F, hF⟩ := exists_eq_levelRaise_of_mem_qSupportedOnDvdSubmodule hlN χ.toUnitHom hfχ
+    (mem_qSupportedOnDvdSubmodule.mpr hf)
+  rw [hF]
+  exact levelRaise_mem_cuspFormsOld (Nat.mul_div_cancel' hlN).dvd
+    (Nat.ne_of_lt (Nat.div_lt_self (NeZero.pos N)
+      (Nat.one_lt_iff_ne_zero_and_ne_one.mpr ⟨NeZero.ne l, hl⟩))) k F
+
+/-- **Supported forms of fixed nebentypus are exactly the degeneracy images with that
+nebentypus.** Intersecting the forms supported on multiples of `l` with `S_k(N, χ)` gives the
+intersection of `S_k(N, χ)` with the range of `V_l` from level `N / l`. No character is chosen
+on the source: the target intersection records exactly the transformation law needed at level
+`N`. -/
+theorem qSupportedOnDvdSubmodule_inf_cuspFormCharSpace_eq_range_inf {l : ℕ} [NeZero l]
+    (hlN : l ∣ N) (χ : (ZMod N)ˣ →* ℂˣ) :
+    qSupportedOnDvdSubmodule N k l ⊓ cuspFormCharSpace k χ =
+      LinearMap.range (CuspForm.levelRaiseₗ (k := k) l
+        (Gamma1_map_le_conjAct_scaleGL_of_dvd (Nat.mul_div_cancel' hlN).dvd)) ⊓
+        cuspFormCharSpace k χ := by
+  ext f
+  simp only [Submodule.mem_inf]
+  refine ⟨fun hf ↦ ⟨?_, hf.2⟩, fun hf ↦ ⟨?_, hf.2⟩⟩
+  · obtain ⟨F, hF⟩ := exists_eq_levelRaise_of_mem_qSupportedOnDvdSubmodule hlN χ hf.2 hf.1
+    exact ⟨F, by rw [CuspForm.levelRaiseₗ_apply, ← hF]⟩
+  · exact range_levelRaise_le_qSupportedOnDvdSubmodule (N / l)
+      (Nat.mul_div_cancel' hlN).dvd hf.1
 
 end TauCeti
 

--- a/TauCeti/NumberTheory/ModularForms/Newforms/PrimeDecomposition.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/PrimeDecomposition.lean
@@ -1,0 +1,94 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.NumberTheory.ModularForms.Newforms.MainLemma
+
+/-!
+# Prime degeneracy decomposition in the Atkin--Lehner Main Lemma
+
+The Atkin--Lehner Main Lemma says that a cusp form whose Fourier coefficients vanish at every
+index coprime to its level is old.  For a form of fixed nebentypus, the stronger conclusion used
+in newform theory is an explicit decomposition
+
+`f = ∑ p ∣ N, V_p f_p`,
+
+where `f_p` has level `N / p`.  This file derives that sharp form from the prime-supported
+decomposition of `Newforms/MainLemma.lean` and the level-lowering dichotomy: each summand supported
+on multiples of `p` is the level-raise of a genuine cusp form at level `N / p` (or is zero).
+
+## Main result
+
+* `TauCeti.exists_eq_sum_levelRaise_prime_of_forall_coprime_qExpansion_coeff_eq_zero`: the
+  prime-degeneracy form of the Main Lemma in a fixed nebentypus space.
+
+## Provenance
+
+The mathematical decomposition is Miyake's Lemma 4.6.8 and the sharp form of the Atkin--Lehner
+Main Lemma in Diamond--Shurman, Theorem 5.7.1.  The proof follows the route in the AINTLIB
+`LeanModularForms` project (Chris Birkbeck, Apache-2.0,
+<https://github.com/CBirkbeck/AINTLIB> at commit
+`eb9621e7bcb0ce220ad53983ec45d987cb5b9002`), combining
+`StrongMultiplicityOne/InductiveStep.lean` with the level-lowering dichotomy in
+`Eigenforms/ConductorTheorem.lean`.  Tau Ceti's existing sieve already supplies the
+prime-supported summands; only the explicit lower-level witnesses are assembled here.
+
+## References
+
+* [T. Miyake, *Modular forms*][miyake1989], Lemma 4.6.8.
+* [F. Diamond and J. Shurman, *A first course in modular forms*][diamondshurman2005],
+  Theorem 5.7.1.
+-/
+
+public section
+
+open Matrix.SpecialLinearGroup UpperHalfPlane CongruenceSubgroup
+
+open scoped MatrixGroups ModularForm
+
+namespace TauCeti
+
+variable {N : ℕ} [NeZero N] {k : ℤ}
+
+/-- **Prime-degeneracy form of the Atkin--Lehner Main Lemma, at fixed nebentypus.**
+If `f ∈ S_k(N, χ)` has vanishing Fourier coefficient at every index coprime to `N`, then
+`f` is a sum of prime degeneracy images `V_p f_p`, with `f_p` a cusp form of level `N / p` for
+each prime `p ∣ N`.  In particular, this records the lower-level witnesses hidden by the
+oldspace-membership conclusion of the Main Lemma. -/
+theorem exists_eq_sum_levelRaise_prime_of_forall_coprime_qExpansion_coeff_eq_zero
+    {χ : (ZMod N)ˣ →* ℂˣ} {f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k}
+    (hf : f ∈ cuspFormCharSpace k χ)
+    (hvan : ∀ n, Nat.Coprime n N → (qExpansion 1 f).coeff n = 0) :
+    ∃ F : ∀ p : {p // p ∈ N.primeFactors},
+        CuspForm ((Gamma1 (N / p.1)).map (mapGL ℝ)) k,
+      f = ∑ p : {p // p ∈ N.primeFactors},
+        haveI : NeZero p.1 := ⟨(Nat.prime_of_mem_primeFactors p.2).ne_zero⟩
+        CuspForm.levelRaise p.1
+          (Gamma1_map_le_conjAct_scaleGL_of_dvd
+            (Nat.mul_div_cancel' (Nat.dvd_of_mem_primeFactors p.2)).dvd) (F p) := by
+  obtain ⟨g, hsum, hsupp, hchar⟩ :=
+    exists_eq_sum_of_forall_coprime_prod_qExpansion_coeff_eq_zero (Finset.Subset.refl _) hf
+      fun n hn ↦ hvan n (Nat.coprime_of_dvd fun q hq hqn hqN ↦ hq.one_lt.ne'
+        (Nat.Coprime.eq_one_of_dvd (Nat.Coprime.coprime_dvd_left hqn hn)
+          (Finset.dvd_prod_of_mem id (Nat.mem_primeFactors.mpr ⟨hq, hqN, NeZero.ne N⟩))))
+  have hex : ∀ p : {p // p ∈ N.primeFactors},
+      ∃ G : CuspForm ((Gamma1 (N / p.1)).map (mapGL ℝ)) k,
+        haveI : NeZero p.1 := ⟨(Nat.prime_of_mem_primeFactors p.2).ne_zero⟩
+        g p.1 = CuspForm.levelRaise p.1
+          (Gamma1_map_le_conjAct_scaleGL_of_dvd
+            (Nat.mul_div_cancel' (Nat.dvd_of_mem_primeFactors p.2)).dvd) G := by
+    intro p
+    have hp := Nat.prime_of_mem_primeFactors p.2
+    have hpN := Nat.dvd_of_mem_primeFactors p.2
+    let _ : NeZero p.1 := ⟨hp.ne_zero⟩
+    exact exists_eq_levelRaise_of_mem_qSupportedOnDvdSubmodule hpN χ
+      (hchar p.1 p.2) (hsupp p.1 p.2)
+  choose F hF using hex
+  refine ⟨F, ?_⟩
+  rw [hsum, ← Finset.sum_attach]
+  exact Finset.sum_congr rfl fun p _ ↦ hF p
+
+end TauCeti


### PR DESCRIPTION
This PR proves the fixed-nebentypus prime-degeneracy form of the Atkin–Lehner Main Lemma: convert every prime-supported summand into an explicit `V_p` image of a cusp form at level `N / p`, then assemble the finite sum over the prime divisors of `N`.

The exact roadmap target is `ModularForms/README.md`, Layer 4, “The Atkin–Lehner Main Lemma,” specifically its sharp conclusion `f = ∑_{p ∣ N} ι_p f_p`. This is the next critical-path step after the merged fixed-nebentypus prime-supported sieve: it replaces same-level support witnesses with the lower-level witnesses required by the theorem. The consumer milestone is Layer 4A, “Existence of a primitive associate,” whose induction uses this Main Lemma decomposition. After this PR, the global character-free assembly and the application of the decomposition to construct primitive associates remain.

The reusable theorem `exists_eq_levelRaise_of_mem_qSupportedOnDvdSubmodule` handles one arbitrary nonzero divisor, while `qSupportedOnDvdSubmodule_inf_cuspFormCharSpace_eq_range_inf` records the exact subspace characterization. The new `PrimeDecomposition` module combines that API with `exists_eq_sum_of_forall_coprime_prod_qExpansion_coeff_eq_zero`. The existing oldspace-membership proof is refactored to consume the same descent theorem.

The mathematical route follows Chris Birkbeck's AINTLIB `LeanModularForms` project (Apache-2.0), commit `eb9621e7bcb0ce220ad53983ec45d987cb5b9002`, especially `StrongMultiplicityOne/InductiveStep.lean` and `Eigenforms/ConductorTheorem.lean`, and is attributed in the module documentation alongside Miyake, Lemma 4.6.8, and Diamond–Shurman, Theorem 5.7.1. No Mathlib infrastructure is vendored.

Roadmap: ModularForms

<!--tauceti-target:v1 {"focus":"ModularForms","id":"atkin-lehner-main-lemma-prime-decomposition"}-->

🤖 Prepared with Codex
