### PR TITLE
feat: add local coefficient systems

### DIFF
--- a/TauCeti/AlgebraicTopology/LocalCoefficient.lean
+++ b/TauCeti/AlgebraicTopology/LocalCoefficient.lean
@@ -63,6 +63,12 @@ theorem constantFunctor_obj_map (X : TopCat.{v}) (M : ModuleCat.{w} R)
     ((constantFunctor (R := R) X).obj M).map p = 𝟙 M := by
   simp [constantFunctor]
 
+@[simp]
+theorem constantFunctor_map_app (X : TopCat.{v}) {M N : ModuleCat.{w} R} (f : M ⟶ N)
+    (x : FundamentalGroupoid X) :
+    ((constantFunctor (R := R) X).map f).app x = f :=
+  rfl
+
 /-- Pull back local coefficient systems along a continuous map. -/
 @[expose] def pullback {X : TopCat.{v₁}} {Y : TopCat.{v₂}} (f : C(X, Y)) :
     LocalCoefficientSystem.{u, v₂, w} R Y ⥤ LocalCoefficientSystem.{u, v₁, w} R X :=
@@ -104,7 +110,11 @@ def pullbackIdIso (X : TopCat.{v}) :
 theorem pullbackIdIso_hom_app_app (X : TopCat.{v}) (L : LocalCoefficientSystem.{u, v, w} R X)
     (x : FundamentalGroupoid X) :
     ((pullbackIdIso (R := R) X).hom.app L).app x = 𝟙 _ := by
-  -- Expose the whiskered `eqToHom` component underlying the isomorphism.
+  -- The source of the isomorphism, `(pullback (.id X)).obj L`, is only *definitionally* the
+  -- whiskered functor `FundamentalGroupoid.map (.id X) ⋙ L`, so `rw`/`simp` cannot reach the
+  -- underlying `Iso.trans`: rewriting with `Iso.trans_hom` fails with "the target expression is
+  -- not type-correct under the `implicit` transparency level".  `change` crosses that gap once,
+  -- after which the remaining steps are ordinary rewrites.
   change L.map ((eqToHom FundamentalGroupoid.map_id).app x) ≫ 𝟙 _ = 𝟙 _
   rw [eqToHom_app, eqToHom_map, Category.comp_id]
   rfl
