### PR TITLE
feat(EllipticCurve): a valuation with no pole at x is integral on the coordinate ring

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/CoordinateRingIntegral.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/CoordinateRingIntegral.lean
@@ -1,0 +1,80 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Affine.FunctionField.GenericPoint
+public import Mathlib.RingTheory.Valuation.IsTrivialOn
+-- Proof-only: `moduleFinite_coordinateRing`, the finiteness that makes the coordinate ring
+-- integral over `F[x]`.
+import TauCeti.AlgebraicGeometry.EllipticCurve.Affine.FunctionField.Finrank
+-- Proof-only: `Valuation.aeval_le_one`, bounding a valuation on every polynomial in `x`.
+import TauCeti.RingTheory.Valuation.Polynomial
+-- Proof-only: `Valuation.Integers.isIntegral_iff_v_le_one`, the integrality criterion.
+import Mathlib.RingTheory.Valuation.Integral
+
+/-!
+# Valuations of a Weierstrass function field that are integral on the coordinate ring
+
+A valuation of `F(W)` which is trivial on `F` is determined on the affine chart by what it does to
+the coordinate `x`: the coordinate ring is integral over `F[x]`, so once `x` has no pole the whole
+of `W.CoordinateRing` lands in the valuation's integers.
+
+This is the affine-chart half of the classification of such valuations. The other half is
+`WeierstrassCurve.Affine.isEquiv_infinityPlace_of_one_lt`, which settles the case `1 < v x`: there
+the valuation is the place at infinity. Neither half needs any `Place` packaging — no
+normalization, no surjectivity, no Dedekind hypothesis and no ellipticity — which is why they are
+stated for a bare valuation.
+
+## Main results
+
+* `WeierstrassCurve.Affine.val_algebraMap_coordinateRing_le_one`: a valuation trivial on `F` with
+  `v x ≤ 1` is at most `1` on the whole coordinate ring.
+
+## References
+
+* [H. Stichtenoth, *Algebraic Function Fields and Codes*][stichtenoth2009], I.1.
+
+## Provenance
+
+Not ported. The statement is the valuation-level content of the backward direction of
+`TauCeti.Place.exists_eq_ofPrime_iff_valuation_X_le_one`, which consumes it.
+-/
+
+public section
+
+open Polynomial
+
+namespace WeierstrassCurve.Affine
+
+variable {F : Type*} [Field F] {Γ₀ : Type*} [LinearOrderedCommGroupWithZero Γ₀]
+  {W : WeierstrassCurve.Affine F} (v : Valuation W.FunctionField Γ₀) [v.IsTrivialOn F]
+
+/-- **A valuation of the function field with no pole at `x` is integral on the coordinate ring.**
+For `v` trivial on `F` with `v x ≤ 1`, every element of `W.CoordinateRing` has value at most `1`
+in `F(W)`. -/
+theorem val_algebraMap_coordinateRing_le_one
+    (hx : v (algebraMap F[X] W.FunctionField Polynomial.X) ≤ 1) (r : W.CoordinateRing) :
+    v (algebraMap W.CoordinateRing W.FunctionField r) ≤ 1 := by
+  -- every polynomial in `x` is integral, then every element of the coordinate ring is integral
+  -- over those, and a valuation is `≤ 1` exactly on the elements integral over its integers
+  have hpoly : ∀ q : F[X], v (algebraMap F[X] W.FunctionField q) ≤ 1 := fun q ↦ by
+    rw [algebraMap_eq_aeval_genericX]
+    have hx' : v W.genericX ≤ 1 := by rwa [genericX_eq_algebraMap]
+    exact v.aeval_le_one (Valuation.IsTrivialOn.valuation_algebraMap_le_one v) hx' q
+  let _ : Algebra F[X] v.integer :=
+    ((algebraMap F[X] W.FunctionField).codRestrict _ fun q ↦ hpoly q).toAlgebra
+  have _ : IsScalarTower F[X] v.integer W.FunctionField :=
+    IsScalarTower.of_algebraMap_eq fun _ ↦ rfl
+  have : Algebra.IsIntegral F[X] W.CoordinateRing := Algebra.IsIntegral.of_finite _ _
+  have hint : _root_.IsIntegral F[X] (algebraMap W.CoordinateRing W.FunctionField r) :=
+    (Algebra.IsIntegral.isIntegral r).map
+      (IsScalarTower.toAlgHom F[X] W.CoordinateRing W.FunctionField)
+  exact (Valuation.Integers.isIntegral_iff_v_le_one (Valuation.integer.integers v)).1
+    hint.tower_top
+
+end WeierstrassCurve.Affine
+
+end

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/CoordinateRingIntegral.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/CoordinateRingIntegral.lean
@@ -18,9 +18,10 @@ import Mathlib.RingTheory.Valuation.Integral
 /-!
 # Valuations of a Weierstrass function field that are integral on the coordinate ring
 
