### PR TITLE
feat(ModularForms): finitely many q-coefficients determine a modular form

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/QExpansion/Truncation.lean
+++ b/TauCeti/NumberTheory/ModularForms/QExpansion/Truncation.lean
@@ -11,21 +11,23 @@ public import TauCeti.NumberTheory.ModularForms.QExpansion.Basic
 /-!
 # Finitely many `q`-coefficients determine a modular form
 
-A modular form is determined by its whole `q`-expansion. On a finite-dimensional space of forms
-it is determined by a *finite* initial segment of it, and this file says so: the kernels
+A modular form is determined by its whole `q`-expansion. Where the space of forms satisfies
+the descending chain condition it is determined by a *finite* initial segment of it, and this
+file says so: the kernels
 `qKerBelow N` of "the first `N` coefficients" decrease, meet in `⊥`, and therefore — the space
 being Artinian — reach `⊥` at some finite `N`, at which point the truncation is injective.
 
-Nothing here proves finite-dimensionality; it is a hypothesis. The point of the statement is the
-converse use: a bound on `N` turns a space of forms into a subspace of `ℂ^N`.
+Nothing here proves that condition; it is a hypothesis, and the stated form is `IsArtinian`
+rather than `FiniteDimensional` because only the chain condition is used. The point of the
+statement is the converse use: a bound on `N` turns a space of forms into a subspace of `ℂ^N`.
 
 ## Main results
 
 * `ModularForm.qCoeffTruncation`: the first `N` coefficients, as a `ℂ`-linear map to
   `Fin N → ℂ`, with `qKerBelow` its kernel.
 * `ModularForm.qKerBelow_iInf_eq_bot`: the kernels meet in `⊥`.
-* `ModularForm.exists_qCoeffTruncation_injective`: on a finite-dimensional space of
-  forms, some finite truncation is injective.
+* `ModularForm.exists_qCoeffTruncation_injective`: on an Artinian space of forms, some finite
+  truncation is injective.
 
 ## References
 
