### PR TITLE
feat: prove flatness of rational restriction maps

### DIFF
--- a/TauCeti/RingTheory/Huber/LocalizationTopology/Laurent/Flat.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/Laurent/Flat.lean
@@ -105,7 +105,38 @@ where Lemma 8.31 needs it too.
 -/
 public section
 
-namespace TauCeti.Huber
+namespace TauCeti
+
+/-- Flatness passes across a heterogeneous equality between ring homomorphisms of completions
+whose source and target uniformities agree. -/
+theorem ringHom_flat_of_completion_heq
+    {S S' : Type*} [CommRing S] [CommRing S']
+    {u₁ u₂ : UniformSpace S} (hu : u₂ = u₁) {v₁ v₂ : UniformSpace S'} (hv : v₂ = v₁)
+    (g₁ : @IsUniformAddGroup S u₁ _) (g₂ : @IsUniformAddGroup S u₂ _)
+    (t₁ : @IsTopologicalRing S u₁.toTopologicalSpace _)
+    (t₂ : @IsTopologicalRing S u₂.toTopologicalSpace _)
+    (g₁' : @IsUniformAddGroup S' v₁ _) (g₂' : @IsUniformAddGroup S' v₂ _)
+    (t₁' : @IsTopologicalRing S' v₁.toTopologicalSpace _)
+    (t₂' : @IsTopologicalRing S' v₂.toTopologicalSpace _) :
+    let R₁ := @UniformSpace.Completion S u₁
+    let R₂ := @UniformSpace.Completion S u₂
+    let B₁ := @UniformSpace.Completion S' v₁
+    let B₂ := @UniformSpace.Completion S' v₂
+    let r₁ := @UniformSpace.Completion.commRing S _ u₁ g₁ t₁
+    let r₂ := @UniformSpace.Completion.commRing S _ u₂ g₂ t₂
+    let b₁ := @UniformSpace.Completion.commRing S' _ v₁ g₁' t₁'
+    let b₂ := @UniformSpace.Completion.commRing S' _ v₂ g₂' t₂'
+    ∀ (f₂ : @RingHom R₂ B₂ r₂.toNonAssocSemiring b₂.toNonAssocSemiring)
+      (f₁ : @RingHom R₁ B₁ r₁.toNonAssocSemiring b₁.toNonAssocSemiring),
+      HEq f₂ f₁ → @RingHom.Flat R₂ B₂ r₂ b₂ f₂ →
+        @RingHom.Flat R₁ B₁ r₁ b₁ f₁ := by
+  subst hu
+  subst hv
+  dsimp only
+  intro f₂ f₁ hf hflat
+  rwa [eq_of_heq hf] at hflat
+
+namespace Huber
 
 open TauCeti.Localization
 
@@ -553,12 +584,8 @@ private theorem flat_restrictionRingHomOfSubset_of_isTopologicallyNilpotent_of_s
 `A⟨T/s⟩ → A⟨T'/s⟩` attached to a numerator enlargement is flat when `T` together with `s`
 generates the unit ideal.
 
-No topological-nilpotence condition is imposed on `s`. For a proper enlargement, a power of a
-pseudouniformiser rescales `s` to a topologically nilpotent denominator. Multiplying every
-numerator by the same unit preserves the two localisation topologies and the restriction map, so
-the topologically nilpotent case applies to the rescaled presentations.
-
-The three hypotheses are conditional on `T ⊂ T'`. Thus the identity enlargement remains
+No topological-nilpotence condition is imposed on `s`. The three hypotheses are conditional on
+`T ⊂ T'`. Thus the identity enlargement remains
 hypothesis-free, while in the intended application to rational subsets of a strongly noetherian
 Tate ring they are supplied by the ambient instances and by
 `TauCeti.Huber.IsTateRing.isOpen_iff_eq_top`. -/
@@ -616,34 +643,7 @@ theorem flat_restrictionRingHomOfSubset_of_span_eq_top [IsHuberRing A]
     have htarget := locSubring_eq_of_coe_eq_image_mul_left P T' U' u s S' hU'
     have hmap := restrictionRingHomOfSubset_heq P T T' s S hden S' hden' hTT'
       U U' (u * s) hdenU hdenU' hUU' hsource htarget
-    -- Flatness is a proposition about a map whose source and target mention both uniformities.
-    -- Abstracting them together lets the heterogeneous map equality transport the proposition.
-    have htransport {u₁ u₂ : UniformSpace S} (hus : u₂ = u₁)
-        {v₁ v₂ : UniformSpace S'} (hus' : v₂ = v₁)
-        (g₁ : @IsUniformAddGroup S u₁ _) (g₂ : @IsUniformAddGroup S u₂ _)
-        (t₁ : @IsTopologicalRing S u₁.toTopologicalSpace _)
-        (t₂ : @IsTopologicalRing S u₂.toTopologicalSpace _)
-        (g₁' : @IsUniformAddGroup S' v₁ _) (g₂' : @IsUniformAddGroup S' v₂ _)
-        (t₁' : @IsTopologicalRing S' v₁.toTopologicalSpace _)
-        (t₂' : @IsTopologicalRing S' v₂.toTopologicalSpace _) :
-        let R₁ := @UniformSpace.Completion S u₁
-        let R₂ := @UniformSpace.Completion S u₂
-        let B₁ := @UniformSpace.Completion S' v₁
-        let B₂ := @UniformSpace.Completion S' v₂
-        let r₁ := @UniformSpace.Completion.commRing S _ u₁ g₁ t₁
-        let r₂ := @UniformSpace.Completion.commRing S _ u₂ g₂ t₂
-        let b₁ := @UniformSpace.Completion.commRing S' _ v₁ g₁' t₁'
-        let b₂ := @UniformSpace.Completion.commRing S' _ v₂ g₂' t₂'
-        ∀ (f₂ : @RingHom R₂ B₂ r₂.toNonAssocSemiring b₂.toNonAssocSemiring)
-          (f₁ : @RingHom R₁ B₁ r₁.toNonAssocSemiring b₁.toNonAssocSemiring),
-          HEq f₂ f₁ → @RingHom.Flat R₂ B₂ r₂ b₂ f₂ →
-            @RingHom.Flat R₁ B₁ r₁ b₁ f₁ := by
-      subst hus
-      subst hus'
-      dsimp only
-      intro f₂ f₁ hf hflat
-      rwa [eq_of_heq hf] at hflat
-    exact htransport
+    exact ringHom_flat_of_completion_heq
       (locUniformSpace_congr P T U s (u * s) S hden hdenU hsource)
       (locUniformSpace_congr P T' U' s (u * s) S' hden' hdenU' htarget)
       (isUniformAddGroup_locUniformSpace P T s S hden)

--- a/TauCeti/RingTheory/Huber/LocalizationTopology/Laurent/Flat.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/Laurent/Flat.lean
@@ -30,8 +30,7 @@ statements below run in increasing generality:
 * the same conclusion asking strong noetherianity only at `T`, the per-intermediate hypothesis
   being derived rather than assumed;
 * the same conclusion asking strong noetherianity of `A` alone, for a presentation whose
-  numerators generate the unit ideal together with `s` — Proposition 8.30 for a topologically
-  nilpotent denominator, which is not yet the proposition in full.
+  numerators generate the unit ideal together with `s` — Wedhorn's Proposition 8.30 in full.
 
 Changing the localisation that carries a presentation is flat with no hypotheses at all.
 
@@ -61,20 +60,17 @@ in: `s` topologically nilpotent over a strongly noetherian base.
 * `TauCeti.Huber.PairOfDefinition.flat_restrictionRingHomOfSubset_of_isStronglyNoetherian_base` :
   the same conclusion asking strong noetherianity only at `T`, the family hypothesis above being
   derived from it rather than assumed.
-* `PairOfDefinition.flat_restrictionRingHomOfSubset_of_isTopologicallyNilpotent_of_span_eq_top` :
-  strong
-  noetherianity asked of `A`, as Wedhorn asks it, the passage to `A⟨T/s⟩` being supplied by
-  `TauCeti.Huber.PairOfDefinition.isStronglyNoetherian_completion`. Its explicit hypotheses are
-  the unit-ideal condition on `(T, s)` and topological nilpotence of the denominator. The
-  latter is what still separates it from Proposition 8.30 in full.
+* `PairOfDefinition.flat_restrictionRingHomOfSubset_of_span_eq_top` : **Wedhorn's Proposition
+  8.30**. Strong noetherianity is asked of `A`, as Wedhorn asks it, and the unit-ideal condition on
+  `(T, s)` is the algebraic form of rationality over a Tate ring. No condition is imposed on the
+  denominator itself.
 
 ## The three chain results, and which to use
 
 Where strong noetherianity is assumed is the primary distinction, and each is the right one for a
 different caller. It is not the only one: the third asks the Tate condition, strong noetherianity,
-the unit-ideal condition on `(T, s)` and topological nilpotence of the denominator — all four
-**only of a proper enlargement**, as explicit hypotheses rather than instances. Its one
-unconditional assumption is `[IsHuberRing A]`.
+and the unit-ideal condition on `(T, s)` — all three **only of a proper enlargement**, as explicit
+hypotheses rather than instances. Its one unconditional assumption is `[IsHuberRing A]`.
 
 `TauCeti.Huber.PairOfDefinition.flat_restrictionRingHomOfSubset_of_forall_isStronglyNoetherian`
 asks it of `A⟨U/s⟩` for *every* `U` with `T ⊆ U ⊂ T'` — a family of hypotheses, carried rather
@@ -87,16 +83,14 @@ asks it only at `T`, deriving the rest by
 when the localisation is known to be strongly noetherian but `A` is not, or when `(T, s)` is not
 known to cut out a rational subset.
 
-`PairOfDefinition.flat_restrictionRingHomOfSubset_of_isTopologicallyNilpotent_of_span_eq_top`
-asks it of `A`, which is Wedhorn's own hypothesis. It costs four explicit hypotheses, each asked
-only when `T ⊂ T'`: `IsTateRing A`, `IsStronglyNoetherian A`, the unit-ideal condition on
-`(T, s)`, and topological nilpotence of the denominator. The first three are free in the intended
-use — restriction between rational subsets of `Spa(A, A⁺)` of a strongly noetherian Tate ring —
-where the first two hold by hypothesis and the third follows from rationality, since an open ideal
-of a Tate ring is `⊤` (`TauCeti.Huber.IsTateRing.isOpen_iff_eq_top`). A caller there passes
+`PairOfDefinition.flat_restrictionRingHomOfSubset_of_span_eq_top` asks it of `A`, which is
+Wedhorn's own hypothesis. It costs three explicit hypotheses, each asked only when `T ⊂ T'`:
+`IsTateRing A`, `IsStronglyNoetherian A`, and the unit-ideal condition on `(T, s)`. All three are
+free in the intended use — restriction between rational subsets of `Spa(A, A⁺)` of a strongly
+noetherian Tate ring — where the first two hold by hypothesis and the third follows from
+rationality, since an open ideal of a Tate ring is `⊤`
+(`TauCeti.Huber.IsTateRing.isOpen_iff_eq_top`). A caller there passes
 `fun _ ↦ inferInstance` for the first two.
-**The fourth is not**: a rational-subset presentation may have `s = 1`, and `1` is not topologically
-nilpotent in a nonzero Tate ring. That is what leaves this short of Proposition 8.30 in general.
 
 Only `[IsHuberRing A]` remains an instance binder, because stating `IsStronglyNoetherian A` needs
 the nonarchimedean structure it carries.
@@ -465,9 +459,8 @@ than deriving.
 `TauCeti.Huber.PairOfDefinition.flat_restrictionRingHomOfSubset_of_isStronglyNoetherian_base`
 supplies that derivation, reducing the family hypothesis to strong noetherianity of `A⟨T/s⟩`
 alone. The passage from `A` to `A⟨T/s⟩` is supplied in turn by
-`flat_restrictionRingHomOfSubset_of_isTopologicallyNilpotent_of_span_eq_top`,
-which reaches Wedhorn's own hypothesis at the cost of the unit-ideal condition on `(T, s)`
-and topological nilpotence of the denominator. This form remains the one to use when strong
+`flat_restrictionRingHomOfSubset_of_span_eq_top`, which reaches Wedhorn's own hypothesis at the
+cost of the unit-ideal condition on `(T, s)`. This form remains the one to use when strong
 noetherianity is known only at the intermediate presentations.
 
 The enlargement is arbitrary and so is the localisation `S'` carrying the target, matching
@@ -513,9 +506,9 @@ any numerator enlargement is flat.
 **It is not Wedhorn's Proposition 8.30 as he states it.** He assumes strong noetherianity
 of `A`; this asks it of `A⟨T/s⟩`. The passage between the two is
 `TauCeti.Huber.PairOfDefinition.isStronglyNoetherian_completion`, applied in
-`flat_restrictionRingHomOfSubset_of_isTopologicallyNilpotent_of_span_eq_top`
-below, which asks `A` alone but adds the unit-ideal condition on `(T, s)`. Both hypotheses
-here are asked only of a *proper* enlargement: for `T' = T` the map is flat outright, by
+`flat_restrictionRingHomOfSubset_of_span_eq_top` below, which asks `A` alone but adds the
+unit-ideal condition on `(T, s)`. Both hypotheses here are asked only of a *proper* enlargement:
+for `T' = T` the map is flat outright, by
 `TauCeti.Huber.PairOfDefinition.flat_restrictionRingHomOfSubset_self`. -/
 theorem flat_restrictionRingHomOfSubset_of_isStronglyNoetherian_base
     (hnil : T ⊂ T' → IsTopologicallyNilpotent s)
@@ -537,42 +530,9 @@ theorem flat_restrictionRingHomOfSubset_of_isStronglyNoetherian_base
       isStronglyNoetherian_completion_of_subset P T s S hden U hU
         (fun _ ↦ hnil (lt_of_le_of_lt hU hUlt)) (hSN (lt_of_le_of_lt hU hUlt))
 
-/-- **Proposition 8.30 for a topologically nilpotent denominator.** Over a strongly noetherian
-Tate ring, the restriction map `A⟨T/s⟩ → A⟨T'/s⟩` of a numerator enlargement is flat, provided
-the denominator is topologically nilpotent whenever the enlargement is proper.
-
-**This is not yet Wedhorn's Proposition 8.30**, which asks nothing of the denominator beyond the
-rational-subset condition. `hnil` does not follow from that condition, nor from the Tate and
-strong-noetherian hypotheses: `s = 1` makes `hspan` automatic, and `1` is not topologically
-nilpotent in a nonzero Tate ring. Removing it needs a change of presentation — scaling `(T, s)`
-by a power of a topologically nilpotent unit leaves the rational subset and the localisation
-alone while making the denominator topologically nilpotent — and that is not proved here.
-
-What this *does* remove is the hypothesis on the localisation. Its predecessors ask strong
-noetherianity of `A⟨T/s⟩`; this asks it of `A`, which is Wedhorn's own standing hypothesis. The
-step that closes that gap is
-`TauCeti.Huber.PairOfDefinition.isStronglyNoetherian_completion`, which carries strong
-noetherianity from `A` to `A⟨T/s⟩` along the finite-type presentation; the base form above then
-propagates it along the chain of intermediate enlargements.
-
-`hspan` says that `T` together with the denominator generates the **unit** ideal. That is not the
-definition of a rational subset, which asks only that the ideal be *open*, and over a general Huber
-ring the unit-ideal condition is strictly stronger. The two coincide exactly when `A` is Tate, by
-`TauCeti.Huber.IsTateRing.isOpen_iff_eq_top` — an open ideal of a Tate ring is `⊤` — and `hspan` is
-asked only when `hTate` is, both being conditional on `T ⊂ T'`, so the equivalence is available
-wherever `hspan` bites. It is not implied by
-`TauCeti.Huber.PairOfDefinition.HasDenominatorPower`, so it has to be asked for.
-
-**Every** hypothesis is asked only of a *proper* enlargement — the Tate and strong-noetherian
-conditions on `A` included, which is why they are conditional hypotheses rather than instance
-binders. What stays unconditional is only `[IsHuberRing A]`, and only because stating
-`IsStronglyNoetherian A` needs the nonarchimedean structure it carries; `IsTateRing` would have
-done, but is strictly stronger. For `T' = T` the map is flat outright and none of the four
-hypotheses is used, by
-`TauCeti.Huber.PairOfDefinition.flat_restrictionRingHomOfSubset_self`. A caller in the intended
-setting, where `A` really is a strongly noetherian Tate ring, supplies each as
-`fun _ ↦ inferInstance`. -/
-theorem flat_restrictionRingHomOfSubset_of_isTopologicallyNilpotent_of_span_eq_top [IsHuberRing A]
+-- The topologically nilpotent case used after rescaling in the full proposition below.
+private theorem flat_restrictionRingHomOfSubset_of_isTopologicallyNilpotent_of_span_eq_top
+    [IsHuberRing A]
     (hTate : T ⊂ T' → IsTateRing A) (hSN : T ⊂ T' → IsStronglyNoetherian A)
     (hnil : T ⊂ T' → IsTopologicallyNilpotent s)
     (hspan : T ⊂ T' → Ideal.span (insert s (T : Set A)) = ⊤) :
@@ -588,6 +548,115 @@ theorem flat_restrictionRingHomOfSubset_of_isTopologicallyNilpotent_of_span_eq_t
       have : IsTateRing A := hTate hproper
       have : IsStronglyNoetherian A := hSN hproper
       isStronglyNoetherian_completion P T s S hden (hspan hproper)
+
+/-- **Wedhorn's Proposition 8.30.** Over a strongly noetherian Tate ring, the restriction map
+`A⟨T/s⟩ → A⟨T'/s⟩` attached to a numerator enlargement is flat when `T` together with `s`
+generates the unit ideal.
+
+No topological-nilpotence condition is imposed on `s`. For a proper enlargement, a power of a
+pseudouniformiser rescales `s` to a topologically nilpotent denominator. Multiplying every
+numerator by the same unit preserves the two localisation topologies and the restriction map, so
+the topologically nilpotent case applies to the rescaled presentations.
+
+The three hypotheses are conditional on `T ⊂ T'`. Thus the identity enlargement remains
+hypothesis-free, while in the intended application to rational subsets of a strongly noetherian
+Tate ring they are supplied by the ambient instances and by
+`TauCeti.Huber.IsTateRing.isOpen_iff_eq_top`. -/
+theorem flat_restrictionRingHomOfSubset_of_span_eq_top [IsHuberRing A]
+    (hTate : T ⊂ T' → IsTateRing A) (hSN : T ⊂ T' → IsStronglyNoetherian A)
+    (hspan : T ⊂ T' → Ideal.span (insert s (T : Set A)) = ⊤) :
+    letI := locUniformSpace P T s S hden
+    letI := isUniformAddGroup_locUniformSpace P T s S hden
+    letI := isTopologicalRing_locUniformSpace P T s S hden
+    letI := locUniformSpace P T' s S' hden'
+    letI := isUniformAddGroup_locUniformSpace P T' s S' hden'
+    letI := isTopologicalRing_locUniformSpace P T' s S' hden'
+    (restrictionRingHomOfSubset P T s S hden T' S' hden' hTT').Flat := by
+  by_cases hproper : T ⊂ T'
+  · let _ := hTate hproper
+    let _ := hSN hproper
+    classical
+    obtain ⟨ϖ, i, hϖ, hnil⟩ := IsTateRing.exists_isTopologicallyNilpotent_pow_mul s
+    let u := ϖ ^ i
+    have hu : IsUnit u := hϖ.isUnit.pow i
+    let U := T.image (u * ·)
+    let U' := T'.image (u * ·)
+    have hU : (U : Set A) = (u * ·) '' (T : Set A) := Finset.coe_image
+    have hU' : (U' : Set A) = (u * ·) '' (T' : Set A) := Finset.coe_image
+    let _ : IsLocalization.Away (u * s) S :=
+      IsLocalization.Away.of_associated (associated_unit_mul_left s u hu).symm
+    let _ : IsLocalization.Away (u * s) S' :=
+      IsLocalization.Away.of_associated (associated_unit_mul_left s u hu).symm
+    have hdenU : HasDenominatorPower P U (u * s) S :=
+      hden.of_coe_eq_image_mul_left hu hU
+    have hdenU' : HasDenominatorPower P U' (u * s) S' :=
+      hden'.of_coe_eq_image_mul_left hu hU'
+    have hUU' : ∀ x ∈ U, x ∈ U' := by
+      intro x hx
+      obtain ⟨t, ht, rfl⟩ := hU ▸ Finset.mem_coe.mpr hx
+      exact Finset.mem_coe.mp (hU' ▸ Set.mem_image_of_mem _ (hTT' t ht))
+    have hspanU : Ideal.span (insert (u * s) (U : Set A)) = ⊤ := by
+      apply top_unique
+      rw [← hspan hproper, Ideal.span_le]
+      intro x hx
+      have hux : u * x ∈ insert (u * s) (U : Set A) := by
+        rcases hx with rfl | hx
+        · exact Set.mem_insert _ _
+        · exact Set.mem_insert_iff.mpr <| Or.inr <| hU ▸ Set.mem_image_of_mem _ hx
+      have huinv : (↑hu.unit⁻¹ : A) * u = 1 := by
+        simpa only [hu.unit_spec] using Units.inv_mul hu.unit
+      have hmul := (Ideal.span (insert (u * s) (U : Set A))).mul_mem_left
+        (↑hu.unit⁻¹ : A) (Ideal.subset_span hux)
+      rwa [← mul_assoc, huinv, one_mul] at hmul
+    have hflat :=
+      flat_restrictionRingHomOfSubset_of_isTopologicallyNilpotent_of_span_eq_top
+        P U (u * s) S hdenU U' S' hdenU' hUU' (fun _ ↦ inferInstance)
+          (fun _ ↦ inferInstance) (fun _ ↦ hnil) (fun _ ↦ hspanU)
+    have hsource := locSubring_eq_of_coe_eq_image_mul_left P T U u s S hU
+    have htarget := locSubring_eq_of_coe_eq_image_mul_left P T' U' u s S' hU'
+    have hmap := restrictionRingHomOfSubset_heq P T T' s S hden S' hden' hTT'
+      U U' (u * s) hdenU hdenU' hUU' hsource htarget
+    -- Flatness is a proposition about a map whose source and target mention both uniformities.
+    -- Abstracting them together lets the heterogeneous map equality transport the proposition.
+    have htransport {u₁ u₂ : UniformSpace S} (hus : u₂ = u₁)
+        {v₁ v₂ : UniformSpace S'} (hus' : v₂ = v₁)
+        (g₁ : @IsUniformAddGroup S u₁ _) (g₂ : @IsUniformAddGroup S u₂ _)
+        (t₁ : @IsTopologicalRing S u₁.toTopologicalSpace _)
+        (t₂ : @IsTopologicalRing S u₂.toTopologicalSpace _)
+        (g₁' : @IsUniformAddGroup S' v₁ _) (g₂' : @IsUniformAddGroup S' v₂ _)
+        (t₁' : @IsTopologicalRing S' v₁.toTopologicalSpace _)
+        (t₂' : @IsTopologicalRing S' v₂.toTopologicalSpace _) :
+        let R₁ := @UniformSpace.Completion S u₁
+        let R₂ := @UniformSpace.Completion S u₂
+        let B₁ := @UniformSpace.Completion S' v₁
+        let B₂ := @UniformSpace.Completion S' v₂
+        let r₁ := @UniformSpace.Completion.commRing S _ u₁ g₁ t₁
+        let r₂ := @UniformSpace.Completion.commRing S _ u₂ g₂ t₂
+        let b₁ := @UniformSpace.Completion.commRing S' _ v₁ g₁' t₁'
+        let b₂ := @UniformSpace.Completion.commRing S' _ v₂ g₂' t₂'
+        ∀ (f₂ : @RingHom R₂ B₂ r₂.toNonAssocSemiring b₂.toNonAssocSemiring)
+          (f₁ : @RingHom R₁ B₁ r₁.toNonAssocSemiring b₁.toNonAssocSemiring),
+          HEq f₂ f₁ → @RingHom.Flat R₂ B₂ r₂ b₂ f₂ →
+            @RingHom.Flat R₁ B₁ r₁ b₁ f₁ := by
+      subst hus
+      subst hus'
+      dsimp only
+      intro f₂ f₁ hf hflat
+      rwa [eq_of_heq hf] at hflat
+    exact htransport
+      (locUniformSpace_congr P T U s (u * s) S hden hdenU hsource)
+      (locUniformSpace_congr P T' U' s (u * s) S' hden' hdenU' htarget)
+      (isUniformAddGroup_locUniformSpace P T s S hden)
+      (isUniformAddGroup_locUniformSpace P U (u * s) S hdenU)
+      (isTopologicalRing_locUniformSpace P T s S hden)
+      (isTopologicalRing_locUniformSpace P U (u * s) S hdenU)
+      (isUniformAddGroup_locUniformSpace P T' s S' hden')
+      (isUniformAddGroup_locUniformSpace P U' (u * s) S' hdenU')
+      (isTopologicalRing_locUniformSpace P T' s S' hden')
+      (isTopologicalRing_locUniformSpace P U' (u * s) S' hdenU') _ _ hmap hflat
+  · exact flat_restrictionRingHomOfSubset_of_isTopologicallyNilpotent_of_span_eq_top
+      P T s S hden T' S' hden' hTT' (False.elim ∘ hproper) (False.elim ∘ hproper)
+      (False.elim ∘ hproper) (False.elim ∘ hproper)
 
 end PairOfDefinition
 

--- a/TauCeti/RingTheory/Huber/LocalizationTopology/Restriction.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/Restriction.lean
@@ -109,7 +109,52 @@ So the construction here is unconditional where AINTLIB's rests on an assumed cl
     Nullstellensatz* name used above.
 -/
 
-namespace TauCeti.Huber
+namespace TauCeti
+
+/-- Two completion ring homomorphisms are heterogeneously equal when their source and target
+uniformities agree and the first map satisfies the characterization that uniquely determines the
+second. -/
+theorem completionRingHom_heq_of_uniformSpace_eq
+    {A S S' : Type*} [CommRing A] [CommRing S] [CommRing S']
+    {u₁ u₂ : UniformSpace S} (hu : u₂ = u₁) {v₁ v₂ : UniformSpace S'} (hv : v₂ = v₁)
+    (g₁ : @IsUniformAddGroup S u₁ _) (g₂ : @IsUniformAddGroup S u₂ _)
+    (t₁ : @IsTopologicalRing S u₁.toTopologicalSpace _)
+    (t₂ : @IsTopologicalRing S u₂.toTopologicalSpace _)
+    (g₁' : @IsUniformAddGroup S' v₁ _) (g₂' : @IsUniformAddGroup S' v₂ _)
+    (t₁' : @IsTopologicalRing S' v₁.toTopologicalSpace _)
+    (t₂' : @IsTopologicalRing S' v₂.toTopologicalSpace _) :
+    let B₁ := @UniformSpace.Completion S u₁
+    let B₂ := @UniformSpace.Completion S u₂
+    let C₁ := @UniformSpace.Completion S' v₁
+    let C₂ := @UniformSpace.Completion S' v₂
+    let b₁ := @UniformSpace.Completion.commRing S _ u₁ g₁ t₁
+    let b₂ := @UniformSpace.Completion.commRing S _ u₂ g₂ t₂
+    let c₁ := @UniformSpace.Completion.commRing S' _ v₁ g₁' t₁'
+    let c₂ := @UniformSpace.Completion.commRing S' _ v₂ g₂' t₂'
+    ∀ (f₂ : @RingHom B₂ C₂ b₂.toNonAssocSemiring c₂.toNonAssocSemiring)
+      (f₁ : @RingHom B₁ C₁ b₁.toNonAssocSemiring c₁.toNonAssocSemiring)
+      (a₂ : @RingHom A B₂ _ b₂.toNonAssocSemiring)
+      (a₁ : @RingHom A B₁ _ b₁.toNonAssocSemiring)
+      (d₂ : @RingHom A C₂ _ c₂.toNonAssocSemiring)
+      (d₁ : @RingHom A C₁ _ c₁.toNonAssocSemiring),
+      @Continuous B₂ C₂ (@UniformSpace.Completion.uniformSpace S u₂).toTopologicalSpace
+        (@UniformSpace.Completion.uniformSpace S' v₂).toTopologicalSpace f₂ →
+      HEq a₂ a₁ → HEq d₂ d₁ → f₂.comp a₂ = d₂ →
+      (∀ f : @RingHom B₁ C₁ b₁.toNonAssocSemiring c₁.toNonAssocSemiring,
+        @Continuous B₁ C₁
+          (@UniformSpace.Completion.uniformSpace S u₁).toTopologicalSpace
+          (@UniformSpace.Completion.uniformSpace S' v₁).toTopologicalSpace f →
+        f.comp a₁ = d₁ → f = f₁) →
+      HEq f₂ f₁ := by
+  subst hu
+  subst hv
+  dsimp only
+  intro f₂ f₁ a₂ a₁ d₂ d₁ hf₂ ha hd hcomp₂ huniq
+  apply heq_of_eq
+  apply huniq f₂ hf₂
+  rw [← eq_of_heq ha, hcomp₂, eq_of_heq hd]
+
+namespace Huber
 
 open TauCeti.Localization
 
@@ -430,9 +475,7 @@ presentations do likewise inside `S'`. Then the corresponding numerator-enlargem
 maps are heterogeneously equal.
 
 The conclusion is `HEq` because changing a presentation changes the uniformity used to form each
-completion. The equalities of candidate rings identify those uniformities by
-`locUniformSpace_congr`; after that identification, continuity and compatibility with the
-structure maps characterize both restriction maps. -/
+completion. -/
 theorem restrictionRingHomOfSubset_heq
     (P : PairOfDefinition A)
     (T₁ T₁' : Finset A) (s₁ : A) (S : Type*) [CommRing S] [Algebra A S]
@@ -446,48 +489,7 @@ theorem restrictionRingHomOfSubset_heq
     (hS' : locSubring P T₂' s₂ S' = locSubring P T₁' s₁ S') :
     HEq (restrictionRingHomOfSubset P T₂ s₂ S hden₂ T₂' S' hden₂' hT₂T₂')
       (restrictionRingHomOfSubset P T₁ s₁ S hden₁ T₁' S' hden₁' hT₁T₁') := by
-  -- Abstract the two source and target uniformities simultaneously. This avoids rewriting
-  -- dependent `IsUniformAddGroup` and `IsTopologicalRing` arguments one at a time.
-  have htransport {u₁ u₂ : UniformSpace S} (hu : u₂ = u₁)
-      {v₁ v₂ : UniformSpace S'} (hv : v₂ = v₁)
-      (g₁ : @IsUniformAddGroup S u₁ _) (g₂ : @IsUniformAddGroup S u₂ _)
-      (t₁ : @IsTopologicalRing S u₁.toTopologicalSpace _)
-      (t₂ : @IsTopologicalRing S u₂.toTopologicalSpace _)
-      (g₁' : @IsUniformAddGroup S' v₁ _) (g₂' : @IsUniformAddGroup S' v₂ _)
-      (t₁' : @IsTopologicalRing S' v₁.toTopologicalSpace _)
-      (t₂' : @IsTopologicalRing S' v₂.toTopologicalSpace _) :
-      let B₁ := @UniformSpace.Completion S u₁
-      let B₂ := @UniformSpace.Completion S u₂
-      let C₁ := @UniformSpace.Completion S' v₁
-      let C₂ := @UniformSpace.Completion S' v₂
-      let b₁ := @UniformSpace.Completion.commRing S _ u₁ g₁ t₁
-      let b₂ := @UniformSpace.Completion.commRing S _ u₂ g₂ t₂
-      let c₁ := @UniformSpace.Completion.commRing S' _ v₁ g₁' t₁'
-      let c₂ := @UniformSpace.Completion.commRing S' _ v₂ g₂' t₂'
-      ∀ (f₂ : @RingHom B₂ C₂ b₂.toNonAssocSemiring c₂.toNonAssocSemiring)
-        (f₁ : @RingHom B₁ C₁ b₁.toNonAssocSemiring c₁.toNonAssocSemiring)
-        (a₂ : @RingHom A B₂ _ b₂.toNonAssocSemiring)
-        (a₁ : @RingHom A B₁ _ b₁.toNonAssocSemiring)
-        (d₂ : @RingHom A C₂ _ c₂.toNonAssocSemiring)
-        (d₁ : @RingHom A C₁ _ c₁.toNonAssocSemiring),
-        @Continuous B₂ C₂ (@UniformSpace.Completion.uniformSpace S u₂).toTopologicalSpace
-          (@UniformSpace.Completion.uniformSpace S' v₂).toTopologicalSpace f₂ →
-        @Continuous B₁ C₁ (@UniformSpace.Completion.uniformSpace S u₁).toTopologicalSpace
-          (@UniformSpace.Completion.uniformSpace S' v₁).toTopologicalSpace f₁ →
-        HEq a₂ a₁ → HEq d₂ d₁ → f₂.comp a₂ = d₂ → f₁.comp a₁ = d₁ →
-        (∀ f : @RingHom B₁ C₁ b₁.toNonAssocSemiring c₁.toNonAssocSemiring,
-          @Continuous B₁ C₁
-            (@UniformSpace.Completion.uniformSpace S u₁).toTopologicalSpace
-            (@UniformSpace.Completion.uniformSpace S' v₁).toTopologicalSpace f →
-          f.comp a₁ = d₁ → f = f₁) → HEq f₂ f₁ := by
-    subst hu
-    subst hv
-    dsimp only
-    intro f₂ f₁ a₂ a₁ d₂ d₁ hf₂ _ ha hd hcomp₂ _ huniq
-    apply heq_of_eq
-    apply huniq f₂ hf₂
-    rw [← eq_of_heq ha, hcomp₂, eq_of_heq hd]
-  exact htransport
+  exact completionRingHom_heq_of_uniformSpace_eq
     (locUniformSpace_congr P T₁ T₂ s₁ s₂ S hden₁ hden₂ hS)
     (locUniformSpace_congr P T₁' T₂' s₁ s₂ S' hden₁' hden₂' hS')
     (isUniformAddGroup_locUniformSpace P T₁ s₁ S hden₁)
@@ -503,13 +505,10 @@ theorem restrictionRingHomOfSubset_heq
     (toCompletionLoc P T₂ s₂ S hden₂) (toCompletionLoc P T₁ s₁ S hden₁)
     (toCompletionLoc P T₂' s₂ S' hden₂') (toCompletionLoc P T₁' s₁ S' hden₁')
     (continuous_restrictionRingHomOfSubset P T₂ s₂ S hden₂ T₂' S' hden₂' hT₂T₂')
-    (continuous_restrictionRingHomOfSubset P T₁ s₁ S hden₁ T₁' S' hden₁' hT₁T₁')
     (toCompletionLoc_heq P T₁ T₂ s₁ s₂ S hden₁ hden₂ hS)
     (toCompletionLoc_heq P T₁' T₂' s₁ s₂ S' hden₁' hden₂' hS')
     (restrictionRingHomOfSubset_comp_toCompletionLoc P T₂ s₂ S hden₂ T₂' S'
       hden₂' hT₂T₂')
-    (restrictionRingHomOfSubset_comp_toCompletionLoc P T₁ s₁ S hden₁ T₁' S'
-      hden₁' hT₁T₁')
     (eq_restrictionRingHomOfSubset P T₁ s₁ S hden₁ T₁' S' hden₁' hT₁T₁')
 
 /-- **The restriction map carries `t/s` to `t/s`**, for every `t`. This is the fact the Laurent

--- a/TauCeti/RingTheory/Huber/LocalizationTopology/Restriction.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/Restriction.lean
@@ -53,6 +53,9 @@ because `locTopology` is deliberately not an instance; this is the same preamble
   `…restrictionRingHom_comp_toCompletionLoc` : the two properties that determine it.
 * `TauCeti.Huber.PairOfDefinition.eq_restrictionRingHom` : anything with those two properties is
   it.
+* `TauCeti.Huber.PairOfDefinition.restrictionRingHomOfSubset_heq` : changing the source and target
+  presentations without changing their candidate rings of definition leaves the restriction map
+  unchanged.
 * `TauCeti.Huber.PairOfDefinition.restrictionRingHom_self` and
   `…restrictionRingHom_comp_restrictionRingHom` : the identity and composition laws — a
   presentation refines itself with cofactor `1` and gives the identity map, and refinements compose
@@ -420,6 +423,94 @@ theorem eq_restrictionRingHomOfSubset :
       g = restrictionRingHomOfSubset P T s S hden T' S' hden' hTT' :=
   eq_restrictionRingHom P T s S hden T' s S' hden' 1 (mul_one s).symm
     fun u hu ↦ by simpa using hTT' u hu
+
+/-- **Restriction maps are independent of a simultaneous change of presentation.** Suppose two
+source presentations give the same candidate ring of definition inside `S`, and two target
+presentations do likewise inside `S'`. Then the corresponding numerator-enlargement restriction
+maps are heterogeneously equal.
+
+The conclusion is `HEq` because changing a presentation changes the uniformity used to form each
+completion. The equalities of candidate rings identify those uniformities by
+`locUniformSpace_congr`; after that identification, continuity and compatibility with the
+structure maps characterize both restriction maps. -/
+theorem restrictionRingHomOfSubset_heq
+    (P : PairOfDefinition A)
+    (T₁ T₁' : Finset A) (s₁ : A) (S : Type*) [CommRing S] [Algebra A S]
+    [IsLocalization.Away s₁ S] (hden₁ : HasDenominatorPower P T₁ s₁ S)
+    (S' : Type*) [CommRing S'] [Algebra A S'] [IsLocalization.Away s₁ S']
+    (hden₁' : HasDenominatorPower P T₁' s₁ S') (hT₁T₁' : ∀ t ∈ T₁, t ∈ T₁')
+    (T₂ T₂' : Finset A) (s₂ : A) [IsLocalization.Away s₂ S]
+    [IsLocalization.Away s₂ S'] (hden₂ : HasDenominatorPower P T₂ s₂ S)
+    (hden₂' : HasDenominatorPower P T₂' s₂ S') (hT₂T₂' : ∀ t ∈ T₂, t ∈ T₂')
+    (hS : locSubring P T₂ s₂ S = locSubring P T₁ s₁ S)
+    (hS' : locSubring P T₂' s₂ S' = locSubring P T₁' s₁ S') :
+    HEq (restrictionRingHomOfSubset P T₂ s₂ S hden₂ T₂' S' hden₂' hT₂T₂')
+      (restrictionRingHomOfSubset P T₁ s₁ S hden₁ T₁' S' hden₁' hT₁T₁') := by
+  -- Abstract the two source and target uniformities simultaneously. This avoids rewriting
+  -- dependent `IsUniformAddGroup` and `IsTopologicalRing` arguments one at a time.
+  have htransport {u₁ u₂ : UniformSpace S} (hu : u₂ = u₁)
+      {v₁ v₂ : UniformSpace S'} (hv : v₂ = v₁)
+      (g₁ : @IsUniformAddGroup S u₁ _) (g₂ : @IsUniformAddGroup S u₂ _)
+      (t₁ : @IsTopologicalRing S u₁.toTopologicalSpace _)
+      (t₂ : @IsTopologicalRing S u₂.toTopologicalSpace _)
+      (g₁' : @IsUniformAddGroup S' v₁ _) (g₂' : @IsUniformAddGroup S' v₂ _)
+      (t₁' : @IsTopologicalRing S' v₁.toTopologicalSpace _)
+      (t₂' : @IsTopologicalRing S' v₂.toTopologicalSpace _) :
+      let B₁ := @UniformSpace.Completion S u₁
+      let B₂ := @UniformSpace.Completion S u₂
+      let C₁ := @UniformSpace.Completion S' v₁
+      let C₂ := @UniformSpace.Completion S' v₂
+      let b₁ := @UniformSpace.Completion.commRing S _ u₁ g₁ t₁
+      let b₂ := @UniformSpace.Completion.commRing S _ u₂ g₂ t₂
+      let c₁ := @UniformSpace.Completion.commRing S' _ v₁ g₁' t₁'
+      let c₂ := @UniformSpace.Completion.commRing S' _ v₂ g₂' t₂'
+      ∀ (f₂ : @RingHom B₂ C₂ b₂.toNonAssocSemiring c₂.toNonAssocSemiring)
+        (f₁ : @RingHom B₁ C₁ b₁.toNonAssocSemiring c₁.toNonAssocSemiring)
+        (a₂ : @RingHom A B₂ _ b₂.toNonAssocSemiring)
+        (a₁ : @RingHom A B₁ _ b₁.toNonAssocSemiring)
+        (d₂ : @RingHom A C₂ _ c₂.toNonAssocSemiring)
+        (d₁ : @RingHom A C₁ _ c₁.toNonAssocSemiring),
+        @Continuous B₂ C₂ (@UniformSpace.Completion.uniformSpace S u₂).toTopologicalSpace
+          (@UniformSpace.Completion.uniformSpace S' v₂).toTopologicalSpace f₂ →
+        @Continuous B₁ C₁ (@UniformSpace.Completion.uniformSpace S u₁).toTopologicalSpace
+          (@UniformSpace.Completion.uniformSpace S' v₁).toTopologicalSpace f₁ →
+        HEq a₂ a₁ → HEq d₂ d₁ → f₂.comp a₂ = d₂ → f₁.comp a₁ = d₁ →
+        (∀ f : @RingHom B₁ C₁ b₁.toNonAssocSemiring c₁.toNonAssocSemiring,
+          @Continuous B₁ C₁
+            (@UniformSpace.Completion.uniformSpace S u₁).toTopologicalSpace
+            (@UniformSpace.Completion.uniformSpace S' v₁).toTopologicalSpace f →
+          f.comp a₁ = d₁ → f = f₁) → HEq f₂ f₁ := by
+    subst hu
+    subst hv
+    dsimp only
+    intro f₂ f₁ a₂ a₁ d₂ d₁ hf₂ _ ha hd hcomp₂ _ huniq
+    apply heq_of_eq
+    apply huniq f₂ hf₂
+    rw [← eq_of_heq ha, hcomp₂, eq_of_heq hd]
+  exact htransport
+    (locUniformSpace_congr P T₁ T₂ s₁ s₂ S hden₁ hden₂ hS)
+    (locUniformSpace_congr P T₁' T₂' s₁ s₂ S' hden₁' hden₂' hS')
+    (isUniformAddGroup_locUniformSpace P T₁ s₁ S hden₁)
+    (isUniformAddGroup_locUniformSpace P T₂ s₂ S hden₂)
+    (isTopologicalRing_locUniformSpace P T₁ s₁ S hden₁)
+    (isTopologicalRing_locUniformSpace P T₂ s₂ S hden₂)
+    (isUniformAddGroup_locUniformSpace P T₁' s₁ S' hden₁')
+    (isUniformAddGroup_locUniformSpace P T₂' s₂ S' hden₂')
+    (isTopologicalRing_locUniformSpace P T₁' s₁ S' hden₁')
+    (isTopologicalRing_locUniformSpace P T₂' s₂ S' hden₂')
+    (restrictionRingHomOfSubset P T₂ s₂ S hden₂ T₂' S' hden₂' hT₂T₂')
+    (restrictionRingHomOfSubset P T₁ s₁ S hden₁ T₁' S' hden₁' hT₁T₁')
+    (toCompletionLoc P T₂ s₂ S hden₂) (toCompletionLoc P T₁ s₁ S hden₁)
+    (toCompletionLoc P T₂' s₂ S' hden₂') (toCompletionLoc P T₁' s₁ S' hden₁')
+    (continuous_restrictionRingHomOfSubset P T₂ s₂ S hden₂ T₂' S' hden₂' hT₂T₂')
+    (continuous_restrictionRingHomOfSubset P T₁ s₁ S hden₁ T₁' S' hden₁' hT₁T₁')
+    (toCompletionLoc_heq P T₁ T₂ s₁ s₂ S hden₁ hden₂ hS)
+    (toCompletionLoc_heq P T₁' T₂' s₁ s₂ S' hden₁' hden₂' hS')
+    (restrictionRingHomOfSubset_comp_toCompletionLoc P T₂ s₂ S hden₂ T₂' S'
+      hden₂' hT₂T₂')
+    (restrictionRingHomOfSubset_comp_toCompletionLoc P T₁ s₁ S hden₁ T₁' S'
+      hden₁' hT₁T₁')
+    (eq_restrictionRingHomOfSubset P T₁ s₁ S hden₁ T₁' S' hden₁' hT₁T₁')
 
 /-- **The restriction map carries `t/s` to `t/s`**, for every `t`. This is the fact the Laurent
 presentation of a refinement rests on; the numerator condition `t ∈ T'` is not needed here, only


### PR DESCRIPTION
This PR proves Wedhorn's Proposition 8.30 for numerator-enlargement restriction maps, removing the previous topological-nilpotence hypothesis on the denominator by rescaling both presentations with a power of a pseudouniformiser and transporting the canonical restriction homomorphism back.

It advances `AdicSpaces/README.md`, Layer 4.1, item 3, “Proposition 8.30: prove that restriction maps between rational localisations are flat.” The new `PairOfDefinition.flat_restrictionRingHomOfSubset_of_span_eq_top` assumes strong noetherianity and the Tate condition on the ambient ring, together with the unit-ideal form of rationality, but imposes no condition on the denominator. After this PR, Layer 4.1 still needs Corollary 8.32, the two-piece Laurent-cover exactness of Lemma 8.33, the refinement argument of Lemma 8.34, and the resulting sheafiness and all-degree Čech exactness.

The restriction-map API gains `PairOfDefinition.restrictionRingHomOfSubset_heq`, which identifies the maps arising from simultaneous source and target presentation changes whose candidate rings of definition agree. The flatness proof chooses a pseudouniformiser power making the denominator topologically nilpotent, proves the rescaled generators still span the unit ideal, applies the existing Laurent-chain argument, and uses this presentation invariance to transport flatness. The superseded topologically-nilpotent capstone is retained only as private proof infrastructure, so the public API exposes the full proposition without a redundant weaker variant.

The mathematical source is T. Wedhorn, *Adic Spaces*, arXiv:1910.05934v1, Proposition 8.30, already cited in the module. No Mathlib implementation or external formalization is vendored; the proof reuses Tau Ceti's existing pseudouniformiser rescaling, localization-presentation, and strong-noetherianity results.

Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"proposition-8-30-rational-localisation-flatness"}-->

🤖 Prepared with Codex