-A valuation of `F(W)` which is trivial on `F` is determined on the affine chart by what it does to
-the coordinate `x`: the coordinate ring is integral over `F[x]`, so once `x` has no pole the whole
-of `W.CoordinateRing` lands in the valuation's integers.
+For a valuation of `F(W)` trivial on `F`, having no pole at the coordinate `x` forces the valuation
+to be at most `1` on the whole coordinate ring: `W.CoordinateRing` is integral over `F[x]`, and a
+valuation is at most `1` exactly on what is integral over its integers. This bounds those elements;
+it does not compute their values.
 
 This is the affine-chart half of the classification of such valuations. The other half is
 `WeierstrassCurve.Affine.isEquiv_infinityPlace_of_one_lt`, which settles the case `1 < v x`: there
@@ -30,8 +31,8 @@ stated for a bare valuation.
 
 ## Main results
 
-* `WeierstrassCurve.Affine.val_algebraMap_coordinateRing_le_one`: a valuation trivial on `F` with
-  `v x ≤ 1` is at most `1` on the whole coordinate ring.
+* `Valuation.algebraMap_coordinateRing_le_one`: a valuation trivial on `F` with `v x ≤ 1` is at
+  most `1` on the whole coordinate ring.
 
 ## References
 
@@ -45,9 +46,9 @@ Not ported. The statement is the valuation-level content of the backward directi
 
 public section
 
-open Polynomial
+open Polynomial WeierstrassCurve.Affine
 
-namespace WeierstrassCurve.Affine
+namespace Valuation
 
 variable {F : Type*} [Field F] {Γ₀ : Type*} [LinearOrderedCommGroupWithZero Γ₀]
   {W : WeierstrassCurve.Affine F} (v : Valuation W.FunctionField Γ₀) [v.IsTrivialOn F]
