### PR TITLE
feat: construct the free locus covering

### DIFF
--- a/TauCeti/Topology/Algebra/ConstMulAction.lean
+++ b/TauCeti/Topology/Algebra/ConstMulAction.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Algebra.Group.Subgroup.Actions
 public import Mathlib.Algebra.Group.Submonoid.MulAction
+public import Mathlib.GroupTheory.GroupAction.SubMulAction
 public import Mathlib.Topology.Algebra.ConstMulAction
 
 /-!
@@ -20,6 +21,8 @@ an ambient scalar action; and a properly discontinuous action has `Finite` point
 
 * `Submonoid.continuousConstSMul` and `TauCeti.Subgroup.continuousConstSMul`: continuity
   in the point is inherited by a submonoid, hence by a subgroup.
+* `SubMulAction.properlyDiscontinuousSMul`: proper discontinuity is inherited by every invariant
+  subspace.
 * `TauCeti.finite_stabilizer_of_properlyDiscontinuousSMul`: a properly discontinuous action has
   finite point stabilisers, as an instance rather than as `Set.Finite` of the carrier.
 -/
@@ -45,6 +48,24 @@ instance continuousConstSMul {G X : Type*} [Group G] [TopologicalSpace X] [SMul 
   Submonoid.continuousConstSMul S.toSubmonoid
 
 end Subgroup
+
+end TauCeti
+
+namespace SubMulAction
+
+/-- A group action remains properly discontinuous on every invariant subspace. -/
+theorem properlyDiscontinuousSMul {G X : Type*} [Group G] [TopologicalSpace X] [MulAction G X]
+    [ProperlyDiscontinuousSMul G X] (S : SubMulAction G X) : ProperlyDiscontinuousSMul G S where
+  finite_disjoint_inter_image {K L} hK hL := by
+    refine (ProperlyDiscontinuousSMul.finite_disjoint_inter_image
+      (hK.image continuous_subtype_val) (hL.image continuous_subtype_val)).subset ?_
+    rintro g ⟨y, ⟨x, hx, hxy⟩, hy⟩
+    exact
+      ⟨(y : X), ⟨(x : X), ⟨x, hx, rfl⟩, congrArg Subtype.val hxy⟩, ⟨y, hy, rfl⟩⟩
+
+end SubMulAction
+
+namespace TauCeti
 
 /-- **A properly discontinuous action has finite point stabilisers**, as a `Finite` instance.
 

--- a/TauCeti/Topology/Algebra/GroupAction/FreeLocus.lean
+++ b/TauCeti/Topology/Algebra/GroupAction/FreeLocus.lean
@@ -1,0 +1,98 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Topology.Covering.Quotient
+public import TauCeti.Topology.Algebra.ConstMulAction
+
+/-!
+# The free locus of a properly discontinuous group action
+
+For a group acting on a space, the free locus consists of the points with trivial stabilizer.
+It is naturally an invariant subspace. If the action is properly discontinuous on a locally
+compact Hausdorff space, this subspace is open: a sufficiently small neighbourhood of a free
+point meets none of its nontrivial translates.
+
+On the free locus, the orbit projection is a quotient covering map. In particular it is both a
+covering map and a local homeomorphism. This separates the unramified part of a quotient from
+points with nontrivial stabilizer, where the full orbit projection need not be a covering map.
+-/
+
+public section
+
+namespace TauCeti
+
+open Topology
+
+variable (G : Type*) (X : Type*) [Group G] [MulAction G X]
+
+/-- The invariant subspace of points whose stabilizer is trivial. -/
+def freeLocus : SubMulAction G X where
+  carrier := {x | MulAction.stabilizer G x = ⊥}
+  smul_mem' g x hx := by
+    have hx' : MulAction.stabilizer G x = ⊥ := hx
+    exact (MulAction.stabilizer_smul_eq_stabilizer_map_conj g x).trans
+      (by rw [hx', Subgroup.map_bot])
+
+@[simp]
+theorem mem_freeLocus {x : X} : x ∈ freeLocus G X ↔ MulAction.stabilizer G x = ⊥ :=
+  Iff.rfl
+
+/-- The action restricted to the free locus is free. -/
+instance freeLocus.instIsCancelSMul : IsCancelSMul G (freeLocus G X) := by
+  rw [isCancelSMul_iff_stabilizer_eq_bot]
+  intro x
+  rw [SubMulAction.stabilizer_of_subMul, x.property]
+
+/-- The action on the free locus is continuous in the point when the ambient action is. -/
+instance freeLocus.instContinuousConstSMul [TopologicalSpace X] [ContinuousConstSMul G X] :
+    ContinuousConstSMul G (freeLocus G X) :=
+  Topology.IsInducing.subtypeVal.continuousConstSMul id rfl
+
+section Topology
+
+variable [TopologicalSpace X] [T2Space X] [LocallyCompactSpace X]
+  [ContinuousConstSMul G X] [ProperlyDiscontinuousSMul G X]
+
+/-- The free locus of a properly discontinuous action on a locally compact Hausdorff space is
+open. -/
+theorem isOpen_freeLocus : IsOpen (freeLocus G X : Set X) := by
+  rw [isOpen_iff_mem_nhds]
+  intro x hx
+  obtain ⟨U, hU, hdisjoint⟩ :=
+    ProperlyDiscontinuousSMul.exists_nhds_image_smul_eq_self G x
+  filter_upwards [hU] with y hy
+  refine (mem_freeLocus G X).mpr (Subgroup.eq_bot_iff_forall _ |>.mpr fun g hg ↦ ?_)
+  rw [MulAction.mem_stabilizer_iff] at hg
+  rw [← Subgroup.mem_bot, ← (mem_freeLocus (G := G) (X := X)).mp hx,
+    MulAction.mem_stabilizer_iff]
+  exact hdisjoint g ⟨y, ⟨y, hy, hg⟩, hy⟩
+
+/-- On the free locus of a properly discontinuous action, the ordinary orbit projection is a
+quotient covering map. -/
+theorem isQuotientCoveringMap_quotientMk_freeLocus :
+    IsQuotientCoveringMap
+      (Quotient.mk (MulAction.orbitRel G (freeLocus G X))) G := by
+  let _ : ProperlyDiscontinuousSMul G (freeLocus G X) :=
+    SubMulAction.properlyDiscontinuousSMul (freeLocus G X)
+  let _ : LocallyCompactSpace (freeLocus G X) := (isOpen_freeLocus G X).locallyCompactSpace
+  exact isQuotientCoveringMap_quotientMk_of_properlyDiscontinuousSMul
+
+/-- The orbit projection from the free locus of a properly discontinuous action is a covering
+map. -/
+theorem isCoveringMap_quotientMk_freeLocus :
+    IsCoveringMap (Quotient.mk (MulAction.orbitRel G (freeLocus G X))) :=
+  (isQuotientCoveringMap_quotientMk_freeLocus G X).isCoveringMap
+
+/-- The orbit projection from the free locus of a properly discontinuous action is a local
+homeomorphism. -/
+theorem isLocalHomeomorph_quotientMk_freeLocus :
+    IsLocalHomeomorph (Quotient.mk (MulAction.orbitRel G (freeLocus G X))) :=
+  (isCoveringMap_quotientMk_freeLocus G X).isLocalHomeomorph
+
+end Topology
+
+end TauCeti


### PR DESCRIPTION
This PR constructs the invariant free locus of a group action, proves that it is open for a properly discontinuous action on a locally compact Hausdorff space, and proves that its ordinary orbit projection is a quotient covering map, hence a covering map and local homeomorphism.

It advances `FuchsianOrbifolds/README.md`, Layer 0, item 5, “Define the free locus by `stabilizer Γ z = bot`; prove it is open and invariant. Apply the generic quotient theorem there and prove the projection is a covering and local biholomorphism.” This serves the free-quotient portion of completion milestone 2: for every discrete `Γ ≤ PSL(2, ℝ)`, the proper-action instance on `main` specializes these declarations directly to `UpperHalfPlane`. After this PR, Layer 0 still needs the finite-cyclic/derivative classification of nontrivial stabilizers and the complex-analytic local-biholomorphism upgrade of this topological local homeomorphism.

The new 98-line module `TauCeti.Topology.Algebra.GroupAction.FreeLocus` provides `freeLocus`, its membership theorem, the free and continuous restricted-action instances, `isOpen_freeLocus`, and the quotient-covering, covering, and local-homeomorphism theorems. The 21-line extension to `TauCeti.Topology.Algebra.ConstMulAction` proves at the natural generality that proper discontinuity passes to every invariant `SubMulAction`; the free-locus covering then reuses Mathlib's `ProperlyDiscontinuousSMul.exists_nhds_image_smul_eq_self` and `isQuotientCoveringMap_quotientMk_of_properlyDiscontinuousSMul`. No Mathlib implementation or external formalization is vendored.

Roadmap: FuchsianOrbifolds

<!--tauceti-target:v1 {"focus":"FuchsianOrbifolds","id":"free-locus-covering-projection"}-->

🤖 Prepared with Codex
