### PR TITLE
feat(GroupTheory): the third isomorphism theorem for coset spaces

### DIFF
--- a/TauCeti/GroupTheory/QuotientGroup/Index.lean
+++ b/TauCeti/GroupTheory/QuotientGroup/Index.lean
@@ -8,15 +8,27 @@ module
 public import Mathlib.GroupTheory.Index
 
 /-!
-# Indices in quotient groups
+# Cosets of the image of a subgroup in a quotient group
 
-This file records how the index of the image of a subgroup in a quotient group is computed in
-the original group.
+For a normal subgroup `N` of `G` and an **arbitrary** subgroup `H`, the cosets of the image
+`H·N/N` in `G ⧸ N` are the cosets of `H ⊔ N` in `G`. This is Noether's third isomorphism
+theorem with the normality of the upper subgroup dropped: `H` is unconstrained, so neither
+`(G ⧸ N) ⧸ H·N/N` nor `G ⧸ (H ⊔ N)` need carry a group structure, and what remains is a
+bijection of coset spaces. Mathlib's `QuotientGroup.quotientQuotientEquivQuotient` is the
+group isomorphism this generalises, stated for `N ≤ M` with `M` normal.
+
+The bijection is what a family or a sum indexed by cosets needs — an index equality only says
+the two index *types* have the same cardinality, not which coset of one corresponds to which
+coset of the other. The index equality follows from it.
 
 ## Main results
 
+* `Subgroup.mk_mem_map_mk'_iff`: the class of `g` modulo `N` lies in the image of `H` exactly
+  when `g` lies in `H ⊔ N`.
+* `QuotientGroup.quotientQuotientEquivQuotientSup`: the bijection
+  `(G ⧸ N) ⧸ H.map (mk' N) ≃ G ⧸ (H ⊔ N)`, sending the class of `g` to the class of `g`.
 * `Subgroup.index_map_mk'_eq_index_sup`: the index of the image of `H` in `G ⧸ N` is the
-  index of `H ⊔ N` in `G`.
+  index of `H ⊔ N` in `G` — the cardinality shadow of that bijection.
 -/
 
 public section
@@ -25,13 +37,56 @@ namespace TauCeti
 
 variable {G : Type*} [Group G]
 
