### PR TITLE
feat: the Dirichlet coordinate marginal is a Beta law

### DIFF
--- a/TauCeti/Probability/Distributions/Dirichlet/Marginal.lean
+++ b/TauCeti/Probability/Distributions/Dirichlet/Marginal.lean
@@ -1,0 +1,128 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Probability.Distributions.Dirichlet.Basic
+public import TauCeti.Probability.Distributions.Gamma.Beta
+public import TauCeti.Probability.Distributions.Gamma.Sum
+
+/-!
+# Coordinate marginals of the Dirichlet distribution
+
+A Dirichlet vector is a vector of independent unit-rate Gamma variables divided by its own total.
+Its `i`th coordinate is therefore one Gamma variable divided by the sum of itself and the total of
+the remaining, independent, Gamma variables.  That total is again Gamma with the summed shape, so
+the Gamma--Beta change of variables identifies the coordinate as a Beta variable whose first
+parameter is `a i` and whose second parameter is the total of the other concentration parameters.
+
+Two indices are needed for the second Beta parameter to be positive.  On a one-element index type
+the Dirichlet law is instead the Dirac mass at the only point of the simplex, and that boundary
+case is recorded here as well.
+
+## Main results
+
+* `TauCeti.Probability.map_eval_dirichletMeasure` — a coordinate marginal is a Beta law.
+* `TauCeti.Probability.map_eval_zero_dirichletMeasure_fin_two` — the two-parameter case, where the
+  first coordinate carries the Beta law of the two concentration parameters themselves.
+* `TauCeti.Probability.dirichletMeasure_eq_dirac_of_card_eq_one` — on a one-element index type the
+  Dirichlet law is a Dirac mass.
+
+## References
+
+* N. L. Johnson, S. Kotz, N. Balakrishnan, *Continuous Multivariate Distributions*, vol. 1,
+  2nd ed., Wiley, 2000, Chapter 49.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory ProbabilityTheory
+
+namespace TauCeti
+
+namespace Probability
+
+variable {ι : Type*} [Fintype ι]
+
+/-- Under a positive concentration vector, a Dirichlet coordinate is the ratio of its own Gamma
+variable to the total of all of them. -/
+private theorem map_eval_dirichletMeasure_eq [Nonempty ι] {a : ι → ℝ} (ha : ∀ i, 0 < a i)
+    (i : ι) :
+    (dirichletMeasure a).map (fun x ↦ x i) =
+      (Measure.pi fun j ↦ gammaMeasure (a j) 1).map (fun x ↦ x i / ∑ j, x j) := by
+  rw [dirichletMeasure_of_pos ha, Measure.map_map (by fun_prop) measurable_dirichletNormalize]
+  simp only [Function.comp_def, dirichletNormalize_apply]
+
+/-- Under a Dirichlet law with positive concentration parameters, a coordinate has the Beta law
+whose first parameter is that coordinate's concentration parameter and whose second parameter is
+the total of the remaining ones. -/
+theorem map_eval_dirichletMeasure [DecidableEq ι] [Nontrivial ι] {a : ι → ℝ} (ha : ∀ i, 0 < a i)
+    (i : ι) :
+    (dirichletMeasure a).map (fun x ↦ x i) =
+      betaMeasure (a i) (∑ j with j ≠ i, a j) := by
+  rw [Finset.filter_ne']
+  have _ : ∀ j, IsProbabilityMeasure (gammaMeasure (a j) 1) :=
+    fun j ↦ isProbabilityMeasure_gammaMeasure (ha j) one_pos
+  have hlaw : ∀ j, HasLaw (fun x : ι → ℝ ↦ x j) (gammaMeasure (a j) 1)
+      (Measure.pi fun k ↦ gammaMeasure (a k) 1) :=
+    fun j ↦ (measurePreserving_eval (fun k ↦ gammaMeasure (a k) 1) j).hasLaw
+  have hindep : iIndepFun (fun (j : ι) (x : ι → ℝ) ↦ x j)
+      (Measure.pi fun k ↦ gammaMeasure (a k) 1) :=
+    iIndepFun_pi (X := fun _ ↦ id) fun _ ↦ aemeasurable_id
+  have hs : (Finset.univ.erase i).Nonempty := by
+    obtain ⟨j, hj⟩ := exists_ne i
+    exact ⟨j, Finset.mem_erase.2 ⟨hj, Finset.mem_univ j⟩⟩
+  have hspos : 0 < ∑ j ∈ Finset.univ.erase i, a j := Finset.sum_pos (fun j _ ↦ ha j) hs
+  have hrest : HasLaw (fun x : ι → ℝ ↦ ∑ j ∈ Finset.univ.erase i, x j)
+      (gammaMeasure (∑ j ∈ Finset.univ.erase i, a j) 1)
+      (Measure.pi fun k ↦ gammaMeasure (a k) 1) :=
+    hasLaw_sum_gammaMeasure_of_iIndepFun hindep one_pos hs (fun j _ ↦ ha j) hlaw
+  have hpair : IndepFun (fun x : ι → ℝ ↦ x i) (fun x ↦ ∑ j ∈ Finset.univ.erase i, x j)
+      (Measure.pi fun k ↦ gammaMeasure (a k) 1) := by
+    have hsplit : (∑ j ∈ Finset.univ.erase i, fun x : ι → ℝ ↦ x j) =
+        fun x ↦ ∑ j ∈ Finset.univ.erase i, x j :=
+      funext fun x ↦ Finset.sum_apply x _ _
+    have h := (hindep.indepFun_finsetSum_of_notMem₀ (fun j ↦ (hlaw j).aemeasurable)
+      (Finset.notMem_erase i Finset.univ)).symm
+    rwa [hsplit] at h
+  have hbeta := hasLaw_div_add_gammaMeasure_of_indepFun (ha i) hspos one_pos hpair (hlaw i) hrest
+  rw [map_eval_dirichletMeasure_eq ha i, ← hbeta.map_eq]
+  refine Measure.map_congr (.of_forall fun x ↦ ?_)
+  exact congrArg (x i / ·) (Finset.add_sum_erase _ _ (Finset.mem_univ i)).symm
+
+/-- The `Fin 2` Dirichlet law has the Beta law of the same two parameters as its first
+coordinate. -/
+theorem map_eval_zero_dirichletMeasure_fin_two {a : Fin 2 → ℝ} (ha : ∀ i, 0 < a i) :
+    (dirichletMeasure a).map (fun x ↦ x 0) = betaMeasure (a 0) (a 1) := by
+  have herase : Finset.univ.erase (0 : Fin 2) = {1} := by decide
+  rw [map_eval_dirichletMeasure ha 0, Finset.filter_ne', herase, Finset.sum_singleton]
+
+/-- On a one-element index type the Dirichlet law is the Dirac mass at the only point of the
+standard simplex. -/
+theorem dirichletMeasure_eq_dirac_of_card_eq_one {a : ι → ℝ} (ha : ∀ i, 0 < a i)
+    (hcard : Fintype.card ι = 1) :
+    dirichletMeasure a = Measure.dirac ((EuclideanSpace.equiv ι ℝ).symm fun _ ↦ 1) := by
+  have _ : Nonempty ι := Fintype.card_pos_iff.1 (hcard ▸ Nat.one_pos)
+  have _ : Subsingleton ι := Fintype.card_le_one_iff_subsingleton.1 hcard.le
+  have _ : ∀ j, IsProbabilityMeasure (gammaMeasure (a j) 1) :=
+    fun j ↦ isProbabilityMeasure_gammaMeasure (ha j) one_pos
+  rw [dirichletMeasure_of_pos ha]
+  have hae : dirichletNormalize =ᵐ[Measure.pi fun j ↦ gammaMeasure (a j) 1]
+      fun _ ↦ (EuclideanSpace.equiv ι ℝ).symm fun _ ↦ (1 : ℝ) := by
+    filter_upwards [ae_pos_pi_gammaMeasure a fun _ ↦ 1] with x hx
+    apply (EuclideanSpace.equiv ι ℝ).injective
+    ext j
+    have htotal : ∑ k, x k = x j :=
+      Finset.sum_eq_single_of_mem j (Finset.mem_univ j)
+        fun b _ hb ↦ absurd (Subsingleton.elim b j) hb
+    simp [dirichletNormalize_apply, htotal, div_self (hx j).ne']
+  rw [Measure.map_congr hae, Measure.map_const]
+  simp
+
+end Probability
+
+end TauCeti

--- a/TauCeti/Probability/Distributions/Gamma/Sum.lean
+++ b/TauCeti/Probability/Distributions/Gamma/Sum.lean
@@ -1,0 +1,73 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Probability.HasLaw
+public import TauCeti.Probability.Distributions.Gamma.Basic
+
+/-!
+# Finite sums of independent gamma variables
+
+The gamma family is closed under sums of independent variables sharing a rate: adding two of them
+adds their shapes, which is `TauCeti.gammaMeasure_conv_gammaMeasure`.  This file iterates that
+identity over a nonempty finite family, so that a sum of independent gamma variables with a common
+positive rate has the gamma law whose shape is the total of the individual shapes.
+
+Splitting a gamma vector into a coordinate and the total of the remaining coordinates is the
+elementary use of this closure; combined with the Gamma--Beta change of variables it produces the
+coordinate marginals of the Dirichlet distribution.
+
+## Main result
+
+* `TauCeti.hasLaw_sum_gammaMeasure_of_iIndepFun` — a nonempty finite sum of independent gamma
+  variables with a common rate is gamma with the summed shape.
+
+## References
+
+* N. L. Johnson, S. Kotz, N. Balakrishnan, *Continuous Univariate Distributions*, vol. 1,
+  2nd ed., Wiley, 1994, ch. 17.
+-/
+
+public section
+
+namespace TauCeti
+
+open MeasureTheory ProbabilityTheory
+
+variable {Ω ι : Type*} {mΩ : MeasurableSpace Ω} {P : Measure Ω} {X : ι → Ω → ℝ} {a : ι → ℝ} {r : ℝ}
+
+/-- A nonempty finite sum of independent gamma variables with a common positive rate has the gamma
+law whose shape is the sum of the individual shapes. -/
+theorem hasLaw_sum_gammaMeasure_of_iIndepFun {s : Finset ι} (hindep : iIndepFun X P) (hr : 0 < r)
+    (hs : s.Nonempty) (ha : ∀ i ∈ s, 0 < a i)
+    (hlaw : ∀ i, HasLaw (X i) (gammaMeasure (a i) r) P) :
+    HasLaw (fun ω ↦ ∑ i ∈ s, X i ω) (gammaMeasure (∑ i ∈ s, a i) r) P := by
+  classical
+  let _ : IsProbabilityMeasure P := hindep.isProbabilityMeasure
+  have key : ∀ t : Finset ι, t.Nonempty → (∀ i ∈ t, 0 < a i) →
+      HasLaw (∑ i ∈ t, X i) (gammaMeasure (∑ i ∈ t, a i) r) P := by
+    intro t
+    induction t using Finset.induction_on with
+    | empty => simp
+    | insert i t hi ih =>
+        intro _ hat
+        have hai : 0 < a i := hat i (Finset.mem_insert_self i t)
+        rcases t.eq_empty_or_nonempty with rfl | ht
+        · simpa using hlaw i
+        · have hat' : ∀ j ∈ t, 0 < a j := fun j hj ↦ hat j (Finset.mem_insert_of_mem hj)
+          have htpos : 0 < ∑ j ∈ t, a j := Finset.sum_pos hat' ht
+          let _ := isProbabilityMeasure_gammaMeasure hai hr
+          let _ := isProbabilityMeasure_gammaMeasure htpos hr
+          have hadd := (hindep.indepFun_finsetSum_of_notMem₀
+            (fun j ↦ (hlaw j).aemeasurable) hi).symm.hasLaw_add (hlaw i) (ih ht hat')
+          rw [gammaMeasure_conv_gammaMeasure hai htpos hr] at hadd
+          simpa only [Finset.sum_insert hi] using hadd
+  have hfun : (fun ω ↦ ∑ i ∈ s, X i ω) = ∑ i ∈ s, X i :=
+    funext fun ω ↦ (Finset.sum_apply ω s X).symm
+  rw [hfun]
+  exact key s hs ha
+
+end TauCeti

--- a/TauCeti/Probability/Distributions/Sums.lean
+++ b/TauCeti/Probability/Distributions/Sums.lean
@@ -6,7 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Probability.Distributions.Exponential
-public import TauCeti.Probability.Distributions.Gamma.Basic
+public import TauCeti.Probability.Distributions.Gamma.Sum
 public import TauCeti.Probability.Distributions.Geometric
 public import TauCeti.Probability.Distributions.Laplace
 public import TauCeti.Probability.Distributions.NegativeBinomial.Basic
@@ -153,30 +153,10 @@ theorem iIndepFun.hasLaw_sum_expMeasure {ι : Type*} [Fintype ι] [Nonempty ι]
     {X : ι → Ω → ℝ} {r : ℝ} (hindep : iIndepFun X P) (hr : 0 < r)
     (hlaw : ∀ i, HasLaw (X i) (expMeasure r) P) :
     HasLaw (fun ω => ∑ i, X i ω) (gammaMeasure (Fintype.card ι) r) P := by
-  classical
-  let _ : IsProbabilityMeasure P := hindep.isProbabilityMeasure
-  have hsum (s : Finset ι) (hs : s.Nonempty) :
-      HasLaw (∑ i ∈ s, X i) (gammaMeasure (s.card : ℝ) r) P := by
-    induction s using Finset.induction_on with
-    | empty => simp at hs
-    | @insert i s hi ih =>
-        rcases s.eq_empty_or_nonempty with rfl | hs'
-        · simpa [expMeasure] using hlaw i
-        · have hcard : (0 : ℝ) < s.card := by exact_mod_cast hs'.card_pos
-          let _ : IsProbabilityMeasure (expMeasure r) := isProbabilityMeasure_expMeasure hr
-          let _ : IsProbabilityMeasure (gammaMeasure (s.card : ℝ) r) :=
-            isProbabilityMeasure_gammaMeasure hcard hr
-          have hadd :=
-            (hindep.indepFun_finsetSum_of_notMem₀
-              (fun j => (hlaw j).aemeasurable) hi).symm.hasLaw_add (hlaw i) (ih hs')
-          rw [expMeasure, gammaMeasure_conv_gammaMeasure zero_lt_one hcard hr] at hadd
-          simpa only [Finset.sum_insert hi, Finset.card_insert_of_notMem hi, Nat.cast_add,
-            Nat.cast_one, add_comm] using hadd
-  have hX : (fun ω => ∑ i, X i ω) = ∑ i, X i := by
-    funext ω
-    exact (Fintype.sum_apply ω X).symm
-  rw [hX]
-  simpa only [Finset.card_univ] using hsum Finset.univ Finset.univ_nonempty
+  have h := hasLaw_sum_gammaMeasure_of_iIndepFun (a := fun _ => (1 : ℝ)) (s := Finset.univ)
+    hindep hr Finset.univ_nonempty (fun i _ => one_pos)
+    (fun i => by simpa only [expMeasure] using hlaw i)
+  simpa only [Finset.sum_const, Finset.card_univ, nsmul_eq_mul, mul_one] using h
 
 end Probability
 


### PR DESCRIPTION
This PR proves that a coordinate of a Dirichlet vector has a Beta law: for a positive concentration vector `a` on a finite index type with at least two elements, `(dirichletMeasure a).map (fun x => x i) = betaMeasure (a i) (∑ j with j ≠ i, a j)`. This is the Layer 5, item 6 ("Dirichlet distribution") target stated as "If `[Nontrivial ι]`, prove the coordinate marginal `(dirichletMeasure a).map (fun x => EuclideanSpace.equiv x i) = betaMeasure (a i) (∑ j with j ≠ i, a j)`", listed among that layer's key declarations as `dirichletMeasure_marginal_beta` and among its completion checks as "Evaluation at `0` of the `Fin 2` Dirichlet is `betaMeasure`". The same bullet's boundary case, "When `Fintype.card ι = 1`, prove instead `dirichletMeasure a = Measure.dirac (EuclideanSpace.equiv.symm (fun _ => 1))`", is proved here too, so every finite index type is now covered.

Roadmap: StandardDistributions

<!--tauceti-target:v1 {"focus":"StandardDistributions","id":"dirichletmeasure-marginal-beta"}-->

The milestone is Layer 5 of `StandardDistributions`, whose remaining gaps are the multivariate-Gaussian density and Bochner mean, and the Dirichlet family. Of the Dirichlet targets, `dirichletMeasure` and its simplex support landed in #6427; after this PR the family still needs the mean, variance and covariance (with the `covMatrix` and `covarianceBilin` packaging), the fibre-sum pushforward along a surjective reindexing, the lower-dimensional chart density, and the `integrableExpSet` statement.

The mathematics is the classical one. A Dirichlet vector is a vector of independent unit-rate gamma variables divided by its own total, so its `i`th coordinate is `X i / (X i + Y)` where `Y` is the total of the other coordinates. Mathlib's `iIndepFun_pi` and `measurePreserving_eval` supply the independence and the coordinate laws of the gamma product, `TauCeti.map_div_add_gammaMeasure` (already on `main`, from the Gamma--Beta change of variables) turns that ratio into a Beta variable, and the only missing input is that `Y` is again gamma with the summed shape.

That input is the new `TauCeti.hasLaw_sum_gammaMeasure_of_iIndepFun` in `TauCeti/Probability/Distributions/Gamma/Sum.lean`: a nonempty finite sum of independent gamma variables at a common positive rate has the gamma law whose shape is the total of the individual shapes. It iterates the existing two-variable `gammaMeasure_conv_gammaMeasure` over a `Finset`. The exponential special case `iIndepFun.hasLaw_sum_expMeasure` in `TauCeti/Probability/Distributions/Sums.lean` was proving the same induction for shape `1`, so it now specializes the general statement instead; that is the only change to existing code. The chi-squared sum in `TauCeti/Probability/Distributions/ChiSquared.lean` is deliberately left alone: it admits zero degrees of freedom, where the law is a Dirac mass and the gamma shape is not positive.

The new theorem is named `map_eval_dirichletMeasure` rather than the roadmap's suggested `dirichletMeasure_marginal_beta`, to match the adjacent coordinate-marginal theorem `map_eval_multinomialMeasure` in `TauCeti/Probability/Distributions/Multinomial/Marginal.lean`. No Mathlib material is vendored; the constructions follow Johnson, Kotz and Balakrishnan, *Continuous Multivariate Distributions*, vol. 1, ch. 49, cited in the file.

Files: `TauCeti/Probability/Distributions/Dirichlet/Marginal.lean` (new, 128 lines), `TauCeti/Probability/Distributions/Gamma/Sum.lean` (new, 73 lines), `TauCeti/Probability/Distributions/Sums.lean` (26 lines removed, 5 added).

🤖 Prepared with Claude Code
