### PR TITLE
feat: characterize ramification by relative discriminants

### DIFF
--- a/TauCeti/NumberTheory/DedekindDomain/RelNorm.lean
+++ b/TauCeti/NumberTheory/DedekindDomain/RelNorm.lean
@@ -23,6 +23,8 @@ this consequence.
 
 * `Ideal.eq_of_le_of_relNorm_eq`: a containment of ideals of `B` with equal relative norms over `A`
   is an equality.
+* `Ideal.dvd_relNorm_iff_exists_liesOver_dvd`: a nonzero prime divides a relative norm exactly
+  when a prime above it divides the original ideal.
 -/
 
 public section
@@ -54,6 +56,52 @@ theorem eq_of_le_of_relNorm_eq {I J : Ideal B} (hIJ : I ≤ J)
     have := hle (Submodule.mem_top (x := (1 : A)))
     rwa [mem_comap, map_one] at this
   rw [hC, hCtop, mul_top]
+
+/-- **Prime divisors of a relative norm are exactly the primes lying below prime divisors.**
+
+For a nonzero prime ideal `p` of `A` and an ideal `I` of `B`, `p` divides the relative norm of `I`
+if and only if some prime ideal of `B` lying over `p` divides `I`. -/
+theorem dvd_relNorm_iff_exists_liesOver_dvd {p : Ideal A} [p.IsPrime] (hp : p ≠ ⊥)
+    {I : Ideal B} :
+    p ∣ relNorm A I ↔ ∃ P : p.primesOver B, (P : Ideal B) ∣ I := by
+  by_cases hI : I = ⊥
+  · subst I
+    obtain ⟨P⟩ := (inferInstance : Nonempty (p.primesOver B))
+    exact ⟨fun _ ↦ ⟨P, dvd_zero _⟩, fun _ ↦ by rw [relNorm_bot]; exact dvd_zero _⟩
+  have hp_prime : Prime p := prime_of_isPrime hp inferInstance
+  constructor
+  · intro hpdvd
+    rw [← prod_normalizedFactors_eq_self hI, map_multiset_prod] at hpdvd
+    obtain ⟨N, hNmem, hpN⟩ := hp_prime.exists_mem_multiset_dvd hpdvd
+    obtain ⟨P, hPmem, rfl⟩ := Multiset.mem_map.mp hNmem
+    have hPdata := (Ideal.mem_normalizedFactors_iff (A := B) hI).mp hPmem
+    have hPprime : P.IsPrime := hPdata.1
+    have hPdvd : P ∣ I := dvd_iff_le.mpr hPdata.2
+    let _ : P.IsPrime := hPprime
+    have hP0 : P ≠ ⊥ := ne_bot_of_le_ne_bot hI hPdata.2
+    have hunder0 : P.under A ≠ ⊥ := by
+      intro h
+      have : P.LiesOver (⊥ : Ideal A) := h ▸ inferInstance
+      exact hP0 (eq_bot_of_liesOver_bot A P)
+    have hunder_prime : Prime (P.under A) := prime_of_isPrime hunder0 inferInstance
+    obtain ⟨n, hn⟩ := exists_relNorm_eq_pow_of_isPrime P (P.under A)
+    rw [hn] at hpN
+    have hpunder : p ∣ P.under A := hp_prime.dvd_of_dvd_pow hpN
+    have hpeq : p = P.under A := by
+      rw [Prime.dvd_prime_iff_associated hp_prime hunder_prime, associated_iff_eq] at hpunder
+      exact hpunder
+    exact ⟨⟨P, hPprime, hpeq ▸ inferInstance⟩, hPdvd⟩
+  · rintro ⟨P, hPdvd⟩
+    obtain ⟨n, hn⟩ := exists_relNorm_eq_pow_of_isPrime (P : Ideal B) p
+    have hn0 : n ≠ 0 := by
+      intro hnzero
+      have hnorm_top : relNorm A (P : Ideal B) = ⊤ := by simpa [hnzero] using hn
+      have htop_le : (⊤ : Ideal A) ≤ p := by
+        have hover : p = (P : Ideal B).under A := Ideal.LiesOver.over
+        rw [hover]
+        exact hnorm_top ▸ relNorm_le_comap A (P : Ideal B)
+      exact (inferInstance : p.IsPrime).ne_top (top_unique htop_le)
+    exact (hn ▸ dvd_pow_self p hn0).trans (map_dvd (relNorm A) hPdvd)
 
 end Ideal
 