@@ -64,6 +66,7 @@ noncomputable def qKerBelow (hh : 0 < h) (hΓ : h ∈ Γ.strictPeriods) (k : ℤ
     Submodule ℂ (ModularForm Γ k) :=
   LinearMap.ker (qCoeffTruncation hh hΓ k N)
 
+@[simp]
 theorem mem_qKerBelow_iff {hh : 0 < h} {hΓ : h ∈ Γ.strictPeriods} {N : ℕ}
     {f : ModularForm Γ k} :
     f ∈ qKerBelow hh hΓ k N ↔ ∀ n < N, (qExpansion h f).coeff n = 0 := by
@@ -83,9 +86,11 @@ theorem qKerBelow_iInf_eq_bot (hh : 0 < h) (hΓ : h ∈ Γ.strictPeriods) :
     (_root_.ModularForm.qExpansion_eq_zero_iff hh hΓ f).1 <| PowerSeries.ext fun n ↦ ?_
   exact mem_qKerBelow_iff.1 (Submodule.mem_iInf _ |>.1 hf (n + 1)) n (Nat.lt_succ_self n)
 
-/-- **The kernel reaches `⊥` at a finite stage**, the space of forms being Artinian. -/
+/-- **The kernel reaches `⊥` at a finite stage**, the space of forms being Artinian. Only
+the descending-chain condition is used, so a finite-dimensional space qualifies through
+Mathlib's instance rather than by hypothesis. -/
 theorem exists_qKerBelow_eq_bot (hh : 0 < h) (hΓ : h ∈ Γ.strictPeriods)
-    [FiniteDimensional ℂ (ModularForm Γ k)] :
+    [IsArtinian ℂ (ModularForm Γ k)] :
     ∃ N : ℕ, qKerBelow (Γ := Γ) hh hΓ k N = ⊥ := by
   obtain ⟨N, hN⟩ := IsArtinian.monotone_stabilizes (R := ℂ) (M := ModularForm Γ k)
     { toFun := fun N ↦ OrderDual.toDual (qKerBelow (Γ := Γ) hh hΓ k N)
@@ -99,10 +104,10 @@ theorem exists_qKerBelow_eq_bot (hh : 0 < h) (hΓ : h ∈ Γ.strictPeriods)
     le_antisymm (le_iInf hle) (iInf_le _ N)
   rw [hEq, qKerBelow_iInf_eq_bot (Γ := Γ) (k := k) hh hΓ]
 
-/-- **Finitely many `q`-coefficients determine a modular form**, on a finite-dimensional space
-of them: some truncation `f ↦ (a₀ f, …, a_{N-1} f)` is injective. -/
+/-- **Finitely many `q`-coefficients determine a modular form**, on an Artinian space of them:
+some truncation `f ↦ (a₀ f, …, a_{N-1} f)` is injective. -/
 theorem exists_qCoeffTruncation_injective (hh : 0 < h) (hΓ : h ∈ Γ.strictPeriods)
-    [FiniteDimensional ℂ (ModularForm Γ k)] :
+    [IsArtinian ℂ (ModularForm Γ k)] :
     ∃ N : ℕ, Function.Injective (qCoeffTruncation (Γ := Γ) hh hΓ k N) := by
   obtain ⟨N, hN⟩ := exists_qKerBelow_eq_bot (Γ := Γ) (k := k) hh hΓ
   exact ⟨N, LinearMap.ker_eq_bot.1 hN⟩

--- a/TauCeti/NumberTheory/ModularForms/QExpansion/Truncation.lean
+++ b/TauCeti/NumberTheory/ModularForms/QExpansion/Truncation.lean
@@ -1,0 +1,110 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RingTheory.Artinian.Module
+public import TauCeti.NumberTheory.ModularForms.QExpansion.Basic
+
+/-!
+# Finitely many `q`-coefficients determine a modular form
+
+A modular form is determined by its whole `q`-expansion. On a finite-dimensional space of forms
+it is determined by a *finite* initial segment of it, and this file says so: the kernels
+`qKerBelow N` of "the first `N` coefficients" decrease, meet in `⊥`, and therefore — the space
+being Artinian — reach `⊥` at some finite `N`, at which point the truncation is injective.
+
+Nothing here proves finite-dimensionality; it is a hypothesis. The point of the statement is the
+converse use: a bound on `N` turns a space of forms into a subspace of `ℂ^N`.
+
+## Main results
+
+* `ModularForm.qCoeffTruncation`: the first `N` coefficients, as a `ℂ`-linear map to
+  `Fin N → ℂ`, with `qKerBelow` its kernel.
+* `ModularForm.qKerBelow_iInf_eq_bot`: the kernels meet in `⊥`.
+* `ModularForm.exists_qCoeffTruncation_injective`: on a finite-dimensional space of
+  forms, some finite truncation is injective.
+
+## References
+
+Ported from AINTLIB's `LeanModularForms` project
+([github.com/CBirkbeck/AINTLIB](https://github.com/CBirkbeck/AINTLIB), commit `6d87d596a537`,
+Apache 2.0),
+`projects/LeanModularForms/LeanModularForms/Modularforms/DimGenCongLevels/FiniteDimensional.lean`
+(`qKerBelow`, `qKerBelow_antitone`, `qKerBelow_iInf_eq_bot`, `exists_qKerBelow_eq_bot`,
+`exists_qCoeff_injective`). The truncation is bundled as a linear map here, built from this
+repository's `ModularForm.qExpansionLinearMap`, so that `qKerBelow` is a `LinearMap.ker` rather
+than a submodule with hand-written closure proofs.
+-/
+
+public section
+
+open UpperHalfPlane
+
+namespace ModularForm
+
+variable {Γ : Subgroup (GL (Fin 2) ℝ)} [Γ.HasDetOne] {h : ℝ} {k : ℤ}
+
+/-- **The first `N` `q`-expansion coefficients**, as a `ℂ`-linear map to `Fin N → ℂ`. -/
+noncomputable def qCoeffTruncation (hh : 0 < h) (hΓ : h ∈ Γ.strictPeriods) (k : ℤ) (N : ℕ) :
+    ModularForm Γ k →ₗ[ℂ] (Fin N → ℂ) :=
+  LinearMap.pi fun n ↦
+    (PowerSeries.coeff (n : ℕ)).comp (TauCeti.ModularForm.qExpansionLinearMap hh hΓ k)
+
+@[simp]
+theorem qCoeffTruncation_apply (hh : 0 < h) (hΓ : h ∈ Γ.strictPeriods) (N : ℕ)
+    (f : ModularForm Γ k) (n : Fin N) :
+    qCoeffTruncation hh hΓ k N f n = (qExpansion h f).coeff (n : ℕ) := by
+  simp [qCoeffTruncation]
+
+/-- **The forms whose first `N` `q`-coefficients vanish**: the kernel of the truncation. -/
+noncomputable def qKerBelow (hh : 0 < h) (hΓ : h ∈ Γ.strictPeriods) (k : ℤ) (N : ℕ) :
+    Submodule ℂ (ModularForm Γ k) :=
+  LinearMap.ker (qCoeffTruncation hh hΓ k N)
+
+theorem mem_qKerBelow_iff {hh : 0 < h} {hΓ : h ∈ Γ.strictPeriods} {N : ℕ}
+    {f : ModularForm Γ k} :
+    f ∈ qKerBelow hh hΓ k N ↔ ∀ n < N, (qExpansion h f).coeff n = 0 := by
+  simp only [qKerBelow, LinearMap.mem_ker, funext_iff, Pi.zero_apply, qCoeffTruncation_apply]
+  exact ⟨fun hf n hn ↦ hf ⟨n, hn⟩, fun hf n ↦ hf n n.2⟩
+
+/-- **Asking for more vanishing coefficients cuts the kernel down.** -/
+theorem qKerBelow_antitone (hh : 0 < h) (hΓ : h ∈ Γ.strictPeriods) :
+    Antitone (qKerBelow hh hΓ k) := fun _ _ hAB _ hf ↦
+  mem_qKerBelow_iff.2 fun n hn ↦ mem_qKerBelow_iff.1 hf n (hn.trans_le hAB)
+
+/-- **The kernels meet in `⊥`**: a form all of whose coefficients vanish is zero. -/
+theorem qKerBelow_iInf_eq_bot (hh : 0 < h) (hΓ : h ∈ Γ.strictPeriods) :
+    (⨅ N : ℕ, qKerBelow (Γ := Γ) hh hΓ k N) = ⊥ := by
+  refine eq_bot_iff.2 fun f hf ↦ ?_
+  refine (Submodule.mem_bot ℂ).2 <|
+    (_root_.ModularForm.qExpansion_eq_zero_iff hh hΓ f).1 <| PowerSeries.ext fun n ↦ ?_
+  exact mem_qKerBelow_iff.1 (Submodule.mem_iInf _ |>.1 hf (n + 1)) n (Nat.lt_succ_self n)
+
+/-- **The kernel reaches `⊥` at a finite stage**, the space of forms being Artinian. -/
+theorem exists_qKerBelow_eq_bot (hh : 0 < h) (hΓ : h ∈ Γ.strictPeriods)
+    [FiniteDimensional ℂ (ModularForm Γ k)] :
+    ∃ N : ℕ, qKerBelow (Γ := Γ) hh hΓ k N = ⊥ := by
+  obtain ⟨N, hN⟩ := IsArtinian.monotone_stabilizes (R := ℂ) (M := ModularForm Γ k)
+    { toFun := fun N ↦ OrderDual.toDual (qKerBelow (Γ := Γ) hh hΓ k N)
+      monotone' := fun _ _ hAB ↦ qKerBelow_antitone hh hΓ hAB }
+  have hle : ∀ M : ℕ, qKerBelow (Γ := Γ) hh hΓ k N ≤ qKerBelow hh hΓ k M := fun M ↦ by
+    by_cases hNM : N ≤ M
+    · exact le_of_eq (congrArg OrderDual.ofDual (hN M hNM))
+    · exact qKerBelow_antitone hh hΓ (Nat.le_of_not_ge hNM)
+  refine ⟨N, ?_⟩
+  have hEq : qKerBelow (Γ := Γ) hh hΓ k N = ⨅ M : ℕ, qKerBelow (Γ := Γ) hh hΓ k M :=
+    le_antisymm (le_iInf hle) (iInf_le _ N)
+  rw [hEq, qKerBelow_iInf_eq_bot (Γ := Γ) (k := k) hh hΓ]
+
+/-- **Finitely many `q`-coefficients determine a modular form**, on a finite-dimensional space
+of them: some truncation `f ↦ (a₀ f, …, a_{N-1} f)` is injective. -/
+theorem exists_qCoeffTruncation_injective (hh : 0 < h) (hΓ : h ∈ Γ.strictPeriods)
+    [FiniteDimensional ℂ (ModularForm Γ k)] :
+    ∃ N : ℕ, Function.Injective (qCoeffTruncation (Γ := Γ) hh hΓ k N) := by
+  obtain ⟨N, hN⟩ := exists_qKerBelow_eq_bot (Γ := Γ) (k := k) hh hΓ
+  exact ⟨N, LinearMap.ker_eq_bot.1 hN⟩
+
+end ModularForm


### PR DESCRIPTION
Roadmap: ModularForms

**Which node.** `TauCetiRoadmap/ModularForms/README.md`, **Layer 10 — "The Sturm bound and
finite-dimensionality — consume level one, build the general case"**, whose dependency note says
the `Module.Finite ℂ (ModularForm 𝒢 k)` instance is *not* in Mathlib and Layer 10 builds it here.

Provenance: github.com/CBirkbeck/AINTLIB @ `6d87d596a537`, Apache-2.0 —
`projects/LeanModularForms/LeanModularForms/Modularforms/DimGenCongLevels/FiniteDimensional.lean`
(`qKerBelow`, `qKerBelow_antitone`, `qKerBelow_iInf_eq_bot`, `exists_qKerBelow_eq_bot`,
`exists_qCoeff_injective`).

A modular form is determined by its whole `q`-expansion. This says that on a
finite-dimensional space of forms a *finite* initial segment already determines it:

```text
qKerBelow N = {f : a₀ f = … = a_{N-1} f = 0}   decreases,   ⨅ N, qKerBelow N = ⊥,
```

so the space being Artinian, the chain reaches `⊥` and the truncation `f ↦ (a₀ f, …, a_{N-1} f)`
is injective at that `N`.

**Finite-dimensionality is a hypothesis here, not a conclusion.** That is worth stating plainly,
because the name of the AINTLIB file it comes from (`FiniteDimensional.lean`) suggests otherwise.
The value of the statement is the other direction: given finite-dimensionality, it bounds a space
of forms inside `ℂ^N`, which is what the Sturm-bound arguments consume.

**Divergence from the source, deliberate.** AINTLIB builds `qKerBelow` as a `Submodule` with
hand-written `zero_mem'`/`add_mem'`/`smul_mem'` proofs. This repository already has
`TauCeti.ModularForm.qExpansionLinearMap`, so the truncation is bundled as a genuine linear map
`ModularForm Γ k →ₗ[ℂ] (Fin N → ℂ)` and `qKerBelow` is its `LinearMap.ker` — the closure proofs
then come for free, and `exists_qCoeffTruncation_injective` is `LinearMap.ker_eq_bot` rather than
a hand-rolled `sub_eq_zero` argument. `mem_qKerBelow_iff` recovers AINTLIB's characterisation.

The declarations sit in `ModularForm` at root rather than `TauCeti.ModularForm`, because the
dot-notation lint flags `TauCeti.<Mathlib namespace>` declarations taking an argument of that
type, and `qCoeffTruncation`/`_apply` do.

This does not prove finite-dimensionality at general level, so it carries no target marker.

Build green (11361 jobs); `#lint in` the new module 0 errors across 15 linters; axioms
`propext`, `Classical.choice`, `Quot.sound`; dot-notation 0 new; longest proof 11 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KrTkwbwKqMk3543hugPHmw