@@ -55,7 +56,7 @@ variable {F : Type*} [Field F] {Γ₀ : Type*} [LinearOrderedCommGroupWithZero �
 /-- **A valuation of the function field with no pole at `x` is integral on the coordinate ring.**
 For `v` trivial on `F` with `v x ≤ 1`, every element of `W.CoordinateRing` has value at most `1`
 in `F(W)`. -/
-theorem val_algebraMap_coordinateRing_le_one
+theorem algebraMap_coordinateRing_le_one
     (hx : v (algebraMap F[X] W.FunctionField Polynomial.X) ≤ 1) (r : W.CoordinateRing) :
     v (algebraMap W.CoordinateRing W.FunctionField r) ≤ 1 := by
   -- every polynomial in `x` is integral, then every element of the coordinate ring is integral
@@ -75,6 +76,6 @@ theorem val_algebraMap_coordinateRing_le_one
   exact (Valuation.Integers.isIntegral_iff_v_le_one (Valuation.integer.integers v)).1
     hint.tower_top
 
-end WeierstrassCurve.Affine
+end Valuation
 
 end

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/InfinityPlace/Unique.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/InfinityPlace/Unique.lean
@@ -15,11 +15,6 @@ import TauCeti.AlgebraicGeometry.EllipticCurve.Affine.CoordinateRing
 -- Proof-only: the generic point's equation, and the general two-to-three pole ratio it feeds.
 import TauCeti.AlgebraicGeometry.EllipticCurve.Affine.FunctionField.GenericPoint
 import TauCeti.AlgebraicGeometry.EllipticCurve.Affine.ValuationIntegrality
--- Proof-only: `Valuation.aeval_le_one`, that a valuation bounded on the base and at `x` is
--- bounded on every polynomial in `x`.
-import TauCeti.RingTheory.Valuation.Polynomial
--- Proof-only: `Valuation.Integers.isIntegral_iff_v_le_one`, the integrality criterion.
-import Mathlib.RingTheory.Valuation.Integral
 import Mathlib.NumberTheory.RatFunc.Ostrowski
 
 /-!
@@ -61,8 +56,6 @@ The route has three steps, and none of them needs a Riemann–Roch theorem or a 
   `WeierstrassCurve.Affine.val_algebraMap_eq_pow_natDegree`: the value of a rational function, and
   of a polynomial, in `x`, as a power of `v x`; `val_algebraMap_le_pow` is the bound that also
   covers the zero polynomial.
-* `WeierstrassCurve.Affine.val_algebraMap_coordinateRing_le_one`: the complementary case — when
-  `x` has no pole, every element of the coordinate ring is integral for `v`.
 * `WeierstrassCurve.Affine.val_X_lt_val_mk_Y` and `WeierstrassCurve.Affine.val_mk_Y_sq`:
   `v x < v y` and
   `(v y) ^ 2 = (v x) ^ 3` — the pole orders `2` and `3`, for any such `v`.
@@ -351,28 +344,6 @@ theorem isEquiv_infinityPlace_of_one_lt [v.IsTrivialOn F]
   refine Valuation.isEquiv_iff_val_le_one.mpr fun {z} ↦ ?_
   obtain ⟨A, B, rfl⟩ := exists_ratFunc_add_mul_mk_Y W z
   rw [val_add_mul_mk_Y_le_one_iff v hx, val_add_mul_mk_Y_le_one_iff _ (one_lt_infinityPlace_X W)]
-
-/-- **The other side of the dichotomy: when `x` has no pole, the whole coordinate ring is
-integral.** A valuation of `F(W)` trivial on `F` with `v x ≤ 1` satisfies `v r ≤ 1` for every `r`
-in the image of `W.CoordinateRing`. -/
-theorem val_algebraMap_coordinateRing_le_one [v.IsTrivialOn F]
-    (hx : v (algebraMap F[X] W.FunctionField Polynomial.X) ≤ 1) (r : W.CoordinateRing) :
-    v (algebraMap W.CoordinateRing W.FunctionField r) ≤ 1 := by
-  -- every polynomial in `x` is integral, then every element of the coordinate ring is integral
-  -- over those, and a valuation is `≤ 1` exactly on the elements integral over its integers
-  have hpoly : ∀ q : F[X], v (algebraMap F[X] W.FunctionField q) ≤ 1 := fun q ↦ by
-    rw [algebraMap_eq_aeval_genericX]
-    have hx' : v W.genericX ≤ 1 := by rwa [genericX_eq_algebraMap]
-    exact v.aeval_le_one (Valuation.IsTrivialOn.valuation_algebraMap_le_one v) hx' q
-  let _ : Algebra F[X] v.integer :=
-    ((algebraMap F[X] W.FunctionField).codRestrict _ fun q ↦ hpoly q).toAlgebra
-  have _ : IsScalarTower F[X] v.integer W.FunctionField :=
-    IsScalarTower.of_algebraMap_eq fun _ ↦ rfl
-  have hint : _root_.IsIntegral F[X] (algebraMap W.CoordinateRing W.FunctionField r) :=
-    (Algebra.IsIntegral.isIntegral r).map
-      (IsScalarTower.toAlgHom F[X] W.CoordinateRing W.FunctionField)
-  exact (Valuation.Integers.isIntegral_iff_v_le_one (Valuation.integer.integers v)).1
-    hint.tower_top
 
 end Main
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/InfinityPlace/Unique.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/InfinityPlace/Unique.lean
@@ -15,6 +15,11 @@ import TauCeti.AlgebraicGeometry.EllipticCurve.Affine.CoordinateRing
 -- Proof-only: the generic point's equation, and the general two-to-three pole ratio it feeds.
 import TauCeti.AlgebraicGeometry.EllipticCurve.Affine.FunctionField.GenericPoint
 import TauCeti.AlgebraicGeometry.EllipticCurve.Affine.ValuationIntegrality
+-- Proof-only: `Valuation.aeval_le_one`, that a valuation bounded on the base and at `x` is
+-- bounded on every polynomial in `x`.
+import TauCeti.RingTheory.Valuation.Polynomial
+-- Proof-only: `Valuation.Integers.isIntegral_iff_v_le_one`, the integrality criterion.
+import Mathlib.RingTheory.Valuation.Integral
 import Mathlib.NumberTheory.RatFunc.Ostrowski
 
 /-!
@@ -56,6 +61,8 @@ The route has three steps, and none of them needs a Riemann–Roch theorem or a 
   `WeierstrassCurve.Affine.val_algebraMap_eq_pow_natDegree`: the value of a rational function, and
   of a polynomial, in `x`, as a power of `v x`; `val_algebraMap_le_pow` is the bound that also
   covers the zero polynomial.
+* `WeierstrassCurve.Affine.val_algebraMap_coordinateRing_le_one`: the complementary case — when
+  `x` has no pole, every element of the coordinate ring is integral for `v`.
 * `WeierstrassCurve.Affine.val_X_lt_val_mk_Y` and `WeierstrassCurve.Affine.val_mk_Y_sq`:
   `v x < v y` and
   `(v y) ^ 2 = (v x) ^ 3` — the pole orders `2` and `3`, for any such `v`.
@@ -344,6 +351,28 @@ theorem isEquiv_infinityPlace_of_one_lt [v.IsTrivialOn F]
   refine Valuation.isEquiv_iff_val_le_one.mpr fun {z} ↦ ?_
   obtain ⟨A, B, rfl⟩ := exists_ratFunc_add_mul_mk_Y W z
   rw [val_add_mul_mk_Y_le_one_iff v hx, val_add_mul_mk_Y_le_one_iff _ (one_lt_infinityPlace_X W)]
+
+/-- **The other side of the dichotomy: when `x` has no pole, the whole coordinate ring is
+integral.** A valuation of `F(W)` trivial on `F` with `v x ≤ 1` satisfies `v r ≤ 1` for every `r`
+in the image of `W.CoordinateRing`. -/
+theorem val_algebraMap_coordinateRing_le_one [v.IsTrivialOn F]
+    (hx : v (algebraMap F[X] W.FunctionField Polynomial.X) ≤ 1) (r : W.CoordinateRing) :
+    v (algebraMap W.CoordinateRing W.FunctionField r) ≤ 1 := by
+  -- every polynomial in `x` is integral, then every element of the coordinate ring is integral
+  -- over those, and a valuation is `≤ 1` exactly on the elements integral over its integers
+  have hpoly : ∀ q : F[X], v (algebraMap F[X] W.FunctionField q) ≤ 1 := fun q ↦ by
+    rw [algebraMap_eq_aeval_genericX]
+    have hx' : v W.genericX ≤ 1 := by rwa [genericX_eq_algebraMap]
+    exact v.aeval_le_one (Valuation.IsTrivialOn.valuation_algebraMap_le_one v) hx' q
+  let _ : Algebra F[X] v.integer :=
+    ((algebraMap F[X] W.FunctionField).codRestrict _ fun q ↦ hpoly q).toAlgebra
+  have _ : IsScalarTower F[X] v.integer W.FunctionField :=
+    IsScalarTower.of_algebraMap_eq fun _ ↦ rfl
+  have hint : _root_.IsIntegral F[X] (algebraMap W.CoordinateRing W.FunctionField r) :=
+    (Algebra.IsIntegral.isIntegral r).map
+      (IsScalarTower.toAlgHom F[X] W.CoordinateRing W.FunctionField)
+  exact (Valuation.Integers.isIntegral_iff_v_le_one (Valuation.integer.integers v)).1
+    hint.tower_top
 
 end Main
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/PointPlace.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/PointPlace.lean
@@ -147,18 +147,7 @@ theorem exists_eq_ofPrime_iff_valuation_X_le_one [IsDedekindDomain W.CoordinateR
     simpa only [IsScalarTower.algebraMap_apply F[X] W.CoordinateRing W.FunctionField] using
       P.mem_integers_iff.mp (hR (algebraMap F[X] W.CoordinateRing Polynomial.X))
   · intro hx r
-    apply P.mem_integers_of_isIntegral
-      (R := F[X]) (fun p ↦ ?_) ((Algebra.IsIntegral.isIntegral r).map
-        (IsScalarTower.toAlgHom F[X] W.CoordinateRing W.FunctionField))
-    apply P.adjoin_le_integers_iff.mpr (P.mem_integers_iff.mpr hx)
-    rw [Algebra.adjoin_singleton_eq_range_aeval, AlgHom.mem_range]
-    have heval :
-        (Polynomial.aeval (algebraMap F[X] W.FunctionField Polynomial.X) :
-            F[X] →ₐ[F] W.FunctionField) =
-          IsScalarTower.toAlgHom F F[X] W.FunctionField := by
-      apply Polynomial.algHom_ext
-      rw [Polynomial.aeval_X, IsScalarTower.toAlgHom_apply]
-    exact ⟨p, congrArg (fun f : F[X] →ₐ[F] W.FunctionField ↦ f p) heval⟩
+    exact P.mem_integers_iff.mpr (W.val_algebraMap_coordinateRing_le_one P.valuation hx r)
 
 /-- If the coordinate ring is Dedekind, every normalized place of a Weierstrass function field is
 either the place at infinity or the place of a unique height-one prime of the coordinate ring. -/

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/PointPlace.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/PointPlace.lean
@@ -150,7 +150,7 @@ theorem exists_eq_ofPrime_iff_valuation_X_le_one [IsDedekindDomain W.CoordinateR
     simpa only [IsScalarTower.algebraMap_apply F[X] W.CoordinateRing W.FunctionField] using
       P.mem_integers_iff.mp (hR (algebraMap F[X] W.CoordinateRing Polynomial.X))
   · intro hx r
-    exact P.mem_integers_iff.mpr (W.val_algebraMap_coordinateRing_le_one P.valuation hx r)
+    exact P.mem_integers_iff.mpr (P.valuation.algebraMap_coordinateRing_le_one hx r)
 
 /-- If the coordinate ring is Dedekind, every normalized place of a Weierstrass function field is
 either the place at infinity or the place of a unique height-one prime of the coordinate ring. -/

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/PointPlace.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/PointPlace.lean
@@ -8,6 +8,9 @@ module
 public import TauCeti.AlgebraicGeometry.EllipticCurve.Affine.FunctionField.InfinityPlace.Unique
 public import TauCeti.AlgebraicGeometry.EllipticCurve.Affine.Point.Place
 public import TauCeti.FieldTheory.FunctionField.AffineModel.Prime
+-- Proof-only: `val_algebraMap_coordinateRing_le_one`, the integrality of the coordinate ring at a
+-- valuation with no pole at `x`.
+import TauCeti.AlgebraicGeometry.EllipticCurve.Affine.FunctionField.CoordinateRingIntegral
 
 /-!
 # Rational points as degree-one places of an elliptic function field


### PR DESCRIPTION
Roadmap: EllipticCurves

A valuation of `F(W)` that is trivial on `F` is pinned down on the affine chart by what it does to
the coordinate `x`. This PR states the case where `x` has no pole.

* **New module** `Affine/FunctionField/CoordinateRingIntegral.lean`, with
  `Valuation.algebraMap_coordinateRing_le_one`:

```lean
theorem algebraMap_coordinateRing_le_one [v.IsTrivialOn F]
    (hx : v (algebraMap F[X] W.FunctionField Polynomial.X) ≤ 1) (r : W.CoordinateRing) :
    v (algebraMap W.CoordinateRing W.FunctionField r) ≤ 1
```

Polynomials in `x` are bounded by `Valuation.aeval_le_one`; the coordinate ring is integral over
those; and a valuation is `≤ 1` exactly on what is integral over its integers. No `Place` packaging
is involved — no normalization, no surjectivity, no Dedekind hypothesis, no ellipticity.

### It pays for itself where the argument was already being made

`TauCeti.Place.exists_eq_ofPrime_iff_valuation_X_le_one` — a place lies on the affine chart exactly
when `x` has no pole there — was making this argument inline. Its backward direction is now one
line, and with it go the `mem_integers_of_isIntegral` plumbing, the `adjoin_le_integers_iff` step,
and the `heval` identification of `aeval x` with the scalar tower's algebra map.

### Notes

Imports are proof-only except the two the statement needs: `moduleFinite_coordinateRing` comes from
`FunctionField/Finrank.lean`, and `Valuation.aeval_le_one` from
`TauCeti/RingTheory/Valuation/Polynomial.lean`. `_root_.IsIntegral` is spelled out because inside
`namespace WeierstrassCurve.Affine` the bare name resolves to `WeierstrassCurve.IsIntegral`.

Full build green (11359 jobs). New module is 80 lines. No `tauceti-target` marker: this authors no
roadmap target, it is a prerequisite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