--- a/TauCeti/NumberTheory/NumberField/Discriminant/Ramification.lean
+++ b/TauCeti/NumberTheory/NumberField/Discriminant/Ramification.lean
@@ -1,0 +1,53 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.NumberTheory.RamificationInertia.Unramified
+public import TauCeti.NumberTheory.NumberField.Discriminant.Relative
+public import TauCeti.RingTheory.DedekindDomain.Discriminant.Ramification
+
+/-!
+# Ramification and relative discriminants of number fields
+
+For an extension of number fields, the primes dividing the relative discriminant are exactly the
+primes below an upper prime whose ramification index is greater than one. This is the classical
+ramification criterion in the number-field setting, where finite residue fields make ramification
+equivalent to a nontrivial ramification index.
+
+## Main results
+
+* `TauCeti.NumberField.dvd_relDiscr_iff_exists_one_lt_ramificationIdx`: a prime divides the
+  relative discriminant exactly when a prime above it has ramification index greater than one.
+-/
+
+public section
+
+open scoped NumberField nonZeroDivisors
+
+namespace TauCeti.NumberField
+
+variable {K L : Type*} [Field K] [NumberField K] [Field L] [NumberField L] [Algebra K L]
+
+/-- **A nonzero prime divides a number-field relative discriminant exactly when an upper prime has
+ramification index greater than one.** -/
+theorem dvd_relDiscr_iff_exists_one_lt_ramificationIdx {p : Ideal (𝓞 K)} [p.IsPrime]
+    (hp : p ≠ ⊥) :
+    p ∣ relDiscr (𝓞 K) (𝓞 L) ↔
+      ∃ P : p.primesOver (𝓞 L), 1 < (P : Ideal (𝓞 L)).ramificationIdx (𝓞 K) := by
+  rw [dvd_relDiscr_iff_exists_not_isUnramifiedAt hp]
+  apply exists_congr
+  intro P
+  constructor
+  · intro hPram
+    refine Nat.one_lt_iff_ne_zero_and_ne_one.mpr
+      ⟨(Ideal.ramificationIdx_pos (P : Ideal (𝓞 L)) (𝓞 K)).ne', ?_⟩
+    exact fun h => hPram (Ideal.ramificationIdx_eq_one_iff.mp h)
+  · intro he hur
+    exact he.ne' (Ideal.ramificationIdx_eq_one_of_isUnramifiedAt (R := 𝓞 K))
+
+end TauCeti.NumberField
+
+end

--- a/TauCeti/RingTheory/DedekindDomain/Discriminant/Ramification.lean
+++ b/TauCeti/RingTheory/DedekindDomain/Discriminant/Ramification.lean
@@ -1,0 +1,54 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.NumberTheory.DedekindDomain.RelNorm
+public import TauCeti.RingTheory.DedekindDomain.Discriminant.Separable
+
+/-!
+# Ramification and the relative discriminant
+
+For a separable extension of fraction fields of Dedekind domains, a nonzero prime divides the
+relative discriminant exactly when some prime above it is ramified. Here ramification is expressed
+intrinsically by failure of `Algebra.IsUnramifiedAt`; no residue-field separability is required.
+
+## Main results
+
+* `TauCeti.dvd_relDiscr_iff_exists_not_isUnramifiedAt`: a prime divides the relative discriminant
+  exactly when the extension ramifies at a prime above it.
+
+This is the relative-discriminant ramification criterion of Neukirch, *Algebraic Number Theory*,
+Chapter III, §2, Proposition 12.
+-/
+
+public section
+
+namespace TauCeti
+
+open scoped nonZeroDivisors
+
+attribute [local instance] FractionRing.liftAlgebra
+
+variable {A B : Type*} [CommRing A] [IsDedekindDomain A]
+  [CommRing B] [IsDedekindDomain B] [Algebra A B] [Module.Finite A B]
+  [Module.IsTorsionFree A B] [Algebra.IsSeparable (FractionRing A) (FractionRing B)]
+
+/-- **A nonzero prime divides the relative discriminant exactly when a prime above it is
+ramified.** Ramification means failure of `Algebra.IsUnramifiedAt`, so this statement does not
+need the residue extensions to be separable. -/
+theorem dvd_relDiscr_iff_exists_not_isUnramifiedAt {p : Ideal A} [p.IsPrime] (hp : p ≠ ⊥) :
+    p ∣ relDiscr A B ↔
+      ∃ P : p.primesOver B, ¬ Algebra.IsUnramifiedAt A (P : Ideal B) := by
+  rw [relDiscr_def, Ideal.dvd_relNorm_iff_exists_liesOver_dvd hp]
+  apply exists_congr
+  intro P
+  constructor
+  · exact dvd_differentIdeal_iff.mp
+  · exact dvd_differentIdeal_iff.mpr
+
+end TauCeti
+
+end


### PR DESCRIPTION
This PR proves the ramification criterion for the relative discriminant: a nonzero prime of a Dedekind base divides `relDiscr A B` exactly when some prime above it fails `Algebra.IsUnramifiedAt A`, and for number fields this is equivalent to an upper ramification index greater than one.

The exact roadmap target is `NumberFieldArithmetic/README.md`, Layer 4.2, “The relative discriminant ideal, its theory,” specifically “prove the ramification criterion.” This is the most effective next step after the merged Layer 4.1 definition and initial Layer 4.2 transitivity work because it gives Layer 4.3 `ramifiedSupport` its required membership characterization. After this PR, Layer 4.2 still needs the named localization comparison chain before the milestone is complete.

The proof first adds `Ideal.dvd_relNorm_iff_exists_liesOver_dvd` in the existing relative-norm module. It factors an ideal into normalized prime factors, uses Mathlib's `Ideal.exists_relNorm_eq_pow_of_isPrime` to identify which base prime lies below each factor, and also handles the zero ideal without an unnecessary hypothesis. `TauCeti.dvd_relDiscr_iff_exists_not_isUnramifiedAt` then combines that result with Mathlib's `dvd_differentIdeal_iff`; `TauCeti.NumberField.dvd_relDiscr_iff_exists_one_lt_ramificationIdx` uses finite residue fields to express the same criterion by ramification index.

The mathematical criterion follows Neukirch, *Algebraic Number Theory*, Chapter III, §2, Proposition 12, as recorded in the generic module documentation. No Mathlib infrastructure is vendored, and searches of the pinned Mathlib and Tau Ceti trees found no existing relative-norm prime-divisor theorem or relative-discriminant ramification criterion.

Roadmap: NumberFieldArithmetic

<!--tauceti-target:v1 {"focus":"NumberFieldArithmetic","id":"reldiscr-ramification-criterion"}-->

🤖 Prepared with Codex