+/-- **Membership in the image of a subgroup under a quotient map.** The class of `g` modulo `N`
+lies in the image of `H` exactly when `g` lies in `H ⊔ N`: a witness `h ∈ H` with `⟦h⟧ = ⟦g⟧`
+is the same data as a factorisation `g = h * n` with `n ∈ N`. -/
+@[to_additive /-- **Membership in the image of a subgroup under a quotient map.** The class of `g`
+modulo `N` lies in the image of `H` exactly when `g` lies in `H ⊔ N`. -/]
+theorem _root_.Subgroup.mk_mem_map_mk'_iff {H N : Subgroup G} [N.Normal] {g : G} :
+    (g : G ⧸ N) ∈ H.map (QuotientGroup.mk' N) ↔ g ∈ H ⊔ N := by
+  simp only [Subgroup.mem_map, QuotientGroup.mk'_apply, QuotientGroup.eq,
+    Subgroup.mem_sup_of_normal_right]
+  exact ⟨fun ⟨h, hh, hg⟩ ↦ ⟨h, hh, h⁻¹ * g, hg, mul_inv_cancel_left h g⟩,
+    fun ⟨h, hh, n, hn, hg⟩ ↦ ⟨h, hh, by rw [← hg]; simpa using hn⟩⟩
+
+/-- **The third isomorphism theorem for coset spaces.** For a normal `N` and an *arbitrary*
+subgroup `H`, the cosets of the image of `H` in `G ⧸ N` are the cosets of `H ⊔ N` in `G`, both
+directions sending the class of `g` to the class of `g`.
+
+Mathlib's `QuotientGroup.quotientQuotientEquivQuotient` is the group isomorphism this
+generalises: it asks for `N ≤ M` with `M` normal, so that both sides are groups and the map is a
+homomorphism. Here neither side need be a group — `H` is unconstrained — and what survives is the
+bijection of coset spaces, which is what a coset-indexed sum or family needs.
+`Subgroup.index_map_mk'_eq_index_sup` is its cardinality shadow, and is now read off it. -/
+@[to_additive /-- **The third isomorphism theorem for coset spaces**, additive version: for a
+normal `N` and an arbitrary subgroup `H`, the cosets of the image of `H` in `G ⧸ N` are the
+cosets of `H ⊔ N` in `G`. -/]
+def _root_.QuotientGroup.quotientQuotientEquivQuotientSup (H N : Subgroup G) [N.Normal] :
+    (G ⧸ N) ⧸ H.map (QuotientGroup.mk' N) ≃ G ⧸ (H ⊔ N) where
+  toFun := Quotient.lift (Subgroup.quotientMapOfLE (le_sup_right : N ≤ H ⊔ N)) <| by
+    refine Quotient.ind fun x ↦ Quotient.ind fun y hxy ↦ ?_
+    have h := QuotientGroup.leftRel_apply.mp hxy
+    simp only [← QuotientGroup.mk_inv, ← QuotientGroup.mk_mul] at h
+    exact QuotientGroup.eq.mpr (Subgroup.mk_mem_map_mk'_iff.mp h)
+  invFun := Quotient.lift (fun g : G ↦ ((g : G ⧸ N) : (G ⧸ N) ⧸ H.map (QuotientGroup.mk' N)))
+    fun x y hxy ↦ QuotientGroup.eq.mpr <| by
+      simpa only [← QuotientGroup.mk_inv, ← QuotientGroup.mk_mul] using
+        Subgroup.mk_mem_map_mk'_iff.mpr (QuotientGroup.leftRel_apply.mp hxy)
+  left_inv := Quotient.ind fun x ↦ QuotientGroup.induction_on x fun _ ↦ rfl
+  right_inv := fun q ↦ QuotientGroup.induction_on q fun _ ↦ rfl
+
+@[to_additive (attr := simp), simp]
+theorem _root_.QuotientGroup.quotientQuotientEquivQuotientSup_mk_mk (H N : Subgroup G) [N.Normal]
+    (g : G) :
+    QuotientGroup.quotientQuotientEquivQuotientSup H N
+        ((g : G ⧸ N) : (G ⧸ N) ⧸ H.map (QuotientGroup.mk' N)) = (g : G ⧸ (H ⊔ N)) := (rfl)
+
 /-- The index of the image of a subgroup in a quotient is the index of its join with the
-quotienting subgroup. -/
+quotienting subgroup: the two coset spaces are in bijection, by
+`QuotientGroup.quotientQuotientEquivQuotientSup`. -/
 @[to_additive (attr := simp), simp]
 theorem _root_.Subgroup.index_map_mk'_eq_index_sup (H N : Subgroup G) [N.Normal] :
-    (H.map (QuotientGroup.mk' N)).index = (H ⊔ N).index := by
-  rw [H.index_map, QuotientGroup.ker_mk',
-    (QuotientGroup.mk' N).range_eq_top_of_surjective
-      (QuotientGroup.mk'_surjective N), Subgroup.index_top, mul_one]
+    (H.map (QuotientGroup.mk' N)).index = (H ⊔ N).index :=
+  Nat.card_congr (QuotientGroup.quotientQuotientEquivQuotientSup H N)
 
 end TauCeti

--- a/TauCeti/GroupTheory/QuotientGroup/Index.lean
+++ b/TauCeti/GroupTheory/QuotientGroup/Index.lean
@@ -6,29 +6,19 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.GroupTheory.Index
+public import TauCeti.GroupTheory.QuotientGroup.ThirdIso
 
 /-!
-# Cosets of the image of a subgroup in a quotient group
+# Indices in quotient groups
 
-For a normal subgroup `N` of `G` and an **arbitrary** subgroup `H`, the cosets of the image
-`H·N/N` in `G ⧸ N` are the cosets of `H ⊔ N` in `G`. This is Noether's third isomorphism
-theorem with the normality of the upper subgroup dropped: `H` is unconstrained, so neither
-`(G ⧸ N) ⧸ H·N/N` nor `G ⧸ (H ⊔ N)` need carry a group structure, and what remains is a
-bijection of coset spaces. Mathlib's `QuotientGroup.quotientQuotientEquivQuotient` is the
-group isomorphism this generalises, stated for `N ≤ M` with `M` normal.
-
-The bijection is what a family or a sum indexed by cosets needs — an index equality only says
-the two index *types* have the same cardinality, not which coset of one corresponds to which
-coset of the other. The index equality follows from it.
+This file records how the index of the image of a subgroup in a quotient group is computed in
+the original group. It is the cardinality shadow of the coset-space bijection
+`QuotientGroup.quotientQuotientEquivQuotientSup`, and is read off it.
 
 ## Main results
 
-* `Subgroup.mk_mem_map_mk'_iff`: the class of `g` modulo `N` lies in the image of `H` exactly
-  when `g` lies in `H ⊔ N`.
-* `QuotientGroup.quotientQuotientEquivQuotientSup`: the bijection
-  `(G ⧸ N) ⧸ H.map (mk' N) ≃ G ⧸ (H ⊔ N)`, sending the class of `g` to the class of `g`.
 * `Subgroup.index_map_mk'_eq_index_sup`: the index of the image of `H` in `G ⧸ N` is the
-  index of `H ⊔ N` in `G` — the cardinality shadow of that bijection.
+  index of `H ⊔ N` in `G`.
 -/
 
 public section
@@ -36,50 +26,6 @@ public section
 namespace TauCeti
 
 variable {G : Type*} [Group G]
-
-/-- **Membership in the image of a subgroup under a quotient map.** The class of `g` modulo `N`
-lies in the image of `H` exactly when `g` lies in `H ⊔ N`: a witness `h ∈ H` with `⟦h⟧ = ⟦g⟧`
-is the same data as a factorisation `g = h * n` with `n ∈ N`. -/
-@[to_additive /-- **Membership in the image of a subgroup under a quotient map.** The class of `g`
-modulo `N` lies in the image of `H` exactly when `g` lies in `H ⊔ N`. -/]
-theorem _root_.Subgroup.mk_mem_map_mk'_iff {H N : Subgroup G} [N.Normal] {g : G} :
-    (g : G ⧸ N) ∈ H.map (QuotientGroup.mk' N) ↔ g ∈ H ⊔ N := by
-  simp only [Subgroup.mem_map, QuotientGroup.mk'_apply, QuotientGroup.eq,
-    Subgroup.mem_sup_of_normal_right]
-  exact ⟨fun ⟨h, hh, hg⟩ ↦ ⟨h, hh, h⁻¹ * g, hg, mul_inv_cancel_left h g⟩,
-    fun ⟨h, hh, n, hn, hg⟩ ↦ ⟨h, hh, by rw [← hg]; simpa using hn⟩⟩
-
-/-- **The third isomorphism theorem for coset spaces.** For a normal `N` and an *arbitrary*
-subgroup `H`, the cosets of the image of `H` in `G ⧸ N` are the cosets of `H ⊔ N` in `G`, both
-directions sending the class of `g` to the class of `g`.
-
-Mathlib's `QuotientGroup.quotientQuotientEquivQuotient` is the group isomorphism this
-generalises: it asks for `N ≤ M` with `M` normal, so that both sides are groups and the map is a
-homomorphism. Here neither side need be a group — `H` is unconstrained — and what survives is the
-bijection of coset spaces, which is what a coset-indexed sum or family needs.
-`Subgroup.index_map_mk'_eq_index_sup` is its cardinality shadow, and is now read off it. -/
-@[to_additive /-- **The third isomorphism theorem for coset spaces**, additive version: for a
-normal `N` and an arbitrary subgroup `H`, the cosets of the image of `H` in `G ⧸ N` are the
-cosets of `H ⊔ N` in `G`. -/]
-def _root_.QuotientGroup.quotientQuotientEquivQuotientSup (H N : Subgroup G) [N.Normal] :
-    (G ⧸ N) ⧸ H.map (QuotientGroup.mk' N) ≃ G ⧸ (H ⊔ N) where
-  toFun := Quotient.lift (Subgroup.quotientMapOfLE (le_sup_right : N ≤ H ⊔ N)) <| by
-    refine Quotient.ind fun x ↦ Quotient.ind fun y hxy ↦ ?_
-    have h := QuotientGroup.leftRel_apply.mp hxy
-    simp only [← QuotientGroup.mk_inv, ← QuotientGroup.mk_mul] at h
-    exact QuotientGroup.eq.mpr (Subgroup.mk_mem_map_mk'_iff.mp h)
-  invFun := Quotient.lift (fun g : G ↦ ((g : G ⧸ N) : (G ⧸ N) ⧸ H.map (QuotientGroup.mk' N)))
-    fun x y hxy ↦ QuotientGroup.eq.mpr <| by
-      simpa only [← QuotientGroup.mk_inv, ← QuotientGroup.mk_mul] using
-        Subgroup.mk_mem_map_mk'_iff.mpr (QuotientGroup.leftRel_apply.mp hxy)
-  left_inv := Quotient.ind fun x ↦ QuotientGroup.induction_on x fun _ ↦ rfl
-  right_inv := fun q ↦ QuotientGroup.induction_on q fun _ ↦ rfl
-
-@[to_additive (attr := simp), simp]
-theorem _root_.QuotientGroup.quotientQuotientEquivQuotientSup_mk_mk (H N : Subgroup G) [N.Normal]
-    (g : G) :
-    QuotientGroup.quotientQuotientEquivQuotientSup H N
-        ((g : G ⧸ N) : (G ⧸ N) ⧸ H.map (QuotientGroup.mk' N)) = (g : G ⧸ (H ⊔ N)) := (rfl)
 
 /-- The index of the image of a subgroup in a quotient is the index of its join with the
 quotienting subgroup: the two coset spaces are in bijection, by

--- a/TauCeti/GroupTheory/QuotientGroup/Index.lean
+++ b/TauCeti/GroupTheory/QuotientGroup/Index.lean
@@ -12,7 +12,7 @@ public import TauCeti.GroupTheory.QuotientGroup.ThirdIso
 # Indices in quotient groups
 
 This file records how the index of the image of a subgroup in a quotient group is computed in
-the original group. It is the cardinality shadow of the coset-space bijection
+the original group. It is the `Nat.card` shadow of the coset-space bijection
 `QuotientGroup.quotientQuotientEquivQuotientSup`, and is read off it.
 
 ## Main results

--- a/TauCeti/GroupTheory/QuotientGroup/ThirdIso.lean
+++ b/TauCeti/GroupTheory/QuotientGroup/ThirdIso.lean
@@ -1,0 +1,77 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.GroupTheory.QuotientGroup.Basic
+
+/-!
+# The third isomorphism theorem for coset spaces
+
+For a normal subgroup `N` of `G` and an **arbitrary** subgroup `H`, the cosets of the image
+`H·N/N` in `G ⧸ N` are the cosets of `H ⊔ N` in `G`. This is Noether's third isomorphism
+theorem with the normality of the upper subgroup dropped: `H` is unconstrained, so neither
+`(G ⧸ N) ⧸ H·N/N` nor `G ⧸ (H ⊔ N)` need carry a group structure, and what remains is a
+bijection of coset spaces. Mathlib's `QuotientGroup.quotientQuotientEquivQuotient` is the
+group isomorphism this generalises, stated for `N ≤ M` with `M` normal.
+
+The bijection is what a family or a sum indexed by cosets needs: an index equality only says
+the two index *types* have the same cardinality, not which coset of one corresponds to which
+coset of the other.
+
+## Main results
+
+* `QuotientGroup.quotientQuotientEquivQuotientSup`: the bijection
+  `(G ⧸ N) ⧸ H.map (mk' N) ≃ G ⧸ (H ⊔ N)`, sending the class of `g` to the class of `g`.
+-/
+
+public section
+
+namespace QuotientGroup
+
+variable {G : Type*} [Group G]
+
+/-- **The third isomorphism theorem for coset spaces.** For a normal `N` and an *arbitrary*
+subgroup `H`, the cosets of the image of `H` in `G ⧸ N` are the cosets of `H ⊔ N` in `G`, both
+directions sending the class of `g` to the class of `g`.
+
+Mathlib's `QuotientGroup.quotientQuotientEquivQuotient` is the group isomorphism this
+generalises: it asks for `N ≤ M` with `M` normal, so that both sides are groups and the map is a
+homomorphism. Here neither side need be a group — `H` is unconstrained — and what survives is the
+bijection of coset spaces, which is what a coset-indexed sum or family needs. -/
+@[to_additive /-- **The third isomorphism theorem for coset spaces**, additive version: for a
+normal `N` and an arbitrary subgroup `H`, the cosets of the image of `H` in `G ⧸ N` are the
+cosets of `H ⊔ N` in `G`. -/]
+def quotientQuotientEquivQuotientSup (H N : Subgroup G) [N.Normal] :
+    (G ⧸ N) ⧸ H.map (QuotientGroup.mk' N) ≃ G ⧸ (H ⊔ N) where
+  toFun := Quotient.lift (Subgroup.quotientMapOfLE (le_sup_right : N ≤ H ⊔ N)) <| by
+    refine Quotient.ind fun x ↦ Quotient.ind fun y hxy ↦ ?_
+    have h := QuotientGroup.leftRel_apply.mp hxy
+    rw [← QuotientGroup.mk_inv, ← QuotientGroup.mk_mul, ← QuotientGroup.mk'_apply,
+      ← Subgroup.mem_comap, QuotientGroup.comap_map_mk', sup_comm] at h
+    exact QuotientGroup.eq.mpr h
+  invFun := Quotient.lift (fun g : G ↦ ((g : G ⧸ N) : (G ⧸ N) ⧸ H.map (QuotientGroup.mk' N)))
+    fun x y hxy ↦ QuotientGroup.eq.mpr <| by
+      rw [← QuotientGroup.mk_inv, ← QuotientGroup.mk_mul, ← QuotientGroup.mk'_apply,
+        ← Subgroup.mem_comap, QuotientGroup.comap_map_mk', sup_comm]
+      exact QuotientGroup.leftRel_apply.mp hxy
+  left_inv := Quotient.ind fun x ↦ QuotientGroup.induction_on x fun _ ↦ rfl
+  right_inv := fun q ↦ QuotientGroup.induction_on q fun _ ↦ rfl
+
+/-- The equivalence sends the nested class of `g` to the class of `g`. -/
+@[to_additive (attr := simp) /-- The equivalence sends the nested class of `g` to the class of
+`g`. -/, simp]
+theorem quotientQuotientEquivQuotientSup_mk_mk (H N : Subgroup G) [N.Normal] (g : G) :
+    quotientQuotientEquivQuotientSup H N
+      ((g : G ⧸ N) : (G ⧸ N) ⧸ H.map (QuotientGroup.mk' N)) = (g : G ⧸ (H ⊔ N)) := (rfl)
+
+/-- The inverse equivalence sends the class of `g` to the nested class of `g`. -/
+@[to_additive (attr := simp) /-- The inverse equivalence sends the class of `g` to the nested
+class of `g`. -/, simp]
+theorem quotientQuotientEquivQuotientSup_symm_mk (H N : Subgroup G) [N.Normal] (g : G) :
+    (quotientQuotientEquivQuotientSup H N).symm (g : G ⧸ (H ⊔ N)) =
+      ((g : G ⧸ N) : (G ⧸ N) ⧸ H.map (QuotientGroup.mk' N)) := (rfl)
+
+end QuotientGroup

--- a/TauCeti/GroupTheory/QuotientGroup/ThirdIso.lean
+++ b/TauCeti/GroupTheory/QuotientGroup/ThirdIso.lean
@@ -17,9 +17,11 @@ theorem with the normality of the upper subgroup dropped: `H` is unconstrained, 
 bijection of coset spaces. Mathlib's `QuotientGroup.quotientQuotientEquivQuotient` is the
 group isomorphism this generalises, stated for `N ≤ M` with `M` normal.
 
-The bijection is what a family or a sum indexed by cosets needs: an index equality only says
-the two index *types* have the same cardinality, not which coset of one corresponds to which
-coset of the other.
+The bijection is what a family or a sum indexed by cosets needs. The corresponding index
+equality, `Subgroup.index_map_mk'_eq_index_sup`, records only that the two coset spaces have
+equal `Nat.card` — the same finite cardinality when they are finite, and jointly `0` when they
+are infinite, whatever their cardinalities. It supplies no correspondence between the cosets
+themselves, so it cannot reindex a family.
 
 ## Main results
 

--- a/TauCeti/GroupTheory/QuotientGroup/ThirdIso.lean
+++ b/TauCeti/GroupTheory/QuotientGroup/ThirdIso.lean
@@ -33,6 +33,18 @@ namespace QuotientGroup
 
 variable {G : Type*} [Group G]
 
+/-- The relation defining `(G ⧸ N) ⧸ H.map (mk' N)`, read on representatives: two classes modulo
+`N` are congruent modulo the image of `H` exactly when their representatives are congruent modulo
+`H ⊔ N`. Both halves of `quotientQuotientEquivQuotientSup` are this statement, in opposite
+directions, so it is stated once here rather than rewritten twice. -/
+@[to_additive /-- The relation defining `(G ⧸ N) ⧸ H.map (mk' N)`, read on representatives: two
+classes modulo `N` are congruent modulo the image of `H` exactly when their representatives are
+congruent modulo `H ⊔ N`. -/]
+private theorem mk_inv_mul_mk_mem_map_iff (H N : Subgroup G) [N.Normal] (x y : G) :
+    ((x : G ⧸ N))⁻¹ * (y : G ⧸ N) ∈ H.map (QuotientGroup.mk' N) ↔ x⁻¹ * y ∈ H ⊔ N := by
+  rw [← QuotientGroup.mk_inv, ← QuotientGroup.mk_mul, ← QuotientGroup.mk'_apply,
+    ← Subgroup.mem_comap, QuotientGroup.comap_map_mk', sup_comm]
+
 /-- **The third isomorphism theorem for coset spaces.** For a normal `N` and an *arbitrary*
 subgroup `H`, the cosets of the image of `H` in `G ⧸ N` are the cosets of `H ⊔ N` in `G`, both
 directions sending the class of `g` to the class of `g`.
@@ -48,15 +60,11 @@ def quotientQuotientEquivQuotientSup (H N : Subgroup G) [N.Normal] :
     (G ⧸ N) ⧸ H.map (QuotientGroup.mk' N) ≃ G ⧸ (H ⊔ N) where
   toFun := Quotient.lift (Subgroup.quotientMapOfLE (le_sup_right : N ≤ H ⊔ N)) <| by
     refine Quotient.ind fun x ↦ Quotient.ind fun y hxy ↦ ?_
-    have h := QuotientGroup.leftRel_apply.mp hxy
-    rw [← QuotientGroup.mk_inv, ← QuotientGroup.mk_mul, ← QuotientGroup.mk'_apply,
-      ← Subgroup.mem_comap, QuotientGroup.comap_map_mk', sup_comm] at h
-    exact QuotientGroup.eq.mpr h
+    exact QuotientGroup.eq.mpr
+      ((mk_inv_mul_mk_mem_map_iff H N x y).mp (QuotientGroup.leftRel_apply.mp hxy))
   invFun := Quotient.lift (fun g : G ↦ ((g : G ⧸ N) : (G ⧸ N) ⧸ H.map (QuotientGroup.mk' N)))
-    fun x y hxy ↦ QuotientGroup.eq.mpr <| by
-      rw [← QuotientGroup.mk_inv, ← QuotientGroup.mk_mul, ← QuotientGroup.mk'_apply,
-        ← Subgroup.mem_comap, QuotientGroup.comap_map_mk', sup_comm]
-      exact QuotientGroup.leftRel_apply.mp hxy
+    fun x y hxy ↦ QuotientGroup.eq.mpr
+      ((mk_inv_mul_mk_mem_map_iff H N x y).mpr (QuotientGroup.leftRel_apply.mp hxy))
   left_inv := Quotient.ind fun x ↦ QuotientGroup.induction_on x fun _ ↦ rfl
   right_inv := fun q ↦ QuotientGroup.induction_on q fun _ ↦ rfl
 


### PR DESCRIPTION
**Noether's third isomorphism theorem for coset spaces**: for a normal `N` and an **arbitrary**
subgroup `H`, the cosets of the image of `H` in `G ⧸ N` are the cosets of `H ⊔ N` in `G`.

```lean
QuotientGroup.quotientQuotientEquivQuotientSup (H N : Subgroup G) [N.Normal] :
    (G ⧸ N) ⧸ H.map (QuotientGroup.mk' N) ≃ G ⧸ (H ⊔ N)
```

Mathlib's `QuotientGroup.quotientQuotientEquivQuotient` is the group isomorphism this
generalises. It asks for `N ≤ M` with **`M` normal**, so that both quotients are groups and the
map is a homomorphism. Dropping that hypothesis costs the group structure — neither side need be
a group — but the bijection of coset spaces survives, and that is what a family or a sum indexed
by cosets actually needs.

`TauCeti/GroupTheory/QuotientGroup/ThirdIso.lean` (new) holds the equivalence and its two
computation rules, both `@[simp]`: `…_mk_mk` for the forward map and `…_symm_mk` for the inverse.
`TauCeti/GroupTheory/QuotientGroup/Index.lean` keeps only `Subgroup.index_map_mk'_eq_index_sup`,
whose statement is unchanged and whose proof is now one line — `Nat.card_congr` of the bijection,
replacing four lines of index arithmetic. All declarations are `@[to_additive]`.

**An index equality is not a bijection**, which is why the existing index lemma was not enough.
`Subgroup.index` is `Nat.card`, which is `0` on every infinite type, so the equality records only
that the two coset spaces have equal `Nat.card` — equal finite cardinality when finite, jointly
`0` when infinite, whatever their cardinalities. Either way it names no correspondence between
the cosets, so it cannot reindex a family. The consumer below needs the map itself.

## Which roadmap target needs this

`TauCetiRoadmap/ModularForms/README.md`, **Layer 3**, the Petersson inner product — specifically
the construction milestone *"a measurable finite-volume fundamental domain for every finite-index
subgroup with independence of the choice"*. The dependency path is direct:

1. That milestone needs a fundamental domain for a congruence subgroup `Γ`.
2. #6504 supplies one as the coset tiling `⋃ q : PSL(2, ℤ) ⧸ H, (q.out)⁻¹ • 𝒟ᵒ`, indexed by
   cosets in the **projective** group — forced, since `−I` acts trivially on `ℍ` and the
   `SL(2, ℤ)`-translates of a positive-measure set are never pairwise disjoint.
3. TauCeti's Petersson product is `CuspForm.peterssonInnerCosets`, a sum over
   `SL(2, ℤ) ⧸ Γ.withCenter` (`Petersson/FiniteIndex.lean`, `Petersson/Adjoint.lean`).
4. Identifying those two index sets *is* this equivalence at `N = Z(SL(2, ℤ))` and `H = Γ`:
   `Γ.withCenter` is `Γ ⊔ Z` by definition, so the statement reads
   `SL(2, ℤ) ⧸ Γ.withCenter ≃ PSL(2, ℤ) ⧸ Γ.map (mk' Z)`.

Mathlib's version does not apply at that instantiation: `Γ.withCenter` is **not normal** in
`SL(2, ℤ)` for a congruence subgroup, so neither side is a group and the homomorphism statement
is unavailable. That is the gap this PR fills.

No `tauceti-target` marker: this is a prerequisite of that node, not the node itself. #6504
authors the fundamental-domain target and carries the marker; a second PR repeating the id would
expose both to the duplicate sweeper.

Nothing here mentions `ℍ`, `SL(2, ℤ)` or modular forms; the statement is general group theory and
is stated as such.

**Verified:** `lake build TauCeti` green; `#lint` (all 15 linters) clean on both files;
`lint-dot-notation` `0 new`; module-system and header-style linters silent; no `set_option`; no
line over 100 characters; axioms are `propext`, `Classical.choice`, `Quot.sound`.

Roadmap: ModularForms
Provenance: none — this is general group theory with no source outside Mathlib. Mathlib's
`QuotientGroup.quotientQuotientEquivQuotient`
(`Mathlib/GroupTheory/QuotientGroup/Basic.lean`) is the normal-subgroup statement being
generalised; the proof here is independent of it, and the membership step goes through Mathlib's
`QuotientGroup.comap_map_mk'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KrTkwbwKqMk3543hugPHmw