@@ -113,7 +123,8 @@ theorem pullbackIdIso_hom_app_app (X : TopCat.{v}) (L : LocalCoefficientSystem.{
 theorem pullbackIdIso_inv_app_app (X : TopCat.{v}) (L : LocalCoefficientSystem.{u, v, w} R X)
     (x : FundamentalGroupoid X) :
     ((pullbackIdIso (R := R) X).inv.app L).app x = 𝟙 _ := by
-  -- Expose the whiskered `eqToHom` component underlying the isomorphism.
+  -- As in `pullbackIdIso_hom_app_app`, the target of the isomorphism is only definitionally a
+  -- whiskered functor, so the underlying `Iso.trans` is unreachable by rewriting.
   change 𝟙 _ ≫ L.map ((eqToHom FundamentalGroupoid.map_id.symm).app x) = 𝟙 _
   rw [eqToHom_app, eqToHom_map, Category.id_comp]
   rfl
@@ -136,7 +147,8 @@ theorem pullbackCompIso_hom_app_app {X : TopCat.{v₁}} {Y : TopCat.{v₂}} {Z :
     (f : C(X, Y)) (g : C(Y, Z)) (L : LocalCoefficientSystem.{u, v₃, w} R Z)
     (x : FundamentalGroupoid X) :
     ((pullbackCompIso (R := R) f g).hom.app L).app x = 𝟙 _ := by
-  -- Expose the whiskered `eqToHom` component underlying the isomorphism.
+  -- As in `pullbackIdIso_hom_app_app`, `(pullback (g.comp f)).obj L` is only definitionally a
+  -- whiskered functor, so the underlying `Iso.trans` is unreachable by rewriting.
   change L.map ((eqToHom (FundamentalGroupoid.map_comp g f)).app x) ≫ 𝟙 _ = 𝟙 _
   rw [eqToHom_app, eqToHom_map, Category.comp_id]
   rfl
@@ -146,7 +158,8 @@ theorem pullbackCompIso_inv_app_app {X : TopCat.{v₁}} {Y : TopCat.{v₂}} {Z :
     (f : C(X, Y)) (g : C(Y, Z)) (L : LocalCoefficientSystem.{u, v₃, w} R Z)
     (x : FundamentalGroupoid X) :
     ((pullbackCompIso (R := R) f g).inv.app L).app x = 𝟙 _ := by
-  -- Expose the whiskered `eqToHom` component underlying the isomorphism.
+  -- As in `pullbackIdIso_hom_app_app`, `(pullback (g.comp f)).obj L` is only definitionally a
+  -- whiskered functor, so the underlying `Iso.trans` is unreachable by rewriting.
   change 𝟙 _ ≫ L.map ((eqToHom (FundamentalGroupoid.map_comp g f).symm).app x) = 𝟙 _
   rw [eqToHom_app, eqToHom_map, Category.id_comp]
   rfl
@@ -226,9 +239,7 @@ theorem transport_symm {x y : X} (L : LocalCoefficientSystem.{u, v, w} R X)
   apply (transport L p).injective
   rw [LinearEquiv.apply_symm_apply]
   simp only [transport_apply, ← L.map_comp_apply]
-  -- Expose the path concatenation underlying composition in the fundamental groupoid.
-  change L.map (p.symm.trans p) a = a
-  rw [Path.Homotopic.Quotient.symm_trans]
+  rw [FundamentalGroupoid.comp_eq, Path.Homotopic.Quotient.symm_trans]
   have h : Path.Homotopic.Quotient.refl y = 𝟙 (FundamentalGroupoid.mk y) :=
     (FundamentalGroupoid.id_eq_path_refl _).symm
   rw [h]
@@ -249,9 +260,8 @@ theorem pullback_transport {X : TopCat.{v₁}} {Y : TopCat.{v₂}} (f : C(X, Y))
     {x y : X} (p : Path.Homotopic.Quotient x y) :
     transport ((pullback (R := R) f).obj L) p = transport L (p.map f) := by
   ext a
-  -- Expose precomposition by the induced fundamental-groupoid functor.
-  change L.map ((FundamentalGroupoid.map f).map p) a = L.map (p.map f) a
-  rfl
+  simp only [transport_apply, pullback_obj_map, FundamentalGroupoid.map_map]
+  exact (transport_apply L (p.map f) a).symm
 
 /-- The monodromy representation of a local coefficient system at a basepoint. -/
 @[expose] def monodromyRepresentation (L : LocalCoefficientSystem.{u, v, w} R X) (x : X) :
@@ -344,7 +354,13 @@ theorem monodromyFunctor_map_hom (x : X) {L K : LocalCoefficientSystem.{u, v, w}
     ext a
     let α := (Groupoid.isoEquivHom (FundamentalGroupoid.mk x)
       (FundamentalGroupoid.mk y)).symm (⟦p⟧ : Path.Homotopic.Quotient x y)
-    -- Expose the underlying module maps so that functoriality of conjugation applies.
+    -- Transport is `L.mapIso α` read as a linear equivalence and the monodromy action is
+    -- `L.map`, so the goal is the image under `L` of `α`-conjugation.  Neither `rw` nor `simp`
+    -- can bridge those coercions here: once the `Representation.Equiv` and `LinearEquiv`
+    -- coercions are peeled off, rewriting with `transport_apply` fails with "the target
+    -- expression is not type-correct under the `implicit` transparency level".  This single
+    -- `change` states the same goal purely in terms of `L.map`, after which `Functor.map_conj`
+    -- and ordinary rewriting finish it.
     change L.map α.hom (L.map g a) = L.map (α.conj g) (L.map α.hom a)
     rw [L.map_conj]
     simp only [Iso.conj_apply, ModuleCat.comp_apply, Functor.mapIso_hom, Functor.mapIso_inv]

--- a/TauCeti/AlgebraicTopology/LocalCoefficient.lean
+++ b/TauCeti/AlgebraicTopology/LocalCoefficient.lean
@@ -100,6 +100,24 @@ def pullbackIdIso (X : TopCat.{v}) :
     ext x a
     simp [pullback])
 
+@[simp]
+theorem pullbackIdIso_hom_app_app (X : TopCat.{v}) (L : LocalCoefficientSystem.{u, v, w} R X)
+    (x : FundamentalGroupoid X) :
+    ((pullbackIdIso (R := R) X).hom.app L).app x = 𝟙 _ := by
+  -- Expose the whiskered `eqToHom` component underlying the isomorphism.
+  change L.map ((eqToHom FundamentalGroupoid.map_id).app x) ≫ 𝟙 _ = 𝟙 _
+  rw [eqToHom_app, eqToHom_map, Category.comp_id]
+  rfl
+
+@[simp]
+theorem pullbackIdIso_inv_app_app (X : TopCat.{v}) (L : LocalCoefficientSystem.{u, v, w} R X)
+    (x : FundamentalGroupoid X) :
+    ((pullbackIdIso (R := R) X).inv.app L).app x = 𝟙 _ := by
+  -- Expose the whiskered `eqToHom` component underlying the isomorphism.
+  change 𝟙 _ ≫ L.map ((eqToHom FundamentalGroupoid.map_id.symm).app x) = 𝟙 _
+  rw [eqToHom_app, eqToHom_map, Category.id_comp]
+  rfl
+
 /-- Pullback along a composite is naturally isomorphic to the composite of the two pullback
 functors, in contravariant order. -/
 def pullbackCompIso {X : TopCat.{v₁}} {Y : TopCat.{v₂}} {Z : TopCat.{v₃}}
@@ -113,12 +131,44 @@ def pullbackCompIso {X : TopCat.{v₁}} {Y : TopCat.{v₂}} {Z : TopCat.{v₃}}
     ext x a
     simp [pullback])
 
+@[simp]
+theorem pullbackCompIso_hom_app_app {X : TopCat.{v₁}} {Y : TopCat.{v₂}} {Z : TopCat.{v₃}}
+    (f : C(X, Y)) (g : C(Y, Z)) (L : LocalCoefficientSystem.{u, v₃, w} R Z)
+    (x : FundamentalGroupoid X) :
+    ((pullbackCompIso (R := R) f g).hom.app L).app x = 𝟙 _ := by
+  -- Expose the whiskered `eqToHom` component underlying the isomorphism.
+  change L.map ((eqToHom (FundamentalGroupoid.map_comp g f)).app x) ≫ 𝟙 _ = 𝟙 _
+  rw [eqToHom_app, eqToHom_map, Category.comp_id]
+  rfl
+
+@[simp]
+theorem pullbackCompIso_inv_app_app {X : TopCat.{v₁}} {Y : TopCat.{v₂}} {Z : TopCat.{v₃}}
+    (f : C(X, Y)) (g : C(Y, Z)) (L : LocalCoefficientSystem.{u, v₃, w} R Z)
+    (x : FundamentalGroupoid X) :
+    ((pullbackCompIso (R := R) f g).inv.app L).app x = 𝟙 _ := by
+  -- Expose the whiskered `eqToHom` component underlying the isomorphism.
+  change 𝟙 _ ≫ L.map ((eqToHom (FundamentalGroupoid.map_comp g f).symm).app x) = 𝟙 _
+  rw [eqToHom_app, eqToHom_map, Category.id_comp]
+  rfl
+
 /-- Pulling back a constant local coefficient system leaves it constant. -/
 def pullbackConstantIso {X : TopCat.{v₁}} {Y : TopCat.{v₂}} (f : C(X, Y))
     (M : ModuleCat.{w} R) :
     (pullback (R := R) f).obj ((constantFunctor (R := R) Y).obj M) ≅
       (constantFunctor (R := R) X).obj M :=
   Iso.refl _
+
+@[simp]
+theorem pullbackConstantIso_hom_app {X : TopCat.{v₁}} {Y : TopCat.{v₂}} (f : C(X, Y))
+    (M : ModuleCat.{w} R) (x : FundamentalGroupoid X) :
+    (pullbackConstantIso (R := R) f M).hom.app x = 𝟙 M :=
+  (rfl)
+
+@[simp]
+theorem pullbackConstantIso_inv_app {X : TopCat.{v₁}} {Y : TopCat.{v₂}} (f : C(X, Y))
+    (M : ModuleCat.{w} R) (x : FundamentalGroupoid X) :
+    (pullbackConstantIso (R := R) f M).inv.app x = 𝟙 M :=
+  (rfl)
 
 /-- Evaluation of a local coefficient system at a point of the space. -/
 @[expose] def fiberFunctor (R : Type u) [Ring R] (X : TopCat.{v}) (x : X) :
@@ -148,6 +198,7 @@ theorem transport_apply {x y : X} (L : LocalCoefficientSystem.{u, v, w} R X)
     transport L p a = L.map p a :=
   by simp [transport]
 
+/-- Transport along the constant path is the identity. -/
 @[simp]
 theorem transport_refl (L : LocalCoefficientSystem.{u, v, w} R X) (x : X) :
     transport L (Path.Homotopic.Quotient.refl x) = LinearEquiv.refl R _ := by
@@ -158,6 +209,7 @@ theorem transport_refl (L : LocalCoefficientSystem.{u, v, w} R X) (x : X) :
   rw [h]
   exact L.map_id_apply _ a
 
+/-- Transport along a concatenation of paths is the composite of the two transports. -/
 @[simp]
 theorem transport_trans {x y z : X} (L : LocalCoefficientSystem.{u, v, w} R X)
     (p : Path.Homotopic.Quotient x y) (q : Path.Homotopic.Quotient y z) :
@@ -165,6 +217,7 @@ theorem transport_trans {x y z : X} (L : LocalCoefficientSystem.{u, v, w} R X)
   ext a
   exact L.map_comp_apply p q a
 
+/-- Transport along the reversed path is the inverse of transport along the path. -/
 @[simp]
 theorem transport_symm {x y : X} (L : LocalCoefficientSystem.{u, v, w} R X)
     (p : Path.Homotopic.Quotient x y) :
@@ -218,6 +271,7 @@ theorem monodromyRepresentation_apply
     monodromyRepresentation L x g a = L.map g a :=
   rfl
 
+/-- The monodromy representation of a constant local coefficient system is trivial. -/
 @[simp]
 theorem constant_monodromyRepresentation (X : TopCat.{v}) (M : ModuleCat.{w} R) (x : X) :
     monodromyRepresentation ((constantFunctor (R := R) X).obj M) x =
@@ -225,6 +279,8 @@ theorem constant_monodromyRepresentation (X : TopCat.{v}) (M : ModuleCat.{w} R) 
   ext g a
   rfl
 
+/-- The monodromy representation of a pullback is the monodromy representation at the image
+point, restricted along the induced map of fundamental groups. -/
 @[simp]
 theorem pullback_monodromyRepresentation {X : TopCat.{v₁}} {Y : TopCat.{v₂}}
     (f : C(X, Y)) (L : LocalCoefficientSystem.{u, v₂, w} R Y) (x : X) :

--- a/TauCeti/AlgebraicTopology/Singular/LocalCoefficient.lean
+++ b/TauCeti/AlgebraicTopology/Singular/LocalCoefficient.lean
@@ -1,0 +1,310 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.AlgebraicTopology.FundamentalGroupoid.FundamentalGroup
+public import Mathlib.RepresentationTheory.Rep.Basic
+
+/-!
+# Local coefficient systems on topological spaces
+
+A local coefficient system of modules on a space `X` is a functor from the fundamental
+groupoid of `X` to `ModuleCat`.  Thus a path class supplies a linear transport map, and the
+groupoid laws give all compatibility with concatenation and reversal of paths.
+
+This file provides the categorical operations needed before constructing singular chains with
+local coefficients: constant systems, pullback along continuous maps, evaluation at a point,
+path transport, and the monodromy representation of the fundamental group.  It also proves that
+these constructions interact in the expected way.  In particular, a morphism of local systems
+induces an intertwining map on monodromy representations, and transport along a path identifies
+the monodromy at its endpoints.
+
+The functorial definition and the monodromy interpretation follow Hatcher, *Algebraic Topology*,
+Section 3.H.
+-/
+
+public section
+
+noncomputable section
+
+open CategoryTheory
+
+universe u v w v₁ v₂ v₃
+
+namespace TauCeti
+
+/-- An `R`-module-valued local coefficient system on `X` is a functor from the fundamental
+groupoid of `X` to `ModuleCat R`. -/
+abbrev LocalCoefficientSystem (R : Type u) [Ring R] (X : TopCat.{v}) :=
+  FundamentalGroupoid X ⥤ ModuleCat.{w} R
+
+namespace LocalCoefficientSystem
+
+variable {R : Type u} [Ring R]
+variable {X : TopCat.{v}}
+
+/-- The constant local coefficient system with fibre `M`. -/
+@[expose] def constantFunctor (X : TopCat.{v}) :
+    ModuleCat.{w} R ⥤ LocalCoefficientSystem.{u, v, w} R X :=
+  Functor.const (FundamentalGroupoid X)
+
+@[simp]
+theorem constantFunctor_obj_obj (X : TopCat.{v}) (M : ModuleCat.{w} R)
+    (x : FundamentalGroupoid X) :
+    ((constantFunctor (R := R) X).obj M).obj x = M :=
+  rfl
+
+@[simp]
+theorem constantFunctor_obj_map (X : TopCat.{v}) (M : ModuleCat.{w} R)
+    {x y : FundamentalGroupoid X} (p : x ⟶ y) :
+    ((constantFunctor (R := R) X).obj M).map p = 𝟙 M := by
+  simp [constantFunctor]
+
+/-- Pull back local coefficient systems along a continuous map. -/
+@[expose] def pullback {X : TopCat.{v₁}} {Y : TopCat.{v₂}} (f : C(X, Y)) :
+    LocalCoefficientSystem.{u, v₂, w} R Y ⥤ LocalCoefficientSystem.{u, v₁, w} R X :=
+  (Functor.whiskeringLeft _ _ _).obj (FundamentalGroupoid.map f)
+
+@[simp]
+theorem pullback_obj_obj {X : TopCat.{v₁}} {Y : TopCat.{v₂}} (f : C(X, Y))
+    (L : LocalCoefficientSystem.{u, v₂, w} R Y)
+    (x : FundamentalGroupoid X) :
+    ((pullback (R := R) f).obj L).obj x = L.obj ((FundamentalGroupoid.map f).obj x) :=
+  rfl
+
+@[simp]
+theorem pullback_obj_map {X : TopCat.{v₁}} {Y : TopCat.{v₂}} (f : C(X, Y))
+    (L : LocalCoefficientSystem.{u, v₂, w} R Y)
+    {x y : FundamentalGroupoid X} (p : x ⟶ y) :
+    ((pullback (R := R) f).obj L).map p = L.map ((FundamentalGroupoid.map f).map p) :=
+  rfl
+
+@[simp]
+theorem pullback_map_app {X : TopCat.{v₁}} {Y : TopCat.{v₂}} (f : C(X, Y))
+    {L K : LocalCoefficientSystem.{u, v₂, w} R Y}
+    (η : L ⟶ K) (x : FundamentalGroupoid X) :
+    ((pullback (R := R) f).map η).app x =
+      η.app ((FundamentalGroupoid.map f).obj x) :=
+  rfl
+
+/-- Pullback along the identity map is naturally isomorphic to the identity functor. -/
+def pullbackIdIso (X : TopCat.{v}) :
+    pullback (R := R) (.id X) ≅ 𝟭 (LocalCoefficientSystem.{u, v, w} R X) :=
+  NatIso.ofComponents (fun L ↦
+    Functor.isoWhiskerRight (eqToIso FundamentalGroupoid.map_id) L ≪≫ L.leftUnitor)
+    (naturality := by
+    intro L K η
+    ext x a
+    simp [pullback])
+
+/-- Pullback along a composite is naturally isomorphic to the composite of the two pullback
+functors, in contravariant order. -/
+def pullbackCompIso {X : TopCat.{v₁}} {Y : TopCat.{v₂}} {Z : TopCat.{v₃}}
+    (f : C(X, Y)) (g : C(Y, Z)) :
+    pullback (R := R) (g.comp f) ≅ pullback (R := R) g ⋙ pullback (R := R) f :=
+  NatIso.ofComponents (fun L ↦
+    Functor.isoWhiskerRight (eqToIso (FundamentalGroupoid.map_comp g f)) L ≪≫
+      Functor.associator _ _ L)
+    (naturality := by
+    intro L K η
+    ext x a
+    simp [pullback])
+
+/-- Pulling back a constant local coefficient system leaves it constant. -/
+def pullbackConstantIso {X : TopCat.{v₁}} {Y : TopCat.{v₂}} (f : C(X, Y))
+    (M : ModuleCat.{w} R) :
+    (pullback (R := R) f).obj ((constantFunctor (R := R) Y).obj M) ≅
+      (constantFunctor (R := R) X).obj M :=
+  Iso.refl _
+
+/-- Evaluation of a local coefficient system at a point of the space. -/
+@[expose] def fiberFunctor (R : Type u) [Ring R] (X : TopCat.{v}) (x : X) :
+    LocalCoefficientSystem.{u, v, w} R X ⥤ ModuleCat.{w} R :=
+  (evaluation _ _).obj (FundamentalGroupoid.mk x)
+
+@[simp]
+theorem fiberFunctor_obj (x : X) (L : LocalCoefficientSystem.{u, v, w} R X) :
+    (fiberFunctor R X x).obj L = L.obj (FundamentalGroupoid.mk x) :=
+  rfl
+
+@[simp]
+theorem fiberFunctor_map (x : X) {L K : LocalCoefficientSystem.{u, v, w} R X}
+    (η : L ⟶ K) :
+    (fiberFunctor R X x).map η = η.app (FundamentalGroupoid.mk x) :=
+  rfl
+
+/-- Parallel transport along a path class, as a linear equivalence between the endpoint fibres. -/
+def transport {x y : X} (L : LocalCoefficientSystem.{u, v, w} R X)
+    (p : Path.Homotopic.Quotient x y) :
+    L.obj (FundamentalGroupoid.mk x) ≃ₗ[R] L.obj (FundamentalGroupoid.mk y) :=
+  (L.mapIso ((Groupoid.isoEquivHom _ _).symm p)).toLinearEquiv
+
+@[simp]
+theorem transport_apply {x y : X} (L : LocalCoefficientSystem.{u, v, w} R X)
+    (p : Path.Homotopic.Quotient x y) (a : L.obj (FundamentalGroupoid.mk x)) :
+    transport L p a = L.map p a :=
+  by simp [transport]
+
+@[simp]
+theorem transport_refl (L : LocalCoefficientSystem.{u, v, w} R X) (x : X) :
+    transport L (Path.Homotopic.Quotient.refl x) = LinearEquiv.refl R _ := by
+  ext a
+  rw [transport_apply, LinearEquiv.refl_apply]
+  have h : Path.Homotopic.Quotient.refl x = 𝟙 (FundamentalGroupoid.mk x) :=
+    (FundamentalGroupoid.id_eq_path_refl _).symm
+  rw [h]
+  exact L.map_id_apply _ a
+
+@[simp]
+theorem transport_trans {x y z : X} (L : LocalCoefficientSystem.{u, v, w} R X)
+    (p : Path.Homotopic.Quotient x y) (q : Path.Homotopic.Quotient y z) :
+    transport L (p.trans q) = (transport L p).trans (transport L q) := by
+  ext a
+  exact L.map_comp_apply p q a
+
+@[simp]
+theorem transport_symm {x y : X} (L : LocalCoefficientSystem.{u, v, w} R X)
+    (p : Path.Homotopic.Quotient x y) :
+    transport L p.symm = (transport L p).symm := by
+  ext a
+  apply (transport L p).injective
+  rw [LinearEquiv.apply_symm_apply]
+  simp only [transport_apply, ← L.map_comp_apply]
+  -- Expose the path concatenation underlying composition in the fundamental groupoid.
+  change L.map (p.symm.trans p) a = a
+  rw [Path.Homotopic.Quotient.symm_trans]
+  have h : Path.Homotopic.Quotient.refl y = 𝟙 (FundamentalGroupoid.mk y) :=
+    (FundamentalGroupoid.id_eq_path_refl _).symm
+  rw [h]
+  exact L.map_id_apply _ a
+
+/-- Transport commutes with a morphism of local coefficient systems. -/
+theorem transport_naturality {x y : X} {L K : LocalCoefficientSystem.{u, v, w} R X}
+    (η : L ⟶ K) (p : Path.Homotopic.Quotient x y)
+    (a : L.obj (FundamentalGroupoid.mk x)) :
+    η.app (FundamentalGroupoid.mk y) (transport L p a) =
+      transport K p (η.app (FundamentalGroupoid.mk x) a) := by
+  exact η.naturality_apply p a
+
+/-- Pullback transport is transport along the image path. -/
+@[simp]
+theorem pullback_transport {X : TopCat.{v₁}} {Y : TopCat.{v₂}} (f : C(X, Y))
+    (L : LocalCoefficientSystem.{u, v₂, w} R Y)
+    {x y : X} (p : Path.Homotopic.Quotient x y) :
+    transport ((pullback (R := R) f).obj L) p = transport L (p.map f) := by
+  ext a
+  -- Expose precomposition by the induced fundamental-groupoid functor.
+  change L.map ((FundamentalGroupoid.map f).map p) a = L.map (p.map f) a
+  rfl
+
+/-- The monodromy representation of a local coefficient system at a basepoint. -/
+@[expose] def monodromyRepresentation (L : LocalCoefficientSystem.{u, v, w} R X) (x : X) :
+    Representation R (FundamentalGroup X x) (L.obj (FundamentalGroupoid.mk x)) where
+  toFun g := (L.map g).hom
+  map_one' := by
+    ext a
+    simp
+  map_mul' g h := by
+    ext a
+    exact L.map_comp_apply h g a
+
+@[simp]
+theorem monodromyRepresentation_apply
+    (L : LocalCoefficientSystem.{u, v, w} R X) (x : X)
+    (g : FundamentalGroup X x) (a : L.obj (FundamentalGroupoid.mk x)) :
+    monodromyRepresentation L x g a = L.map g a :=
+  rfl
+
+@[simp]
+theorem constant_monodromyRepresentation (X : TopCat.{v}) (M : ModuleCat.{w} R) (x : X) :
+    monodromyRepresentation ((constantFunctor (R := R) X).obj M) x =
+      Representation.trivial R (FundamentalGroup X x) M := by
+  ext g a
+  rfl
+
+@[simp]
+theorem pullback_monodromyRepresentation {X : TopCat.{v₁}} {Y : TopCat.{v₂}}
+    (f : C(X, Y)) (L : LocalCoefficientSystem.{u, v₂, w} R Y) (x : X) :
+    monodromyRepresentation ((pullback (R := R) f).obj L) x =
+      (monodromyRepresentation L (f x)).comp (FundamentalGroup.map f x) :=
+  rfl
+
+/-- A morphism of local coefficient systems induces an intertwining map between the monodromy
+representations on each fibre. -/
+@[expose] def monodromyMap {L K : LocalCoefficientSystem.{u, v, w} R X}
+    (η : L ⟶ K) (x : X) :
+    (monodromyRepresentation L x).IntertwiningMap (monodromyRepresentation K x) where
+  toLinearMap := (η.app (FundamentalGroupoid.mk x)).hom
+  isIntertwining' g := by
+    ext a
+    exact η.naturality_apply g a
+
+@[simp]
+theorem monodromyMap_apply {L K : LocalCoefficientSystem.{u, v, w} R X} (η : L ⟶ K)
+    (x : X) (a : L.obj (FundamentalGroupoid.mk x)) :
+    monodromyMap η x a = η.app (FundamentalGroupoid.mk x) a :=
+  rfl
+
+/-- Evaluation at a basepoint, equipped with monodromy, is a functor from local coefficient
+systems to representations of the fundamental group. -/
+@[expose] def monodromyFunctor (R : Type u) [Ring R] (X : TopCat.{v}) (x : X) :
+    LocalCoefficientSystem.{u, v, w} R X ⥤ Rep.{w} R (FundamentalGroup X x) where
+  obj L := Rep.of (monodromyRepresentation L x)
+  map η := Rep.ofHom (monodromyMap η x)
+  map_id L := by
+    ext a
+    rfl
+  map_comp η θ := by
+    ext a
+    rfl
+
+@[simp]
+theorem monodromyFunctor_obj_V (x : X) (L : LocalCoefficientSystem.{u, v, w} R X) :
+    ((monodromyFunctor R X x).obj L).V =
+      L.obj (FundamentalGroupoid.mk x) :=
+  rfl
+
+@[simp]
+theorem monodromyFunctor_obj_ρ (x : X) (L : LocalCoefficientSystem.{u, v, w} R X) :
+    ((monodromyFunctor R X x).obj L).ρ = monodromyRepresentation L x :=
+  rfl
+
+@[simp]
+theorem monodromyFunctor_map_hom_apply (x : X)
+    {L K : LocalCoefficientSystem.{u, v, w} R X} (η : L ⟶ K)
+    (a : L.obj (FundamentalGroupoid.mk x)) :
+    ((monodromyFunctor R X x).map η).hom' a =
+      η.app (FundamentalGroupoid.mk x) a :=
+  rfl
+
+/-- Transport along a path intertwines monodromy after changing the basepoint along that path. -/
+@[expose] def basepointChangeEquiv (L : LocalCoefficientSystem.{u, v, w} R X) {x y : X}
+    (p : Path x y) :
+    (monodromyRepresentation L x).Equiv
+      ((monodromyRepresentation L y).comp
+        (FundamentalGroup.fundamentalGroupMulEquivOfPath p).toMonoidHom) :=
+  Representation.Equiv.mk (transport L ⟦p⟧) fun g => by
+    ext a
+    let α := (Groupoid.isoEquivHom (FundamentalGroupoid.mk x)
+      (FundamentalGroupoid.mk y)).symm (⟦p⟧ : Path.Homotopic.Quotient x y)
+    -- Expose the underlying module maps so that functoriality of conjugation applies.
+    change L.map α.hom (L.map g a) = L.map (α.conj g) (L.map α.hom a)
+    rw [L.map_conj]
+    simp only [Iso.conj_apply, ModuleCat.comp_apply, Functor.mapIso_hom, Functor.mapIso_inv]
+    have h : L.map α.inv (L.map α.hom a) = a := by
+      rw [← L.map_comp_apply, α.hom_inv_id]
+      exact L.map_id_apply _ a
+    rw [h]
+
+@[simp]
+theorem basepointChangeEquiv_apply (L : LocalCoefficientSystem.{u, v, w} R X) {x y : X}
+    (p : Path x y) (a : L.obj (FundamentalGroupoid.mk x)) :
+    basepointChangeEquiv L p a = transport L ⟦p⟧ a :=
+  rfl
+
+end LocalCoefficientSystem
+
+end TauCeti

--- a/TauCeti/AlgebraicTopology/Singular/LocalCoefficient.lean
+++ b/TauCeti/AlgebraicTopology/Singular/LocalCoefficient.lean
@@ -273,11 +273,9 @@ theorem monodromyFunctor_obj_ρ (x : X) (L : LocalCoefficientSystem.{u, v, w} R 
   rfl
 
 @[simp]
-theorem monodromyFunctor_map_hom_apply (x : X)
-    {L K : LocalCoefficientSystem.{u, v, w} R X} (η : L ⟶ K)
-    (a : L.obj (FundamentalGroupoid.mk x)) :
-    ((monodromyFunctor R X x).map η).hom' a =
-      η.app (FundamentalGroupoid.mk x) a :=
+theorem monodromyFunctor_map_hom (x : X) {L K : LocalCoefficientSystem.{u, v, w} R X}
+    (η : L ⟶ K) :
+    ((monodromyFunctor R X x).map η).hom = monodromyMap η x :=
   rfl
 
 /-- Transport along a path intertwines monodromy after changing the basepoint along that path. -/


### PR DESCRIPTION
This PR adds module-valued local coefficient systems on a topological space as functors from Mathlib's fundamental groupoid to `ModuleCat`, together with constant systems, functorial pullback, fibre evaluation, path transport, monodromy representations, and basepoint-change equivariance. It advances `AlgebraicTopology/README.md`, Stage 2, item 6, “Define a local coefficient system as a functor from Mathlib's fundamental groupoid to the coefficient-module category,” by supplying the coefficient-system and monodromy foundation consumed by twisted singular chains and relative homology. After this PR, Stage 2 item 6 still needs twisted absolute and relative singular chain complexes and homology, together with their chain-level pullback, naturality, and constant-system comparison.

The construction works over an arbitrary ring and for continuous maps between spaces in independent universes. Pullback is contravariantly coherent under identities and composition, transport is invariant under path homotopy and respects reversal and concatenation, local-system morphisms induce intertwining maps, and transport along a path intertwines the endpoint monodromy representations.

No Mathlib infrastructure is vendored. The implementation reuses `FundamentalGroupoid.map`, `Functor.whiskeringLeft`, `Functor.mapIso`, `FundamentalGroup.map`, and Mathlib's `Representation` and `Rep` APIs. The mathematical presentation follows Hatcher, *Algebraic Topology*, Section 3.H.

Roadmap: AlgebraicTopology

<!--tauceti-target:v1 {"focus":"AlgebraicTopology","id":"local-coefficient-system"}-->

🤖 Prepared with Codex
